### PR TITLE
[FLINK-7746][network] move ResultPartitionWriter#writeBufferToAllChannels implementation up into ResultPartition

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/ResultPartitionWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/ResultPartitionWriter.java
@@ -82,17 +82,7 @@ public class ResultPartitionWriter implements EventListener<TaskEvent> {
 	 * @throws IOException
 	 */
 	public void writeBufferToAllChannels(final Buffer eventBuffer) throws IOException {
-		try {
-			for (int targetChannel = 0; targetChannel < partition.getNumberOfSubpartitions(); targetChannel++) {
-				// retain the buffer so that it can be recycled by each channel of targetPartition
-				eventBuffer.retain();
-				writeBuffer(eventBuffer, targetChannel);
-			}
-		} finally {
-			// we do not need to further retain the eventBuffer
-			// (it will be recycled after the last channel stops using it)
-			eventBuffer.recycle();
-		}
+		partition.addToAllChannels(eventBuffer);
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
@@ -293,6 +293,27 @@ public class ResultPartition implements BufferPoolOwner {
 	}
 
 	/**
+	 * Writes the given buffer to all available target channels.
+	 *
+	 * <p>The buffer is taken over and used for each of the channels. It will be recycled afterwards.
+	 *
+	 * @param buffer the buffer to write
+	 */
+	public void addToAllChannels(Buffer buffer) throws IOException {
+		try {
+			for (int targetChannel = 0; targetChannel < subpartitions.length; targetChannel++) {
+				// retain the buffer so that it can be recycled by each channel of targetPartition
+				buffer.retain();
+				add(buffer, targetChannel);
+			}
+		} finally {
+			// we do not need to further retain the buffer
+			// (it will be recycled after the last channel stops using it)
+			buffer.recycle();
+		}
+	}
+
+	/**
 	 * Finishes the result partition.
 	 *
 	 * <p> After this operation, it is not possible to add further data to the result partition.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
@@ -302,9 +302,8 @@ public class ResultPartition implements BufferPoolOwner {
 	public void addToAllChannels(Buffer buffer) throws IOException {
 		try {
 			for (int targetChannel = 0; targetChannel < subpartitions.length; targetChannel++) {
-				// retain the buffer so that it can be recycled by each channel of targetPartition
-				buffer.retain();
-				add(buffer, targetChannel);
+				// retain the buffer so that it can be recycled by each channel
+				add(buffer.retain(), targetChannel);
 			}
 		} finally {
 			// we do not need to further retain the buffer


### PR DESCRIPTION
## What is the purpose of the change

As a step towards removing the (unneeded) `ResultPartitionWriter` wrapper, we should move `ResultPartitionWriter#writeBufferToAllChannels` into `ResultPartition` where single-channel writing happens anyway.

## Brief change log

- move the implementation of `ResultPartitionWriter#writeBufferToAllChannels` into `ResultPartition` (keep a delegating method for now - until `ResultPartitionWriter` is removed)

## Verifying this change

This change is a trivial rework / code cleanup without any (new) test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (yes)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (JavaDocs)

