### PR TITLE
[FLINK-7745][tests] add tests for ensuring NetworkBufferPool overprovisioning behaviour

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/BufferPoolFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/BufferPoolFactoryTest.java
@@ -21,7 +21,9 @@ package org.apache.flink.runtime.io.network.buffer;
 import org.apache.flink.core.memory.MemoryType;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -30,15 +32,24 @@ import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
+/**
+ * Tests for the creation of {@link LocalBufferPool} instances from the {@link NetworkBufferPool}
+ * factory.
+ */
 public class BufferPoolFactoryTest {
 
-	private final static int numBuffers = 1024;
+	private static final int numBuffers = 1024;
 
-	private final static int memorySegmentSize = 128;
+	private static final int memorySegmentSize = 128;
 
 	private NetworkBufferPool networkBufferPool;
+
+	@Rule
+	public ExpectedException expectedException = ExpectedException.none();
 
 	@Before
 	public void setupNetworkBufferPool() {
@@ -53,9 +64,89 @@ public class BufferPoolFactoryTest {
 		networkBufferPool.destroy();
 	}
 
-	@Test(expected = IOException.class)
-	public void testRequireMoreThanPossible() throws IOException {
-		networkBufferPool.createBufferPool(networkBufferPool.getTotalNumberOfMemorySegments() * 2, Integer.MAX_VALUE);
+	/**
+	 * Tests creating one buffer pool which requires more buffers than available.
+	 */
+	@Test
+	public void testRequireMoreThanPossible1() throws IOException {
+		expectedException.expect(IOException.class);
+		expectedException.expectMessage("Insufficient number of network buffers");
+
+		networkBufferPool.createBufferPool(networkBufferPool.getTotalNumberOfMemorySegments() + 1,
+			Integer.MAX_VALUE);
+	}
+
+	/**
+	 * Tests creating two buffer pools which together require more buffers than available.
+	 */
+	@Test
+	public void testRequireMoreThanPossible2() throws IOException {
+		expectedException.expect(IOException.class);
+		expectedException.expectMessage("Insufficient number of network buffers");
+
+		networkBufferPool.createBufferPool(numBuffers / 2 + 1, numBuffers);
+		networkBufferPool.createBufferPool(numBuffers / 2 + 1, numBuffers);
+	}
+
+	/**
+	 * Tests creating two buffer pools which together require as many buffers as available but where
+	 * there are less buffers available to the {@link NetworkBufferPool} at the time of the second
+	 * {@link LocalBufferPool} creation.
+	 */
+	@Test
+	public void testOverprovisioned() throws IOException {
+		int buffersToTakeFromPool1 = numBuffers / 2 + 1;
+		int buffersToTakeFromPool2 = numBuffers - buffersToTakeFromPool1;
+
+		List<Buffer> buffers = new ArrayList<>(numBuffers);
+		BufferPool lbp1 = null, lbp2 = null;
+		try {
+			lbp1 = networkBufferPool.createBufferPool(buffersToTakeFromPool2, numBuffers);
+
+			// take more buffers than the minimum required
+			for (int i = 0; i < buffersToTakeFromPool1; ++i) {
+				Buffer buffer = lbp1.requestBuffer();
+				buffers.add(buffer);
+				assertNotNull(buffer);
+			}
+			assertEquals(buffersToTakeFromPool1, lbp1.bestEffortGetNumOfUsedBuffers());
+			assertEquals(numBuffers, lbp1.getNumBuffers());
+
+			// create a second pool which requires more than are freely available at the moment
+			lbp2 = networkBufferPool.createBufferPool(buffersToTakeFromPool1, numBuffers);
+
+			assertEquals(lbp2.getNumberOfRequiredMemorySegments(), lbp2.getNumBuffers());
+			assertEquals(lbp1.getNumberOfRequiredMemorySegments(), lbp1.getNumBuffers());
+			assertNull(lbp1.requestBuffer());
+
+			// take all remaining buffers
+			for (int i = 0; i < buffersToTakeFromPool2; ++i) {
+				Buffer buffer = lbp2.requestBuffer();
+				buffers.add(buffer);
+				assertNotNull(buffer);
+			}
+			assertEquals(buffersToTakeFromPool2, lbp2.bestEffortGetNumOfUsedBuffers());
+
+			// we should be able to get one more but this is currently given out to lbp1 and taken by buffer1
+			assertNull(lbp2.requestBuffer());
+
+			// as soon as the excess buffer of lbp1 is recycled, it should be available for lbp2
+			buffers.remove(buffers.size() - 1).recycle();
+
+			Buffer buffer = lbp2.requestBuffer();
+			buffers.add(buffer);
+			assertNotNull(buffer);
+		} finally {
+			for (Buffer buffer : buffers) {
+				buffer.recycle();
+			}
+			if (lbp1 != null) {
+				lbp1.lazyDestroy();
+			}
+			if (lbp2 != null) {
+				lbp2.lazyDestroy();
+			}
+		}
 	}
 
 	@Test
@@ -201,7 +292,7 @@ public class BufferPoolFactoryTest {
 		for (int i = 0; i < 1_000; ++i) {
 			Random random = new Random();
 
-			List<BufferPool> pools = new ArrayList<BufferPool>();
+			List<BufferPool> pools = new ArrayList<>();
 
 			int numPools = numBuffers / 32;
 			long maxTotalUsed = 0;


### PR DESCRIPTION
## What is the purpose of the change

Currently, there are no unit tests verifying `NetworkBufferPool`'s behaviour in the case that the available number of buffers is too small for it to create LocalBufferPool instances. This PR adds some.

## Brief change log

- add unit tests for `NetworkBufferPool` not having as many buffers as required

## Verifying this change

This change only adds unit tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (JavaDocs)

