### PR TITLE
[FLINK-7808] [REST] JobDetails constructor checks size of tasksPerSta…

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/messages/webmonitor/JobDetails.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/messages/webmonitor/JobDetails.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.messages.webmonitor;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.jobgraph.JobStatus;
+import org.apache.flink.util.Preconditions;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
@@ -92,6 +93,8 @@ public class JobDetails implements Serializable {
 		this.duration = duration;
 		this.status = checkNotNull(status);
 		this.lastUpdateTime = lastUpdateTime;
+		Preconditions.checkArgument(tasksPerState.length == ExecutionState.values().length, 
+			"tasksPerState argument must be of size {}.", ExecutionState.values().length);
 		this.tasksPerState = checkNotNull(tasksPerState);
 		this.numTasks = numTasks;
 	}


### PR DESCRIPTION
…te argument
## What is the purpose of the change

This PR modifies the JobDetails constructor to verify that the `tasksPerState` array size is equal to `ExecutionState.values().length`. The array contains the number of tasks in each execution state, and it thus required that the sizes match.
