### PR TITLE
[FLINK-7834] [table] cost model extends network cost and memory cost

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/BatchTableEnvironment.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/BatchTableEnvironment.scala
@@ -33,6 +33,7 @@ import org.apache.flink.api.java.typeutils.GenericTypeInfo
 import org.apache.flink.api.java.{DataSet, ExecutionEnvironment}
 import org.apache.flink.table.explain.PlanJsonParser
 import org.apache.flink.table.expressions.{Expression, TimeAttribute}
+import org.apache.flink.table.plan.cost.{DataSetCost, FlinkCostFactory}
 import org.apache.flink.table.plan.nodes.FlinkConventions
 import org.apache.flink.table.plan.nodes.dataset.DataSetRel
 import org.apache.flink.table.plan.rules.FlinkRuleSets
@@ -152,6 +153,11 @@ abstract class BatchTableEnvironment(
         throw new TableException("Only BatchTableSink can be registered in BatchTableEnvironment.")
     }
   }
+
+  /**
+    * Returns specific FlinkCostFactory of this Environment.
+    */
+  override protected def getFlinkCostFactory: FlinkCostFactory = DataSetCost.FACTORY
 
   /**
     * Writes a [[Table]] to a [[TableSink]].

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/StreamTableEnvironment.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/StreamTableEnvironment.scala
@@ -39,12 +39,13 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.apache.flink.table.calcite.{FlinkTypeFactory, RelTimeIndicatorConverter}
 import org.apache.flink.table.explain.PlanJsonParser
 import org.apache.flink.table.expressions._
+import org.apache.flink.table.plan.cost.{DataSetCost, FlinkCostFactory}
 import org.apache.flink.table.plan.nodes.FlinkConventions
 import org.apache.flink.table.plan.nodes.datastream.{DataStreamRel, UpdateAsRetractionTrait}
 import org.apache.flink.table.plan.rules.FlinkRuleSets
+import org.apache.flink.table.plan.schema.{DataStreamTable, RowSchema, StreamTableSourceTable, TableSinkTable}
 import org.apache.flink.table.plan.util.UpdatingPlanChecker
 import org.apache.flink.table.runtime.conversion._
-import org.apache.flink.table.plan.schema.{DataStreamTable, RowSchema, StreamTableSourceTable, TableSinkTable}
 import org.apache.flink.table.runtime.types.{CRow, CRowTypeInfo}
 import org.apache.flink.table.runtime.{CRowMapRunner, OutputRowtimeProcessFunction}
 import org.apache.flink.table.sinks._
@@ -182,6 +183,12 @@ abstract class StreamTableEnvironment(
             "registered in StreamTableEnvironment.")
     }
   }
+
+  /**
+    * Returns specific FlinkCostFactory of this Environment.
+    * Currently we use DataSetCostFactory, and will change this later.
+    */
+  override protected def getFlinkCostFactory: FlinkCostFactory = DataSetCost.FACTORY
 
   /**
     * Writes a [[Table]] to a [[TableSink]].

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/TableEnvironment.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/TableEnvironment.scala
@@ -52,7 +52,7 @@ import org.apache.flink.table.codegen.{ExpressionReducer, FunctionCodeGenerator,
 import org.apache.flink.table.expressions._
 import org.apache.flink.table.functions.utils.UserDefinedFunctionUtils._
 import org.apache.flink.table.functions.{AggregateFunction, ScalarFunction, TableFunction}
-import org.apache.flink.table.plan.cost.DataSetCostFactory
+import org.apache.flink.table.plan.cost.FlinkCostFactory
 import org.apache.flink.table.plan.logical.{CatalogNode, LogicalRelNode}
 import org.apache.flink.table.plan.rules.FlinkRuleSets
 import org.apache.flink.table.plan.schema.{RelTable, RowSchema, TableSinkTable}
@@ -86,7 +86,7 @@ abstract class TableEnvironment(val config: TableConfig) {
     .newConfigBuilder
     .defaultSchema(rootSchema)
     .parserConfig(getSqlParserConfig)
-    .costFactory(new DataSetCostFactory)
+    .costFactory(getFlinkCostFactory)
     .typeSystem(new FlinkTypeSystem)
     .operatorTable(getSqlOperatorTable)
     // set the executor to evaluate constant expressions
@@ -215,6 +215,11 @@ abstract class TableEnvironment(val config: TableConfig) {
         sqlParserConfig
     }
   }
+
+  /**
+    * Returns specific FlinkCostFactory of TableEnvironment's subclass.
+    */
+  protected def getFlinkCostFactory: FlinkCostFactory
 
   /**
     * Returns the built-in normalization rules that are defined by the environment.

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/cost/AbstractFlinkCost.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/cost/AbstractFlinkCost.scala
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.cost
+
+import org.apache.calcite.plan.RelOptCost
+import org.apache.calcite.runtime.Utilities
+
+abstract class AbstractFlinkCost(
+    val rowCount: Double,
+    val cpu: Double,
+    val io: Double,
+    val network: Double,
+    val memory: Double)
+  extends FlinkCost {
+
+  override def getRows: Double = rowCount
+
+  override def getCpu: Double = cpu
+
+  override def getIo: Double = io
+
+  override def getNetwork: Double = network
+
+  override def getMemory: Double = memory
+
+  override def isLt(other: RelOptCost): Boolean = {
+    isLe(other) && !(this == other)
+  }
+
+  override def hashCode(): Int = {
+    Utilities.hashCode(rowCount) +
+      Utilities.hashCode(cpu) +
+      Utilities.hashCode(io) +
+      Utilities.hashCode(network) +
+      Utilities.hashCode(memory)
+  }
+
+  override def toString: String = {
+    s"{$rowCount rows, $cpu cpu, $io io, $network network, $memory memory}"
+  }
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/cost/DataSetCost.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/cost/DataSetCost.scala
@@ -18,48 +18,50 @@
 
 package org.apache.flink.table.plan.cost
 
-import org.apache.calcite.plan.{RelOptUtil, RelOptCostFactory, RelOptCost}
-import org.apache.calcite.util.Util
+import org.apache.calcite.plan.{RelOptCost, RelOptUtil}
 
 /**
   * This class is based on Apache Calcite's `org.apache.calcite.plan.volcano.VolcanoCost` and has
-  * an adapted cost comparison method `isLe(other: RelOptCost)` that takes io and cpu into account.
+  * an adapted cost comparison method `isLe(other: RelOptCost)` that takes io, cpu, network
+  * and memory into account.
   */
