### PR TITLE
[FLINK-7741][build][hotfix] Fix NPE when throw new SlotNotFoundException

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTable.java
@@ -448,7 +448,7 @@ public class TaskSlotTable implements TimeoutListener<AllocationID> {
 				throw new SlotNotActiveException(task.getJobID(), task.getAllocationId());
 			}
 		} else {
-			throw new SlotNotFoundException(taskSlot.getAllocationId());
+			throw new SlotNotFoundException(task.getAllocationId());
 		}
 	}
 


### PR DESCRIPTION
if **taskSlot** is null  then **throw new SlotNotFoundException(taskSlot.getAllocationId());** will have NPE.
the code segment in **org.apache.flink.runtime.taskexecutor.slot.TaskSlotTable** class： 
```
	public boolean addTask(Task task) throws SlotNotFoundException, SlotNotActiveException {
		Preconditions.checkNotNull(task);

		TaskSlot taskSlot = getTaskSlot(task.getAllocationId());

		if (taskSlot != null) {
			if (taskSlot.isActive(task.getJobID(), task.getAllocationId())) {
				if (taskSlot.add(task)) {
					taskSlotMappings.put(task.getExecutionId(), new TaskSlotMapping(task, taskSlot));

					return true;
				} else {
					return false;
				}
			} else {
				throw new SlotNotActiveException(task.getJobID(), task.getAllocationId());
			}
		} else {
			throw new SlotNotFoundException(taskSlot.getAllocationId());
		}
	}
```
