### PR TITLE
[FLINK-7674][Streaming Connectors] NullPointerException in ContinuousFileMonitoringFunction close

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileMonitoringFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileMonitoringFunction.java
@@ -336,9 +336,12 @@ public class ContinuousFileMonitoringFunction<OUT>
 	@Override
 	public void close() throws Exception {
 		super.close();
-		synchronized (checkpointLock) {
-			globalModificationTime = Long.MAX_VALUE;
-			isRunning = false;
+
+		if (checkpointLock != null) {
+			synchronized (checkpointLock) {
+				globalModificationTime = Long.MAX_VALUE;
+				isRunning = false;
+			}
 		}
 
 		if (LOG.isDebugEnabled()) {


### PR DESCRIPTION
## What is the purpose of the change

If the ContinuousFileMonitoringFunction is closed before run is called (because initialization fails), we get a `NullPointerException`, because checkpointLock has not been set.

```java
synchronized (checkpointLock) {
  globalModificationTime = Long.MAX_VALUE;
  isRunning = false;
}
```

We need to add a null check that wraps the synchronized clause


## Brief change log

Add a null check that wraps the synchronized clause, as:

```java
if (checkpointLock != null) {
  synchronized (checkpointLock) {
    globalModificationTime = Long.MAX_VALUE;
    isRunning = false;
  }
}
```

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

none

## Documentation

none