### PR TITLE
[hotfix] [hbase] Set root log level to OFF for flink-hbase tests.

### DIFF
--- a/flink-connectors/flink-hbase/src/test/resources/log4j-test.properties
+++ b/flink-connectors/flink-hbase/src/test/resources/log4j-test.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-log4j.rootLogger=DEBUG, stdout
+log4j.rootLogger=OFF, stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target=System.out
 log4j.appender.stdout.threshold=INFO


### PR DESCRIPTION
## What is the purpose of the change

Fix `flink-hbase` tests that fail on local builds and pass on Travis.

## Brief change log

* Set root log level of `flink-hbase` to `OFF`
* Log level is changed due to a buggy Calcite check that causes a NPE.
* The check is only performed if log level DEBUG is enabled.

## Verifying this change

* Tests on `flink-hbase` pass.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **n/a**

