### PR TITLE
[FLINK-7663] [flip6] Return BAD_REQUEST if HandlerRequest cannot be created

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/AbstractRestHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/AbstractRestHandler.java
@@ -127,7 +127,7 @@ public abstract class AbstractRestHandler<T extends RestfulGateway, R extends Re
 				HandlerUtils.sendErrorResponse(
 					ctx,
 					httpRequest,
-					new ErrorResponseBody(String.format("Could not create the handler request: %s", hre.getMessage())),
+					new ErrorResponseBody(String.format("Bad request, could not parse parameters: %s", hre.getMessage())),
 					HttpResponseStatus.BAD_REQUEST);
 				return;
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/AbstractRestHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/AbstractRestHandler.java
@@ -117,11 +117,26 @@ public abstract class AbstractRestHandler<T extends RestfulGateway, R extends Re
 				}
 			}
 
-			CompletableFuture<P> response;
+			final HandlerRequest<R, M> handlerRequest;
+
 			try {
-				HandlerRequest<R, M> handlerRequest = new HandlerRequest<>(request, messageHeaders.getUnresolvedMessageParameters(), routed.pathParams(), routed.queryParams());
+				handlerRequest = new HandlerRequest<>(request, messageHeaders.getUnresolvedMessageParameters(), routed.pathParams(), routed.queryParams());
+			} catch (HandlerRequestException hre) {
+				log.error("Could not create the handler request.", hre);
+
+				HandlerUtils.sendErrorResponse(
+					ctx,
+					httpRequest,
+					new ErrorResponseBody(String.format("Could not create the handler request: %s", hre.getMessage())),
+					HttpResponseStatus.BAD_REQUEST);
+				return;
+			}
+
+			CompletableFuture<P> response;
+
+			try {
 				response = handleRequest(handlerRequest, gateway);
-			} catch (Exception e) {
+			} catch (RestHandlerException e) {
 				response = FutureUtils.completedExceptionally(e);
 			}
 
@@ -138,7 +153,7 @@ public abstract class AbstractRestHandler<T extends RestfulGateway, R extends Re
 					HandlerUtils.sendResponse(ctx, httpRequest, resp, messageHeaders.getResponseStatusCode());
 				}
 			});
