### PR TITLE
[FLINK-7540] Apply consistent hostname normalization

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
@@ -41,6 +41,7 @@ import org.apache.flink.runtime.client.JobClient;
 import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.client.JobListeningContext;
 import org.apache.flink.runtime.client.JobStatusMessage;
+import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.runtime.clusterframework.messages.GetClusterStatusResponse;
 import org.apache.flink.runtime.concurrent.Executors;
 import org.apache.flink.runtime.concurrent.FutureUtils;
@@ -83,7 +84,6 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
 
 import scala.Option;
-import scala.Tuple2;
 import scala.concurrent.Await;
 import scala.concurrent.Future;
 import scala.concurrent.duration.FiniteDuration;
@@ -239,9 +239,11 @@ public abstract class ClusterClient {
 				}
 
 				try {
-					actorSystem = AkkaUtils.createActorSystem(
+					actorSystem = BootstrapTools.startActorSystem(
 						configuration,
-						Option.apply(new Tuple2<String, Object>(ownHostname.getCanonicalHostName(), 0)));
+						ownHostname.getCanonicalHostName(),
+						0,
+						log);
 				} catch (Exception e) {
 					throw new FlinkException("Could not start the ActorSystem lazily.", e);
 				}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceUtils.java
@@ -73,7 +73,7 @@ public class AkkaRpcServiceUtils {
 	 * @throws Exception      Thrown is some other error occurs while creating akka actor system
 	 */
 	public static RpcService createRpcService(String hostname, int port, Configuration configuration) throws Exception {
-		LOG.info("Starting AkkaRpcService at {}.", NetUtils.hostAndPortToUrlString(hostname, port));
+		LOG.info("Starting AkkaRpcService at {}.", NetUtils.unresolvedHostAndPortToNormalizedString(hostname, port));
 
 		final ActorSystem actorSystem;
 

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
@@ -268,9 +268,14 @@ object AkkaUtils {
    * @param externalPort The port to expect for Akka messages
    * @return Flink's Akka configuration for remote actor systems
    */
-  private def getRemoteAkkaConfig(configuration: Configuration,
-                                  bindAddress: String, port: Int,
-                                  externalHostname: String, externalPort: Int): Config = {
+  private def getRemoteAkkaConfig(
+      configuration: Configuration,
+      bindAddress: String,
+      port: Int,
+      externalHostname: String,
+      externalPort: Int): Config = {
+
+    val normalizedExternalHostname = NetUtils.unresolvedHostToNormalizedString(externalHostname)
 
     val akkaAskTimeout = Duration(configuration.getString(AkkaOptions.ASK_TIMEOUT))
 
@@ -360,8 +365,8 @@ object AkkaUtils {
        """.stripMargin
 
     val effectiveHostname =
-      if (externalHostname != null && externalHostname.nonEmpty) {
-        externalHostname
+      if (normalizedExternalHostname != null && normalizedExternalHostname.nonEmpty) {
+        normalizedExternalHostname
       } else {
         // if bindAddress is null or empty, then leave bindAddress unspecified. Akka will pick
         // InetAddress.getLocalHost.getHostAddress

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerStartupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerStartupTest.java
@@ -32,6 +32,8 @@ import org.apache.flink.runtime.highavailability.nonha.embedded.EmbeddedHaServic
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.util.StartupUtils;
 import org.apache.flink.util.NetUtils;
+import org.apache.flink.util.TestLogger;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -50,7 +52,7 @@ import java.util.UUID;
  * Tests that check how the TaskManager behaves when encountering startup
  * problems.
  */
-public class TaskManagerStartupTest {
+public class TaskManagerStartupTest extends TestLogger {
 
 	private HighAvailabilityServices highAvailabilityServices;
 
@@ -96,7 +98,7 @@ public class TaskManagerStartupTest {
 			fail("This should fail with an IOException");
 
 		}
-		catch (IOException e) {
+		catch (Exception e) {
 			// expected. validate the error message
 			List<Throwable> causes = StartupUtils.getExceptionCauses(e, new ArrayList<Throwable>());
 			for (Throwable cause : causes) {
@@ -104,11 +106,8 @@ public class TaskManagerStartupTest {
 					throw (BindException) cause;
 				}
 			}
+
 			fail("This should fail with an exception caused by BindException");
-		}
-		catch (Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
 		}
 		finally {
 			if (blocker != null) {

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/akka/AkkaUtilsTest.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/akka/AkkaUtilsTest.scala
@@ -20,14 +20,14 @@ package org.apache.flink.runtime.akka
 
 import java.net.InetSocketAddress
 
+import org.apache.flink.configuration.Configuration
 import org.apache.flink.runtime.highavailability.HighAvailabilityServicesUtils.AddressResolution
-import org.apache.flink.runtime.jobmanager.JobManager
 import org.apache.flink.runtime.rpc.akka.AkkaRpcServiceUtils
 import org.apache.flink.runtime.rpc.akka.AkkaRpcServiceUtils.AkkaProtocol
 import org.apache.flink.util.NetUtils
 import org.junit.runner.RunWith
-import org.scalatest.{BeforeAndAfterAll, FunSuite, Matchers}
 import org.scalatest.junit.JUnitRunner
+import org.scalatest.{BeforeAndAfterAll, FunSuite, Matchers}
 
 @RunWith(classOf[JUnitRunner])
 class AkkaUtilsTest
@@ -135,5 +135,16 @@ class AkkaUtilsTest
     val result = AkkaUtils.getInetSockeAddressFromAkkaURL(url)
 
     result should equal(address)
+  }
+
+  test("getAkkaConfig should normalize the hostname") {
+    val configuration = new Configuration()
+    val hostname = "AbC123foOBaR"
+    val port = 1234
+
+    val akkaConfig = AkkaUtils.getAkkaConfig(configuration, hostname, port)
+
+    akkaConfig.getString("akka.remote.netty.tcp.hostname") should
+      equal(NetUtils.unresolvedHostToNormalizedString(hostname))
   }
 }


### PR DESCRIPTION
## What is the purpose of the change

The hostname normalization is now applied when generating the remote akka config.
That way it should be ensured that all ActorSystems are bound to a normalized
hostname.

## Brief change log

- Add hostname normalization to `AkkaUtils#getAkkaConfig`
- Replace manual ActorSystem instantiation with `BootstrapTools#startActorSystem`

## Verifying this change

- Added `AkkaUtilsTest#getAkkaConfig`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes) It affects how `ActorSystem` are instantiated.

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

