### PR TITLE
[FLINK-7651] [flip-6] Delay RetryingRegistration in case of connection error

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/registration/RetryingRegistrationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/registration/RetryingRegistrationTest.java
@@ -22,16 +22,17 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.TestingRpcService;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
 import org.slf4j.LoggerFactory;
 
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -115,7 +116,7 @@ public class RetryingRegistrationTest extends TestLogger {
 		final String testId = "laissez les bon temps roulez";
 		final UUID leaderId = UUID.randomUUID();
 
-		ExecutorService executor = Executors.newCachedThreadPool();
+		ExecutorService executor = TestingUtils.defaultExecutor();
 		TestRegistrationGateway testGateway = new TestRegistrationGateway(new TestRegistrationSuccess(testId));
 
 		try {
@@ -126,12 +127,29 @@ public class RetryingRegistrationTest extends TestLogger {
 					CompletableFuture.completedFuture(testGateway)                         // second connection attempt succeeds
 			);
 			when(rpc.getExecutor()).thenReturn(executor);
+			when(rpc.scheduleRunnable(any(Runnable.class), anyLong(), any(TimeUnit.class))).thenAnswer(
+				(InvocationOnMock invocation) -> {
+					final Runnable runnable = invocation.getArgumentAt(0, Runnable.class);
+					final long delay = invocation.getArgumentAt(1, Long.class);
+					final TimeUnit timeUnit = invocation.getArgumentAt(2, TimeUnit.class);
+					return TestingUtils.defaultScheduledExecutor().schedule(runnable, delay, timeUnit);
+				});
 
 			TestRetryingRegistration registration = new TestRetryingRegistration(rpc, "foobar address", leaderId);
+
+			long start = System.currentTimeMillis();
+
 			registration.startRegistration();
 
 			Tuple2<TestRegistrationGateway, TestRegistrationSuccess> success =
 				registration.getFuture().get(10L, TimeUnit.SECONDS);
+
+			// measure the duration of the registration --> should be longer than the error delay
+			long duration = System.currentTimeMillis() - start;
+
+			assertTrue(
+				"The registration should have failed the first time. Thus the duration should be longer than at least a single error delay.",
+				duration > TestRetryingRegistration.DELAY_ON_ERROR);
 
 			// validate correct invocation and result
 			assertEquals(testId, success.f1.getCorrelationId());
@@ -139,7 +157,6 @@ public class RetryingRegistrationTest extends TestLogger {
 		}
 		finally {
 			testGateway.stop();
-			executor.shutdown();
 		}
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

Similar to a registration error we should also delay the retrying registration in case of
connection error which could happen if the remote endpoint has not been started yet.


## Brief change log

- delay `RetryingRegistration` in case of connection error.

## Verifying this change

This change is already covered by existing tests, such as `RetryingRegistrationTest#testRetryConnectOnFailure`. I simply added a time measurement which is used to check that the retrying is delayed.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

