### PR TITLE
FLINK-7736: fix some lgtm.com alerts

### DIFF
--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/dag/GroupReduceNode.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/dag/GroupReduceNode.java
@@ -97,7 +97,7 @@ public class GroupReduceNode extends SingleInputNode {
 		
 		// check if we can work with a grouping (simple reducer), or if we need ordering because of a group order
 		Ordering groupOrder = null;
-		if (getOperator() instanceof GroupReduceOperatorBase) {
+		if (getOperator() != null) {
 			groupOrder = getOperator().getGroupOrder();
 			if (groupOrder != null && groupOrder.getNumberOfFields() == 0) {
 				groupOrder = null;

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarListHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarListHandler.java
@@ -111,8 +111,7 @@ public class JarListHandler extends AbstractJsonRequestHandler {
 						gen.writeArrayFieldStart("entry");
 
 						String[] classes = new String[0];
-						try {
-							JarFile jar = new JarFile(f);
+						try (JarFile jar = new JarFile(f)) {
 							Manifest manifest = jar.getManifest();
 							String assemblerClass = null;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
@@ -568,7 +568,7 @@ public class MemoryManager {
 	 * @return The number of pages corresponding to the memory fraction.
 	 */
 	public long computeMemorySize(double fraction) {
-		return pageSize * computeNumberOfPages(fraction);
+		return pageSize * (long) computeNumberOfPages(fraction);
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/InPlaceMutableHashTable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/InPlaceMutableHashTable.java
@@ -199,7 +199,7 @@ public class InPlaceMutableHashTable<T> extends AbstractMutableHashTable<T> {
 	 * @return The hash table's total capacity.
 	 */
 	public long getCapacity() {
-		return numAllMemorySegments * segmentSize;
+		return numAllMemorySegments * (long)segmentSize;
 	}
 
 	/**
@@ -562,7 +562,7 @@ public class InPlaceMutableHashTable<T> extends AbstractMutableHashTable<T> {
 		}
 
 		public long getTotalSize() {
-			return segments.size() * segmentSize;
+			return segments.size() * (long)segmentSize;
 		}
 
 		// ----------------------- Output -----------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -981,7 +981,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 		Preconditions.checkNotNull(jobID);
 		Preconditions.checkNotNull(resourceID);
 		Preconditions.checkNotNull(jobMasterGateway);
-		Preconditions.checkArgument(blobPort > 0 || blobPort < MAX_BLOB_PORT, "Blob server port is out of range.");
+		Preconditions.checkArgument(blobPort > 0 && blobPort < MAX_BLOB_PORT, "Blob server port is out of range.");
 
 		TaskManagerActions taskManagerActions = new TaskManagerActionsImpl(jobMasterGateway);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTable.java
@@ -452,7 +452,7 @@ public class TaskSlotTable implements TimeoutListener<AllocationID> {
 				throw new SlotNotActiveException(task.getJobID(), task.getAllocationId());
 			}
 		} else {
-			throw new SlotNotFoundException(taskSlot.getAllocationId());
+			throw new SlotNotFoundException(task.getAllocationId());
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/JarFileCreator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/JarFileCreator.java
@@ -190,7 +190,7 @@ public class JarFileCreator {
 			this.outputFile.delete();
 		}
 
-		try ( JarOutputStream jos = new JarOutputStream(new FileOutputStream(this.outputFile), new Manifest())) {
+		try ( FileOutputStream fos = new FileOutputStream(this.outputFile); JarOutputStream jos = new JarOutputStream(fos, new Manifest())) {
 			final Iterator<Class<?>> it = this.classSet.iterator();
 			while (it.hasNext()) {
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/history/ArchivedJson.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/history/ArchivedJson.java
@@ -18,11 +18,9 @@
 
 package org.apache.flink.runtime.webmonitor.history;
 
-import java.util.Objects;
-
-import org.apache.flink.runtime.jobmanager.MemoryArchivist;
 import org.apache.flink.util.Preconditions;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import java.util.Objects;
 
 /**
  * A simple container for a handler's JSON response and the REST URLs for which the response would've been returned.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/history/ArchivedJson.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/history/ArchivedJson.java
@@ -21,6 +21,8 @@ package org.apache.flink.runtime.webmonitor.history;
 import org.apache.flink.runtime.jobmanager.MemoryArchivist;
 import org.apache.flink.util.Preconditions;
 
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
 /**
  * A simple container for a handler's JSON response and the REST URLs for which the response would've been returned.
  *
@@ -53,6 +55,13 @@ public class ArchivedJson {
 		} else {
 			return false;
 		}
+	}
+
+	public int hashCode() {
+		HashCodeBuilder bldr = new HashCodeBuilder();
+		bldr.append(path);
+		bldr.append(json);
+		return bldr.toHashCode();
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/history/ArchivedJson.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/history/ArchivedJson.java
@@ -18,9 +18,10 @@
 
 package org.apache.flink.runtime.webmonitor.history;
 
+import java.util.Objects;
+
 import org.apache.flink.runtime.jobmanager.MemoryArchivist;
 import org.apache.flink.util.Preconditions;
-
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 /**
@@ -57,11 +58,9 @@ public class ArchivedJson {
 		}
 	}
 
+	@Override
 	public int hashCode() {
-		HashCodeBuilder bldr = new HashCodeBuilder();
-		bldr.append(path);
-		bldr.append(json);
-		return bldr.toHashCode();
+		return Objects.hash(path, json);
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/history/ArchivedJsonTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/history/ArchivedJsonTest.java
@@ -38,4 +38,14 @@ public class ArchivedJsonTest {
 		Assert.assertNotEquals(original, identicalPath);
 		Assert.assertNotEquals(original, identicalJson);
 	}
+
+	@Test
+	public void testHashCode() {
+		ArchivedJson original = new ArchivedJson("path", "json");
+		ArchivedJson twin = new ArchivedJson("path", "json");
+
+		Assert.assertEquals(original, original);
+		Assert.assertEquals(original, twin);
+		Assert.assertEquals(original.hashCode(), twin.hashCode());
+	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/SocketTextStreamFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/SocketTextStreamFunction.java
@@ -94,21 +94,22 @@ public class SocketTextStreamFunction implements SourceFunction<String> {
 
 				LOG.info("Connecting to server socket " + hostname + ':' + port);
 				socket.connect(new InetSocketAddress(hostname, port), CONNECTION_TIMEOUT_TIME);
-				BufferedReader reader = new BufferedReader(new InputStreamReader(socket.getInputStream()));
+				try (BufferedReader reader = new BufferedReader(new InputStreamReader(socket.getInputStream()))) {
 
-				char[] cbuf = new char[8192];
-				int bytesRead;
-				while (isRunning && (bytesRead = reader.read(cbuf)) != -1) {
-					buffer.append(cbuf, 0, bytesRead);
-					int delimPos;
-					while (buffer.length() >= delimiter.length() && (delimPos = buffer.indexOf(delimiter)) != -1) {
-						String record = buffer.substring(0, delimPos);
-						// truncate trailing carriage return
-						if (delimiter.equals("\n") && record.endsWith("\r")) {
-							record = record.substring(0, record.length() - 1);
+					char[] cbuf = new char[8192];
+					int bytesRead;
+					while (isRunning && (bytesRead = reader.read(cbuf)) != -1) {
+						buffer.append(cbuf, 0, bytesRead);
+						int delimPos;
+						while (buffer.length() >= delimiter.length() && (delimPos = buffer.indexOf(delimiter)) != -1) {
+							String record = buffer.substring(0, delimPos);
+							// truncate trailing carriage return
+							if (delimiter.equals("\n") && record.endsWith("\r")) {
+								record = record.substring(0, record.length() - 1);
+							}
+							ctx.collect(record);
+							buffer.delete(0, delimPos + delimiter.length());
 						}
-						ctx.collect(record);
-						buffer.delete(0, delimPos + delimiter.length());
 					}
 				}
 			}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/typeutils/FieldAccessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/typeutils/FieldAccessor.java
@@ -204,10 +204,6 @@ public abstract class FieldAccessor<T, F> implements Serializable {
 						typeInfo.toString() + "\", which is an invalid index.");
 			}
 
-			if (pos < 0) {
-				throw new CompositeType.InvalidFieldReferenceException("Tried to select " + ((Integer) pos).toString() + ". field.");
-			}
-
 			this.pos = pos;
 			this.innerAccessor = innerAccessor;
 			this.fieldType = innerAccessor.fieldType;

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnApplicationMasterRunner.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnApplicationMasterRunner.java
@@ -139,7 +139,7 @@ public class YarnApplicationMasterRunner {
 			LOG.debug("All environment variables: {}", ENV);
 
 			final String yarnClientUsername = ENV.get(YarnConfigKeys.ENV_HADOOP_USER_NAME);
-			require(yarnClientUsername != null, "YARN client user name environment variable {} not set",
+			require(yarnClientUsername != null, "YARN client user name environment variable (%s) not set",
 				YarnConfigKeys.ENV_HADOOP_USER_NAME);
 
 			final String currDir = ENV.get(Environment.PWD.key());

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
@@ -292,7 +292,7 @@ public class YarnResourceManager extends ResourceManager<YarnWorkerNode> impleme
 			resourceManagerClient.releaseAssignedContainer(container.getId());
 			workerNodeMap.remove(workerNode.getResourceID());
 		} else {
-			log.error("Can not find container with resource ID {}.", workerNode.getResourceID());
+			log.error("Can not find container for null workerNode.");
 		}
 		return true;
 	}


### PR DESCRIPTION

## What is the purpose of the change

lgtm.com performs deep analysis on more than 50,000 open source projects including many of the apache projects, identifying bugs and other opportunities for improvement of the code. This PR addresses 14 of the more straightforward ones found (see https://issues.apache.org/jira/browse/FLINK-7736 for details)


## Brief change log

Fixed the following alerts:

1) dereferenced variable is always null, in TaskSlotTable
2-3) array index out of bounds, in KVStateRequestSerializer and Utils
4) inconsistent equals and hashCode, in ArchivedJson
5-6) close input, in JarListHandler and SocketTextStreamFunction
7) close output, in JarFileCreator
8) unused format argument, in YarnApplicationMasterRunner
9) useless type test, in GroupReduceNode
10-11) useless comparison, in TaskExecutor and FieldAccessor
12-14) Result of integer multiplication cast to long, in MemoryManager and twice in InPlaceMutableHashTable

Also added a new test

## Verifying this change

This change added tests and can be verified as follows:

  - *Added test that verifies that hashCode and equals are consistent in ArchivedJson


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

