### PR TITLE
[FLINK-7802] [hotfix] Exception occur when empty field collection was pushed into CSVTableSource

### DIFF
--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/batch/sql/TableSourceITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/batch/sql/TableSourceITCase.scala
@@ -77,4 +77,34 @@ class TableSourceITCase(
     TestBaseUtils.compareResultAsText(result.asJava, expected)
   }
 
+  @Test
+  def testCsvTableSourceWithProjectionWithCountStar(): Unit = {
+    val csvTable = CommonTestData.getCsvTableSource
+
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+
+    tEnv.registerTableSource("csvTable", csvTable)
+
+    val result = tEnv.sqlQuery("SELECT COUNT(*) FROM csvTable").collect()
+
+    val expected = "8"
+    TestBaseUtils.compareResultAsText(result.asJava, expected)
+  }
+
+  @Test
+  def testCsvTableSourceWithProjectionWithCount1(): Unit = {
+    val csvTable = CommonTestData.getCsvTableSource
+
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+
+    tEnv.registerTableSource("csvTable", csvTable)
+
+    val result = tEnv.sqlQuery("SELECT COUNT(1) FROM csvTable").collect()
+
+    val expected = "8"
+    TestBaseUtils.compareResultAsText(result.asJava, expected)
+  }
+
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/batch/table/TableSourceITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/batch/table/TableSourceITCase.scala
@@ -61,6 +61,24 @@ class TableSourceITCase(
   }
 
   @Test
+  def testCsvTableSourceWithProjectionWithCount1(): Unit = {
+    val csvTable = CommonTestData.getCsvTableSource
+
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+
+    tEnv.registerTableSource("csvTable", csvTable)
+
+    val results = tEnv
+      .scan("csvTable")
+      .select(1.count)
+      .collect()
+
+    val expected = "8"
+    TestBaseUtils.compareResultAsText(results.asJava, expected)
+  }
+
+  @Test
   def testTableSourceWithFilterable(): Unit = {
     val tableName = "MyTable"
     val env = ExecutionEnvironment.getExecutionEnvironment


### PR DESCRIPTION
## What is the purpose of the change

*This pull request fix the bug: Exception occur when empty field collection was pushed into CSVTableSource*


## Brief change log

  - *Handle empty field collection in CSVTableSource when project push down*


## Verifying this change

This change added tests and can be verified as follows:

  - *Add integration tests for SQL like: select count(1) from csv_table*
  

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)

