### PR TITLE
[FLINK-7844] [ckPt] Fail unacknowledged pending checkpoints for fine grained recovery

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
@@ -184,6 +184,10 @@ public class PendingCheckpoint {
 		return this.notYetAcknowledgedTasks.isEmpty() && !discarded;
 	}
 
+	public boolean isAcknowledgedBy(ExecutionAttemptID executionAttemptId) {
+		return !notYetAcknowledgedTasks.containsKey(executionAttemptId);
+	}
+
 	public boolean isDiscarded() {
 		return discarded;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -941,7 +941,7 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 						}
 					} catch (Throwable tt) {
 						// no reason this should ever happen, but log it to be safe
-						LOG.error("Error triggering cancel call while marking task as failed.", tt);
+						LOG.error("Error triggering cancel call while marking task {} as failed.", getVertex().getTaskNameWithSubtaskIndex(), tt);
 					}
 				}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -1710,6 +1710,11 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 			if (execution.getGlobalModVersion() == globalModVersion) {
 				try {
 					failoverStrategy.onTaskFailure(execution, ex);
+
+					// fail all checkpoints which the failed task has not yet acknowledged
+					if (checkpointCoordinator != null) {
+						checkpointCoordinator.failUnacknowledgedPendingCheckpointsFor(execution.getAttemptId(), ex);
+					}
 				}
 				catch (Throwable t) {
 					// bug in the failover strategy - fall back to global failover

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/IndividualRestartsConcurrencyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/IndividualRestartsConcurrencyTest.java
@@ -21,6 +21,13 @@ package org.apache.flink.runtime.executiongraph;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.core.testutils.ManuallyTriggeredDirectExecutor;
+import org.apache.flink.runtime.checkpoint.CheckpointCoordinator;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointStatsTracker;
+import org.apache.flink.runtime.checkpoint.PendingCheckpoint;
+import org.apache.flink.runtime.checkpoint.StandaloneCheckpointIDCounter;
+import org.apache.flink.runtime.checkpoint.StandaloneCompletedCheckpointStore;
+import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.failover.FailoverStrategy;
 import org.apache.flink.runtime.executiongraph.failover.FailoverStrategy.Factory;
@@ -33,17 +40,39 @@ import org.apache.flink.runtime.instance.SlotProvider;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
+import org.apache.flink.runtime.jobgraph.tasks.ExternalizedCheckpointSettings;
+import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
+import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.messages.checkpoint.AcknowledgeCheckpoint;
+import org.apache.flink.runtime.operators.testutils.UnregisteredTaskMetricsGroup;
+import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
+import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.waitUntilExecutionState;
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.waitUntilJobStatus;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * These tests make sure that global failover (restart all) always takes precedence over
@@ -52,7 +81,7 @@ import static org.junit.Assert.assertTrue;
  * <p>This test must be in the package it resides in, because it uses package-private methods
  * from the ExecutionGraph classes.
  */
-public class IndividualRestartsConcurrencyTest {
+public class IndividualRestartsConcurrencyTest extends TestLogger {
 
 	/**
 	 * Tests that a cancellation concurrent to a local failover leads to a properly
@@ -259,6 +288,122 @@ public class IndividualRestartsConcurrencyTest {
 
 		// make sure all slots are in use
 		assertEquals(0, slotProvider.getNumberOfAvailableSlots());
+	}
+
+	/**
+	 * Tests that a local failure fails all pending checkpoints which have not been acknowledged by the failing
+	 * task.
+	 */
+	@Test
+	public void testLocalFailureFailsPendingCheckpoints() throws Exception {
+		final JobID jid = new JobID();
+		final int parallelism = 2;
+		final long verifyTimeout = 5000L;
+
+		final TaskManagerGateway taskManagerGateway = mock(TaskManagerGateway.class);
+		when(taskManagerGateway.submitTask(any(TaskDeploymentDescriptor.class), any(Time.class))).thenReturn(CompletableFuture.completedFuture(Acknowledge.get()));
+		when(taskManagerGateway.cancelTask(any(ExecutionAttemptID.class), any(Time.class))).thenReturn(CompletableFuture.completedFuture(Acknowledge.get()));
+
+		final SimpleSlotProvider slotProvider = new SimpleSlotProvider(jid, parallelism, taskManagerGateway);
+		final Executor executor = TestingUtils.defaultExecutor();
+
+
+		final CheckpointCoordinatorConfiguration checkpointCoordinatorConfiguration = new CheckpointCoordinatorConfiguration(
+			10L,
+			100000L,
+			1L,
+			3,
+			ExternalizedCheckpointSettings.none(),
+			true);
+
+		final ExecutionGraph graph = createSampleGraph(
+			jid,
+			new IndividualFailoverWithCustomExecutor(executor),
+			slotProvider,
+			parallelism);
+
+		final List<ExecutionJobVertex> allVertices = new ArrayList<>(graph.getAllVertices().values());
+
+		final StandaloneCheckpointIDCounter standaloneCheckpointIDCounter = new StandaloneCheckpointIDCounter();
+
+		graph.enableCheckpointing(
+			checkpointCoordinatorConfiguration.getCheckpointInterval(),
+			checkpointCoordinatorConfiguration.getCheckpointTimeout(),
+			checkpointCoordinatorConfiguration.getMinPauseBetweenCheckpoints(),
+			checkpointCoordinatorConfiguration.getMaxConcurrentCheckpoints(),
+			checkpointCoordinatorConfiguration.getExternalizedCheckpointSettings(),
+			allVertices,
+			allVertices,
+			allVertices,
+			Collections.emptyList(),
+			standaloneCheckpointIDCounter,
+			new StandaloneCompletedCheckpointStore(1),
+			"",
+			new MemoryStateBackend(),
+			new CheckpointStatsTracker(
+				1,
+				allVertices,
+				checkpointCoordinatorConfiguration,
+				new UnregisteredTaskMetricsGroup()));
+
+		final CheckpointCoordinator checkpointCoordinator = graph.getCheckpointCoordinator();
+
+		final ExecutionJobVertex ejv = graph.getVerticesTopologically().iterator().next();
+		final ExecutionVertex vertex1 = ejv.getTaskVertices()[0];
+		final ExecutionVertex vertex2 = ejv.getTaskVertices()[1];
+
+		graph.scheduleForExecution();
+		assertEquals(JobStatus.RUNNING, graph.getState());
+
+		verify(taskManagerGateway, timeout(verifyTimeout).times(parallelism)).submitTask(any(TaskDeploymentDescriptor.class), any(Time.class));
+
+		// switch all executions to running
+		for (ExecutionVertex executionVertex : graph.getAllExecutionVertices()) {
+			executionVertex.getCurrentExecutionAttempt().switchToRunning();
+		}
+
+		// wait for a first checkpoint to be triggered
+		verify(taskManagerGateway, timeout(verifyTimeout).times(3)).triggerCheckpoint(
+			eq(vertex1.getCurrentExecutionAttempt().getAttemptId()),
+			any(JobID.class),
+			anyLong(),
+			anyLong(),
+			any(CheckpointOptions.class));
+
+		verify(taskManagerGateway, timeout(verifyTimeout).times(3)).triggerCheckpoint(
+			eq(vertex2.getCurrentExecutionAttempt().getAttemptId()),
+			any(JobID.class),
+			anyLong(),
+			anyLong(),
+			any(CheckpointOptions.class));
+
+		assertEquals(3, checkpointCoordinator.getNumberOfPendingCheckpoints());
+
+		long checkpointToAcknowledge = standaloneCheckpointIDCounter.getLast();
+
+		checkpointCoordinator.receiveAcknowledgeMessage(
+			new AcknowledgeCheckpoint(
+				graph.getJobID(),
+				vertex1.getCurrentExecutionAttempt().getAttemptId(),
+				checkpointToAcknowledge));
+
+		Map<Long, PendingCheckpoint> oldPendingCheckpoints = new HashMap<>(3);
+
+		for (PendingCheckpoint pendingCheckpoint : checkpointCoordinator.getPendingCheckpoints().values()) {
+			assertFalse(pendingCheckpoint.isDiscarded());
+			oldPendingCheckpoints.put(pendingCheckpoint.getCheckpointId(), pendingCheckpoint);
+		}
+
+		// let one of the vertices fail - this should trigger the failing of not acknowledged pending checkpoints
+		vertex1.getCurrentExecutionAttempt().fail(new Exception("test failure"));
+
+		for (PendingCheckpoint pendingCheckpoint : oldPendingCheckpoints.values()) {
+			if (pendingCheckpoint.getCheckpointId() == checkpointToAcknowledge) {
+				assertFalse(pendingCheckpoint.isDiscarded());
+			} else {
+				assertTrue(pendingCheckpoint.isDiscarded());
+			}
+		}
 	}
 
 	// ------------------------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change

This commit will fail all pending checkpoints which have not been acknowledged by
the failed task in case of fine grained recovery. This is done in order to avoid
long checkpoint timeouts which might block the CheckpointCoordinator from triggering
new checkpoints.

## Brief change log

- Introduce `CheckpointCoordinator#failUnacknowledgedPendingCheckpointsFor` to fail all unacknowledged pending checkpoints for a given `ExecutionAttemptID`
- Fail unacknowledged pending checkpoints in `ExecutionGraph#notifyExecutionChange`

## Verifying this change

- `IndividualRestartsConcurrencyTest#testLocalFailureFailsPendingCheckpoints` tests that unacknowledged pending checkpoints are discarded and removed from the `CheckpointCoordinator` in case of a local failure

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

