### PR TITLE
[FLINK-7754] [rpc] Complete termination future after actor has been stopped

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcEndpoint.java
@@ -223,11 +223,12 @@ public abstract class RpcEndpoint implements RpcGateway {
 	}
 
 	/**
-	 * Return a future which is completed when the rpc endpoint has been terminated.
+	 * Return a future which is completed with true when the rpc endpoint has been terminated.
+	 * In case of a failure, this future is completed with the occurring exception.
 	 *
 	 * @return Future which is completed when the rpc endpoint has been terminated.
 	 */
-	public CompletableFuture<Void> getTerminationFuture() {
+	public CompletableFuture<Boolean> getTerminationFuture() {
 		return rpcServer.getTerminationFuture();
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcServer.java
@@ -30,5 +30,5 @@ public interface RpcServer extends StartStoppable, MainThreadExecutable, RpcGate
 	 *
 	 * @return Future indicating when the rpc endpoint has been terminated
 	 */
-	CompletableFuture<Void> getTerminationFuture();
+	CompletableFuture<Boolean> getTerminationFuture();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaBasedEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaBasedEndpoint.java
@@ -18,13 +18,28 @@
 
 package org.apache.flink.runtime.rpc.akka;
 
-import akka.actor.ActorRef;
 import org.apache.flink.runtime.rpc.RpcGateway;
+
+import akka.actor.ActorRef;
+
+import java.util.concurrent.CompletableFuture;
 
 /**
  * Interface for Akka based rpc gateways
  */
-interface AkkaGateway extends RpcGateway {
+interface AkkaBasedEndpoint extends RpcGateway {
 
-	ActorRef getRpcEndpoint();
+	/**
+	 * Returns the {@link ActorRef} of the underlying RPC actor.
+	 *
+	 * @return the {@link ActorRef} of the underlying RPC actor
+	 */
+	ActorRef getActorRef();
+
+	/**
+	 * Returns the internal termination future.
+	 *
+	 * @return Internal termination future
+	 */
+	CompletableFuture<Void> getInternalTerminationFuture();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActor.java
@@ -77,12 +77,12 @@ class AkkaRpcActor<T extends RpcEndpoint & RpcGateway> extends UntypedActor {
 	/** the helper that tracks whether calls come from the main thread. */
 	private final MainThreadValidatorUtil mainThreadValidator;
 
-	private final CompletableFuture<Void> terminationFuture;
+	private final CompletableFuture<Void> internalTerminationFuture;
 
-	AkkaRpcActor(final T rpcEndpoint, final CompletableFuture<Void> terminationFuture) {
+	AkkaRpcActor(final T rpcEndpoint, final CompletableFuture<Void> internalTerminationFuture) {
 		this.rpcEndpoint = checkNotNull(rpcEndpoint, "rpc endpoint");
 		this.mainThreadValidator = new MainThreadValidatorUtil(rpcEndpoint);
-		this.terminationFuture = checkNotNull(terminationFuture);
+		this.internalTerminationFuture = checkNotNull(internalTerminationFuture);
 	}
 
 	@Override
@@ -106,9 +106,9 @@ class AkkaRpcActor<T extends RpcEndpoint & RpcGateway> extends UntypedActor {
 			// Complete the termination future so that others know that we've stopped.
 
 			if (shutdownThrowable != null) {
-				terminationFuture.completeExceptionally(shutdownThrowable);
+				internalTerminationFuture.completeExceptionally(shutdownThrowable);
 			} else {
-				terminationFuture.complete(null);
+				internalTerminationFuture.complete(null);
 			}
 		} finally {
 			mainThreadValidator.exitMainThread();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/FencedAkkaRpcActor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/FencedAkkaRpcActor.java
@@ -38,8 +38,8 @@ import java.util.concurrent.CompletableFuture;
  */
 public class FencedAkkaRpcActor<F extends Serializable, T extends FencedRpcEndpoint<F> & RpcGateway> extends AkkaRpcActor<T> {
 
-	public FencedAkkaRpcActor(T rpcEndpoint, CompletableFuture<Void> terminationFuture) {
-		super(rpcEndpoint, terminationFuture);
+	public FencedAkkaRpcActor(T rpcEndpoint, CompletableFuture<Void> internalTerminationFuture) {
+		super(rpcEndpoint, internalTerminationFuture);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -163,7 +163,7 @@ public class TaskManagerRunner implements FatalErrorHandler {
 	}
 
 	// export the termination future for caller to know it is terminated
-	public CompletableFuture<Void> getTerminationFuture() {
+	public CompletableFuture<Boolean> getTerminationFuture() {
 		return taskManager.getTerminationFuture();
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceTest.java
@@ -18,13 +18,14 @@
 
 package org.apache.flink.runtime.rpc.akka;
 
-import akka.actor.ActorSystem;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.util.TestLogger;
 
+import akka.actor.ActorSystem;
 import org.junit.AfterClass;
 import org.junit.Test;
 
@@ -49,13 +50,16 @@ public class AkkaRpcServiceTest extends TestLogger {
 
 	private static ActorSystem actorSystem = AkkaUtils.createDefaultActorSystem();
 
+	private static final Time timeout = Time.milliseconds(10000);
+
 	private static AkkaRpcService akkaRpcService =
-			new AkkaRpcService(actorSystem, Time.milliseconds(10000));
+			new AkkaRpcService(actorSystem, timeout);
 
 	@AfterClass
 	public static void shutdown() {
 		akkaRpcService.stopService();
 		actorSystem.shutdown();
+		actorSystem.awaitTermination(FutureUtils.toFiniteDuration(timeout));
 	}
 
 	// ------------------------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change

This commit waits not only until the Actor has called postStop but also until the actor
has been completely shut down by the ActorSystem before completing the termination
future.

## Brief change log

- Introduce an `internalTerminationFuture` which is passed to the `AkkaRpcActors`
- Use `internalTerminationFuture` to capture shut down exceptions in the `RpcEndpoint`
- Use `Patterns.gracefulShutdown` with a `Kill` message to terminate `AkkaRpcActors`
- Wait on the completion of the `Patterns.gracefulShutdown` returned future and the `internalTerminationFuture` to complete the `RpcEndpoint's` termination future
- Also complete the `RpcEndpoint's` termination future when stopping the complete `AkkaRpcService`

## Verifying this change

This change added tests and can be verified as follows:

- `AkkaRcpActorTest#testActorTerminationWhenServiceShutdown` tests that the termination future of a `RpcEndpoint` is completed when the underlying `RpcService` is shut down.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

