### PR TITLE
[FLINK-7627] [table] SingleElementIterable should implement with Serializable

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/GeneratedAggregations.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/GeneratedAggregations.scala
@@ -121,9 +121,9 @@ abstract class GeneratedAggregations extends Function {
   def close()
 }
 
-class SingleElementIterable[T] extends java.lang.Iterable[T] {
+class SingleElementIterable[T] extends java.lang.Iterable[T] with Serializable {
 
-  class SingleElementIterator extends java.util.Iterator[T] {
+  class SingleElementIterator extends java.util.Iterator[T] with Serializable {
 
     var element: T = _
     var newElement: Boolean = false

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/types/SingleElementIterableTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/types/SingleElementIterableTest.scala
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.types
+
+import org.apache.flink.table.functions.aggfunctions.IntegralAvgAccumulator
+import org.apache.flink.table.runtime.aggregate.SingleElementIterable
+import org.apache.flink.util.InstantiationUtil
+import org.junit.Test
+
+class SingleElementIterableTest {
+  @Test
+  def testSerializable(): Unit = {
+    val sei = new SingleElementIterable[IntegralAvgAccumulator]();
+    InstantiationUtil.serializeObject(sei);
+  }
+}


### PR DESCRIPTION

## What is the purpose of the change

*This pull request is a bugfix which implements `SingleElementIterable` with `Serializable`*


## Brief change log

  - *Implement SingleElementIterable with Serializable*


## Verifying this change

This change added tests and can be verified as follows:

  - *Added test that validates that `SingleElementIterable` can be serialized, otherwise exceptions will be throwed*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no )

## Documentation

  - Does this pull request introduce a new feature? (no)