-		} catch (Exception e) {
+		} catch (Throwable e) {
 			log.error("Request processing failed.", e);
 			HandlerUtils.sendErrorResponse(ctx, httpRequest, new ErrorResponseBody("Internal server error."), HttpResponseStatus.INTERNAL_SERVER_ERROR);
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/HandlerRequest.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/HandlerRequest.java
@@ -42,7 +42,7 @@ public class HandlerRequest<R extends RequestBody, M extends MessageParameters> 
 	private final Map<Class<? extends MessagePathParameter<?>>, MessagePathParameter<?>> pathParameters = new HashMap<>(2);
 	private final Map<Class<? extends MessageQueryParameter<?>>, MessageQueryParameter<?>> queryParameters = new HashMap<>(2);
 
-	public HandlerRequest(R requestBody, M messageParameters, Map<String, String> receivedPathParameters, Map<String, List<String>> receivedQueryParameters) {
+	public HandlerRequest(R requestBody, M messageParameters, Map<String, String> receivedPathParameters, Map<String, List<String>> receivedQueryParameters) throws HandlerRequestException {
 		this.requestBody = Preconditions.checkNotNull(requestBody);
 		Preconditions.checkNotNull(messageParameters);
 		Preconditions.checkNotNull(receivedQueryParameters);
@@ -51,7 +51,11 @@ public class HandlerRequest<R extends RequestBody, M extends MessageParameters> 
 		for (MessagePathParameter<?> pathParameter : messageParameters.getPathParameters()) {
 			String value = receivedPathParameters.get(pathParameter.getKey());
 			if (value != null) {
-				pathParameter.resolveFromString(value);
+				try {
+					pathParameter.resolveFromString(value);
+				} catch (Exception e) {
+					throw new HandlerRequestException("Cannot resolve path parameter (" + pathParameter.getKey() + ") from value \"" + value + "\".");
+				}
 
 				@SuppressWarnings("unchecked")
 				Class<? extends MessagePathParameter<?>> clazz = (Class<? extends MessagePathParameter<?>>) pathParameter.getClass();
@@ -64,7 +68,12 @@ public class HandlerRequest<R extends RequestBody, M extends MessageParameters> 
 			if (values != null && !values.isEmpty()) {
 				StringJoiner joiner = new StringJoiner(",");
 				values.forEach(joiner::add);
-				queryParameter.resolveFromString(joiner.toString());
+
+				try {
+					queryParameter.resolveFromString(joiner.toString());
+				} catch (Exception e) {
+					throw new HandlerRequestException("Cannot resolve query parameter (" + queryParameter.getKey() + ") from value \"" + joiner + "\".");
+				}
 
 				@SuppressWarnings("unchecked")
 				Class<? extends MessageQueryParameter<?>> clazz = (Class<? extends MessageQueryParameter<?>>) queryParameter.getClass();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/HandlerRequestException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/HandlerRequestException.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler;
+
+import org.apache.flink.util.FlinkException;
+
+/**
+ * Base class for all {@link HandlerRequest} related exceptions.
+ */
+public class HandlerRequestException extends FlinkException {
+
+	private static final long serialVersionUID = 7310878739304006028L;
+
+	public HandlerRequestException(String message) {
+		super(message);
+	}
+
+	public HandlerRequestException(Throwable cause) {
+		super(cause);
+	}
+
+	public HandlerRequestException(String message, Throwable cause) {
+		super(message, cause);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/ConversionException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/ConversionException.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages;
+
+import org.apache.flink.util.FlinkException;
+
+/**
+ * Exception which is thrown if an input cannot converted into the requested type.
+ */
+public class ConversionException extends FlinkException {
+
+	private static final long serialVersionUID = -3994595267407963335L;
+
+	public ConversionException(String message) {
+		super(message);
+	}
+
+	public ConversionException(Throwable cause) {
+		super(cause);
+	}
+
+	public ConversionException(String message, Throwable cause) {
+		super(message, cause);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/MessageParameter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/MessageParameter.java
@@ -72,7 +72,7 @@ public abstract class MessageParameter<X> {
 	 *
 	 * @param value string representation of value to resolve this parameter with
 	 */
-	public final void resolveFromString(String value) {
+	public final void resolveFromString(String value) throws ConversionException {
 		resolve(convertFromString(value));
 	}
 
@@ -82,7 +82,7 @@ public abstract class MessageParameter<X> {
 	 * @param value string representation of parameter value
 	 * @return parameter value
 	 */
-	protected abstract X convertFromString(String value);
+	protected abstract X convertFromString(String value) throws ConversionException;
 
 	/**
 	 * Converts the given value to its string representation.

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestEndpointITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestEndpointITCase.java
@@ -26,16 +26,19 @@ import org.apache.flink.runtime.rest.handler.AbstractRestHandler;
 import org.apache.flink.runtime.rest.handler.HandlerRequest;
 import org.apache.flink.runtime.rest.handler.RestHandlerException;
 import org.apache.flink.runtime.rest.handler.RestHandlerSpecification;
+import org.apache.flink.runtime.rest.messages.ConversionException;
 import org.apache.flink.runtime.rest.messages.MessageHeaders;
 import org.apache.flink.runtime.rest.messages.MessageParameters;
 import org.apache.flink.runtime.rest.messages.MessagePathParameter;
 import org.apache.flink.runtime.rest.messages.MessageQueryParameter;
 import org.apache.flink.runtime.rest.messages.RequestBody;
 import org.apache.flink.runtime.rest.messages.ResponseBody;
+import org.apache.flink.runtime.rest.util.RestClientException;
 import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.webmonitor.RestfulGateway;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.TestLogger;
 
@@ -44,16 +47,22 @@ import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseSt
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.junit.Assert;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import javax.annotation.Nonnull;
 
+import java.net.InetSocketAddress;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -68,8 +77,11 @@ public class RestEndpointITCase extends TestLogger {
 	private static final String JOB_ID_KEY = "jobid";
 	private static final Time timeout = Time.seconds(10L);
 
-	@Test
-	public void testEndpoints() throws Exception {
+	private RestServerEndpoint serverEndpoint;
+	private RestClient clientEndpoint;
+
+	@Before
+	public void setup() throws Exception {
 		Configuration config = new Configuration();
 
 		RestServerEndpointConfiguration serverConfig = RestServerEndpointConfiguration.fromConfiguration(config);
@@ -86,46 +98,97 @@ public class RestEndpointITCase extends TestLogger {
 			mockGatewayRetriever,
 			RpcUtils.INF_TIMEOUT);
 
-		RestServerEndpoint serverEndpoint = new TestRestServerEndpoint(serverConfig, testHandler);
-		RestClient clientEndpoint = new TestRestClient(clientConfig);
+		serverEndpoint = new TestRestServerEndpoint(serverConfig, testHandler);
+		clientEndpoint = new TestRestClient(clientConfig);
 
-		try {
-			serverEndpoint.start();
+		serverEndpoint.start();
+	}
 
-			TestParameters parameters = new TestParameters();
-			parameters.jobIDPathParameter.resolve(PATH_JOB_ID);
-			parameters.jobIDQueryParameter.resolve(Collections.singletonList(QUERY_JOB_ID));
+	@After
+	public void teardown() {
+		if (clientEndpoint != null) {
+			clientEndpoint.shutdown(timeout);
+			clientEndpoint = null;
+		}
 
-			// send first request and wait until the handler blocks
-			CompletableFuture<TestResponse> response1;
-			synchronized (TestHandler.LOCK) {
-				response1 = clientEndpoint.sendRequest(
-					serverConfig.getEndpointBindAddress(),
-					serverConfig.getEndpointBindPort(),
-					new TestHeaders(),
-					parameters,
-					new TestRequest(1));
-				TestHandler.LOCK.wait();
-			}
+		if (serverEndpoint != null) {
+			serverEndpoint.shutdown(timeout);
+			serverEndpoint = null;
+		}
+	}
 
-			// send second request and verify response
-			CompletableFuture<TestResponse> response2 = clientEndpoint.sendRequest(
-				serverConfig.getEndpointBindAddress(),
-				serverConfig.getEndpointBindPort(),
+	@Test
+	public void testEndpoints() throws Exception {
+
+		TestParameters parameters = new TestParameters();
+		parameters.jobIDPathParameter.resolve(PATH_JOB_ID);
+		parameters.jobIDQueryParameter.resolve(Collections.singletonList(QUERY_JOB_ID));
+
+		// send first request and wait until the handler blocks
+		CompletableFuture<TestResponse> response1;
+		final InetSocketAddress serverAddress = serverEndpoint.getServerAddress();
+
+		synchronized (TestHandler.LOCK) {
+			response1 = clientEndpoint.sendRequest(
+				serverAddress.getHostName(),
+				serverAddress.getPort(),
 				new TestHeaders(),
 				parameters,
-				new TestRequest(2));
-			Assert.assertEquals(2, response2.get().id);
+				new TestRequest(1));
+			TestHandler.LOCK.wait();
+		}
 
-			// wake up blocked handler
-			synchronized (TestHandler.LOCK) {
-				TestHandler.LOCK.notifyAll();
-			}
-			// verify response to first request
-			Assert.assertEquals(1, response1.get().id);
-		} finally {
-			clientEndpoint.shutdown(timeout);
-			serverEndpoint.shutdown(timeout);
+		// send second request and verify response
+		CompletableFuture<TestResponse> response2 = clientEndpoint.sendRequest(
+			serverAddress.getHostName(),
+			serverAddress.getPort(),
+			new TestHeaders(),
+			parameters,
+			new TestRequest(2));
+		assertEquals(2, response2.get().id);
+
+		// wake up blocked handler
+		synchronized (TestHandler.LOCK) {
+			TestHandler.LOCK.notifyAll();
+		}
+		// verify response to first request
+		assertEquals(1, response1.get().id);
+	}
+
+	/**
+	 * Tests that a bad handler request (HandlerRequest cannot be created) is reported as a BAD_REQUEST
+	 * and not an internal server error.
+	 *
+	 * <p>See FLINK-7663
+	 */
+	@Test
+	public void testBadHandlerRequest() throws Exception {
+		final InetSocketAddress serverAddress = serverEndpoint.getServerAddress();
+
+		final FaultyTestParameters parameters = new FaultyTestParameters();
+
+		parameters.faultyJobIDPathParameter.resolve(PATH_JOB_ID);
+		parameters.jobIDQueryParameter.resolve(Collections.singletonList(QUERY_JOB_ID));
+
+		CompletableFuture<TestResponse> response = clientEndpoint.sendRequest(
+			serverAddress.getHostName(),
+			serverAddress.getPort(),
+			new TestHeaders(),
+			parameters,
+			new TestRequest(2));
+
+		try {
+			response.get();
+
+			fail("The request should fail with a bad request return code.");
+		} catch (ExecutionException ee) {
+			Throwable t = ExceptionUtils.stripExecutionException(ee);
+
+			assertTrue(t instanceof RestClientException);
+
+			RestClientException rce = (RestClientException) t;
+
+			assertEquals(HttpResponseStatus.BAD_REQUEST, rce.getHttpResponseStatus());
 		}
 	}
 
@@ -162,8 +225,8 @@ public class RestEndpointITCase extends TestLogger {
 
 		@Override
 		protected CompletableFuture<TestResponse> handleRequest(@Nonnull HandlerRequest<TestRequest, TestParameters> request, RestfulGateway gateway) throws RestHandlerException {
-			Assert.assertEquals(request.getPathParameter(JobIDPathParameter.class), PATH_JOB_ID);
-			Assert.assertEquals(request.getQueryParameter(JobIDQueryParameter.class).get(0), QUERY_JOB_ID);
+			assertEquals(request.getPathParameter(JobIDPathParameter.class), PATH_JOB_ID);
+			assertEquals(request.getQueryParameter(JobIDQueryParameter.class).get(0), QUERY_JOB_ID);
 
 			if (request.getRequestBody().id == 1) {
 				synchronized (LOCK) {
@@ -237,8 +300,8 @@ public class RestEndpointITCase extends TestLogger {
 	}
 
 	private static class TestParameters extends MessageParameters {
-		private final JobIDPathParameter jobIDPathParameter = new JobIDPathParameter();
-		private final JobIDQueryParameter jobIDQueryParameter = new JobIDQueryParameter();
+		protected final JobIDPathParameter jobIDPathParameter = new JobIDPathParameter();
+		protected final JobIDQueryParameter jobIDQueryParameter = new JobIDQueryParameter();
 
 		@Override
 		public Collection<MessagePathParameter<?>> getPathParameters() {
@@ -248,6 +311,15 @@ public class RestEndpointITCase extends TestLogger {
 		@Override
 		public Collection<MessageQueryParameter<?>> getQueryParameters() {
 			return Collections.singleton(jobIDQueryParameter);
+		}
+	}
+
+	private static class FaultyTestParameters extends TestParameters {
+		private final FaultyJobIDPathParameter faultyJobIDPathParameter = new FaultyJobIDPathParameter();
+
+		@Override
+		public Collection<MessagePathParameter<?>> getPathParameters() {
+			return Collections.singleton(faultyJobIDPathParameter);
 		}
 	}
 
@@ -264,6 +336,23 @@ public class RestEndpointITCase extends TestLogger {
 		@Override
 		protected String convertToString(JobID value) {
 			return value.toString();
+		}
+	}
+
+	static class FaultyJobIDPathParameter extends MessagePathParameter<JobID> {
+
+		FaultyJobIDPathParameter() {
+			super(JOB_ID_KEY);
+		}
+
+		@Override
+		protected JobID convertFromString(String value) throws ConversionException {
+			return JobID.fromHexString(value);
+		}
+
+		@Override
+		protected String convertToString(JobID value) {
+			return "foobar";
 		}
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

This commit changes the behaviour such that a failure in creating a `HandlerRequest` will
result in a BAD_REQUEST response by the AbstractRestHandler.

## Brief change log

- Introduce the `HandlerRequestException` indicating that the `HandlerRequest` could not be created
- Introduce a checked `ConversionException` for `MessageParameter#convertFromString` to let conversions fail explicitly
- Send `BAD_REQUEST` response in case that the `HandlerRequest` could not be created

## Verifying this change

- Added `RestEndpointITCase#testBadHandlerRequest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

R @zentol 

