### PR TITLE
[FLINK-7076] [ResourceManager] implement YARN stopWorker logic

### DIFF
--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManager.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManager.java
@@ -421,14 +421,13 @@ public class MesosResourceManager extends ResourceManager<RegisteredMesosWorkerN
 	}
 
 	@Override
-	public boolean stopWorker(ResourceID resourceID) {
-		LOG.info("Stopping worker {}.", resourceID);
-
+	public boolean stopWorker(RegisteredMesosWorkerNode workerNode) {
+		LOG.info("Stopping worker {}.", workerNode.getResourceID());
 		try {
 
-			if (workersInLaunch.containsKey(resourceID)) {
+			if (workersInLaunch.containsKey(workerNode.getResourceID())) {
 				// update persistent state of worker to Released
-				MesosWorkerStore.Worker worker = workersInLaunch.remove(resourceID);
+				MesosWorkerStore.Worker worker = workersInLaunch.remove(workerNode.getResourceID());
 				worker = worker.releaseWorker();
 				workerStore.putWorker(worker);
 				workersBeingReturned.put(extractResourceID(worker.taskID()), worker);
@@ -440,11 +439,11 @@ public class MesosResourceManager extends ResourceManager<RegisteredMesosWorkerN
 					launchCoordinator.tell(new LaunchCoordinator.Unassign(worker.taskID(), worker.hostname().get()), selfActor);
 				}
 			}
-			else if (workersBeingReturned.containsKey(resourceID)) {
-				LOG.info("Ignoring request to stop worker {} because it is already being stopped.", resourceID);
+			else if (workersBeingReturned.containsKey(workerNode.getResourceID())) {
+				LOG.info("Ignoring request to stop worker {} because it is already being stopped.", workerNode.getResourceID());
 			}
 			else {
-				LOG.warn("Unrecognized worker {}.", resourceID);
+				LOG.warn("Unrecognized worker {}.", workerNode.getResourceID());
 			}
 		}
 		catch (Exception e) {

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
@@ -701,7 +701,7 @@ public class MesosResourceManagerTest extends TestLogger {
 			resourceManager.launchCoordinator.expectMsgClass(LaunchCoordinator.Assign.class);
 
 			// tell the RM to stop the worker
-			resourceManager.stopWorker(extractResourceID(task1));
+			resourceManager.stopWorker(new RegisteredMesosWorkerNode(worker1launched));
 
 			// verify that the instance state was updated
 			MesosWorkerStore.Worker worker1Released = worker1launched.releaseWorker();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -63,7 +63,6 @@ import org.apache.flink.runtime.taskexecutor.TaskExecutorRegistrationSuccess;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -87,7 +86,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  *     <li>{@link #requestSlot(JobMasterId, SlotRequest, Time)} requests a slot from the resource manager</li>
  * </ul>
  */
-public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable & Serializable>
+public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 		extends FencedRpcEndpoint<ResourceManagerId>
 		implements ResourceManagerGateway, LeaderContender {
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.messages.InfoMessage;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.ResourceIDRetrievable;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotID;
 import org.apache.flink.runtime.concurrent.FutureUtils;
@@ -86,7 +87,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  *     <li>{@link #requestSlot(JobMasterId, SlotRequest, Time)} requests a slot from the resource manager</li>
  * </ul>
  */
-public abstract class ResourceManager<WorkerType extends Serializable>
+public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable & Serializable>
 		extends FencedRpcEndpoint<ResourceManagerId>
 		implements ResourceManagerGateway, LeaderContender {
 
@@ -800,21 +801,22 @@ public abstract class ResourceManager<WorkerType extends Serializable>
 	}
 
 	protected void releaseResource(InstanceID instanceId) {
-		ResourceID resourceID = null;
+		WorkerType worker = null;
 
 		// TODO: Improve performance by having an index on the instanceId
 		for (Map.Entry<ResourceID, WorkerRegistration<WorkerType>> entry : taskExecutors.entrySet()) {
 			if (entry.getValue().getInstanceID().equals(instanceId)) {
-				resourceID = entry.getKey();
+				worker = entry.getValue().getWorker();
 				break;
 			}
 		}
 
-		if (resourceID != null) {
-			if (stopWorker(resourceID)) {
-				closeTaskManagerConnection(resourceID, new FlinkException("Worker was stopped."));
+		if (worker != null) {
+			if (stopWorker(worker)) {
+				closeTaskManagerConnection(worker.getResourceID(),
+						new FlinkException("Worker was stopped."));
 			} else {
-				log.debug("Worker {} was not stopped.", resourceID);
+				log.debug("Worker {} was not stopped.", worker.getResourceID());
 			}
 		} else {
 			// unregister in order to clean up potential left over state
@@ -958,10 +960,10 @@ public abstract class ResourceManager<WorkerType extends Serializable>
 	/**
 	 * Stops the given worker.
 	 *
-	 * @param resourceID identifying the worker to be stopped
+	 * @param worker The worker.
 	 * @return True if the worker was stopped, otherwise false
 	 */
-	public abstract boolean stopWorker(ResourceID resourceID);
+	public abstract boolean stopWorker(WorkerType worker);
 
 	// ------------------------------------------------------------------------
 	//  Static utility classes

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/registration/WorkerRegistration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/registration/WorkerRegistration.java
@@ -18,16 +18,15 @@
 
 package org.apache.flink.runtime.resourcemanager.registration;
 
+import org.apache.flink.runtime.clusterframework.types.ResourceIDRetrievable;
 import org.apache.flink.runtime.instance.HardwareDescription;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
 import org.apache.flink.util.Preconditions;
 
-import java.io.Serializable;
-
 /**
  * This class extends the {@link TaskExecutorConnection}, adding the worker information.
  */
-public class WorkerRegistration<WorkerType extends Serializable> extends TaskExecutorConnection {
+public class WorkerRegistration<WorkerType extends ResourceIDRetrievable> extends TaskExecutorConnection {
 
 	private final WorkerType worker;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
@@ -959,4 +959,21 @@ public class SlotManager implements AutoCloseable {
 			return false;
 		}
 	}
+
+	@VisibleForTesting
+	public void unregisterTaskManagersAndReleaseResources() {
+		Iterator<Map.Entry<InstanceID, TaskManagerRegistration>> taskManagerRegistrationIterator =
+				taskManagerRegistrations.entrySet().iterator();
+
+		while (taskManagerRegistrationIterator.hasNext()) {
+			TaskManagerRegistration taskManagerRegistration =
+					taskManagerRegistrationIterator.next().getValue();
+
+			taskManagerRegistrationIterator.remove();
+
+			internalUnregisterTaskManager(taskManagerRegistration);
+
+			resourceActions.releaseResource(taskManagerRegistration.getInstanceId());
+		}
+	}
 }

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnWorkerNode.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnWorkerNode.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.yarn;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.ResourceIDRetrievable;
+
+import org.apache.hadoop.yarn.api.records.Container;
+
+import java.io.Serializable;
+
+/**
+ * A stored YARN worker, which contains the YARN container.
+ */
+public class YarnWorkerNode implements ResourceIDRetrievable, Serializable {
+
+	private Container yarnContainer;
+
+	public YarnWorkerNode(Container container) {
+		this.yarnContainer = container;
+	}
+
+	@Override
+	public ResourceID getResourceID() {
+		return new ResourceID(yarnContainer.getId().toString());
+	}
+
+	public Container getYarnContainer() {
+		return yarnContainer;
+	}
+}

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnWorkerNode.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnWorkerNode.java
@@ -20,28 +20,30 @@ package org.apache.flink.yarn;
 
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceIDRetrievable;
+import org.apache.flink.util.Preconditions;
 
 import org.apache.hadoop.yarn.api.records.Container;
-
-import java.io.Serializable;
 
 /**
  * A stored YARN worker, which contains the YARN container.
  */
-public class YarnWorkerNode implements ResourceIDRetrievable, Serializable {
+public class YarnWorkerNode implements ResourceIDRetrievable {
 
-	private Container yarnContainer;
+	private final ResourceID resourceID;
+	private final Container container;
 
 	public YarnWorkerNode(Container container) {
-		this.yarnContainer = container;
+		Preconditions.checkNotNull(container);
+		this.resourceID = new ResourceID(container.getId().toString());
+		this.container = container;
 	}
 
 	@Override
 	public ResourceID getResourceID() {
-		return new ResourceID(yarnContainer.getId().toString());
+		return resourceID;
 	}
 
-	public Container getYarnContainer() {
-		return yarnContainer;
+	public Container getContainer() {
+		return container;
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

*Implement stopWorker logic for YarnResourceManager*


## Brief change log

  - *Added a ConcurrentHashMap to keep the ResourceID to Yarn ContainerId mappings*
  - *Implement the stopWorker logic for YARN*


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

  - *Added test that validates that YARN container is stopped and released when slotManager unregister the Task Executors and release the resource.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: yes

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

