### PR TITLE
[FLINK-7623][tests] Add tests to make sure operator is never restored when using new operator id

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StateAssignmentOperation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StateAssignmentOperation.java
@@ -219,7 +219,7 @@ public class StateAssignmentOperation {
 		}
 	}
 
-	private static OperatorSubtaskState operatorSubtaskStateFrom(
+	public static OperatorSubtaskState operatorSubtaskStateFrom(
 			OperatorInstanceID instanceID,
 			Map<OperatorInstanceID, List<OperatorStateHandle>> subManagedOperatorState,
 			Map<OperatorInstanceID, List<OperatorStateHandle>> subRawOperatorState,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
@@ -111,8 +111,11 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>> implements Strea
 				StreamEdge outEdge = outEdgesInOrder.get(i);
 
 				RecordWriterOutput<?> streamOutput = createStreamOutput(
-						outEdge, chainedConfigs.get(outEdge.getSourceId()), i,
-						containingTask.getEnvironment(), containingTask.getName());
+					outEdge,
+					chainedConfigs.get(outEdge.getSourceId()),
+					i,
+					containingTask.getEnvironment(),
+					containingTask.getName());
 
 				this.streamOutputs[i] = streamOutput;
 				streamOutputMap.put(outEdge, streamOutput);
@@ -120,8 +123,13 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>> implements Strea
 
 			// we create the chain of operators and grab the collector that leads into the chain
 			List<StreamOperator<?>> allOps = new ArrayList<>(chainedConfigs.size());
-			this.chainEntryPoint = createOutputCollector(containingTask, configuration,
-					chainedConfigs, userCodeClassloader, streamOutputMap, allOps);
+			this.chainEntryPoint = createOutputCollector(
+				containingTask,
+				configuration,
+				chainedConfigs,
+				userCodeClassloader,
+				streamOutputMap,
+				allOps);
 
 			if (headOperator != null) {
 				Output output = getChainEntryPoint();
@@ -272,7 +280,13 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>> implements Strea
 			StreamConfig chainedOpConfig = chainedConfigs.get(outputId);
 
 			Output<StreamRecord<T>> output = createChainedOperator(
-					containingTask, chainedOpConfig, chainedConfigs, userCodeClassloader, streamOutputs, allOperators, outputEdge.getOutputTag());
+				containingTask,
+				chainedOpConfig,
+				chainedConfigs,
+				userCodeClassloader,
+				streamOutputs,
+				allOperators,
+				outputEdge.getOutputTag());
 			allOutputs.add(new Tuple2<>(output, outputEdge));
 		}
 
@@ -330,7 +344,12 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>> implements Strea
 			OutputTag<IN> outputTag) {
 		// create the output that the operator writes to first. this may recursively create more operators
 		Output<StreamRecord<OUT>> output = createOutputCollector(
-				containingTask, operatorConfig, chainedConfigs, userCodeClassloader, streamOutputs, allOperators);
+			containingTask,
+			operatorConfig,
+			chainedConfigs,
+			userCodeClassloader,
+			streamOutputs,
+			allOperators);
 
 		// now create the operator and give it the output collector to write its output to
 		OneInputStreamOperator<IN, OUT> chainedOperator = operatorConfig.getStreamOperator(userCodeClassloader);
