### PR TITLE
[FLINK-6703][savepoint/doc] Document how to take a savepoint on YARN

### DIFF
--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -138,17 +138,30 @@ This allows the job to finish processing all inflight data.
 
 [Savepoints]({{site.baseurl}}/ops/state/savepoints.html) are controlled via the command line client:
 
-#### Trigger a savepoint
+#### Trigger a Savepoint
 
 {% highlight bash %}
-./bin/flink savepoint <jobID> [savepointDirectory]
+./bin/flink savepoint <jobId> [savepointDirectory]
 {% endhighlight %}
 
-Returns the path of the created savepoint. You need this path to restore and dispose savepoints.
+This will trigger a savepoint for the job with ID `jobId`, and returns the path of the created savepoint. You need this path to restore and dispose savepoints.
 
-You can optionally specify a `savepointDirectory` when triggering the savepoint. If you don't specify one here, you need to configure a default savepoint directory for the Flink installation (see [Savepoints]({{site.baseurl}}/ops/state/savepoints.html#configuration)).
 
-##### Cancel with a savepoint
+Furthermore, you can optionally specify a target file system directory to store the savepoint in. The directory needs to be accessible by the JobManager.
+
+If you don't specify a target directory, you need to have [configured a default directory](#configuration) (see [Savepoints]({{site.baseurl}}/ops/state/savepoints.html#configuration)). Otherwise, triggering the savepoint will fail.
+
+#### Trigger a Savepoint with YARN
+
+{% highlight bash %}
+./bin/flink savepoint <jobId> [savepointDirectory] -yid <yarnAppId>
+{% endhighlight %}
+
+This will trigger a savepoint for the job with ID `jobId` and YARN application ID `yarnAppId`, and returns the path of the created savepoint.
+
+Everything else is the same as described in the above **Trigger a Savepoint** section.
+
+#### Cancel with a savepoint
 
 You can atomically trigger a savepoint and cancel a job.
 

--- a/docs/ops/state/savepoints.md
+++ b/docs/ops/state/savepoints.md
@@ -103,12 +103,24 @@ Note that if you use the `MemoryStateBackend`, metadata *and* savepoint state wi
 #### Trigger a Savepoint
 
 ```sh
-$ bin/flink savepoint :jobId [:targetDirectory]
+$ bin/flink savepoint :jobId [:savepointDirectory]
 ```
 
-This will trigger a savepoint for the job with ID `:jobid`. Furthermore, you can specify a target file system directory to store the savepoint in. The directory needs to be accessible by the JobManager.
+This will trigger a savepoint for the job with ID `:jobId`, and returns the path of the created savepoint. You need this path to restore and dispose savepoints.
 
-If you don't specify a target directory, you need to have [configured a default directory](#configuration). Otherwise, triggering the savepoint will fail.
+Furthermore, you can optionally specify a target file system directory to store the savepoint in. The directory needs to be accessible by the JobManager.
+
+If you don't specify a target directory, you need to have [configured a default directory](#configuration) (see [Savepoints]({{site.baseurl}}/ops/state/savepoints.html#configuration)). Otherwise, triggering the savepoint will fail.
+
+#### Trigger a Savepoint with YARN
+
+```sh
+$ bin/flink savepoint :jobId [:savepointDirectory] -yid :yarnAppId
+```
+
+This will trigger a savepoint for the job with ID `:jobId` and YARN application ID `:yarnAppId`, and returns the path of the created savepoint.
+
+Everything else is the same as described in the above **Trigger a Savepoint** section.
 
 #### Cancel Job with Savepoint
 


### PR DESCRIPTION
## What is the purpose of the change

The documentation should have a separate entry for savepoint related CLI commands in combination with YARN. It is currently not documented that you have to supply the application id, nor how you can pass it.

## Brief change log

- *add instruction of taking savepoints on YARN to both Savepoint and CLI doc*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

none

## Documentation

none

