### PR TITLE
[FLINK-7446] [table] Change DefinedRowtimeAttribute to work on existing field.

### DIFF
--- a/docs/dev/table/sourceSinks.md
+++ b/docs/dev/table/sourceSinks.md
@@ -387,14 +387,70 @@ StreamTableSource[T] extends TableSource[T] {
 </div>
 </div>
 
-**Note:** If a Table needs to be processed in event-time, the `DataStream` returned by the `getDataStream()` method must carry timestamps and watermarks. Please see the documentation on [timestamp and watermark assignment]({{ site.baseurl }}/dev/event_timestamps_watermarks.html) for details on how to assign timestamps and watermarks.
+**IMPORTANT:** Time-based operations on streaming tables such as windows require explicitly specified [time attributes]({{ site.baseurl }}/dev/table/streaming.html#time-attributes) (both for the [Table API](tableApi.html#group-windows) and [SQL](sql.html#group-windows)). A `StreamTableSource` defines 
 
-**Note:** Time-based operations on streaming tables such as windows in both the [Table API](tableApi.html#group-windows) and [SQL](sql.html#group-windows) require explicitly specified time attributes. 
+- an *event-time attribute* by implementing the `DefinedRowtimeAttribute` interface and
+- a *processing-time attribute* by implementing the `DefinedProctimeAttribute` interface.
 
-- `DefinedRowtimeAttribute` provides the `getRowtimeAttribute()` method to specify the name of the event-time time attribute.
-- `DefinedProctimeAttribute` provides the `getProctimeAttribute()` method to specify the name of the processing-time time attribute.
+Both are described in the following sections.
 
-Please see the documentation on [time attributes]({{ site.baseurl }}/dev/table/streaming.html#time-attributes) for details.
+#### DefinedRowtimeAttribute
+
+The `DefinedRowtimeAttribute` interface provides a single method.
+
+<div class="codetabs" markdown="1">
+<div data-lang="java" markdown="1">
+{% highlight java %}
+DefinedRowtimeAttribute {
+
+  public String getRowtimeAttribute();
+}
+{% endhighlight %}
+</div>
+
+<div data-lang="scala" markdown="1">
+{% highlight scala %}
+DefinedRowtimeAttribute {
+
+  def getRowtimeAttribute(): String
+}
+{% endhighlight %}
+</div>
+</div>
+
+The `getRowtimeAttribute()` method returns the name of the field that holds the event-time timestamps for the rows of the table. The field must exist in the schema of the `StreamTableSource` and be of type `LONG` or `TIMESTAMP`. Moreover, the `DataStream` returned by `StreamTableSource.getDataStream()` must have [watermarks]({{ site.baseurl }}/dev/event_timestamps_watermarks.html) assigned which are aligned with the values of the specified timestamp field. 
+
+Please see the documentation on [timestamp and watermark assignment]({{ site.baseurl }}/dev/event_timestamps_watermarks.html) for details on how to assign watermarks. Please note that the timestamps of a `DataStream` (the ones which are assigned by a `TimestampAssigner`) are ignored. Only the values of the `TableSource`'s rowtime field are relevant.
+
+**Note:** A `TableSource` that returns a rowtime attribute does not support projection pushdown.
+
+#### DefinedProctimeAttribute
+
+The `DefinedProctimeAttribute` interface provides a single method.
+
+<div class="codetabs" markdown="1">
+<div data-lang="java" markdown="1">
+{% highlight java %}
+DefinedProctimeAttribute {
+
+  public String getProctimeAttribute();
+}
+{% endhighlight %}
+</div>
+
+<div data-lang="scala" markdown="1">
+{% highlight scala %}
+DefinedProctimeAttribute {
+
+  def getProctimeAttribute(): String
+}
+{% endhighlight %}
+</div>
+</div>
+
+The `getProctimeAttribute()` method returns the name of a field that is appended to each row returned by the `StreamTableSource`. The appended field serves as a processing time timestamp and can be used in time-based operations.
+
+**Note:** A `TableSource` that returns a processing time attribute does not support projection pushdown.
 
 {% top %}
 

--- a/docs/dev/table/streaming.md
+++ b/docs/dev/table/streaming.md
@@ -336,7 +336,7 @@ val windowedTable = tEnv
 
 ### Event time
 
-Event time allows a table program to produce results based on the time that is contained in every record. This allows for consistent results even in case of out-of-order events or late events. It also ensures replayable results of the table program when reading records from persistent storage. 
+Event time allows a table program to produce results based on the time that is contained in every record. This allows for consistent results even in case of out-of-order events or late events. It also ensures replayable results of the table program when reading records from persistent storage.
 
 Additionally, event time allows for unified syntax for table programs in both batch and streaming environments. A time attribute in a streaming environment can be a regular field of a record in a batch environment.
 
@@ -344,19 +344,16 @@ In order to handle out-of-order events and distinguish between on-time and late 
 
 An event time attribute can be defined either during DataStream-to-Table conversion or by using a TableSource. 
 
-The Table API & SQL assume that in both cases timestamps and watermarks have been generated in the [underlying DataStream API]({{ site.baseurl }}/dev/event_timestamps_watermarks.html) before. Ideally, this happens within a `TableSource` with knowledge about the incoming data's characteristics and is hidden from the end user of the API.
-
-
 #### During DataStream-to-Table Conversion
 
-The event time attribute is defined with the `.rowtime` property during schema definition. 
+The event time attribute is defined with the `.rowtime` property during schema definition. Timestamps and watermarks must have been assigned in the `DataStream` that is converted.
 
-Timestamps and watermarks must have been assigned in the `DataStream` that is converted.
+There are two ways of defining the time attribute when converting a `DataStream` into a `Table`. Depending on whether the specified `.rowtime` field name exists in the schema of the `DataStream` or not, the timestamp field is either 
 
-There are two ways of defining the time attribute when converting a `DataStream` into a `Table`:
+- appended as a new field to the schema or
+- replaces an existing field.
 
-- Extending the physical schema by an additional logical field
-- Replacing a physical field by a logical field (e.g. because it is no longer needed after timestamp extraction).
+In either case the event time timestamp field will hold the value of the `DataStream` event time timestamp.
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
@@ -415,9 +412,9 @@ val windowedTable = table.window(Tumble over 10.minutes on 'UserActionTime as 'u
 
 #### Using a TableSource
 
-The event time attribute is defined by a `TableSource` that implements the `DefinedRowtimeAttribute` interface. The logical time attribute is appended to the physical schema defined by the return type of the `TableSource`.
+The event time attribute is defined by a `TableSource` that implements the `DefinedRowtimeAttribute` interface. The `getRowtimeAttribute()` method returns the name of an existing field that carries the event time attribute of the table and is of type `LONG` or `TIMESTAMP`.
 
-Timestamps and watermarks must be assigned in the stream that is returned by the `getDataStream()` method.
+Moreover, the `DataStream` returned by the `getDataStream()` method must have watermarks assigned that are aligned with the defined time attribute. Please note that the timestamps of the `DataStream` (the ones which are assigned by a `TimestampAssigner`) are ignored. Only the values of the `TableSource`'s rowtime attribute are relevant.
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
@@ -427,8 +424,9 @@ public class UserActionSource implements StreamTableSource<Row>, DefinedRowtimeA
 
 	@Override
 	public TypeInformation<Row> getReturnType() {
-		String[] names = new String[] {"Username" , "Data"};
-		TypeInformation[] types = new TypeInformation[] {Types.STRING(), Types.STRING()};
+		String[] names = new String[] {"Username", "Data", "UserActionTime"};
+		TypeInformation[] types = 
+		    new TypeInformation[] {Types.STRING(), Types.STRING(), Types.LONG()};
 		return Types.ROW(names, types);
 	}
 
@@ -436,14 +434,14 @@ public class UserActionSource implements StreamTableSource<Row>, DefinedRowtimeA
 	public DataStream<Row> getDataStream(StreamExecutionEnvironment execEnv) {
 		// create stream 
 		// ...
-		// extract timestamp and assign watermarks based on knowledge of the stream
+		// assign watermarks based on the "UserActionTime" attribute
 		DataStream<Row> stream = inputStream.assignTimestampsAndWatermarks(...);
 		return stream;
 	}
 
 	@Override
 	public String getRowtimeAttribute() {
-		// field with this name will be appended as a third field 
+		// Mark the "UserActionTime" attribute as event-time attribute.
 		return "UserActionTime";
 	}
 }
@@ -462,21 +460,21 @@ WindowedTable windowedTable = tEnv
 class UserActionSource extends StreamTableSource[Row] with DefinedRowtimeAttribute {
 
 	override def getReturnType = {
-		val names = Array[String]("Username" , "Data")
-		val types = Array[TypeInformation[_]](Types.STRING, Types.STRING)
+		val names = Array[String]("Username" , "Data", "UserActionTime")
+		val types = Array[TypeInformation[_]](Types.STRING, Types.STRING, Types.LONG)
 		Types.ROW(names, types)
 	}
 
 	override def getDataStream(execEnv: StreamExecutionEnvironment): DataStream[Row] = {
 		// create stream 
 		// ...
-		// extract timestamp and assign watermarks based on knowledge of the stream
+		// assign watermarks based on the "UserActionTime" attribute
 		val stream = inputStream.assignTimestampsAndWatermarks(...)
 		stream
 	}
 
 	override def getRowtimeAttribute = {
-		// field with this name will be appended as a third field
+		// Mark the "UserActionTime" attribute as event-time attribute.
 		"UserActionTime"
 	}
 }

--- a/docs/dev/table/streaming.md
+++ b/docs/dev/table/streaming.md
@@ -346,7 +346,7 @@ An event time attribute can be defined either during DataStream-to-Table convers
 
 #### During DataStream-to-Table Conversion
 
-The event time attribute is defined with the `.rowtime` property during schema definition. Timestamps and watermarks must have been assigned in the `DataStream` that is converted.
+The event time attribute is defined with the `.rowtime` property during schema definition. [Timestamps and watermarks]({{ site.baseurl }}/dev/event_time.html) must have been assigned in the `DataStream` that is converted.
 
 There are two ways of defining the time attribute when converting a `DataStream` into a `Table`. Depending on whether the specified `.rowtime` field name exists in the schema of the `DataStream` or not, the timestamp field is either 
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/StreamTableEnvironment.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/StreamTableEnvironment.scala
@@ -111,7 +111,7 @@ abstract class StreamTableEnvironment(
 
     // check if event-time is enabled
     tableSource match {
-      case dra: DefinedRowtimeAttribute if
+      case dra: DefinedRowtimeAttribute if dra.getRowtimeAttribute != null &&
           execEnv.getStreamTimeCharacteristic != TimeCharacteristic.EventTime =>
 
         throw TableException(

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
@@ -269,7 +269,8 @@ abstract class CodeGenerator(
         // Change output type to rowtime indicator
         if (FlinkTypeFactory.isRowtimeIndicatorType(outType) &&
           (inputAccess.resultType == Types.LONG || inputAccess.resultType == Types.SQL_TIMESTAMP)) {
-          // Hard cast possible because LONG, TIMESTAMP, and ROW_TIMEINDICATOR are internally
+          // This case is required for TableSources that implement DefinedRowtimeAttribute.
+          // Hard cast possible because LONG, TIMESTAMP, and ROWTIME_INDICATOR are internally
           // represented as Long.
           GeneratedExpression(
             inputAccess.resultTerm,

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
@@ -255,11 +255,30 @@ abstract class CodeGenerator(
         generateRowtimeAccess()
       case TimeIndicatorTypeInfo.PROCTIME_MARKER =>
         // attribute is proctime indicator.
-        // We use a null literal and generate a timestamp when we need it.
+        // we use a null literal and generate a timestamp when we need it.
         generateNullLiteral(TimeIndicatorTypeInfo.PROCTIME_INDICATOR)
       case idx =>
-        // regular attribute. Access attribute in input data type.
-        generateInputAccess(input1, input1Term, idx)
+        // get type of result field
+        val outIdx = input1Mapping.indexOf(idx)
+        val outType = returnType match {
+          case pt: PojoTypeInfo[_] => pt.getTypeAt(resultFieldNames(outIdx))
+          case ct: CompositeType[_] => ct.getTypeAt(outIdx)
+          case t: TypeInformation[_] => t
+        }
+        val inputAccess = generateInputAccess(input1, input1Term, idx)
+        // Change output type to rowtime indicator
+        if (FlinkTypeFactory.isRowtimeIndicatorType(outType) &&
+          (inputAccess.resultType == Types.LONG || inputAccess.resultType == Types.SQL_TIMESTAMP)) {
+          // Hard cast possible because LONG, TIMESTAMP, and ROW_TIMEINDICATOR are internally
+          // represented as Long.
+          GeneratedExpression(
+            inputAccess.resultTerm,
+            inputAccess.nullTerm,
+            inputAccess.code,
+            TimeIndicatorTypeInfo.ROWTIME_INDICATOR)
+        } else {
+          inputAccess
+        }
     }
 
     val input2AccessExprs = input2 match {

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/StreamTableSourceScan.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/StreamTableSourceScan.scala
@@ -20,16 +20,15 @@ package org.apache.flink.table.plan.nodes.datastream
 
 import org.apache.calcite.plan._
 import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.metadata.RelMetadataQuery
 import org.apache.flink.streaming.api.datastream.DataStream
-import org.apache.flink.table.api.{StreamQueryConfig, StreamTableEnvironment, TableEnvironment}
+import org.apache.flink.table.api.{StreamQueryConfig, StreamTableEnvironment}
 import org.apache.flink.table.calcite.FlinkTypeFactory
 import org.apache.flink.table.plan.nodes.PhysicalTableSourceScan
 import org.apache.flink.table.plan.schema.{RowSchema, StreamTableSourceTable}
-import org.apache.flink.table.sources._
 import org.apache.flink.table.runtime.types.CRow
 import org.apache.flink.table.sources.{StreamTableSource, TableSource}
-import org.apache.flink.table.typeutils.TimeIndicatorTypeInfo
 
 /** Flink RelNode to read data from an external source defined by a [[StreamTableSource]]. */
 class StreamTableSourceScan(
@@ -40,35 +39,11 @@ class StreamTableSourceScan(
   extends PhysicalTableSourceScan(cluster, traitSet, table, tableSource)
   with StreamScan {
 
-  override def deriveRowType() = {
-    val flinkTypeFactory = cluster.getTypeFactory.asInstanceOf[FlinkTypeFactory]
+  override def deriveRowType(): RelDataType = {
 
-    val fieldNames = TableEnvironment.getFieldNames(tableSource).toList
-    val fieldTypes = TableEnvironment.getFieldTypes(tableSource.getReturnType).toList
-
-    val fields = fieldNames.zip(fieldTypes)
-
-    val withRowtime = tableSource match {
-      case timeSource: DefinedRowtimeAttribute if timeSource.getRowtimeAttribute != null =>
-        val rowtimeAttribute = timeSource.getRowtimeAttribute
-        fields :+ (rowtimeAttribute, TimeIndicatorTypeInfo.ROWTIME_INDICATOR)
-      case _ =>
-        fields
-    }
-
-    val withProctime = tableSource match {
-      case timeSource: DefinedProctimeAttribute if timeSource.getProctimeAttribute != null =>
-        val proctimeAttribute = timeSource.getProctimeAttribute
-        withRowtime :+ (proctimeAttribute, TimeIndicatorTypeInfo.PROCTIME_INDICATOR)
-      case _ =>
-        withRowtime
-    }
-
-    val (fieldNamesWithIndicators, fieldTypesWithIndicators) = withProctime.unzip
-
-    flinkTypeFactory.buildLogicalRowType(
-      fieldNamesWithIndicators,
-      fieldTypesWithIndicators)
+    StreamTableSourceTable.deriveRowTypeOfTableSource(
+      tableSource.asInstanceOf[StreamTableSource[_]],
+      cluster.getTypeFactory.asInstanceOf[FlinkTypeFactory])
   }
 
   override def computeSelfCost (planner: RelOptPlanner, metadata: RelMetadataQuery): RelOptCost = {

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/logical/FlinkLogicalTableSourceScan.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/logical/FlinkLogicalTableSourceScan.scala
@@ -25,12 +25,11 @@ import org.apache.calcite.rel.core.TableScan
 import org.apache.calcite.rel.logical.LogicalTableScan
 import org.apache.calcite.rel.metadata.RelMetadataQuery
 import org.apache.calcite.rel.{RelNode, RelWriter}
-import org.apache.flink.table.api.TableEnvironment
+import org.apache.flink.table.api.{TableEnvironment, TableException}
 import org.apache.flink.table.calcite.FlinkTypeFactory
 import org.apache.flink.table.plan.nodes.FlinkConventions
-import org.apache.flink.table.plan.schema.TableSourceTable
-import org.apache.flink.table.sources.{DefinedProctimeAttribute, DefinedRowtimeAttribute, TableSource}
-import org.apache.flink.table.typeutils.TimeIndicatorTypeInfo
+import org.apache.flink.table.plan.schema.{StreamTableSourceTable, TableSourceTable}
+import org.apache.flink.table.sources.{BatchTableSource, StreamTableSource, TableSource}
 
 import scala.collection.JavaConverters._
 
@@ -47,34 +46,18 @@ class FlinkLogicalTableSourceScan(
   }
 
   override def deriveRowType(): RelDataType = {
+
     val flinkTypeFactory = cluster.getTypeFactory.asInstanceOf[FlinkTypeFactory]
 
-    val fieldNames = TableEnvironment.getFieldNames(tableSource).toList
-    val fieldTypes = TableEnvironment.getFieldTypes(tableSource.getReturnType).toList
-
-    val fields = fieldNames.zip(fieldTypes)
-
-    val withRowtime = tableSource match {
-      case timeSource: DefinedRowtimeAttribute if timeSource.getRowtimeAttribute != null =>
-        val rowtimeAttribute = timeSource.getRowtimeAttribute
-        fields :+ (rowtimeAttribute, TimeIndicatorTypeInfo.ROWTIME_INDICATOR)
-      case _ =>
-        fields
+    tableSource match {
+      case s: StreamTableSource[_] =>
+        StreamTableSourceTable.deriveRowTypeOfTableSource(s, flinkTypeFactory)
+      case b: BatchTableSource[_] =>
+        val fieldNames = TableEnvironment.getFieldNames(tableSource).toList
+        val fieldTypes = TableEnvironment.getFieldTypes(tableSource.getReturnType).toList
+        flinkTypeFactory.buildLogicalRowType(fieldNames, fieldTypes)
+      case _ => throw new TableException("Unknown TableSource type.")
     }
-
-    val withProctime = tableSource match {
-      case timeSource: DefinedProctimeAttribute if timeSource.getProctimeAttribute != null =>
-        val proctimeAttribute = timeSource.getProctimeAttribute
-        withRowtime :+ (proctimeAttribute, TimeIndicatorTypeInfo.PROCTIME_INDICATOR)
-      case _ =>
-        withRowtime
-    }
-
-    val (fieldNamesWithIndicators, fieldTypesWithIndicators) = withProctime.unzip
-
-    flinkTypeFactory.buildLogicalRowType(
-      fieldNamesWithIndicators,
-      fieldTypesWithIndicators)
   }
 
   override def computeSelfCost(planner: RelOptPlanner, metadata: RelMetadataQuery): RelOptCost = {

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/logical/FlinkLogicalTableSourceScan.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/logical/FlinkLogicalTableSourceScan.scala
@@ -52,7 +52,7 @@ class FlinkLogicalTableSourceScan(
     tableSource match {
       case s: StreamTableSource[_] =>
         StreamTableSourceTable.deriveRowTypeOfTableSource(s, flinkTypeFactory)
-      case b: BatchTableSource[_] =>
+      case _: BatchTableSource[_] =>
         val fieldNames = TableEnvironment.getFieldNames(tableSource).toList
         val fieldTypes = TableEnvironment.getFieldTypes(tableSource.getReturnType).toList
         flinkTypeFactory.buildLogicalRowType(fieldNames, fieldTypes)

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/schema/StreamTableSourceTable.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/schema/StreamTableSourceTable.scala
@@ -49,7 +49,7 @@ class StreamTableSourceTable[T](
 object StreamTableSourceTable {
 
   private def adjustFieldIndexes(tableSource: TableSource[_]): Array[Int] = {
-    val (rowtime, proctime) = getTimeIndicators(tableSource)
+    val (_, proctime) = getTimeIndicators(tableSource)
 
     val original = TableEnvironment.getFieldIndices(tableSource)
 
@@ -62,7 +62,7 @@ object StreamTableSourceTable {
   }
 
   private def adjustFieldNames(tableSource: TableSource[_]): Array[String] = {
-    val (rowtime, proctime) = getTimeIndicators(tableSource)
+    val (_, proctime) = getTimeIndicators(tableSource)
 
     val original = TableEnvironment.getFieldNames(tableSource)
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/schema/StreamTableSourceTable.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/schema/StreamTableSourceTable.scala
@@ -20,10 +20,10 @@ package org.apache.flink.table.plan.schema
 
 import org.apache.calcite.rel.`type`.{RelDataType, RelDataTypeFactory}
 import org.apache.flink.api.common.typeinfo.TypeInformation
-import org.apache.flink.table.api.{TableEnvironment, TableException}
+import org.apache.flink.table.api.{TableEnvironment, TableException, Types}
 import org.apache.flink.table.calcite.FlinkTypeFactory
 import org.apache.flink.table.plan.stats.FlinkStatistic
-import org.apache.flink.table.sources.{DefinedProctimeAttribute, DefinedRowtimeAttribute, TableSource}
+import org.apache.flink.table.sources.{DefinedProctimeAttribute, DefinedRowtimeAttribute, StreamTableSource, TableSource}
 import org.apache.flink.table.typeutils.TimeIndicatorTypeInfo
 
 class StreamTableSourceTable[T](
@@ -53,18 +53,11 @@ object StreamTableSourceTable {
 
     val original = TableEnvironment.getFieldIndices(tableSource)
 
-    // append rowtime marker
-    val withRowtime = if (rowtime.isDefined) {
-      original :+ TimeIndicatorTypeInfo.ROWTIME_MARKER
-    } else {
-      original
-    }
-
     // append proctime marker
     if (proctime.isDefined) {
-      withRowtime :+ TimeIndicatorTypeInfo.PROCTIME_MARKER
+      original :+ TimeIndicatorTypeInfo.PROCTIME_MARKER
     } else {
-      withRowtime
+      original
     }
   }
 
@@ -73,18 +66,11 @@ object StreamTableSourceTable {
 
     val original = TableEnvironment.getFieldNames(tableSource)
 
-    // append rowtime field
-    val withRowtime = if (rowtime.isDefined) {
-      original :+ rowtime.get
-    } else {
-      original
-    }
-
     // append proctime field
     if (proctime.isDefined) {
-      withRowtime :+ proctime.get
+      original :+ proctime.get
     } else {
-      withRowtime
+      original
     }
   }
 
@@ -93,9 +79,11 @@ object StreamTableSourceTable {
 
     val original = TableEnvironment.getFieldTypes(tableSource.getReturnType)
 
-    // append rowtime type
+    // update rowtime type
     val withRowtime = if (rowtime.isDefined) {
-      original :+ TimeIndicatorTypeInfo.ROWTIME_INDICATOR
+      // replace field type by RowtimeIndicator type
+      val rowtimeIdx = TableEnvironment.getFieldNames(tableSource).indexOf(rowtime.get)
+      original.patch(rowtimeIdx, Seq(TimeIndicatorTypeInfo.ROWTIME_INDICATOR), 1)
     } else {
       original
     }
@@ -112,13 +100,31 @@ object StreamTableSourceTable {
 
   private def getTimeIndicators(tableSource: TableSource[_]): (Option[String], Option[String]) = {
 
+    val fieldNames = TableEnvironment.getFieldNames(tableSource).toList
+    val fieldTypes = TableEnvironment.getFieldTypes(tableSource.getReturnType).toList
+
     val rowtime: Option[String] = tableSource match {
       case timeSource: DefinedRowtimeAttribute if timeSource.getRowtimeAttribute == null =>
         None
       case timeSource: DefinedRowtimeAttribute if timeSource.getRowtimeAttribute.trim.equals("") =>
         throw TableException("The name of the rowtime attribute must not be empty.")
+
       case timeSource: DefinedRowtimeAttribute =>
+        // validate the rowtime field exists and is of type Long or Timestamp
         val rowtimeAttribute = timeSource.getRowtimeAttribute
+        val rowtimeIdx = fieldNames.indexOf(rowtimeAttribute)
+
+        if (rowtimeIdx < 0) {
+          throw TableException(
+            s"Rowtime field '$rowtimeAttribute' is not present in TableSource. " +
+            s"Available fields are ${fieldNames.mkString("[", ", ", "]") }.")
+        }
+        val fieldType = fieldTypes(rowtimeIdx)
+        if (fieldType != Types.LONG && fieldType != Types.SQL_TIMESTAMP) {
+          throw TableException(
+            s"Rowtime field '$rowtimeAttribute' must be of type Long or Timestamp " +
+            s"but of type ${fieldTypes(rowtimeIdx)}.")
+        }
         Some(rowtimeAttribute)
       case _ =>
         None
@@ -137,5 +143,15 @@ object StreamTableSourceTable {
         None
     }
     (rowtime, proctime)
+  }
+
+  def deriveRowTypeOfTableSource(
+    tableSource: StreamTableSource[_],
+    typeFactory: FlinkTypeFactory): RelDataType = {
+
+    val fieldNames = adjustFieldNames(tableSource)
+    val fieldTypes = adjustFieldTypes(tableSource)
+
+    typeFactory.buildLogicalRowType(fieldNames, fieldTypes)
   }
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sources/definedTimeAttributes.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sources/definedTimeAttributes.scala
@@ -24,22 +24,27 @@ package org.apache.flink.table.sources
   * event-time.
   *
   * A [[TableSource]] that implements this interface defines the name of
-  * the event-time attribute. The attribute will be added to the schema of the
-  * [[org.apache.flink.table.api.Table]] produced by the [[TableSource]].
+  * the event-time attribute. The attribute must be present in the schema of the [[TableSource]]
+  * and must be of type [[Long]] or [[java.sql.Timestamp]].
   */
 trait DefinedRowtimeAttribute {
 
   /**
     * Defines a name of the event-time attribute that represents Flink's event-time, i.e., an
-    * attribute that is aligned with the watermarks of the table.
+    * attribute that is aligned with the watermarks of the
+    * [[org.apache.flink.streaming.api.datastream.DataStream]] returned by
+    * [[StreamTableSource.getDataStream()]].
+    *
     * An attribute with the given name must be present in the schema of the [[TableSource]].
     * The attribute must be of type [[Long]] or [[java.sql.Timestamp]].
     *
     * The method should return null if no rowtime attribute is defined.
     *
     * @return The name of the field that represents the event-time field and which is aligned
-    *         with the watermarks of the table. The field must be present in the schema of the
-    *         [[TableSource]].
+    *         with the watermarks of the [[org.apache.flink.streaming.api.datastream.DataStream]]
+    *         returned by [[StreamTableSource.getDataStream()]].
+    *         The field must be present in the schema of the [[TableSource]] and be of type [[Long]]
+    *         or [[java.sql.Timestamp]].
     */
   def getRowtimeAttribute: String
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sources/definedTimeAttributes.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sources/definedTimeAttributes.scala
@@ -30,10 +30,16 @@ package org.apache.flink.table.sources
 trait DefinedRowtimeAttribute {
 
   /**
-    * Defines a name of the event-time attribute that represents Flink's
-    * event-time. Null if no rowtime should be available.
+    * Defines a name of the event-time attribute that represents Flink's event-time, i.e., an
+    * attribute that is aligned with the watermarks of the table.
+    * An attribute with the given name must be present in the schema of the [[TableSource]].
+    * The attribute must be of type [[Long]] or [[java.sql.Timestamp]].
     *
-    * The field will be appended to the schema provided by the [[TableSource]].
+    * The method should return null if no rowtime attribute is defined.
+    *
+    * @return The name of the field that represents the event-time field and which is aligned
+    *         with the watermarks of the table. The field must be present in the schema of the
+    *         [[TableSource]].
     */
   def getRowtimeAttribute: String
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/validation/TableSourceValidationTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/validation/TableSourceValidationTest.scala
@@ -18,7 +18,8 @@
 
 package org.apache.flink.table.api.stream.table.validation
 
-import org.apache.flink.table.api.TableException
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.table.api.{TableException, Types}
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.api.stream.table.{TestProctimeSource, TestRowtimeSource}
 import org.apache.flink.table.utils.TableTestBase
@@ -28,8 +29,16 @@ class TableSourceValidationTest extends TableTestBase {
 
   @Test(expected = classOf[TableException])
   def testRowtimeTableSourceWithEmptyName(): Unit = {
+
+    val tableSource = new TestRowtimeSource(
+      Array("id", "rowtime", "val", "name"),
+      Array(Types.INT, Types.LONG, Types.LONG, Types.STRING)
+        .asInstanceOf[Array[TypeInformation[_]]],
+      "rowtime"
+    )
+
     val util = streamTestUtil()
-    util.tableEnv.registerTableSource("rowTimeT", new TestRowtimeSource(" "))
+    util.tableEnv.registerTableSource("rowTime", tableSource)
 
     val t = util.tableEnv.scan("rowTimeT")
             .select('id)

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/TableSourceITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/TableSourceITCase.scala
@@ -18,16 +18,21 @@
 
 package org.apache.flink.table.runtime.stream.table
 
+import org.apache.calcite.runtime.SqlFunctions.{internalToTimestamp => toTimestamp}
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.api.scala._
+import org.apache.flink.streaming.api.TimeCharacteristic
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.apache.flink.streaming.util.StreamingMultipleProgramsTestBase
-import org.apache.flink.table.api.TableEnvironment
+import org.apache.flink.table.api.{TableEnvironment, Types}
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.runtime.utils.{CommonTestData, StreamITCase}
-import org.apache.flink.table.utils.TestFilterableTableSource
+import org.apache.flink.table.utils.{TestFilterableTableSource, TestTableSourceWithTime}
 import org.apache.flink.types.Row
 import org.junit.Assert._
 import org.junit.Test
+import java.lang.{Integer => JInt, Long => JLong}
 
 import scala.collection.mutable
 
@@ -77,4 +82,139 @@ class TableSourceITCase extends StreamingMultipleProgramsTestBase {
       "5,Record_5", "6,Record_6", "7,Record_7", "8,Record_8")
     assertEquals(expected.sorted, StreamITCase.testResults.sorted)
   }
+
+  @Test
+  def testRowtimeTableSource(): Unit = {
+    StreamITCase.testResults = mutable.MutableList()
+    val tableName = "MyTable"
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
+    val tEnv = TableEnvironment.getTableEnvironment(env)
+
+    val data = Seq(
+      Row.of("Mary", new JLong(1L), new JInt(10)),
+      Row.of("Bob", new JLong(2L), new JInt(20)),
+      Row.of("Mary", new JLong(2L), new JInt(30)),
+      Row.of("Liz", new JLong(2001L), new JInt(40)))
+    val rowType = new RowTypeInfo(
+      Array(Types.STRING, Types.LONG, Types.INT).asInstanceOf[Array[TypeInformation[_]]],
+      Array("name", "rtime", "amount"))
+
+    tEnv.registerTableSource(tableName, new TestTableSourceWithTime(data, rowType, "rtime", null))
+
+    tEnv.scan(tableName)
+      .window(Tumble over 1.second on 'rtime as 'w)
+      .groupBy('name, 'w)
+      .select('name, 'w.start, 'amount.sum)
+      .addSink(new StreamITCase.StringSink[Row])
+    env.execute()
+
+    val expected = mutable.MutableList(
+      "Mary,1970-01-01 00:00:00.0,40",
+      "Bob,1970-01-01 00:00:00.0,20",
+      "Liz,1970-01-01 00:00:02.0,40")
+    assertEquals(expected.sorted, StreamITCase.testResults.sorted)
+  }
+
+  @Test
+  def testProctimeTableSource(): Unit = {
+    StreamITCase.testResults = mutable.MutableList()
+    val tableName = "MyTable"
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
+    val tEnv = TableEnvironment.getTableEnvironment(env)
+
+    val data = Seq(
+      Row.of("Mary", new JLong(1L), new JInt(10)),
+      Row.of("Bob", new JLong(2L), new JInt(20)),
+      Row.of("Mary", new JLong(2L), new JInt(30)),
+      Row.of("Liz", new JLong(2001L), new JInt(40)))
+    val rowType = new RowTypeInfo(
+      Array(Types.STRING, Types.LONG, Types.INT).asInstanceOf[Array[TypeInformation[_]]],
+      Array("name", "rtime", "amount"))
+
+    tEnv.registerTableSource(tableName, new TestTableSourceWithTime(data, rowType, null, "ptime"))
+
+    tEnv.scan(tableName)
+      .where('ptime.cast(Types.LONG) > 0L)
+      .select('name, 'amount)
+      .addSink(new StreamITCase.StringSink[Row])
+    env.execute()
+
+    val expected = mutable.MutableList(
+      "Mary,10",
+      "Bob,20",
+      "Mary,30",
+      "Liz,40")
+    assertEquals(expected.sorted, StreamITCase.testResults.sorted)
+  }
+
+  @Test
+  def testRowtimeProctimeTableSource(): Unit = {
+    StreamITCase.testResults = mutable.MutableList()
+    val tableName = "MyTable"
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
+    val tEnv = TableEnvironment.getTableEnvironment(env)
+
+    val data = Seq(
+      Row.of("Mary", new JLong(1L), new JInt(10)),
+      Row.of("Bob", new JLong(2L), new JInt(20)),
+      Row.of("Mary", new JLong(2L), new JInt(30)),
+      Row.of("Liz", new JLong(2001L), new JInt(40)))
+    val rowType = new RowTypeInfo(
+      Array(Types.STRING, Types.LONG, Types.INT).asInstanceOf[Array[TypeInformation[_]]],
+      Array("name", "rtime", "amount"))
+
+    tEnv.registerTableSource(
+      tableName,
+      new TestTableSourceWithTime(data, rowType, "rtime", "ptime"))
+
+    tEnv.scan(tableName)
+      .window(Tumble over 1.second on 'rtime as 'w)
+      .groupBy('name, 'w)
+      .select('name, 'w.start, 'amount.sum)
+      .addSink(new StreamITCase.StringSink[Row])
+    env.execute()
+
+    val expected = mutable.MutableList(
+      "Mary,1970-01-01 00:00:00.0,40",
+      "Bob,1970-01-01 00:00:00.0,20",
+      "Liz,1970-01-01 00:00:02.0,40")
+    assertEquals(expected.sorted, StreamITCase.testResults.sorted)
+  }
+
+  @Test
+  def testRowtimeAsTimestampTableSource(): Unit = {
+    StreamITCase.testResults = mutable.MutableList()
+    val tableName = "MyTable"
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
+    val tEnv = TableEnvironment.getTableEnvironment(env)
+
+    val data = Seq(
+      Row.of("Mary", toTimestamp(1L), new JInt(10)),
+      Row.of("Bob", toTimestamp(2L), new JInt(20)),
+      Row.of("Mary", toTimestamp(2L), new JInt(30)),
+      Row.of("Liz", toTimestamp(2001L), new JInt(40)))
+    val rowType = new RowTypeInfo(
+      Array(Types.STRING, Types.SQL_TIMESTAMP, Types.INT).asInstanceOf[Array[TypeInformation[_]]],
+      Array("name", "rtime", "amount"))
+
+    tEnv.registerTableSource(tableName, new TestTableSourceWithTime(data, rowType, "rtime", null))
+
+    tEnv.scan(tableName)
+      .window(Tumble over 1.second on 'rtime as 'w)
+      .groupBy('name, 'w)
+      .select('name, 'w.start, 'amount.sum)
+      .addSink(new StreamITCase.StringSink[Row])
+    env.execute()
+
+    val expected = mutable.MutableList(
+      "Mary,1970-01-01 00:00:00.0,40",
+      "Bob,1970-01-01 00:00:00.0,20",
+      "Liz,1970-01-01 00:00:02.0,40")
+    assertEquals(expected.sorted, StreamITCase.testResults.sorted)
+  }
+
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/utils/TestTableSourceWithTime.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/utils/TestTableSourceWithTime.scala
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.utils
+
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.typeutils.RowTypeInfo
+import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
+import org.apache.flink.table.sources._
+import org.apache.flink.types.Row
+
+import scala.collection.JavaConverters._
+
+class TestTableSourceWithTime(
+    rows: Seq[Row],
+    rowType: RowTypeInfo,
+    rowtime: String,
+    proctime: String)
+  extends StreamTableSource[Row]
+    with DefinedRowtimeAttribute
+    with DefinedProctimeAttribute {
+
+  override def getDataStream(execEnv: StreamExecutionEnvironment): DataStream[Row] = {
+
+    // The source deliberately does not assign timestamps and watermarks.
+    // If a rowtime field is configured, the field carries the timestamp.
+    // The FromElementsFunction sends out a Long.MaxValue watermark when all rows are emitted.
+    execEnv.fromCollection(rows.asJava, rowType)
+  }
+
+  override def getRowtimeAttribute: String = rowtime
+
+  override def getProctimeAttribute: String = proctime
+
+  override def getReturnType: TypeInformation[Row] = rowType
+}


### PR DESCRIPTION
## What is the purpose of the change

Changes the contract of the `DefinedRowtimeAttribute` interface. The rowtime attribute is no longer appended to the schema of the row but marks an existing field in the input that will be handled as event time attribute. The specified field must be of type `Long` or `Timestamp`. The watermarks of `DataStream` must be aligned to the specified field.

## Brief change log

- rowtime fields are no longer appended but an existing Long or Timestamp field is marked as event time field
- Add checks that projections are not pushed to `TableSources` that implement `DefinedRowtimeAttribute` or `DefinedProctimeAttribute`
- Added several tests for table sources with rowtime or proctime attributes
- Updated the documenation

## Verifying this change

- Check the added test cases

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**

## Documentation

- Documentation is updated according to the changes of the PR.
