### PR TITLE
[FLINK-5706] [file systems] Add S3 file systems without Hadoop dependencies

### DIFF
--- a/docs/dev/libs/cep.md
+++ b/docs/dev/libs/cep.md
@@ -24,13 +24,12 @@ under the License.
 -->
 
 FlinkCEP is the Complex Event Processing (CEP) library implemented on top of Flink.
-It allows you to easily detect event patterns in an endless stream of events, thus
-giving you the opportunity to quickly get hold of what's really important in your
+It allows you to detect event patterns in an endless stream of events, giving you the opportunity to get hold of what's important in your
 data.
 
 This page describes the API calls available in Flink CEP. We start by presenting the [Pattern API](#the-pattern-api),
 which allows you to specify the patterns that you want to detect in your stream, before presenting how you can
-[detect and act upon matching event sequences](#detecting-patterns). At the end, we present the assumptions the CEP
+[detect and act upon matching event sequences](#detecting-patterns). We then present the assumptions the CEP
 library makes when [dealing with lateness](#handling-lateness-in-event-time) in event time and how you can
 [migrate your job](#migrating-from-an-older-flink-version) from an older Flink version to Flink-1.3.
 
@@ -39,7 +38,7 @@ library makes when [dealing with lateness](#handling-lateness-in-event-time) in 
 
 ## Getting Started
 
-If you want to jump right in, you have to [set up a Flink program]({{ site.baseurl }}/dev/linking_with_flink.html) and
+If you want to jump right in, [set up a Flink program]({{ site.baseurl }}/dev/linking_with_flink.html) and
 add the FlinkCEP dependency to the `pom.xml` of your project.
 
 <div class="codetabs" markdown="1">
@@ -64,14 +63,13 @@ add the FlinkCEP dependency to the `pom.xml` of your project.
 </div>
 </div>
 
-Note that FlinkCEP is currently not part of the binary distribution.
-See linking with it for cluster execution [here]({{site.baseurl}}/dev/linking.html).
+{% info %} FlinkCEP is not part of the binary distribution. See how to link with it for cluster execution [here]({{site.baseurl}}/dev/linking.html).
 
 Now you can start writing your first CEP program using the Pattern API.
 
 {% warn Attention %} The events in the `DataStream` to which
 you want to apply pattern matching must implement proper `equals()` and `hashCode()` methods
-because these are used for comparing and matching events.
+because FlinkCEP uses them for comparing and matching events.
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
@@ -130,41 +128,33 @@ val result: DataStream[Alert] = patternStream.select(createAlert(_))
 
 ## The Pattern API
 
-The pattern API allows you to quickly define complex pattern sequences that you want to extract
-from your input stream.
+The pattern API allows you to define complex pattern sequences that you want to extract from your input stream.
 
-Each such complex pattern sequence consists of multiple simple patterns, i.e. patterns looking for
-individual events with the same properties. From now on, these simple patterns will be called **patterns**, and
-the final complex pattern sequence we are searching for in the stream, the **pattern sequence**. A pattern sequence
-can be seen as a graph of such patterns, where transitions from one pattern to the next occur based on user-specified
+Each complex pattern sequence consists of multiple simple patterns, i.e. patterns looking for individual events with the same properties. From now on, we will call these simple patterns **patterns**, and the final complex pattern sequence we are searching for in the stream, the **pattern sequence**. You can see a pattern sequence as a graph of such patterns, where transitions from one pattern to the next occur based on user-specified
 *conditions*, e.g. `event.getName().equals("start")`. A **match** is a sequence of input events which visits all
 patterns of the complex pattern graph, through a sequence of valid pattern transitions.
 
-{% warn Attention %} Each pattern must have a unique name, which is used to later
-identify the matched events.
+{% warn Attention %} Each pattern must have a unique name, which you use later to identify the matched events.
 
 {% warn Attention %} Pattern names **CANNOT** contain the character `":"`.
 
-In the remainder of this section we will first describe how to define [Individual Patterns](#individual-patterns), and then cover how you can
-combine individual patterns into [Complex Patterns](#combining-patterns).
+In the rest of this section we will first describe how to define [Individual Patterns](#individual-patterns), and then how you can combine individual patterns into [Complex Patterns](#combining-patterns).
 
 ### Individual Patterns
 
-A **Pattern** can be either a *singleton* pattern, or a *looping* one. Singleton patterns accept a single
-event, while looping ones can accept more than one. In pattern matching symbols, in the pattern `"a b+ c? d"` (or `"a"`,
-followed by *one or more* `"b"`'s, optionally followed by a `"c"`, followed by a `"d"`), `a`, `c?`, and `d` are
+A **Pattern** can be either a *singleton* or a *looping* pattern. Singleton patterns accept a single
+event, while looping patterns can accept more than one. In pattern matching symbols, the pattern `"a b+ c? d"` (or `"a"`, followed by *one or more* `"b"`'s, optionally followed by a `"c"`, followed by a `"d"`), `a`, `c?`, and `d` are
 singleton patterns, while `b+` is a looping one. By default, a pattern is a singleton pattern and you can transform
-it to a looping one by using [Quantifiers](#quantifiers). In addition, each pattern can have one or more
+it to a looping one by using [Quantifiers](#quantifiers). Each pattern can have one or more
 [Conditions](#conditions) based on which it accepts events.
 
 #### Quantifiers
 
-In FlinkCEP, looping patterns can be specified using these methods: `pattern.oneOrMore()`, for patterns that expect one or
-more occurrences of a given event (e.g. the `b+` mentioned previously); and `pattern.times(#ofTimes)`, for patterns that
-expect a specific number of occurrences of a given type of event, e.g. 4 `a`'s; and `pattern.times(#fromTimes, #toTimes)`,
-for patterns that expect a specific minimum number of occurrences and maximum number of occurrences of a given type of event,
-e.g. 2-4 `a`s. Looping patterns can be made greedy using the `pattern.greedy()` method and group pattern cannot be made greedy
-currently. All patterns, looping or not, can be made optional using the `pattern.optional()` method.
+In FlinkCEP, you can specifiy looping patterns using these methods: `pattern.oneOrMore()`, for patterns that expect one or more occurrences of a given event (e.g. the `b+` mentioned before); and `pattern.times(#ofTimes)`, for patterns that
+expect a specific number of occurrences of a given type of event, e.g. 4 `a`'s; and `pattern.times(#fromTimes, #toTimes)`, for patterns that expect a specific minimum number of occurrences and a maximum number of occurrences of a given type of event, e.g. 2-4 `a`s.
+
+You can make looping patterns greedy using the `pattern.greedy()` method, but you cannot yet make group patterns greedy. You can make all patterns, looping or not, optional using the `pattern.optional()` method.
+
 For a pattern named `start`, the following are valid quantifiers:
 
  <div class="codetabs" markdown="1">
@@ -260,13 +250,13 @@ For a pattern named `start`, the following are valid quantifiers:
 
 #### Conditions
 
-At every pattern, and in order to go from one pattern to the next, you can specify additional **conditions**.
-These conditions can be related to:
+At every pattern, and to go from one pattern to the next, you can specify additional **conditions**.
+You can relate these conditions to:
 
- 1. a [property of the incoming event](#conditions-on-properties), e.g. its value should be larger than 5,
+ 1. A [property of the incoming event](#conditions-on-properties), e.g. its value should be larger than 5,
  or larger than the average value of the previously accepted events.
 
- 2. the [contiguity of the matching events](#conditions-on-contiguity), e.g. detect pattern `a,b,c` without
+ 2. The [contiguity of the matching events](#conditions-on-contiguity), e.g. detect pattern `a,b,c` without
  non-matching events between any matching ones.
 
 The latter refers to "looping" patterns, *i.e.* patterns that can accept more than one event, e.g. the `b+` in `a b+ c`,
@@ -274,16 +264,13 @@ which searches for one or more `b`'s.
 
 ##### Conditions on Properties
 
-Conditions on the event properties can be specified via the `pattern.where()`, `pattern.or()` or the `pattern.until()` method. These can
-be either `IterativeCondition`s or `SimpleCondition`s.
+You can specify conditions on the event properties via the `pattern.where()`, `pattern.or()` or the `pattern.until()` method. These can be either `IterativeCondition`s or `SimpleCondition`s.
 
-**Iterative Conditions:** This is the most general type of conditions. This is how you can specify a condition that
-accepts subsequent events based on properties of the previously accepted events or some statistic over a subset of them.
+**Iterative Conditions:** This is the most general type of condition. This is how you can specify a condition that
+accepts subsequent events based on properties of the previously accepted events or a statistic over a subset of them.
 
 Below is the code for an iterative condition that accepts the next event for a pattern named "middle" if its name starts
-with "foo", and if the sum of the prices of the previously accepted events for that pattern plus the price of the current
-event do not exceed the value of 5.0. Iterative conditions can be very powerful, especially in combination with looping
-patterns, e.g. `oneOrMore()`.
+with "foo", and if the sum of the prices of the previously accepted events for that pattern plus the price of the current event do not exceed the value of 5.0. Iterative conditions can be powerful, especially in combination with looping patterns, e.g. `oneOrMore()`.
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
@@ -343,7 +330,7 @@ start.where(event => event.getName.startsWith("foo"))
 </div>
 </div>
 
-Finally, we can also restrict the type of the accepted event to some subtype of the initial event type (here `Event`)
+Finally, you can also restrict the type of the accepted event to a subtype of the initial event type (here `Event`)
 via the `pattern.subtype(subClass)` method.
 
 <div class="codetabs" markdown="1">
@@ -365,10 +352,7 @@ start.subtype(classOf[SubEvent]).where(subEvent => ... /* some condition */)
 </div>
 </div>
 
-**Combining Conditions:** As shown, the `subtype` condition can be combined with additional conditions.
-In fact, this holds for every condition. You can arbitrarily combine conditions by sequentially calling
-`where()`. The final result will be the logical **AND** of the results of the individual conditions. In
-order to combine conditions using **OR**, you can use the `or()` method, as shown below.
+**Combining Conditions:** As shown above, you can combine the `subtype` condition with additional conditions. This holds for every condition. You can arbitrarily combine conditions by sequentially calling `where()`. The final result will be the logical **AND** of the results of the individual conditions. To combine conditions using **OR**, you can use the `or()` method, as shown below.
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
@@ -412,22 +396,21 @@ As you can see `{a1 a2 a3}` or `{a2 a3}` are not returned due to the stop condit
 
 FlinkCEP supports the following forms of contiguity between events:
 
- 1. Strict Contiguity: which expects all matching events to appear strictly the one after the other,
- without any non-matching events in-between.
+ 1. **Strict Contiguity**: Expects all matching events to appear strictly one after the other, without any non-matching events in-between.
 
- 2. Relaxed Contiguity: which simply ignores non-matching events appearing in-between the matching ones.
+ 2. **Relaxed Contiguity**: Ignores non-matching events appearing in-between the matching ones.
 
- 3. Non-Deterministic Relaxed Contiguity: which further relaxes contiguity, allowing additional matches
+ 3. **Non-Deterministic Relaxed Contiguity**: Further relaxes contiguity, allowing additional matches
  that ignore some matching events.
 
 To illustrate the above with an example, a pattern sequence `"a+ b"` (one or more `"a"`'s followed by a `"b"`) with
 input `"a1", "c", "a2", "b"` will have the following results:
 
- 1. Strict Contiguity: `{a2 b}` -- the `"c"` after `"a1"` causes `"a1"` to be discarded.
+ 1. **Strict Contiguity**: `{a2 b}` -- the `"c"` after `"a1"` causes `"a1"` to be discarded.
 
- 2. Relaxed Contiguity: `{a1 b}` and `{a1 a2 b}` -- `c` is simply ignored.
+ 2. **Relaxed Contiguity**: `{a1 b}` and `{a1 a2 b}` -- `c` is ignored.
 
- 3. Non-Deterministic Relaxed Contiguity: `{a1 b}`, `{a2 b}`, and `{a1 a2 b}`.
+ 3. **Non-Deterministic Relaxed Contiguity**: `{a1 b}`, `{a2 b}`, and `{a1 a2 b}`.
 
 For looping patterns (e.g. `oneOrMore()` and `times()`) the default is *relaxed contiguity*. If you want
 strict contiguity, you have to explicitly specify it by using the `consecutive()` call, and if you want
@@ -487,7 +470,7 @@ pattern.where(new IterativeCondition<Event>() {
               <tr>
                  <td><strong>until(condition)</strong></td>
                  <td>
-                     <p>Specifies a stop condition for looping pattern. Meaning if event matching the given condition occurs, no more
+                     <p>Specifies a stop condition for a looping pattern. Meaning if event matching the given condition occurs, no more
                      events will be accepted into the pattern.</p>
                      <p>Applicable only in conjunction with <code>oneOrMore()</code></p>
                      <p><b>NOTE:</b> It allows for cleaning state for corresponding pattern on event-based condition.</p>
@@ -820,7 +803,7 @@ Pattern.begin("start").where(_.getName().equals("c"))
 
 ### Combining Patterns
 
-Now that we have seen what an individual pattern can look like, it is time to see how to combine them
+Now that you've seen what an individual pattern can look like, it is time to see how to combine them
 into a full pattern sequence.
 
 A pattern sequence has to start with an initial pattern, as shown below:
@@ -901,23 +884,22 @@ val relaxedNot: Pattern[Event, _] = start.notFollowedBy("not").where(...)
 </div>
 </div>
 
-Bear in mind that relaxed contiguity means that only the first succeeding matching event will be matched, while
+Relaxed contiguity means that only the first succeeding matching event will be matched, while
 with non-deterministic relaxed contiguity, multiple matches will be emitted for the same beginning. As an example,
 a pattern `a b`, given the event sequence `"a", "c", "b1", "b2"`, will give the following results:
 
-1. Strict Contiguity between `a` and `b`: `{}` (no match) -- the `"c"` after `"a"` causes `"a"` to be discarded.
+1. Strict Contiguity between `a` and `b`: `{}` (no match), the `"c"` after `"a"` causes `"a"` to be discarded.
 
-2. Relaxed Contiguity between `a` and `b`: `{a b1}` -- as relaxed continuity is viewed as "skip non-matching events
+2. Relaxed Contiguity between `a` and `b`: `{a b1}`, as relaxed continuity is viewed as "skip non-matching events
 till the next matching one".
 
-3. Non-Deterministic Relaxed Contiguity between `a` and `b`: `{a b1}`, `{a b2}` -- as this is the most general form.
+3. Non-Deterministic Relaxed Contiguity between `a` and `b`: `{a b1}`, `{a b2}`, as this is the most general form.
 
-Finally, it is also possible to define a temporal constraint for the pattern to be valid.
+It's also possible to define a temporal constraint for the pattern to be valid.
 For example, you can define that a pattern should occur within 10 seconds via the `pattern.within()` method.
 Temporal patterns are supported for both [processing and event time]({{site.baseurl}}/dev/event_time.html).
 
-{% warn Attention %} A pattern sequence can only have one temporal constraint. If
-multiple such constraints are defined on different individual patterns, then the smallest one is applied.
+{% warn Attention %} A pattern sequence can only have one temporal constraint. If multiple such constraints are defined on different individual patterns, then the smallest is applied.
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
@@ -933,7 +915,7 @@ next.within(Time.seconds(10))
 </div>
 </div>
 
-It is also possible to define a pattern sequence as the condition for `begin`, `followedBy`, `followedByAny` and
+It's also possible to define a pattern sequence as the condition for `begin`, `followedBy`, `followedByAny` and
 `next`. The pattern sequence will be considered as the matching condition logically and a `GroupPattern` will be
 returned and it is possible to apply `oneOrMore()`, `times(#ofTimes)`, `times(#fromTimes, #toTimes)`, `optional()`,
 `consecutive()`, `allowCombinations()` to the `GroupPattern`.
@@ -1252,8 +1234,7 @@ pattern.within(Time.seconds(10))
 
 ### After Match Skip Strategy
 
-For a given pattern, same event may be assigned to multiple successful matches. In order to control to how many matches an event will be assigned, we need to specify the skip strategy called `AfterMatchSkipStrategy`. 
-There're four types of skip strategies, listed as follows:
+For a given pattern, the same event may be assigned to multiple successful matches. To control to how many matches an event will be assigned, you need to specify the skip strategy called `AfterMatchSkipStrategy`. There are four types of skip strategies, listed as follows:
 
 * <strong>*NO_SKIP*</strong>: Every possible match will be emitted.
 * <strong>*SKIP_PAST_LAST_EVENT*</strong>: Discards every partial match that contains event of the match.
@@ -1262,7 +1243,7 @@ There're four types of skip strategies, listed as follows:
 
 Notice that when using *SKIP_TO_FIRST* and *SKIP_TO_LAST* skip strategy, a valid *PatternName* should also be specified.
 
-Let's take an example: For a given pattern `a b{2}` and a data stream `ab1, ab2, ab3, ab4, ab5, ab6`, the differences between these four skip strategies can be listed as follows:
+For example, for a given pattern `a b{2}` and a data stream `ab1, ab2, ab3, ab4, ab5, ab6`, the differences between these four skip strategies are as follows:
 
 <table class="table table-bordered">
     <tr>
@@ -1352,10 +1333,8 @@ Pattern.begin("patternName", skipStrategy)
 ## Detecting Patterns
 
 After specifying the pattern sequence you are looking for, it is time to apply it to your input stream to detect
-potential matches. In order to run a stream of events against your pattern sequence, you have to create a `PatternStream`.
-Given an input stream `input`, a pattern `pattern` and an optional comparator `comparator` which is used to
-sort events with the same timestamp in case of EventTime or that arrived at the same moment, you create the
-`PatternStream` by calling:
+potential matches. To run a stream of events against your pattern sequence, you have to create a `PatternStream`.
+Given an input stream `input`, a pattern `pattern` and an optional comparator `comparator` used to sort events with the same timestamp in case of EventTime or that arrived at the same moment, you create the `PatternStream` by calling:
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
@@ -1381,8 +1360,7 @@ val patternStream: PatternStream[Event] = CEP.pattern(input, pattern, comparator
 
 The input stream can be *keyed* or *non-keyed* depending on your use-case.
 
-{% warn Attention %} Applying your pattern on a non-keyed stream will result in a job with
-parallelism equal to 1.
+{% warn Attention %} Applying your pattern on a non-keyed stream will result in a job with parallelism equal to 1.
 
 ### Selecting from Patterns
 
@@ -1395,8 +1373,7 @@ A `PatternSelectFunction` has a `select` method which is called for each matchin
 It receives a match in the form of `Map<String, List<IN>>` where the key is the name of each pattern in your pattern
 sequence and the value is a list of all accepted events for that pattern (`IN` is the type of your input elements).
 The events for a given pattern are ordered by timestamp. The reason for returning a list of accepted events for each
-pattern is that when using looping patterns (e.g. `oneToMany()` and `times()`), more than one event may be accepted for a
-given pattern. The selection function returns exactly one result.
+pattern is that when using looping patterns (e.g. `oneToMany()` and `times()`), more than one event may be accepted for a given pattern. The selection function returns exactly one result.
 
 {% highlight java %}
 class MyPatternSelectFunction<IN, OUT> implements PatternSelectFunction<IN, OUT> {
@@ -1410,7 +1387,7 @@ class MyPatternSelectFunction<IN, OUT> implements PatternSelectFunction<IN, OUT>
 {% endhighlight %}
 
 A `PatternFlatSelectFunction` is similar to the `PatternSelectFunction`, with the only distinction that it can return an
-arbitrary number of results. In order to do this, the `select` method has an additional `Collector` parameter which is
+arbitrary number of results. To do this, the `select` method has an additional `Collector` parameter which is
 used to forward your output elements downstream.
 
 {% highlight java %}
@@ -1432,9 +1409,8 @@ class MyPatternFlatSelectFunction<IN, OUT> implements PatternFlatSelectFunction<
 The `select()` method takes a selection function as argument, which is called for each matching event sequence.
 It receives a match in the form of `Map[String, Iterable[IN]]` where the key is the name of each pattern in your pattern
 sequence and the value is an Iterable over all accepted events for that pattern (`IN` is the type of your input elements).
-The events for a given pattern are ordered by timestamp. The reason for returning an iterable of accepted events for each
-pattern is that when using looping patterns (e.g. `oneToMany()` and `times()`), more than one event may be accepted for a
-given pattern. The selection function returns exactly one result per call.
+
+The events for a given pattern are ordered by timestamp. The reason for returning an iterable of accepted events for each pattern is that when using looping patterns (e.g. `oneToMany()` and `times()`), more than one event may be accepted for a given pattern. The selection function returns exactly one result per call.
 
 {% highlight scala %}
 def selectFn(pattern : Map[String, Iterable[IN]]): OUT = {
@@ -1463,12 +1439,12 @@ def flatSelectFn(pattern : Map[String, Iterable[IN]], collector : Collector[OUT]
 ### Handling Timed Out Partial Patterns
 
 Whenever a pattern has a window length attached via the `within` keyword, it is possible that partial event sequences
-are discarded because they exceed the window length. In order to react to these timed out partial matches the `select`
-and `flatSelect` API calls allow a timeout handler to be specified. This timeout handler is called for each timed out
+are discarded because they exceed the window length. To react to these timed out partial matches the `select`
+and `flatSelect` API calls allow you to specify a timeout handler. This timeout handler is called for each timed out
 partial event sequence. The timeout handler receives all the events that have been matched so far by the pattern, and
 the timestamp when the timeout was detected.
 
-In order to treat partial patterns, the `select` and `flatSelect` API calls offer an overloaded version which takes as
+To treat partial patterns, the `select` and `flatSelect` API calls offer an overloaded version which takes as
 parameters
 
  * `PatternTimeoutFunction`/`PatternFlatTimeoutFunction`
@@ -1519,8 +1495,7 @@ val timeoutResult: DataStream<TimeoutEvent> = result.getSideOutput(outputTag);
 ~~~
 
 The `flatSelect` API call offers the same overloaded version which takes as the first parameter a timeout function and as second parameter a selection function.
-In contrast to the `select` functions, the `flatSelect` functions are called with a `Collector`.
-The collector can be used to emit an arbitrary number of events.
+In contrast to the `select` functions, the `flatSelect` functions are called with a `Collector`. You can use the collector to emit an arbitrary number of events.
 
 ~~~scala
 val patternStream: PatternStream[Event] = CEP.pattern(input, pattern)
@@ -1543,21 +1518,18 @@ val timeoutResult: DataStream<TimeoutEvent> = result.getSideOutput(outputTag);
 
 ## Handling Lateness in Event Time
 
-In `CEP` the order in which elements are processed matters. To guarantee that elements are processed in the correct order
-when working in event time, an incoming element is initially put in a buffer where elements are *sorted in ascending
-order based on their timestamp*, and when a watermark arrives, all the elements in this buffer with timestamps smaller
-than that of the watermark are processed. This implies that elements between watermarks are processed in event-time order.
+In `CEP` the order in which elements are processed matters. To guarantee that elements are processed in the correct order when working in event time, an incoming element is initially put in a buffer where elements are *sorted in ascending order based on their timestamp*, and when a watermark arrives, all the elements in this buffer with timestamps smaller than that of the watermark are processed. This implies that elements between watermarks are processed in event-time order.
 
 {% warn Attention %} The library assumes correctness of the watermark when working in event time.
 
-To also guarantee that elements across watermarks are processed in event-time order, Flink's CEP library assumes
+To guarantee that elements across watermarks are processed in event-time order, Flink's CEP library assumes
 *correctness of the watermark*, and considers as *late* elements whose timestamp is smaller than that of the last
 seen watermark. Late elements are not further processed.
 
 ## Examples
 
 The following example detects the pattern `start, middle(name = "error") -> end(name = "critical")` on a keyed data
-stream of `Events`. The events are keyed by their ids and a valid pattern has to occur within 10 seconds.
+stream of `Events`. The events are keyed by their `id`s and a valid pattern has to occur within 10 seconds.
 The whole processing is done with event time.
 
 <div class="codetabs" markdown="1">

--- a/flink-core/src/test/java/org/apache/flink/util/FileUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/FileUtilsTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.util;
 
 import org.apache.flink.core.testutils.CheckedThread;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -27,12 +28,15 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.AccessDeniedException;
-import java.nio.file.Files;
-import java.util.Random;
 
-import static org.junit.Assert.*;
-import static org.junit.Assume.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
 
+/**
+ * Tests for the {@link FileUtils}.
+ */
 public class FileUtilsTest {
 
 	@Rule
@@ -97,6 +101,21 @@ public class FileUtilsTest {
 			cannotDeleteParent.setWritable(true);
 			//noinspection ResultOfMethodCallIgnored
 			cannotDeleteChild.setWritable(true);
+		}
+	}
+
+	@Test
+	public void testDeleteDirectoryWhichIsAFile() throws Exception {
+
+		// deleting a directory that is actually a file should fails
+
+		File file = tmp.newFile();
+		try {
+			FileUtils.deleteDirectory(file);
+			fail("this should fail with an exception");
+		}
+		catch (IOException ignored) {
+			// this is what we expect
 		}
 	}
 

--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -153,7 +153,7 @@ under the License.
 			<artifactId>flink-hadoop-fs</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-mapr-fs</artifactId>
@@ -297,7 +297,21 @@ under the License.
 			<version>${project.version}</version>
 			<scope>provided</scope>
 		</dependency>
-		
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-s3-fs-hadoop</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-s3-fs-presto</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
 		<!-- end optional Flink libraries -->
 
 		<!-- test dependencies -->

--- a/flink-dist/src/main/assemblies/opt.xml
+++ b/flink-dist/src/main/assemblies/opt.xml
@@ -117,5 +117,19 @@
 			<destName>flink-metrics-datadog-${project.version}.jar</destName>
 			<fileMode>0644</fileMode>
 		</file>
+
+		<file>
+			<source>../flink-filesystems/flink-s3-fs-hadoop/target/flink-s3-fs-hadoop-${project.version}.jar</source>
+			<outputDirectory>opt/</outputDirectory>
+			<destName>flink-s3-fs-hadoop-${project.version}.jar</destName>
+			<fileMode>0644</fileMode>
+		</file>
+
+		<file>
+			<source>../flink-filesystems/flink-s3-fs-presto/target/flink-s3-fs-presto-${project.version}.jar</source>
+			<outputDirectory>opt/</outputDirectory>
+			<destName>flink-s3-fs-presto-${project.version}.jar</destName>
+			<fileMode>0644</fileMode>
+		</file>
 	</files>
 </assembly>

--- a/flink-filesystems/flink-s3-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-s3-fs-hadoop/pom.xml
@@ -1,0 +1,271 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.apache.flink</groupId>
+		<artifactId>flink-filesystems</artifactId>
+		<version>1.4-SNAPSHOT</version>
+		<relativePath>..</relativePath>
+	</parent>
+
+	<artifactId>flink-s3-fs-hadoop</artifactId>
+	<name>flink-s3-fs-hadoop</name>
+
+	<packaging>jar</packaging>
+
+	<properties>
+		<s3hadoop.hadoop.version>2.8.1</s3hadoop.hadoop.version>
+		<s3hadoop.aws.version>1.11.95</s3hadoop.aws.version>
+	</properties>
+
+	<dependencies>
+
+		<!-- Flink core -->
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-core</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- File system builds on the Hadoop file system support -->
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-hadoop-fs</artifactId>
+			<version>${project.version}</version>
+
+			<!-- this exclusion is only needed to run tests in the IDE, pre shading,
+				because the optional Hadoop dependency is also pulled in for tests -->
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.flink</groupId>
+					<artifactId>flink-shaded-hadoop2</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<!-- Hadoop's S3a file system -->
+
+		<dependency>
+			<groupId>org.apache.hadoop</groupId>
+			<artifactId>hadoop-client</artifactId>
+			<version>${s3hadoop.hadoop.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.hadoop</groupId>
+					<artifactId>hadoop-mapreduce-client-core</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.hadoop</groupId>
+					<artifactId>hadoop-yarn-api</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.hadoop</groupId>
+					<artifactId>hadoop-mapreduce-client-jobclient</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.hadoop</groupId>
+					<artifactId>hadoop-mapreduce-client-app</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.avro</groupId>
+					<artifactId>avro</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>javax.servlet.jsp</groupId>
+					<artifactId>jsp-api</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.directory.server</groupId>
+					<artifactId>apacheds-kerberos-codec</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.curator</groupId>
+					<artifactId>curator-client</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.curator</groupId>
+					<artifactId>curator-framework</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.curator</groupId>
+					<artifactId>curator-recipes</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.zookeeper</groupId>
+					<artifactId>zookeeper</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.hadoop</groupId>
+			<artifactId>hadoop-aws</artifactId>
+			<version>${s3hadoop.hadoop.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.avro</groupId>
+					<artifactId>avro</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<dependency>
+			<groupId>com.amazonaws</groupId>
+			<artifactId>aws-java-sdk-core</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.amazonaws</groupId>
+			<artifactId>aws-java-sdk-kms</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.amazonaws</groupId>
+			<artifactId>aws-java-sdk-s3</artifactId>
+		</dependency>
+
+		<!-- make sure that also logger and JSR is provided -->
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>com.google.code.findbugs</groupId>
+			<artifactId>jsr305</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- test dependencies -->
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-test-utils-junit</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<!-- We need to bump the AWS dependencies compared to the ones referenced
+    by Hadoop, because the older versions have bugs affecting this project -->
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>com.amazonaws</groupId>
+				<artifactId>aws-java-sdk-core</artifactId>
+				<version>${s3hadoop.aws.version}</version>
+			</dependency>
+	
+			<dependency>
+				<groupId>com.amazonaws</groupId>
+				<artifactId>aws-java-sdk-kms</artifactId>
+				<version>${s3hadoop.aws.version}</version>
+			</dependency>
+	
+			<dependency>
+				<groupId>com.amazonaws</groupId>
+				<artifactId>aws-java-sdk-s3</artifactId>
+				<version>${s3hadoop.aws.version}</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+
+				<!-- we need to explicitly override this version, because the -->
+				<!-- earlier versions of the shade plugin have a bug relocating services -->
+				<version>3.0.0</version>
+
+				<executions>
+					<execution>
+						<id>shade-flink</id>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<artifactSet>
+								<includes>
+									<include>*:*</include>
+								</includes>
+							</artifactSet>
+							<relocations>
+								<relocation>
+									<pattern>org</pattern>
+									<shadedPattern>org.apache.flink.s3hadoop.shaded.org</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>com</pattern>
+									<shadedPattern>org.apache.flink.s3hadoop.shaded.com</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>net</pattern>
+									<shadedPattern>org.apache.flink.s3hadoop.shaded.net</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>okio</pattern>
+									<shadedPattern>org.apache.flink.s3hadoop.shaded.okio</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>software</pattern>
+									<shadedPattern>org.apache.flink.s3hadoop.shaded.software</shadedPattern>
+								</relocation>
+							</relocations>
+							<filters>
+								<filter>
+									<artifact>*</artifact>
+									<excludes>
+										<exclude>log4j.properties</exclude>
+										<exclude>mime.types</exclude>
+										<exclude>properties.dtd</exclude>
+										<exclude>PropertyList-1.0.dtd</exclude>
+										<exclude>models/**</exclude>
+										<exclude>mozilla/**</exclude>
+										<exclude>META-INF/maven/com*/**</exclude>
+										<exclude>META-INF/maven/net*/**</exclude>
+										<exclude>META-INF/maven/software*/**</exclude>
+										<exclude>META-INF/maven/joda*/**</exclude>
+										<exclude>META-INF/maven/org.mortbay.jetty/**</exclude>
+										<exclude>META-INF/maven/org.apache.h*/**</exclude>
+										<exclude>META-INF/maven/org.apache.commons/**</exclude>
+										<exclude>META-INF/maven/org.apache.flink/flink-hadoop-fs/**</exclude>
+										<exclude>META-INF/maven/org.apache.flink/force-shading/**</exclude>
+									</excludes>
+								</filter>
+							</filters>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/java/org/apache/flink/fs/s3hadoop/S3FileSystemFactory.java
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/java/org/apache/flink/fs/s3hadoop/S3FileSystemFactory.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.s3hadoop;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.FileSystemFactory;
+import org.apache.flink.runtime.fs.hdfs.HadoopFileSystem;
+import org.apache.flink.runtime.util.HadoopUtils;
+
+import org.apache.hadoop.fs.s3a.S3AFileSystem;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URI;
+
+/**
+ * Simple factory for the S3 file system.
+ */
+public class S3FileSystemFactory implements FileSystemFactory {
+
+	private static final Logger LOG = LoggerFactory.getLogger(S3FileSystemFactory.class);
+
+	/** The prefixes that Flink adds to the Hadoop config under 'fs.s3a.'. */
+	private static final String[] CONFIG_PREFIXES = { "s3.", "s3a.", "fs.s3a." };
+
+	/** Keys that are replaced (after prefix replacement, to give a more uniform experience
+	 * across different file system implementations. */
+	private static final String[][] MIRRORED_CONFIG_KEYS = {
+			{ "fs.s3a.access-key", "fs.s3a.access.key" },
+			{ "fs.s3a.secret-key", "fs.s3a.secret.key" }
+	};
+
+	/** Flink's configuration object. */
+	private Configuration flinkConfig;
+
+	/** Hadoop's configuration for the file systems, lazily initialized. */
+	private org.apache.hadoop.conf.Configuration hadoopConfig;
+
+	@Override
+	public String getScheme() {
+		return "s3";
+	}
+
+	@Override
+	public void configure(Configuration config) {
+		flinkConfig = config;
+		hadoopConfig = null;
+	}
+
+	@Override
+	public FileSystem create(URI fsUri) throws IOException {
+		LOG.debug("Creating S3 file system (backed by a Hadoop s3a file system)");
+
+		try {
+			// -- (1) get the loaded Hadoop config (or fall back to one loaded from the classpath)
+
+			org.apache.hadoop.conf.Configuration hadoopConfig = this.hadoopConfig;
+			if (hadoopConfig == null) {
+				if (flinkConfig != null) {
+					LOG.debug("Loading Hadoop configuration for s3a file system");
+					hadoopConfig = HadoopUtils.getHadoopConfiguration(flinkConfig);
+
+					// add additional config entries from the Flink config to the Presto Hadoop config
+					for (String key : flinkConfig.keySet()) {
+						for (String prefix : CONFIG_PREFIXES) {
+							if (key.startsWith(prefix)) {
+								String value = flinkConfig.getString(key, null);
+								String newKey = "fs.s3a." + key.substring(prefix.length());
+								hadoopConfig.set(newKey, flinkConfig.getString(key, null));
+
+								LOG.debug("Adding Flink config entry for {} as {}={} to Hadoop config for " +
+										"S3A File System", key, newKey, value);
+							}
+						}
+					}
+
+					// mirror certain keys to make use more uniform across s3 implementations
+					// with different keys
+					for (String[] mirrored : MIRRORED_CONFIG_KEYS) {
+						String value = hadoopConfig.get(mirrored[0], null);
+						if (value != null) {
+							hadoopConfig.set(mirrored[1], value);
+						}
+					}
+
+					this.hadoopConfig = hadoopConfig;
+				}
+				else {
+					LOG.warn("The factory has not been configured prior to loading the S3 file system."
+							+ " Using Hadoop configuration from the classpath.");
+
+					hadoopConfig = new org.apache.hadoop.conf.Configuration();
+					this.hadoopConfig = hadoopConfig;
+				}
+			}
+
+			// -- (2) Instantiate the Hadoop file system class for that scheme
+
+			final String scheme = fsUri.getScheme();
+			final String authority = fsUri.getAuthority();
+
+			if (scheme == null && authority == null) {
+				fsUri = org.apache.hadoop.fs.FileSystem.getDefaultUri(hadoopConfig);
+			}
+			else if (scheme != null && authority == null) {
+				URI defaultUri = org.apache.hadoop.fs.FileSystem.getDefaultUri(hadoopConfig);
+				if (scheme.equals(defaultUri.getScheme()) && defaultUri.getAuthority() != null) {
+					fsUri = defaultUri;
+				}
+			}
+
+			LOG.debug("Using scheme {} for s3a file system backing the S3 File System", fsUri);
+
+			final S3AFileSystem fs = new S3AFileSystem();
+			fs.initialize(fsUri, hadoopConfig);
+
+			return new HadoopFileSystem(fs);
+		}
+		catch (IOException e) {
+			throw e;
+		}
+		catch (Exception e) {
+			throw new IOException(e.getMessage(), e);
+		}
+	}
+}

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,98 @@
+This project includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+-------------------------------------------------------------
+
+This project bundles the following dependencies under
+the Apache Software License 2.0
+
+  - commons-collections : commons-collections version 3.2.2
+  - commons-cli : commons-cli version 1.3.1
+  - commons-codec : commons-codec version 1.10
+  - commons-io : commons-io version 2.4
+  - commons-net : commons-net version 3.1
+  - commons-logging : commons-logging version 1.1.3
+  - commons-lang : commons-lang version 2.6
+  - commons-configuration : commons-configuration version 1.7
+  - commons-digester : commons-digester version 1.8.1
+  - commons-beanutils : commons-beanutils version 1.8.3
+  - org.apache.commons : commons-compress version 1.4.1
+  - org.apache.commons : commons-math3 version 3.5
+  - org.apache.httpcomponents : httpclient version 4.5.3
+  - org.apache.httpcomponents : httpcore version 4.4.6
+  - org.apache.htrace : htrace-core4 version 4.0.1-incubating
+  - org.apache.hadoop : hadoop-client version 2.8.1
+  - org.apache.hadoop : hadoop-common version 2.8.1
+  - org.apache.hadoop : hadoop-auth version 2.8.1
+  - org.apache.hadoop : hadoop-hdfs version 2.8.1
+  - org.apache.hadoop : hadoop-hdfs-client version 2.8.1
+  - org.apache.hadoop : hadoop-annotations version 2.8.1
+  - org.apache.hadoop : hadoop-aws version 2.8.1
+  - com.google.guava : guava version 11.0.2
+  - com.google.protobuf : protobuf-java version 2.5.0
+  - com.google.code.gson : gson version 2.2.4
+  - org.mortbay.jetty : jetty-sslengine version 6.1.26
+  - com.nimbusds : nimbus-jose-jwt version 3.9
+  - net.minidev : json-smart version 1.1.1
+  - joda-time : joda-time version 2.5
+  - com.squareup.okhttp : okhttp version 2.4.0
+  - com.squareup.okio : okio version 1.4.0
+  - com.amazonaws : aws-java-sdk-s3 version 1.10.6
+  - com.amazonaws : aws-java-sdk-kms version 1.10.6
+  - com.amazonaws : aws-java-sdk-core version 1.10.6
+  - org.codehaus.jackson : jackson-core-asl version 1.9.13
+  - org.codehaus.jackson : jackson-mapper-asl version 1.9.13
+  - com.fasterxml.jackson.core : jackson-core version 2.7.4
+  - com.fasterxml.jackson.core : jackson-databind version 2.7.4
+  - com.fasterxml.jackson.core : jackson-annotations version 2.7.4
+  
+-------------------------------------------------------------
+
+This project bundles the following dependencies under
+the BSD License
+
+  - xmlenc : xmlenc version 0.52 - Copyright 2003-2005, Ernst de Haan <wfe.dehaan@gmail.com>
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+-------------------------------------------
+Notice for  org.tukaani : xz
+-------------------------------------------
+
+This Java implementation of XZ has been put into the public domain, thus you can do whatever
+you want with it. All the files in the package have been written by Lasse Collin, but some files
+are heavily based on public domain code written by Igor Pavlov.
+
+
+-------------------------------------------
+Notice for  net.jcip : jcip-annotations
+-------------------------------------------
+
+This project bundles net.jcip : jcip-annotations version 1.0, which
+has been released to the public domain.

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/services/org.apache.flink.core.fs.FileSystemFactory
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/services/org.apache.flink.core.fs.FileSystemFactory
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.fs.s3hadoop.S3FileSystemFactory

--- a/flink-filesystems/flink-s3-fs-hadoop/src/test/java/org/apache/flink/fs/s3hadoop/HadoopS3FileSystemITCase.java
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/test/java/org/apache/flink/fs/s3hadoop/HadoopS3FileSystemITCase.java
@@ -1,0 +1,204 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.s3hadoop;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.core.fs.FSDataOutputStream;
+import org.apache.flink.core.fs.FileStatus;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.FileSystem.WriteMode;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Unit tests for the S3 file system support via Presto's PrestoS3FileSystem.
+ * These tests do not actually read from or write to S3.
+ */
+public class HadoopS3FileSystemITCase extends TestLogger {
+
+	private static final String BUCKET = System.getenv("ARTIFACTS_AWS_BUCKET");
+
+	private static final String TEST_DATA_DIR = "tests-" + UUID.randomUUID();
+
+	private static final String ACCESS_KEY = System.getenv("ARTIFACTS_AWS_ACCESS_KEY");
+	private static final String SECRET_KEY = System.getenv("ARTIFACTS_AWS_SECRET_KEY");
+
+	@BeforeClass
+	public static void checkIfCredentialsArePresent() {
+		Assume.assumeTrue("AWS S3 bucket not configured, skipping test...", BUCKET != null);
+		Assume.assumeTrue("AWS S3 access key not configured, skipping test...", ACCESS_KEY != null);
+		Assume.assumeTrue("AWS S3 secret key not configured, skipping test...", SECRET_KEY != null);
+	}
+
+	@Test
+	public void testConfigKeysForwarding() throws Exception {
+		final Path path = new Path("s3://" + BUCKET + '/');
+
+		// access without credentials should fail
+		{
+			FileSystem.initialize(new Configuration());
+
+			try {
+				path.getFileSystem();
+				fail("should fail with an exception");
+			} catch (IOException ignored) {}
+		}
+
+		// standard Hadoop-style credential keys
+		{
+			Configuration conf = new Configuration();
+			conf.setString("fs.s3a.access.key", ACCESS_KEY);
+			conf.setString("fs.s3a.secret.key", SECRET_KEY);
+
+			FileSystem.initialize(conf);
+			path.getFileSystem();
+		}
+
+		// shortened Hadoop-style credential keys
+		{
+			Configuration conf = new Configuration();
+			conf.setString("s3.access.key", ACCESS_KEY);
+			conf.setString("s3.secret.key", SECRET_KEY);
+
+			FileSystem.initialize(conf);
+			path.getFileSystem();
+		}
+
+		// shortened Presto-style credential keys
+		{
+			Configuration conf = new Configuration();
+			conf.setString("s3.access-key", ACCESS_KEY);
+			conf.setString("s3.secret-key", SECRET_KEY);
+
+			FileSystem.initialize(conf);
+			path.getFileSystem();
+		}
+
+		// see that setting a blank config again clears everything
+		// and access without credentials should fail
+		FileSystem.initialize(new Configuration());
+		try {
+			path.getFileSystem();
+			fail("should fail with an exception");
+		} catch (IOException ignored) {}
+	}
+
+	@Test
+	public void testSimpleFileWriteAndRead() throws Exception {
+		final Configuration conf = new Configuration();
+		conf.setString("s3.access.key", ACCESS_KEY);
+		conf.setString("s3.secret.key", SECRET_KEY);
+
+		final String testLine = "Hello Upload!";
+
+		FileSystem.initialize(conf);
+
+		final Path path = new Path("s3://" + BUCKET + '/' + TEST_DATA_DIR + "/test.txt");
+		final FileSystem fs = path.getFileSystem();
+
+		try {
+			try (FSDataOutputStream out = fs.create(path, WriteMode.OVERWRITE);
+					OutputStreamWriter writer = new OutputStreamWriter(out, StandardCharsets.UTF_8)) {
+				writer.write(testLine);
+			}
+
+			try (FSDataInputStream in = fs.open(path);
+					InputStreamReader ir = new InputStreamReader(in, StandardCharsets.UTF_8);
+					BufferedReader reader = new BufferedReader(ir)) {
+				String line = reader.readLine();
+				assertEquals(testLine, line);
+			}
+		}
+		finally {
+			fs.delete(path, false);
+		}
+	}
+
+	@Test
+	public void testDirectoryListing() throws Exception {
+		final Configuration conf = new Configuration();
+		conf.setString("s3.access.key", ACCESS_KEY);
+		conf.setString("s3.secret.key", SECRET_KEY);
+
+		FileSystem.initialize(conf);
+
+		final Path directory = new Path("s3://" + BUCKET + '/' + TEST_DATA_DIR + "/testdir/");
+		final FileSystem fs = directory.getFileSystem();
+
+		// directory must not yet exist
+		assertFalse(fs.exists(directory));
+
+		try {
+			// create directory
+			assertTrue(fs.mkdirs(directory));
+
+			// seems the presto file system does not assume existence of empty directories in S3
+			assertTrue(fs.exists(directory));
+
+			// directory empty
+			assertEquals(0, fs.listStatus(directory).length);
+
+			// create some files
+			final int numFiles = 3;
+			for (int i = 0; i < numFiles; i++) {
+				Path file = new Path(directory, "/file-" + i);
+				try (FSDataOutputStream out = fs.create(file, WriteMode.NO_OVERWRITE);
+						OutputStreamWriter writer = new OutputStreamWriter(out, StandardCharsets.UTF_8)) {
+					writer.write("hello-" + i + "\n");
+				}
+			}
+
+			FileStatus[] files = fs.listStatus(directory);
+			assertNotNull(files);
+			assertEquals(3, files.length);
+
+			for (FileStatus status : files) {
+				assertFalse(status.isDir());
+			}
+
+			// now that there are files, the directory must exist
+			assertTrue(fs.exists(directory));
+		}
+		finally {
+			// clean up
+			fs.delete(directory, true);
+		}
+
+		// now directory must be gone
+		assertFalse(fs.exists(directory));
+	}
+}

--- a/flink-filesystems/flink-s3-fs-hadoop/src/test/resources/log4j-test.properties
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/test/resources/log4j-test.properties
@@ -1,0 +1,27 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# Set root logger level to OFF to not flood build logs
+# set manually to INFO for debugging purposes
+log4j.rootLogger=OFF, testlogger
+
+# testlogger is set to be a ConsoleAppender.
+log4j.appender.testlogger=org.apache.log4j.ConsoleAppender
+log4j.appender.testlogger.target = System.err
+log4j.appender.testlogger.layout=org.apache.log4j.PatternLayout
+log4j.appender.testlogger.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n

--- a/flink-filesystems/flink-s3-fs-presto/pom.xml
+++ b/flink-filesystems/flink-s3-fs-presto/pom.xml
@@ -1,0 +1,293 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.apache.flink</groupId>
+		<artifactId>flink-filesystems</artifactId>
+		<version>1.4-SNAPSHOT</version>
+		<relativePath>..</relativePath>
+	</parent>
+
+	<artifactId>flink-s3-fs-presto</artifactId>
+	<name>flink-s3-fs-presto</name>
+
+	<packaging>jar</packaging>
+
+	<properties>
+		<presto.version>0.185</presto.version>
+	</properties>
+
+	<dependencies>
+
+		<!-- Flink core -->
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-core</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- File system builds on the Hadoop file system support -->
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-hadoop-fs</artifactId>
+			<version>${project.version}</version>
+
+			<!-- this exclusion is only needed to run tests in the IDE, pre shading,
+				because the optional Hadoop dependency is also pulled in for tests -->
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.flink</groupId>
+					<artifactId>flink-shaded-hadoop2</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<!-- Presto's S3 file system -->
+		
+		<dependency>
+			<groupId>com.facebook.presto</groupId>
+			<artifactId>presto-hive</artifactId>
+			<version>${presto.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>com.facebook.hive</groupId>
+					<artifactId>hive-dwrf</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.facebook.presto.hive</groupId>
+					<artifactId>hive-apache</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.facebook.presto</groupId>
+					<artifactId>presto-spi</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.facebook.presto</groupId>
+					<artifactId>presto-plugin-toolkit</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.facebook.presto</groupId>
+					<artifactId>presto-orc</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.facebook.presto</groupId>
+					<artifactId>presto-rcfile</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-jdk14</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>log4j-over-slf4j</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>jcl-over-slf4j</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.thrift</groupId>
+					<artifactId>libthrift</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>io.airlift</groupId>
+					<artifactId>json</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>io.airlift</groupId>
+					<artifactId>bootstrap</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>io.airlift</groupId>
+					<artifactId>concurrent</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>io.airlift</groupId>
+					<artifactId>event</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>io.airlift</groupId>
+					<artifactId>http-client</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>io.airlift</groupId>
+					<artifactId>aircompressor</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>javax.inject</groupId>
+					<artifactId>javax.inject</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.google.inject</groupId>
+					<artifactId>guice</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.google.inject.extensions</groupId>
+					<artifactId>guice-multibindings</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>it.unimi.dsi</groupId>
+					<artifactId>fastutil</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.xerial.snappy</groupId>
+					<artifactId>snappy-java</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.bval</groupId>
+					<artifactId>bval-jsr</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>javax.validation</groupId>
+					<artifactId>validation-api</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.openjdk.jol</groupId>
+					<artifactId>jol-core</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>cglib</groupId>
+					<artifactId>cglib-nodep</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.google.code.findbugs</groupId>
+					<artifactId>annotations</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>com.facebook.presto.hadoop</groupId>
+			<artifactId>hadoop-apache2</artifactId>
+			<version>2.7.3-1</version>
+		</dependency>
+
+		<!-- make sure that also logger and JSR is provided -->
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>com.google.code.findbugs</groupId>
+			<artifactId>jsr305</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- test dependencies -->
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-test-utils-junit</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+
+				<!-- we need to explicitly override this version, because the -->
+				<!-- earlier versions of the shade plugin have a bug relocating services -->
+				<version>3.0.0</version>
+
+				<executions>
+					<execution>
+						<id>shade-flink</id>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<artifactSet>
+								<includes>
+									<include>*:*</include>
+								</includes>
+								<excludes>
+									<exclude>org.openjdk.jol</exclude>
+								</excludes>
+							</artifactSet>
+							<relocations>
+								<relocation>
+									<pattern>org</pattern>
+									<shadedPattern>org.apache.flink.s3presto.shaded.org</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>com</pattern>
+									<shadedPattern>org.apache.flink.s3presto.shaded.com</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>io</pattern>
+									<shadedPattern>org.apache.flink.s3presto.shaded.io</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>net</pattern>
+									<shadedPattern>org.apache.flink.s3presto.shaded.net</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>software</pattern>
+									<shadedPattern>org.apache.flink.s3presto.shaded.software</shadedPattern>
+								</relocation>
+							</relocations>
+							<filters>
+								<filter>
+									<artifact>*</artifact>
+									<excludes>
+										<exclude>log4j.properties</exclude>
+										<exclude>core-default.xml</exclude>
+										<exclude>core-site.xml</exclude>
+										<exclude>hdfs-default.xml</exclude>
+										<exclude>mapred-default.xml</exclude>
+										<exclude>mime.types</exclude>
+										<exclude>mozilla/**</exclude>
+										<exclude>nativelib/**</exclude>
+										<exclude>META-INF/native/**</exclude>
+										<exclude>META-INF/maven/com*/**</exclude>
+										<exclude>META-INF/maven/io*/**</exclude>
+										<exclude>META-INF/maven/org.w*/**</exclude>
+										<exclude>META-INF/maven/org.h*/**</exclude>
+										<exclude>META-INF/maven/software*/**</exclude>
+										<exclude>META-INF/maven/joda*/**</exclude>
+										<exclude>META-INF/maven/org.mortbay.jetty/**</exclude>
+										<exclude>META-INF/maven/org.apache.h*/**</exclude>
+										<exclude>META-INF/maven/org.apache.flink/flink-hadoop-fs/**</exclude>
+										<exclude>META-INF/maven/org.apache.flink/force-shading/**</exclude>
+									</excludes>
+								</filter>
+							</filters>
+							<minimizeJar>true</minimizeJar>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/flink-filesystems/flink-s3-fs-presto/src/main/java/org/apache/flink/fs/s3presto/S3FileSystemFactory.java
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/java/org/apache/flink/fs/s3presto/S3FileSystemFactory.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.s3presto;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.FileSystemFactory;
+import org.apache.flink.runtime.fs.hdfs.HadoopFileSystem;
+import org.apache.flink.runtime.util.HadoopUtils;
+
+import com.facebook.presto.hive.PrestoS3FileSystem;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URI;
+
+/**
+ * Simple factory for the S3 file system.
+ */
+public class S3FileSystemFactory implements FileSystemFactory {
+
+	private static final Logger LOG = LoggerFactory.getLogger(S3FileSystemFactory.class);
+
+	/** The prefixes that Flink adds to the Hadoop config under 'presto.s3.'. */
+	private static final String[] CONFIG_PREFIXES = { "s3.", "presto.s3." };
+
+	/** Keys that are replaced (after prefix replacement, to give a more uniform experience
+	 * across different file system implementations. */
+	private static final String[][] MIRRORED_CONFIG_KEYS = {
+			{ "presto.s3.access.key", "presto.s3.access-key" },
+			{ "presto.s3.secret.key", "presto.s3.secret-key" }
+	};
+
+	/** Flink's configuration object. */
+	private Configuration flinkConfig;
+
+	/** Hadoop's configuration for the file systems, lazily initialized. */
+	private org.apache.hadoop.conf.Configuration hadoopConfig;
+
+	@Override
+	public String getScheme() {
+		return "s3";
+	}
+
+	@Override
+	public void configure(Configuration config) {
+		flinkConfig = config;
+		hadoopConfig = null;
+	}
+
+	@Override
+	public FileSystem create(URI fsUri) throws IOException {
+		LOG.debug("Creating S3 file system (backed by a Hadoop s3a file system");
+
+		try {
+			// -- (1) get the loaded Hadoop config (or fall back to one loaded from the classpath)
+
+			org.apache.hadoop.conf.Configuration hadoopConfig = this.hadoopConfig;
+			if (hadoopConfig == null) {
+				if (flinkConfig != null) {
+					LOG.debug("Loading Hadoop configuration for Presto S3 file system");
+					hadoopConfig = HadoopUtils.getHadoopConfiguration(flinkConfig);
+
+					// add additional config entries from the Flink config to the Presto Hadoop config
+					for (String key : flinkConfig.keySet()) {
+						for (String prefix : CONFIG_PREFIXES) {
+							if (key.startsWith(prefix)) {
+								String value = flinkConfig.getString(key, null);
+								String newKey = "presto.s3." + key.substring(prefix.length());
+								hadoopConfig.set(newKey, flinkConfig.getString(key, null));
+
+								LOG.debug("Adding Flink config entry for {} as {}={} to Hadoop config for " +
+										"Presto S3 File System", key, newKey, value);
+							}
+						}
+					}
+
+					// mirror certain keys to make use more uniform across s3 implementations
+					// with different keys
+					for (String[] mirrored : MIRRORED_CONFIG_KEYS) {
+						String value = hadoopConfig.get(mirrored[0], null);
+						if (value != null) {
+							hadoopConfig.set(mirrored[1], value);
+						}
+					}
+
+					this.hadoopConfig = hadoopConfig;
+				}
+				else {
+					LOG.warn("The factory has not been configured prior to loading the S3 file system."
+							+ " Using Hadoop configuration from the classpath.");
+
+					hadoopConfig = new org.apache.hadoop.conf.Configuration();
+					this.hadoopConfig = hadoopConfig;
+				}
+			}
+
+			// -- (2) Instantiate the Presto file system class for that scheme
+
+			final String scheme = fsUri.getScheme();
+			final String authority = fsUri.getAuthority();
+			final URI initUri;
+
+			if (scheme == null && authority == null) {
+				initUri = new URI("s3://s3.amazonaws.com");
+			}
+			else if (scheme != null && authority == null) {
+				initUri = new URI(scheme + "://s3.amazonaws.com");
+			}
+			else {
+				initUri = fsUri;
+			}
+
+			final PrestoS3FileSystem fs = new PrestoS3FileSystem();
+			fs.initialize(initUri, hadoopConfig);
+
+			return new HadoopFileSystem(fs);
+		}
+		catch (IOException e) {
+			throw e;
+		}
+		catch (Exception e) {
+			throw new IOException(e.getMessage(), e);
+		}
+	}
+}

--- a/flink-filesystems/flink-s3-fs-presto/src/main/java/org/openjdk/jol/info/ClassLayout.java
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/java/org/openjdk/jol/info/ClassLayout.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openjdk.jol.info;
+
+/**
+ * Mock class avoid a dependency on OpenJDK JOL,
+ * which is incompatible with the Apache License.
+ */
+public class ClassLayout {
+
+	public static ClassLayout parseClass(Class<?> ignored) {
+		return new ClassLayout();
+	}
+
+	public int instanceSize() {
+		return 64; // random, means nothing
+	}
+}

--- a/flink-filesystems/flink-s3-fs-presto/src/main/java/org/openjdk/jol/info/package-info.java
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/java/org/openjdk/jol/info/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This package contains mock classes to avoid a dependency on OpenJDK JOL,
+ * which is incompatible with the Apache License.
+ * This package does not contain any implementation of similar logic, it
+ * simply puts dummy place holders here to make the code work without JOL.
+ */
+package org.openjdk.jol.info;

--- a/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,82 @@
+This project includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+-------------------------------------------------------------
+
+This project bundles the following dependencies under
+the Apache Software License 2.0
+
+  - com.facebook.presto : presto-hive version 0.185
+  - com.facebook.presto.hadoop : hadoop-apache2 version 2.7.3-1
+  - com.amazonaws : aws-java-sdk-core version 1.11.165
+  - com.amazonaws : aws-java-sdk-s3 version 1.11.165
+  - com.amazonaws : aws-java-sdk-kms version 1.11.165
+  - com.amazonaws : jmespath-java version 1.11.165
+  - software.amazon.ion : ion-java version 1.0.2
+  - io.airlift : stats version 0.148
+  - io.airlift : log version 0.148
+  - io.airlift : configuration version 0.148
+  - io.airlift : slice version 0.31
+  - io.airlift : units version 1.0
+  - com.google.guava : guava version 21.0
+  - com.google.code.findbugs : annotations version 2.0.3
+  - org.weakref : jmxutils version 1.19
+  - joda-time : joda-time version 2.5
+  - commons-logging : commons-logging version 1.1.3
+  - org.apache.httpcomponents : httpclient version 4.5.3
+  - org.apache.httpcomponents : httpcore version 4.4.6
+  - commons-codec : commons-codec version 1.10
+  - com.fasterxml.jackson.core : jackson-core version 2.7.4
+  - com.fasterxml.jackson.core : jackson-databind version 2.7.4
+  - com.fasterxml.jackson.core : jackson-annotations version 2.7.4
+  - com.fasterxml.jackson.dataformat : jackson-dataformat-cbor version 2.6.7  
+
+===================================
+       Notice for HdrHistogram
+===================================
+
+This project bundles HdrHistogram (v. 2.1.9) under the BSD 2-Clause License 
+
+Original source repository: https://github.com/HdrHistogram/HdrHistogram
+
+The code in this repository code was Written by Gil Tene, Michael Barker,
+and Matt Warren, and released to the public domain, as explained at
+http://creativecommons.org/publicdomain/zero/1.0/
+
+For users of this code who wish to consume it under the "BSD" license
+rather than under the public domain or CC0 contribution text mentioned
+above, the code found under this directory is *also* provided under the
+following license (commonly referred to as the BSD 2-Clause License). This
+license does not detract from the above stated release of the code into
+the public domain, and simply represents an additional license granted by
+the Author.
+
+-----------------------------------------------------------------------------
+** Beginning of "BSD 2-Clause License" text. **
+
+ Copyright (c) 2012, 2013, 2014, 2015, 2016 Gil Tene
+ Copyright (c) 2014 Michael Barker
+ Copyright (c) 2014 Matt Warren
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ THE POSSIBILITY OF SUCH DAMAGE.

--- a/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/services/org.apache.flink.core.fs.FileSystemFactory
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/services/org.apache.flink.core.fs.FileSystemFactory
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.fs.s3presto.S3FileSystemFactory

--- a/flink-filesystems/flink-s3-fs-presto/src/test/java/org/apache/flink/fs/s3presto/PrestoS3FileSystemITCase.java
+++ b/flink-filesystems/flink-s3-fs-presto/src/test/java/org/apache/flink/fs/s3presto/PrestoS3FileSystemITCase.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.s3presto;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.core.fs.FSDataOutputStream;
+import org.apache.flink.core.fs.FileStatus;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.FileSystem.WriteMode;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for the S3 file system support via Presto's PrestoS3FileSystem.
+ * These tests do not actually read from or write to S3.
+ */
+public class PrestoS3FileSystemITCase extends TestLogger {
+
+	private static final String BUCKET = System.getenv("ARTIFACTS_AWS_BUCKET");
+
+	private static final String TEST_DATA_DIR = "tests-" + UUID.randomUUID();
+
+	private static final String ACCESS_KEY = System.getenv("ARTIFACTS_AWS_ACCESS_KEY");
+	private static final String SECRET_KEY = System.getenv("ARTIFACTS_AWS_SECRET_KEY");
+
+	@BeforeClass
+	public static void checkIfCredentialsArePresent() {
+		Assume.assumeTrue("AWS S3 bucket not configured, skipping test...", BUCKET != null);
+		Assume.assumeTrue("AWS S3 access key not configured, skipping test...", ACCESS_KEY != null);
+		Assume.assumeTrue("AWS S3 secret key not configured, skipping test...", SECRET_KEY != null);
+	}
+
+	@Test
+	public void testSimpleFileWriteAndRead() throws Exception {
+		final Configuration conf = new Configuration();
+		conf.setString("s3.access-key", ACCESS_KEY);
+		conf.setString("s3.secret-key", SECRET_KEY);
+
+		final String testLine = "Hello Upload!";
+
+		FileSystem.initialize(conf);
+
+		final Path path = new Path("s3://" + BUCKET + '/' + TEST_DATA_DIR + "/test.txt");
+		final FileSystem fs = path.getFileSystem();
+
+		try {
+			try (FSDataOutputStream out = fs.create(path, WriteMode.OVERWRITE);
+					OutputStreamWriter writer = new OutputStreamWriter(out, StandardCharsets.UTF_8)) {
+				writer.write(testLine);
+			}
+
+			try (FSDataInputStream in = fs.open(path);
+					InputStreamReader ir = new InputStreamReader(in, StandardCharsets.UTF_8);
+					BufferedReader reader = new BufferedReader(ir)) {
+				String line = reader.readLine();
+				assertEquals(testLine, line);
+			}
+		}
+		finally {
+			fs.delete(path, false);
+		}
+	}
+
+	@Test
+	public void testDirectoryListing() throws Exception {
+		final Configuration conf = new Configuration();
+		conf.setString("s3.access-key", ACCESS_KEY);
+		conf.setString("s3.secret-key", SECRET_KEY);
+
+		FileSystem.initialize(conf);
+
+		final Path directory = new Path("s3://" + BUCKET + '/' + TEST_DATA_DIR + "/testdir/");
+		final FileSystem fs = directory.getFileSystem();
+
+		// directory must not yet exist
+		assertFalse(fs.exists(directory));
+
+		try {
+			// create directory
+			assertTrue(fs.mkdirs(directory));
+
+			// seems the presto file system does not assume existence of empty directories in S3
+//			assertTrue(fs.exists(directory));
+
+			// directory empty
+			assertEquals(0, fs.listStatus(directory).length);
+
+			// create some files
+			final int numFiles = 3;
+			for (int i = 0; i < numFiles; i++) {
+				Path file = new Path(directory, "/file-" + i);
+				try (FSDataOutputStream out = fs.create(file, WriteMode.NO_OVERWRITE);
+						OutputStreamWriter writer = new OutputStreamWriter(out, StandardCharsets.UTF_8)) {
+					writer.write("hello-" + i + "\n");
+				}
+			}
+
+			FileStatus[] files = fs.listStatus(directory);
+			assertNotNull(files);
+			assertEquals(3, files.length);
+
+			for (FileStatus status : files) {
+				assertFalse(status.isDir());
+			}
+
+			// now that there are files, the directory must exist
+			assertTrue(fs.exists(directory));
+		}
+		finally {
+			// clean up
+			fs.delete(directory, true);
+		}
+
+		// now directory must be gone
+		assertFalse(fs.exists(directory));
+	}
+}

--- a/flink-filesystems/flink-s3-fs-presto/src/test/java/org/apache/flink/fs/s3presto/PrestoS3FileSystemTest.java
+++ b/flink-filesystems/flink-s3-fs-presto/src/test/java/org/apache/flink/fs/s3presto/PrestoS3FileSystemTest.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.s3presto;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.runtime.fs.hdfs.HadoopFileSystem;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.services.s3.AmazonS3Client;
+
+import com.facebook.presto.hive.PrestoS3FileSystem;
+
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.net.URI;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for the S3 file system support via Presto's PrestoS3FileSystem.
+ * These tests do not actually read from or write to S3.
+ */
+public class PrestoS3FileSystemTest {
+
+	@Test
+	public void testConfigPropagation() throws Exception{
+		final Configuration conf = new Configuration();
+		conf.setString("s3.access-key", "test_access_key_id");
+		conf.setString("s3.secret-key", "test_secret_access_key");
+
+		FileSystem.initialize(conf);
+
+		FileSystem fs = FileSystem.get(new URI("s3://test"));
+		validateBasicCredentials(fs);
+	}
+
+	@Test
+	public void testConfigPropagationWithPrestoPrefix() throws Exception{
+		final Configuration conf = new Configuration();
+		conf.setString("presto.s3.access-key", "test_access_key_id");
+		conf.setString("presto.s3.secret-key", "test_secret_access_key");
+
+		FileSystem.initialize(conf);
+
+		FileSystem fs = FileSystem.get(new URI("s3://test"));
+		validateBasicCredentials(fs);
+	}
+
+	@Test
+	public void testConfigPropagationAlternateStyle() throws Exception{
+		final Configuration conf = new Configuration();
+		conf.setString("s3.access.key", "test_access_key_id");
+		conf.setString("s3.secret.key", "test_secret_access_key");
+
+		FileSystem.initialize(conf);
+
+		FileSystem fs = FileSystem.get(new URI("s3://test"));
+		validateBasicCredentials(fs);
+	}
+
+	// ------------------------------------------------------------------------
+	//  utilities
+	// ------------------------------------------------------------------------
+
+	private static void validateBasicCredentials(FileSystem fs) throws Exception {
+		assertTrue(fs instanceof HadoopFileSystem);
+
+		org.apache.hadoop.fs.FileSystem hadoopFs = ((HadoopFileSystem) fs).getHadoopFileSystem();
+		assertTrue(hadoopFs instanceof PrestoS3FileSystem);
+
+		try (PrestoS3FileSystem prestoFs = (PrestoS3FileSystem) hadoopFs) {
+			AWSCredentialsProvider provider = getAwsCredentialsProvider(prestoFs);
+			assertTrue(provider instanceof AWSStaticCredentialsProvider);
+		}
+	}
+
+	private static AWSCredentialsProvider getAwsCredentialsProvider(PrestoS3FileSystem fs) throws Exception {
+		Field amazonS3field = PrestoS3FileSystem.class.getDeclaredField("s3");
+		amazonS3field.setAccessible(true);
+		AmazonS3Client amazonS3 = (AmazonS3Client) amazonS3field.get(fs);
+
+		Field providerField = AmazonS3Client.class.getDeclaredField("awsCredentialsProvider");
+		providerField.setAccessible(true);
+		return (AWSCredentialsProvider) providerField.get(amazonS3);
+	}
+}

--- a/flink-filesystems/flink-s3-fs-presto/src/test/resources/log4j-test.properties
+++ b/flink-filesystems/flink-s3-fs-presto/src/test/resources/log4j-test.properties
@@ -1,0 +1,27 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# Set root logger level to OFF to not flood build logs
+# set manually to INFO for debugging purposes
+log4j.rootLogger=OFF, testlogger
+
+# testlogger is set to be a ConsoleAppender.
+log4j.appender.testlogger=org.apache.log4j.ConsoleAppender
+log4j.appender.testlogger.target = System.err
+log4j.appender.testlogger.layout=org.apache.log4j.PatternLayout
+log4j.appender.testlogger.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n

--- a/flink-filesystems/pom.xml
+++ b/flink-filesystems/pom.xml
@@ -38,6 +38,8 @@ under the License.
 	<modules>
 		<module>flink-hadoop-fs</module>
 		<module>flink-mapr-fs</module>
+		<module>flink-s3-fs-hadoop</module>
+		<module>flink-s3-fs-presto</module>
 	</modules>
 
 </project>

--- a/tools/travis_mvn_watchdog.sh
+++ b/tools/travis_mvn_watchdog.sh
@@ -71,6 +71,10 @@ flink-libraries/flink-table"
 
 MODULES_CONNECTORS="\
 flink-contrib/flink-connector-wikiedits,\
+flink-filesystems/flink-hadoop-fs,\
+flink-filesystems/flink-mapr-fs,\
+flink-filesystems/flink-s3-fs-hadoop,\
+flink-filesystems/flink-s3-fs-presto,\
 flink-connectors/flink-avro,\
 flink-connectors/flink-hbase,\
 flink-connectors/flink-hcatalog,\


### PR DESCRIPTION
## What is the purpose of the change

This adds two implementations of a file system that write to S3 so that users can use Flink with S3 without depending on Hadoop and have an alternative to Hadoop's S3 connectors.

Both are not actual re-implementations but wrap other implementations and shade dependencies.

1. The first is a wrapper around Hadoop's s3a file system. By pulling a smaller dependency tree and shading all dependencies away, this keeps the appearance of Flink being Hadoop-free, from a dependency perspective. We can also bump the shaded Hadoop dependency here to get improvements to s3a in (as in Hadoop 3.0) without causing dependency conflicts.

2. The second S3 file system is from the Presto Project. Initial simple tests seem to indicate that it responds slightly faster and in a bit more lightweight manner to write/read/list requests, compared to the Hadoop s3a FS, but it has some semantical differences. For example, creating a directory does not mean the file system recognized that the directory is there. The directory is only recognized as existing once files are inserted. For checkpointing, that could even be preferable.

Both file systems register themselves under `s3` to not overload the `s3n` and `s3a` schemes used by Hadoop.

Both file systems are not in the classpath of Flink by default, but must be explicitly added. They register themselves via the service mechanism. Their jars are built into the `/opt` directory in the distribution.

## Brief change log

  - Adds `flink-filesystems/flink-s3-fs-hadoop`
  - Adds `flink-filesystems/flink-s3-fs-presto`

## Verifying this change

This adds some initial integration tests, which do depend on S3 credentials. These credentials are not in the code, but only encrypted on Travis, which is why the tests can only run in a meaningful way either on the `apache/flink` master branch, or in a committer repository when the committer enabled Travis uploads to S3 (for logs) - the tests here use the same secret credentials.

Since this does not implement the actual S3 communication, we have no tests for that. The tests only test instantiation and whether S3 communication can be established (simple reads/writes to a bucket, listing, etc).

Change can also be verified by building Flink, pulling the respective S3 FS jar from `/opt` into `/lib` and running a workload that checkpoints or writes to S3.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**yes** / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)

Proper behavior of the File Systems is important, otherwise checkpointing may fail. In some sense we are already relying on proper tests of HDFS and S3 connectors by the Hadoop project. This adds a similar dependency.

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)

Will add documentation once the details of this feature are agreed upon.

