### PR TITLE
[FLINK-7757] [checkpointing] Introduce resource guard for RocksDBKeye…

### DIFF
--- a/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011.java
@@ -28,7 +28,6 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
-import org.apache.flink.runtime.util.SerializableObject;
 import org.apache.flink.streaming.api.functions.sink.TwoPhaseCommitSinkFunction;
 import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
 import org.apache.flink.streaming.connectors.kafka.internal.FlinkKafkaProducer;
@@ -42,6 +41,7 @@ import org.apache.flink.streaming.util.serialization.SerializationSchema;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.NetUtils;
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.SerializableObject;
 
 import org.apache.flink.shaded.guava18.com.google.common.collect.Lists;
 

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerBase.java
@@ -24,7 +24,6 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
-import org.apache.flink.runtime.util.SerializableObject;
 import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
 import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
 import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
@@ -33,6 +32,7 @@ import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaDelegat
 import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartitioner;
 import org.apache.flink.streaming.util.serialization.KeyedSerializationSchema;
 import org.apache.flink.util.NetUtils;
+import org.apache.flink.util.SerializableObject;
 
 import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.KafkaProducer;

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/testutils/IntegerSource.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/testutils/IntegerSource.java
@@ -19,9 +19,9 @@
 package org.apache.flink.streaming.connectors.kafka.testutils;
 
 import org.apache.flink.runtime.state.CheckpointListener;
-import org.apache.flink.runtime.util.SerializableObject;
 import org.apache.flink.streaming.api.checkpoint.ListCheckpointed;
 import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
+import org.apache.flink.util.SerializableObject;
 
 import java.util.Collections;
 import java.util.List;

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
@@ -72,11 +72,11 @@ import org.apache.flink.runtime.state.internal.InternalListState;
 import org.apache.flink.runtime.state.internal.InternalMapState;
 import org.apache.flink.runtime.state.internal.InternalReducingState;
 import org.apache.flink.runtime.state.internal.InternalValueState;
-import org.apache.flink.runtime.util.SerializableObject;
 import org.apache.flink.util.FileUtils;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.IOUtils;
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.ResourceGuard;
 import org.apache.flink.util.StateMigrationException;
 
 import org.rocksdb.Checkpoint;
@@ -158,11 +158,10 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 	private final File instanceRocksDBPath;
 
 	/**
-	 * Lock for protecting cleanup of the RocksDB against the checkpointing thread. We acquire this when doing
-	 * asynchronous checkpoints and when disposing the DB. Otherwise, the asynchronous snapshot might try
-	 * iterating over a disposed DB. After aquriring the lock, always first check if (db == null).
+	 * Protects access to RocksDB in other threads, like the checkpointing thread from parallel call that dispose the
+	 * RocksDb object.
 	 */