-class DataSetCost(val rowCount: Double, val cpu: Double, val io: Double) extends RelOptCost {
-
-  def getCpu: Double = cpu
+class DataSetCost(
+    override val rowCount: Double,
+    override val cpu: Double,
+    override val io: Double,
+    override val network: Double,
+    override val memory: Double)
+  extends AbstractFlinkCost(rowCount, cpu, io, network, memory) {
 
   def isInfinite: Boolean = {
     (this eq DataSetCost.Infinity) ||
       (this.rowCount == Double.PositiveInfinity) ||
       (this.cpu == Double.PositiveInfinity) ||
-      (this.io == Double.PositiveInfinity)
+      (this.io == Double.PositiveInfinity) ||
+      (this.network == Double.PositiveInfinity) ||
+      (this.memory == Double.PositiveInfinity)
   }
-
-  def getIo: Double = io
 
   def isLe(other: RelOptCost): Boolean = {
     val that: DataSetCost = other.asInstanceOf[DataSetCost]
     (this eq that) ||
-      (this.io < that.io) ||
-      (this.io == that.io && this.cpu < that.cpu) ||
-      (this.io == that.io && this.cpu == that.cpu && this.rowCount < that.rowCount)
+      (this.memory < that.memory) ||
+      (this.memory == that.memory && this.network < that.network) ||
+      (this.memory == that.memory && this.network == that.network && this.io < that.io) ||
+      (this.memory == that.memory && this.network == that.network && this.io == that.io &&
+        this.cpu < that.cpu) ||
+      (this.memory == that.memory && this.network == that.network && this.io == that.io &&
+        this.cpu == that.cpu && this.rowCount < that.rowCount)
   }
-
-  def isLt(other: RelOptCost): Boolean = {
-    isLe(other) && !(this == other)
-  }
-
-  def getRows: Double = rowCount
-
-  override def hashCode: Int = Util.hashCode(rowCount) + Util.hashCode(cpu) + Util.hashCode(io)
 
   def equals(other: RelOptCost): Boolean = {
     (this eq other) ||
       other.isInstanceOf[DataSetCost] &&
         (this.rowCount == other.asInstanceOf[DataSetCost].rowCount) &&
         (this.cpu == other.asInstanceOf[DataSetCost].cpu) &&
-        (this.io == other.asInstanceOf[DataSetCost].io)
+        (this.io == other.asInstanceOf[DataSetCost].io) &&
+        (this.network == other.asInstanceOf[DataSetCost].network) &&
+        (this.memory == other.asInstanceOf[DataSetCost].memory)
   }
 
   def isEqWithEpsilon(other: RelOptCost): Boolean = {
@@ -70,7 +72,9 @@ class DataSetCost(val rowCount: Double, val cpu: Double, val io: Double) extends
     (this eq that) ||
       ((Math.abs(this.rowCount - that.rowCount) < RelOptUtil.EPSILON) &&
         (Math.abs(this.cpu - that.cpu) < RelOptUtil.EPSILON) &&
-        (Math.abs(this.io - that.io) < RelOptUtil.EPSILON))
+        (Math.abs(this.io - that.io) < RelOptUtil.EPSILON) &&
+        (Math.abs(this.network - that.network) < RelOptUtil.EPSILON) &&
+        (Math.abs(this.memory - that.memory) < RelOptUtil.EPSILON))
   }
 
   def minus(other: RelOptCost): RelOptCost = {
@@ -78,14 +82,19 @@ class DataSetCost(val rowCount: Double, val cpu: Double, val io: Double) extends
       return this
     }
     val that: DataSetCost = other.asInstanceOf[DataSetCost]
-    new DataSetCost(this.rowCount - that.rowCount, this.cpu - that.cpu, this.io - that.io)
+    new DataSetCost(
+      this.rowCount - that.rowCount,
+      this.cpu - that.cpu,
+      this.io - that.io,
+      this.network - that.network,
+      this.memory - that.memory)
   }
 
   def multiplyBy(factor: Double): RelOptCost = {
     if (this eq DataSetCost.Infinity) {
       return this
     }
-    new DataSetCost(rowCount * factor, cpu * factor, io * factor)
+    new DataSetCost(rowCount * factor, cpu * factor, io * factor, network * factor, memory * factor)
   }
 
   def divideBy(cost: RelOptCost): Double = {
@@ -93,8 +102,7 @@ class DataSetCost(val rowCount: Double, val cpu: Double, val io: Double) extends
     var d: Double = 1
     var n: Double = 0
     if ((this.rowCount != 0) && !this.rowCount.isInfinite &&
-      (that.rowCount != 0) && !that.rowCount.isInfinite)
-    {
+      (that.rowCount != 0) && !that.rowCount.isInfinite) {
       d *= this.rowCount / that.rowCount
       n += 1
     }
@@ -104,6 +112,16 @@ class DataSetCost(val rowCount: Double, val cpu: Double, val io: Double) extends
     }
     if ((this.io != 0) && !this.io.isInfinite && (that.io != 0) && !that.io.isInfinite) {
       d *= this.io / that.io
+      n += 1
+    }
+    if ((this.network != 0) && !this.network.isInfinite &&
+      (that.network != 0) && !that.network.isInfinite) {
+      d *= this.network / that.network
+      n += 1
+    }
+    if ((this.memory != 0) && !this.memory.isInfinite &&
+      (that.memory != 0) && !that.memory.isInfinite) {
+      d *= this.memory / that.memory
       n += 1
     }
     if (n == 0) {
@@ -117,10 +135,13 @@ class DataSetCost(val rowCount: Double, val cpu: Double, val io: Double) extends
     if ((this eq DataSetCost.Infinity) || (that eq DataSetCost.Infinity)) {
       return DataSetCost.Infinity
     }
-    new DataSetCost(this.rowCount + that.rowCount, this.cpu + that.cpu, this.io + that.io)
+    new DataSetCost(
+      this.rowCount + that.rowCount,
+      this.cpu + that.cpu,
+      this.io + that.io,
+      this.network + that.network,
+      this.memory + that.memory)
   }
