### PR TITLE
[hotfix] [docs] Enable creating an empty SNAPSHOT project easily

### DIFF
--- a/docs/quickstart/java_api_quickstart.md
+++ b/docs/quickstart/java_api_quickstart.md
@@ -43,10 +43,11 @@ Use one of the following commands to __create a project__:
 </ul>
 <div class="tab-content">
     <div class="tab-pane active" id="maven-archetype">
-    {% highlight bash %}
-    $ mvn archetype:generate                               \
-      -DarchetypeGroupId=org.apache.flink              \
-      -DarchetypeArtifactId=flink-quickstart-java      \{% unless site.is_stable %}
+    {% highlight bash %}{% if site.is_stable %}
+    $ mvn archetype:generate \{% else %}
+    $ mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate \{% endif %}
+      -DarchetypeGroupId=org.apache.flink \
+      -DarchetypeArtifactId=flink-quickstart-java \{% unless site.is_stable %}
       -DarchetypeCatalog=https://repository.apache.org/content/repositories/snapshots/ \{% endunless %}
       -DarchetypeVersion={{site.version}}
     {% endhighlight %}

--- a/docs/quickstart/scala_api_quickstart.md
+++ b/docs/quickstart/scala_api_quickstart.md
@@ -128,8 +128,9 @@ Use one of the following commands to __create a project__:
 
 <div class="tab-content">
     <div class="tab-pane active" id="maven-archetype">
-    {% highlight bash %}
-    $ mvn archetype:generate                               \
+    {% highlight bash %}{% if site.is_stable %}
+    $ mvn archetype:generate \{% else %}
+    $ mvn org.apache.maven.plugins:maven-archetype-plugin:2.4:generate \{% endif %}
       -DarchetypeGroupId=org.apache.flink              \
       -DarchetypeArtifactId=flink-quickstart-scala     \{% unless site.is_stable %}
       -DarchetypeCatalog=https://repository.apache.org/content/repositories/snapshots/ \{% endunless %}


### PR DESCRIPTION
Improves the documentation for allowing to create an empty SNAPSHOT project in one command. This does not affect stable releases, if we are fine with using this command. I will also adapt the `quickstart-SNAPSHOT.sh` script.

