### PR TITLE
[FLINK-7826][QS] Add support for all types of state to the QS Client.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/state/FoldingStateDescriptor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/FoldingStateDescriptor.java
@@ -30,7 +30,7 @@ import static java.util.Objects.requireNonNull;
  * {@link StateDescriptor} for {@link FoldingState}. This can be used to create partitioned
  * folding state.
  *
- * @param <T> Type of the values folded int othe state
+ * @param <T> Type of the values folded in the other state
  * @param <ACC> Type of the value in the state
  *
  * @deprecated will be removed in a future version in favor of {@link AggregatingStateDescriptor}

--- a/flink-queryable-state/flink-queryable-state-java/src/main/java/org/apache/flink/queryablestate/client/state/ImmutableAggregatingState.java
+++ b/flink-queryable-state/flink-queryable-state-java/src/main/java/org/apache/flink/queryablestate/client/state/ImmutableAggregatingState.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.queryablestate.client.state;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.state.AggregatingState;
+import org.apache.flink.api.common.state.AggregatingStateDescriptor;
+import org.apache.flink.runtime.query.netty.message.KvStateSerializer;
+import org.apache.flink.util.Preconditions;
+
+import java.io.IOException;
+
+/**
+ * A read-only {@link AggregatingState} that <b>does not</b> allow for modifications.
+ *
+ * <p>This is the type of the result returned when querying Flink's keyed state using the
+ * {@link org.apache.flink.queryablestate.client.QueryableStateClient Queryable State Client} and
+ * providing an {@link AggregatingStateDescriptor}.
+ */
+@PublicEvolving
+public final class ImmutableAggregatingState<IN, OUT> extends ImmutableState implements AggregatingState<IN, OUT> {
+
+	private final OUT value;
+
+	private ImmutableAggregatingState(OUT value) {
+		this.value = Preconditions.checkNotNull(value);
+	}
+
+	@Override
+	public OUT get() {
+		return value;
+	}
+
+	@Override
+	public void add(Object newValue) {
+		throw MODIFICATION_ATTEMPT_ERROR;
+	}
+
+	@Override
+	public void clear() {
+		throw MODIFICATION_ATTEMPT_ERROR;
+	}
+
+	public static <IN, ACC, OUT> ImmutableAggregatingState<IN, OUT> createState(
+			final AggregatingStateDescriptor<IN, ACC, OUT> stateDescriptor,
+			final byte[] serializedValue) throws IOException {
+
+		final ACC accumulator = KvStateSerializer.deserializeValue(
+				serializedValue,
+				stateDescriptor.getSerializer());
+
+		final OUT state = stateDescriptor.getAggregateFunction().getResult(accumulator);
+		return new ImmutableAggregatingState<>(state);
+	}
+}

--- a/flink-queryable-state/flink-queryable-state-java/src/main/java/org/apache/flink/queryablestate/client/state/ImmutableFoldingState.java
+++ b/flink-queryable-state/flink-queryable-state-java/src/main/java/org/apache/flink/queryablestate/client/state/ImmutableFoldingState.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.queryablestate.client.state;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.state.FoldingState;
+import org.apache.flink.api.common.state.FoldingStateDescriptor;
+import org.apache.flink.runtime.query.netty.message.KvStateSerializer;
+import org.apache.flink.util.Preconditions;
+
+import java.io.IOException;
+
+/**
+ * A read-only {@link FoldingState} that does not allow for modifications.
+ *
+ * <p>This is the result returned when querying Flink's keyed state using the
+ * {@link org.apache.flink.queryablestate.client.QueryableStateClient Queryable State Client} and
+ * providing an {@link FoldingStateDescriptor}.
+ */
+@PublicEvolving
+@Deprecated
+public final class ImmutableFoldingState<IN, ACC> extends ImmutableState implements FoldingState<IN, ACC> {
+
+	private final ACC value;
+
+	private ImmutableFoldingState(ACC value) {
+		this.value = Preconditions.checkNotNull(value);
+	}
+
+	@Override
+	public ACC get() {
+		return value;
+	}
+
+	@Override
+	public void add(Object newValue) {
+		throw MODIFICATION_ATTEMPT_ERROR;
+	}
+
+	@Override
+	public void clear() {
+		throw MODIFICATION_ATTEMPT_ERROR;
+	}
+
+	public static <IN, ACC> ImmutableFoldingState<IN, ACC> createState(
+			final FoldingStateDescriptor<IN, ACC> stateDescriptor,
+			final byte[] serializedState) throws IOException {
+
+		final ACC state = KvStateSerializer.deserializeValue(
+				serializedState,
+				stateDescriptor.getSerializer());
+		return new ImmutableFoldingState<>(state);
+	}
+}

