### PR TITLE
[FLINK-7738] [flip-6] Create WebSocket handler (server, client)

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
@@ -21,14 +21,19 @@ package org.apache.flink.runtime.rest;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.runtime.rest.handler.PipelineErrorHandler;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
 import org.apache.flink.runtime.rest.messages.ErrorResponseBody;
 import org.apache.flink.runtime.rest.messages.MessageHeaders;
 import org.apache.flink.runtime.rest.messages.MessageParameters;
 import org.apache.flink.runtime.rest.messages.RequestBody;
 import org.apache.flink.runtime.rest.messages.ResponseBody;
+import org.apache.flink.runtime.rest.messages.WebSocketUpgradeResponseBody;
 import org.apache.flink.runtime.rest.util.RestClientException;
 import org.apache.flink.runtime.rest.util.RestConstants;
 import org.apache.flink.runtime.rest.util.RestMapperUtils;
+import org.apache.flink.runtime.rest.websocket.WebSocket;
+import org.apache.flink.runtime.rest.websocket.WebSocketHandlerUtils;
+import org.apache.flink.runtime.rest.websocket.WebSocketListener;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.Preconditions;
 
@@ -36,6 +41,7 @@ import org.apache.flink.shaded.netty4.io.netty.bootstrap.Bootstrap;
 import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
 import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBufInputStream;
 import org.apache.flink.shaded.netty4.io.netty.buffer.Unpooled;
+import org.apache.flink.shaded.netty4.io.netty.channel.Channel;
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelFuture;
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelHandlerContext;
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelInitializer;
@@ -43,7 +49,9 @@ import org.apache.flink.shaded.netty4.io.netty.channel.SimpleChannelInboundHandl
 import org.apache.flink.shaded.netty4.io.netty.channel.nio.NioEventLoopGroup;
 import org.apache.flink.shaded.netty4.io.netty.channel.socket.SocketChannel;
 import org.apache.flink.shaded.netty4.io.netty.channel.socket.nio.NioSocketChannel;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.EncoderException;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.DefaultFullHttpRequest;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.DefaultHttpHeaders;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.FullHttpRequest;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.FullHttpResponse;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpClientCodec;
@@ -52,7 +60,11 @@ import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpObjectAggr
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponse;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpVersion;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.websocketx.WebSocketClientProtocolHandler;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.websocketx.WebSocketVersion;
 import org.apache.flink.shaded.netty4.io.netty.handler.ssl.SslHandler;
+import org.apache.flink.shaded.netty4.io.netty.util.ReferenceCountUtil;
 import org.apache.flink.shaded.netty4.io.netty.util.concurrent.DefaultThreadFactory;
 
 import com.fasterxml.jackson.core.JsonParseException;
