### PR TITLE
[FLINK-7653] Properly implement Dispatcher#requestClusterOverview

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/akka/AkkaJobManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/akka/AkkaJobManagerGateway.java
@@ -30,12 +30,12 @@ import org.apache.flink.runtime.jobmaster.JobManagerGateway;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.messages.FlinkJobNotFoundException;
 import org.apache.flink.runtime.messages.JobManagerMessages;
+import org.apache.flink.runtime.messages.webmonitor.ClusterOverview;
 import org.apache.flink.runtime.messages.webmonitor.JobsWithIDsOverview;
 import org.apache.flink.runtime.messages.webmonitor.MultipleJobsDetails;
 import org.apache.flink.runtime.messages.webmonitor.RequestJobDetails;
 import org.apache.flink.runtime.messages.webmonitor.RequestJobsWithIDsOverview;
 import org.apache.flink.runtime.messages.webmonitor.RequestStatusOverview;
-import org.apache.flink.runtime.messages.webmonitor.StatusOverview;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.Preconditions;
 
@@ -244,11 +244,11 @@ public class AkkaJobManagerGateway implements JobManagerGateway {
 	}
 
 	@Override
-	public CompletableFuture<StatusOverview> requestStatusOverview(Time timeout) {
+	public CompletableFuture<ClusterOverview> requestClusterOverview(Time timeout) {
 		return FutureUtils.toJava(
 			jobManagerGateway
 				.ask(RequestStatusOverview.getInstance(), FutureUtils.toFiniteDuration(timeout))
-				.mapTo(ClassTag$.MODULE$.apply(StatusOverview.class)));
+				.mapTo(ClassTag$.MODULE$.apply(ClusterOverview.class)));
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherRestEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherRestEndpoint.java
@@ -44,6 +44,7 @@ import org.apache.flink.runtime.rest.handler.legacy.DashboardConfigHandler;
 import org.apache.flink.runtime.rest.handler.legacy.ExecutionGraphCache;
 import org.apache.flink.runtime.rest.handler.legacy.files.StaticFileServerHandler;
 import org.apache.flink.runtime.rest.handler.legacy.files.WebContentHandlerSpecification;
+import org.apache.flink.runtime.rest.handler.legacy.messages.ClusterOverviewWithVersion;
 import org.apache.flink.runtime.rest.messages.ClusterConfigurationInfo;
 import org.apache.flink.runtime.rest.messages.ClusterConfigurationInfoHeaders;
 import org.apache.flink.runtime.rest.messages.ClusterOverviewHeaders;
@@ -54,7 +55,6 @@ import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
 import org.apache.flink.runtime.rest.messages.JobConfigHeaders;
 import org.apache.flink.runtime.rest.messages.JobPlanHeaders;
 import org.apache.flink.runtime.rest.messages.JobTerminationHeaders;
-import org.apache.flink.runtime.rest.messages.StatusOverviewWithVersion;
 import org.apache.flink.runtime.rest.messages.checkpoints.CheckpointConfigHeaders;
 import org.apache.flink.runtime.rest.messages.checkpoints.CheckpointStatisticDetailsHeaders;
 import org.apache.flink.runtime.rest.messages.checkpoints.CheckpointingStatisticsHeaders;
@@ -113,7 +113,7 @@ public class DispatcherRestEndpoint extends RestServerEndpoint {
 
 		final Time timeout = restConfiguration.getTimeout();
 
-		LegacyRestHandlerAdapter<DispatcherGateway, StatusOverviewWithVersion, EmptyMessageParameters> clusterOverviewHandler = new LegacyRestHandlerAdapter<>(
+		LegacyRestHandlerAdapter<DispatcherGateway, ClusterOverviewWithVersion, EmptyMessageParameters> clusterOverviewHandler = new LegacyRestHandlerAdapter<>(
 			restAddressFuture,
 			leaderRetriever,
 			timeout,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/StandaloneDispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/StandaloneDispatcher.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.jobmaster.JobManagerRunner;
 import org.apache.flink.runtime.jobmaster.JobManagerServices;
 import org.apache.flink.runtime.jobmaster.JobMaster;
 import org.apache.flink.runtime.metrics.MetricRegistry;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
 
@@ -45,6 +46,7 @@ public class StandaloneDispatcher extends Dispatcher {
 			String endpointId,
 			Configuration configuration,
 			HighAvailabilityServices highAvailabilityServices,
+			ResourceManagerGateway resourceManagerGateway,
 			BlobServer blobServer,
 			HeartbeatServices heartbeatServices,
 			MetricRegistry metricRegistry,
@@ -55,6 +57,7 @@ public class StandaloneDispatcher extends Dispatcher {
 			endpointId,
 			configuration,
 			highAvailabilityServices,
+			resourceManagerGateway,
 			blobServer,
 			heartbeatServices,
 			metricRegistry,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/SessionClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/SessionClusterEntrypoint.java
@@ -32,6 +32,7 @@ import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.resourcemanager.ResourceManager;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.rest.RestServerEndpointConfiguration;
 import org.apache.flink.runtime.rest.handler.RestHandlerConfiguration;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
@@ -100,6 +101,7 @@ public abstract class SessionClusterEntrypoint extends ClusterEntrypoint {
 			configuration,
 			rpcService,
 			highAvailabilityServices,
+			resourceManager.getSelfGateway(ResourceManagerGateway.class),
 			blobServer,
 			heartbeatServices,
 			metricRegistry,
@@ -168,6 +170,7 @@ public abstract class SessionClusterEntrypoint extends ClusterEntrypoint {
 		Configuration configuration,
 		RpcService rpcService,
 		HighAvailabilityServices highAvailabilityServices,
+		ResourceManagerGateway resourceManagerGateway,
 		BlobServer blobServer,
 		HeartbeatServices heartbeatServices,
 		MetricRegistry metricRegistry,
@@ -180,6 +183,7 @@ public abstract class SessionClusterEntrypoint extends ClusterEntrypoint {
 			Dispatcher.DISPATCHER_NAME,
 			configuration,
 			highAvailabilityServices,
+			resourceManagerGateway,
 			blobServer,
 			heartbeatServices,
 			metricRegistry,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -750,6 +750,11 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 		return CompletableFuture.completedFuture(executionGraph.archive());
 	}
 
+	@Override
+	public CompletableFuture<JobStatus> requestJobStatus(Time timeout) {
+		return CompletableFuture.completedFuture(executionGraph.getState());
+	}
+
 	//----------------------------------------------------------------------------------------------
 	// Internal methods
 	//----------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.io.network.partition.ResultPartition;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobmaster.message.ClassloadingProps;
 import org.apache.flink.runtime.messages.Acknowledge;
@@ -249,4 +250,12 @@ public interface JobMasterGateway extends CheckpointCoordinatorGateway, FencedRp
 	 * @return Future archived execution graph derived from the currently executed job
 	 */
 	CompletableFuture<AccessExecutionGraph> requestArchivedExecutionGraph(@RpcTimeout Time timeout);
+
+	/**
+	 * Requests the current job status.
+	 *
+	 * @param timeout for the rpc call
+	 * @return Future containing the current job status
+	 */
+	CompletableFuture<JobStatus> requestJobStatus(@RpcTimeout Time timeout);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/messages/webmonitor/ClusterOverview.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/messages/webmonitor/ClusterOverview.java
@@ -25,7 +25,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * Response to the {@link RequestStatusOverview} message, carrying a description
  * of the Flink cluster status.
  */
-public class StatusOverview extends JobsOverview {
+public class ClusterOverview extends JobsOverview {
 
 	private static final long serialVersionUID = -729861859715105265L;
 
@@ -43,7 +43,7 @@ public class StatusOverview extends JobsOverview {
 	private final int numSlotsAvailable;
 
 	@JsonCreator
-	public StatusOverview(
+	public ClusterOverview(
 			@JsonProperty(FIELD_NAME_TASKMANAGERS) int numTaskManagersConnected,
 			@JsonProperty(FIELD_NAME_SLOTS_TOTAL) int numSlotsTotal,
 			@JsonProperty(FIELD_NAME_SLOTS_AVAILABLE) int numSlotsAvailable,
@@ -59,8 +59,8 @@ public class StatusOverview extends JobsOverview {
 		this.numSlotsAvailable = numSlotsAvailable;
 	}
 
-	public StatusOverview(int numTaskManagersConnected, int numSlotsTotal, int numSlotsAvailable,
-							JobsOverview jobs1, JobsOverview jobs2) {
+	public ClusterOverview(int numTaskManagersConnected, int numSlotsTotal, int numSlotsAvailable,
+						   JobsOverview jobs1, JobsOverview jobs2) {
 		super(jobs1, jobs2);
 		this.numTaskManagersConnected = numTaskManagersConnected;
 		this.numSlotsTotal = numSlotsTotal;
@@ -86,8 +86,8 @@ public class StatusOverview extends JobsOverview {
 		if (this == obj) {
 			return true;
 		}
-		else if (obj instanceof  StatusOverview) {
-			StatusOverview that = (StatusOverview) obj;
+		else if (obj instanceof ClusterOverview) {
+			ClusterOverview that = (ClusterOverview) obj;
 			return this.numTaskManagersConnected == that.numTaskManagersConnected &&
 					this.numSlotsTotal == that.numSlotsTotal &&
 					this.numSlotsAvailable == that.numSlotsAvailable &&

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/messages/webmonitor/RequestStatusOverview.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/messages/webmonitor/RequestStatusOverview.java
@@ -21,7 +21,7 @@ package org.apache.flink.runtime.messages.webmonitor;
 /**
  * This message requests an overview of the status, such as how many TaskManagers
  * are currently connected, how many slots are available, how many are free, ...
- * The response to this message is a {@link StatusOverview} message.
+ * The response to this message is a {@link ClusterOverview} message.
  */
 public class RequestStatusOverview implements InfoMessage {
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -480,6 +480,18 @@ public abstract class ResourceManager<WorkerType extends Serializable>
 		return CompletableFuture.completedFuture(taskExecutors.size());
 	}
 
+	@Override
+	public CompletableFuture<ResourceOverview> requestResourceOverview(Time timeout) {
+		final int numberSlots = slotManager.getNumberRegisteredSlots();
+		final int numberFreeSlots = slotManager.getNumberFreeSlots();
+
+		return CompletableFuture.completedFuture(
+			new ResourceOverview(
+				taskExecutors.size(),
+				numberSlots,
+				numberFreeSlots));
+	}
+
 	// ------------------------------------------------------------------------
 	//  Internal methods
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerGateway.java
@@ -157,4 +157,13 @@ public interface ResourceManagerGateway extends FencedRpcGateway<ResourceManager
 	 * @param cause for the disconnection of the JobManager
 	 */
 	void disconnectJobManager(JobID jobId, Exception cause);
+
+	/**
+	 * Requests the resource overview. The resource overview provides information about the
+	 * connected TaskManagers, the total number of slots and the number of available slots.
+	 *
+	 * @param timeout of the request
+	 * @return Future containing the resource overview
+	 */
+	CompletableFuture<ResourceOverview> requestResourceOverview(@RpcTimeout Time timeout);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceOverview.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceOverview.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager;
+
+import java.io.Serializable;
+
+/**
+ * Class containing information about the available cluster resources.
+ */
+public class ResourceOverview implements Serializable {
+
+	private static final long serialVersionUID = 7618746920569224557L;
+
+	private final int numberTaskManagers;
+
+	private final int numberRegisteredSlots;
+
+	private final int numberFreeSlots;
+
+	public ResourceOverview(int numberTaskManagers, int numberRegisteredSlots, int numberFreeSlots) {
+		this.numberTaskManagers = numberTaskManagers;
+		this.numberRegisteredSlots = numberRegisteredSlots;
+		this.numberFreeSlots = numberFreeSlots;
+	}
+
+	public int getNumberTaskManagers() {
+		return numberTaskManagers;
+	}
+
+	public int getNumberRegisteredSlots() {
+		return numberRegisteredSlots;
+	}
+
+	public int getNumberFreeSlots() {
+		return numberFreeSlots;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
@@ -22,8 +22,8 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
-import org.apache.flink.runtime.clusterframework.types.TaskManagerSlot;
 import org.apache.flink.runtime.clusterframework.types.SlotID;
+import org.apache.flink.runtime.clusterframework.types.TaskManagerSlot;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.messages.Acknowledge;
@@ -36,8 +36,8 @@ import org.apache.flink.runtime.taskexecutor.SlotStatus;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
 import org.apache.flink.runtime.taskexecutor.exceptions.SlotAllocationException;
 import org.apache.flink.runtime.taskexecutor.exceptions.SlotOccupiedException;
-import org.apache.flink.util.AbstractID;
 import org.apache.flink.util.Preconditions;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,7 +65,7 @@ import java.util.concurrent.TimeoutException;
  * slots are currently not used) and pending slot requests time out triggering their release and
  * failure, respectively.
  */
-public class SlotManager<T extends AbstractID> implements AutoCloseable {
+public class SlotManager implements AutoCloseable {
 	private static final Logger LOG = LoggerFactory.getLogger(SlotManager.class);
 
 	/** Scheduled executor for timeouts */
@@ -134,6 +134,14 @@ public class SlotManager<T extends AbstractID> implements AutoCloseable {
 		slotRequestTimeoutCheck = null;
 
 		started = false;
+	}
+
+	public int getNumberRegisteredSlots() {
+		return slots.size();
+	}
+
+	public int getNumberFreeSlots() {
+		return freeSlots.size();
 	}
 
 	// ---------------------------------------------------------------------------------------------
@@ -922,11 +930,6 @@ public class SlotManager<T extends AbstractID> implements AutoCloseable {
 	@VisibleForTesting
 	TaskManagerSlot getSlot(SlotID slotId) {
 		return slots.get(slotId);
-	}
-
-	@VisibleForTesting
-	int getNumberRegisteredSlots() {
-		return slots.size();
 	}
 
 	@VisibleForTesting

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/messages/ClusterOverviewWithVersion.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/messages/ClusterOverviewWithVersion.java
@@ -16,10 +16,11 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.rest.messages;
+package org.apache.flink.runtime.rest.handler.legacy.messages;
 
+import org.apache.flink.runtime.messages.webmonitor.ClusterOverview;
 import org.apache.flink.runtime.messages.webmonitor.JobsOverview;
-import org.apache.flink.runtime.messages.webmonitor.StatusOverview;
+import org.apache.flink.runtime.rest.messages.ResponseBody;
 import org.apache.flink.util.Preconditions;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -28,9 +29,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
 
 /**
- * Status overview message including the current Flink version and commit id.
+ * Cluster overview message including the current Flink version and commit id.
  */
-public class StatusOverviewWithVersion extends StatusOverview implements ResponseBody {
+public class ClusterOverviewWithVersion extends ClusterOverview implements ResponseBody {
 
 	private static final long serialVersionUID = 5000058311783413216L;
 
@@ -44,7 +45,7 @@ public class StatusOverviewWithVersion extends StatusOverview implements Respons
 	private final String commitId;
 
 	@JsonCreator
-	public StatusOverviewWithVersion(
+	public ClusterOverviewWithVersion(
 			@JsonProperty(FIELD_NAME_TASKMANAGERS) int numTaskManagersConnected,
 			@JsonProperty(FIELD_NAME_SLOTS_TOTAL) int numSlotsTotal,
 			@JsonProperty(FIELD_NAME_SLOTS_AVAILABLE) int numSlotsAvailable,
@@ -67,7 +68,7 @@ public class StatusOverviewWithVersion extends StatusOverview implements Respons
 		this.commitId = Preconditions.checkNotNull(commitId);
 	}
 
-	public StatusOverviewWithVersion(
+	public ClusterOverviewWithVersion(
 			int numTaskManagersConnected,
 			int numSlotsTotal,
 			int numSlotsAvailable,
@@ -81,8 +82,8 @@ public class StatusOverviewWithVersion extends StatusOverview implements Respons
 		this.commitId = Preconditions.checkNotNull(commitId);
 	}
 
-	public static StatusOverviewWithVersion fromStatusOverview(StatusOverview statusOverview, String version, String commitId) {
-		return new StatusOverviewWithVersion(
+	public static ClusterOverviewWithVersion fromStatusOverview(ClusterOverview statusOverview, String version, String commitId) {
+		return new ClusterOverviewWithVersion(
 			statusOverview.getNumTaskManagersConnected(),
 			statusOverview.getNumSlotsTotal(),
 			statusOverview.getNumSlotsAvailable(),
@@ -114,7 +115,7 @@ public class StatusOverviewWithVersion extends StatusOverview implements Respons
 			return false;
 		}
 
-		StatusOverviewWithVersion that = (StatusOverviewWithVersion) o;
+		ClusterOverviewWithVersion that = (ClusterOverviewWithVersion) o;
 
 		return Objects.equals(version, that.getVersion()) && Objects.equals(commitId, that.getCommitId());
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/ClusterOverviewHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/ClusterOverviewHeaders.java
@@ -20,13 +20,14 @@ package org.apache.flink.runtime.rest.messages;
 
 import org.apache.flink.runtime.rest.HttpMethodWrapper;
 import org.apache.flink.runtime.rest.handler.legacy.ClusterOverviewHandler;
+import org.apache.flink.runtime.rest.handler.legacy.messages.ClusterOverviewWithVersion;
 
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
 
 /**
  * Message headers for the {@link ClusterOverviewHandler}.
  */
-public final class ClusterOverviewHeaders implements MessageHeaders<EmptyRequestBody, StatusOverviewWithVersion, EmptyMessageParameters> {
+public final class ClusterOverviewHeaders implements MessageHeaders<EmptyRequestBody, ClusterOverviewWithVersion, EmptyMessageParameters> {
 
 	private static final ClusterOverviewHeaders INSTANCE = new ClusterOverviewHeaders();
 
@@ -51,8 +52,8 @@ public final class ClusterOverviewHeaders implements MessageHeaders<EmptyRequest
 	}
 
 	@Override
-	public Class<StatusOverviewWithVersion> getResponseClass() {
-		return StatusOverviewWithVersion.class;
+	public Class<ClusterOverviewWithVersion> getResponseClass() {
+		return ClusterOverviewWithVersion.class;
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/RestfulGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/RestfulGateway.java
@@ -22,8 +22,8 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.messages.FlinkJobNotFoundException;
+import org.apache.flink.runtime.messages.webmonitor.ClusterOverview;
 import org.apache.flink.runtime.messages.webmonitor.MultipleJobsDetails;
-import org.apache.flink.runtime.messages.webmonitor.StatusOverview;
 import org.apache.flink.runtime.rpc.RpcEndpoint;
 import org.apache.flink.runtime.rpc.RpcGateway;
 import org.apache.flink.runtime.rpc.RpcTimeout;
@@ -75,5 +75,5 @@ public interface RestfulGateway extends RpcGateway {
 	 * @param timeout for the asynchronous operation
 	 * @return Future containing the status overview
 	 */
-	CompletableFuture<StatusOverview> requestStatusOverview(@RpcTimeout Time timeout);
+	CompletableFuture<ClusterOverview> requestClusterOverview(@RpcTimeout Time timeout);
 }

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -1676,7 +1676,7 @@ class JobManager(
           val future = (archive ? RequestJobsOverview.getInstance())(timeout)
           future.onSuccess {
             case archiveOverview: JobsOverview =>
-              theSender ! new StatusOverview(numTMs, numSlotsTotal, numSlotsAvailable,
+              theSender ! new ClusterOverview(numTMs, numSlotsTotal, numSlotsAvailable,
                 ourJobs, archiveOverview)
           }(context.dispatcher)
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -35,6 +35,7 @@ import org.apache.flink.runtime.jobmaster.JobManagerServices;
 import org.apache.flink.runtime.leaderelection.TestingLeaderElectionService;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.metrics.MetricRegistry;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.RpcUtils;
@@ -105,6 +106,7 @@ public class DispatcherTest extends TestLogger {
 			Dispatcher.DISPATCHER_NAME,
 			new Configuration(),
 			haServices,
+			mock(ResourceManagerGateway.class),
 			mock(BlobServer.class),
 			heartbeatServices,
 			mock(MetricRegistry.class),
@@ -164,6 +166,7 @@ public class DispatcherTest extends TestLogger {
 			Dispatcher.DISPATCHER_NAME,
 			new Configuration(),
 			haServices,
+			mock(ResourceManagerGateway.class),
 			mock(BlobServer.class),
 			heartbeatServices,
 			mock(MetricRegistry.class),
@@ -198,6 +201,7 @@ public class DispatcherTest extends TestLogger {
 				String endpointId,
 				Configuration configuration,
 				HighAvailabilityServices highAvailabilityServices,
+				ResourceManagerGateway resourceManagerGateway,
 				BlobServer blobServer,
 				HeartbeatServices heartbeatServices,
 				MetricRegistry metricRegistry,
@@ -209,6 +213,7 @@ public class DispatcherTest extends TestLogger {
 				endpointId,
 				configuration,
 				highAvailabilityServices,
+				resourceManagerGateway,
 				blobServer,
 				heartbeatServices,
 				metricRegistry,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/messages/WebMonitorMessagesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/messages/WebMonitorMessagesTest.java
@@ -29,7 +29,7 @@ import org.apache.flink.runtime.messages.webmonitor.RequestJobDetails;
 import org.apache.flink.runtime.messages.webmonitor.RequestJobsOverview;
 import org.apache.flink.runtime.messages.webmonitor.RequestJobsWithIDsOverview;
 import org.apache.flink.runtime.messages.webmonitor.RequestStatusOverview;
-import org.apache.flink.runtime.messages.webmonitor.StatusOverview;
+import org.apache.flink.runtime.messages.webmonitor.ClusterOverview;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -53,7 +53,7 @@ public class WebMonitorMessagesTest {
 			GenericMessageTester.testMessageInstance(RequestJobsOverview.getInstance());
 
 			GenericMessageTester.testMessageInstance(GenericMessageTester.instantiateGeneric(RequestJobDetails.class, rnd));
-			GenericMessageTester.testMessageInstance(GenericMessageTester.instantiateGeneric(StatusOverview.class, rnd));
+			GenericMessageTester.testMessageInstance(GenericMessageTester.instantiateGeneric(ClusterOverview.class, rnd));
 			GenericMessageTester.testMessageInstance(GenericMessageTester.instantiateGeneric(JobsOverview.class, rnd));
 			
 			GenericMessageTester.testMessageInstance(new JobsWithIDsOverview(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/messages/ClusterOverviewWithVersionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/messages/ClusterOverviewWithVersionTest.java
@@ -16,21 +16,23 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.rest.messages;
+package org.apache.flink.runtime.rest.handler.legacy.messages;
+
+import org.apache.flink.runtime.rest.messages.RestResponseMarshallingTestBase;
 
 /**
- * Tests for the {@link StatusOverviewWithVersion}.
+ * Tests for the {@link ClusterOverviewWithVersion}.
  */
-public class StatusOverviewWithVersionTest extends RestResponseMarshallingTestBase<StatusOverviewWithVersion> {
+public class ClusterOverviewWithVersionTest extends RestResponseMarshallingTestBase<ClusterOverviewWithVersion> {
 
 	@Override
-	protected Class<StatusOverviewWithVersion> getTestResponseClass() {
-		return StatusOverviewWithVersion.class;
+	protected Class<ClusterOverviewWithVersion> getTestResponseClass() {
+		return ClusterOverviewWithVersion.class;
 	}
 
 	@Override
-	protected StatusOverviewWithVersion getTestResponseInstance() {
-		return new StatusOverviewWithVersion(
+	protected ClusterOverviewWithVersion getTestResponseInstance() {
+		return new ClusterOverviewWithVersion(
 			1,
 			3,
 			3,


### PR DESCRIPTION
## What is the purpose of the change

This commit implements the ClusterOverview generation on the Dispatcher. In
order to do this, the Dispatcher requests the ResourceOverview from the
ResourceManager and the job status from all JobMasters. After receiving all
information, it is compiled into the ClusterOverview.

Note: StatusOverview has been renamed to ClusterOverview

## Verifying this change

Tested the changes manually.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

