### PR TITLE
[FLINK-7678] [table] Support composite inputs for user-defined functions

### DIFF
--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/UserDefinedScalarFunctionTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/UserDefinedScalarFunctionTest.scala
@@ -30,6 +30,7 @@ import org.apache.flink.table.api.scala._
 import org.apache.flink.table.expressions.utils.{ExpressionTestBase, _}
 import org.apache.flink.table.functions.ScalarFunction
 import org.junit.Test
+import java.lang.{Boolean => JBoolean}
 
 class UserDefinedScalarFunctionTest extends ExpressionTestBase {
 
@@ -107,6 +108,14 @@ class UserDefinedScalarFunctionTest extends ExpressionTestBase {
       "Nullable(f0)",
       "Nullable(f0)",
       "42")
+
+    // test row type input
+    testAllApis(
+      Func19('f14),
+      "Func19(f14)",
+      "Func19(f14)",
+      "12,true,1,2,3"
+    )
   }
 
   @Test
@@ -368,7 +377,7 @@ class UserDefinedScalarFunctionTest extends ExpressionTestBase {
   // ----------------------------------------------------------------------------------------------
 
   override def testData: Any = {
-    val testData = new Row(14)
+    val testData = new Row(15)
     testData.setField(0, 42)
     testData.setField(1, "Test")
     testData.setField(2, null)
@@ -383,6 +392,11 @@ class UserDefinedScalarFunctionTest extends ExpressionTestBase {
     testData.setField(11, 3.toByte)
     testData.setField(12, 3.toShort)
     testData.setField(13, 3.toFloat)
+    testData.setField(14, Row.of(
+      12.asInstanceOf[Integer],
+      true.asInstanceOf[JBoolean],
+      Row.of(1.asInstanceOf[Integer], 2.asInstanceOf[Integer], 3.asInstanceOf[Integer]))
+    )
     testData
   }
 
@@ -401,7 +415,8 @@ class UserDefinedScalarFunctionTest extends ExpressionTestBase {
       BasicArrayTypeInfo.INT_ARRAY_TYPE_INFO,
       Types.BYTE,
       Types.SHORT,
-      Types.FLOAT
+      Types.FLOAT,
+      Types.ROW(Types.INT, Types.BOOLEAN, Types.ROW(Types.INT, Types.INT, Types.INT))
     ).asInstanceOf[TypeInformation[Any]]
   }
 
@@ -427,6 +442,7 @@ class UserDefinedScalarFunctionTest extends ExpressionTestBase {
     "Func15" -> Func15,
     "Func16" -> Func16,
     "Func17" -> Func17,
+    "Func19" -> Func19,
     "JavaFunc0" -> new JavaFunc0,
     "JavaFunc1" -> new JavaFunc1,
     "JavaFunc2" -> new JavaFunc2,

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/utils/userDefinedScalarFunctions.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/utils/userDefinedScalarFunctions.scala
@@ -22,7 +22,8 @@ import java.sql.{Date, Time, Timestamp}
 
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.table.api.Types
-import org.apache.flink.table.functions.{ScalarFunction, FunctionContext}
+import org.apache.flink.table.functions.{FunctionContext, ScalarFunction}
+import org.apache.flink.types.Row
 import org.junit.Assert
 
 import scala.annotation.varargs
@@ -273,4 +274,17 @@ object Func18 extends ScalarFunction {
   def eval(str: String, prefix: String): Boolean = {
     str.startsWith(prefix)
   }
+}
+
+object Func19 extends ScalarFunction {
+  def eval(row: Row): Row = {
+    row
+  }
+
+  override def getParameterTypes(signature: Array[Class[_]]): Array[TypeInformation[_]] =
+    Array(Types.ROW(Types.INT, Types.BOOLEAN, Types.ROW(Types.INT, Types.INT, Types.INT)))
+
+  override def getResultType(signature: Array[Class[_]]): TypeInformation[_] =
+    Types.ROW(Types.INT, Types.BOOLEAN, Types.ROW(Types.INT, Types.INT, Types.INT))
+
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/batch/table/CorrelateITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/batch/table/CorrelateITCase.scala
@@ -22,13 +22,12 @@ import java.sql.{Date, Timestamp}
 
 import org.apache.flink.api.scala._
 import org.apache.flink.api.scala.util.CollectionDataSets
-import org.apache.flink.table.api.{TableEnvironment, TableException, Types, ValidationException}
-import org.apache.flink.table.runtime.utils.JavaUserDefinedTableFunctions.JavaTableFunc0
 import org.apache.flink.table.api.scala._
-import org.apache.flink.table.expressions.utils.{Func1, Func13, Func18, RichFunc2}
-import org.apache.flink.table.runtime.utils.TableProgramsClusterTestBase
+import org.apache.flink.table.api.{TableEnvironment, Types, ValidationException}
+import org.apache.flink.table.expressions.utils.{Func1, Func18, RichFunc2}
+import org.apache.flink.table.runtime.utils.JavaUserDefinedTableFunctions.JavaTableFunc0
 import org.apache.flink.table.runtime.utils.TableProgramsTestBase.TableConfigMode
-import org.apache.flink.table.runtime.utils._
+import org.apache.flink.table.runtime.utils.{TableProgramsClusterTestBase, _}
 import org.apache.flink.table.utils._
 import org.apache.flink.test.util.MultipleProgramsTestBase.TestExecutionMode
 import org.apache.flink.test.util.TestBaseUtils

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/utils/UserDefinedTableFunctions.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/utils/UserDefinedTableFunctions.scala
@@ -119,6 +119,26 @@ class TableFunc4 extends TableFunction[Row] {
   }
 }
 
+class TableFunc5 extends TableFunction[Row] {
+  def eval(row: Row): Unit = {
+    collect(row)
+  }
+
+  override def getParameterTypes(signature: Array[Class[_]]): Array[TypeInformation[_]] =
+    Array(Types.ROW(Types.INT, Types.INT, Types.INT))
+
+  override def getResultType: TypeInformation[Row] =
+    Types.ROW(Types.INT, Types.INT, Types.INT)
+
+}
+
+class VarArgsFunc0 extends TableFunction[String] {
+  @varargs
+  def eval(str: String*): Unit = {
+    str.foreach(collect)
+  }
+}
+
 class HierarchyTableFunction extends SplittableTableFunction[Boolean, Integer] {
   def eval(user: String) {
     if (user.contains("#")) {
@@ -213,12 +233,5 @@ class RichTableFunc1 extends TableFunction[String] {
 
   override def close(): Unit = {
     separator = None
-  }
-}
-
-class VarArgsFunc0 extends TableFunction[String] {
-  @varargs
-  def eval(str: String*): Unit = {
-    str.foreach(collect)
   }
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR adds tests for rows as inputs for TableFunctions and ScalarFunctions.

## Brief change log

Tests added


## Verifying this change

This change added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

