### PR TITLE
[hotfix] [doc] Fix typo for s3a config in AWS deployment documentation

### DIFF
--- a/docs/ops/deployment/aws.md
+++ b/docs/ops/deployment/aws.md
@@ -124,7 +124,7 @@ You need to point Flink to a valid Hadoop configuration, which contains the foll
 </configuration>
 ```
 
-This registers `S3AFileSystem` as the default FileSystem for URIs with the `s3://` scheme.
+This registers `S3AFileSystem` as the default FileSystem for URIs with the `s3a://` scheme.
 
 #### `NativeS3FileSystem`
 

--- a/docs/ops/deployment/aws.md
+++ b/docs/ops/deployment/aws.md
@@ -117,7 +117,7 @@ You need to point Flink to a valid Hadoop configuration, which contains the foll
 <!-- Comma separated list of local directories used to buffer
      large results prior to transmitting them to S3. -->
 <property>
-  <name>fs.s3.buffer.dir</name>
+  <name>fs.s3a.buffer.dir</name>
   <value>/tmp</value>
 </property>
 


### PR DESCRIPTION
Should use `fs.s3a.buffer.dir` in `core-site.xml` to set s3a directories for buffering files.
