### PR TITLE
[FLINK-5859] [table] Add PartitionableTableSource for partition pruning

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/literals.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/literals.scala
@@ -26,6 +26,7 @@ import org.apache.calcite.sql.SqlIntervalQualifier
 import org.apache.calcite.sql.`type`.SqlTypeName
 import org.apache.calcite.sql.parser.SqlParserPos
 import org.apache.calcite.tools.RelBuilder
+import org.apache.calcite.util.NlsString
 import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, SqlTimeTypeInfo, TypeInformation}
 import org.apache.flink.table.calcite.FlinkTypeFactory
 import org.apache.flink.table.typeutils.{RowIntervalTypeInfo, TimeIntervalTypeInfo}
@@ -72,7 +73,10 @@ case class Literal(value: Any, resultType: TypeInformation[_]) extends LeafExpre
 
       // create BIGINT literals for long type
       case BasicTypeInfo.LONG_TYPE_INFO =>
-        val bigint = java.math.BigDecimal.valueOf(value.asInstanceOf[Long])
+        val bigint = value match {
+          case d: java.math.BigDecimal => d
+          case _ => java.math.BigDecimal.valueOf(value.asInstanceOf[Long])
+        }
         relBuilder.getRexBuilder.makeBigintLiteral(bigint)
 
       // date/time
@@ -99,7 +103,12 @@ case class Literal(value: Any, resultType: TypeInformation[_]) extends LeafExpre
           SqlParserPos.ZERO)
         relBuilder.getRexBuilder.makeIntervalLiteral(interval, intervalQualifier)
 
