### PR TITLE
[FLINK-7755] [table] Fix NULL handling in batch joins.

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/FunctionCodeGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/FunctionCodeGenerator.scala
@@ -125,6 +125,18 @@ class FunctionCodeGenerator(
              s"$inputTypeTerm2 $input2Term = ($inputTypeTerm2) _in2;"))
     }
 
+    // JoinFunction
+    else if (clazz == classOf[JoinFunction[_, _, _]]) {
+      val baseClass = classOf[RichJoinFunction[_, _, _]]
+      val inputTypeTerm1 = boxedTypeTermForTypeInfo(input1)
+      val inputTypeTerm2 = boxedTypeTermForTypeInfo(input2.getOrElse(
+        throw new CodeGenException("Input 2 for JoinFunction should not be null")))
+      (baseClass,
+        s"Object join(Object _in1, Object _in2)",
+        List(s"$inputTypeTerm1 $input1Term = ($inputTypeTerm1) _in1;",
+          s"$inputTypeTerm2 $input2Term = ($inputTypeTerm2) _in2;"))
+    }
+
     // ProcessFunction
     else if (clazz == classOf[ProcessFunction[_, _]]) {
       val baseClass = classOf[ProcessFunction[_, _]]

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/ScalarOperators.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/ScalarOperators.scala
@@ -382,33 +382,23 @@ object ScalarOperators {
          |boolean $resultTerm = false;
          |boolean $nullTerm = false;
          |if (!${left.nullTerm} && !${left.resultTerm}) {
-         |  // left expr is false, skip right expr
+         |  // left expr is false, result is always false
+         |  // skip right expr
          |} else {
          |  ${right.code}
          |
-         |  if (!${left.nullTerm} && !${right.nullTerm}) {
-         |    $resultTerm = ${left.resultTerm} && ${right.resultTerm};
-         |    $nullTerm = false;
-         |  }
-         |  else if (!${left.nullTerm} && ${left.resultTerm} && ${right.nullTerm}) {
-         |    $resultTerm = false;
-         |    $nullTerm = true;
-         |  }
-         |  else if (!${left.nullTerm} && !${left.resultTerm} && ${right.nullTerm}) {
-         |    $resultTerm = false;
-         |    $nullTerm = false;
-         |  }
-         |  else if (${left.nullTerm} && !${right.nullTerm} && ${right.resultTerm}) {
-         |    $resultTerm = false;
-         |    $nullTerm = true;
-         |  }
-         |  else if (${left.nullTerm} && !${right.nullTerm} && !${right.resultTerm}) {
-         |    $resultTerm = false;
-         |    $nullTerm = false;
-         |  }
-         |  else {
-         |    $resultTerm = false;
-         |    $nullTerm = true;
+         |  if (${left.nullTerm}) {
+         |    // left is null (unknown)
+         |    if (${right.nullTerm} || ${right.resultTerm}) {
+         |      $nullTerm = true;
+         |    }
+         |  } else {
+         |    // left is true
+         |    if (${right.nullTerm}) {
+         |      $nullTerm = true;
+         |    } else if (${right.resultTerm}) {
+         |      $resultTerm = true;
+         |    }
          |  }
          |}
        """.stripMargin

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/logical/operators.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/logical/operators.scala
@@ -486,11 +486,6 @@ case class Join(
         s"Invalid join condition: $expression. At least one equi-join predicate is " +
           s"required.")
     }
-    if (joinType != JoinType.INNER && (nonEquiJoinPredicateFound || localPredicateFound)) {
-      failValidation(
-        s"Invalid join condition: $expression. Non-equality join predicates or local" +
-          s" predicates are not supported in outer joins.")
-    }
   }
 }
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/dataset/DataSetJoin.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/dataset/DataSetJoin.scala
@@ -18,6 +18,9 @@
 
 package org.apache.flink.table.plan.nodes.dataset
 
+import java.lang.Iterable
+import java.lang.{Boolean => JBool}
+
 import org.apache.calcite.plan._
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.core.{JoinInfo, JoinRelType}
@@ -25,15 +28,19 @@ import org.apache.calcite.rel.metadata.RelMetadataQuery
 import org.apache.calcite.rel.{BiRel, RelNode, RelWriter}
 import org.apache.calcite.rex.RexNode
 import org.apache.calcite.util.mapping.IntPair
-import org.apache.flink.api.common.functions.FlatJoinFunction
+import org.apache.flink.api.common.functions.{FilterFunction, FlatJoinFunction, GroupReduceFunction, JoinFunction}
+import org.apache.flink.api.common.operators.Order
 import org.apache.flink.api.common.operators.base.JoinOperatorBase.JoinHint
+import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.DataSet
-import org.apache.flink.table.api.{BatchTableEnvironment, TableException}
+import org.apache.flink.api.java.typeutils.RowTypeInfo
+import org.apache.flink.table.api.{BatchTableEnvironment, TableConfig, TableException, Types}
 import org.apache.flink.table.calcite.FlinkTypeFactory
-import org.apache.flink.table.codegen.FunctionCodeGenerator
+import org.apache.flink.table.codegen.{FunctionCodeGenerator, GeneratedFunction}
 import org.apache.flink.table.plan.nodes.CommonJoin
-import org.apache.flink.table.runtime.FlatJoinRunner
+import org.apache.flink.table.runtime._
 import org.apache.flink.types.Row
+import org.apache.flink.util.Collector
 
 import scala.collection.JavaConversions._
 import scala.collection.mutable.ArrayBuffer
@@ -156,65 +163,394 @@ class DataSetJoin(
     val leftDataSet = left.asInstanceOf[DataSetRel].translateToPlan(tableEnv)
     val rightDataSet = right.asInstanceOf[DataSetRel].translateToPlan(tableEnv)
 
-    val (joinOperator, nullCheck) = joinType match {
-      case JoinRelType.INNER => (leftDataSet.join(rightDataSet), false)
-      case JoinRelType.LEFT => (leftDataSet.leftOuterJoin(rightDataSet), true)
-      case JoinRelType.RIGHT => (leftDataSet.rightOuterJoin(rightDataSet), true)
-      case JoinRelType.FULL => (leftDataSet.fullOuterJoin(rightDataSet), true)
+    joinType match {
+      case JoinRelType.INNER =>
+        addInnerJoin(
+          leftDataSet,
+          rightDataSet,
+          leftKeys.toArray,
+          rightKeys.toArray,
+          returnType,
+          config)
+      case JoinRelType.LEFT =>
+        addLeftOuterJoin(
+          leftDataSet,
+          rightDataSet,
+          leftKeys.toArray,
+          rightKeys.toArray,
+          returnType,
+          config)
+      case JoinRelType.RIGHT =>
+        addRightOuterJoin(
+          leftDataSet,
+          rightDataSet,
+          leftKeys.toArray,
+          rightKeys.toArray,
+          returnType,
+          config)
+      case JoinRelType.FULL =>
+        addFullOuterJoin(
+          leftDataSet,
+          rightDataSet,
+          leftKeys.toArray,
+          rightKeys.toArray,
+          returnType,
+          config)
     }
+  }
 
-    if (nullCheck && !config.getNullCheck) {
-      throw TableException("Null check in TableConfig must be enabled for outer joins.")
-    }
+  private def addInnerJoin(
+      left: DataSet[Row],
+      right: DataSet[Row],
+      leftKeys: Array[Int],
+      rightKeys: Array[Int],
+      resultType: TypeInformation[Row],
+      config: TableConfig): DataSet[Row] = {
 
     val generator = new FunctionCodeGenerator(
       config,
-      nullCheck,
-      leftDataSet.getType,
-      Some(rightDataSet.getType))
+      false,
+      left.getType,
+      Some(right.getType))
     val conversion = generator.generateConverterResultExpression(
-      returnType,
+      resultType,
       joinRowType.getFieldNames)
 
-    var body = ""
+    val condition = generator.generateExpression(joinCondition)
+    val body =
+      s"""
+         |${condition.code}
+         |if (${condition.resultTerm}) {
+         |  ${conversion.code}
+         |  ${generator.collectorTerm}.collect(${conversion.resultTerm});
+         |}
+         |""".stripMargin
 
-    if (joinInfo.isEqui) {
-      // only equality condition
-      body = s"""
-           |${conversion.code}
-           |${generator.collectorTerm}.collect(${conversion.resultTerm});
-           |""".stripMargin
-    }
-    else {
-      val nonEquiPredicates = joinInfo.getRemaining(this.cluster.getRexBuilder)
-      val condition = generator.generateExpression(nonEquiPredicates)
-      body = s"""
-           |${condition.code}
-           |if (${condition.resultTerm}) {
-           |  ${conversion.code}
-           |  ${generator.collectorTerm}.collect(${conversion.resultTerm});
-           |}
-           |""".stripMargin
-    }
     val genFunction = generator.generateFunction(
       ruleDescription,
       classOf[FlatJoinFunction[Row, Row, Row]],
       body,
-      returnType)
+      resultType)
 
     val joinFun = new FlatJoinRunner[Row, Row, Row](
       genFunction.name,
       genFunction.code,
       genFunction.returnType)
 
-    val joinOpName =
-      s"where: (${joinConditionToString(joinRowType, joinCondition, getExpressionString)}), " +
-        s"join: (${joinSelectionToString(joinRowType)})"
-
-    joinOperator
-      .where(leftKeys.toArray: _*)
-      .equalTo(rightKeys.toArray: _*)
+    left.join(right)
+      .where(leftKeys: _*)
+      .equalTo(rightKeys: _*)
       .`with`(joinFun)
-      .name(joinOpName)
+      .name(getJoinOpName)
   }
+
+  private def addLeftOuterJoin(
+      left: DataSet[Row],
+      right: DataSet[Row],
+      leftKeys: Array[Int],
+      rightKeys: Array[Int],
+      resultType: TypeInformation[Row],
+      config: TableConfig): DataSet[Row] = {
+
+    if (!config.getNullCheck) {
+      throw TableException("Null check in TableConfig must be enabled for outer joins.")
+    }
+
+    val joinOpName = getJoinOpName
+
+    // replace field names by indexed names for easier key handling
+    val leftType = new RowTypeInfo(left.getType.asInstanceOf[RowTypeInfo].getFieldTypes: _*)
+    val rightType = right.getType.asInstanceOf[RowTypeInfo]
+
+    // partition and sort left input
+    // this step ensures we can reuse the sorting for all following operations
+    // (groupBy->join->groupBy)
+    val partitionedSortedLeft: DataSet[Row] = partitionAndSort(left, leftKeys)
+
+    // deduplicate the rows of the left input
+    val deduplicatedRowsLeft: DataSet[Row] = deduplicateRows(partitionedSortedLeft, leftType)
+
+    // create JoinFunction to evaluate join predicate
+    val predFun = generatePredicateFunction(leftType, rightType, config)
+    val joinOutType = new RowTypeInfo(leftType, rightType, Types.INT)
+    val joinFun = new LeftOuterJoinRunner(predFun.name, predFun.code, joinOutType)
+
+    // join left and right inputs, evaluate join predicate, and emit join pairs
+    val nestedLeftKeys = leftKeys.map(i => s"f0.f$i")
+    val joinPairs = deduplicatedRowsLeft.leftOuterJoin(right, JoinHint.REPARTITION_SORT_MERGE)
+      .where(nestedLeftKeys: _*)
+      .equalTo(rightKeys: _*)
+      .`with`(joinFun)
+      .withForwardedFieldsFirst("f0->f0")
+      .name(joinOpName)
+
+    // create GroupReduceFunction to generate the join result
+    val convFun = generateConversionFunction(leftType, rightType, resultType, config)
+    val reduceFun = new LeftOuterJoinGroupReduceRunner(
+      convFun.name,
+      convFun.code,
+      convFun.returnType)
+
+    // convert join pairs to result.
+    // This step ensures we preserve the rows of the left input.
+    joinPairs
+      .groupBy("f0")
+      .reduceGroup(reduceFun)
+      .name(joinOpName)
+      .returns(resultType)
+  }
+
+  private def addRightOuterJoin(
+      left: DataSet[Row],
+      right: DataSet[Row],
+      leftKeys: Array[Int],
+      rightKeys: Array[Int],
+      resultType: TypeInformation[Row],
+      config: TableConfig): DataSet[Row] = {
+
+    if (!config.getNullCheck) {
+      throw TableException("Null check in TableConfig must be enabled for outer joins.")
+    }
+
+    val joinOpName = getJoinOpName
+
+    // replace field names by indexed names for easier key handling
+    val leftType = left.getType.asInstanceOf[RowTypeInfo]
+    val rightType = new RowTypeInfo(right.getType.asInstanceOf[RowTypeInfo].getFieldTypes: _*)
+
+    // partition and sort right input
+    // this step ensures we can reuse the sorting for all following operations
+    // (groupBy->join->groupBy)
+    val partitionedSortedRight: DataSet[Row] = partitionAndSort(right, rightKeys)
+
+    // deduplicate the rows of the right input
+    val deduplicatedRowsRight: DataSet[Row] = deduplicateRows(partitionedSortedRight, rightType)
+
+    // create JoinFunction to evaluate join predicate
+    val predFun = generatePredicateFunction(leftType, rightType, config)
+    val joinOutType = new RowTypeInfo(leftType, rightType, Types.INT)
+    val joinFun = new RightOuterJoinRunner(predFun.name, predFun.code, joinOutType)
+
+    // join left and right inputs, evaluate join predicate, and emit join pairs
+    val nestedRightKeys = rightKeys.map(i => s"f0.f$i")
+    val joinPairs = left.rightOuterJoin(deduplicatedRowsRight, JoinHint.REPARTITION_SORT_MERGE)
+      .where(leftKeys: _*)
+      .equalTo(nestedRightKeys: _*)
+      .`with`(joinFun)
+      .withForwardedFieldsSecond("f0->f1")
+      .name(joinOpName)
+
+    // create GroupReduceFunction to generate the join result
+    val convFun = generateConversionFunction(leftType, rightType, resultType, config)
+    val reduceFun = new RightOuterJoinGroupReduceRunner(
+      convFun.name,
+      convFun.code,
+      convFun.returnType)
+
+    // convert join pairs to result
+    // This step ensures we preserve the rows of the right input.
+    joinPairs
+      .groupBy("f1")
+      .reduceGroup(reduceFun)
+      .name(joinOpName)
+      .returns(resultType)
+  }
+
+  private def addFullOuterJoin(
+      left: DataSet[Row],
+      right: DataSet[Row],
+      leftKeys: Array[Int],
+      rightKeys: Array[Int],
+      resultType: TypeInformation[Row],
+      config: TableConfig): DataSet[Row] = {
+
+    if (!config.getNullCheck) {
+      throw TableException("Null check in TableConfig must be enabled for outer joins.")
+    }
+
+    val joinOpName = getJoinOpName
+
+    // replace field names by indexed names for easier key handling
+    val leftType = new RowTypeInfo(left.getType.asInstanceOf[RowTypeInfo].getFieldTypes: _*)
+    val rightType = new RowTypeInfo(right.getType.asInstanceOf[RowTypeInfo].getFieldTypes: _*)
+
+    // partition and sort left and right input
+    // this step ensures we can reuse the sorting for all following operations
+    // (groupBy->join->groupBy), except the second grouping to preserve right rows.
+    val partitionedSortedLeft: DataSet[Row] = partitionAndSort(left, leftKeys)
+    val partitionedSortedRight: DataSet[Row] = partitionAndSort(right, rightKeys)
+
+    // deduplicate the rows of the left and right input
+    val deduplicatedRowsLeft: DataSet[Row] = deduplicateRows(partitionedSortedLeft, leftType)
+    val deduplicatedRowsRight: DataSet[Row] = deduplicateRows(partitionedSortedRight, rightType)
+
+    // create JoinFunction to evaluate join predicate
+    val predFun = generatePredicateFunction(leftType, rightType, config)
+    val joinOutType = new RowTypeInfo(leftType, rightType, Types.INT, Types.INT)
+    val joinFun = new FullOuterJoinRunner(predFun.name, predFun.code, joinOutType)
+
+    // join left and right inputs, evaluate join predicate, and emit join pairs
+    val nestedLeftKeys = leftKeys.map(i => s"f0.f$i")
+    val nestedRightKeys = rightKeys.map(i => s"f0.f$i")
+    val joinPairs = deduplicatedRowsLeft
+      .fullOuterJoin(deduplicatedRowsRight, JoinHint.REPARTITION_SORT_MERGE)
+      .where(nestedLeftKeys: _*)
+      .equalTo(nestedRightKeys: _*)
+      .`with`(joinFun)
+      .withForwardedFieldsFirst("f0->f0")
+      .withForwardedFieldsSecond("f0->f1")
+      .name(joinOpName)
+
+    // create GroupReduceFunctions to generate the join result
+    val convFun = generateConversionFunction(leftType, rightType, resultType, config)
+    val leftReduceFun = new LeftFullOuterJoinGroupReduceRunner(
+      convFun.name,
+      convFun.code,
+      convFun.returnType)
+    val rightReduceFun = new RightFullOuterJoinGroupReduceRunner(
+      convFun.name,
+      convFun.code,
+      convFun.returnType)
+
+    // compute joined (left + right) and left preserved (left + null)
+    val joinedAndLeftPreserved = joinPairs
+      // filter for pairs with left row
+      .filter(new FilterFunction[Row](){
+        override def filter(row: Row): Boolean = row.getField(0) != null})
+      .groupBy("f0")
+      .reduceGroup(leftReduceFun)
+      .name(joinOpName)
+      .returns(resultType)
+
+    // compute right preserved (null + right)
+    val rightPreserved = joinPairs
+      // filter for pairs with right row
+      .filter(new FilterFunction[Row](){
+        override def filter(row: Row): Boolean = row.getField(1) != null})
+      .groupBy("f1")
+      .reduceGroup(rightReduceFun)
+      .name(joinOpName)
+      .returns(resultType)
+
+    // union joined (left + right), left preserved (left + null), and right preserved (null + right)
+    joinedAndLeftPreserved.union(rightPreserved)
+  }
+
+  private def getJoinOpName: String = {
+    s"where: (${joinConditionToString(joinRowType, joinCondition, getExpressionString)}), " +
+      s"join: (${joinSelectionToString(joinRowType)})"
+  }
+
+  /** Returns an array of indicies with some indicies being a prefix. */
+  private def getFullIndiciesWithPrefix(keys: Array[Int], numFields: Int): Array[Int] = {
+    // get indicies of all fields which are not keys
+    val nonKeys = (0 until numFields).filter(i => !keys.contains(i))
+    // return all field indicies prefixed by keys
+    keys ++ nonKeys
+  }
+
+  /**
+    * Partitions the data set on the join keys and sort it on all field with the join keys being a
+    * prefix.
+    */
+  private def partitionAndSort(
+      dataSet: DataSet[Row],
+      partitionKeys: Array[Int]): DataSet[Row] = {
+
+    // construct full sort keys with partitionKeys being a prefix
+    val sortKeys = getFullIndiciesWithPrefix(partitionKeys, dataSet.getType.getArity)
+    // partition
+    val partitioned: DataSet[Row] = dataSet.partitionByHash(partitionKeys: _*)
+    // sort on all fields
+    sortKeys.foldLeft(partitioned: DataSet[Row]) { (d, i) =>
+      d.sortPartition(i, Order.ASCENDING).asInstanceOf[DataSet[Row]]
+    }
+  }
+
+  /**
+    * Deduplicates the rows of a data set and emits a row for each unique row with with the first
+    * field being the unique row and the second field being the number of duplicates of the row.
+    */
+  private def deduplicateRows(
+      dataSet: DataSet[Row],
+      dataSetType: TypeInformation[Row]): DataSet[Row] = {
+
+    val resultType = new RowTypeInfo(dataSetType, Types.INT)
+    val groupKeys = 0 until dataSetType.getArity
+
+    dataSet
+      // group on all fields of the input row
+      .groupBy(groupKeys: _*)
+      // remove duplicates
+      .reduceGroup(new GroupReduceFunction[Row, Row] {
+        val outTuple = new Row(2)
+        override def reduce(values: Iterable[Row], out: Collector[Row]): Unit = {
+          // count number of duplicates
+          var cnt = 0
+          val it = values.iterator()
+          while (it.hasNext) {
+            // set output row
+            outTuple.setField(0, it.next())
+            cnt += 1
+          }
+          // set count
+          outTuple.setField(1, cnt)
+          // emit deduplicated row with count
+          out.collect(outTuple)
+        }
+      })
+      .returns(resultType)
+      .withForwardedFields("*->f0")
+      .name("deduplicate")
+  }
+
+  /**
+    * Generates a [[GeneratedFunction]] of a [[JoinFunction]] to evaluate the join predicate.
+    * The function returns the result of the predicate as [[JBool]].
+    */
+  private def generatePredicateFunction(
+      leftType: TypeInformation[Row],
+      rightType: TypeInformation[Row],
+      config: TableConfig): GeneratedFunction[JoinFunction[Row, Row, JBool], JBool] = {
+    val predGenerator = new FunctionCodeGenerator(config, false, leftType, Some(rightType))
+    val condition = predGenerator.generateExpression(joinCondition)
+    val predCode =
+      s"""
+         |${condition.code}
+         |return (${condition.resultTerm});
+         |""".stripMargin
+
+    predGenerator.generateFunction(
+      "OuterJoinPredicate",
+      classOf[JoinFunction[Row, Row, JBool]],
+      predCode,
+      Types.BOOLEAN)
+  }
+
+  /**
+    * Generates a [[GeneratedFunction]] of a [[JoinFunction]] to produce the join result.
+    */
+  private def generateConversionFunction(
+      leftType: TypeInformation[Row],
+      rightType: TypeInformation[Row],
+      resultType: TypeInformation[Row],
+      config: TableConfig): GeneratedFunction[JoinFunction[Row, Row, Row], Row] = {
+
+    val conversionGenerator = new FunctionCodeGenerator(config, true, leftType, Some(rightType))
+    val conversion = conversionGenerator.generateConverterResultExpression(
+      resultType,
+      joinRowType.getFieldNames)
+    val convCode =
+      s"""
+         |${conversion.code}
+         |return ${conversion.resultTerm};
+         |""".stripMargin
+
+    conversionGenerator.generateFunction(
+      "OuterJoinConverter",
+      classOf[JoinFunction[Row, Row, Row]],
+      convCode,
+      resultType)
+  }
+
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/logical/FlinkLogicalJoin.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/logical/FlinkLogicalJoin.scala
@@ -77,7 +77,7 @@ private class FlinkLogicalJoinConverter
     val join: LogicalJoin = call.rel(0).asInstanceOf[LogicalJoin]
     val joinInfo = join.analyzeCondition
 
-    hasEqualityPredicates(join, joinInfo) || isSingleRowJoin(join)
+    hasEqualityPredicates(joinInfo) || isSingleRowJoin(join)
   }
 
   override def convert(rel: RelNode): RelNode = {
@@ -95,7 +95,7 @@ private class FlinkLogicalJoinConverter
       join.getJoinType)
   }
 
-  private def hasEqualityPredicates(join: LogicalJoin, joinInfo: JoinInfo): Boolean = {
+  private def hasEqualityPredicates(joinInfo: JoinInfo): Boolean = {
     // joins require an equi-condition or a conjunctive predicate with at least one equi-condition
     !joinInfo.pairs().isEmpty
   }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/logical/FlinkLogicalJoin.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/logical/FlinkLogicalJoin.scala
@@ -97,8 +97,7 @@ private class FlinkLogicalJoinConverter
 
   private def hasEqualityPredicates(join: LogicalJoin, joinInfo: JoinInfo): Boolean = {
     // joins require an equi-condition or a conjunctive predicate with at least one equi-condition
-    // and disable outer joins with non-equality predicates(see FLINK-5520)
-    !joinInfo.pairs().isEmpty && (joinInfo.isEqui || join.getJoinType == JoinRelType.INNER)
+    !joinInfo.pairs().isEmpty
   }
 
   private def isSingleRowJoin(join: LogicalJoin): Boolean = {

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/dataSet/DataSetJoinRule.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/dataSet/DataSetJoinRule.scala
@@ -41,8 +41,7 @@ class DataSetJoinRule
     val joinInfo = join.analyzeCondition
 
     // joins require an equi-condition or a conjunctive predicate with at least one equi-condition
-    // and disable outer joins with non-equality predicates(see FLINK-5520)
-    !joinInfo.pairs().isEmpty && (joinInfo.isEqui || join.getJoinType == JoinRelType.INNER)
+    !joinInfo.pairs().isEmpty
   }
 
   override def convert(rel: RelNode): RelNode = {

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/outerJoinGroupReduceRunners.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/outerJoinGroupReduceRunners.scala
@@ -1,0 +1,244 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.runtime
+
+import java.lang.Iterable
+
+import org.apache.flink.api.common.functions.{JoinFunction, RichGroupReduceFunction}
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.table.codegen.Compiler
+import org.apache.flink.table.util.Logging
+import org.apache.flink.types.Row
+import org.apache.flink.util.Collector
+
+abstract class OuterJoinGroupReduceRunner(
+    name: String,
+    code: String,
+    @transient var returnType: TypeInformation[Row])
+  extends RichGroupReduceFunction[Row, Row]
+    with Compiler[JoinFunction[Row, Row, Row]] with Logging {
+
+  protected var function: JoinFunction[Row, Row, Row] = null
+
+  override def open(config: Configuration) {
+    LOG.debug(s"Compiling JoinFunction: $name \n\n Code:\n$code")
+    val clazz = compile(getRuntimeContext.getUserCodeClassLoader, name, code)
+    LOG.debug("Instantiating JoinFunction.")
+    function = clazz.newInstance()
+  }
+}
+
+class LeftOuterJoinGroupReduceRunner(
+    name: String,
+    code: String,
+    returnType: TypeInformation[Row])
+  extends OuterJoinGroupReduceRunner(name, code, returnType) {
+
+  override final def reduce(pairs: Iterable[Row], out: Collector[Row]): Unit = {
+
+    var needsNull = true
+    var left: Row = null
+    var dupCnt: Int = 0
+
+    val pairsIt = pairs.iterator()
+
+    // go over all joined pairs
+    while (pairsIt.hasNext) {
+
+      val pair = pairsIt.next()
+      left = pair.getField(0).asInstanceOf[Row]
+      dupCnt = pair.getField(2).asInstanceOf[Int]
+      val right = pair.getField(1).asInstanceOf[Row]
+
+      if (right != null) {
+        // we have a joining right record. Do not emit a null-padded result record.
+        needsNull = false
+        val result = function.join(left, right)
+        // emit as many result records as the duplication count of the left record
+        var i = dupCnt
+        while (i > 0) {
+          out.collect(result)
+          i -= 1
+        }
+      }
+    }
+
+    // we did not find a single joining right record. Emit null-padded result records.
+    if (needsNull) {
+      val result = function.join(left, null)
+      // emit as many null-padded result records as the duplication count of the left record.
+      while (dupCnt > 0) {
+        out.collect(result)
+        dupCnt -= 1
+      }
+    }
+  }
+}
+
+class RightOuterJoinGroupReduceRunner(
+  name: String,
+  code: String,
+  returnType: TypeInformation[Row])
+  extends OuterJoinGroupReduceRunner(name, code, returnType) {
+
+  override final def reduce(pairs: Iterable[Row], out: Collector[Row]): Unit = {
+
+    var needsNull = true
+    var right: Row = null
+    var dupCnt: Int = 0
+
+    val pairsIt = pairs.iterator()
+
+    // go over all joined pairs
+    while (pairsIt.hasNext) {
+
+      val pair = pairsIt.next()
+      right = pair.getField(1).asInstanceOf[Row]
+      dupCnt = pair.getField(2).asInstanceOf[Int]
+      val left = pair.getField(0).asInstanceOf[Row]
+
+      if (left != null) {
+        // we have a joining left record. Do not emit a null-padded result record.
+        needsNull = false
+        val result = function.join(left, right)
+        // emit as many result records as the duplication count of the right record
+        var i = dupCnt
+        while (i > 0) {
+          out.collect(result)
+          i -= 1
+        }
+      }
+    }
+
+    // we did not find a single joining left record. Emit null-padded result records.
+    if (needsNull) {
+      val result = function.join(null, right)
+      // emit as many null-padded result records as the duplication count of the right record.
+      while (dupCnt > 0) {
+        out.collect(result)
+        dupCnt -= 1
+      }
+    }
+  }
+}
+
+/**
+  * Emits a part of the results of a full outer join:
+  *
+  * - join result from matching join pairs (left + right)
+  * - preserved left rows (left + null)
+  *
+  * Preserved right rows (null, right) are emitted by RightFullOuterJoinGroupReduceRunner.
+  */
+class LeftFullOuterJoinGroupReduceRunner(
+  name: String,
+  code: String,
+  returnType: TypeInformation[Row])
+  extends OuterJoinGroupReduceRunner(name, code, returnType) {
+
+  override final def reduce(pairs: Iterable[Row], out: Collector[Row]): Unit = {
+
+    var needsNull = true
+    var left: Row = null
+    var leftDupCnt: Int = 0
+
+    val pairsIt = pairs.iterator()
+
+    // go over all joined pairs
+    while (pairsIt.hasNext) {
+
+      val pair = pairsIt.next()
+      left = pair.getField(0).asInstanceOf[Row]
+      leftDupCnt = pair.getField(2).asInstanceOf[Int]
+      val right = pair.getField(1).asInstanceOf[Row]
+
+      if (right != null) {
+        // we have a joining right record. Do not emit a null-padded result record.
+        needsNull = false
+        val rightDupCnt = pair.getField(3).asInstanceOf[Int]
+        // emit as many result records as the product of the duplication counts of left and right.
+        var i = leftDupCnt * rightDupCnt
+        val result = function.join(left, right)
+        while (i > 0) {
+          out.collect(result)
+          i -= 1
+        }
+      }
+    }
+
+    // we did not find a single joining right record. Emit null-padded result records.
+    if (needsNull) {
+      val result = function.join(left, null)
+      // emit as many null-padded result records as the duplication count of the left record.
+      while (leftDupCnt > 0) {
+        out.collect(result)
+        leftDupCnt -= 1
+      }
+    }
+  }
+}
+
+/**
+  * Emits a part of the results of a full outer join:
+  *
+  * - preserved right rows (null, right)
+  *
+  * Join result from matching join pairs (left + right) and preserved left rows (left + null) are
+  * emitted by LeftFullOuterJoinGroupReduceRunner.
+  */
+class RightFullOuterJoinGroupReduceRunner(
+  name: String,
+  code: String,
+  returnType: TypeInformation[Row])
+  extends OuterJoinGroupReduceRunner(name, code, returnType) {
+
+  override final def reduce(pairs: Iterable[Row], out: Collector[Row]): Unit = {
+
+    var needsNull = true
+    var right: Row = null
+    var rightDupCnt: Int = 0
+
+    val pairsIt = pairs.iterator()
+
+    // go over all joined pairs
+    while (pairsIt.hasNext && needsNull) {
+
+      val pair = pairsIt.next()
+      right = pair.getField(1).asInstanceOf[Row]
+      rightDupCnt = pair.getField(3).asInstanceOf[Int]
+      val left = pair.getField(0).asInstanceOf[Row]
+
+      if (left != null) {
+        // we have a joining left record. Do not emit a null-padded result record.
+        needsNull = false
+        // we do NOT emit join results here. This was done by LeftFullOuterJoinGroupReduceRunner.
+      }
+    }
+
+    // we did not find a single joining left record. Emit null-padded result records.
+    if (needsNull) {
+      val result = function.join(null, right)
+      // emit as many null-padded result records as the duplication count of the right record.
+      while (rightDupCnt > 0) {
+        out.collect(result)
+        rightDupCnt -= 1
+      }
+    }
+  }
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/outerJoinRunners.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/outerJoinRunners.scala
@@ -1,0 +1,195 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime
+
+import java.lang.{Boolean => JBool}
+
+import org.apache.flink.api.common.functions.{JoinFunction, RichFlatJoinFunction}
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.typeutils.ResultTypeQueryable
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.table.codegen.Compiler
+import org.apache.flink.table.util.Logging
+import org.apache.flink.types.Row
+import org.apache.flink.util.Collector
+
+abstract class OuterJoinRunner(
+    name: String,
+    code: String,
+    @transient var returnType: TypeInformation[Row])
+  extends RichFlatJoinFunction[Row, Row, Row]
+  with ResultTypeQueryable[Row]
+  with Compiler[JoinFunction[Row, Row, JBool]]
+  with Logging {
+
+  protected var function: JoinFunction[Row, Row, JBool] = null
+
+  override def open(parameters: Configuration): Unit = {
+    LOG.debug(s"Compiling FlatJoinFunction: $name \n\n Code:\n$code")
+    val clazz = compile(getRuntimeContext.getUserCodeClassLoader, name, code)
+    LOG.debug("Instantiating FlatJoinFunction.")
+    function = clazz.newInstance()
+  }
+
+  override def getProducedType: TypeInformation[Row] = returnType
+}
+
+/**
+  * Emits left outer join pairs of left and right rows.
+  * Left rows are always preserved if no matching right row is found (predicate evaluates to false
+  * or right input row is null).
+  */
+class LeftOuterJoinRunner(
+    name: String,
+    code: String,
+    returnType: TypeInformation[Row])
+  extends OuterJoinRunner(name, code, returnType) {
+
+  val outRow = new Row(3)
+
+  override final def join(leftWithCnt: Row, right: Row, out: Collector[Row]): Unit = {
+
+    val left: Row = leftWithCnt.getField(0).asInstanceOf[Row]
+    val leftCnt = leftWithCnt.getField(1)
+
+    outRow.setField(0, left)
+    outRow.setField(2, leftCnt)
+
+    if (right == null) {
+      // right input row is null. Emit pair with null as right row
+      outRow.setField(1, null)
+    } else {
+      // evaluate predicate.
+      if (function.join(left, right)) {
+        // emit pair with right row
+        outRow.setField(1, right)
+      } else {
+        // emit pair with null as right row
+        outRow.setField(1, null)
+      }
+    }
+    out.collect(outRow)
+
+  }
+}
+
+/**
+  * Emits right outer join pairs of left and right rows.
+  * Right rows are always preserved if no matching left row is found (predicate evaluates to false
+  * or left input row is null).
+  */
+class RightOuterJoinRunner(
+  name: String,
+  code: String,
+  returnType: TypeInformation[Row])
+  extends OuterJoinRunner(name, code, returnType) {
+
+  val outRow = new Row(3)
+
+  override final def join(left: Row, rightWithCnt: Row, out: Collector[Row]): Unit = {
+
+    val right: Row = rightWithCnt.getField(0).asInstanceOf[Row]
+    val rightCnt = rightWithCnt.getField(1)
+
+    outRow.setField(1, right)
+    outRow.setField(2, rightCnt)
+
+    if (left == null) {
+      // left input row is null. Emit pair with null as left row
+      outRow.setField(0, null)
+    } else {
+      // evaluate predicate.
+      if (function.join(left, right)) {
+        outRow.setField(0, left)
+      } else {
+        outRow.setField(0, null)
+      }
+    }
+    out.collect(outRow)
+  }
+}
+
+/**
+  * Emits full outer join pairs of left and right rows.
+  * Left and right rows are always preserved if no matching right row is found (predicate evaluates
+  * to false or left or right input row is null).
+  */
+class FullOuterJoinRunner(
+  name: String,
+  code: String,
+  returnType: TypeInformation[Row])
+  extends OuterJoinRunner(name, code, returnType) {
+
+  val outRow = new Row(4)
+
+  override final def join(leftWithCnt: Row, rightWithCnt: Row, out: Collector[Row]): Unit = {
+
+    if (leftWithCnt == null) {
+      // left row is null. Emit join pair with null as left row.
+      val right: Row = rightWithCnt.getField(0).asInstanceOf[Row]
+      val rightCnt = rightWithCnt.getField(1)
+
+      outRow.setField(0, null)
+      outRow.setField(1, right)
+      outRow.setField(2, null)
+      outRow.setField(3, rightCnt)
+      out.collect(outRow)
+    } else if (rightWithCnt == null) {
+      // right row is null. Emit join pair with null as right row.
+      val left: Row = leftWithCnt.getField(0).asInstanceOf[Row]
+      val leftCnt = leftWithCnt.getField(1)
+
+      outRow.setField(0, left)
+      outRow.setField(1, null)
+      outRow.setField(2, leftCnt)
+      outRow.setField(3, null)
+      out.collect(outRow)
+    } else {
+      // both input rows are not null. Evaluate predicate.
+      val left: Row = leftWithCnt.getField(0).asInstanceOf[Row]
+      val leftCnt = leftWithCnt.getField(1)
+      val right: Row = rightWithCnt.getField(0).asInstanceOf[Row]
+      val rightCnt = rightWithCnt.getField(1)
+
+      if (function.join(left, right)) {
+        // predicate was true. Set rows in join pair
+        outRow.setField(0, left)
+        outRow.setField(1, right)
+        outRow.setField(2, leftCnt)
+        outRow.setField(3, rightCnt)
+        out.collect(outRow)
+      } else {
+        // predicate was false. Emit two join pairs to preserve both input rows.
+        // emit pair with left row and null as right row
+        outRow.setField(0, left)
+        outRow.setField(1, null)
+        outRow.setField(2, leftCnt)
+        outRow.setField(3, null)
+        out.collect(outRow)
+
+        // emit pair with right row and null as left row
+        outRow.setField(0, null)
+        outRow.setField(1, right)
+        outRow.setField(2, null)
+        outRow.setField(3, rightCnt)
+        out.collect(outRow)
+      }
+    }
+  }
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/batch/sql/JoinTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/batch/sql/JoinTest.scala
@@ -1,0 +1,314 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api.batch.sql
+
+import org.apache.flink.api.scala._
+import org.apache.flink.table.api.scala._
+import org.apache.flink.table.utils.TableTestBase
+import org.apache.flink.table.utils.TableTestUtil._
+import org.junit.Test
+
+class JoinTest extends TableTestBase {
+
+  @Test
+  def testLeftOuterJoinEquiPred(): Unit = {
+    val util = batchTestUtil()
+    util.addTable[(Int, Long, String)]("t", 'a, 'b, 'c)
+    util.addTable[(Long, String, Int)]("s", 'x, 'y, 'z)
+
+    val query = "SELECT b, y FROM t LEFT OUTER JOIN s ON a = z"
+    val result = util.tableEnv.sqlQuery(query)
+
+    val expected = unaryNode(
+      "DataSetCalc",
+      binaryNode(
+        "DataSetJoin",
+        unaryNode(
+          "DataSetCalc",
+          batchTableNode(0),
+          term("select", "a", "b")
+        ),
+        unaryNode(
+          "DataSetCalc",
+          batchTableNode(1),
+          term("select", "y", "z")
+        ),
+        term("where", "=(a, z)"),
+        term("join", "a", "b", "y", "z"),
+        term("joinType", "LeftOuterJoin")
+      ),
+      term("select", "b", "y")
+    )
+
+    util.verifyTable(result, expected)
+  }
+
+  @Test
+  def testLeftOuterJoinEquiAndLocalPred(): Unit = {
+    val util = batchTestUtil()
+    util.addTable[(Int, Long, String)]("t", 'a, 'b, 'c)
+    util.addTable[(Long, String, Int)]("s", 'x, 'y, 'z)
+
+    val query = "SELECT b, y FROM t LEFT OUTER JOIN s ON a = z AND b < 2"
+    val result = util.tableEnv.sqlQuery(query)
+
+    val expected = unaryNode(
+      "DataSetCalc",
+      binaryNode(
+        "DataSetJoin",
+        unaryNode(
+          "DataSetCalc",
+          batchTableNode(0),
+          term("select", "a", "b", "<(b, 2) AS $f3")
+        ),
+        unaryNode(
+          "DataSetCalc",
+          batchTableNode(1),
+          term("select", "y", "z")
+        ),
+        term("where", "AND(=(a, z), $f3)"),
+        term("join", "a", "b", "$f3", "y", "z"),
+        term("joinType", "LeftOuterJoin")
+      ),
+      term("select", "b", "y")
+    )
+
+    util.verifyTable(result, expected)
+  }
+
+  @Test
+  def testLeftOuterJoinEquiAndNonEquiPred(): Unit = {
+    val util = batchTestUtil()
+    util.addTable[(Int, Long, String)]("t", 'a, 'b, 'c)
+    util.addTable[(Long, String, Int)]("s", 'x, 'y, 'z)
+
+    val query = "SELECT b, y FROM t LEFT OUTER JOIN s ON a = z AND b < x"
+    val result = util.tableEnv.sqlQuery(query)
+
+    val expected = unaryNode(
+      "DataSetCalc",
+      binaryNode(
+        "DataSetJoin",
+        unaryNode(
+          "DataSetCalc",
+          batchTableNode(0),
+          term("select", "a", "b")
+        ),
+        batchTableNode(1),
+        term("where", "AND(=(a, z), <(b, x))"),
+        term("join", "a", "b", "x", "y", "z"),
+        term("joinType", "LeftOuterJoin")
+      ),
+      term("select", "b", "y")
+    )
+
+    util.verifyTable(result, expected)
+  }
+
+  @Test
+  def testRightOuterJoinEquiPred(): Unit = {
+    val util = batchTestUtil()
+    util.addTable[(Int, Long, String)]("t", 'a, 'b, 'c)
+    util.addTable[(Long, String, Int)]("s", 'x, 'y, 'z)
+
+    val query = "SELECT b, y FROM t RIGHT OUTER JOIN s ON a = z"
+    val result = util.tableEnv.sqlQuery(query)
+
+    val expected = unaryNode(
+      "DataSetCalc",
+      binaryNode(
+        "DataSetJoin",
+        unaryNode(
+          "DataSetCalc",
+          batchTableNode(0),
+          term("select", "a", "b")
+        ),
+        unaryNode(
+          "DataSetCalc",
+          batchTableNode(1),
+          term("select", "y", "z")
+        ),
+        term("where", "=(a, z)"),
+        term("join", "a", "b", "y", "z"),
+        term("joinType", "RightOuterJoin")
+      ),
+      term("select", "b", "y")
+    )
+
+    util.verifyTable(result, expected)
+  }
+
+  @Test
+  def testRightOuterJoinEquiAndLocalPred(): Unit = {
+    val util = batchTestUtil()
+    util.addTable[(Int, Long, String)]("t", 'a, 'b, 'c)
+    util.addTable[(Long, String, Int)]("s", 'x, 'y, 'z)
+
+    val query = "SELECT b, x FROM t RIGHT OUTER JOIN s ON a = z AND x < 2"
+    val result = util.tableEnv.sqlQuery(query)
+
+    val expected = unaryNode(
+      "DataSetCalc",
+      binaryNode(
+        "DataSetJoin",
+        unaryNode(
+          "DataSetCalc",
+          batchTableNode(0),
+          term("select", "a", "b")
+        ),
+        unaryNode(
+          "DataSetCalc",
+          batchTableNode(1),
+          term("select", "x", "z", "<(x, 2) AS $f3")
+        ),
+        term("where", "AND(=(a, z), $f3)"),
+        term("join", "a", "b", "x", "z", "$f3"),
+        term("joinType", "RightOuterJoin")
+      ),
+      term("select", "b", "x")
+    )
+
+    util.verifyTable(result, expected)
+  }
+
+  @Test
+  def testRightOuterJoinEquiAndNonEquiPred(): Unit = {
+    val util = batchTestUtil()
+    util.addTable[(Int, Long, String)]("t", 'a, 'b, 'c)
+    util.addTable[(Long, String, Int)]("s", 'x, 'y, 'z)
+
+    val query = "SELECT b, y FROM t RIGHT OUTER JOIN s ON a = z AND b < x"
+    val result = util.tableEnv.sqlQuery(query)
+
+    val expected = unaryNode(
+      "DataSetCalc",
+      binaryNode(
+        "DataSetJoin",
+        unaryNode(
+          "DataSetCalc",
+          batchTableNode(0),
+          term("select", "a", "b")
+        ),
+        batchTableNode(1),
+        term("where", "AND(=(a, z), <(b, x))"),
+        term("join", "a", "b", "x", "y", "z"),
+        term("joinType", "RightOuterJoin")
+      ),
+      term("select", "b", "y")
+    )
+
+    util.verifyTable(result, expected)
+  }
+
+  @Test
+  def testFullOuterJoinEquiPred(): Unit = {
+    val util = batchTestUtil()
+    util.addTable[(Int, Long, String)]("t", 'a, 'b, 'c)
+    util.addTable[(Long, String, Int)]("s", 'x, 'y, 'z)
+
+    val query = "SELECT b, y FROM t FULL OUTER JOIN s ON a = z"
+    val result = util.tableEnv.sqlQuery(query)
+
+    val expected = unaryNode(
+      "DataSetCalc",
+      binaryNode(
+        "DataSetJoin",
+        unaryNode(
+          "DataSetCalc",
+          batchTableNode(0),
+          term("select", "a", "b")
+        ),
+        unaryNode(
+          "DataSetCalc",
+          batchTableNode(1),
+          term("select", "y", "z")
+        ),
+        term("where", "=(a, z)"),
+        term("join", "a", "b", "y", "z"),
+        term("joinType", "FullOuterJoin")
+      ),
+      term("select", "b", "y")
+    )
+
+    util.verifyTable(result, expected)
+  }
+
+  @Test
+  def testFullOuterJoinEquiAndLocalPred(): Unit = {
+    val util = batchTestUtil()
+    util.addTable[(Int, Long, String)]("t", 'a, 'b, 'c)
+    util.addTable[(Long, String, Int)]("s", 'x, 'y, 'z)
+
+    val query = "SELECT b, y FROM t FULL OUTER JOIN s ON a = z AND b < 2 AND z > 5"
+    val result = util.tableEnv.sqlQuery(query)
+
+    val expected = unaryNode(
+      "DataSetCalc",
+      binaryNode(
+        "DataSetJoin",
+        unaryNode(
+          "DataSetCalc",
+          batchTableNode(0),
+          term("select", "a", "b", "<(b, 2) AS $f3")
+        ),
+        unaryNode(
+          "DataSetCalc",
+          batchTableNode(1),
+          term("select", "y", "z", ">(z, 5) AS $f3")
+        ),
+        term("where", "AND(=(a, z), $f3, $f30)"),
+        term("join", "a", "b", "$f3", "y", "z", "$f30"),
+        term("joinType", "FullOuterJoin")
+      ),
+      term("select", "b", "y")
+    )
+
+    util.verifyTable(result, expected)
+  }
+
+  @Test
+  def testFullOuterJoinEquiAndNonEquiPred(): Unit = {
+    val util = batchTestUtil()
+    util.addTable[(Int, Long, String)]("t", 'a, 'b, 'c)
+    util.addTable[(Long, String, Int)]("s", 'x, 'y, 'z)
+
+    val query = "SELECT b, y FROM t FULL OUTER JOIN s ON a = z AND b < x"
+    val result = util.tableEnv.sqlQuery(query)
+
+    val expected = unaryNode(
+      "DataSetCalc",
+      binaryNode(
+        "DataSetJoin",
+        unaryNode(
+          "DataSetCalc",
+          batchTableNode(0),
+          term("select", "a", "b")
+        ),
+        batchTableNode(1),
+        term("where", "AND(=(a, z), <(b, x))"),
+        term("join", "a", "b", "x", "y", "z"),
+        term("joinType", "FullOuterJoin")
+      ),
+      term("select", "b", "y")
+    )
+
+    util.verifyTable(result, expected)
+  }
+
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/batch/sql/validation/JoinValidationTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/batch/sql/validation/JoinValidationTest.scala
@@ -83,67 +83,34 @@ class JoinValidationTest extends TableTestBase {
   }
 
   @Test(expected = classOf[TableException])
-  def testRightOuterJoinWithNonEquiJoinPredicate(): Unit = {
+  def testRightOuterJoinNoEquiJoinPredicate(): Unit = {
     val util = batchTestUtil()
     util.addTable[(Int, Long, String)]("Table3", 'a, 'b, 'c)
     util.addTable[(Int, Long, Int, String, Long)]("Table5", 'd, 'e, 'f, 'g, 'h)
 
-    val sqlQuery = "SELECT c, g FROM Table3 RIGHT OUTER JOIN Table5 ON b = e and a > d"
+    val sqlQuery = "SELECT c, g FROM Table3 RIGHT OUTER JOIN Table5 ON b < e"
 
     util.tableEnv.sqlQuery(sqlQuery).toDataSet[Row]
   }
 
   @Test(expected = classOf[TableException])
-  def testLeftOuterJoinWithNonEquiJoinPredicate(): Unit = {
+  def testLeftOuterJoinNoEquiJoinPredicate(): Unit = {
     val util = batchTestUtil()
     util.addTable[(Int, Long, String)]("Table3", 'a, 'b, 'c)
     util.addTable[(Int, Long, Int, String, Long)]("Table5", 'd, 'e, 'f, 'g, 'h)
 
-    val sqlQuery = "SELECT c, g FROM Table3 LEFT OUTER JOIN Table5 ON b = e and a > d"
+    val sqlQuery = "SELECT c, g FROM Table3 LEFT OUTER JOIN Table5 ON b > e"
 
     util.tableEnv.sqlQuery(sqlQuery).toDataSet[Row]
   }
 
   @Test(expected = classOf[TableException])
-  def testFullOuterJoinWithNonEquiJoinPredicate(): Unit = {
+  def testFullOuterJoinNoEquiJoinPredicate(): Unit = {
     val util = batchTestUtil()
     util.addTable[(Int, Long, String)]("Table3", 'a, 'b, 'c)
     util.addTable[(Int, Long, Int, String, Long)]("Table5", 'd, 'e, 'f, 'g, 'h)
 
-    val sqlQuery = "SELECT c, g FROM Table3 FULL OUTER JOIN Table5 ON b = e and a > d"
-
-    util.tableEnv.sqlQuery(sqlQuery).toDataSet[Row]
-  }
-
-  @Test(expected = classOf[TableException])
-  def testRightOuterJoinWithLocalPredicate(): Unit = {
-    val util = batchTestUtil()
-    util.addTable[(Int, Long, String)]("Table3", 'a, 'b, 'c)
-    util.addTable[(Int, Long, Int, String, Long)]("Table5", 'd, 'e, 'f, 'g, 'h)
-
-    val sqlQuery = "SELECT c, g FROM Table3 RIGHT OUTER JOIN Table5 ON b = e and e > 3"
-
-    util.tableEnv.sqlQuery(sqlQuery).toDataSet[Row]
-  }
-
-  @Test(expected = classOf[TableException])
-  def testLeftOuterJoinWithLocalPredicate(): Unit = {
-    val util = batchTestUtil()
-    util.addTable[(Int, Long, String)]("Table3", 'a, 'b, 'c)
-    util.addTable[(Int, Long, Int, String, Long)]("Table5", 'd, 'e, 'f, 'g, 'h)
-
-    val sqlQuery = "SELECT c, g FROM Table3 LEFT OUTER JOIN Table5 ON b = e and b > 3"
-
-    util.tableEnv.sqlQuery(sqlQuery).toDataSet[Row]
-  }
-
-  @Test(expected = classOf[TableException])
-  def testFullOuterJoinWithLocalPredicate(): Unit = {
-    val util = batchTestUtil()
-    util.addTable[(Int, Long, String)]("Table3", 'a, 'b, 'c)
-    util.addTable[(Int, Long, Int, String, Long)]("Table5", 'd, 'e, 'f, 'g, 'h)
-
-    val sqlQuery = "SELECT c, g FROM Table3 FULL OUTER JOIN Table5 ON b = e and b > 3"
+    val sqlQuery = "SELECT c, g FROM Table3 FULL OUTER JOIN Table5 ON b <> e"
 
     util.tableEnv.sqlQuery(sqlQuery).toDataSet[Row]
   }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/batch/table/JoinTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/batch/table/JoinTest.scala
@@ -1,0 +1,304 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api.batch.table
+
+import org.apache.flink.api.scala._
+import org.apache.flink.table.api.scala._
+import org.apache.flink.table.utils.TableTestBase
+import org.apache.flink.table.utils.TableTestUtil._
+import org.junit.Test
+
+class JoinTest extends TableTestBase {
+
+  @Test
+  def testLeftOuterJoinEquiPred(): Unit = {
+    val util = batchTestUtil()
+    val t = util.addTable[(Int, Long, String)]("T", 'a, 'b, 'c)
+    val s = util.addTable[(Long, String, Int)]("S", 'x, 'y, 'z)
+
+    val joined = t.leftOuterJoin(s, 'a === 'z).select('b, 'y)
+
+    val expected = unaryNode(
+      "DataSetCalc",
+      binaryNode(
+        "DataSetJoin",
+        unaryNode(
+          "DataSetCalc",
+          batchTableNode(0),
+          term("select", "a", "b")
+        ),
+        unaryNode(
+          "DataSetCalc",
+          batchTableNode(1),
+          term("select", "y", "z")
+        ),
+        term("where", "=(a, z)"),
+        term("join", "a", "b", "y", "z"),
+        term("joinType", "LeftOuterJoin")
+      ),
+      term("select", "b", "y")
+    )
+
+    util.verifyTable(joined, expected)
+  }
+
+  @Test
+  def testLeftOuterJoinEquiAndLocalPred(): Unit = {
+    val util = batchTestUtil()
+    val t = util.addTable[(Int, Long, String)]("T", 'a, 'b, 'c)
+    val s = util.addTable[(Long, String, Int)]("S", 'x, 'y, 'z)
+
+    val joined = t.leftOuterJoin(s, 'a === 'z && 'b < 2).select('b, 'y)
+
+    val expected = unaryNode(
+      "DataSetCalc",
+      binaryNode(
+        "DataSetJoin",
+        unaryNode(
+          "DataSetCalc",
+          batchTableNode(0),
+          term("select", "a", "b")
+        ),
+        unaryNode(
+          "DataSetCalc",
+          batchTableNode(1),
+          term("select", "y", "z")
+        ),
+        term("where", "AND(=(a, z), <(b, 2))"),
+        term("join", "a", "b", "y", "z"),
+        term("joinType", "LeftOuterJoin")
+      ),
+      term("select", "b", "y")
+    )
+
+    util.verifyTable(joined, expected)
+  }
+
+  @Test
+  def testLeftOuterJoinEquiAndNonEquiPred(): Unit = {
+    val util = batchTestUtil()
+    val t = util.addTable[(Int, Long, String)]("T", 'a, 'b, 'c)
+    val s = util.addTable[(Long, String, Int)]("S", 'x, 'y, 'z)
+
+    val joined = t.leftOuterJoin(s, 'a === 'z && 'b < 'x).select('b, 'y)
+
+    val expected = unaryNode(
+      "DataSetCalc",
+      binaryNode(
+        "DataSetJoin",
+        unaryNode(
+          "DataSetCalc",
+          batchTableNode(0),
+          term("select", "a", "b")
+        ),
+        batchTableNode(1),
+        term("where", "AND(=(a, z), <(b, x))"),
+        term("join", "a", "b", "x", "y", "z"),
+        term("joinType", "LeftOuterJoin")
+      ),
+      term("select", "b", "y")
+    )
+
+    util.verifyTable(joined, expected)
+  }
+
+  @Test
+  def testRightOuterJoinEquiPred(): Unit = {
+    val util = batchTestUtil()
+    val t = util.addTable[(Int, Long, String)]("T", 'a, 'b, 'c)
+    val s = util.addTable[(Long, String, Int)]("S", 'x, 'y, 'z)
+
+    val joined = t.rightOuterJoin(s, 'a === 'z).select('b, 'y)
+
+    val expected = unaryNode(
+      "DataSetCalc",
+      binaryNode(
+        "DataSetJoin",
+        unaryNode(
+          "DataSetCalc",
+          batchTableNode(0),
+          term("select", "a", "b")
+        ),
+        unaryNode(
+          "DataSetCalc",
+          batchTableNode(1),
+          term("select", "y", "z")
+        ),
+        term("where", "=(a, z)"),
+        term("join", "a", "b", "y", "z"),
+        term("joinType", "RightOuterJoin")
+      ),
+      term("select", "b", "y")
+    )
+
+    util.verifyTable(joined, expected)
+  }
+
+  @Test
+  def testRightOuterJoinEquiAndLocalPred(): Unit = {
+    val util = batchTestUtil()
+    val t = util.addTable[(Int, Long, String)]("T", 'a, 'b, 'c)
+    val s = util.addTable[(Long, String, Int)]("S", 'x, 'y, 'z)
+
+    val joined = t.rightOuterJoin(s, 'a === 'z && 'x < 2).select('b, 'x)
+
+    val expected = unaryNode(
+      "DataSetCalc",
+      binaryNode(
+        "DataSetJoin",
+        unaryNode(
+          "DataSetCalc",
+          batchTableNode(0),
+          term("select", "a", "b")
+        ),
+        unaryNode(
+          "DataSetCalc",
+          batchTableNode(1),
+          term("select", "x", "z")
+        ),
+        term("where", "AND(=(a, z), <(x, 2))"),
+        term("join", "a", "b", "x", "z"),
+        term("joinType", "RightOuterJoin")
+      ),
+      term("select", "b", "x")
+    )
+
+    util.verifyTable(joined, expected)
+  }
+
+  @Test
+  def testRightOuterJoinEquiAndNonEquiPred(): Unit = {
+    val util = batchTestUtil()
+    val t = util.addTable[(Int, Long, String)]("T", 'a, 'b, 'c)
+    val s = util.addTable[(Long, String, Int)]("S", 'x, 'y, 'z)
+
+    val joined = t.rightOuterJoin(s, 'a === 'z && 'b < 'x).select('b, 'y)
+
+    val expected = unaryNode(
+      "DataSetCalc",
+      binaryNode(
+        "DataSetJoin",
+        unaryNode(
+          "DataSetCalc",
+          batchTableNode(0),
+          term("select", "a", "b")
+        ),
+        batchTableNode(1),
+        term("where", "AND(=(a, z), <(b, x))"),
+        term("join", "a", "b", "x", "y", "z"),
+        term("joinType", "RightOuterJoin")
+      ),
+      term("select", "b", "y")
+    )
+
+    util.verifyTable(joined, expected)
+  }
+
+  @Test
+  def testFullOuterJoinEquiPred(): Unit = {
+    val util = batchTestUtil()
+    val t = util.addTable[(Int, Long, String)]("T", 'a, 'b, 'c)
+    val s = util.addTable[(Long, String, Int)]("S", 'x, 'y, 'z)
+
+    val joined = t.fullOuterJoin(s, 'a === 'z).select('b, 'y)
+
+    val expected = unaryNode(
+      "DataSetCalc",
+      binaryNode(
+        "DataSetJoin",
+        unaryNode(
+          "DataSetCalc",
+          batchTableNode(0),
+          term("select", "a", "b")
+        ),
+        unaryNode(
+          "DataSetCalc",
+          batchTableNode(1),
+          term("select", "y", "z")
+        ),
+        term("where", "=(a, z)"),
+        term("join", "a", "b", "y", "z"),
+        term("joinType", "FullOuterJoin")
+      ),
+      term("select", "b", "y")
+    )
+
+    util.verifyTable(joined, expected)
+  }
+
+  @Test
+  def testFullOuterJoinEquiAndLocalPred(): Unit = {
+    val util = batchTestUtil()
+    val t = util.addTable[(Int, Long, String)]("T", 'a, 'b, 'c)
+    val s = util.addTable[(Long, String, Int)]("S", 'x, 'y, 'z)
+
+    val joined = t.fullOuterJoin(s, 'a === 'z && 'b < 2).select('b, 'y)
+
+    val expected = unaryNode(
+      "DataSetCalc",
+      binaryNode(
+        "DataSetJoin",
+        unaryNode(
+          "DataSetCalc",
+          batchTableNode(0),
+          term("select", "a", "b")
+        ),
+        unaryNode(
+          "DataSetCalc",
+          batchTableNode(1),
+          term("select", "y", "z")
+        ),
+        term("where", "AND(=(a, z), <(b, 2))"),
+        term("join", "a", "b", "y", "z"),
+        term("joinType", "FullOuterJoin")
+      ),
+      term("select", "b", "y")
+    )
+
+    util.verifyTable(joined, expected)
+  }
+
+  @Test
+  def testFullOuterJoinEquiAndNonEquiPred(): Unit = {
+    val util = batchTestUtil()
+    val t = util.addTable[(Int, Long, String)]("T", 'a, 'b, 'c)
+    val s = util.addTable[(Long, String, Int)]("S", 'x, 'y, 'z)
+
+    val joined = t.fullOuterJoin(s, 'a === 'z && 'b < 'x).select('b, 'y)
+
+    val expected = unaryNode(
+      "DataSetCalc",
+      binaryNode(
+        "DataSetJoin",
+        unaryNode(
+          "DataSetCalc",
+          batchTableNode(0),
+          term("select", "a", "b")
+        ),
+        batchTableNode(1),
+        term("where", "AND(=(a, z), <(b, x))"),
+        term("join", "a", "b", "x", "y", "z"),
+        term("joinType", "FullOuterJoin")
+      ),
+      term("select", "b", "y")
+    )
+
+    util.verifyTable(joined, expected)
+  }
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/batch/table/validation/JoinValidationTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/batch/table/validation/JoinValidationTest.scala
@@ -92,16 +92,7 @@ class JoinValidationTest extends TableTestBase {
   }
 
   @Test(expected = classOf[ValidationException])
-  def testNoJoinCondition(): Unit = {
-    val util = batchTestUtil()
-    val ds1 = util.addTable[(Int, Long, String)]("Table3",'a, 'b, 'c)
-    val ds2 = util.addTable[(Int, Long, Int, String, Long)]("Table5", 'd, 'e, 'f, 'g, 'h)
-
-    ds2.leftOuterJoin(ds1, 'b === 'd && 'b < 3).select('c, 'g)
-  }
-
-  @Test(expected = classOf[ValidationException])
-  def testNoEquiJoin(): Unit = {
+  def testLeftJoinNoEquiJoinPredicate(): Unit = {
     val util = batchTestUtil()
     val ds1 = util.addTable[(Int, Long, String)]("Table3",'a, 'b, 'c)
     val ds2 = util.addTable[(Int, Long, Int, String, Long)]("Table5", 'd, 'e, 'f, 'g, 'h)
@@ -110,57 +101,21 @@ class JoinValidationTest extends TableTestBase {
   }
 
   @Test(expected = classOf[ValidationException])
-  def testRightJoinWithNonEquiJoinPredicate(): Unit = {
+  def testRightJoinNoEquiJoinPredicate(): Unit = {
     val util = batchTestUtil()
     val ds1 = util.addTable[(Int, Long, String)]("Table3",'a, 'b, 'c)
     val ds2 = util.addTable[(Int, Long, Int, String, Long)]("Table5", 'd, 'e, 'f, 'g, 'h)
 
-    ds1.rightOuterJoin(ds2, 'a === 'd && 'b < 'h).select('c, 'g)
+    ds2.rightOuterJoin(ds1, 'b < 'd).select('c, 'g)
   }
 
   @Test(expected = classOf[ValidationException])
-  def testLeftJoinWithLocalPredicate(): Unit = {
+  def testFullJoinNoEquiJoinPredicate(): Unit = {
     val util = batchTestUtil()
     val ds1 = util.addTable[(Int, Long, String)]("Table3",'a, 'b, 'c)
     val ds2 = util.addTable[(Int, Long, Int, String, Long)]("Table5", 'd, 'e, 'f, 'g, 'h)
 
-    ds1.leftOuterJoin(ds2, 'a === 'd && 'b < 3).select('c, 'g)
-  }
-
-  @Test(expected = classOf[ValidationException])
-  def testFullJoinWithLocalPredicate(): Unit = {
-    val util = batchTestUtil()
-    val ds1 = util.addTable[(Int, Long, String)]("Table3",'a, 'b, 'c)
-    val ds2 = util.addTable[(Int, Long, Int, String, Long)]("Table5", 'd, 'e, 'f, 'g, 'h)
-
-    ds1.fullOuterJoin(ds2, 'a === 'd && 'b < 3).select('c, 'g)
-  }
-
-  @Test(expected = classOf[ValidationException])
-  def testRightJoinWithLocalPredicate(): Unit = {
-    val util = batchTestUtil()
-    val ds1 = util.addTable[(Int, Long, String)]("Table3",'a, 'b, 'c)
-    val ds2 = util.addTable[(Int, Long, Int, String, Long)]("Table5", 'd, 'e, 'f, 'g, 'h)
-
-    ds1.rightOuterJoin(ds2, 'a === 'd && 'b < 3).select('c, 'g)
-  }
-
-  @Test(expected = classOf[ValidationException])
-  def testLeftJoinWithNonEquiJoinPredicate(): Unit = {
-    val util = batchTestUtil()
-    val ds1 = util.addTable[(Int, Long, String)]("Table3",'a, 'b, 'c)
-    val ds2 = util.addTable[(Int, Long, Int, String, Long)]("Table5", 'd, 'e, 'f, 'g, 'h)
-
-    ds1.leftOuterJoin(ds2, 'a === 'd && 'b < 'h).select('c, 'g)
-  }
-
-  @Test(expected = classOf[ValidationException])
-  def testFullJoinWithNonEquiJoinPredicate(): Unit = {
-    val util = batchTestUtil()
-    val ds1 = util.addTable[(Int, Long, String)]("Table3",'a, 'b, 'c)
-    val ds2 = util.addTable[(Int, Long, Int, String, Long)]("Table5", 'd, 'e, 'f, 'g, 'h)
-
-    ds1.fullOuterJoin(ds2, 'a === 'd && 'b < 'h).select('c, 'g)
+    ds2.fullOuterJoin(ds1, 'b < 'd).select('c, 'g)
   }
 
   @Test(expected = classOf[ValidationException])

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/batch/table/JoinITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/batch/table/JoinITCase.scala
@@ -18,16 +18,21 @@
 
 package org.apache.flink.table.runtime.batch.table
 
+import java.lang.Iterable
+
+import org.apache.flink.api.common.functions.MapPartitionFunction
 import org.apache.flink.api.scala._
 import org.apache.flink.api.scala.util.CollectionDataSets
 import org.apache.flink.table.api.TableEnvironment
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.expressions.Literal
-import org.apache.flink.table.runtime.utils.TableProgramsCollectionTestBase
+import org.apache.flink.table.runtime.utils.TableProgramsClusterTestBase
 import org.apache.flink.table.runtime.utils.TableProgramsTestBase.TableConfigMode
 import org.apache.flink.table.utils.TableFunc2
+import org.apache.flink.test.util.MultipleProgramsTestBase.TestExecutionMode
 import org.apache.flink.test.util.TestBaseUtils
 import org.apache.flink.types.Row
+import org.apache.flink.util.Collector
 import org.junit._
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
@@ -36,8 +41,9 @@ import scala.collection.JavaConverters._
 
 @RunWith(classOf[Parameterized])
 class JoinITCase(
+    execMode: TestExecutionMode,
     configMode: TableConfigMode)
-  extends TableProgramsCollectionTestBase(configMode) {
+  extends TableProgramsClusterTestBase(execMode, configMode) {
 
   @Test
   def testJoin(): Unit = {
@@ -106,8 +112,10 @@ class JoinITCase(
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
     val tEnv = TableEnvironment.getTableEnvironment(env, config)
 
-    val ds1 = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
-    val ds2 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
+    val ds1 = addNullKey3Tuples(
+      CollectionDataSets.get3TupleDataSet(env)).toTable(tEnv, 'a, 'b, 'c)
+    val ds2 = addNullKey5Tuples(
+      CollectionDataSets.get5TupleDataSet(env)).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
 
     val joinT = ds1.join(ds2).filter('a === 'd && 'b === 'h).select('c, 'g)
 
@@ -214,8 +222,10 @@ class JoinITCase(
     val tEnv = TableEnvironment.getTableEnvironment(env, config)
     tEnv.getConfig.setNullCheck(true)
 
-    val ds1 = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
-    val ds2 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
+    val ds1 = addNullKey3Tuples(
+      CollectionDataSets.get3TupleDataSet(env)).toTable(tEnv, 'a, 'b, 'c)
+    val ds2 = addNullKey5Tuples(
+      CollectionDataSets.get5TupleDataSet(env)).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
 
     val joinT = ds1.leftOuterJoin(ds2, 'a === 'd && 'b === 'h).select('c, 'g)
 
@@ -225,9 +235,60 @@ class JoinITCase(
       "Comment#3,null\n" + "Comment#4,null\n" + "Comment#5,null\n" + "Comment#6,null\n" +
       "Comment#7,null\n" + "Comment#8,null\n" + "Comment#9,null\n" + "Comment#10,null\n" +
       "Comment#11,null\n" + "Comment#12,null\n" + "Comment#13,null\n" + "Comment#14,null\n" +
-      "Comment#15,null\n"
+      "Comment#15,null\n" +
+      "NullTuple,null\n" + "NullTuple,null\n"
     val results = joinT.toDataSet[Row].collect()
     TestBaseUtils.compareResultAsText(results.asJava, expected)
+  }
+
+  @Test
+  def testLeftJoinWithNonEquiJoinPred(): Unit = {
+    val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    tEnv.getConfig.setNullCheck(true)
+
+    val ds1 = addNullKey3Tuples(
+      CollectionDataSets.get3TupleDataSet(env)).toTable(tEnv, 'a, 'b, 'c)
+    val ds2 = addNullKey5Tuples(
+      CollectionDataSets.get5TupleDataSet(env)).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
+
+    val joinT = ds1.leftOuterJoin(ds2, 'a === 'd && 'b <= 'h).select('c, 'g)
+
+    val expected = Seq(
+      "Hi,Hallo", "Hello,Hallo Welt", "Hello world,Hallo Welt wie gehts?", "Hello world,ABC",
+      "Hello world,BCD", "I am fine.,HIJ", "I am fine.,IJK",
+      "Hello world, how are you?,null", "Luke Skywalker,null", "Comment#1,null", "Comment#2,null",
+      "Comment#3,null", "Comment#4,null", "Comment#5,null", "Comment#6,null", "Comment#7,null",
+      "Comment#8,null", "Comment#9,null", "Comment#10,null", "Comment#11,null", "Comment#12,null",
+      "Comment#13,null", "Comment#14,null", "Comment#15,null",
+      "NullTuple,null", "NullTuple,null")
+    val results = joinT.toDataSet[Row].collect()
+    TestBaseUtils.compareResultAsText(results.asJava, expected.mkString("\n"))
+  }
+
+  @Test
+  def testLeftJoinWithLeftLocalPred(): Unit = {
+    val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    tEnv.getConfig.setNullCheck(true)
+
+    val ds1 = addNullKey3Tuples(
+      CollectionDataSets.get3TupleDataSet(env)).toTable(tEnv, 'a, 'b, 'c)
+    val ds2 = addNullKey5Tuples(
+      CollectionDataSets.get5TupleDataSet(env)).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
+
+    val joinT = ds1.leftOuterJoin(ds2, 'a === 'd && 'b === 2).select('c, 'g)
+
+    val expected = Seq(
+      "Hello,Hallo Welt", "Hello,Hallo Welt wie",
+      "Hello world,Hallo Welt wie gehts?", "Hello world,ABC", "Hello world,BCD",
+      "Hi,null", "Hello world, how are you?,null", "I am fine.,null", "Luke Skywalker,null",
+      "Comment#1,null", "Comment#2,null", "Comment#3,null", "Comment#4,null", "Comment#5,null",
+      "Comment#6,null", "Comment#7,null", "Comment#8,null", "Comment#9,null", "Comment#10,null",
+      "Comment#11,null", "Comment#12,null", "Comment#13,null", "Comment#14,null", "Comment#15,null",
+      "NullTuple,null", "NullTuple,null")
+    val results = joinT.toDataSet[Row].collect()
+    TestBaseUtils.compareResultAsText(results.asJava, expected.mkString("\n"))
   }
 
   @Test
@@ -236,17 +297,70 @@ class JoinITCase(
     val tEnv = TableEnvironment.getTableEnvironment(env, config)
     tEnv.getConfig.setNullCheck(true)
 
-    val ds1 = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
-    val ds2 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
+    val ds1 = addNullKey3Tuples(
+      CollectionDataSets.get3TupleDataSet(env)).toTable(tEnv, 'a, 'b, 'c)
+    val ds2 = addNullKey5Tuples(
+      CollectionDataSets.get5TupleDataSet(env)).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
 
     val joinT = ds1.rightOuterJoin(ds2, 'a === 'd && 'b === 'h).select('c, 'g)
 
     val expected = "Hi,Hallo\n" + "Hello,Hallo Welt\n" + "null,Hallo Welt wie\n" +
       "Hello world,Hallo Welt wie gehts?\n" + "Hello world,ABC\n" + "null,BCD\n" + "null,CDE\n" +
       "null,DEF\n" + "null,EFG\n" + "null,FGH\n" + "null,GHI\n" + "I am fine.,HIJ\n" +
-      "I am fine.,IJK\n" + "null,JKL\n" + "null,KLM\n"
+      "I am fine.,IJK\n" + "null,JKL\n" + "null,KLM\n" +
+      "null,NullTuple\n" + "null,NullTuple\n"
     val results = joinT.toDataSet[Row].collect()
     TestBaseUtils.compareResultAsText(results.asJava, expected)
+  }
+
+  @Test
+  def testRightJoinWithNonEquiJoinPred(): Unit = {
+    val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    tEnv.getConfig.setNullCheck(true)
+
+    val ds1 = addNullKey5Tuples(
+      CollectionDataSets.get5TupleDataSet(env)).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
+    val ds2 = addNullKey3Tuples(
+      CollectionDataSets.get3TupleDataSet(env)).toTable(tEnv, 'a, 'b, 'c)
+
+    val joinT = ds1.rightOuterJoin(ds2, 'a === 'd && 'b <= 'h).select('c, 'g)
+
+    val expected = Seq(
+      "Hi,Hallo", "Hello,Hallo Welt", "Hello world,Hallo Welt wie gehts?", "Hello world,ABC",
+      "Hello world,BCD", "I am fine.,HIJ", "I am fine.,IJK",
+      "Hello world, how are you?,null", "Luke Skywalker,null", "Comment#1,null", "Comment#2,null",
+      "Comment#3,null", "Comment#4,null", "Comment#5,null", "Comment#6,null", "Comment#7,null",
+      "Comment#8,null", "Comment#9,null", "Comment#10,null", "Comment#11,null", "Comment#12,null",
+      "Comment#13,null", "Comment#14,null", "Comment#15,null",
+      "NullTuple,null", "NullTuple,null")
+    val results = joinT.toDataSet[Row].collect()
+    TestBaseUtils.compareResultAsText(results.asJava, expected.mkString("\n"))
+  }
+
+  @Test
+  def testRightJoinWithLeftLocalPred(): Unit = {
+    val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    tEnv.getConfig.setNullCheck(true)
+
+    val ds1 = addNullKey5Tuples(
+      CollectionDataSets.get5TupleDataSet(env)).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
+    val ds2 = addNullKey3Tuples(
+      CollectionDataSets.get3TupleDataSet(env)).toTable(tEnv, 'a, 'b, 'c)
+
+    val joinT = ds1.rightOuterJoin(ds2, 'a === 'd && 'b === 2).select('c, 'g)
+
+    val expected = Seq(
+      "Hello,Hallo Welt", "Hello,Hallo Welt wie",
+      "Hello world,Hallo Welt wie gehts?", "Hello world,ABC", "Hello world,BCD",
+      "Hi,null", "Hello world, how are you?,null", "I am fine.,null", "Luke Skywalker,null",
+      "Comment#1,null", "Comment#2,null", "Comment#3,null", "Comment#4,null", "Comment#5,null",
+      "Comment#6,null", "Comment#7,null", "Comment#8,null", "Comment#9,null", "Comment#10,null",
+      "Comment#11,null", "Comment#12,null", "Comment#13,null", "Comment#14,null", "Comment#15,null",
+      "NullTuple,null", "NullTuple,null")
+    val results = joinT.toDataSet[Row].collect()
+    TestBaseUtils.compareResultAsText(results.asJava, expected.mkString("\n"))
   }
 
   @Test
@@ -255,8 +369,10 @@ class JoinITCase(
     val tEnv = TableEnvironment.getTableEnvironment(env, config)
     tEnv.getConfig.setNullCheck(true)
 
-    val ds1 = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
-    val ds2 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
+    val ds1 = addNullKey3Tuples(
+      CollectionDataSets.get3TupleDataSet(env)).toTable(tEnv, 'a, 'b, 'c)
+    val ds2 = addNullKey5Tuples(
+      CollectionDataSets.get5TupleDataSet(env)).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
 
     val joinT = ds1.fullOuterJoin(ds2, 'a === 'd && 'b === 'h).select('c, 'g)
 
@@ -268,9 +384,71 @@ class JoinITCase(
       "Comment#5,null\n" + "Comment#6,null\n" + "Comment#7,null\n" + "Comment#8,null\n" +
       "Comment#9,null\n" + "Comment#10,null\n" + "Comment#11,null\n" + "Comment#12,null\n" +
       "Comment#13,null\n" + "Comment#14,null\n" + "Comment#15,null\n" +
-      "Hello world, how are you?,null\n"
+      "Hello world, how are you?,null\n" +
+      "NullTuple,null\n" + "NullTuple,null\n" + "null,NullTuple\n" + "null,NullTuple\n"
     val results = joinT.toDataSet[Row].collect()
     TestBaseUtils.compareResultAsText(results.asJava, expected)
+  }
+
+  @Test
+  def testFullJoinWithNonEquiJoinPred(): Unit = {
+    val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    tEnv.getConfig.setNullCheck(true)
+
+    val ds1 = addNullKey3Tuples(
+      CollectionDataSets.get3TupleDataSet(env)).toTable(tEnv, 'a, 'b, 'c)
+    val ds2 = addNullKey5Tuples(
+      CollectionDataSets.get5TupleDataSet(env)).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
+
+    val joinT = ds1.fullOuterJoin(ds2, 'a === 'd && 'b <= 'h).select('c, 'g)
+
+    val expected = Seq(
+      // join matches
+      "Hi,Hallo", "Hello,Hallo Welt", "Hello world,Hallo Welt wie gehts?", "Hello world,ABC",
+      "Hello world,BCD", "I am fine.,HIJ", "I am fine.,IJK",
+      // preserved left
+      "Hello world, how are you?,null", "Luke Skywalker,null", "Comment#1,null", "Comment#2,null",
+      "Comment#3,null", "Comment#4,null", "Comment#5,null", "Comment#6,null", "Comment#7,null",
+      "Comment#8,null", "Comment#9,null", "Comment#10,null", "Comment#11,null", "Comment#12,null",
+      "Comment#13,null", "Comment#14,null", "Comment#15,null", "NullTuple,null", "NullTuple,null",
+      // preserved right
+      "null,Hallo Welt wie", "null,CDE", "null,DEF", "null,EFG", "null,FGH", "null,GHI", "null,JKL",
+      "null,KLM", "null,NullTuple", "null,NullTuple")
+    val results = joinT.toDataSet[Row].collect()
+    TestBaseUtils.compareResultAsText(results.asJava, expected.mkString("\n"))
+  }
+
+  @Test
+  def testFullJoinWithLeftLocalPred(): Unit = {
+    val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    tEnv.getConfig.setNullCheck(true)
+
+    val ds1 = addNullKey3Tuples(
+      CollectionDataSets.get3TupleDataSet(env)).toTable(tEnv, 'a, 'b, 'c)
+    val ds2 = addNullKey5Tuples(
+      CollectionDataSets.get5TupleDataSet(env)).toTable(tEnv, 'd, 'e, 'f, 'g, 'h)
+
+    val joinT = ds1.fullOuterJoin(ds2, 'a === 'd && 'b >= 2 && 'h === 1).select('c, 'g)
+
+    val expected = Seq(
+      // join matches
+      "Hello,Hallo Welt wie", "Hello world, how are you?,DEF", "Hello world, how are you?,EFG",
+      "I am fine.,GHI",
+      // preserved left
+      "Hi,null", "Hello world,null", "Luke Skywalker,null",
+      "Comment#1,null", "Comment#2,null", "Comment#3,null", "Comment#4,null", "Comment#5,null",
+      "Comment#6,null", "Comment#7,null", "Comment#8,null", "Comment#9,null", "Comment#10,null",
+      "Comment#11,null", "Comment#12,null", "Comment#13,null", "Comment#14,null", "Comment#15,null",
+      "NullTuple,null", "NullTuple,null",
+      // preserved right
+      "null,Hallo", "null,Hallo Welt", "null,Hallo Welt wie gehts?", "null,ABC", "null,BCD",
+      "null,CDE", "null,FGH", "null,HIJ", "null,IJK", "null,JKL", "null,KLM",
+      "null,NullTuple", "null,NullTuple")
+
+    val results = joinT.toDataSet[Row].collect()
+    TestBaseUtils.compareResultAsText(results.asJava, expected.mkString("\n"))
   }
 
   @Test
@@ -293,6 +471,42 @@ class JoinITCase(
       "how#are#you,are,3",
       "how#are#you,you,3").mkString("\n")
     TestBaseUtils.compareResultAsText(results.asJava, expected)
+  }
+
+  private def addNullKey3Tuples(rows: DataSet[(Int, Long, String)]) = {
+    rows.mapPartition(
+      new MapPartitionFunction[(Int, Long, String), (Integer, Long, String)] {
+
+        override def mapPartition(
+            vals: Iterable[(Int, Long, String)],
+            out: Collector[(Integer, Long, String)]): Unit = {
+          val it = vals.iterator()
+          while (it.hasNext) {
+            val v = it.next()
+            out.collect((int2Integer(v._1), v._2, v._3))
+          }
+          out.collect((null.asInstanceOf[Integer], 999L, "NullTuple"))
+          out.collect((null.asInstanceOf[Integer], 999L, "NullTuple"))
+        }
+      })
+  }
+
+  private def addNullKey5Tuples(rows: DataSet[(Int, Long, Int, String, Long)]) = {
+    rows.mapPartition(
+      new MapPartitionFunction[(Int, Long, Int, String, Long), (Integer, Long, Int, String, Long)] {
+
+        override def mapPartition(
+            vals: Iterable[(Int, Long, Int, String, Long)],
+            out: Collector[(Integer, Long, Int, String, Long)]): Unit = {
+          val it = vals.iterator()
+          while (it.hasNext) {
+            val v = it.next()
+            out.collect((int2Integer(v._1), v._2, v._3, v._4, v._5))
+          }
+          out.collect((null.asInstanceOf[Integer], 999L, 999, "NullTuple", 999L))
+          out.collect((null.asInstanceOf[Integer], 999L, 999, "NullTuple", 999L))
+        }
+      })
   }
 
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes a couple of issues with Table API / SQL batch joins:
- Proper support for joining null values for inner and outer joins
- Support for non-equi join predicates in outer joins (at least one equi-join predicate is required)
- Support for local predicates on the outer input of outer joins (at least one equi-join predicate is required)

## Brief change log

- Inner & Outer Joins: Evaluate all join predicates in a code-gen'd function (also equi-join predicates) for correct handling of three-value logic
- Outer joins: translate outer joins into a sequence of GroupReduce -> OuterJoin -> GroupReduce. 
  - The first GroupReduce groups on the full input row and deduplicates the outer side(s) of the join. A count for the number of deduplicated rows is kept.
  - The OuterJoin evaluates the join predicate and computes possible join pairs of left and right rows. The non-outer element of the pair can be null if the join predicate does not match.
  - The second GroupReduce groups again on the full input row and computes for each outer row the join result. If it was not match with any inner row, it produces a null-padded result.
  - The plan for left and right outer joins requires only a single initial partitioning and sort of each input. The all operators can reuse the initial sort and produce a sorted result again. A full outer join requires an additional partitioning and sorting step.
- Checks for outer join translation are removed to allow outer joins with non-equi and local predicates.

## Verifying this change

- added ITCases for the new outer join features to `JoinITCase`
- added plan tests for Table API and SQL for the new outer join features
- updated validation tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **yes**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**

## Documentation

The documentation does not need to be adjusted because the outer join limitation were not documented. 
