### PR TITLE
[FLINK-7684] Avoid data copies in MergingWindowSet

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
@@ -121,6 +121,8 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 
 	private CodeAnalysisMode codeAnalysisMode = CodeAnalysisMode.DISABLE;
 
+	private OptimizationTarget optimizationTarget = OptimizationTarget.IO;
+
 	/** If set to true, progress updates are printed to System.out during execution */
 	private boolean printProgressDuringExecution = true;
 
@@ -631,6 +633,24 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 	@PublicEvolving
 	public CodeAnalysisMode getCodeAnalysisMode() {
 		return codeAnalysisMode;
+	}
+
+	/**
+	 * Sets the {@link OptimizationTarget} of the program.
+	 *
+	 * By default Flink will optimize for IO.
+	 */
+	@PublicEvolving
+	public void setOptimizationTarget(OptimizationTarget optimizationTarget) {
+		this.optimizationTarget = optimizationTarget;
+	}
+
+	/**
+	 * Returns the {@link OptimizationTarget} of the program.
+	 */
+	@PublicEvolving
+	public OptimizationTarget getOptimizationTarget() {
+		return optimizationTarget;
 	}
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/api/common/OptimizationTarget.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/OptimizationTarget.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+/**
+ * Specifies target for Flink optimizer. Flink will assume that the target is a performance
+ * bottleneck and this can change the behaviour of some operators (for example performing more
+ * CPU computation in order to save some IO throughput).
+ *
+ * By default Flink will optimize for IO.
+ */
+@PublicEvolving
+public enum OptimizationTarget {
+
+	/**
+	 * Optimize for CPU usage.
+	 */
+	CPU,
+
+	/**
+	 * Optimize for IO operations (including state backend).
+	 */
+	IO
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.runtime.operators.windowing;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.OptimizationTarget;
 import org.apache.flink.api.common.state.AppendingState;
 import org.apache.flink.api.common.state.FoldingState;
 import org.apache.flink.api.common.state.FoldingStateDescriptor;
@@ -608,7 +609,10 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 	protected MergingWindowSet<W> getMergingWindowSet() throws Exception {
 		@SuppressWarnings("unchecked")
 		MergingWindowAssigner<? super IN, W> mergingAssigner = (MergingWindowAssigner<? super IN, W>) windowAssigner;
-		return new MergingWindowSet<>(mergingAssigner, mergingSetsState);
+		return new MergingWindowSet<>(
+			mergingAssigner,
+			mergingSetsState,
+			getExecutionConfig().getOptimizationTarget() == OptimizationTarget.CPU);
 	}
 
 	/**


### PR DESCRIPTION
## What is the purpose of the change

Previously MergingWindowSet uses ListState of tuples to persists it's mapping. This is inefficient because this ListState of tuples must be converted to a HashMap on each access.

Furthermore, for some cases it might be inefficient to check whether mapping has changed before saving it on state.

Fixing those two issues improve session windows [benchmarks](https://github.com/dataArtisans/flink-benchmarks) results by 10 - 20%

First commit comes from different PR #4722 

## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: **yes** (it changes how WindowOperator is being serialized)
  - The runtime per-record code paths (performance sensitive): **yes**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs

