### PR TITLE
[FLINK-7426] [table] Support null values in keys

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/types/Row.java
+++ b/flink-core/src/main/java/org/apache/flink/types/Row.java
@@ -142,15 +142,29 @@ public class Row implements Serializable{
 
 	/**
 	 * Creates a new Row which copied from another row.
+	 * This method does not perform a deep copy.
 	 *
 	 * @param row The row being copied.
 	 * @return The cloned new Row
 	 */
 	public static Row copy(Row row) {
-		Row ret = new Row(row.getArity());
-		for (int i = 0; i < row.getArity(); ++i) {
-			ret.setField(i, row.getField(i));
+		final Row newRow = new Row(row.fields.length);
+		System.arraycopy(row.fields, 0, newRow.fields, 0, row.fields.length);
+		return newRow;
+	}
+
+	/**
+	 * Creates a new Row with projected fields from another row.
+	 * This method does not perform a deep copy.
+	 *
+	 * @param fields fields to be projected
+	 * @return the new projected Row
+	 */
+	public static Row project(Row row, int[] fields) {
+		final Row newRow = new Row(fields.length);
+		for (int i = 0; i < fields.length; i++) {
+			newRow.fields[i] = row.fields[fields[i]];
 		}
-		return ret;
+		return newRow;
 	}
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/calcite/FlinkTypeFactory.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/calcite/FlinkTypeFactory.scala
@@ -149,19 +149,19 @@ class FlinkTypeFactory(typeSystem: RelDataTypeSystem) extends JavaTypeFactoryImp
           createTypeFromTypeInfo(oa.getComponentInfo, isNullable = true),
           isNullable)
 
-      case mp: MapTypeInfo[_, _] =>
-        new MapRelDataType(
-          mp,
-          createTypeFromTypeInfo(mp.getKeyTypeInfo, isNullable = true),
-          createTypeFromTypeInfo(mp.getValueTypeInfo, isNullable = true),
-          isNullable)
-
       case mts: MultisetTypeInfo[_] =>
         new MultisetRelDataType(
           mts,
           createTypeFromTypeInfo(mts.getElementTypeInfo, isNullable = true),
           isNullable
         )
+
+      case mp: MapTypeInfo[_, _] =>
+        new MapRelDataType(
+          mp,
+          createTypeFromTypeInfo(mp.getKeyTypeInfo, isNullable = true),
+          createTypeFromTypeInfo(mp.getValueTypeInfo, isNullable = true),
+          isNullable)
 
       case ti: TypeInformation[_] =>
         new GenericRelDataType(

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamGroupAggregate.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamGroupAggregate.scala
@@ -27,6 +27,7 @@ import org.apache.flink.table.codegen.AggregationCodeGenerator
 import org.apache.flink.table.plan.nodes.CommonAggregate
 import org.apache.flink.table.plan.rules.datastream.DataStreamRetractionRules
 import org.apache.flink.table.plan.schema.RowSchema
+import org.apache.flink.table.runtime.CRowKeySelector
 import org.apache.flink.table.runtime.aggregate.AggregateUtil.CalcitePair
 import org.apache.flink.table.runtime.aggregate._
 import org.apache.flink.table.runtime.types.{CRow, CRowTypeInfo}
@@ -144,7 +145,7 @@ class DataStreamGroupAggregate(
     // grouped / keyed aggregation
       if (groupings.nonEmpty) {
         inputDS
-        .keyBy(groupings: _*)
+        .keyBy(new CRowKeySelector(groupings, inputSchema.projectedTypeInfo(groupings)))
         .process(processFunction)
         .returns(outRowType)
         .name(keyedAggOpName)

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamOverAggregate.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamOverAggregate.scala
@@ -34,6 +34,7 @@ import org.apache.flink.table.codegen.AggregationCodeGenerator
 import org.apache.flink.table.plan.nodes.OverAggregate
 import org.apache.flink.table.plan.rules.datastream.DataStreamRetractionRules
 import org.apache.flink.table.plan.schema.RowSchema
+import org.apache.flink.table.runtime.CRowKeySelector
 import org.apache.flink.table.runtime.aggregate.AggregateUtil.CalcitePair
 import org.apache.flink.table.runtime.aggregate._
 import org.apache.flink.table.runtime.types.{CRow, CRowTypeInfo}
@@ -214,7 +215,7 @@ class DataStreamOverAggregate(
     // partitioned aggregation
       if (partitionKeys.nonEmpty) {
         inputDS
-          .keyBy(partitionKeys: _*)
+          .keyBy(new CRowKeySelector(partitionKeys, inputSchema.projectedTypeInfo(partitionKeys)))
           .process(processFunction)
           .returns(returnTypeInfo)
           .name(aggOpName)
@@ -264,7 +265,7 @@ class DataStreamOverAggregate(
     // partitioned aggregation
       if (partitionKeys.nonEmpty) {
         inputDS
-          .keyBy(partitionKeys: _*)
+          .keyBy(new CRowKeySelector(partitionKeys, inputSchema.projectedTypeInfo(partitionKeys)))
           .process(processFunction)
           .returns(returnTypeInfo)
           .name(aggOpName)

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/schema/RowSchema.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/schema/RowSchema.scala
@@ -62,4 +62,12 @@ class RowSchema(private val logicalRowType: RelDataType) {
     */
   def fieldNames: Seq[String] = logicalRowType.getFieldNames
 
+  /**
+    * Returns a projected [[TypeInformation]] of the schema.
+    */
+  def projectedTypeInfo(fields: Array[Int]): TypeInformation[Row] = {
+    val projectedTypes = fields.map(fieldTypeInfos(_))
+    val projectedNames = fields.map(fieldNames(_))
+    new RowTypeInfo(projectedTypes, projectedNames)
+  }
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/CRowKeySelector.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/CRowKeySelector.scala
@@ -34,17 +34,7 @@ class CRowKeySelector(
   with ResultTypeQueryable[Row] {
 
   override def getKey(value: CRow): Row = {
-    val row = value.row
-    val fields = keyFields
-
-    val newKey = new Row(fields.length)
-    var i = 0
-    while (i < fields.length) {
-      newKey.setField(i, row.getField(fields(i)))
-      i += 1
-    }
-
-    newKey
+    Row.project(value.row, keyFields)
   }
 
   override def getProducedType: TypeInformation[Row] = returnType

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/CRowKeySelector.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/CRowKeySelector.scala
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime
+
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.functions.KeySelector
+import org.apache.flink.api.java.typeutils.ResultTypeQueryable
+import org.apache.flink.table.runtime.types.CRow
+import org.apache.flink.types.Row
+
+/**
+  * Null-aware key selector.
+  */
+class CRowKeySelector(
+    val keyFields: Array[Int],
+    @transient var returnType: TypeInformation[Row])
+  extends KeySelector[CRow, Row]
+  with ResultTypeQueryable[Row] {
+
+  override def getKey(value: CRow): Row = {
+    val row = value.row
+    val fields = keyFields
+
+    val newKey = new Row(fields.length)
+    var i = 0
+    while (i < fields.length) {
+      newKey.setField(i, row.getField(fields(i)))
+      i += 1
+    }
+
+    newKey
+  }
+
+  override def getProducedType: TypeInformation[Row] = returnType
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/AggregateUtil.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/AggregateUtil.scala
@@ -27,8 +27,7 @@ import org.apache.calcite.sql.fun._
 import org.apache.calcite.sql.{SqlAggFunction, SqlKind}
 import org.apache.flink.api.common.functions.{MapFunction, RichGroupReduceFunction, AggregateFunction => DataStreamAggFunction, _}
 import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
-import org.apache.flink.api.java.tuple.Tuple
-import org.apache.flink.api.java.typeutils.{GenericTypeInfo, RowTypeInfo}
+import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.streaming.api.functions.ProcessFunction
 import org.apache.flink.streaming.api.functions.windowing.{AllWindowFunction, WindowFunction}
 import org.apache.flink.streaming.api.windowing.windows.{Window => DataStreamWindow}
@@ -981,7 +980,7 @@ object AggregateUtil {
       numAggregates: Int,
       finalRowArity: Int,
       properties: Seq[NamedWindowProperty]):
-    WindowFunction[Row, CRow, Tuple, DataStreamWindow] = {
+    WindowFunction[Row, CRow, Row, DataStreamWindow] = {
 
     if (isTimeWindow(window)) {
       val (startPos, endPos, timePos) = computeWindowPropertyPos(properties)
@@ -992,7 +991,7 @@ object AggregateUtil {
         endPos,
         timePos,
         finalRowArity)
-        .asInstanceOf[WindowFunction[Row, CRow, Tuple, DataStreamWindow]]
+        .asInstanceOf[WindowFunction[Row, CRow, Row, DataStreamWindow]]
     } else {
       new IncrementalAggregateWindowFunction(
         numGroupingKeys,

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/IncrementalAggregateTimeWindowFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/IncrementalAggregateTimeWindowFunction.scala
@@ -59,7 +59,7 @@ class IncrementalAggregateTimeWindowFunction(
   }
 
   override def apply(
-      key: Tuple,
+      key: Row,
       window: TimeWindow,
       records: Iterable[Row],
       out: Collector[CRow]): Unit = {

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/IncrementalAggregateWindowFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/IncrementalAggregateWindowFunction.scala
@@ -19,12 +19,11 @@ package org.apache.flink.table.runtime.aggregate
 
 import java.lang.Iterable
 
-import org.apache.flink.api.java.tuple.Tuple
-import org.apache.flink.types.Row
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.streaming.api.functions.windowing.RichWindowFunction
 import org.apache.flink.streaming.api.windowing.windows.Window
 import org.apache.flink.table.runtime.types.CRow
+import org.apache.flink.types.Row
 import org.apache.flink.util.Collector
 
 /**
@@ -38,7 +37,7 @@ class IncrementalAggregateWindowFunction[W <: Window](
     private val numGroupingKey: Int,
     private val numAggregates: Int,
     private val finalRowArity: Int)
-  extends RichWindowFunction[Row, CRow, Tuple, W] {
+  extends RichWindowFunction[Row, CRow, Row, W] {
 
   private var output: CRow = _
 
@@ -51,7 +50,7 @@ class IncrementalAggregateWindowFunction[W <: Window](
     * Row based on the mapping relation between intermediate aggregate data and output data.
     */
   override def apply(
-      key: Tuple,
+      key: Row,
       window: W,
       records: Iterable[Row],
       out: Collector[CRow]): Unit = {

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/sql/JoinITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/sql/JoinITCase.scala
@@ -23,8 +23,9 @@ import org.apache.flink.streaming.api.TimeCharacteristic
 import org.apache.flink.streaming.api.functions.AssignerWithPunctuatedWatermarks
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.apache.flink.streaming.api.watermark.Watermark
-import org.apache.flink.table.api.TableEnvironment
 import org.apache.flink.table.api.scala._
+import org.apache.flink.table.api.{TableEnvironment, Types}
+import org.apache.flink.table.expressions.Null
 import org.apache.flink.table.runtime.utils.{StreamITCase, StreamingWithStateTestBase}
 import org.apache.flink.types.Row
 import org.hamcrest.CoreMatchers
@@ -65,7 +66,9 @@ class JoinITCase extends StreamingWithStateTestBase {
     data2.+=((2, 2L, "HeHe"))
 
     val t1 = env.fromCollection(data1).toTable(tEnv, 'a, 'b, 'c, 'proctime.proctime)
+      .select(('a === 1)?(Null(Types.INT), 'a) as 'a, 'b, 'c, 'proctime) // test null values
     val t2 = env.fromCollection(data2).toTable(tEnv, 'a, 'b, 'c, 'proctime.proctime)
+      .select(('a === 1)?(Null(Types.INT), 'a) as 'a, 'b, 'c, 'proctime) // test null values
 
     tEnv.registerTable("T1", t1)
     tEnv.registerTable("T2", t2)

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/GroupWindowITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/GroupWindowITCase.scala
@@ -61,7 +61,8 @@ class GroupWindowITCase extends StreamingMultipleProgramsTestBase {
     (4L, 5, 5d, 5f, new BigDecimal("5"), "Hello"),
     (7L, 3, 3d, 3f, new BigDecimal("3"), "Hello"),
     (8L, 3, 3d, 3f, new BigDecimal("3"), "Hello world"),
-    (16L, 4, 4d, 4f, new BigDecimal("4"), "Hello world"))
+    (16L, 4, 4d, 4f, new BigDecimal("4"), "Hello world"),
+    (32L, 4, 4d, 4f, new BigDecimal("4"), null.asInstanceOf[String]))
 
   @Test
   def testProcessingTimeSlidingGroupWindowOverCount(): Unit = {
@@ -232,8 +233,6 @@ class GroupWindowITCase extends StreamingMultipleProgramsTestBase {
     assertEquals(expected.sorted, StreamITCase.testResults.sorted)
   }
 
-
-
   // ----------------------------------------------------------------------------------------------
   // Sliding windows
   // ----------------------------------------------------------------------------------------------
@@ -270,7 +269,10 @@ class GroupWindowITCase extends StreamingMultipleProgramsTestBase {
       "2,1970-01-01 00:00:00.006,1970-01-01 00:00:00.011",
       "3,1970-01-01 00:00:00.002,1970-01-01 00:00:00.007",
       "3,1970-01-01 00:00:00.004,1970-01-01 00:00:00.009",
-      "4,1970-01-01 00:00:00.0,1970-01-01 00:00:00.005")
+      "4,1970-01-01 00:00:00.0,1970-01-01 00:00:00.005",
+      "1,1970-01-01 00:00:00.028,1970-01-01 00:00:00.033",
+      "1,1970-01-01 00:00:00.03,1970-01-01 00:00:00.035",
+      "1,1970-01-01 00:00:00.032,1970-01-01 00:00:00.037")
     assertEquals(expected.sorted, StreamITCase.testResults.sorted)
   }
 
@@ -308,7 +310,9 @@ class GroupWindowITCase extends StreamingMultipleProgramsTestBase {
       "Hello,2,1969-12-31 23:59:59.995,1970-01-01 00:00:00.005",
       "Hello,3,1970-01-01 00:00:00.0,1970-01-01 00:00:00.01",
       "Hi,1,1969-12-31 23:59:59.995,1970-01-01 00:00:00.005",
-      "Hi,1,1970-01-01 00:00:00.0,1970-01-01 00:00:00.01")
+      "Hi,1,1970-01-01 00:00:00.0,1970-01-01 00:00:00.01",
+      "null,1,1970-01-01 00:00:00.025,1970-01-01 00:00:00.035",
+      "null,1,1970-01-01 00:00:00.03,1970-01-01 00:00:00.04")
     assertEquals(expected.sorted, StreamITCase.testResults.sorted)
   }
 
@@ -343,7 +347,9 @@ class GroupWindowITCase extends StreamingMultipleProgramsTestBase {
       "Hello world,1,1970-01-01 00:00:00.016,1970-01-01 00:00:00.021",
       "Hello,2,1970-01-01 00:00:00.0,1970-01-01 00:00:00.005",
       "Hello,2,1970-01-01 00:00:00.004,1970-01-01 00:00:00.009",
-      "Hi,1,1970-01-01 00:00:00.0,1970-01-01 00:00:00.005")
+      "Hi,1,1970-01-01 00:00:00.0,1970-01-01 00:00:00.005",
+      "null,1,1970-01-01 00:00:00.028,1970-01-01 00:00:00.033",
+      "null,1,1970-01-01 00:00:00.032,1970-01-01 00:00:00.037")
     assertEquals(expected.sorted, StreamITCase.testResults.sorted)
   }
 
@@ -373,7 +379,8 @@ class GroupWindowITCase extends StreamingMultipleProgramsTestBase {
     val expected = Seq(
       "Hallo,1,1970-01-01 00:00:00.0,1970-01-01 00:00:00.005",
       "Hello,2,1970-01-01 00:00:00.0,1970-01-01 00:00:00.005",
-      "Hi,1,1970-01-01 00:00:00.0,1970-01-01 00:00:00.005")
+      "Hi,1,1970-01-01 00:00:00.0,1970-01-01 00:00:00.005",
+      "null,1,1970-01-01 00:00:00.03,1970-01-01 00:00:00.035")
     assertEquals(expected.sorted, StreamITCase.testResults.sorted)
   }
 
@@ -402,7 +409,8 @@ class GroupWindowITCase extends StreamingMultipleProgramsTestBase {
 
     val expected = Seq(
       "Hallo,1,1970-01-01 00:00:00.0,1970-01-01 00:00:00.003",
-      "Hi,1,1970-01-01 00:00:00.0,1970-01-01 00:00:00.003")
+      "Hi,1,1970-01-01 00:00:00.0,1970-01-01 00:00:00.003",
+      "null,1,1970-01-01 00:00:00.03,1970-01-01 00:00:00.033")
     assertEquals(expected.sorted, StreamITCase.testResults.sorted)
   }
 
@@ -430,7 +438,8 @@ class GroupWindowITCase extends StreamingMultipleProgramsTestBase {
     env.execute()
     val expected = Seq(
       "Hallo,1,1970-01-01 00:00:00.0,1970-01-01 00:00:00.003",
-      "Hi,1,1970-01-01 00:00:00.0,1970-01-01 00:00:00.003")
+      "Hi,1,1970-01-01 00:00:00.0,1970-01-01 00:00:00.003",
+      "null,1,1970-01-01 00:00:00.03,1970-01-01 00:00:00.033")
     assertEquals(expected.sorted, StreamITCase.testResults.sorted)
   }
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/OverWindowITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/OverWindowITCase.scala
@@ -52,7 +52,8 @@ class OverWindowITCase extends StreamingWithStateTestBase {
       (7L, 7, "Hello World"),
       (8L, 8, "Hello World"),
       (8L, 8, "Hello World"),
-      (20L, 20, "Hello World"))
+      (20L, 20, "Hello World"),
+      (20L, 20, null.asInstanceOf[String]))
 
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     env.setParallelism(1)
@@ -80,7 +81,8 @@ class OverWindowITCase extends StreamingWithStateTestBase {
 
     val expected = Seq(
       "Hello World,1,7,1", "Hello World,2,7,2", "Hello World,3,7,2", "Hello World,4,13,3",
-      "Hello,1,1,1", "Hello,2,1,2", "Hello,3,2,3", "Hello,4,3,4", "Hello,5,3,5", "Hello,6,4,6")
+      "Hello,1,1,1", "Hello,2,1,2", "Hello,3,2,3", "Hello,4,3,4", "Hello,5,3,5", "Hello,6,4,6",
+      "null,1,20,1")
     assertEquals(expected.sorted, StreamITCase.testResults.sorted)
   }
 


### PR DESCRIPTION
## What is the purpose of the change

This PR adds support for null values in keys by not relying on the default `KeySelector`.


## Brief change log

- New `CRowKeySelector`


## Verifying this change

Two tests have been extended that would fail otherwise.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes, for Table programs
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

