### PR TITLE
[FLINK-7690] [Cluster Management] Do not call actorSystem.awaitTermination from akka's main message han…

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcService.java
@@ -313,10 +313,6 @@ public class AkkaRpcService implements RpcService {
 			actorSystem.shutdown();
 			actors.clear();
 		}
-
-		actorSystem.awaitTermination();
-
-		LOG.info("Stopped Akka RPC service.");
 	}
 
 	@Override


### PR DESCRIPTION
## What is the purpose of the change

*During shutdown, do not wait for the ActorSystem's termination within the main akka message handling thread as it will block the job from terminating forever.*


## Brief change log

  - *call ActorSystem.awaitTermination from a different thread.*


## Verifying this change

  - *Manually verified the change by running the example streaming WordCount job on local YARN cluster.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: yes

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented?  N/A

