### PR TITLE
 [FLINK-7791] [REST][client] Integrate LIST command into RestClusterClient

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/CliFrontend.java
@@ -60,7 +60,6 @@ import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.messages.JobManagerMessages;
-import org.apache.flink.runtime.messages.webmonitor.JobDetails;
 import org.apache.flink.runtime.security.SecurityConfiguration;
 import org.apache.flink.runtime.security.SecurityUtils;
 import org.apache.flink.runtime.util.EnvironmentInformation;

--- a/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
@@ -55,7 +55,6 @@ import org.apache.flink.runtime.messages.JobManagerMessages;
 import org.apache.flink.runtime.messages.accumulators.AccumulatorResultsErroneous;
 import org.apache.flink.runtime.messages.accumulators.AccumulatorResultsFound;
 import org.apache.flink.runtime.messages.accumulators.RequestAccumulatorResults;
-import org.apache.flink.runtime.messages.webmonitor.JobDetails;
 import org.apache.flink.runtime.messages.webmonitor.MultipleJobsDetails;
 import org.apache.flink.runtime.messages.webmonitor.RequestJobDetails;
 import org.apache.flink.runtime.util.LeaderConnectionInfo;

--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
@@ -205,7 +205,11 @@ public class RestClusterClient extends ClusterClient {
 			headers
 		);
 		return jobDetailsFuture
-			.thenApply(MultipleJobsDetails::getRunning);
+			.thenApply(details -> {
+				Collection<JobDetails> flattenedDetails = details.getRunning();
+				flattenedDetails.addAll(details.getFinished());
+				return flattenedDetails;
+			});
 	}
 
 	// ======================================

--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
@@ -30,9 +30,12 @@ import org.apache.flink.runtime.blob.PermanentBlobKey;
 import org.apache.flink.runtime.client.JobSubmissionException;
 import org.apache.flink.runtime.clusterframework.messages.GetClusterStatusResponse;
 import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.messages.webmonitor.JobDetails;
+import org.apache.flink.runtime.messages.webmonitor.MultipleJobsDetails;
 import org.apache.flink.runtime.rest.RestClient;
 import org.apache.flink.runtime.rest.messages.BlobServerPortHeaders;
 import org.apache.flink.runtime.rest.messages.BlobServerPortResponseBody;
+import org.apache.flink.runtime.rest.messages.CurrentJobsOverviewHandlerHeaders;
 import org.apache.flink.runtime.rest.messages.EmptyResponseBody;
 import org.apache.flink.runtime.rest.messages.JobTerminationHeaders;
 import org.apache.flink.runtime.rest.messages.JobTerminationMessageParameters;
@@ -49,6 +52,7 @@ import javax.annotation.Nullable;
 
 import java.net.InetSocketAddress;
 import java.net.URL;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -190,6 +194,18 @@ public class RestClusterClient extends ClusterClient {
 		);
 		return responseFuture
 			.thenApply(response -> response.location);
+	}
+
+	@Override
+	public CompletableFuture<Collection<JobDetails>> listJobs() throws Exception {
+		CurrentJobsOverviewHandlerHeaders headers = CurrentJobsOverviewHandlerHeaders.getInstance();
+		CompletableFuture<MultipleJobsDetails> jobDetailsFuture = restClient.sendRequest(
+			restClusterClientConfiguration.getRestServerAddress(),
+			restClusterClientConfiguration.getRestServerPort(),
+			headers
+		);
+		return jobDetailsFuture
+			.thenApply(MultipleJobsDetails::getRunning);
 	}
 
 	// ======================================

--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
@@ -31,7 +31,6 @@ import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.runtime.client.JobSubmissionException;
 import org.apache.flink.runtime.clusterframework.messages.GetClusterStatusResponse;
 import org.apache.flink.runtime.jobgraph.JobGraph;
-import org.apache.flink.runtime.messages.webmonitor.JobDetails;
 import org.apache.flink.runtime.messages.webmonitor.MultipleJobsDetails;
 import org.apache.flink.runtime.rest.RestClient;
 import org.apache.flink.runtime.rest.messages.BlobServerPortHeaders;

--- a/flink-clients/src/test/java/org/apache/flink/client/CliFrontendCancelTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/CliFrontendCancelTest.java
@@ -42,7 +42,7 @@ import static org.powermock.api.mockito.PowerMockito.doThrow;
 /**
  * Tests for the CANCEL command.
  */