--- a/flink-queryable-state/flink-queryable-state-java/src/main/java/org/apache/flink/queryablestate/client/state/ImmutableListState.java
+++ b/flink-queryable-state/flink-queryable-state-java/src/main/java/org/apache/flink/queryablestate/client/state/ImmutableListState.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.queryablestate.client.state;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.runtime.query.netty.message.KvStateSerializer;
+import org.apache.flink.util.Preconditions;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * A read-only {@link ListState} that does not allow for modifications.
+ *
+ * <p>This is the result returned when querying Flink's keyed state using the
+ * {@link org.apache.flink.queryablestate.client.QueryableStateClient Queryable State Client} and
+ * providing an {@link ListStateDescriptor}.
+ */
+@PublicEvolving
+public final class ImmutableListState<V> extends ImmutableState implements ListState<V> {
+
+	private final List<V> listState;
+
+	private ImmutableListState(final List<V> state) {
+		this.listState = Preconditions.checkNotNull(state);
+	}
+
+	@Override
+	public Iterable<V> get() {
+		return listState;
+	}
+
+	@Override
+	public void add(V value) {
+		throw MODIFICATION_ATTEMPT_ERROR;
+	}
+
+	@Override
+	public void clear() {
+		throw MODIFICATION_ATTEMPT_ERROR;
+	}
+
+	public static <V> ImmutableListState<V> createState(
+			final ListStateDescriptor<V> stateDescriptor,
+			final byte[] serializedState) throws IOException {
+
+		final List<V> state = KvStateSerializer.deserializeList(
+				serializedState,
+				stateDescriptor.getElementSerializer());
+		return new ImmutableListState<>(state);
+	}
+}

--- a/flink-queryable-state/flink-queryable-state-java/src/main/java/org/apache/flink/queryablestate/client/state/ImmutableMapState.java
+++ b/flink-queryable-state/flink-queryable-state-java/src/main/java/org/apache/flink/queryablestate/client/state/ImmutableMapState.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.queryablestate.client.state;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.state.MapState;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.runtime.query.netty.message.KvStateSerializer;
+import org.apache.flink.util.Preconditions;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A read-only {@link MapState} that does not allow for modifications.
+ *
+ * <p>This is the result returned when querying Flink's keyed state using the
+ * {@link org.apache.flink.queryablestate.client.QueryableStateClient Queryable State Client} and
+ * providing an {@link MapStateDescriptor}.
+ */
+@PublicEvolving
+public final class ImmutableMapState<K, V> extends ImmutableState implements MapState<K, V> {
+
+	private final Map<K, V> state;
+
+	private ImmutableMapState(final Map<K, V> mapState) {
+		this.state = Preconditions.checkNotNull(mapState);
+	}
+
+	@Override
+	public V get(K key) {
+		return state.get(key);
+	}
+
+	@Override
+	public void put(K key, V value) {
+		throw MODIFICATION_ATTEMPT_ERROR;
+	}
+
+	@Override
+	public void putAll(Map<K, V> map) {
+		throw MODIFICATION_ATTEMPT_ERROR;
+	}
+
+	@Override
+	public void remove(K key) {
+		throw MODIFICATION_ATTEMPT_ERROR;
+	}
+
+	@Override
+	public boolean contains(K key) {
+		return state.containsKey(key);
+	}
+
+	/**
+	 * Returns all the mappings in the state in a {@link Collections#unmodifiableSet(Set)}.
+	 *
+	 * @return A read-only iterable view of all the key-value pairs in the state.
+	 *
+	 * @throws Exception Thrown if the system cannot access the state.
+	 */
+	@Override
+	public Iterable<Map.Entry<K, V>> entries() {
+		return Collections.unmodifiableSet(state.entrySet());
+	}
+
+	/**
+	 * Returns all the keys in the state in a {@link Collections#unmodifiableSet(Set)}.
+	 *
+	 * @return A read-only iterable view of all the keys in the state.
+	 *
+	 * @throws Exception Thrown if the system cannot access the state.
+	 */
+	@Override
+	public Iterable<K> keys() {
+		return Collections.unmodifiableSet(state.keySet());
+	}
+
+	/**
+	 * Returns all the values in the state in a {@link Collections#unmodifiableCollection(Collection)}.
+	 *
+	 * @return A read-only iterable view of all the values in the state.
+	 *
+	 * @throws Exception Thrown if the system cannot access the state.
+	 */
+	@Override
+	public Iterable<V> values() {
+		return Collections.unmodifiableCollection(state.values());
+	}
+
+	/**
+	 * Iterates over all the mappings in the state. The iterator cannot
+	 * remove elements.
+	 *
+	 * @return A read-only iterator over all the mappings in the state
+	 *
+	 * @throws Exception Thrown if the system cannot access the state.
+	 */
+	@Override
+	public Iterator<Map.Entry<K, V>> iterator() {
+		return Collections.unmodifiableSet(state.entrySet()).iterator();
+	}
+
+	@Override
+	public void clear() {
+		throw MODIFICATION_ATTEMPT_ERROR;
+	}
+
+	public static <K, V> ImmutableMapState<K, V> createState(
+			final MapStateDescriptor<K, V> stateDescriptor,
+			final byte[] serializedState) throws IOException {
+
+		final Map<K, V> state = KvStateSerializer.deserializeMap(
+				serializedState,
+				stateDescriptor.getKeySerializer(),
+				stateDescriptor.getValueSerializer());
+		return new ImmutableMapState<>(state);
+	}
+}

