### PR TITLE
[FLINK-3828][build][WIP] POM Cleanup flink-runtime

### DIFF
--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -220,6 +220,12 @@ under the License.
 			<groupId>com.data-artisans</groupId>
 			<artifactId>flakka-testkit_${scala.binary.version}</artifactId>
 		</dependency>
+
+		<dependency>
+			<groupId>com.google.code.findbugs</groupId>
+			<artifactId>annotations</artifactId>
+			<version>2.0.1</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -40,6 +40,12 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-annotations</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-core</artifactId>
 			<version>${project.version}</version>
 		</dependency>
@@ -49,10 +55,10 @@ under the License.
 			<artifactId>flink-java</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-shaded-hadoop2</artifactId>
+			<artifactId>flink-metrics-core</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 
@@ -80,11 +86,20 @@ under the License.
 			<artifactId>commons-cli</artifactId>
 		</dependency>
 
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>commons-collections</groupId>
+			<artifactId>commons-collections</artifactId>
+		</dependency>
+
 		<!-- See: https://groups.google.com/forum/#!msg/netty/-aAPDBNUnDg/SkGOXL2Ma2QJ -->
 		<dependency>
 			<groupId>org.javassist</groupId>
 			<artifactId>javassist</artifactId>
-			<!-- Version is set in root POM -->
 		</dependency>
 
 		<dependency>
@@ -100,11 +115,6 @@ under the License.
 		<dependency>
 			<groupId>com.data-artisans</groupId>
 			<artifactId>flakka-remote_${scala.binary.version}</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>com.data-artisans</groupId>
-			<artifactId>flakka-slf4j_${scala.binary.version}</artifactId>
 		</dependency>
 
 		<dependency>
