### PR TITLE
[FLINK-7832] [flip6] Extend SlotManager to report free slots per TM

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/TaskManagerSlot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/TaskManagerSlot.java
@@ -113,11 +113,12 @@ public class TaskManagerSlot {
 	}
 
 	public void completeAllocation(AllocationID allocationId) {
+		Preconditions.checkNotNull(allocationId, "Allocation id must not be null.");
 		Preconditions.checkState(state == State.PENDING, "In order to complete an allocation, the slot has to be allocated.");
 		Preconditions.checkState(Objects.equals(allocationId, assignedSlotRequest.getAllocationId()), "Mismatch between allocation id of the pending slot request.");
 
 		state = State.ALLOCATED;
-		this.allocationId = Preconditions.checkNotNull(allocationId);
+		this.allocationId = allocationId;
 		assignedSlotRequest = null;
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/TaskManagerSlot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/TaskManagerSlot.java
@@ -21,6 +21,9 @@ package org.apache.flink.runtime.clusterframework.types;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.resourcemanager.registration.TaskExecutorConnection;
 import org.apache.flink.runtime.resourcemanager.slotmanager.PendingSlotRequest;
+import org.apache.flink.util.Preconditions;
+
+import java.util.Objects;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -45,17 +48,23 @@ public class TaskManagerSlot {
 	/** Assigned slot request if there is currently an ongoing request */
 	private PendingSlotRequest assignedSlotRequest;
 
+	private State state;
+
 	public TaskManagerSlot(
 			SlotID slotId,
 			ResourceProfile resourceProfile,
-			TaskExecutorConnection taskManagerConnection,
-			AllocationID allocationId) {
+			TaskExecutorConnection taskManagerConnection) {
 		this.slotId = checkNotNull(slotId);
 		this.resourceProfile = checkNotNull(resourceProfile);
 		this.taskManagerConnection = checkNotNull(taskManagerConnection);
 
-		this.allocationId = allocationId;
+		this.state = State.FREE;
+		this.allocationId = null;
 		this.assignedSlotRequest = null;
+	}
+
+	public State getState() {
+		return state;
 	}
 
 	public SlotID getSlotId() {
@@ -74,20 +83,49 @@ public class TaskManagerSlot {
 		return allocationId;
 	}
 
-	public void setAllocationId(AllocationID allocationId) {
-		this.allocationId = allocationId;
-	}
-
 	public PendingSlotRequest getAssignedSlotRequest() {
 		return assignedSlotRequest;
 	}
 
-	public void setAssignedSlotRequest(PendingSlotRequest assignedSlotRequest) {
-		this.assignedSlotRequest = assignedSlotRequest;
-	}
-
 	public InstanceID getInstanceId() {
 		return taskManagerConnection.getInstanceID();
+	}
+
+	public void freeSlot() {
+		Preconditions.checkState(state == State.ALLOCATED, "Slot must be allocated before freeing it.");
+
+		state = State.FREE;
+		allocationId = null;
+	}
+
+	public void clearPendingSlotRequest() {
+		Preconditions.checkState(state == State.PENDING, "No slot request to clear.");
+
+		state = State.FREE;
+		assignedSlotRequest = null;
+	}
+
+	public void assignPendingSlotRequest(PendingSlotRequest pendingSlotRequest) {
+		Preconditions.checkState(state == State.FREE, "Slot must be free to be assigned a slot request.");
+
+		state = State.PENDING;
+		assignedSlotRequest = Preconditions.checkNotNull(pendingSlotRequest);
+	}
+
+	public void completeAllocation(AllocationID allocationId) {
+		Preconditions.checkState(state == State.PENDING, "In order to complete an allocation, the slot has to be allocated.");
+		Preconditions.checkState(Objects.equals(allocationId, assignedSlotRequest.getAllocationId()), "Mismatch between allocation id of the pending slot request.");
+
+		state = State.ALLOCATED;
+		this.allocationId = Preconditions.checkNotNull(allocationId);
+		assignedSlotRequest = null;
+	}
+
+	public void updateAllocation(AllocationID allocationId) {
+		Preconditions.checkState(state == State.FREE, "The slot has to be free in order to set an allocation id.");
+
+		state = State.ALLOCATED;
+		this.allocationId = Preconditions.checkNotNull(allocationId);
 	}
 
 	/**
@@ -100,15 +138,9 @@ public class TaskManagerSlot {
 		return resourceProfile.isMatching(required);
 	}
 
-	public boolean isFree() {
-		return !isAllocated() && !hasPendingSlotRequest();
-	}
-
-	public boolean isAllocated() {
-		return null != allocationId;
-	}
-
-	public boolean hasPendingSlotRequest() {
-		return null != assignedSlotRequest;
+	public enum State {
+		FREE,
+		PENDING,
+		ALLOCATED
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
@@ -41,6 +41,8 @@ import org.apache.flink.util.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -140,8 +142,28 @@ public class SlotManager implements AutoCloseable {
 		return slots.size();
 	}
 
+	public int getNumberRegisteredSlotsOf(InstanceID instanceId) {
+		TaskManagerRegistration taskManagerRegistration = taskManagerRegistrations.get(instanceId);
+
+		if (taskManagerRegistration != null) {
+			return taskManagerRegistration.getNumberRegisteredSlots();
+		} else {
+			return 0;
+		}
+	}
+
 	public int getNumberFreeSlots() {
 		return freeSlots.size();
+	}
+
+	public int getNumberFreeSlotsOf(InstanceID instanceId) {
+		TaskManagerRegistration taskManagerRegistration = taskManagerRegistrations.get(instanceId);
+
+		if (taskManagerRegistration != null) {
+			return taskManagerRegistration.getNumberFreeSlots();
+		} else {
+			return 0;
+		}
 	}
 
 	// ---------------------------------------------------------------------------------------------
@@ -313,7 +335,10 @@ public class SlotManager implements AutoCloseable {
 				reportedSlots.add(slotStatus.getSlotID());
 			}
 
-			TaskManagerRegistration taskManagerRegistration = new TaskManagerRegistration(taskExecutorConnection, reportedSlots);
+			TaskManagerRegistration taskManagerRegistration = new TaskManagerRegistration(
+				taskExecutorConnection,
+				reportedSlots);
+
 			taskManagerRegistrations.put(taskExecutorConnection.getInstanceID(), taskManagerRegistration);
 
 			// next register the new slots
@@ -323,15 +348,6 @@ public class SlotManager implements AutoCloseable {
 					slotStatus.getAllocationID(),
 					slotStatus.getResourceProfile(),
 					taskExecutorConnection);
-			}
-
-			// determine if the task manager is idle or not
-			boolean idle = !anySlotUsed(taskManagerRegistration.getSlots());
-
-			if (idle) {
-				taskManagerRegistration.markIdle();
-			} else {
-				taskManagerRegistration.markUsed();
 			}
 		}
 
@@ -373,28 +389,9 @@ public class SlotManager implements AutoCloseable {
 		TaskManagerRegistration taskManagerRegistration = taskManagerRegistrations.get(instanceId);
 
 		if (null != taskManagerRegistration) {
-			boolean idle = true;
 
 			for (SlotStatus slotStatus : slotReport) {
-
-				// We assume that the slots of a TaskManager don't change over its lifetime and they are registered
-				// once when the TaskManager is registered
-				if (taskManagerRegistration.containsSlot(slotStatus.getSlotID()) && updateSlot(slotStatus.getSlotID(), slotStatus.getAllocationID())) {
-					TaskManagerSlot slot = slots.get(slotStatus.getSlotID());
-					idle &= slot.isFree();
-				} else {
-					// sanity check to guarantee that slots of a TaskManager don't change
-					throw new IllegalStateException("Reported a slot status for slot " +  slotStatus.getSlotID() +
-						" which has not been registered.");
-				}
-			}
-
-			if (idle) {
-				// no slot of this task manager is being used --> mark this task manager to be idle which allows it to
-				// time out
-				taskManagerRegistration.markIdle();
-			} else {
-				taskManagerRegistration.markUsed();
+				updateSlot(slotStatus.getSlotID(), slotStatus.getAllocationID());
 			}
 
 			return true;
@@ -418,26 +415,17 @@ public class SlotManager implements AutoCloseable {
 		TaskManagerSlot slot = slots.get(slotId);
 
 		if (null != slot) {
-			if (slot.isAllocated()) {
+			if (slot.getState() == TaskManagerSlot.State.ALLOCATED) {
 				if (Objects.equals(allocationId, slot.getAllocationId())) {
-					// free the slot
-					slot.setAllocationId(null);
-					fulfilledSlotRequests.remove(allocationId);
-
-					if (slot.isFree()) {
-						handleFreeSlot(slot);
-					}
 
 					TaskManagerRegistration taskManagerRegistration = taskManagerRegistrations.get(slot.getInstanceId());
 
-					if (null != taskManagerRegistration) {
-						if (anySlotUsed(taskManagerRegistration.getSlots())) {
-							taskManagerRegistration.markUsed();
-						} else {
-							taskManagerRegistration.markIdle();
-						}
+					if (taskManagerRegistration == null) {
+						throw new IllegalStateException("Trying to free a slot from a TaskManager " +
+							slot.getInstanceId() + " which has not been registered.");
 					}
 
+					updateSlotInternal(slot, taskManagerRegistration, null);
 				} else {
 					LOG.debug("Received request to free slot {} with expected allocation id {}, " +
 						"but actual allocation id {} differs. Ignoring the request.", slotId, allocationId, slot.getAllocationId());
@@ -495,7 +483,7 @@ public class SlotManager implements AutoCloseable {
 			TaskManagerSlot taskManagerSlot = iterator.next().getValue();
 
 			// sanity check
-			Preconditions.checkState(taskManagerSlot.isFree());
+			Preconditions.checkState(taskManagerSlot.getState() == TaskManagerSlot.State.FREE);
 
 			if (taskManagerSlot.getResourceProfile().isMatching(requestResourceProfile)) {
 				iterator.remove();
@@ -534,18 +522,11 @@ public class SlotManager implements AutoCloseable {
 		TaskManagerSlot slot = new TaskManagerSlot(
 			slotId,
 			resourceProfile,
-			taskManagerConnection,
-			allocationId);
+			taskManagerConnection);
 
 		slots.put(slotId, slot);
 
-		if (slot.isFree()) {
-			handleFreeSlot(slot);
-		}
-
-		if (slot.isAllocated()) {
-			fulfilledSlotRequests.put(slot.getAllocationId(), slotId);
-		}
+		updateSlot(slotId, allocationId);
 	}
 
 	/**
@@ -556,14 +537,30 @@ public class SlotManager implements AutoCloseable {
 	 * @return True if the slot could be updated; otherwise false
 	 */
 	private boolean updateSlot(SlotID slotId, AllocationID allocationId) {
-		TaskManagerSlot slot = slots.get(slotId);
+		final TaskManagerSlot slot = slots.get(slotId);
 
-		if (null != slot) {
-			// we assume the given allocation id to be the ground truth (coming from the TM)
-			slot.setAllocationId(allocationId);
+		if (slot != null) {
+			final TaskManagerRegistration taskManagerRegistration = taskManagerRegistrations.get(slot.getInstanceId());
 
-			if (null != allocationId) {
-				if (slot.hasPendingSlotRequest()){
+			if (taskManagerRegistration != null) {
+				updateSlotInternal(slot, taskManagerRegistration, allocationId);
+
+				return true;
+			} else {
+				throw new IllegalStateException("Trying to update a slot from a TaskManager " +
+					slot.getInstanceId() + " which has not been registered.");
+			}
+		} else {
+			LOG.debug("Trying to update unknown slot with slot id {}.", slotId);
+
+			return false;
+		}
+	}
+
+	private void updateSlotInternal(TaskManagerSlot slot, TaskManagerRegistration taskManagerRegistration, @Nullable AllocationID allocationId) {
+		if (null != allocationId) {
+			switch (slot.getState()) {
+				case PENDING:
 					// we have a pending slot request --> check whether we have to reject it
 					PendingSlotRequest pendingSlotRequest = slot.getAssignedSlotRequest();
 
@@ -573,31 +570,53 @@ public class SlotManager implements AutoCloseable {
 
 						// remove the pending slot request, since it has been completed
 						pendingSlotRequests.remove(pendingSlotRequest.getAllocationId());
+
+						slot.completeAllocation(allocationId);
 					} else {
+						// we first have to free the slot in order to set a new allocationId
+						slot.clearPendingSlotRequest();
+						// set the allocation id such that the slot won't be considered for the pending slot request
+						slot.updateAllocation(allocationId);
+
 						// this will try to find a new slot for the request
 						rejectPendingSlotRequest(
 							pendingSlotRequest,
-							new Exception("Task manager reported slot " + slotId + " being already allocated."));
+							new Exception("Task manager reported slot " + slot.getSlotId() + " being already allocated."));
 					}
 
-					slot.setAssignedSlotRequest(null);
-				}
-
-				fulfilledSlotRequests.put(allocationId, slotId);
-
-				TaskManagerRegistration taskManagerRegistration = taskManagerRegistrations.get(slot.getInstanceId());
-
-				if (null != taskManagerRegistration) {
-					// mark this TaskManager to be used to exempt it from timing out
-					taskManagerRegistration.markUsed();
-				}
+					taskManagerRegistration.occupySlot();
+					break;
+				case ALLOCATED:
+					if (!Objects.equals(allocationId, slot.getAllocationId())) {
+						slot.freeSlot();
+						slot.updateAllocation(allocationId);
+					}
+					break;
+				case FREE:
+					slot.updateAllocation(allocationId);
+					taskManagerRegistration.occupySlot();
+					break;
 			}
 
-			return true;
+			fulfilledSlotRequests.put(allocationId, slot.getSlotId());
 		} else {
-			LOG.debug("Trying to update unknown slot with slot id {}.", slotId);
+			// no allocation reported
+			switch (slot.getState()) {
+				case FREE:
+					handleFreeSlot(slot);
+					break;
+				case PENDING:
+					// don't do anything because we still have a pending slot request
+					break;
+				case ALLOCATED:
+					AllocationID oldAllocation = slot.getAllocationId();
+					slot.freeSlot();
+					fulfilledSlotRequests.remove(oldAllocation);
+					taskManagerRegistration.freeSlot();
 
-			return false;
+					handleFreeSlot(slot);
+					break;
+			}
 		}
 	}
 
@@ -627,6 +646,8 @@ public class SlotManager implements AutoCloseable {
 	 * @param pendingSlotRequest to allocate the given slot for
 	 */
 	private void allocateSlot(TaskManagerSlot taskManagerSlot, PendingSlotRequest pendingSlotRequest) {
+		Preconditions.checkState(taskManagerSlot.getState() == TaskManagerSlot.State.FREE);
+
 		TaskExecutorConnection taskExecutorConnection = taskManagerSlot.getTaskManagerConnection();
 		TaskExecutorGateway gateway = taskExecutorConnection.getTaskExecutorGateway();
 
@@ -634,18 +655,17 @@ public class SlotManager implements AutoCloseable {
 		final AllocationID allocationId = pendingSlotRequest.getAllocationId();
 		final SlotID slotId = taskManagerSlot.getSlotId();
 
-		taskManagerSlot.setAssignedSlotRequest(pendingSlotRequest);
+		taskManagerSlot.assignPendingSlotRequest(pendingSlotRequest);
 		pendingSlotRequest.setRequestFuture(completableFuture);
 
 		TaskManagerRegistration taskManagerRegistration = taskManagerRegistrations.get(taskManagerSlot.getInstanceId());
 
-		if (taskManagerRegistration != null) {
-			// mark the task manager to be used since we have a pending slot request assigned ot one of its slots
-			taskManagerRegistration.markUsed();
-		} else {
+		if (taskManagerRegistration == null) {
 			throw new IllegalStateException("Could not find a registered task manager for instance id " +
 				taskManagerSlot.getInstanceId() + '.');
 		}
+
+		taskManagerRegistration.markUsed();
 
 		// RPC call to the task manager
 		CompletableFuture<Acknowledge> requestFuture = gateway.requestSlot(
@@ -667,21 +687,25 @@ public class SlotManager implements AutoCloseable {
 
 		completableFuture.whenCompleteAsync(
 			(Acknowledge acknowledge, Throwable throwable) -> {
-				if (acknowledge != null) {
-					updateSlot(slotId, allocationId);
-				} else {
-					if (throwable instanceof SlotOccupiedException) {
-						SlotOccupiedException exception = (SlotOccupiedException) throwable;
-						updateSlot(slotId, exception.getAllocationId());
+				try {
+					if (acknowledge != null) {
+						updateSlot(slotId, allocationId);
 					} else {
-						removeSlotRequestFromSlot(slotId, allocationId);
-					}
+						if (throwable instanceof SlotOccupiedException) {
+							SlotOccupiedException exception = (SlotOccupiedException) throwable;
+							updateSlot(slotId, exception.getAllocationId());
+						} else {
+							removeSlotRequestFromSlot(slotId, allocationId);
+						}
 
-					if (!(throwable instanceof CancellationException)) {
-						handleFailedSlotRequest(slotId, allocationId, throwable);
-					} else {
-						LOG.debug("Slot allocation request {} has been cancelled.", allocationId, throwable);
+						if (!(throwable instanceof CancellationException)) {
+							handleFailedSlotRequest(slotId, allocationId, throwable);
+						} else {
+							LOG.debug("Slot allocation request {} has been cancelled.", allocationId, throwable);
+						}
 					}
+				} catch (Exception e) {
+					LOG.error("Error while completing the slot allocation.", e);
 				}
 			},
 			mainThreadExecutor);
@@ -694,6 +718,8 @@ public class SlotManager implements AutoCloseable {
 	 * @param freeSlot to find a new slot request for
 	 */
 	private void handleFreeSlot(TaskManagerSlot freeSlot) {
+		Preconditions.checkState(freeSlot.getState() == TaskManagerSlot.State.FREE);
+
 		PendingSlotRequest pendingSlotRequest = findMatchingRequest(freeSlot.getResourceProfile());
 
 		if (null != pendingSlotRequest) {
@@ -725,7 +751,7 @@ public class SlotManager implements AutoCloseable {
 		if (null != slot) {
 			freeSlots.remove(slotId);
 
-			if (slot.hasPendingSlotRequest()) {
+			if (slot.getState() == TaskManagerSlot.State.PENDING) {
 				// reject the pending slot request --> triggering a new allocation attempt
 				rejectPendingSlotRequest(
 					slot.getAssignedSlotRequest(),
@@ -755,18 +781,20 @@ public class SlotManager implements AutoCloseable {
 		TaskManagerSlot taskManagerSlot = slots.get(slotId);
 
 		if (null != taskManagerSlot) {
-			if (taskManagerSlot.hasPendingSlotRequest() && Objects.equals(allocationId, taskManagerSlot.getAssignedSlotRequest().getAllocationId())) {
-				taskManagerSlot.setAssignedSlotRequest(null);
-			}
+			if (taskManagerSlot.getState() == TaskManagerSlot.State.PENDING && Objects.equals(allocationId, taskManagerSlot.getAssignedSlotRequest().getAllocationId())) {
 
-			if (taskManagerSlot.isFree()) {
-				handleFreeSlot(taskManagerSlot);
-			}
+				TaskManagerRegistration taskManagerRegistration = taskManagerRegistrations.get(taskManagerSlot.getInstanceId());
 
-			TaskManagerRegistration taskManagerRegistration = taskManagerRegistrations.get(taskManagerSlot.getInstanceId());
+				if (taskManagerRegistration == null) {
+					throw new IllegalStateException("Trying to remove slot request from slot for which there is no TaskManager " + taskManagerSlot.getInstanceId() + " is registered.");
+				}
 
-			if (null != taskManagerRegistration && !anySlotUsed(taskManagerRegistration.getSlots())) {
-				taskManagerRegistration.markIdle();
+				// clear the pending slot request
+				taskManagerSlot.clearPendingSlotRequest();
+
+				updateSlotInternal(taskManagerSlot, taskManagerRegistration, null);
+			} else {
+				LOG.debug("Ignore slot request removal for slot {}.", slotId);
 			}
 		} else {
 			LOG.debug("There was no slot with {} registered. Probably this slot has been already freed.", slotId);
@@ -848,9 +876,7 @@ public class SlotManager implements AutoCloseable {
 				TaskManagerRegistration taskManagerRegistration = taskManagerRegistrationIterator.next().getValue();
 				LOG.debug("Evaluating TaskManager {} for idleness.", taskManagerRegistration.getInstanceId());
 
-				if (anySlotUsed(taskManagerRegistration.getSlots())) {
-					taskManagerRegistration.markUsed();
-				} else if (currentTime - taskManagerRegistration.getIdleSince() >= taskManagerTimeout.toMilliseconds()) {
+				if (currentTime - taskManagerRegistration.getIdleSince() >= taskManagerTimeout.toMilliseconds()) {
 					LOG.info("Removing idle TaskManager {} from the SlotManager.", taskManagerRegistration.getInstanceId());
 
 					taskManagerRegistrationIterator.remove();
@@ -900,23 +926,6 @@ public class SlotManager implements AutoCloseable {
 
 	private boolean checkDuplicateRequest(AllocationID allocationId) {
 		return pendingSlotRequests.containsKey(allocationId) || fulfilledSlotRequests.containsKey(allocationId);
-	}
-
-	private boolean anySlotUsed(Iterable<SlotID> slotsToCheck) {
-
-		if (null != slotsToCheck) {
-			for (SlotID slotId : slotsToCheck) {
-				TaskManagerSlot taskManagerSlot = slots.get(slotId);
-
-				if (null != taskManagerSlot) {
-					if (taskManagerSlot.isAllocated()) {
-						return true;
-					}
-				}
-			}
-		}
-
-		return false;
 	}
 
 	private void checkInit() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
@@ -425,7 +425,7 @@ public class SlotManager implements AutoCloseable {
 							slot.getInstanceId() + " which has not been registered.");
 					}
 
-					updateSlotInternal(slot, taskManagerRegistration, null);
+					updateSlotState(slot, taskManagerRegistration, null);
 				} else {
 					LOG.debug("Received request to free slot {} with expected allocation id {}, " +
 						"but actual allocation id {} differs. Ignoring the request.", slotId, allocationId, slot.getAllocationId());
@@ -543,7 +543,7 @@ public class SlotManager implements AutoCloseable {
 			final TaskManagerRegistration taskManagerRegistration = taskManagerRegistrations.get(slot.getInstanceId());
 
 			if (taskManagerRegistration != null) {
-				updateSlotInternal(slot, taskManagerRegistration, allocationId);
+				updateSlotState(slot, taskManagerRegistration, allocationId);
 
 				return true;
 			} else {
@@ -557,7 +557,7 @@ public class SlotManager implements AutoCloseable {
 		}
 	}
 
-	private void updateSlotInternal(TaskManagerSlot slot, TaskManagerRegistration taskManagerRegistration, @Nullable AllocationID allocationId) {
+	private void updateSlotState(TaskManagerSlot slot, TaskManagerRegistration taskManagerRegistration, @Nullable AllocationID allocationId) {
 		if (null != allocationId) {
 			switch (slot.getState()) {
 				case PENDING:
@@ -792,7 +792,7 @@ public class SlotManager implements AutoCloseable {
 				// clear the pending slot request
 				taskManagerSlot.clearPendingSlotRequest();
 
-				updateSlotInternal(taskManagerSlot, taskManagerRegistration, null);
+				updateSlotState(taskManagerSlot, taskManagerRegistration, null);
 			} else {
 				LOG.debug("Ignore slot request removal for slot {}.", slotId);
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskManagerRegistration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskManagerRegistration.java
@@ -32,6 +32,8 @@ public class TaskManagerRegistration {
 
 	private final HashSet<SlotID> slots;
 
+	private int numberFreeSlots;
+
 	/** Timestamp when the last time becoming idle. Otherwise Long.MAX_VALUE. */
 	private long idleSince;
 
@@ -44,7 +46,9 @@ public class TaskManagerRegistration {
 
 		this.slots = new HashSet<>(slots);
 
-		idleSince = Long.MAX_VALUE;
+		this.numberFreeSlots = slots.size();
+
+		idleSince = System.currentTimeMillis();
 	}
 
 	public TaskExecutorConnection getTaskManagerConnection() {
@@ -53,6 +57,34 @@ public class TaskManagerRegistration {
 
 	public InstanceID getInstanceId() {
 		return taskManagerConnection.getInstanceID();
+	}
+
+	public int getNumberRegisteredSlots() {
+		return slots.size();
+	}
+
+	public int getNumberFreeSlots() {
+		return numberFreeSlots;
+	}
+
+	public void freeSlot() {
+		Preconditions.checkState(
+			numberFreeSlots < slots.size(),
+			"The number of free slots cannot exceed the number of registered slots. This indicates a bug.");
+		numberFreeSlots++;
+
+		if (numberFreeSlots == getNumberRegisteredSlots() && idleSince == Long.MAX_VALUE) {
+			idleSince = System.currentTimeMillis();
+		}
+	}
+
+	public void occupySlot() {
+		Preconditions.checkState(
+			numberFreeSlots > 0,
+			"There are no more free slots. This indicates a bug.");
+		numberFreeSlots--;
+
+		idleSince = Long.MAX_VALUE;
 	}
 
 	public Iterable<SlotID> getSlots() {
@@ -65,12 +97,6 @@ public class TaskManagerRegistration {
 
 	public boolean isIdle() {
 		return idleSince != Long.MAX_VALUE;
-	}
-
-	public void markIdle() {
-		if (!isIdle()) {
-			idleSince = System.currentTimeMillis();
-		}
 	}
 
 	public void markUsed() {


### PR DESCRIPTION
## What is the purpose of the change

Extend the `SlotManager` such that we count the free slots per `TaskManager`. This has the advantage that we don't have to iterate over all registered slots and aggregate their state in order to decide whether a TaskManager is idle or not. Moreover, it allows to easily query how many free slots every `TaskManager` still has.

## Brief change log

- Fail if slot belongs to a unregistered TaskManager
- Add more sanity checks
- Make the TaskManagerSlot state transitions clearer
- Introduce proper TaskManagerSlot state enum and state transitions
- Refactor SlotManager for better maintainability
- Add free slot counting

## Verifying this change

This change is already covered by existing tests, such as `SlotManagerTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

