### PR TITLE
[FLINK-7620] [table] Supports user defined optimization phase

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/BatchTableEnvironment.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/BatchTableEnvironment.scala
@@ -31,7 +31,7 @@ import org.apache.flink.api.java.{DataSet, ExecutionEnvironment}
 import org.apache.flink.table.explain.PlanJsonParser
 import org.apache.flink.table.expressions.{Expression, TimeAttribute}
 import org.apache.flink.table.plan.nodes.dataset.DataSetRel
-import org.apache.flink.table.plan.rules.FlinkRuleSets
+import org.apache.flink.table.plan.optimize.BatchOptimizeContext
 import org.apache.flink.table.plan.schema.{DataSetTable, RowSchema, TableSinkTable, TableSourceTable}
 import org.apache.flink.table.runtime.MapRunner
 import org.apache.flink.table.sinks.{BatchTableSink, TableSink}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/StreamTableEnvironment.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/StreamTableEnvironment.scala
@@ -37,12 +37,11 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.apache.flink.table.calcite.FlinkTypeFactory
 import org.apache.flink.table.explain.PlanJsonParser
 import org.apache.flink.table.expressions._
-import org.apache.flink.table.plan.nodes.FlinkConventions
-import org.apache.flink.table.plan.nodes.datastream.{DataStreamRel, UpdateAsRetractionTrait}
-import org.apache.flink.table.plan.rules.FlinkRuleSets
+import org.apache.flink.table.plan.nodes.datastream.DataStreamRel
+import org.apache.flink.table.plan.optimize.StreamOptimizeContext
+import org.apache.flink.table.plan.schema.{DataStreamTable, RowSchema, StreamTableSourceTable, TableSinkTable}
 import org.apache.flink.table.plan.util.UpdatingPlanChecker
 import org.apache.flink.table.runtime.conversion._
-import org.apache.flink.table.plan.schema.{DataStreamTable, RowSchema, StreamTableSourceTable, TableSinkTable}
 import org.apache.flink.table.runtime.types.{CRow, CRowTypeInfo}
 import org.apache.flink.table.runtime.{CRowMapRunner, OutputRowtimeProcessFunction}
 import org.apache.flink.table.sinks._

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/calcite/CalciteConfig.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/calcite/CalciteConfig.scala
@@ -18,14 +18,11 @@
 
 package org.apache.flink.table.calcite
 
-import org.apache.calcite.plan.RelOptRule
 import org.apache.calcite.sql.SqlOperatorTable
 import org.apache.calcite.sql.parser.SqlParser
 import org.apache.calcite.sql.util.ChainedSqlOperatorTable
-import org.apache.calcite.tools.{RuleSet, RuleSets}
+import org.apache.flink.table.plan.optimize._
 import org.apache.flink.util.Preconditions
-
-import scala.collection.JavaConverters._
 
 /**
   * Builder for creating a Calcite configuration.
@@ -33,30 +30,14 @@ import scala.collection.JavaConverters._
 class CalciteConfigBuilder {
 
   /**
-    * Defines the normalization rule set. Normalization rules are dedicated for rewriting
-    * predicated logical plan before volcano optimization.
+    * Defines the optimize programs for batch table plan.
     */
-  private var replaceNormRules: Boolean = false
-  private var normRuleSets: List[RuleSet] = Nil
+  private var batchPrograms = FlinkBatchPrograms.buildPrograms()
 
   /**
-    * Defines the logical optimization rule set.
+    * Defines the optimize programs for stream table plan.
     */
-  private var replaceLogicalOptRules: Boolean = false
-  private var logicalOptRuleSets: List[RuleSet] = Nil
-
-  /**
-    * Defines the physical optimization rule set.
-    */
-  private var replacePhysicalOptRules: Boolean = false
-  private var physicalOptRuleSets: List[RuleSet] = Nil
-
-  /**
-    * Defines the decoration rule set. Decoration rules are dedicated for rewriting predicated
-    * logical plan after volcano optimization.
-    */
-  private var replaceDecoRules: Boolean = false
-  private var decoRuleSets: List[RuleSet] = Nil
+  private var streamPrograms = FlinkStreamPrograms.buildPrograms()
 
   /**
     * Defines the SQL operator tables.
@@ -65,92 +46,43 @@ class CalciteConfigBuilder {
   private var operatorTables: List[SqlOperatorTable] = Nil
 
   /**
+    * Gets batch table optimize programs.
+    *
+    * @return batch table optimize programs instance.
+    */
+  def getBatchPrograms: FlinkChainedPrograms[BatchOptimizeContext] = batchPrograms
+
+  /**
+    * Replaces the built-in batch table optimize programs.
+    */
+  def replaceBatchPrograms(
+    programs: FlinkChainedPrograms[BatchOptimizeContext])
+  : CalciteConfigBuilder = {
+    batchPrograms = Preconditions.checkNotNull(programs)
+    this
+  }
+
+  /**
+    * Gets stream table optimize programs.
+    *
+    * @return stream table optimize programs instance.
+    */
+  def getStreamPrograms: FlinkChainedPrograms[StreamOptimizeContext] = streamPrograms
+
+  /**
+    * Replaces the built-in stream table optimize programs.
+    */
+  def replaceStreamPrograms(
+    programs: FlinkChainedPrograms[StreamOptimizeContext])
+  : CalciteConfigBuilder = {
+    streamPrograms = Preconditions.checkNotNull(programs)
+    this
+  }
+
+  /**
     * Defines a SQL parser configuration.
     */
   private var replaceSqlParserConfig: Option[SqlParser.Config] = None