@@ -349,7 +368,9 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>> implements Strea
 	}
 
 	private <T> RecordWriterOutput<T> createStreamOutput(
-			StreamEdge edge, StreamConfig upStreamConfig, int outputIndex,
+			StreamEdge edge,
+			StreamConfig upStreamConfig,
+			int outputIndex,
 			Environment taskEnvironment,
 			String taskName) {
 		OutputTag sideOutputTag = edge.getOutputTag(); // OutputTag, return null if not sideOutput
@@ -529,10 +550,12 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>> implements Strea
 			} catch (ClassCastException e) {
 				// Enrich error message
 				ClassCastException replace = new ClassCastException(
-						String.format("%s. Failed to push OutputTag with id '%s' to operator. " +
-								"This can occur when multiple OutputTags with different types " +
-								"but identical names are being used.",
-								e.getMessage(), outputTag.getId()));
+					String.format(
+						"%s. Failed to push OutputTag with id '%s' to operator. " +
+						"This can occur when multiple OutputTags with different types " +
+						"but identical names are being used.",
+						e.getMessage(),
+						outputTag.getId()));
 
 				throw new ExceptionInChainedOperatorException(replace);
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorTest.java
@@ -27,7 +27,6 @@ import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
-import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.execution.Environment;
@@ -54,11 +53,11 @@ import org.apache.flink.streaming.api.operators.async.queue.StreamElementQueueEn
 import org.apache.flink.streaming.api.operators.async.queue.StreamRecordQueueEntry;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.tasks.AcknowledgeStreamMockEnvironment;
 import org.apache.flink.streaming.runtime.tasks.OneInputStreamTask;
 import org.apache.flink.streaming.runtime.tasks.OneInputStreamTaskTestHarness;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeCallback;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
-import org.apache.flink.streaming.runtime.tasks.StreamMockEnvironment;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
 import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
@@ -595,43 +594,6 @@ public class AsyncWaitOperatorTest extends TestLogger {
 				"StateAndRestored Test Output was not correct.",
 				expectedOutput,
 				restoredTaskHarness.getOutput());
