### PR TITLE
[FLINK-7761] [examples] Include shaded guava dependency in Twitter ex…

### DIFF
--- a/flink-examples/flink-examples-streaming/pom.xml
+++ b/flink-examples/flink-examples-streaming/pom.xml
@@ -543,6 +543,7 @@ under the License.
 								<filter>
 									<artifact>*</artifact>
 									<includes>
+										<include>org/apache/flink/twitter/shaded/com/google/common/**</include>
 										<include>org/apache/flink/streaming/examples/twitter/**</include>
 										<include>org/apache/flink/streaming/connectors/twitter/**</include>
 										<include>org/apache/http/**</include>


### PR DESCRIPTION
With the introduction of flink-shaded the twitter connector no longer uses the gauva dependency shipped with Flink. The build script for the streaming examples however was not adjusted to include the connectors own shaded guava dependency, which this PR fixes.