### PR TITLE
[FLINK-7831] Make last received heartbeat retrievable

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatManager.java
@@ -50,4 +50,12 @@ public interface HeartbeatManager<I, O> extends HeartbeatTarget<I> {
 	 * Stops the heartbeat manager.
 	 */
 	void stop();
+
+	/**
+	 * Returns the last received heartbeat from the given target.
+	 *
+	 * @param resourceId for which to return the last heartbeat
+	 * @return Last heartbeat received from the given target or -1 if the target is not being monitored.
+	 */
+	long getLastHeartbeatFrom(ResourceID resourceId);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerImpl.java
@@ -163,6 +163,17 @@ public class HeartbeatManagerImpl<I, O> implements HeartbeatManager<I, O> {
 		heartbeatTargets.clear();
 	}
 
+	@Override
+	public long getLastHeartbeatFrom(ResourceID resourceId) {
+		HeartbeatMonitor<O> heartbeatMonitor = heartbeatTargets.get(resourceId);
+
+		if (heartbeatMonitor != null) {
+			return heartbeatMonitor.getLastHeartbeat();
+		} else {
+			return -1L;
+		}
+	}
+
 	//----------------------------------------------------------------------------------------------
 	// HeartbeatTarget methods
 	//----------------------------------------------------------------------------------------------
@@ -252,6 +263,8 @@ public class HeartbeatManagerImpl<I, O> implements HeartbeatManager<I, O> {
 
 		private final AtomicReference<State> state = new AtomicReference<>(State.RUNNING);
 
+		private volatile long lastHeartbeat;
+
 		HeartbeatMonitor(
 			ResourceID resourceID,
 			HeartbeatTarget<O> heartbeatTarget,
@@ -267,6 +280,8 @@ public class HeartbeatManagerImpl<I, O> implements HeartbeatManager<I, O> {
 			Preconditions.checkArgument(heartbeatTimeoutIntervalMs >= 0L, "The heartbeat timeout interval has to be larger than 0.");
 			this.heartbeatTimeoutIntervalMs = heartbeatTimeoutIntervalMs;
 
+			lastHeartbeat = 0L;
+
 			resetHeartbeatTimeout(heartbeatTimeoutIntervalMs);
 		}
 
@@ -274,7 +289,12 @@ public class HeartbeatManagerImpl<I, O> implements HeartbeatManager<I, O> {
 			return heartbeatTarget;
 		}
 
+		public long getLastHeartbeat() {
+			return lastHeartbeat;
+		}
+
 		void reportHeartbeat() {
+			lastHeartbeat = System.currentTimeMillis();
 			resetHeartbeatTimeout(heartbeatTimeoutIntervalMs);
 		}
 


### PR DESCRIPTION
## What is the purpose of the change

This commit adds functionality to retrieve the last received heartbeat from
the HeartbeatManager.

## Verifying this change

- `HeartbeatManagerTest#testLastHeartbeatFrom` and `HeartbeatManager#testLastHeartbeatFromUnregisteredTarget`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

