### PR TITLE
[hotifx] [docs] Add required option -yn to example command

### DIFF
--- a/docs/ops/deployment/aws.md
+++ b/docs/ops/deployment/aws.md
@@ -59,7 +59,7 @@ After creating your cluster, you can [connect to the master node](http://docs.aw
 2. Extract the Flink distribution and you are ready to deploy [Flink jobs via YARN](yarn_setup.html) after **setting the Hadoop config directory**:
 
 ```bash
-HADOOP_CONF_DIR=/etc/hadoop/conf bin/flink run -m yarn-cluster examples/streaming/WordCount.jar
+HADOOP_CONF_DIR=/etc/hadoop/conf bin/flink run -m yarn-cluster -yn 1 examples/streaming/WordCount.jar
 ```
 
 {% top %}


### PR DESCRIPTION
Example command to start the WordCount job via YARN does not work because it is missing the `-yn` option, which specifies the number of YARN container to allocate (i.e., number of Task Managers).
