### PR TITLE
[FLINK-7840] [build] Shade netty in akka

### DIFF
--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -427,17 +427,42 @@ under the License.
 							<goal>shade</goal>
 						</goals>
 						<configuration>
+							<!-- we need this to avoid having to specify all of akka's dependencies -->
+							<promoteTransitiveDependencies>true</promoteTransitiveDependencies>
 							<artifactSet>
 								<includes combine.children="append">
 									<include>org.apache.flink:flink-shaded-curator-recipes</include>
+									<!-- add akka, akka's netty, akka uncommon math -->
+									<!-- we can do this only because our own netty dependency is
+										already externally shaded (flink-shaded-netty) -->
+									<include>com.typesafe.akka:akka-remote_*</include>
+									<include>io.netty:netty</include>
+									<include>org.uncommons.maths:uncommons-maths</include>
 								</includes>
 							</artifactSet>
 							<relocations combine.children="append">
+								<relocation>
+									<pattern>org.jboss.netty</pattern>
+									<shadedPattern>org.apache.flink.shaded.akka.org.jboss.netty</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.uncommons.math</pattern>
+									<shadedPattern>org.apache.flink.shaded.akka.org.uncommons.math</shadedPattern>
+								</relocation>
 								<relocation>
 									<pattern>org.apache.curator</pattern>
 									<shadedPattern>org.apache.flink.shaded.org.apache.curator</shadedPattern>
 								</relocation>
 							</relocations>
