### PR TITLE
[FLINK-7577][build][WIP] POM Cleanup flink-core

### DIFF
--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -56,28 +56,24 @@ under the License.
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
-			<!-- managed version -->
 		</dependency>
 
 		<!-- for the fallback generic serializer -->
 		<dependency>
 			<groupId>com.esotericsoftware.kryo</groupId>
 			<artifactId>kryo</artifactId>
-			<!-- managed version -->
 		</dependency>
 
 		<!-- The common collections are needed for some hash tables used in the collection execution -->
 		<dependency>
 			<groupId>commons-collections</groupId>
 			<artifactId>commons-collections</artifactId>
-			<!-- managed version -->
 		</dependency>
 
 		<!-- Commons compression, for additional decompressors -->
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-compress</artifactId>
-			<!-- managed version -->
 		</dependency>
 
 		<!-- Avro is needed for the interoperability with Avro types for serialization -->
@@ -110,12 +106,6 @@ under the License.
 		<dependency>
 			<groupId>joda-time</groupId>
 			<artifactId>joda-time</artifactId>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.joda</groupId>
-			<artifactId>joda-convert</artifactId>
 			<scope>test</scope>
 		</dependency>
     </dependencies>


### PR DESCRIPTION
## What is the purpose of the change
This PR changes the flink-core pom to

- not contain unused dependencies
- contain all used dependencies

## Brief change log
## Verifying this change
_mvn dependency:analyze_

```
[INFO] --- maven-dependency-plugin:2.10:analyze (default-cli) @ flink-core ---
[WARNING] Used undeclared dependencies found:
[WARNING]    org.hamcrest:hamcrest-core:jar:1.3:test
[WARNING]    org.powermock:powermock-core:jar:1.6.5:test
[WARNING]    org.powermock:powermock-reflect:jar:1.6.5:test
[WARNING]    org.objenesis:objenesis:jar:2.1:compile
[WARNING] Unused declared dependencies found:
[WARNING]    org.xerial.snappy:snappy-java:jar:1.1.1.3:compile
[WARNING]    org.hamcrest:hamcrest-all:jar:1.3:test
[WARNING]    org.apache.flink:force-shading:jar:1.4-SNAPSHOT:compile
[WARNING]    log4j:log4j:jar:1.2.17:test
[WARNING]    org.joda:joda-convert:jar:1.7:test
[WARNING]    org.slf4j:slf4j-log4j12:jar:1.7.7:test
```

After the change:

```
[INFO] --- maven-dependency-plugin:2.10:analyze (default-cli) @ flink-core ---
[WARNING] Used undeclared dependencies found:
[WARNING]    org.hamcrest:hamcrest-core:jar:1.3:test
[WARNING]    org.powermock:powermock-core:jar:1.6.5:test
[WARNING]    org.powermock:powermock-reflect:jar:1.6.5:test
[WARNING]    org.objenesis:objenesis:jar:2.1:compile
[WARNING] Unused declared dependencies found:
[WARNING]    org.xerial.snappy:snappy-java:jar:1.1.1.3:compile
[WARNING]    org.hamcrest:hamcrest-all:jar:1.3:test
[WARNING]    org.apache.flink:force-shading:jar:1.4-SNAPSHOT:compile
[WARNING]    log4j:log4j:jar:1.2.17:test
[WARNING]    org.slf4j:slf4j-log4j12:jar:1.7.7:test
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes)

## Documentation
none