### PR TITLE
[FLINK-7608][metric] Refactor latency statistics metric

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/DescriptiveStatisticsHistogram.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/DescriptiveStatisticsHistogram.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.metrics;
+
+import org.apache.flink.metrics.Histogram;
+import org.apache.flink.metrics.HistogramStatistics;
+
+import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
+
+/**
+ * The {@link DescriptiveStatisticsHistogram} use a DescriptiveStatistics {@link DescriptiveStatistics} as a Flink {@link Histogram}.
+ */
+public class DescriptiveStatisticsHistogram implements org.apache.flink.metrics.Histogram {
+
+	private final DescriptiveStatistics descriptiveStatistics;
+
+	public DescriptiveStatisticsHistogram(int windowSize) {
+		this.descriptiveStatistics = new DescriptiveStatistics(windowSize);
+	}
+
+	@Override
+	public void update(long value) {
+		this.descriptiveStatistics.addValue(value);
+	}
+
+	@Override
+	public long getCount() {
+		return this.descriptiveStatistics.getN();
+	}
+
+	@Override
+	public HistogramStatistics getStatistics() {
+		return new DescriptiveStatisticsHistogramStatistics(this.descriptiveStatistics);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/DescriptiveStatisticsHistogramStatistics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/DescriptiveStatisticsHistogramStatistics.java
@@ -23,7 +23,6 @@ import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
 
 import java.util.Arrays;
 
-
 /**
  * DescriptiveStatistics histogram statistics implementation returned by {@link DescriptiveStatisticsHistogram}.
  * The statistics class wraps a {@link DescriptiveStatistics} instance and forwards the method calls accordingly.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/DescriptiveStatisticsHistogramStatistics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/DescriptiveStatisticsHistogramStatistics.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.metrics;
+
+import org.apache.flink.metrics.HistogramStatistics;
+
+import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
+
+import java.util.Arrays;
+
+
+/**
+ * DescriptiveStatistics histogram statistics implementation returned by {@link DescriptiveStatisticsHistogram}.
+ * The statistics class wraps a {@link DescriptiveStatistics} instance and forwards the method calls accordingly.
+ */
+public class DescriptiveStatisticsHistogramStatistics extends HistogramStatistics {
+	private final DescriptiveStatistics descriptiveStatistics;
+
+	public DescriptiveStatisticsHistogramStatistics(DescriptiveStatistics latencyHistogram) {
+		this.descriptiveStatistics = latencyHistogram;
+	}
+
+	@Override
+	public double getQuantile(double quantile) {
+		return descriptiveStatistics.getPercentile(quantile * 100);
+	}
+
+	@Override
+	public long[] getValues() {
+		return Arrays.stream(descriptiveStatistics.getValues()).mapToLong(i -> (long) i).toArray();
+	}
+
+	@Override
+	public int size() {
+		return (int) descriptiveStatistics.getN();
+	}
+
+	@Override
+	public double getMean() {
+		return descriptiveStatistics.getMean();
+	}
+
+	@Override
+	public double getStdDev() {
+		return descriptiveStatistics.getStandardDeviation();
+	}
+
+	@Override
+	public long getMax() {
+		return (long) descriptiveStatistics.getMax();
+	}
+
+	@Override
+	public long getMin() {
+		return (long) descriptiveStatistics.getMin();
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSink.java
@@ -59,7 +59,7 @@ public class StreamSink<IN> extends AbstractUdfStreamOperator<Object, SinkFuncti
 	@Override
 	protected void reportOrForwardLatencyMarker(LatencyMarker maker) {
 		// all operators are tracking latencies
-		this.latencyGauge.reportLatency(maker, true);
+		this.latencyStats.reportLatency(maker, true);
 
 		// sinks don't forward latency markers
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSink.java
@@ -57,10 +57,9 @@ public class StreamSink<IN> extends AbstractUdfStreamOperator<Object, SinkFuncti
 	}
 
 	@Override
-	protected void reportOrForwardLatencyMarker(LatencyMarker maker) {
+	protected void reportOrForwardLatencyMarker(LatencyMarker marker) {
 		// all operators are tracking latencies
-		this.latencyStats.reportLatency(maker, true);
-
+		this.latencyStats.reportLatency(marker);
 		// sinks don't forward latency markers
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSource.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSource.java
@@ -18,6 +18,7 @@
 package org.apache.flink.streaming.api.operators;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.api.watermark.Watermark;
@@ -67,7 +68,7 @@ public class StreamSource<OUT, SRC extends SourceFunction<OUT>>
 				getProcessingTimeService(),
 				collector,
 				getExecutionConfig().getLatencyTrackingInterval(),
-				getOperatorConfig().getVertexID(),
+				this.getOperatorID(),
 				getRuntimeContext().getIndexOfThisSubtask());
 		}
 
@@ -138,7 +139,7 @@ public class StreamSource<OUT, SRC extends SourceFunction<OUT>>
 				final ProcessingTimeService processingTimeService,
 				final Output<StreamRecord<OUT>> output,
 				long latencyTrackingInterval,
-				final int vertexID,
+				final OperatorID operatorId,
 				final int subtaskIndex) {
 
 			latencyMarkTimer = processingTimeService.scheduleAtFixedRate(
@@ -147,7 +148,7 @@ public class StreamSource<OUT, SRC extends SourceFunction<OUT>>
 					public void onProcessingTime(long timestamp) throws Exception {
 						try {
 							// ProcessingTimeService callbacks are executed under the checkpointing lock
-							output.emitLatencyMarker(new LatencyMarker(timestamp, vertexID, subtaskIndex));
+							output.emitLatencyMarker(new LatencyMarker(timestamp, operatorId, subtaskIndex));
 						} catch (Throwable t) {
 							// we catch the Throwables here so that we don't trigger the processing
 							// timer services async exception handler

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/streamrecord/LatencyMarker.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/streamrecord/LatencyMarker.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.runtime.streamrecord;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.runtime.jobgraph.OperatorID;
 
 /**
  * Special record type carrying a timestamp of its creation time at a source operator
@@ -35,16 +36,16 @@ public final class LatencyMarker extends StreamElement {
 	/** The time the latency mark is denoting. */
 	private final long markedTime;
 
-	private final int vertexID;
+	private final OperatorID operatorId;
 
 	private final int subtaskIndex;
 
 	/**
 	 * Creates a latency mark with the given timestamp.
 	 */
-	public LatencyMarker(long markedTime, int vertexID, int subtaskIndex) {
+	public LatencyMarker(long markedTime, OperatorID operatorId, int subtaskIndex) {
 		this.markedTime = markedTime;
-		this.vertexID = vertexID;
+		this.operatorId = operatorId;
 		this.subtaskIndex = subtaskIndex;
 	}
 
@@ -55,8 +56,8 @@ public final class LatencyMarker extends StreamElement {
 		return markedTime;
 	}
 
-	public int getVertexID() {
-		return vertexID;
+	public OperatorID getOperatorId() {
+		return operatorId;
 	}
 
 	public int getSubtaskIndex() {
@@ -79,7 +80,7 @@ public final class LatencyMarker extends StreamElement {
 		if (markedTime != that.markedTime) {
 			return false;
 		}
-		if (vertexID != that.vertexID) {
+		if (operatorId != that.operatorId) {
 			return false;
 		}
 		return subtaskIndex == that.subtaskIndex;
@@ -89,7 +90,7 @@ public final class LatencyMarker extends StreamElement {
 	@Override
 	public int hashCode() {
 		int result = (int) (markedTime ^ (markedTime >>> 32));
-		result = 31 * result + vertexID;
+		result = 31 * result + operatorId.hashCode();
 		result = 31 * result + subtaskIndex;
 		return result;
 	}
@@ -98,7 +99,7 @@ public final class LatencyMarker extends StreamElement {
 	public String toString() {
 		return "LatencyMarker{" +
 				"markedTime=" + markedTime +
-				", vertexID=" + vertexID +
+				", operatorId=" + operatorId +
 				", subtaskIndex=" + subtaskIndex +
 				'}';
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/LatencyStats.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/LatencyStats.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.util;
+
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
+import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * The {@link LatencyStats} objects are used to track and report on the behavior of latencies across measurements.
+ */
+public class LatencyStats {
+	private final Map<String, DescriptiveStatisticsHistogram> latencyStats = new HashMap<>();
+	private final MetricGroup metricGroup;
+	private final int historySize;
+
+	public LatencyStats(MetricGroup metricGroup, int historySize) {
+		this.metricGroup = metricGroup;
+		this.historySize = historySize;
+	}
+
+	public void reportLatency(LatencyMarker marker, boolean isSink) {
+		String latencyMetricName = identifyLatencySource(marker, !isSink);
+		DescriptiveStatisticsHistogram latencyHistogram = this.latencyStats.get(latencyMetricName);
+		if (latencyHistogram == null) {
+			latencyHistogram = new DescriptiveStatisticsHistogram(this.historySize);
+			this.latencyStats.put(latencyMetricName, latencyHistogram);
+			this.metricGroup.histogram(latencyMetricName, latencyHistogram);
+		}
+
+		long now = System.currentTimeMillis();
+		latencyHistogram.update(now - marker.getMarkedTime());
+	}
+
+	/**
+	 * Creates an identifier for a latency source. from a given {@code LatencyMarker}.
+	 *
+	 * @param marker             The latency marker to extract the LatencySourceDescriptor from.
+	 * @param ignoreSubtaskIndex Set to true to ignore the subtask index, to treat the latencies
+	 *                           from all the parallel instances of a source as the same.
+	 * @return A string that identifies the latency source.
+	 */
+	private String identifyLatencySource(LatencyMarker marker, boolean ignoreSubtaskIndex) {
+		if (ignoreSubtaskIndex) {
+			return String.valueOf(marker.getVertexID());
+		} else {
+			return marker.getVertexID() + "_" + marker.getSubtaskIndex();
+		}
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorTest.java
@@ -214,7 +214,7 @@ public class StreamSourceOperatorTest {
 		for (; i < output.size() - 1; i++) {
 			StreamElement se = output.get(i);
 			Assert.assertTrue(se.isLatencyMarker());
-			Assert.assertEquals(-1, se.asLatencyMarker().getVertexID());
+			Assert.assertEquals(-1, se.asLatencyMarker().getOperatorId());
 			Assert.assertEquals(0, se.asLatencyMarker().getSubtaskIndex());
 			Assert.assertTrue(se.asLatencyMarker().getMarkedTime() == timestamp);
 


### PR DESCRIPTION
A detailed description of this PR, see  [#issue FLINK-7608: LatencyGauge change to histogram metric](https://issues.apache.org/jira/browse/FLINK-7608)

## Verifying this change

This change is already covered by existing tests.

build flink from source, run a test job [LatencyStatsJob.java](https://gist.github.com/yew1eb/3329239f866b691364f4d11a7f0a846a).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)

