### PR TITLE
[FLINK-7659][REST] Unprotected access to inProgress in JobCancellationWithSavepointHandlers#handleNewRequest

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/JobCancellationWithSavepointHandlers.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/JobCancellationWithSavepointHandlers.java
@@ -218,7 +218,9 @@ public class JobCancellationWithSavepointHandlers {
 									completed.put(requestId, path);
 								}
 							} finally {
-								inProgress.remove(jobId);
+								synchronized (lock) {
+									inProgress.remove(jobId);
+								}
 							}
 						}, executor);
 


### PR DESCRIPTION
## What is the purpose of the change

There's a thread accessing `inProgress` without proper synchronization

## Brief change log

Add synchronization to access `inProgress` 

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

## Documentation

  - Does this pull request introduce a new feature? (no)