-      case _ => relBuilder.literal(value)
+      case _ =>
+        val strValue = value match {
+          case s: NlsString => s.getValue
+          case _ => value
+        }
+        relBuilder.literal(strValue)
     }
   }
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/util/PartitionPredicateExtractor.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/util/PartitionPredicateExtractor.scala
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.util
+
+import org.apache.flink.table.expressions.{Expression, ResolvedFieldReference}
+
+object PartitionPredicateExtractor {
+
+  /**
+    * Extract partition predicate from filter condition.
+    *
+    * @param predicates          Filter condition.
+    * @param partitionFieldNames Partition field names.
+    * @return Partition predicates and non-partition predicates.
+    */
+  def extractPartitionPredicates(
+    predicates: Array[Expression],
+    partitionFieldNames: Array[String]): (Array[Expression], Array[Expression]) = {
+
+    predicates.partition(postOrderVisit(_, partitionFieldNames))
+  }
+
+  private def postOrderVisit(e: Expression, partitionFieldNames: Array[String]): Boolean = {
+    e.children.forall {
+      case r@ResolvedFieldReference(name, _) =>
+        // skip non partition field
+        postOrderVisit(r, partitionFieldNames) && partitionFieldNames.contains(name)
+      case o@_ => postOrderVisit(o, partitionFieldNames)
+    }
+  }
+}
+
+

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/util/PartitionPruner.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/util/PartitionPruner.scala
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.util
+
+import java.math.{BigDecimal => JBigDecimal, BigInteger => JBigInteger}
+import java.util.{ArrayList => JArrayList, List => JList}
+
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rex.RexNode
+import org.apache.calcite.tools.RelBuilder
+import org.apache.flink.api.common.functions.FlatMapFunction
+import org.apache.flink.api.common.functions.util.ListCollector
+import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
+import org.apache.flink.api.java.typeutils.RowTypeInfo
+import org.apache.flink.table.api.{TableConfig, TableException}
+import org.apache.flink.table.calcite.FlinkTypeFactory
+import org.apache.flink.table.codegen.{Compiler, FunctionCodeGenerator}
+import org.apache.flink.table.expressions.Expression
+import org.apache.flink.table.sources.Partition
+import org.apache.flink.types.Row
+import org.apache.flink.util.Preconditions
+
+import scala.collection.JavaConverters._
+
+/**
+  * The base class for partition pruning.
+  *
+  * Creates partition filter instance (a [[FlatMapFunction]]) with partition predicates by code-gen,
+  * and then evaluates all partition values against the partition filter to get final partitions.
+  *
+  */
+abstract class PartitionPruner extends Compiler[FlatMapFunction[Row, Boolean]] {
+
+  /**
+    * get pruned partitions from all partitions by partition filters
+    *
+    * @param partitionFieldNames Partition field names.
+    * @param partitionFieldTypes Partition field types.
+    * @param allPartitions       All partition values.
+    * @param partitionPredicates A filter expression that will be applied against partition values.
+    * @param relBuilder          Builder for relational expressions.
+    * @return Pruned partitions.
+    */
+  def getPrunedPartitions(
+    partitionFieldNames: Array[String],
+    partitionFieldTypes: Array[TypeInformation[_]],
+    allPartitions: JList[Partition],
+    partitionPredicates: Array[Expression],
+    relBuilder: RelBuilder): JList[Partition] = {
+
+    if (allPartitions.isEmpty || partitionPredicates.isEmpty) {
+      return allPartitions
+    }
+
+    // convert predicates to RexNode
+    val typeFactory = relBuilder.getTypeFactory.asInstanceOf[FlinkTypeFactory]
+    val relDataType = typeFactory.buildLogicalRowType(partitionFieldNames, partitionFieldTypes)
+    val predicateRexNode = convertPredicatesToRexNode(partitionPredicates, relBuilder, relDataType)
+
+    // TODO using TableEnvironment's table config ???
+    val config = new TableConfig
+    val rowType = new RowTypeInfo(partitionFieldTypes, partitionFieldNames)
+    val returnType = BasicTypeInfo.BOOLEAN_TYPE_INFO.asInstanceOf[TypeInformation[Any]]
+
+    val generator = new FunctionCodeGenerator(
+      config, false, rowType.asInstanceOf[TypeInformation[Any]])
+
+    val filterExpression = generator.generateExpression(predicateRexNode)
+
+    val filterFunctionBody =
+      s"""
+         |${filterExpression.code}
+         |if (${filterExpression.resultTerm}) {
+         |  ${generator.collectorTerm}.collect(true);
+         |} else {
+         |  ${generator.collectorTerm}.collect(false);
+         |}
+         |""".stripMargin
+
+    val genFunction = generator.generateFunction(
+      "PartitionPruner",
+      classOf[FlatMapFunction[Row, Boolean]],
+      filterFunctionBody,
+      returnType)
+
+    // create filter class instance
+    val clazz = compile(getClass.getClassLoader, genFunction.name, genFunction.code)
+    val function = clazz.newInstance()
+
+    val results: JList[Boolean] = new JArrayList[Boolean](allPartitions.size)
+    val collector = new ListCollector[Boolean](results)
+
+    // do filter against all partitions
+    allPartitions.asScala.foreach {
+      partition =>
+        val row = convertPartitionToRow(partitionFieldNames, partitionFieldTypes, partition)
+        function.flatMap(row, collector)
+    }
+
+    // get pruned partitions
+    allPartitions.asScala.zipWithIndex.filter {
+      case (_, index) => results.get(index)
+    }.unzip._1.asJava
+  }
+
+  /**
+    * create new Row from partition, set partition values to corresponding positions of row.
+    */
+  def convertPartitionToRow(
+    partitionFieldNames: Array[String],
+    partitionFieldTypes: Array[TypeInformation[_]],
+    partition: Partition): Row = {
+
+    val row = new Row(partitionFieldNames.length)
+    partitionFieldNames.zip(partitionFieldTypes).zipWithIndex.foreach {
+      case ((fieldName, fieldType), index) =>
+        val value = convertPartitionFieldValue(partition.getFieldValue(fieldName), fieldType)
+        row.setField(index, value)
+    }
+    row
+  }
+
+  /**
+    * Converts a collection of expressions into an AND RexNode.
+    */
+  private def convertPredicatesToRexNode(
+    predicates: Array[Expression],
+    relBuilder: RelBuilder,
+    relDataType: RelDataType): RexNode = {
+
+    relBuilder.values(relDataType)
+    predicates.map(expr => expr.toRexNode(relBuilder)).reduce((l, r) => relBuilder.and(l, r))
+  }
+
+  /**
+    * Convert partition field value to expect type object value
+    *
+    * @param partitionFieldValue partition field value
+    * @param partitionFieldType  partition field types
+    * @return The expect type object value
+    */
+  def convertPartitionFieldValue(
+    partitionFieldValue: Any,
+    partitionFieldType: TypeInformation[_]): Any
+
+}
+
+/**
+  * Default implementation of PartitionPruner
+  */
+class DefaultPartitionPrunerImpl extends PartitionPruner {
+
+  // by default supports BasicTypeInfo conversion, excluding DATE_TYPE_INFO and VOID_TYPE_INFO
+  override def convertPartitionFieldValue(partitionFieldValue: Any,
+    partitionFieldType: TypeInformation[_]): Any = {
+    partitionFieldValue match {
+      case null => null
+      case _ =>
+        val value = partitionFieldValue.toString
+        partitionFieldType match {
+          case BasicTypeInfo.STRING_TYPE_INFO => value
+          case BasicTypeInfo.BOOLEAN_TYPE_INFO => value.toBoolean
+          case BasicTypeInfo.BYTE_TYPE_INFO => value.toByte
+          case BasicTypeInfo.SHORT_TYPE_INFO => value.toShort
+          case BasicTypeInfo.INT_TYPE_INFO => value.toInt
+          case BasicTypeInfo.LONG_TYPE_INFO => value.toLong
+          case BasicTypeInfo.FLOAT_TYPE_INFO => value.toFloat
+          case BasicTypeInfo.DOUBLE_TYPE_INFO => value.toDouble
+          case BasicTypeInfo.CHAR_TYPE_INFO =>
+            Preconditions.checkArgument(value.length == 1)
+            value.charAt(0)
+          case BasicTypeInfo.BIG_INT_TYPE_INFO => new JBigInteger(value)
+          case BasicTypeInfo.BIG_DEC_TYPE_INFO => new JBigDecimal(value)
+          case _ => throw TableException(s"Unsupported Type: $partitionFieldType, " +
+            s"please extends PartitionPruner to support it.")
+        }
+    }
+  }
+}
+
+object PartitionPruner {
+  val INSTANCE = new DefaultPartitionPrunerImpl
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sources/FilterableTableSource.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sources/FilterableTableSource.scala
@@ -20,6 +20,7 @@ package org.apache.flink.table.sources
 
 import java.util.{List => JList}
 
+import org.apache.calcite.tools.RelBuilder
 import org.apache.flink.table.expressions.Expression
 /**
   * Adds support for filtering push-down to a [[TableSource]].
@@ -44,8 +45,7 @@ trait FilterableTableSource[T] {
     * @param predicates A list contains conjunctive predicates, you should pick and remove all
     *                   expressions that can be pushed down. The remaining elements of this list
     *                   will further evaluated by framework.
-    * @return A new cloned instance of [[TableSource]] with or without any filters been
-    *         pushed into it.
+    * @return A new cloned instance of [[TableSource]]
     */
   def applyPredicate(predicates: JList[Expression]): TableSource[T]
 
@@ -54,5 +54,10 @@ trait FilterableTableSource[T] {
     * the returned instance of [[applyPredicate]].
     */
   def isFilterPushedDown: Boolean
+
+  /**
+    * @param relBuilder Builder for relational expressions.
+    */
+  def setRelBuilder(relBuilder: RelBuilder): Unit
 
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sources/PartitionableTableSource.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sources/PartitionableTableSource.scala
@@ -32,6 +32,8 @@ import scala.collection.JavaConverters._
   * A [[TableSource]] extending this class is a partition table,
   * and will get the relevant partitions about the query.
   *
+  * Knows more detail about partition pruning, please see [[PartitionPruner]].
+  *
   * @tparam T The return type of the [[TableSource]].
   */
 abstract class PartitionableTableSource[T] extends FilterableTableSource[T] {
@@ -62,28 +64,30 @@ abstract class PartitionableTableSource[T] extends FilterableTableSource[T] {
   /**
     * Whether drop partition predicates after apply partition pruning.
     *
-    * @return true only if the result is correct without partition predicate
+    * @return True only if the filter result is correct without dropped partition predicates.
     */
-  def supportDropPartitionPredicate: Boolean = false
+  def supportDropPartitionPredicates: Boolean = false
 
   /**
-    * @return Pruned partitions
+    * @return The remaining partitions after partition pruning applied.
     */
-  def getPrunedPartitions: JList[Partition]
+  def getRemainingPartitions: JList[Partition]
 
   /**
-    * @return True if apply partition pruning
+    * @return True If the filter dose contain partition predicates, otherwise false.
     */
-  def isPartitionPruned: Boolean
+  def isPartitionPrunedApplied: Boolean
 
   /**
+    * Apply partition pruning results.
+    *
     * If a partitionable table source which can't apply non-partition filters should not pick any
     * predicates.
     * If a partitionable table source which can apply non-partition filters should check and pick
     * only predicates this table source can support.
     *
-    * After trying to push pruned-partitions and predicates down, we should return a new
-    * [[TableSource]] instance which holds all pruned-partitions and all pushed down predicates.
+    * After trying to push remaining partitions and predicates down, we should return a new
+    * [[TableSource]] instance which holds all remaining partitions and all pushed down predicates.
     * Even if we actually pushed nothing down, it is recommended that we still return a new
     * [[TableSource]] instance since we will mark the returned instance as filter push down has
     * been tried.
@@ -92,17 +96,19 @@ abstract class PartitionableTableSource[T] extends FilterableTableSource[T] {
     * organized in CNF conjunctive form, and we should only take or leave each element from the
     * list. Don't try to reorganize the predicates if you are absolutely confident with that.
     *
-    * @param partitionPruned  Whether partition pruning is applied.
-    * @param prunedPartitions Remaining partitions after partition pruning applied.
-    *                         Notes: If partition pruning is not applied, prunedPartitions is empty.
+    * @param isPartitionPrunedApplied  Whether partition pruning is applied. If the filter dose
+    *                                  contain partition predicates, isPartitionPrunedApplied is
+    *                                  true; otherwise it's false.
+    * @param remainingPartitions Remaining partitions after partition pruning applied. Notes: If
+    *                            partition pruning is not applied, remainingPartitions is empty.
     * @param predicates       A list contains conjunctive predicates, you should pick and remove all
     *                         expressions that can be pushed down. The remaining elements of this
     *                         list will further evaluated by framework.
     * @return A new cloned instance of [[TableSource]].
     */
-  def applyPrunedPartitionsAndPredicate(
-    partitionPruned: Boolean,
-    prunedPartitions: JList[Partition],
+  def applyRemainingPartitionsAndPredicates(
+    isPartitionPrunedApplied: Boolean,
+    remainingPartitions: JList[Partition],
     predicates: JList[Expression]): TableSource[T]
 
 
@@ -126,8 +132,8 @@ abstract class PartitionableTableSource[T] extends FilterableTableSource[T] {
     * @return A new cloned instance of [[TableSource]].
     */
   override def applyPredicate(predicates: JList[Expression]): TableSource[T] = {
-    var partitionPruned = false
-    var prunedPartitions: JList[Partition] = new JArrayList()
+    var hasPartitionPredicates = false
+    var remainingPartitions: JList[Partition] = new JArrayList()
 
     // extract partition predicate
     val (partitionPredicates, _) = PartitionPredicateExtractor.extractPartitionPredicates(
@@ -135,15 +141,15 @@ abstract class PartitionableTableSource[T] extends FilterableTableSource[T] {
     if (partitionPredicates.nonEmpty) {
       // do partition pruning
       val builder = relBuilder.getOrElse(throw new TableException("relBuilder is null"))
-      prunedPartitions = applyPartitionPruning(partitionPredicates, builder)
-      partitionPruned = true
+      remainingPartitions = applyPartitionPruning(partitionPredicates, builder)
+      hasPartitionPredicates = true
     }
 
-    if (supportDropPartitionPredicate) {
+    if (supportDropPartitionPredicates) {
       predicates.removeAll(partitionPredicates.toList.asJava)
     }
 
-    applyPrunedPartitionsAndPredicate(partitionPruned, prunedPartitions, predicates)
+    applyRemainingPartitionsAndPredicates(hasPartitionPredicates, remainingPartitions, predicates)
   }
 
   /**
@@ -158,12 +164,12 @@ abstract class PartitionableTableSource[T] extends FilterableTableSource[T] {
     *
     * @param partitionPredicates A filter expression that will be applied against partition values.
     * @param relBuilder          Builder for relational expressions.
-    * @return The pruned partitions.
+    * @return The remaining partitions after partition pruning applied.
     */
   def applyPartitionPruning(
     partitionPredicates: Array[Expression],
     relBuilder: RelBuilder): JList[Partition] = {
-    PartitionPruner.INSTANCE.getPrunedPartitions(
+    PartitionPruner.INSTANCE.getRemainingPartitions(
       getPartitionFieldNames,
       getPartitionFieldTypes,
       getAllPartitions,
@@ -174,19 +180,39 @@ abstract class PartitionableTableSource[T] extends FilterableTableSource[T] {
 }
 
 /**
-  * The base class of partition
+  * A Partition is a division of a logical table horizontally(row-wise) split by partition columns,
+  * and data within a table is split across multiple partitions, each partition corresponds to a
+  * particular rows.
+  *
+  * A Partition could be simple, and also could be composite consisting of other partitions.
+  * For example: there is a logs table stored on file system,
+  * A simple partition represents a file split by year. The path could be /logs/2015.csv,
+  * /logs/2016.csv, so a simple partition could be "year=2015" or "year=2016".
+  * A composite partition corresponds to a directory split by year, month and day. The path cloud be
+  * /logs/2015/01/01.csv, /logs/2015/01/10.csv, /logs/2016/05/01.csv, /logs/2016/06/01.csv,
+  * so a complex partition could be "year=2015,month=01,day=01" or "year=2016,month=06,day=01".
   */
 trait Partition {
 
   /**
-    * Get partition field value by name
+    * Get partition field value associated with the given name
     *
-    * @param fieldName Partition field name
-    * @return Partition field value associated with the given key
+    * In the example above,
+    * for partition "year=2015", "2015" is the expected value corresponding to field name "year".
+    * for partition "year=2016,month=06,day=01", "2016" is the expected value corresponding to
+    * field name "year", "06" is corresponding to "month", "01" is corresponding to "day".
+    *
+    * @param fieldName Partition field name.
+    * @return Partition field value associated with the given name, if not found return null.
     */
   def getFieldValue(fieldName: String): Any
 
   /**
+    * Gets the origin value which represents the entire partition value.
+    *
+    * In the example above, for simple partition "year=2015" is the origin partition value,
+    * for complex partition "year=2016,month=06,day=01" is the origin partition value.
+    *
     * @return Origin partition value
     */
   def getOriginValue: Any

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sources/PartitionableTableSource.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sources/PartitionableTableSource.scala
@@ -1,0 +1,193 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.sources
+
+import java.util.{ArrayList => JArrayList, List => JList}
+
+import org.apache.calcite.tools.RelBuilder
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.table.api.TableException
+import org.apache.flink.table.expressions.Expression
+import org.apache.flink.table.plan.util.{PartitionPredicateExtractor, PartitionPruner}
+
+import scala.collection.JavaConverters._
+
+/**
+  * A [[TableSource]] extending this class is a partition table,
+  * and will get the relevant partitions about the query.
+  *
+  * @tparam T The return type of the [[TableSource]].
+  */
+abstract class PartitionableTableSource[T] extends FilterableTableSource[T] {
+
+  private var relBuilder: Option[RelBuilder] = None
+
+  /**
+    * Get all partitions belong to this table
+    *
+    * @return All partitions belong to this table
+    */
+  def getAllPartitions: JList[Partition]
+
+  /**
+    * Get partition field names.
+    *
+    * @return Partition field names.
+    */
+  def getPartitionFieldNames: Array[String]
+
+  /**
+    * Get partition field types.
+    *
+    * @return Partition field types.
+    */
+  def getPartitionFieldTypes: Array[TypeInformation[_]]
+
+  /**
+    * Whether drop partition predicates after apply partition pruning.
+    *
+    * @return true only if the result is correct without partition predicate
+    */
+  def supportDropPartitionPredicate: Boolean = false
+
+  /**
+    * @return Pruned partitions
+    */
+  def getPrunedPartitions: JList[Partition]
+
+  /**
+    * @return True if apply partition pruning
+    */
+  def isPartitionPruned: Boolean
+
+  /**
+    * If a partitionable table source which can't apply non-partition filters should not pick any
+    * predicates.
+    * If a partitionable table source which can apply non-partition filters should check and pick
+    * only predicates this table source can support.
+    *
+    * After trying to push pruned-partitions and predicates down, we should return a new
+    * [[TableSource]] instance which holds all pruned-partitions and all pushed down predicates.
+    * Even if we actually pushed nothing down, it is recommended that we still return a new
+    * [[TableSource]] instance since we will mark the returned instance as filter push down has
+    * been tried.
+    * <p>
+    * We also should note to not changing the form of the predicates passed in. It has been
+    * organized in CNF conjunctive form, and we should only take or leave each element from the
+    * list. Don't try to reorganize the predicates if you are absolutely confident with that.
+    *
+    * @param partitionPruned  Whether partition pruning is applied.
+    * @param prunedPartitions Remaining partitions after partition pruning applied.
+    *                         Notes: If partition pruning is not applied, prunedPartitions is empty.
+    * @param predicates       A list contains conjunctive predicates, you should pick and remove all
+    *                         expressions that can be pushed down. The remaining elements of this
+    *                         list will further evaluated by framework.
+    * @return A new cloned instance of [[TableSource]].
+    */
+  def applyPrunedPartitionsAndPredicate(
+    partitionPruned: Boolean,
+    prunedPartitions: JList[Partition],
+    predicates: JList[Expression]): TableSource[T]
+
+
+  /**
+    * Check and pick all predicates this table source can support. The passed in predicates
+    * have been translated in conjunctive form, and table source can only pick those predicates
+    * that it supports.
+    * <p>
+    * After trying to push predicates down, we should return a new [[TableSource]]
+    * instance which holds all pushed down predicates. Even if we actually pushed nothing down,
+    * it is recommended that we still return a new [[TableSource]] instance since we will
+    * mark the returned instance as filter push down has been tried.
+    * <p>
+    * We also should note to not changing the form of the predicates passed in. It has been
+    * organized in CNF conjunctive form, and we should only take or leave each element from the
+    * list. Don't try to reorganize the predicates if you are absolutely confident with that.
+    *
+    * @param predicates A list contains conjunctive predicates, you should pick and remove all
+    *                   expressions that can be pushed down. The remaining elements of this list
+    *                   will further evaluated by framework.
+    * @return A new cloned instance of [[TableSource]].
+    */
+  override def applyPredicate(predicates: JList[Expression]): TableSource[T] = {
+    var partitionPruned = false
+    var prunedPartitions: JList[Partition] = new JArrayList()
+
+    // extract partition predicate
+    val (partitionPredicates, _) = PartitionPredicateExtractor.extractPartitionPredicates(
+      predicates.asScala.toArray, getPartitionFieldNames)
+    if (partitionPredicates.nonEmpty) {
+      // do partition pruning
+      val builder = relBuilder.getOrElse(throw new TableException("relBuilder is null"))
+      prunedPartitions = applyPartitionPruning(partitionPredicates, builder)
+      partitionPruned = true
+    }
+
+    if (supportDropPartitionPredicate) {
+      predicates.removeAll(partitionPredicates.toList.asJava)
+    }
+
+    applyPrunedPartitionsAndPredicate(partitionPruned, prunedPartitions, predicates)
+  }
+
+  /**
+    * @param relBuilder Builder for relational expressions.
+    */
+  def setRelBuilder(relBuilder: RelBuilder): Unit = {
+    this.relBuilder = Some(relBuilder)
+  }
+
+  /**
+    * Default implementation for partition pruning.
+    *
+    * @param partitionPredicates A filter expression that will be applied against partition values.
+    * @param relBuilder          Builder for relational expressions.
+    * @return The pruned partitions.
+    */
+  def applyPartitionPruning(
+    partitionPredicates: Array[Expression],
+    relBuilder: RelBuilder): JList[Partition] = {
+    PartitionPruner.INSTANCE.getPrunedPartitions(
+      getPartitionFieldNames,
+      getPartitionFieldTypes,
+      getAllPartitions,
+      partitionPredicates,
+      relBuilder)
+  }
+
+}
+
+/**
+  * The base class of partition
+  */
+trait Partition {
+
+  /**
+    * Get partition field value by name
+    *
+    * @param fieldName Partition field name
+    * @return Partition field value associated with the given key
+    */
+  def getFieldValue(fieldName: String): Any
+
+  /**
+    * @return Origin partition value
+    */
+  def getOriginValue: Any
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/plan/util/PartitionPredicateExtractorTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/plan/util/PartitionPredicateExtractorTest.scala
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.util
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo
+import org.apache.flink.table.api.scala._
+import org.apache.flink.table.expressions.{Expression, ResolvedFieldReference,
+UnresolvedFieldReference}
+import org.apache.flink.table.plan.util.PartitionPredicateExtractor.extractPartitionPredicates
+import org.junit.Assert._
+import org.junit.Test
+
+class PartitionPredicateExtractorTest {
+
+  def resolveFields(
+    predicates: Array[Expression],
+    allFieldNames: Array[String]): Array[Expression] = {
+    val fieldTypes = allFieldNames.zip(allFieldNames.map(_ => BasicTypeInfo.STRING_TYPE_INFO)).toMap
+
+    val rule: PartialFunction[Expression, Expression] = {
+      case u@UnresolvedFieldReference(name) =>
+        ResolvedFieldReference(name, fieldTypes(name))
+    }
+    predicates.map(_.postOrderTransform(rule))
+  }
+
+  @Test
+  def testNonePartitionField(): Unit = {
+    val partitionFieldNames = Array("part")
+    val predicate = resolveFields(Array[Expression]('name === "abc"), Array("part", "name"))
+    val (partitionPredicate, remaining) = extractPartitionPredicates(predicate, partitionFieldNames)
+    assertTrue(partitionPredicate.isEmpty)
+    assertEquals(1, remaining.length)
+    assertEquals(predicate.head, remaining.head)
+  }
+
+  @Test
+  def testOnePartitionField(): Unit = {
+    val partitionFieldNames = Array("part")
+    val predicate = resolveFields(Array[Expression]('part === "test"), Array("part"))
+    val (partitionPredicate, remaining) = extractPartitionPredicates(predicate, partitionFieldNames)
+    assertEquals(1, partitionPredicate.length)
+    assertEquals(predicate.head, partitionPredicate.head)
+    assertTrue(remaining.isEmpty)
+  }
+
+  @Test
+  def testOnePartitionFieldWithOr(): Unit = {
+    val partitionFieldNames = Array("part")
+    val predicate = resolveFields(
+      Array[Expression]('part === "test1" || 'part === "test2"), Array("part"))
+    val (partitionPredicate, remaining) = extractPartitionPredicates(predicate, partitionFieldNames)
+    assertEquals(1, partitionPredicate.length)
+    assertEquals(predicate.head, partitionPredicate.head)
+    assertTrue(remaining.isEmpty)
+  }
+
+  @Test
+  def testOnePartitionOrNonPartitionField(): Unit = {
+    val partitionFieldNames = Array("part")
+    val predicate = resolveFields(
+      Array[Expression]('name === "abc" || 'part === "test"), Array("name", "part"))
+    val (partitionPredicate, remaining) = extractPartitionPredicates(predicate, partitionFieldNames)
+    assertTrue(partitionPredicate.isEmpty)
+    assertEquals(1, remaining.length)
+    assertEquals(predicate.head, remaining.head)
+  }
+
+  @Test
+  def testTwoPartitionFieldsWithOr(): Unit = {
+    val partitionFieldNames = Array("part1", "part2")
+    val predicate = resolveFields(
+      Array[Expression]('part1 === "test1" || 'part2 === "test2"), Array("part1", "part2"))
+    val (partitionPredicate, remaining) = extractPartitionPredicates(predicate, partitionFieldNames)
+    assertEquals(1, partitionPredicate.length)
+    assertEquals(predicate.head, partitionPredicate.head)
+    assertTrue(remaining.isEmpty)
+  }
+
+  @Test
+  def testTwoPartitionFieldsOrNonPartitionField(): Unit = {
+    val partitionFieldNames = Array("part1", "part2")
+    val predicate = resolveFields(
+      Array[Expression]('part1 === "test1" && 'part2 === "test2" || 'name === "abc"),
+      Array("name", "part1", "part2"))
+    val (partitionPredicate, remaining) = extractPartitionPredicates(predicate, partitionFieldNames)
+    assertTrue(partitionPredicate.isEmpty)
+    assertEquals(1, remaining.length)
+    assertEquals(predicate.head, remaining.head)
+  }
+
+  @Test
+  def testLike(): Unit = {
+    val partitionFieldNames = Array("part")
+    val predicate = resolveFields(Array[Expression]('part.like("%est")), Array("part"))
+    val (partitionPredicate, remaining) = extractPartitionPredicates(predicate, partitionFieldNames)
+    assertEquals(1, partitionPredicate.length)
+    assertEquals(predicate.head, partitionPredicate.head)
+    assertTrue(remaining.isEmpty)
+  }
+
+  @Test
+  def testIsNull(): Unit = {
+    val partitionFieldNames = Array("part")
+    val predicate = resolveFields(Array[Expression]('part.isNull), Array("part"))
+    val (partitionPredicate, remaining) = extractPartitionPredicates(predicate, partitionFieldNames)
+    assertEquals(1, partitionPredicate.length)
+    assertEquals(predicate.head, partitionPredicate.head)
+    assertTrue(remaining.isEmpty)
+  }
+
+  @Test
+  def testIsNotNull(): Unit = {
+    val partitionFieldNames = Array("part")
+    val predicate = resolveFields(Array[Expression]('part.isNotNull), Array("part"))
+    val (partitionPredicate, remaining) = extractPartitionPredicates(predicate, partitionFieldNames)
+    assertEquals(1, partitionPredicate.length)
+    assertEquals(predicate.head, partitionPredicate.head)
+    assertTrue(remaining.isEmpty)
+  }
+
+  @Test
+  def testCast(): Unit = {
+    val partitionFieldNames = Array("part")
+    val predicate = resolveFields(
+      Array[Expression]('part.cast(BasicTypeInfo.INT_TYPE_INFO)), Array("part"))
+    val (partitionPredicate, remaining) = extractPartitionPredicates(predicate, partitionFieldNames)
+    assertEquals(1, partitionPredicate.length)
+    assertEquals(predicate.head, partitionPredicate.head)
+    assertTrue(remaining.isEmpty)
+  }
+
+  @Test
+  def testIf(): Unit = {
+    val partitionFieldNames = Array("part")
+    val predicate = resolveFields(
+      Array[Expression]('part.isNull.?("test1", "test2")), Array("part"))
+    val (partitionPredicate, remaining) = extractPartitionPredicates(predicate, partitionFieldNames)
+    assertEquals(1, partitionPredicate.length)
+    assertEquals(predicate.head, partitionPredicate.head)
+    assertTrue(remaining.isEmpty)
+  }
+
+  @Test
+  def testMultipleCompositeExpressions(): Unit = {
+    val partitionFieldNames = Array("part1", "part2")
+    val predicate = resolveFields(Array[Expression](
+      'part1 > "test1",
+      'name >= "abc",
+      'name === "def" || 'part1 === "test",
+      'part1 >= "test1" || 'part2 < "test2",
+      'part1 === "test1" && 'part2 === "test2" || 'name === "abc",
+      'part1.isNotNull || 'part2.like("test") || 'part2.cast(BasicTypeInfo.INT_TYPE_INFO) === 1,
+      'part2.toTimestamp === 123456789,
+      'part1.isNull.?("test1", "test2") || 'part2.isNotNull.upperCase === "TEST"
+    ), Array("part1", "part2", "name"))
+    val (partitionPredicate, remaining) = extractPartitionPredicates(predicate, partitionFieldNames)
+    assertEquals(5, partitionPredicate.length)
+    assertEquals(predicate.head, partitionPredicate.head)
+    assertEquals(predicate(3), partitionPredicate(1))
+    assertEquals(predicate(5), partitionPredicate(2))
+    assertEquals(predicate(6), partitionPredicate(3))
+    assertEquals(predicate(7), partitionPredicate(4))
+
+    assertEquals(3, remaining.length)
+    assertEquals(predicate(1), remaining.head)
+    assertEquals(predicate(2), remaining(1))
+    assertEquals(predicate(4), remaining(2))
+  }
+
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/plan/util/PartitionPrunerTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/plan/util/PartitionPrunerTest.scala
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.util
+
+import java.util.{ArrayList => JArrayList, List => JList}
+
+import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
+import org.apache.flink.api.java.ExecutionEnvironment
+import org.apache.flink.table.api.TableEnvironment
+import org.apache.flink.table.api.scala._
+import org.apache.flink.table.expressions._
+import org.apache.flink.table.sources.Partition
+import org.junit.Assert._
+import org.junit.Test
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+
+class PartitionPrunerTest {
+
+  val partitionFieldNames = Array("part1", "part2")
+  val partitionFieldTypes: Array[TypeInformation[_]] =
+    Array(BasicTypeInfo.STRING_TYPE_INFO, BasicTypeInfo.INT_TYPE_INFO)
+  val allPartitions = Seq(
+    new TestPartition("part1=p1,part2=2").asInstanceOf[Partition],
+    new TestPartition("part1=p3,part2=4").asInstanceOf[Partition],
+    new TestPartition("part1=p5,part2=6").asInstanceOf[Partition],
+    new TestPartition("part1=p7,part2=8").asInstanceOf[Partition]).toList.asJava
+  val env = ExecutionEnvironment.getExecutionEnvironment
+  val tEnv = TableEnvironment.getTableEnvironment(env)
+  val relBuilder = tEnv.getRelBuilder
+
+  def getPrunedPartitions(
+    allPartitions: JList[Partition],
+    partitionPredicate: Array[Expression]): JList[Partition] = {
+    PartitionPruner.INSTANCE.getPrunedPartitions(
+      partitionFieldNames,
+      partitionFieldTypes,
+      allPartitions,
+      partitionPredicate,
+      relBuilder)
+  }
+
+  def resolveFields(predicate: Array[Expression]): Array[Expression] = {
+    val fieldTypes = partitionFieldNames.zip(partitionFieldTypes).toMap
+    val rule: PartialFunction[Expression, Expression] = {
+      case u@UnresolvedFieldReference(name) =>
+        ResolvedFieldReference(name, fieldTypes(name))
+    }
+    predicate.map(_.postOrderTransform(rule))
+  }
+
+  @Test
+  def testEmptyPartitions(): Unit = {
+    val allPartitions = new JArrayList[Partition]()
+    val predicate = Array[Expression]('part1 === "p1")
+    val prunedPartitions = getPrunedPartitions(allPartitions, predicate)
+    assertTrue(prunedPartitions.isEmpty)
+  }
+
+  @Test
+  def testOnePartition(): Unit = {
+    val predicate1 = resolveFields(Array[Expression]('part1 === "p1"))
+    val prunedPartitions1 = getPrunedPartitions(allPartitions, predicate1)
+    assertEquals(1, prunedPartitions1.size())
+    assertEquals("part1=p1,part2=2", prunedPartitions1.get(0).getOriginValue)
+
+    val predicate2 = resolveFields(Array[Expression]('part2 === 4))
+    val prunedPartitions2 = getPrunedPartitions(allPartitions, predicate2)
+    assertEquals(1, prunedPartitions2.size())
+    assertEquals("part1=p3,part2=4", prunedPartitions2.get(0).getOriginValue)
+  }
+
+  @Test
+  def testTwoPartitionAnd(): Unit = {
+    val predicate = resolveFields(Array[Expression]('part1 === "p3", 'part2 === 4))
+    val prunedPartitions = getPrunedPartitions(allPartitions, predicate)
+    assertEquals(1, prunedPartitions.size())
+    assertEquals("part1=p3,part2=4", prunedPartitions.get(0).getOriginValue)
+  }
+
+  @Test
+  def testTwoPartitionOr(): Unit = {
+    val predicate = resolveFields(Array[Expression]('part1 === "p1" || 'part2 === 4))
+    val prunedPartitions = getPrunedPartitions(allPartitions, predicate)
+    assertEquals(2, prunedPartitions.size())
+    assertEquals("part1=p1,part2=2", prunedPartitions.get(0).getOriginValue)
+    assertEquals("part1=p3,part2=4", prunedPartitions.get(1).getOriginValue)
+  }
+
+}
+
+class TestPartition(partition: String) extends Partition {
+
+  private val map = mutable.Map[String, Any]()
+  partition.split(",").foreach { p =>
+    val kv = p.split("=")
+    map.put(kv(0), kv(1))
+  }
+
+  override def getFieldValue(fieldName: String): Any = map.getOrElse(fieldName, null)
+
+  override def getOriginValue: String = partition
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/plan/util/PartitionPrunerTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/plan/util/PartitionPrunerTest.scala
@@ -46,10 +46,10 @@ class PartitionPrunerTest {
   val tEnv = TableEnvironment.getTableEnvironment(env)
   val relBuilder = tEnv.getRelBuilder
 
-  def getPrunedPartitions(
+  def getRemainingPartitions(
     allPartitions: JList[Partition],
     partitionPredicate: Array[Expression]): JList[Partition] = {
-    PartitionPruner.INSTANCE.getPrunedPartitions(
+    PartitionPruner.INSTANCE.getRemainingPartitions(
       partitionFieldNames,
       partitionFieldTypes,
       allPartitions,
@@ -70,38 +70,38 @@ class PartitionPrunerTest {
   def testEmptyPartitions(): Unit = {
     val allPartitions = new JArrayList[Partition]()
     val predicate = Array[Expression]('part1 === "p1")
-    val prunedPartitions = getPrunedPartitions(allPartitions, predicate)
-    assertTrue(prunedPartitions.isEmpty)
+    val remainingPartitions = getRemainingPartitions(allPartitions, predicate)
+    assertTrue(remainingPartitions.isEmpty)
   }
 
   @Test
   def testOnePartition(): Unit = {
     val predicate1 = resolveFields(Array[Expression]('part1 === "p1"))
-    val prunedPartitions1 = getPrunedPartitions(allPartitions, predicate1)
-    assertEquals(1, prunedPartitions1.size())
-    assertEquals("part1=p1,part2=2", prunedPartitions1.get(0).getOriginValue)
+    val remainingPartitions1 = getRemainingPartitions(allPartitions, predicate1)
+    assertEquals(1, remainingPartitions1.size())
+    assertEquals("part1=p1,part2=2", remainingPartitions1.get(0).getOriginValue)
 
     val predicate2 = resolveFields(Array[Expression]('part2 === 4))
-    val prunedPartitions2 = getPrunedPartitions(allPartitions, predicate2)
-    assertEquals(1, prunedPartitions2.size())
-    assertEquals("part1=p3,part2=4", prunedPartitions2.get(0).getOriginValue)
+    val remainingPartitions2 = getRemainingPartitions(allPartitions, predicate2)
+    assertEquals(1, remainingPartitions2.size())
+    assertEquals("part1=p3,part2=4", remainingPartitions2.get(0).getOriginValue)
   }
 
   @Test
   def testTwoPartitionAnd(): Unit = {
     val predicate = resolveFields(Array[Expression]('part1 === "p3", 'part2 === 4))
-    val prunedPartitions = getPrunedPartitions(allPartitions, predicate)
-    assertEquals(1, prunedPartitions.size())
-    assertEquals("part1=p3,part2=4", prunedPartitions.get(0).getOriginValue)
+    val remainingPartitions = getRemainingPartitions(allPartitions, predicate)
+    assertEquals(1, remainingPartitions.size())
+    assertEquals("part1=p3,part2=4", remainingPartitions.get(0).getOriginValue)
   }
 
   @Test
   def testTwoPartitionOr(): Unit = {
     val predicate = resolveFields(Array[Expression]('part1 === "p1" || 'part2 === 4))
-    val prunedPartitions = getPrunedPartitions(allPartitions, predicate)
-    assertEquals(2, prunedPartitions.size())
-    assertEquals("part1=p1,part2=2", prunedPartitions.get(0).getOriginValue)
-    assertEquals("part1=p3,part2=4", prunedPartitions.get(1).getOriginValue)
+    val remainingPartitions = getRemainingPartitions(allPartitions, predicate)
+    assertEquals(2, remainingPartitions.size())
+    assertEquals("part1=p1,part2=2", remainingPartitions.get(0).getOriginValue)
+    assertEquals("part1=p3,part2=4", remainingPartitions.get(1).getOriginValue)
   }
 
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/utils/TestFilterableTableSource.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/utils/TestFilterableTableSource.scala
@@ -20,6 +20,7 @@ package org.apache.flink.table.utils
 
 import java.util.{List => JList}
 
+import org.apache.calcite.tools.RelBuilder
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.api.java.{DataSet, ExecutionEnvironment}
@@ -97,6 +98,8 @@ class TestFilterableTableSource(
   }
 
   override def isFilterPushedDown: Boolean = filterPushedDown
+
+  override def setRelBuilder(relBuilder: RelBuilder): Unit = {}
 
   private def generateDynamicCollection(): Seq[Row] = {
     Preconditions.checkArgument(filterPredicates.length == filterValues.length)

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/utils/TestPartitionableTableSource.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/utils/TestPartitionableTableSource.scala
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.utils
+
+import java.util.{ArrayList => JArrayList, List => JList}
+
+import org.apache.flink.api.common.io.statistics.BaseStatistics
+import org.apache.flink.api.common.io.{DefaultInputSplitAssigner, InputFormat}
+import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
+import org.apache.flink.api.java.typeutils.RowTypeInfo
+import org.apache.flink.api.java.{DataSet, ExecutionEnvironment}
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.core.io.{GenericInputSplit, InputSplit, InputSplitAssigner}
+import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
+import org.apache.flink.table.expressions.Expression
+import org.apache.flink.table.sources._
+import org.apache.flink.types.Row
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+
+class TestPartitionableTableSource(
+  val filterPushDown: Boolean = false,
+  val partitionPruned: Boolean = false,
+  val prunedPartitions: JList[Partition] = new JArrayList()
+) extends PartitionableTableSource[Row]
+  with StreamTableSource[Row]
+  with BatchTableSource[Row] {
+
+  private val fieldTypes: Array[TypeInformation[_]] = Array(
+    BasicTypeInfo.INT_TYPE_INFO,
+    BasicTypeInfo.STRING_TYPE_INFO,
+    BasicTypeInfo.STRING_TYPE_INFO,
+    BasicTypeInfo.STRING_TYPE_INFO)
+  // 'part' is partition field
+  // 'remaining_parts' contains remaining partitions concatenated by '#' after partition pruning,
+  // and if partition pruning is not applied, the value of 'remaining_parts' is null.
+  private val fieldNames = Array("id", "name", "part", "remaining_parts")
+  private val returnType = new RowTypeInfo(fieldTypes, fieldNames)
+
+  private val allPartitions = Seq("part=1", "part=2", "part=3")
+  private val data = mutable.Map[String, Seq[Row]](
+    "part=1" -> Seq(createRow(1, "Anna", "1"), createRow(2, "Jack", "1")),
+    "part=2" -> Seq(createRow(3, "John", "2"), createRow(4, "nosharp", "2")),
+    "part=3" -> Seq(createRow(5, "Peter", "3"), createRow(6, "Lucy", "3"))
+  )
+
+  private def createRow(id: Int, name: String, part: String): Row = {
+    Row.of(id.asInstanceOf[Object], name, part, null)
+  }
+
+  private def getPartitionData: Array[Seq[Row]] = {
+    val remainingParts = if (partitionPruned) {
+      prunedPartitions.asScala.map(_.getOriginValue.toString).sorted.mkString("#")
+    } else {
+      null
+    }
+
+    val remainingData = data.filterKeys {
+      key => !partitionPruned || prunedPartitions.asScala.map(_.getOriginValue).contains(key)
+    }.values.toArray
+
+    remainingData.foreach {
+      rows => rows.foreach(row => row.setField(3, remainingParts))
+    }
+
+    remainingData
+  }
+
+  override def getDataSet(execEnv: ExecutionEnvironment): DataSet[Row] = {
+    execEnv.createInput(new TestPartitionInputFormat(getPartitionData), returnType)
+      .setParallelism(1)
+  }
+
+  override def getDataStream(execEnv: StreamExecutionEnvironment): DataStream[Row] = {
+    execEnv.createInput(new TestPartitionInputFormat(getPartitionData), returnType)
+      .setParallelism(1)
+  }
+
+  override def getReturnType: TypeInformation[Row] = returnType
+
+  override def getAllPartitions: JList[Partition] = {
+    allPartitions.map(p => new TestPartition(p).asInstanceOf[Partition]).toList.asJava
+  }
+
+  override def getPartitionFieldNames: Array[String] = Array("part")
+
+  override def getPartitionFieldTypes: Array[TypeInformation[_]] = {
+    Array(BasicTypeInfo.STRING_TYPE_INFO)
+  }
+
+  override def supportDropPartitionPredicate: Boolean = true
+
+  override def explainSource(): String = {
+    val partitions = getPrunedPartitions.asScala.map(_.getOriginValue).mkString(",")
+    s"TestPartitionableTableSource=(filterPushDown=$filterPushDown," +
+      s"partitionPruned=$isPartitionPruned,prunedPartitions=$partitions)"
+  }
+
+  override def isFilterPushedDown: Boolean = filterPushDown
+
+  override def isPartitionPruned: Boolean = partitionPruned
+
+  override def getPrunedPartitions: JList[Partition] = prunedPartitions
+
+  override def applyPrunedPartitionsAndPredicate(
+    partitionPruned: Boolean,
+    prunedPartitions: JList[Partition],
+    predicates: JList[Expression]): TableSource[Row] = {
+    new TestPartitionableTableSource(true, partitionPruned, prunedPartitions)
+  }
+
+}
+
+class TestPartition(partition: String) extends Partition {
+
+  private val kv = partition.split("=")
+  private val map = Map[String, Any](kv(0) -> kv(1))
+
+  override def getFieldValue(fieldName: String): Any = map.getOrElse(fieldName, null)
+
+  override def getOriginValue: String = partition
+}
+
+class TestPartitionInputFormat(data: Array[Seq[Row]]) extends InputFormat[Row, GenericInputSplit] {
+
+  var currentSplitNumber = 0
+  var currentSplitIndex = 0
+
+  override def configure(parameters: Configuration): Unit = {}
+
+  override def nextRecord(reuse: Row): Row = {
+    val row = data(currentSplitNumber)(currentSplitIndex)
+    currentSplitIndex += 1
+    row
+  }
+
+  override def getInputSplitAssigner(inputSplits: Array[GenericInputSplit]): InputSplitAssigner = {
+    new DefaultInputSplitAssigner(inputSplits.asInstanceOf[Array[InputSplit]])
+  }
+
+  override def reachedEnd(): Boolean = currentSplitIndex >= data(currentSplitNumber).size
+
+  override def getStatistics(cachedStatistics: BaseStatistics): BaseStatistics = null
+
+  override def close(): Unit = {}
+
+  override def createInputSplits(minNumSplits: Int): Array[GenericInputSplit] = {
+    data.zipWithIndex.map {
+      case (_, index) => new GenericInputSplit(index, data.length)
+    }
+  }
+
+  override def open(split: GenericInputSplit): Unit = {
+    currentSplitNumber = split.getSplitNumber
+    currentSplitIndex = 0
+  }
+}


### PR DESCRIPTION
## What is the purpose of the change

This pull request adds PartitionableTableSource for partition pruning when optimizing the query plan. That way both query optimization time and execution time can be reduced obviously, especially for a large partitioned table.

## Brief change log

  - *Adds PartitionableTableSource which extends FilterableTableSource*
  - *Adds setRelBuilder method in FilterableTableSource class*
  - *Adds implementation for partition pruning and extracting partition predicates*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added integration tests for PartitionableTableSource on batch and stream sql*
  - *Added test that validates the correct of partition pruning*
  - *Added test that validates the correct of extracting partition predicates*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)

