### PR TITLE
[FLINK-7839] [doc] Add a note on possible maven failure for creating quickstart project

### DIFF
--- a/docs/quickstart/java_api_quickstart.md
+++ b/docs/quickstart/java_api_quickstart.md
@@ -60,7 +60,13 @@ Use one of the following commands to __create a project__:
     $ curl https://flink.apache.org/q/quickstart-SNAPSHOT.sh | bash
 {% endif %}
     {% endhighlight %}
+
     </div>
+    {% unless site.is_stable %}
+    <p style="border-radius: 5px; padding: 5px" class="bg-danger">
+        <b>Note</b>: For Maven 3.0 or higher, it is no longer possible to specify the repository (-DarchetypeCatalog) via the commandline. If you wish to use the snapshot repository, you need to add a repository entry to your settings.xml. For details about this change, please refer to <a href="http://maven.apache.org/archetype/maven-archetype-plugin/archetype-repository.html">Maven official document</a>
+    </p>
+    {% endunless %}
 </div>
 
 ## Inspect Project

--- a/docs/quickstart/run_example_quickstart.md
+++ b/docs/quickstart/run_example_quickstart.md
@@ -53,6 +53,12 @@ $ mvn archetype:generate \
     -DinteractiveMode=false
 {% endhighlight %}
 
+{% unless site.is_stable %}
+<p style="border-radius: 5px; padding: 5px" class="bg-danger">
+    <b>Note</b>: For Maven 3.0 or higher, it is no longer possible to specify the repository (-DarchetypeCatalog) via the commandline. If you wish to use the snapshot repository, you need to add a repository entry to your settings.xml. For details about this change, please refer to <a href="http://maven.apache.org/archetype/maven-archetype-plugin/archetype-repository.html">Maven official document</a>
+</p>
+{% endunless %}
+
 You can edit the `groupId`, `artifactId` and `package` if you like. With the above parameters,
 Maven will create a project structure that looks like this:
 

--- a/docs/quickstart/scala_api_quickstart.md
+++ b/docs/quickstart/scala_api_quickstart.md
@@ -146,6 +146,11 @@ Use one of the following commands to __create a project__:
 {% endif %}
 {% endhighlight %}
     </div>
+    {% unless site.is_stable %}
+    <p style="border-radius: 5px; padding: 5px" class="bg-danger">
+        <b>Note</b>: For Maven 3.0 or higher, it is no longer possible to specify the repository (-DarchetypeCatalog) via the commandline. If you wish to use the snapshot repository, you need to add a repository entry to your settings.xml. For details about this change, please refer to <a href="http://maven.apache.org/archetype/maven-archetype-plugin/archetype-repository.html">Maven official document</a>
+    </p>
+    {% endunless %}
 </div>
 
 


### PR DESCRIPTION


## What is the purpose of the change


This only applies before project release; {%site.is_stable == false %}.

Add an warning note on recent Maven change (3.0+) for -DarchetypeCatalog while creating quickstart project.



## Verifying this change

Only doc change


