### PR TITLE
[FLINK-3829][build][WIP] POM Cleanup flink-java

### DIFF
--- a/flink-java/pom.xml
+++ b/flink-java/pom.xml
@@ -37,7 +37,19 @@ under the License.
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-annotations</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-core</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-metrics-core</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 
@@ -49,13 +61,16 @@ under the License.
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
-			<!-- managed version -->
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-math3</artifactId>
-			<!-- managed version -->
+		</dependency>
+
+		<dependency>
+			<groupId>com.esotericsoftware.kryo</groupId>
+			<artifactId>kryo</artifactId>
 		</dependency>
 
 		<!-- test dependencies -->


### PR DESCRIPTION
## What is the purpose of the change
This PR changes the flink-java pom to

- not contain unused dependencies
- contain all used dependencies

## Brief change log
## Verifying this change
_mvn dependency:analyze_

```
[INFO] --- maven-dependency-plugin:2.10:analyze (default-cli) @ flink-java ---
[WARNING] Used undeclared dependencies found:
[WARNING]    org.apache.flink:flink-metrics-core:jar:1.4-SNAPSHOT:compile
[WARNING]    com.esotericsoftware.kryo:kryo:jar:2.24.0:compile
[WARNING]    org.apache.flink:flink-annotations:jar:1.4-SNAPSHOT:compile
[WARNING]    commons-cli:commons-cli:jar:1.3.1:compile
[WARNING]    org.hamcrest:hamcrest-core:jar:1.3:test
[WARNING] Unused declared dependencies found:
[WARNING]    org.hamcrest:hamcrest-all:jar:1.3:test
[WARNING]    org.apache.flink:force-shading:jar:1.4-SNAPSHOT:compile
[WARNING]    org.powermock:powermock-module-junit4:jar:1.6.5:test
[WARNING]    com.google.code.findbugs:jsr305:jar:1.3.9:compile
[WARNING]    log4j:log4j:jar:1.2.17:test
[WARNING]    org.powermock:powermock-api-mockito:jar:1.6.5:test
[WARNING]    org.slf4j:slf4j-log4j12:jar:1.7.7:test
```

After the change:

```
[INFO] --- maven-dependency-plugin:2.10:analyze (default-cli) @ flink-java ---
[WARNING] Used undeclared dependencies found:
[WARNING]    org.hamcrest:hamcrest-core:jar:1.3:test
[WARNING] Unused declared dependencies found:
[WARNING]    org.hamcrest:hamcrest-all:jar:1.3:test
[WARNING]    org.apache.flink:force-shading:jar:1.4-SNAPSHOT:compile
[WARNING]    org.powermock:powermock-module-junit4:jar:1.6.5:test
[WARNING]    com.google.code.findbugs:jsr305:jar:1.3.9:compile
[WARNING]    log4j:log4j:jar:1.2.17:test
[WARNING]    org.powermock:powermock-api-mockito:jar:1.6.5:test
[WARNING]    org.slf4j:slf4j-log4j12:jar:1.7.7:test
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes)

## Documentation
none