-
-  /**
-    * Replaces the built-in normalization rule set with the given rule set.
-    */
-  def replaceNormRuleSet(replaceRuleSet: RuleSet): CalciteConfigBuilder = {
-    Preconditions.checkNotNull(replaceRuleSet)
-    normRuleSets = List(replaceRuleSet)
-    replaceNormRules = true
-    this
-  }
-
-  /**
-    * Appends the given normalization rule set to the built-in rule set.
-    */
-  def addNormRuleSet(addedRuleSet: RuleSet): CalciteConfigBuilder = {
-    Preconditions.checkNotNull(addedRuleSet)
-    normRuleSets = addedRuleSet :: normRuleSets
-    this
-  }
-
-  /**
-    * Replaces the built-in optimization rule set with the given rule set.
-    */
-  def replaceLogicalOptRuleSet(replaceRuleSet: RuleSet): CalciteConfigBuilder = {
-    Preconditions.checkNotNull(replaceRuleSet)
-    logicalOptRuleSets = List(replaceRuleSet)
-    replaceLogicalOptRules = true
-    this
-  }
-
-  /**
-    * Appends the given optimization rule set to the built-in rule set.
-    */
-  def addLogicalOptRuleSet(addedRuleSet: RuleSet): CalciteConfigBuilder = {
-    Preconditions.checkNotNull(addedRuleSet)
-    logicalOptRuleSets = addedRuleSet :: logicalOptRuleSets
-    this
-  }
-
-  /**
-    * Replaces the built-in optimization rule set with the given rule set.
-    */
-  def replacePhysicalOptRuleSet(replaceRuleSet: RuleSet): CalciteConfigBuilder = {
-    Preconditions.checkNotNull(replaceRuleSet)
-    physicalOptRuleSets = List(replaceRuleSet)
-    replacePhysicalOptRules = true
-    this
-  }
-
-  /**
-    * Appends the given optimization rule set to the built-in rule set.
-    */
-  def addPhysicalOptRuleSet(addedRuleSet: RuleSet): CalciteConfigBuilder = {
-    Preconditions.checkNotNull(addedRuleSet)
-    physicalOptRuleSets = addedRuleSet :: physicalOptRuleSets
-    this
-  }
-
-  /**
-    * Replaces the built-in decoration rule set with the given rule set.
-    *
-    * The decoration rules are applied after the cost-based optimization phase.
-    * The decoration phase allows to rewrite the optimized plan and is not cost-based.
-    *
-    */
-  def replaceDecoRuleSet(replaceRuleSet: RuleSet): CalciteConfigBuilder = {
-    Preconditions.checkNotNull(replaceRuleSet)
-    decoRuleSets = List(replaceRuleSet)
-    replaceDecoRules = true
-    this
-  }
-
-  /**
-    * Appends the given decoration rule set to the built-in rule set.
-    *
-    * The decoration rules are applied after the cost-based optimization phase.
-    * The decoration phase allows to rewrite the optimized plan and is not cost-based.
-    */
-  def addDecoRuleSet(addedRuleSet: RuleSet): CalciteConfigBuilder = {
-    Preconditions.checkNotNull(addedRuleSet)
-    decoRuleSets = addedRuleSet :: decoRuleSets
-    this
-  }
 
   /**
     * Replaces the built-in SQL operator table with the given table.
@@ -181,47 +113,19 @@ class CalciteConfigBuilder {
   }
 
   private class CalciteConfigImpl(
-      val getNormRuleSet: Option[RuleSet],
-      val replacesNormRuleSet: Boolean,
-      val getLogicalOptRuleSet: Option[RuleSet],
-      val replacesLogicalOptRuleSet: Boolean,
-      val getPhysicalOptRuleSet: Option[RuleSet],
-      val replacesPhysicalOptRuleSet: Boolean,
-      val getDecoRuleSet: Option[RuleSet],
-      val replacesDecoRuleSet: Boolean,
+      val getBatchPrograms: FlinkChainedPrograms[BatchOptimizeContext],
+      val getStreamPrograms: FlinkChainedPrograms[StreamOptimizeContext],
       val getSqlOperatorTable: Option[SqlOperatorTable],
       val replacesSqlOperatorTable: Boolean,
       val getSqlParserConfig: Option[SqlParser.Config])
     extends CalciteConfig
 
-
-  /**
-    * Convert the [[RuleSet]] List to [[Option]] type
-    */
-  private def getRuleSet(inputRuleSet: List[RuleSet]): Option[RuleSet] = {
-    inputRuleSet match {
-      case Nil => None
-      case h :: Nil => Some(h)
-      case _ =>
-        // concat rule sets
-        val concatRules =
-          inputRuleSet.foldLeft(Nil: Iterable[RelOptRule])((c, r) => r.asScala ++ c)
-        Some(RuleSets.ofList(concatRules.asJava))
-    }
-  }
-
   /**
     * Builds a new [[CalciteConfig]].
     */
   def build(): CalciteConfig = new CalciteConfigImpl(
-    getRuleSet(normRuleSets),
-    replaceNormRules,
-    getRuleSet(logicalOptRuleSets),
-    replaceLogicalOptRules,
-    getRuleSet(physicalOptRuleSets),
-    replacePhysicalOptRules,
-    getRuleSet(decoRuleSets),
-    replaceDecoRules,
+    getBatchPrograms,
+    getStreamPrograms,
     operatorTables match {
       case Nil => None
       case h :: Nil => Some(h)
@@ -239,44 +143,14 @@ class CalciteConfigBuilder {
 trait CalciteConfig {
 
   /**
-    * Returns whether this configuration replaces the built-in normalization rule set.
+    * Returns batch table optimize programs.
     */
-  def replacesNormRuleSet: Boolean
+  def getBatchPrograms: FlinkChainedPrograms[BatchOptimizeContext]
 
   /**
-    * Returns a custom normalization rule set.
+    * Returns stream table optimize programs.
     */
-  def getNormRuleSet: Option[RuleSet]
-
-  /**
-    * Returns whether this configuration replaces the built-in logical optimization rule set.
-    */
-  def replacesLogicalOptRuleSet: Boolean
-
-  /**
-    * Returns a custom logical optimization rule set.
-    */
-  def getLogicalOptRuleSet: Option[RuleSet]
-
-  /**
-    * Returns whether this configuration replaces the built-in physical optimization rule set.
-    */
-  def replacesPhysicalOptRuleSet: Boolean
-
-  /**
-    * Returns a custom physical optimization rule set.
-    */
-  def getPhysicalOptRuleSet: Option[RuleSet]
-
-  /**
-    * Returns whether this configuration replaces the built-in decoration rule set.
-    */
-  def replacesDecoRuleSet: Boolean
-
-  /**
-    * Returns a custom decoration rule set.
-    */
-  def getDecoRuleSet: Option[RuleSet]
+  def getStreamPrograms: FlinkChainedPrograms[StreamOptimizeContext]
 
   /**
     * Returns whether this configuration replaces the built-in SQL operator table.

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/optimize/BatchOptimizeContext.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/optimize/BatchOptimizeContext.scala
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.optimize
+
+/**
+  * A OptimizeContext allows to obtain batch table environment information when optimizing.
+  */
+trait BatchOptimizeContext extends OptimizeContext {
+
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/optimize/FlinkBatchPrograms.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/optimize/FlinkBatchPrograms.scala
@@ -39,7 +39,8 @@ object FlinkBatchPrograms {
     // convert sub-queries before query decorrelation
     programs.addLast(
       SUBQUERY,
-      FlinkHepProgramBuilder.newBuilder
+      FlinkHepRuleSetProgramBuilder.newBuilder
+        .setHepRulesExecutionType(HEP_RULES_EXECUTION_TYPE.RULE_SEQUENCE)
         .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
         .add(FlinkRuleSets.TABLE_SUBQUERY_RULES)
         .build())
@@ -47,7 +48,8 @@ object FlinkBatchPrograms {
     // convert table references
     programs.addLast(
       TABLE_REF,
-      FlinkHepProgramBuilder.newBuilder
+      FlinkHepRuleSetProgramBuilder.newBuilder
+        .setHepRulesExecutionType(HEP_RULES_EXECUTION_TYPE.RULE_SEQUENCE)
         .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
         .add(FlinkRuleSets.TABLE_REF_RULES)
         .build())
@@ -58,7 +60,8 @@ object FlinkBatchPrograms {
     // normalize the logical plan
     programs.addLast(
       NORMALIZATION,
-      FlinkHepProgramBuilder.newBuilder
+      FlinkHepRuleSetProgramBuilder.newBuilder
+        .setHepRulesExecutionType(HEP_RULES_EXECUTION_TYPE.RULE_SEQUENCE)
         .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
         .add(FlinkRuleSets.DATASET_NORM_RULES)
         .build())

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/optimize/FlinkBatchPrograms.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/optimize/FlinkBatchPrograms.scala
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.optimize
+
+import org.apache.calcite.plan.hep.HepMatchOrder
+import org.apache.flink.table.plan.nodes.FlinkConventions
+import org.apache.flink.table.plan.rules.FlinkRuleSets
+
+/**
+  * Defines a sequence of programs to optimize batch table plan.
+  */
+object FlinkBatchPrograms {
+  val SUBQUERY = "subquery"
+  val TABLE_REF = "table_ref"
+  val DECORRELATE = "decorrelate"
+  val NORMALIZATION = "normalization"
+  val LOGICAL = "logical"
+  val PHYSICAL = "physical"
+
+  def buildPrograms(): FlinkChainedPrograms[BatchOptimizeContext] = {
+    val programs = new FlinkChainedPrograms[BatchOptimizeContext]()
+
+    // convert sub-queries before query decorrelation
+    programs.addLast(
+      SUBQUERY,
+      FlinkHepProgramBuilder.newBuilder
+        .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
+        .add(FlinkRuleSets.TABLE_SUBQUERY_RULES)
+        .build())
+
+    // convert table references
+    programs.addLast(
+      TABLE_REF,
+      FlinkHepProgramBuilder.newBuilder
+        .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
+        .add(FlinkRuleSets.TABLE_REF_RULES)
+        .build())
+
+    // decorrelate
+    programs.addLast(DECORRELATE, new FlinkDecorrelateProgram)
+
+    // normalize the logical plan
+    programs.addLast(
+      NORMALIZATION,
+      FlinkHepProgramBuilder.newBuilder
+        .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
+        .add(FlinkRuleSets.DATASET_NORM_RULES)
+        .build())
+
+    // optimize the logical Flink plan
+    programs.addLast(
+      LOGICAL,
+      FlinkVolcanoProgramBuilder.newBuilder
+        .add(FlinkRuleSets.LOGICAL_OPT_RULES)
+        .setTargetTraits(Array(FlinkConventions.LOGICAL))
+        .build())
+
+    // optimize the physical Flink plan
+    programs.addLast(
+      PHYSICAL,
+      FlinkVolcanoProgramBuilder.newBuilder
+        .add(FlinkRuleSets.DATASET_OPT_RULES)
+        .setTargetTraits(Array(FlinkConventions.DATASET))
+        .build())
+
+    programs
+  }
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/optimize/FlinkChainedPrograms.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/optimize/FlinkChainedPrograms.scala
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.optimize
+
+import java.util
+
+import org.apache.calcite.rel.RelNode
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+
+/**
+  * FlinkChainedPrograms contains a sequence of [[FlinkOptimizeProgram]]s which are chained
+  * together.
+  *
+  * The chained-order of programs can be adjusted by addXXX and [[remove]] methods.
+  *
+  * When [[optimize]] method called, each program's optimize method will be called in sequence.
+  *
+  * @tparam OC OptimizeContext
+  */
+class FlinkChainedPrograms[OC <: OptimizeContext] {
+  private val programMap = new mutable.HashMap[String, FlinkOptimizeProgram[OC]]()
+  private val programNames = new mutable.ListBuffer[String]()
+
+  /**
+    * Calling each program's optimize method in sequence.
+    */
+  def optimize(root: RelNode, context: OC): RelNode = {
+    programNames.foldLeft(root) {
+      (input, name) =>
+        get(name)
+          .getOrElse(throw new RuntimeException(s"program of $name does not exist"))
+          .optimize(input, context)
+    }
+  }
+
+  /**
+    * Gets program associated with the given name. If not found, return [[None]].
+    */
+  def get(name: String): Option[FlinkOptimizeProgram[OC]] = {
+    val program = programMap.get(name)
+    if (program.isDefined) {
+      // using Option instead of Some to convert null to None
+      Option(programMap.get(name).get)
+    } else {
+      None
+    }
+  }
+
+  /**
+    * Gets FlinkRuleSetProgram associated with the given name. If the program is not found or is
+    * not a [[FlinkRuleSetProgram]], return [[None]].
+    */
+  def getFlinkRuleSetProgram(name: String): Option[FlinkRuleSetProgram[OC]] = {
+    get(name).getOrElse(None) match {
+      case p: FlinkRuleSetProgram[OC] => Some(p)
+      case _ => None
+    }
+  }
+
+  /**
+    * Appends the specified program to the end of program collection.
+    *
+    * @return false if program collection contains the specified program; otherwise true.
+    */
+  def addLast(name: String, program: FlinkOptimizeProgram[OC]): Boolean = {
+    if (programNames.contains(name)) {
+      false
+    } else {
+      programNames += name
+      programMap.put(name, program)
+      true
+    }
+  }
+
+  /**
+    * Inserts the specified program to the beginning of program collection.
+    *
+    * @return false if program collection contains the specified program; otherwise true.
+    */
+  def addFirst(name: String, program: FlinkOptimizeProgram[OC]): Boolean = {
+    if (programNames.contains(name)) {
+      false
+    } else {
+      programNames.insert(0, name)
+      programMap.put(name, program)
+      true
+    }
+  }
+
+  /**
+    * Inserts the specified program before `nameOfBefore`.
+    *
+    * @return false if program collection contains the specified program or
+    *         does not contain `nameOfBefore`; otherwise true.
+    */
+  def addBefore(nameOfBefore: String, name: String, program: FlinkOptimizeProgram[OC]): Boolean = {
+    if (programNames.contains(name) || !programNames.contains(nameOfBefore)) {
+      false
+    } else if (programNames.isEmpty) {
+      addLast(name, program)
+    } else {
+      val index = programNames.indexOf(nameOfBefore)
+      programNames.insert(index, name)
+      programMap.put(name, program)
+      true
+    }
+  }
+
+  /**
+    * Removes program associated with the given name from program collection.
+    *
+    * @return The removed program associated with the given name. If not found, return [[None]].
+    */
+  def remove(name: String): Option[FlinkOptimizeProgram[OC]] = {
+    val index = programNames.indexOf(name)
+    if (index >= 0) {
+      programNames.remove(index)
+    }
+    programMap.remove(name)
+  }
+
+  /**
+    * Returns program names with chained order.
+    */
+  def getProgramNames: util.List[String] = new util.ArrayList[String](programNames.asJava)
+
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/optimize/FlinkDecorateProgram.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/optimize/FlinkDecorateProgram.scala
@@ -23,11 +23,12 @@ import org.apache.calcite.plan.hep.HepMatchOrder
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.tools.RuleSet
 import org.apache.flink.table.plan.nodes.datastream.UpdateAsRetractionTrait
+import org.apache.flink.table.plan.optimize.HEP_RULES_EXECUTION_TYPE.HEP_RULES_EXECUTION_TYPE
 
 /**
   * A FlinkHepProgram that deals with retraction.
   */
-class FlinkDecorateProgram extends FlinkHepProgram[StreamOptimizeContext] {
+class FlinkDecorateProgram extends FlinkHepRuleSetProgram[StreamOptimizeContext] {
 
   override def optimize(input: RelNode, context: StreamOptimizeContext): RelNode = {
     val output = if (context.updateAsRetraction()) {
@@ -43,6 +44,13 @@ class FlinkDecorateProgram extends FlinkHepProgram[StreamOptimizeContext] {
 
 class FlinkDecorateProgramBuilder {
   private val decorateProgram = new FlinkDecorateProgram
+
+  def setHepRulesExecutionType(
+    executionType: HEP_RULES_EXECUTION_TYPE)
+  : FlinkDecorateProgramBuilder = {
+    decorateProgram.setHepRulesExecutionType(executionType)
+    this
+  }
 
   def setHepMatchOrder(matchOrder: HepMatchOrder): FlinkDecorateProgramBuilder = {
     decorateProgram.setHepMatchOrder(matchOrder)
@@ -64,9 +72,7 @@ class FlinkDecorateProgramBuilder {
     this
   }
 
-  def build(): FlinkDecorateProgram = {
-    decorateProgram
-  }
+  def build(): FlinkDecorateProgram = decorateProgram
 
 }
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/optimize/FlinkDecorateProgram.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/optimize/FlinkDecorateProgram.scala
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.optimize
+
+import org.apache.calcite.plan.RelTrait
+import org.apache.calcite.plan.hep.HepMatchOrder
+import org.apache.calcite.rel.RelNode
+import org.apache.calcite.tools.RuleSet
+import org.apache.flink.table.plan.nodes.datastream.UpdateAsRetractionTrait
+
+/**
+  * A FlinkHepProgram that deals with retraction.
+  */
+class FlinkDecorateProgram extends FlinkHepProgram[StreamOptimizeContext] {
+
+  override def optimize(input: RelNode, context: StreamOptimizeContext): RelNode = {
+    val output = if (context.updateAsRetraction()) {
+      input.copy(
+        input.getTraitSet.plus(new UpdateAsRetractionTrait(true)),
+        input.getInputs)
+    } else {
+      input
+    }
+    super.optimize(output, context)
+  }
+}
+
+class FlinkDecorateProgramBuilder {
+  private val decorateProgram = new FlinkDecorateProgram
+
+  def setHepMatchOrder(matchOrder: HepMatchOrder): FlinkDecorateProgramBuilder = {
+    decorateProgram.setHepMatchOrder(matchOrder)
+    this
+  }
+
+  def setMatchLimit(matchLimit: Int): FlinkDecorateProgramBuilder = {
+    decorateProgram.setMatchLimit(matchLimit)
+    this
+  }
+
+  def add(ruleSet: RuleSet): FlinkDecorateProgramBuilder = {
+    decorateProgram.add(ruleSet)
+    this
+  }
+
+  def setTargetTraits(relTraits: Array[RelTrait]): FlinkDecorateProgramBuilder = {
+    decorateProgram.setTargetTraits(relTraits)
+    this
+  }
+
+  def build(): FlinkDecorateProgram = {
+    decorateProgram
+  }
+
+}
+
+object FlinkDecorateProgramBuilder {
+  def newBuilder = new FlinkDecorateProgramBuilder
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/optimize/FlinkDecorrelateProgram.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/optimize/FlinkDecorrelateProgram.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.optimize
+
+import org.apache.calcite.rel.RelNode
+import org.apache.calcite.sql2rel.RelDecorrelator
+
+/**
+  * A FlinkOptimizeProgram that decorrelates a query.
+  *
+  * @tparam OC OptimizeContext
+  */
+class FlinkDecorrelateProgram[OC <: OptimizeContext] extends FlinkOptimizeProgram[OC] {
+
+  def optimize(input: RelNode, context: OC): RelNode = {
+    RelDecorrelator.decorrelateQuery(input)
+  }
+
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/optimize/FlinkHepProgram.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/optimize/FlinkHepProgram.scala
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.optimize
+
+import org.apache.calcite.plan.RelTrait
+import org.apache.calcite.plan.hep.{HepMatchOrder, HepPlanner, HepProgramBuilder}
+import org.apache.calcite.rel.RelNode
+import org.apache.calcite.tools.RuleSet
+import org.apache.flink.util.Preconditions
+
+/**
+  * A FlinkRuleSetProgram that runs with [[HepPlanner]].
+  *
+  * @tparam OC OptimizeContext
+  */
+class FlinkHepProgram[OC <: OptimizeContext] extends FlinkRuleSetProgram[OC] {
+
+  private var matchOrder: Option[HepMatchOrder] = None
+  private var matchLimit: Option[Int] = None
+
+  override def optimize(input: RelNode, context: OC): RelNode = {
+    if (rules.isEmpty) {
+      return input
+    }
+
+    val builder = new HepProgramBuilder
+    if (matchOrder.isDefined) {
+      builder.addMatchOrder(matchOrder.get)
+    }
+
+    if (matchLimit.isDefined) {
+      Preconditions.checkArgument(matchLimit.get > 0)
+      builder.addMatchLimit(matchLimit.get)
+    }
+
+    rules.foreach(builder.addRuleInstance)
+
+    val planner = new HepPlanner(builder.build, context.getContext)
+    planner.setRoot(input)
+
+    if (targetTraits.nonEmpty) {
+      val targetTraitSet = input.getTraitSet.plusAll(targetTraits)
+      if (!input.getTraitSet.equals(targetTraitSet)) {
+        planner.changeTraits(input, targetTraitSet.simplify)
+      }
+    }
+
+    planner.findBestExp
+  }
+
+  def setHepMatchOrder(matchOrder: HepMatchOrder): Unit = {
+    this.matchOrder = Option(matchOrder)
+  }
+
+  def setMatchLimit(matchLimit: Int): Unit = {
+    this.matchLimit = Option(matchLimit)
+  }
+}
+
+class FlinkHepProgramBuilder[OC <: OptimizeContext] {
+  private val hepProgram = new FlinkHepProgram[OC]
+
+  def setHepMatchOrder(matchOrder: HepMatchOrder): FlinkHepProgramBuilder[OC] = {
+    hepProgram.setHepMatchOrder(matchOrder)
+    this
+  }
+
+  def setMatchLimit(matchLimit: Int): FlinkHepProgramBuilder[OC] = {
+    hepProgram.setMatchLimit(matchLimit)
+    this
+  }
+
+  def add(ruleSet: RuleSet): FlinkHepProgramBuilder[OC] = {
+    hepProgram.add(ruleSet)
+    this
+  }
+
+  def setTargetTraits(relTraits: Array[RelTrait]): FlinkHepProgramBuilder[OC] = {
+    hepProgram.setTargetTraits(relTraits)
+    this
+  }
+
+  def build(): FlinkHepProgram[OC] = {
+    hepProgram
+  }
+}
+
+object FlinkHepProgramBuilder {
+  def newBuilder[OC <: OptimizeContext] = new FlinkHepProgramBuilder[OC]
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/optimize/FlinkHepRuleSetProgram.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/optimize/FlinkHepRuleSetProgram.scala
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.optimize
+
+import org.apache.calcite.plan.RelTrait
+import org.apache.calcite.plan.hep.{HepMatchOrder, HepPlanner, HepProgramBuilder}
+import org.apache.calcite.rel.RelNode
+import org.apache.calcite.tools.RuleSet
+import org.apache.flink.table.plan.optimize.HEP_RULES_EXECUTION_TYPE.HEP_RULES_EXECUTION_TYPE
+import org.apache.flink.util.Preconditions
+
+import scala.collection.JavaConverters._
+
+/**
+  * A FlinkRuleSetProgram that runs with [[HepPlanner]].
+  *
+  * <p>In most case this program could meet our requirements, otherwise we could choose
+  * [[FlinkHepProgram]] for some advanced features.
+  *
+  * <p>Currently, default hep execution type is [[HEP_RULES_EXECUTION_TYPE.RULE_SEQUENCE]].
+  * (Please refer to [[HEP_RULES_EXECUTION_TYPE]] for more info about execution types)
+  *
+  * @tparam OC OptimizeContext
+  */
+class FlinkHepRuleSetProgram[OC <: OptimizeContext] extends FlinkRuleSetProgram[OC] {
+
+  private var matchOrder: Option[HepMatchOrder] = None
+  private var matchLimit: Option[Int] = None
+  // default execution type is RULE_SEQUENCE
+  private var executionType: HEP_RULES_EXECUTION_TYPE = HEP_RULES_EXECUTION_TYPE.RULE_SEQUENCE
+
+  override def optimize(input: RelNode, context: OC): RelNode = {
+    if (rules.isEmpty) {
+      return input
+    }
+
+    // build HepProgram
+    val builder = new HepProgramBuilder
+    matchOrder.foreach(builder.addMatchOrder)
+    matchLimit.foreach(builder.addMatchLimit)
+    executionType match {
+      case HEP_RULES_EXECUTION_TYPE.RULE_SEQUENCE =>
+        rules.foreach(builder.addRuleInstance)
+      case HEP_RULES_EXECUTION_TYPE.RULE_COLLECTION =>
+        builder.addRuleCollection(rules.asJava)
+      case _ =>
+        throw new RuntimeException(s"Unsupported HEP_RULES_EXECUTION_TYPE: $executionType")
+    }
+
+    // optimize with HepProgram
+    val flinkHepProgram = FlinkHepProgram[OC](builder.build(), targetTraits)
+    flinkHepProgram.optimize(input, context)
+  }
+
+  def setHepMatchOrder(matchOrder: HepMatchOrder): Unit = {
+    Preconditions.checkNotNull(matchOrder)
+    this.matchOrder = Some(matchOrder)
+  }
+
+  def setMatchLimit(matchLimit: Int): Unit = {
+    Preconditions.checkArgument(matchLimit > 0)
+    this.matchLimit = Some(matchLimit)
+  }
+
+  def setHepRulesExecutionType(executionType: HEP_RULES_EXECUTION_TYPE): Unit = {
+    Preconditions.checkNotNull(executionType)
+    this.executionType = executionType
+  }
+}
+
+/**
+  * An enumeration of hep rule execution type, usable to tell the [[HepPlanner]] how exactly
+  * execute the rules.
+  */
+object HEP_RULES_EXECUTION_TYPE extends Enumeration {
+  type HEP_RULES_EXECUTION_TYPE = Value
+
+  /**
+    * Rules in RULE_SEQUENCE type are executed with RuleInstance.
+    * RuleInstance is an instruction that matches a specific rule, each rule in the rule
+    * collection is associated with one RuleInstance. Each RuleInstance will be executed
+    * only once according to the order defined by the rule collection, but a rule may be applied
+    * more than once. If arbitrary order is needed, use RULE_COLLECTION instead.
+    *
+    * Please refer to [[HepProgramBuilder#addRuleInstance]] for more info about RuleInstance.
+    */
+  val RULE_SEQUENCE = Value
+
+  /**
+    * Rules in RULE_COLLECTION type are executed with RuleCollection.
+    * RuleCollection is an instruction that matches any rules in a given collection.
+    * The order in which the rules within a collection will be attempted is arbitrary,
+    * so if more control is needed, use RULE_SEQUENCE instead.
+    *
+    * Please refer to [[HepProgramBuilder#addRuleCollection]] for more info about RuleCollection.
+    */
+  val RULE_COLLECTION = Value
+}
+
+class FlinkHepRuleSetProgramBuilder[OC <: OptimizeContext] {
+  private val flinkHepProgram = new FlinkHepRuleSetProgram[OC]
+
+  def setHepRulesExecutionType(
+    executionType: HEP_RULES_EXECUTION_TYPE)
+  : FlinkHepRuleSetProgramBuilder[OC] = {
+    flinkHepProgram.setHepRulesExecutionType(executionType)
+    this
+  }
+
+  def setHepMatchOrder(matchOrder: HepMatchOrder): FlinkHepRuleSetProgramBuilder[OC] = {
+    flinkHepProgram.setHepMatchOrder(matchOrder)
+    this
+  }
+
+  def setMatchLimit(matchLimit: Int): FlinkHepRuleSetProgramBuilder[OC] = {
+    flinkHepProgram.setMatchLimit(matchLimit)
+    this
+  }
+
+  def add(ruleSet: RuleSet): FlinkHepRuleSetProgramBuilder[OC] = {
+    flinkHepProgram.add(ruleSet)
+    this
+  }
+
+  def setTargetTraits(relTraits: Array[RelTrait]): FlinkHepRuleSetProgramBuilder[OC] = {
+    flinkHepProgram.setTargetTraits(relTraits)
+    this
+  }
+
+  def build(): FlinkHepRuleSetProgram[OC] = flinkHepProgram
+
+}
+
+object FlinkHepRuleSetProgramBuilder {
+  def newBuilder[OC <: OptimizeContext] = new FlinkHepRuleSetProgramBuilder[OC]
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/optimize/FlinkOptimizeProgram.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/optimize/FlinkOptimizeProgram.scala
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.optimize
+
+import org.apache.calcite.rel.RelNode
+
+/**
+  * Likes [[org.apache.calcite.tools.Program]], FlinkOptimizeProgram transforms a relational
+  * expression into another relational expression.
+  *
+  * @tparam OC OptimizeContext
+  */
+trait FlinkOptimizeProgram[OC <: OptimizeContext] {
+
+  /**
+    * Transforms a relational expression into another relational expression.
+    */
+  def optimize(input: RelNode, context: OC): RelNode
+
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/optimize/FlinkRelTimeIndicatorProgram.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/optimize/FlinkRelTimeIndicatorProgram.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.optimize
+
+import org.apache.calcite.rel.RelNode
+import org.apache.flink.table.calcite.RelTimeIndicatorConverter
+import org.apache.flink.util.Preconditions
+
+/**
+  * A FlinkOptimizeProgram that deals with time.
+  */
+class FlinkRelTimeIndicatorProgram extends FlinkOptimizeProgram[StreamOptimizeContext] {
+
+  override def optimize(input: RelNode, context: StreamOptimizeContext): RelNode = {
+    val rexBuilder = Preconditions.checkNotNull(context.getRexBuilder)
+    RelTimeIndicatorConverter.convert(input, rexBuilder)
+  }
+
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/optimize/FlinkRuleSetProgram.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/optimize/FlinkRuleSetProgram.scala
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.optimize
+
+import org.apache.calcite.plan.{RelOptRule, RelTrait}
+import org.apache.calcite.tools.RuleSet
+import org.apache.flink.util.Preconditions
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+
+/**
+  * A FlinkOptimizeProgram that transforms a relational expression into
+  * another relational expression with [[RuleSet]].
+  */
+abstract class FlinkRuleSetProgram[OC <: OptimizeContext] extends FlinkOptimizeProgram[OC] {
+
+  protected val rules = new mutable.ArrayBuffer[RelOptRule]()
+  protected var targetTraits = Array.empty[RelTrait]
+
+  /**
+    * Adds specified rules to this program.
+    */
+  def add(ruleSet: RuleSet): Unit = {
+    Preconditions.checkNotNull(ruleSet)
+    ruleSet.asScala.foreach { r =>
+      if (!contains(r)) {
+        rules += r
+      }
+    }
+  }
+
+  /**
+    * Removes specified rules from this program.
+    */
+  def remove(ruleSet: RuleSet): Unit = {
+    Preconditions.checkNotNull(ruleSet)
+    ruleSet.asScala.foreach { r =>
+      val index = rules.indexOf(r)
+      if (index >= 0) {
+        rules.remove(index)
+      }
+    }
+  }
+
+  /**
+    * Removes all rules from this program first, and then adds specified rules to this program.
+    */
+  def replaceAll(ruleSet: RuleSet): Unit = {
+    Preconditions.checkNotNull(ruleSet)
+    rules.clear()
+    ruleSet.asScala.foreach { r =>
+      rules += r
+    }
+  }
+
+  /**
+    * Checks whether this program contains the specified rule.
+    */
+  def contains(rule: RelOptRule): Boolean = {
+    Preconditions.checkNotNull(rule)
+    rules.contains(rule)
+  }
+
+  /**
+    * Sets target traits that the optimized relational expression should contain them.
+    */
+  def setTargetTraits(relTraits: Array[RelTrait]): Unit = {
+    if (relTraits != null) {
+      targetTraits = relTraits
+    } else {
+      targetTraits = Array.empty[RelTrait]
+    }
+  }
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/optimize/FlinkStreamPrograms.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/optimize/FlinkStreamPrograms.scala
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.optimize
+
+import org.apache.calcite.plan.hep.HepMatchOrder
+import org.apache.flink.table.plan.nodes.FlinkConventions
+import org.apache.flink.table.plan.rules.FlinkRuleSets
+
+/**
+  * Defines a sequence of programs to optimize for stream table plan.
+  */
+object FlinkStreamPrograms {
+  val SUBQUERY = "subquery"
+  val TABLE_REF = "table_ref"
+  val DECORRELATE = "decorrelate"
+  val TIME_INDICATOR = "time_indicator"
+  val NORMALIZATION = "normalization"
+  val LOGICAL = "logical"
+  val PHYSICAL = "physical"
+  val DECORATE = "decorate"
+
+  def buildPrograms(): FlinkChainedPrograms[StreamOptimizeContext] = {
+    val programs = new FlinkChainedPrograms[StreamOptimizeContext]()
+
+    // convert sub-queries before query decorrelation
+    programs.addLast(
+      SUBQUERY,
+      FlinkHepProgramBuilder.newBuilder
+        .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
+        .add(FlinkRuleSets.TABLE_SUBQUERY_RULES)
+        .build())
+
+    // convert table references
+    programs.addLast(
+      TABLE_REF,
+      FlinkHepProgramBuilder.newBuilder
+        .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
+        .add(FlinkRuleSets.TABLE_REF_RULES)
+        .build())
+
+    // decorrelate
+    programs.addLast(DECORRELATE, new FlinkDecorrelateProgram)
+
+    // convert time indicators
+    programs.addLast(TIME_INDICATOR, new FlinkRelTimeIndicatorProgram)
+
+    //  normalize the logical plan
+    programs.addLast(
+      NORMALIZATION,
+      FlinkHepProgramBuilder.newBuilder
+        .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
+        .add(FlinkRuleSets.DATASTREAM_NORM_RULES)
+        .build())
+
+    // optimize the logical Flink plan
+    programs.addLast(
+      LOGICAL,
+      FlinkVolcanoProgramBuilder.newBuilder
+        .add(FlinkRuleSets.LOGICAL_OPT_RULES)
+        .setTargetTraits(Array(FlinkConventions.LOGICAL))
+        .build())
+
+    // optimize the physical Flink plan
+    programs.addLast(
+      PHYSICAL,
+      FlinkVolcanoProgramBuilder.newBuilder
+        .add(FlinkRuleSets.DATASTREAM_OPT_RULES)
+        .setTargetTraits(Array(FlinkConventions.DATASTREAM))
+        .build())
+
+    // decorate the optimized plan
+    programs.addLast(
+      DECORATE,
+      FlinkDecorateProgramBuilder.newBuilder
+        .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
+        .add(FlinkRuleSets.DATASTREAM_DECO_RULES)
+        .build())
+
+    programs
+  }
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/optimize/FlinkStreamPrograms.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/optimize/FlinkStreamPrograms.scala
@@ -41,7 +41,8 @@ object FlinkStreamPrograms {
     // convert sub-queries before query decorrelation
     programs.addLast(
       SUBQUERY,
-      FlinkHepProgramBuilder.newBuilder
+      FlinkHepRuleSetProgramBuilder.newBuilder
+        .setHepRulesExecutionType(HEP_RULES_EXECUTION_TYPE.RULE_SEQUENCE)
         .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
         .add(FlinkRuleSets.TABLE_SUBQUERY_RULES)
         .build())
@@ -49,7 +50,8 @@ object FlinkStreamPrograms {
     // convert table references
     programs.addLast(
       TABLE_REF,
-      FlinkHepProgramBuilder.newBuilder
+      FlinkHepRuleSetProgramBuilder.newBuilder
+        .setHepRulesExecutionType(HEP_RULES_EXECUTION_TYPE.RULE_SEQUENCE)
         .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
         .add(FlinkRuleSets.TABLE_REF_RULES)
         .build())
@@ -63,7 +65,8 @@ object FlinkStreamPrograms {
     //  normalize the logical plan
     programs.addLast(
       NORMALIZATION,
-      FlinkHepProgramBuilder.newBuilder
+      FlinkHepRuleSetProgramBuilder.newBuilder
+        .setHepRulesExecutionType(HEP_RULES_EXECUTION_TYPE.RULE_SEQUENCE)
         .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
         .add(FlinkRuleSets.DATASTREAM_NORM_RULES)
         .build())
@@ -88,6 +91,7 @@ object FlinkStreamPrograms {
     programs.addLast(
       DECORATE,
       FlinkDecorateProgramBuilder.newBuilder
+        .setHepRulesExecutionType(HEP_RULES_EXECUTION_TYPE.RULE_SEQUENCE)
         .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
         .add(FlinkRuleSets.DATASTREAM_DECO_RULES)
         .build())

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/optimize/FlinkVolcanoProgram.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/optimize/FlinkVolcanoProgram.scala
@@ -84,9 +84,8 @@ class FlinkVolcanoProgramBuilder[OC <: OptimizeContext] {
     this
   }
 
-  def build(): FlinkVolcanoProgram[OC] = {
-    volcanoProgram
-  }
+  def build(): FlinkVolcanoProgram[OC] = volcanoProgram
+
 }
 
 object FlinkVolcanoProgramBuilder {

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/optimize/FlinkVolcanoProgram.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/optimize/FlinkVolcanoProgram.scala
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.optimize
+
+import com.google.common.collect.ImmutableList
+import org.apache.calcite.plan.RelOptPlanner.CannotPlanException
+import org.apache.calcite.plan._
+import org.apache.calcite.rel.RelNode
+import org.apache.calcite.tools.{Programs, RuleSet}
+import org.apache.flink.table.api.TableException
+import org.apache.flink.util.Preconditions
+
+/**
+  * A FlinkRuleSetProgram that runs with [[org.apache.calcite.plan.volcano.VolcanoPlanner]].
+  *
+  * @tparam OC OptimizeContext
+  */
+class FlinkVolcanoProgram[OC <: OptimizeContext] extends FlinkRuleSetProgram[OC] {
+
+  override def optimize(input: RelNode, context: OC): RelNode = {
+    if (rules.isEmpty) {
+      return input
+    }
+
+    val planner = Preconditions.checkNotNull(context.getRelOptPlanner)
+
+    val optProgram = Programs.ofRules(rules: _*)
+
+    val targetTraitSet = if (targetTraits.isEmpty) {
+      input.getTraitSet
+    } else {
+      input.getTraitSet.plusAll(targetTraits).simplify()
+    }
+
+    val output = try {
+      optProgram.run(planner, input, targetTraitSet, ImmutableList.of(), ImmutableList.of())
+    } catch {
+      case e: CannotPlanException =>
+        throw new TableException(
+          s"Cannot generate a valid execution plan for the given query: \n\n" +
+            s"${RelOptUtil.toString(input)}\n" +
+            s"This exception indicates that the query uses an unsupported SQL feature.\n" +
+            s"Please check the documentation for the set of currently supported SQL features.")
+      case t: TableException =>
+        throw new TableException(
+          s"Cannot generate a valid execution plan for the given query: \n\n" +
+            s"${RelOptUtil.toString(input)}\n" +
+            s"${t.msg}\n" +
+            s"Please check the documentation for the set of currently supported SQL features.")
+      case a: AssertionError =>
+        throw a
+    }
+    output
+  }
+
+}
+
+class FlinkVolcanoProgramBuilder[OC <: OptimizeContext] {
+  private val volcanoProgram = new FlinkVolcanoProgram[OC]
+
+  def add(ruleSet: RuleSet): FlinkVolcanoProgramBuilder[OC] = {
+    volcanoProgram.add(ruleSet)
+    this
+  }
+
+  def setTargetTraits(relTraits: Array[RelTrait]): FlinkVolcanoProgramBuilder[OC] = {
+    volcanoProgram.setTargetTraits(relTraits)
+    this
+  }
+
+  def build(): FlinkVolcanoProgram[OC] = {
+    volcanoProgram
+  }
+}
+
+object FlinkVolcanoProgramBuilder {
+  def newBuilder[OC <: OptimizeContext] = new FlinkVolcanoProgramBuilder[OC]
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/optimize/OptimizeContext.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/optimize/OptimizeContext.scala
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.optimize
+
+import org.apache.calcite.plan.{Context, RelOptPlanner}
+
+/**
+  * A OptimizeContext allows to obtain table environment information when optimizing.
+  */
+trait OptimizeContext {
+
+  /**
+    * Gets the Calcite [[Context]] defined in [[org.apache.flink.table.api.TableEnvironment]].
+    */
+  def getContext: Context
+
+  /**
+    * Gets the Calcite [[RelOptPlanner]] defined in [[org.apache.flink.table.api.TableEnvironment]].
+    */
+  def getRelOptPlanner: RelOptPlanner
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/optimize/StreamOptimizeContext.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/optimize/StreamOptimizeContext.scala
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.optimize
+
+import org.apache.calcite.rex.RexBuilder
+
+/**
+  * A OptimizeContext allows to obtain stream table environment information when optimizing.
+  */
+trait StreamOptimizeContext extends OptimizeContext {
+
+  /**
+    * Gets the Calcite [[RexBuilder]] defined in [[org.apache.flink.table.api.TableEnvironment]].
+    */
+  def getRexBuilder: RexBuilder
+
+  /**
+    * Returns true if the sink requests updates as retraction messages
+    * defined in [[org.apache.flink.table.api.StreamTableEnvironment.optimize]].
+    */
+  def updateAsRetraction(): Boolean
+}

--- a/flink-libraries/flink-table/src/test/java/org/apache/flink/table/runtime/batch/table/JavaTableEnvironmentITCase.java
+++ b/flink-libraries/flink-table/src/test/java/org/apache/flink/table/runtime/batch/table/JavaTableEnvironmentITCase.java
@@ -31,14 +31,13 @@ import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.java.BatchTableEnvironment;
-import org.apache.flink.table.calcite.CalciteConfig;
 import org.apache.flink.table.calcite.CalciteConfigBuilder;
+import org.apache.flink.table.plan.optimize.FlinkBatchPrograms;
 import org.apache.flink.table.runtime.utils.TableProgramsCollectionTestBase;
 import org.apache.flink.table.runtime.utils.TableProgramsTestBase;
 import org.apache.flink.test.operators.util.CollectionDataSets;
 import org.apache.flink.types.Row;
 
-import org.apache.calcite.tools.RuleSets;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -474,11 +473,10 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env, config());
 
-		CalciteConfig cc = new CalciteConfigBuilder()
-				.replaceLogicalOptRuleSet(RuleSets.ofList())
-				.replacePhysicalOptRuleSet(RuleSets.ofList())
-				.build();
-		tableEnv.getConfig().setCalciteConfig(cc);
+		CalciteConfigBuilder builder = new CalciteConfigBuilder();
+		builder.getBatchPrograms().remove(FlinkBatchPrograms.LOGICAL());
+		builder.getBatchPrograms().remove(FlinkBatchPrograms.PHYSICAL());
+		tableEnv.getConfig().setCalciteConfig(builder.build());
 
 		DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.get3TupleDataSet(env);
 		Table t = tableEnv.fromDataSet(ds);

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/calcite/CalciteConfigBuilderTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/calcite/CalciteConfigBuilderTest.scala
@@ -38,7 +38,7 @@ class CalciteConfigBuilderTest {
     val builder = new CalciteConfigBuilder()
     val batchPrograms = new FlinkChainedPrograms[BatchOptimizeContext]
     batchPrograms.addLast(FlinkBatchPrograms.NORMALIZATION,
-      new FlinkHepProgramBuilder().add(FlinkRuleSets.DATASET_NORM_RULES).build())
+      new FlinkHepRuleSetProgramBuilder().add(FlinkRuleSets.DATASET_NORM_RULES).build())
     builder.replaceBatchPrograms(batchPrograms)
 
     val streamPrograms = FlinkStreamPrograms.buildPrograms()

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/plan/optimize/FlinkChainedProgramsTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/plan/optimize/FlinkChainedProgramsTest.scala
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.optimize
+
+import org.apache.calcite.plan.hep.HepMatchOrder
+import org.apache.calcite.rel.core.TableScan
+import org.apache.calcite.rel.rules.ReduceExpressionsRule
+import org.apache.calcite.tools.RuleSets
+import org.junit.Assert._
+import org.junit.Test
+
+import scala.collection.JavaConverters._
+import org.mockito.Mockito._
+
+/**
+  * Tests for [[FlinkChainedPrograms]].
+  */
+class FlinkChainedProgramsTest {
+
+  @Test
+  def testAddGetRemovePrograms(): Unit = {
+    val programs = new FlinkChainedPrograms
+    assertTrue(programs.getProgramNames.isEmpty)
+    assertTrue(programs.get("o1").isEmpty)
+
+    val program1 = FlinkHepProgramBuilder.newBuilder
+      .add(RuleSets.ofList(ReduceExpressionsRule.FILTER_INSTANCE))
+      .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
+      .build()
+    var result = programs.addFirst("o2", program1)
+    assertTrue(result)
+    assertEquals(Seq("o2"), programs.getProgramNames.asScala)
+    assertTrue(programs.get("o2").isDefined)
+    assertTrue(program1 == programs.get("o2").get)
+
+    val program2 = FlinkHepProgramBuilder.newBuilder
+      .add(RuleSets.ofList(ReduceExpressionsRule.CALC_INSTANCE))
+      .build()
+    result = programs.addFirst("o1", program2)
+    assertTrue(result)
+    assertEquals(Seq("o1", "o2"), programs.getProgramNames.asScala)
+    assertTrue(programs.get("o1").isDefined)
+    assertTrue(program2 == programs.get("o1").get)
+
+    val program3 = FlinkHepProgramBuilder.newBuilder
+      .add(RuleSets.ofList(ReduceExpressionsRule.PROJECT_INSTANCE))
+      .setMatchLimit(100)
+      .build()
+    result = programs.addLast("o4", program3)
+    assertTrue(result)
+    assertEquals(Seq("o1", "o2", "o4"), programs.getProgramNames.asScala)
+    assertTrue(programs.get("o4").isDefined)
+    assertTrue(program3 == programs.get("o4").get)
+
+    val program4 = FlinkHepProgramBuilder.newBuilder
+      .add(RuleSets.ofList(ReduceExpressionsRule.JOIN_INSTANCE))
+      .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
+      .build()
+    result = programs.addBefore("o4", "o3", program4)
+    assertTrue(result)
+    assertEquals(Seq("o1", "o2", "o3", "o4"), programs.getProgramNames.asScala)
+    assertTrue(programs.get("o3").isDefined)
+    assertTrue(program4 == programs.get("o3").get)
+
+    var p = programs.remove("o2")
+    assertTrue(p.isDefined)
+    assertTrue(p.get == program1)
+    p = programs.remove("o0")
+    assertTrue(p.isEmpty)
+    assertEquals(Seq("o1", "o3", "o4"), programs.getProgramNames.asScala)
+
+    result = programs.addFirst("o3", program1)
+    assertFalse(result)
+    result = programs.addLast("o4", program1)
+    assertFalse(result)
+    result = programs.addBefore("o0", "o4", program1)
+    assertFalse(result)
+    assertEquals(Seq("o1", "o3", "o4"), programs.getProgramNames.asScala)
+  }
+
+  @Test
+  def testGetFlinkRuleSetProgram(): Unit = {
+    val programs = new FlinkChainedPrograms
+    assertTrue(programs.getProgramNames.isEmpty)
+
+    val program1 = FlinkHepProgramBuilder.newBuilder
+      .add(RuleSets.ofList(ReduceExpressionsRule.FILTER_INSTANCE))
+      .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
+      .build()
+    programs.addFirst("o1", program1)
+    assertTrue(programs.getFlinkRuleSetProgram("o1").isDefined)
+    assertTrue(program1 == programs.getFlinkRuleSetProgram("o1").get)
+
+    val program2 = new FlinkDecorrelateProgram
+    programs.addLast("o2", program2)
+    assertTrue(programs.get("o2").isDefined)
+    assertTrue(program2 == programs.get("o2").get)
+    assertTrue(programs.getFlinkRuleSetProgram("o2").isEmpty)
+
+    assertTrue(programs.getFlinkRuleSetProgram("o3").isEmpty)
+  }
+
+  @Test(expected = classOf[RuntimeException])
+  def testOptimizeWithNotExistProgram(): Unit = {
+    val programs = new FlinkChainedPrograms[BatchOptimizeContext]
+    programs.addLast("o1", null)
+    val scan = mock(classOf[TableScan])
+    val context = mock(classOf[BatchOptimizeContext])
+    programs.optimize(scan, context)
+  }
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/plan/optimize/FlinkHepRuleSetProgramTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/plan/optimize/FlinkHepRuleSetProgramTest.scala
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.optimize
+
+import org.apache.calcite.plan.hep.HepMatchOrder
+import org.apache.calcite.rel.rules._
+import org.apache.calcite.tools.RuleSets
+import org.junit.Test
+
+/**
+  * Tests for [[FlinkHepRuleSetProgram]].
+  */
+class FlinkHepRuleSetProgramTest {
+
+  @Test
+  def testOperations(): Unit = {
+    FlinkHepRuleSetProgramBuilder.newBuilder
+      .add(RuleSets.ofList(
+        ReduceExpressionsRule.FILTER_INSTANCE,
+        ReduceExpressionsRule.PROJECT_INSTANCE,
+        ReduceExpressionsRule.CALC_INSTANCE,
+        ReduceExpressionsRule.JOIN_INSTANCE
+      ))
+      .setHepRulesExecutionType(HEP_RULES_EXECUTION_TYPE.RULE_SEQUENCE)
+      .setMatchLimit(10)
+      .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
+      .build()
+  }
+
+  @Test(expected = classOf[IllegalArgumentException])
+  def testIllegalOperations_NullMatchLimit(): Unit = {
+    FlinkHepRuleSetProgramBuilder.newBuilder.setMatchLimit(null.asInstanceOf[Int])
+  }
+
+  @Test(expected = classOf[IllegalArgumentException])
+  def testIllegalOperations_MatchLimitLessThan1(): Unit = {
+    FlinkHepRuleSetProgramBuilder.newBuilder.setMatchLimit(0)
+  }
+
+  @Test(expected = classOf[NullPointerException])
+  def testIllegalOperations_NullHepMatchOrder(): Unit = {
+    FlinkHepRuleSetProgramBuilder.newBuilder.setHepMatchOrder(null)
+  }
+
+  @Test(expected = classOf[NullPointerException])
+  def testIllegalOperations_NullHepRulesExecutionType(): Unit = {
+    FlinkHepRuleSetProgramBuilder.newBuilder.setHepRulesExecutionType(null)
+  }
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/plan/optimize/FlinkRuleSetProgramTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/plan/optimize/FlinkRuleSetProgramTest.scala
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.optimize
+
+import org.apache.calcite.rel.rules._
+import org.apache.calcite.tools.RuleSets
+import org.junit.Assert._
+import org.junit.Test
+
+/**
+  * Tests for [[FlinkRuleSetProgram]].
+  */
+class FlinkRuleSetProgramTest {
+
+  @Test
+  def testRulesOperations(): Unit = {
+
+    val program = FlinkHepRuleSetProgramBuilder.newBuilder
+      .add(RuleSets.ofList(
+        ReduceExpressionsRule.FILTER_INSTANCE,
+        ReduceExpressionsRule.PROJECT_INSTANCE,
+        ReduceExpressionsRule.CALC_INSTANCE,
+        ReduceExpressionsRule.JOIN_INSTANCE
+      )).build()
+
+    assertTrue(program.contains(ReduceExpressionsRule.FILTER_INSTANCE))
+    assertTrue(program.contains(ReduceExpressionsRule.PROJECT_INSTANCE))
+    assertTrue(program.contains(ReduceExpressionsRule.CALC_INSTANCE))
+    assertTrue(program.contains(ReduceExpressionsRule.JOIN_INSTANCE))
+    assertFalse(program.contains(SubQueryRemoveRule.FILTER))
+
+    program.remove(RuleSets.ofList(
+      ReduceExpressionsRule.FILTER_INSTANCE,
+      ReduceExpressionsRule.PROJECT_INSTANCE))
+    assertFalse(program.contains(ReduceExpressionsRule.FILTER_INSTANCE))
+    assertFalse(program.contains(ReduceExpressionsRule.PROJECT_INSTANCE))
+    assertTrue(program.contains(ReduceExpressionsRule.CALC_INSTANCE))
+    assertTrue(program.contains(ReduceExpressionsRule.JOIN_INSTANCE))
+
+    program.replaceAll(RuleSets.ofList(SubQueryRemoveRule.FILTER))
+    assertFalse(program.contains(ReduceExpressionsRule.CALC_INSTANCE))
+    assertFalse(program.contains(ReduceExpressionsRule.JOIN_INSTANCE))
+    assertTrue(program.contains(SubQueryRemoveRule.FILTER))
+
+    program.add(RuleSets.ofList(
+      SubQueryRemoveRule.PROJECT,
+      SubQueryRemoveRule.JOIN))
+    assertTrue(program.contains(SubQueryRemoveRule.FILTER))
+    assertTrue(program.contains(SubQueryRemoveRule.PROJECT))
+    assertTrue(program.contains(SubQueryRemoveRule.JOIN))
+  }
+
+  @Test(expected = classOf[NullPointerException])
+  def testIllegalOperations_NullRuleSets(): Unit = {
+    FlinkHepRuleSetProgramBuilder.newBuilder.add(null)
+  }
+
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/utils/MockTableEnvironment.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/utils/MockTableEnvironment.scala
@@ -37,10 +37,6 @@ class MockTableEnvironment extends TableEnvironment(new TableConfig) {
 
   override def registerTableSource(name: String, tableSource: TableSource[_]): Unit = ???
 
-  override protected def getBuiltInNormRuleSet: RuleSet = ???
-
-  override protected def getBuiltInPhysicalOptRuleSet: RuleSet = ???
-
   override def registerTableSink(
       name: String,
       fieldNames: Array[String],


### PR DESCRIPTION
## What is the purpose of the change

*This pull request makes Flink supports user defined optimization phase. before this PR, the optimization phases are hardcode in BatchTableEnvironment and StreamTableEnvironment, It's hard to add a new optimization phase or adjust the phase-orders. This PR makes it more flexible for developer and user.*


## Brief change log

  - *Adds new interface FlinkOptimizeProgram which represents an optimization phase to transform a relational expression into another relational expression*
  - *Moves the optimization phases from BatchTableEnvironment/StreamTableEnvironment to FlinkBatchPrograms /FlinkStreamPrograms using new implementation*
  - *Removes the useless code(such as getLogicalOptRuleSet, replaceNormRules). Updates the corresponding implementations*
  - *Updates existed test cases, adds new test cases*



## Verifying this change

This change is already covered by existing tests, such as *IT cases could validates new implementation about  the optimization phases*.

This change added tests and can be verified as follows:
- *Added test that validates the correct of FlinkChainedPrograms implementation*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)

