### PR TITLE
[Flink-7611]add metrics to measure the num of data dropped due to the data arrived late

### DIFF
--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -885,7 +885,7 @@ Thus, in order to infer the metric identifier:
       <td>The number of records this operator/task sends per second.</td>
     </tr>
     <tr>
-          <td>numLateElementsDropped</td>
+          <td>numLateRecordsDropped</td>
           <td>The number of records dropped this window operator/task due to arrived late</td>
     </tr>
     <tr>

--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -885,7 +885,7 @@ Thus, in order to infer the metric identifier:
       <td>The number of records this operator/task sends per second.</td>
     </tr>
     <tr>
-          <td>numLateRecords</td>
+          <td>numLateElementsDropped</td>
           <td>The number of records dropped this window operator/task due to arrived late</td>
     </tr>
     <tr>

--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -868,7 +868,7 @@ Thus, in order to infer the metric identifier:
       <td>The number of bytes this task emits per second.</td>
     </tr>
     <tr>
-      <th rowspan="4"><strong>Task/Operator</strong></th>
+      <th rowspan="5"><strong>Task/Operator</strong></th>
       <td>numRecordsIn</td>
       <td>The total number of records this operator/task has received.</td>
     </tr>
@@ -883,6 +883,10 @@ Thus, in order to infer the metric identifier:
     <tr>
       <td>numRecordsOutPerSecond</td>
       <td>The number of records this operator/task sends per second.</td>
+    </tr>
+    <tr>
+          <td>numLateRecords</td>
+          <td>The number of records dropped this window operator/task due to arrived late</td>
     </tr>
     <tr>
       <th rowspan="2"><strong>Operator</strong></th>

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/EvictingWindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/EvictingWindowOperator.java
@@ -153,6 +153,7 @@ public class EvictingWindowOperator<K, IN, OUT, W extends Window>
 
 				// drop if the window is already late
 				if (isWindowLate(actualWindow)) {
+					this.lostDataCount.inc();
 					mergingWindows.retireWindow(actualWindow);
 					continue;
 				}
@@ -195,6 +196,7 @@ public class EvictingWindowOperator<K, IN, OUT, W extends Window>
 
 				// check if the window is already inactive
 				if (isWindowLate(window)) {
+					this.lostDataCount.inc();
 					continue;
 				}
 				isSkippedElement = false;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/EvictingWindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/EvictingWindowOperator.java
@@ -231,7 +231,7 @@ public class EvictingWindowOperator<K, IN, OUT, W extends Window>
 		// windowAssigner is event time and current timestamp + allowed lateness no less than element timestamp
 		if (isSkippedElement && lateDataOutputTag != null && isElementLate(element)) {
 			sideOutput(element);
-		} else if (isSkippedElement) {
+		} else if (isSkippedElement && isElementLate(element)) {
 			this.lostDataCount.inc();
 		}
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/EvictingWindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/EvictingWindowOperator.java
@@ -153,7 +153,6 @@ public class EvictingWindowOperator<K, IN, OUT, W extends Window>
 
 				// drop if the window is already late
 				if (isWindowLate(actualWindow)) {
-					this.lostDataCount.inc();
 					mergingWindows.retireWindow(actualWindow);
 					continue;
 				}
@@ -196,7 +195,6 @@ public class EvictingWindowOperator<K, IN, OUT, W extends Window>
 
 				// check if the window is already inactive
 				if (isWindowLate(window)) {
-					this.lostDataCount.inc();
 					continue;
 				}
 				isSkippedElement = false;
@@ -233,6 +231,8 @@ public class EvictingWindowOperator<K, IN, OUT, W extends Window>
 		// windowAssigner is event time and current timestamp + allowed lateness no less than element timestamp
 		if (isSkippedElement && lateDataOutputTag != null && isElementLate(element)) {
 			sideOutput(element);
+		} else if (isSkippedElement) {
+			this.lostDataCount.inc();
 		}
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/EvictingWindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/EvictingWindowOperator.java
@@ -229,10 +229,12 @@ public class EvictingWindowOperator<K, IN, OUT, W extends Window>
 		// element not handled by any window
 		// late arriving tag has been set
 		// windowAssigner is event time and current timestamp + allowed lateness no less than element timestamp
