### PR TITLE
[FLINK-7656] [runtime] Switch to user classloader before calling initializeOnMaster and finalizeOnMaster.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/OutputFormatVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/OutputFormatVertex.java
@@ -73,15 +73,24 @@ public class OutputFormatVertex extends JobVertex {
 		catch (Throwable t) {
 			throw new Exception("Instantiating the OutputFormat (" + formatDescription + ") failed: " + t.getMessage(), t);
 		}
+
+		// set user classloader before calling user code
+		final ClassLoader prevContextCl = Thread.currentThread().getContextClassLoader();
+		Thread.currentThread().setContextClassLoader(loader);
+
 		try {
-			outputFormat.configure(cfg.getStubParameters());
-		}
-		catch (Throwable t) {
-			throw new Exception("Configuring the OutputFormat (" + formatDescription + ") failed: " + t.getMessage(), t);
-		}
-		
-		if (outputFormat instanceof InitializeOnMaster) {
-			((InitializeOnMaster) outputFormat).initializeGlobal(getParallelism());
+			// configure output format
+			try {
+				outputFormat.configure(cfg.getStubParameters());
+			} catch (Throwable t) {
+				throw new Exception("Configuring the OutputFormat (" + formatDescription + ") failed: " + t.getMessage(), t);
+			}
+			if (outputFormat instanceof InitializeOnMaster) {
+				((InitializeOnMaster) outputFormat).initializeGlobal(getParallelism());
+			}
+		} finally {
+			// restore previous classloader
+			Thread.currentThread().setContextClassLoader(prevContextCl);
 		}
 	}
 	
