### PR TITLE
[FLINK-6505] Proactively cleanup local FS for RocksDBKeyedStateBackend on startup

### DIFF
--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
@@ -235,6 +235,8 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 		this.instanceBasePath = Preconditions.checkNotNull(instanceBasePath);
 		this.instanceRocksDBPath = new File(instanceBasePath, "db");
 
+		cleanInstanceBasePath();
+
 		if (!instanceBasePath.exists()) {
 			if (!instanceBasePath.mkdirs()) {
 				throw new IOException("Could not create RocksDB data directory.");
@@ -313,10 +315,16 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 		IOUtils.closeQuietly(dbOptions);
 		IOUtils.closeQuietly(columnOptions);
 
+		cleanInstanceBasePath();
+	}
+
+	private void cleanInstanceBasePath() {
 		try {
-			FileUtils.deleteDirectory(instanceBasePath);
+			if(instanceBasePath.exists()) {
+				FileUtils.deleteDirectory(instanceBasePath);
+			}
 		} catch (IOException ioex) {
-			LOG.info("Could not delete instace base path for RocksDB: " + instanceBasePath, ioex);
+			LOG.warn("Could not delete instance base path for RocksDB: " + instanceBasePath, ioex);
 		}
 	}
 

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
@@ -235,9 +235,9 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 		this.instanceBasePath = Preconditions.checkNotNull(instanceBasePath);
 		this.instanceRocksDBPath = new File(instanceBasePath, "db");
 
-		// Clear the base directory when the backend is created
-		// in case something crashed and the backend never reached dispose()
 		if (instanceBasePath.exists()) {
+			// Clear the base directory when the backend is created
+			// in case something crashed and the backend never reached dispose()
 			cleanInstanceBasePath();
 		} else {
 			if (!instanceBasePath.mkdirs()) {

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
@@ -239,10 +239,10 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 			// Clear the base directory when the backend is created
 			// in case something crashed and the backend never reached dispose()
 			cleanInstanceBasePath();
-		} else {
-			if (!instanceBasePath.mkdirs()) {
-				throw new IOException("Could not create RocksDB data directory.");
-			}
+		}
+
+		if (!instanceBasePath.mkdirs()) {
+			throw new IOException("Could not create RocksDB data directory.");
 		}
 
 		this.keyGroupPrefixBytes = getNumberOfKeyGroups() > (Byte.MAX_VALUE + 1) ? 2 : 1;

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
@@ -235,6 +235,8 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 		this.instanceBasePath = Preconditions.checkNotNull(instanceBasePath);
 		this.instanceRocksDBPath = new File(instanceBasePath, "db");
 
+		// Clear this directory when the backend is created
+		// in case something crashed and the backend never reached dispose()
 		cleanInstanceBasePath();
 
 		if (!instanceBasePath.exists()) {

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
@@ -322,7 +322,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 
 	private void cleanInstanceBasePath() {
 		try {
-			if(instanceBasePath.exists()) {
+			if (instanceBasePath.exists()) {
 				FileUtils.deleteDirectory(instanceBasePath);
 			}
 		} catch (IOException ioex) {


### PR DESCRIPTION
## What is the purpose of the change

In `RocksDBKeyedStateBackend`, the `instanceBasePath` is cleared on `dispose()`. It also make sense to also clear this directory when the backend is created, in case something crashed and the backend never reached `dispose()`. At least for previous runs of the same job, we can know what to delete on restart. 

In general, it is very important for this backend to clean up the local FS, because the local quota might be very limited compared to the DFS. And a node that runs out of local disk space can bring down the whole job, with no way to recover (it might always get rescheduled to that node).

## Brief change log

clear `instanceBasePath` when `RocksDBKeyedStateBackend ` is created

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

none

## Documentation

none