-		if (isSkippedElement && lateDataOutputTag != null && isElementLate(element)) {
-			sideOutput(element);
-		} else if (isSkippedElement && isElementLate(element)) {
-			this.lostDataCount.inc();
+		if (isSkippedElement && isElementLate(element)) {
+			if (lateDataOutputTag != null){
+				sideOutput(element);
+			} else {
+				this.lostDataCount.inc();
+			}
 		}
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
@@ -43,6 +43,7 @@ import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.api.java.typeutils.runtime.TupleSerializer;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.runtime.state.VoidNamespace;
 import org.apache.flink.runtime.state.VoidNamespaceSerializer;
 import org.apache.flink.runtime.state.internal.InternalAppendingState;
@@ -133,12 +134,9 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 	 */
 	protected final OutputTag<IN> lateDataOutputTag;
 
-	/**
-	* Metrics about the lost data due to arrive late.
-	* */
-	protected final String loseData = "lost_data";
+	protected final static String LATE_ELEMENTS_METRIC_NAME = "numLateRecords";
 
-	protected Counter lostDataCount;
+	protected final Counter lostDataCount = new SimpleCounter();
 
 	// ------------------------------------------------------------------------
 	// State that is not checkpointed
@@ -216,7 +214,7 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 	public void open() throws Exception {
 		super.open();
 
-		this.lostDataCount = metrics.counter(loseData);
+		metrics.counter(LATE_ELEMENTS_METRIC_NAME, this.lostDataCount);
 		timestampedCollector = new TimestampedCollector<>(output);
 
 		internalTimerService =

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
@@ -134,7 +134,7 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 	 */
 	protected final OutputTag<IN> lateDataOutputTag;
 
-	protected final static String LATE_ELEMENTS_METRIC_NAME = "numLateRecords";
+	protected static final  String LATE_ELEMENTS_METRIC_NAME = "numLateRecords";
 
 	protected final Counter lostDataCount = new SimpleCounter();
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
@@ -134,9 +134,9 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 	protected final OutputTag<IN> lateDataOutputTag;
 
 	/**
-	* Metrics about the lost data due to arrive late
+	* Metrics about the lost data due to arrive late.
 	* */
-	protected final String METRICS_LOST_DATA = "lost_data";
+	protected final String loseData = "lost_data";
 
 	protected Counter lostDataCount;
 
@@ -216,7 +216,7 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 	public void open() throws Exception {
 		super.open();
 
-		this.lostDataCount = metrics.counter(METRICS_LOST_DATA);
+		this.lostDataCount = metrics.counter(loseData);
 		timestampedCollector = new TimestampedCollector<>(output);
 
 		internalTimerService =

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
@@ -133,7 +133,7 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 	 */
 	protected final OutputTag<IN> lateDataOutputTag;
 
-	protected static final  String LATE_ELEMENTS_METRIC_NAME = "numLateRecords";
+	protected static final  String LATE_ELEMENTS_METRIC_NAME = "numLateElementsDropped";
 
 	protected Counter lostDataCount;
 
@@ -339,7 +339,6 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 
 				// drop if the window is already late
 				if (isWindowLate(actualWindow)) {
-					this.lostDataCount.inc();
 					mergingWindows.retireWindow(actualWindow);
 					continue;
 				}
@@ -379,7 +378,6 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 
 				// drop if the window is already late
 				if (isWindowLate(window)) {
-					this.lostDataCount.inc();
 					continue;
 				}
 				isSkippedElement = false;
@@ -413,6 +411,8 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 		// windowAssigner is event time and current timestamp + allowed lateness no less than element timestamp
 		if (isSkippedElement && lateDataOutputTag != null && isElementLate(element)) {
 			sideOutput(element);
+		} else if (isSkippedElement) {
+			this.lostDataCount.inc();
 		}
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
@@ -43,7 +43,6 @@ import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.api.java.typeutils.runtime.TupleSerializer;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.MetricGroup;
-import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.runtime.state.VoidNamespace;
 import org.apache.flink.runtime.state.VoidNamespaceSerializer;
 import org.apache.flink.runtime.state.internal.InternalAppendingState;
@@ -136,7 +135,7 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 
 	protected static final  String LATE_ELEMENTS_METRIC_NAME = "numLateRecords";
 
-	protected final Counter lostDataCount = new SimpleCounter();
+	protected Counter lostDataCount;
 
 	// ------------------------------------------------------------------------
 	// State that is not checkpointed
@@ -214,7 +213,7 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 	public void open() throws Exception {
 		super.open();
 
-		metrics.counter(LATE_ELEMENTS_METRIC_NAME, this.lostDataCount);
+		this.lostDataCount = metrics.counter(LATE_ELEMENTS_METRIC_NAME);
 		timestampedCollector = new TimestampedCollector<>(output);
 
 		internalTimerService =

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
@@ -133,7 +133,7 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 	 */
 	protected final OutputTag<IN> lateDataOutputTag;
 
-	protected static final  String LATE_ELEMENTS_METRIC_NAME = "numLateElementsDropped";
+	protected static final  String LATE_ELEMENTS_METRIC_NAME = "numLateRecordsDropped";
 
 	protected Counter lostDataCount;
 
@@ -411,7 +411,7 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 		// windowAssigner is event time and current timestamp + allowed lateness no less than element timestamp
 		if (isSkippedElement && lateDataOutputTag != null && isElementLate(element)) {
 			sideOutput(element);
-		} else if (isSkippedElement) {
+		} else if (isSkippedElement && isElementLate(element)) {
 			this.lostDataCount.inc();
 		}
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
@@ -409,10 +409,12 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 		// element not handled by any window
 		// late arriving tag has been set
 		// windowAssigner is event time and current timestamp + allowed lateness no less than element timestamp
-		if (isSkippedElement && lateDataOutputTag != null && isElementLate(element)) {
-			sideOutput(element);
-		} else if (isSkippedElement && isElementLate(element)) {
-			this.lostDataCount.inc();
+		if (isSkippedElement && isElementLate(element)) {
+			if (lateDataOutputTag != null){
+				sideOutput(element);
+			} else {
+				this.lostDataCount.inc();
+			}
 		}
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

1. add metrics to measure the num of data dropped due to the data arrived late,this is meanningful when to guide the user to set the suitable allowLatency or MaxOutOfOrder time


## Brief change log

  -  register counter metrics in windowOperator#open()
  - invoke inc() method, when judged the isWindowLate()

## Verifying this change

This change is already covered by existing tests by `mvn clean verify`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)

