### PR TITLE
[hotfix][doc] Remove outdated best-practice suggestion to use .withParameters()

### DIFF
--- a/docs/dev/best_practices.md
+++ b/docs/dev/best_practices.md
@@ -111,28 +111,6 @@ DataSet<Tuple2<String, Integer>> counts = text.flatMap(new Tokenizer(parameters)
 
 and then use it inside the function for getting values from the command line.
 
-
-#### Passing parameters as a `Configuration` object to single functions
-
-The example below shows how to pass the parameters as a `Configuration` object to a user defined function.
-
-{% highlight java %}
-ParameterTool parameters = ParameterTool.fromArgs(args);
-DataSet<Tuple2<String, Integer>> counts = text
-        .flatMap(new Tokenizer()).withParameters(parameters.getConfiguration())
-{% endhighlight %}
-
-In the `Tokenizer`, the object is now accessible in the `open(Configuration conf)` method:
-
-{% highlight java %}
-public static final class Tokenizer extends RichFlatMapFunction<String, Tuple2<String, Integer>> {
-    @Override
-    public void open(Configuration parameters) throws Exception {
-	parameters.getInteger("myInt", -1);
-	// .. do
-{% endhighlight %}
-
-
 #### Register the parameters globally
 
 Parameters registered as global job parameters in the `ExecutionConfig` can be accessed as configuration values from the JobManager web interface and in all functions defined by the user.


### PR DESCRIPTION
This way of passing parameters does not work with the streaming API and
is actually confusing for users.

R: @zentol 