### PR TITLE
[FLINK-6173] [table] Clean-up flink-table jar and dependencies

### DIFF
--- a/flink-examples/flink-examples-table/pom.xml
+++ b/flink-examples/flink-examples-table/pom.xml
@@ -39,14 +39,12 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-table_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
-			<scope>compile</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-streaming-scala_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
-			<scope>compile</scope>
 		</dependency>
 	</dependencies>
 
@@ -93,19 +91,13 @@ under the License.
 								<filter>
 									<artifact>*:*</artifact>
 									<includes>
+										<include>org/apache/calcite/**</include>
+										<include>org/apache/flink/calcite/shaded/**</include>
+										<include>org/apache/flink/table/**</include>
 										<include>org.codehaus.commons.compiler.properties</include>
 										<include>org/codehaus/janino/**</include>
 										<include>org/codehaus/commons/**</include>
-										<include>org/apache/calcite/**</include>
-										<include>org/apache/flink/table/**</include>
-										<include>org/apache/flink/shaded/calcite/com/google/common/**</include>
-										<include>org/apache/flink/shaded/calcite/org/eigenbase/util/property/**</include>
 									</includes>
-									<excludes>
-										<exclude>META-INF/*.SF</exclude>
-										<exclude>META-INF/*.DSA</exclude>
-										<exclude>META-INF/*.RSA</exclude>
-									</excludes>
 								</filter>
 							</filters>
 						</configuration>

--- a/flink-libraries/flink-table/pom.xml
+++ b/flink-libraries/flink-table/pom.xml
@@ -96,29 +96,25 @@ under the License.
 					<groupId>commons-dbcp</groupId>
 					<artifactId>commons-dbcp</artifactId>
 				</exclusion>
-				<exclusion>
-					<groupId>org.pentaho</groupId>
-					<artifactId>pentaho-aggdesigner-algorithm</artifactId>
-				</exclusion>
 			</exclusions>
 		</dependency>
 
-        <dependency>
-            <groupId>org.reflections</groupId>
-            <artifactId>reflections</artifactId>
-            <version>0.9.10</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.google.code.findbugs</groupId>
-                    <artifactId>annotations</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.google.guava</groupId>
-                    <artifactId>guava</artifactId>
-                </exclusion>
-            </exclusions>
-            <scope>compile</scope>
-        </dependency>
+		<dependency>
+			<groupId>org.reflections</groupId>
+			<artifactId>reflections</artifactId>
+			<version>0.9.10</version>
+			<exclusions>
+				<exclusion>
+					<groupId>com.google.code.findbugs</groupId>
+					<artifactId>annotations</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.google.guava</groupId>
+					<artifactId>guava</artifactId>
+				</exclusion>
+			</exclusions>
+			<scope>compile</scope>
+		</dependency>
 
 		<dependency>
 			<groupId>joda-time</groupId>
@@ -213,36 +209,49 @@ under the License.
 								<filter>
 									<artifact>*:*</artifact>
 									<excludes>
+										<!-- excluded all these files for a clean flink-table jar -->
 										<exclude>org-apache-calcite-jdbc.properties</exclude>
+										<exclude>common.proto</exclude>
+										<exclude>requests.proto</exclude>
+										<exclude>responses.proto</exclude>
 										<exclude>mozilla/**</exclude>
 										<exclude>codegen/**</exclude>
 										<exclude>google/**</exclude>
 										<exclude>META-INF/*.SF</exclude>
 										<exclude>META-INF/*.DSA</exclude>
 										<exclude>META-INF/*.RSA</exclude>
+										<exclude>META-INF/services/**</exclude>
+										<exclude>properties.dtd</exclude>
+										<exclude>PropertyList-1.0.dtd</exclude>
+										<exclude>digesterRules.xml</exclude>
+										<!-- not excluded for now -->
+										<!-- <exclude>org.codehaus.commons.compiler.properties</exclude> -->
 									</excludes>
 								</filter>
 							</filters>
 							<artifactSet>
 								<includes combine.children="append">
+									<!-- Calcite and its dependencies -->
 									<include>org.apache.calcite:*</include>
 									<include>org.apache.calcite.avatica:*</include>
-									<include>net.hydromatic:*</include>
-									<include>org.reflections:*</include>
-									<include>org.codehaus.janino:*</include>
 									<include>com.google.guava:guava</include>
-                                </includes>
+									<include>org.eigenbase:*</include>
+									<include>net.hydromatic:*</include>
+
+									<!-- flink-table dependencies -->
+									<include>commons-configuration:*</include>
+									<include>commons-lang:*</include>
+									<include>commons-codec:*</include>
+									<include>org.codehaus.janino:*</include>
+									<include>org.reflections:*</include>
+									<include>joda-time:*</include>
+								</includes>
 							</artifactSet>
 							<relocations>
-								<!-- We currently don't relocate slf4j as we have "logger not found" 
-									warnings otherwise during runtime -->
-								<!--<relocation>
-									<pattern>org.slf4j</pattern>
-									<shadedPattern>org.apache.flink.shaded.calcite.org.slf4j</shadedPattern>
-								</relocation>-->
+								<!-- Calcite and its dependencies -->
 								<relocation>
-									<pattern>com.fasterxml.jackson</pattern>
-									<shadedPattern>org.apache.flink.shaded.calcite.com.fasterxml.jackson</shadedPattern>
+									<pattern>org.apache.calcite</pattern>
+									<shadedPattern>org.apache.flink.shaded.calcite.org.apache.calcite</shadedPattern>
 								</relocation>
 								<relocation>
 									<pattern>com.google</pattern>
@@ -252,6 +261,29 @@ under the License.
 									<pattern>org.eigenbase</pattern>
 									<shadedPattern>org.apache.flink.shaded.calcite.org.eigenbase</shadedPattern>
 								</relocation>
+								<relocation>
+									<pattern>org.pentaho</pattern>
+									<shadedPattern>org.apache.flink.shaded.calcite.org.pentaho</shadedPattern>
+								</relocation>
+
+								<!-- flink-table dependencies -->
+								<relocation>
+									<pattern>org.apache.commons</pattern>
+									<shadedPattern>org.apache.flink.shaded.org.apache.commons</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.reflections</pattern>
+									<shadedPattern>org.apache.flink.shaded.org.reflections</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.joda.time</pattern>
+									<shadedPattern>org.apache.flink.shaded.org.joda.time</shadedPattern>
+								</relocation>
+								<!-- not relocated for now -->
+								<!--<relocation>
+									<pattern>org.codehaus</pattern>
+									<shadedPattern>org.apache.flink.shaded.org.codehaus</shadedPattern>
+								</relocation>-->
 							</relocations>
 						</configuration>
 					</execution>

--- a/flink-libraries/flink-table/pom.xml
+++ b/flink-libraries/flink-table/pom.xml
@@ -224,16 +224,18 @@ under the License.
 										<exclude>properties.dtd</exclude>
 										<exclude>PropertyList-1.0.dtd</exclude>
 										<exclude>digesterRules.xml</exclude>
-										<!-- not excluded for now -->
-										<!-- <exclude>org.codehaus.commons.compiler.properties</exclude> -->
+										<!-- not relocated for now, because it is needed by Calcite -->
+										<!--<exclude>org.codehaus.commons.compiler.properties</exclude>-->
 									</excludes>
 								</filter>
 							</filters>
 							<artifactSet>
 								<includes combine.children="append">
-									<!-- Calcite and its dependencies -->
-									<include>org.apache.calcite:*</include>
-									<include>org.apache.calcite.avatica:*</include>
+									<!-- Calcite is not relocated for now, because we expose it at some locations such as CalciteConfig -->
+									<!--<include>org.apache.calcite:*</include>
+									<include>org.apache.calcite.avatica:*</include>-->
+
+									<!-- Calcite's dependencies -->
 									<include>com.google.guava:guava</include>
 									<include>org.eigenbase:*</include>
 									<include>net.hydromatic:*</include>
@@ -248,11 +250,13 @@ under the License.
 								</includes>
 							</artifactSet>
 							<relocations>
-								<!-- Calcite and its dependencies -->
-								<relocation>
+								<!-- Calcite is not relocated for now, because we expose it at some locations such as CalciteConfig -->
+								<!--<relocation>
 									<pattern>org.apache.calcite</pattern>
 									<shadedPattern>org.apache.flink.calcite.shaded.org.apache.calcite</shadedPattern>
-								</relocation>
+								</relocation>-->
+
+								<!-- Calcite's dependencies -->
 								<relocation>
 									<pattern>com.google</pattern>
 									<shadedPattern>org.apache.flink.calcite.shaded.com.google</shadedPattern>
@@ -279,7 +283,7 @@ under the License.
 									<pattern>org.joda.time</pattern>
 									<shadedPattern>org.apache.flink.table.shaded.org.joda.time</shadedPattern>
 								</relocation>
-								<!-- not relocated for now -->
+								<!-- not relocated for now, because we need to change the contents of the properties field otherwise -->
 								<!--<relocation>
 									<pattern>org.codehaus</pattern>
 									<shadedPattern>org.apache.flink.table.shaded.org.codehaus</shadedPattern>

--- a/flink-libraries/flink-table/pom.xml
+++ b/flink-libraries/flink-table/pom.xml
@@ -251,38 +251,38 @@ under the License.
 								<!-- Calcite and its dependencies -->
 								<relocation>
 									<pattern>org.apache.calcite</pattern>
-									<shadedPattern>org.apache.flink.shaded.calcite.org.apache.calcite</shadedPattern>
+									<shadedPattern>org.apache.flink.calcite.shaded.org.apache.calcite</shadedPattern>
 								</relocation>
 								<relocation>
 									<pattern>com.google</pattern>
-									<shadedPattern>org.apache.flink.shaded.calcite.com.google</shadedPattern>
+									<shadedPattern>org.apache.flink.calcite.shaded.com.google</shadedPattern>
 								</relocation>
 								<relocation>
 									<pattern>org.eigenbase</pattern>
-									<shadedPattern>org.apache.flink.shaded.calcite.org.eigenbase</shadedPattern>
+									<shadedPattern>org.apache.flink.calcite.shaded.org.eigenbase</shadedPattern>
 								</relocation>
 								<relocation>
 									<pattern>org.pentaho</pattern>
-									<shadedPattern>org.apache.flink.shaded.calcite.org.pentaho</shadedPattern>
+									<shadedPattern>org.apache.flink.calcite.shaded.org.pentaho</shadedPattern>
 								</relocation>
 
 								<!-- flink-table dependencies -->
 								<relocation>
 									<pattern>org.apache.commons</pattern>
-									<shadedPattern>org.apache.flink.shaded.org.apache.commons</shadedPattern>
+									<shadedPattern>org.apache.flink.table.shaded.org.apache.commons</shadedPattern>
 								</relocation>
 								<relocation>
 									<pattern>org.reflections</pattern>
-									<shadedPattern>org.apache.flink.shaded.org.reflections</shadedPattern>
+									<shadedPattern>org.apache.flink.table.shaded.org.reflections</shadedPattern>
 								</relocation>
 								<relocation>
 									<pattern>org.joda.time</pattern>
-									<shadedPattern>org.apache.flink.shaded.org.joda.time</shadedPattern>
+									<shadedPattern>org.apache.flink.table.shaded.org.joda.time</shadedPattern>
 								</relocation>
 								<!-- not relocated for now -->
 								<!--<relocation>
 									<pattern>org.codehaus</pattern>
-									<shadedPattern>org.apache.flink.shaded.org.codehaus</shadedPattern>
+									<shadedPattern>org.apache.flink.table.shaded.org.codehaus</shadedPattern>
 								</relocation>-->
 							</relocations>
 						</configuration>


### PR DESCRIPTION
## What is the purpose of the change

This PR cleans the `flink-table` dependencies almost entirely. The jar only contains files that are important. It shades everything except for Janino, because this causes problems. I think this PR makes the dependency management for users easier. The resulting jar looks like:

<img width="514" alt="screen shot 2017-10-16 at 3 24 24 pm" src="https://user-images.githubusercontent.com/5746567/31614275-27bd5c74-b286-11e7-9d7b-113f6c4f7585.png">

I ran some smaller test programs and could not spot any problems, feel free to test it as well.

## Brief change log

Modification of the `flink-table` `pom.xml`.

## Verifying this change

Run all tests and run an example program on the cluster.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no)
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

