### PR TITLE
[FLINK-7759][TableAPI & SQL] Fix Bug that fieldName with Boolean pref…

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/ExpressionParser.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/ExpressionParser.scala
@@ -201,7 +201,7 @@ object ExpressionParser extends JavaTokenParsers with PackratParsers {
   }
 
   lazy val atom: PackratParser[Expression] =
-    ( "(" ~> expression <~ ")" ) | literalExpr | fieldReference
+    ( "(" ~> expression <~ ")" ) | (fieldReference ||| literalExpr)
 
   lazy val over: PackratParser[Expression] = composite ~ OVER ~ fieldReference ^^ {
     case agg ~ _ ~ windowRef => UnresolvedOverCall(agg, windowRef)

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/batch/table/stringexpr/StringExpressionTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/batch/table/stringexpr/StringExpressionTest.scala
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api.batch.table.stringexpr
+
+import org.apache.flink.table.expressions.{ExpressionParser, Literal, UnresolvedFieldReference}
+import org.junit.{Assert, Test}
+
+class StringExpressionTest {
+
+  @Test
+  def testFieldWithBooleanPrefix: Unit = {
+
+    Assert.assertEquals(
+      UnresolvedFieldReference("trUex"),
+      ExpressionParser.parseExpression("trUex")
+    )
+
+    Assert.assertEquals(
+      UnresolvedFieldReference("FALSE_A"),
+      ExpressionParser.parseExpression("FALSE_A")
+    )
+
+    Assert.assertEquals(
+      Literal(true),
+      ExpressionParser.parseExpression("true")
+    )
+
+    Assert.assertEquals(
+      Literal(false),
+      ExpressionParser.parseExpression("false")
+    )
+
+  }
+
+}


### PR DESCRIPTION
Fix Bug that fieldName with Boolean prefix can't be parsed by ExpressionParser

## What is the purpose of the change

Fix bug that field names with boolean prefix like "truex" or "FALSE_TARGET" can't be parsed by `ExpressionParser`


## Brief change log

use `||| ` instead of ` | ` in `atom` parser, try to match as long as possible, and exchanging of positions of `fieldReference` parser and ` literalExpr ` parser is necessary, because `boolean` can be matched by both parsers, then it's captured by the latter one ` literalExpr ` .


## Verifying this change

This change added tests and can be verified as follows:

StringExpressionTest.testFieldWithBooleanPrefix

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive):no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not documented

