### PR TITLE
[FLINK-7694][REST][Webfrontend]Port JobMetricsHandler to new REST handler

### DIFF
--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitor.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitor.java
@@ -304,22 +304,21 @@ public class WebRuntimeMonitor implements WebMonitor {
 		get(router, new JobAccumulatorsHandler(executionGraphCache, scheduledExecutor));
 
 		get(router, new TaskManagersHandler(scheduledExecutor, DEFAULT_REQUEST_TIMEOUT, metricFetcher));
-		get(router,
-			new TaskManagerLogHandler(
-				retriever,
-				scheduledExecutor,
-				localRestAddress,
-				timeout,
-				TaskManagerLogHandler.FileMode.LOG,
-				config));
-		get(router,
-			new TaskManagerLogHandler(
-				retriever,
-				scheduledExecutor,
-				localRestAddress,
-				timeout,
-				TaskManagerLogHandler.FileMode.STDOUT,
-				config));
+		get(router, new TaskManagerLogHandler(
+							retriever,
+							scheduledExecutor,
+							localRestAddress,
+							timeout,
+							TaskManagerLogHandler.FileMode.LOG,
+							config));
+		get(router, new TaskManagerLogHandler(
+							retriever,
+							scheduledExecutor,
+							localRestAddress,
+							timeout,
+							TaskManagerLogHandler.FileMode.STDOUT,
+							config));
+		get(router, new TaskManagerMetricsHandler(scheduledExecutor, metricFetcher));
 
 		router
 			// log and stdout

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/AbstractMetricsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/AbstractMetricsHandler.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.rest.handler.legacy.metrics;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.jobmaster.JobManagerGateway;
 import org.apache.flink.runtime.rest.handler.legacy.AbstractJsonRequestHandler;
 import org.apache.flink.runtime.rest.handler.legacy.JsonFactory;
@@ -45,10 +46,9 @@ import java.util.concurrent.Executor;
  * {@code [ { "id" : "X", "value" : "S" }, { "id" : "Y", "value" : "T" } ] }
  */
 public abstract class AbstractMetricsHandler extends AbstractJsonRequestHandler {
-
 	public static final String PARAMETER_METRICS = "get";
 
-	private final MetricFetcher fetcher;
+	protected final MetricFetcher fetcher;
 
 	public AbstractMetricsHandler(Executor executor, MetricFetcher fetcher) {
 		super(executor);
@@ -82,7 +82,8 @@ public abstract class AbstractMetricsHandler extends AbstractJsonRequestHandler 
 	 */
 	protected abstract Map<String, String> getMapFor(Map<String, String> pathParams, MetricStore metrics);
 
-	private String getMetricsValues(Map<String, String> pathParams, String requestedMetricsList) throws IOException {
+	@VisibleForTesting
+	protected String getMetricsValues(Map<String, String> pathParams, String requestedMetricsList) throws IOException {
 		if (requestedMetricsList.isEmpty()) {
 			/*
 			 * The WebInterface doesn't check whether the list of available metrics was empty. This can lead to a
@@ -115,7 +116,8 @@ public abstract class AbstractMetricsHandler extends AbstractJsonRequestHandler 
 		return writer.toString();
 	}
 
-	private String getAvailableMetricsList(Map<String, String> pathParams) throws IOException {
+	@VisibleForTesting
+	protected String getAvailableMetricsList(Map<String, String> pathParams) throws IOException {
 		Map<String, String> metrics = getMapFor(pathParams, fetcher.getMetricStore());
 		if (metrics == null) {
 			return "";

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/JobMetricsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/JobMetricsHandler.java
@@ -18,8 +18,22 @@
 
 package org.apache.flink.runtime.rest.handler.legacy.metrics;
 
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.dispatcher.DispatcherGateway;
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.LegacyRestHandler;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.JobIDPathParameter;
+import org.apache.flink.runtime.rest.messages.metrics.MetricEntry;
+import org.apache.flink.runtime.rest.messages.metrics.MetricMessageParameters;
+import org.apache.flink.runtime.rest.messages.metrics.MetricNameParameter;
+import org.apache.flink.runtime.rest.messages.metrics.MetricsOverview;
+
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.stream.Collectors;
 
 /**
  * Request handler that returns for a given job a list of all available metrics or the values for a set of metrics.
@@ -29,11 +43,15 @@ import java.util.concurrent.Executor;
  *
  * <p>If the query parameters do contain a "get" parameter, a comma-separated list of metric names is expected as a value.
  * {@code /metrics?get=X,Y}
+ *
  * The handler will then return a list containing the values of the requested metrics.
  * {@code [ { "id" : "X", "value" : "S" }, { "id" : "Y", "value" : "T" } ] }
  */
-public class JobMetricsHandler extends AbstractMetricsHandler {
+public class JobMetricsHandler extends AbstractMetricsHandler
+		implements LegacyRestHandler<DispatcherGateway, MetricsOverview, MetricMessageParameters> {
+
 	public static final String PARAMETER_JOB_ID = "jobid";
+
 	private static final String JOB_METRICS_REST_PATH = "/jobs/:jobid/metrics";
 
 	public JobMetricsHandler(Executor executor, MetricFetcher fetcher) {
@@ -48,8 +66,43 @@ public class JobMetricsHandler extends AbstractMetricsHandler {
 	@Override
 	protected Map<String, String> getMapFor(Map<String, String> pathParams, MetricStore metrics) {
 		MetricStore.ComponentMetricStore job = metrics.getJobMetricStore(pathParams.get(PARAMETER_JOB_ID));
-		return job != null
-			? job.metrics
-			: null;
+		return job != null ? job.metrics : null;
+	}
+
+	@Override
+	public CompletableFuture<MetricsOverview> handleRequest(HandlerRequest<EmptyRequestBody, MetricMessageParameters> request, DispatcherGateway gateway) {
+		return CompletableFuture.supplyAsync(
+				() -> {
+					fetcher.update();
+					JobID jobID = request.getPathParameter(JobIDPathParameter.class);
+					List<String> requestedMetrics = request.getQueryParameter(MetricNameParameter.class);
+					return getMetricsOverview(jobID, requestedMetrics);
+				},
+				executor);
+	}
+
+	protected MetricsOverview getMetricsOverview(JobID jobID, List<String> requestedMetrics) {
+		Map<String, String> metricsMap = getMetricsMapByJobId(jobID, fetcher.getMetricStore());
+		if (metricsMap == null) {
+			return new MetricsOverview();
+		}
+
+		if (requestedMetrics == null || requestedMetrics.isEmpty()) {
+			return new MetricsOverview(
+					metricsMap.entrySet().stream()
+							.map(e -> new MetricEntry(e.getKey(), e.getValue()))
+							.collect(Collectors.toList()));
+		} else {
+			return new MetricsOverview(
+					requestedMetrics.stream()
+							.filter(e -> metricsMap.get(e) != null)
+							.map(e -> new MetricEntry(e, metricsMap.get(e)))
+							.collect(Collectors.toList()));
+		}
+	}
+
+	private Map<String, String> getMetricsMapByJobId(JobID jobID, MetricStore metrics) {
+		MetricStore.ComponentMetricStore metricStore = metrics.getJobMetricStore(jobID);
+		return metricStore != null ? metricStore.metrics : null;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/JobMetricsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/JobMetricsHandler.java
@@ -43,7 +43,6 @@ import java.util.stream.Collectors;
  *
  * <p>If the query parameters do contain a "get" parameter, a comma-separated list of metric names is expected as a value.
  * {@code /metrics?get=X,Y}
- *
  * The handler will then return a list containing the values of the requested metrics.
  * {@code [ { "id" : "X", "value" : "S" }, { "id" : "Y", "value" : "T" } ] }
  */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/MetricStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/MetricStore.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.rest.handler.legacy.metrics;
 
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.metrics.dump.MetricDump;
 import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
 
@@ -117,6 +118,16 @@ public class MetricStore {
 	 */
 	public synchronized ComponentMetricStore getJobMetricStore(String jobID) {
 		return jobID == null ? null : ComponentMetricStore.unmodifiable(jobs.get(jobID));
+	}
+
+	/**
+	 * Returns the {@link ComponentMetricStore} for the given job ID.
+	 *
+	 * @param jobID job ID
+	 * @return ComponentMetricStore for the given ID, or null if no store for the given argument exists
+	 */
+	public synchronized ComponentMetricStore getJobMetricStore(JobID jobID) {
+		return jobID == null ? null : ComponentMetricStore.unmodifiable(jobs.get(jobID.toString()));
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/ClusterConfigurationInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/ClusterConfigurationInfo.java
@@ -24,7 +24,7 @@ import org.apache.flink.runtime.rest.handler.legacy.ClusterConfigHandler;
 import java.util.ArrayList;
 
 /**
- * Response of the {@link ClusterConfigHandler}, respresented as a list
+ * Response of the {@link ClusterConfigHandler}, represented as a list
  * of key-value pairs of the cluster {@link Configuration}.
  */
 public class ClusterConfigurationInfo extends ArrayList<ClusterConfigurationInfoEntry> implements ResponseBody {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/metrics/MetricEntry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/metrics/MetricEntry.java
@@ -25,7 +25,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 
 /**
- *
+ * Entry for metric id and value pair.
  */
 public class MetricEntry {
 	public static final String FIELD_NAME_ID = "id";

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/metrics/MetricEntry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/metrics/MetricEntry.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.metrics;
+
+import org.apache.flink.util.Preconditions;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+
+/**
+ *
+ */
+public class MetricEntry {
+	public static final String FIELD_NAME_ID = "id";
+	public static final String FIELD_NAME_VALUE = "value";
+
+	@JsonProperty(FIELD_NAME_ID)
+	private final String id;
+
+	@JsonProperty(FIELD_NAME_VALUE)
+	private final String value;
+
+	@JsonCreator
+	public MetricEntry(
+			@JsonProperty(FIELD_NAME_ID) String id,
+			@JsonProperty(FIELD_NAME_VALUE) String value) {
+		Preconditions.checkNotNull("id cannot be null", id);
+		Preconditions.checkNotNull("value cannot be null", value);
+
+		this.id = id;
+		this.value = value;
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public String getValue() {
+		return value;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+
+		MetricEntry that = (MetricEntry) o;
+
+		return id.equals(that.getId()) && value.equals(that.value);
+	}
+
+	@Override
+	public int hashCode() {
+		int result = id != null ? id.hashCode() : 0;
+		result = 31 * result + (value != null ? value.hashCode() : 0);
+		return result;
+	}
+
+	@Override
+	public String toString() {
+		return "MetricEntry {" +
+				"id=" + id +
+				", value=" + value +
+				"}";
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/metrics/MetricEntry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/metrics/MetricEntry.java
@@ -20,8 +20,8 @@ package org.apache.flink.runtime.rest.messages.metrics;
 
 import org.apache.flink.util.Preconditions;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 
 
 /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/metrics/MetricMessageParameters.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/metrics/MetricMessageParameters.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.metrics;
+
+import org.apache.flink.runtime.rest.messages.JobIDPathParameter;
+import org.apache.flink.runtime.rest.messages.MessageParameters;
+import org.apache.flink.runtime.rest.messages.MessagePathParameter;
+import org.apache.flink.runtime.rest.messages.MessageQueryParameter;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ *
+ */
+public class MetricMessageParameters extends MessageParameters {
+	private final JobIDPathParameter jobIDPathParameter = new JobIDPathParameter();
+	private final MetricNameParameter metricNameParameter = new MetricNameParameter();
+
+	@Override
+	public Collection<MessagePathParameter<?>> getPathParameters() {
+		return Collections.singleton(jobIDPathParameter);
+	}
+
+	@Override
+	public Collection<MessageQueryParameter<?>> getQueryParameters() {
+		return Collections.singleton(metricNameParameter);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/metrics/MetricMessageParameters.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/metrics/MetricMessageParameters.java
@@ -27,7 +27,7 @@ import java.util.Collection;
 import java.util.Collections;
 
 /**
- *
+ * Parameters for getting metrics.
  */
 public class MetricMessageParameters extends MessageParameters {
 	private final JobIDPathParameter jobIDPathParameter = new JobIDPathParameter();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/metrics/MetricNameParameter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/metrics/MetricNameParameter.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.metrics;
+
+import org.apache.flink.runtime.rest.messages.MessageQueryParameter;
+
+/**
+ *
+ */
+public class MetricNameParameter extends MessageQueryParameter<String> {
+	private static final String GET = "get";
+
+	public MetricNameParameter() {
+		super(GET, MessageParameterRequisiteness.OPTIONAL);
+	}
+
+	@Override
+	public String convertValueFromString(String value) {
+		return value;
+	}
+
+	@Override
+	public String convertStringToValue(String value) {
+		return value;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/metrics/MetricNameParameter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/metrics/MetricNameParameter.java
@@ -21,7 +21,7 @@ package org.apache.flink.runtime.rest.messages.metrics;
 import org.apache.flink.runtime.rest.messages.MessageQueryParameter;
 
 /**
- *
+ * GET parameter identifying metric names.
  */
 public class MetricNameParameter extends MessageQueryParameter<String> {
 	private static final String GET = "get";

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/metrics/MetricsHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/metrics/MetricsHeaders.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.metrics;
+
+import org.apache.flink.runtime.rest.HttpMethodWrapper;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+/**
+ *
+ */
+public final class MetricsHeaders implements MessageHeaders<EmptyRequestBody, MetricsOverview, MetricMessageParameters> {
+
+	private static final MetricsHeaders INSTANCE = new MetricsHeaders();
+
+	public static final String PARAMETER_JOB_ID = "jobid";
+	public static final String JOB_METRICS_REST_PATH = "/jobs/:jobid/metrics";
+
+	private MetricsHeaders() {
+	}
+
+	@Override
+	public HttpMethodWrapper getHttpMethod() {
+		return HttpMethodWrapper.GET;
+	}
+
+	@Override
+	public String getTargetRestEndpointURL() {
+		return JOB_METRICS_REST_PATH;
+	}
+
+	@Override
+	public Class<EmptyRequestBody> getRequestClass() {
+		return EmptyRequestBody.class;
+	}
+
+	@Override
+	public Class<MetricsOverview> getResponseClass() {
+		return MetricsOverview.class;
+	}
+
+	@Override
+	public HttpResponseStatus getResponseStatusCode() {
+		return HttpResponseStatus.OK;
+	}
+
+	@Override
+	public MetricMessageParameters getUnresolvedMessageParameters() {
+		return new MetricMessageParameters();
+	}
+
+	public static MetricsHeaders getInstance() {
+		return INSTANCE;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/metrics/MetricsHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/metrics/MetricsHeaders.java
@@ -25,7 +25,7 @@ import org.apache.flink.runtime.rest.messages.MessageHeaders;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
 
 /**
- *
+ * Message header for metrics handler.
  */
 public final class MetricsHeaders implements MessageHeaders<EmptyRequestBody, MetricsOverview, MetricMessageParameters> {
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/metrics/MetricsOverview.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/metrics/MetricsOverview.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.metrics;
+
+import org.apache.flink.runtime.rest.messages.ResponseBody;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+/**
+ *
+ */
+public class MetricsOverview extends ArrayList<MetricEntry> implements ResponseBody {
+	public MetricsOverview() {
+	}
+
+	public MetricsOverview(int initialCapacity) {
+		super(initialCapacity);
+	}
+
+	public MetricsOverview(Collection<? extends MetricEntry> c) {
+		super(c);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/metrics/MetricsOverview.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/metrics/MetricsOverview.java
@@ -24,7 +24,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 
 /**
- *
+ * Response of metrics handlers, represented as a list of {@link MetricEntry}.
  */
 public class MetricsOverview extends ArrayList<MetricEntry> implements ResponseBody {
 	public MetricsOverview() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/metrics/JobMetricsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/metrics/JobMetricsHandlerTest.java
@@ -50,10 +50,10 @@ public class JobMetricsHandlerTest extends TestLogger {
 	@Test
 	public void getMapFor() throws Exception {
 		MetricFetcher fetcher = new MetricFetcher(
-			mock(GatewayRetriever.class),
-			mock(MetricQueryServiceRetriever.class),
-			Executors.directExecutor(),
-			TestingUtils.TIMEOUT());
+										mock(GatewayRetriever.class),
+										mock(MetricQueryServiceRetriever.class),
+										Executors.directExecutor(),
+										TestingUtils.TIMEOUT());
 		MetricStore store = MetricStoreTest.setupStore(fetcher.getMetricStore());
 
 		JobMetricsHandler handler = new JobMetricsHandler(Executors.directExecutor(), fetcher);
@@ -65,15 +65,28 @@ public class JobMetricsHandlerTest extends TestLogger {
 
 		assertEquals("2", metrics.get("abc.metric3"));
 		assertEquals("3", metrics.get("abc.metric4"));
+		assertEquals(
+				"[" +
+						"{\"id\":\"abc.metric4\"}," +
+						"{\"id\":\"abc.metric3\"}" +
+						"]",
+				handler.getAvailableMetricsList(pathParams));
+		assertEquals("", handler.getMetricsValues(pathParams, ""));
+		assertEquals(
+				"[" +
+						"{\"id\":\"abc.metric3\",\"value\":\"2\"}," +
+						"{\"id\":\"abc.metric4\",\"value\":\"3\"}" +
+						"]",
+				handler.getMetricsValues(pathParams, "abc.metric3,abc.metric4"));
 	}
 
 	@Test
 	public void getMapForNull() {
 		MetricFetcher fetcher = new MetricFetcher(
-			mock(GatewayRetriever.class),
-			mock(MetricQueryServiceRetriever.class),
-			Executors.directExecutor(),
-			TestingUtils.TIMEOUT());
+										mock(GatewayRetriever.class),
+										mock(MetricQueryServiceRetriever.class),
+										Executors.directExecutor(),
+										TestingUtils.TIMEOUT());
 		MetricStore store = fetcher.getMetricStore();
 
 		JobMetricsHandler handler = new JobMetricsHandler(Executors.directExecutor(), fetcher);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/metrics/MetricsOverviewTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/metrics/MetricsOverviewTest.java
@@ -21,7 +21,7 @@ package org.apache.flink.runtime.rest.messages.metrics;
 import org.apache.flink.runtime.rest.messages.RestResponseMarshallingTestBase;
 
 /**
- *
+ * Tests for {@link MetricsOverview}.
  */
 public class MetricsOverviewTest extends RestResponseMarshallingTestBase<MetricsOverview> {
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/metrics/MetricsOverviewTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/metrics/MetricsOverviewTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.metrics;
+
+import org.apache.flink.runtime.rest.messages.RestResponseMarshallingTestBase;
+
+/**
+ *
+ */
+public class MetricsOverviewTest extends RestResponseMarshallingTestBase<MetricsOverview> {
+	@Override
+	protected Class<MetricsOverview> getTestResponseClass() {
+		return MetricsOverview.class;
+	}
+
+	@Override
+	protected MetricsOverview getTestResponseInstance() throws Exception {
+		final MetricsOverview expected = new MetricsOverview(2);
+		expected.add(new MetricEntry("a", "1"));
+		expected.add(new MetricEntry("b", "2"));
+
+		return expected;
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

Port JobMetricsHandler to new REST handler

## Brief change log

- added `MetricEntry` and `MetricsOverview` for json serialization
- implemented `JobMetricsHandler#handleRequests()`
- added `MetricsHeaders`

## Verifying this change

This change added tests and can be verified as follows:

  - Added unit tests for marshalling `MetricsOverview`

## Does this pull request potentially affect one of the following parts:

none

## Documentation

none
