### PR TITLE
[hotfix] [cep] Fix afterMatchStrategy parameter missing issue

### DIFF
--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/AbstractKeyedCEPPatternOperator.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/AbstractKeyedCEPPatternOperator.java
@@ -329,7 +329,7 @@ public abstract class AbstractKeyedCEPPatternOperator<IN, KEY, OUT, F extends Fu
 	 */
 	private void processEvent(NFA<IN> nfa, IN event, long timestamp)  {
 		Tuple2<Collection<Map<String, List<IN>>>, Collection<Tuple2<Map<String, List<IN>>, Long>>> patterns =
-			nfa.process(event, timestamp);
+			nfa.process(event, timestamp, afterMatchSkipStrategy);
 
 		try {
 			processMatchedSequences(patterns.f0, timestamp);

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/CEPITCase.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/CEPITCase.java
@@ -21,6 +21,7 @@ package org.apache.flink.cep;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.cep.nfa.AfterMatchSkipStrategy;
 import org.apache.flink.cep.nfa.NFA;
 import org.apache.flink.cep.pattern.Pattern;
 import org.apache.flink.cep.pattern.conditions.SimpleCondition;
@@ -678,5 +679,39 @@ public class CEPITCase extends StreamingMultipleProgramsTestBase {
 		public int compare(Event o1, Event o2) {
 			return Double.compare(o1.getPrice(), o2.getPrice());
 		}
+	}
+
+	@Test
+	public void testSimpleAfterMatchSkip() throws Exception {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		DataStream<Tuple2<Integer, String>> input = env.fromElements(
+			new Tuple2<>(1, "a"),
+			new Tuple2<>(2, "a"),
+			new Tuple2<>(3, "a"),
+			new Tuple2<>(4, "a"));
+
+		Pattern<Tuple2<Integer, String>, ?> pattern =
+			Pattern.<Tuple2<Integer, String>>begin("start", AfterMatchSkipStrategy.skipPastLastEvent())
+				.where(new SimpleCondition<Tuple2<Integer, String>>() {
+					@Override
+					public boolean filter(Tuple2<Integer, String> rec) throws Exception {
+						return rec.f1.equals("a");
+					}
+				});
+
+		PatternStream<Tuple2<Integer, String>> pStream = CEP.pattern(input, pattern);
+
+		DataStream<Tuple2<Integer, String>> result = pStream.select(new PatternSelectFunction<Tuple2<Integer, String>, Tuple2<Integer, String>>() {
+			@Override
+			public Tuple2<Integer, String> select(Map<String, List<Tuple2<Integer, String>>> pattern) throws Exception {
+				return pattern.get("start").get(0);
+			}
+		});
+
+		result.writeAsText(resultPath, FileSystem.WriteMode.OVERWRITE);
+
+		expected = "(1,a)\n(2,a)\n(3,a)\n(4,a)";
+
+		env.execute();
 	}
 }

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/CEPITCase.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/CEPITCase.java
@@ -697,7 +697,7 @@ public class CEPITCase extends StreamingMultipleProgramsTestBase {
 					public boolean filter(Tuple2<Integer, String> rec) throws Exception {
 						return rec.f1.equals("a");
 					}
-				});
+				}).times(2);
 
 		PatternStream<Tuple2<Integer, String>> pStream = CEP.pattern(input, pattern);
 
@@ -710,7 +710,7 @@ public class CEPITCase extends StreamingMultipleProgramsTestBase {
 
 		result.writeAsText(resultPath, FileSystem.WriteMode.OVERWRITE);
 
-		expected = "(1,a)\n(2,a)\n(3,a)\n(4,a)";
+		expected = "(1,a)\n(3,a)";
 
 		env.execute();
 	}


### PR DESCRIPTION


## What is the purpose of the change
Fix afterMatchSkipStrategy parameter missing when calling `nfa.process()` function. This issue may be introduced during merging conflicts.

## Brief change log


## Verifying this change

This change added tests and can be verified as follows:
append a aftermatch test case in `CEPITCase` to exam this kind of problems.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