-	private final SerializableObject asyncSnapshotLock = new SerializableObject();
+	private final ResourceGuard rocksDBResourceGuard;
 
 	/**
 	 * Our RocksDB data base, this is used by the actual subclasses of {@link AbstractRocksDBState}
@@ -225,6 +224,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 		this.operatorIdentifier = Preconditions.checkNotNull(operatorIdentifier);
 
 		this.enableIncrementalCheckpointing = enableIncrementalCheckpointing;
+		this.rocksDBResourceGuard = new ResourceGuard();
 
 		// ensure that we use the right merge operator, because other code relies on this
 		this.columnOptions = Preconditions.checkNotNull(columnFamilyOptions)
@@ -281,30 +281,29 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 	public void dispose() {
 		super.dispose();
 
-		// Acquire the lock, so that no ongoing snapshots access the db during cleanup
-		synchronized (asyncSnapshotLock) {
-			// IMPORTANT: null reference to signal potential async checkpoint workers that the db was disposed, as
-			// working on the disposed object results in SEGFAULTS. Other code has to check field #db for null
-			// and access it in a synchronized block that locks on #dbDisposeLock.
-			if (db != null) {
+		// This call will block until all clients that still acquired access to the RocksDB instance have released it,
+		// so that we cannot release the native resources while clients are still working with it in parallel.
+		rocksDBResourceGuard.close();
 
-				// RocksDB's native memory management requires that *all* CFs (including default) are closed before the
-				// DB is closed. So we start with the ones created by Flink...
-				for (Tuple2<ColumnFamilyHandle, RegisteredKeyedBackendStateMetaInfo<?, ?>> columnMetaData :
-					kvStateInformation.values()) {
-					IOUtils.closeQuietly(columnMetaData.f0);
-				}
+		// IMPORTANT: null reference to signal potential async checkpoint workers that the db was disposed, as
+		// working on the disposed object results in SEGFAULTS.
+		if (db != null) {
 
-				// ... close the default CF ...
-				IOUtils.closeQuietly(defaultColumnFamily);
-
-				// ... and finally close the DB instance ...
-				IOUtils.closeQuietly(db);
-
-				// invalidate the reference before releasing the lock so that other accesses will not cause crashes
-				db = null;
-
+			// RocksDB's native memory management requires that *all* CFs (including default) are closed before the
+			// DB is closed. So we start with the ones created by Flink...
+			for (Tuple2<ColumnFamilyHandle, RegisteredKeyedBackendStateMetaInfo<?, ?>> columnMetaData :
+				kvStateInformation.values()) {
+				IOUtils.closeQuietly(columnMetaData.f0);
 			}
+
+			// ... close the default CF ...
+			IOUtils.closeQuietly(defaultColumnFamily);
+
+			// ... and finally close the DB instance ...
+			IOUtils.closeQuietly(db);
+
+			// invalidate the reference before releasing the lock so that other accesses will not cause crashes
+			db = null;
 		}
 
 		kvStateInformation.clear();
@@ -356,6 +355,18 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 		final long checkpointTimestamp,
 		final CheckpointStreamFactory checkpointStreamFactory) throws Exception {
 
+		if (db == null) {
+			throw new IOException("RocksDB closed.");
+		}
+
+		if (kvStateInformation.isEmpty()) {
+			if (LOG.isDebugEnabled()) {
+				LOG.debug("Asynchronous RocksDB snapshot performed on empty keyed state at " +
+					checkpointTimestamp + " . Returning null.");
+			}
+			return DoneFuture.nullValue();
+		}
+
 		final RocksDBIncrementalSnapshotOperation<K> snapshotOperation =
 			new RocksDBIncrementalSnapshotOperation<>(
 				this,
@@ -363,21 +374,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 				checkpointId,
 				checkpointTimestamp);
 
-		synchronized (asyncSnapshotLock) {
-			if (db == null) {
-				throw new IOException("RocksDB closed.");
-			}
-
-			if (kvStateInformation.isEmpty()) {
-				if (LOG.isDebugEnabled()) {
-					LOG.debug("Asynchronous RocksDB snapshot performed on empty keyed state at " +
-						checkpointTimestamp + " . Returning null.");
-				}
-				return DoneFuture.nullValue();
-			}
-
-			snapshotOperation.takeSnapshot();
-		}
+		snapshotOperation.takeSnapshot();
 
 		return new FutureTask<KeyedStateHandle>(
 			new Callable<KeyedStateHandle>() {
@@ -410,27 +407,17 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 
 		final RocksDBFullSnapshotOperation<K> snapshotOperation;
 
-		// hold the db lock while operation on the db to guard us against async db disposal
-		synchronized (asyncSnapshotLock) {
-
-			if (db != null) {
-
-				if (kvStateInformation.isEmpty()) {
-					if (LOG.isDebugEnabled()) {
-						LOG.debug("Asynchronous RocksDB snapshot performed on empty keyed state at " + timestamp +
-							" . Returning null.");
-					}
-					return DoneFuture.nullValue();
-				}
-
-				snapshotOperation =
-					new RocksDBFullSnapshotOperation<>(this, streamFactory, snapshotCloseableRegistry);
-
-				snapshotOperation.takeDBSnapShot(checkpointId, timestamp);
-			} else {
-				throw new IOException("RocksDB closed.");
+		if (kvStateInformation.isEmpty()) {
+			if (LOG.isDebugEnabled()) {
+				LOG.debug("Asynchronous RocksDB snapshot performed on empty keyed state at " + timestamp +
+					" . Returning null.");
 			}
+
+			return DoneFuture.nullValue();
 		}
+
+		snapshotOperation = new RocksDBFullSnapshotOperation<>(this, streamFactory, snapshotCloseableRegistry);
+		snapshotOperation.takeDBSnapShot(checkpointId, timestamp);
 
 		// implementation of the async IO operation, based on FutureTask
 		AbstractAsyncCallableWithResources<KeyedStateHandle> ioCallable =
@@ -450,9 +437,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 
 				private void releaseSnapshotOperationResources() {
 					// hold the db lock while operation on the db to guard us against async db disposal
-					synchronized (asyncSnapshotLock) {
-						snapshotOperation.releaseSnapshotResources();
-					}
+					snapshotOperation.releaseSnapshotResources();
 				}
 
 				@Override
@@ -474,15 +459,11 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 				public KeyGroupsStateHandle performOperation() throws Exception {
 					long startTime = System.currentTimeMillis();
 
-					synchronized (asyncSnapshotLock) {
-						// hold the db lock while operation on the db to guard us against async db disposal
-						if (db == null) {
-							throw new IOException("RocksDB closed.");
-						}
-
-						snapshotOperation.writeDBSnapshot();
-						snapshotOperation.createSnapshotResultStateHandleFromOutputStream();
+					if (isStopped()) {
+						throw new IOException("RocksDB closed.");
 					}
+
+					snapshotOperation.writeDBSnapshot();
 
 					LOG.info("Asynchronous RocksDB snapshot ({}, asynchronous part) in thread {} took {} ms.",
 						streamFactory, Thread.currentThread(), (System.currentTimeMillis() - startTime));
@@ -509,6 +490,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 		private final KeyGroupRangeOffsets keyGroupRangeOffsets;
 		private final CheckpointStreamFactory checkpointStreamFactory;
 		private final CloseableRegistry snapshotCloseableRegistry;
+		private final ResourceGuard.Lease dbLease;
 
 		private long checkpointId;
 		private long checkpointTimeStamp;
@@ -519,17 +501,17 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 
 		private CheckpointStreamFactory.CheckpointStateOutputStream outStream;
 		private DataOutputView outputView;
-		private KeyGroupsStateHandle snapshotResultStateHandle;
 
 		RocksDBFullSnapshotOperation(
 			RocksDBKeyedStateBackend<K> stateBackend,
 			CheckpointStreamFactory checkpointStreamFactory,
-			CloseableRegistry registry) {
+			CloseableRegistry registry) throws IOException {
 
 			this.stateBackend = stateBackend;
 			this.checkpointStreamFactory = checkpointStreamFactory;
 			this.keyGroupRangeOffsets = new KeyGroupRangeOffsets(stateBackend.keyGroupRange);
 			this.snapshotCloseableRegistry = registry;
+			this.dbLease = this.stateBackend.rocksDBResourceGuard.acquireResource();
 		}
 
 		/**
@@ -575,11 +557,11 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 		}
 
 		/**
-		 * 4) Close the CheckpointStateOutputStream after writing and receive a state handle.
+		 * 4) Returns a state handle to the snapshot after the snapshot procedure is completed and null before.
 		 *
-		 * @throws IOException
+		 * @return state handle to the completed snapshot
 		 */
