### PR TITLE
[FLINK-7793] [flip6] Defer slot release to ResourceManager

### DIFF
--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManager.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManager.java
@@ -421,8 +421,9 @@ public class MesosResourceManager extends ResourceManager<RegisteredMesosWorkerN
 	}
 
 	@Override
-	public void stopWorker(ResourceID resourceID) {
+	public boolean stopWorker(ResourceID resourceID) {
 		LOG.info("Stopping worker {}.", resourceID);
+
 		try {
 
 			if (workersInLaunch.containsKey(resourceID)) {
@@ -449,6 +450,8 @@ public class MesosResourceManager extends ResourceManager<RegisteredMesosWorkerN
 		catch (Exception e) {
 			onFatalError(new ResourceManagerException("Unable to release a worker.", e));
 		}
+
+		return true;
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -866,14 +866,15 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 		errorHandler.onFatalError(cause);
 	}
 
-	private void jobStatusChanged(final JobStatus newJobStatus, long timestamp, final Throwable error) {
+	private void jobStatusChanged(
+			final JobStatus newJobStatus,
+			long timestamp,
+			@Nullable final Throwable error) {
 		validateRunsInMainThread();
 
 		final JobID jobID = executionGraph.getJobID();
 		final String jobName = executionGraph.getJobName();
-
-		log.info("Status of job {} ({}) changed to {}.", jobID, jobName, newJobStatus, error);
-
+		
 		if (newJobStatus.isGloballyTerminalState()) {
 			switch (newJobStatus) {
 				case FINISHED:

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/StandaloneResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/StandaloneResourceManager.java
@@ -75,8 +75,9 @@ public class StandaloneResourceManager extends ResourceManager<ResourceID> {
 	}
 
 	@Override
-	public void stopWorker(ResourceID resourceID) {
-
+	public boolean stopWorker(ResourceID resourceID) {
+		// standalone resource manager cannot stop workers
+		return false;
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/ResourceActions.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/ResourceActions.java
@@ -24,11 +24,32 @@ import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.resourcemanager.exceptions.ResourceManagerException;
 
-public interface ResourceManagerActions {
+/**
+ * Resource related actions which the {@link SlotManager} can perform.
+ */
+public interface ResourceActions {
 
+	/**
+	 * Releases the resource with the given instance id.
+	 *
+	 * @param instanceId identifying which resource to release
+	 */
 	void releaseResource(InstanceID instanceId);
 
+	/**
+	 * Requests to allocate a resource with the given {@link ResourceProfile}.
+	 *
+	 * @param resourceProfile for the to be allocated resource
+	 * @throws ResourceManagerException if the resource cannot be allocated
+	 */
 	void allocateResource(ResourceProfile resourceProfile) throws ResourceManagerException;
 
+	/**
+	 * Notifies that an allocation failure has occurred.
+	 *
+	 * @param jobId to which the allocation belonged
+	 * @param allocationId identifying the failed allocation
+	 * @param cause of the allocation failure
+	 */
 	void notifyAllocationFailure(JobID jobId, AllocationID allocationId, Exception cause);
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerTest.java
@@ -76,7 +76,7 @@ public class SlotManagerTest extends TestLogger {
 	@Test
 	public void testTaskManagerRegistration() throws Exception {
 		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
-		final ResourceManagerActions resourceManagerActions = mock(ResourceManagerActions.class);
+		final ResourceActions resourceManagerActions = mock(ResourceActions.class);
 
 		final TaskExecutorGateway taskExecutorGateway = mock(TaskExecutorGateway.class);
 		final TaskExecutorConnection taskManagerConnection = new TaskExecutorConnection(taskExecutorGateway);
@@ -105,7 +105,7 @@ public class SlotManagerTest extends TestLogger {
 	@Test
 	public void testTaskManagerUnregistration() throws Exception {
 		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
-		final ResourceManagerActions resourceManagerActions = mock(ResourceManagerActions.class);
+		final ResourceActions resourceManagerActions = mock(ResourceActions.class);
 		final JobID jobId = new JobID();
 
 		final TaskExecutorGateway taskExecutorGateway = mock(TaskExecutorGateway.class);
@@ -175,7 +175,7 @@ public class SlotManagerTest extends TestLogger {
 			resourceProfile,
 			"localhost");
 
-		ResourceManagerActions resourceManagerActions = mock(ResourceManagerActions.class);
+		ResourceActions resourceManagerActions = mock(ResourceActions.class);
 
 		try (SlotManager slotManager = createSlotManager(resourceManagerId, resourceManagerActions)) {
 
@@ -198,7 +198,7 @@ public class SlotManagerTest extends TestLogger {
 			resourceProfile,
 			"localhost");
 
-		ResourceManagerActions resourceManagerActions = mock(ResourceManagerActions.class);
+		ResourceActions resourceManagerActions = mock(ResourceActions.class);
 		doThrow(new ResourceManagerException("Test exception")).when(resourceManagerActions).allocateResource(any(ResourceProfile.class));
 
 		try (SlotManager slotManager = createSlotManager(resourceManagerId, resourceManagerActions)) {
@@ -230,7 +230,7 @@ public class SlotManagerTest extends TestLogger {
 			resourceProfile,
 			targetAddress);
 
-		ResourceManagerActions resourceManagerActions = mock(ResourceManagerActions.class);
+		ResourceActions resourceManagerActions = mock(ResourceActions.class);
 
 		try (SlotManager slotManager = createSlotManager(resourceManagerId, resourceManagerActions)) {
 
@@ -270,7 +270,7 @@ public class SlotManagerTest extends TestLogger {
 	@Test
 	public void testUnregisterPendingSlotRequest() throws Exception {
 		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
-		final ResourceManagerActions resourceManagerActions = mock(ResourceManagerActions.class);
+		final ResourceActions resourceManagerActions = mock(ResourceActions.class);
 		final SlotID slotId = new SlotID(ResourceID.generate(), 0);
 		final AllocationID allocationId = new AllocationID();
 
@@ -329,7 +329,7 @@ public class SlotManagerTest extends TestLogger {
 			resourceProfile,
 			targetAddress);
 
-		ResourceManagerActions resourceManagerActions = mock(ResourceManagerActions.class);
+		ResourceActions resourceManagerActions = mock(ResourceActions.class);
 
 		// accept an incoming slot request
 		final TaskExecutorGateway taskExecutorGateway = mock(TaskExecutorGateway.class);
@@ -376,7 +376,7 @@ public class SlotManagerTest extends TestLogger {
 		final AllocationID allocationId = new AllocationID();
 		final ResourceProfile resourceProfile = new ResourceProfile(42.0, 1337);
 
-		ResourceManagerActions resourceManagerActions = mock(ResourceManagerActions.class);
+		ResourceActions resourceManagerActions = mock(ResourceActions.class);
 
 		// accept an incoming slot request
 		final TaskExecutorGateway taskExecutorGateway = mock(TaskExecutorGateway.class);
@@ -416,7 +416,7 @@ public class SlotManagerTest extends TestLogger {
 	@Test
 	public void testDuplicatePendingSlotRequest() throws Exception {
 		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
-		final ResourceManagerActions resourceManagerActions = mock(ResourceManagerActions.class);
+		final ResourceActions resourceManagerActions = mock(ResourceActions.class);
 		final AllocationID allocationId = new AllocationID();
 		final ResourceProfile resourceProfile1 = new ResourceProfile(1.0, 2);
 		final ResourceProfile resourceProfile2 = new ResourceProfile(2.0, 1);
@@ -440,7 +440,7 @@ public class SlotManagerTest extends TestLogger {
 	@Test
 	public void testDuplicatePendingSlotRequestAfterSlotReport() throws Exception {
 		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
-		final ResourceManagerActions resourceManagerActions = mock(ResourceManagerActions.class);
+		final ResourceActions resourceManagerActions = mock(ResourceActions.class);
 		final JobID jobId = new JobID();
 		final AllocationID allocationId = new AllocationID();
 		final ResourceProfile resourceProfile = new ResourceProfile(1.0, 1);
@@ -468,7 +468,7 @@ public class SlotManagerTest extends TestLogger {
 	@Test
 	public void testDuplicatePendingSlotRequestAfterSuccessfulAllocation() throws Exception {
 		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
-		final ResourceManagerActions resourceManagerActions = mock(ResourceManagerActions.class);
+		final ResourceActions resourceManagerActions = mock(ResourceActions.class);
 		final AllocationID allocationId = new AllocationID();
 		final ResourceProfile resourceProfile1 = new ResourceProfile(1.0, 2);
 		final ResourceProfile resourceProfile2 = new ResourceProfile(2.0, 1);
@@ -513,7 +513,7 @@ public class SlotManagerTest extends TestLogger {
 	@Test
 	public void testAcceptingDuplicateSlotRequestAfterAllocationRelease() throws Exception {
 		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
-		final ResourceManagerActions resourceManagerActions = mock(ResourceManagerActions.class);
+		final ResourceActions resourceManagerActions = mock(ResourceActions.class);
 		final AllocationID allocationId = new AllocationID();
 		final ResourceProfile resourceProfile1 = new ResourceProfile(1.0, 2);
 		final ResourceProfile resourceProfile2 = new ResourceProfile(2.0, 1);
@@ -566,7 +566,7 @@ public class SlotManagerTest extends TestLogger {
 	@Test
 	public void testReceivingUnknownSlotReport() throws Exception {
 		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
-		final ResourceManagerActions resourceManagerActions = mock(ResourceManagerActions.class);
+		final ResourceActions resourceManagerActions = mock(ResourceActions.class);
 
 		final InstanceID unknownInstanceID = new InstanceID();
 		final SlotID unknownSlotId = new SlotID(ResourceID.generate(), 0);
@@ -592,7 +592,7 @@ public class SlotManagerTest extends TestLogger {
 	@Test
 	public void testUpdateSlotReport() throws Exception {
 		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
-		final ResourceManagerActions resourceManagerActions = mock(ResourceManagerActions.class);
+		final ResourceActions resourceManagerActions = mock(ResourceActions.class);
 
 		final JobID jobId = new JobID();
 		final AllocationID allocationId = new AllocationID();
@@ -649,7 +649,7 @@ public class SlotManagerTest extends TestLogger {
 	public void testTaskManagerTimeout() throws Exception {
 		final long tmTimeout = 500L;
 
-		final ResourceManagerActions resourceManagerActions = mock(ResourceManagerActions.class);
+		final ResourceActions resourceManagerActions = mock(ResourceActions.class);
 		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
 
 		final TaskExecutorGateway taskExecutorGateway = mock(TaskExecutorGateway.class);
@@ -691,7 +691,7 @@ public class SlotManagerTest extends TestLogger {
 	public void testSlotRequestTimeout() throws Exception {
 		final long allocationTimeout = 50L;
 
-		final ResourceManagerActions resourceManagerActions = mock(ResourceManagerActions.class);
+		final ResourceActions resourceManagerActions = mock(ResourceActions.class);
 		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
 		final JobID jobId = new JobID();
 		final AllocationID allocationId = new AllocationID();
@@ -740,7 +740,7 @@ public class SlotManagerTest extends TestLogger {
 	@SuppressWarnings("unchecked")
 	public void testTaskManagerSlotRequestTimeoutHandling() throws Exception {
 		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
-		final ResourceManagerActions resourceManagerActions = mock(ResourceManagerActions.class);
+		final ResourceActions resourceManagerActions = mock(ResourceActions.class);
 
 		final JobID jobId = new JobID();
 		final AllocationID allocationId = new AllocationID();
@@ -819,7 +819,7 @@ public class SlotManagerTest extends TestLogger {
 	public void testSlotReportWhileActiveSlotRequest() throws Exception {
 		final long verifyTimeout = 10000L;
 		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
-		final ResourceManagerActions resourceManagerActions = mock(ResourceManagerActions.class);
+		final ResourceActions resourceManagerActions = mock(ResourceActions.class);
 
 		final JobID jobId = new JobID();
 		final AllocationID allocationId = new AllocationID();
@@ -937,7 +937,7 @@ public class SlotManagerTest extends TestLogger {
 		final long verifyTimeout = taskManagerTimeout * 10L;
 
 		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
-		final ResourceManagerActions resourceManagerActions = mock(ResourceManagerActions.class);
+		final ResourceActions resourceManagerActions = mock(ResourceActions.class);
 		final ScheduledExecutor scheduledExecutor = TestingUtils.defaultScheduledExecutor();
 
 		final ResourceID resourceId = ResourceID.generate();
@@ -1024,7 +1024,50 @@ public class SlotManagerTest extends TestLogger {
 		}
 	}
 
-	private SlotManager createSlotManager(ResourceManagerId resourceManagerId, ResourceManagerActions resourceManagerActions) {
+	/**
+	 * Tests that a task manager timeout does not remove the slots from the SlotManager.
+	 * A timeout should only trigger the {@link ResourceActions#releaseResource(InstanceID)}
+	 * callback. The receiver of the callback can then decide what to do with the TaskManager.
+	 *
+	 * FLINK-7793
+	 */
+	@Test
+	public void testTaskManagerTimeoutDoesNotRemoveSlots() throws Exception {
+		final Time taskManagerTimeout = Time.milliseconds(10L);
+		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
+		final ResourceActions resourceActions = mock(ResourceActions.class);
+		final TaskExecutorGateway taskExecutorGateway = mock(TaskExecutorGateway.class);
+
+		final TaskExecutorConnection taskExecutorConnection = new TaskExecutorConnection(taskExecutorGateway);
+		final SlotStatus slotStatus = new SlotStatus(
+			new SlotID(ResourceID.generate(), 0),
+			new ResourceProfile(1.0, 1));
+		final SlotReport initialSlotReport = new SlotReport(slotStatus);
+
+		try (final SlotManager slotManager = new SlotManager(
+			TestingUtils.defaultScheduledExecutor(),
+			TestingUtils.infiniteTime(),
+			TestingUtils.infiniteTime(),
+			taskManagerTimeout)) {
+
+			slotManager.start(resourceManagerId, Executors.directExecutor(), resourceActions);
+
+			slotManager.registerTaskManager(taskExecutorConnection, initialSlotReport);
+
+			assertEquals(1, slotManager.getNumberRegisteredSlots());
+
+			// wait for the timeout call to happen
+			verify(resourceActions, timeout(taskManagerTimeout.toMilliseconds() * 3L)).releaseResource(eq(taskExecutorConnection.getInstanceID()));
+
+			assertEquals(1, slotManager.getNumberRegisteredSlots());
+
+			slotManager.unregisterTaskManager(taskExecutorConnection.getInstanceID());
+
+			assertEquals(0, slotManager.getNumberRegisteredSlots());
+		}
+	}
+
+	private SlotManager createSlotManager(ResourceManagerId resourceManagerId, ResourceActions resourceManagerActions) {
 		SlotManager slotManager = new SlotManager(
 			TestingUtils.defaultScheduledExecutor(),
 			TestingUtils.infiniteTime(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerTest.java
@@ -1057,7 +1057,7 @@ public class SlotManagerTest extends TestLogger {
 			assertEquals(1, slotManager.getNumberRegisteredSlots());
 
 			// wait for the timeout call to happen
-			verify(resourceActions, timeout(taskManagerTimeout.toMilliseconds() * 3L)).releaseResource(eq(taskExecutorConnection.getInstanceID()));
+			verify(resourceActions, timeout(taskManagerTimeout.toMilliseconds() * 3L).atLeast(1)).releaseResource(eq(taskExecutorConnection.getInstanceID()));
 
 			assertEquals(1, slotManager.getNumberRegisteredSlots());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotProtocolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotProtocolTest.java
@@ -85,7 +85,7 @@ public class SlotProtocolTest extends TestLogger {
 			TestingUtils.infiniteTime(),
 			TestingUtils.infiniteTime())) {
 
-			ResourceManagerActions resourceManagerActions = mock(ResourceManagerActions.class);
+			ResourceActions resourceManagerActions = mock(ResourceActions.class);
 
 			slotManager.start(rmLeaderID, Executors.directExecutor(), resourceManagerActions);
 
@@ -147,7 +147,7 @@ public class SlotProtocolTest extends TestLogger {
 			TestingUtils.infiniteTime(),
 			TestingUtils.infiniteTime())) {
 
-			ResourceManagerActions resourceManagerActions = mock(ResourceManagerActions.class);
+			ResourceActions resourceManagerActions = mock(ResourceActions.class);
 
 			slotManager.start(rmLeaderID, Executors.directExecutor(), resourceManagerActions);
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
@@ -227,8 +227,9 @@ public class YarnResourceManager extends ResourceManager<ResourceID> implements 
 	}
 
 	@Override
-	public void stopWorker(ResourceID resourceID) {
+	public boolean stopWorker(ResourceID resourceID) {
 		// TODO: Implement to stop the worker
+		return false;
 	}
 
 	@Override


### PR DESCRIPTION
## What is the purpose of the change

This commit changes the SlotManager behaviour such that upon a TaskManager timeout
the ResourceManager is only notified about it without removing the slots. The
ResourceManager can then decide whether it stops the TaskManager and removes the slots
from the SlotManager or to keep the TaskManager still around.

## Brief change log

- Rename `ResourceManagerActions` into `ResourceActions`
- Remove automatic slot removal from `SlotManager` in case of `TaskManager` timeout
- Add `ResourceManager#releaseResource` method which removes the slots depending on the `stopWorker` call

## Verifying this change

This change added tests and can be verified as follows:

- `SlotManagerTest#testTaskManagerTimeoutDoesNotRemoveSlots`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

