### PR TITLE
[hotfix] [REST] Various rest-related hotfixes

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
@@ -21,6 +21,9 @@ package org.apache.flink.runtime.rest;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.runtime.rest.handler.PipelineErrorHandler;
+import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.EmptyResponseBody;
 import org.apache.flink.runtime.rest.messages.ErrorResponseBody;
 import org.apache.flink.runtime.rest.messages.MessageHeaders;
 import org.apache.flink.runtime.rest.messages.MessageParameters;
@@ -131,6 +134,18 @@ public class RestClient {
 		} catch (Exception e) {
 			LOG.warn("Rest endpoint shutdown failed.", e);
 		}
+	}
+
+	public <M extends MessageHeaders<EmptyRequestBody, P, U>, U extends MessageParameters, P extends ResponseBody> CompletableFuture<P> sendRequest(String targetAddress, int targetPort, M messageHeaders, U messageParameters) throws IOException {
+		return sendRequest(targetAddress, targetPort, messageHeaders, messageParameters, EmptyRequestBody.getInstance());
+	}
+
+	public <M extends MessageHeaders<R, P, EmptyMessageParameters>, R extends RequestBody, P extends ResponseBody> CompletableFuture<P> sendRequest(String targetAddress, int targetPort, M messageHeaders, R request) throws IOException {
+		return sendRequest(targetAddress, targetPort, messageHeaders, EmptyMessageParameters.getInstance(), request);
+	}
+
+	public <M extends MessageHeaders<EmptyRequestBody, P, EmptyMessageParameters>, P extends ResponseBody> CompletableFuture<P> sendRequest(String targetAddress, int targetPort, M messageHeaders) throws IOException {
+		return sendRequest(targetAddress, targetPort, messageHeaders, EmptyMessageParameters.getInstance(), EmptyRequestBody.getInstance());
 	}
 
 	public <M extends MessageHeaders<R, P, U>, U extends MessageParameters, R extends RequestBody, P extends ResponseBody> CompletableFuture<P> sendRequest(String targetAddress, int targetPort, M messageHeaders, U messageParameters, R request) throws IOException {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
@@ -23,7 +23,6 @@ import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.runtime.rest.handler.PipelineErrorHandler;
 import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
 import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
-import org.apache.flink.runtime.rest.messages.EmptyResponseBody;
 import org.apache.flink.runtime.rest.messages.ErrorResponseBody;
 import org.apache.flink.runtime.rest.messages.MessageHeaders;
 import org.apache.flink.runtime.rest.messages.MessageParameters;
@@ -262,7 +261,18 @@ public class RestClient {
 				LOG.debug("Received response {}.", rawResponse);
 			} catch (JsonParseException je) {
 				LOG.error("Response was not valid JSON.", je);
-				jsonFuture.completeExceptionally(new RestClientException("Response was not valid JSON.", je, msg.getStatus()));
+				// let's see if it was a plain-text message instead
+				content.readerIndex(0);
+				try {
+					ByteBufInputStream in = new ByteBufInputStream(content);
+					byte[] data = new byte[in.available()];
+					in.readFully(data);
+					String message = new String(data);
+					LOG.error("Unexpected plain-text response: {}", message);
+					jsonFuture.completeExceptionally(new RestClientException("Response was not valid JSON, but plain-text: " + message, je, msg.getStatus()));
+				} catch (IOException e) {
+					jsonFuture.completeExceptionally(new RestClientException("Response was not valid JSON, nor plain-text.", je, msg.getStatus()));
+				}
 				return;
 			} catch (IOException ioe) {
 				LOG.error("Response could not be read.", ioe);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/AbstractRestHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/AbstractRestHandler.java
@@ -103,8 +103,8 @@ public abstract class AbstractRestHandler<T extends RestfulGateway, R extends Re
 				try {
 					request = mapper.readValue("{}", messageHeaders.getRequestClass());
 				} catch (JsonParseException | JsonMappingException je) {
-					log.error("Implementation error: Get request bodies must have a no-argument constructor.", je);
-					HandlerUtils.sendErrorResponse(ctx, httpRequest, new ErrorResponseBody("Internal server error."), HttpResponseStatus.INTERNAL_SERVER_ERROR);
+					log.error("Request did not conform to expected format.", je);
+					HandlerUtils.sendErrorResponse(ctx, httpRequest, new ErrorResponseBody("Bad request received."), HttpResponseStatus.BAD_REQUEST);
 					return;
 				}
 			} else {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/EmptyRequestBody.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/EmptyRequestBody.java
@@ -22,4 +22,13 @@ package org.apache.flink.runtime.rest.messages;
  * Request which do not have a request payload.
  */
 public class EmptyRequestBody implements RequestBody {
+
+	private static final EmptyRequestBody INSTANCE = new EmptyRequestBody();
+
+	private EmptyRequestBody() {
+	}
+
+	public static EmptyRequestBody getInstance() {
+		return INSTANCE;
+	}
 }


### PR DESCRIPTION
This PR is based on #4700.

## What is the purpose of the change

This PR contains a number of smaller changes that i made while working on FLINK-7072, which are however not really related to it, so I decided to front-load them instead.

## Brief change log

* modify the existing `EmptyRequestBody` class to be a singleton
* add QoL variations of `RestClient#sendRequest` for empty requests/parameters

* add PATCH http method wrapper

* Fix the error message when a GET message could not mapped to the respective RequestBody. This now properly returns BAD_REQUEST instead of INTERNAL_SERVER_ERROR.

* Add a special case to the `RestClient` for reading plain-text responses, which previously failed with cryptic json parsing exceptions.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
