### PR TITLE
[FLINK-7780] [REST][Client] Define protocol for triggering savepoints

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
@@ -40,6 +40,9 @@ import org.apache.flink.runtime.rest.messages.TerminationModeQueryParameter;
 import org.apache.flink.runtime.rest.messages.job.JobSubmitHeaders;
 import org.apache.flink.runtime.rest.messages.job.JobSubmitRequestBody;
 import org.apache.flink.runtime.rest.messages.job.JobSubmitResponseBody;
+import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointMessageParameters;
+import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointTriggerHeaders;
+import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointTriggerResponseBody;
 import org.apache.flink.runtime.util.ExecutorThreadFactory;
 
 import javax.annotation.Nullable;
@@ -168,7 +171,25 @@ public class RestClusterClient extends ClusterClient {
 
 	@Override
 	public String cancelWithSavepoint(JobID jobId, @Nullable String savepointDirectory) throws Exception {
-		throw new UnsupportedOperationException();
+		throw new UnsupportedOperationException("Not implemented yet.");
+	}
+
+	@Override
+	public CompletableFuture<String> triggerSavepoint(JobID jobId, @Nullable String savepointDirectory) throws Exception {
+		SavepointTriggerHeaders headers = SavepointTriggerHeaders.getInstance();
+		SavepointMessageParameters params = headers.getUnresolvedMessageParameters();
+		params.jobID.resolve(jobId);
+		if (savepointDirectory != null) {
+			params.targetDirectory.resolve(Collections.singletonList(savepointDirectory));
+		}
+		CompletableFuture<SavepointTriggerResponseBody> responseFuture = restClient.sendRequest(
+			restClusterClientConfiguration.getRestServerAddress(),
+			restClusterClientConfiguration.getRestServerPort(),
+			headers,
+			params
+		);
+		return responseFuture
+			.thenApply(response -> response.location);
 	}
 
 	// ======================================

--- a/flink-clients/src/test/java/org/apache/flink/client/CliFrontendListCancelTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/CliFrontendListCancelTest.java
@@ -22,10 +22,8 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.client.cli.CancelOptions;
 import org.apache.flink.client.cli.CliFrontendParser;
 import org.apache.flink.client.cli.CommandLineOptions;
-import org.apache.flink.client.cli.CustomCommandLine;
 import org.apache.flink.client.cli.Flip6DefaultCLI;
-import org.apache.flink.client.program.ClusterClient;
-import org.apache.flink.configuration.Configuration;
+import org.apache.flink.client.util.MockedCliFrontend;
 import org.apache.flink.runtime.akka.FlinkUntypedActor;
 import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.instance.AkkaActorGateway;
@@ -36,7 +34,6 @@ import akka.actor.ActorSystem;
 import akka.actor.Props;
 import akka.actor.Status;
 import akka.testkit.JavaTestKit;
-import org.apache.commons.cli.CommandLine;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -55,8 +52,6 @@ import static org.mockito.Matchers.isNull;
 import static org.mockito.Matchers.notNull;
 import static org.mockito.Mockito.times;
 import static org.powermock.api.mockito.PowerMockito.doThrow;
-import static org.powermock.api.mockito.PowerMockito.mock;
-import static org.powermock.api.mockito.PowerMockito.when;
 
 /**
  * Tests for the CANCEL and LIST commands.
@@ -220,24 +215,13 @@ public class CliFrontendListCancelTest {
 		}
 	}
 
-	private static final class CancelTestCliFrontend extends CliFrontend {
-		private final ClusterClient client;
+	private static final class CancelTestCliFrontend extends MockedCliFrontend {
 
 		CancelTestCliFrontend(boolean reject) throws Exception {
-			super(CliFrontendTestUtils.getConfigDir());
-			this.client = mock(ClusterClient.class);
 			if (reject) {
 				doThrow(new IllegalArgumentException("Test exception")).when(client).cancel(any(JobID.class));
 				doThrow(new IllegalArgumentException("Test exception")).when(client).cancelWithSavepoint(any(JobID.class), anyString());
 			}
-		}
-
-		@Override
-		public CustomCommandLine getActiveCustomCommandLine(CommandLine commandLine) {
-			CustomCommandLine ccl = mock(CustomCommandLine.class);
-			when(ccl.retrieveCluster(any(CommandLine.class), any(Configuration.class), anyString()))
-				.thenReturn(client);
-			return ccl;
 		}
 	}
 

--- a/flink-clients/src/test/java/org/apache/flink/client/CliFrontendStopTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/CliFrontendStopTest.java
@@ -20,14 +20,11 @@ package org.apache.flink.client;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.client.cli.CliFrontendParser;
-import org.apache.flink.client.cli.CustomCommandLine;
 import org.apache.flink.client.cli.Flip6DefaultCLI;
 import org.apache.flink.client.cli.StopOptions;
-import org.apache.flink.client.program.ClusterClient;
-import org.apache.flink.configuration.Configuration;
+import org.apache.flink.client.util.MockedCliFrontend;
 import org.apache.flink.util.TestLogger;
 
-import org.apache.commons.cli.CommandLine;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -36,11 +33,8 @@ import static org.apache.flink.client.CliFrontendTestUtils.pipeSystemOutToNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.times;
 import static org.powermock.api.mockito.PowerMockito.doThrow;
-import static org.powermock.api.mockito.PowerMockito.mock;
-import static org.powermock.api.mockito.PowerMockito.when;
 
 /**
  * Tests for the STOP command.
@@ -105,23 +99,12 @@ public class CliFrontendStopTest extends TestLogger {
 		}
 	}
 
-	private static final class StopTestCliFrontend extends CliFrontend {
-		private final ClusterClient client;
+	private static final class StopTestCliFrontend extends MockedCliFrontend {
 
 		StopTestCliFrontend(boolean reject) throws Exception {
-			super(CliFrontendTestUtils.getConfigDir());
-			this.client = mock(ClusterClient.class);
 			if (reject) {
 				doThrow(new IllegalArgumentException("Test exception")).when(client).stop(any(JobID.class));
 			}
-		}
-
-		@Override
-		public CustomCommandLine getActiveCustomCommandLine(CommandLine commandLine) {
-			CustomCommandLine ccl = mock(CustomCommandLine.class);
-			when(ccl.retrieveCluster(any(CommandLine.class), any(Configuration.class), anyString()))
-				.thenReturn(client);
-			return ccl;
 		}
 	}
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
@@ -39,6 +39,10 @@ import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
 import org.apache.flink.runtime.rest.messages.EmptyResponseBody;
 import org.apache.flink.runtime.rest.messages.JobTerminationHeaders;
 import org.apache.flink.runtime.rest.messages.JobTerminationMessageParameters;
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+import org.apache.flink.runtime.rest.messages.MessageParameters;
+import org.apache.flink.runtime.rest.messages.RequestBody;
+import org.apache.flink.runtime.rest.messages.ResponseBody;
 import org.apache.flink.runtime.rest.messages.TerminationModeQueryParameter;
 import org.apache.flink.runtime.rest.messages.job.JobSubmitHeaders;
 import org.apache.flink.runtime.rest.messages.job.JobSubmitRequestBody;
@@ -128,15 +132,11 @@ public class RestClusterClientTest extends TestLogger {
 		}
 	}
 
-	private static class TestBlobServerPortHandler extends AbstractRestHandler<DispatcherGateway, EmptyRequestBody, BlobServerPortResponseBody, EmptyMessageParameters> {
+	private static class TestBlobServerPortHandler extends TestHandler<EmptyRequestBody, BlobServerPortResponseBody, EmptyMessageParameters> {
 		private volatile boolean portRetrieved = false;
 
 		private TestBlobServerPortHandler() {
-			super(
-				CompletableFuture.completedFuture(restAddress),
-				mockGatewayRetriever,
-				RpcUtils.INF_TIMEOUT,
-				BlobServerPortHeaders.getInstance());
+			super(BlobServerPortHeaders.getInstance());
 		}
 
 		@Override
@@ -146,15 +146,11 @@ public class RestClusterClientTest extends TestLogger {
 		}
 	}
 
-	private static class TestJobSubmitHandler extends AbstractRestHandler<DispatcherGateway, JobSubmitRequestBody, JobSubmitResponseBody, EmptyMessageParameters> {
+	private static class TestJobSubmitHandler extends TestHandler<JobSubmitRequestBody, JobSubmitResponseBody, EmptyMessageParameters> {
 		private volatile boolean jobSubmitted = false;
 
 		private TestJobSubmitHandler() {
-			super(
-				CompletableFuture.completedFuture(restAddress),
-				mockGatewayRetriever,
-				RpcUtils.INF_TIMEOUT,
-				JobSubmitHeaders.getInstance());
+			super(JobSubmitHeaders.getInstance());
 		}
 
 		@Override
@@ -164,16 +160,12 @@ public class RestClusterClientTest extends TestLogger {
 		}
 	}
 
-	private static class TestJobTerminationHandler extends AbstractRestHandler<DispatcherGateway, EmptyRequestBody, EmptyResponseBody, JobTerminationMessageParameters> {
+	private static class TestJobTerminationHandler extends TestHandler<EmptyRequestBody, EmptyResponseBody, JobTerminationMessageParameters> {
 		private volatile boolean jobCanceled = false;
 		private volatile boolean jobStopped = false;
 
 		private TestJobTerminationHandler() {
-			super(
-				CompletableFuture.completedFuture(restAddress),
-				mockGatewayRetriever,
-				RpcUtils.INF_TIMEOUT,
-				JobTerminationHeaders.getInstance());
+			super(JobTerminationHeaders.getInstance());
 		}
 
 		@Override
@@ -187,6 +179,17 @@ public class RestClusterClientTest extends TestLogger {
 					break;
 			}
 			return CompletableFuture.completedFuture(EmptyResponseBody.getInstance());
+		}
+	}
+
+	private abstract static class TestHandler<R extends RequestBody, P extends ResponseBody, M extends MessageParameters> extends AbstractRestHandler<DispatcherGateway, R, P, M> {
+
+		private TestHandler(MessageHeaders<R, P, M> headers) {
+			super(
+				CompletableFuture.completedFuture(restAddress),
+				mockGatewayRetriever,
+				RpcUtils.INF_TIMEOUT,
+				headers);
 		}
 	}
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/util/MockedCliFrontend.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/util/MockedCliFrontend.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.util;
+
+import org.apache.flink.client.CliFrontend;
+import org.apache.flink.client.CliFrontendTestUtils;
+import org.apache.flink.client.cli.CustomCommandLine;
+import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.configuration.Configuration;
+
+import org.apache.commons.cli.CommandLine;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+/**
+ * Utility class for mocking the {@link ClusterClient} within a {@link CliFrontend}.
+ *
+ * <p>The mocking behavior can be defined in the constructor of the sub-class.
+ */
+public class MockedCliFrontend extends CliFrontend {
+	public final ClusterClient client;
+
+	protected MockedCliFrontend() throws Exception {
+		super(CliFrontendTestUtils.getConfigDir());
+		this.client = mock(ClusterClient.class);
+	}
+
+	@Override
+	public CustomCommandLine getActiveCustomCommandLine(CommandLine commandLine) {
+		CustomCommandLine ccl = mock(CustomCommandLine.class);
+		when(ccl.retrieveCluster(any(CommandLine.class), any(Configuration.class), anyString()))
+			.thenReturn(client);
+		return ccl;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointMessageParameters.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointMessageParameters.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.job.savepoints;
+
+import org.apache.flink.runtime.rest.messages.JobIDPathParameter;
+import org.apache.flink.runtime.rest.messages.MessageParameters;
+import org.apache.flink.runtime.rest.messages.MessagePathParameter;
+import org.apache.flink.runtime.rest.messages.MessageQueryParameter;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * The parameters for triggering a savepoint.
+ */
+public class SavepointMessageParameters extends MessageParameters {
+
+	public JobIDPathParameter jobID = new JobIDPathParameter();
+	public SavepointTargetDirectoryParameter targetDirectory = new SavepointTargetDirectoryParameter();
+
+	@Override
+	public Collection<MessagePathParameter<?>> getPathParameters() {
+		return Collections.singleton(jobID);
+	}
+
+	@Override
+	public Collection<MessageQueryParameter<?>> getQueryParameters() {
+		return Collections.singleton(targetDirectory);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointTargetDirectoryParameter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointTargetDirectoryParameter.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.job.savepoints;
+
+import org.apache.flink.runtime.rest.messages.MessageQueryParameter;
+
+/**
+ * The parameter denoting the directory where to which a savepoint should be written to.
+ */
+public class SavepointTargetDirectoryParameter extends MessageQueryParameter<String> {
+
+	SavepointTargetDirectoryParameter() {
+		super("targetDirectory", MessageParameterRequisiteness.OPTIONAL);
+	}
+
+	@Override
+	public String convertValueFromString(String value) {
+		return value;
+	}
+
+	@Override
+	public String convertStringToValue(String value) {
+		return value;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointTriggerHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointTriggerHeaders.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.job.savepoints;
+
+import org.apache.flink.runtime.rest.HttpMethodWrapper;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+/**
+ * These headers define the protocol for triggering a savepoint.
+ */
+public class SavepointTriggerHeaders implements MessageHeaders<EmptyRequestBody, SavepointTriggerResponseBody, SavepointMessageParameters> {
+
+	private static final SavepointTriggerHeaders INSTANCE = new SavepointTriggerHeaders();
+
+	private SavepointTriggerHeaders() {
+	}
+
+	@Override
+	public Class<EmptyRequestBody> getRequestClass() {
+		return EmptyRequestBody.class;
+	}
+
+	@Override
+	public Class<SavepointTriggerResponseBody> getResponseClass() {
+		return SavepointTriggerResponseBody.class;
+	}
+
+	@Override
+	public HttpResponseStatus getResponseStatusCode() {
+		return HttpResponseStatus.ACCEPTED;
+	}
+
+	@Override
+	public SavepointMessageParameters getUnresolvedMessageParameters() {
+		return new SavepointMessageParameters();
+	}
+
+	@Override
+	public HttpMethodWrapper getHttpMethod() {
+		return HttpMethodWrapper.POST;
+	}
+
+	@Override
+	public String getTargetRestEndpointURL() {
+		/*
+		Note: this is different to the existing implementation for which the targetDirectory is a path parameter
+		Having it as a path parameter has several downsides as it
+			- is optional (which we only allow for query parameters)
+			- causes parsing issues, since the path is not reliably treated as a single parameter
+			- does not denote a hierarchy which path parameters are supposed to do
+			- interacts badly with the POST spec, as it would require the progress url to also contain the targetDirectory
+		 */
+
+		return "/jobs/:jobid/savepoints";
+	}
+
+	public static SavepointTriggerHeaders getInstance() {
+		return INSTANCE;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointTriggerResponseBody.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointTriggerResponseBody.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.job.savepoints;
+
+import org.apache.flink.runtime.rest.messages.ResponseBody;
+import org.apache.flink.util.Preconditions;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Response to the triggering of a savepoint.
+ */
+public class SavepointTriggerResponseBody implements ResponseBody {
+
+	private static final String FIELD_NAME_STATUS = "status";
+
+	private static final String FIELD_NAME_LOCATION = "location";
+
+	private static final String FIELD_NAME_REQUEST_ID = "request-id";
+
+	@JsonProperty(FIELD_NAME_STATUS)
+	public final String status;
+
+	@JsonProperty(FIELD_NAME_LOCATION)
+	public final String location;
+
+	@JsonProperty(FIELD_NAME_REQUEST_ID)
+	public final String requestId;
+
+	@JsonCreator
+	public SavepointTriggerResponseBody(
+			@JsonProperty(FIELD_NAME_STATUS) String status,
+			@JsonProperty(FIELD_NAME_LOCATION) String location,
+			@JsonProperty(FIELD_NAME_REQUEST_ID) String requestId) {
+		this.status = status;
+		this.location = Preconditions.checkNotNull(location);
+		this.requestId = requestId;
+	}
+
+	@Override
+	public int hashCode() {
+		return 79 * location.hashCode();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (object instanceof SavepointTriggerResponseBody) {
+			SavepointTriggerResponseBody other = (SavepointTriggerResponseBody) object;
+			return this.location.equals(other.location);
+		}
+		return false;
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointTriggerResponseBodyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointTriggerResponseBodyTest.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.job.savepoints;
+
+import org.apache.flink.runtime.rest.handler.legacy.messages.RestResponseMarshallingTestBase;
+
+/**
+ * Tests for the {@link SavepointTriggerResponseBody}.
+ */
+public class SavepointTriggerResponseBodyTest extends RestResponseMarshallingTestBase<SavepointTriggerResponseBody> {
+
+	@Override
+	protected Class<SavepointTriggerResponseBody> getTestResponseClass() {
+		return SavepointTriggerResponseBody.class;
+	}
+
+	@Override
+	protected SavepointTriggerResponseBody getTestResponseInstance() throws Exception {
+		return new SavepointTriggerResponseBody("growing", "/universe", "big-bang");
+	}
+}


### PR DESCRIPTION
Based on #4788.

## What is the purpose of the change

This PR includes all the client-side changes necessary to trigger savepoints with FLIP-6, including the message headers etc. . It does NOT include a port of the savepoint handlers.

Do note that the REST protocol is _incompatible_ with the existing savepoint handlers. For one it is now a POST instead of GET (as it should be), and the savepoint target directory is no longer a path but a query parameter (for the reasoning, see SavepointTriggerHeaders#getTargetRestEndpointURL). There has also been a recent discussion on the mailing list to make this a query parameter.

## Brief change log

* refactor/add utility classes for easier testing
* move savepoint logic from CliFrontend into ClusterClient (as we did with stop/cancel in ad380463d3d44cdd98302bf072bc5deba8696b5b)
* define REST protocol for triggering savepoints and integrate it into the `RestClusterClient`

## Verifying this change

This change added tests and can be verified as follows:

* the changes to the CliFrontend are covered by modified tests in CliFrontendSavepointTest
* the changes to the ClusterClient are covered by new tests in ClusterClientTest
* the changes to the RestClusterClient are covered by RestClusterClientTest#testTriggerSavepoint