-
-  override def toString: String = s"{$rowCount rows, $cpu cpu, $io io}"
 
 }
 
@@ -129,22 +150,24 @@ object DataSetCost {
   private[flink] val Infinity = new DataSetCost(
     Double.PositiveInfinity,
     Double.PositiveInfinity,
-    Double.PositiveInfinity)
-  {
+    Double.PositiveInfinity,
+    Double.PositiveInfinity,
+    Double.PositiveInfinity) {
     override def toString: String = "{inf}"
   }
 
-  private[flink] val Huge = new DataSetCost(Double.MaxValue, Double.MaxValue, Double.MaxValue) {
+  private[flink] val Huge = new DataSetCost(
+    Double.MaxValue, Double.MaxValue, Double.MaxValue, Double.MaxValue, Double.MaxValue) {
     override def toString: String = "{huge}"
   }
 
-  private[flink] val Zero = new DataSetCost(0.0, 0.0, 0.0) {
+  private[flink] val Zero = new DataSetCost(0.0, 0.0, 0.0, 0.0, 0.0) {
     override def toString: String = "{0}"
   }
 
-  private[flink] val Tiny = new DataSetCost(1.0, 1.0, 0.0) {
+  private[flink] val Tiny = new DataSetCost(1.0, 1.0, 0.0, 0.0, 0.0) {
     override def toString = "{tiny}"
   }
 
-  val FACTORY: RelOptCostFactory = new DataSetCostFactory
+  val FACTORY: DataSetCostFactory = new DataSetCostFactory
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/cost/FlinkCost.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/cost/FlinkCost.scala
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.cost
+
+import org.apache.calcite.plan.RelOptCost
+
+/**
+  * A [[RelOptCost]] that extends network cost and memory cost.
+  */
+trait FlinkCost extends RelOptCost {
+
+  /**
+    * @return usage of network resources
+    */
+  def getNetwork: Double
+
+  /**
+    * @return usage of memory resources
+    */
+  def getMemory: Double
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/cost/FlinkCostFactory.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/cost/FlinkCostFactory.scala
@@ -18,43 +18,19 @@
 
 package org.apache.flink.table.plan.cost
 
-import org.apache.calcite.plan.RelOptCost
+import org.apache.calcite.plan.{RelOptCost, RelOptCostFactory}
 
 /**
-  * This class is based on Apache Calcite's `org.apache.calcite.plan.volcano.VolcanoCost#Factory`.
+  * A [[RelOptCostFactory]] that adds makeCost methods with network and memory parameters.
   */
-class DataSetCostFactory extends FlinkCostFactory {
+trait FlinkCostFactory extends RelOptCostFactory {
 
-  override def makeCost(
+  def makeCost(
     rowCount: Double,
     cpu: Double,
     io: Double,
     network: Double,
-    memory: Double): RelOptCost = {
-    new DataSetCost(rowCount, cpu, io, network, memory)
-  }
+    memory: Double): RelOptCost
 
-  override def makeCost(rowCount: Double, cpu: Double, io: Double, network: Double): RelOptCost = {
-    new DataSetCost(rowCount, cpu, io, network, 0.0)
-  }
-
-  override def makeCost(dRows: Double, dCpu: Double, dIo: Double): RelOptCost = {
-    new DataSetCost(dRows, dCpu, dIo, 0.0, 0.0)
-  }
-
-  override def makeHugeCost: RelOptCost = {
-    DataSetCost.Huge
-  }
-
-  override def makeInfiniteCost: RelOptCost = {
-    DataSetCost.Infinity
-  }
-
-  override def makeTinyCost: RelOptCost = {
-    DataSetCost.Tiny
-  }
-
-  override def makeZeroCost: RelOptCost = {
-    DataSetCost.Zero
-  }
+  def makeCost(rowCount: Double, cpu: Double, io: Double, network: Double): RelOptCost
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/utils/MockTableEnvironment.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/utils/MockTableEnvironment.scala
@@ -21,6 +21,7 @@ package org.apache.flink.table.utils
 import org.apache.calcite.tools.RuleSet
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.table.api.{QueryConfig, Table, TableConfig, TableEnvironment}
+import org.apache.flink.table.plan.cost.FlinkCostFactory
 import org.apache.flink.table.sinks.TableSink
 import org.apache.flink.table.sources.TableSource
 
@@ -30,6 +31,8 @@ class MockTableEnvironment extends TableEnvironment(new TableConfig) {
       table: Table,
       sink: TableSink[T],
       queryConfig: QueryConfig): Unit = ???
+
+  override protected def getFlinkCostFactory: FlinkCostFactory = ???
 
   override protected def checkValidTableName(name: String): Unit = ???
 


### PR DESCRIPTION
## What is the purpose of the change

*This pull request makes cost model (RelOptCost) extends network cost and memory cost*


## Brief change log

  - *The FlinkCost extends RelOptCost and adds network cost and memory cost*
  - *Updates DataSetCost*
  - *Adds getFlinkCostFactory method in TableEnvironment to get  specific FlinkCostFactory*


## Verifying this change

This change is already covered by existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)