@@ -67,7 +79,11 @@ import javax.net.ssl.SSLEngine;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
@@ -79,38 +95,23 @@ public class RestClient {
 
 	private static final ObjectMapper objectMapper = RestMapperUtils.getStrictObjectMapper();
 
+	private final RestClientConfiguration configuration;
+
 	// used to open connections to a rest server endpoint
 	private final Executor executor;
 
 	private Bootstrap bootstrap;
 
 	public RestClient(RestClientConfiguration configuration, Executor executor) {
-		Preconditions.checkNotNull(configuration);
+		this.configuration = Preconditions.checkNotNull(configuration);
 		this.executor = Preconditions.checkNotNull(executor);
 
-		SSLEngine sslEngine = configuration.getSslEngine();
-		ChannelInitializer<SocketChannel> initializer = new ChannelInitializer<SocketChannel>() {
-			@Override
-			protected void initChannel(SocketChannel socketChannel) throws Exception {
-				// SSL should be the first handler in the pipeline
-				if (sslEngine != null) {
-					socketChannel.pipeline().addLast("ssl", new SslHandler(sslEngine));
-				}
-
-				socketChannel.pipeline()
-					.addLast(new HttpClientCodec())
-					.addLast(new HttpObjectAggregator(1024 * 1024))
-					.addLast(new ClientHandler())
-					.addLast(new PipelineErrorHandler(LOG));
-			}
-		};
 		NioEventLoopGroup group = new NioEventLoopGroup(1, new DefaultThreadFactory("flink-rest-client-netty"));
 
 		bootstrap = new Bootstrap();
 		bootstrap
 			.group(group)
-			.channel(NioSocketChannel.class)
-			.handler(initializer);
+			.channel(NioSocketChannel.class);
 
 		LOG.info("Rest client endpoint started.");
 	}
@@ -161,7 +162,17 @@ public class RestClient {
 	}
 
 	private <P extends ResponseBody> CompletableFuture<P> submitRequest(String targetAddress, int targetPort, FullHttpRequest httpRequest, Class<P> responseClass) {
-		return CompletableFuture.supplyAsync(() -> bootstrap.connect(targetAddress, targetPort), executor)
+		Bootstrap bootstrap1 = bootstrap.clone().handler(new ClientBootstrap() {
+			@Override
+			protected void initChannel(SocketChannel channel) throws Exception {
+				super.initChannel(channel);
+				channel.pipeline()
+					.addLast(new ClientHandler())
+					.addLast(new PipelineErrorHandler(LOG));
+			}
+		});
+
+		return CompletableFuture.supplyAsync(() -> bootstrap1.connect(targetAddress, targetPort), executor)
 			.thenApply((channel) -> {
 				try {
 					return channel.sync();
@@ -205,6 +216,21 @@ public class RestClient {
 			}
 		}
 		return responseFuture;
+	}
+
+	private class ClientBootstrap extends ChannelInitializer<SocketChannel> {
+		@Override
+		protected void initChannel(SocketChannel channel) throws Exception {
+			SSLEngine sslEngine = configuration.getSslEngine();
+
+			// SSL should be the first handler in the pipeline
+			if (sslEngine != null) {
+				channel.pipeline().addLast("ssl", new SslHandler(sslEngine));
+			}
+			channel.pipeline()
+				.addLast(new HttpClientCodec())
+				.addLast(new HttpObjectAggregator(1024 * 1024));
+		}
 	}
 
 	private static class ClientHandler extends SimpleChannelInboundHandler<Object> {
@@ -273,6 +299,123 @@ public class RestClient {
 
 		public HttpResponseStatus getHttpResponseStatus() {
 			return httpResponseStatus;
+		}
+	}
+
+	public <M extends MessageHeaders<EmptyRequestBody, WebSocketUpgradeResponseBody, U>, U extends MessageParameters, R extends ResponseBody> CompletableFuture<WebSocket> sendWebSocketRequest(String targetAddress, int targetPort, M messageHeaders, U messageParameters, Class<R> messageClazz, WebSocketListener... listeners) throws IOException {
+		Preconditions.checkNotNull(targetAddress);
+		Preconditions.checkArgument(0 <= targetPort && targetPort < 65536, "The target port " + targetPort + " is not in the range (0, 65536].");
+		Preconditions.checkNotNull(messageHeaders);
+		Preconditions.checkNotNull(messageParameters);
+		Preconditions.checkState(messageParameters.isResolved(), "Message parameters were not resolved.");
+
+		String targetUrl = MessageParameters.resolveUrl(messageHeaders.getTargetRestEndpointURL(), messageParameters);
+		URI webSocketURL = URI.create("ws://" + targetAddress + ":" + targetPort).resolve(targetUrl);
+		LOG.debug("Sending WebSocket request to {}", webSocketURL);
+
+		final HttpHeaders headers = new DefaultHttpHeaders()
+			.add(HttpHeaders.Names.CONTENT_TYPE, RestConstants.REST_CONTENT_TYPE);
+
+		Bootstrap bootstrap1 = bootstrap.clone().handler(new ClientBootstrap() {
+			@Override
+			protected void initChannel(SocketChannel channel) throws Exception {
+				super.initChannel(channel);
+				channel.pipeline()
+					.addLast(new WebSocketClientProtocolHandler(webSocketURL, WebSocketVersion.V13, null, false, headers, 65535))
+					.addLast(new WsResponseHandler(channel, messageClazz, listeners));
+			}
+		});
+
+		return CompletableFuture.supplyAsync(() -> bootstrap1.connect(targetAddress, targetPort), executor)
+			.thenApply((channel) -> {
+				try {
+					return channel.sync();
+				} catch (InterruptedException e) {
+					throw new FlinkRuntimeException(e);
+				}
+			})
+			.thenApply((ChannelFuture::channel))
+			.thenCompose(channel -> {
+				WsResponseHandler handler = channel.pipeline().get(WsResponseHandler.class);
+				return handler.getWebSocketFuture();
+			});
+	}
+
+	private static class WsResponseHandler extends SimpleChannelInboundHandler<Object> implements WebSocket {
+
+		private final Channel channel;
+		private final Class<? extends ResponseBody> messageClazz;
+		private final List<WebSocketListener> listeners = new CopyOnWriteArrayList<>();
+
+		private final CompletableFuture<WebSocket> webSocketFuture = new CompletableFuture<>();
+
+		CompletableFuture<WebSocket> getWebSocketFuture() {
+			return webSocketFuture;
+		}
+
+		public WsResponseHandler(Channel channel, Class<? extends ResponseBody> messageClazz, WebSocketListener[] listeners) {
+			this.channel = channel;
+			this.messageClazz = messageClazz;
+			this.listeners.addAll(Arrays.asList(listeners));
+		}
+
+		@Override
+		public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+			LOG.warn("WebSocket exception", cause);
+			webSocketFuture.completeExceptionally(cause);
+		}
+
+		@Override
+		public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+			if (evt instanceof WebSocketClientProtocolHandler.ClientHandshakeStateEvent) {
+				WebSocketClientProtocolHandler.ClientHandshakeStateEvent wsevt = (WebSocketClientProtocolHandler.ClientHandshakeStateEvent) evt;
+				switch(wsevt) {
+					case HANDSHAKE_ISSUED:
+						LOG.debug("WebSocket handshake initiated");
+						break;
+					case HANDSHAKE_COMPLETE:
+						LOG.debug("WebSocket handshake completed");
+						webSocketFuture.complete(this);
+						break;
+				}
+			}
+			else {
+				super.userEventTriggered(ctx, evt);
+			}
+		}
+
+		@Override
+		protected void channelRead0(ChannelHandlerContext channelHandlerContext, Object o) throws Exception {
+			if (o instanceof TextWebSocketFrame) {
+				ResponseBody message = WebSocketHandlerUtils.decodeMessage((TextWebSocketFrame) o, messageClazz);
+				for (WebSocketListener listener : listeners) {
+					listener.onEvent(message);
+				}
+			}
+		}
+
+		@Override
+		public void addListener(WebSocketListener listener) {
+			listeners.add(listener);
+		}
+
+		@Override
+		public ChannelFuture send(ResponseBody message) {
+			try {
+				TextWebSocketFrame frame = WebSocketHandlerUtils.encodeMessage(message);
+				return channel.writeAndFlush(frame);
+			}
+			catch (IOException e) {
+				throw new EncoderException(e);
+			}
+			finally {
+				ReferenceCountUtil.release(message);
+			}
+		}
+
+		@Override
+		public ChannelFuture close() {
+			return channel.close();
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/AbstractRestHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/AbstractRestHandler.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.rest.messages.MessageHeaders;
 import org.apache.flink.runtime.rest.messages.MessageParameters;
 import org.apache.flink.runtime.rest.messages.RequestBody;
 import org.apache.flink.runtime.rest.messages.ResponseBody;
+import org.apache.flink.runtime.rest.messages.WebSocketUpgradeResponseBody;
 import org.apache.flink.runtime.rest.util.RestMapperUtils;
 import org.apache.flink.runtime.webmonitor.RestfulGateway;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
@@ -39,6 +40,8 @@ import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.FullHttpReques
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpRequest;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.router.Routed;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler;
+import org.apache.flink.shaded.netty4.io.netty.util.ReferenceCountUtil;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -157,13 +160,34 @@ public abstract class AbstractRestHandler<T extends RestfulGateway, R extends Re
 						HandlerUtils.sendErrorResponse(ctx, httpRequest, new ErrorResponseBody("Internal server error."), HttpResponseStatus.INTERNAL_SERVER_ERROR);
 					}
 				} else {
-					HandlerUtils.sendResponse(ctx, httpRequest, resp, messageHeaders.getResponseStatusCode());
+					if (resp instanceof WebSocketUpgradeResponseBody) {
+						upgradeToWebSocket(ctx, routed, (WebSocketUpgradeResponseBody) resp);
+					}
+					else {
+						HandlerUtils.sendResponse(ctx, httpRequest, resp, messageHeaders.getResponseStatusCode());
+					}
 				}
 			});
 		} catch (Throwable e) {
 			log.error("Request processing failed.", e);
 			HandlerUtils.sendErrorResponse(ctx, httpRequest, new ErrorResponseBody("Internal server error."), HttpResponseStatus.INTERNAL_SERVER_ERROR);
 		}
