### PR TITLE
[FLINK-7647] [flip6] Port JobManagerConfigHandler to new REST endpoint

### DIFF
--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitor.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitor.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.jobmaster.JobManagerGateway;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
 import org.apache.flink.runtime.net.SSLUtils;
 import org.apache.flink.runtime.rest.handler.WebHandler;
+import org.apache.flink.runtime.rest.handler.legacy.ClusterConfigHandler;
 import org.apache.flink.runtime.rest.handler.legacy.ClusterOverviewHandler;
 import org.apache.flink.runtime.rest.handler.legacy.ConstantTextHandler;
 import org.apache.flink.runtime.rest.handler.legacy.CurrentJobIdsHandler;
@@ -40,7 +41,6 @@ import org.apache.flink.runtime.rest.handler.legacy.JobCancellationWithSavepoint
 import org.apache.flink.runtime.rest.handler.legacy.JobConfigHandler;
 import org.apache.flink.runtime.rest.handler.legacy.JobDetailsHandler;
 import org.apache.flink.runtime.rest.handler.legacy.JobExceptionsHandler;
-import org.apache.flink.runtime.rest.handler.legacy.JobManagerConfigHandler;
 import org.apache.flink.runtime.rest.handler.legacy.JobPlanHandler;
 import org.apache.flink.runtime.rest.handler.legacy.JobStoppingHandler;
 import org.apache.flink.runtime.rest.handler.legacy.JobVertexAccumulatorsHandler;
