### PR TITLE
[FLINK-7730] [table] Restrict the predicates of table function left outer join

### DIFF
--- a/docs/dev/table/sql.md
+++ b/docs/dev/table/sql.md
@@ -436,11 +436,12 @@ FROM Orders CROSS JOIN UNNEST(tags) AS t (tag)
     </tr>
     <tr>
     	<td>
-        <strong>User Defined Table Functions (UDTF)</strong><br>
+        <strong>Join with User Defined Table Functions (UDTF)</strong><br>
         <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span>
       </td>
     	<td>
       <p>UDTFs must be registered in the TableEnvironment. See the <a href="udfs.html">UDF documentation</a> for details on how to specify and register UDTFs. </p>
+      <p><b>Note:</b> Currently only local predicates on the left table can be provided for the table function left outer join.</p>
 {% highlight sql %}
 SELECT users, tag
 FROM Orders LATERAL VIEW UNNEST_UDTF(tags) t AS tag

--- a/docs/dev/table/tableApi.md
+++ b/docs/dev/table/tableApi.md
@@ -547,7 +547,7 @@ Table result = left.fullOuterJoin(right, "a = d").select("a, b, e");
     </tr>
     <tr>
     	<td>
-        <strong>TableFunction Join</strong><br>
+        <strong>TableFunction Inner Join</strong><br>
         <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span>
       </td>
     	<td>
@@ -561,7 +561,7 @@ tEnv.registerFunction("split", split);
 // join
 Table orders = tableEnv.scan("Orders");
 Table result = orders
-    .join(new Table(tEnv, "split(c)").as("s", "t", "v")))
+    .join(new Table(tEnv, "split(c)").as("s", "t", "v"))
     .select("a, b, s, t, v");
 {% endhighlight %}
       </td>
@@ -573,6 +573,7 @@ Table result = orders
       </td>
       <td>
         <p>Joins a table with a the results of a table function. Each row of the left (outer) table is joined with all rows produced by the corresponding call of the table function. If a table function call returns an empty result, the corresponding outer row is preserved and the result padded with null values.
+        <p><b>Note:</b> Currently only local predicates on the left table can be provided for the table function left outer join.</p>
         </p>
 {% highlight java %}
 // register function
@@ -582,7 +583,8 @@ tEnv.registerFunction("split", split);
 // join
 Table orders = tableEnv.scan("Orders");
 Table result = orders
-    .leftOuterJoin(new Table(tEnv, "split(c)").as("s", "t", "v")))
+    .leftOuterJoin(new Table(tEnv, "split(c)").as("s", "t", "v"))
+    .where("a > 5")
     .select("a, b, s, t, v");
 {% endhighlight %}
       </td>