--- a/flink-queryable-state/flink-queryable-state-java/src/main/java/org/apache/flink/queryablestate/client/state/ImmutableReducingState.java
+++ b/flink-queryable-state/flink-queryable-state-java/src/main/java/org/apache/flink/queryablestate/client/state/ImmutableReducingState.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.queryablestate.client.state;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.state.ReducingState;
+import org.apache.flink.api.common.state.ReducingStateDescriptor;
+import org.apache.flink.runtime.query.netty.message.KvStateSerializer;
+import org.apache.flink.util.Preconditions;
+
+import java.io.IOException;
+
+/**
+ * A read-only {@link ReducingState} that does not allow for modifications.
+ *
+ * <p>This is the result returned when querying Flink's keyed state using the
+ * {@link org.apache.flink.queryablestate.client.QueryableStateClient Queryable State Client} and
+ * providing an {@link ReducingStateDescriptor}.
+ */
+@PublicEvolving
+public final class ImmutableReducingState<V> extends ImmutableState implements ReducingState<V> {
+
+	private final V value;
+
+	private ImmutableReducingState(V value) {
+		this.value = Preconditions.checkNotNull(value);
+	}
+
+	@Override
+	public V get() {
+		return value;
+	}
+
+	@Override
+	public void add(V newValue) {
+		throw MODIFICATION_ATTEMPT_ERROR;
+	}
+
+	@Override
+	public void clear() {
+		throw MODIFICATION_ATTEMPT_ERROR;
+	}
+
+	public static <V> ImmutableReducingState<V> createState(
+			final ReducingStateDescriptor<V> stateDescriptor,
+			final byte[] serializedState) throws IOException {
+
+		final V state = KvStateSerializer.deserializeValue(
+				serializedState,
+				stateDescriptor.getSerializer());
+		return new ImmutableReducingState<>(state);
+	}
+}

--- a/flink-queryable-state/flink-queryable-state-java/src/main/java/org/apache/flink/queryablestate/client/state/ImmutableState.java
+++ b/flink-queryable-state/flink-queryable-state-java/src/main/java/org/apache/flink/queryablestate/client/state/ImmutableState.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.queryablestate.client.state;
+
+/**
+ * A base class for the <b>read-only</b> types of state returned
+ * as results from the Queryable State Client.
+ */
+abstract class ImmutableState {
+
+	protected static final UnsupportedOperationException MODIFICATION_ATTEMPT_ERROR =
+			new UnsupportedOperationException("State is read-only. No modifications allowed.");
+}

--- a/flink-queryable-state/flink-queryable-state-java/src/main/java/org/apache/flink/queryablestate/client/state/ImmutableStateBinder.java
+++ b/flink-queryable-state/flink-queryable-state-java/src/main/java/org/apache/flink/queryablestate/client/state/ImmutableStateBinder.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.queryablestate.client.state;
+
+import org.apache.flink.api.common.state.AggregatingState;
+import org.apache.flink.api.common.state.AggregatingStateDescriptor;
+import org.apache.flink.api.common.state.FoldingState;
+import org.apache.flink.api.common.state.FoldingStateDescriptor;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.state.MapState;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.state.ReducingState;
+import org.apache.flink.api.common.state.ReducingStateDescriptor;
+import org.apache.flink.api.common.state.StateBinder;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.util.Preconditions;
+
+/**
+ * A {@link StateBinder} used to deserialize the results returned by the
+ * {@link org.apache.flink.queryablestate.client.QueryableStateClient}.
+ *
+ * <p>The result is an immutable {@link org.apache.flink.api.common.state.State State}
+ * object containing the requested result.
+ */
+public class ImmutableStateBinder implements StateBinder {
+
+	private final byte[] serializedState;
+
+	public ImmutableStateBinder(final byte[] content) {
+		serializedState = Preconditions.checkNotNull(content);
+	}
+
+	@Override
+	public <T> ValueState<T> createValueState(ValueStateDescriptor<T> stateDesc) throws Exception {
+		return ImmutableValueState.createState(stateDesc, serializedState);
+	}
+
+	@Override
+	public <T> ListState<T> createListState(ListStateDescriptor<T> stateDesc) throws Exception {
+		return ImmutableListState.createState(stateDesc, serializedState);
+	}
+
+	@Override
+	public <T> ReducingState<T> createReducingState(ReducingStateDescriptor<T> stateDesc) throws Exception {
+		return ImmutableReducingState.createState(stateDesc, serializedState);
+	}
+
+	@Override
+	public <IN, ACC, OUT> AggregatingState<IN, OUT> createAggregatingState(AggregatingStateDescriptor<IN, ACC, OUT> stateDesc) throws Exception {
+		return ImmutableAggregatingState.createState(stateDesc, serializedState);
+	}
+
+	@Override
+	public <T, ACC> FoldingState<T, ACC> createFoldingState(FoldingStateDescriptor<T, ACC> stateDesc) throws Exception {
+		return ImmutableFoldingState.createState(stateDesc, serializedState);
+	}
+
+	@Override
+	public <MK, MV> MapState<MK, MV> createMapState(MapStateDescriptor<MK, MV> stateDesc) throws Exception {
+		return ImmutableMapState.createState(stateDesc, serializedState);
+	}
+}

