### PR TITLE
[FLINK-7655] [flip6] Set fencing token to null if not leader

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -93,7 +93,7 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 			MetricRegistry metricRegistry,
 			FatalErrorHandler fatalErrorHandler,
 			Optional<String> restAddress) throws Exception {
-		super(rpcService, endpointId, DispatcherId.generate());
+		super(rpcService, endpointId);
 
 		this.configuration = Preconditions.checkNotNull(configuration);
 		this.highAvailabilityServices = Preconditions.checkNotNull(highAvailabilityServices);
@@ -384,7 +384,8 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 					log.warn("Could not properly clear the Dispatcher state while revoking leadership.", e);
 				}
 
-				setFencingToken(DispatcherId.generate());
+				// clear the fencing token indicating that we don't have the leadership right now
+				setFencingToken(null);
 			});
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -212,7 +212,7 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 			FatalErrorHandler errorHandler,
 			ClassLoader userCodeLoader) throws Exception {
 
-		super(rpcService, AkkaRpcServiceUtils.createRandomName(JobMaster.JOB_MANAGER_NAME), JobMasterId.INITIAL_JOB_MASTER_ID);
+		super(rpcService, AkkaRpcServiceUtils.createRandomName(JobMaster.JOB_MANAGER_NAME));
 
 		selfGateway = getSelfGateway(JobMasterGateway.class);
 
@@ -735,7 +735,7 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 			return Acknowledge.get();
 		}
 
