### PR TITLE
[FLINK-7661][network] Add credit field in PartitionRequest message

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
@@ -22,16 +22,21 @@ import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.core.memory.MemoryType;
+import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.MathUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.TimeUnit;
 
+import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -129,6 +134,63 @@ public class NetworkBufferPool implements BufferPoolFactory {
 		// however, since this happens when references to the global pool are also released,
 		// making the availableMemorySegments queue and its contained object reclaimable
 		availableMemorySegments.add(segment);
+	}
+
+	public List<MemorySegment> requestMemorySegments(int numRequiredBuffers) throws IOException {
+		checkArgument(numRequiredBuffers > 0, "The number of required buffers should be larger than 0.");
+
+		synchronized (factoryLock) {
+			if (isDestroyed) {
+				throw new IllegalStateException("Network buffer pool has already been destroyed.");
+			}
+
+			if (numTotalRequiredBuffers + numRequiredBuffers > totalNumberOfMemorySegments) {
+				throw new IOException(String.format("Insufficient number of network buffers: " +
+								"required %d, but only %d available. The total number of network " +
+								"buffers is currently set to %d of %d bytes each. You can increase this " +
+								"number by setting the configuration keys '%s', '%s', and '%s'.",
+						numRequiredBuffers,
+						totalNumberOfMemorySegments - numTotalRequiredBuffers,
+						totalNumberOfMemorySegments,
+						memorySegmentSize,
+						TaskManagerOptions.NETWORK_BUFFERS_MEMORY_FRACTION.key(),
+						TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN.key(),
+						TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX.key()));
+			}
+
+			this.numTotalRequiredBuffers += numRequiredBuffers;
+
+			redistributeBuffers();
+		}
+
+		final List<MemorySegment> segments = new ArrayList<>(numRequiredBuffers);
+		try {
+			while (segments.size() < numRequiredBuffers) {
+				if (isDestroyed) {
+					throw new IllegalStateException("Buffer pool is destroyed.");
+				}
+
+				final MemorySegment segment = availableMemorySegments.poll(2, TimeUnit.SECONDS);
+				if (segment != null) {
+					segments.add(segment);
+				}
+			}
+		} catch (Throwable e) {
+			recycleMemorySegments(segments);
+			ExceptionUtils.rethrowIOException(e);
+		}
+
+		return segments;
+	}
+
+	public void recycleMemorySegments(List<MemorySegment> segments) throws IOException {
+		synchronized (factoryLock) {
+			numTotalRequiredBuffers -= segments.size();
+
+			availableMemorySegments.addAll(segments);
+
+			redistributeBuffers();
+		}
 	}
 
 	public void destroy() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyMessage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyMessage.java