-	}
-
-	private static class AcknowledgeStreamMockEnvironment extends StreamMockEnvironment {
-		private volatile long checkpointId;
-		private volatile TaskStateSnapshot checkpointStateHandles;
-
-		private final OneShotLatch checkpointLatch = new OneShotLatch();
-
-		public long getCheckpointId() {
-			return checkpointId;
-		}
-
-		AcknowledgeStreamMockEnvironment(
-				Configuration jobConfig, Configuration taskConfig,
-				ExecutionConfig executionConfig, long memorySize,
-				MockInputSplitProvider inputSplitProvider, int bufferSize) {
-				super(jobConfig, taskConfig, executionConfig, memorySize, inputSplitProvider, bufferSize);
-		}
-
-		@Override
-		public void acknowledgeCheckpoint(
-				long checkpointId,
-				CheckpointMetrics checkpointMetrics,
-				TaskStateSnapshot checkpointStateHandles) {
-
-			this.checkpointId = checkpointId;
-			this.checkpointStateHandles = checkpointStateHandles;
-			checkpointLatch.trigger();
-		}
-
-		public OneShotLatch getCheckpointLatch() {
-			return checkpointLatch;
-		}
-
-		public TaskStateSnapshot getCheckpointStateHandles() {
-			return checkpointStateHandles;
-		}
 	}
 
 	@Test

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/AcknowledgeStreamMockEnvironment.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/AcknowledgeStreamMockEnvironment.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.testutils.OneShotLatch;
+import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
+import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
+import org.apache.flink.runtime.operators.testutils.MockInputSplitProvider;
+
+/**
+ * Stream environment that allows to wait for checkpoint acknowledgement.
+ */
+public class AcknowledgeStreamMockEnvironment extends StreamMockEnvironment {
+	private final OneShotLatch checkpointLatch = new OneShotLatch();
+	private volatile long checkpointId;
+	private volatile TaskStateSnapshot checkpointStateHandles;
+
+	public AcknowledgeStreamMockEnvironment(
+		Configuration jobConfig,
+		Configuration taskConfig,
+		ExecutionConfig executionConfig,
+		long memorySize,
+		MockInputSplitProvider inputSplitProvider,
+		int bufferSize) {
+		super(jobConfig, taskConfig, executionConfig, memorySize, inputSplitProvider, bufferSize);
+	}
+
+	public long getCheckpointId() {
+		return checkpointId;
+	}
+
+	@Override
+	public void acknowledgeCheckpoint(
+		long checkpointId,
+		CheckpointMetrics checkpointMetrics,
+		TaskStateSnapshot checkpointStateHandles) {
+
+		this.checkpointId = checkpointId;
+		this.checkpointStateHandles = checkpointStateHandles;
+		checkpointLatch.trigger();
+	}
+
+	public OneShotLatch getCheckpointLatch() {
+		return checkpointLatch;
+	}
+
+	public TaskStateSnapshot getCheckpointStateHandles() {
+		return checkpointStateHandles;
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.streaming.runtime.tasks;
 
-import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.functions.RichMapFunction;
 import org.apache.flink.api.common.state.ListState;
@@ -28,9 +27,7 @@ import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
-import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
@@ -610,43 +607,6 @@ public class OneInputStreamTaskTest extends TestLogger {
 		@Override
 		public IN getKey(IN value) throws Exception {
 			return value;
-		}
-	}
-
-	private static class AcknowledgeStreamMockEnvironment extends StreamMockEnvironment {
-		private volatile long checkpointId;
-		private volatile TaskStateSnapshot checkpointStateHandles;
-
-		private final OneShotLatch checkpointLatch = new OneShotLatch();
-
-		public long getCheckpointId() {
-			return checkpointId;
-		}
-
-		AcknowledgeStreamMockEnvironment(
-			Configuration jobConfig, Configuration taskConfig,
-			ExecutionConfig executionConfig, long memorySize,
-			MockInputSplitProvider inputSplitProvider, int bufferSize) {
-			super(jobConfig, taskConfig, executionConfig, memorySize, inputSplitProvider, bufferSize);
-		}
-
-		@Override
-		public void acknowledgeCheckpoint(
-			long checkpointId,
-			CheckpointMetrics checkpointMetrics,
-			TaskStateSnapshot checkpointStateHandles) {
-
-			this.checkpointId = checkpointId;
-			this.checkpointStateHandles = checkpointStateHandles;
-			checkpointLatch.trigger();
-		}
-
-		public OneShotLatch getCheckpointLatch() {
-			return checkpointLatch;
-		}
-
-		public TaskStateSnapshot getCheckpointStateHandles() {
-			return checkpointStateHandles;
 		}
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTest.java
@@ -39,7 +39,6 @@ import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.operators.testutils.MockInputSplitProvider;
 import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.runtime.state.StateSnapshotContext;
-import org.apache.flink.streaming.api.collector.selector.OutputSelector;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.graph.StreamEdge;
 import org.apache.flink.streaming.api.graph.StreamNode;
@@ -47,7 +46,6 @@ import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.operators.StreamMap;
 import org.apache.flink.streaming.api.watermark.Watermark;
-import org.apache.flink.streaming.runtime.partitioner.BroadcastPartitioner;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.streamstatus.StreamStatus;
 import org.apache.flink.streaming.util.TestHarnessUtil;
@@ -61,7 +59,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -253,71 +250,14 @@ public class OneInputStreamTaskTest extends TestLogger {
 				BasicTypeInfo.STRING_TYPE_INFO,
 				BasicTypeInfo.STRING_TYPE_INFO);
 
-		// ------------------ setup the chain ------------------
-
 		TriggerableFailOnWatermarkTestOperator headOperator = new TriggerableFailOnWatermarkTestOperator();
-		StreamConfig headOperatorConfig = testHarness.getStreamConfig();
-
 		WatermarkGeneratingTestOperator watermarkOperator = new WatermarkGeneratingTestOperator();
-		StreamConfig watermarkOperatorConfig = new StreamConfig(new Configuration());
-
 		TriggerableFailOnWatermarkTestOperator tailOperator = new TriggerableFailOnWatermarkTestOperator();
-		StreamConfig tailOperatorConfig = new StreamConfig(new Configuration());
 
-		headOperatorConfig.setStreamOperator(headOperator);
-		headOperatorConfig.setOperatorID(new OperatorID(42L, 42L));
-		headOperatorConfig.setChainStart();
-		headOperatorConfig.setChainIndex(0);
-		headOperatorConfig.setChainedOutputs(Collections.singletonList(new StreamEdge(
-			new StreamNode(null, 0, null, null, null, null, null),
-			new StreamNode(null, 1, null, null, null, null, null),
-			0,
-			Collections.<String>emptyList(),
-			null,
-			null
-		)));
-
-		watermarkOperatorConfig.setStreamOperator(watermarkOperator);
-		watermarkOperatorConfig.setOperatorID(new OperatorID(4711L, 42L));
-		watermarkOperatorConfig.setTypeSerializerIn1(StringSerializer.INSTANCE);
-		watermarkOperatorConfig.setChainIndex(1);
-		watermarkOperatorConfig.setChainedOutputs(Collections.singletonList(new StreamEdge(
-			new StreamNode(null, 1, null, null, null, null, null),
-			new StreamNode(null, 2, null, null, null, null, null),
-			0,
-			Collections.<String>emptyList(),
-			null,
-			null
-		)));
-
-		List<StreamEdge> outEdgesInOrder = new LinkedList<StreamEdge>();
-		outEdgesInOrder.add(new StreamEdge(
-			new StreamNode(null, 2, null, null, null, null, null),
-			new StreamNode(null, 3, null, null, null, null, null),
-			0,
-			Collections.<String>emptyList(),
-			new BroadcastPartitioner<Object>(),
-			null));
-
-		tailOperatorConfig.setStreamOperator(tailOperator);
-		tailOperatorConfig.setOperatorID(new OperatorID(123L, 123L));
-		tailOperatorConfig.setTypeSerializerIn1(StringSerializer.INSTANCE);
-		tailOperatorConfig.setBufferTimeout(0);
-		tailOperatorConfig.setChainIndex(2);
-		tailOperatorConfig.setChainEnd();
-		tailOperatorConfig.setOutputSelectors(Collections.<OutputSelector<?>>emptyList());
-		tailOperatorConfig.setNumberOfOutputs(1);
-		tailOperatorConfig.setOutEdgesInOrder(outEdgesInOrder);
-		tailOperatorConfig.setNonChainedOutputs(outEdgesInOrder);
-		tailOperatorConfig.setTypeSerializerOut(StringSerializer.INSTANCE);
-
-		Map<Integer, StreamConfig> chainedConfigs = new HashMap<>(2);
-		chainedConfigs.put(1, watermarkOperatorConfig);
-		chainedConfigs.put(2, tailOperatorConfig);
-		headOperatorConfig.setTransitiveChainedTaskConfigs(chainedConfigs);
-		headOperatorConfig.setOutEdgesInOrder(outEdgesInOrder);
-
-		// -----------------------------------------------------
+		testHarness.setupOpertorChain(new OperatorID(42L, 42L), headOperator)
+			.chain(new OperatorID(4711L, 42L), watermarkOperator, StringSerializer.INSTANCE)
+			.chain(new OperatorID(123L, 123L), tailOperator, StringSerializer.INSTANCE)
+			.finish();
 
 		// --------------------- begin test ---------------------
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/RestoreStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/RestoreStreamTaskTest.java
@@ -1,0 +1,359 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeutils.base.LongSerializer;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
+import org.apache.flink.runtime.checkpoint.StateAssignmentOperation;
+import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.jobgraph.OperatorInstanceID;
+import org.apache.flink.runtime.operators.testutils.MockInputSplitProvider;
+import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.runtime.state.StateSnapshotContext;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.TestHarnessUtil;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests ensuring correct behaviour of {@link org.apache.flink.runtime.state.ManagedInitializationContext#isRestored}
+ * method.
+ */
+public class RestoreStreamTaskTest extends TestLogger {
+
+	private static final Set<OperatorID> RESTORED_OPERATORS = ConcurrentHashMap.newKeySet();
+
+	@Before
+	public void setup() {
+		RESTORED_OPERATORS.clear();
+	}
+
+	@Test
+	public void testRestore() throws Exception {
+		OperatorID headOperatorID = new OperatorID(42L, 42L);
+		OperatorID tailOperatorID = new OperatorID(44L, 44L);
+		AcknowledgeStreamMockEnvironment environment1 = createRunAndCheckpointOperatorChain(
+			headOperatorID,
+			new CounterOperator(),
+			tailOperatorID,
+			new CounterOperator(),
+			Optional.empty());
+
+		assertEquals(2, environment1.getCheckpointStateHandles().getSubtaskStateMappings().size());
+
+		TaskStateSnapshot stateHandles = environment1.getCheckpointStateHandles();
+
+		AcknowledgeStreamMockEnvironment environment2 = createRunAndCheckpointOperatorChain(
+			headOperatorID,
+			new CounterOperator(),
+			tailOperatorID,
+			new CounterOperator(),
+			Optional.of(stateHandles));
+
+		assertEquals(
+			new HashSet<OperatorID>() {{
+				add(headOperatorID);
+				add(tailOperatorID);
+			}},
+			RESTORED_OPERATORS);
+	}
+
+	@Test
+	public void testRestoreHeadWithNewId() throws Exception {
+		OperatorID tailOperatorID = new OperatorID(44L, 44L);
+		AcknowledgeStreamMockEnvironment environment1 = createRunAndCheckpointOperatorChain(
+			new OperatorID(42L, 42L),
+			new CounterOperator(),
+			tailOperatorID,
+			new CounterOperator(),
+			Optional.empty());
+
+		assertEquals(2, environment1.getCheckpointStateHandles().getSubtaskStateMappings().size());
+
+		TaskStateSnapshot stateHandles = environment1.getCheckpointStateHandles();
+
+		AcknowledgeStreamMockEnvironment environment2 = createRunAndCheckpointOperatorChain(
+			new OperatorID(4242L, 4242L),
+			new CounterOperator(),
+			tailOperatorID,
+			new CounterOperator(),
+			Optional.of(stateHandles));
+
+		assertEquals(
+			new HashSet<OperatorID>() {{
+				add(tailOperatorID);
+			}},
+			RESTORED_OPERATORS);
+	}
+
+	@Test
+	public void testRestoreTailWithNewId() throws Exception {
+		OperatorID headOperatorID = new OperatorID(42L, 42L);
+
+		AcknowledgeStreamMockEnvironment environment1 = createRunAndCheckpointOperatorChain(
+			headOperatorID,
+			new CounterOperator(),
+			new OperatorID(44L, 44L),
+			new CounterOperator(),
+			Optional.empty());
+
+		assertEquals(2, environment1.getCheckpointStateHandles().getSubtaskStateMappings().size());
+
+		TaskStateSnapshot stateHandles = environment1.getCheckpointStateHandles();
+
+		AcknowledgeStreamMockEnvironment environment2 = createRunAndCheckpointOperatorChain(
+			headOperatorID,
+			new CounterOperator(),
+			new OperatorID(4444L, 4444L),
+			new CounterOperator(),
+			Optional.of(stateHandles));
+
+		assertEquals(
+			new HashSet<OperatorID>() {{
+				add(headOperatorID);
+			}},
+			RESTORED_OPERATORS);
+	}
+
+	@Test
+	public void testRestoreAfterScaleUp() throws Exception {
+		OperatorID headOperatorID = new OperatorID(42L, 42L);
+		OperatorID tailOperatorID = new OperatorID(44L, 44L);
+
+		AcknowledgeStreamMockEnvironment environment1 = createRunAndCheckpointOperatorChain(
+			headOperatorID,
+			new CounterOperator(),
+			tailOperatorID,
+			new CounterOperator(),
+			Optional.empty());
+
+		assertEquals(2, environment1.getCheckpointStateHandles().getSubtaskStateMappings().size());
+
+		// test empty state in case of scale up
+		OperatorSubtaskState emptyHeadOperatorState = StateAssignmentOperation.operatorSubtaskStateFrom(
+			new OperatorInstanceID(0, headOperatorID),
+			Collections.emptyMap(),
+			Collections.emptyMap(),
+			Collections.emptyMap(),
+			Collections.emptyMap());
+
+		TaskStateSnapshot stateHandles = environment1.getCheckpointStateHandles();
+		stateHandles.putSubtaskStateByOperatorID(headOperatorID, emptyHeadOperatorState);
+
+		AcknowledgeStreamMockEnvironment environment2 = createRunAndCheckpointOperatorChain(
+			headOperatorID,
+			new CounterOperator(),
+			tailOperatorID,
+			new CounterOperator(),
+			Optional.of(stateHandles));
+
+		assertEquals(
+			new HashSet<OperatorID>() {{
+				add(headOperatorID);
+				add(tailOperatorID);
+			}},
+			RESTORED_OPERATORS);
+	}
+
+	@Test
+	public void testRestoreWithoutState() throws Exception {
+		OperatorID headOperatorID = new OperatorID(42L, 42L);
+		OperatorID tailOperatorID = new OperatorID(44L, 44L);
+
+		AcknowledgeStreamMockEnvironment environment1 = createRunAndCheckpointOperatorChain(
+			headOperatorID,
+			new StatelessOperator(),
+			tailOperatorID,
+			new CounterOperator(),
+			Optional.empty());
+
+		assertEquals(2, environment1.getCheckpointStateHandles().getSubtaskStateMappings().size());
+
+		TaskStateSnapshot stateHandles = environment1.getCheckpointStateHandles();
+
+		AcknowledgeStreamMockEnvironment environment2 = createRunAndCheckpointOperatorChain(
+			headOperatorID,
+			new StatelessOperator(),
+			tailOperatorID,
+			new CounterOperator(),
+			Optional.of(stateHandles));
+
+		assertEquals(
+			new HashSet<OperatorID>() {{
+				add(headOperatorID);
+				add(tailOperatorID);
+			}},
+			RESTORED_OPERATORS);
+	}
+
+	private AcknowledgeStreamMockEnvironment createRunAndCheckpointOperatorChain(
+			OperatorID headId,
+			OneInputStreamOperator<String, String> headOperator,
+			OperatorID tailId,
+			OneInputStreamOperator<String, String> tailOperator,
+			Optional<TaskStateSnapshot> stateHandles) throws Exception {
+
+		final OneInputStreamTask<String, String> streamTask = new OneInputStreamTask<>();
+		final OneInputStreamTaskTestHarness<String, String> testHarness =
+			new OneInputStreamTaskTestHarness<String, String>(
+				streamTask, 1, 1,
+				BasicTypeInfo.STRING_TYPE_INFO,
+				BasicTypeInfo.STRING_TYPE_INFO);
+
+		testHarness.setupOpertorChain(headId, headOperator)
+			.chain(tailId, tailOperator, StringSerializer.INSTANCE)
+			.finish();
+
+		AcknowledgeStreamMockEnvironment environment = new AcknowledgeStreamMockEnvironment(
+			testHarness.jobConfig,
+			testHarness.taskConfig,
+			testHarness.executionConfig,
+			testHarness.memorySize,
+			new MockInputSplitProvider(),
+			testHarness.bufferSize);
+
+		if (stateHandles.isPresent()) {
+			streamTask.setInitialState(stateHandles.get());
+		}
+		testHarness.invoke(environment);
+		testHarness.waitForTaskRunning();
+
+		processRecords(testHarness);
+		triggerCheckpoint(testHarness, environment, streamTask);
+
+		testHarness.endInput();
+		testHarness.waitForTaskCompletion();
+
+		return environment;
+	}
+
+	private void triggerCheckpoint(
+			OneInputStreamTaskTestHarness<String, String> testHarness,
+			AcknowledgeStreamMockEnvironment environment,
+			OneInputStreamTask<String, String> streamTask) throws Exception {
+		long checkpointId = 1L;
+		CheckpointMetaData checkpointMetaData = new CheckpointMetaData(checkpointId, 1L);
+
+		while (!streamTask.triggerCheckpoint(checkpointMetaData, CheckpointOptions.forFullCheckpoint())) {}
+
+		environment.getCheckpointLatch().await();
+		assertEquals(checkpointId, environment.getCheckpointId());
+	}
+
+	private void processRecords(OneInputStreamTaskTestHarness<String, String> testHarness) throws Exception {
+		ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+
+		testHarness.processElement(new StreamRecord<>("10"), 0, 0);
+		testHarness.processElement(new StreamRecord<>("20"), 0, 0);
+		testHarness.processElement(new StreamRecord<>("30"), 0, 0);
+
+		testHarness.waitForInputProcessing();
+
+		expectedOutput.add(new StreamRecord<>("10"));
+		expectedOutput.add(new StreamRecord<>("20"));
+		expectedOutput.add(new StreamRecord<>("30"));
+		TestHarnessUtil.assertOutputEquals("Output was not correct.", expectedOutput, testHarness.getOutput());
+	}
+
+	private abstract static class RestoreWatchOperator<IN, OUT>
+		extends AbstractStreamOperator<OUT>
+		implements OneInputStreamOperator<IN, OUT> {
+
+		@Override
+		public void initializeState(StateInitializationContext context) throws Exception {
+			if (context.isRestored()) {
+				RESTORED_OPERATORS.add(getOperatorID());
+			}
+		}
+	}
+
+	/**
+	 * Operator that counts processed messages and keeps result on state.
+	 */
+	private static class CounterOperator extends RestoreWatchOperator<String, String> {
+		private static final long serialVersionUID = 2048954179291813243L;
+
+		private ListState<Long> counterState;
+		private long counter = 0;
+
+		@Override
+		public void processElement(StreamRecord<String> element) throws Exception {
+			counter++;
+			output.collect(element);
+		}
+
+		@Override
+		public void initializeState(StateInitializationContext context) throws Exception {
+			super.initializeState(context);
+
+			counterState = context
+				.getOperatorStateStore()
+				.getListState(new ListStateDescriptor<>("counter-state", LongSerializer.INSTANCE));
+
+			if (context.isRestored()) {
+				for (Long value : counterState.get()) {
+					counter += value;
+				}
+				counterState.clear();
+			}
+		}
+
+		@Override
+		public void snapshotState(StateSnapshotContext context) throws Exception {
+			counterState.add(counter);
+		}
+	}
+
+	/**
+	 * Operator that does nothing except counting state restorations.
+	 */
+	private static class StatelessOperator extends RestoreWatchOperator<String, String> {
+
+		private static final long serialVersionUID = 2048954179291813244L;
+
+		@Override
+		public void processElement(StreamRecord<String> element) throws Exception {
+			output.collect(element);
+		}
+
+		@Override
+		public void snapshotState(StateSnapshotContext context) throws Exception {
+		}
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamConfigChainer.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamConfigChainer.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.streaming.api.graph.StreamConfig;
+import org.apache.flink.streaming.api.graph.StreamEdge;
+import org.apache.flink.streaming.api.graph.StreamNode;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.runtime.partitioner.BroadcastPartitioner;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Helper class to build StreamConfig for chain of operators.
+ */
+public class StreamConfigChainer {
+	private final StreamConfig headConfig;
+	private final Map<Integer, StreamConfig> chainedConfigs = new HashMap<>();
+
+	private StreamConfig tailConfig;
+	private int chainIndex = 0;
+
+	public StreamConfigChainer(OperatorID headOperatorID, StreamOperator<?> headOperator, StreamConfig headConfig) {
+		this.headConfig = checkNotNull(headConfig);
+		this.tailConfig = checkNotNull(headConfig);
+
+		head(headOperator, headOperatorID);
+	}
+
+	private void head(StreamOperator<?> headOperator, OperatorID headOperatorID) {
+		headConfig.setStreamOperator(headOperator);
+		headConfig.setOperatorID(headOperatorID);
+		headConfig.setChainStart();
+		headConfig.setChainIndex(chainIndex);
+	}
+
+	public <T> StreamConfigChainer chain(
+			OperatorID operatorID,
+			OneInputStreamOperator<T, T> operator,
+			TypeSerializer<T> typeSerializer) {
+		return chain(operatorID, operator, typeSerializer, typeSerializer);
+	}
+
+	public <IN, OUT> StreamConfigChainer chain(
+			OperatorID operatorID,
+			OneInputStreamOperator<IN, OUT> operator,
+			TypeSerializer<IN> inputSerializer,
+			TypeSerializer<OUT> outputSerializer) {
+		chainIndex++;
+
+		tailConfig.setChainedOutputs(Collections.singletonList(
+			new StreamEdge(
+				new StreamNode(null, tailConfig.getChainIndex(), null, null, null, null, null),
+				new StreamNode(null, chainIndex, null, null, null, null, null),
+				0,
+				Collections.<String>emptyList(),
+				null,
+				null)));
+		tailConfig = new StreamConfig(new Configuration());
+		tailConfig.setStreamOperator(checkNotNull(operator));
+		tailConfig.setOperatorID(checkNotNull(operatorID));
+		tailConfig.setTypeSerializerIn1(inputSerializer);
+		tailConfig.setTypeSerializerOut(outputSerializer);
+		tailConfig.setChainIndex(chainIndex);
+
+		chainedConfigs.put(chainIndex, tailConfig);
+
+		return this;
+	}
+
+	public void finish() {
+
+		List<StreamEdge> outEdgesInOrder = new LinkedList<StreamEdge>();
+		outEdgesInOrder.add(
+			new StreamEdge(
+				new StreamNode(null, chainIndex, null, null, null, null, null),
+				new StreamNode(null, chainIndex , null, null, null, null, null),
+				0,
+				Collections.<String>emptyList(),
+				new BroadcastPartitioner<Object>(),
+				null));
+
+		tailConfig.setBufferTimeout(0);
+		tailConfig.setChainEnd();
+		tailConfig.setOutputSelectors(Collections.emptyList());
+		tailConfig.setNumberOfOutputs(1);
+		tailConfig.setOutEdgesInOrder(outEdgesInOrder);
+		tailConfig.setNonChainedOutputs(outEdgesInOrder);
+		headConfig.setTransitiveChainedTaskConfigs(chainedConfigs);
+		headConfig.setOutEdgesInOrder(outEdgesInOrder);
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
@@ -34,6 +34,7 @@ import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.graph.StreamEdge;
 import org.apache.flink.streaming.api.graph.StreamNode;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.runtime.partitioner.BroadcastPartitioner;
 import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
@@ -368,6 +369,10 @@ public class StreamTaskTestHarness<OUT> {
 		for (int i = 0; i < numInputGates; i++) {
 			inputGates[i].endInput();
 		}
+	}
+
+	public StreamConfigChainer setupOpertorChain(OperatorID headOperatorId, OneInputStreamOperator<?, ?> headOperator) {
+		return new StreamConfigChainer(headOperatorId, headOperator, getStreamConfig());
 	}
 
 	// ------------------------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change

This PR adds tests coverage for correct behaviour of `ManagedInitializationContext#isRestored` flag - if application is restarted and a some operator has a new `uid`, it should return false. This bug was fixed by #4353. 

## Brief change log

Please check commit messages for change log

## Verifying this change

This PR adds `RestoreStreamTaskTest` and is not changing any productional code.