### PR TITLE
[FLINK-6926] [table] Add support for MD5,SHA1 and SHA256 in SQL

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
@@ -1054,4 +1054,34 @@ object concat_ws {
   }
 }
 
+/**
+  * Returns the MD5 of the string srgument
+  * Returns NULL if string is NULL
+  */
+object md5 {
+  def apply(string: Expression): Expression = {
+    new Md5(string)
+  }
+}
+
+/**
+  * Returns the SHA-1 of the string srgument
+  * Returns NULL if string is NULL
+  */
+object sha1 {
+  def apply(string: Expression): Expression = {
+    new Sha1(string)
+  }
+}
+
+/**
+  * Returns the SHA-256 of the string srgument
+  * Returns NULL if string is NULL
+  */
+object sha256 {
+  def apply(string: Expression): Expression = {
+    new Sha256(string)
+  }
+}
+
 // scalastyle:on object.name

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/FunctionGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/FunctionGenerator.scala
@@ -28,8 +28,7 @@ import org.apache.calcite.util.BuiltInMethod
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo._
 import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, SqlTimeTypeInfo, TypeInformation}
 import org.apache.flink.api.java.typeutils.GenericTypeInfo
-import org.apache.flink.table.functions.sql.DateTimeSqlFunction
-import org.apache.flink.table.functions.sql.ScalarSqlFunctions
+import org.apache.flink.table.functions.sql.{DateTimeSqlFunction, HashCalcFunctions, ScalarSqlFunctions}
 import org.apache.flink.table.functions.utils.{ScalarSqlFunction, TableSqlFunction}
 import org.apache.flink.table.functions.sql.ScalarSqlFunctions._
 