@@ -107,15 +116,24 @@ public class OutputFormatVertex extends JobVertex {
 		catch (Throwable t) {
 			throw new Exception("Instantiating the OutputFormat (" + formatDescription + ") failed: " + t.getMessage(), t);
 		}
+
+		// set user classloader before calling user code
+		final ClassLoader prevContextCl = Thread.currentThread().getContextClassLoader();
+		Thread.currentThread().setContextClassLoader(loader);
+
 		try {
-			outputFormat.configure(cfg.getStubParameters());
-		}
-		catch (Throwable t) {
-			throw new Exception("Configuring the OutputFormat (" + formatDescription + ") failed: " + t.getMessage(), t);
-		}
-		
-		if (outputFormat instanceof FinalizeOnMaster) {
-			((FinalizeOnMaster) outputFormat).finalizeGlobal(getParallelism());
+			// configure output format
+			try {
+				outputFormat.configure(cfg.getStubParameters());
+			} catch (Throwable t) {
+				throw new Exception("Configuring the OutputFormat (" + formatDescription + ") failed: " + t.getMessage(), t);
+			}
+			if (outputFormat instanceof FinalizeOnMaster) {
+				((FinalizeOnMaster) outputFormat).finalizeGlobal(getParallelism());
+			}
+		} finally {
+			// restore previous classloader
+			Thread.currentThread().setContextClassLoader(prevContextCl);
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobgraph/JobTaskVertexTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobgraph/JobTaskVertexTest.java
@@ -18,14 +18,17 @@
 
 package org.apache.flink.runtime.jobgraph;
 
+import org.apache.flink.api.common.io.FinalizeOnMaster;
 import org.apache.flink.api.common.io.GenericInputFormat;
 import org.apache.flink.api.common.io.InitializeOnMaster;
 import org.apache.flink.api.common.io.InputFormat;
 import org.apache.flink.api.common.io.OutputFormat;
 import org.apache.flink.api.common.operators.util.UserCodeObjectWrapper;
 import org.apache.flink.api.java.io.DiscardingOutputFormat;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.io.GenericInputSplit;
 import org.apache.flink.core.io.InputSplit;
+import org.apache.flink.runtime.execution.librarycache.FlinkUserCodeClassLoader;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.operators.util.TaskConfig;
 import org.apache.flink.util.InstantiationUtil;
@@ -33,6 +36,7 @@ import org.apache.flink.util.InstantiationUtil;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.net.URL;
 
 import static org.junit.Assert.*;
 
@@ -84,10 +88,10 @@ public class JobTaskVertexTest {
 	@Test
 	public void testOutputFormatVertex() {
 		try {
-			final TestingOutputFormat outputFormat = new TestingOutputFormat();
+			final OutputFormat outputFormat = new TestingOutputFormat();
 			final OutputFormatVertex of = new OutputFormatVertex("Name");
 			new TaskConfig(of.getConfiguration()).setStubWrapper(new UserCodeObjectWrapper<OutputFormat<?>>(outputFormat));
-			final ClassLoader cl = getClass().getClassLoader();
+			final ClassLoader cl = new FlinkUserCodeClassLoader(new URL[0], getClass().getClassLoader());
 			
 			try {
 				of.initializeOnMaster(cl);
@@ -97,19 +101,29 @@ public class JobTaskVertexTest {
 			}
 			
 			OutputFormatVertex copy = InstantiationUtil.clone(of);
+			ClassLoader ctxCl = Thread.currentThread().getContextClassLoader();
 			try {
 				copy.initializeOnMaster(cl);
 				fail("Did not throw expected exception.");
 			} catch (TestException e) {
 				// all good
 			}
+			assertEquals("Previous classloader was not restored.", ctxCl, Thread.currentThread().getContextClassLoader());
+
+			try {
+				copy.finalizeOnMaster(cl);
+				fail("Did not throw expected exception.");
+			} catch (TestException e) {
+				// all good
+			}
+			assertEquals("Previous classloader was not restored.", ctxCl, Thread.currentThread().getContextClassLoader());
 		}
 		catch (Exception e) {
 			e.printStackTrace();
 			fail(e.getMessage());
 		}
 	}
-	
+
 	@Test
 	public void testInputFormatVertex() {
 		try {
@@ -134,16 +148,7 @@ public class JobTaskVertexTest {
 	
 	// --------------------------------------------------------------------------------------------
 	
-	private static final class TestingOutputFormat extends DiscardingOutputFormat<Object> implements InitializeOnMaster {
-		@Override
-		public void initializeGlobal(int parallelism) throws IOException {
-			throw new TestException();
-		}
-	}
-	
 	private static final class TestException extends IOException {}
-	
-	// --------------------------------------------------------------------------------------------
 	
 	private static final class TestSplit extends GenericInputSplit {
 		
@@ -168,5 +173,46 @@ public class JobTaskVertexTest {
 		public GenericInputSplit[] createInputSplits(int numSplits) throws IOException {
 			return new GenericInputSplit[] { new TestSplit(0, 1) };
 		}
+	}
+
+	private static final class TestingOutputFormat extends DiscardingOutputFormat<Object> implements InitializeOnMaster, FinalizeOnMaster {
+
+		private boolean isConfigured = false;
+
+		@Override
+		public void initializeGlobal(int parallelism) throws IOException {
+			if (!isConfigured) {
+				throw new IllegalStateException("OutputFormat was not configured before initializeGlobal was called.");
+			}
+			if (!(Thread.currentThread().getContextClassLoader() instanceof FlinkUserCodeClassLoader)) {
+				throw new IllegalStateException("Context ClassLoader is not a FlinkUserCodeClassLoader.");
+			}
+			// notify we have been here.
+			throw new TestException();
+		}
+
+		@Override
+		public void finalizeGlobal(int parallelism) throws IOException {
+			if (!isConfigured) {
+				throw new IllegalStateException("OutputFormat was not configured before finalizeGlobal was called.");
+			}
+			if (!(Thread.currentThread().getContextClassLoader() instanceof FlinkUserCodeClassLoader)) {
+				throw new IllegalStateException("Context ClassLoader is not a FlinkUserCodeClassLoader.");
+			}
+			// notify we have been here.
+			throw new TestException();
+		}
+
+		@Override
+		public void configure(Configuration parameters) {
+			if (isConfigured) {
+				throw new IllegalStateException("OutputFormat is already configured.");
+			}
+			if (!(Thread.currentThread().getContextClassLoader() instanceof FlinkUserCodeClassLoader)) {
+				throw new IllegalStateException("Context ClassLoader is not a FlinkUserCodeClassLoader.");
+			}
+			isConfigured = true;
+		}
+
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

Fixes a classloading issue for `OutputFormat`s that implement `InitializeOnMaster` or `FinalizeOnMaster`. The initialize and finalize methods are called without setting the context classloader to the usercode classloader.

## Brief change log

* Set the context classloader to the usercode classloader before calling `InitializeOnMaster.initializeGlobal()` and `FinalizeOnMaster.finalizeGlobal()` and restore the original classloader afterwards.
* Extend test to check that the correct classloader is set.

## Verifying this change

* Run `JobTaskVertexTest.testOutputFormatVertex()`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **YES**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **n/a**

