### PR TITLE
[FLINK-5372] [tests] Fix RocksDBAsyncSnapshotTest.testCancelFullyAsyn…

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/util/ResourceGuardTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/ResourceGuardTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-public class ResourceGuardTest {
+public class ResourceGuardTest extends TestLogger {
 
 	@Test
 	public void testClose() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/BlockerCheckpointStreamFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/BlockerCheckpointStreamFactory.java
@@ -33,10 +33,10 @@ import java.io.IOException;
 @Internal
 public class BlockerCheckpointStreamFactory implements CheckpointStreamFactory {
 
-	private final int maxSize;
-	private volatile int afterNumberInvocations;
-	private volatile OneShotLatch blocker;
-	private volatile OneShotLatch waiter;
+	protected final int maxSize;
+	protected volatile int afterNumberInvocations;
+	protected volatile OneShotLatch blocker;
+	protected volatile OneShotLatch waiter;
 
 	MemCheckpointStreamFactory.MemoryCheckpointOutputStream lastCreatedStream;
 
@@ -58,6 +58,14 @@ public class BlockerCheckpointStreamFactory implements CheckpointStreamFactory {
 
 	public void setWaiterLatch(OneShotLatch latch) {
 		this.waiter = latch;
+	}
+
+	public OneShotLatch getBlockerLatch() {
+		return blocker;
+	}
+
+	public OneShotLatch getWaiterLatch() {
+		return waiter;
 	}
 
 	@Override


### PR DESCRIPTION
…cCheckpoints()

## What is the purpose of the change

This PR fixes `RocksDBAsyncSnapshotTest.testCancelFullyAsyncCheckpoints()`, so that the test can be reactivated.

Furthermore, it also fixes some problems in the same test class related to unreleased native RocksDB resources (missing calls to `RocksDBKeyedStateBackend::dispose()`). I did a search for similar problems by placing log statements for instance creation and dispose calls in the log and ensured that there are always matching pairs. I did this for the rocksdb tests and flink-tests - found and fixed one more case in `RocksDBStateBackendConfigTest`.

## Brief change log

First problem is, that the test uses a checkpoint stream factory that produces streams that block on latches, then wants to call close() while the stream is supposed to be blocked in an async thread executing and writing the rocksdb snapshot. While the test fails is, that the first stream is actually used to take s snapshot of the timer service into raw keyed state. The timer service is not async and therefore the test blocks and cannot reach close(). I will fix the test through a different factory, that gives a blocking stream on the second call, i.e. for the request that is actually from the keyed backend.
For the second problem, this was a bit nasty to reproduce but simple in cause and solution. The test testCleanupOfSnapshotsInFailureCase created an instance of RocksDBKeyedStateBackend, but never called the dispose method to release native resources. Since the latest RocksDB update, their code has assertions in place that are executed in finalize() and will detect leaking native resources. This happens only when the resource is GC'ed, and this explains why you could only observe the test crash when it was executed with more tests, eventually reaching a GC.

*Changes*
  - *`RocksDBAsyncSnapshotTest.testCancelFullyAsyncCheckpoints()` used a checkpoint stream factory that produces streams that block on latches, then wants to call `close()` while the stream is supposed to be blocked in an async thread executing and writing the rocksdb snapshot. The test fails because the first created stream is actually used to take a snapshot of the timer service into raw keyed state. The timer service is not async and therefore the test blocks and cannot reach `close()`. The fix introduces a different factory that gives a blocking stream on the second call, i.e. for the request that is actually from the keyed backend.*

  - *Introduces some missing calls to `RocksDBKeyedStateBackend::dispose()`*


## Verifying this change
`RocksDBAsyncSnapshotTest.testCancelFullyAsyncCheckpoints()` is reactivated and works.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)