@@ -126,13 +136,16 @@ under the License.
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-core</artifactId>
-			<version>${jackson.version}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>${jackson.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-annotations</artifactId>
 		</dependency>
 
 		<dependency>
@@ -143,7 +156,6 @@ under the License.
 		<dependency>
 			<groupId>org.xerial.snappy</groupId>
 			<artifactId>snappy-java</artifactId>
-			<version>1.1.4</version>
 		</dependency>
 
 		<!--
@@ -162,6 +174,11 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-shaded-curator-recipes</artifactId>
 			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.esotericsoftware.kryo</groupId>
+			<artifactId>kryo</artifactId>
 		</dependency>
 
 		<!-- test dependencies -->
@@ -198,12 +215,6 @@ under the License.
 			<groupId>com.data-artisans</groupId>
 			<artifactId>flakka-testkit_${scala.binary.version}</artifactId>
 		</dependency>
-
-		<dependency>
-			<groupId>org.reflections</groupId>
-			<artifactId>reflections</artifactId>
-		</dependency>
-
 	</dependencies>
 
 	<build>

--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -118,6 +118,11 @@ under the License.
 		</dependency>
 
 		<dependency>
+			<groupId>com.data-artisans</groupId>
+			<artifactId>flakka-slf4j_${scala.binary.version}</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>org.clapper</groupId>
 			<artifactId>grizzled-slf4j_${scala.binary.version}</artifactId>
 		</dependency>


### PR DESCRIPTION
## What is the purpose of the change

This PR changes the flink-runtime pom to

not contain unused dependencies
contain all used dependencies

## Brief change log

## Verifying this change
_mvn dependency:analyze_
```
[INFO] --- maven-dependency-plugin:2.10:analyze (default-cli) @ flink-runtime_2.11 ---
[WARNING] Used undeclared dependencies found:
[WARNING]    org.apache.flink:flink-metrics-core:jar:1.4-SNAPSHOT:compile
[WARNING]    org.apache.curator:curator-client:jar:2.12.0:compile
[WARNING]    io.netty:netty:jar:3.8.0.Final:compile
[WARNING]    com.google.code.findbugs:annotations:jar:2.0.1:test
[WARNING]    com.esotericsoftware.kryo:kryo:jar:2.24.0:compile
[WARNING]    com.typesafe:config:jar:1.2.1:compile
[WARNING]    org.apache.flink:flink-annotations:jar:1.4-SNAPSHOT:compile
[WARNING]    commons-io:commons-io:jar:2.4:compile
[WARNING]    org.hamcrest:hamcrest-core:jar:1.3:test
[WARNING]    org.powermock:powermock-api-support:jar:1.6.5:test
[WARNING]    javax.xml.bind:jaxb-api:jar:2.2.2:compile
[WARNING]    commons-collections:commons-collections:jar:3.2.2:compile
[WARNING]    com.fasterxml.jackson.core:jackson-annotations:jar:2.7.4:compile
[WARNING]    org.apache.hadoop:hadoop-common:jar:2.4.1:compile
[WARNING]    org.apache.curator:curator-recipes:jar:2.12.0:compile
[WARNING]    org.apache.hadoop:hadoop-auth:jar:2.4.1:compile
[WARNING]    org.powermock:powermock-core:jar:1.6.5:test
[WARNING]    org.apache.curator:curator-framework:jar:2.12.0:compile
[WARNING]    org.powermock:powermock-reflect:jar:1.6.5:test
[WARNING] Unused declared dependencies found:
[WARNING]    org.apache.flink:flink-shaded-hadoop2:jar:1.4-SNAPSHOT:compile
[WARNING]    com.data-artisans:flakka-slf4j_2.11:jar:2.3-custom:compile
[WARNING]    org.reflections:reflections:jar:0.9.10:test
[WARNING]    org.javassist:javassist:jar:3.18.2-GA:compile
[WARNING]    org.apache.flink:force-shading:jar:1.4-SNAPSHOT:compile
[WARNING]    com.google.code.findbugs:jsr305:jar:1.3.9:compile
[WARNING]    log4j:log4j:jar:1.2.17:test
[WARNING]    com.twitter:chill_2.11:jar:0.7.4:compile
[WARNING]    org.apache.flink:flink-shaded-curator-recipes:jar:1.4-SNAPSHOT:compile
[WARNING]    org.slf4j:slf4j-log4j12:jar:1.7.7:test
```
After the change:

```
[INFO] --- maven-dependency-plugin:2.10:analyze (default-cli) @ flink-runtime_2.11 ---
[WARNING] Used undeclared dependencies found:
[WARNING]    org.apache.curator:curator-client:jar:2.12.0:compile
[WARNING]    io.netty:netty:jar:3.8.0.Final:compile
[WARNING]    com.typesafe:config:jar:1.2.1:compile
[WARNING]    org.hamcrest:hamcrest-core:jar:1.3:test
[WARNING]    org.powermock:powermock-api-support:jar:1.6.5:test
[WARNING]    javax.xml.bind:jaxb-api:jar:2.2.2:compile
[WARNING]    org.apache.hadoop:hadoop-common:jar:2.4.1:compile
[WARNING]    org.apache.curator:curator-recipes:jar:2.12.0:compile
[WARNING]    org.apache.hadoop:hadoop-auth:jar:2.4.1:compile
[WARNING]    org.powermock:powermock-core:jar:1.6.5:test
[WARNING]    org.apache.curator:curator-framework:jar:2.12.0:compile
[WARNING]    org.powermock:powermock-reflect:jar:1.6.5:test
[WARNING] Unused declared dependencies found:
[WARNING]    org.javassist:javassist:jar:3.18.2-GA:compile
[WARNING]    org.apache.flink:force-shading:jar:1.4-SNAPSHOT:compile
[WARNING]    log4j:log4j:jar:1.2.17:test
[WARNING]    com.twitter:chill_2.11:jar:0.7.4:compile
[WARNING]    org.apache.flink:flink-shaded-curator-recipes:jar:1.4-SNAPSHOT:compile
[WARNING]    org.slf4j:slf4j-log4j12:jar:1.7.7:test
```
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes)

## Documentation
none