### PR TITLE
[FLINK-7371] [table] Add support for constant parameters in OVER aggregate

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/AggregationCodeGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/AggregationCodeGenerator.scala
@@ -247,7 +247,7 @@ class AggregationCodeGenerator(
             val dataViewFieldTerm = createDataViewTerm(i, dataViewField.getName)
             val field =
               s"""
-                 |    transient $dataViewTypeTerm $dataViewFieldTerm = null;
+                 |    final $dataViewTypeTerm $dataViewFieldTerm;
                  |""".stripMargin
             reusableMemberStatements.add(field)
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/AggregationCodeGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/AggregationCodeGenerator.scala
@@ -20,6 +20,7 @@ package org.apache.flink.table.codegen
 import java.lang.reflect.{Modifier, ParameterizedType}
 import java.lang.{Iterable => JIterable}
 
+import org.apache.calcite.rex.RexLiteral
 import org.apache.commons.codec.binary.Base64
 import org.apache.flink.api.common.state.{State, StateDescriptor}
 import org.apache.flink.api.common.typeinfo.TypeInformation
@@ -41,11 +42,13 @@ import scala.collection.mutable
   * @param config configuration that determines runtime behavior
   * @param nullableInput input(s) can be null.
   * @param input type information about the input of the Function
+  * @param constants constant expressions that act like a second input in the parameter indices.
   */
 class AggregationCodeGenerator(
     config: TableConfig,
     nullableInput: Boolean,
-    input: TypeInformation[_ <: Any])
+    input: TypeInformation[_ <: Any],
+    constants: Option[Seq[RexLiteral]])
   extends CodeGenerator(config, nullableInput, input) {
 
   // set of statements for cleanup dataview that will be added only once
@@ -81,25 +84,26 @@ class AggregationCodeGenerator(
     * @param needRetract a flag to indicate if the aggregate needs the retract method
     * @param needMerge a flag to indicate if the aggregate needs the merge method
     * @param needReset a flag to indicate if the aggregate needs the resetAccumulator method
+    * @param accConfig Data view specification for accumulators
     *
     * @return A GeneratedAggregationsFunction
     */
   def generateAggregations(
-    name: String,
-    physicalInputTypes: Seq[TypeInformation[_]],
-    aggregates: Array[AggregateFunction[_ <: Any, _ <: Any]],
-    aggFields: Array[Array[Int]],
-    aggMapping: Array[Int],
-    partialResults: Boolean,
-    fwdMapping: Array[Int],
-    mergeMapping: Option[Array[Int]],
-    constantFlags: Option[Array[(Int, Boolean)]],
-    outputArity: Int,
-    needRetract: Boolean,
-    needMerge: Boolean,
-    needReset: Boolean,
-    accConfig: Option[Array[Seq[DataViewSpec[_]]]])
-  : GeneratedAggregationsFunction = {
+      name: String,
+      physicalInputTypes: Seq[TypeInformation[_]],
+      aggregates: Array[AggregateFunction[_ <: Any, _ <: Any]],
+      aggFields: Array[Array[Int]],
+      aggMapping: Array[Int],
+      partialResults: Boolean,
+      fwdMapping: Array[Int],
+      mergeMapping: Option[Array[Int]],
+      constantFlags: Option[Array[(Int, Boolean)]],
+      outputArity: Int,
+      needRetract: Boolean,
+      needMerge: Boolean,
+      needReset: Boolean,
+      accConfig: Option[Array[Seq[DataViewSpec[_]]]])
+    : GeneratedAggregationsFunction = {
 
     // get unique function name
     val funcName = newName(name)
@@ -112,17 +116,41 @@ class AggregationCodeGenerator(
     }
     val accTypes = accTypeClasses.map(_.getCanonicalName)
 
+    // create constants
+    val constantExprs = constants.map(_.map(generateExpression)).getOrElse(Seq())
+    val constantTypes = constantExprs.map(_.resultType)
+    val constantFields = constantExprs.map(addReusableBoxedConstant)
+
     // get parameter lists for aggregation functions
     val parametersCode = aggFields.map { inFields =>
-      val fields = for (f <- inFields) yield
-        s"(${CodeGenUtils.boxedTypeTermForTypeInfo(physicalInputTypes(f))}) input.getField($f)"
+      val fields = inFields.map { f =>
+        // index to constant
+        if (f >= physicalInputTypes.length) {
+          constantFields(f - physicalInputTypes.length)
+        }
+        // index to input field
+        else {
+          s"(${CodeGenUtils.boxedTypeTermForTypeInfo(physicalInputTypes(f))}) input.getField($f)"
+        }
+      }
+
       fields.mkString(", ")
     }
 
     // get method signatures
     val classes = UserDefinedFunctionUtils.typeInfoToClass(physicalInputTypes)
+    val constantClasses = UserDefinedFunctionUtils.typeInfoToClass(constantTypes)
     val methodSignaturesList = aggFields.map { inFields =>
-      inFields.map(classes(_))
+      inFields.map { f =>
+        // index to constant
+        if (f >= physicalInputTypes.length) {
+          constantClasses(f - physicalInputTypes.length)
+        }
+        // index to input field
+        else {
+          classes(f)
+        }
+      }
     }
 
     // initialize and create data views

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
@@ -1327,12 +1327,12 @@ abstract class CodeGenerator(
     val statement = ti match {
       case rt: RowTypeInfo =>
         s"""
-          |transient ${ti.getTypeClass.getCanonicalName} $outRecordTerm =
+          |final ${ti.getTypeClass.getCanonicalName} $outRecordTerm =
           |    new ${ti.getTypeClass.getCanonicalName}(${rt.getArity});
           |""".stripMargin
       case _ =>
         s"""
-          |${ti.getTypeClass.getCanonicalName} $outRecordTerm =
+          |final ${ti.getTypeClass.getCanonicalName} $outRecordTerm =
           |    new ${ti.getTypeClass.getCanonicalName}();
           |""".stripMargin
     }
@@ -1352,7 +1352,7 @@ abstract class CodeGenerator(
     val fieldTerm = s"field_${clazz.getCanonicalName.replace('.', '$')}_$fieldName"
     val fieldExtraction =
       s"""
-        |transient java.lang.reflect.Field $fieldTerm =
+        |final java.lang.reflect.Field $fieldTerm =
         |    org.apache.flink.api.java.typeutils.TypeExtractor.getDeclaredField(
         |      ${clazz.getCanonicalName}.class, "$fieldName");
         |""".stripMargin
@@ -1381,7 +1381,7 @@ abstract class CodeGenerator(
       val fieldTerm = newName("decimal")
       val fieldDecimal =
         s"""
-          |transient java.math.BigDecimal $fieldTerm =
+          |final java.math.BigDecimal $fieldTerm =
           |    new java.math.BigDecimal("${decimal.toString}");
           |""".stripMargin
       reusableMemberStatements.add(fieldDecimal)
@@ -1400,7 +1400,7 @@ abstract class CodeGenerator(
 
     val field =
       s"""
-         |transient java.util.Random $fieldTerm;
+         |final java.util.Random $fieldTerm;
          |""".stripMargin
     reusableMemberStatements.add(field)
 
@@ -1440,7 +1440,7 @@ abstract class CodeGenerator(
 
     val field =
       s"""
-         |transient org.joda.time.format.DateTimeFormatter $fieldTerm;
+         |final org.joda.time.format.DateTimeFormatter $fieldTerm;
          |""".stripMargin
     reusableMemberStatements.add(field)
 
@@ -1469,7 +1469,7 @@ abstract class CodeGenerator(
 
     val fieldFunction =
       s"""
-        |transient $classQualifier $fieldTerm = null;
+        |final $classQualifier $fieldTerm;
         |""".stripMargin
     reusableMemberStatements.add(fieldFunction)
 
@@ -1516,7 +1516,7 @@ abstract class CodeGenerator(
     parameterTypes.zipWithIndex.foreach { case (t, index) =>
       val classQualifier = t.getCanonicalName
       val fieldTerm = newName(s"instance_${classQualifier.replace('.', '$')}")
-      val field = s"transient $classQualifier $fieldTerm = null;"
+      val field = s"final $classQualifier $fieldTerm;"
       reusableMemberStatements.add(field)
       fieldTerms += fieldTerm
       parameters += s"$classQualifier arg$index"
@@ -1537,7 +1537,7 @@ abstract class CodeGenerator(
     val initArray = classQualifier.replaceFirst("\\[", s"[$size")
     val fieldArray =
       s"""
-        |transient $classQualifier $fieldTerm =
+        |final $classQualifier $fieldTerm =
         |    new $initArray;
         |""".stripMargin
     reusableMemberStatements.add(fieldArray)
@@ -1644,7 +1644,7 @@ abstract class CodeGenerator(
 
     val field =
       s"""
-        |transient java.util.Set $fieldTerm = null;
+        |final java.util.Set $fieldTerm;
         |""".stripMargin
     reusableMemberStatements.add(field)
 
@@ -1687,7 +1687,7 @@ abstract class CodeGenerator(
 
     val field =
       s"""
-        |transient $boxedType $fieldTerm;
+        |final $boxedType $fieldTerm;
         |""".stripMargin
     reusableMemberStatements.add(field)
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
@@ -1670,4 +1670,34 @@ abstract class CodeGenerator(
 
     fieldTerm
   }
+
+  /**
+    * Adds a reusable constant to the member area of the generated [[Function]].
+    *
+    * @param constant constant expression
+    * @return member variable term
+    */
+  def addReusableBoxedConstant(constant: GeneratedExpression): String = {
+    require(constant.literal, "Literal expected")
+
+    val fieldTerm = newName("constant")
+
+    val boxed = generateOutputFieldBoxing(constant)
+    val boxedType = boxedTypeTermForTypeInfo(boxed.resultType)
+
+    val field =
+      s"""
+        |transient $boxedType $fieldTerm;
+        |""".stripMargin
+    reusableMemberStatements.add(field)
+
+    val init =
+      s"""
+        |${boxed.code}
+        |$fieldTerm = ${boxed.resultTerm};
+        |""".stripMargin
+    reusableInitStatements.add(init)
+
+    fieldTerm
+  }
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/dataset/DataSetAggregate.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/dataset/DataSetAggregate.scala
@@ -98,7 +98,8 @@ class DataSetAggregate(
     val generator = new AggregationCodeGenerator(
       tableEnv.getConfig,
       false,
-      inputDS.getType)
+      inputDS.getType,
+      None)
 
     val (
       preAgg: Option[DataSetPreAggFunction],

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/dataset/DataSetWindowAggregate.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/dataset/DataSetWindowAggregate.scala
@@ -112,7 +112,8 @@ class DataSetWindowAggregate(
     val generator = new AggregationCodeGenerator(
       tableEnv.getConfig,
       false,
-      inputDS.getType)
+      inputDS.getType,
+      None)
 
     // whether identifiers are matched case-sensitively
     val caseSensitive = tableEnv.getFrameworkConfig.getParserConfig.caseSensitive()

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamCalc.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamCalc.scala
@@ -27,8 +27,8 @@ import org.apache.calcite.rex.RexProgram
 import org.apache.flink.streaming.api.datastream.DataStream
 import org.apache.flink.streaming.api.functions.ProcessFunction
 import org.apache.flink.table.api.{StreamQueryConfig, StreamTableEnvironment}
+import org.apache.flink.table.calcite.RelTimeIndicatorConverter
 import org.apache.flink.table.codegen.FunctionCodeGenerator
-import org.apache.flink.table.calcite.{FlinkTypeFactory, RelTimeIndicatorConverter}
 import org.apache.flink.table.plan.nodes.CommonCalc
 import org.apache.flink.table.plan.schema.RowSchema
 import org.apache.flink.table.runtime.CRowProcessRunner

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamGroupAggregate.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamGroupAggregate.scala
@@ -116,7 +116,8 @@ class DataStreamGroupAggregate(
     val generator = new AggregationCodeGenerator(
       tableEnv.getConfig,
       false,
-      inputSchema.typeInfo)
+      inputSchema.typeInfo,
+      None)
 
     val aggString = aggregationToString(
       inputSchema.relDataType,

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamGroupWindowAggregate.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamGroupWindowAggregate.scala
@@ -173,7 +173,8 @@ class DataStreamGroupWindowAggregate(
     val generator = new AggregationCodeGenerator(
       tableEnv.getConfig,
       false,
-      inputSchema.typeInfo)
+      inputSchema.typeInfo,
+      None)
 
     val needMerge = window match {
       case SessionGroupWindow(_, _, _) => true

--- a/flink-libraries/flink-table/src/test/java/org/apache/flink/table/runtime/utils/JavaUserDefinedAggFunctions.java
+++ b/flink-libraries/flink-table/src/test/java/org/apache/flink/table/runtime/utils/JavaUserDefinedAggFunctions.java
@@ -86,6 +86,13 @@ public class JavaUserDefinedAggFunctions {
 		}
 
 		// overloaded accumulate method
+		// dummy to test constants
+		public void accumulate(WeightedAvgAccum accumulator, long iValue, int iWeight, int x, String string) {
+			accumulator.sum += iWeight + Integer.parseInt(string);
+			accumulator.count += iWeight + Integer.parseInt(string);
+		}
+
+		// overloaded accumulate method
 		public void accumulate(WeightedAvgAccum accumulator, long iValue, int iWeight) {
 			accumulator.sum += iValue * iWeight;
 			accumulator.count += iWeight;

--- a/flink-libraries/flink-table/src/test/java/org/apache/flink/table/runtime/utils/JavaUserDefinedAggFunctions.java
+++ b/flink-libraries/flink-table/src/test/java/org/apache/flink/table/runtime/utils/JavaUserDefinedAggFunctions.java
@@ -88,8 +88,8 @@ public class JavaUserDefinedAggFunctions {
 		// overloaded accumulate method
 		// dummy to test constants
 		public void accumulate(WeightedAvgAccum accumulator, long iValue, int iWeight, int x, String string) {
-			accumulator.sum += iWeight + Integer.parseInt(string);
-			accumulator.count += iWeight + Integer.parseInt(string);
+			accumulator.sum += (iValue + Integer.parseInt(string)) * iWeight;
+			accumulator.count += iWeight;
 		}
 
 		// overloaded accumulate method

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/OverWindowITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/OverWindowITCase.scala
@@ -112,15 +112,14 @@ class OverWindowITCase extends StreamingWithStateTestBase {
       .window(
         Over partitionBy 'c orderBy 'proctime preceding UNBOUNDED_ROW as 'w)
       .select('c, weightAvgFun('a, 42, 'b, "2") over 'w as 'wAvg)
-      .select('c, 'wAvg)
 
     val results = windowedTable.toAppendStream[Row]
     results.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
     val expected = Seq(
-      "Hello World,1", "Hello World,1", "Hello World,1", "Hello World,1", "Hello,1",
-      "Hello,1", "Hello,1", "Hello,1", "Hello,1", "Hello,1")
+      "Hello World,12", "Hello World,9", "Hello World,9", "Hello World,9", "Hello,3",
+      "Hello,3", "Hello,4", "Hello,4", "Hello,5", "Hello,5")
     assertEquals(expected.sorted, StreamITCase.testResults.sorted)
   }
 


### PR DESCRIPTION
## What is the purpose of the change

This PR allows to pass constants to OVER window aggregates. E.g. `.select('c, weightAvgFun('a, 42, 'b, "2") over 'w as 'wAvg)`.


## Brief change log

Until now the constants where simply ignored. I added code generation for the literals in `AggregationCodeGenerator`.


## Verifying this change

I add a ITCase for it. I might add more tests if I have time. In general, we need to rework the logic there a little bit, because I think we also do not support DATE, TIME etc. right now.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