-		public void createSnapshotResultStateHandleFromOutputStream() throws IOException {
+		public KeyGroupsStateHandle getSnapshotResultStateHandle() throws IOException {
 
 			if (snapshotCloseableRegistry.unregisterCloseable(outStream)) {
 
@@ -587,9 +569,10 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 				outStream = null;
 
 				if (stateHandle != null) {
-					this.snapshotResultStateHandle = new KeyGroupsStateHandle(keyGroupRangeOffsets, stateHandle);
+					return new KeyGroupsStateHandle(keyGroupRangeOffsets, stateHandle);
 				}
 			}
+			return null;
 		}
 
 		/**
@@ -618,38 +601,8 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 				IOUtils.closeQuietly(readOptions);
 				readOptions = null;
 			}
-		}
 
-		/**
-		 * Drop the created snapshot if we have ben cancelled.
-		 */
-		public void dropSnapshotResult() {
-			if (null != snapshotResultStateHandle) {
-				try {
-					snapshotResultStateHandle.discardState();
-				} catch (Exception e) {
-					LOG.warn("Exception occurred during snapshot state handle cleanup.", e);
-				}
-			}
-		}
-
-		/**
-		 * Returns the current CheckpointStateOutputStream (when it was opened and not yet closed) into which we write
-		 * the state snapshot.
-		 *
-		 * @return the current CheckpointStateOutputStream
-		 */
-		public CheckpointStreamFactory.CheckpointStateOutputStream getOutStream() {
-			return outStream;
-		}
-
-		/**
-		 * Returns a state handle to the snapshot after the snapshot procedure is completed and null before.
-		 *
-		 * @return state handle to the completed snapshot
-		 */
-		public KeyGroupsStateHandle getSnapshotResultStateHandle() {
-			return snapshotResultStateHandle;
+			this.dbLease.close();
 		}
 
 		private void writeKVStateMetaData() throws IOException {
@@ -827,18 +780,22 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 		// handles to the misc files in the current snapshot
 		private final Map<StateHandleID, StreamStateHandle> miscFiles = new HashMap<>();
 
+		// This lease protects from concurrent disposal of the native rocksdb instance.
+		private final ResourceGuard.Lease dbLease;
+
 		private StreamStateHandle metaStateHandle = null;
 
 		private RocksDBIncrementalSnapshotOperation(
 			RocksDBKeyedStateBackend<K> stateBackend,
 			CheckpointStreamFactory checkpointStreamFactory,
 			long checkpointId,
-			long checkpointTimestamp) {
+			long checkpointTimestamp) throws IOException {
 
 			this.stateBackend = stateBackend;
 			this.checkpointStreamFactory = checkpointStreamFactory;
 			this.checkpointId = checkpointId;
 			this.checkpointTimestamp = checkpointTimestamp;
+			this.dbLease = this.stateBackend.rocksDBResourceGuard.acquireResource();
 		}
 
 		private StreamStateHandle materializeStateData(Path filePath) throws Exception {
@@ -919,7 +876,6 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 		}
 
 		void takeSnapshot() throws Exception {
-			assert (Thread.holdsLock(stateBackend.asyncSnapshotLock));
 
 			final long lastCompletedCheckpoint;
 
@@ -940,6 +896,9 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 
 			// save state data
 			backupPath = new Path(stateBackend.instanceBasePath.getAbsolutePath(), "chk-" + checkpointId);
+
+			LOG.trace("Local RocksDB checkpoint goes to backup path {}.", backupPath);
+
 			backupFileSystem = backupPath.getFileSystem();
 			if (backupFileSystem.exists(backupPath)) {
 				throw new IllegalStateException("Unexpected existence of the backup directory.");
@@ -1013,6 +972,8 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 
 		void releaseResources(boolean canceled) {
 
+			dbLease.close();
+
 			if (stateBackend.cancelStreamRegistry.unregisterCloseable(closeableRegistry)) {
 				try {
 					closeableRegistry.close();
@@ -1024,6 +985,8 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 			if (backupPath != null) {
 				try {
 					if (backupFileSystem.exists(backupPath)) {
+
+						LOG.trace("Deleting local RocksDB backup path {}.", backupPath);
 						backupFileSystem.delete(backupPath, true);
 					}
 				} catch (Exception e) {

--- a/flink-core/src/main/java/org/apache/flink/util/ResourceGuard.java
+++ b/flink-core/src/main/java/org/apache/flink/util/ResourceGuard.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.util;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * This class is a guard for shared resources with the following invariants. The resource can be acquired by multiple
+ * clients in parallel through the {@link #acquireResource()} call. As a result of the call, each client gets a
+ * {@link Lease}. The {@link #close()} method of the lease releases the resources and reduces the client count in
+ * the {@link ResourceGuard} object.
+ * The protected resource should only be disposed once the corresponding resource guard is successfully closed, but
+ * the guard can only be closed once all clients that acquired a lease for the guarded resource have released it.
+ * Before this is happened, the call to {@link #close()} will block until the zero-open-leases condition is triggered.
+ * After the resource guard is closed, calls to {@link #acquireResource()} will fail with exception. Notice that,
+ * obviously clients are responsible to release the resource after usage. All clients are considered equal, i.e. there
+ * is only a global count maintained how many times the resource was acquired but not by whom.
+ */
+public class ResourceGuard implements AutoCloseable, Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * The object that serves as lock for count and the closed-flag.
+	 */
+	private final SerializableObject lock;
+
+	/**
+	 * Number of clients that have ongoing access to the resource.
+	 */
+	private volatile int leaseCount;
+
+	/**
+	 * This flag indicated if it is still possible to acquire access to the resource.
+	 */
+	private volatile boolean closed;
+
+	public ResourceGuard() {
+		this.lock = new SerializableObject();
+		this.leaseCount = 0;
+		this.closed = false;
+	}
+
+	/**
+	 * Acquired access from one new client for the guarded resource.
+	 *
+	 * @throws IOException when the resource guard is already closed.
+	 */
+	public Lease acquireResource() throws IOException {
+
+		synchronized (lock) {
+
+			if (closed) {
+				throw new IOException("Resource guard was already closed.");
+			}
+
+			++leaseCount;
+		}
+
+		return new Lease();
+	}
+
+	/**
+	 * Releases access for one client of the guarded resource. This method must only be called after a matching call to
+	 * {@link #acquireResource()}.
+	 */
+	private void releaseResource() {
+
+		synchronized (lock) {
+
+			--leaseCount;
+
+			if (closed && leaseCount == 0) {
+				lock.notifyAll();
+			}
+		}
+	}
+
+	/**
+	 * Closed the resource guard. This method will block until all calls to {@link #acquireResource()} have seen their
+	 * matching call to {@link #releaseResource()}.
+	 */
+	@Override
+	public void close() {
+
+		synchronized (lock) {
+
+			closed = true;
+
+			while (leaseCount > 0) {
+
+				try {
+					lock.wait();
+				} catch (InterruptedException ignore) {
+					// Even on interruption, we cannot terminate the loop until all open leases are closed.
+				}
+			}
+		}
+	}
+
+	/**
+	 * Returns true if the resource guard is closed, i.e. after {@link #close()} was called.
+	 */
+	public boolean isClosed() {
+		return closed;
+	}
+
+	/**
+	 * Returns the current count of open leases.
+	 */
+	public int getLeaseCount() {
+		return leaseCount;
+	}
+
+	/**
+	 * A lease is issued by the {@link ResourceGuard} as result of calls to {@link #acquireResource()}. The owner of the
+	 * lease can release it via the {@link #close()} call.
+	 */
+	public class Lease implements AutoCloseable {
+
+		private final AtomicBoolean closed;
+
+		private Lease() {
+			this.closed = new AtomicBoolean(false);
+		}
+
+		@Override
+		public void close() {
+			if (closed.compareAndSet(false, true)) {
+				releaseResource();
+			}
+		}
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/util/SerializableObject.java
+++ b/flink-core/src/main/java/org/apache/flink/util/SerializableObject.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.util;
+package org.apache.flink.util;
 
 /**
  * A simple object that only implements {@link java.io.Serializable}, so it can be used

--- a/flink-core/src/test/java/org/apache/flink/util/ResourceGuardTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/ResourceGuardTest.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class ResourceGuardTest {
+
+	@Test
+	public void testClose() {
+		ResourceGuard resourceGuard = new ResourceGuard();
+		Assert.assertFalse(resourceGuard.isClosed());
+		resourceGuard.close();
+		Assert.assertTrue(resourceGuard.isClosed());
+		try {
+			resourceGuard.acquireResource();
+			Assert.fail();
+		} catch (IOException ignore) {
+		}
+	}
+
+	@Test
+	public void testAcquireReleaseClose() throws IOException {
+		ResourceGuard resourceGuard = new ResourceGuard();
+		ResourceGuard.Lease lease = resourceGuard.acquireResource();
+		Assert.assertEquals(1, resourceGuard.getLeaseCount());
+		lease.close();
+		Assert.assertEquals(0, resourceGuard.getLeaseCount());
+		resourceGuard.close();
+		Assert.assertTrue(resourceGuard.isClosed());
+	}
+
+	@Test
+	public void testCloseBlockIfAcquired() throws Exception {
+		ResourceGuard resourceGuard = new ResourceGuard();
+		ResourceGuard.Lease lease_1 = resourceGuard.acquireResource();
+		AtomicBoolean checker = new AtomicBoolean(true);
+
+		Thread closerThread = new Thread() {
+			@Override
+			public void run() {
+				try {
+					// this line should block until all acquires are matched by releases.
+					resourceGuard.close();
+					checker.set(false);
+				} catch (Exception ignore) {
+					checker.set(false);
+				}
+			}
+		};
+
+		closerThread.start();
+
+		ResourceGuard.Lease lease_2 = resourceGuard.acquireResource();
+		lease_2.close();
+		Assert.assertTrue(checker.get());
+
+		// this matches the first acquire and will unblock the close.
+		lease_1.close();
+		closerThread.join(60_000);
+		Assert.assertFalse(checker.get());
+	}
+
+	@Test
+	public void testInterruptHandledCorrectly() throws Exception {
+		ResourceGuard resourceGuard = new ResourceGuard();
+		ResourceGuard.Lease lease = resourceGuard.acquireResource();
+		AtomicBoolean checker = new AtomicBoolean(true);
+
+		Thread closerThread = new Thread() {
+			@Override
+			public void run() {
+				try {
+					// this line should block until all acquires are matched by releases.
+					resourceGuard.close();
+					checker.set(false);
+				} catch (Exception ignore) {
+					checker.set(false);
+				}
+			}
+		};
+
+		closerThread.start();
+		closerThread.interrupt();
+
+		Assert.assertTrue(checker.get());
+
+		lease.close();
+		closerThread.join(60_000);
+		Assert.assertFalse(checker.get());
+	}
+
+	@Test
+	public void testLeaseCloseIsIdempotent() throws Exception {
+		ResourceGuard resourceGuard = new ResourceGuard();
+		ResourceGuard.Lease lease_1 = resourceGuard.acquireResource();
+		ResourceGuard.Lease lease_2 = resourceGuard.acquireResource();
+		Assert.assertEquals(2, resourceGuard.getLeaseCount());
+		lease_1.close();
+		Assert.assertEquals(1, resourceGuard.getLeaseCount());
+		lease_1.close();
+		Assert.assertEquals(1, resourceGuard.getLeaseCount());
+		lease_2.close();
+		Assert.assertEquals(0, resourceGuard.getLeaseCount());
+		ResourceGuard.Lease lease_3 = resourceGuard.acquireResource();
+		Assert.assertEquals(1, resourceGuard.getLeaseCount());
+		lease_2.close();
+		Assert.assertEquals(1, resourceGuard.getLeaseCount());
+		lease_3.close();
+		Assert.assertEquals(0, resourceGuard.getLeaseCount());
+		resourceGuard.close();
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackend.java
@@ -233,19 +233,25 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 
 				@Override
 				protected void acquireResources() throws Exception {
-					out = streamFactory.createCheckpointStateOutputStream(checkpointId, timestamp);
-					closeStreamOnCancelRegistry.registerCloseable(out);
+					openOutStream();
 				}
 
 				@Override
 				protected void releaseResources() throws Exception {
-					if (closeStreamOnCancelRegistry.unregisterCloseable(out)) {
-						IOUtils.closeQuietly(out);
-					}
+					closeOutStream();
 				}
 
 				@Override
 				protected void stopOperation() throws Exception {
+					closeOutStream();
+				}
+
+				private void openOutStream() throws Exception {
+					out = streamFactory.createCheckpointStateOutputStream(checkpointId, timestamp);
+					closeStreamOnCancelRegistry.registerCloseable(out);
+				}
+
+				private void closeOutStream() {
 					if (closeStreamOnCancelRegistry.unregisterCloseable(out)) {
 						IOUtils.closeQuietly(out);
 					}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStateRestoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStateRestoreTest.java
@@ -33,7 +33,7 @@ import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.runtime.state.SharedStateRegistry;
-import org.apache.flink.runtime.util.SerializableObject;
+import org.apache.flink.util.SerializableObject;
 
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/SocketClientSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/SocketClientSink.java
@@ -19,8 +19,8 @@ package org.apache.flink.streaming.api.functions.sink;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.runtime.util.SerializableObject;
 import org.apache.flink.streaming.util.serialization.SerializationSchema;
+import org.apache.flink.util.SerializableObject;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;


### PR DESCRIPTION
…dStateBackend to reduce locking and avoid blocking behavior.

## What is the purpose of the change

`RocksDBKeyedStateBackend` uses a lock to guard the db instance against disposal of the native resources while some parallel threads might still access db, which might otherwise lead to segfaults.

Unfortunately, this locking is a bit to strict and can lead to situations where snapshots block the pipeline. This can happen when a snapshot s1 is running and somewhere blocking in IO while holding the guarding lock. A second snapshot s2 can be triggered in parallel and requires to hold the lock in the synchronous part to get a snapshot from db. As s1 is still holding on to the lock, s2 can block here and stop the operator from processing further elements.
A simple solution could remove lock acquisition from the synchronous phase, because both, synchronous phase and disposing the backend are only allowed to be triggered from the thread that also drives element processing.

This PR removes long sections under the lock all together, to open up the possibility of parallel checkpointing. The change introduces a guard for the rocksdb instance that blocks disposal for as long as there are still clients potentially accessing the instance in parallel. This is realized by keeping a synchronized counter for active clients and block disposal until the client count drops to zero.

This approach could also be integrated with triggering timers, which have always been problematic in the disposal phase are currently unregulated. In the new model, they could register as yet another client.


## Brief change log

  - *Introduce a class `ResourceGuard` as client counter*
  - *Replaced use of `asyncSnapshotLock` with the guard*

## Verifying this change

This change is mostly covered by existing tests.

I added unit test `ResourceGuardTest` and `StateBackendTestBase::testParallelAsyncSnapshots` to ensure that parallel snapshots work.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)

## Documentation

  - Does this pull request introduce a new feature? (no)

