### PR TITLE
[hotfix] [docs] Update function name in DataStream API

### DIFF
--- a/docs/dev/datastream_api.md
+++ b/docs/dev/datastream_api.md
@@ -619,7 +619,7 @@ import org.apache.flink.contrib.streaming.DataStreamUtils
 import scala.collection.JavaConverters.asScalaIteratorConverter
 
 val myResult: DataStream[(String, Int)] = ...
-val myOutput: Iterator[(String, Int)] = DataStreamUtils.collect(myResult.getJavaStream).asScala
+val myOutput: Iterator[(String, Int)] = DataStreamUtils.collect(myResult.javaStream).asScala
 {% endhighlight %}
 </div>
 </div>


### PR DESCRIPTION
Currently, the `javaStream` should be used to get the underlying java DataStream object -- not `getJavaStream`

