### PR TITLE
[FLINK-7643] [core] Rework FileSystem loading to use factories

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/CliFrontend.java
@@ -179,7 +179,7 @@ public class CliFrontend {
 		this.config = GlobalConfiguration.loadConfiguration(configDirectory.getAbsolutePath());
 
 		try {
-			FileSystem.setDefaultScheme(config);
+			FileSystem.initialize(config);
 		} catch (IOException e) {
 			throw new Exception("Error while setting the default " +
 				"filesystem scheme from configuration.", e);

--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -195,6 +195,9 @@ under the License.
 						<excludes combine.children="append">
 							<exclude>org.apache.flink.api.common.ExecutionConfig#CONFIG_KEY</exclude>
 							<exclude>org.apache.flink.core.fs.FileSystem\$FSKey</exclude>
+							<exclude>org.apache.flink.core.fs.FileSystem#initialize(java.net.URI)</exclude>
+							<exclude>org.apache.flink.core.fs.FileSystem#isFlinkSupportedScheme(java.lang.String)</exclude>
+							<exclude>org.apache.flink.core.fs.FileSystem#setDefaultScheme(org.apache.flink.configuration.Configuration)</exclude>
 							<exclude>org.apache.flink.api.java.typeutils.WritableTypeInfo</exclude>
 							<!-- Breaking changes between 1.1 and 1.2.
 							We ignore these changes because these are low-level, internal runtime configuration parameters -->

--- a/flink-core/src/main/java/org/apache/flink/core/fs/FileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/FileSystem.java
@@ -406,17 +406,6 @@ public abstract class FileSystem {
 		return FileSystemSafetyNet.wrapWithSafetyNetWhenActivated(getUnguardedFileSystem(uri));
 	}
 
-	/**
-	 * Returns a boolean indicating whether a scheme has built-in Flink support.
-	 *
-	 * @param scheme
-	 *        a file system scheme
-	 * @return a boolean indicating whether the provided scheme has built-in Flink support
-	 */
-	public static boolean isFlinkSupportedScheme(String scheme) {
-		return FSDIRECTORY.containsKey(scheme);
-	}
-
 	//Class must implement Hadoop FileSystem interface. The class is not avaiable in 'flink-core'.
 	private static FileSystem instantiateHadoopFileSystemWrapper(Class<?> wrappedFileSystem) throws IOException {
 		try {

--- a/flink-core/src/main/java/org/apache/flink/core/fs/FileSystemFactory.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/FileSystemFactory.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.fs;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.configuration.Configuration;
+
+import java.io.IOException;
+import java.net.URI;
+
+/**
+ * A factory to create file systems.
+ *
+ * <p>The factory is typically configured via {@link #configure(Configuration)} before
+ * creating file systems via {@link #create(URI)}.
+ */
+@PublicEvolving
+public interface FileSystemFactory {
+
+	/**
+	 * Applies the given configuration to this factory. All future file system
+	 * instantiations via {@link #create(URI)} should take the configuration into
+	 * account.
+	 *
+	 * @param config The configuration to apply.
+	 */
+	void configure(Configuration config);
+
+	/**
+	 * Creates a new file system for the given file system URI.
+	 * The URI describes the type of file system (via its scheme) and optionally the
+	 * authority (for example the host) of the file system.
+	 *
+	 * @param fsUri The URI that describes the file system.
+	 * @return A new instance of the specified file system.
+	 *
+	 * @throws IOException Thrown if the file system could not be instantiated.
+	 */
+	FileSystem create(URI fsUri) throws IOException;
+}

--- a/flink-core/src/main/java/org/apache/flink/core/fs/SafetyNetWrapperFileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/SafetyNetWrapperFileSystem.java
@@ -60,11 +60,6 @@ public class SafetyNetWrapperFileSystem extends FileSystem implements WrappingPr
 	}
 
 	@Override
-	public void initialize(URI name) throws IOException {
-		unsafeFileSystem.initialize(name);
-	}
-
-	@Override
 	public FileStatus getFileStatus(Path f) throws IOException {
 		return unsafeFileSystem.getFileStatus(f);
 	}

--- a/flink-core/src/main/java/org/apache/flink/core/fs/UnsupportedFileSystemSchemeException.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/UnsupportedFileSystemSchemeException.java
@@ -15,18 +15,34 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.flink.core.fs;
 
-import org.apache.flink.annotation.PublicEvolving;
+import java.io.IOException;
 
-@PublicEvolving
-public interface HadoopFileSystemWrapper {
+/**
+ * An exception to indicate that a specific file system scheme is not supported.
+ */
+public class UnsupportedFileSystemSchemeException extends IOException {
+
+	private static final long serialVersionUID = 1L;
 
 	/**
-	 * Test whether the HadoopWrapper can wrap the given file system scheme.
-	 * 
-	 * @param scheme The scheme of the file system.
-	 * @return The class implementing the file system.
+	 * Creates a new exception with the given message.
+	 *
+	 * @param message The exception message
 	 */
-	public Class<?> getHadoopWrapperClassNameForFileSystem(String scheme);
+	public UnsupportedFileSystemSchemeException(String message) {
+		super(message);
+	}
+
+	/**
+	 * Creates a new exception with the given message and cause.
+	 *
+	 * @param message The exception message
+	 * @param cause The exception cause
+	 */
+	public UnsupportedFileSystemSchemeException(String message, Throwable cause) {
+		super(message, cause);
+	}
 }

--- a/flink-core/src/main/java/org/apache/flink/core/fs/factories/HadoopFileSystemFactoryLoader.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/factories/HadoopFileSystemFactoryLoader.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.fs.factories;
+
+import org.apache.flink.core.fs.FileSystemFactory;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A utility class to check and reflectively load the Hadoop file system factory.
+ */
+public class HadoopFileSystemFactoryLoader {
+
+	private static final Logger LOG = LoggerFactory.getLogger(HadoopFileSystemFactoryLoader.class);
+
+	private static final String FACTORY_CLASS = "org.apache.flink.runtime.fs.hdfs.HadoopFsFactory";
+
+	private static final String HADOOP_CONFIG_CLASS = "org.apache.hadoop.conf.Configuration";
+
+	private static final String HADOOP_FS_CLASS = "org.apache.hadoop.fs.FileSystem";
+
+
+	/**
+	 * Loads the FileSystemFactory for the Hadoop-backed file systems.
+	 */
+	public static FileSystemFactory loadFactory() {
+		final ClassLoader cl = HadoopFileSystemFactoryLoader.class.getClassLoader();
+
+		// first, see if the Flink runtime classes are available
+		final Class<? extends FileSystemFactory> factoryClass;
+		try {
+			factoryClass = Class.forName(FACTORY_CLASS, false, cl).asSubclass(FileSystemFactory.class);
+		}
+		catch (ClassNotFoundException e) {
+			LOG.info("No Flink runtime dependency present - the extended set of supported File Systems " +
+					"via Hadoop is not available.");
+			return new UnsupportedSchemeFactory("Flink runtime classes missing in classpath/dependencies.");
+		}
+		catch (Exception | LinkageError e) {
+			LOG.warn("Flink's Hadoop file system factory could not be loaded", e);
+			return new UnsupportedSchemeFactory("Flink's Hadoop file system factory could not be loaded", e);
+		}
+
+		// check (for eager and better exception messages) if the Hadoop classes are available here
+		try {
+			Class.forName(HADOOP_CONFIG_CLASS, false, cl);
+			Class.forName(HADOOP_FS_CLASS, false, cl);
+		}
+		catch (ClassNotFoundException e) {
+			LOG.info("Hadoop is not in the classpath/dependencies - the extended set of supported File Systems " +
+					"via Hadoop is not available.");
+			return new UnsupportedSchemeFactory("Hadoop is not in the classpath/dependencies.");
+		}
+
+		// Create the factory.
+		try {
+			return factoryClass.newInstance();
+		}
+		catch (Exception | LinkageError e) {
+			LOG.warn("Flink's Hadoop file system factory could not be created", e);
+			return new UnsupportedSchemeFactory("Flink's Hadoop file system factory could not be created", e);
+		}
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/core/fs/factories/LocalFileSystemFactory.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/factories/LocalFileSystemFactory.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.fs.factories;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.FileSystemFactory;
+import org.apache.flink.core.fs.local.LocalFileSystem;
+
+import java.net.URI;
+
+/**
+ * A factory for the {@link LocalFileSystem}.
+ */
+@PublicEvolving
+public class LocalFileSystemFactory implements FileSystemFactory {
+
+	@Override
+	public void configure(Configuration config) {
+		// the local file system takes no configuration, so nothing to do here
+	}
+
+	@Override
+	public FileSystem create(URI fsUri) {
+		return LocalFileSystem.getSharedInstance();
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/core/fs/factories/MapRFsFactory.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/factories/MapRFsFactory.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.fs.factories;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.FileSystemFactory;
+
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.net.URI;
+
+/**
+ * A factory for the MapR file system.
+ * 
+ * <p>This factory tries to reflectively instantiate the MapR file system. It can only be
+ * used when the MapR FS libraries are in the classpath.
+ */
+public class MapRFsFactory implements FileSystemFactory {
+
+	private static final String MAPR_FILESYSTEM_CLASS = "org.apache.flink.runtime.fs.maprfs.MapRFileSystem";
+
+	@Override
+	public void configure(Configuration config) {
+		// nothing to configure based on the configuration here
+	}
+
+	@Override
+	public FileSystem create(URI fsUri) throws IOException {
+		try {
+			Class<? extends FileSystem> fsClass = Class.forName(
+					MAPR_FILESYSTEM_CLASS, false, getClass().getClassLoader()).asSubclass(FileSystem.class);
+
+			Constructor<? extends FileSystem> constructor = fsClass.getConstructor(URI.class);
+
+			try {
+				return constructor.newInstance(fsUri);
+			}
+			catch (InvocationTargetException e) {
+				throw e.getTargetException();
+			}
+		}
+		catch (ClassNotFoundException e) {
+			throw new IOException("Could not load MapR file system class '" + MAPR_FILESYSTEM_CLASS + 
+					"\'. Please make sure the Flink runtime classes are part of the classpath or dependencies.", e);
+		}
+		catch (LinkageError e) {
+			throw new IOException("Some of the MapR FS or required Hadoop classes seem to be missing or incompatible. " 
+					+ "Please check that a compatible version of the MapR Hadoop libraries is in the classpath.", e);
+		}
+		catch (IOException e) {
+			throw e;
+		}
+		catch (Throwable t) {
+			throw new IOException("Could not instantiate MapR file system class '" + MAPR_FILESYSTEM_CLASS + "'.", t);
+		}
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/core/fs/factories/UnsupportedSchemeFactory.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/factories/UnsupportedSchemeFactory.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.fs.factories;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.FileSystemFactory;
+import org.apache.flink.core.fs.UnsupportedFileSystemSchemeException;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.net.URI;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A file system factory to throw an UnsupportedFileSystemSchemeException when called.
+ */
+public class UnsupportedSchemeFactory implements FileSystemFactory {
+
+	private final String exceptionMessage;
+
+	@Nullable
+	private final Throwable exceptionCause;
+
+	public UnsupportedSchemeFactory(String exceptionMessage) {
+		this(exceptionMessage, null);
+	}
+
+	public UnsupportedSchemeFactory(String exceptionMessage, @Nullable Throwable exceptionCause) {
+		this.exceptionMessage = checkNotNull(exceptionMessage);
+		this.exceptionCause = exceptionCause;
+	}
+
+	@Override
+	public void configure(Configuration config) {
+		// nothing to do here
+	}
+
+	@Override
+	public FileSystem create(URI fsUri) throws IOException {
+		if (exceptionCause == null) {
+			throw new UnsupportedFileSystemSchemeException(exceptionMessage);
+		}
+		else {
+			throw new UnsupportedFileSystemSchemeException(exceptionMessage, exceptionCause);
+		}
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalFileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalFileSystem.java
@@ -62,7 +62,10 @@ public class LocalFileSystem extends FileSystem {
 	private static final Logger LOG = LoggerFactory.getLogger(LocalFileSystem.class);
 
 	/** The URI representing the local file system. */
-	private static final URI uri = OperatingSystem.isWindows() ? URI.create("file:/") : URI.create("file:///");
+	private static final URI LOCAL_URI = OperatingSystem.isWindows() ? URI.create("file:/") : URI.create("file:///");
+
+	/** The shared instance of the local file system */
+	private static final LocalFileSystem INSTANCE = new LocalFileSystem();
 
 	/** Path pointing to the current working directory.
 	 * Because Paths are not immutable, we cannot cache the proper path here */
@@ -114,7 +117,7 @@ public class LocalFileSystem extends FileSystem {
 
 	@Override
 	public URI getUri() {
-		return uri;
+		return LOCAL_URI;
 	}
 
 	@Override
@@ -126,9 +129,6 @@ public class LocalFileSystem extends FileSystem {
 	public Path getHomeDirectory() {
 		return new Path(homeDir);
 	}
-
-	@Override
-	public void initialize(final URI name) throws IOException {}
 
 	@Override
 	public FSDataInputStream open(final Path f, final int bufferSize) throws IOException {
@@ -293,6 +293,15 @@ public class LocalFileSystem extends FileSystem {
 	 * @return The URI that represents the local file system.
 	 */
 	public static URI getLocalFsURI() {
-		return uri;
+		return LOCAL_URI;
+	}
+
+	/**
+	 * Gets the shared instance of this file system.
+	 * 
+	 * @return The shared instance of this file system.
+	 */
+	public static LocalFileSystem getSharedInstance() {
+		return INSTANCE;
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalFileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalFileSystem.java
@@ -258,13 +258,6 @@ public class LocalFileSystem extends FileSystem {
 	}
 
 	@Override
-	public FSDataOutputStream create(
-			Path f, boolean overwrite, int bufferSize, short replication, long blockSize) throws IOException {
-		return create(f, overwrite ? WriteMode.OVERWRITE : WriteMode.NO_OVERWRITE);
-	}
-
-
-	@Override
 	public boolean rename(final Path src, final Path dst) throws IOException {
 		final File srcFile = pathToFile(src);
 		final File dstFile = pathToFile(dst);
@@ -288,5 +281,18 @@ public class LocalFileSystem extends FileSystem {
 	@Override
 	public boolean isDistributedFS() {
 		return false;
+	}
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Gets the URI that represents the local file system.
+	 * That URI is {@code "file:/"} on Windows platforms and {@code "file:///"} on other
+	 * UNIX family platforms.
+	 * 
+	 * @return The URI that represents the local file system.
+	 */
+	public static URI getLocalFsURI() {
+		return uri;
 	}
 }

--- a/flink-core/src/test/java/org/apache/flink/configuration/FilesystemSchemeConfigTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/FilesystemSchemeConfigTest.java
@@ -19,114 +19,86 @@
 package org.apache.flink.configuration;
 
 import org.apache.flink.core.fs.FileSystem;
-import org.apache.flink.core.fs.Path;
-import org.apache.flink.core.testutils.CommonTestUtils;
+import org.apache.flink.core.fs.UnsupportedFileSystemSchemeException;
+import org.apache.flink.core.fs.local.LocalFileSystem;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.After;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
-import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.PrintWriter;
-import java.lang.reflect.Field;
 import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.UUID;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-public class FilesystemSchemeConfigTest {
+public class FilesystemSchemeConfigTest extends TestLogger {
+
+	@Rule
+	public final TemporaryFolder tempFolder = new TemporaryFolder();
+
+	@After
+	public void clearFsSettings() throws IOException {
+		FileSystem.initialize(new Configuration());
+	}
+
+	// ------------------------------------------------------------------------
 
 	@Test
-	public void testExplicitFilesystemScheme() {
-		testSettingFilesystemScheme(false, "fs.default-scheme: otherFS://localhost:1234/", true);
+	public void testDefaultsToLocal() throws Exception {
+		URI justPath = new URI(tempFolder.newFile().toURI().getPath());
+		assertNull(justPath.getScheme());
+
+		FileSystem fs = FileSystem.get(justPath);
+		assertEquals("file", fs.getUri().getScheme());
 	}
 
 	@Test
-	public void testSettingFilesystemSchemeInConfiguration() {
-		testSettingFilesystemScheme(false, "fs.default-scheme: file:///", false);
+	public void testExplicitlySetToLocal() throws Exception {
+		final Configuration conf = new Configuration();
+		conf.setString(ConfigConstants.FILESYSTEM_SCHEME, LocalFileSystem.getLocalFsURI().toString());
+		FileSystem.initialize(conf);
+
+		URI justPath = new URI(tempFolder.newFile().toURI().getPath());
+		assertNull(justPath.getScheme());
+
+		FileSystem fs = FileSystem.get(justPath);
+		assertEquals("file", fs.getUri().getScheme());
 	}
 
 	@Test
-	public void testUsingDefaultFilesystemScheme() {
-		testSettingFilesystemScheme(true, "fs.default-scheme: file:///", false);
-	}
+	public void testExplicitlySetToOther() throws Exception {
+		final Configuration conf = new Configuration();
+		conf.setString(ConfigConstants.FILESYSTEM_SCHEME, "otherFS://localhost:1234/");
+		FileSystem.initialize(conf);
 
-	private void testSettingFilesystemScheme(boolean useDefaultScheme,
-											String configFileScheme, boolean useExplicitScheme) {
-		final File tmpDir = getTmpDir();
-		final File confFile = new File(tmpDir, GlobalConfiguration.FLINK_CONF_FILENAME);
+		URI justPath = new URI(tempFolder.newFile().toURI().getPath());
+		assertNull(justPath.getScheme());
+
 		try {
-			confFile.createNewFile();
-		} catch (IOException e) {
-			throw new RuntimeException("Couldn't create file", e);
+			FileSystem.get(justPath);
+			fail("should have failed with an exception");
 		}
-		final File testFile = new File(tmpDir.getAbsolutePath() + File.separator + "testing.txt");
-
-		try {
-			try {
-				final PrintWriter pw1 = new PrintWriter(confFile);
-				if(!useDefaultScheme) {
-					pw1.println(configFileScheme);
-				}
-				pw1.close();
-
-				final PrintWriter pwTest = new PrintWriter(testFile);
-				pwTest.close();
-
-			} catch (FileNotFoundException e) {
-				fail(e.getMessage());
-			}
-
-			Configuration conf = GlobalConfiguration.loadConfiguration(tmpDir.getAbsolutePath());
-
-			try {
-				FileSystem.setDefaultScheme(conf);
-				String noSchemePath = testFile.toURI().getPath(); // remove the scheme.
-
-				URI uri = new URI(noSchemePath);
-				// check if the scheme == null (so that we get the configuration one.
-				assertTrue(uri.getScheme() == null);
-
-				// get the filesystem with the default scheme as set in the confFile1
-				FileSystem fs = useExplicitScheme ? FileSystem.get(testFile.toURI()) : FileSystem.get(uri);
-				assertTrue(fs.exists(new Path(noSchemePath)));
-
-			} catch (IOException e) {
-				fail(e.getMessage());
-			} catch (URISyntaxException e) {
-				e.printStackTrace();
-			}
-		} finally {
-			try {
-				// clear the default scheme set in the FileSystem class.
-				// we do it through reflection to avoid creating a publicly
-				// accessible method, which could also be wrongly used by users.
-
-				Field f = FileSystem.class.getDeclaredField("defaultScheme");
-				f.setAccessible(true);
-				f.set(null, null);
-			} catch (IllegalAccessException | NoSuchFieldException e) {
-				e.printStackTrace();
-				fail("Cannot reset default scheme: " + e.getMessage());
-			}
-			
-			confFile.delete();
-			testFile.delete();
-			tmpDir.delete();
+		catch (UnsupportedFileSystemSchemeException e) {
+			assertTrue(e.getMessage().contains("otherFS"));
 		}
 	}
 
-	private File getTmpDir() {
-		File tmpDir = new File(CommonTestUtils.getTempDir() + File.separator
-			+ UUID.randomUUID().toString() + File.separator);
-		
-		assertTrue(tmpDir.mkdirs());
+	@Test
+	public void testExplicitlyPathTakesPrecedence() throws Exception {
+		final Configuration conf = new Configuration();
+		conf.setString(ConfigConstants.FILESYSTEM_SCHEME, "otherFS://localhost:1234/");
+		FileSystem.initialize(conf);
 
-		return tmpDir;
-	}
+		URI pathAndScheme = tempFolder.newFile().toURI();
+		assertNotNull(pathAndScheme.getScheme());
 
-	private File createRandomFile(File path, String suffix) {
-		return new File(path.getAbsolutePath() + File.separator + UUID.randomUUID() + suffix);
+		FileSystem fs = FileSystem.get(pathAndScheme);
+		assertEquals("file", fs.getUri().getScheme());
 	}
 }

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosTaskExecutorRunner.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosTaskExecutorRunner.java
@@ -99,12 +99,11 @@ public class MesosTaskExecutorRunner {
 			configuration.setString(ConfigConstants.TASK_MANAGER_TMP_DIR_KEY, tmpDirs);
 		}
 
-		// configure the default filesystem
+		// configure the filesystems
 		try {
-			FileSystem.setDefaultScheme(configuration);
+			FileSystem.initialize(configuration);
 		} catch (IOException e) {
-			throw new IOException("Error while setting the default " +
-				"filesystem scheme from configuration.", e);
+			throw new IOException("Error while configuring the filesystems.", e);
 		}
 
 		// tell akka to die in case of an error

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosApplicationMasterRunner.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosApplicationMasterRunner.java
@@ -156,12 +156,11 @@ public class MesosApplicationMasterRunner {
 			final Configuration dynamicProperties = BootstrapTools.parseDynamicProperties(cmd);
 			final Configuration config = GlobalConfiguration.loadConfigurationWithDynamicProperties(dynamicProperties);
 
-			// configure the default filesystem
+			// configure the filesystems
 			try {
-				FileSystem.setDefaultScheme(config);
+				FileSystem.initialize(config);
 			} catch (IOException e) {
-				throw new IOException("Error while setting the default " +
-					"filesystem scheme from configuration.", e);
+				throw new IOException("Error while configuring the filesystems.", e);
 			}
 
 			// configure security

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerRunner.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerRunner.java
@@ -99,12 +99,11 @@ public class MesosTaskManagerRunner {
 			configuration.setString(ConfigConstants.TASK_MANAGER_TMP_DIR_KEY, tmpDirs);
 		}
 
-		// configure the default filesystem
+		// configure the filesystems
 		try {
-			FileSystem.setDefaultScheme(configuration);
+			FileSystem.initialize(configuration);
 		} catch (IOException e) {
-			throw new IOException("Error while setting the default " +
-				"filesystem scheme from configuration.", e);
+			throw new IOException("Error while confoguring the filesystems.", e);
 		}
 
 		// tell akka to die in case of an error

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -103,7 +103,7 @@ public abstract class ClusterEntrypoint implements FatalErrorHandler {
 		LOG.info("Starting {}.", getClass().getSimpleName());
 
 		try {
-			installDefaultFileSystem(configuration);
+			configureFileSystems(configuration);
 
 			SecurityContext securityContext = installSecurityContext(configuration);
 
@@ -128,11 +128,11 @@ public abstract class ClusterEntrypoint implements FatalErrorHandler {
 		}
 	}
 
-	protected void installDefaultFileSystem(Configuration configuration) throws Exception {
+	protected void configureFileSystems(Configuration configuration) throws Exception {
 		LOG.info("Install default filesystem.");
 
 		try {
-			FileSystem.setDefaultScheme(configuration);
+			FileSystem.initialize(configuration);
 		} catch (IOException e) {
 			throw new IOException("Error while setting the default " +
 				"filesystem scheme from configuration.", e);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopFileSystem.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopFileSystem.java
@@ -18,252 +18,47 @@
 
 package org.apache.flink.runtime.fs.hdfs;
 
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.core.fs.BlockLocation;
 import org.apache.flink.core.fs.FileStatus;
 import org.apache.flink.core.fs.FileSystem;
-import org.apache.flink.core.fs.HadoopFileSystemWrapper;
 import org.apache.flink.core.fs.Path;
-import org.apache.flink.util.InstantiationUtil;
+import org.apache.flink.runtime.util.HadoopUtils;
 
-import org.apache.hadoop.conf.Configuration;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.Method;
 import java.net.URI;
-import java.net.UnknownHostException;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
- * Concrete implementation of the {@link FileSystem} base class for the Hadoop File System. The
- * class is a wrapper class which encapsulated the original Hadoop HDFS API.
- *
- * <p>If no file system class is specified, the wrapper will automatically load the Hadoop
- * distributed file system (HDFS).
- *
+ * A {@link FileSystem} that wraps an {@link org.apache.hadoop.fs.FileSystem Hadoop File System}.
  */
-public final class HadoopFileSystem extends FileSystem implements HadoopFileSystemWrapper {
+public final class HadoopFileSystem extends FileSystem {
 
-	private static final Logger LOG = LoggerFactory.getLogger(HadoopFileSystem.class);
-
-	private static final String DEFAULT_HDFS_CLASS = "org.apache.hadoop.hdfs.DistributedFileSystem";
-
-	/**
-	 * Configuration value name for the DFS implementation name. Usually not specified in hadoop configurations.
-	 */
-	private static final String HDFS_IMPLEMENTATION_KEY = "fs.hdfs.impl";
-
-	private final org.apache.hadoop.conf.Configuration conf;
-
+	/** The wrapped Hadoop File System. */
 	private final org.apache.hadoop.fs.FileSystem fs;
 
-
 	/**
-	 * Creates a new DistributedFileSystem object to access HDFS, based on a class name
-	 * and picking up the configuration from the class path or the Flink configuration.
+	 * Wraps the given Hadoop File System object as a Flink File System object.
+	 * The given Hadoop file system object is expected to be initialized already.
 	 *
-	 * @throws IOException
-	 *         throw if the required HDFS classes cannot be instantiated
-	 */
-	public HadoopFileSystem(Class<? extends org.apache.hadoop.fs.FileSystem> fsClass) throws IOException {
-		// Create new Hadoop configuration object
-		this.conf = getHadoopConfiguration();
-
-		if (fsClass == null) {
-			fsClass = getDefaultHDFSClass();
-		}
-
-		this.fs = instantiateFileSystem(fsClass);
-	}
-
-	/**
-	 * Creates a new DistributedFileSystem that uses the given Hadoop
-	 * {@link org.apache.hadoop.fs.FileSystem} under the hood.
-	 *
-	 * @param hadoopConfig The Hadoop configuration that the FileSystem is based on.
 	 * @param hadoopFileSystem The Hadoop FileSystem that will be used under the hood.
 	 */
-	public HadoopFileSystem(
-			org.apache.hadoop.conf.Configuration hadoopConfig,
-			org.apache.hadoop.fs.FileSystem hadoopFileSystem) {
-
-		this.conf = checkNotNull(hadoopConfig, "hadoopConfig");
+	public HadoopFileSystem(org.apache.hadoop.fs.FileSystem hadoopFileSystem) {
 		this.fs = checkNotNull(hadoopFileSystem, "hadoopFileSystem");
 	}
 
-	private Class<? extends org.apache.hadoop.fs.FileSystem> getDefaultHDFSClass() throws IOException {
-		Class<? extends org.apache.hadoop.fs.FileSystem> fsClass = null;
-
-		// try to get the FileSystem implementation class Hadoop 2.0.0 style
-		{
-			LOG.debug("Trying to load HDFS class Hadoop 2.x style.");
-
-			Object fsHandle = null;
-			try {
-				Method newApi = org.apache.hadoop.fs.FileSystem.class.getMethod("getFileSystemClass", String.class, org.apache.hadoop.conf.Configuration.class);
-				fsHandle = newApi.invoke(null, "hdfs", conf);
-			} catch (Exception e) {
-				// if we can't find the FileSystem class using the new API,
-				// clazz will still be null, we assume we're running on an older Hadoop version
-			}
-
-			if (fsHandle != null) {
-				if (fsHandle instanceof Class && org.apache.hadoop.fs.FileSystem.class.isAssignableFrom((Class<?>) fsHandle)) {
-					fsClass = ((Class<?>) fsHandle).asSubclass(org.apache.hadoop.fs.FileSystem.class);
-
-					if (LOG.isDebugEnabled()) {
-						LOG.debug("Loaded '{}' as HDFS class.", fsClass.getName());
-					}
-				}
-				else {
-					LOG.debug("Unexpected return type from 'org.apache.hadoop.fs.FileSystem.getFileSystemClass(String, Configuration)'.");
-					throw new RuntimeException("The value returned from org.apache.hadoop.fs.FileSystem.getFileSystemClass(String, Configuration) is not a valid subclass of org.apache.hadoop.fs.FileSystem.");
-				}
-			}
-		}
-
-		// fall back to an older Hadoop version
-		if (fsClass == null) {
-			// first of all, check for a user-defined hdfs class
-			if (LOG.isDebugEnabled()) {
-				LOG.debug("Falling back to loading HDFS class old Hadoop style. Looking for HDFS class configuration entry '{}'.",
-						HDFS_IMPLEMENTATION_KEY);
-			}
-
-			Class<?> classFromConfig = conf.getClass(HDFS_IMPLEMENTATION_KEY, null);
-
-			if (classFromConfig != null) {
-				if (org.apache.hadoop.fs.FileSystem.class.isAssignableFrom(classFromConfig)) {
-					fsClass = classFromConfig.asSubclass(org.apache.hadoop.fs.FileSystem.class);
-
-					if (LOG.isDebugEnabled()) {
-						LOG.debug("Loaded HDFS class '{}' as specified in configuration.", fsClass.getName());
-					}
-				}
-				else {
-					if (LOG.isDebugEnabled()) {
-						LOG.debug("HDFS class specified by {} is of wrong type.", HDFS_IMPLEMENTATION_KEY);
-					}
-
-					throw new IOException("HDFS class specified by " + HDFS_IMPLEMENTATION_KEY +
-							" cannot be cast to a FileSystem type.");
-				}
-			}
-			else {
-				// load the default HDFS class
-				if (LOG.isDebugEnabled()) {
-					LOG.debug("Trying to load default HDFS implementation {}.", DEFAULT_HDFS_CLASS);
-				}
-
-				try {
-					Class <?> reflectedClass = Class.forName(DEFAULT_HDFS_CLASS);
-					if (org.apache.hadoop.fs.FileSystem.class.isAssignableFrom(reflectedClass)) {
-						fsClass = reflectedClass.asSubclass(org.apache.hadoop.fs.FileSystem.class);
-					} else {
-						if (LOG.isDebugEnabled()) {
-							LOG.debug("Default HDFS class is of wrong type.");
-						}
-
-						throw new IOException("The default HDFS class '" + DEFAULT_HDFS_CLASS +
-								"' cannot be cast to a FileSystem type.");
-					}
-				}
-				catch (ClassNotFoundException e) {
-					if (LOG.isDebugEnabled()) {
-						LOG.debug("Default HDFS class cannot be loaded.");
-					}
-
-					throw new IOException("No HDFS class has been configured and the default class '" +
-							DEFAULT_HDFS_CLASS + "' cannot be loaded.");
-				}
-			}
-		}
-		return fsClass;
-	}
-
 	/**
-	 * Returns a new Hadoop Configuration object using the path to the hadoop conf configured
-	 * in the main configuration (flink-conf.yaml).
-	 * This method is public because its being used in the HadoopDataSource.
+	 * Gets the underlying Hadoop FileSystem.
+	 * @return The underlying Hadoop FileSystem.
 	 */
-	public static org.apache.hadoop.conf.Configuration getHadoopConfiguration() {
-
-		org.apache.flink.configuration.Configuration flinkConfiguration =
-			GlobalConfiguration.loadConfiguration();
-
-		Configuration retConf = new org.apache.hadoop.conf.Configuration();
-
-		// We need to load both core-site.xml and hdfs-site.xml to determine the default fs path and
-		// the hdfs configuration
-		// Try to load HDFS configuration from Hadoop's own configuration files
-		// 1. approach: Flink configuration
-		final String hdfsDefaultPath = flinkConfiguration.getString(ConfigConstants.HDFS_DEFAULT_CONFIG, null);
-		if (hdfsDefaultPath != null) {
-			retConf.addResource(new org.apache.hadoop.fs.Path(hdfsDefaultPath));
-		} else {
-			LOG.trace("{} configuration key for hdfs-default configuration file not set", ConfigConstants.HDFS_DEFAULT_CONFIG);
-		}
-
-		final String hdfsSitePath = flinkConfiguration.getString(ConfigConstants.HDFS_SITE_CONFIG, null);
-		if (hdfsSitePath != null) {
-			retConf.addResource(new org.apache.hadoop.fs.Path(hdfsSitePath));
-		} else {
-			LOG.trace("{} configuration key for hdfs-site configuration file not set", ConfigConstants.HDFS_SITE_CONFIG);
-		}
-
-		// 2. Approach environment variables
-		String[] possibleHadoopConfPaths = new String[4];
-		possibleHadoopConfPaths[0] = flinkConfiguration.getString(ConfigConstants.PATH_HADOOP_CONFIG, null);
-		possibleHadoopConfPaths[1] = System.getenv("HADOOP_CONF_DIR");
-
-		if (System.getenv("HADOOP_HOME") != null) {
-			possibleHadoopConfPaths[2] = System.getenv("HADOOP_HOME") + "/conf";
-			possibleHadoopConfPaths[3] = System.getenv("HADOOP_HOME") + "/etc/hadoop"; // hadoop 2.2
-		}
-
-		for (String possibleHadoopConfPath : possibleHadoopConfPaths) {
-			if (possibleHadoopConfPath != null) {
-				if (new File(possibleHadoopConfPath).exists()) {
-					if (new File(possibleHadoopConfPath + "/core-site.xml").exists()) {
-						retConf.addResource(new org.apache.hadoop.fs.Path(possibleHadoopConfPath + "/core-site.xml"));
-					} else {
-						LOG.debug("File {}/core-site.xml not found.", possibleHadoopConfPath);
-					}
-
-					if (new File(possibleHadoopConfPath + "/hdfs-site.xml").exists()) {
-						retConf.addResource(new org.apache.hadoop.fs.Path(possibleHadoopConfPath + "/hdfs-site.xml"));
-					} else {
-						LOG.debug("File {}/hdfs-site.xml not found.", possibleHadoopConfPath);
-					}
-				}
-			}
-		}
-		return retConf;
+	public org.apache.hadoop.fs.FileSystem getHadoopFileSystem() {
+		return this.fs;
 	}
 
-	private org.apache.hadoop.fs.FileSystem instantiateFileSystem(Class<? extends org.apache.hadoop.fs.FileSystem> fsClass)
-		throws IOException {
-		try {
-			return fsClass.newInstance();
-		}
-		catch (ExceptionInInitializerError e) {
-			throw new IOException("The filesystem class '" + fsClass.getName() + "' throw an exception upon initialization.", e.getException());
-		}
-		catch (Throwable t) {
-			String errorMessage = InstantiationUtil.checkForInstantiationError(fsClass);
-			if (errorMessage != null) {
-				throw new IOException("The filesystem class '" + fsClass.getName() + "' cannot be instantiated: " + errorMessage);
-			} else {
-				throw new IOException("An error occurred while instantiating the filesystem class '" +
-						fsClass.getName() + "'.", t);
-			}
-		}
-	}
+	// ------------------------------------------------------------------------
+	//  file system methods
+	// ------------------------------------------------------------------------
 
 	@Override
 	public Path getWorkingDirectory() {
@@ -277,87 +72,6 @@ public final class HadoopFileSystem extends FileSystem implements HadoopFileSyst
 	@Override
 	public URI getUri() {
 		return fs.getUri();
-	}
-
-	/**
-	 * Gets the underlying Hadoop FileSystem.
-	 * @return The underlying Hadoop FileSystem.
-	 */
-	public org.apache.hadoop.fs.FileSystem getHadoopFileSystem() {
-		return this.fs;
-	}
-
-	@Override
-	public void initialize(URI path) throws IOException {
-
-		// If the authority is not part of the path, we initialize with the fs.defaultFS entry.
-		if (path.getAuthority() == null) {
-
-			String configEntry = this.conf.get("fs.defaultFS", null);
-			if (configEntry == null) {
-				// fs.default.name deprecated as of hadoop 2.2.0 http://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-common/DeprecatedProperties.html
-				configEntry = this.conf.get("fs.default.name", null);
-			}
-
-			if (LOG.isDebugEnabled()) {
-				LOG.debug("fs.defaultFS is set to {}", configEntry);
-			}
-
-			if (configEntry == null) {
-				throw new IOException(getMissingAuthorityErrorPrefix(path) + "Either no default file system (hdfs) configuration was registered, " +
-						"or that configuration did not contain an entry for the default file system (usually 'fs.defaultFS').");
-			} else {
-				try {
-					URI initURI = URI.create(configEntry);
-
-					if (initURI.getAuthority() == null) {
-						throw new IOException(getMissingAuthorityErrorPrefix(path) + "Either no default file system was registered, " +
-								"or the provided configuration contains no valid authority component (fs.default.name or fs.defaultFS) " +
-								"describing the (hdfs namenode) host and port.");
-					} else {
-						try {
-							this.fs.initialize(initURI, this.conf);
-						}
-						catch (IOException e) {
-							throw new IOException(getMissingAuthorityErrorPrefix(path) +
-									"Could not initialize the file system connection with the given default file system address: " + e.getMessage(), e);
-						}
-					}
-				}
-				catch (IllegalArgumentException e) {
-					throw new IOException(getMissingAuthorityErrorPrefix(path) +
-							"The configuration contains an invalid file system default name (fs.default.name or fs.defaultFS): " + configEntry);
-				}
-			}
-		}
-		else {
-			// Initialize file system
-			try {
-				this.fs.initialize(path, this.conf);
-			}
-			catch (UnknownHostException e) {
-				String message = "The (HDFS NameNode) host at '" + path.getAuthority()
-						+ "', specified by file path '" + path.toString() + "', cannot be resolved"
-						+ (e.getMessage() != null ? ": " + e.getMessage() : ".");
-
-				if (path.getPort() == -1) {
-					message += " Hint: Have you forgotten a slash? (correct URI would be 'hdfs:///" + path.getAuthority() + path.getPath() + "' ?)";
-				}
-
-				throw new IOException(message, e);
-			}
-			catch (Exception e) {
-				throw new IOException("The given file URI (" + path.toString() + ") points to the HDFS NameNode at "
-						+ path.getAuthority() + ", but the File System could not be initialized with that address"
-					+ (e.getMessage() != null ? ": " + e.getMessage() : "."), e);
-			}
-		}
-	}
-
-	private static String getMissingAuthorityErrorPrefix(URI path) {
-		return "The given HDFS file URI (" + path.toString() + ") did not describe the HDFS NameNode." +
-				" The attempt to use a default HDFS configuration, as specified in the '" + ConfigConstants.HDFS_DEFAULT_CONFIG + "' or '" +
-				ConfigConstants.HDFS_SITE_CONFIG + "' config parameter failed due to the following problem: ";
 	}
 
 	@Override
@@ -456,19 +170,26 @@ public final class HadoopFileSystem extends FileSystem implements HadoopFileSyst
 		return true;
 	}
 
-	@Override
-	public Class<?> getHadoopWrapperClassNameForFileSystem(String scheme) {
-		Configuration hadoopConf = getHadoopConfiguration();
-		Class<? extends org.apache.hadoop.fs.FileSystem> clazz = null;
-		try {
-			clazz = org.apache.hadoop.fs.FileSystem.getFileSystemClass(scheme, hadoopConf);
-		} catch (IOException e) {
-			LOG.info("Flink could not load the Hadoop File system implementation for scheme " + scheme);
-		}
+	// ------------------------------------------------------------------------
+	//  Miscellaneous Utilities
+	// ------------------------------------------------------------------------
 
-		if (clazz != null && LOG.isDebugEnabled()) {
-			LOG.debug("Flink supports {} with the Hadoop file system wrapper, impl {}", scheme, clazz);
-		}
-		return clazz;
+	/**
+	 * Returns a new Hadoop Configuration object using the path to the hadoop conf configured
+	 * in the main configuration (flink-conf.yaml).
+	 * This method is public because its being used in the HadoopDataSource.
+	 *
+	 * @deprecated This method should not be used, because it dynamically (and possibly incorrectly)
+	 *             re-loads the Flink configuration.
+	 *             Use {@link HadoopUtils#getHadoopConfiguration(org.apache.flink.configuration.Configuration)}
+	 *             instead.
+	 */
+	@Deprecated
+	public static org.apache.hadoop.conf.Configuration getHadoopConfiguration() {
+
+		org.apache.flink.configuration.Configuration flinkConfiguration =
+				GlobalConfiguration.loadConfiguration();
+
+		return HadoopUtils.getHadoopConfiguration(flinkConfiguration);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopFsFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopFsFactory.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.fs.hdfs;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.FileSystemFactory;
+import org.apache.flink.core.fs.UnsupportedFileSystemSchemeException;
+import org.apache.flink.runtime.util.HadoopUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.UnknownHostException;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A file system factory for Hadoop-based file systems.
+ *
+ * <p>This factory calls Hadoop's mechanism to find a file system implementation for a given file
+ * system scheme (a {@link org.apache.hadoop.fs.FileSystem}) and wraps it as a Flink file system
+ * (a {@link org.apache.flink.core.fs.FileSystem}).
+ */
+public class HadoopFsFactory implements FileSystemFactory {
+
+	private static final Logger LOG = LoggerFactory.getLogger(HadoopFsFactory.class);
+
+	/** Hadoop's configuration for the file systems. */
+	private org.apache.hadoop.conf.Configuration hadoopConfig;
+
+	@Override
+	public void configure(Configuration config) {
+		hadoopConfig = HadoopUtils.getHadoopConfiguration(config);
+	}
+
+	@Override
+	public FileSystem create(URI fsUri) throws IOException {
+		checkNotNull(fsUri, "fsUri");
+
+		final String scheme = fsUri.getScheme();
+		checkArgument(scheme != null, "file system has null scheme");
+
+		// -- (1) get the loaded Hadoop config (or fall back to one loaded from the classpath)
+
+		final org.apache.hadoop.conf.Configuration hadoopConfig;
+		if (this.hadoopConfig != null) {
+			hadoopConfig = this.hadoopConfig;
+		}
+		else {
+			LOG.warn("Hadoop configuration has not been explicitly initialized prior to loading a Hadoop file system."
+					+ " Using configuration from the classpath.");
+
+			hadoopConfig = new org.apache.hadoop.conf.Configuration();
+		}
+
+		// -- (2) create the proper URI to initialize the file system
+
+		final URI initUri;
+		if (fsUri.getAuthority() != null) {
+			initUri = fsUri;
+		}
+		else {
+			LOG.debug("URI {} does not specify file system authority, trying to load default authority (fs.defaultFS)");
+
+			String configEntry = hadoopConfig.get("fs.defaultFS", null);
+			if (configEntry == null) {
+				// fs.default.name deprecated as of hadoop 2.2.0 - see
+				// http://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-common/DeprecatedProperties.html
+				configEntry = hadoopConfig.get("fs.default.name", null);
+			}
+
+			if (LOG.isDebugEnabled()) {
+				LOG.debug("Hadoop's 'fs.defaultFS' is set to {}", configEntry);
+			}
+
+			if (configEntry == null) {
+				throw new IOException(getMissingAuthorityErrorPrefix(fsUri) +
+						"Hadoop configuration did not contain an entry for the default file system ('fs.defaultFS').");
+			}
+			else {
+				try {
+					initUri = URI.create(configEntry);
+				}
+				catch (IllegalArgumentException e) {
+					throw new IOException(getMissingAuthorityErrorPrefix(fsUri) +
+							"The configuration contains an invalid file system default name " +
+							"('fs.default.name' or 'fs.defaultFS'): " + configEntry);
+				}
+
+				if (initUri.getAuthority() == null) {
+					throw new IOException(getMissingAuthorityErrorPrefix(fsUri) +
+							"Hadoop configuration for default file system ('fs.default.name' or 'fs.defaultFS') " +
+							"contains no valid authority component (like hdfs namenode, S3 host, etc)");
+				}
+			}
+		}
+
+		// -- (3) get the Hadoop file system class for that scheme
+
+		final Class<? extends org.apache.hadoop.fs.FileSystem> fsClass;
+		try {
+			fsClass = org.apache.hadoop.fs.FileSystem.getFileSystemClass(scheme, hadoopConfig);
+		}
+		catch (IOException e) {
+			throw new UnsupportedFileSystemSchemeException(
+					"Hadoop File System abstraction does not support scheme '" + scheme + "'. " +
+							"Either no file system implementation exists for that scheme, " +
+							"or the relevant classes are missing from the classpath.", e);
+		}
+
+		LOG.debug("Instantiating for file system scheme {} Hadoop File System {}", scheme, fsClass.getName());
+
+		// -- (4) instantiate the Hadoop file system
+
+		final org.apache.hadoop.fs.FileSystem hadoopFs;
+		try {
+			hadoopFs = fsClass.newInstance();
+		}
+		catch (Exception e) {
+			throw new IOException("The Hadoop file system class '" + fsClass.getName() + "' cannot be instantiated.", e);
+		}
+
+		// -- (5) configure the Hadoop file system
+
+		try {
+			hadoopFs.initialize(initUri, hadoopConfig);
+		}
+		catch (UnknownHostException e) {
+			String message = "The Hadoop file system's authority (" + initUri.getAuthority() +
+					"), specified by either the file URI or the configuration, cannot be resolved.";
+
+			throw new IOException(message, e);
+		}
+		catch (Exception e) {
+			throw new IOException("Hadoop file system " + fsClass.getName() + " for scheme '" + scheme +
+					"' could not ne initialized.", e);
+		}
+
+		return new HadoopFileSystem(hadoopFs);
+	}
+
+	private static String getMissingAuthorityErrorPrefix(URI fsURI) {
+		return "The given file system URI (" + fsURI.toString() + ") did not describe the authority " +
+				"(like for example HDFS NameNode address/port or S3 host). " +
+				"The attempt to use a configured default authority failed: ";
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackend.java
@@ -31,12 +31,9 @@ import org.apache.flink.runtime.state.DefaultOperatorStateBackend;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.OperatorStateBackend;
 import org.apache.flink.runtime.state.heap.HeapKeyedStateBackend;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.URI;
-import java.net.URISyntaxException;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 
@@ -52,8 +49,6 @@ import static org.apache.flink.util.Preconditions.checkArgument;
 public class FsStateBackend extends AbstractStateBackend {
 
 	private static final long serialVersionUID = -8191916350224044011L;
-
-	private static final Logger LOG = LoggerFactory.getLogger(FsStateBackend.class);
 
 	/** By default, state smaller than 1024 bytes will not be written to files, but
 	 * will be stored directly with the metadata */
@@ -341,7 +336,7 @@ public class FsStateBackend extends AbstractStateBackend {
 	 * @throws IllegalArgumentException Thrown, if the URI misses scheme or path. 
 	 * @throws IOException Thrown, if no file system can be found for the URI's scheme.
 	 */
-	public static Path validateAndNormalizeUri(URI checkpointDataUri) throws IOException {
+	private static Path validateAndNormalizeUri(URI checkpointDataUri) throws IOException {
 		final String scheme = checkpointDataUri.getScheme();
 		final String path = checkpointDataUri.getPath();
 
@@ -358,41 +353,6 @@ public class FsStateBackend extends AbstractStateBackend {
 			throw new IllegalArgumentException("Cannot use the root directory for checkpoints.");
 		}
 
-		if (!FileSystem.isFlinkSupportedScheme(checkpointDataUri.getScheme())) {
-			// skip verification checks for non-flink supported filesystem
-			// this is because the required filesystem classes may not be available to the flink client
-			return new Path(checkpointDataUri);
-		} else {
-			// we do a bit of work to make sure that the URI for the filesystem refers to exactly the same
-			// (distributed) filesystem on all hosts and includes full host/port information, even if the
-			// original URI did not include that. We count on the filesystem loading from the configuration
-			// to fill in the missing data.
-
-			// try to grab the file system for this path/URI
-			FileSystem filesystem = FileSystem.get(checkpointDataUri);
-			if (filesystem == null) {
-				String reason = "Could not find a file system for the given scheme in" +
-				"the available configurations.";
-				LOG.warn("Could not verify checkpoint path. This might be caused by a genuine " +
-						"problem or by the fact that the file system is not accessible from the " +
-						"client. Reason:{}", reason);
-				return new Path(checkpointDataUri);
-			}
-
-			URI fsURI = filesystem.getUri();
-			try {
-				URI baseURI = new URI(fsURI.getScheme(), fsURI.getAuthority(), path, null, null);
-				return new Path(baseURI);
-			} catch (URISyntaxException e) {
-				String reason = String.format(
-						"Cannot create file system URI for checkpointDataUri %s and filesystem URI %s: " + e.toString(),
-						checkpointDataUri,
-						fsURI);
-				LOG.warn("Could not verify checkpoint path. This might be caused by a genuine " +
-						"problem or by the fact that the file system is not accessible from the " +
-						"client. Reason: {}", reason);
-				return new Path(checkpointDataUri);
-			}
-		}
+		return new Path(checkpointDataUri);
 	}
 }

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -2386,7 +2386,7 @@ object JobManager {
     val configuration = GlobalConfiguration.loadConfiguration(configDir)
 
     try {
-      FileSystem.setDefaultScheme(configuration)
+      FileSystem.initialize(configuration)
     }
     catch {
       case e: IOException => {

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/MemoryArchivist.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/MemoryArchivist.scala
@@ -291,11 +291,12 @@ class MemoryArchivist(
       throw new IllegalArgumentException("Cannot use the root directory for storing job archives.")
     }
 
-    if (!FileSystem.isFlinkSupportedScheme(archivePathUri.getScheme)) {
-      // skip verification checks for non-flink supported filesystem
-      // this is because the required filesystem classes may not be available to the flink client
-      throw new IllegalArgumentException("No file system found with scheme " + scheme
-        + ", referenced in file URI '" + archivePathUri.toString + "'.")
+    try {
+      FileSystem.get(archivePathUri)
+    }
+    catch {
+      case e: Exception =>
+          throw new IllegalArgumentException(s"No file system found for URI '${archivePathUri}'.")
     }
     new Path(archivePathUri)
   }

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -1617,7 +1617,7 @@ object TaskManager {
     }
 
     try {
-      FileSystem.setDefaultScheme(conf)
+      FileSystem.initialize(conf)
     }
     catch {
       case e: IOException => {

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
@@ -611,10 +611,10 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 			YarnClientApplication yarnApplication,
 			ClusterSpecification clusterSpecification) throws Exception {
 
-		// ------------------ Set default file system scheme -------------------------
+		// ------------------ Initialize the file systems -------------------------
 
 		try {
-			org.apache.flink.core.fs.FileSystem.setDefaultScheme(flinkConfiguration);
+			org.apache.flink.core.fs.FileSystem.initialize(flinkConfiguration);
 		} catch (IOException e) {
 			throw new IOException("Error while setting the default " +
 					"filesystem scheme from configuration.", e);

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnTaskExecutorRunner.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnTaskExecutorRunner.java
@@ -100,7 +100,7 @@ public class YarnTaskExecutorRunner {
 			LOG.info("TM: remote keytab principal obtained {}", remoteKeytabPrincipal);
 
 			final Configuration configuration = GlobalConfiguration.loadConfiguration(currDir);
-			FileSystem.setDefaultScheme(configuration);
+			FileSystem.initialize(configuration);
 
 			// configure local directory
 			String flinkTempDirs = configuration.getString(ConfigConstants.TASK_MANAGER_TMP_DIR_KEY, null);

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/highavailability/YarnHighAvailabilityServices.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/highavailability/YarnHighAvailabilityServices.java
@@ -142,7 +142,7 @@ public abstract class YarnHighAvailabilityServices implements HighAvailabilitySe
 			throw new IOException("Cannot instantiate YARN's Hadoop file system for " + fsUri, e);
 		}
 
-		this.flinkFileSystem = new HadoopFileSystem(hadoopConf, hadoopFileSystem);
+		this.flinkFileSystem = new HadoopFileSystem(hadoopFileSystem);
 
 		this.workingDirectory = new Path(hadoopFileSystem.getWorkingDirectory().toUri());
 		this.haDataDirectory = new Path(workingDirectory, FLINK_RECOVERY_DATA_DIR);


### PR DESCRIPTION
## What is the purpose of the change

This change reworks the loading and instantiation of File System objects (including file systems supported via Hadoop) to use factories. 

This makes sure that configurations (Flink and possibly Hadoop) are loaded once (on TaskManager / JobManager startup) and file system instances are properly reused by scheme and authority. That way, this change 

This change is also a prerequisite for an extensible file system loading mechanism via a service framework.

## Brief change log

  - The special-case configuration of the `FileSystem` class to set the "default file system scheme" is extended to a generic configuration call.
  - The directory of directly supported file systems is changed from classes (instantiated via reflection) to factories.
  - These factories are also configured when the `FileSystem` is configured.
  - The Hadoop file system factory loads the Hadoop configuration once when being configured and applies it to all subsequently instantiated file systems.
  - File systems supported via Hadoop are now properly cached and not reloaded, reinstantiated, and reconfigured on each access.
  - This also throws out a lot of legacy code for how to find Hadoop file system implementations
  - The `FileSystem` class is much cleaner now because a lot of the Hadoop FS
  - All file systems now eagerly initialize their settings, rather than dividing that between the constructor and the `initialize()` method.
  - This also factors out a lot of the special treatment of Hadoop file systems and simply makes the Hadoop File System factory the default fallback factory.

## Verifying this change

Reworked some tests to cover the behavior of this change:
  - `flink-core/src/test/java/org/apache/flink/configuration/FilesystemSchemeConfigTest.java`
  - `flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerConfigurationTest.java`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)

*Note:* The breaking changes made on `@Public` class `FileSystem` do not include methods that are meant for users, but only the setup configuration.

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)

