### PR TITLE
[FLINK-7649] [flip6] Extend JobTerminationHandler to support stop

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/ExceptionUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/ExceptionUtils.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.Optional;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -309,6 +310,21 @@ public final class ExceptionUtils {
 	 */
 	public static Throwable stripExecutionException(Throwable throwable) {
 		while (throwable instanceof ExecutionException && throwable.getCause() != null) {
+			throwable = throwable.getCause();
+		}
+
+		return throwable;
+	}
+
+	/**
+	 * Unpacks an {@link CompletionException} and returns its cause. Otherwise the given
+	 * Throwable is returned.
+	 *
+	 * @param throwable to unpack if it is an CompletionException
+	 * @return Cause of CompletionException or given Throwable
+	 */
+	public static Throwable stripCompletionException(Throwable throwable) {
+		while (throwable instanceof CompletionException && throwable.getCause() != null) {
 			throwable = throwable.getCause();
 		}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -254,6 +254,17 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 	}
 
 	@Override
+	public CompletableFuture<Acknowledge> stopJob(JobID jobId, Time timeout) {
+		JobManagerRunner jobManagerRunner = jobManagerRunners.get(jobId);
+
+		if (jobManagerRunner == null) {
+			return FutureUtils.completedExceptionally(new FlinkJobNotFoundException(jobId));
+		} else {
+			return jobManagerRunner.getJobManagerGateway().stop(timeout);
+		}
+	}
+
+	@Override
 	public CompletableFuture<String> requestRestAddress(Time timeout) {
 		return restAddressFuture;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherGateway.java
@@ -48,7 +48,7 @@ public interface DispatcherGateway extends FencedRpcGateway<DispatcherId>, Restf
 		@RpcTimeout Time timeout);
 
 	/**
-	 * Lists the current set of submitted jobs.
+	 * List the current set of submitted jobs.
 	 *
 	 * @param timeout RPC timeout
 	 * @return A future collection of currently submitted jobs
@@ -56,6 +56,21 @@ public interface DispatcherGateway extends FencedRpcGateway<DispatcherId>, Restf
 	CompletableFuture<Collection<JobID>> listJobs(
 		@RpcTimeout Time timeout);
 
+	/**
+	 * Cancel the given job.
+	 *
+	 * @param jobId identifying the job to cancel
+	 * @param timeout of the operation
+	 * @return A future acknowledge if the cancellation succeeded
+	 */
+	CompletableFuture<Acknowledge> cancelJob(JobID jobId, @RpcTimeout Time timeout);
+
+	/**
+	 * Request the cluster overview.
+	 *
+	 * @param timeout of the operation
+	 * @return Future {@link StatusOverview} containing the cluster information
+	 */
 	CompletableFuture<StatusOverview> requestStatusOverview(@RpcTimeout Time timeout);
 
 	CompletableFuture<MultipleJobsDetails> requestJobDetails(@RpcTimeout Time timeout);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherGateway.java
@@ -66,6 +66,15 @@ public interface DispatcherGateway extends FencedRpcGateway<DispatcherId>, Restf
 	CompletableFuture<Acknowledge> cancelJob(JobID jobId, @RpcTimeout Time timeout);
 
 	/**
+	 * Stop the given job.
+	 *
+	 * @param jobId identifying the job to stop
+	 * @param timeout of the operation
+	 * @return A future acknowledge if the stopping succeeded
+	 */
+	CompletableFuture<Acknowledge> stopJob(JobID jobId, @RpcTimeout Time timeout);
+
+	/**
 	 * Request the cluster overview.
 	 *
 	 * @param timeout of the operation

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherRestEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherRestEndpoint.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.rest.handler.legacy.ClusterConfigHandler;
 import org.apache.flink.runtime.rest.handler.legacy.ClusterOverviewHandler;
 import org.apache.flink.runtime.rest.handler.legacy.CurrentJobsOverviewHandler;
 import org.apache.flink.runtime.rest.handler.legacy.DashboardConfigHandler;
+import org.apache.flink.runtime.rest.handler.legacy.JobCancellationHandler;
 import org.apache.flink.runtime.rest.handler.legacy.files.StaticFileServerHandler;
 import org.apache.flink.runtime.rest.handler.legacy.files.WebContentHandlerSpecification;
 import org.apache.flink.runtime.rest.handler.legacy.messages.ClusterConfigurationInfo;
@@ -41,6 +42,9 @@ import org.apache.flink.runtime.rest.messages.ClusterOverviewHeaders;
 import org.apache.flink.runtime.rest.messages.CurrentJobsOverviewHandlerHeaders;
 import org.apache.flink.runtime.rest.messages.DashboardConfigurationHeaders;
 import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
+import org.apache.flink.runtime.rest.messages.EmptyResponseBody;
+import org.apache.flink.runtime.rest.messages.JobCancellationHeaders;
+import org.apache.flink.runtime.rest.messages.JobMessageParameters;
 import org.apache.flink.runtime.webmonitor.WebMonitorUtils;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
 import org.apache.flink.util.FileUtils;
@@ -114,6 +118,15 @@ public class DispatcherRestEndpoint extends RestServerEndpoint {
 				true,
 				true));
 
+		LegacyRestHandlerAdapter<DispatcherGateway, EmptyResponseBody, JobMessageParameters> jobCancellationHandler = new LegacyRestHandlerAdapter<>(
+			restAddressFuture,
+			leaderRetriever,
+			timeout,
+			JobCancellationHeaders.getInstance(),
+			new JobCancellationHandler(
+				executor,
+				timeout));
+
 		LegacyRestHandlerAdapter<DispatcherGateway, ClusterConfigurationInfo, EmptyMessageParameters> clusterConfigurationHandler = new LegacyRestHandlerAdapter<>(
 			restAddressFuture,
 			leaderRetriever,
@@ -142,6 +155,7 @@ public class DispatcherRestEndpoint extends RestServerEndpoint {
 		handlers.add(Tuple2.of(ClusterConfigurationInfoHeaders.getInstance(), clusterConfigurationHandler));
 		handlers.add(Tuple2.of(DashboardConfigurationHeaders.getInstance(), dashboardConfigurationHandler));
 		handlers.add(Tuple2.of(CurrentJobsOverviewHandlerHeaders.getInstance(), currentJobsOverviewHandler));
+		handlers.add(Tuple2.of(JobCancellationHeaders.getInstance(), jobCancellationHandler));
 
 		optWebContent.ifPresent(
 			webContent -> handlers.add(Tuple2.of(WebContentHandlerSpecification.getInstance(), webContent)));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -28,6 +28,7 @@ import org.apache.flink.core.io.InputSplit;
 import org.apache.flink.core.io.InputSplitAssigner;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+import org.apache.flink.runtime.StoppingException;
 import org.apache.flink.runtime.blob.BlobServer;
 import org.apache.flink.runtime.checkpoint.CheckpointCoordinator;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
@@ -360,6 +361,17 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 	@Override
 	public CompletableFuture<Acknowledge> cancel(Time timeout) {
 		executionGraph.cancel();
+
+		return CompletableFuture.completedFuture(Acknowledge.get());
+	}
+
+	@Override
+	public CompletableFuture<Acknowledge> stop(Time timeout) {
+		try {
+			executionGraph.stop();
+		} catch (StoppingException e) {
+			return FutureUtils.completedExceptionally(e);
+		}
 
 		return CompletableFuture.completedFuture(Acknowledge.get());
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -357,6 +357,13 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 	// RPC methods
 	//----------------------------------------------------------------------------------------------
 
+	@Override
+	public CompletableFuture<Acknowledge> cancel(Time timeout) {
+		executionGraph.cancel();
+
+		return CompletableFuture.completedFuture(Acknowledge.get());
+	}
+
 	/**
 	 * Updates the task execution state for a given task.
 	 *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
@@ -63,6 +63,14 @@ public interface JobMasterGateway extends CheckpointCoordinatorGateway, FencedRp
 	CompletableFuture<Acknowledge> cancel(@RpcTimeout Time timeout);
 
 	/**
+	 * Cancel the currently executed job.
+	 *
+	 * @param timeout of this operation
+	 * @return Future acknowledge if the cancellation was successful
+	 */
+	CompletableFuture<Acknowledge> stop(@RpcTimeout Time timeout);
+
+	/**
 	 * Updates the task execution state for a given task.
 	 *
 	 * @param taskExecutionState New task execution state for a given task

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
@@ -55,6 +55,14 @@ import java.util.concurrent.CompletableFuture;
 public interface JobMasterGateway extends CheckpointCoordinatorGateway, FencedRpcGateway<JobMasterId> {
 
 	/**
+	 * Cancels the currently executed job.
+	 *
+	 * @param timeout of this operation
+	 * @return Future acknowledge of the operation
+	 */
+	CompletableFuture<Acknowledge> cancel(@RpcTimeout Time timeout);
+
+	/**
 	 * Updates the task execution state for a given task.
 	 *
 	 * @param taskExecutionState New task execution state for a given task
@@ -64,8 +72,9 @@ public interface JobMasterGateway extends CheckpointCoordinatorGateway, FencedRp
 			final TaskExecutionState taskExecutionState);
 
 	/**
-	 * Requesting next input split for the {@link ExecutionJobVertex}. The next input split is sent back to the sender
-	 * as a {@link SerializedInputSplit} message.
+	 * Requests the next input split for the {@link ExecutionJobVertex}.
+	 * The next input split is sent back to the sender as a
+	 * {@link SerializedInputSplit} message.
 	 *
 	 * @param vertexID         The job vertex id
 	 * @param executionAttempt The execution attempt id
@@ -76,8 +85,8 @@ public interface JobMasterGateway extends CheckpointCoordinatorGateway, FencedRp
 			final ExecutionAttemptID executionAttempt);
 
 	/**
-	 * Requests the current state of the partition.
-	 * The state of a partition is currently bound to the state of the producing execution.
+	 * Requests the current state of the partition. The state of a
+	 * partition is currently bound to the state of the producing execution.
 	 *
 	 * @param intermediateResultId The execution attempt ID of the task requesting the partition state.
 	 * @param partitionId          The partition ID of the partition to request the state of.
@@ -89,12 +98,12 @@ public interface JobMasterGateway extends CheckpointCoordinatorGateway, FencedRp
 
 	/**
 	 * Notifies the JobManager about available data for a produced partition.
-	 * <p>
-	 * There is a call to this method for each {@link ExecutionVertex} instance once per produced
+	 *
+	 * <p>There is a call to this method for each {@link ExecutionVertex} instance once per produced
 	 * {@link ResultPartition} instance, either when first producing data (for pipelined executions)
 	 * or when all data has been produced (for staged executions).
-	 * <p>
-	 * The JobManager then can decide when to schedule the partition consumers of the given session.
+	 *
+	 * <p>The JobManager then can decide when to schedule the partition consumers of the given session.
 	 *
 	 * @param partitionID     The partition which has already produced data
 	 * @param timeout         before the rpc call fails
@@ -132,6 +141,8 @@ public interface JobMasterGateway extends CheckpointCoordinatorGateway, FencedRp
 	CompletableFuture<KvStateLocation> lookupKvStateLocation(final String registrationName);
 
 	/**
+	 * Notifies that queryable state has been registered.
+	 *
 	 * @param jobVertexId          JobVertexID the KvState instance belongs to.
 	 * @param keyGroupRange        Key group range the KvState instance belongs to.
 	 * @param registrationName     Name under which the KvState has been registered.
@@ -146,6 +157,8 @@ public interface JobMasterGateway extends CheckpointCoordinatorGateway, FencedRp
 			final KvStateServerAddress kvStateServerAddress);
 
 	/**
+	 * Notifies that queryable state has been unregistered.
+	 *
 	 * @param jobVertexId      JobVertexID the KvState instance belongs to.
 	 * @param keyGroupRange    Key group index the KvState instance belongs to.
 	 * @param registrationName Name under which the KvState has been registered.
@@ -161,7 +174,7 @@ public interface JobMasterGateway extends CheckpointCoordinatorGateway, FencedRp
 	CompletableFuture<ClassloadingProps> requestClassloadingProps();
 
 	/**
-	 * Offer the given slots to the job manager. The response contains the set of accepted slots.
+	 * Offers the given slots to the job manager. The response contains the set of accepted slots.
 	 *
 	 * @param taskManagerId identifying the task manager
 	 * @param slots         to offer to the job manager
@@ -174,7 +187,7 @@ public interface JobMasterGateway extends CheckpointCoordinatorGateway, FencedRp
 			@RpcTimeout final Time timeout);
 
 	/**
-	 * Fail the slot with the given allocation id and cause.
+	 * Fails the slot with the given allocation id and cause.
 	 *
 	 * @param taskManagerId identifying the task manager
 	 * @param allocationId  identifying the slot to fail
@@ -185,7 +198,7 @@ public interface JobMasterGateway extends CheckpointCoordinatorGateway, FencedRp
 			final Exception cause);
 
 	/**
-	 * Register the task manager at the job manager.
+	 * Registers the task manager at the job manager.
 	 *
 	 * @param taskManagerRpcAddress the rpc address of the task manager
 	 * @param taskManagerLocation   location of the task manager
@@ -198,14 +211,14 @@ public interface JobMasterGateway extends CheckpointCoordinatorGateway, FencedRp
 			@RpcTimeout final Time timeout);
 
 	/**
-	 * Send the heartbeat to job manager from task manager
+	 * Sends the heartbeat to job manager from task manager
 	 *
 	 * @param resourceID unique id of the task manager
 	 */
 	void heartbeatFromTaskManager(final ResourceID resourceID);
 
 	/**
-	 * Heartbeat request from the resource manager
+	 * Sends heartbeat request from the resource manager
 	 *
 	 * @param resourceID unique id of the resource manager
 	 */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/messages/FlinkJobNotFoundException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/messages/FlinkJobNotFoundException.java
@@ -16,31 +16,19 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.rest.handler;
+package org.apache.flink.runtime.messages;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.util.FlinkException;
 
-import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
-
 /**
- * An exception that is thrown if the failure of a REST operation was detected by a handler.
+ * Exception which is returned if a Flink job could not be found.
  */
-public class RestHandlerException extends FlinkException {
-	private static final long serialVersionUID = -1358206297964070876L;
+public class FlinkJobNotFoundException extends FlinkException {
 
-	private final int responseCode;
+	private static final long serialVersionUID = -7803390762010615384L;
 
-	public RestHandlerException(String errorMessage, HttpResponseStatus httpResponseStatus) {
-		super(errorMessage);
-		this.responseCode = httpResponseStatus.code();
-	}
-
-	public RestHandlerException(String errorMessage, HttpResponseStatus httpResponseStatus, Throwable cause) {
-		super(errorMessage, cause);
-		this.responseCode = httpResponseStatus.code();
-	}
-
-	public HttpResponseStatus getHttpResponseStatus() {
-		return HttpResponseStatus.valueOf(responseCode);
+	public FlinkJobNotFoundException(JobID jobId) {
+		super("Could not find Flink job (" + jobId + ").");
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
@@ -256,6 +256,14 @@ public abstract class RestServerEndpoint {
 			case POST:
 				router.POST(specificationHandler.f0.getTargetRestEndpointURL(), specificationHandler.f1);
 				break;
+			case DELETE:
+				router.DELETE(specificationHandler.f0.getTargetRestEndpointURL(), specificationHandler.f1);
+				break;
+			case PATCH:
+				router.PATCH(specificationHandler.f0.getTargetRestEndpointURL(), specificationHandler.f1);
+				break;
+			default:
+				throw new RuntimeException("Unsupported http method: " + specificationHandler.f0.getHttpMethod() + '.');
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobTerminationHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobTerminationHandler.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.job;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.dispatcher.DispatcherGateway;
+import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.messages.FlinkJobNotFoundException;
+import org.apache.flink.runtime.rest.handler.AbstractRestHandler;
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.RestHandlerException;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.EmptyResponseBody;
+import org.apache.flink.runtime.rest.messages.JobIDPathParameter;
+import org.apache.flink.runtime.rest.messages.JobTerminationMessageParameters;
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+import org.apache.flink.runtime.rest.messages.TerminationModeQueryParameter;
+import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+import org.apache.flink.util.ExceptionUtils;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Request handler for the cancel and stop request.
+ */
+public class JobTerminationHandler extends AbstractRestHandler<DispatcherGateway, EmptyRequestBody, EmptyResponseBody, JobTerminationMessageParameters> {
+
+	public JobTerminationHandler(
+			CompletableFuture<String> localRestAddress,
+			GatewayRetriever<DispatcherGateway> leaderRetriever,
+			Time timeout,
+			MessageHeaders<EmptyRequestBody, EmptyResponseBody, JobTerminationMessageParameters> messageHeaders) {
+		super(localRestAddress, leaderRetriever, timeout, messageHeaders);
+	}
+
+	@Override
+	public CompletableFuture<EmptyResponseBody> handleRequest(HandlerRequest<EmptyRequestBody, JobTerminationMessageParameters> request, DispatcherGateway gateway) {
+		final JobID jobId = request.getPathParameter(JobIDPathParameter.class);
+		final List<TerminationModeQueryParameter.TerminationMode> terminationModes = request.getQueryParameter(TerminationModeQueryParameter.class);
+		final TerminationModeQueryParameter.TerminationMode terminationMode;
+
+		if (terminationModes.isEmpty()) {
+			terminationMode = TerminationModeQueryParameter.TerminationMode.CANCEL;
+		} else {
+			// picking the first termination mode value
+			terminationMode = terminationModes.get(0);
+		}
+
+		final CompletableFuture<Acknowledge> terminationFuture;
+
+		switch (terminationMode) {
+			case CANCEL:
+				terminationFuture = gateway.cancelJob(jobId, timeout);
+				break;
+			case STOP:
+				terminationFuture = gateway.stopJob(jobId, timeout);
+				break;
+			default:
+				terminationFuture = FutureUtils.completedExceptionally(new RestHandlerException("Unknown termination mode " + terminationMode + '.', HttpResponseStatus.BAD_REQUEST));
+		}
+
+		return terminationFuture.handle(
+			(Acknowledge ack, Throwable throwable) -> {
+				if (throwable != null) {
+					Throwable error = ExceptionUtils.stripCompletionException(throwable);
+
+					if (error instanceof TimeoutException) {
+						throw new CompletionException(
+							new RestHandlerException(
+								"Job termination (" + terminationMode + ") timed out.",
+								HttpResponseStatus.REQUEST_TIMEOUT, error));
+					} else if (error instanceof FlinkJobNotFoundException) {
+						throw new CompletionException(
+							new RestHandlerException(
+								"Job could not be found.",
+								HttpResponseStatus.NOT_FOUND, error));
+					} else {
+						throw new CompletionException(
+							new RestHandlerException(
+								"Job termination (" + terminationMode + ") failed: " + error.getMessage(),
+								HttpResponseStatus.INTERNAL_SERVER_ERROR, error));
+					}
+				} else {
+					return EmptyResponseBody.getInstance();
+				}
+			});
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/JobCancellationHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/JobCancellationHandler.java
@@ -20,34 +20,20 @@ package org.apache.flink.runtime.rest.handler.legacy;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.runtime.dispatcher.DispatcherGateway;
 import org.apache.flink.runtime.jobmaster.JobManagerGateway;
-import org.apache.flink.runtime.messages.Acknowledge;
-import org.apache.flink.runtime.messages.FlinkJobNotFoundException;
-import org.apache.flink.runtime.rest.handler.HandlerRequest;
-import org.apache.flink.runtime.rest.handler.LegacyRestHandler;
-import org.apache.flink.runtime.rest.handler.RestHandlerException;
-import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
-import org.apache.flink.runtime.rest.messages.EmptyResponseBody;
-import org.apache.flink.runtime.rest.messages.JobIDPathParameter;
-import org.apache.flink.runtime.rest.messages.JobMessageParameters;
-import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.StringUtils;
-
-import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
-import java.util.concurrent.TimeoutException;
 
 /**
- * Request handler for the CANCEL request.
+ * Request handler for the cancel and stop request.
  */
-public class JobCancellationHandler extends AbstractJsonRequestHandler implements LegacyRestHandler<DispatcherGateway, EmptyResponseBody, JobMessageParameters> {
+public class JobCancellationHandler extends AbstractJsonRequestHandler {
 
 	private static final String JOB_CONCELLATION_REST_PATH = "/jobs/:jobid/cancel";
 	private static final String JOB_CONCELLATION_YARN_REST_PATH = "/jobs/:jobid/yarn-cancel";
@@ -83,38 +69,5 @@ public class JobCancellationHandler extends AbstractJsonRequestHandler implement
 				}
 			},
 			executor);
-	}
-
-	@Override
-	public CompletableFuture<EmptyResponseBody> handleRequest(HandlerRequest<EmptyRequestBody, JobMessageParameters> request, DispatcherGateway gateway) {
-		final JobID jobId = request.getPathParameter(JobIDPathParameter.class);
-
-		CompletableFuture<Acknowledge> cancelFuture = gateway.cancelJob(jobId, timeout);
-
-		return cancelFuture.handle(
-			(Acknowledge ack, Throwable throwable) -> {
-				if (throwable != null) {
-					Throwable error = ExceptionUtils.stripCompletionException(throwable);
-
-					if (error instanceof TimeoutException) {
-						throw new CompletionException(
-							new RestHandlerException(
-								"Job cancellation timed out.",
-								HttpResponseStatus.REQUEST_TIMEOUT, error));
-					} else if (error instanceof FlinkJobNotFoundException) {
-						throw new CompletionException(
-							new RestHandlerException(
-								"Job could not be found.",
-								HttpResponseStatus.NOT_FOUND, error));
-					} else {
-						throw new CompletionException(
-							new RestHandlerException(
-								"Job cancellation failed: " + error.getMessage(),
-								HttpResponseStatus.INTERNAL_SERVER_ERROR, error));
-					}
-				} else {
-					return EmptyResponseBody.getInstance();
-				}
-			});
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/EmptyResponseBody.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/EmptyResponseBody.java
@@ -16,26 +16,22 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.rest;
-
-import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpMethod;
+package org.apache.flink.runtime.rest.messages;
 
 /**
- * This class wraps netty's {@link HttpMethod}s into an enum, allowing us to use them in switches.
+ * Empty {@link ResponseBody} implementation.
  */
-public enum HttpMethodWrapper {
-	GET(HttpMethod.GET),
-	POST(HttpMethod.POST),
-	DELETE(HttpMethod.DELETE),
-	PATCH(HttpMethod.PATCH);
+public class EmptyResponseBody implements ResponseBody {
 
-	private HttpMethod nettyHttpMethod;
+	private static final EmptyResponseBody INSTANCE = new EmptyResponseBody();
 
-	HttpMethodWrapper(HttpMethod nettyHttpMethod) {
-		this.nettyHttpMethod = nettyHttpMethod;
+	private EmptyResponseBody() {}
+
+	private Object readResolve() {
+		return INSTANCE;
 	}
 
-	public HttpMethod getNettyHttpMethod() {
-		return nettyHttpMethod;
+	public static EmptyResponseBody getInstance() {
+		return INSTANCE;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobCancellationHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobCancellationHeaders.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages;
+
+import org.apache.flink.runtime.rest.HttpMethodWrapper;
+import org.apache.flink.runtime.rest.handler.legacy.JobCancellationHandler;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+/**
+ * Message headers for the {@link JobCancellationHandler}.
+ */
+public class JobCancellationHeaders implements MessageHeaders<EmptyRequestBody, EmptyResponseBody, JobMessageParameters> {
+
+	public static final String URL = "/jobs/:jobid";
+
+	private static final JobCancellationHeaders INSTANCE = new JobCancellationHeaders();
+
+	private JobCancellationHeaders() {}
+
+	@Override
+	public Class<EmptyRequestBody> getRequestClass() {
+		return EmptyRequestBody.class;
+	}
+
+	@Override
+	public Class<EmptyResponseBody> getResponseClass() {
+		return EmptyResponseBody.class;
+	}
+
+	@Override
+	public HttpResponseStatus getResponseStatusCode() {
+		return HttpResponseStatus.ACCEPTED;
+	}
+
+	@Override
+	public JobMessageParameters getUnresolvedMessageParameters() {
+		return new JobMessageParameters();
+	}
+
+	@Override
+	public HttpMethodWrapper getHttpMethod() {
+		return HttpMethodWrapper.PATCH;
+	}
+
+	@Override
+	public String getTargetRestEndpointURL() {
+		return URL;
+	}
+
+	public static JobCancellationHeaders getInstance() {
+		return INSTANCE;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobIDPathParameter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobIDPathParameter.java
@@ -16,26 +16,28 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.rest;
+package org.apache.flink.runtime.rest.messages;
 
-import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpMethod;
+import org.apache.flink.api.common.JobID;
 
 /**
- * This class wraps netty's {@link HttpMethod}s into an enum, allowing us to use them in switches.
+ * Path parameter identifying jobs.
  */
-public enum HttpMethodWrapper {
-	GET(HttpMethod.GET),
-	POST(HttpMethod.POST),
-	DELETE(HttpMethod.DELETE),
-	PATCH(HttpMethod.PATCH);
+public class JobIDPathParameter extends MessagePathParameter<JobID> {
 
-	private HttpMethod nettyHttpMethod;
+	private static final String JOB_ID = "jobid";
 
-	HttpMethodWrapper(HttpMethod nettyHttpMethod) {
-		this.nettyHttpMethod = nettyHttpMethod;
+	public JobIDPathParameter() {
+		super(JOB_ID);
 	}
 
-	public HttpMethod getNettyHttpMethod() {
-		return nettyHttpMethod;
+	@Override
+	protected JobID convertFromString(String value) {
+		return JobID.fromHexString(value);
+	}
+
+	@Override
+	protected String convertToString(JobID value) {
+		return value.toString();
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobMessageParameters.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobMessageParameters.java
@@ -16,26 +16,27 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.rest;
+package org.apache.flink.runtime.rest.messages;
 
-import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpMethod;
+import java.util.Collection;
+import java.util.Collections;
 
 /**
- * This class wraps netty's {@link HttpMethod}s into an enum, allowing us to use them in switches.
+ * Parameters for job related REST handlers.
+ *
+ * <p>A job related REST handler always requires a {@link JobIDPathParameter}.
  */
-public enum HttpMethodWrapper {
-	GET(HttpMethod.GET),
-	POST(HttpMethod.POST),
-	DELETE(HttpMethod.DELETE),
-	PATCH(HttpMethod.PATCH);
+public class JobMessageParameters extends MessageParameters {
 
-	private HttpMethod nettyHttpMethod;
+	private final JobIDPathParameter jobPathParameter = new JobIDPathParameter();
 
-	HttpMethodWrapper(HttpMethod nettyHttpMethod) {
-		this.nettyHttpMethod = nettyHttpMethod;
+	@Override
+	public Collection<MessagePathParameter<?>> getPathParameters() {
+		return Collections.singleton(jobPathParameter);
 	}
 
-	public HttpMethod getNettyHttpMethod() {
-		return nettyHttpMethod;
+	@Override
+	public Collection<MessageQueryParameter<?>> getQueryParameters() {
+		return Collections.emptyList();
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobTerminationHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobTerminationHeaders.java
@@ -26,13 +26,13 @@ import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseSt
 /**
  * Message headers for the {@link JobCancellationHandler}.
  */
-public class JobCancellationHeaders implements MessageHeaders<EmptyRequestBody, EmptyResponseBody, JobMessageParameters> {
+public class JobTerminationHeaders implements MessageHeaders<EmptyRequestBody, EmptyResponseBody, JobTerminationMessageParameters> {
 
 	public static final String URL = "/jobs/:jobid";
 
-	private static final JobCancellationHeaders INSTANCE = new JobCancellationHeaders();
+	private static final JobTerminationHeaders INSTANCE = new JobTerminationHeaders();
 
-	private JobCancellationHeaders() {}
+	private JobTerminationHeaders() {}
 
 	@Override
 	public Class<EmptyRequestBody> getRequestClass() {
@@ -50,8 +50,8 @@ public class JobCancellationHeaders implements MessageHeaders<EmptyRequestBody, 
 	}
 
 	@Override
-	public JobMessageParameters getUnresolvedMessageParameters() {
-		return new JobMessageParameters();
+	public JobTerminationMessageParameters getUnresolvedMessageParameters() {
+		return new JobTerminationMessageParameters();
 	}
 
 	@Override
@@ -64,7 +64,7 @@ public class JobCancellationHeaders implements MessageHeaders<EmptyRequestBody, 
 		return URL;
 	}
 
-	public static JobCancellationHeaders getInstance() {
+	public static JobTerminationHeaders getInstance() {
 		return INSTANCE;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobTerminationMessageParameters.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobTerminationMessageParameters.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * Parameters for job related REST handlers.
+ *
+ * <p>A job related REST handler always requires a {@link JobIDPathParameter}.
+ */
+public class JobTerminationMessageParameters extends MessageParameters {
+
+	private final JobIDPathParameter jobPathParameter = new JobIDPathParameter();
+	private final TerminationModeQueryParameter terminationModeQueryParameter = new TerminationModeQueryParameter();
+
+	@Override
+	public Collection<MessagePathParameter<?>> getPathParameters() {
+		return Collections.singleton(jobPathParameter);
+	}
+
+	@Override
+	public Collection<MessageQueryParameter<?>> getQueryParameters() {
+		return Collections.singleton(terminationModeQueryParameter);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/TerminationModeQueryParameter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/TerminationModeQueryParameter.java
@@ -18,25 +18,34 @@
 
 package org.apache.flink.runtime.rest.messages;
 
-import java.util.Collection;
-import java.util.Collections;
+import org.apache.flink.runtime.rest.handler.legacy.JobCancellationHandler;
 
 /**
- * Parameters for job related REST handlers.
- *
- * <p>A job related REST handler always requires a {@link JobIDPathParameter}.
+ * Termination mode for the {@link JobCancellationHandler}.
  */
-public class JobMessageParameters extends MessageParameters {
+public class TerminationModeQueryParameter extends MessageQueryParameter<TerminationModeQueryParameter.TerminationMode> {
 
-	private final JobIDPathParameter jobPathParameter = new JobIDPathParameter();
+	private static final String key = "mode";
 
-	@Override
-	public Collection<MessagePathParameter<?>> getPathParameters() {
-		return Collections.singleton(jobPathParameter);
+	public TerminationModeQueryParameter() {
+		super(key, MessageParameterRequisiteness.OPTIONAL);
 	}
 
 	@Override
-	public Collection<MessageQueryParameter<?>> getQueryParameters() {
-		return Collections.emptyList();
+	public TerminationMode convertValueFromString(String value) {
+		return TerminationMode.valueOf(value.toUpperCase());
+	}
+
+	@Override
+	public String convertStringToValue(TerminationMode value) {
+		return value.name().toLowerCase();
+	}
+
+	/**
+	 * Supported termination modes.
+	 */
+	public enum TerminationMode {
+		CANCEL,
+		STOP
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

Rename the JobCancellationHandler into JobTerminationHandler which is now responsible
for terminating jobs. Moreover, this commits adds two termination modes, cancel and stop,
which are specified by providing a query parameter.

## Brief change log

- Rename `JobCancellationHandler` into `JobTerminationHandler` being now responsible for the job termination (cancelling and stopping so far)
- Introduce a `TerminationModeQueryParameter` which allows to specify the termination mode (`stop` and `cancel`)
- Add `stopJob` to `DispatcherGateway` and `stop` to `JobMasterGateway`
- Adapt `JobTerminationHandler` to either call `cancelJob` or `stopJob` on the `Dispatcher` depending on the mode (default is `cancel`)

## Verifying this change

Tested manual that the right termination call is executed.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

