### PR TITLE
[FLINK-6444] [build] Add a check that '@VisibleForTesting' methods ar…

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -439,7 +439,7 @@ public abstract class StreamExecutionEnvironment {
 	 * from operations on {@link org.apache.flink.streaming.api.datastream.KeyedStream}) is maintained
 	 * (heap, managed memory, externally), and where state snapshots/checkpoints are stored, both for
 	 * the key/value state, and for checkpointed functions (implementing the interface
-	 * {@link org.apache.flink.streaming.api.checkpoint.Checkpointed}).
+	 * {@link org.apache.flink.streaming.api.checkpoint.ListCheckpointed}).
 	 *
 	 * <p>The {@link org.apache.flink.runtime.state.memory.MemoryStateBackend} for example
 	 * maintains the state in heap memory, as objects. It is lightweight without extra dependencies,

--- a/flink-tests/src/test/java/org/apache/flink/test/manual/CheckVisibleForTestingUsage.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/manual/CheckVisibleForTestingUsage.java
@@ -41,11 +41,14 @@ public class CheckVisibleForTestingUsage {
 
 	@Test
 	public void testCheckVisibleForTesting() throws Exception {
-		final Reflections reflections = new Reflections(new ConfigurationBuilder()
+		ConfigurationBuilder configurationBuilder = new ConfigurationBuilder()
 			.useParallelExecutor(Runtime.getRuntime().availableProcessors())
-			.addUrls(ClasspathHelper.forPackage("org.apache.flink"))
-			.addScanners(new MemberUsageScanner(),
-				new MethodAnnotationsScanner()));
+			.addUrls(ClasspathHelper.forPackage("org.apache.flink.core"))
+			.addScanners(
+				new MemberUsageScanner(),
+				new MethodAnnotationsScanner());
+
+		final Reflections reflections = new Reflections(configurationBuilder);
 
 		Set<Method> methods = reflections.getMethodsAnnotatedWith(VisibleForTesting.class);
 
@@ -53,9 +56,9 @@ public class CheckVisibleForTestingUsage {
 			Set<Member> usages = reflections.getMethodUsage(method);
 			for (Member member : usages) {
 				if (member instanceof Method) {
-					Method methodHopeWithTestAnnotation = (Method) member;
-					if (!methodHopeWithTestAnnotation.isAnnotationPresent(Test.class)) {
-						assertEquals("Unexpected calls: " + methodHopeWithTestAnnotation.getDeclaringClass() + "#" + methodHopeWithTestAnnotation.getName(),
+					Method visibleForTestingUsageScope = (Method) member;
+					if (!visibleForTestingUsageScope.isAnnotationPresent(Test.class)) {
+						assertEquals("Unexpected calls: " + visibleForTestingUsageScope.getDeclaringClass() + "#" + visibleForTestingUsageScope.getName(),
 							"Only Suggest used in tests.");
 					}
 				}

--- a/flink-tests/src/test/java/org/apache/flink/test/manual/CheckVisibleForTestingUsage.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/manual/CheckVisibleForTestingUsage.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.manual;
+
+import org.apache.flink.annotation.VisibleForTesting;
+
+import org.junit.Test;
+import org.reflections.Reflections;
+import org.reflections.scanners.MemberUsageScanner;
+import org.reflections.scanners.MethodAnnotationsScanner;
+import org.reflections.util.ClasspathHelper;
+import org.reflections.util.ConfigurationBuilder;
+
+import java.lang.reflect.Member;
+import java.lang.reflect.Method;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * This test check the methods are annotated with @VisibleForTesting. But still was called from the class
+ * which does not belong to the tests. These methods should only be called from tests.
+ */
+public class CheckVisibleForTestingUsage {
+
+	@Test
+	public void testCheckVisibleForTesting() throws Exception {
+		final Reflections reflections = new Reflections(new ConfigurationBuilder()
+			.useParallelExecutor(Runtime.getRuntime().availableProcessors())
+			.addUrls(ClasspathHelper.forPackage("org.apache.flink"))
+			.addScanners(new MemberUsageScanner(),
+				new MethodAnnotationsScanner()));
+
+		Set<Method> methods = reflections.getMethodsAnnotatedWith(VisibleForTesting.class);
+
+		for (Method method : methods) {
+			Set<Member> usages = reflections.getMethodUsage(method);
+			for (Member member : usages) {
+				if (member instanceof Method) {
+					Method methodHopeWithTestAnnotation = (Method) member;
+					if (!methodHopeWithTestAnnotation.isAnnotationPresent(Test.class)) {
+						assertEquals("Unexpected calls: " + methodHopeWithTestAnnotation.getDeclaringClass() + "#" + methodHopeWithTestAnnotation.getName(),
+							"Only Suggest used in tests.");
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR fix the issue which some methods are annotated with @VisibleForTesting. But still called from non-test class.

## Brief change log
Create a test class named `CheckVisibleForTestingUsage#testCheckVisibleForTesting` to verify and prevent this issue from happening in the future

## Verifying this change
This change is a trivial work with a test coverage.