+							<filters>
+								<filter>
+									<artifact>*</artifact>
+									<excludes>
+										<exclude>META-INF/maven/io.netty/**</exclude>
+										<exclude>META-INF/maven/org.uncommons.maths/**</exclude>
+									</excludes>
+								</filter>
+							</filters>
 						</configuration>
 					</execution>
 				</executions>

--- a/flink-test-utils-parent/flink-test-utils/pom.xml
+++ b/flink-test-utils-parent/flink-test-utils/pom.xml
@@ -65,6 +65,13 @@ under the License.
 		</dependency>
 
 		<dependency>
+			<groupId>io.netty</groupId>
+			<artifactId>netty</artifactId>
+			<version>3.10.6.Final</version>
+			<scope>compile</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>${junit.version}</version>
@@ -116,6 +123,41 @@ under the License.
 				<version>3.0.1</version>
 				<inherited>true</inherited>
 				<extensions>true</extensions>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>shade-flink</id>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<artifactSet>
+								<includes combine.children="append">
+									<include>io.netty:netty</include>
+								</includes>
+							</artifactSet>
+							<relocations combine.children="append">
+								<relocation>
+									<pattern>org.jboss.netty</pattern>
+									<shadedPattern>org.apache.flink.shaded.testutils.org.jboss.netty</shadedPattern>
+								</relocation>
+							</relocations>
+							<filters>
+								<filter>
+									<artifact>*</artifact>
+									<excludes>
+										<exclude>META-INF/maven/io.netty/**</exclude>
+									</excludes>
+								</filter>
+							</filters>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/networking/NetworkFailureHandler.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/networking/NetworkFailureHandler.java
@@ -30,6 +30,7 @@ import org.jboss.netty.channel.ExceptionEvent;
 import org.jboss.netty.channel.MessageEvent;
 import org.jboss.netty.channel.SimpleChannelUpstreamHandler;
 import org.jboss.netty.channel.socket.ClientSocketChannelFactory;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/flink-yarn/pom.xml
+++ b/flink-yarn/pom.xml
@@ -26,7 +26,7 @@ under the License.
 		<version>1.4-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
-	
+
 	<artifactId>flink-yarn_${scala.binary.version}</artifactId>
 	<name>flink-yarn</name>
 	<packaging>jar</packaging>
@@ -39,12 +39,6 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
-			<exclusions>
-				<exclusion>
-					<artifactId>hadoop-core</artifactId>
-					<groupId>org.apache.hadoop</groupId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 
 		<dependency>
@@ -60,21 +54,15 @@ under the License.
 		</dependency>
 
 		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-test-utils_${scala.binary.version}</artifactId>
-			<version>${project.version}</version>
-			<type>test-jar</type>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
 			<groupId>com.typesafe.akka</groupId>
 			<artifactId>akka-actor_${scala.binary.version}</artifactId>
+			<scope>provided</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>com.typesafe.akka</groupId>
 			<artifactId>akka-remote_${scala.binary.version}</artifactId>
+			<scope>provided</scope>
 		</dependency>
 
 		<dependency>
@@ -88,13 +76,15 @@ under the License.
 			</exclusions>
 		</dependency>
 
+		<!-- test dependencies -->
+
 		<dependency>
-			<groupId>com.typesafe.akka</groupId>
-			<artifactId>akka-testkit_${scala.binary.version}</artifactId>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-test-utils_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>
-
-		<!-- test dependencies -->
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
@@ -118,6 +108,12 @@ under the License.
 			<scope>test</scope>
 			<type>test-jar</type>
 			<version>${hadoop.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.typesafe.akka</groupId>
+			<artifactId>akka-testkit_${scala.binary.version}</artifactId>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/tools/travis_mvn_watchdog.sh
+++ b/tools/travis_mvn_watchdog.sh
@@ -301,10 +301,18 @@ check_shaded_artifacts() {
 		return 1
 	fi
 
-	NETTY=`cat allClasses | grep '^io/netty' | wc -l`
-	if [ "$NETTY" != "0" ]; then
+	IO_NETTY=`cat allClasses | grep '^io/netty' | wc -l`
+	if [ "$IO_NETTY" != "0" ]; then
 		echo "=============================================================================="
-		echo "Detected '$NETTY' unshaded netty dependencies in fat jar"
+		echo "Detected '$IO_NETTY' unshaded io.netty classes in fat jar"
+		echo "=============================================================================="
+		return 1
+	fi
+
+	ORG_NETTY=`cat allClasses | grep '^org/jboss/netty' | wc -l`
+	if [ "$ORG_NETTY" != "0" ]; then
+		echo "=============================================================================="
+		echo "Detected '$ORG_NETTY' unshaded org.jboss.netty classes in fat jar"
 		echo "=============================================================================="
 		return 1
 	fi


### PR DESCRIPTION
## What is the purpose of the change

This change shade's Akka's dependency on Netty away.

**Note:** Akka itself cannot be shaded away, there is some magic in Scala and annotations that Scala adds to preserve some compile time information, which make shading impossible (results in inconsistent code). That creates some problems.

I tried several approaches to shading Akka's Netty:

1. Add all Akka dependencies to `flink-runtime`. The dependencies disappear due to shading, but the classes are present in the same namespace.
  This leads to problems. For example, tests pull in the regular akka dependencies as well (transitively from `akka-testkit`) and for some reason it creates problems with the mixing of classes loaded from `flink-runtime` and `akka-actor`. One could fix that by adding all other akka dependencies as `provided` wherever `akka-testkit` is used.
  Similarly, users that want to use akka have to add their own dependency to akka and will get a similar clash of classes.
  This can be summed up as: Adding a dependency to a shaded jar (hence removing the dependency) without relocating the classes creates problems with dependency management.

  2. Add only `akka-remote` to the `flink-runtime` jar. That is the minimum we need to add to shade the Netty dependency. It softens the problem mentioned in (1), because only one of the akka dependencies is present in the `flink-runtime` jar, but it does not solve it completely.

We shade all akka dependencies into the `flink-dist` jar anyways, so anyone running a job with Flink will need to set all its akka dependencies to `provided` and assume Flink's version anyways (reloading in a different classloader through child-first loading as a workaround aside).

So from the user's perspective, akka is always provided. Child-first class loading can save the day for some users (allowing them to have a different akka version in the user code class loader than Flink has in the system class loader), but we should not strictly rely on that - its a pretty delicate thing.

## Brief change log

  - Set all akka compile time dependencies outside `flink-runtime` to *provided*.
  - Add `akka-remote_*` , `io.netty` and `org.uncommons.math` to the shaded `flink-runtime` jar
  - Relocate `org.jboss.netty` and `org.uncommons.math`
  - Add Netty as an explicit dependency to `flink-testutils` for the network proxy and shade it there as well.
  - Adds a check for unshaded Netty to the Travis CI script

## Verifying this change

  - The tests for this change pass on Travis.
  - One can simply test this by manually building the change and starting a simple standalone cluster and running one of the sample jobs.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**): t removes dependencies
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know): It affects akka which is used for communication and thus for failure detection.

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
