### PR TITLE
[FLINK-7790] [REST] Unresolved query params not added to request URL

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/MessageParameters.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/MessageParameters.java
@@ -84,7 +84,7 @@ public abstract class MessageParameters {
 		}
 		boolean isFirstQueryParameter = true;
 		for (MessageQueryParameter<?> queryParameter : parameters.getQueryParameters()) {
-			if (parameters.isResolved()) {
+			if (queryParameter.isResolved()) {
 				if (isFirstQueryParameter) {
 					queryParameters.append('?');
 					isFirstQueryParameter = false;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/MessageParametersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/MessageParametersTest.java
@@ -45,6 +45,23 @@ public class MessageParametersTest extends TestLogger {
 		Assert.assertEquals("/jobs/" + pathJobID + "/state?jobid=" + queryJobID, resolvedUrl);
 	}
 
+	@Test
+	public void testUnresolvedParameters() {
+		String genericUrl = "/jobs/:jobid/state";
+		TestMessageParameters parameters = new TestMessageParameters();
+		try {
+			MessageParameters.resolveUrl(genericUrl, parameters);
+			Assert.fail();
+		} catch (IllegalStateException expected) {
+			// the mandatory jobid path parameter was not resolved
+		}
+		JobID jobID = new JobID();
+		parameters.pathParameter.resolve(jobID);
+
+		String resolvedUrl = MessageParameters.resolveUrl(genericUrl, parameters);
+		Assert.assertEquals("/jobs/" + jobID + "/state", resolvedUrl);
+	}
+
 	private static class TestMessageParameters extends MessageParameters {
 		private final TestPathParameter pathParameter = new TestPathParameter();
 		private final TestQueryParameter queryParameter = new TestQueryParameter();
@@ -80,7 +97,7 @@ public class MessageParametersTest extends TestLogger {
 	private static class TestQueryParameter extends MessageQueryParameter<JobID> {
 
 		TestQueryParameter() {
-			super("jobid", MessageParameterRequisiteness.MANDATORY);
+			super("jobid", MessageParameterRequisiteness.OPTIONAL);
 		}
 
 		@Override


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes a bug where unresolved optional parameters where still included in the request URL by the RestClusterClient.

For example, imagine a request to list the current jobs, with an optional query parameter "state" to select only running/completed jobs. If this parameter was unresolved (aka no explicit value was set for it by the client), this currently causes the request URL to look like this: "/jobs?state=null", whereas it should be "/jobs",

This is caused by a faulty check in `MessageParameters#resolveUrl` that constructs the request URL from a set of parameters. It did not properly verify whether a query was resolved before adding it to the URL.

## Brief change log

* fix the bug
* add a test

## Verifying this change

This change added tests and can be verified as follows:

* run `MessageParametersTest#testUnresolvedParameters`
