### PR TITLE
[FLINK-7629] [scala] Fix KeyedStream.aggregate for nested field expressions

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/typeutils/FieldAccessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/typeutils/FieldAccessor.java
@@ -356,11 +356,11 @@ public abstract class FieldAccessor<T, F> implements Serializable {
 			checkNotNull(innerAccessor, "innerAccessor must not be null.");
 
 			this.pos = pos;
-			this.fieldType = ((TupleTypeInfoBase<T>) typeInfo).getTypeAt(pos);
 			this.serializer = (TupleSerializerBase<T>) typeInfo.createSerializer(config);
 			this.length = this.serializer.getArity();
 			this.fields = new Object[this.length];
 			this.innerAccessor = innerAccessor;
+			this.fieldType = innerAccessor.getFieldType();
 		}
 
 		@SuppressWarnings("unchecked")

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/typeutils/FieldAccessorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/typeutils/FieldAccessorTest.java
@@ -48,6 +48,7 @@ public class FieldAccessorTest {
 				(TupleTypeInfo<Tuple2<String, Integer>>) TypeExtractor.getForObject(t);
 
 		FieldAccessor<Tuple2<String, Integer>, String> f0 = FieldAccessorFactory.getAccessor(tpeInfo, "f0", null);
+		assertEquals(String.class, f0.getFieldType().getTypeClass());
 		assertEquals("aa", f0.get(t));
 		assertEquals("aa", t.f0);
 		t = f0.set(t, "b");
@@ -55,6 +56,7 @@ public class FieldAccessorTest {
 		assertEquals("b", t.f0);
 
 		FieldAccessor<Tuple2<String, Integer>, Integer> f1 = FieldAccessorFactory.getAccessor(tpeInfo, "f1", null);
+		assertEquals(Integer.class, f1.getFieldType().getTypeClass());
 		assertEquals(5, (int) f1.get(t));
 		assertEquals(5, (int) t.f1);
 		t = f1.set(t, 7);
@@ -64,6 +66,7 @@ public class FieldAccessorTest {
 		assertEquals("b", t.f0);
 
 		FieldAccessor<Tuple2<String, Integer>, Integer> f1n = FieldAccessorFactory.getAccessor(tpeInfo, 1, null);
+		assertEquals(Integer.class, f1n.getFieldType().getTypeClass());
 		assertEquals(7, (int) f1n.get(t));
 		assertEquals(7, (int) t.f1);
 		t = f1n.set(t, 10);
@@ -74,6 +77,7 @@ public class FieldAccessorTest {
 		assertEquals("b", t.f0);
 
 		FieldAccessor<Tuple2<String, Integer>, Integer> f1ns = FieldAccessorFactory.getAccessor(tpeInfo, "1", null);
+		assertEquals(Integer.class, f1ns.getFieldType().getTypeClass());
 		assertEquals(10, (int) f1ns.get(t));
 		assertEquals(10, (int) t.f1);
 		t = f1ns.set(t, 11);
@@ -85,6 +89,7 @@ public class FieldAccessorTest {
 
 		// This is technically valid (the ".0" is selecting the 0th field of a basic type).
 		FieldAccessor<Tuple2<String, Integer>, String> f0f0 = FieldAccessorFactory.getAccessor(tpeInfo, "f0.0", null);
+		assertEquals(String.class, f0f0.getFieldType().getTypeClass());
 		assertEquals("b", f0f0.get(t));
 		assertEquals("b", t.f0);
 		t = f0f0.set(t, "cc");
@@ -110,11 +115,13 @@ public class FieldAccessorTest {
 
 		FieldAccessor<Tuple2<String, Tuple3<Integer, Long, Double>>, String> f0 = FieldAccessorFactory
 			.getAccessor(tpeInfo, "f0", null);
+		assertEquals(String.class, f0.getFieldType().getTypeClass());
 		assertEquals("aa", f0.get(t));
 		assertEquals("aa", t.f0);
 
 		FieldAccessor<Tuple2<String, Tuple3<Integer, Long, Double>>, Double> f1f2 = FieldAccessorFactory
 			.getAccessor(tpeInfo, "f1.f2", null);
+		assertEquals(Double.class, f1f2.getFieldType().getTypeClass());
 		assertEquals(2.0, f1f2.get(t), 0);
 		assertEquals(2.0, t.f1.f2, 0);
 		t = f1f2.set(t, 3.0);
@@ -125,6 +132,7 @@ public class FieldAccessorTest {
 
 		FieldAccessor<Tuple2<String, Tuple3<Integer, Long, Double>>, Tuple3<Integer, Long, Double>> f1 =
 			FieldAccessorFactory.getAccessor(tpeInfo, "f1", null);
+		assertEquals(Tuple3.class, f1.getFieldType().getTypeClass());
 		assertEquals(Tuple3.of(5, 9L, 3.0), f1.get(t));
 		assertEquals(Tuple3.of(5, 9L, 3.0), t.f1);
 		t = f1.set(t, Tuple3.of(8, 12L, 4.0));
@@ -135,6 +143,7 @@ public class FieldAccessorTest {
 
 		FieldAccessor<Tuple2<String, Tuple3<Integer, Long, Double>>, Tuple3<Integer, Long, Double>> f1n =
 			FieldAccessorFactory.getAccessor(tpeInfo, 1, null);
+		assertEquals(Tuple3.class, f1n.getFieldType().getTypeClass());
 		assertEquals(Tuple3.of(8, 12L, 4.0), f1n.get(t));
 		assertEquals(Tuple3.of(8, 12L, 4.0), t.f1);
 		t = f1n.set(t, Tuple3.of(10, 13L, 5.0));
@@ -175,6 +184,7 @@ public class FieldAccessorTest {
 				(TupleTypeInfo<Tuple2<String, Foo>>) TypeExtractor.getForObject(t);
 
 		FieldAccessor<Tuple2<String, Foo>, Long> f1tf1 = FieldAccessorFactory.getAccessor(tpeInfo, "f1.t.f1", null);
+		assertEquals(Long.class, f1tf1.getFieldType().getTypeClass());
 		assertEquals(9L, (long) f1tf1.get(t));
 		assertEquals(9L, (long) t.f1.t.f1);
 		t = f1tf1.set(t, 12L);
@@ -182,6 +192,7 @@ public class FieldAccessorTest {
 		assertEquals(12L, (long) t.f1.t.f1);
 
 		FieldAccessor<Tuple2<String, Foo>, String> f1tf0 = FieldAccessorFactory.getAccessor(tpeInfo, "f1.t.f0", null);
+		assertEquals(String.class, f1tf0.getFieldType().getTypeClass());
 		assertEquals("ddd", f1tf0.get(t));
 		assertEquals("ddd", t.f1.t.f0);
 		t = f1tf0.set(t, "alma");
@@ -190,6 +201,8 @@ public class FieldAccessorTest {
 
 		FieldAccessor<Tuple2<String, Foo>, Foo> f1 = FieldAccessorFactory.getAccessor(tpeInfo, "f1", null);
 		FieldAccessor<Tuple2<String, Foo>, Foo> f1n = FieldAccessorFactory.getAccessor(tpeInfo, 1, null);
+		assertEquals(Foo.class, f1.getFieldType().getTypeClass());
+		assertEquals(Foo.class, f1n.getFieldType().getTypeClass());
 		assertEquals(Tuple2.of("alma", 12L), f1.get(t).t);
 		assertEquals(Tuple2.of("alma", 12L), f1n.get(t).t);
 		assertEquals(Tuple2.of("alma", 12L), t.f1.t);
@@ -261,6 +274,7 @@ public class FieldAccessorTest {
 		PojoTypeInfo<Outer> tpeInfo = (PojoTypeInfo<Outer>) TypeInformation.of(Outer.class);
 
 		FieldAccessor<Outer, Long> fix = FieldAccessorFactory.getAccessor(tpeInfo, "i.x", null);
+		assertEquals(Long.class, fix.getFieldType().getTypeClass());
 		assertEquals(4L, (long) fix.get(o));
 		assertEquals(4L, o.i.x);
 		o = fix.set(o, 22L);
@@ -268,6 +282,7 @@ public class FieldAccessorTest {
 		assertEquals(22L, o.i.x);
 
 		FieldAccessor<Outer, Inner> fi = FieldAccessorFactory.getAccessor(tpeInfo, "i", null);
+		assertEquals(Inner.class, fi.getFieldType().getTypeClass());
 		assertEquals(22L, fi.get(o).x);
 		assertEquals(22L, (long) fix.get(o));
 		assertEquals(22L, o.i.x);
@@ -328,6 +343,7 @@ public class FieldAccessorTest {
 		PojoTypeInfo<ArrayInPojo> tpeInfo = (PojoTypeInfo<ArrayInPojo>) TypeInformation.of(ArrayInPojo.class);
 
 		FieldAccessor<ArrayInPojo, Integer> fix = FieldAccessorFactory.getAccessor(tpeInfo, "arr.1", null);
+		assertEquals(Integer.class, fix.getFieldType().getTypeClass());
 		assertEquals(4, (int) fix.get(o));
 		assertEquals(4L, o.arr[1]);
 		o = fix.set(o, 8);
@@ -341,12 +357,14 @@ public class FieldAccessorTest {
 		TypeInformation<Long> tpeInfo = BasicTypeInfo.LONG_TYPE_INFO;
 
 		FieldAccessor<Long, Long> f = FieldAccessorFactory.getAccessor(tpeInfo, 0, null);
+		assertEquals(Long.class, f.getFieldType().getTypeClass());
 		assertEquals(7L, (long) f.get(x));
 		x = f.set(x, 12L);
 		assertEquals(12L, (long) f.get(x));
 		assertEquals(12L, (long) x);
 
 		FieldAccessor<Long, Long> f2 = FieldAccessorFactory.getAccessor(tpeInfo, "*", null);
+		assertEquals(Long.class, f2.getFieldType().getTypeClass());
 		assertEquals(12L, (long) f2.get(x));
 		x = f2.set(x, 14L);
 		assertEquals(14L, (long) f2.get(x));

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/KeyedStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/KeyedStream.scala
@@ -26,7 +26,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer
 import org.apache.flink.streaming.api.datastream.{QueryableStateStream, DataStream => JavaStream, KeyedStream => KeyedJavaStream, WindowedStream => WindowedJavaStream}
 import org.apache.flink.streaming.api.functions.ProcessFunction
 import org.apache.flink.streaming.api.functions.aggregation.AggregationFunction.AggregationType
-import org.apache.flink.streaming.api.functions.aggregation.{ComparableAggregator, SumAggregator}
+import org.apache.flink.streaming.api.functions.aggregation.{AggregationFunction, ComparableAggregator, SumAggregator}
 import org.apache.flink.streaming.api.functions.query.{QueryableAppendingStateOperator, QueryableValueStateOperator}
 import org.apache.flink.streaming.api.operators.StreamGroupedReduce
 import org.apache.flink.streaming.api.scala.function.StatefulFunction
@@ -350,13 +350,19 @@ class KeyedStream[T, K](javaStream: KeyedJavaStream[T, K]) extends DataStream[T]
     aggregate(AggregationType.MAXBY, field)
     
   private def aggregate(aggregationType: AggregationType, field: String): DataStream[T] = {
-    val position = fieldNames2Indices(javaStream.getType(), Array(field))(0)
-    aggregate(aggregationType, position)
+    val aggregationFunc = aggregationType match {
+      case AggregationType.SUM =>
+        new SumAggregator(field, javaStream.getType, javaStream.getExecutionConfig)
+      case _ =>
+        new ComparableAggregator(field, javaStream.getType, aggregationType, true,
+          javaStream.getExecutionConfig)
+    }
+
+    aggregate(aggregationFunc)
   }
 
   private def aggregate(aggregationType: AggregationType, position: Int): DataStream[T] = {
-
-    val reducer = aggregationType match {
+    val aggregationFunc = aggregationType match {
       case AggregationType.SUM =>
         new SumAggregator(position, javaStream.getType, javaStream.getExecutionConfig)
       case _ =>
@@ -364,10 +370,14 @@ class KeyedStream[T, K](javaStream: KeyedJavaStream[T, K]) extends DataStream[T]
           javaStream.getExecutionConfig)
     }
 
-    val invokable =  new StreamGroupedReduce[T](reducer,
-      getType().createSerializer(getExecutionConfig))
-     
-    new DataStream[T](javaStream.transform("aggregation", javaStream.getType(),invokable))
+    aggregate(aggregationFunc)
+  }
+
+  private def aggregate(aggregationFunc: AggregationFunction[T]): DataStream[T] = {
+    val invokable =
+      new StreamGroupedReduce[T](aggregationFunc, dataType.createSerializer(executionConfig))
+
+    new DataStream[T](javaStream.transform("aggregation", javaStream.getType(), invokable))
       .asInstanceOf[DataStream[T]]
   }
 

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/CaseClassFieldAccessorTest.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/CaseClassFieldAccessorTest.scala
@@ -36,6 +36,9 @@ class CaseClassFieldAccessorTest extends TestLogger with JUnitSuiteLike {
       val accessor1 = FieldAccessorFactory.getAccessor[IntBoolean, Int](tpeInfo, "foo", null)
       val accessor2 = FieldAccessorFactory.getAccessor[IntBoolean, Boolean](tpeInfo, "bar", null)
 
+      assert(accessor1.getFieldType.getTypeClass.getSimpleName == "Integer")
+      assert(accessor2.getFieldType.getTypeClass.getSimpleName == "Boolean")
+
       val x1 = IntBoolean(5, false)
       assert(accessor1.get(x1) == 5)
       assert(accessor2.get(x1) == false)
@@ -56,6 +59,9 @@ class CaseClassFieldAccessorTest extends TestLogger with JUnitSuiteLike {
       // by field pos
       val accessor1 = FieldAccessorFactory.getAccessor[IntBoolean, Int](tpeInfo, 0, null)
       val accessor2 = FieldAccessorFactory.getAccessor[IntBoolean, Boolean](tpeInfo, 1, null)
+
+      assert(accessor1.getFieldType.getTypeClass.getSimpleName == "Integer")
+      assert(accessor2.getFieldType.getTypeClass.getSimpleName == "Boolean")
 
       val x1 = IntBoolean(5, false)
       assert(accessor1.get(x1) == 5)
@@ -82,6 +88,7 @@ class CaseClassFieldAccessorTest extends TestLogger with JUnitSuiteLike {
     val cfg = new ExecutionConfig
 
     val fib = FieldAccessorFactory.getAccessor[Outer, Boolean](tpeInfo, "i.b", cfg)
+    assert(fib.getFieldType.getTypeClass.getSimpleName == "Boolean")
     assert(fib.get(x) == true)
     assert(x.i.b == true)
     x = fib.set(x, false)
@@ -89,6 +96,7 @@ class CaseClassFieldAccessorTest extends TestLogger with JUnitSuiteLike {
     assert(x.i.b == false)
 
     val fi = FieldAccessorFactory.getAccessor[Outer, FieldAccessorTest.Inner](tpeInfo, "i", cfg)
+    assert(fi.getFieldType.getTypeClass.getSimpleName == "Inner")
     assert(fi.get(x).x == 3L)
     assert(x.i.x == 3L)
     x = fi.set(x, new FieldAccessorTest.Inner(4L, true))
@@ -96,6 +104,7 @@ class CaseClassFieldAccessorTest extends TestLogger with JUnitSuiteLike {
     assert(x.i.x == 4L)
 
     val fin = FieldAccessorFactory.getAccessor[Outer, FieldAccessorTest.Inner](tpeInfo, 1, cfg)
+    assert(fin.getFieldType.getTypeClass.getSimpleName == "Inner")
     assert(fin.get(x).x == 4L)
     assert(x.i.x == 4L)
     x = fin.set(x, new FieldAccessorTest.Inner(5L, true))
@@ -108,6 +117,7 @@ class CaseClassFieldAccessorTest extends TestLogger with JUnitSuiteLike {
     val tpeInfo = createTypeInformation[(Int, Long)]
     var x = (5, 6L)
     val f0 = FieldAccessorFactory.getAccessor[(Int, Long), Int](tpeInfo, 0, null)
+    assert(f0.getFieldType.getTypeClass.getSimpleName == "Integer")
     assert(f0.get(x) == 5)
     x = f0.set(x, 8)
     assert(f0.get(x) == 8)
@@ -123,6 +133,7 @@ class CaseClassFieldAccessorTest extends TestLogger with JUnitSuiteLike {
     var x = Outer(1, Inner(2, "alma"), true)
 
     val fib = FieldAccessorFactory.getAccessor[Outer, String](tpeInfo, "i.b", null)
+    assert(fib.getFieldType.getTypeClass.getSimpleName == "String")
     assert(fib.get(x) == "alma")
     assert(x.i.b == "alma")
     x = fib.set(x, "korte")
@@ -130,6 +141,7 @@ class CaseClassFieldAccessorTest extends TestLogger with JUnitSuiteLike {
     assert(x.i.b == "korte")
 
     val fi = FieldAccessorFactory.getAccessor[Outer, Inner](tpeInfo, "i", null)
+    assert(fi.getFieldType.getTypeClass == classOf[Inner])
     assert(fi.get(x) == Inner(2, "korte"))
     x = fi.set(x, Inner(3, "aaa"))
     assert(x.i == Inner(3, "aaa"))

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/StreamingOperatorsITCase.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/StreamingOperatorsITCase.scala
@@ -31,8 +31,10 @@ class StreamingOperatorsITCase extends ScalaStreamingMultipleProgramsTestBase {
 
   var resultPath1: String = _
   var resultPath2: String = _
+  var resultPath3: String = _
   var expected1: String = _
   var expected2: String = _
+  var expected3: String = _
 
   val _tempFolder = new TemporaryFolder()
 
@@ -44,14 +46,17 @@ class StreamingOperatorsITCase extends ScalaStreamingMultipleProgramsTestBase {
     val temp = tempFolder
     resultPath1 = temp.newFile.toURI.toString
     resultPath2 = temp.newFile.toURI.toString
+    resultPath3 = temp.newFile.toURI.toString
     expected1 = ""
     expected2 = ""
+    expected3 = ""
   }
 
   @After
   def after(): Unit = {
     TestBaseUtils.compareResultsByLinesInMemory(expected1, resultPath1)
     TestBaseUtils.compareResultsByLinesInMemory(expected2, resultPath2)
+    TestBaseUtils.compareResultsByLinesInMemory(expected3, resultPath3)
   }
 
   /** Tests the streaming fold operation. For this purpose a stream of Tuple[Int, Int] is created.
@@ -122,4 +127,35 @@ class StreamingOperatorsITCase extends ScalaStreamingMultipleProgramsTestBase {
 
     env.execute()
   }
+
+  @Test
+  def testKeyedAggregation(): Unit = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+
+    env.setParallelism(1)
+    env.getConfig.setMaxParallelism(1)
+
+    val inp = env.fromElements(
+      Outer(1, Inner(3, "alma"), true),
+      Outer(1, Inner(6, "alma"), true),
+      Outer(2, Inner(7, "alma"), true),
+      Outer(2, Inner(8, "alma"), true)
+    )
+
+    inp
+      .keyBy("a")
+      .sum("i.c")
+        .writeAsText(resultPath3, FileSystem.WriteMode.OVERWRITE)
+
+    expected3 =
+      "Outer(1,Inner(3,alma),true)\n" +
+      "Outer(1,Inner(9,alma),true)\n" +
+      "Outer(2,Inner(15,alma),true)\n" +
+      "Outer(2,Inner(7,alma),true)"
+
+    env.execute()
+  }
 }
+
+case class Inner(c: Short, d: String)
+case class Outer(a: Int, i: Inner, b: Boolean)


### PR DESCRIPTION
## What is the purpose of the change

Make `KeyedStream.aggregate` (and `sum`, `maxBy`, etc.) able to handle nested field expressions.


## Brief change log

The first commit fixes a bug in `RecursiveProductFieldAccessor`: the `fieldType` field should contain the type of the innermost field. I.e., if the field expression is `"field1.field2.field3"`, then it should be the type of `field3`, and not `field1`.

The second commit modifies the string overload of `KeyedStream.aggregate` to not use `fieldNames2Indices` to resolve the given field expression, but directly create a `SumAggregator` or `ComparableAggregator`, whose constructors call `FieldAccessorFactory.getAccessor`, which correctly resolves nested field expressions like `"field1.field2.field3"`.

## Verifying this change

- Extended the tests in `FieldAccessorTest` to catch the `fieldType` issue.
- Added a test which calls `KeyedStream.sum` with a nested field expression.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? The feature was already documented in the JavaDocs of the aggregation methods of `KeyedStream`. This PR just brings the functionality up-to-date with the documentation.