+	}
+
+	private void upgradeToWebSocket(final ChannelHandlerContext ctx, Routed routed, WebSocketUpgradeResponseBody upgrade) {
+		// inject the websocket protocol handler into this channel, to be active
+		// until the channel is closed.  note that the handshake may or may not complete synchronously.
+		ctx.pipeline().addAfter(ctx.name(), WebSocketServerProtocolHandler.class.getName(),
+			new WebSocketServerProtocolHandler(routed.path()));
+
+		// inject the message handler
+		ChannelHandler messageHandler = upgrade.getChannelHandler();
+		ctx.pipeline().addAfter(WebSocketServerProtocolHandler.class.getName(), messageHandler.getClass().getName(), messageHandler);
+
+		// forward the message to the installed protocol handler to initiate handshaking
+		HttpRequest request = routed.request();
+		ReferenceCountUtil.retain(request);
+		ctx.fireChannelRead(request);
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/AbstractWebSocketMessageHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/AbstractWebSocketMessageHandler.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler;
+
+import org.apache.flink.runtime.rest.messages.ResponseBody;
+import org.apache.flink.runtime.rest.websocket.KeyedChannelRouter;
+import org.apache.flink.runtime.rest.websocket.WebSocketHandlerUtils;
+
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelDuplexHandler;
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelHandlerContext;
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelPromise;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler.ServerHandshakeStateEvent;
+import org.apache.flink.shaded.netty4.io.netty.util.ReferenceCountUtil;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Super class for netty-based websocket message handlers.
+ *
+ * <p>A message handler subclass is registered into the channel pipeline by
+ * the {@link AbstractRestHandler} following a websocket handshake request.
+ * Once registered, the message handler typically reacts to handshake success by:
+ *  - initiating an application-level interaction with the client
+ *  - registering the channel with a {@link KeyedChannelRouter}
+ */
+public abstract class AbstractWebSocketMessageHandler extends ChannelDuplexHandler {
+
+	protected final Logger log = LoggerFactory.getLogger(getClass());
+
+	@Override
+	public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+		if (evt instanceof ServerHandshakeStateEvent) {
+			ServerHandshakeStateEvent handshakeEvent = (ServerHandshakeStateEvent) evt;
+			if (handshakeEvent == ServerHandshakeStateEvent.HANDSHAKE_COMPLETE) {
+				log.debug("Handshake completed for channel {}.", ctx.channel().remoteAddress());
+				handshakeComplete(ctx);
+			}
+		}
+
+		super.userEventTriggered(ctx, evt);
+	}
+
+	protected abstract void handshakeComplete(ChannelHandlerContext ctx) throws Exception;
+
+	@Override
+	public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+		if (msg instanceof ResponseBody) {
+			// write the message as a websocket text frame
+			WebSocketHandlerUtils.sendMessage(ctx, (ResponseBody) msg);
+			ReferenceCountUtil.release(msg);
+		}
+		else {
+			super.write(ctx, msg, promise);
+		}
+	}
+
+	@Override
+	public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+		log.error("WebSocket channel error; closing the channel.", cause);
+		ctx.close();
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/WebSocketUpgradeResponseBody.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/WebSocketUpgradeResponseBody.java
@@ -18,15 +18,29 @@
 
 package org.apache.flink.runtime.rest.messages;
 
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelHandler;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
 /**
- * Marker interface for all responses of the REST API. This class represents the body of an HTTP response or WebSocket message.
+ * Special {@link ResponseBody} implementation for a WebSocket upgrade response.
  *
- * <p>Subclass instances are converted to JSON using jackson-databind. Subclasses must have a constructor that accepts
- * all fields of the JSON response, that should be annotated with {@code @JsonCreator}.
- *
- * <p>All fields that should part of the JSON response must be accessible either by being public or having a getter.
- *
- * <p>When adding methods that are prefixed with {@code get} make sure to annotate them with {@code @JsonIgnore}.
+ * <p>This response type is not actually sent to the client, rather it triggers an
+ * actual WebSocket handshake response, and then registers the contained channel handler
+ * for subsequent message processing.
  */
