### PR TITLE
[FLINK-7847][avro] Fix typo in jackson shading pattern

### DIFF
--- a/flink-connectors/flink-avro/pom.xml
+++ b/flink-connectors/flink-avro/pom.xml
@@ -196,7 +196,7 @@ under the License.
 							<relocations>
 								<relocation>
 									<pattern>org.codehaus.jackson</pattern>
-									<shadedPattern>org.apache.flink.avro.shaded.org.codehouse.jackson</shadedPattern>
+									<shadedPattern>org.apache.flink.avro.shaded.org.codehaus.jackson</shadedPattern>
 								</relocation>
 							</relocations>
 						</configuration>


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes a funny typo in the jackson shading pattern of flink-avro.

