### PR TITLE
[FLINK-6861][metrics] Use OperatorID in metric system

### DIFF
--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -292,7 +292,9 @@ or by assigning unique names to jobs and operators.
 - TaskManager: &lt;host&gt;, &lt;tm_id&gt;
 - Job: &lt;job_id&gt;, &lt;job_name&gt;
 - Task: &lt;task_id&gt;, &lt;task_name&gt;, &lt;task_attempt_id&gt;, &lt;task_attempt_num&gt;, &lt;subtask_index&gt;
-- Operator: &lt;operator_name&gt;, &lt;subtask_index&gt;
+- Operator: &lt;operator_id&gt;,&lt;operator_name&gt;, &lt;subtask_index&gt;
+
+**Important:** For the Batch API, &lt;operator_id&gt; is always equal to &lt;task_id&gt;.
 
 ## Reporter
 

--- a/flink-metrics/flink-metrics-dropwizard/src/test/java/org/apache/flink/dropwizard/ScheduledDropwizardReporterTest.java
+++ b/flink-metrics/flink-metrics-dropwizard/src/test/java/org/apache/flink/dropwizard/ScheduledDropwizardReporterTest.java
@@ -33,6 +33,7 @@ import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.metrics.reporter.MetricReporter;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.metrics.groups.TaskManagerJobMetricGroup;
@@ -97,7 +98,7 @@ public class ScheduledDropwizardReporterTest {
 
 		TaskManagerMetricGroup tmMetricGroup = new TaskManagerMetricGroup(metricRegistry, hostname, taskManagerId);
 		TaskManagerJobMetricGroup tmJobMetricGroup = new TaskManagerJobMetricGroup(metricRegistry, tmMetricGroup, new JobID(), jobName);
-		TaskMetricGroup taskMetricGroup = new TaskMetricGroup(metricRegistry, tmJobMetricGroup, new AbstractID(), new AbstractID(), taskName, 0, 0);
+		TaskMetricGroup taskMetricGroup = new TaskMetricGroup(metricRegistry, tmJobMetricGroup, new JobVertexID(), new AbstractID(), taskName, 0, 0);
 
 		SimpleCounter myCounter = new SimpleCounter();
 		com.codahale.metrics.Meter dropwizardMeter = new com.codahale.metrics.Meter();

--- a/flink-metrics/flink-metrics-statsd/src/test/java/org/apache/flink/metrics/statsd/StatsDReporterTest.java
+++ b/flink-metrics/flink-metrics-statsd/src/test/java/org/apache/flink/metrics/statsd/StatsDReporterTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.metrics.MetricConfig;
 import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.metrics.reporter.MetricReporter;
 import org.apache.flink.metrics.util.TestMeter;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.metrics.groups.TaskManagerJobMetricGroup;
@@ -94,7 +95,7 @@ public class StatsDReporterTest extends TestLogger {
 
 		TaskManagerMetricGroup tmMetricGroup = new TaskManagerMetricGroup(metricRegistry, hostname, taskManagerId);
 		TaskManagerJobMetricGroup tmJobMetricGroup = new TaskManagerJobMetricGroup(metricRegistry, tmMetricGroup, new JobID(), jobName);
-		TaskMetricGroup taskMetricGroup = new TaskMetricGroup(metricRegistry, tmJobMetricGroup, new AbstractID(), new AbstractID(), taskName, 0, 0);
+		TaskMetricGroup taskMetricGroup = new TaskMetricGroup(metricRegistry, tmJobMetricGroup, new JobVertexID(), new AbstractID(), taskName, 0, 0);
 
 		SimpleCounter myCounter = new SimpleCounter();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/OperatorMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/OperatorMetricGroup.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.metrics.groups;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.metrics.CharacterFilter;
+import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
 import org.apache.flink.runtime.metrics.scope.ScopeFormat;
@@ -35,11 +36,13 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @Internal
 public class OperatorMetricGroup extends ComponentMetricGroup<TaskMetricGroup> {
 	private final String operatorName;
+	private final OperatorID operatorID;
 
 	private final OperatorIOMetricGroup ioMetrics;
 
-	public OperatorMetricGroup(MetricRegistry registry, TaskMetricGroup parent, String operatorName) {
-		super(registry, registry.getScopeFormats().getOperatorFormat().formatScope(checkNotNull(parent), operatorName), parent);
+	public OperatorMetricGroup(MetricRegistry registry, TaskMetricGroup parent, OperatorID operatorID, String operatorName) {
+		super(registry, registry.getScopeFormats().getOperatorFormat().formatScope(checkNotNull(parent), operatorID, operatorName), parent);
+		this.operatorID = operatorID;
 		this.operatorName = operatorName;
 
 		ioMetrics = new OperatorIOMetricGroup(this);
@@ -75,6 +78,7 @@ public class OperatorMetricGroup extends ComponentMetricGroup<TaskMetricGroup> {
 
 	@Override
 	protected void putVariables(Map<String, String> variables) {
+		variables.put(ScopeFormat.SCOPE_OPERATOR_ID, String.valueOf(operatorID));
 		variables.put(ScopeFormat.SCOPE_OPERATOR_NAME, operatorName);
 		// we don't enter the subtask_index as the task group does that already
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskMetricGroup.java
@@ -20,6 +20,8 @@ package org.apache.flink.runtime.metrics.groups;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.metrics.CharacterFilter;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
 import org.apache.flink.runtime.metrics.scope.ScopeFormat;
@@ -40,7 +42,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @Internal
 public class TaskMetricGroup extends ComponentMetricGroup<TaskManagerJobMetricGroup> {
 
-	private final Map<String, OperatorMetricGroup> operators = new HashMap<>();
+	private final Map<OperatorID, OperatorMetricGroup> operators = new HashMap<>();
 
 	static final int METRICS_OPERATOR_NAME_MAX_LENGTH = 80;
 
@@ -50,7 +52,7 @@ public class TaskMetricGroup extends ComponentMetricGroup<TaskManagerJobMetricGr
 	private final AbstractID executionId;
 
 	@Nullable
-	protected final AbstractID vertexId;
+	protected final JobVertexID vertexId;
 
 	@Nullable
 	private final String taskName;
@@ -64,7 +66,7 @@ public class TaskMetricGroup extends ComponentMetricGroup<TaskManagerJobMetricGr
 	public TaskMetricGroup(
 			MetricRegistry registry,
 			TaskManagerJobMetricGroup parent,
-			@Nullable AbstractID vertexId,
+			@Nullable JobVertexID vertexId,
 			AbstractID executionId,
 			@Nullable String taskName,
 			int subtaskIndex,
@@ -124,7 +126,7 @@ public class TaskMetricGroup extends ComponentMetricGroup<TaskManagerJobMetricGr
 	protected QueryScopeInfo.TaskQueryScopeInfo createQueryServiceMetricInfo(CharacterFilter filter) {
 		return new QueryScopeInfo.TaskQueryScopeInfo(
 			this.parent.jobId.toString(),
-			this.vertexId.toString(),
+			String.valueOf(this.vertexId),
 			this.subtaskIndex);
 	}
 
@@ -133,20 +135,24 @@ public class TaskMetricGroup extends ComponentMetricGroup<TaskManagerJobMetricGr
 	// ------------------------------------------------------------------------
 
 	public OperatorMetricGroup addOperator(String name) {
+		return addOperator(OperatorID.fromJobVertexID(vertexId), name);
+	}
+
+	public OperatorMetricGroup addOperator(OperatorID operatorID, String name) {
 		if (name != null && name.length() > METRICS_OPERATOR_NAME_MAX_LENGTH) {
 			LOG.warn("The operator name {} exceeded the {} characters length limit and was truncated.", name, METRICS_OPERATOR_NAME_MAX_LENGTH);
 			name = name.substring(0, METRICS_OPERATOR_NAME_MAX_LENGTH);
 		}
-		OperatorMetricGroup operator = new OperatorMetricGroup(this.registry, this, name);
+		OperatorMetricGroup operator = new OperatorMetricGroup(this.registry, this, operatorID, name);
 
 		synchronized (this) {
-			OperatorMetricGroup previous = operators.put(name, operator);
+			OperatorMetricGroup previous = operators.put(operatorID, operator);
 			if (previous == null) {
 				// no operator group so far
 				return operator;
 			} else {
 				// already had an operator group. restore that one.
-				operators.put(name, previous);
+				operators.put(operatorID, previous);
 				return previous;
 			}
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/scope/OperatorScopeFormat.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/scope/OperatorScopeFormat.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.metrics.scope;
 
+import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
 
 /**
@@ -36,11 +37,12 @@ public class OperatorScopeFormat extends ScopeFormat {
 				SCOPE_TASK_NAME,
 				SCOPE_TASK_SUBTASK_INDEX,
 				SCOPE_TASK_ATTEMPT_NUM,
+				SCOPE_OPERATOR_ID,
 				SCOPE_OPERATOR_NAME
 		});
 	}
 
-	public String[] formatScope(TaskMetricGroup parent, String operatorName) {
+	public String[] formatScope(TaskMetricGroup parent, OperatorID operatorID, String operatorName) {
 
 		final String[] template = copyTemplate();
 		final String[] values = {
@@ -53,6 +55,7 @@ public class OperatorScopeFormat extends ScopeFormat {
 				valueOrNull(parent.taskName()),
 				String.valueOf(parent.subtaskIndex()),
 				String.valueOf(parent.attemptNumber()),
+				valueOrNull(operatorID),
 				valueOrNull(operatorName)
 		};
 		return bindVariables(template, values);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/scope/ScopeFormat.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/scope/ScopeFormat.java
@@ -89,6 +89,7 @@ public abstract class ScopeFormat {
 
 	// ----- Operator ----
 
+	public static final String SCOPE_OPERATOR_ID = asVariable("operator_id");
 	public static final String SCOPE_OPERATOR_NAME = asVariable("operator_name");
 
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/MetricGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/MetricGroupTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.metrics.CharacterFilter;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.Metric;
 import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
@@ -131,7 +132,7 @@ public class MetricGroupTest extends TestLogger {
 	@Test
 	public void testCreateQueryServiceMetricInfo() {
 		JobID jid = new JobID();
-		AbstractID vid = new AbstractID();
+		JobVertexID vid = new JobVertexID();
 		AbstractID eid = new AbstractID();
 		MetricRegistry registry = new MetricRegistry(defaultMetricRegistryConfiguration);
 		TaskManagerMetricGroup tm = new TaskManagerMetricGroup(registry, "host", "id");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/OperatorGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/OperatorGroupTest.java
@@ -19,6 +19,8 @@
 package org.apache.flink.runtime.metrics.groups;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
@@ -47,8 +49,8 @@ public class OperatorGroupTest extends TestLogger {
 		TaskManagerMetricGroup tmGroup = new TaskManagerMetricGroup(registry, "theHostName", "test-tm-id");
 		TaskManagerJobMetricGroup jmGroup = new TaskManagerJobMetricGroup(registry, tmGroup, new JobID(), "myJobName");
 		TaskMetricGroup taskGroup = new TaskMetricGroup(
-				registry, jmGroup,  new AbstractID(),  new AbstractID(), "aTaskName", 11, 0);
-		OperatorMetricGroup opGroup = new OperatorMetricGroup(registry, taskGroup, "myOpName");
+				registry, jmGroup,  new JobVertexID(),  new AbstractID(), "aTaskName", 11, 0);
+		OperatorMetricGroup opGroup = new OperatorMetricGroup(registry, taskGroup, new OperatorID(), "myOpName");
 
 		assertArrayEquals(
 				new String[] { "theHostName", "taskmanager", "test-tm-id", "myJobName", "myOpName", "11" },
@@ -68,8 +70,8 @@ public class OperatorGroupTest extends TestLogger {
 		TaskManagerMetricGroup tmGroup = new TaskManagerMetricGroup(registry, "theHostName", "test-tm-id");
 		TaskManagerJobMetricGroup jmGroup = new TaskManagerJobMetricGroup(registry, tmGroup, new JobID(), "myJobName");
 		TaskMetricGroup taskGroup = new TaskMetricGroup(
-			registry, jmGroup, new AbstractID(), new AbstractID(), "aTaskName", 11, 0);
-		OperatorMetricGroup opGroup = new OperatorMetricGroup(registry, taskGroup, "myOpName");
+			registry, jmGroup, new JobVertexID(), new AbstractID(), "aTaskName", 11, 0);
+		OperatorMetricGroup opGroup = new OperatorMetricGroup(registry, taskGroup, new OperatorID(), "myOpName");
 
 		assertNotNull(opGroup.getIOMetricGroup());
 		assertNotNull(opGroup.getIOMetricGroup().getNumRecordsInCounter());
@@ -83,14 +85,15 @@ public class OperatorGroupTest extends TestLogger {
 		MetricRegistry registry = new MetricRegistry(MetricRegistryConfiguration.defaultMetricRegistryConfiguration());
 
 		JobID jid = new JobID();
-		AbstractID tid = new AbstractID();
+		JobVertexID tid = new JobVertexID();
 		AbstractID eid = new AbstractID();
+		OperatorID oid = new OperatorID();
 
 		TaskManagerMetricGroup tmGroup = new TaskManagerMetricGroup(registry, "theHostName", "test-tm-id");
 		TaskManagerJobMetricGroup jmGroup = new TaskManagerJobMetricGroup(registry, tmGroup, jid, "myJobName");
 		TaskMetricGroup taskGroup = new TaskMetricGroup(
 			registry, jmGroup,  tid,  eid, "aTaskName", 11, 0);
-		OperatorMetricGroup opGroup = new OperatorMetricGroup(registry, taskGroup, "myOpName");
+		OperatorMetricGroup opGroup = new OperatorMetricGroup(registry, taskGroup, oid, "myOpName");
 
 		Map<String, String> variables = opGroup.getAllVariables();
 
@@ -103,6 +106,7 @@ public class OperatorGroupTest extends TestLogger {
 		testVariable(variables, ScopeFormat.SCOPE_TASK_ATTEMPT_ID, eid.toString());
 		testVariable(variables, ScopeFormat.SCOPE_TASK_SUBTASK_INDEX, "11");
 		testVariable(variables, ScopeFormat.SCOPE_TASK_ATTEMPT_NUM, "0");
+		testVariable(variables, ScopeFormat.SCOPE_OPERATOR_ID, oid.toString());
 		testVariable(variables, ScopeFormat.SCOPE_OPERATOR_NAME, "myOpName");
 
 		registry.shutdown();
@@ -117,13 +121,14 @@ public class OperatorGroupTest extends TestLogger {
 	@Test
 	public void testCreateQueryServiceMetricInfo() {
 		JobID jid = new JobID();
-		AbstractID vid = new AbstractID();
+		JobVertexID vid = new JobVertexID();
 		AbstractID eid = new AbstractID();
+		OperatorID oid = new OperatorID();
 		MetricRegistry registry = new MetricRegistry(MetricRegistryConfiguration.defaultMetricRegistryConfiguration());
 		TaskManagerMetricGroup tm = new TaskManagerMetricGroup(registry, "host", "id");
 		TaskManagerJobMetricGroup job = new TaskManagerJobMetricGroup(registry, tm, jid, "jobname");
 		TaskMetricGroup task = new TaskMetricGroup(registry, job, vid, eid, "taskName", 4, 5);
-		OperatorMetricGroup operator = new OperatorMetricGroup(registry, task, "operator");
+		OperatorMetricGroup operator = new OperatorMetricGroup(registry, task, oid, "operator");
 
 		QueryScopeInfo.OperatorQueryScopeInfo info = operator.createQueryServiceMetricInfo(new DummyCharacterFilter());
 		assertEquals("", info.scope);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/TaskMetricGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/TaskMetricGroupTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MetricOptions;
 import org.apache.flink.metrics.Metric;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
@@ -49,7 +50,7 @@ public class TaskMetricGroupTest extends TestLogger {
 	@Test
 	public void testGenerateScopeDefault() {
 		MetricRegistry registry = new MetricRegistry(MetricRegistryConfiguration.defaultMetricRegistryConfiguration());
-		AbstractID vertexId = new AbstractID();
+		JobVertexID vertexId = new JobVertexID();
 		AbstractID executionId = new AbstractID();
 
 		TaskManagerMetricGroup tmGroup = new TaskManagerMetricGroup(registry, "theHostName", "test-tm-id");
@@ -75,7 +76,7 @@ public class TaskMetricGroupTest extends TestLogger {
 		MetricRegistry registry = new MetricRegistry(MetricRegistryConfiguration.fromConfiguration(cfg));
 
 		JobID jid = new JobID();
-		AbstractID vertexId = new AbstractID();
+		JobVertexID vertexId = new JobVertexID();
 		AbstractID executionId = new AbstractID();
 
 		TaskManagerMetricGroup tmGroup = new TaskManagerMetricGroup(registry, "theHostName", "test-tm-id");
@@ -105,7 +106,7 @@ public class TaskMetricGroupTest extends TestLogger {
 		TaskManagerJobMetricGroup jmGroup = new TaskManagerJobMetricGroup(registry, tmGroup, new JobID(), "myJobName");
 
 		TaskMetricGroup taskGroup = new TaskMetricGroup(
-				registry, jmGroup, new AbstractID(), executionId, "aTaskName", 13, 1);
+				registry, jmGroup, new JobVertexID(), executionId, "aTaskName", 13, 1);
 
 		assertArrayEquals(
 				new String[]{"theHostName", "taskmanager", "test-tm-id", "myJobName", executionId.toString(), "13"},
@@ -120,7 +121,7 @@ public class TaskMetricGroupTest extends TestLogger {
 	@Test
 	public void testCreateQueryServiceMetricInfo() {
 		JobID jid = new JobID();
-		AbstractID vid = new AbstractID();
+		JobVertexID vid = new JobVertexID();
 		AbstractID eid = new AbstractID();
 		MetricRegistry registry = new MetricRegistry(MetricRegistryConfiguration.defaultMetricRegistryConfiguration());
 		TaskManagerMetricGroup tm = new TaskManagerMetricGroup(registry, "host", "id");
@@ -139,7 +140,7 @@ public class TaskMetricGroupTest extends TestLogger {
 		CountingMetricRegistry registry = new CountingMetricRegistry(new Configuration());
 		TaskManagerMetricGroup taskManagerMetricGroup = new TaskManagerMetricGroup(registry, "localhost", "0");
 		TaskManagerJobMetricGroup taskManagerJobMetricGroup = new TaskManagerJobMetricGroup(registry, taskManagerMetricGroup, new JobID(), "job");
-		TaskMetricGroup taskMetricGroup = new TaskMetricGroup(registry, taskManagerJobMetricGroup, new AbstractID(), new AbstractID(), "task", 0, 0);
+		TaskMetricGroup taskMetricGroup = new TaskMetricGroup(registry, taskManagerJobMetricGroup, new JobVertexID(), new AbstractID(), "task", 0, 0);
 
 		// the io metric should have registered predefined metrics
 		assertTrue(registry.getNumberRegisteredMetrics() > 0);
@@ -159,7 +160,7 @@ public class TaskMetricGroupTest extends TestLogger {
 		MetricRegistry registry = new MetricRegistry(MetricRegistryConfiguration.fromConfiguration(cfg));
 		TaskManagerMetricGroup tm = new TaskManagerMetricGroup(registry, "host", "id");
 		TaskManagerJobMetricGroup job = new TaskManagerJobMetricGroup(registry, tm, new JobID(), "jobname");
-		TaskMetricGroup taskMetricGroup = new TaskMetricGroup(registry, job, new AbstractID(), new AbstractID(), "task", 0, 0);
+		TaskMetricGroup taskMetricGroup = new TaskMetricGroup(registry, job, new JobVertexID(), new AbstractID(), "task", 0, 0);
 
 		String originalName = new String(new char[100]).replace("\0", "-");
 		OperatorMetricGroup operatorMetricGroup = taskMetricGroup.addOperator(originalName);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/UnregisteredTaskMetricsGroup.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/UnregisteredTaskMetricsGroup.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.metrics.Metric;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.metrics.groups.OperatorMetricGroup;
 import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
@@ -76,7 +77,7 @@ public class UnregisteredTaskMetricsGroup extends TaskMetricGroup {
 
 	public static class DummyOperatorMetricGroup extends OperatorMetricGroup {
 		public DummyOperatorMetricGroup() {
-			super(EMPTY_REGISTRY, new UnregisteredTaskMetricsGroup(), "testoperator");
+			super(EMPTY_REGISTRY, new UnregisteredTaskMetricsGroup(), new OperatorID(), "testoperator");
 		}
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
@@ -192,6 +192,7 @@ public abstract class AbstractStreamOperator<OUT>
 		} catch (Exception e) {
 			LOG.warn("An error occurred while instantiating task metrics.", e);
 			this.metrics = new UnregisteredMetricsGroup();
+			this.output = output;
 		}
 		Configuration taskManagerConfig = container.getEnvironment().getTaskManagerInfo().getConfiguration();
 		int historySize = taskManagerConfig.getInteger(MetricOptions.LATENCY_HISTORY_SIZE);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
@@ -33,6 +33,7 @@ import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions.CheckpointType;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
@@ -178,13 +179,19 @@ public abstract class AbstractStreamOperator<OUT>
 	public void setup(StreamTask<?, ?> containingTask, StreamConfig config, Output<StreamRecord<OUT>> output) {
 		this.container = containingTask;
 		this.config = config;
-		this.metrics = container.getEnvironment().getMetricGroup().addOperator(config.getOperatorName());
-		this.output = new CountingOutput(output, ((OperatorMetricGroup) this.metrics).getIOMetricGroup().getNumRecordsOutCounter());
-		if (config.isChainStart()) {
-			((OperatorMetricGroup) this.metrics).getIOMetricGroup().reuseInputMetricsForTask();
-		}
-		if (config.isChainEnd()) {
-			((OperatorMetricGroup) this.metrics).getIOMetricGroup().reuseOutputMetricsForTask();
+		try {
+			OperatorMetricGroup operatorMetricGroup = container.getEnvironment().getMetricGroup().addOperator(config.getOperatorID(), config.getOperatorName());
+			this.output = new CountingOutput(output, operatorMetricGroup.getIOMetricGroup().getNumRecordsOutCounter());
+			if (config.isChainStart()) {
+				operatorMetricGroup.getIOMetricGroup().reuseInputMetricsForTask();
+			}
+			if (config.isChainEnd()) {
+				operatorMetricGroup.getIOMetricGroup().reuseOutputMetricsForTask();
+			}
+			this.metrics = operatorMetricGroup;
+		} catch (Exception e) {
+			LOG.warn("An error occurred while instantiating task metrics.", e);
+			this.metrics = new UnregisteredMetricsGroup();
 		}
 		Configuration taskManagerConfig = container.getEnvironment().getTaskManagerInfo().getConfiguration();
 		int historySize = taskManagerConfig.getInteger(MetricOptions.LATENCY_HISTORY_SIZE);


### PR DESCRIPTION
## What is the purpose of the change

This PR introduces Operator IDs to the metric system.

## Brief change log

* store OperatorID in OperatorMetricGroup
  * for the batch API, this ID is equal to the JobVertexID of the task
  * modify TaskMetricGroup to store a JobVertexID instead of AbstractID (required for conversion of task ID to operator ID)
* update OperatorScopeFormat to also accept the operator ID
* update documentation


## Verifying this change

This change is already covered by existing tests, such as `OperatorGroupTest#testVariables`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)

