### PR TITLE
[FLINK-7875] [flip6] Start StaticFileServerHandler with random tmp dir

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/RestHandlerConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/RestHandlerConfiguration.java
@@ -24,6 +24,7 @@ import org.apache.flink.configuration.WebOptions;
 import org.apache.flink.util.Preconditions;
 
 import java.io.File;
+import java.util.UUID;
 
 /**
  * Configuration object containing values for the rest handler configuration.
@@ -75,7 +76,8 @@ public class RestHandlerConfiguration {
 
 		final Time timeout = Time.milliseconds(configuration.getLong(WebOptions.TIMEOUT));
 
-		final File tmpDir = new File(configuration.getString(WebOptions.TMP_DIR));
+		final String rootDir = "flink-web-" + UUID.randomUUID();
+		final File tmpDir = new File(configuration.getString(WebOptions.TMP_DIR), rootDir);
 
 		return new RestHandlerConfiguration(refreshInterval, maxCheckpointStatisticCacheEntries, timeout, tmpDir);
 	}


### PR DESCRIPTION
## What is the purpose of the change

Start the `StaticFileServerHandler` in the `DispatcherRestEndpoint` with a random temporary directory. This ensures that multiple Rest endpoints don't interfere with each other.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

