### PR TITLE
[hotfix] [Javadoc] Fix typos

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/InputTypeConfigurable.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/InputTypeConfigurable.java
@@ -25,7 +25,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 
 /**
  * {@link org.apache.flink.api.common.io.OutputFormat}s can implement this interface to be configured
- * with the data type they will operate on. The method {@link #setInputType(TypeInformation, ExecutionConfig)
+ * with the data type they will operate on. The method {@link #setInputType(TypeInformation, ExecutionConfig)}
  * will be called when the output format is used with an output API method.
  */
 @Public

--- a/flink-core/src/main/java/org/apache/flink/core/fs/FileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/FileSystem.java
@@ -493,7 +493,7 @@ public abstract class FileSystem {
 	 *
 	 * @param f
 	 *        given path
-	 * @return the statuses of the files/directories in the given patch
+	 * @return the statuses of the files/directories in the given path
 	 * @throws IOException
 	 */
 	public abstract FileStatus[] listStatus(Path f) throws IOException;


### PR DESCRIPTION
Fix typos in Javadoc for classes:

- `org.apache.flink.api.java.typeutils.InputTypeConfigurable`
- `org.apache.flink.core.fs.FileSystem`