-public interface ResponseBody {
+public class WebSocketUpgradeResponseBody implements ResponseBody {
+
+	private final ChannelHandler channelHandler;
+
+	public WebSocketUpgradeResponseBody(ChannelHandler channelHandler) {
+		this.channelHandler = checkNotNull(channelHandler);
+	}
+
+	@JsonIgnore
+	public ChannelHandler getChannelHandler() {
+		return channelHandler;
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/websocket/KeyedChannelRouter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/websocket/KeyedChannelRouter.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.websocket;
+
+import org.apache.flink.shaded.netty4.io.netty.channel.Channel;
+import org.apache.flink.shaded.netty4.io.netty.channel.group.ChannelGroup;
+import org.apache.flink.shaded.netty4.io.netty.channel.group.ChannelGroupFuture;
+import org.apache.flink.shaded.netty4.io.netty.util.AttributeKey;
+
+import javax.annotation.Nonnull;
+
+import java.util.Objects;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Routes messages to channels based on a routing key.
+ * @param <K> the key type.
+ */
+public class KeyedChannelRouter<K> {
+
+	private final AttributeKey<K> attributeKey;
+
+	private final ChannelGroup channels;
+
+	public KeyedChannelRouter(AttributeKey<K> attributeKey, ChannelGroup channelGroup) {
+		this.attributeKey = checkNotNull(attributeKey);
+		this.channels = checkNotNull(channelGroup);
+	}
+
+	/**
+	 * Registers a channel to receive messages for a given routing key.
+	 *
+	 * @param channel the channel to register.
+	 */
+	public void register(@Nonnull Channel channel, @Nonnull K routingKey) {
+		channel.attr(attributeKey).set(routingKey);
+		channels.add(channel);
+	}
+
+	/**
+	 * Unregisters a channel.
+	 *
+	 * @param channel the channel to unregister.
+	 */
+	public void unregister(@Nonnull Channel channel) {
+		channels.remove(channel);
+	}
+
+	/**
+	 * Writes and flushes an object to select channels based on a routing key.
+	 *
+	 * @param routingKey the key to select the target channel(s).
+	 * @param o the object to write and flush.
+	 */
+	public ChannelGroupFuture write(@Nonnull K routingKey, @Nonnull Object o) {
+		return channels.write(o, channel -> isMatch(channel, routingKey));
+	}
+
+	/**
+	 * Writes and flushes an object to select channels based on a routing key.
+	 *
+	 * @param routingKey the key to select the target channel(s).
+	 * @param o the object to write and flush.
+	 */
+	public ChannelGroupFuture writeAndFlush(@Nonnull K routingKey, @Nonnull Object o) {
+		return channels.writeAndFlush(o, channel -> isMatch(channel, routingKey));
+	}
+
+	/**
+	 * Closes all channels associated with the given routing key.
+	 */
+	public ChannelGroupFuture close(@Nonnull K routingKey) {
+		return channels.close(channel -> isMatch(channel, routingKey));
+	}
+
+	private boolean isMatch(Channel channel, K routingKey) {
+		return Objects.equals(routingKey, channel.attr(attributeKey).get());
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/websocket/WebSocket.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/websocket/WebSocket.java
@@ -16,17 +16,29 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.rest.messages;
+package org.apache.flink.runtime.rest.websocket;
+
+import org.apache.flink.runtime.rest.messages.ResponseBody;
+
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelFuture;
 
 /**
- * Marker interface for all responses of the REST API. This class represents the body of an HTTP response or WebSocket message.
- *
- * <p>Subclass instances are converted to JSON using jackson-databind. Subclasses must have a constructor that accepts
- * all fields of the JSON response, that should be annotated with {@code @JsonCreator}.
- *
- * <p>All fields that should part of the JSON response must be accessible either by being public or having a getter.
- *
- * <p>When adding methods that are prefixed with {@code get} make sure to annotate them with {@code @JsonIgnore}.
+ * A WebSocket for sending and receiving messages.
  */
-public interface ResponseBody {
+public interface WebSocket {
+
+	/**
+	 * Adds a listener for websocket messages.
+	 */
+	void addListener(WebSocketListener listener);
+
+	/**
+	 * Sends a message.
+	 */
+	ChannelFuture send(ResponseBody message);
+
+	/**
+	 * Closes the websocket.
+	 */
+	ChannelFuture close();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/websocket/WebSocketHandlerUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/websocket/WebSocketHandlerUtils.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.websocket;
+
+import org.apache.flink.runtime.rest.messages.ErrorResponseBody;
+import org.apache.flink.runtime.rest.messages.ResponseBody;
+import org.apache.flink.runtime.rest.util.RestMapperUtils;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelFuture;
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelFutureListener;
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelHandlerContext;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.io.StringWriter;
+
+/**
+ * Utilities for WebSocket handlers.
+ */
+public class WebSocketHandlerUtils {
+	private static final ObjectMapper mapper = RestMapperUtils.getStrictObjectMapper();
+
+	/**
+	 * Sends the websocket response to the given channel.
+	 *
+	 * @param channelHandlerContext identifying the open channel
+	 * @param response which should be sent
+	 * @param <P> type of the response
+	 */
+	public static <P extends ResponseBody> void sendMessage(
+		ChannelHandlerContext channelHandlerContext,
+		P response) {
+
+		StringWriter sw = new StringWriter();
+		try {
+			mapper.writeValue(sw, response);
+		} catch (IOException ioe) {
+			sendErrorMessage(channelHandlerContext, new ErrorResponseBody("Internal server error. Could not map response to JSON."));
+			return;
+		}
+		sendMessageInternal(channelHandlerContext, sw.toString()).addListener(ChannelFutureListener.CLOSE_ON_FAILURE);
+	}
+
+	/**
+	 * Sends the websocket error message to the given channel.
+	 *
+	 * @param channelHandlerContext identifying the open channel
+	 * @param errorMessage which should be sent
+	 */
+	public static void sendErrorMessage(
+		ChannelHandlerContext channelHandlerContext,
+		ErrorResponseBody errorMessage) {
+
+		StringWriter sw = new StringWriter();
+		try {
+			mapper.writeValue(sw, errorMessage);
+		} catch (IOException e) {
+			// this should never happen
+			throw new FlinkRuntimeException("Could not map error response to JSON.", e);
+		}
+		sendMessageInternal(channelHandlerContext, sw.toString()).addListener(ChannelFutureListener.CLOSE);
+	}
+
+	private static <P extends ResponseBody> ChannelFuture sendMessageInternal(
+		ChannelHandlerContext channelHandlerContext,
+		String text) {
+
+		TextWebSocketFrame frame = new TextWebSocketFrame(text);
+		return channelHandlerContext.writeAndFlush(frame);
+	}
+
+	public static TextWebSocketFrame encodeMessage(ResponseBody message) throws IOException {
+		StringWriter sw = new StringWriter();
+		mapper.writeValue(sw, message);
+		return new TextWebSocketFrame(sw.toString());
+	}
+
+	public static <T extends ResponseBody> T decodeMessage(TextWebSocketFrame frame, Class<T> clazz) throws IOException {
+		return mapper.readValue(frame.text(), clazz);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/websocket/WebSocketListener.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/websocket/WebSocketListener.java
@@ -16,17 +16,12 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.rest.messages;
+package org.apache.flink.runtime.rest.websocket;
+
+import org.apache.flink.runtime.rest.messages.ResponseBody;
+import org.apache.flink.runtime.util.event.EventListener;
 
 /**
- * Marker interface for all responses of the REST API. This class represents the body of an HTTP response or WebSocket message.
- *
- * <p>Subclass instances are converted to JSON using jackson-databind. Subclasses must have a constructor that accepts
- * all fields of the JSON response, that should be annotated with {@code @JsonCreator}.
- *
- * <p>All fields that should part of the JSON response must be accessible either by being public or having a getter.
- *
- * <p>When adding methods that are prefixed with {@code get} make sure to annotate them with {@code @JsonIgnore}.
+ * A listener for WebSocket messages.
  */
-public interface ResponseBody {
-}
+public interface WebSocketListener extends EventListener<ResponseBody> { }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/AbstractRestHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/AbstractRestHandlerTest.java
@@ -1,0 +1,233 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.rest.HttpMethodWrapper;
+import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+import org.apache.flink.runtime.rest.messages.WebSocketUpgradeResponseBody;
+import org.apache.flink.runtime.rpc.RpcUtils;
+import org.apache.flink.runtime.webmonitor.RestfulGateway;
+import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelDuplexHandler;
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelHandler;
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelHandlerContext;
+import org.apache.flink.shaded.netty4.io.netty.channel.embedded.EmbeddedChannel;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.DefaultFullHttpRequest;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.FullHttpRequest;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.FullHttpResponse;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpHeaders;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpRequestDecoder;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseEncoder;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpVersion;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.router.Routed;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.websocketx.WebSocketClientHandshaker13;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.websocketx.WebSocketVersion;
+import org.apache.flink.shaded.netty4.io.netty.util.ReferenceCountUtil;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.annotation.Nonnull;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link AbstractRestHandler}.
+ */
+public class AbstractRestHandlerTest {
+
+	private static final String WS_SUBPROTOCOL = "test";
+	private static final String REST_ADDRESS = "http://localhost:1234";
+
+	private CompletableFuture<String> gatewayRestAddress;
+	private GatewayRetriever<RestfulGateway> gatewayRetriever;
+
+	@Before
+	public void setup() throws Exception {
+		// setup a mock gateway and retriever to satisfy the RedirectHandler
+		RestfulGateway mockRestfulGateway = mock(RestfulGateway.class);
+		when(mockRestfulGateway.requestRestAddress(any(Time.class))).thenReturn(CompletableFuture.completedFuture(REST_ADDRESS));
+		gatewayRetriever = mock(GatewayRetriever.class);
+		when(gatewayRetriever.getNow()).thenReturn(Optional.of(mockRestfulGateway));
+	}
+
+	// ----- WebSocket support -----
+
+	/**
+	 * Tests the websocket upgrade logic of AbstractRestHandler.
+	 */
+	@Test
+	public void testWebSocketUpgrade() {
+		// write a handshake request
+		EmbeddedChannel channel = channel(new TestWebSocketRestHandler());
+		Routed request = handshakeRequest(WebSocketTestHandlerSpecification.INSTANCE, Collections.emptyMap(), Collections.emptyMap());
+		channel.writeInbound(request);
+
+		// check for a websocket handshaker and message handler in the pipeline
+		Assert.assertNotNull(channel.pipeline().get(TestWebSocketMessageHandler.class));
+		Assert.assertNotNull(channel.pipeline().get(WebSocketServerProtocolHandler.class));
+
+		// check for a websocket handshake response
+		FullHttpResponse response = (FullHttpResponse) channel.readOutbound();
+		Assert.assertNotNull(response);
+		Assert.assertEquals(HttpResponseStatus.SWITCHING_PROTOCOLS, response.getStatus());
+	}
+
+	/**
+	 * A handler for testing websocket upgrade responses.
+	 */
+	private class TestWebSocketRestHandler extends AbstractRestHandler<RestfulGateway, EmptyRequestBody, WebSocketUpgradeResponseBody, EmptyMessageParameters> {
+
+		public final ChannelHandler messageHandler = new TestWebSocketMessageHandler();
+
+		public TestWebSocketRestHandler() {
+			super(CompletableFuture.completedFuture(REST_ADDRESS), gatewayRetriever, RpcUtils.INF_TIMEOUT, WebSocketTestHandlerSpecification.INSTANCE);
+		}
+
+		@Override
+		protected CompletableFuture<WebSocketUpgradeResponseBody> handleRequest(@Nonnull HandlerRequest<EmptyRequestBody, EmptyMessageParameters> request, @Nonnull RestfulGateway gateway) throws RestHandlerException {
+			WebSocketUpgradeResponseBody response = new WebSocketUpgradeResponseBody(messageHandler);
+			return CompletableFuture.completedFuture(response);
+		}
+	}
+
+	private class TestWebSocketMessageHandler extends ChannelDuplexHandler {
+	}
+
+	private static class WebSocketTestHandlerSpecification implements MessageHeaders<EmptyRequestBody, WebSocketUpgradeResponseBody, EmptyMessageParameters> {
+
+		private static final WebSocketTestHandlerSpecification INSTANCE = new WebSocketTestHandlerSpecification();
+
+		@Override
+		public HttpMethodWrapper getHttpMethod() {
+			return HttpMethodWrapper.GET;
+		}
+
+		@Override
+		public String getTargetRestEndpointURL() {
+			return "/";
+		}
+
+		@Override
+		public Class<EmptyRequestBody> getRequestClass() {
+			return EmptyRequestBody.class;
+		}
+
+		@Override
+		public Class<WebSocketUpgradeResponseBody> getResponseClass() {
+			return WebSocketUpgradeResponseBody.class;
+		}
+
+		@Override
+		public HttpResponseStatus getResponseStatusCode() {
+			return HttpResponseStatus.OK;
+		}
+
+		@Override
+		public EmptyMessageParameters getUnresolvedMessageParameters() {
+			return EmptyMessageParameters.getInstance();
+		}
+
+		public WebSocketTestHandlerSpecification getInstance() {
+			return INSTANCE;
+		}
+	}
+
+	// ----- Utility -----
+
+	/**
+	 * Creates an embedded channel for HTTP/websocket test purposes.
+	 */
+	private EmbeddedChannel channel(ChannelHandler handler) {
+		// the websocket handshaker looks for HTTP decoder/encoder (to know where to inject WS handlers).
+		// For test purposes, use a passthru encoder so that tests may assert various aspects of the response.
+		return new EmbeddedChannel(new HttpRequestDecoder(), new TestHttpResponseEncoder(), handler);
+	}
+
+	/**
+	 * Creates an URI for the given REST spec.
+	 */
+	private static URI requestUri(MessageHeaders spec) {
+		return URI.create(REST_ADDRESS).resolve(spec.getTargetRestEndpointURL());
+	}
+
+	/**
+	 * Creates a handshake request for the given spec.
+	 */
+	private static Routed handshakeRequest(MessageHeaders spec, Map<String, String> pathParams, Map<String, List<String>> queryParams) {
+		URI wsURL = URI.create(requestUri(spec).toString().replace("http:", "ws:"));
+		TestHandshaker handshaker = new TestHandshaker(wsURL, HttpHeaders.EMPTY_HEADERS);
+		FullHttpRequest httpRequest = handshaker.newHandshakeRequest();
+		Routed routed = new Routed(null, false, httpRequest, spec.getTargetRestEndpointURL(), pathParams, queryParams);
+		return routed;
+	}
+
+	/**
+	 * Creates an HTTP request for the given spec.
+	 */
+	private static Routed request(MessageHeaders spec, Map<String, String> pathParams, Map<String, List<String>> queryParams) {
+		FullHttpRequest httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, spec.getHttpMethod().getNettyHttpMethod(), spec.getTargetRestEndpointURL());
+		Routed routed = new Routed(null, false, httpRequest, spec.getTargetRestEndpointURL(), pathParams, queryParams);
+		return routed;
+	}
+
+	/**
+	 * A helper class for using Netty's built-in handshaking class to construct valid handshake requests.
+	 */
+	private static class TestHandshaker extends WebSocketClientHandshaker13 {
+		public TestHandshaker(URI webSocketURL, HttpHeaders customHeaders) {
+			super(webSocketURL, WebSocketVersion.V13, WS_SUBPROTOCOL, false, customHeaders, Integer.MAX_VALUE);
+		}
+
+		@Override
+		public FullHttpRequest newHandshakeRequest() {
+			return super.newHandshakeRequest();
+		}
+	}
+
+	/**
+	 * A no-op encoder that must exist to satisfy the WS handshaker.
+	 */
+	private static class TestHttpResponseEncoder extends HttpResponseEncoder {
+		@Override
+		protected void encode(ChannelHandlerContext ctx, Object msg, List<Object> out) throws Exception {
+			if (msg != null) {
+				ReferenceCountUtil.retain(msg);
+				out.add(msg);
+			}
+		}
+	}
+
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/AbstractWebSocketMessageHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/AbstractWebSocketMessageHandlerTest.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler;
+
+import org.apache.flink.runtime.rest.messages.ResponseBody;
+
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelHandlerContext;
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelInboundHandlerAdapter;
+import org.apache.flink.shaded.netty4.io.netty.channel.embedded.EmbeddedChannel;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.DefaultFullHttpResponse;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpVersion;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler;
+import org.apache.flink.shaded.netty4.io.netty.util.AbstractReferenceCounted;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests the {@link AbstractWebSocketMessageHandler}.
+ */
+public class AbstractWebSocketMessageHandlerTest {
+
+	/**
+	 * Validates that the handler correctly processes handshake completion.
+	 */
+	@Test
+	public void testHandshakeComplete() throws Exception {
+		TestWebSocketMessageHandler handler = new TestWebSocketMessageHandler();
+		EmbeddedChannel channel = new EmbeddedChannel(new Driver(), handler);
+		Assert.assertTrue(handler.handshakeCompleted);
+	}
+
+	/**
+	 * Tests message writing.
+	 */
+	@Test
+	public void testWriteMessage() throws Exception {
+		TestWebSocketMessageHandler handler = new TestWebSocketMessageHandler();
+		EmbeddedChannel channel = new EmbeddedChannel(new Driver(), handler);
+
+		TestMessage expected = new TestMessage();
+		channel.writeAndFlush(expected);
+		Assert.assertEquals(0, expected.refCnt());
+		TextWebSocketFrame actual = (TextWebSocketFrame) channel.readOutbound();
+		Assert.assertNotNull(actual);
+		Assert.assertEquals(1, actual.refCnt());
+	}
+
+	/**
+	 * Tests passthrough of HTTP responses as written by the websocket handshake handler.
+	 */
+	@Test
+	public void testWritePassthrough() throws Exception {
+		TestWebSocketMessageHandler handler = new TestWebSocketMessageHandler();
+		EmbeddedChannel channel = new EmbeddedChannel(new Driver(), handler);
+
+		DefaultFullHttpResponse expected = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.SWITCHING_PROTOCOLS);
+		channel.writeAndFlush(expected);
+		DefaultFullHttpResponse actual = (DefaultFullHttpResponse) channel.readOutbound();
+		Assert.assertSame(expected, actual);
+		Assert.assertEquals(1, actual.refCnt());
+	}
+
+	/**
+	 * Tests exception handling.
+	 */
+	@Test
+	public void testExceptionHandling() throws Exception {
+		TestWebSocketMessageHandler handler = new TestWebSocketMessageHandler();
+		EmbeddedChannel channel = new EmbeddedChannel(new ChannelInboundHandlerAdapter() {
+			@Override
+			public void channelActive(ChannelHandlerContext ctx) throws Exception {
+				super.channelActive(ctx);
+				// fire an exception as would the websocket protocol handler
+				ctx.fireExceptionCaught(new Exception());
+			}
+		}, handler);
+
+		Assert.assertTrue(!channel.isOpen());
+	}
+
+	private static class Driver extends ChannelInboundHandlerAdapter {
+		@Override
+		public void channelActive(ChannelHandlerContext ctx) throws Exception {
+			super.channelActive(ctx);
+			ctx.fireUserEventTriggered(WebSocketServerProtocolHandler.ServerHandshakeStateEvent.HANDSHAKE_COMPLETE);
+		}
+	}
+
+	private static class TestWebSocketMessageHandler extends AbstractWebSocketMessageHandler {
+		boolean handshakeCompleted = false;
+
+		@Override
+		protected void handshakeComplete(ChannelHandlerContext ctx) throws Exception {
+			handshakeCompleted = true;
+		}
+	}
+
+	private static class TestMessage extends AbstractReferenceCounted implements ResponseBody {
+		@Override
+		protected void deallocate() {
+		}
+	}
+}


### PR DESCRIPTION

## What is the purpose of the change

Introduces WebSocket support for the FLIP-6 REST server and client.

The basic idea is to use the normal REST handler to initiate a websocket upgrade.    In this way, the normal request parsing logic may be used.  For example, a REST method of `/jobs/:jobid/subscribe` may be developed using a normal REST handler.  The handler responds such that the server initiates the upgrade procedure rather than producing a normal REST response.   A new type of handler based on `AbstractWebSocketMessageHandler` is then installed into the pipeline for subsequent interaction.

Netty's `ChannelGroup` is leveraged to act as an event bus to easily dispatch a message to one or more channels based on a routing key.  In the above example, the routing key might be `jobid`, meaning that a given channel is listening to events related to a certain job.   It is expected that a concrete subclass of `RestServerEndpoint` create one or more `KeyedChannelRouter` instances as needed for its handlers, and then write messages as it sees fit.

The client was similarly adapted to open a `WebSocket` with associated listeners.  Consider the work to be a stop-gap pending further discussion.

The `RestEndpointITCase` test was enhanced with an end-to-end demonstration.   A separate unit test for `AbstractRestHandler` was also introduced.

## Brief change log
- Introduce `AbstractWebSocketMessageHandler` to handle inbound and outbound websocket messages.
- Introduce `WebSocketUpgradeResponseBody` as a special REST response that triggers a websocket upgrade.
- Update `AbstractRestHandler` to handle websocket upgrades.
- Introduce `KeyedChannelRouter` to route websocket messages to interested channels.
- Update `RestClient` with a new method, `sendWebSocketRequest`.
- Introduce `WebSocket` and `WebSocketListener`.
- Update `RestEndpointITCase` with end-to-end websocket test.

## Verifying this change

This change added tests and can be verified as follows:
- `AbstractRestHandlerTest`
- `RestEndpointITCase`
- `AbstractWebSocketMessageHandlerTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive):no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no

## Documentation

  - Does this pull request introduce a new feature? no

