### PR TITLE
[FLINK-7701][network] really fix watermark configuration order this time

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyServer.java
@@ -124,8 +124,18 @@ class NettyServer {
 		}
 
 		// Low and high water marks for flow control
-		bootstrap.childOption(ChannelOption.WRITE_BUFFER_HIGH_WATER_MARK, 2 * config.getMemorySegmentSize());
-		bootstrap.childOption(ChannelOption.WRITE_BUFFER_LOW_WATER_MARK, config.getMemorySegmentSize() + 1);
+		// hack around the impossibility (in the current netty version) to set both watermarks at
+		// the same time:
+		final int defaultHighWaterMark = 64 * 1024; // from DefaultChannelConfig (not exposed)
+		final int newLowWaterMark = config.getMemorySegmentSize() + 1;
+		final int newHighWaterMark = 2 * config.getMemorySegmentSize();
+		if (newLowWaterMark > defaultHighWaterMark) {
+			bootstrap.childOption(ChannelOption.WRITE_BUFFER_HIGH_WATER_MARK, newHighWaterMark);
+			bootstrap.childOption(ChannelOption.WRITE_BUFFER_LOW_WATER_MARK, newLowWaterMark);
+		} else { // including (newHighWaterMark < defaultLowWaterMark)
+			bootstrap.childOption(ChannelOption.WRITE_BUFFER_LOW_WATER_MARK, newLowWaterMark);
+			bootstrap.childOption(ChannelOption.WRITE_BUFFER_HIGH_WATER_MARK, newHighWaterMark);
+		}
 
 		// SSL related configuration
 		try {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyServerLowAndHighWatermarkTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyServerLowAndHighWatermarkTest.java
@@ -39,29 +39,46 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+/**
+ * Verifies that high and low watermarks for {@link NettyServer} may be set to any (valid) values
+ * given by the user.
+ */
 public class NettyServerLowAndHighWatermarkTest {
 
 	/**
-	 * Pick a larger memory segment size here in order to trigger
-	 * <a href="https://issues.apache.org/jira/browse/FLINK-7258">FLINK-7258</a>.
+	 * Verify low and high watermarks being set correctly for larger memory segment sizes which
+	 * trigger <a href="https://issues.apache.org/jira/browse/FLINK-7258">FLINK-7258</a>.
 	 */
-	private final static int PageSize = 65536;
+	@Test
+	public void testLargeLowAndHighWatermarks() throws Throwable {
+		testLowAndHighWatermarks(65536);
+	}
+
+	/**
+	 * Verify low and high watermarks being set correctly for smaller memory segment sizes than
+	 * Netty's defaults.
+	 */
+	@Test
+	public void testSmallLowAndHighWatermarks() throws Throwable {
+		testLowAndHighWatermarks(1024);
+	}
 
 	/**
 	 * Verifies that the high and low watermark are set in relation to the page size.
 	 *
-	 * <p> The high and low water marks control the data flow to the wire. If the Netty write buffer
+	 * <p>The high and low water marks control the data flow to the wire. If the Netty write buffer
 	 * has size greater or equal to the high water mark, the channel state becomes not-writable.
 	 * Only when the size falls below the low water mark again, the state changes to writable again.
 	 *
-	 * <p> The Channel writability state needs to be checked by the handler when writing to the
+	 * <p>The Channel writability state needs to be checked by the handler when writing to the
 	 * channel and is not enforced in the sense that you cannot write a channel, which is in
 	 * not-writable state.
+	 *
+	 * @param pageSize memory segment size to test with (influences high and low watermarks)
 	 */
-	@Test
-	public void testLowAndHighWatermarks() throws Throwable {
-		final int expectedLowWatermark = PageSize + 1;
-		final int expectedHighWatermark = 2 * PageSize;
+	private void testLowAndHighWatermarks(int pageSize) throws Throwable {
+		final int expectedLowWatermark = pageSize + 1;
+		final int expectedHighWatermark = 2 * pageSize;
 
 		final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
 		final NettyProtocol protocol = new NettyProtocol() {
@@ -69,7 +86,7 @@ public class NettyServerLowAndHighWatermarkTest {
 			public ChannelHandler[] getServerChannelHandlers() {
 				// The channel handler implements the test
 				return new ChannelHandler[] {new TestLowAndHighWatermarkHandler(
-					expectedLowWatermark, expectedHighWatermark, error)};
+					pageSize, expectedLowWatermark, expectedHighWatermark, error)};
 			}
 
 			@Override
@@ -78,7 +95,7 @@ public class NettyServerLowAndHighWatermarkTest {
 			}
 		};
 
-		final NettyConfig conf = createConfig(PageSize);
+		final NettyConfig conf = createConfig(pageSize);
 
 		final NettyServerAndClient serverAndClient = initServerAndClient(protocol, conf);
 
@@ -103,9 +120,11 @@ public class NettyServerLowAndHighWatermarkTest {
 	/**
 	 * This handler implements the test.
 	 *
-	 * <p> Verifies that the high and low watermark are set in relation to the page size.
+	 * <p>Verifies that the high and low watermark are set in relation to the page size.
 	 */
 	private static class TestLowAndHighWatermarkHandler extends ChannelInboundHandlerAdapter {
+
+		private final int pageSize;
 
 		private final int expectedLowWatermark;
 
@@ -115,7 +134,10 @@ public class NettyServerLowAndHighWatermarkTest {
 
 		private boolean hasFlushed;
 
-		public TestLowAndHighWatermarkHandler(int expectedLowWatermark, int expectedHighWatermark, AtomicReference<Throwable> error) {
+		public TestLowAndHighWatermarkHandler(
+				int pageSize, int expectedLowWatermark, int expectedHighWatermark,
+				AtomicReference<Throwable> error) {
+			this.pageSize = pageSize;
 			this.expectedLowWatermark = expectedLowWatermark;
 			this.expectedHighWatermark = expectedHighWatermark;
 			this.error = error;
@@ -167,13 +189,13 @@ public class NettyServerLowAndHighWatermarkTest {
 
 			super.exceptionCaught(ctx, cause);
 		}
+
+		private ByteBuf buffer() {
+			return NettyServerLowAndHighWatermarkTest.buffer(pageSize);
+		}
 	}
 
 	// ---------------------------------------------------------------------------------------------
-
-	private static ByteBuf buffer() {
-		return buffer(PageSize);
-	}
 
 	/**
 	 * Creates a new buffer of the given size.


### PR DESCRIPTION
## What is the purpose of the change

Netty (in the version we use) only allows setting high and low watermarks after another but complains about invalid values and ignores them, e.g. if the new high watermark is less than the (old) low watermark. This makes it important to get the order of the configuration options right. #4391 fixed this for large memory segment sizes (where the low watermark would have been larger than the high watermark) but broke the of small segment sizes which lead to the scenario outlined above. This should fix both.

## Brief change log

- configure `ServerBootstrap` based on the current values vs. the defaults (those are unfortunately not exposed, so we need to inline the current one)
- adapt `NettyServerLowAndHighWatermarkTest` to reflect both use cases (outlined above)

## Verifying this change

This change added tests and can be verified as follows:

- adapted `NettyServerLowAndHighWatermarkTest` to cover both high and low segment sizes
- as before, no test for the `KvStateServer` since watermarks cannot be configured there (make sure it works the same way, though!)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)