@@ -348,13 +348,16 @@ abstract class NettyMessage {
 
 		InputChannelID receiverId;
 
+		int credit;
+
 		public PartitionRequest() {
 		}
 
-		PartitionRequest(ResultPartitionID partitionId, int queueIndex, InputChannelID receiverId) {
+		PartitionRequest(ResultPartitionID partitionId, int queueIndex, InputChannelID receiverId, int credit) {
 			this.partitionId = partitionId;
 			this.queueIndex = queueIndex;
 			this.receiverId = receiverId;
+			this.credit = credit;
 		}
 
 		@Override
@@ -362,12 +365,13 @@ abstract class NettyMessage {
 			ByteBuf result = null;
 
 			try {
-				result = allocateBuffer(allocator, ID, 16 + 16 + 4 + 16);
+				result = allocateBuffer(allocator, ID, 16 + 16 + 4 + 16 + 4);
 
 				partitionId.getPartitionId().writeTo(result);
 				partitionId.getProducerId().writeTo(result);
 				result.writeInt(queueIndex);
 				receiverId.writeTo(result);
+				result.writeInt(credit);
 
 				return result;
 			}
@@ -385,6 +389,7 @@ abstract class NettyMessage {
 			partitionId = new ResultPartitionID(IntermediateResultPartitionID.fromByteBuf(buffer), ExecutionAttemptID.fromByteBuf(buffer));
 			queueIndex = buffer.readInt();
 			receiverId = InputChannelID.fromByteBuf(buffer);
+			credit = buffer.readInt();
 		}
 
 		@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClient.java
@@ -106,7 +106,7 @@ public class PartitionRequestClient {
 		partitionRequestHandler.addInputChannel(inputChannel);
 
 		final PartitionRequest request = new PartitionRequest(
-				partitionId, subpartitionIndex, inputChannel.getInputChannelId());
+				partitionId, subpartitionIndex, inputChannel.getInputChannelId(), inputChannel.getInitialCredit());
 
 		final ChannelFutureListener listener = new ChannelFutureListener() {
 			@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionType.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionType.java
@@ -20,9 +20,9 @@ package org.apache.flink.runtime.io.network.partition;
 
 public enum ResultPartitionType {
 
-	BLOCKING(false, false, false),
+	BLOCKING(false, false, false, false),
 
-	PIPELINED(true, true, false),
+	PIPELINED(true, true, false, false),
 
 	/**
 	 * Pipelined partitions with a bounded (local) buffer pool.
@@ -35,7 +35,13 @@ public enum ResultPartitionType {
 	 * For batch jobs, it will be best to keep this unlimited ({@link #PIPELINED}) since there are
 	 * no checkpoint barriers.
 	 */
-	PIPELINED_BOUNDED(true, true, true);
+	PIPELINED_BOUNDED(true, true, true, false),
+
+	/**
+	 * Pipelined partitions with a bounded (local) buffer pool for floating buffers in input gate, and a number
+	 * of exclusive buffers per input channel. The producer transfers data based on consumer's available credits.
+	 */
+	PIPELINED_CREDIT_BASED(true, true, true, true);
 
 	/** Can the partition be consumed while being produced? */
 	private final boolean isPipelined;
@@ -46,13 +52,17 @@ public enum ResultPartitionType {
 	/** Does this partition use a limited number of (network) buffers? */
 	private final boolean isBounded;
 
+	/** Does this partition only send data when consumer has available buffers? */
+	private final boolean isCreditBased;
+
 	/**
 	 * Specifies the behaviour of an intermediate result partition at runtime.
 	 */
-	ResultPartitionType(boolean isPipelined, boolean hasBackPressure, boolean isBounded) {
+	ResultPartitionType(boolean isPipelined, boolean hasBackPressure, boolean isBounded, boolean isCreditBased) {
 		this.isPipelined = isPipelined;
 		this.hasBackPressure = hasBackPressure;
 		this.isBounded = isBounded;
+		this.isCreditBased = isCreditBased;
 	}
 
 	public boolean hasBackPressure() {
@@ -74,5 +84,14 @@ public enum ResultPartitionType {
 	 */
 	public boolean isBounded() {
 		return isBounded;
+	}
+
+	/**
+	 * Whether this partition uses the credit-based mode to transfer data or not.
+	 *
+	 * @return <tt>true</tt> if the data is transferred based on consumer's credit
+	 */
+	public boolean isCreditBased() {
+		return isCreditBased;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -328,6 +328,10 @@ public class RemoteInputChannel extends InputChannel implements BufferRecycler {
 		return id;
 	}
 
+	public int getInitialCredit() {
+		return initialCredit;
+	}
+
 	public BufferProvider getBufferProvider() throws IOException {
 		if (isReleased.get()) {
 			return null;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.io.network.partition.consumer;
 
+import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.event.TaskEvent;
 import org.apache.flink.runtime.io.network.ConnectionID;
 import org.apache.flink.runtime.io.network.ConnectionManager;
@@ -30,6 +31,7 @@ import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
 
 import java.io.IOException;
 import java.util.ArrayDeque;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -95,6 +97,10 @@ public class RemoteInputChannel extends InputChannel {
 
 		this.connectionId = checkNotNull(connectionId);
 		this.connectionManager = checkNotNull(connectionManager);
+	}
+
+	void assignExclusiveSegments(List<MemorySegment> segments) {
+		// TODO in next PR
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -24,23 +24,29 @@ import org.apache.flink.runtime.io.network.ConnectionID;
 import org.apache.flink.runtime.io.network.ConnectionManager;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferProvider;
+import org.apache.flink.runtime.io.network.buffer.BufferRecycler;
 import org.apache.flink.runtime.io.network.netty.PartitionRequestClient;
 import org.apache.flink.runtime.io.network.partition.PartitionNotFoundException;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
+import org.apache.flink.util.ExceptionUtils;
 
 import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.List;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * An input channel, which requests a remote partition queue.
  */
-public class RemoteInputChannel extends InputChannel {
+public class RemoteInputChannel extends InputChannel implements BufferRecycler {
 
 	/** ID to distinguish this channel from other channels sharing the same TCP connection. */
 	private final InputChannelID id = new InputChannelID();
@@ -72,6 +78,15 @@ public class RemoteInputChannel extends InputChannel {
 	 */
 	private int expectedSequenceNumber = 0;
 
+	/** The initial number of exclusive buffers assigned to this channel. */
+	private int initialCredit;
+
+	/** The current available buffers including both exclusive buffers and requested floating buffers. */
+	private final ArrayDeque<Buffer> availableBuffers = new ArrayDeque<>();
+
+	/** The number of available buffers that have not been unannounced to producer yet. */
+	private final AtomicInteger unannouncedCredit = new AtomicInteger(0);
+
 	public RemoteInputChannel(
 		SingleInputGate inputGate,
 		int channelIndex,
@@ -99,8 +114,24 @@ public class RemoteInputChannel extends InputChannel {
 		this.connectionManager = checkNotNull(connectionManager);
 	}
 
+	/**
+	 * Assigns exclusive buffers to this input channel, and this method should be called only once
+	 * after this input channel is created.
+	 */
 	void assignExclusiveSegments(List<MemorySegment> segments) {
-		// TODO in next PR
+		checkState(this.initialCredit == 0, "Bug in input channel setup logic: exclusive buffers have" +
+			"already been set for this input channel.");
+
+		checkNotNull(segments);
+		checkArgument(segments.size() > 0, "The number of exclusive buffers per channel should be larger than 0.");
+
+		this.initialCredit = segments.size();
+
+		synchronized(availableBuffers) {
+			for (MemorySegment segment : segments) {
+				availableBuffers.add(new Buffer(segment, this));
+			}
+		}
 	}
 
 	// ------------------------------------------------------------------------
@@ -183,16 +214,39 @@ public class RemoteInputChannel extends InputChannel {
 	}
 
 	/**
-	 * Releases all received buffers and closes the partition request client.
+	 * Releases all exclusive and floating buffers, closes the partition request client.
 	 */
 	@Override
 	void releaseAllResources() throws IOException {
 		if (isReleased.compareAndSet(false, true)) {
+
+			// Gather all exclusive buffers and recycle them to global pool in batch
+			final List<MemorySegment> exclusiveRecyclingSegments = new ArrayList<>();
+
 			synchronized (receivedBuffers) {
 				Buffer buffer;
 				while ((buffer = receivedBuffers.poll()) != null) {
-					buffer.recycle();
+					if (buffer.getRecycler() == this) {
+						exclusiveRecyclingSegments.add(buffer.getMemorySegment());
+					} else {
+						buffer.recycle();
+					}
 				}
+			}
+
+			synchronized (availableBuffers) {
+				Buffer buffer;
+				while ((buffer = availableBuffers.poll()) != null) {
+					if (buffer.getRecycler() == this) {
+						exclusiveRecyclingSegments.add(buffer.getMemorySegment());
+					} else {
+						buffer.recycle();
+					}
+				}
+			}
+
+			if (exclusiveRecyclingSegments.size() > 0) {
+				inputGate.returnExclusiveSegments(exclusiveRecyclingSegments);
 			}
 
 			// The released flag has to be set before closing the connection to ensure that
@@ -212,6 +266,48 @@ public class RemoteInputChannel extends InputChannel {
 	@Override
 	public String toString() {
 		return "RemoteInputChannel [" + partitionId + " at " + connectionId + "]";
+	}
+
+	// ------------------------------------------------------------------------
+	// Credit-based
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Enqueue this input channel in the pipeline for sending unannounced credits to producer.
+	 */
+	void notifyCreditAvailable() {
+		//TODO in next PR
+	}
+
+	/**
+	 * Exclusive buffer is recycled to this input channel directly and it may trigger notify
+	 * credit to producer.
+	 *
+	 * @param segment The exclusive segment of this channel.
+	 */
+	@Override
+	public void recycle(MemorySegment segment) {
+		synchronized (availableBuffers) {
+			if (isReleased.get()) {
+				try {
+					inputGate.returnExclusiveSegments(Arrays.asList(segment));
+					return;
+				} catch (Throwable t) {
+					ExceptionUtils.rethrow(t);
+				}
+			}
+			availableBuffers.add(new Buffer(segment, this));
+		}
+
+		if (unannouncedCredit.getAndAdd(1) == 0) {
+			notifyCreditAvailable();
+		}
+	}
+
+	public int getNumberOfAvailableBuffers() {
+		synchronized (availableBuffers) {
+			return availableBuffers.size();
+		}
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/BufferPoolFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/BufferPoolFactoryTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.io.network.buffer;
 
+import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.memory.MemoryType;
 import org.junit.After;
 import org.junit.Before;
@@ -149,9 +150,61 @@ public class BufferPoolFactoryTest {
 		assertEquals(1, third.getNumBuffers());
 
 		// similar to #verifyAllBuffersReturned()
-		String msg = "Did not return all buffers to network buffer pool after test.";
+		String msg = "Wrong number of available segments after creating buffer pools.";
 		assertEquals(msg, 3, globalPool.getNumberOfAvailableMemorySegments());
 		// in case buffers have actually been requested, we must release them again
+		globalPool.destroy();
+	}
+
+	/**
+	 * Tests the interaction of requesting memory segments and creating local buffer pool and
+	 * verifies the number of assigned buffers match after redistributing buffers because of newly
+	 * requested memory segments or new buffer pools created.
+	 */
+	@Test
+	public void testUniformDistributionBounded4() throws IOException {
+		NetworkBufferPool globalPool = new NetworkBufferPool(10, 128, MemoryType.HEAP);
+
+		BufferPool first = globalPool.createBufferPool(0, 10);
+		assertEquals(10, first.getNumBuffers());
+
+		List<MemorySegment> segmentList1 = globalPool.requestMemorySegments(2);
+		assertEquals(2, segmentList1.size());
+		assertEquals(8, first.getNumBuffers());
+
+		BufferPool second = globalPool.createBufferPool(0, 10);
+		assertEquals(4, first.getNumBuffers());
+		assertEquals(4, second.getNumBuffers());
+
+		List<MemorySegment> segmentList2 = globalPool.requestMemorySegments(2);
+		assertEquals(2, segmentList2.size());
+		assertEquals(3, first.getNumBuffers());
+		assertEquals(3, second.getNumBuffers());
+
+		List<MemorySegment> segmentList3 = globalPool.requestMemorySegments(2);
+		assertEquals(2, segmentList3.size());
+		assertEquals(2, first.getNumBuffers());
+		assertEquals(2, second.getNumBuffers());
+
+		String msg = "Wrong number of available segments after creating buffer pool and requesting segments.";
+		assertEquals(msg, 4, globalPool.getNumberOfAvailableMemorySegments());
+
+		globalPool.recycleMemorySegments(segmentList1);
+		assertEquals(msg, 6, globalPool.getNumberOfAvailableMemorySegments());
+		assertEquals(3, first.getNumBuffers());
+		assertEquals(3, second.getNumBuffers());
+
+		globalPool.recycleMemorySegments(segmentList2);
+		assertEquals(msg, 8, globalPool.getNumberOfAvailableMemorySegments());
+		assertEquals(4, first.getNumBuffers());
+		assertEquals(4, second.getNumBuffers());
+
+		globalPool.recycleMemorySegments(segmentList3);
+		assertEquals(msg, 10, globalPool.getNumberOfAvailableMemorySegments());
+		assertEquals(5, first.getNumBuffers());
+		assertEquals(5, second.getNumBuffers());
+
+		globalPool.destroyAllBufferPools();
 		globalPool.destroy();
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPoolTest.java
@@ -18,19 +18,35 @@
 
 package org.apache.flink.runtime.io.network.buffer;
 
+import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.memory.MemoryType;
+import org.apache.flink.core.testutils.CheckedThread;
+import org.apache.flink.core.testutils.OneShotLatch;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
+import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.core.IsCollectionContaining.hasItem;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.core.IsNot.not;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class NetworkBufferPoolTest {
+
+	@Rule
+	public ExpectedException expectedException = ExpectedException.none();
 
 	@Test
 	public void testCreatePoolAfterDestroy() {
@@ -167,5 +183,161 @@ public class NetworkBufferPoolTest {
 			e.printStackTrace();
 			fail(e.getMessage());
 		}
+	}
+
+	/**
+	 * Tests {@link NetworkBufferPool#requestMemorySegments(int)} with the {@link NetworkBufferPool}
+	 * currently containing the number of required free segments.
+	 */
+	@Test
+	public void testRequestMemorySegmentsLessThanTotalBuffers() throws Exception {
+		final int numBuffers = 10;
+
+		NetworkBufferPool globalPool = new NetworkBufferPool(numBuffers, 128, MemoryType.HEAP);
+
+		List<MemorySegment> memorySegments = Collections.emptyList();
+		try {
+			memorySegments = globalPool.requestMemorySegments(numBuffers / 2);
+			assertEquals(memorySegments.size(), numBuffers / 2);
+
+			globalPool.recycleMemorySegments(memorySegments);
+			memorySegments.clear();
+			assertEquals(globalPool.getNumberOfAvailableMemorySegments(), numBuffers);
+		} finally {
+			globalPool.recycleMemorySegments(memorySegments); // just in case
+			globalPool.destroy();
+		}
+	}
+
+	/**
+	 * Tests {@link NetworkBufferPool#requestMemorySegments(int)} with the number of required
+	 * buffers exceeding the capacity of {@link NetworkBufferPool}.
+	 */
+	@Test
+	public void testRequestMemorySegmentsMoreThanTotalBuffers() throws Exception {
+		final int numBuffers = 10;
+
+		NetworkBufferPool globalPool = new NetworkBufferPool(numBuffers, 128, MemoryType.HEAP);
+
+		try {
+			globalPool.requestMemorySegments(numBuffers + 1);
+			fail("Should throw an IOException");
+		} catch (IOException e) {
+			assertEquals(globalPool.getNumberOfAvailableMemorySegments(), numBuffers);
+		} finally {
+			globalPool.destroy();
+		}
+	}
+
+	/**
+	 * Tests {@link NetworkBufferPool#requestMemorySegments(int)} with the invalid argument to
+	 * cause exception.
+	 */
+	@Test
+	public void testRequestMemorySegmentsWithInvalidArgument() throws Exception {
+		final int numBuffers = 10;
+
+		NetworkBufferPool globalPool = new NetworkBufferPool(numBuffers, 128, MemoryType.HEAP);
+
+		try {
+			// the number of requested buffers should be larger than zero
+			globalPool.requestMemorySegments(0);
+			fail("Should throw an IllegalArgumentException");
+		} catch (IllegalArgumentException e) {
+			assertEquals(globalPool.getNumberOfAvailableMemorySegments(), numBuffers);
+		} finally {
+			globalPool.destroy();
+		}
+	}
+
+	/**
+	 * Tests {@link NetworkBufferPool#requestMemorySegments(int)} with the {@link NetworkBufferPool}
+	 * currently not containing the number of required free segments (currently occupied by a buffer pool).
+	 */
+	@Test
+	public void testRequestMemorySegmentsWithBuffersTaken() throws IOException, InterruptedException {
+		final int numBuffers = 10;
+
+		NetworkBufferPool networkBufferPool = new NetworkBufferPool(numBuffers, 128, MemoryType.HEAP);
+
+		final List<Buffer> buffers = new ArrayList<>(numBuffers);
+		List<MemorySegment> memorySegments = Collections.emptyList();
+		Thread bufferRecycler = null;
+		BufferPool lbp1 = null;
+		try {
+			lbp1 = networkBufferPool.createBufferPool(numBuffers / 2, numBuffers);
+
+			// take all buffers (more than the minimum required)
+			for (int i = 0; i < numBuffers; ++i) {
+				Buffer buffer = lbp1.requestBuffer();
+				buffers.add(buffer);
+				assertNotNull(buffer);
+			}
+
+			// requestMemorySegments() below will wait for buffers
+			// this will make sure that enough buffers are freed eventually for it to continue
+			final OneShotLatch isRunning = new OneShotLatch();
+			bufferRecycler = new Thread(() -> {
+				try {
+					isRunning.trigger();
+					Thread.sleep(100);
+				} catch (InterruptedException ignored) {
+				}
+
+				for (Buffer buffer : buffers) {
+					buffer.recycle();
+				}
+			});
+			bufferRecycler.start();
+
+			// take more buffers than are freely available at the moment via requestMemorySegments()
+			isRunning.await();
+			memorySegments = networkBufferPool.requestMemorySegments(numBuffers / 2);
+			assertThat(memorySegments, not(hasItem(nullValue())));
+		} finally {
+			if (bufferRecycler != null) {
+				bufferRecycler.join();
+			}
+			if (lbp1 != null) {
+				lbp1.lazyDestroy();
+			}
+			networkBufferPool.recycleMemorySegments(memorySegments);
+			networkBufferPool.destroy();
+		}
+	}
+
+	/**
+	 * Tests {@link NetworkBufferPool#requestMemorySegments(int)}, verifying it may be aborted in
+	 * case of a concurrent {@link NetworkBufferPool#destroy()} call.
+	 */
+	@Test
+	public void testRequestMemorySegmentsInterruptable() throws Exception {
+		final int numBuffers = 10;
+
+		NetworkBufferPool globalPool = new NetworkBufferPool(numBuffers, 128, MemoryType.HEAP);
+		MemorySegment segment = globalPool.requestMemorySegment();
+		assertNotNull(segment);
+
+		final OneShotLatch isRunning = new OneShotLatch();
+		CheckedThread asyncRequest = new CheckedThread() {
+			@Override
+			public void go() throws Exception {
+				isRunning.trigger();
+				globalPool.requestMemorySegments(10);
+			}
+		};
+		asyncRequest.start();
+
+		// We want the destroy call inside the blocking part of the globalPool.requestMemorySegments()
+		// call above. We cannot guarantee this though but make it highly probable:
+		isRunning.await();
+		Thread.sleep(10);
+		globalPool.destroy();
+
+		segment.free();
+
+		expectedException.expect(IllegalStateException.class);
+		expectedException.expectMessage("destroyed");
+		asyncRequest.sync();
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CancelPartitionRequestTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CancelPartitionRequestTest.java
@@ -97,7 +97,7 @@ public class CancelPartitionRequestTest {
 			Channel ch = connect(serverAndClient);
 
 			// Request for non-existing input channel => results in cancel request
-			ch.writeAndFlush(new PartitionRequest(pid, 0, new InputChannelID())).await();
+			ch.writeAndFlush(new PartitionRequest(pid, 0, new InputChannelID(), 2)).await();
 
 			// Wait for the notification
 			if (!sync.await(TestingUtils.TESTING_DURATION().toMillis(), TimeUnit.MILLISECONDS)) {
@@ -150,7 +150,7 @@ public class CancelPartitionRequestTest {
 			// Request for non-existing input channel => results in cancel request
 			InputChannelID inputChannelId = new InputChannelID();
 
-			ch.writeAndFlush(new PartitionRequest(pid, 0, inputChannelId)).await();
+			ch.writeAndFlush(new PartitionRequest(pid, 0, inputChannelId, 2)).await();
 
 			// Wait for the notification
 			if (!sync.await(TestingUtils.TESTING_DURATION().toMillis(), TimeUnit.MILLISECONDS)) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyMessageSerializationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyMessageSerializationTest.java
@@ -126,12 +126,13 @@ public class NettyMessageSerializationTest {
 		}
 
 		{
-			NettyMessage.PartitionRequest expected = new NettyMessage.PartitionRequest(new ResultPartitionID(new IntermediateResultPartitionID(), new ExecutionAttemptID()), random.nextInt(), new InputChannelID());
+			NettyMessage.PartitionRequest expected = new NettyMessage.PartitionRequest(new ResultPartitionID(new IntermediateResultPartitionID(), new ExecutionAttemptID()), random.nextInt(), new InputChannelID(), random.nextInt());
 			NettyMessage.PartitionRequest actual = encodeAndDecode(expected);
 
 			assertEquals(expected.partitionId, actual.partitionId);
 			assertEquals(expected.queueIndex, actual.queueIndex);
 			assertEquals(expected.receiverId, actual.receiverId);
+			assertEquals(expected.credit, actual.credit);
 		}
 
 		{

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/ServerTransportErrorHandlingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/ServerTransportErrorHandlingTest.java
@@ -106,7 +106,7 @@ public class ServerTransportErrorHandlingTest {
 			Channel ch = connect(serverAndClient);
 
 			// Write something to trigger close by server
-			ch.writeAndFlush(new NettyMessage.PartitionRequest(new ResultPartitionID(), 0, new InputChannelID()));
+			ch.writeAndFlush(new NettyMessage.PartitionRequest(new ResultPartitionID(), 0, new InputChannelID(), 2));
 
 			// Wait for the notification
 			if (!sync.await(TestingUtils.TESTING_DURATION().toMillis(), TimeUnit.MILLISECONDS)) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.io.network.partition.consumer;
 
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.runtime.execution.CancelTaskException;
 import org.apache.flink.runtime.io.network.ConnectionID;
 import org.apache.flink.runtime.io.network.ConnectionManager;
@@ -33,6 +35,7 @@ import org.junit.Test;
 import scala.Tuple2;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
@@ -42,8 +45,10 @@ import java.util.concurrent.Future;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyListOf;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -279,6 +284,73 @@ public class RemoteInputChannelTest {
 
 		// Should throw an instance of CancelTaskException.
 		ch.getNextBuffer();
+	}
+
+	/**
+	 * Tests {@link RemoteInputChannel#recycle(MemorySegment)}, verifying the exclusive segment is
+	 * recycled to available buffers directly and it triggers notify of announced credit.
+	 */
+	@Test
+	public void testRecycleExclusiveBufferBeforeReleased() throws Exception {
+		final SingleInputGate inputGate = mock(SingleInputGate.class);
+		final RemoteInputChannel inputChannel = spy(createRemoteInputChannel(inputGate));
+
+		// Recycle exclusive segment
+		inputChannel.recycle(MemorySegmentFactory.getFactory().allocateUnpooledSegment(1024, inputChannel));
+
+		assertEquals("There should have one available buffer after recycle.",
+			1, inputChannel.getNumberOfAvailableBuffers());
+		verify(inputChannel, times(1)).notifyCreditAvailable();
+	}
+
+	/**
+	 * Tests {@link RemoteInputChannel#recycle(MemorySegment)}, verifying the exclusive segment is
+	 * recycled to global pool via input gate when channel is released.
+	 */
+	@Test
+	public void testRecycleExclusiveBufferAfterReleased() throws Exception {
+		// Setup
+		final SingleInputGate inputGate = mock(SingleInputGate.class);
+		final RemoteInputChannel inputChannel = spy(createRemoteInputChannel(inputGate));
+
+		inputChannel.releaseAllResources();
+
+		// Recycle exclusive segment after channel released
+		inputChannel.recycle(MemorySegmentFactory.getFactory().allocateUnpooledSegment(1024, inputChannel));
+
+		assertEquals("Resource leak during recycling buffer after channel is released.",
+			0, inputChannel.getNumberOfAvailableBuffers());
+		verify(inputChannel, times(0)).notifyCreditAvailable();
+		verify(inputGate, times(1)).returnExclusiveSegments(anyListOf(MemorySegment.class));
+	}
+
+	/**
+	 * Tests {@link RemoteInputChannel#releaseAllResources()}, verifying the exclusive segments are
+	 * recycled to global pool via input gate and no resource leak.
+	 */
+	@Test
+	public void testReleaseExclusiveBuffers() throws Exception {
+		// Setup
+		final SingleInputGate inputGate = mock(SingleInputGate.class);
+		final RemoteInputChannel inputChannel = createRemoteInputChannel(inputGate);
+
+		// Assign exclusive segments to channel
+		final List<MemorySegment> exclusiveSegments = new ArrayList<>();
+		final int numExclusiveBuffers = 2;
+		for (int i = 0; i < numExclusiveBuffers; i++) {
+			exclusiveSegments.add(MemorySegmentFactory.getFactory().allocateUnpooledSegment(1024, inputChannel));
+		}
+		inputChannel.assignExclusiveSegments(exclusiveSegments);
+
+		assertEquals("The number of available buffers is not equal to the assigned amount.",
+			numExclusiveBuffers, inputChannel.getNumberOfAvailableBuffers());
+
+		// Release this channel
+		inputChannel.releaseAllResources();
+
+		assertEquals("Resource leak after channel is released.",
+			0, inputChannel.getNumberOfAvailableBuffers());
+		verify(inputGate, times(1)).returnExclusiveSegments(anyListOf(MemorySegment.class));
 	}
 
 	// ---------------------------------------------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change

*`PartitionRequest` message adds the credit field which corresponds to the number of exclusive segments in `InputChannel`*.

*This pull request is based on [4499](https://github.com/apache/flink/pull/4499) whose commit is also included for passing travis. Review the third commit for this PR change*.

## Brief change log

  - *Add credit field in `PartitionRequest` message*
  - *Add `getInitialCredit()` method in `RemoteInputChannel`*

## Verifying this change

This change is already covered by existing tests, such as *NettyMessageSerializationTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

