### PR TITLE
[FLINK-7636] [table] Introduce Flink RelOptTable, and remove tableSource from all TableSourceScan node constructor

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/calcite/FlinkCalciteCatalogReader.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/calcite/FlinkCalciteCatalogReader.scala
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.calcite
+
+import java.util
+
+import org.apache.calcite.jdbc.CalciteSchema
+import org.apache.calcite.prepare.CalciteCatalogReader
+import org.apache.calcite.rel.`type`.RelDataTypeFactory
+import org.apache.calcite.schema.Table
+import org.apache.calcite.prepare.Prepare.PreparingTable
+import org.apache.flink.table.plan.schema.{FlinkRelOptTable, FlinkTable, RelTable, TableSinkTable}
+
+/**
+  * Flink specific [[CalciteCatalogReader]] that changes the RelOptTable which wrapped a
+  * FlinkTable to a [[org.apache.flink.table.plan.schema.FlinkRelOptTable]].
+  */
+class FlinkCalciteCatalogReader(
+    rootSchema: CalciteSchema,
+    caseSensitive: Boolean,
+    defaultSchema: util.List[String],
+    typeFactory: RelDataTypeFactory)
+    extends CalciteCatalogReader(rootSchema, caseSensitive, defaultSchema, typeFactory) {
+
+  override def getTable(names: util.List[String]): PreparingTable = {
+    val originRelOptTable = super.getTable(names)
+    if (originRelOptTable == null) {
+      originRelOptTable
+    } else {
+      val table = originRelOptTable.unwrap(classOf[Table])
+      table match {
+        case _: RelTable | _: FlinkTable[_] | _: TableSinkTable[_] =>
+          FlinkRelOptTable.create(
+            originRelOptTable.getRelOptSchema,
+            originRelOptTable.getRowType,
+            originRelOptTable.getQualifiedName,
+            table)
+        case _ => originRelOptTable
+      }
+    }
+  }
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/calcite/FlinkPlannerImpl.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/calcite/FlinkPlannerImpl.scala
@@ -155,7 +155,7 @@ class FlinkPlannerImpl(
 
   private def createCatalogReader: CalciteCatalogReader = {
     val rootSchema: SchemaPlus = FlinkPlannerImpl.rootSchema(defaultSchema)
-    new CalciteCatalogReader(
+    new FlinkCalciteCatalogReader(
       CalciteSchema.from(rootSchema),
       parserConfig.caseSensitive,
       CalciteSchema.from(defaultSchema).path(null),

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/calcite/FlinkRelBuilder.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/calcite/FlinkRelBuilder.scala
@@ -24,7 +24,6 @@ import java.util.Collections
 import org.apache.calcite.jdbc.CalciteSchema
 import org.apache.calcite.plan._
 import org.apache.calcite.plan.volcano.VolcanoPlanner
-import org.apache.calcite.prepare.CalciteCatalogReader
 import org.apache.calcite.rel.logical.LogicalAggregate
 import org.apache.calcite.rex.RexBuilder
 import org.apache.calcite.tools.RelBuilder.{AggCall, GroupKey}
@@ -83,7 +82,7 @@ object FlinkRelBuilder {
     planner.addRelTraitDef(ConventionTraitDef.INSTANCE)
     val cluster = FlinkRelOptClusterFactory.create(planner, new RexBuilder(typeFactory))
     val calciteSchema = CalciteSchema.from(config.getDefaultSchema)
-    val relOptSchema = new CalciteCatalogReader(
+    val relOptSchema = new FlinkCalciteCatalogReader(
       calciteSchema,
       config.getParserConfig.caseSensitive(),
       Collections.emptyList(),

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/PhysicalTableSourceScan.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/PhysicalTableSourceScan.scala
@@ -24,6 +24,7 @@ import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.core.TableScan
 import org.apache.flink.table.api.TableEnvironment
 import org.apache.flink.table.calcite.FlinkTypeFactory
+import org.apache.flink.table.plan.schema.{FlinkRelOptTable, TableSourceTable}
 import org.apache.flink.table.sources.TableSource
 
 import scala.collection.JavaConverters._
@@ -31,9 +32,10 @@ import scala.collection.JavaConverters._
 abstract class PhysicalTableSourceScan(
     cluster: RelOptCluster,
     traitSet: RelTraitSet,
-    table: RelOptTable,
-    val tableSource: TableSource[_])
-  extends TableScan(cluster, traitSet, table) {
+    relOptTable: RelOptTable)
+  extends TableScan(cluster, traitSet, relOptTable) {
+
+  protected val tableSource: TableSource[_]
 
   override def deriveRowType(): RelDataType = {
     val flinkTypeFactory = cluster.getTypeFactory.asInstanceOf[FlinkTypeFactory]
@@ -66,6 +68,6 @@ abstract class PhysicalTableSourceScan(
     }
   }
 
-  def copy(traitSet: RelTraitSet, tableSource: TableSource[_]): PhysicalTableSourceScan
+  def copy(traitSet: RelTraitSet, relOptTable: FlinkRelOptTable): PhysicalTableSourceScan
 
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/dataSet/BatchTableSourceScanRule.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/dataSet/BatchTableSourceScanRule.scala
@@ -24,7 +24,7 @@ import org.apache.calcite.rel.convert.ConverterRule
 import org.apache.calcite.rel.core.TableScan
 import org.apache.flink.table.plan.nodes.FlinkConventions
 import org.apache.flink.table.plan.nodes.dataset.BatchTableSourceScan
-import org.apache.flink.table.plan.schema.TableSourceTable
+import org.apache.flink.table.plan.schema.{FlinkRelOptTable, TableSourceTable}
 import org.apache.flink.table.plan.nodes.logical.FlinkLogicalTableSourceScan
 import org.apache.flink.table.sources.BatchTableSource
 
@@ -38,8 +38,8 @@ class BatchTableSourceScanRule
   /** Rule must only match if TableScan targets a [[BatchTableSource]] */
   override def matches(call: RelOptRuleCall): Boolean = {
     val scan: TableScan = call.rel(0).asInstanceOf[TableScan]
-    val dataSetTable = scan.getTable.unwrap(classOf[TableSourceTable[_]])
-    dataSetTable match {
+    val tableSourceTable = scan.getTable.unwrap(classOf[TableSourceTable[_]])
+    tableSourceTable match {
       case tst: TableSourceTable[_] =>
         tst.tableSource match {
           case _: BatchTableSource[_] =>
@@ -58,8 +58,7 @@ class BatchTableSourceScanRule
     new BatchTableSourceScan(
       rel.getCluster,
       traitSet,
-      scan.getTable,
-      scan.tableSource.asInstanceOf[BatchTableSource[_]]
+      scan.getTable.asInstanceOf[FlinkRelOptTable]
     )
   }
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/datastream/StreamTableSourceScanRule.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/datastream/StreamTableSourceScanRule.scala
@@ -24,7 +24,7 @@ import org.apache.calcite.rel.convert.ConverterRule
 import org.apache.calcite.rel.core.TableScan
 import org.apache.flink.table.plan.nodes.FlinkConventions
 import org.apache.flink.table.plan.nodes.datastream.StreamTableSourceScan
-import org.apache.flink.table.plan.schema.TableSourceTable
+import org.apache.flink.table.plan.schema.{FlinkRelOptTable, TableSourceTable}
 import org.apache.flink.table.plan.nodes.logical.FlinkLogicalTableSourceScan
 import org.apache.flink.table.sources.StreamTableSource
 
@@ -39,8 +39,8 @@ class StreamTableSourceScanRule
   /** Rule must only match if TableScan targets a [[StreamTableSource]] */
   override def matches(call: RelOptRuleCall): Boolean = {
     val scan: TableScan = call.rel(0).asInstanceOf[TableScan]
-    val dataSetTable = scan.getTable.unwrap(classOf[TableSourceTable[_]])
-    dataSetTable match {
+    val tableSourceTable = scan.getTable.unwrap(classOf[TableSourceTable[_]])
+    tableSourceTable match {
       case tst: TableSourceTable[_] =>
         tst.tableSource match {
           case _: StreamTableSource[_] =>
@@ -60,8 +60,7 @@ class StreamTableSourceScanRule
     new StreamTableSourceScan(
       rel.getCluster,
       traitSet,
-      scan.getTable,
-      scan.tableSource.asInstanceOf[StreamTableSource[_]]
+      scan.getTable.asInstanceOf[FlinkRelOptTable]
     )
   }
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/schema/FlinkRelOptTable.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/schema/FlinkRelOptTable.scala
@@ -1,0 +1,257 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.schema
+
+import java.util.{List => JList}
+
+import com.google.common.collect.ImmutableList
+
+import org.apache.calcite.plan.{RelOptCluster, RelOptSchema, RelOptTable}
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.prepare.CalcitePrepareImpl
+
+import org.apache.calcite.adapter.enumerable.EnumerableTableScan
+import org.apache.calcite.linq4j.tree.Expression
+import org.apache.calcite.plan.RelOptTable.ToRelContext
+import org.apache.calcite.prepare.Prepare.PreparingTable
+import org.apache.calcite.rel.`type`.{RelDataTypeFactory, RelDataTypeField}
+import org.apache.calcite.rel._
+import org.apache.calcite.rel.logical.LogicalTableScan
+import org.apache.calcite.runtime.Hook
+import org.apache.calcite.schema.Table
+import org.apache.calcite.schema.StreamableTable
+import org.apache.calcite.sql.SqlAccessType
+import org.apache.calcite.sql.validate.{SqlModality, SqlMonotonicity}
+import org.apache.calcite.sql2rel.InitializerContext
+import org.apache.calcite.util.ImmutableBitSet
+
+import scala.collection.JavaConverters._
+
+/**
+  * FlinkRelOptTable wraps a FlinkTable
+  *
+  * @param schema        the [[RelOptSchema]] this table belongs to
+  * @param rowType       the type of rows returned by this table
+  * @param qualifiedName the identifier for this table. The identifier must be unique with
+  *                      respect to the Connection producing this table.
+  * @param table         wrapped flink table
+  */
+
+class FlinkRelOptTable private(
+    schema: RelOptSchema,
+    rowType: RelDataType,
+    qualifiedName: JList[String],
+    table: Table) extends PreparingTable {
+
+  private[this] lazy val statistic = Option(table.getStatistic)
+
+  /**
+    * Creates a copy of this Flink RelOptTable with new Flink Table and new row type.
+    *
+    * @param newTable    new flink table
+    * @param typeFactory type factory to create new row type of new flink table
+    * @return The copy of this Flink RelOptTable with new Flink table and new row type
+    */
+  def copy(newTable: Table, typeFactory: RelDataTypeFactory): FlinkRelOptTable = {
+    val newRowType = newTable.getRowType(typeFactory)
+    FlinkRelOptTable.create(schema, newRowType, qualifiedName, newTable)
+  }
+
+  /**
+    * Extends a table with the given extra fields. The operation is not supported now.
+    *
+    * @param extendedFields
+    * @return
+    */
+  override def extend(extendedFields: JList[RelDataTypeField]): RelOptTable =
+    throw new UnsupportedOperationException
+
+  /**
+    * Obtains an identifier for this table.
+    *
+    * @return qualified name
+    */
+  override def getQualifiedName: JList[String] = qualifiedName
+
+
+  /**
+    * Obtains the access type of the table.
+    *
+    * @return access types of given table
+    */
+  override def getAllowedAccess: SqlAccessType = table match {
+    case _: TableSinkTable[_] =>
+      // support INSERT/ SELECT for TableSink now
+      SqlAccessType.create("SELECT, INSERT")
+    // support SELECT for TableSouceTable/ DataSetTableTable/RelTable  now
+    case _: RelTable | _: FlinkTable[_] => SqlAccessType.READ_ONLY
+    case _ => throw new AssertionError
+  }
+
+  override def unwrap[T](clazz: Class[T]): T = {
+    if (clazz.isInstance(this)) {
+      clazz.cast(this)
+    } else if (clazz.isInstance(table)) {
+      clazz.cast(table)
+    } else {
+      null.asInstanceOf[T]
+    }
+  }
+
+  override def supportsModality(modality: SqlModality): Boolean =
+    modality match {
+      case SqlModality.STREAM =>
+        table.isInstanceOf[StreamableTable]
+      case _ =>
+        !table.isInstanceOf[StreamableTable]
+    }
+
+  /**
+    * Obtains the type of rows returned by this table.
+    *
+    * @return the type of rows returned by this table.
+    */
+  override def getRowType: RelDataType = rowType
+
+  /**
+    * Obtains whether a given column is monotonic.
+    *
+    * @param columnName
+    * @return true if the given column is monotonic
+    */
+  override def getMonotonicity(columnName: String): SqlMonotonicity = {
+    val columnIdx = rowType.getFieldNames.indexOf(columnName)
+    assert(columnIdx >= 0)
+    statistic match {
+      case Some(statistic) =>
+        statistic.getCollations
+            .asScala
+            .map(_.getFieldCollations.get(0))
+            .find(_.getFieldIndex == columnIdx)
+            .map(_.direction.monotonicity())
+            .getOrElse(SqlMonotonicity.NOT_MONOTONIC)
+      case _ => SqlMonotonicity.NOT_MONOTONIC
+    }
+
+  }
+
+  /**
+    * Obtains an estimate of the number of rows in the table.
+    *
+    * @return the number of rows in the table
+    */
+  override def getRowCount: java.lang.Double = statistic.map(_.getRowCount).getOrElse(100D)
+
+  /**
+    * Converts this table into a RelNode relational expression.
+    *
+    * @param context
+    * @return
+    */
+  override def toRel(context: ToRelContext): RelNode = {
+    val cluster: RelOptCluster = context.getCluster
+    table match {
+      case t: RelTable => t.toRel(context, this)
+      case _ =>
+        if (Hook.ENABLE_BINDABLE.get(false)) {
+          LogicalTableScan.create(cluster, this)
+        } else if (CalcitePrepareImpl.ENABLE_ENUMERABLE) {
+          EnumerableTableScan.create(cluster, this)
+        } else {
+          throw new AssertionError
+        }
+    }
+  }
+
+  /**
+    * Obtains the [[RelOptSchema]] this table belongs to.
+    *
+    * @return the [[RelOptSchema]] this table belongs to
+    */
+  override def getRelOptSchema: RelOptSchema = schema
+
+  /**
+    * Returns whether the given columns are a key or a superset of a unique key
+    * of this table.
+    *
+    * @param columns Ordinals of key columns
+    * @return true if the given columns are a key or a superset of a key
+    */
+  override def isKey(columns: ImmutableBitSet): Boolean =
+    statistic.map(_.isKey(columns)).getOrElse(false)
+
+  /**
+    * Obtains the referential constraints existing for this table.
+    *
+    * @return the referential constraints existing for this table
+    */
+  override def getReferentialConstraints: JList[RelReferentialConstraint] =
+    statistic.map(_.getReferentialConstraints).getOrElse(ImmutableList.of())
+
+
+  /**
+    * Obtains a description of the physical ordering (or orderings) of the rows
+    * returned from this table.
+    *
+    * @return the ordering properties of the table
+    */
+  override def getCollationList: JList[RelCollation] =
+    statistic.map(_.getCollations).getOrElse(ImmutableList.of())
+
+  /**
+    * Obtains a description of the physical distribution of the rows
+    * in this table.
+    *
+    * @return the distribution properties of the table
+    */
+  override def getDistribution: RelDistribution =
+    statistic.map(_.getDistribution).getOrElse(RelDistributionTraitDef.INSTANCE.getDefault)
+
+  /**
+    * Generates code for this table. The operation is not supported now.
+    *
+    * @param clazz The desired collection class; for example { @code Queryable}
+    * @return
+    */
+  override def getExpression(clazz: java.lang.Class[_]): Expression =
+    throw new UnsupportedOperationException
+
+  /**
+    * Obtains whether the ordinal column has a default value.
+    *
+    * @param rowType
+    * @param ordinal
+    * @param initializerContext
+    * @return true if the column has a default value
+    */
+  override def columnHasDefaultValue(
+      rowType: RelDataType,
+      ordinal: Int,
+      initializerContext: InitializerContext): Boolean = false
+}
+
+object FlinkRelOptTable {
+
+  def create(schema: RelOptSchema,
+      rowType: RelDataType,
+      names: JList[String],
+      table: Table): FlinkRelOptTable =
+    new FlinkRelOptTable(schema, rowType, names, table)
+
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/calcite/FlinkCalciteCatalogReaderTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/calcite/FlinkCalciteCatalogReaderTest.scala
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.calcite
+
+import java.util.Collections
+
+import org.apache.calcite.jdbc.CalciteSchema
+import org.apache.calcite.schema.{SchemaPlus, Table}
+import org.apache.flink.table.plan.schema.{FlinkRelOptTable, FlinkTable}
+import com.google.common.collect.ImmutableList
+import org.apache.calcite.rel.`type`.RelDataType
+import org.junit.Assert._
+import org.junit.{Before, Test}
+import org.mockito.Mockito.{mock, when}
+
+class FlinkCalciteCatalogReaderTest {
+
+  private val typeFactory: FlinkTypeFactory = new FlinkTypeFactory(new FlinkTypeSystem())
+  private val tableMockName = "ts"
+  private var rootSchemaPlus: SchemaPlus = _
+  private var catalogReader: FlinkCalciteCatalogReader = _
+
+  @Before
+  def setup(): Unit = {
+    rootSchemaPlus = CalciteSchema.createRootSchema(true, false).plus()
+    catalogReader = new FlinkCalciteCatalogReader(
+      CalciteSchema.from(rootSchemaPlus),
+      false,
+      Collections.emptyList(),
+      typeFactory)
+  }
+
+  @Test
+  def testGetFlinkTable(): Unit = {
+    val flinkTableMock = mock(classOf[FlinkTable[Any]])
+    when(flinkTableMock.getRowType(typeFactory)).thenReturn(mock(classOf[RelDataType]))
+    rootSchemaPlus.add(tableMockName, flinkTableMock)
+    val resultTable = catalogReader.getTable(ImmutableList.of(tableMockName))
+    assertTrue(resultTable.isInstanceOf[FlinkRelOptTable])
+  }
+
+  @Test
+  def testGetNonFlinkTable(): Unit = {
+    val nonFlinkTableMock = mock(classOf[Table])
+    when(nonFlinkTableMock.getRowType(typeFactory)).thenReturn(mock(classOf[RelDataType]))
+    rootSchemaPlus.add(tableMockName, nonFlinkTableMock)
+    val resultTable = catalogReader.getTable(ImmutableList.of(tableMockName))
+    assertFalse(resultTable.isInstanceOf[FlinkRelOptTable])
+  }
+
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/catalog/ExternalCatalogSchemaTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/catalog/ExternalCatalogSchemaTest.scala
@@ -25,7 +25,7 @@ import org.apache.calcite.jdbc.CalciteSchema
 import org.apache.calcite.prepare.CalciteCatalogReader
 import org.apache.calcite.schema.SchemaPlus
 import org.apache.calcite.sql.validate.SqlMonikerType
-import org.apache.flink.table.calcite.{FlinkTypeFactory, FlinkTypeSystem}
+import org.apache.flink.table.calcite.{FlinkCalciteCatalogReader, FlinkTypeFactory, FlinkTypeSystem}
 import org.apache.flink.table.plan.schema.TableSourceTable
 import org.apache.flink.table.runtime.utils.CommonTestData
 import org.apache.flink.table.sources.CsvTableSource
@@ -37,7 +37,6 @@ import scala.collection.JavaConverters._
 class ExternalCatalogSchemaTest {
 
   private val schemaName: String = "test"
-  private var externalCatalogSchema: SchemaPlus = _
   private var calciteCatalogReader: CalciteCatalogReader = _
   private val db = "db1"
   private val tb = "tb1"
@@ -47,9 +46,8 @@ class ExternalCatalogSchemaTest {
     val rootSchemaPlus: SchemaPlus = CalciteSchema.createRootSchema(true, false).plus()
     val catalog = CommonTestData.getInMemoryTestCatalog
     ExternalCatalogSchema.registerCatalog(rootSchemaPlus, schemaName, catalog)
-    externalCatalogSchema = rootSchemaPlus.getSubSchema("schemaName")
     val typeFactory = new FlinkTypeFactory(new FlinkTypeSystem())
-    calciteCatalogReader = new CalciteCatalogReader(
+    calciteCatalogReader = new FlinkCalciteCatalogReader(
       CalciteSchema.from(rootSchemaPlus),
       false,
       Collections.emptyList(),


### PR DESCRIPTION
## What is the purpose of the change

There are two ways to fetch TableSource of TableSourceScan node (e.g FlinkLogicalTableSourceScan, PhysicalTableSourceScan and its subclass):
1. 
val relOptTable: RelOptTable = getTable()
val tableSourceTable = relOptTable.unwrap(classOf[TableSourceTable[_]])
val tableSouce = tableSourceTable.tableSource

the result of getTable() is instance of RelOptTableImpl now, and it will not change after RelNode tree is built.
2.  TableSourceScan node contains a tablesource as constructor parameter, so we could fetch the tablesource directly later.
 
The returned tableSource is different with each other through above two ways after apply project push(PPD) down or filter push down(FPD).  It is very confusing and will cause problems.

The pr aims to fix the problem by introducing FlinkRelOptTable to replace RelOptTableImpl, and remove tableSource parameter from TableSourceScan's constructor. After PPD or FPD,  a new FlinkRelOptTable instance which contains a new TableSourceTable will be passed to TableSourceScan constructor. 

## Brief change log

  - *Adds FlinkRelOptTable to replace default RelOptTable implementation (RelOptTableImpl)*
  - *Adds FlinkCalciteCatalogReader, which is subclass of  CalciteCatalogReader. It overrides getTable method to return FlinkRelOptTable instance instead of RelOptTableImpl instance*
  - *Removes tableSource parameter from TableSourceScan's constructor. A new FlinkRelOptTable instance which contains a new TableSourceTable will be passed to TableSourceScan constructor.*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added test that validates that FlinkRelOptTable instance is returned once call getTable method of FlinkCalciteCatalogReader*
  - *Other change is already covered by existing tests, such as (TableSourceTest, TableSourceITCase)*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)