### PR TITLE
[FLINK-6495] Fix Akka's default value for heartbeat pause

### DIFF
--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -328,9 +328,9 @@ The following parameters configure Flink's JobManager and TaskManagers.
 
 - `akka.framesize`: Maximum size of messages which are sent between the JobManager and the TaskManagers. If Flink fails because messages exceed this limit, then you should increase it. The message size requires a size-unit specifier (DEFAULT: **10485760b**).
 
-- `akka.watch.heartbeat.interval`: Heartbeat interval for Akka's DeathWatch mechanism to detect dead TaskManagers. If TaskManagers are wrongly marked dead because of lost or delayed heartbeat messages, then you should increase this value. A thorough description of Akka's DeathWatch can be found [here](http://doc.akka.io/docs/akka/snapshot/scala/remoting.html#failure-detector) (DEFAULT: **10 s**).
+- `akka.watch.heartbeat.interval`: Heartbeat interval for Akka's DeathWatch mechanism to detect dead TaskManagers. If TaskManagers are wrongly marked dead because of lost or delayed heartbeat messages, then you should decrease this value or increase `akka.watch.heartbeat.pause`. A thorough description of Akka's DeathWatch can be found [here](http://doc.akka.io/docs/akka/snapshot/scala/remoting.html#failure-detector) (DEFAULT: **10 s**).
 
-- `akka.watch.heartbeat.pause`: Acceptable heartbeat pause for Akka's DeathWatch mechanism. A low value does not allow a irregular heartbeat. A thorough description of Akka's DeathWatch can be found [here](http://doc.akka.io/docs/akka/snapshot/scala/remoting.html#failure-detector) (DEFAULT: **60 s**).
+- `akka.watch.heartbeat.pause`: Acceptable heartbeat pause for Akka's DeathWatch mechanism. A low value does not allow an irregular heartbeat. If TaskManagers are wrongly marked dead because of lost or delayed heartbeat messages, then you should increase this value or decrease `akka.watch.heartbeat.interval`. Higher value increases the time to detect a dead TaskManager. A thorough description of Akka's DeathWatch can be found [here](http://doc.akka.io/docs/akka/snapshot/scala/remoting.html#failure-detector) (DEFAULT: **60 s**).
 
 - `akka.watch.threshold`: Threshold for the DeathWatch failure detector. A low value is prone to false positives whereas a high value increases the time to detect a dead TaskManager. A thorough description of Akka's DeathWatch can be found [here](http://doc.akka.io/docs/akka/snapshot/scala/remoting.html#failure-detector) (DEFAULT: **12**).
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/AkkaOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/AkkaOptions.java
@@ -47,7 +47,7 @@ public class AkkaOptions {
 	 */
 	public static final ConfigOption<String> WATCH_HEARTBEAT_PAUSE = ConfigOptions
 		.key("akka.watch.heartbeat.pause")
-		.defaultValue(ASK_TIMEOUT.defaultValue());
+		.defaultValue("60 s");
 
 	/**
 	 * The Akka tcp connection timeout.

--- a/flink-core/src/main/java/org/apache/flink/configuration/IllegalConfigurationException.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/IllegalConfigurationException.java
@@ -42,6 +42,17 @@ public class IllegalConfigurationException extends RuntimeException {
 
 	/**
 	 * Constructs an new IllegalConfigurationException with the given error message
+	 * format and arguments.
+	 *
+	 * @param format The error message format for the exception.
+	 * @param arguments The arguments for the format.
+	 */
+	public IllegalConfigurationException(String format, Object... arguments) {
+		super(String.format(format, arguments));
+	}
+
+	/**
+	 * Constructs an new IllegalConfigurationException with the given error message
 	 * and a given cause.
 	 *
 	 * @param message The error message for the exception.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/FixedDelayRestartStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/FixedDelayRestartStrategy.java
@@ -96,7 +96,7 @@ public class FixedDelayRestartStrategy implements RestartStrategy {
 		} catch (NumberFormatException nfe) {
 			if (delayString.equals(timeoutString)) {
 				throw new Exception("Invalid config value for " +
-						AkkaOptions.WATCH_HEARTBEAT_PAUSE.key() + ": " + timeoutString +
+						AkkaOptions.WATCH_HEARTBEAT_INTERVAL.key() + ": " + timeoutString +
 						". Value must be a valid duration (such as '10 s' or '1 min')");
 			} else {
 				throw new Exception("Invalid config value for " +

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/akka/AkkaUtilsTest.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/akka/AkkaUtilsTest.scala
@@ -20,7 +20,7 @@ package org.apache.flink.runtime.akka
 
 import java.net.InetSocketAddress
 
-import org.apache.flink.configuration.Configuration
+import org.apache.flink.configuration.{AkkaOptions, Configuration, IllegalConfigurationException}
 import org.apache.flink.runtime.highavailability.HighAvailabilityServicesUtils.AddressResolution
 import org.apache.flink.runtime.rpc.akka.AkkaRpcServiceUtils
 import org.apache.flink.runtime.rpc.akka.AkkaRpcServiceUtils.AkkaProtocol
@@ -34,6 +34,26 @@ class AkkaUtilsTest
   extends FunSuite
   with Matchers
   with BeforeAndAfterAll {
+
+  test("getAkkaConfig should validate watch heartbeats") {
+    val configuration = new Configuration()
+    configuration.setString(
+      AkkaOptions.WATCH_HEARTBEAT_PAUSE.key(),
+      AkkaOptions.WATCH_HEARTBEAT_INTERVAL.defaultValue())
+    intercept[IllegalConfigurationException] {
+      AkkaUtils.getAkkaConfig(configuration, Some(("localhost", 31337)))
+    }
+  }
+
+  test("getAkkaConfig should validate transport heartbeats") {
+    val configuration = new Configuration()
+    configuration.setString(
+      AkkaOptions.TRANSPORT_HEARTBEAT_PAUSE.key(),
+      AkkaOptions.TRANSPORT_HEARTBEAT_INTERVAL.defaultValue())
+    intercept[IllegalConfigurationException] {
+      AkkaUtils.getAkkaConfig(configuration, Some(("localhost", 31337)))
+    }
+  }
 
   test("getHostFromAkkaURL should return the correct host from a remote Akka URL") {
     val host = "127.0.0.1"


### PR DESCRIPTION
## Brief change log

This PR consists of two hotfixes regarding akka's heartbeat pause. **The critical one** is reverting it's default value from 10s back to 60s (bug introduced by #3935)

## Verifying this change

This change is already covered by existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes (default config values)** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)