-		if (!Objects.equals(getFencingToken(), JobMasterId.INITIAL_JOB_MASTER_ID)) {
+		if (getFencingToken() != null) {
 			log.info("Restarting old job with JobMasterId {}. The new JobMasterId is {}.", getFencingToken(), newJobMasterId);
 
 			// first we have to suspend the current execution
@@ -791,13 +791,13 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 	private Acknowledge suspendExecution(final Throwable cause) {
 		validateRunsInMainThread();
 
-		if (Objects.equals(JobMasterId.INITIAL_JOB_MASTER_ID, getFencingToken())) {
+		if (getFencingToken() == null) {
 			log.debug("Job has already been suspended or shutdown.");
 			return Acknowledge.get();
 		}
 
-		// not leader anymore --> set the JobMasterId to the initial id
-		setFencingToken(JobMasterId.INITIAL_JOB_MASTER_ID);
+		// not leader anymore --> set the JobMasterId to null
+		setFencingToken(null);
 
 		try {
 			resourceManagerLeaderRetriever.stop();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterId.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterId.java
@@ -29,8 +29,6 @@ public class JobMasterId extends AbstractID {
 
 	private static final long serialVersionUID = -933276753644003754L;
 
-	public static final JobMasterId INITIAL_JOB_MASTER_ID = new JobMasterId(0L, 0L);
-
 	public JobMasterId(byte[] bytes) {
 		super(bytes);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -139,7 +139,7 @@ public abstract class ResourceManager<WorkerType extends Serializable>
 			JobLeaderIdService jobLeaderIdService,
 			FatalErrorHandler fatalErrorHandler) {
 
-		super(rpcService, resourceManagerEndpointId, ResourceManagerId.generate());
+		super(rpcService, resourceManagerEndpointId);
 
 		this.resourceId = checkNotNull(resourceId);
 		this.resourceManagerConfiguration = checkNotNull(resourceManagerConfiguration);
@@ -772,13 +772,11 @@ public abstract class ResourceManager<WorkerType extends Serializable>
 	public void revokeLeadership() {
 		runAsyncWithoutFencing(
 			() -> {
-				final ResourceManagerId newResourceManagerId = ResourceManagerId.generate();
-
-				log.info("ResourceManager {} was revoked leadership. Setting fencing token to {}.", getAddress(), newResourceManagerId);
+				log.info("ResourceManager {} was revoked leadership. Clearing fencing token.", getAddress());
 
 				clearState();
 
-				setFencingToken(newResourceManagerId);
+				setFencingToken(null);
 
 				slotManager.suspend();
 			});

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/exceptions/FencingTokenException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/exceptions/FencingTokenException.java
@@ -25,18 +25,18 @@ import org.apache.flink.runtime.rpc.exceptions.RpcException;
  * Exception which is thrown if the fencing tokens of a {@link FencedRpcEndpoint} do
  * not match.
  */
-public class FencingTokenMismatchException extends RpcException {
+public class FencingTokenException extends RpcException {
 	private static final long serialVersionUID = -500634972988881467L;
 
-	public FencingTokenMismatchException(String message) {
+	public FencingTokenException(String message) {
 		super(message);
 	}
 
-	public FencingTokenMismatchException(String message, Throwable cause) {
+	public FencingTokenException(String message, Throwable cause) {
 		super(message, cause);
 	}
 
-	public FencingTokenMismatchException(Throwable cause) {
+	public FencingTokenException(Throwable cause) {
 		super(cause);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/messages/LocalFencedMessage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/messages/LocalFencedMessage.java
@@ -20,6 +20,8 @@ package org.apache.flink.runtime.rpc.messages;
 
 import org.apache.flink.util.Preconditions;
 
+import javax.annotation.Nullable;
+
 import java.io.Serializable;
 
 /**
@@ -34,8 +36,8 @@ public class LocalFencedMessage<F extends Serializable, P> implements FencedMess
 	private final F fencingToken;
 	private final P payload;
 
-	public LocalFencedMessage(F fencingToken, P payload) {
-		this.fencingToken = Preconditions.checkNotNull(fencingToken);
+	public LocalFencedMessage(@Nullable F fencingToken, P payload) {
+		this.fencingToken = fencingToken;
 		this.payload = Preconditions.checkNotNull(payload);
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/messages/RemoteFencedMessage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/messages/RemoteFencedMessage.java
@@ -20,6 +20,8 @@ package org.apache.flink.runtime.rpc.messages;
 
 import org.apache.flink.util.Preconditions;
 
+import javax.annotation.Nullable;
+
 import java.io.Serializable;
 
 /**
@@ -35,8 +37,8 @@ public class RemoteFencedMessage<F extends Serializable, P extends Serializable>
 	private final F fencingToken;
 	private final P payload;
 
-	public RemoteFencedMessage(F fencingToken, P payload) {
-		this.fencingToken = Preconditions.checkNotNull(fencingToken);
+	public RemoteFencedMessage(@Nullable F fencingToken, P payload) {
+		this.fencingToken = fencingToken;
 		this.payload = Preconditions.checkNotNull(payload);
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerHATest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerHATest.java
@@ -108,7 +108,7 @@ public class ResourceManagerHATest extends TestLogger {
 		try {
 			resourceManager.start();
 
-			Assert.assertNotNull(resourceManager.getFencingToken());
+			Assert.assertNull(resourceManager.getFencingToken());
 			final UUID leaderId = UUID.randomUUID();
 			leaderElectionService.isLeader(leaderId);
 			// after grant leadership, resourceManager's leaderId has value

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTaskExecutorTest.java
@@ -30,7 +30,7 @@ import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.registration.RegistrationResponse;
-import org.apache.flink.runtime.rpc.exceptions.FencingTokenMismatchException;
+import org.apache.flink.runtime.rpc.exceptions.FencingTokenException;
 import org.apache.flink.runtime.taskexecutor.SlotReport;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorRegistrationSuccess;
@@ -134,7 +134,7 @@ public class ResourceManagerTaskExecutorTest extends TestLogger {
 				unMatchedLeaderFuture.get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
 				fail("Should have failed because we are using a wrongly fenced ResourceManagerGateway.");
 			} catch (ExecutionException e) {
-				assertTrue(ExceptionUtils.stripExecutionException(e) instanceof FencingTokenMismatchException);
+				assertTrue(ExceptionUtils.stripExecutionException(e) instanceof FencingTokenException);
 			}
 		} finally {
 			if (testingFatalErrorHandler.hasExceptionOccurred()) {


### PR DESCRIPTION
## What is the purpose of the change

This commit changes the fencing behaviour such that a component which is not the
leader will set its fencing token to null. This distinction allows to throw different
exceptions depending on whether it is a token mismatch or whether the receiver has
no fencing token set (== not being the leader).

## Brief change log

- allow the fencing token to be null in `FencedRpcEndpoint`
- allow `FencedAkkaInvocationHandler` to send a `null` fencing token
- filter out messages if component is not a leader in `FencedAkkaRpcActor`
- Adapt `Dispatcher`, `ResourceManager` and `JobMaster` to set fencing token to `null` at start-up

## Verifying this change

This change is already covered by existing tests, such as `FencedRpcEndpointTest` and `AsyncCallsTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

