### PR TITLE
[FLINK-7618][table] Add BINARY supported in FlinkTypeFactory

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/calcite/FlinkTypeFactory.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/calcite/FlinkTypeFactory.scala
@@ -371,6 +371,8 @@ object FlinkTypeFactory {
       val mapRelDataType = relDataType.asInstanceOf[MapRelDataType]
       mapRelDataType.typeInfo
 
+    case BINARY => PrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO
+
     case _@t =>
       throw TableException(s"Type is not supported: $t")
   }


### PR DESCRIPTION
## What is the purpose of the change

*Add BINARY supported in FlinkTypeFactory*

## Brief change log

  - *Only improve `FlinkTypeFactory#toTypeInfo` add `BINARY` mapping to `PrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO`*

## Verifying this change
This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)