@@ -501,6 +500,28 @@ object FunctionGenerator {
     DateTimeSqlFunction.DATE_FORMAT,
     Seq(SqlTimeTypeInfo.TIMESTAMP, STRING_TYPE_INFO),
     new DateFormatCallGen
+  )
+
+  // ----------------------------------------------------------------------------------------------
+  // Cryptographic Hash functions
+  // ----------------------------------------------------------------------------------------------
+
+  addSqlFunction(
+    HashCalcFunctions.MD5_CALC,
+    Seq(STRING_TYPE_INFO),
+    new HashCalcCallGen("MD5")
+  )
+
+  addSqlFunction(
+    HashCalcFunctions.SHA1_CALC,
+    Seq(STRING_TYPE_INFO),
+    new HashCalcCallGen("SHA-1")
+  )
+
+  addSqlFunction(
+    HashCalcFunctions.SHA256_CALC,
+    Seq(STRING_TYPE_INFO),
+    new HashCalcCallGen("SHA-256")
   )
 
   // ----------------------------------------------------------------------------------------------

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/HashCalcCallGen.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/HashCalcCallGen.scala
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.flink.table.codegen.calls
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo._
+import org.apache.flink.table.codegen.CodeGenUtils.{newName, primitiveTypeTermForTypeInfo}
+import org.apache.flink.table.codegen.{CodeGenerator, GeneratedExpression}
+
+class HashCalcCallGen(algName: String) extends CallGenerator {
+
+  override def generate(codeGenerator: CodeGenerator,
+                        operands: Seq[GeneratedExpression])
+  : GeneratedExpression = {
+
+    val resultTypeTerm = primitiveTypeTermForTypeInfo(STRING_TYPE_INFO)
+    val resultTerm = newName("result")
+    val nullTerm = newName("isNull")
+  val innerCalc =
+    s"""
+       |  try {
+       |    java.security.MessageDigest md =
+       |          java.security.MessageDigest.getInstance("$algName");
+       |    md.update(${operands(0).resultTerm}.getBytes());
+       |    $resultTerm =
+       |          org.apache.commons.codec.binary.Hex.encodeHexString(md.digest());
+       |    $nullTerm = false;
+       |  } catch (java.security.NoSuchAlgorithmException e) {
+       |    $nullTerm = true;
+       |    $resultTerm = null;
+       |  }
+     """.stripMargin
+
+    val code = if (codeGenerator.nullCheck) {
+               s"""
+               |${operands.map(_.code).mkString("\n")}
+               |boolean $nullTerm = ${operands.map(_.nullTerm).mkString(" || ")};
+               |$resultTypeTerm $resultTerm = null;
+               |if (${codeGenerator.nullCheck} && $nullTerm) {
+               |  $nullTerm = true;
+               |  $resultTerm = null;
+               |}
+               |else {
+               |  $innerCalc
+               |}
+         """.stripMargin;
+    }
+    else {
+      s"""
+         |${operands.map(_.code).mkString("\n")}
+         |$resultTypeTerm $resultTerm = null;
+         |$innerCalc
+       """.stripMargin
+    }
+
+    GeneratedExpression(resultTerm, nullTerm, code, STRING_TYPE_INFO)
+
+    }
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/hashExpressions.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/hashExpressions.scala
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.expressions
+
+import org.apache.calcite.rex.RexNode
+import org.apache.calcite.tools.RelBuilder
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo._
+import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
+import org.apache.flink.table.functions.sql.HashCalcFunctions
+
+case class Md5(child: Expression) extends UnaryExpression with InputTypeSpec {
+
+  override private[flink] def resultType: TypeInformation[_] = BasicTypeInfo.STRING_TYPE_INFO
+
+  override private[flink] def expectedTypes: Seq[TypeInformation[_]] = STRING_TYPE_INFO :: Nil
+
+  override def toString: String = s"md5($child)"
+
+  override private[flink] def toRexNode(implicit relBuilder: RelBuilder): RexNode = {
+    relBuilder.call(HashCalcFunctions.MD5_CALC, child.toRexNode)
+  }
+}
+
+case class Sha1(child: Expression) extends UnaryExpression with InputTypeSpec {
+
+  override private[flink] def resultType: TypeInformation[_] = STRING_TYPE_INFO
+
+  override private[flink] def expectedTypes: Seq[TypeInformation[_]] = STRING_TYPE_INFO :: Nil
+
+  override def toString: String = s"sha1($child)"
+
+  override private[flink] def toRexNode(implicit relBuilder: RelBuilder): RexNode = {
+    relBuilder.call(HashCalcFunctions.SHA1_CALC, child.toRexNode)
+  }
+}
+
+case class Sha256(child: Expression) extends UnaryExpression with InputTypeSpec {
+
+  override private[flink] def resultType: TypeInformation[_] = STRING_TYPE_INFO
+
+  override private[flink] def expectedTypes: Seq[TypeInformation[_]] = STRING_TYPE_INFO :: Nil
+
+  override def toString: String = s"sha256($child)"
+
+  override private[flink] def toRexNode(implicit relBuilder: RelBuilder): RexNode = {
+    relBuilder.call(HashCalcFunctions.SHA256_CALC, child.toRexNode)
+  }
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/stringExpressions.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/stringExpressions.scala
@@ -24,7 +24,7 @@ import org.apache.calcite.tools.RelBuilder
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo._
 import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
 import org.apache.flink.table.expressions.TrimMode.TrimMode
-import org.apache.flink.table.functions.sql.ScalarSqlFunctions
+import org.apache.flink.table.functions.sql.{HashCalcFunctions, ScalarSqlFunctions}
 import org.apache.flink.table.validate._
 
 /**

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/sql/HashCalcFunctions.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/sql/HashCalcFunctions.scala
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.functions.sql
+
+import org.apache.calcite.sql.`type`._
+import org.apache.calcite.sql.{SqlFunction, SqlFunctionCategory, SqlKind}
+
+
+object HashCalcFunctions {
+  val MD5_CALC = new SqlFunction(
+    "MD5",
+    SqlKind.OTHER_FUNCTION,
+    ReturnTypes.ARG0_NULLABLE_VARYING,
+    null,
+    OperandTypes.ONE_OR_MORE,
+    SqlFunctionCategory.STRING
+  )
+
+  val SHA1_CALC = new SqlFunction(
+    "SHA1",
+    SqlKind.OTHER_FUNCTION,
+    ReturnTypes.ARG0_NULLABLE_VARYING,
+    null,
+    OperandTypes.ONE_OR_MORE,
+    SqlFunctionCategory.STRING
+  )
+
+  val SHA256_CALC = new SqlFunction(
+    "SHA256",
+    SqlKind.OTHER_FUNCTION,
+    ReturnTypes.ARG0_NULLABLE_VARYING,
+    null,
+    OperandTypes.ONE_OR_MORE,
+    SqlFunctionCategory.STRING
+  )
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
@@ -23,7 +23,7 @@ import org.apache.calcite.sql.util.{ChainedSqlOperatorTable, ListSqlOperatorTabl
 import org.apache.calcite.sql.{SqlFunction, SqlOperator, SqlOperatorTable}
 import org.apache.flink.table.api._
 import org.apache.flink.table.expressions._
-import org.apache.flink.table.functions.sql.{DateTimeSqlFunction, ScalarSqlFunctions}
+import org.apache.flink.table.functions.sql.{DateTimeSqlFunction, HashCalcFunctions, ScalarSqlFunctions}
 import org.apache.flink.table.functions.utils.{AggSqlFunction, ScalarSqlFunction, TableSqlFunction}
 import org.apache.flink.table.functions.{AggregateFunction, ScalarFunction, TableFunction}
 
@@ -248,7 +248,12 @@ object FunctionCatalog {
 
     // ordering
     "asc" -> classOf[Asc],
-    "desc" -> classOf[Desc]
+    "desc" -> classOf[Desc],
+
+    // crypto hash
+    "md5" -> classOf[Md5],
+    "sha1" -> classOf[Sha1],
+    "sha256" -> classOf[Sha256]
   )
 
   /**
@@ -409,7 +414,12 @@ class BasicOperatorTable extends ReflectiveSqlOperatorTable {
     SqlStdOperatorTable.HOP_END,
     SqlStdOperatorTable.SESSION,
     SqlStdOperatorTable.SESSION_START,
-    SqlStdOperatorTable.SESSION_END
+    SqlStdOperatorTable.SESSION_END,
+
+    // Hash functions
+    HashCalcFunctions.MD5_CALC,
+    HashCalcFunctions.SHA1_CALC,
+    HashCalcFunctions.SHA256_CALC
   )
 
   builtInSqlOperators.foreach(register)

--- a/flink-libraries/flink-table/src/test/java/org/apache/flink/table/runtime/batch/sql/JavaSqlITCase.java
+++ b/flink-libraries/flink-table/src/test/java/org/apache/flink/table/runtime/batch/sql/JavaSqlITCase.java
@@ -175,4 +175,29 @@ public class JavaSqlITCase extends TableProgramsCollectionTestBase {
 		String expected = "bar\n" + "spam\n";
 		compareResultAsText(results, expected);
 	}
+
+	@Test
+	public void testMd5Hash() throws Exception {
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		BatchTableEnvironment tableEnv = TableEnvironment.getTableEnvironment(env, config());
+
+		List<Tuple2<Integer, Map<String, String>>> rows = new ArrayList<>();
+		rows.add(new Tuple2<>(1, Collections.singletonMap("foo", "bar")));
+		rows.add(new Tuple2<>(2, Collections.singletonMap("foo", "spam")));
+
+		TypeInformation<Tuple2<Integer, Map<String, String>>> ty = new TupleTypeInfo<>(
+			BasicTypeInfo.INT_TYPE_INFO,
+			new MapTypeInfo<>(BasicTypeInfo.STRING_TYPE_INFO, BasicTypeInfo.STRING_TYPE_INFO));
+
+		DataSet<Tuple2<Integer, Map<String, String>>> ds1 = env.fromCollection(rows, ty);
+		tableEnv.registerDataSet("t1", ds1, "a, b");
+
+		String sqlQuery = "SELECT MD5('')";
+		Table result = tableEnv.sql(sqlQuery);
+
+		DataSet<Row> resultSet = tableEnv.toDataSet(result, Row.class);
+		List<Row> results = resultSet.collect();
+		String expected = "d41d8cd98f00b204e9800998ecf8427e";
+		compareResultAsText(results, expected);
+	}
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/HashFunctionTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/HashFunctionTest.scala
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.expressions
+
+import org.apache.flink.api.common.typeinfo.{TypeInformation, Types}
+import org.apache.flink.api.java.typeutils.RowTypeInfo
+import org.apache.flink.table.api.scala._
+import org.apache.flink.table.expressions.utils.ExpressionTestBase
+import org.apache.flink.types.Row
+import org.junit.Test
+
+class HashFunctionTest extends ExpressionTestBase {
+
+  @Test
+  def testCalcHash(): Unit = {
+    val expectedMd5 = "098f6bcd4621d373cade4e832627b4f6"
+    val expectedSha1 = "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3"
+    val expectedSha256 = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+
+    testAllApis(
+      md5("test"),
+      "md5(\"test\")",
+      "MD5('test')",
+      expectedMd5)
+
+    testAllApis(
+      sha1("test"),
+      "sha1(\"test\")",
+      "SHA1('test')",
+      expectedSha1)
+
+    testAllApis(
+      sha256("test"),
+      "sha256(\"test\")",
+      "SHA256('test')",
+      expectedSha256)
+
+    testAllApis(
+      md5('f2),
+      "sha256(f2)",
+      "SHA256(f2)",
+      "null")
+
+    testAllApis(
+      sha1('f2),
+      "sha256(f2)",
+      "SHA256(f2)",
+      "null")
+
+    testAllApis(
+      sha256('f2),
+      "sha256(f2)",
+      "SHA256(f2)",
+      "null")
+  }
+
+  override def testData: Any = {
+    val testData = new Row(3)
+    testData.setField(0, "")
+    testData.setField(1, "test")
+    testData.setField(2, null)
+    testData
+  }
+
+  override def typeInfo: TypeInformation[Any] =
+    new RowTypeInfo(
+      Types.STRING,
+      Types.STRING,
+      Types.STRING).asInstanceOf[TypeInformation[Any]]
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/SqlExpressionTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/SqlExpressionTest.scala
@@ -137,6 +137,22 @@ class SqlExpressionTest extends ExpressionTestBase {
   }
 
   @Test
+  def testHashFunctions(): Unit = {
+    testSqlApi("MD5('')", "d41d8cd98f00b204e9800998ecf8427e")
+    testSqlApi("MD5('test')", "098f6bcd4621d373cade4e832627b4f6")
+
+    testSqlApi("SHA1('')", "da39a3ee5e6b4b0d3255bfef95601890afd80709")
+    testSqlApi("SHA1('test')", "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3")
+
+    testSqlApi("SHA256('')", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+    testSqlApi("SHA256('test')", "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08")
+
+    testSqlApi("MD5(CAST(NULL AS VARCHAR))", "null")
+    testSqlApi("SHA1(CAST(NULL AS VARCHAR))", "null")
+    testSqlApi("SHA256(CAST(NULL AS VARCHAR))", "null")
+  }
+
+  @Test
   def testConditionalFunctions(): Unit = {
     testSqlApi("CASE 2 WHEN 1, 2 THEN 2 ELSE 3 END", "2")
     testSqlApi("CASE WHEN 1 = 2 THEN 2 WHEN 1 = 1 THEN 3 ELSE 3 END", "3")


### PR DESCRIPTION
## What is the purpose of the change

This pull request implements MD5, SHA1 and SHA256 support in Flink SQL as discussed in FLINK-6926

## Brief change log

  - Added MD5, SHA1, SHA256 SQL functions
  - Added relevant unit tests

## Verifying this change

This change added tests and can be verified as follows:

  - Added SQL expression tests
  - Added HashFunctionsTest with testAllApis
  - Validated both correct calculation and behavior for null input

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: don't know
  - The runtime per-record code paths (performance sensitive): don't know
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? not documented

