### PR TITLE
[FLINK-7821] [table] Deprecate Table.limit() and replace it by Table.offset() and Table.fetch().

### DIFF
--- a/docs/dev/table/tableApi.md
+++ b/docs/dev/table/tableApi.md
@@ -957,7 +957,7 @@ val result = left.select('a, 'b, 'c).where('a.in(right));
 
 {% top %}
 
-### OrderBy & Limit
+### OrderBy, Offset & Fetch
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
@@ -985,19 +985,22 @@ Table result = in.orderBy("a.asc");
 
     <tr>
       <td>
-        <strong>Limit</strong><br>
+        <strong>Offset &amp; Fetch</strong><br>
         <span class="label label-primary">Batch</span>
       </td>
       <td>
-        <p>Similar to a SQL LIMIT clause. Limits a sorted result to a specified number of records from an offset position. Limit is technically part of the Order By operator and thus must be preceded by it.</p>
+        <p>Similar to the SQL OFFSET and FETCH clauses. Offset and Fetch limit the number of records returned from a sorted result. Offset and Fetch are technically part of the Order By operator and thus must be preceded by it.</p>
 {% highlight java %}
 Table in = tableEnv.fromDataSet(ds, "a, b, c");
-Table result = in.orderBy("a.asc").limit(3); // returns unlimited number of records beginning with the 4th record
-{% endhighlight %}
-or
-{% highlight java %}
-Table in = tableEnv.fromDataSet(ds, "a, b, c");
-Table result = in.orderBy("a.asc").limit(3, 5); // returns 5 records beginning with the 4th record
+
+// returns the first 5 records from the sorted result
+Table result1 = in.orderBy("a.asc").fetch(5); 
+
+// returns all records beginning with the 4th record from the sorted result
+Table result2 = in.orderBy("a.asc").offset(3);
+
+// returns the first 5 records beginning with the 10th record from the sorted result
+Table result3 = in.orderBy("a.asc").offset(10).fetch(5);
 {% endhighlight %}
       </td>
     </tr>