--- a/flink-queryable-state/flink-queryable-state-java/src/main/java/org/apache/flink/queryablestate/client/state/ImmutableValueState.java
+++ b/flink-queryable-state/flink-queryable-state-java/src/main/java/org/apache/flink/queryablestate/client/state/ImmutableValueState.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.queryablestate.client.state;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.runtime.query.netty.message.KvStateSerializer;
+import org.apache.flink.util.Preconditions;
+
+import java.io.IOException;
+
+/**
+ * A read-only {@link ValueState} that does not allow for modifications.
+ *
+ * <p>This is the result returned when querying Flink's keyed state using the
+ * {@link org.apache.flink.queryablestate.client.QueryableStateClient Queryable State Client} and
+ * providing an {@link ValueStateDescriptor}.
+ */
+@PublicEvolving
+public final class ImmutableValueState<V> extends ImmutableState implements ValueState<V> {
+
+	private final V value;
+
+	private ImmutableValueState(V value) {
+		this.value = Preconditions.checkNotNull(value);
+	}
+
+	@Override
+	public V value() {
+		return value;
+	}
+
+	@Override
+	public void update(V newValue) {
+		throw MODIFICATION_ATTEMPT_ERROR;
+	}
+
+	@Override
+	public void clear() {
+		throw MODIFICATION_ATTEMPT_ERROR;
+	}
+
+	public static <V> ImmutableValueState<V> createState(
+			final ValueStateDescriptor<V> stateDescriptor,
+			final byte[] serializedState) throws IOException {
+
+		final V state = KvStateSerializer.deserializeValue(
+				serializedState,
+				stateDescriptor.getSerializer());
+		return new ImmutableValueState<>(state);
+	}
+}

--- a/flink-queryable-state/flink-queryable-state-java/src/main/java/org/apache/flink/queryablestate/network/AbstractServerHandler.java
+++ b/flink-queryable-state/flink-queryable-state-java/src/main/java/org/apache/flink/queryablestate/network/AbstractServerHandler.java
@@ -121,7 +121,7 @@ public abstract class AbstractServerHandler<REQ extends MessageBody, RESP extend
 				// Execute actual query async, because it is possibly
 				// blocking (e.g. file I/O).
 				//