-public class CliFrontendListCancelTest {
+public class CliFrontendCancelTest {
 
 	@BeforeClass
 	public static void init() {

--- a/flink-clients/src/test/java/org/apache/flink/client/CliFrontendListCancelTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/CliFrontendListCancelTest.java
@@ -21,27 +21,13 @@ package org.apache.flink.client;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.client.cli.CancelOptions;
 import org.apache.flink.client.cli.CliFrontendParser;
-import org.apache.flink.client.cli.CommandLineOptions;
 import org.apache.flink.client.cli.Flip6DefaultCLI;
 import org.apache.flink.client.util.MockedCliFrontend;
-import org.apache.flink.runtime.akka.FlinkUntypedActor;
-import org.apache.flink.runtime.instance.ActorGateway;
-import org.apache.flink.runtime.instance.AkkaActorGateway;
-import org.apache.flink.runtime.messages.JobManagerMessages;
 
-import akka.actor.ActorRef;
-import akka.actor.ActorSystem;
-import akka.actor.Props;
-import akka.actor.Status;
-import akka.testkit.JavaTestKit;
-import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import java.util.UUID;
-
-import static org.apache.flink.client.CliFrontendTestUtils.pipeSystemOutToNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
@@ -54,23 +40,9 @@ import static org.mockito.Mockito.times;
 import static org.powermock.api.mockito.PowerMockito.doThrow;
 
 /**
- * Tests for the CANCEL and LIST commands.
+ * Tests for the CANCEL command.
  */
 public class CliFrontendListCancelTest {
-
-	private static ActorSystem actorSystem;
-
-	@BeforeClass
-	public static void setup(){
-		pipeSystemOutToNull();
-		actorSystem = ActorSystem.create("TestingActorSystem");
-	}
-
-	@AfterClass
-	public static void teardown() {
-		JavaTestKit.shutdownActorSystem(actorSystem);
-		actorSystem = null;
-	}
 
 	@BeforeClass
 	public static void init() {
@@ -180,41 +152,6 @@ public class CliFrontendListCancelTest {
 		}
 	}
 
-	@Test
-	public void testList() {
-		try {
-			// test unrecognized option
-			{
-				String[] parameters = {"-v", "-k"};
-				CliFrontend testFrontend = new CliFrontend(CliFrontendTestUtils.getConfigDir());
-				int retCode = testFrontend.list(parameters);
-				assertTrue(retCode != 0);
-			}
-
-			// test list properly
-			{
-				final UUID leaderSessionID = UUID.randomUUID();
-				final ActorRef jm = actorSystem.actorOf(
-						Props.create(
-								CliJobManager.class,
-								null,
-								leaderSessionID
-						)
-				);
-				final ActorGateway gateway = new AkkaActorGateway(jm, leaderSessionID);
-				String[] parameters = {"-r", "-s"};
-				InfoListTestCliFrontend testFrontend = new InfoListTestCliFrontend(gateway);
-				int retCode = testFrontend.list(parameters);
-				assertTrue(retCode == 0);
-			}
-		}
-		catch (Exception e) {
-			System.err.println(e.getMessage());
-			e.printStackTrace();
-			fail("Program caused an exception: " + e.getMessage());
-		}
-	}
-
 	private static final class CancelTestCliFrontend extends MockedCliFrontend {
 
 		CancelTestCliFrontend(boolean reject) throws Exception {
@@ -222,89 +159,6 @@ public class CliFrontendListCancelTest {
 				doThrow(new IllegalArgumentException("Test exception")).when(client).cancel(any(JobID.class));
 				doThrow(new IllegalArgumentException("Test exception")).when(client).cancelWithSavepoint(any(JobID.class), anyString());
 			}
-		}
-	}
-
-	private static final class InfoListTestCliFrontend extends CliFrontend {
-
-		private ActorGateway jobManagerGateway;
-
-		InfoListTestCliFrontend(ActorGateway jobManagerGateway) throws Exception {
-			super(CliFrontendTestUtils.getConfigDir());
-			this.jobManagerGateway = jobManagerGateway;
-		}
-
-		@Override
-		public ActorGateway getJobManagerGateway(CommandLineOptions options) {
-			return jobManagerGateway;
-		}
-	}
-
-	private static final class CliJobManager extends FlinkUntypedActor {
-		private final JobID jobID;
-		private final UUID leaderSessionID;
-		private final String targetDirectory;
-
-		public CliJobManager(final JobID jobID, final UUID leaderSessionID){
-			this(jobID, leaderSessionID, null);
-		}
-
-		public CliJobManager(final JobID jobID, final UUID leaderSessionID, String targetDirectory){
-			this.jobID = jobID;
-			this.leaderSessionID = leaderSessionID;
-			this.targetDirectory = targetDirectory;
-		}
-
-		@Override
-		public void handleMessage(Object message) {
-			if (message instanceof JobManagerMessages.RequestTotalNumberOfSlots$) {
-				getSender().tell(decorateMessage(1), getSelf());
-			}
-			else if (message instanceof JobManagerMessages.CancelJob) {
-				JobManagerMessages.CancelJob cancelJob = (JobManagerMessages.CancelJob) message;
-
-				if (jobID != null && jobID.equals(cancelJob.jobID())) {
-					getSender().tell(
-							decorateMessage(new Status.Success(new JobManagerMessages.CancellationSuccess(jobID, null))),
-							getSelf());
-				}
-				else {
-					getSender().tell(
-							decorateMessage(new Status.Failure(new Exception("Wrong or no JobID"))),
-							getSelf());
-				}
-			}
-			else if (message instanceof JobManagerMessages.CancelJobWithSavepoint) {
-				JobManagerMessages.CancelJobWithSavepoint cancelJob = (JobManagerMessages.CancelJobWithSavepoint) message;
-
-				if (jobID != null && jobID.equals(cancelJob.jobID())) {
-					if (targetDirectory == null && cancelJob.savepointDirectory() == null ||
-							targetDirectory != null && targetDirectory.equals(cancelJob.savepointDirectory())) {
-						getSender().tell(
-								decorateMessage(new JobManagerMessages.CancellationSuccess(jobID, targetDirectory)),
-								getSelf());
-					} else {
-						getSender().tell(
-								decorateMessage(new JobManagerMessages.CancellationFailure(jobID, new Exception("Wrong target directory"))),
-								getSelf());
-					}
-				}
-				else {
-					getSender().tell(
-							decorateMessage(new JobManagerMessages.CancellationFailure(jobID, new Exception("Wrong or no JobID"))),
-							getSelf());
-				}
-			}
-			else if (message instanceof JobManagerMessages.RequestRunningJobsStatus$) {
-				getSender().tell(
-						decorateMessage(new JobManagerMessages.RunningJobsStatus()),
-						getSelf());
-			}
-		}
-
-		@Override
-		protected UUID getLeaderSessionID() {
-			return leaderSessionID;
 		}
 	}
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/CliFrontendListTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/CliFrontendListTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client;
+
+import org.apache.flink.client.util.MockedCliFrontend;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+/**
+ * Tests for the CANCEL command.
+ */
+public class CliFrontendListTest extends TestLogger {
+
+	@BeforeClass
+	public static void init() {
+		CliFrontendTestUtils.pipeSystemOutToNull();
+	}
+
+	@Test
+	public void testList() throws Exception {
+		// test unrecognized option
+		{
+			String[] parameters = {"-v", "-k"};
+			CliFrontend testFrontend = new CliFrontend(CliFrontendTestUtils.getConfigDir());
+			int retCode = testFrontend.list(parameters);
+			assertTrue(retCode != 0);
+		}
+
+		// test list properly
+		{
+			String[] parameters = {"-r", "-s"};
+			ListTestCliFrontend testFrontend = new ListTestCliFrontend();
+			int retCode = testFrontend.list(parameters);
+			assertTrue(retCode == 0);
+			Mockito.verify(testFrontend.client, times(1))
+				.listJobs();
+		}
+	}
+
+	private static final class ListTestCliFrontend extends MockedCliFrontend {
+
+		ListTestCliFrontend() throws Exception {
+			when(client.listJobs()).thenReturn(CompletableFuture.completedFuture(Collections.emptyList()));
+		}
+	}
+}

--- a/flink-clients/src/test/java/org/apache/flink/client/CliFrontendListTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/CliFrontendListTest.java
@@ -33,7 +33,7 @@ import static org.mockito.Mockito.times;
 import static org.powermock.api.mockito.PowerMockito.when;
 
 /**
- * Tests for the CANCEL command.
+ * Tests for the LIST command.
  */
 public class CliFrontendListTest extends TestLogger {
 

--- a/flink-clients/src/test/java/org/apache/flink/client/program/ClusterClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/ClusterClientTest.java
@@ -36,6 +36,7 @@ import org.junit.Test;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.concurrent.CompletableFuture;
 
 import scala.concurrent.Future;
@@ -151,9 +152,11 @@ public class ClusterClientTest extends TestLogger {
 			CompletableFuture<Collection<JobDetails>> jobDetailsFuture = clusterClient.listJobs();
 			Collection<JobDetails> jobDetails = jobDetailsFuture.get();
 			Assert.assertTrue(gateway.messageArrived);
-			// finished jobs should be ignored
-			Assert.assertEquals(1, jobDetails.size());
-			Assert.assertEquals(JobStatus.RUNNING, jobDetails.iterator().next().getStatus());
+			Assert.assertEquals(2, jobDetails.size());
+			Iterator<JobDetails> jobDetailsIterator = jobDetails.iterator();
+			JobDetails job1 = jobDetailsIterator.next();
+			JobDetails job2 = jobDetailsIterator.next();
+			Assert.assertNotEquals("The job statues should not be equal.", job1.getStatus(), job2.getStatus());
 		} finally {
 			clusterClient.shutdown();
 		}

--- a/flink-clients/src/test/java/org/apache/flink/client/program/ClusterClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/ClusterClientTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.client.program;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.instance.DummyActorGateway;
@@ -149,14 +150,14 @@ public class ClusterClientTest extends TestLogger {
 		TestListActorGateway gateway = new TestListActorGateway();
 		ClusterClient clusterClient = new TestClusterClient(config, gateway);
 		try {
-			CompletableFuture<Collection<JobDetails>> jobDetailsFuture = clusterClient.listJobs();
-			Collection<JobDetails> jobDetails = jobDetailsFuture.get();
+			CompletableFuture<Collection<JobStatusMessage>> jobDetailsFuture = clusterClient.listJobs();
+			Collection<JobStatusMessage> jobDetails = jobDetailsFuture.get();
 			Assert.assertTrue(gateway.messageArrived);
 			Assert.assertEquals(2, jobDetails.size());
-			Iterator<JobDetails> jobDetailsIterator = jobDetails.iterator();
-			JobDetails job1 = jobDetailsIterator.next();
-			JobDetails job2 = jobDetailsIterator.next();
-			Assert.assertNotEquals("The job statues should not be equal.", job1.getStatus(), job2.getStatus());
+			Iterator<JobStatusMessage> jobDetailsIterator = jobDetails.iterator();
+			JobStatusMessage job1 = jobDetailsIterator.next();
+			JobStatusMessage job2 = jobDetailsIterator.next();
+			Assert.assertNotEquals("The job statues should not be equal.", job1.getJobState(), job2.getJobState());
 		} finally {
 			clusterClient.shutdown();
 		}

--- a/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.runtime.dispatcher.Dispatcher;
 import org.apache.flink.runtime.dispatcher.DispatcherGateway;
 import org.apache.flink.runtime.jobgraph.JobGraph;
@@ -291,12 +292,12 @@ public class RestClusterClientTest extends TestLogger {
 			rse.start();
 
 			{
-				CompletableFuture<Collection<JobDetails>> jobDetailsFuture = rcc.listJobs();
-				Collection<JobDetails> jobDetails = jobDetailsFuture.get();
-				Iterator<JobDetails> jobDetailsIterator = jobDetails.iterator();
-				JobDetails job1 = jobDetailsIterator.next();
-				JobDetails job2 = jobDetailsIterator.next();
-				Assert.assertNotEquals("The job statues should not be equal.", job1.getStatus(), job2.getStatus());
+				CompletableFuture<Collection<JobStatusMessage>> jobDetailsFuture = rcc.listJobs();
+				Collection<JobStatusMessage> jobDetails = jobDetailsFuture.get();
+				Iterator<JobStatusMessage> jobDetailsIterator = jobDetails.iterator();
+				JobStatusMessage job1 = jobDetailsIterator.next();
+				JobStatusMessage job2 = jobDetailsIterator.next();
+				Assert.assertNotEquals("The job statues should not be equal.", job1.getJobState(), job2.getJobState());
 			}
 		} finally {
 			rcc.shutdown();

--- a/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
@@ -69,6 +69,7 @@ import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -292,9 +293,10 @@ public class RestClusterClientTest extends TestLogger {
 			{
 				CompletableFuture<Collection<JobDetails>> jobDetailsFuture = rcc.listJobs();
 				Collection<JobDetails> jobDetails = jobDetailsFuture.get();
-				// finished jobs should be ignored
-				Assert.assertEquals(1, jobDetails.size());
-				Assert.assertEquals(JobStatus.RUNNING, jobDetails.iterator().next().getStatus());
+				Iterator<JobDetails> jobDetailsIterator = jobDetails.iterator();
+				JobDetails job1 = jobDetailsIterator.next();
+				JobDetails job2 = jobDetailsIterator.next();
+				Assert.assertNotEquals("The job statues should not be equal.", job1.getStatus(), job2.getStatus());
 			}
 		} finally {
 			rcc.shutdown();

--- a/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
@@ -26,6 +26,9 @@ import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.runtime.dispatcher.Dispatcher;
 import org.apache.flink.runtime.dispatcher.DispatcherGateway;
 import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobStatus;
+import org.apache.flink.runtime.messages.webmonitor.JobDetails;
+import org.apache.flink.runtime.messages.webmonitor.MultipleJobsDetails;
 import org.apache.flink.runtime.rest.RestServerEndpoint;
 import org.apache.flink.runtime.rest.RestServerEndpointConfiguration;
 import org.apache.flink.runtime.rest.handler.AbstractRestHandler;
@@ -34,6 +37,7 @@ import org.apache.flink.runtime.rest.handler.RestHandlerException;
 import org.apache.flink.runtime.rest.handler.RestHandlerSpecification;
 import org.apache.flink.runtime.rest.messages.BlobServerPortHeaders;
 import org.apache.flink.runtime.rest.messages.BlobServerPortResponseBody;
+import org.apache.flink.runtime.rest.messages.CurrentJobsOverviewHandlerHeaders;
 import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
 import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
 import org.apache.flink.runtime.rest.messages.EmptyResponseBody;
@@ -64,6 +68,7 @@ import javax.annotation.Nonnull;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -74,6 +79,9 @@ import static org.mockito.Mockito.when;
 
 /**
  * Tests for the {@link RestClusterClient}.
+ *
+ * <p>These tests verify that the client uses the appropriate headers for each
+ * request, properly constructs the request bodies/parameters and processes the responses correctly.
  */
 public class RestClusterClientTest extends TestLogger {
 
@@ -254,6 +262,56 @@ public class RestClusterClientTest extends TestLogger {
 					return CompletableFuture.completedFuture(new SavepointTriggerResponseBody("growing", "savepoint directory (" + targetDir + ") did not match expected (" + expectedSavepointDirectory + ')', "big-bang"));
 				}
 			}
+		}
+	}
+
+	@Test
+	public void testListJobs() throws Exception {
+
+		Configuration config = new Configuration();
+		config.setString(JobManagerOptions.ADDRESS, "localhost");
+
+		RestServerEndpointConfiguration rsec = RestServerEndpointConfiguration.fromConfiguration(config);
+
+		TestListJobsHandler listJobsHandler = new TestListJobsHandler();
+
+		RestServerEndpoint rse = new RestServerEndpoint(rsec) {
+			@Override
+			protected Collection<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> initializeHandlers(CompletableFuture<String> restAddressFuture) {
+
+				Collection<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> handlers = new ArrayList<>();
+				handlers.add(Tuple2.of(listJobsHandler.getMessageHeaders(), listJobsHandler));
+				return handlers;
+			}
+		};
+
+		RestClusterClient rcc = new RestClusterClient(config);
+		try {
+			rse.start();
+
+			{
+				CompletableFuture<Collection<JobDetails>> jobDetailsFuture = rcc.listJobs();
+				Collection<JobDetails> jobDetails = jobDetailsFuture.get();
+				// finished jobs should be ignored
+				Assert.assertEquals(1, jobDetails.size());
+				Assert.assertEquals(JobStatus.RUNNING, jobDetails.iterator().next().getStatus());
+			}
+		} finally {
+			rcc.shutdown();
+			rse.shutdown(Time.seconds(5));
+		}}
+
+	private static class TestListJobsHandler extends TestHandler<EmptyRequestBody, MultipleJobsDetails, EmptyMessageParameters> {
+
+		private TestListJobsHandler() {
+			super(CurrentJobsOverviewHandlerHeaders.getInstance());
+		}
+
+		@Override
+		protected CompletableFuture<MultipleJobsDetails> handleRequest(@Nonnull HandlerRequest<EmptyRequestBody, EmptyMessageParameters> request, @Nonnull DispatcherGateway gateway) throws RestHandlerException {
+			JobDetails running = new JobDetails(new JobID(), "job1", 0, 0, 0, JobStatus.RUNNING, 0, new int[9], 0);
+			JobDetails finished = new JobDetails(new JobID(), "job2", 0, 0, 0, JobStatus.FINISHED, 0, new int[9], 0);
+			return CompletableFuture.completedFuture(new MultipleJobsDetails(Collections.singleton(running), Collections.singleton(finished)));
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/messages/webmonitor/JobDetails.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/messages/webmonitor/JobDetails.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.messages.webmonitor;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.jobgraph.JobStatus;
+import org.apache.flink.util.Preconditions;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
@@ -92,6 +93,8 @@ public class JobDetails implements Serializable {
 		this.duration = duration;
 		this.status = checkNotNull(status);
 		this.lastUpdateTime = lastUpdateTime;
+		Preconditions.checkArgument(tasksPerState.length == ExecutionState.values().length, 
+			"tasksPerState argument must be of size {}.", ExecutionState.values().length);
 		this.tasksPerState = checkNotNull(tasksPerState);
 		this.numTasks = numTasks;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/util/HandlerUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/util/HandlerUtils.java
@@ -36,6 +36,8 @@ import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseSt
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.LastHttpContent;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 
@@ -50,6 +52,8 @@ import static org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpVer
  * Utilities for the REST handlers.
  */
 public class HandlerUtils {
+
+	private static final Logger LOG = LoggerFactory.getLogger(HandlerUtils.class);
 
 	private static final ObjectMapper mapper = RestMapperUtils.getStrictObjectMapper();
 
@@ -71,6 +75,7 @@ public class HandlerUtils {
 		try {
 			mapper.writeValue(sw, response);
 		} catch (IOException ioe) {
+			LOG.error("Internal server error. Could not map response to JSON.", ioe);
 			sendErrorResponse(channelHandlerContext, httpRequest, new ErrorResponseBody("Internal server error. Could not map response to JSON."), HttpResponseStatus.INTERNAL_SERVER_ERROR);
 			return;
 		}
@@ -96,6 +101,7 @@ public class HandlerUtils {
 			mapper.writeValue(sw, errorMessage);
 		} catch (IOException e) {
 			// this should never happen
+			LOG.error("Internal server error. Could not map error response to JSON.", e);
 			sendResponse(channelHandlerContext, httpRequest, "Internal server error. Could not map error response to JSON.", HttpResponseStatus.INTERNAL_SERVER_ERROR);
 		}
 		sendResponse(channelHandlerContext, httpRequest, sw.toString(), statusCode);


### PR DESCRIPTION
## What is the purpose of the change

This PR integrates the LIST command into the RestClusterClient. This is a fully working implementation and leverages the CurrentJobsOverviewHeaders.

## Brief change log

* move LIST logic from CliFrontend into ClusterClient
* separate CliFrontendListCancelTest into distinct test cases for list & cancel
* implement LIST logic for RestClusterClient, based on the CurrentJobsOverviewHeaders

## Verifying this change

This change added tests and can be verified as follows:

* the changes to the CliFrontend are covered by modified tests in CliFrontendListTest
* the changes to the ClusterClient are covered by new tests in ClusterClientTest
* the changes to the RestClusterClient are covered by RestClusterClientTest#testListJobs

For manual verification:
* start a flip6 cluster with `start-cluster.sh flip6`
* submit a long-running job with `flink run -flip <jar>`
* execute the list command with `flink list -flip6`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)