@@ -1031,19 +1034,22 @@ val result = in.orderBy('a.asc);
 
     <tr>
       <td>
-        <strong>Limit</strong><br>
+        <strong>Offset &amp; Fetch</strong><br>
         <span class="label label-primary">Batch</span>
       </td>
       <td>
-        <p>Similar to a SQL LIMIT clause. Limits a sorted result to a specified number of records from an offset position. Limit is technically part of the Order By operator and thus must be preceded by it.</p>
+        <p>Similar to the SQL OFFSET and FETCH clauses. Offset and Fetch limit the number of records returned from a sorted result. Offset and Fetch are technically part of the Order By operator and thus must be preceded by it.</p>
 {% highlight scala %}
-val in = ds.toTable(tableEnv, 'a, 'b, 'c);
-val result = in.orderBy('a.asc).limit(3); // returns unlimited number of records beginning with the 4th record
-{% endhighlight %}
-or
-{% highlight scala %}
-val in = ds.toTable(tableEnv, 'a, 'b, 'c);
-val result = in.orderBy('a.asc).limit(3, 5); // returns 5 records beginning with the 4th record
+val in = ds.toTable(tableEnv, 'a, 'b, 'c)
+
+// returns the first 5 records from the sorted result
+val result1: Table = in.orderBy('a.asc).fetch(5)
+
+// returns all records beginning with the 4th record from the sorted result
+val result2: Table = in.orderBy('a.asc).offset(3)
+
+// returns the first 5 records beginning with the 10th record from the sorted result
+val result3: Table = in.orderBy('a.asc).offset(10).fetch(5)
 {% endhighlight %}
       </td>
     </tr>

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/batch/table/validation/SortValidationTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/batch/table/validation/SortValidationTest.scala
@@ -27,10 +27,34 @@ import org.junit._
 class SortValidationTest extends TableTestBase {
 
   @Test(expected = classOf[ValidationException])
+  def testOffsetWithoutOrder(): Unit = {
+    val util = batchTestUtil()
+    val ds = util.addTable[(Int, Long, String)]("Table3", 'a, 'b, 'c)
+
+    ds.offset(5)
+  }
+
+  @Test(expected = classOf[ValidationException])
   def testFetchWithoutOrder(): Unit = {
     val util = batchTestUtil()
     val ds = util.addTable[(Int, Long, String)]("Table3", 'a, 'b, 'c)
 
-    ds.limit(0, 5)
+    ds.fetch(5)
+  }
+
+  @Test(expected = classOf[ValidationException])
+  def testFetchBeforeOffset(): Unit = {
+    val util = batchTestUtil()
+    val ds = util.addTable[(Int, Long, String)]("Table3", 'a, 'b, 'c)
+
+    ds.orderBy('a.asc).fetch(5).offset(10)
+  }
+
+  @Test(expected = classOf[ValidationException])
+  def testOffsetBeforeOffset(): Unit = {
+    val util = batchTestUtil()
+    val ds = util.addTable[(Int, Long, String)]("Table3", 'a, 'b, 'c)
+
+    ds.orderBy('a.asc).offset(10).offset(5)
   }
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/validation/CorrelateValidationTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/validation/CorrelateValidationTest.scala
@@ -87,13 +87,13 @@ class CorrelateValidationTest extends TableTestBase {
 
     // table function call limit
     expectExceptionThrown(
-      func1('c).orderBy('f0).limit(3),
+      func1('c).orderBy('f0).offset(3),
       "TableFunction can only be used in join and leftOuterJoin."
     )
 
     // table function call limit
     expectExceptionThrown(
-      func1('c).orderBy('f0).limit(0, 3),
+      func1('c).orderBy('f0).fetch(3),
       "TableFunction can only be used in join and leftOuterJoin."
     )
 

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/validation/UnsupportedOpsValidationTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/validation/UnsupportedOpsValidationTest.scala
@@ -89,11 +89,19 @@ class UnsupportedOpsValidationTest extends StreamingMultipleProgramsTestBase {
   }
 
   @Test(expected = classOf[ValidationException])
-  def testLimit(): Unit = {
+  def testOffset(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     val tEnv = TableEnvironment.getTableEnvironment(env)
     val t1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv)
-    t1.limit(0,5)
+    t1.offset(5)
+  }
+
+  @Test(expected = classOf[ValidationException])
+  def testFetch(): Unit = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env)
+    val t1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv)
+    t1.fetch(5)
   }
 
   @Test(expected = classOf[ValidationException])

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/batch/table/SortITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/batch/table/SortITCase.scala
@@ -143,7 +143,7 @@ class SortITCase(mode: TestExecutionMode, configMode: TableConfigMode)
     val tEnv = TableEnvironment.getTableEnvironment(env, config)
 
     val ds = CollectionDataSets.get3TupleDataSet(env)
-    val t = ds.toTable(tEnv).orderBy('_1.asc).limit(3)
+    val t = ds.toTable(tEnv).orderBy('_1.asc).offset(3)
     implicit def tupleOrdering[T <: Product] = Ordering.by((x : T) =>
       x.productElement(0).asInstanceOf[Int] )
 
@@ -171,7 +171,7 @@ class SortITCase(mode: TestExecutionMode, configMode: TableConfigMode)
     val tEnv = TableEnvironment.getTableEnvironment(env, config)
 
     val ds = CollectionDataSets.get3TupleDataSet(env)
-    val t = ds.toTable(tEnv).orderBy('_1.desc).limit(3, 5)
+    val t = ds.toTable(tEnv).orderBy('_1.desc).offset(3).fetch(5)
     implicit def tupleOrdering[T <: Product] = Ordering.by((x : T) =>
       - x.productElement(0).asInstanceOf[Int] )
 
@@ -199,7 +199,7 @@ class SortITCase(mode: TestExecutionMode, configMode: TableConfigMode)
     val tEnv = TableEnvironment.getTableEnvironment(env, config)
 
     val ds = CollectionDataSets.get3TupleDataSet(env)
-    val t = ds.toTable(tEnv).orderBy('_1.asc).limit(0, 5)
+    val t = ds.toTable(tEnv).orderBy('_1.asc).fetch(5)
     implicit def tupleOrdering[T <: Product] = Ordering.by((x : T) =>
       x.productElement(0).asInstanceOf[Int] )
 


### PR DESCRIPTION
## What is the purpose of the change

- `Table.limit(n)` has unexpected semantics of returning all but the first `n` rows.
- Returning the first `n` rows from a sorted result requires to specify a 0 offset (`table.orderBy(...).limit(0, n)`) which is more complicated than necessary.

## Brief change log

- deprecate `Table.limit()` and replace it by `Table.offset()` and `Table.fetch()`

## Verifying this change

- existing tests for `limit` were adapted for `offset` and `fetch`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**

## Documentation

- Documentation was adapted.