### PR TITLE
[FLINK-7863] Generalize MetricFetcher to work with a RestfulGateway

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerRunner.java
@@ -178,6 +178,10 @@ public class JobManagerRunner implements LeaderContender, OnCompletionActions, F
 		}
 	}
 
+	//----------------------------------------------------------------------------------------------
+	// Getter
+	//----------------------------------------------------------------------------------------------
+
 	public JobMasterGateway getJobManagerGateway() {
 		return jobManager.getSelfGateway(JobMasterGateway.class);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerGateway.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.resourcemanager;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
@@ -27,6 +28,7 @@ import org.apache.flink.runtime.clusterframework.types.SlotID;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.jobmaster.JobMasterId;
 import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.metrics.dump.MetricQueryService;
 import org.apache.flink.runtime.rpc.FencedRpcGateway;
 import org.apache.flink.runtime.rpc.RpcTimeout;
 import org.apache.flink.runtime.jobmaster.JobMaster;
@@ -34,6 +36,7 @@ import org.apache.flink.runtime.registration.RegistrationResponse;
 import org.apache.flink.runtime.taskexecutor.SlotReport;
 import org.apache.flink.runtime.taskexecutor.TaskExecutor;
 
+import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -166,4 +169,12 @@ public interface ResourceManagerGateway extends FencedRpcGateway<ResourceManager
 	 * @return Future containing the resource overview
 	 */
 	CompletableFuture<ResourceOverview> requestResourceOverview(@RpcTimeout Time timeout);
+
+	/**
+	 * Requests the paths for the TaskManager's {@link MetricQueryService} to query.
+	 *
+	 * @param timeout for the asynchronous operation
+	 * @return Future containing the collection of instance ids and the corresponding metric query service path
+	 */
+	CompletableFuture<Collection<Tuple2<InstanceID, String>>> requestTaskManagerMetricQueryServicePaths(@RpcTimeout Time timeout);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcService.java
@@ -133,6 +133,10 @@ public class AkkaRpcService implements RpcService {
 		stopped = false;
 	}
 
+	public ActorSystem getActorSystem() {
+		return actorSystem;
+	}
+
 	@Override
 	public String getAddress() {
 		return address;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/RestfulGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/RestfulGateway.java
@@ -20,14 +20,18 @@ package org.apache.flink.runtime.webmonitor;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
+import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.messages.FlinkJobNotFoundException;
 import org.apache.flink.runtime.messages.webmonitor.ClusterOverview;
 import org.apache.flink.runtime.messages.webmonitor.MultipleJobsDetails;
+import org.apache.flink.runtime.metrics.dump.MetricQueryService;
 import org.apache.flink.runtime.rpc.RpcEndpoint;
 import org.apache.flink.runtime.rpc.RpcGateway;
 import org.apache.flink.runtime.rpc.RpcTimeout;
 
+import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -76,4 +80,20 @@ public interface RestfulGateway extends RpcGateway {
 	 * @return Future containing the status overview
 	 */
 	CompletableFuture<ClusterOverview> requestClusterOverview(@RpcTimeout Time timeout);
+
+	/**
+	 * Requests the paths for the {@link MetricQueryService} to query.
+	 *
+	 * @param timeout for the asynchronous operation
+	 * @return Future containing the collection of metric query service paths to query
+	 */
+	CompletableFuture<Collection<String>> requestMetricQueryServicePaths(@RpcTimeout Time timeout);
+
+	/**
+	 * Requests the paths for the TaskManager's {@link MetricQueryService} to query.
+	 *
+	 * @param timeout for the asynchronous operation
+	 * @return Future containing the collection of instance ids and the corresponding metric query service path
+	 */
+	CompletableFuture<Collection<Tuple2<InstanceID, String>>> requestTaskManagerMetricQueryServicePaths(@RpcTimeout Time timeout);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/retriever/MetricQueryServiceGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/retriever/MetricQueryServiceGateway.java
@@ -33,4 +33,6 @@ import java.util.concurrent.CompletableFuture;
 public interface MetricQueryServiceGateway {
 
 	CompletableFuture<MetricDumpSerialization.MetricSerializationResult> queryMetrics(Time timeout);
+
+	String getAddress();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/retriever/impl/AkkaQueryServiceGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/retriever/impl/AkkaQueryServiceGateway.java
@@ -50,4 +50,9 @@ public class AkkaQueryServiceGateway implements MetricQueryServiceGateway {
 				.mapTo(ClassTag$.MODULE$.apply(MetricDumpSerialization.MetricSerializationResult.class))
 		);
 	}
+
+	@Override
+	public String getAddress() {
+		return queryServiceActorRef.path().toString();
+	}
 }


### PR DESCRIPTION
## What is the purpose of the change

Generalize MetricFetcher to work with `T extends RestfulGateway` instead of the `JobManagerGateway`. That way also the Flip-6 code can be used in combination with the `MetricFetcher`.

## Brief change log

- Add `RestfulGateway#requestMetricQueryServicePaths` to obtain the metric service query paths for the cluster (so far only the `JobManager` or the `Dispatcher` in the Flip-6 case)
- Add `RestfulGateway#requestTaskManagerMetricQueryServicePaths` to obtain the metric service query paths for the `TaskManagers`
- Adapt `MetricFetcher` to work with `RestfulGateway`.

## Verifying this change

Manually tested.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