-				// A submission failure is not treated as fatal. todo here if there is a shared resource e.g. registry, then I will have to sync on that.
+				// A submission failure is not treated as fatal.
 				queryExecutor.submit(new AsyncRequestTask<>(this, ctx, requestId, request, stats));
 
 			} else {

--- a/flink-queryable-state/flink-queryable-state-java/src/test/java/org/apache/flink/queryablestate/state/ImmutableAggregatingStateTest.java
+++ b/flink-queryable-state/flink-queryable-state-java/src/test/java/org/apache/flink/queryablestate/state/ImmutableAggregatingStateTest.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.queryablestate.state;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.functions.AggregateFunction;
+import org.apache.flink.api.common.state.AggregatingStateDescriptor;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.queryablestate.client.state.ImmutableAggregatingState;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests the {@link ImmutableAggregatingStateTest}.
+ */
+public class ImmutableAggregatingStateTest {
+
+	private final AggregatingStateDescriptor<Long, MutableString, String> aggrStateDesc =
+			new AggregatingStateDescriptor<>(
+					"test",
+					new SumAggr(),
+					MutableString.class);
+
+	private ImmutableAggregatingState<Long, String> aggrState;
+
+	@Before
+	public void setUp() throws Exception {
+		if (!aggrStateDesc.isSerializerInitialized()) {
+			aggrStateDesc.initializeSerializerUnlessSet(new ExecutionConfig());
+		}
+
+		final MutableString initValue = new MutableString();
+		initValue.value = "42";
+
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		aggrStateDesc.getSerializer().serialize(initValue, new DataOutputViewStreamWrapper(out));
+
+		aggrState = ImmutableAggregatingState.createState(
+				aggrStateDesc,
+				out.toByteArray()
+		);
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void testUpdate() {
+		String value = aggrState.get();
+		assertEquals("42", value);
+
+		aggrState.add(54L);
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void testClear() {
+		String value = aggrState.get();
+		assertEquals("42", value);
+
+		aggrState.clear();
+	}
+
+	/**
+	 * Test {@link AggregateFunction} concatenating the already stored string with the long passed as argument.
+	 */
+	private static class SumAggr implements AggregateFunction<Long, MutableString, String> {
+
+		private static final long serialVersionUID = -6249227626701264599L;
+
+		@Override
+		public MutableString createAccumulator() {
+			return new MutableString();
+		}
+
+		@Override
+		public void add(Long value, MutableString accumulator) {
+			accumulator.value += ", " + value;
+		}
+
+		@Override
+		public String getResult(MutableString accumulator) {
+			return accumulator.value;
+		}
+
+		@Override
+		public MutableString merge(MutableString a, MutableString b) {
+			MutableString nValue = new MutableString();
+			nValue.value = a.value + ", " + b.value;
+			return nValue;
+		}
+	}
+
+	private static final class MutableString {
+		String value;
+	}
+}

--- a/flink-queryable-state/flink-queryable-state-java/src/test/java/org/apache/flink/queryablestate/state/ImmutableFoldingStateTest.java
+++ b/flink-queryable-state/flink-queryable-state-java/src/test/java/org/apache/flink/queryablestate/state/ImmutableFoldingStateTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.queryablestate.state;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.functions.FoldFunction;
+import org.apache.flink.api.common.state.FoldingStateDescriptor;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.queryablestate.client.state.ImmutableFoldingState;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests the {@link ImmutableFoldingState}.
+ */
+public class ImmutableFoldingStateTest {
+
+	private final FoldingStateDescriptor<Long, String> foldingStateDesc =
+			new FoldingStateDescriptor<>(
+					"test",
+					"0",
+					new SumFold(),
+					StringSerializer.INSTANCE);
+
+	private ImmutableFoldingState<Long, String> foldingState;
+
+	@Before
+	public void setUp() throws Exception {
+		if (!foldingStateDesc.isSerializerInitialized()) {
+			foldingStateDesc.initializeSerializerUnlessSet(new ExecutionConfig());
+		}
+
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		StringSerializer.INSTANCE.serialize("42", new DataOutputViewStreamWrapper(out));
+
+		foldingState = ImmutableFoldingState.createState(
+				foldingStateDesc,
+				out.toByteArray()
+		);
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void testUpdate() {
+		String value = foldingState.get();
+		assertEquals("42", value);
+
+		foldingState.add(54L);
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void testClear() {
+		String value = foldingState.get();
+		assertEquals("42", value);
+
+		foldingState.clear();
+	}
+
+	/**
+	 * Test {@link FoldFunction} concatenating the already stored string with the long passed as argument.
+	 */
+	private static class SumFold implements FoldFunction<Long, String> {
+
+		private static final long serialVersionUID = -6249227626701264599L;
+
+		@Override
+		public String fold(String accumulator, Long value) throws Exception {
+			long acc = Long.valueOf(accumulator);
+			acc += value;
+			return Long.toString(acc);
+		}
+	}
+}

--- a/flink-queryable-state/flink-queryable-state-java/src/test/java/org/apache/flink/queryablestate/state/ImmutableListStateTest.java
+++ b/flink-queryable-state/flink-queryable-state-java/src/test/java/org/apache/flink/queryablestate/state/ImmutableListStateTest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.queryablestate.state;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.queryablestate.client.state.ImmutableListState;
+import org.apache.flink.runtime.state.heap.HeapListState;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests the {@link ImmutableListState}.
+ */
+public class ImmutableListStateTest {
+
+	private final ListStateDescriptor<Long> listStateDesc =
+			new ListStateDescriptor<>("test", BasicTypeInfo.LONG_TYPE_INFO);
+
+	private ImmutableListState<Long> listState;
+
+	@Before
+	public void setUp() throws Exception {
+		if (!listStateDesc.isSerializerInitialized()) {
+			listStateDesc.initializeSerializerUnlessSet(new ExecutionConfig());
+		}
+
+		List<Long> init = new ArrayList<>();
+		init.add(42L);
+
+		byte[] serInit = serializeInitValue(init);
+		listState = ImmutableListState.createState(listStateDesc, serInit);
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void testUpdate() {
+		List<Long> list = getStateContents();
+		assertEquals(1L, list.size());
+
+		long element = list.get(0);
+		assertEquals(42L, element);
+
+		listState.add(54L);
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void testClear() {
+		List<Long> list = getStateContents();
+		assertEquals(1L, list.size());
+
+		long element = list.get(0);
+		assertEquals(42L, element);
+
+		listState.clear();
+	}
+
+	/**
+	 * Copied from {@link HeapListState#getSerializedValue(Object, Object)}.
+	 */
+	private byte[] serializeInitValue(List<Long> toSerialize) throws IOException {
+		TypeSerializer<Long> serializer = listStateDesc.getElementSerializer();
+
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		DataOutputViewStreamWrapper view = new DataOutputViewStreamWrapper(baos);
+
+		// write the same as RocksDB writes lists, with one ',' separator
+		for (int i = 0; i < toSerialize.size(); i++) {
+			serializer.serialize(toSerialize.get(i), view);
+			if (i < toSerialize.size() - 1) {
+				view.writeByte(',');
+			}
+		}
+		view.flush();
+
+		return baos.toByteArray();
+	}
+
+	private List<Long> getStateContents() {
+		List<Long> list = new ArrayList<>();
+		for (Long elem: listState.get()) {
+			list.add(elem);
+		}
+		return list;
+	}
+}

--- a/flink-queryable-state/flink-queryable-state-java/src/test/java/org/apache/flink/queryablestate/state/ImmutableMapStateTest.java
+++ b/flink-queryable-state/flink-queryable-state-java/src/test/java/org/apache/flink/queryablestate/state/ImmutableMapStateTest.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.queryablestate.state;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.queryablestate.client.state.ImmutableMapState;
+import org.apache.flink.runtime.query.netty.message.KvStateSerializer;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests the {@link ImmutableMapState}.
+ */
+public class ImmutableMapStateTest {
+
+	private final MapStateDescriptor<Long, Long> mapStateDesc =
+			new MapStateDescriptor<>(
+					"test",
+					BasicTypeInfo.LONG_TYPE_INFO,
+					BasicTypeInfo.LONG_TYPE_INFO);
+
+	private ImmutableMapState<Long, Long> mapState;
+
+	@Before
+	public void setUp() throws Exception {
+		if (!mapStateDesc.isSerializerInitialized()) {
+			mapStateDesc.initializeSerializerUnlessSet(new ExecutionConfig());
+		}
+
+		Map<Long, Long> initMap = new HashMap<>();
+		initMap.put(1L, 5L);
+		initMap.put(2L, 5L);
+
+		byte[] initSer = KvStateSerializer.serializeMap(
+				initMap.entrySet(),
+				BasicTypeInfo.LONG_TYPE_INFO.createSerializer(new ExecutionConfig()),
+				BasicTypeInfo.LONG_TYPE_INFO.createSerializer(new ExecutionConfig()));
+
+		mapState = ImmutableMapState.createState(mapStateDesc, initSer);
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void testPut() {
+		assertTrue(mapState.contains(1L));
+		long value = mapState.get(1L);
+		assertEquals(5L, value);
+
+		assertTrue(mapState.contains(2L));
+		value = mapState.get(2L);
+		assertEquals(5L, value);
+
+		mapState.put(2L, 54L);
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void testPutAll() {
+		assertTrue(mapState.contains(1L));
+		long value = mapState.get(1L);
+		assertEquals(5L, value);
+
+		assertTrue(mapState.contains(2L));
+		value = mapState.get(2L);
+		assertEquals(5L, value);
+
+		Map<Long, Long> nMap = new HashMap<>();
+		nMap.put(1L, 7L);
+		nMap.put(2L, 7L);
+
+		mapState.putAll(nMap);
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void testUpdate() {
+		assertTrue(mapState.contains(1L));
+		long value = mapState.get(1L);
+		assertEquals(5L, value);
+
+		assertTrue(mapState.contains(2L));
+		value = mapState.get(2L);
+		assertEquals(5L, value);
+
+		mapState.put(2L, 54L);
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void testIterator() {
+		assertTrue(mapState.contains(1L));
+		long value = mapState.get(1L);
+		assertEquals(5L, value);
+
+		assertTrue(mapState.contains(2L));
+		value = mapState.get(2L);
+		assertEquals(5L, value);
+
+		Iterator<Map.Entry<Long, Long>> iterator = mapState.iterator();
+		while (iterator.hasNext()) {
+			iterator.remove();
+		}
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void testIterable() {
+		assertTrue(mapState.contains(1L));
+		long value = mapState.get(1L);
+		assertEquals(5L, value);
+
+		assertTrue(mapState.contains(2L));
+		value = mapState.get(2L);
+		assertEquals(5L, value);
+
+		Iterable<Map.Entry<Long, Long>> iterable = mapState.entries();
+		Iterator<Map.Entry<Long, Long>> iterator = iterable.iterator();
+		while (iterator.hasNext()) {
+			assertEquals(5L, (long) iterator.next().getValue());
+			iterator.remove();
+		}
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void testKeys() {
+		assertTrue(mapState.contains(1L));
+		long value = mapState.get(1L);
+		assertEquals(5L, value);
+
+		assertTrue(mapState.contains(2L));
+		value = mapState.get(2L);
+		assertEquals(5L, value);
+
+		Iterator<Long> iterator = mapState.keys().iterator();
+		while (iterator.hasNext()) {
+			iterator.remove();
+		}
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void testValues() {
+		assertTrue(mapState.contains(1L));
+		long value = mapState.get(1L);
+		assertEquals(5L, value);
+
+		assertTrue(mapState.contains(2L));
+		value = mapState.get(2L);
+		assertEquals(5L, value);
+
+		Iterator<Long> iterator = mapState.values().iterator();
+		while (iterator.hasNext()) {
+			iterator.remove();
+		}
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void testClear() {
+		assertTrue(mapState.contains(1L));
+		long value = mapState.get(1L);
+		assertEquals(5L, value);
+
+		assertTrue(mapState.contains(2L));
+		value = mapState.get(2L);
+		assertEquals(5L, value);
+
+		mapState.clear();
+	}
+}

--- a/flink-queryable-state/flink-queryable-state-java/src/test/java/org/apache/flink/queryablestate/state/ImmutableReducingStateTest.java
+++ b/flink-queryable-state/flink-queryable-state-java/src/test/java/org/apache/flink/queryablestate/state/ImmutableReducingStateTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.queryablestate.state;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.state.ReducingStateDescriptor;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.queryablestate.client.state.ImmutableReducingState;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests the {@link ImmutableReducingState}.
+ */
+public class ImmutableReducingStateTest {
+
+	private final ReducingStateDescriptor<Long> reducingStateDesc =
+			new ReducingStateDescriptor<>("test", new SumReduce(), BasicTypeInfo.LONG_TYPE_INFO);
+
+	private ImmutableReducingState<Long> reduceState;
+
+	@Before
+	public void setUp() throws Exception {
+		if (!reducingStateDesc.isSerializerInitialized()) {
+			reducingStateDesc.initializeSerializerUnlessSet(new ExecutionConfig());
+		}
+
+		reduceState = ImmutableReducingState.createState(
+				reducingStateDesc,
+				ByteBuffer.allocate(Long.BYTES).putLong(42L).array()
+		);
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void testUpdate() {
+		long value = reduceState.get();
+		assertEquals(42L, value);
+
+		reduceState.add(54L);
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void testClear() {
+		long value = reduceState.get();
+		assertEquals(42L, value);
+
+		reduceState.clear();
+	}
+
+	/**
+	 * Test {@link ReduceFunction} summing up its two arguments.
+	 */
+	private static class SumReduce implements ReduceFunction<Long> {
+
+		private static final long serialVersionUID = 6041237513913189144L;
+
+		@Override
+		public Long reduce(Long value1, Long value2) throws Exception {
+			return value1 + value2;
+		}
+	}
+}

--- a/flink-queryable-state/flink-queryable-state-java/src/test/java/org/apache/flink/queryablestate/state/ImmutableValueStateTest.java
+++ b/flink-queryable-state/flink-queryable-state-java/src/test/java/org/apache/flink/queryablestate/state/ImmutableValueStateTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.queryablestate.state;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.queryablestate.client.state.ImmutableValueState;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests the {@link ImmutableValueState}.
+ */
+public class ImmutableValueStateTest {
+
+	private final ValueStateDescriptor<Long> valueStateDesc =
+			new ValueStateDescriptor<>("test", BasicTypeInfo.LONG_TYPE_INFO);
+
+	private ImmutableValueState<Long> valueState;
+
+	@Before
+	public void setUp() throws Exception {
+		if (!valueStateDesc.isSerializerInitialized()) {
+			valueStateDesc.initializeSerializerUnlessSet(new ExecutionConfig());
+		}
+
+		valueState = ImmutableValueState.createState(
+				valueStateDesc,
+				ByteBuffer.allocate(Long.BYTES).putLong(42L).array()
+		);
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void testUpdate() {
+		long value = valueState.value();
+		assertEquals(42L, value);
+
+		valueState.update(54L);
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void testClear() {
+		long value = valueState.value();
+		assertEquals(42L, value);
+
+		valueState.clear();
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/KeyedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/KeyedStream.java
@@ -745,7 +745,7 @@ public class KeyedStream<T, KEY> extends DataStream<T> {
 
 		return new QueryableStateStream<>(
 				queryableStateName,
-				stateDescriptor.getSerializer(),
+				stateDescriptor,
 				getKeyType().createSerializer(getExecutionConfig()));
 	}
 
@@ -772,7 +772,7 @@ public class KeyedStream<T, KEY> extends DataStream<T> {
 
 		return new QueryableStateStream<>(
 				queryableStateName,
-				stateDescriptor.getSerializer(),
+				stateDescriptor,
 				getKeyType().createSerializer(getExecutionConfig()));
 	}
 
@@ -796,7 +796,7 @@ public class KeyedStream<T, KEY> extends DataStream<T> {
 
 		return new QueryableStateStream<>(
 				queryableStateName,
-				stateDescriptor.getSerializer(),
+				stateDescriptor,
 				getKeyType().createSerializer(getExecutionConfig()));
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/QueryableStateStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/QueryableStateStream.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.api.datastream;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.util.Preconditions;
 
@@ -37,23 +38,23 @@ public class QueryableStateStream<K, V> {
 	/** Key serializer for the state instance. */
 	private final TypeSerializer<K> keySerializer;
 
-	/** Value serializer for the state instance. */
-	private final TypeSerializer<V> valueSerializer;
+	/** State descriptor for the state instance. */
+	private final StateDescriptor<?, V> stateDescriptor;
 
 	/**
 	 * Creates a queryable state stream.
 	 *
 	 * @param queryableStateName Name under which to publish the queryable state instance
-	 * @param valueSerializer Value serializer for the state instance
+	 * @param stateDescriptor The state descriptor for the state instance
 	 * @param keySerializer Key serializer for the state instance
 	 */
 	public QueryableStateStream(
 			String queryableStateName,
-			TypeSerializer<V> valueSerializer,
+			StateDescriptor<?, V> stateDescriptor,
 			TypeSerializer<K> keySerializer) {
 
 		this.queryableStateName = Preconditions.checkNotNull(queryableStateName, "Queryable state name");
-		this.valueSerializer = Preconditions.checkNotNull(valueSerializer, "Value serializer");
+		this.stateDescriptor = Preconditions.checkNotNull(stateDescriptor, "State Descriptor");
 		this.keySerializer = Preconditions.checkNotNull(keySerializer, "Key serializer");
 	}
 
@@ -67,15 +68,6 @@ public class QueryableStateStream<K, V> {
 	}
 
 	/**
-	 * Returns the value serializer for the queryable state instance.
-	 *
-	 * @return Value serializer for the state instance
-	 */
-	public TypeSerializer<V> getValueSerializer() {
-		return valueSerializer;
-	}
-
-	/**
 	 * Returns the key serializer for the queryable state instance.
 	 *
 	 * @return Key serializer for the state instance.
@@ -84,4 +76,12 @@ public class QueryableStateStream<K, V> {
 		return keySerializer;
 	}
 
+	/**
+	 * Returns the state descriptor for the queryable state instance.
+	 *
+	 * @return State descriptor for the state instance
+	 */
+	public StateDescriptor<?, V> getStateDescriptor() {
+		return stateDescriptor;
+	}
 }

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/KeyedStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/KeyedStream.scala
@@ -497,7 +497,7 @@ class KeyedStream[T, K](javaStream: KeyedJavaStream[T, K]) extends DataStream[T]
 
     new QueryableStateStream(
       queryableStateName,
-      stateDescriptor.getSerializer,
+      stateDescriptor,
       getKeyType.createSerializer(executionConfig))
   }
 
@@ -522,7 +522,7 @@ class KeyedStream[T, K](javaStream: KeyedJavaStream[T, K]) extends DataStream[T]
 
     new QueryableStateStream(
       queryableStateName,
-      stateDescriptor.getSerializer,
+      stateDescriptor,
       getKeyType.createSerializer(executionConfig))
   }
 
@@ -546,7 +546,7 @@ class KeyedStream[T, K](javaStream: KeyedJavaStream[T, K]) extends DataStream[T]
 
     new QueryableStateStream(
       queryableStateName,
-      stateDescriptor.getSerializer,
+      stateDescriptor,
       getKeyType.createSerializer(executionConfig))
   }
   


### PR DESCRIPTION
## What is the purpose of the change

As the JIRA describes, it makes the queryable state client able to query all types of Flink state, as long as the user provides the adequate state descriptor.

## Verifying this change

This change added tests in the `AbstractQueryableStateITCase` and the `org.apache.flink.queryablestate.state` package.

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs / and pending documentation