@@ -244,7 +244,7 @@ public class WebRuntimeMonitor implements WebMonitor {
 		get(router, new ClusterOverviewHandler(executor, DEFAULT_REQUEST_TIMEOUT));
 
 		// job manager configuration
-		get(router, new JobManagerConfigHandler(executor, config));
+		get(router, new ClusterConfigHandler(executor, config));
 
 		// overview over jobs
 		get(router, new CurrentJobsOverviewHandler(executor, DEFAULT_REQUEST_TIMEOUT, true, true));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherRestEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherRestEndpoint.java
@@ -26,9 +26,9 @@ import org.apache.flink.runtime.rest.RestServerEndpointConfiguration;
 import org.apache.flink.runtime.rest.handler.LegacyRestHandlerAdapter;
 import org.apache.flink.runtime.rest.handler.RestHandlerConfiguration;
 import org.apache.flink.runtime.rest.handler.RestHandlerSpecification;
+import org.apache.flink.runtime.rest.handler.legacy.ClusterConfigHandler;
 import org.apache.flink.runtime.rest.handler.legacy.ClusterOverviewHandler;
 import org.apache.flink.runtime.rest.handler.legacy.DashboardConfigHandler;
-import org.apache.flink.runtime.rest.handler.legacy.JobManagerConfigHandler;
 import org.apache.flink.runtime.rest.handler.legacy.files.StaticFileServerHandler;
 import org.apache.flink.runtime.rest.handler.legacy.files.WebContentHandlerSpecification;
 import org.apache.flink.runtime.rest.handler.legacy.messages.ClusterConfiguration;
@@ -105,7 +105,7 @@ public class DispatcherRestEndpoint extends RestServerEndpoint {
 			leaderRetriever,
 			timeout,
 			ClusterConfigurationHeaders.getInstance(),
-			new JobManagerConfigHandler(
+			new ClusterConfigHandler(
 				executor,
 				clusterConfiguration));
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherRestEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherRestEndpoint.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.dispatcher;
 
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.rest.RestServerEndpoint;
 import org.apache.flink.runtime.rest.RestServerEndpointConfiguration;
 import org.apache.flink.runtime.rest.handler.LegacyRestHandlerAdapter;
@@ -27,10 +28,13 @@ import org.apache.flink.runtime.rest.handler.RestHandlerConfiguration;
 import org.apache.flink.runtime.rest.handler.RestHandlerSpecification;
 import org.apache.flink.runtime.rest.handler.legacy.ClusterOverviewHandler;
 import org.apache.flink.runtime.rest.handler.legacy.DashboardConfigHandler;
+import org.apache.flink.runtime.rest.handler.legacy.JobManagerConfigHandler;
 import org.apache.flink.runtime.rest.handler.legacy.files.StaticFileServerHandler;
 import org.apache.flink.runtime.rest.handler.legacy.files.WebContentHandlerSpecification;
+import org.apache.flink.runtime.rest.handler.legacy.messages.ClusterConfiguration;
 import org.apache.flink.runtime.rest.handler.legacy.messages.DashboardConfiguration;
 import org.apache.flink.runtime.rest.handler.legacy.messages.StatusOverviewWithVersion;
+import org.apache.flink.runtime.rest.messages.ClusterConfigurationHeaders;
 import org.apache.flink.runtime.rest.messages.ClusterOverviewHeaders;
 import org.apache.flink.runtime.rest.messages.DashboardConfigurationHeaders;
 import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
@@ -55,16 +59,19 @@ import java.util.concurrent.Executor;
 public class DispatcherRestEndpoint extends RestServerEndpoint {
 
 	private final GatewayRetriever<DispatcherGateway> leaderRetriever;
+	private final Configuration clusterConfiguration;
 	private final RestHandlerConfiguration restConfiguration;
 	private final Executor executor;
 
 	public DispatcherRestEndpoint(
-			RestServerEndpointConfiguration configuration,
+			Configuration clusterConfiguration,
+			RestServerEndpointConfiguration endpointConfiguration,
 			GatewayRetriever<DispatcherGateway> leaderRetriever,
 			RestHandlerConfiguration restConfiguration,
 			Executor executor) {
-		super(configuration);
+		super(endpointConfiguration);
 		this.leaderRetriever = Preconditions.checkNotNull(leaderRetriever);
+		this.clusterConfiguration = Preconditions.checkNotNull(clusterConfiguration);
 		this.restConfiguration = Preconditions.checkNotNull(restConfiguration);
 		this.executor = Preconditions.checkNotNull(executor);
 	}
@@ -93,6 +100,15 @@ public class DispatcherRestEndpoint extends RestServerEndpoint {
 				executor,
 				restConfiguration.getRefreshInterval()));
 
+		LegacyRestHandlerAdapter<DispatcherGateway, ClusterConfiguration, EmptyMessageParameters> clusterConfigurationHandler = new LegacyRestHandlerAdapter<>(
+			restAddressFuture,
+			leaderRetriever,
+			timeout,
+			ClusterConfigurationHeaders.getInstance(),
+			new JobManagerConfigHandler(
+				executor,
+				clusterConfiguration));
+
 		final File tmpDir = restConfiguration.getTmpDir();
 
 		Optional<StaticFileServerHandler<DispatcherGateway>> optWebContent;
@@ -109,6 +125,7 @@ public class DispatcherRestEndpoint extends RestServerEndpoint {
 		}
 
 		handlers.add(Tuple2.of(ClusterOverviewHeaders.getInstance(), clusterOverviewHandler));
+		handlers.add(Tuple2.of(ClusterConfigurationHeaders.getInstance(), clusterConfigurationHandler));
 		handlers.add(Tuple2.of(DashboardConfigurationHeaders.getInstance(), dashboardConfigurationHandler));
 
 		optWebContent.ifPresent(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/SessionClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/SessionClusterEntrypoint.java
@@ -157,6 +157,7 @@ public abstract class SessionClusterEntrypoint extends ClusterEntrypoint {
 			Executor executor) throws Exception {
 
 		return new DispatcherRestEndpoint(
+			configuration,
 			RestServerEndpointConfiguration.fromConfiguration(configuration),
 			dispatcherGatewayRetriever,
 			RestHandlerConfiguration.fromConfiguration(configuration),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/ClusterConfigHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/ClusterConfigHandler.java
@@ -43,12 +43,12 @@ import java.util.concurrent.Executor;
 /**
  * Returns the Job Manager's configuration.
  */
-public class JobManagerConfigHandler extends AbstractJsonRequestHandler
+public class ClusterConfigHandler extends AbstractJsonRequestHandler
 		implements LegacyRestHandler<DispatcherGateway, ClusterConfiguration, EmptyMessageParameters> {
 
 	private final Configuration config;
 
-	public JobManagerConfigHandler(Executor executor, Configuration config) {
+	public ClusterConfigHandler(Executor executor, Configuration config) {
 		super(executor);
 		this.config = Preconditions.checkNotNull(config);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/JobManagerConfigHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/JobManagerConfigHandler.java
@@ -20,7 +20,17 @@ package org.apache.flink.runtime.rest.handler.legacy;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.concurrent.FlinkFutureException;
+import org.apache.flink.runtime.dispatcher.DispatcherGateway;
 import org.apache.flink.runtime.jobmaster.JobManagerGateway;
+
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.LegacyRestHandler;
+import org.apache.flink.runtime.rest.handler.legacy.messages.ClusterConfiguration;
+import org.apache.flink.runtime.rest.handler.legacy.messages.ClusterConfigurationEntry;
+import org.apache.flink.runtime.rest.messages.ClusterConfigurationHeaders;
+import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.util.Preconditions;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 
@@ -33,20 +43,27 @@ import java.util.concurrent.Executor;
 /**
  * Returns the Job Manager's configuration.
  */
-public class JobManagerConfigHandler extends AbstractJsonRequestHandler {
-
-	private static final String JOBMANAGER_CONFIG_REST_PATH = "/jobmanager/config";
+public class JobManagerConfigHandler extends AbstractJsonRequestHandler
+		implements LegacyRestHandler<DispatcherGateway, ClusterConfiguration, EmptyMessageParameters> {
 
 	private final Configuration config;
 
 	public JobManagerConfigHandler(Executor executor, Configuration config) {
 		super(executor);
-		this.config = config;
+		this.config = Preconditions.checkNotNull(config);
 	}
 
 	@Override
 	public String[] getPaths() {
-		return new String[]{JOBMANAGER_CONFIG_REST_PATH};
+		return new String[]{ClusterConfigurationHeaders.CLUSTER_CONFIG_REST_PATH};
+	}
+
+	@Override
+	public CompletableFuture<ClusterConfiguration> handleRequest(
+			HandlerRequest<EmptyRequestBody, EmptyMessageParameters> request,
+			DispatcherGateway gateway) {
+
+		return CompletableFuture.supplyAsync(() -> ClusterConfiguration.from(config), executor);
 	}
 
 	@Override
@@ -60,18 +77,15 @@ public class JobManagerConfigHandler extends AbstractJsonRequestHandler {
 					gen.writeStartArray();
 					for (String key : config.keySet()) {
 						gen.writeStartObject();
-						gen.writeStringField("key", key);
+						gen.writeStringField(ClusterConfigurationEntry.FIELD_NAME_CONFIG_KEY, key);
 
+						String value = config.getString(key, null);
 						// Mask key values which contain sensitive information
-						if (key.toLowerCase().contains("password")) {
-							String value = config.getString(key, null);
-							if (value != null) {
-								value = "******";
-							}
-							gen.writeStringField("value", value);
-						} else {
-							gen.writeStringField("value", config.getString(key, null));
+						if (value != null && key.toLowerCase().contains("password")) {
+							value = "******";
 						}
+						gen.writeStringField(ClusterConfigurationEntry.FIELD_NAME_CONFIG_VALUE, value);
+
 						gen.writeEndObject();
 					}
 					gen.writeEndArray();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/messages/ClusterConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/messages/ClusterConfiguration.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.legacy.messages;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.rest.handler.legacy.JobManagerConfigHandler;
+import org.apache.flink.runtime.rest.messages.ResponseBody;
+
+import java.util.ArrayList;
+
+/**
+ * Response of the {@link JobManagerConfigHandler}, respresented as a list
+ * of key-value pairs of the cluster {@link Configuration}.
+ */
+public class ClusterConfiguration extends ArrayList<ClusterConfigurationEntry> implements ResponseBody {
+
+	// a default constructor is required for collection type marshalling
+	public ClusterConfiguration() {}
+
+	public ClusterConfiguration(int initialEntries) {
+		super(initialEntries);
+	}
+
+	public static ClusterConfiguration from(Configuration config) {
+		ClusterConfiguration clusterConfig = new ClusterConfiguration(config.keySet().size());
+
+		for (String key : config.keySet()) {
+			String value = config.getString(key, null);
+
+			// Mask key values which contain sensitive information
+			if (value != null && key.toLowerCase().contains("password")) {
+				value = "******";
+			}
+
+			clusterConfig.add(new ClusterConfigurationEntry(key, value));
+		}
+
+		return clusterConfig;
+	}
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/messages/ClusterConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/messages/ClusterConfiguration.java
@@ -19,13 +19,13 @@
 package org.apache.flink.runtime.rest.handler.legacy.messages;
 
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.runtime.rest.handler.legacy.JobManagerConfigHandler;
+import org.apache.flink.runtime.rest.handler.legacy.ClusterConfigHandler;
 import org.apache.flink.runtime.rest.messages.ResponseBody;
 
 import java.util.ArrayList;
 
 /**
- * Response of the {@link JobManagerConfigHandler}, respresented as a list
+ * Response of the {@link ClusterConfigHandler}, respresented as a list
  * of key-value pairs of the cluster {@link Configuration}.
  */
 public class ClusterConfiguration extends ArrayList<ClusterConfigurationEntry> implements ResponseBody {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/messages/ClusterConfigurationEntry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/messages/ClusterConfigurationEntry.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.legacy.messages;
+
+import org.apache.flink.util.Preconditions;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+/**
+ * A single key-value pair entry in the {@link ClusterConfiguration} response.
+ */
+public class ClusterConfigurationEntry {
+
+	public static final String FIELD_NAME_CONFIG_KEY = "key";
+	public static final String FIELD_NAME_CONFIG_VALUE = "value";
+
+	@JsonProperty(FIELD_NAME_CONFIG_KEY)
+	private final String key;
+
+	@JsonProperty(FIELD_NAME_CONFIG_VALUE)
+	private final String value;
+
+	@JsonCreator
+	public ClusterConfigurationEntry(
+			@JsonProperty(FIELD_NAME_CONFIG_KEY) String key,
+			@JsonProperty(FIELD_NAME_CONFIG_VALUE) String value) {
+		this.key = Preconditions.checkNotNull(key);
+		this.value = Preconditions.checkNotNull(value);
+	}
+
+	public String getKey() {
+		return key;
+	}
+
+	public String getValue() {
+		return value;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+
+		ClusterConfigurationEntry that = (ClusterConfigurationEntry) o;
+		return key.equals(that.key) && value.equals(that.value);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(key, value);
+	}
+
+	@Override
+	public String toString() {
+		return "(" + key + "," + value + ")";
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/ClusterConfigurationHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/ClusterConfigurationHeaders.java
@@ -19,18 +19,20 @@
 package org.apache.flink.runtime.rest.messages;
 
 import org.apache.flink.runtime.rest.HttpMethodWrapper;
-import org.apache.flink.runtime.rest.handler.legacy.JobManagerConfigHandler;
+import org.apache.flink.runtime.rest.handler.legacy.ClusterConfigHandler;
 import org.apache.flink.runtime.rest.handler.legacy.messages.ClusterConfiguration;
 
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
 
 /**
- * Message headers for the {@link JobManagerConfigHandler}.
+ * Message headers for the {@link ClusterConfigHandler}.
  */
 public final class ClusterConfigurationHeaders implements MessageHeaders<EmptyRequestBody, ClusterConfiguration, EmptyMessageParameters> {
 
 	private static final ClusterConfigurationHeaders INSTANCE = new ClusterConfigurationHeaders();
 
+	// TODO this REST path is inappropriately set due to legacy design reasons, and ideally should be '/config';
+	// TODO changing it would require corresponding path changes in flink-runtime-web
 	public static final String CLUSTER_CONFIG_REST_PATH = "/jobmanager/config";
 
 	private ClusterConfigurationHeaders() {}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/ClusterConfigurationHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/ClusterConfigurationHeaders.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages;
+
+import org.apache.flink.runtime.rest.HttpMethodWrapper;
+import org.apache.flink.runtime.rest.handler.legacy.JobManagerConfigHandler;
+import org.apache.flink.runtime.rest.handler.legacy.messages.ClusterConfiguration;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+/**
+ * Message headers for the {@link JobManagerConfigHandler}.
+ */
+public final class ClusterConfigurationHeaders implements MessageHeaders<EmptyRequestBody, ClusterConfiguration, EmptyMessageParameters> {
+
+	private static final ClusterConfigurationHeaders INSTANCE = new ClusterConfigurationHeaders();
+
+	public static final String CLUSTER_CONFIG_REST_PATH = "/jobmanager/config";
+
+	private ClusterConfigurationHeaders() {}
+
+	@Override
+	public Class<EmptyRequestBody> getRequestClass() {
+		return EmptyRequestBody.class;
+	}
+
+	@Override
+	public HttpMethodWrapper getHttpMethod() {
+		return HttpMethodWrapper.GET;
+	}
+
+	@Override
+	public String getTargetRestEndpointURL() {
+		return CLUSTER_CONFIG_REST_PATH;
+	}
+
+	@Override
+	public Class<ClusterConfiguration> getResponseClass() {
+		return ClusterConfiguration.class;
+	}
+
+	@Override
+	public HttpResponseStatus getResponseStatusCode() {
+		return HttpResponseStatus.OK;
+	}
+
+	@Override
+	public EmptyMessageParameters getUnresolvedMessageParameters() {
+		return EmptyMessageParameters.getInstance();
+	}
+
+	public static ClusterConfigurationHeaders getInstance() {
+		return INSTANCE;
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/ClusterConfigHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/ClusterConfigHandlerTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.rest.handler.legacy;
 
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.concurrent.Executors;
 
 import org.junit.Assert;
@@ -29,7 +30,7 @@ import org.junit.Test;
 public class ClusterConfigHandlerTest {
 	@Test
 	public void testGetPaths() {
-		ClusterConfigHandler handler = new ClusterConfigHandler(Executors.directExecutor(), null);
+		ClusterConfigHandler handler = new ClusterConfigHandler(Executors.directExecutor(), new Configuration());
 		String[] paths = handler.getPaths();
 		Assert.assertEquals(1, paths.length);
 		Assert.assertEquals("/jobmanager/config", paths[0]);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/ClusterConfigHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/ClusterConfigHandlerTest.java
@@ -24,12 +24,12 @@ import org.junit.Assert;
 import org.junit.Test;
 
 /**
- * Tests for the JobManagerConfigHandler.
+ * Tests for the ClusterConfigHandler.
  */
-public class JobManagerConfigHandlerTest {
+public class ClusterConfigHandlerTest {
 	@Test
 	public void testGetPaths() {
-		JobManagerConfigHandler handler = new JobManagerConfigHandler(Executors.directExecutor(), null);
+		ClusterConfigHandler handler = new ClusterConfigHandler(Executors.directExecutor(), null);
 		String[] paths = handler.getPaths();
 		Assert.assertEquals(1, paths.length);
 		Assert.assertEquals("/jobmanager/config", paths[0]);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/messages/ClusterConfigurationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/messages/ClusterConfigurationTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.legacy.messages;
+
+import org.apache.flink.runtime.rest.util.RestMapperUtils;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for the {@link ClusterConfiguration}.
+ */
+public class ClusterConfigurationTest {
+
+	/**
+	 * Tests that we can marshal and unmarshal {@link ClusterConfiguration} objects.
+	 */
+	@Test
+	public void testJsonMarshalling() throws JsonProcessingException {
+		final ClusterConfiguration expected = new ClusterConfiguration(2);
+		expected.add(new ClusterConfigurationEntry("key1", "value1"));
+		expected.add(new ClusterConfigurationEntry("key2", "value2"));
+
+		final ObjectMapper objectMapper = RestMapperUtils.getStrictObjectMapper();
+
+		JsonNode marshaled = objectMapper.valueToTree(expected);
+
+		final ClusterConfiguration unmarshaled = objectMapper.treeToValue(marshaled, ClusterConfiguration.class);
+
+		assertEquals(expected, unmarshaled);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/messages/ClusterConfigurationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/messages/ClusterConfigurationTest.java
@@ -18,36 +18,22 @@
 
 package org.apache.flink.runtime.rest.handler.legacy.messages;
 
-import org.apache.flink.runtime.rest.util.RestMapperUtils;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
-
 /**
  * Tests for the {@link ClusterConfiguration}.
  */
-public class ClusterConfigurationTest {
+public class ClusterConfigurationTest extends RestResponseMarshallingTestBase<ClusterConfiguration> {
 
-	/**
-	 * Tests that we can marshal and unmarshal {@link ClusterConfiguration} objects.
-	 */
-	@Test
-	public void testJsonMarshalling() throws JsonProcessingException {
+	@Override
+	protected Class<ClusterConfiguration> getTestResponseClass() {
+		return ClusterConfiguration.class;
+	}
+
+	@Override
+	protected ClusterConfiguration getTestResponseInstance() {
 		final ClusterConfiguration expected = new ClusterConfiguration(2);
 		expected.add(new ClusterConfigurationEntry("key1", "value1"));
 		expected.add(new ClusterConfigurationEntry("key2", "value2"));
 
-		final ObjectMapper objectMapper = RestMapperUtils.getStrictObjectMapper();
-
-		JsonNode marshaled = objectMapper.valueToTree(expected);
-
-		final ClusterConfiguration unmarshaled = objectMapper.treeToValue(marshaled, ClusterConfiguration.class);
-
-		assertEquals(expected, unmarshaled);
+		return expected;
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/messages/DashboardConfigurationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/messages/DashboardConfigurationTest.java
@@ -18,39 +18,23 @@
 
 package org.apache.flink.runtime.rest.handler.legacy.messages;
 
-import org.apache.flink.runtime.rest.util.RestMapperUtils;
-import org.apache.flink.util.TestLogger;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
-
 /**
  * Tests for the {@link DashboardConfiguration}.
  */
-public class DashboardConfigurationTest extends TestLogger {
+public class DashboardConfigurationTest extends RestResponseMarshallingTestBase<DashboardConfiguration> {
 
-	/**
-	 * Tests that we can marshal and unmarshal {@link DashboardConfiguration} objects.
-	 */
-	@Test
-	public void testJsonMarshalling() throws JsonProcessingException {
-		final DashboardConfiguration expected = new DashboardConfiguration(
+	@Override
+	protected Class<DashboardConfiguration> getTestResponseClass() {
+		return DashboardConfiguration.class;
+	}
+
+	@Override
+	protected DashboardConfiguration getTestResponseInstance() {
+		return new DashboardConfiguration(
 			1L,
 			"foobar",
 			42,
 			"version",
 			"revision");
-
-		final ObjectMapper objectMapper = RestMapperUtils.getStrictObjectMapper();
-
-		JsonNode marshaled = objectMapper.valueToTree(expected);
-
-		final DashboardConfiguration unmarshaled = objectMapper.treeToValue(marshaled, DashboardConfiguration.class);
-
-		assertEquals(expected, unmarshaled);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/messages/RestResponseMarshallingTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/messages/RestResponseMarshallingTestBase.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.legacy.messages;
+
+import org.apache.flink.runtime.rest.messages.ResponseBody;
+import org.apache.flink.runtime.rest.util.RestMapperUtils;
+import org.apache.flink.util.TestLogger;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test base for verifying that marshalling / unmarshalling REST {@link ResponseBody}s work properly.
+ */
+public abstract class RestResponseMarshallingTestBase<R extends ResponseBody> extends TestLogger {
+
+	/**
+	 * Returns the class of the test response.
+	 *
+	 * @return class of the test response type
+	 */
+	protected abstract Class<R> getTestResponseClass();
+
+	/**
+	 * Returns an instance of a response to be tested.
+	 *
+	 * @return instance of the expected test response
+	 */
+	protected abstract R getTestResponseInstance();
+
+	/**
+	 * Tests that we can marshal and unmarshal the response.
+	 */
+	@Test
+	public void testJsonMarshalling() throws JsonProcessingException {
+		final R expected = getTestResponseInstance();
+
+		ObjectMapper objectMapper = RestMapperUtils.getStrictObjectMapper();
+		JsonNode json = objectMapper.valueToTree(expected);
+
+		final R unmarshalled = objectMapper.treeToValue(json, getTestResponseClass());
+		Assert.assertEquals(expected, unmarshalled);
+	}
+
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/messages/StatusOverviewWithVersionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/messages/StatusOverviewWithVersionTest.java
@@ -18,27 +18,19 @@
 
 package org.apache.flink.runtime.rest.handler.legacy.messages;
 
-import org.apache.flink.runtime.rest.util.RestMapperUtils;
-import org.apache.flink.util.TestLogger;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
-
 /**
  * Tests for the {@link StatusOverviewWithVersion}.
  */
-public class StatusOverviewWithVersionTest extends TestLogger {
+public class StatusOverviewWithVersionTest extends RestResponseMarshallingTestBase<StatusOverviewWithVersion> {
 
-	/**
-	 * Tests that we can marshal and unmarshal StatusOverviewWithVersion.
-	 */
-	@Test
-	public void testJsonMarshalling() throws JsonProcessingException {
-		final StatusOverviewWithVersion expected = new StatusOverviewWithVersion(
+	@Override
+	protected Class<StatusOverviewWithVersion> getTestResponseClass() {
+		return StatusOverviewWithVersion.class;
+	}
+
+	@Override
+	protected StatusOverviewWithVersion getTestResponseInstance() {
+		return new StatusOverviewWithVersion(
 			1,
 			3,
 			3,
@@ -48,13 +40,5 @@ public class StatusOverviewWithVersionTest extends TestLogger {
 			0,
 			"version",
 			"commit");
-
-		ObjectMapper objectMapper = RestMapperUtils.getStrictObjectMapper();
-
-		JsonNode json = objectMapper.valueToTree(expected);
-
-		final StatusOverviewWithVersion unmarshalled = objectMapper.treeToValue(json, StatusOverviewWithVersion.class);
-
-		assertEquals(expected, unmarshalled);
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR ports the existing `JobManagerConfigHandler` to the new REST endpoint. This includes introducing the `ClusterConfiguration` response and `ClusterConfigurationHeaders`. The `DispatcherRestEndpoint` now registers the `JobManagerConfigHandler`.

Additionally, this PR also contains other cosmetic changes, such as properly renaming the `JobManagerConfigHandler` to `ClusterConfigHandler`, and refactoring common test logic for marshalling / unmarshalling of REST responses.

## Brief change log

- Let `JobManagerConfigHandler` implement `LegacyRestEHandler`
- Register `JobManagerConfigHandler` at `DispatcherRestEndpoint`
- Rename `JobManagerConfigHandler` to `ClusterConfigHandler`
- Introduce `RestResponseMarshallingTestBase`

## Verifying this change

This change is a trivial rework / code cleanup.
Only additional test is `ClusterConfigurationTest` for the marshalling of the `ClusterConfiguration`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: yes

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

