### PR TITLE
[FLINK-7072] [REST] Add Flip-6 client for submit/job/cancel

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/CliFrontend.java
@@ -60,13 +60,7 @@ import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.messages.JobManagerMessages;
-import org.apache.flink.runtime.messages.JobManagerMessages.CancelJob;
-import org.apache.flink.runtime.messages.JobManagerMessages.CancelJobWithSavepoint;
-import org.apache.flink.runtime.messages.JobManagerMessages.CancellationFailure;
-import org.apache.flink.runtime.messages.JobManagerMessages.CancellationSuccess;
 import org.apache.flink.runtime.messages.JobManagerMessages.RunningJobsStatus;
-import org.apache.flink.runtime.messages.JobManagerMessages.StopJob;
-import org.apache.flink.runtime.messages.JobManagerMessages.StoppingFailure;
 import org.apache.flink.runtime.messages.JobManagerMessages.TriggerSavepoint;
 import org.apache.flink.runtime.messages.JobManagerMessages.TriggerSavepointSuccess;
 import org.apache.flink.runtime.security.SecurityConfiguration;
@@ -564,7 +558,7 @@ public class CliFrontend {
 			logAndSysout("Stopping job " + jobId + '.');
 			client.stop(jobId);
 			logAndSysout("Stopped job " + jobId + '.');
-			
+
 			return 0;
 		}
 		catch (Throwable t) {

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/Flip6DefaultCLI.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/Flip6DefaultCLI.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.cli;
+
+import org.apache.flink.client.ClientUtils;
+import org.apache.flink.client.deployment.ClusterSpecification;
+import org.apache.flink.client.deployment.Flip6StandaloneClusterDescriptor;
+import org.apache.flink.client.program.rest.RestClusterClient;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.HighAvailabilityOptions;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+
+import java.net.InetSocketAddress;
+import java.net.URL;
+import java.util.List;
+
+import static org.apache.flink.client.CliFrontend.setJobManagerAddressInConfig;
+
+/**
+ * The default CLI which is used for interaction with standalone clusters.
+ */
+public class Flip6DefaultCLI implements CustomCommandLine<RestClusterClient> {
+
+	public static final Option FLIP_6 = new Option("flip6", "Switches the client to Flip-6 mode.");
+
+	static {
+		FLIP_6.setRequired(false);
+	}
+
+	@Override
+	public boolean isActive(CommandLine commandLine, Configuration configuration) {
+		return commandLine.hasOption(FLIP_6.getOpt());
+	}
+
+	@Override
+	public String getId() {
+		return "flip6";
+	}
+
+	@Override
+	public void addRunOptions(Options baseOptions) {
+	}
+
+	@Override
+	public void addGeneralOptions(Options baseOptions) {
+		baseOptions.addOption(FLIP_6);
+	}
+
+	@Override
+	public RestClusterClient retrieveCluster(CommandLine commandLine, Configuration config, String configurationDirectory) {
+		if (commandLine.hasOption(CliFrontendParser.ADDRESS_OPTION.getOpt())) {
+			String addressWithPort = commandLine.getOptionValue(CliFrontendParser.ADDRESS_OPTION.getOpt());
+			InetSocketAddress jobManagerAddress = ClientUtils.parseHostPortAddress(addressWithPort);
+			setJobManagerAddressInConfig(config, jobManagerAddress);
+		}
+
+		if (commandLine.hasOption(CliFrontendParser.ZOOKEEPER_NAMESPACE_OPTION.getOpt())) {
+			String zkNamespace = commandLine.getOptionValue(CliFrontendParser.ZOOKEEPER_NAMESPACE_OPTION.getOpt());
+			config.setString(HighAvailabilityOptions.HA_CLUSTER_ID, zkNamespace);
+		}
+
+		Flip6StandaloneClusterDescriptor descriptor = new Flip6StandaloneClusterDescriptor(config);
+		return descriptor.retrieve(null);
+	}
+
+	@Override
+	public RestClusterClient createCluster(
+			String applicationName,
+			CommandLine commandLine,
+			Configuration config,
+			String configurationDirectory,
+			List<URL> userJarFiles) throws UnsupportedOperationException {
+
+		Flip6StandaloneClusterDescriptor descriptor = new Flip6StandaloneClusterDescriptor(config);
+		ClusterSpecification clusterSpecification = ClusterSpecification.fromConfiguration(config);
+
+		return descriptor.deploySessionCluster(clusterSpecification);
+	}
+}

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/Flip6StandaloneClusterDescriptor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/Flip6StandaloneClusterDescriptor.java
@@ -22,6 +22,8 @@ import org.apache.flink.client.program.rest.RestClusterClient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.flink.util.Preconditions;
 
 /**
  * A deployment descriptor for an existing cluster.
@@ -31,7 +33,7 @@ public class Flip6StandaloneClusterDescriptor implements ClusterDescriptor<RestC
 	private final Configuration config;
 
 	public Flip6StandaloneClusterDescriptor(Configuration config) {
-		this.config = config;
+		this.config = Preconditions.checkNotNull(config);
 	}
 
 	@Override
@@ -46,17 +48,17 @@ public class Flip6StandaloneClusterDescriptor implements ClusterDescriptor<RestC
 		try {
 			return new RestClusterClient(config);
 		} catch (Exception e) {
-			throw new RuntimeException("Couldn't retrieve standalone cluster", e);
+			throw new RuntimeException("Couldn't retrieve FLIP-6 standalone cluster", e);
 		}
 	}
 
 	@Override
 	public RestClusterClient deploySessionCluster(ClusterSpecification clusterSpecification) throws UnsupportedOperationException {
-		throw new UnsupportedOperationException("Can't deploy a standalone cluster.");
+		throw new UnsupportedOperationException("Can't deploy a FLIP-6 standalone cluster.");
 	}
 
 	@Override
 	public RestClusterClient deployJobCluster(ClusterSpecification clusterSpecification, JobGraph jobGraph) {
-		throw new UnsupportedOperationException("Can't deploy a standalone per-job cluster.");
+		throw new UnsupportedOperationException("Can't deploy a standalone FLIP-6 per-job cluster.");
 	}
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/Flip6StandaloneClusterDescriptor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/Flip6StandaloneClusterDescriptor.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.deployment;
+
+import org.apache.flink.client.program.rest.RestClusterClient;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+
+/**
+ * A deployment descriptor for an existing cluster.
+ */
+public class Flip6StandaloneClusterDescriptor implements ClusterDescriptor<RestClusterClient> {
+
+	private final Configuration config;
+
+	public Flip6StandaloneClusterDescriptor(Configuration config) {
+		this.config = config;
+	}
+
+	@Override
+	public String getClusterDescription() {
+		String host = config.getString(JobManagerOptions.ADDRESS, "");
+		int port = config.getInteger(JobManagerOptions.PORT, -1);
+		return "FLIP-6 Standalone cluster at " + host + ":" + port;
+	}
+
+	@Override
+	public RestClusterClient retrieve(String applicationID) {
+		try {
+			return new RestClusterClient(config);
+		} catch (Exception e) {
+			throw new RuntimeException("Couldn't retrieve standalone cluster", e);
+		}
+	}
+
+	@Override
+	public RestClusterClient deploySessionCluster(ClusterSpecification clusterSpecification) throws UnsupportedOperationException {
+		throw new UnsupportedOperationException("Can't deploy a standalone cluster.");
+	}
+
+	@Override
+	public RestClusterClient deployJobCluster(ClusterSpecification clusterSpecification, JobGraph jobGraph) {
+		throw new UnsupportedOperationException("Can't deploy a standalone per-job cluster.");
+	}
+}

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/Flip6StandaloneClusterDescriptor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/Flip6StandaloneClusterDescriptor.java
@@ -22,7 +22,6 @@ import org.apache.flink.client.program.rest.RestClusterClient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.runtime.jobgraph.JobGraph;
-import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.Preconditions;
 
 /**

--- a/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
@@ -63,6 +63,8 @@ import akka.actor.ActorSystem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
+
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.URISyntaxException;
@@ -575,25 +577,46 @@ public abstract class ClusterClient {
 	 * @throws Exception In case an error occurred.
 	 */
 	public void cancel(JobID jobId) throws Exception {
-		final ActorGateway jobManagerGateway = getJobManagerGateway();
+		final ActorGateway jobManager = getJobManagerGateway();
 
-		final Future<Object> response;
-		try {
-			response = jobManagerGateway.ask(new JobManagerMessages.CancelJob(jobId), timeout);
-		} catch (final Exception e) {
-			throw new ProgramInvocationException("Failed to query the job manager gateway.", e);
-		}
+		Object cancelMsg = new JobManagerMessages.CancelJob(jobId);
 
-		final Object result = Await.result(response, timeout);
+		Future<Object> response = jobManager.ask(cancelMsg, timeout);
+		final Object rc = Await.result(response, timeout);
 
-		if (result instanceof JobManagerMessages.CancellationSuccess) {
-			logAndSysout("Job cancellation with ID " + jobId + " succeeded.");
-		} else if (result instanceof JobManagerMessages.CancellationFailure) {
-			final Throwable t = ((JobManagerMessages.CancellationFailure) result).cause();
-			logAndSysout("Job cancellation with ID " + jobId + " failed because of " + t.getMessage());
-			throw new Exception("Failed to cancel the job with id " + jobId, t);
+		if (rc instanceof JobManagerMessages.CancellationSuccess) {
+			// no further action required
+		} else if (rc instanceof JobManagerMessages.CancellationFailure) {
+			throw new Exception("Canceling the job with ID " + jobId + " failed.",
+				((JobManagerMessages.CancellationFailure) rc).cause());
 		} else {
-			throw new Exception("Unknown message received while cancelling: " + result.getClass().getName());
+			throw new IllegalStateException("Unexpected response: " + rc);
+		}
+	}
+
+	/**
+	 * Cancels a job identified by the job id and triggers a savepoint.
+	 * @param jobId the job id
+	 * @param savepointDirectory directory the savepoint should be written to
+	 * @return path where the savepoint is located
+	 * @throws Exception In case an error cocurred.
+	 */
+	public String cancelWithSavepoint(JobID jobId, @Nullable String savepointDirectory) throws Exception {
+		final ActorGateway jobManager = getJobManagerGateway();
+
+		Object cancelMsg = new JobManagerMessages.CancelJobWithSavepoint(jobId, savepointDirectory);
+
+		Future<Object> response = jobManager.ask(cancelMsg, timeout);
+		final Object rc = Await.result(response, timeout);
+
+		if (rc instanceof JobManagerMessages.CancellationSuccess) {
+			JobManagerMessages.CancellationSuccess success = (JobManagerMessages.CancellationSuccess) rc;
+			return success.savepointPath();
+		} else if (rc instanceof JobManagerMessages.CancellationFailure) {
+			throw new Exception("Cancel & savepoint for the job with ID " + jobId + " failed.",
+				((JobManagerMessages.CancellationFailure) rc).cause());
+		} else {
+			throw new IllegalStateException("Unexpected response: " + rc);
 		}
 	}
 
@@ -610,25 +633,15 @@ public abstract class ClusterClient {
 	 *             failed. That might be due to an I/O problem, ie, the job-manager is unreachable.
 	 */
 	public void stop(final JobID jobId) throws Exception {
-		final ActorGateway jobManagerGateway = getJobManagerGateway();
+		final ActorGateway jobManager = getJobManagerGateway();
 
-		final Future<Object> response;
-		try {
-			response = jobManagerGateway.ask(new JobManagerMessages.StopJob(jobId), timeout);
-		} catch (final Exception e) {
-			throw new ProgramInvocationException("Failed to query the job manager gateway.", e);
-		}
+		Future<Object> response = jobManager.ask(new JobManagerMessages.StopJob(jobId), timeout);
 
-		final Object result = Await.result(response, timeout);
+		final Object rc = Await.result(response, timeout);
 
-		if (result instanceof JobManagerMessages.StoppingSuccess) {
-			log.info("Job stopping with ID " + jobId + " succeeded.");
-		} else if (result instanceof JobManagerMessages.StoppingFailure) {
-			final Throwable t = ((JobManagerMessages.StoppingFailure) result).cause();
-			log.info("Job stopping with ID " + jobId + " failed.", t);
-			throw new Exception("Failed to stop the job because of \n" + t.getMessage());
-		} else {
-			throw new Exception("Unknown message received while stopping: " + result.getClass().getName());
+		if (rc instanceof JobManagerMessages.StoppingFailure) {
+			throw new Exception("Stopping the job with ID " + jobId + " failed.",
+				((JobManagerMessages.StoppingFailure) rc).cause());
 		}
 	}
 

--- a/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
@@ -639,9 +639,13 @@ public abstract class ClusterClient {
 
 		final Object rc = Await.result(response, timeout);
 
-		if (rc instanceof JobManagerMessages.StoppingFailure) {
+		if (rc instanceof JobManagerMessages.StoppingSuccess) {
+			// no further action required
+		} else if (rc instanceof JobManagerMessages.StoppingFailure) {
 			throw new Exception("Stopping the job with ID " + jobId + " failed.",
 				((JobManagerMessages.StoppingFailure) rc).cause());
+		} else {
+			throw new IllegalStateException("Unexpected response: " + rc);
 		}
 	}
 

--- a/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
@@ -82,7 +82,7 @@ import scala.concurrent.duration.FiniteDuration;
  */
 public abstract class ClusterClient {
 
-	private final Logger log = LoggerFactory.getLogger(getClass());
+	protected final Logger log = LoggerFactory.getLogger(getClass());
 
 	/** The optimizer used in the optimization of batch programs. */
 	final Optimizer compiler;

--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
@@ -62,7 +62,7 @@ public class RestClusterClient extends ClusterClient {
 
 	private final RestClusterClientConfiguration restClusterClientConfiguration;
 	private final RestClient restClient;
-	private final ExecutorService executorService = Executors.newFixedThreadPool(4, new ExecutorThreadFactory("RestClusterClient-IO"));
+	private final ExecutorService executorService = Executors.newFixedThreadPool(4, new ExecutorThreadFactory("Flink-RestClusterClient-IO"));
 
 	public RestClusterClient(Configuration config) throws Exception {
 		this(config, RestClusterClientConfiguration.fromConfiguration(config));

--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
@@ -51,9 +51,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * A {@link ClusterClient} implementation that communicates via HTTP REST requests.

--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.program.rest;
+
+import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobSubmissionResult;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.client.program.ProgramInvocationException;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.blob.BlobClient;
+import org.apache.flink.runtime.blob.BlobKey;
+import org.apache.flink.runtime.client.JobSubmissionException;
+import org.apache.flink.runtime.clusterframework.messages.GetClusterStatusResponse;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.rest.RestClient;
+import org.apache.flink.runtime.rest.messages.BlobServerPortHeaders;
+import org.apache.flink.runtime.rest.messages.BlobServerPortResponseBody;
+import org.apache.flink.runtime.rest.messages.EmptyResponseBody;
+import org.apache.flink.runtime.rest.messages.JobTerminationHeaders;
+import org.apache.flink.runtime.rest.messages.JobTerminationMessageParameters;
+import org.apache.flink.runtime.rest.messages.TerminationModeQueryParameter;
+import org.apache.flink.runtime.rest.messages.job.JobSubmitHeaders;
+import org.apache.flink.runtime.rest.messages.job.JobSubmitRequestBody;
+import org.apache.flink.runtime.rest.messages.job.JobSubmitResponseBody;
+
+import java.net.InetSocketAddress;
+import java.net.URL;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+
+/**
+ * A {@link ClusterClient} implementation that communicates via HTTP REST requests.
+ */
+public class RestClusterClient extends ClusterClient {
+
+	private RestClusterClientConfiguration configuration;
+	private final RestClient restEndpoint;
+
+	public RestClusterClient(Configuration config) throws Exception {
+		this(config, RestClusterClientConfiguration.fromConfiguration(config));
+	}
+
+	public RestClusterClient(Configuration config, RestClusterClientConfiguration configuration) throws Exception {
+		super(config);
+		this.configuration = configuration;
+		this.restEndpoint = new RestClient(configuration.getRestEndpointConfiguration(), Executors.newFixedThreadPool(4));
+	}
+
+	@Override
+	public void shutdown() {
+		this.restEndpoint.shutdown(Time.seconds(5));
+	}
+
+	@Override
+	protected JobSubmissionResult submitJob(JobGraph jobGraph, ClassLoader classLoader) throws ProgramInvocationException {
+		log.info("Submitting job.");
+		try {
+			// temporary hack for FLIP-6
+			jobGraph.setAllowQueuedScheduling(true);
+			submitJob(jobGraph);
+		} catch (JobSubmissionException e) {
+			throw new RuntimeException(e);
+		}
+		// don't return just a JobSubmissionResult here, the signature is lying
+		// The CliFrontend expects this to be a JobExecutionResult
+
+		// TOOD: do not exit this method until job is finished
+		return new JobExecutionResult(jobGraph.getJobID(), 1, Collections.emptyMap());
+	}
+
+	private void submitJob(JobGraph jobGraph) throws JobSubmissionException {
+		log.info("Requesting blob server port.");
+		int blobServerPort;
+		try {
+			CompletableFuture<BlobServerPortResponseBody> portFuture = restEndpoint.sendRequest(
+				configuration.getRestServerAddress(),
+				configuration.getRestServerPort(),
+				BlobServerPortHeaders.getInstance());
+			blobServerPort = portFuture.get().port;
+		} catch (Exception e) {
+			throw new JobSubmissionException(jobGraph.getJobID(), "Failed to retrieve blob server port.", e);
+		}
+
+		log.info("Uploading jar files.");
+		try {
+			InetSocketAddress address = new InetSocketAddress(configuration.getBlobServerAddress(), blobServerPort);
+			List<BlobKey> keys = BlobClient.uploadJarFiles(address, new Configuration(), jobGraph.getJobID(), jobGraph.getUserJars());
+			for (BlobKey key : keys) {
+				jobGraph.addBlob(key);
+			}
+		} catch (Exception e) {
+			throw new JobSubmissionException(jobGraph.getJobID(), "Failed to upload user jars to blob server.", e);
+		}
+
+		log.info("Submitting job graph.");
+		try {
+			CompletableFuture<JobSubmitResponseBody> responseFuture = restEndpoint.sendRequest(
+				configuration.getRestServerAddress(),
+				configuration.getRestServerPort(),
+				JobSubmitHeaders.getInstance(),
+				new JobSubmitRequestBody(jobGraph));
+			JobSubmitResponseBody response = responseFuture.get();
+			System.out.println(response.jobUrl);
+		} catch (Exception e) {
+			throw new JobSubmissionException(jobGraph.getJobID(), "Failed to submit JobGraph.", e);
+		}
+	}
+
+	@Override
+	public void stop(JobID jobID) throws Exception {
+		JobTerminationMessageParameters param = new JobTerminationMessageParameters();
+		param.jobPathParameter.resolve(jobID);
+		param.terminationModeQueryParameter.resolve(Collections.singletonList(TerminationModeQueryParameter.TerminationMode.STOP));
+		CompletableFuture<EmptyResponseBody> responseFuture = restEndpoint.sendRequest(
+			configuration.getRestServerAddress(),
+			configuration.getRestServerPort(),
+			JobTerminationHeaders.getInstance(),
+			param
+		);
+		responseFuture.get();
+		System.out.println("Job stopping initiated.");
+	}
+
+	@Override
+	public void cancel(JobID jobID) throws Exception {
+		JobTerminationMessageParameters param = new JobTerminationMessageParameters();
+		param.jobPathParameter.resolve(jobID);
+		param.terminationModeQueryParameter.resolve(Collections.singletonList(TerminationModeQueryParameter.TerminationMode.CANCEL));
+		CompletableFuture<EmptyResponseBody> responseFuture = restEndpoint.sendRequest(
+			configuration.getRestServerAddress(),
+			configuration.getRestServerPort(),
+			JobTerminationHeaders.getInstance(),
+			param
+		);
+		responseFuture.get();
+		System.out.println("Job canceling initiated.");
+	}
+
+	// ======================================
+	// Legacy stuff we actually implement
+	// ======================================
+
+	@Override
+	public String getClusterIdentifier() {
+		return "Flip-6 Standalone cluster with dispatcher at " + configuration.getRestServerAddress();
+	}
+
+	@Override
+	public boolean hasUserJarsInClassPath(List<URL> userJarFiles) {
+		return false;
+	}
+
+	// ======================================
+	// Legacy stuff we ignore
+	// ======================================
+
+	@Override
+	public void waitForClusterToBeReady() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public String getWebInterfaceURL() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public GetClusterStatusResponse getClusterStatus() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	protected List<String> getNewMessages() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	protected void finalizeCluster() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public int getMaxSlots() {
+		return 0;
+	}
+}

--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClientConfiguration.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClientConfiguration.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.program.rest;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.runtime.rest.RestClientConfiguration;
+import org.apache.flink.util.ConfigurationException;
+
+/**
+ * A configuration object for {@link RestClusterClient}s.
+ */
+public final class RestClusterClientConfiguration {
+
+	private final String blobServerAddress;
+
+	private final RestClientConfiguration restEndpointConfiguration;
+
+	private final String restServerAddress;
+
+	private final int restServerPort;
+
+	private RestClusterClientConfiguration(
+			String blobServerAddress,
+			RestClientConfiguration endpointConfiguration,
+			String restServerAddress,
+			int restServerPort) {
+		this.blobServerAddress = blobServerAddress;
+		this.restEndpointConfiguration = endpointConfiguration;
+		this.restServerAddress = restServerAddress;
+		this.restServerPort = restServerPort;
+	}
+
+	public String getBlobServerAddress() {
+		return blobServerAddress;
+	}
+
+	public String getRestServerAddress() {
+		return restServerAddress;
+	}
+
+	public int getRestServerPort() {
+		return restServerPort;
+	}
+
+	public RestClientConfiguration getRestEndpointConfiguration() {
+		return restEndpointConfiguration;
+	}
+
+	public static RestClusterClientConfiguration fromConfiguration(Configuration config) throws ConfigurationException {
+		String address = config.getString(JobManagerOptions.ADDRESS);
+
+		String serverAddress = config.getString(RestOptions.REST_ADDRESS);
+		int serverPort = config.getInteger(RestOptions.REST_PORT);
+
+		RestClientConfiguration endpointConfiguration = RestClientConfiguration.fromConfiguration(config);
+
+		return new RestClusterClientConfiguration(address, endpointConfiguration, serverAddress, serverPort);
+	}
+}

--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClientConfiguration.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClientConfiguration.java
@@ -32,7 +32,7 @@ public final class RestClusterClientConfiguration {
 
 	private final String blobServerAddress;
 
-	private final RestClientConfiguration restEndpointConfiguration;
+	private final RestClientConfiguration restClientConfiguration;
 
 	private final String restServerAddress;
 
@@ -44,7 +44,7 @@ public final class RestClusterClientConfiguration {
 			String restServerAddress,
 			int restServerPort) {
 		this.blobServerAddress = Preconditions.checkNotNull(blobServerAddress);
-		this.restEndpointConfiguration = Preconditions.checkNotNull(endpointConfiguration);
+		this.restClientConfiguration = Preconditions.checkNotNull(endpointConfiguration);
 		this.restServerAddress = Preconditions.checkNotNull(restServerAddress);
 		this.restServerPort = restServerPort;
 	}
@@ -61,8 +61,8 @@ public final class RestClusterClientConfiguration {
 		return restServerPort;
 	}
 
-	public RestClientConfiguration getRestEndpointConfiguration() {
-		return restEndpointConfiguration;
+	public RestClientConfiguration getRestClientConfiguration() {
+		return restClientConfiguration;
 	}
 
 	public static RestClusterClientConfiguration fromConfiguration(Configuration config) throws ConfigurationException {

--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClientConfiguration.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClientConfiguration.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.runtime.rest.RestClientConfiguration;
 import org.apache.flink.util.ConfigurationException;
+import org.apache.flink.util.Preconditions;
 
 /**
  * A configuration object for {@link RestClusterClient}s.
@@ -42,9 +43,9 @@ public final class RestClusterClientConfiguration {
 			RestClientConfiguration endpointConfiguration,
 			String restServerAddress,
 			int restServerPort) {
-		this.blobServerAddress = blobServerAddress;
-		this.restEndpointConfiguration = endpointConfiguration;
-		this.restServerAddress = restServerAddress;
+		this.blobServerAddress = Preconditions.checkNotNull(blobServerAddress);
+		this.restEndpointConfiguration = Preconditions.checkNotNull(endpointConfiguration);
+		this.restServerAddress = Preconditions.checkNotNull(restServerAddress);
 		this.restServerPort = restServerPort;
 	}
 
@@ -65,13 +66,13 @@ public final class RestClusterClientConfiguration {
 	}
 
 	public static RestClusterClientConfiguration fromConfiguration(Configuration config) throws ConfigurationException {
-		String address = config.getString(JobManagerOptions.ADDRESS);
+		String blobServerAddress = config.getString(JobManagerOptions.ADDRESS);
 
 		String serverAddress = config.getString(RestOptions.REST_ADDRESS);
 		int serverPort = config.getInteger(RestOptions.REST_PORT);
 
-		RestClientConfiguration endpointConfiguration = RestClientConfiguration.fromConfiguration(config);
+		RestClientConfiguration restClientConfiguration = RestClientConfiguration.fromConfiguration(config);
 
-		return new RestClusterClientConfiguration(address, endpointConfiguration, serverAddress, serverPort);
+		return new RestClusterClientConfiguration(blobServerAddress, restClientConfiguration, serverAddress, serverPort);
 	}
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/CliFrontendListCancelTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/CliFrontendListCancelTest.java
@@ -19,7 +19,10 @@
 package org.apache.flink.client;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.client.cli.CancelOptions;
+import org.apache.flink.client.cli.CliFrontendParser;
 import org.apache.flink.client.cli.CommandLineOptions;
+import org.apache.flink.client.cli.Flip6DefaultCLI;
 import org.apache.flink.runtime.akka.FlinkUntypedActor;
 import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.instance.AkkaActorGateway;
@@ -129,6 +132,14 @@ public class CliFrontendListCancelTest {
 				InfoListTestCliFrontend testFrontend = new InfoListTestCliFrontend(gateway);
 
 				assertTrue(testFrontend.cancel(parameters) != 0);
+			}
+
+			// test flip6 switch
+			{
+				String[] parameters =
+					{"-flip6", String.valueOf(new JobID())};
+				CancelOptions options = CliFrontendParser.parseCancelCommand(parameters);
+				assertTrue(options.getCommandLine().hasOption(Flip6DefaultCLI.FLIP_6.getOpt()));
 			}
 		}
 		catch (Exception e) {

--- a/flink-clients/src/test/java/org/apache/flink/client/CliFrontendListCancelTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/CliFrontendListCancelTest.java
@@ -22,7 +22,10 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.client.cli.CancelOptions;
 import org.apache.flink.client.cli.CliFrontendParser;
 import org.apache.flink.client.cli.CommandLineOptions;
+import org.apache.flink.client.cli.CustomCommandLine;
 import org.apache.flink.client.cli.Flip6DefaultCLI;
+import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.FlinkUntypedActor;
 import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.instance.AkkaActorGateway;
@@ -33,9 +36,11 @@ import akka.actor.ActorSystem;
 import akka.actor.Props;
 import akka.actor.Status;
 import akka.testkit.JavaTestKit;
+import org.apache.commons.cli.CommandLine;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.util.UUID;
 
@@ -44,6 +49,14 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.isNull;
+import static org.mockito.Matchers.notNull;
+import static org.mockito.Mockito.times;
+import static org.powermock.api.mockito.PowerMockito.doThrow;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.when;
 
 /**
  * Tests for the CANCEL and LIST commands.
@@ -91,47 +104,27 @@ public class CliFrontendListCancelTest {
 			// test cancel properly
 			{
 				JobID jid = new JobID();
-				String jidString = jid.toString();
 
-				final UUID leaderSessionID = UUID.randomUUID();
-
-				final ActorRef jm = actorSystem.actorOf(Props.create(
-								CliJobManager.class,
-								jid,
-								leaderSessionID
-						)
-				);
-
-				final ActorGateway gateway = new AkkaActorGateway(jm, leaderSessionID);
-
-				String[] parameters = { jidString };
-				InfoListTestCliFrontend testFrontend = new InfoListTestCliFrontend(gateway);
+				String[] parameters = { jid.toString() };
+				CancelTestCliFrontend testFrontend = new CancelTestCliFrontend(false);
 
 				int retCode = testFrontend.cancel(parameters);
 				assertTrue(retCode == 0);
+
+				Mockito.verify(testFrontend.client, times(1)).cancel(any(JobID.class));
 			}
 
 			// test cancel properly
 			{
-				JobID jid1 = new JobID();
-				JobID jid2 = new JobID();
+				JobID jid = new JobID();
 
-				final UUID leaderSessionID = UUID.randomUUID();
+				String[] parameters = { jid.toString() };
+				CancelTestCliFrontend testFrontend = new CancelTestCliFrontend(true);
 
-				final ActorRef jm = actorSystem.actorOf(
-						Props.create(
-								CliJobManager.class,
-								jid1,
-								leaderSessionID
-						)
-				);
+				int retCode = testFrontend.cancel(parameters);
+				assertTrue(retCode != 0);
 
-				final ActorGateway gateway = new AkkaActorGateway(jm, leaderSessionID);
-
-				String[] parameters = { jid2.toString() };
-				InfoListTestCliFrontend testFrontend = new InfoListTestCliFrontend(gateway);
-
-				assertTrue(testFrontend.cancel(parameters) != 0);
+				Mockito.verify(testFrontend.client, times(1)).cancel(any(JobID.class));
 			}
 
 			// test flip6 switch
@@ -156,56 +149,38 @@ public class CliFrontendListCancelTest {
 		{
 			// Cancel with savepoint (no target directory)
 			JobID jid = new JobID();
-			UUID leaderSessionID = UUID.randomUUID();
-
-			Props props = Props.create(CliJobManager.class, jid, leaderSessionID);
-			ActorRef jm = actorSystem.actorOf(props);
-			ActorGateway gateway = new AkkaActorGateway(jm, leaderSessionID);
 
 			String[] parameters = { "-s", jid.toString() };
-			InfoListTestCliFrontend testFrontend = new InfoListTestCliFrontend(gateway);
+			CancelTestCliFrontend testFrontend = new CancelTestCliFrontend(false);
 			assertEquals(0, testFrontend.cancel(parameters));
+
+			Mockito.verify(testFrontend.client, times(1))
+				.cancelWithSavepoint(any(JobID.class), isNull(String.class));
 		}
 
 		{
 			// Cancel with savepoint (with target directory)
 			JobID jid = new JobID();
-			UUID leaderSessionID = UUID.randomUUID();
-
-			Props props = Props.create(CliJobManager.class, jid, leaderSessionID, "targetDirectory");
-			ActorRef jm = actorSystem.actorOf(props);
-			ActorGateway gateway = new AkkaActorGateway(jm, leaderSessionID);
 
 			String[] parameters = { "-s", "targetDirectory", jid.toString() };
-			InfoListTestCliFrontend testFrontend = new InfoListTestCliFrontend(gateway);
+			CancelTestCliFrontend testFrontend = new CancelTestCliFrontend(false);
 			assertEquals(0, testFrontend.cancel(parameters));
+
+			Mockito.verify(testFrontend.client, times(1))
+				.cancelWithSavepoint(any(JobID.class), notNull(String.class));
 		}
 
 		{
 			// Cancel with savepoint (with target directory), but no job ID
-			JobID jid = new JobID();
-			UUID leaderSessionID = UUID.randomUUID();
-
-			Props props = Props.create(CliJobManager.class, jid, leaderSessionID, "targetDirectory");
-			ActorRef jm = actorSystem.actorOf(props);
-			ActorGateway gateway = new AkkaActorGateway(jm, leaderSessionID);
-
 			String[] parameters = { "-s", "targetDirectory" };
-			InfoListTestCliFrontend testFrontend = new InfoListTestCliFrontend(gateway);
+			CliFrontend testFrontend = new CliFrontend(CliFrontendTestUtils.getConfigDir());
 			assertNotEquals(0, testFrontend.cancel(parameters));
 		}
 
 		{
 			// Cancel with savepoint (no target directory) and no job ID
-			JobID jid = new JobID();
-			UUID leaderSessionID = UUID.randomUUID();
-
-			Props props = Props.create(CliJobManager.class, jid, leaderSessionID);
-			ActorRef jm = actorSystem.actorOf(props);
-			ActorGateway gateway = new AkkaActorGateway(jm, leaderSessionID);
-
 			String[] parameters = { "-s" };
-			InfoListTestCliFrontend testFrontend = new InfoListTestCliFrontend(gateway);
+			CliFrontend testFrontend = new CliFrontend(CliFrontendTestUtils.getConfigDir());
 			assertNotEquals(0, testFrontend.cancel(parameters));
 		}
 	}
@@ -245,11 +220,32 @@ public class CliFrontendListCancelTest {
 		}
 	}
 
+	private static final class CancelTestCliFrontend extends CliFrontend {
+		private final ClusterClient client;
+
+		CancelTestCliFrontend(boolean reject) throws Exception {
+			super(CliFrontendTestUtils.getConfigDir());
+			this.client = mock(ClusterClient.class);
+			if (reject) {
+				doThrow(new IllegalArgumentException("Test exception")).when(client).cancel(any(JobID.class));
+				doThrow(new IllegalArgumentException("Test exception")).when(client).cancelWithSavepoint(any(JobID.class), anyString());
+			}
+		}
+
+		@Override
+		public CustomCommandLine getActiveCustomCommandLine(CommandLine commandLine) {
+			CustomCommandLine ccl = mock(CustomCommandLine.class);
+			when(ccl.retrieveCluster(any(CommandLine.class), any(Configuration.class), anyString()))
+				.thenReturn(client);
+			return ccl;
+		}
+	}
+
 	private static final class InfoListTestCliFrontend extends CliFrontend {
 
 		private ActorGateway jobManagerGateway;
 
-		public InfoListTestCliFrontend(ActorGateway jobManagerGateway) throws Exception {
+		InfoListTestCliFrontend(ActorGateway jobManagerGateway) throws Exception {
 			super(CliFrontendTestUtils.getConfigDir());
 			this.jobManagerGateway = jobManagerGateway;
 		}

--- a/flink-clients/src/test/java/org/apache/flink/client/CliFrontendRunTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/CliFrontendRunTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.client;
 
 import org.apache.flink.client.cli.CliFrontendParser;
+import org.apache.flink.client.cli.Flip6DefaultCLI;
 import org.apache.flink.client.cli.RunOptions;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.client.program.PackagedProgram;
@@ -127,6 +128,14 @@ public class CliFrontendRunTest {
 				assertEquals("justavalue", options.getProgramArgs()[2]);
 				assertEquals("--arg2", options.getProgramArgs()[3]);
 				assertEquals("value2", options.getProgramArgs()[4]);
+			}
+
+			// test flip6 switch
+			{
+				String[] parameters =
+					{"-flip6", getTestJarPath()};
+				RunOptions options = CliFrontendParser.parseRunCommand(parameters);
+				assertTrue(options.getCommandLine().hasOption(Flip6DefaultCLI.FLIP_6.getOpt()));
 			}
 		}
 		catch (Exception e) {

--- a/flink-clients/src/test/java/org/apache/flink/client/CliFrontendStopTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/CliFrontendStopTest.java
@@ -20,46 +20,36 @@ package org.apache.flink.client;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.client.cli.CliFrontendParser;
-import org.apache.flink.client.cli.CommandLineOptions;
+import org.apache.flink.client.cli.CustomCommandLine;
 import org.apache.flink.client.cli.Flip6DefaultCLI;
 import org.apache.flink.client.cli.StopOptions;
-import org.apache.flink.runtime.akka.FlinkUntypedActor;
-import org.apache.flink.runtime.instance.ActorGateway;
-import org.apache.flink.runtime.instance.AkkaActorGateway;
-import org.apache.flink.runtime.messages.JobManagerMessages;
+import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.TestLogger;
 
-import akka.actor.ActorRef;
-import akka.actor.ActorSystem;
-import akka.actor.Props;
-import akka.actor.Status;
-import akka.testkit.JavaTestKit;
-import org.junit.AfterClass;
+import org.apache.commons.cli.CommandLine;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import java.util.UUID;
+import org.mockito.Mockito;
 
 import static org.apache.flink.client.CliFrontendTestUtils.pipeSystemOutToNull;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.powermock.api.mockito.PowerMockito.doThrow;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.when;
 
 /**
  * Tests for the STOP command.
  */
 public class CliFrontendStopTest extends TestLogger {
 
-	private static ActorSystem actorSystem;
-
 	@BeforeClass
 	public static void setup() {
 		pipeSystemOutToNull();
-		actorSystem = ActorSystem.create("TestingActorSystem");
-	}
-
-	@AfterClass
-	public static void teardown() {
-		JavaTestKit.shutdownActorSystem(actorSystem);
-		actorSystem = null;
 	}
 
 	@Test
@@ -85,32 +75,25 @@ public class CliFrontendStopTest extends TestLogger {
 			JobID jid = new JobID();
 			String jidString = jid.toString();
 
-			final UUID leaderSessionID = UUID.randomUUID();
-			final ActorRef jm = actorSystem.actorOf(Props.create(CliJobManager.class, jid, leaderSessionID));
-
-			final ActorGateway gateway = new AkkaActorGateway(jm, leaderSessionID);
-
 			String[] parameters = { jidString };
-			StopTestCliFrontend testFrontend = new StopTestCliFrontend(gateway);
+			StopTestCliFrontend testFrontend = new StopTestCliFrontend(false);
 
 			int retCode = testFrontend.stop(parameters);
-			assertTrue(retCode == 0);
+			assertEquals(0, retCode);
+
+			Mockito.verify(testFrontend.client, times(1)).stop(any(JobID.class));
 		}
 
 		// test unknown job Id
 		{
-			JobID jid1 = new JobID();
-			JobID jid2 = new JobID();
+			JobID jid = new JobID();
 
-			final UUID leaderSessionID = UUID.randomUUID();
-			final ActorRef jm = actorSystem.actorOf(Props.create(CliJobManager.class, jid1, leaderSessionID));
-
-			final ActorGateway gateway = new AkkaActorGateway(jm, leaderSessionID);
-
-			String[] parameters = { jid2.toString() };
-			StopTestCliFrontend testFrontend = new StopTestCliFrontend(gateway);
+			String[] parameters = { jid.toString() };
+			StopTestCliFrontend testFrontend = new StopTestCliFrontend(true);
 
 			assertTrue(testFrontend.stop(parameters) != 0);
+
+			Mockito.verify(testFrontend.client, times(1)).stop(any(JobID.class));
 		}
 
 		// test flip6 switch
@@ -123,52 +106,22 @@ public class CliFrontendStopTest extends TestLogger {
 	}
 
 	private static final class StopTestCliFrontend extends CliFrontend {
+		private final ClusterClient client;
 
-		private ActorGateway jobManagerGateway;
-
-		public StopTestCliFrontend(ActorGateway jobManagerGateway) throws Exception {
+		StopTestCliFrontend(boolean reject) throws Exception {
 			super(CliFrontendTestUtils.getConfigDir());
-			this.jobManagerGateway = jobManagerGateway;
-		}
-
-		@Override
-		public ActorGateway getJobManagerGateway(CommandLineOptions options) {
-			return jobManagerGateway;
-		}
-	}
-
-	private static final class CliJobManager extends FlinkUntypedActor {
-		private final JobID jobID;
-		private final UUID leaderSessionID;
-
-		public CliJobManager(final JobID jobID, final UUID leaderSessionID) {
-			this.jobID = jobID;
-			this.leaderSessionID = leaderSessionID;
-		}
-
-		@Override
-		public void handleMessage(Object message) {
-			if (message instanceof JobManagerMessages.RequestTotalNumberOfSlots$) {
-				getSender().tell(decorateMessage(1), getSelf());
-			} else if (message instanceof JobManagerMessages.StopJob) {
-				JobManagerMessages.StopJob stopJob = (JobManagerMessages.StopJob) message;
-
-				if (jobID != null && jobID.equals(stopJob.jobID())) {
-					getSender().tell(decorateMessage(new Status.Success(new Object())), getSelf());
-				} else {
-					getSender()
-							.tell(decorateMessage(new Status.Failure(new Exception(
-									"Wrong or no JobID"))), getSelf());
-				}
-			} else if (message instanceof JobManagerMessages.RequestRunningJobsStatus$) {
-				getSender().tell(decorateMessage(new JobManagerMessages.RunningJobsStatus()),
-						getSelf());
+			this.client = mock(ClusterClient.class);
+			if (reject) {
+				doThrow(new IllegalArgumentException("Test exception")).when(client).stop(any(JobID.class));
 			}
 		}
 
 		@Override
-		protected UUID getLeaderSessionID() {
-			return leaderSessionID;
+		public CustomCommandLine getActiveCustomCommandLine(CommandLine commandLine) {
+			CustomCommandLine ccl = mock(CustomCommandLine.class);
+			when(ccl.retrieveCluster(any(CommandLine.class), any(Configuration.class), anyString()))
+				.thenReturn(client);
+			return ccl;
 		}
 	}
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/CliFrontendStopTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/CliFrontendStopTest.java
@@ -19,7 +19,10 @@
 package org.apache.flink.client;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.client.cli.CliFrontendParser;
 import org.apache.flink.client.cli.CommandLineOptions;
+import org.apache.flink.client.cli.Flip6DefaultCLI;
+import org.apache.flink.client.cli.StopOptions;
 import org.apache.flink.runtime.akka.FlinkUntypedActor;
 import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.instance.AkkaActorGateway;
@@ -108,6 +111,14 @@ public class CliFrontendStopTest extends TestLogger {
 			StopTestCliFrontend testFrontend = new StopTestCliFrontend(gateway);
 
 			assertTrue(testFrontend.stop(parameters) != 0);
+		}
+
+		// test flip6 switch
+		{
+			String[] parameters =
+				{"-flip6", String.valueOf(new JobID())};
+			StopOptions options = CliFrontendParser.parseStopCommand(parameters);
+			assertTrue(options.getCommandLine().hasOption(Flip6DefaultCLI.FLIP_6.getOpt()));
 		}
 	}
 

--- a/flink-clients/src/test/java/org/apache/flink/client/program/ClusterClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/ClusterClientTest.java
@@ -18,11 +18,21 @@
 
 package org.apache.flink.client.program;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.instance.ActorGateway;
+import org.apache.flink.runtime.instance.DummyActorGateway;
+import org.apache.flink.runtime.messages.JobManagerMessages;
 import org.apache.flink.util.TestLogger;
 
+import org.junit.Assert;
 import org.junit.Test;
+
+import scala.concurrent.Future;
+import scala.concurrent.Future$;
+import scala.concurrent.duration.FiniteDuration;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -50,5 +60,138 @@ public class ClusterClientTest extends TestLogger {
 		// check that the client does not clean up HA data but closes the services
 		verify(highAvailabilityServices, never()).closeAndCleanupAllData();
 		verify(highAvailabilityServices).close();
+	}
+
+	@Test
+	public void testClusterClientStop() throws Exception {
+		Configuration config = new Configuration();
+		config.setString(JobManagerOptions.ADDRESS, "localhost");
+
+		JobID jobID = new JobID();
+		TestStopActorGateway gateway = new TestStopActorGateway(jobID);
+		ClusterClient clusterClient = new TestClusterClient(config, gateway);
+		try {
+			clusterClient.stop(jobID);
+			Assert.assertTrue(gateway.messageArrived);
+		} finally {
+			clusterClient.shutdown();
+		}
+	}
+
+	@Test
+	public void testClusterClientCancel() throws Exception {
+		Configuration config = new Configuration();
+		config.setString(JobManagerOptions.ADDRESS, "localhost");
+
+		JobID jobID = new JobID();
+		TestCancelActorGateway gateway = new TestCancelActorGateway(jobID);
+		ClusterClient clusterClient = new TestClusterClient(config, gateway);
+		try {
+			clusterClient.cancel(jobID);
+			Assert.assertTrue(gateway.messageArrived);
+		} finally {
+			clusterClient.shutdown();
+		}
+	}
+
+	@Test
+	public void testClusterClientCancelWithSavepoint() throws Exception {
+		Configuration config = new Configuration();
+		config.setString(JobManagerOptions.ADDRESS, "localhost");
+
+		JobID jobID = new JobID();
+		String savepointPath = "/test/path";
+		TestCancelWithSavepointActorGateway gateway = new TestCancelWithSavepointActorGateway(jobID, savepointPath);
+		ClusterClient clusterClient = new TestClusterClient(config, gateway);
+		try {
+			clusterClient.cancelWithSavepoint(jobID, savepointPath);
+			Assert.assertTrue(gateway.messageArrived);
+		} finally {
+			clusterClient.shutdown();
+		}
+	}
+
+	private static class TestStopActorGateway extends DummyActorGateway {
+
+		private final JobID expectedJobID;
+		private volatile boolean messageArrived = false;
+
+		TestStopActorGateway(JobID expectedJobID) {
+			this.expectedJobID = expectedJobID;
+		}
+
+		@Override
+		public Future<Object> ask(Object message, FiniteDuration timeout) {
+			messageArrived = true;
+			if (message instanceof JobManagerMessages.StopJob) {
+				JobManagerMessages.StopJob stopJob = (JobManagerMessages.StopJob) message;
+				Assert.assertEquals(expectedJobID, stopJob.jobID());
+				return Future$.MODULE$.successful(new JobManagerMessages.StoppingSuccess(stopJob.jobID()));
+			}
+			Assert.fail("Expected StopJob message, got: " + message.getClass());
+			return null;
+		}
+	}
+
+	private static class TestCancelActorGateway extends DummyActorGateway {
+
+		private final JobID expectedJobID;
+		private volatile boolean messageArrived = false;
+
+		TestCancelActorGateway(JobID expectedJobID) {
+			this.expectedJobID = expectedJobID;
+		}
+
+		@Override
+		public Future<Object> ask(Object message, FiniteDuration timeout) {
+			messageArrived = true;
+			if (message instanceof JobManagerMessages.CancelJob) {
+				JobManagerMessages.CancelJob cancelJob = (JobManagerMessages.CancelJob) message;
+				Assert.assertEquals(expectedJobID, cancelJob.jobID());
+				return Future$.MODULE$.successful(new JobManagerMessages.CancellationSuccess(cancelJob.jobID(), null));
+			}
+			Assert.fail("Expected CancelJob message, got: " + message.getClass());
+			return null;
+		}
+	}
+
+	private static class TestCancelWithSavepointActorGateway extends DummyActorGateway {
+
+		private final JobID expectedJobID;
+		private final String expectedTargetDirectory;
+		private volatile boolean messageArrived = false;
+
+		TestCancelWithSavepointActorGateway(JobID expectedJobID, String expectedTargetDirectory) {
+			this.expectedJobID = expectedJobID;
+			this.expectedTargetDirectory = expectedTargetDirectory;
+		}
+
+		@Override
+		public Future<Object> ask(Object message, FiniteDuration timeout) {
+			messageArrived = true;
+			if (message instanceof JobManagerMessages.CancelJobWithSavepoint) {
+				JobManagerMessages.CancelJobWithSavepoint cancelJob = (JobManagerMessages.CancelJobWithSavepoint) message;
+				Assert.assertEquals(expectedJobID, cancelJob.jobID());
+				Assert.assertEquals(expectedTargetDirectory, cancelJob.savepointDirectory());
+				return Future$.MODULE$.successful(new JobManagerMessages.CancellationSuccess(cancelJob.jobID(), null));
+			}
+			Assert.fail("Expected CancelJobWithSavepoint message, got: " + message.getClass());
+			return null;
+		}
+	}
+
+	private static class TestClusterClient extends StandaloneClusterClient {
+
+		private final ActorGateway jobmanagerGateway;
+
+		public TestClusterClient(Configuration config, ActorGateway jobmanagerGateway) throws Exception {
+			super(config);
+			this.jobmanagerGateway = jobmanagerGateway;
+		}
+
+		@Override
+		public ActorGateway getJobManagerGateway() {
+			return jobmanagerGateway;
+		}
 	}
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
@@ -78,7 +78,7 @@ public class RestClusterClientTest extends TestLogger {
 	}
 
 	@Test
-	public void testABC() throws Exception {
+	public void testJobSubmitCancelStop() throws Exception {
 
 		Configuration config = new Configuration();
 		config.setString(JobManagerOptions.ADDRESS, "localhost");
@@ -129,7 +129,7 @@ public class RestClusterClientTest extends TestLogger {
 	}
 
 	private static class TestBlobServerPortHandler extends AbstractRestHandler<DispatcherGateway, EmptyRequestBody, BlobServerPortResponseBody, EmptyMessageParameters> {
-		private boolean portRetrieved = false;
+		private volatile boolean portRetrieved = false;
 
 		private TestBlobServerPortHandler() {
 			super(
@@ -147,7 +147,7 @@ public class RestClusterClientTest extends TestLogger {
 	}
 
 	private static class TestJobSubmitHandler extends AbstractRestHandler<DispatcherGateway, JobSubmitRequestBody, JobSubmitResponseBody, EmptyMessageParameters> {
-		private boolean jobSubmitted = false;
+		private volatile boolean jobSubmitted = false;
 
 		private TestJobSubmitHandler() {
 			super(

--- a/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.program.rest;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.runtime.dispatcher.Dispatcher;
+import org.apache.flink.runtime.dispatcher.DispatcherGateway;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.rest.RestServerEndpoint;
+import org.apache.flink.runtime.rest.RestServerEndpointConfiguration;
+import org.apache.flink.runtime.rest.handler.AbstractRestHandler;
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.RestHandlerException;
+import org.apache.flink.runtime.rest.handler.RestHandlerSpecification;
+import org.apache.flink.runtime.rest.messages.BlobServerPortHeaders;
+import org.apache.flink.runtime.rest.messages.BlobServerPortResponseBody;
+import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.EmptyResponseBody;
+import org.apache.flink.runtime.rest.messages.JobTerminationHeaders;
+import org.apache.flink.runtime.rest.messages.JobTerminationMessageParameters;
+import org.apache.flink.runtime.rest.messages.TerminationModeQueryParameter;
+import org.apache.flink.runtime.rest.messages.job.JobSubmitHeaders;
+import org.apache.flink.runtime.rest.messages.job.JobSubmitRequestBody;
+import org.apache.flink.runtime.rest.messages.job.JobSubmitResponseBody;
+import org.apache.flink.runtime.rpc.RpcUtils;
+import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelInboundHandler;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.annotation.Nonnull;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for the {@link RestClusterClient}.
+ */
+public class RestClusterClientTest {
+
+	private static final String restAddress = "http://localhost:1234";
+	private static final Dispatcher mockRestfulGateway = mock(Dispatcher.class);
+	private static final GatewayRetriever<DispatcherGateway> mockGatewayRetriever = mock(GatewayRetriever.class);
+
+	static {
+		when(mockRestfulGateway.requestRestAddress(any(Time.class))).thenReturn(CompletableFuture.completedFuture(restAddress));
+		when(mockGatewayRetriever.getNow()).thenReturn(Optional.of(mockRestfulGateway));
+	}
+
+	@Test
+	public void testABC() throws Exception {
+
+		Configuration config = new Configuration();
+		config.setString(JobManagerOptions.ADDRESS, "localhost");
+
+		RestServerEndpointConfiguration rsec = RestServerEndpointConfiguration.fromConfiguration(config);
+
+		TestBlobServerPortHandler portHandler = new TestBlobServerPortHandler();
+		TestJobSubmitHandler submitHandler = new TestJobSubmitHandler();
+		TestJobTerminationHandler terminationHandler = new TestJobTerminationHandler();
+
+		RestServerEndpoint rse = new RestServerEndpoint(rsec) {
+			@Override
+			protected Collection<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> initializeHandlers(CompletableFuture<String> restAddressFuture) {
+
+				Collection<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> handlers = new ArrayList<>();
+				handlers.add(Tuple2.of(portHandler.getMessageHeaders(), portHandler));
+				handlers.add(Tuple2.of(submitHandler.getMessageHeaders(), submitHandler));
+				handlers.add(Tuple2.of(terminationHandler.getMessageHeaders(), terminationHandler));
+				return handlers;
+			}
+		};
+
+		RestClusterClient rcc = new RestClusterClient(config);
+		try {
+			rse.start();
+
+			JobGraph job = new JobGraph("testjob");
+			JobID id = job.getJobID();
+
+			Assert.assertFalse(portHandler.portRetrieved);
+			Assert.assertFalse(submitHandler.jobSubmitted);
+			rcc.submitJob(job, ClassLoader.getSystemClassLoader());
+			Assert.assertTrue(portHandler.portRetrieved);
+			Assert.assertTrue(submitHandler.jobSubmitted);
+
+			Assert.assertFalse(terminationHandler.jobCanceled);
+			rcc.cancel(id);
+			Assert.assertTrue(terminationHandler.jobCanceled);
+
+			Assert.assertFalse(terminationHandler.jobStopped);
+			rcc.stop(id);
+			Assert.assertTrue(terminationHandler.jobStopped);
+
+		} finally {
+			rcc.shutdown();
+			rse.shutdown(Time.seconds(5));
+		}
+	}
+
+	private static class TestBlobServerPortHandler extends AbstractRestHandler<DispatcherGateway, EmptyRequestBody, BlobServerPortResponseBody, EmptyMessageParameters> {
+		private boolean portRetrieved = false;
+
+		private TestBlobServerPortHandler() {
+			super(
+				CompletableFuture.completedFuture(restAddress),
+				mockGatewayRetriever,
+				RpcUtils.INF_TIMEOUT,
+				BlobServerPortHeaders.getInstance());
+		}
+
+		@Override
+		protected CompletableFuture<BlobServerPortResponseBody> handleRequest(@Nonnull HandlerRequest<EmptyRequestBody, EmptyMessageParameters> request, @Nonnull DispatcherGateway gateway) throws RestHandlerException {
+			portRetrieved = true;
+			return CompletableFuture.completedFuture(new BlobServerPortResponseBody(12000));
+		}
+	}
+
+	private static class TestJobSubmitHandler extends AbstractRestHandler<DispatcherGateway, JobSubmitRequestBody, JobSubmitResponseBody, EmptyMessageParameters> {
+		private boolean jobSubmitted = false;
+
+		private TestJobSubmitHandler() {
+			super(
+				CompletableFuture.completedFuture(restAddress),
+				mockGatewayRetriever,
+				RpcUtils.INF_TIMEOUT,
+				JobSubmitHeaders.getInstance());
+		}
+
+		@Override
+		protected CompletableFuture<JobSubmitResponseBody> handleRequest(@Nonnull HandlerRequest<JobSubmitRequestBody, EmptyMessageParameters> request, @Nonnull DispatcherGateway gateway) throws RestHandlerException {
+			jobSubmitted = true;
+			return CompletableFuture.completedFuture(new JobSubmitResponseBody("/url"));
+		}
+	}
+
+	private static class TestJobTerminationHandler extends AbstractRestHandler<DispatcherGateway, EmptyRequestBody, EmptyResponseBody, JobTerminationMessageParameters> {
+		private boolean jobCanceled = false;
+		private boolean jobStopped = false;
+
+		private TestJobTerminationHandler() {
+			super(
+				CompletableFuture.completedFuture(restAddress),
+				mockGatewayRetriever,
+				RpcUtils.INF_TIMEOUT,
+				JobTerminationHeaders.getInstance());
+		}
+
+		@Override
+		protected CompletableFuture<EmptyResponseBody> handleRequest(@Nonnull HandlerRequest<EmptyRequestBody, JobTerminationMessageParameters> request, @Nonnull DispatcherGateway gateway) throws RestHandlerException {
+			switch (request.getQueryParameter(TerminationModeQueryParameter.class).get(0)) {
+				case CANCEL:
+					jobCanceled = true;
+					break;
+				case STOP:
+					jobStopped = true;
+					break;
+			}
+			return CompletableFuture.completedFuture(EmptyResponseBody.getInstance());
+		}
+	}
+}

--- a/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
@@ -45,6 +45,7 @@ import org.apache.flink.runtime.rest.messages.job.JobSubmitRequestBody;
 import org.apache.flink.runtime.rest.messages.job.JobSubmitResponseBody;
 import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+import org.apache.flink.util.TestLogger;
 
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelInboundHandler;
 
@@ -65,7 +66,7 @@ import static org.mockito.Mockito.when;
 /**
  * Tests for the {@link RestClusterClient}.
  */
-public class RestClusterClientTest {
+public class RestClusterClientTest extends TestLogger {
 
 	private static final String restAddress = "http://localhost:1234";
 	private static final Dispatcher mockRestfulGateway = mock(Dispatcher.class);
@@ -164,8 +165,8 @@ public class RestClusterClientTest {
 	}
 
 	private static class TestJobTerminationHandler extends AbstractRestHandler<DispatcherGateway, EmptyRequestBody, EmptyResponseBody, JobTerminationMessageParameters> {
-		private boolean jobCanceled = false;
-		private boolean jobStopped = false;
+		private volatile boolean jobCanceled = false;
+		private volatile boolean jobStopped = false;
 
 		private TestJobTerminationHandler() {
 			super(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -311,6 +311,11 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 			return jobManagerRunner.getJobManagerGateway().requestArchivedExecutionGraph(timeout);
 		}
 	}
+		
+	@Override
+	public CompletableFuture<Integer> getBlobServerPort(Time timeout) {
+		return CompletableFuture.completedFuture(jobManagerServices.blobServer.getPort());
+	}
 
 	/**
 	 * Cleans up the job related data from the dispatcher. If cleanupHA is true, then

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -311,7 +311,7 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 			return jobManagerRunner.getJobManagerGateway().requestArchivedExecutionGraph(timeout);
 		}
 	}
-	
+
 	@Override
 	public CompletableFuture<Integer> getBlobServerPort(Time timeout) {
 		return CompletableFuture.completedFuture(jobManagerServices.blobServer.getPort());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -311,7 +311,7 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 			return jobManagerRunner.getJobManagerGateway().requestArchivedExecutionGraph(timeout);
 		}
 	}
-		
+	
 	@Override
 	public CompletableFuture<Integer> getBlobServerPort(Time timeout) {
 		return CompletableFuture.completedFuture(jobManagerServices.blobServer.getPort());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherGateway.java
@@ -71,4 +71,12 @@ public interface DispatcherGateway extends FencedRpcGateway<DispatcherId>, Restf
 	 * @return A future acknowledge if the stopping succeeded
 	 */
 	CompletableFuture<Acknowledge> stopJob(JobID jobId, @RpcTimeout Time timeout);
+
+	/**
+	 * Returns the port of the blob server.
+	 *
+	 * @param timeout of the operation
+	 * @return A future integer of the blob server port
+	 */
+	CompletableFuture<Integer> getBlobServerPort(@RpcTimeout Time timeout);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherRestEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherRestEndpoint.java
@@ -27,7 +27,9 @@ import org.apache.flink.runtime.rest.RestServerEndpointConfiguration;
 import org.apache.flink.runtime.rest.handler.LegacyRestHandlerAdapter;
 import org.apache.flink.runtime.rest.handler.RestHandlerConfiguration;
 import org.apache.flink.runtime.rest.handler.RestHandlerSpecification;
+import org.apache.flink.runtime.rest.handler.job.BlobServerPortHandler;
 import org.apache.flink.runtime.rest.handler.job.JobConfigHandler;
+import org.apache.flink.runtime.rest.handler.job.JobSubmitHandler;
 import org.apache.flink.runtime.rest.handler.job.JobTerminationHandler;
 import org.apache.flink.runtime.rest.handler.job.checkpoints.CheckpointConfigHandler;
 import org.apache.flink.runtime.rest.handler.job.checkpoints.CheckpointStatisticsHandler;
@@ -191,6 +193,12 @@ public class DispatcherRestEndpoint extends RestServerEndpoint {
 		handlers.add(Tuple2.of(JobConfigHeaders.getInstance(), jobConfigHandler));
 		handlers.add(Tuple2.of(CheckpointConfigHeaders.getInstance(), checkpointConfigHandler));
 		handlers.add(Tuple2.of(CheckpointStatisticsHeaders.getInstance(), checkpointStatisticsHandler));
+
+		BlobServerPortHandler blobServerPortHandler = new BlobServerPortHandler(restAddressFuture, leaderRetriever, timeout);
+		handlers.add(Tuple2.of(blobServerPortHandler.getMessageHeaders(), blobServerPortHandler));
+
+		JobSubmitHandler jobSubmitHandler = new JobSubmitHandler(restAddressFuture, leaderRetriever, timeout);
+		handlers.add(Tuple2.of(jobSubmitHandler.getMessageHeaders(), jobSubmitHandler));
 
 		// This handler MUST be added last, as it otherwise masks all subsequent GET handlers
 		optWebContent.ifPresent(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
@@ -54,7 +54,7 @@ import java.util.concurrent.TimeUnit;
  * An abstract class for netty-based REST server endpoints.
  */
 public abstract class RestServerEndpoint {
-	
+
 	public static final long MAX_REQUEST_SIZE_BYTES = 1024 * 1024 * 10;
 	protected final Logger log = LoggerFactory.getLogger(getClass());
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
@@ -55,7 +55,7 @@ import java.util.concurrent.TimeUnit;
  */
 public abstract class RestServerEndpoint {
 
-	public static final long MAX_REQUEST_SIZE_BYTES = 1024 * 1024 * 10;
+	public static final int MAX_REQUEST_SIZE_BYTES = 1024 * 1024 * 10;
 	protected final Logger log = LoggerFactory.getLogger(getClass());
 
 	private final Object lock = new Object();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
@@ -54,6 +54,8 @@ import java.util.concurrent.TimeUnit;
  * An abstract class for netty-based REST server endpoints.
  */
 public abstract class RestServerEndpoint {
+	
+	public static final long MAX_REQUEST_SIZE_BYTES = 1024 * 1024 * 10;
 	protected final Logger log = LoggerFactory.getLogger(getClass());
 
 	private final Object lock = new Object();
@@ -120,7 +122,7 @@ public abstract class RestServerEndpoint {
 
 					ch.pipeline()
 						.addLast(new HttpServerCodec())
-						.addLast(new HttpObjectAggregator(1024 * 1024 * 10))
+						.addLast(new HttpObjectAggregator(MAX_REQUEST_SIZE_BYTES))
 						.addLast(handler.name(), handler)
 						.addLast(new PipelineErrorHandler(log));
 				}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/HandlerRequest.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/HandlerRequest.java
@@ -42,6 +42,10 @@ public class HandlerRequest<R extends RequestBody, M extends MessageParameters> 
 	private final Map<Class<? extends MessagePathParameter<?>>, MessagePathParameter<?>> pathParameters = new HashMap<>(2);
 	private final Map<Class<? extends MessageQueryParameter<?>>, MessageQueryParameter<?>> queryParameters = new HashMap<>(2);
 
+	public HandlerRequest(R requestBody, M messageParameters) throws HandlerRequestException {
+		this(requestBody, messageParameters, Collections.emptyMap(), Collections.emptyMap());
+	}
+
 	public HandlerRequest(R requestBody, M messageParameters, Map<String, String> receivedPathParameters, Map<String, List<String>> receivedQueryParameters) throws HandlerRequestException {
 		this.requestBody = Preconditions.checkNotNull(requestBody);
 		Preconditions.checkNotNull(messageParameters);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/BlobServerPortHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/BlobServerPortHandler.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.rest.handler.job;
 
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.dispatcher.DispatcherGateway;
 import org.apache.flink.runtime.rest.handler.AbstractRestHandler;
 import org.apache.flink.runtime.rest.handler.HandlerRequest;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/BlobServerPortHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/BlobServerPortHandler.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.job;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.dispatcher.DispatcherGateway;
+import org.apache.flink.runtime.rest.handler.AbstractRestHandler;
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.RestHandlerException;
+import org.apache.flink.runtime.rest.messages.BlobServerPortHeaders;
+import org.apache.flink.runtime.rest.messages.BlobServerPortResponseBody;
+import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+import org.apache.flink.util.ExceptionUtils;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+import javax.annotation.Nonnull;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * This handler can be used to retrieve the port that the blob server runs on.
+ */
+public final class BlobServerPortHandler extends AbstractRestHandler<DispatcherGateway, EmptyRequestBody, BlobServerPortResponseBody, EmptyMessageParameters> {
+
+	public BlobServerPortHandler(CompletableFuture<String> localRestAddress, GatewayRetriever<DispatcherGateway> leaderRetriever, Time timeout) {
+		super(localRestAddress, leaderRetriever, timeout, BlobServerPortHeaders.getInstance());
+	}
+
+	@Override
+	protected CompletableFuture<BlobServerPortResponseBody> handleRequest(@Nonnull HandlerRequest<EmptyRequestBody, EmptyMessageParameters> request, @Nonnull DispatcherGateway gateway) throws RestHandlerException {
+		return gateway
+			.getBlobServerPort(Time.seconds(5))
+			.handleAsync((Integer port, Throwable error) -> {
+				if (error != null) {
+					log.error("Failed to retrieve blob server port.", ExceptionUtils.stripCompletionException(error));
+					return FutureUtils.<BlobServerPortResponseBody>completedExceptionally(new RestHandlerException("Failed to retrieve blob server port.", HttpResponseStatus.INTERNAL_SERVER_ERROR));
+				} else {
+					return CompletableFuture.completedFuture(new BlobServerPortResponseBody(port));
+				}
+			})
+			.thenCompose(future -> future);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobSubmitHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobSubmitHandler.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.job;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.dispatcher.DispatcherGateway;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.rest.handler.AbstractRestHandler;
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.RestHandlerException;
+import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
+import org.apache.flink.runtime.rest.messages.job.JobSubmitHeaders;
+import org.apache.flink.runtime.rest.messages.job.JobSubmitRequestBody;
+import org.apache.flink.runtime.rest.messages.job.JobSubmitResponseBody;
+import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+import javax.annotation.Nonnull;
+
+import java.io.ByteArrayInputStream;
+import java.io.ObjectInputStream;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * This handler can be used to submit jobs to a Flink cluster.
+ */
+public final class JobSubmitHandler extends AbstractRestHandler<DispatcherGateway, JobSubmitRequestBody, JobSubmitResponseBody, EmptyMessageParameters> {
+
+	public JobSubmitHandler(CompletableFuture<String> localRestAddress, GatewayRetriever<DispatcherGateway> leaderRetriever, Time timeout) {
+		super(localRestAddress, leaderRetriever, timeout, JobSubmitHeaders.getInstance());
+	}
+
+	@Override
+	protected CompletableFuture<JobSubmitResponseBody> handleRequest(@Nonnull HandlerRequest<JobSubmitRequestBody, EmptyMessageParameters> request, @Nonnull DispatcherGateway gateway) throws RestHandlerException {
+		JobGraph jobGraph;
+		try {
+			ObjectInputStream objectIn = new ObjectInputStream(new ByteArrayInputStream(request.getRequestBody().serializedJobGraph));
+			jobGraph = (JobGraph) objectIn.readObject();
+		} catch (Exception e) {
+			log.error("Failed to deserialize JobGraph.", e);
+			return FutureUtils.completedExceptionally(new RestHandlerException("Failed to deserialize JobGraph.", HttpResponseStatus.BAD_REQUEST));
+		}
+
+		gateway.submitJob(jobGraph, Time.seconds(5));
+
+		return CompletableFuture.completedFuture(new JobSubmitResponseBody("Submitted job with ID " + jobGraph.getJobID() + "."));
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobSubmitHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobSubmitHandler.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.rest.handler.job;
 
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.dispatcher.DispatcherGateway;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.rest.handler.AbstractRestHandler;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobSubmitHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobSubmitHandler.java
@@ -30,7 +30,6 @@ import org.apache.flink.runtime.rest.messages.job.JobSubmitHeaders;
 import org.apache.flink.runtime.rest.messages.job.JobSubmitRequestBody;
 import org.apache.flink.runtime.rest.messages.job.JobSubmitResponseBody;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
-import org.apache.flink.util.ExceptionUtils;
 
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
 
@@ -56,10 +55,10 @@ public final class JobSubmitHandler extends AbstractRestHandler<DispatcherGatewa
 			ObjectInputStream objectIn = new ObjectInputStream(new ByteArrayInputStream(request.getRequestBody().serializedJobGraph));
 			jobGraph = (JobGraph) objectIn.readObject();
 		} catch (Exception e) {
-			return FutureUtils.completedExceptionally(new RestHandlerException(
+			throw new RestHandlerException(
 				"Failed to deserialize JobGraph.",
 				HttpResponseStatus.BAD_REQUEST,
-				e));
+				e);
 		}
 
 		return gateway.submitJob(jobGraph, timeout)

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/BlobServerPortHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/BlobServerPortHeaders.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages;
+
+import org.apache.flink.runtime.rest.HttpMethodWrapper;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+/**
+ * These headers define the protocol for querying the port of the blob server.
+ */
+public class BlobServerPortHeaders implements MessageHeaders<EmptyRequestBody, BlobServerPortResponseBody, EmptyMessageParameters> {
+
+	private static final String URL = "/blobserver/port";
+	private static final BlobServerPortHeaders INSTANCE = new BlobServerPortHeaders();
+
+	private BlobServerPortHeaders() {
+	}
+
+	@Override
+	public Class<EmptyRequestBody> getRequestClass() {
+		return EmptyRequestBody.class;
+	}
+
+	@Override
+	public HttpMethodWrapper getHttpMethod() {
+		return HttpMethodWrapper.GET;
+	}
+
+	@Override
+	public String getTargetRestEndpointURL() {
+		return URL;
+	}
+
+	@Override
+	public Class<BlobServerPortResponseBody> getResponseClass() {
+		return BlobServerPortResponseBody.class;
+	}
+
+	@Override
+	public HttpResponseStatus getResponseStatusCode() {
+		return HttpResponseStatus.OK;
+	}
+
+	@Override
+	public EmptyMessageParameters getUnresolvedMessageParameters() {
+		return EmptyMessageParameters.getInstance();
+	}
+
+	public static BlobServerPortHeaders getInstance() {
+		return INSTANCE;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/BlobServerPortResponseBody.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/BlobServerPortResponseBody.java
@@ -18,26 +18,40 @@
 
 package org.apache.flink.runtime.rest.messages;
 
-import java.util.Collection;
-import java.util.Collections;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- * Parameters for job related REST handlers.
- *
- * <p>A job related REST handler always requires a {@link JobIDPathParameter}.
+ * Response containing the blob server port.
  */
-public class JobTerminationMessageParameters extends MessageParameters {
+public final class BlobServerPortResponseBody implements ResponseBody {
 
-	public final JobIDPathParameter jobPathParameter = new JobIDPathParameter();
-	public final TerminationModeQueryParameter terminationModeQueryParameter = new TerminationModeQueryParameter();
+	static final String FIELD_NAME_PORT = "port";
 
-	@Override
-	public Collection<MessagePathParameter<?>> getPathParameters() {
-		return Collections.singleton(jobPathParameter);
+	/**
+	 * The port of the blob server.
+	 */
+	@JsonProperty(FIELD_NAME_PORT)
+	public final int port;
+
+	@JsonCreator
+	public BlobServerPortResponseBody(
+		@JsonProperty(FIELD_NAME_PORT) int port) {
+
+		this.port = port;
 	}
 
 	@Override
-	public Collection<MessageQueryParameter<?>> getQueryParameters() {
-		return Collections.singleton(terminationModeQueryParameter);
+	public int hashCode() {
+		return 67 * port;
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (object instanceof BlobServerPortResponseBody) {
+			BlobServerPortResponseBody other = (BlobServerPortResponseBody) object;
+			return this.port == other.port;
+		}
+		return false;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobSubmitHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobSubmitHeaders.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.job;
+
+import org.apache.flink.runtime.rest.HttpMethodWrapper;
+import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+/**
+ * These headers define the protocol for submitting a job to a flink cluster.
+ */
+public class JobSubmitHeaders implements MessageHeaders<JobSubmitRequestBody, JobSubmitResponseBody, EmptyMessageParameters> {
+
+	private static final String URL = "/jobs";
+	private static final JobSubmitHeaders INSTANCE = new JobSubmitHeaders();
+
+	private JobSubmitHeaders() {
+	}
+
+	@Override
+	public Class<JobSubmitRequestBody> getRequestClass() {
+		return JobSubmitRequestBody.class;
+	}
+
+	@Override
+	public HttpMethodWrapper getHttpMethod() {
+		return HttpMethodWrapper.POST;
+	}
+
+	@Override
+	public String getTargetRestEndpointURL() {
+		return URL;
+	}
+
+	@Override
+	public Class<JobSubmitResponseBody> getResponseClass() {
+		return JobSubmitResponseBody.class;
+	}
+
+	@Override
+	public HttpResponseStatus getResponseStatusCode() {
+		return HttpResponseStatus.ACCEPTED;
+	}
+
+	@Override
+	public EmptyMessageParameters getUnresolvedMessageParameters() {
+		return EmptyMessageParameters.getInstance();
+	}
+
+	public static JobSubmitHeaders getInstance() {
+		return INSTANCE;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobSubmitRequestBody.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobSubmitRequestBody.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.rest.messages.job;
 
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.rest.messages.RequestBody;
+import org.apache.flink.util.Preconditions;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -52,7 +53,7 @@ public final class JobSubmitRequestBody implements RequestBody {
 	public JobSubmitRequestBody(
 		@JsonProperty(FIELD_NAME_SERIALIZED_JOB_GRAPH) byte[] serializedJobGraph) {
 
-		this.serializedJobGraph = serializedJobGraph;
+		this.serializedJobGraph = Preconditions.checkNotNull(serializedJobGraph);
 	}
 
 	@Override
@@ -70,11 +71,12 @@ public final class JobSubmitRequestBody implements RequestBody {
 	}
 
 	private static byte[] serializeJobGraph(JobGraph jobGraph) throws IOException {
-		ByteArrayOutputStream baos = new ByteArrayOutputStream(1024);
-		ObjectOutputStream out = new ObjectOutputStream(baos);
+		try (ByteArrayOutputStream baos = new ByteArrayOutputStream(64 * 1024)) {
+			ObjectOutputStream out = new ObjectOutputStream(baos);
 
-		out.writeObject(jobGraph);
+			out.writeObject(jobGraph);
 
-		return baos.toByteArray();
+			return baos.toByteArray();
+		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobSubmitRequestBody.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobSubmitRequestBody.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.job;
+
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.rest.messages.RequestBody;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.util.Arrays;
+
+/**
+ * Request for submitting a job.
+ *
+ * <p>We currently require the job-jars to be uploaded through the blob-server.
+ */
+public final class JobSubmitRequestBody implements RequestBody {
+
+	private static final String FIELD_NAME_SERIALIZED_JOB_GRAPH = "serializedJobGraph";
+
+	/**
+	 * The serialized job graph.
+	 */
+	@JsonProperty(FIELD_NAME_SERIALIZED_JOB_GRAPH)
+	public final byte[] serializedJobGraph;
+
+	public JobSubmitRequestBody(JobGraph jobGraph) throws IOException {
+		this(serializeJobGraph(jobGraph));
+	}
+
+	@JsonCreator
+	public JobSubmitRequestBody(
+		@JsonProperty(FIELD_NAME_SERIALIZED_JOB_GRAPH) byte[] serializedJobGraph) {
+
+		this.serializedJobGraph = serializedJobGraph;
+	}
+
+	@Override
+	public int hashCode() {
+		return 71 * Arrays.hashCode(this.serializedJobGraph);
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (object instanceof JobSubmitRequestBody) {
+			JobSubmitRequestBody other = (JobSubmitRequestBody) object;
+			return Arrays.equals(this.serializedJobGraph, other.serializedJobGraph);
+		}
+		return false;
+	}
+
+	private static byte[] serializeJobGraph(JobGraph jobGraph) throws IOException {
+		ByteArrayOutputStream baos = new ByteArrayOutputStream(1024);
+		ObjectOutputStream out = new ObjectOutputStream(baos);
+
+		out.writeObject(jobGraph);
+
+		return baos.toByteArray();
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobSubmitRequestBody.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobSubmitRequestBody.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.rest.messages.job;
 
 import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.rest.RestServerEndpoint;
 import org.apache.flink.runtime.rest.messages.RequestBody;
 import org.apache.flink.util.Preconditions;
 
@@ -53,6 +54,11 @@ public final class JobSubmitRequestBody implements RequestBody {
 	public JobSubmitRequestBody(
 		@JsonProperty(FIELD_NAME_SERIALIZED_JOB_GRAPH) byte[] serializedJobGraph) {
 
+		// check that job graph can be read completely by the HttpObjectAggregator on the server
+		// we subtract 1024 bytes to account for http headers and such.
+		if (serializedJobGraph.length > RestServerEndpoint.MAX_REQUEST_SIZE_BYTES - 1024) {
+			throw new IllegalArgumentException("Serialized job graph exceeded max request size.");
+		}
 		this.serializedJobGraph = Preconditions.checkNotNull(serializedJobGraph);
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobSubmitResponseBody.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobSubmitResponseBody.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.job;
+
+import org.apache.flink.runtime.rest.messages.ResponseBody;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+/**
+ * Response to the submission of a job, containing a URL from which the status of the job can be retrieved from.
+ */
+public final class JobSubmitResponseBody implements ResponseBody {
+
+	public static final String FIELD_NAME_JOB_URL = "jobUrl";
+
+	/**
+	 * The URL under which the job status can monitored.
+	 */
+	@JsonProperty(FIELD_NAME_JOB_URL)
+	public final String jobUrl;
+
+	@JsonCreator
+	public JobSubmitResponseBody(
+		@JsonProperty(FIELD_NAME_JOB_URL) String jobUrl) {
+
+		this.jobUrl = jobUrl;
+	}
+
+	@Override
+	public int hashCode() {
+		return 73 * jobUrl.hashCode();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (object instanceof JobSubmitResponseBody) {
+			JobSubmitResponseBody other = (JobSubmitResponseBody) object;
+			return Objects.equals(this.jobUrl, other.jobUrl);
+		}
+		return false;
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/BlobServerPortHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/BlobServerPortHandlerTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.job;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.dispatcher.DispatcherGateway;
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.messages.BlobServerPortResponseBody;
+import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rpc.RpcUtils;
+import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for the {@link BlobServerPortHandler}.
+ */
+public class BlobServerPortHandlerTest {
+	private static final int PORT = 64;
+
+	@Test
+	public void testPortRetrieval() throws Exception {
+		DispatcherGateway mockGateway = mock(DispatcherGateway.class);
+		when(mockGateway.getBlobServerPort(any(Time.class))).thenReturn(CompletableFuture.completedFuture(PORT));
+		GatewayRetriever<DispatcherGateway> mockGatewayRetriever = mock(GatewayRetriever.class);
+
+		BlobServerPortHandler handler = new BlobServerPortHandler(
+			CompletableFuture.completedFuture("http://localhost:1234"),
+			mockGatewayRetriever,
+			RpcUtils.INF_TIMEOUT);
+
+		BlobServerPortResponseBody portResponse = handler.handleRequest(new HandlerRequest<>(EmptyRequestBody.getInstance(), EmptyMessageParameters.getInstance()), mockGateway).get();
+
+		Assert.assertEquals(PORT, portResponse.port);
+	}
+
+	@Test
+	public void testPortRetrievalFailureHandling() throws Exception {
+
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobSubmitHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobSubmitHandlerTest.java
@@ -36,7 +36,6 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
@@ -60,14 +59,10 @@ public class JobSubmitHandlerTest extends TestLogger {
 
 		JobSubmitRequestBody request = new JobSubmitRequestBody(new byte[0]);
 
-		handler.handleRequest(new HandlerRequest<>(request, EmptyMessageParameters.getInstance()), mockGateway);
-
 		try {
-			handler.handleRequest(new HandlerRequest<>(request, EmptyMessageParameters.getInstance()), mockGateway).get();
+			handler.handleRequest(new HandlerRequest<>(request, EmptyMessageParameters.getInstance()), mockGateway);
 			Assert.fail();
-		} catch (ExecutionException ee) {
-			RestHandlerException rhe = (RestHandlerException) ee.getCause();
-
+		} catch (RestHandlerException rhe) {
 			Assert.assertEquals(HttpResponseStatus.BAD_REQUEST, rhe.getHttpResponseStatus());
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobSubmitHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobSubmitHandlerTest.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
 import org.apache.flink.runtime.rest.messages.job.JobSubmitRequestBody;
 import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+import org.apache.flink.util.TestLogger;
 
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
 
@@ -44,7 +45,7 @@ import static org.mockito.Mockito.when;
 /**
  * Tests for the {@link JobSubmitHandler}.
  */
-public class JobSubmitHandlerTest {
+public class JobSubmitHandlerTest extends TestLogger {
 
 	@Test
 	public void testSerializationFailureHandling() throws Exception {
@@ -85,6 +86,7 @@ public class JobSubmitHandlerTest {
 		JobGraph job = new JobGraph("testjob");
 		JobSubmitRequestBody request = new JobSubmitRequestBody(job);
 
-		handler.handleRequest(new HandlerRequest<>(request, EmptyMessageParameters.getInstance()), mockGateway).get();
+		handler.handleRequest(new HandlerRequest<>(request, EmptyMessageParameters.getInstance()), mockGateway)
+			.get();
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobSubmitHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobSubmitHandlerTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.job;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.dispatcher.DispatcherGateway;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.RestHandlerException;
+import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
+import org.apache.flink.runtime.rest.messages.job.JobSubmitRequestBody;
+import org.apache.flink.runtime.rpc.RpcUtils;
+import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for the {@link JobSubmitHandler}.
+ */
+public class JobSubmitHandlerTest {
+
+	@Test
+	public void testSerializationFailureHandling() throws Exception {
+		DispatcherGateway mockGateway = mock(DispatcherGateway.class);
+		when(mockGateway.submitJob(any(JobGraph.class), any(Time.class))).thenReturn(CompletableFuture.completedFuture(Acknowledge.get()));
+		GatewayRetriever<DispatcherGateway> mockGatewayRetriever = mock(GatewayRetriever.class);
+
+		JobSubmitHandler handler = new JobSubmitHandler(
+			CompletableFuture.completedFuture("http://localhost:1234"),
+			mockGatewayRetriever,
+			RpcUtils.INF_TIMEOUT);
+
+		JobSubmitRequestBody request = new JobSubmitRequestBody(new byte[0]);
+
+		handler.handleRequest(new HandlerRequest<>(request, EmptyMessageParameters.getInstance()), mockGateway);
+
+		try {
+			handler.handleRequest(new HandlerRequest<>(request, EmptyMessageParameters.getInstance()), mockGateway).get();
+			Assert.fail();
+		} catch (ExecutionException ee) {
+			RestHandlerException rhe = (RestHandlerException) ee.getCause();
+
+			Assert.assertEquals(HttpResponseStatus.BAD_REQUEST, rhe.getHttpResponseStatus());
+		}
+	}
+
+	@Test
+	public void testSuccessfulJobSubmission() throws Exception {
+		DispatcherGateway mockGateway = mock(DispatcherGateway.class);
+		when(mockGateway.submitJob(any(JobGraph.class), any(Time.class))).thenReturn(CompletableFuture.completedFuture(Acknowledge.get()));
+		GatewayRetriever<DispatcherGateway> mockGatewayRetriever = mock(GatewayRetriever.class);
+
+		JobSubmitHandler handler = new JobSubmitHandler(
+			CompletableFuture.completedFuture("http://localhost:1234"),
+			mockGatewayRetriever,
+			RpcUtils.INF_TIMEOUT);
+
+		JobGraph job = new JobGraph("testjob");
+		JobSubmitRequestBody request = new JobSubmitRequestBody(job);
+
+		handler.handleRequest(new HandlerRequest<>(request, EmptyMessageParameters.getInstance()), mockGateway).get();
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/BlobServerPortResponseTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/BlobServerPortResponseTest.java
@@ -18,26 +18,20 @@
 
 package org.apache.flink.runtime.rest.messages;
 
-import java.util.Collection;
-import java.util.Collections;
+import org.apache.flink.runtime.rest.handler.legacy.messages.RestResponseMarshallingTestBase;
 
 /**
- * Parameters for job related REST handlers.
- *
- * <p>A job related REST handler always requires a {@link JobIDPathParameter}.
+ * Tests for {@link BlobServerPortResponseBody}.
  */
-public class JobTerminationMessageParameters extends MessageParameters {
-
-	public final JobIDPathParameter jobPathParameter = new JobIDPathParameter();
-	public final TerminationModeQueryParameter terminationModeQueryParameter = new TerminationModeQueryParameter();
+public class BlobServerPortResponseTest extends RestResponseMarshallingTestBase<BlobServerPortResponseBody> {
 
 	@Override
-	public Collection<MessagePathParameter<?>> getPathParameters() {
-		return Collections.singleton(jobPathParameter);
+	protected Class<BlobServerPortResponseBody> getTestResponseClass() {
+		return BlobServerPortResponseBody.class;
 	}
 
 	@Override
-	public Collection<MessageQueryParameter<?>> getQueryParameters() {
-		return Collections.singleton(terminationModeQueryParameter);
+	protected BlobServerPortResponseBody getTestResponseInstance() throws Exception {
+		return new BlobServerPortResponseBody(64);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/JobSubmitRequestBodyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/JobSubmitRequestBodyTest.java
@@ -18,26 +18,24 @@
 
 package org.apache.flink.runtime.rest.messages;
 
-import java.util.Collection;
-import java.util.Collections;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.rest.handler.legacy.messages.RestRequestMarshallingTestBase;
+import org.apache.flink.runtime.rest.messages.job.JobSubmitRequestBody;
+
+import java.io.IOException;
 
 /**
- * Parameters for job related REST handlers.
- *
- * <p>A job related REST handler always requires a {@link JobIDPathParameter}.
+ * Tests for the {@link JobSubmitRequestBody}.
  */
-public class JobTerminationMessageParameters extends MessageParameters {
-
-	public final JobIDPathParameter jobPathParameter = new JobIDPathParameter();
-	public final TerminationModeQueryParameter terminationModeQueryParameter = new TerminationModeQueryParameter();
+public class JobSubmitRequestBodyTest extends RestRequestMarshallingTestBase<JobSubmitRequestBody> {
 
 	@Override
-	public Collection<MessagePathParameter<?>> getPathParameters() {
-		return Collections.singleton(jobPathParameter);
+	protected Class<JobSubmitRequestBody> getTestRequestClass() {
+		return JobSubmitRequestBody.class;
 	}
 
 	@Override
-	public Collection<MessageQueryParameter<?>> getQueryParameters() {
-		return Collections.singleton(terminationModeQueryParameter);
+	protected JobSubmitRequestBody getTestRequestInstance() throws IOException {
+		return new JobSubmitRequestBody(new JobGraph("job"));
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/JobSubmitResponseBodyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/JobSubmitResponseBodyTest.java
@@ -18,26 +18,21 @@
 
 package org.apache.flink.runtime.rest.messages;
 
-import java.util.Collection;
-import java.util.Collections;
+import org.apache.flink.runtime.rest.handler.legacy.messages.RestResponseMarshallingTestBase;
+import org.apache.flink.runtime.rest.messages.job.JobSubmitResponseBody;
 
 /**
- * Parameters for job related REST handlers.
- *
- * <p>A job related REST handler always requires a {@link JobIDPathParameter}.
+ * Tests for {@link JobSubmitResponseBody}.
  */
-public class JobTerminationMessageParameters extends MessageParameters {
-
-	public final JobIDPathParameter jobPathParameter = new JobIDPathParameter();
-	public final TerminationModeQueryParameter terminationModeQueryParameter = new TerminationModeQueryParameter();
+public class JobSubmitResponseBodyTest extends RestResponseMarshallingTestBase<JobSubmitResponseBody> {
 
 	@Override
-	public Collection<MessagePathParameter<?>> getPathParameters() {
-		return Collections.singleton(jobPathParameter);
+	protected Class<JobSubmitResponseBody> getTestResponseClass() {
+		return JobSubmitResponseBody.class;
 	}
 
 	@Override
-	public Collection<MessageQueryParameter<?>> getQueryParameters() {
-		return Collections.singleton(terminationModeQueryParameter);
+	protected JobSubmitResponseBody getTestResponseInstance() throws Exception {
+		return new JobSubmitResponseBody("/url");
 	}
 }


### PR DESCRIPTION
This PR builds on #4730 .

## What is the purpose of the change

This PR adds a new ClusterClient specifically for Flip-6 using the new REST architecture. It supports submitting, canceling and stopping jobs.

The job submission is not done purely via REST. The jar upload is still implemented through the blobserver. Thus, for submitting a job, we first query the blobserver port, upload the jars, and then submit the jobgraph again via REST.

The stopping and canceling of jobs uses the existing JobTerminationHandler that was recently added.

## Brief change log

* define REST protocol for job submissions
* modify dispatcher to expose the blob server port
* add handlers to dispatcher endpoint for querying the blob server port and submitting jobs
* add a new ClusterClient for Flip6 and integrate it into the CLI

## Verifying this change

This change added tests and can be verified as follows:

- start a flip6 cluster using `./bin/start-cluster.sh flip6`
- submit a job using `./bin/flink run -flip6 <jar>` (this will print the job ID)
- stop/cancel the job using `./bin/flink [cancel|stop] -flip6 <jobid>`
- check logs that the job was successfully canceled

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)

