### PR TITLE
[FLINK-7739][kafka-tests] Throttle down data producing thread

### DIFF
--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaProducerTestBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaProducerTestBase.java
@@ -140,6 +140,9 @@ public abstract class KafkaProducerTestBase extends KafkaTestBase {
 					while (running) {
 						ctx.collect(new Tuple2<Long, String>(cnt, "kafka-" + cnt));
 						cnt++;
+						if (cnt % 100 == 0) {
+							Thread.sleep(1);
+						}
 					}
 				}
 


### PR DESCRIPTION
Minor tests improvement in tests to avoid busy loop