@@ -664,7 +666,7 @@ val result = left.fullOuterJoin(right, 'a === 'd).select('a, 'b, 'e)
     </tr>
     <tr>
     	<td>
-        <strong>TableFunction Join</strong><br>
+        <strong>TableFunction Inner Join</strong><br>
         <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span>
       </td>
     	<td>
@@ -687,6 +689,7 @@ val result: Table = table
         <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>
     	<td>
         <p>Joins a table with a the results of a table function. Each row of the left (outer) table is joined with all rows produced by the corresponding call of the table function. If a table function call returns an empty result, the corresponding outer row is preserved and the result padded with null values.
+        <p><b>Note:</b> Currently only local predicates on the left table can be provided for the table function left outer join.</p>
         </p>
 {% highlight scala %}
 // instantiate function
@@ -695,6 +698,7 @@ val split: TableFunction[_] = new MySplitUDTF()
 // join
 val result: Table = table
     .leftOuterJoin(split('c) as ('s, 't, 'v))
+    .where('a > 5)
     .select('a, 'b, 's, 't, 'v)
 {% endhighlight %}
       </td>

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/dataSet/DataSetCalcRule.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/dataSet/DataSetCalcRule.scala
@@ -18,12 +18,14 @@
 
 package org.apache.flink.table.plan.rules.dataSet
 
-import org.apache.calcite.plan.{RelOptRule, RelTraitSet}
+import org.apache.calcite.plan.volcano.RelSubset
+import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall, RelTraitSet}
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.convert.ConverterRule
+import org.apache.calcite.sql.SemiJoinType
 import org.apache.flink.table.plan.nodes.FlinkConventions
 import org.apache.flink.table.plan.nodes.dataset.DataSetCalc
-import org.apache.flink.table.plan.nodes.logical.FlinkLogicalCalc
+import org.apache.flink.table.plan.nodes.logical.{FlinkLogicalCalc, FlinkLogicalCorrelate}
 
 class DataSetCalcRule
   extends ConverterRule(
@@ -32,7 +34,19 @@ class DataSetCalcRule
     FlinkConventions.DATASET,
     "DataSetCalcRule") {
 
-    def convert(rel: RelNode): RelNode = {
+  override def matches(call: RelOptRuleCall): Boolean = {
+    val calc = call.rels(0).asInstanceOf[FlinkLogicalCalc]
+    val input = calc.getInput.asInstanceOf[RelSubset].getBest
+    input match {
+      // All predicates, except for the local ones of the left table, are forbidden for
+      // TableFunction LEFT OUTER JOIN now. See CALCITE-2004 for more details.
+      case node: FlinkLogicalCorrelate
+        if node.getJoinType == SemiJoinType.LEFT && calc.getProgram.getCondition != null => false
+      case _ => true
+    }
+  }
+
+  def convert(rel: RelNode): RelNode = {
       val calc: FlinkLogicalCalc = rel.asInstanceOf[FlinkLogicalCalc]
       val traitSet: RelTraitSet = rel.getTraitSet.replace(FlinkConventions.DATASET)
       val convInput: RelNode = RelOptRule.convert(calc.getInput, FlinkConventions.DATASET)

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/batch/sql/CorrelateTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/batch/sql/CorrelateTest.scala
@@ -19,6 +19,7 @@
 package org.apache.flink.table.api.batch.sql
 
 import org.apache.flink.api.scala._
+import org.apache.flink.table.api.TableException
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.runtime.utils.JavaUserDefinedTableFunctions.JavaVarsArgTableFunc0
 import org.apache.flink.table.utils.TableTestUtil._
@@ -75,8 +76,12 @@ class CorrelateTest extends TableTestBase {
     util.verifySql(sqlQuery2, expected2)
   }
 
+  /**
+    * Due to the improper translation of TableFunction left outer join (see CALCITE-2004), we could
+    * can only accept local join predicates on the left table.
+    */
   @Test
-  def testLeftOuterJoin(): Unit = {
+  def testLeftOuterJoinWithTruePredicates(): Unit = {
     val util = batchTestUtil()
     val func1 = new TableFunc1
     util.addTable[(Int, Long, String)]("MyTable", 'a, 'b, 'c)
@@ -100,6 +105,22 @@ class CorrelateTest extends TableTestBase {
     )
 
     util.verifySql(sqlQuery, expected)
+  }
+
+  /**
+    * Due to the improper translation of TableFunction left outer join (see CALCITE-2004), we could
+    * only accept local join predicates on the left table.
+    */
+  @Test (expected = classOf[TableException])
+  def testLeftOuterJoinWithPredicates(): Unit = {
+    val util = batchTestUtil()
+    val func1 = new TableFunc1
+    util.addTable[(Int, Long, String)]("MyTable", 'a, 'b, 'c)
+    util.addFunction("func1", func1)
+
+    val sqlQuery = "SELECT c, s FROM MyTable LEFT JOIN LATERAL TABLE(func1(c)) AS T(s) ON s = a"
+
+    util.verifySql(sqlQuery, "")
   }
 
   @Test

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/batch/table/CorrelateTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/batch/table/CorrelateTest.scala
@@ -19,6 +19,7 @@
 package org.apache.flink.table.api.batch.table
 
 import org.apache.flink.api.scala._
+import org.apache.flink.table.api.TableException
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.utils.TableTestUtil._
 import org.apache.flink.table.utils.{TableFunc1, TableTestBase}
@@ -73,8 +74,12 @@ class CorrelateTest extends TableTestBase {
     util.verifyTable(result2, expected2)
   }
 
+  /**
+    * Due to the improper translation of TableFunction left outer join (see CALCITE-2004), we could
+    * only accept local join predicates on the left table.
+    */
   @Test
-  def testLeftOuterJoin(): Unit = {
+  def testLeftOuterJoinWithoutPredicates(): Unit = {
     val util = batchTestUtil()
     val table = util.addTable[(Int, Long, String)]("MyTable", 'a, 'b, 'c)
     val function = util.addFunction("func1", new TableFunc1)
@@ -97,5 +102,18 @@ class CorrelateTest extends TableTestBase {
     )
 
     util.verifyTable(result, expected)
+  }
+
+  /**
+    * Due to the improper translation of TableFunction left outer join (see CALCITE-2004), we could
+    * only accept local join predicates on the left table.
+    */
+  @Test (expected = classOf[TableException])
+  def testLeftOuterJoinWithPredicates(): Unit = {
+    val util = batchTestUtil()
+    val table = util.addTable[(Int, Long, String)]("MyTable", 'a, 'b, 'c)
+    val function = util.addFunction("func1", new TableFunc1)
+    val result = table.leftOuterJoin(function('c) as 's).select('c, 's).where('s === "")// forbidden
+    util.verifyTable(result, "")
   }
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/CorrelateTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/CorrelateTest.scala
@@ -19,6 +19,7 @@
 package org.apache.flink.table.api.stream.sql
 
 import org.apache.flink.api.scala._
+import org.apache.flink.table.api.TableException
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.runtime.utils.JavaUserDefinedTableFunctions.JavaVarsArgTableFunc0
 import org.apache.flink.table.utils.TableTestUtil._
@@ -75,20 +76,29 @@ class CorrelateTest extends TableTestBase {
     util.verifySql(sqlQuery2, expected2)
   }
 
+  /**
+    * Due to the improper translation of TableFunction left outer join (see CALCITE-2004), we could
+    * only accept local join predicates on the left table.
+    */
   @Test
-  def testLeftOuterJoin(): Unit = {
+  def testLeftOuterJoinWithLeftLocalPredicates(): Unit = {
     val util = streamTestUtil()
     val func1 = new TableFunc1
     util.addTable[(Int, Long, String)]("MyTable", 'a, 'b, 'c)
     util.addFunction("func1", func1)
 
-    val sqlQuery = "SELECT c, s FROM MyTable LEFT JOIN LATERAL TABLE(func1(c)) AS T(s) ON TRUE"
+    val sqlQuery = "SELECT c, s FROM MyTable LEFT JOIN LATERAL TABLE(func1(c)) AS T(s) ON a > 3"
 
     val expected = unaryNode(
       "DataStreamCalc",
       unaryNode(
         "DataStreamCorrelate",
-        streamTableNode(0),
+        unaryNode(
+          "DataStreamCalc",
+          streamTableNode(0),
+          term("select", "a", "b", "c"),
+          term("where", ">(a, 3)")
+        ),
         term("invocation", "func1($cor0.c)"),
         term("correlate", s"table(func1($$cor0.c))"),
         term("select", "a", "b", "c", "f0"),
@@ -100,6 +110,22 @@ class CorrelateTest extends TableTestBase {
     )
 
     util.verifySql(sqlQuery, expected)
+  }
+
+  /**
+    * Due to the improper translation of TableFunction left outer join (see CALCITE-2004), we could
+    * only accept local join predicates on the left table.
+    */
+  @Test(expected = classOf[TableException])
+  def testLeftOuterJoinWithPredicates(): Unit = {
+    val util = streamTestUtil()
+    val func1 = new TableFunc1
+    util.addTable[(Int, Long, String)]("MyTable", 'a, 'b, 'c)
+    util.addFunction("func1", func1)
+
+    val sqlQuery = "SELECT c, s FROM MyTable LEFT JOIN LATERAL TABLE(func1(c)) AS T(s) ON s > 5"
+
+    util.verifySql(sqlQuery, "")
   }
 
   @Test

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/batch/table/CorrelateITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/batch/table/CorrelateITCase.scala
@@ -22,7 +22,7 @@ import java.sql.{Date, Timestamp}
 
 import org.apache.flink.api.scala._
 import org.apache.flink.api.scala.util.CollectionDataSets
-import org.apache.flink.table.api.TableEnvironment
+import org.apache.flink.table.api.{TableEnvironment, TableException}
 import org.apache.flink.table.runtime.utils.JavaUserDefinedTableFunctions.JavaTableFunc0
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.expressions.utils.{Func1, Func13, Func18, RichFunc2}
@@ -68,8 +68,12 @@ class CorrelateITCase(
     TestBaseUtils.compareResultAsText(results2.asJava, expected2)
   }
 
+  /**
+    * Due to the improper translation of TableFunction left outer join (see CALCITE-2004), we could
+    * only accept local join predicates on the left table.
+    */
   @Test
-  def testLeftOuterJoin(): Unit = {
+  def testLeftOuterJoinWithoutPredicates(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
     val tableEnv = TableEnvironment.getTableEnvironment(env, config)
     val in = testData(env).toTable(tableEnv).as('a, 'b, 'c)
@@ -79,6 +83,27 @@ class CorrelateITCase(
     val results = result.collect()
     val expected = "Jack#22,Jack,4\n" + "Jack#22,22,2\n" + "John#19,John,4\n" +
       "John#19,19,2\n" + "Anna#44,Anna,4\n" + "Anna#44,44,2\n" + "nosharp,null,null"
+    TestBaseUtils.compareResultAsText(results.asJava, expected)
+  }
+
+  /**
+    * Due to the improper translation of TableFunction left outer join (see CALCITE-2004), this
+    * test can not be normally passed.
+    */
+  @Test(expected = classOf[TableException])
+  def testLeftOuterJoinWithPredicates(): Unit = {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val tableEnv = TableEnvironment.getTableEnvironment(env, config)
+    val in = testData(env).toTable(tableEnv).as('a, 'b, 'c)
+
+    val func2 = new TableFunc2
+    val result = in
+      .leftOuterJoin(func2('c) as ('s, 'l))
+      .where('a >= 'l)
+      .select('c, 's, 'l)
+      .toDataSet[Row]
+    val results = result.collect()
+    val expected = "Jack#22,null,null\n" + "John#19,19,2\n" + "Anna#44,44,2\n" + "nosharp,null,null"
     TestBaseUtils.compareResultAsText(results.asJava, expected)
   }
 


### PR DESCRIPTION
## What is the purpose of the change

The PR aims to temporarily cover up the table function left outer join problem by adding restrictions on the join predicates. 

## Brief change log

  - Predicates check for table function left outer join (correlate) are added to `DataSetCalcRule` and `DataStreamCalcRule`.
  - Update related tests.
  - Refine the documents.


## Verifying this change

This change is already covered by existing tests, such as `CorrelateITCase` and `CorrelateTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (docs)
