### PR TITLE
[FLINK-6314] [cassandra] Support user-defined Mapper options

### DIFF
--- a/docs/dev/connectors/cassandra.md
+++ b/docs/dev/connectors/cassandra.md
@@ -69,10 +69,13 @@ The following configuration methods can be used:
     * Sets the cluster builder that is used to configure the connection to cassandra with more sophisticated settings such as consistency level, retry policy and etc.
 3. _setHost(String host[, int port])_
     * Simple version of setClusterBuilder() with host/port information to connect to Cassandra instances
-4. _enableWriteAheadLog([CheckpointCommitter committer])_
+4. _setMapperOptions(MapperOptions options)_
+    * Sets the mapper options that are used to configure the DataStax ObjectMapper.
+    * Only applies when processing __POJO__ data types.
+5. _enableWriteAheadLog([CheckpointCommitter committer])_
     * An __optional__ setting
     * Allows exactly-once processing for non-deterministic algorithms.
-5. _build()_
+6. _build()_
     * Finalizes the configuration and constructs the CassandraSink instance.
 
 ### Write-ahead Log
@@ -236,6 +239,7 @@ DataStream<WordCount> result = text
 
 CassandraSink.addSink(result)
         .setHost("127.0.0.1")
+        .setMapperOptions(() -> new Mapper.Option[]{Mapper.Option.saveNullFields(true)})
         .build();
 
 

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraSink.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraSink.java
@@ -230,6 +230,7 @@ public class CassandraSink<IN> {
 		protected final TypeSerializer<IN> serializer;
 		protected final TypeInformation<IN> typeInfo;
 		protected ClusterBuilder builder;
+		protected MapperOptions mapperOptions;
 		protected String query;
 		protected CheckpointCommitter committer;
 		protected boolean isWriteAheadLogEnabled;
@@ -321,6 +322,21 @@ public class CassandraSink<IN> {
 		}
 
 		/**
+		 * Sets the mapper options for this sink. The mapper options are used to configure the DataStax
+		 * {@link com.datastax.driver.mapping.Mapper} when writing POJOs.
+		 *
+		 * <p>This call has no effect if the input {@link DataStream} for this sink does not contain POJOs.
+		 *
+		 * @param options MapperOptions, that return an array of options that are used to configure the DataStax mapper.
+		 *
+		 * @return this builder
+		 */
+		public CassandraSinkBuilder<IN> setMapperOptions(MapperOptions options) {
+			this.mapperOptions = options;
+			return this;
+		}
+
+		/**
 		 * Finalizes the configuration of this sink.
 		 *
 		 * @return finalized sink
@@ -393,7 +409,7 @@ public class CassandraSink<IN> {
 
 		@Override
 		public CassandraSink<IN> createSink() throws Exception {
-			return new CassandraSink<>(input.addSink(new CassandraPojoSink<>(typeInfo.getTypeClass(), builder)).name("Cassandra Sink"));
+			return new CassandraSink<>(input.addSink(new CassandraPojoSink<>(typeInfo.getTypeClass(), builder, mapperOptions)).name("Cassandra Sink"));
 		}
 
 		@Override

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraSink.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraSink.java
@@ -310,7 +310,7 @@ public class CassandraSink<IN> {
 		 * Enables the write-ahead log, which allows exactly-once processing for non-deterministic algorithms that use
 		 * idempotent updates.
 		 *
-		 * @param committer CheckpointCommitter, that stores informationa bout completed checkpoints in an external
+		 * @param committer CheckpointCommitter, that stores information about completed checkpoints in an external
 		 *                  resource. By default this information is stored within a separate table within Cassandra.
 		 * @return this builder
 		 */

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/MapperOptions.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/MapperOptions.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.cassandra;
+
+import com.datastax.driver.mapping.Mapper;
+
+import java.io.Serializable;
+
+/**
+ * This class is used to configure a {@link com.datastax.driver.mapping.Mapper} after deployment.
+ */
+public interface MapperOptions extends Serializable {
+
+	/**
+	 * Returns an array of {@link com.datastax.driver.mapping.Mapper.Option} that are used configure the mapper.
+	 *
+	 * @return array of options used to configure the mapper.
+	 */
+	Mapper.Option[] getMapperOptions();
+}

--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/example/CassandraPojoSinkExample.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/example/CassandraPojoSinkExample.java
@@ -21,7 +21,6 @@ import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.connectors.cassandra.CassandraSink;
 import org.apache.flink.streaming.connectors.cassandra.ClusterBuilder;
-import org.apache.flink.streaming.connectors.cassandra.MapperOptions;
 
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.Cluster.Builder;

--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/example/CassandraPojoSinkExample.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/example/CassandraPojoSinkExample.java
@@ -21,9 +21,11 @@ import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.connectors.cassandra.CassandraSink;
 import org.apache.flink.streaming.connectors.cassandra.ClusterBuilder;
+import org.apache.flink.streaming.connectors.cassandra.MapperOptions;
 
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.Cluster.Builder;
+import com.datastax.driver.mapping.Mapper;
 
 import java.util.ArrayList;
 
@@ -57,6 +59,7 @@ public class CassandraPojoSinkExample {
 					return builder.addContactPoint("127.0.0.1").build();
 				}
 			})
+			.setMapperOptions(() -> new Mapper.Option[]{Mapper.Option.saveNullFields(true)})
 			.build();
 
 		env.execute("Cassandra Sink example");


### PR DESCRIPTION
## What is the purpose of the change

This PR allows setting MapperOptions for the cassandra POJO sink.

## Brief change log

- modify POJO sink to accept a MapperOptions object (which lazily builds an Mapper.Option array)
- modify CassandraSinkBuilder to support setting the MapperOptions
- adjust example
- adjust documentation

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)

