### PR TITLE
[FLINK-6907][core] Extend TupleGenerator javadocs

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/api/java/tuple/TupleGenerator.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/tuple/TupleGenerator.java
@@ -28,6 +28,8 @@ import java.util.Scanner;
 
 /**
  * Source code generator for tuple classes and classes which depend on the arity of tuples.
+ *
+ * <p>This class is responsible for generating the various {@link Tuple} and TupleBuilder classes.
  */
 class TupleGenerator {
 

--- a/flink-java/src/test/java/org/apache/flink/api/java/tuple/TupleGenerator.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/tuple/TupleGenerator.java
@@ -26,6 +26,10 @@ import java.util.Scanner;
 
 /**
  * Source code generator for tuple classes and classes which depend on the arity of tuples.
+ *
+ * <p>This class is responsible for generating tuple-size dependent code in the {@link org.apache.flink.api.java.io.CsvReader},
+ * {@link org.apache.flink.api.java.operators.ProjectOperator}, {@link org.apache.flink.api.java.operators.JoinOperator.JoinProjection}
+ * and {@link org.apache.flink.api.java.operators.CrossOperator.CrossProjection}.
  */
 class TupleGenerator {
 


### PR DESCRIPTION
## What is the purpose of the change

This PR extends the javadocs of the TupleGenerator classes to clarify their responsibilities.
