### PR TITLE
[FLINK-5944] Support reading of Snappy files

### DIFF
--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -56,6 +56,7 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-shaded-hadoop2</artifactId>
 			<version>${project.version}</version>
+			<scope>provided</scope>
 		</dependency>
 
 		<!-- standard utilities -->

--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -52,6 +52,12 @@ under the License.
 			<artifactId>flink-shaded-asm</artifactId>
 		</dependency>
 
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-shaded-hadoop2</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
 		<!-- standard utilities -->
 		<dependency>
 			<groupId>org.apache.commons</groupId>

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/compression/SnappyHadoopInputStreamFactory.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/compression/SnappyHadoopInputStreamFactory.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.common.io.compression;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.compress.CompressionCodec;
+import org.apache.hadoop.io.compress.CompressionCodecFactory;
+import org.apache.hadoop.io.compress.CompressionInputStream;
+import org.apache.hadoop.io.compress.SnappyCodec;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * Factory for input streams that decompress the Hadoop Snappy compression format.
+ */
+public class SnappyHadoopInputStreamFactory implements InflaterInputStreamFactory<CompressionInputStream> {
+
+	private static SnappyHadoopInputStreamFactory INSTANCE = null;
+	private static CompressionCodec SNAPPY_CODEC = null;
+
+	public static SnappyHadoopInputStreamFactory getInstance() {
+		if (INSTANCE == null) {
+			Configuration hadoopConf = new Configuration();
+			CompressionCodecFactory codecFactory = new CompressionCodecFactory(hadoopConf);
+			SNAPPY_CODEC = codecFactory.getCodecByClassName(SnappyCodec.class.getName());
+
+			INSTANCE = new SnappyHadoopInputStreamFactory();
+		}
+		return INSTANCE;
+	}
+
+	@Override
+	public CompressionInputStream create(InputStream in) throws IOException {
+		return SNAPPY_CODEC.createInputStream(in);
+	}
+
+	@Override
+	public Collection<String> getCommonFileExtensions() {
+		return Collections.singleton("snappy");
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/compression/SnappyXerialInputStreamFactory.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/compression/SnappyXerialInputStreamFactory.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.api.common.io.compression;
+
+import org.xerial.snappy.SnappyInputStream;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * Factory for input streams that decompress the Java (Xerial) Snappy compression format.
+ */
+public class SnappyXerialInputStreamFactory implements InflaterInputStreamFactory<SnappyInputStream> {
+
+	private static SnappyXerialInputStreamFactory INSTANCE = null;
+
+	public static SnappyXerialInputStreamFactory getInstance() {
+		if (INSTANCE == null) {
+			INSTANCE = new SnappyXerialInputStreamFactory();
+		}
+		return INSTANCE;
+	}
+
+	@Override
+	public SnappyInputStream create(InputStream in) throws IOException {
+		return new SnappyInputStream(in);
+	}
+
+	@Override
+	public Collection<String> getCommonFileExtensions() {
+		return Collections.singleton("snappy");
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -344,6 +344,12 @@ public final class ConfigConstants {
 	public static final String FS_STREAM_OPENING_TIMEOUT_KEY = "taskmanager.runtime.fs_timeout";
 
 	/**
+	 * Config parameter defining whether Hadoop Snappy codec should be used for .snappy
+	 * files decompression
+	 */
+	public static final String FS_USE_HADOOP_SNAPPY_KEY = "taskmanager.runtime.fs-hadoop-snappy";
+
+	/**
 	 * Whether to use the LargeRecordHandler when spilling.
 	 */
 	public static final String USE_LARGE_RECORD_HANDLER_KEY = "taskmanager.runtime.large-record-handler";
@@ -1420,6 +1426,11 @@ public final class ConfigConstants {
 	 * The default timeout for filesystem stream opening: infinite (means max long milliseconds).
 	 */
 	public static final int DEFAULT_FS_STREAM_OPENING_TIMEOUT = 0;
+
+	/**
+	 * Whether Hadoop Snappy codec should be used for .snappy files decompression
+	 */
+	public static final boolean DEFAULT_FS_USE_HADOOP_SNAPPY = false;
 
 	/**
 	 * Whether to use the LargeRecordHandler when spilling.

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -1430,7 +1430,7 @@ public final class ConfigConstants {
 	/**
 	 * Whether Hadoop Snappy codec should be used for .snappy files decompression
 	 */
-	public static final boolean DEFAULT_FS_USE_HADOOP_SNAPPY = false;
+	public static final boolean DEFAULT_FS_USE_HADOOP_SNAPPY = true;
 
 	/**
 	 * Whether to use the LargeRecordHandler when spilling.

--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -41,6 +41,12 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-core</artifactId>
 			<version>${project.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.flink</groupId>
+					<artifactId>flink-shaded-hadoop2</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
## What is the purpose of the change

Support reading of Snappy compressed text files (both Xerial and Hadoop snappy)

## Brief change log

  - *Added InputStreamFactories for Xerial and Hadoop snappy*
  - *Added config parameter to control whether Xerial or Hadoop snappy should be used*

## Verifying this change

  - *Manually verified the change by running word count for text files compressed using different Snappy versions*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs 

