### PR TITLE
[FLINK-7617] Remove string format in BitSet to improve the performance of BuildSideOuterjoin

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/util/BitSet.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/util/BitSet.java
@@ -56,8 +56,7 @@ public class BitSet {
 	 * @param index - position
 	 */
 	public void set(int index) {
-		Preconditions.checkArgument(index < bitLength && index >= 0, 
-			String.format("Input Index[%d] is larger than BitSet available size[%d].", index, bitLength));
+		Preconditions.checkArgument(index < bitLength && index >= 0);
 
 		int byteIndex = (index & BYTE_POSITION_MASK) >>> 3;
 		byte current = memorySegment.get(offset + byteIndex);
@@ -72,8 +71,7 @@ public class BitSet {
 	 * @return - value at the bit position
 	 */
 	public boolean get(int index) {
-		Preconditions.checkArgument(index < bitLength && index >= 0,
-			String.format("Input Index[%d] is larger than BitSet available size[%d].", index, bitLength));
+		Preconditions.checkArgument(index < bitLength && index >= 0);
 		
 		int byteIndex = (index & BYTE_POSITION_MASK) >>> 3;
 		byte current = memorySegment.get(offset + byteIndex);


### PR DESCRIPTION
## What is the purpose of the change
Remove string format in BitSet to improve the performance of BuildSideOuterjoin

## Brief change log
  - BitSet.set
  - BitSet.get

## Documentation
  - Does this pull request introduce a new feature? (no)

