### PR TITLE
[FLINK-7752] [flip-6] RedirectHandler should execute on the IO thread

### DIFF
--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/RedirectHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/RedirectHandlerTest.java
@@ -148,6 +148,7 @@ public class RedirectHandlerTest extends TestLogger {
 
 		@Override
 		protected void respondAsLeader(ChannelHandlerContext channelHandlerContext, Routed routed, RestfulGateway gateway) throws Exception {
+			Assert.assertTrue(channelHandlerContext.channel().eventLoop().inEventLoop());
 			HttpResponse response = HandlerRedirectUtils.getResponse(HttpResponseStatus.OK, RESPONSE_MESSAGE);
 			KeepAliveWrite.flush(channelHandlerContext.channel(), routed.request(), response);
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/RedirectHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/RedirectHandler.java
@@ -109,7 +109,7 @@ public abstract class RedirectHandler<T extends RestfulGateway> extends SimpleCh
 						// retain the message for the asynchronous handler
 						ReferenceCountUtil.retain(routed);
 
-						optRedirectAddressFuture.whenComplete(
+						optRedirectAddressFuture.whenCompleteAsync(
 							(Optional<String> optRedirectAddress, Throwable throwable) -> {
 								HttpResponse response;
 								try {
@@ -144,7 +144,7 @@ public abstract class RedirectHandler<T extends RestfulGateway> extends SimpleCh
 									ReferenceCountUtil.release(routed);
 								}
 							}
-						);
+						, channelHandlerContext.executor());
 					}
 				).ifNotPresent(
 					() ->


### PR DESCRIPTION
## What is the purpose of the change
Improves the determinism of REST handlers by running the response method (`respondAsLeader`) on the I/O thread rather than (potentially) on a thread from the gateway retriever's executor.

## Brief change log
- in `RedirectHandler`, upon obtaining the gateway address, run the completion logic using the channel executor.

## Verifying this change

This change added tests and can be verified as follows:
- updated `RedirectHandlerTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive):no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no

## Documentation

  - Does this pull request introduce a new feature? no


