### PR TITLE
[hotfix][docs] Polish docs index page for consistency in voicing, grammar and clarity

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -25,27 +25,26 @@ under the License.
 
 
 
-This documentation is for Apache Flink version {{ site.version_title }}. These pages have been built at: {% build_time %}.
+This documentation is for Apache Flink version {{ site.version_title }}. These pages were built at: {% build_time %}.
 
-Apache Flink is an open source platform for distributed stream and batch data processing. Flink’s core is a streaming dataflow engine that provides data distribution, communication, and fault tolerance for distributed computations over data streams. Flink also builds batch processing on top of the streaming engine, overlaying native iteration support, managed memory, and program optimization.
+Apache Flink is an open source platform for distributed stream and batch data processing. Flink’s core is a streaming dataflow engine that provides data distribution, communication, and fault tolerance for distributed computations over data streams. Flink builds batch processing on top of the streaming engine, overlaying native iteration support, managed memory, and program optimization.
 
 ## First Steps
 
-- **Concepts**: Start with the basic concepts of Flink's [Dataflow Programming Model](concepts/programming-model.html) and [Distributed Runtime Environment](concepts/runtime.html). This will help you to fully understand the other parts of the documentation, including the setup and programming guides. It is highly recommended to read these sections first.
+- **Concepts**: Start with the basic concepts of Flink's [Dataflow Programming Model](concepts/programming-model.html) and [Distributed Runtime Environment](concepts/runtime.html). This will help you understand other parts of the documentation, including the setup and programming guides. We recommended you read these sections first.
 
 - **Quickstarts**: [Run an example program](quickstart/setup_quickstart.html) on your local machine or [study some examples](examples/index.html).
 
-- **Programming Guides**: You can check out our guides about [basic API concepts](dev/api_concepts.html) and the [DataStream API](dev/datastream_api.html) or [DataSet API](dev/batch/index.html) to learn how to write your first Flink programs.
+- **Programming Guides**: You can read our guides about [basic API concepts](dev/api_concepts.html) and the [DataStream API](dev/datastream_api.html) or the [DataSet API](dev/batch/index.html) to learn how to write your first Flink programs.
 
 ## Deployment
 
-Before putting your Flink job into production, be sure to read the [Production Readiness Checklist](ops/production_ready.html).
+Before putting your Flink job into production, read the [Production Readiness Checklist](ops/production_ready.html).
 
 ## Migration Guide
 
-For users of earlier versions of Apache Flink we recommend the [API migration guide](dev/migration.html).
-While all parts of the API that were marked as public and stable are still supported (the public API is backwards compatible), we suggest migrating applications to the
-newer interfaces where applicable.
+For users of earlier versions of Apache Flink, we recommend the [API migration guide](dev/migration.html).
+While all parts of the API marked as public and stable are still supported (the public API is backwards compatible), we suggest migrating applications to the newer interfaces where applicable.
 
 For users that plan to upgrade a Flink system in production, we recommend reading the guide on [upgrading Apache Flink](ops/upgrading.html).
 
@@ -55,5 +54,4 @@ For users that plan to upgrade a Flink system in production, we recommend readin
 
 - **Training**: The [training materials](http://training.data-artisans.com/) from data Artisans include slides, exercises, and sample solutions.
 
-- **Blogs**: The [Apache Flink](https://flink.apache.org/blog/) and [data Artisans](https://data-artisans.com/blog/) blogs publish frequent,
-in-depth technical articles about Flink.
+- **Blogs**: The [Apache Flink](https://flink.apache.org/blog/) and [data Artisans](https://data-artisans.com/blog/) blogs publish frequent, in-depth technical articles about Flink.

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,7 +44,7 @@ Before putting your Flink job into production, read the [Production Readiness Ch
 ## Migration Guide
 
 For users of earlier versions of Apache Flink, we recommend the [API migration guide](dev/migration.html).
-While all parts of the API marked as public and stable are still supported (the public API is backwards compatible), we suggest migrating applications to the newer interfaces where applicable.
+While all parts of the API that were marked as public and stable are still supported (the public API is backwards compatible), we suggest migrating applications to the newer interfaces where applicable.
 
 For users that plan to upgrade a Flink system in production, we recommend reading the guide on [upgrading Apache Flink](ops/upgrading.html).
 


### PR DESCRIPTION
Whilst I was reading through the opening page of the documentation I noticed a few places that I felt needed a little polish. Feel free to accept whichever you think are worthwhile and I'm also happy to explain why I feel these clarify things :)

The commit template didn't specify what to do for docs that weren't in the JavaDoc, so hopefully this message is OK.