### PR TITLE
[FLINK-7792] [tests][client] Only suppress stdout for CLI tests

### DIFF
--- a/flink-clients/src/test/java/org/apache/flink/client/CliFrontendTestUtils.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/CliFrontendTestUtils.java
@@ -66,7 +66,6 @@ public class CliFrontendTestUtils {
 
 	public static void pipeSystemOutToNull() {
 		System.setOut(new PrintStream(new BlackholeOutputSteam()));
-		System.setErr(new PrintStream(new BlackholeOutputSteam()));
 	}
 
 	private static final class BlackholeOutputSteam extends java.io.OutputStream {


### PR DESCRIPTION
## What is the purpose of the change

This PR modifies the CliFrontendTestUtils to only suppress stdout. Previously we were also suppressing stderr, which also disabled logging.

## Verifying this change

To verify that this does not cause noise tests, run all tests under `org.apache.flink.client` in `flink-clients` which are the sole users of this method.