### PR TITLE
[FLINK-7783] Don't always remove checkpoints in ZooKeeperCompletedCheckpointStore#recover()

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/zookeeper/ZooKeeperStateHandleStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/zookeeper/ZooKeeperStateHandleStore.java
@@ -326,7 +326,8 @@ public class ZooKeeperStateHandleStore<T extends Serializable> {
 
 	/**
 	 * Gets all available state handles from ZooKeeper sorted by name (ascending) and locks the
-	 * respective state nodes.
+	 * respective state nodes. The result tuples contain the retrieved state and the path to the
+	 * node in ZooKeeper.
 	 *
 	 * <p>If there is a concurrent modification, the operation is retried until it succeeds.
 	 *

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreTest.java
@@ -21,9 +21,9 @@ package org.apache.flink.runtime.checkpoint;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.concurrent.Executors;
 import org.apache.flink.runtime.state.RetrievableStateHandle;
-import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.runtime.zookeeper.RetrievableStateStorageHelper;
 import org.apache.flink.runtime.zookeeper.ZooKeeperStateHandleStore;
+import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
 
 import org.apache.curator.framework.CuratorFramework;
@@ -48,8 +48,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.Executor;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
@@ -57,7 +59,6 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.doAnswer;
@@ -79,7 +80,7 @@ public class ZooKeeperCompletedCheckpointStoreTest extends TestLogger {
 
 	/**
 	 * Tests that the completed checkpoint store can retrieve all checkpoints stored in ZooKeeper
-	 * and ignores those which cannot be retrieved via their state handles.
+	 * if none of them are broken.
 	 */
 	@Test
 	public void testCheckpointRecovery() throws Exception {
@@ -94,9 +95,6 @@ public class ZooKeeperCompletedCheckpointStoreTest extends TestLogger {
 		expectedCheckpointIds.add(1L);
 		expectedCheckpointIds.add(2L);
 
-		final RetrievableStateHandle<CompletedCheckpoint> failingRetrievableStateHandle = mock(RetrievableStateHandle.class);
-		when(failingRetrievableStateHandle.retrieveState()).thenThrow(new IOException("Test exception"));
-
 		final RetrievableStateHandle<CompletedCheckpoint> retrievableStateHandle1 = mock(RetrievableStateHandle.class);
 		when(retrievableStateHandle1.retrieveState()).thenReturn(completedCheckpoint1);
 
@@ -104,9 +102,7 @@ public class ZooKeeperCompletedCheckpointStoreTest extends TestLogger {
 		when(retrievableStateHandle2.retrieveState()).thenReturn(completedCheckpoint2);
 
 		checkpointsInZooKeeper.add(Tuple2.of(retrievableStateHandle1, "/foobar1"));
-		checkpointsInZooKeeper.add(Tuple2.of(failingRetrievableStateHandle, "/failing1"));
 		checkpointsInZooKeeper.add(Tuple2.of(retrievableStateHandle2, "/foobar2"));
-		checkpointsInZooKeeper.add(Tuple2.of(failingRetrievableStateHandle, "/failing2"));
 
 		final CuratorFramework client = mock(CuratorFramework.class, Mockito.RETURNS_DEEP_STUBS);
 		final RetrievableStateStorageHelper<CompletedCheckpoint> storageHelperMock = mock(RetrievableStateStorageHelper.class);
@@ -183,11 +179,120 @@ public class ZooKeeperCompletedCheckpointStoreTest extends TestLogger {
 		// check that we did not discard any of the state handles which were retrieved
 		verify(retrievableStateHandle1, never()).discardState();
 		verify(retrievableStateHandle2, never()).discardState();
-
-		// check that we have discarded the state handles which could not be retrieved
-		verify(failingRetrievableStateHandle, times(2)).discardState();
 	}
-	
+
+	/**
+	 * Tests that the completed checkpoint store can retrieve all checkpoints stored in ZooKeeper
+	 * and ignores those which cannot be retrieved via their state handles.
+	 */
+	@Test
+	public void testCheckpointRecoveryWithBrokenCheckpoints() throws Exception {
+		final List<Tuple2<RetrievableStateHandle<CompletedCheckpoint>, String>> checkpointsInZooKeeper = new ArrayList<>(4);
+
+		final CompletedCheckpoint completedCheckpoint1 = mock(CompletedCheckpoint.class);
+		when(completedCheckpoint1.getCheckpointID()).thenReturn(1L);
+		final CompletedCheckpoint completedCheckpoint2 = mock(CompletedCheckpoint.class);
+		when(completedCheckpoint2.getCheckpointID()).thenReturn(2L);
+
+		final Collection<Long> expectedCheckpointIds = new HashSet<>(2);
+		expectedCheckpointIds.add(1L);
+		expectedCheckpointIds.add(2L);
+
+		final RetrievableStateHandle<CompletedCheckpoint> failingRetrievableStateHandle = mock(RetrievableStateHandle.class);
+		when(failingRetrievableStateHandle.retrieveState()).thenThrow(new IOException("Test exception"));
+
+		final RetrievableStateHandle<CompletedCheckpoint> retrievableStateHandle1 = mock(RetrievableStateHandle.class);
+		when(retrievableStateHandle1.retrieveState()).thenReturn(completedCheckpoint1);
+
+		final RetrievableStateHandle<CompletedCheckpoint> retrievableStateHandle2 = mock(RetrievableStateHandle.class);
+		when(retrievableStateHandle2.retrieveState()).thenReturn(completedCheckpoint2);
+
+		checkpointsInZooKeeper.add(Tuple2.of(failingRetrievableStateHandle, "/a_failing1"));
+		checkpointsInZooKeeper.add(Tuple2.of(retrievableStateHandle1, "/b_foobar1"));
+		checkpointsInZooKeeper.add(Tuple2.of(failingRetrievableStateHandle, "/c_failing2"));
+		checkpointsInZooKeeper.add(Tuple2.of(retrievableStateHandle2, "/d_foobar2"));
+
+		final CuratorFramework client = mock(CuratorFramework.class, Mockito.RETURNS_DEEP_STUBS);
+		final RetrievableStateStorageHelper<CompletedCheckpoint> storageHelperMock = mock(RetrievableStateStorageHelper.class);
+
+		ZooKeeperStateHandleStore<CompletedCheckpoint> zooKeeperStateHandleStoreMock = spy(new ZooKeeperStateHandleStore<>(client, storageHelperMock, Executors.directExecutor()));
+		whenNew(ZooKeeperStateHandleStore.class).withAnyArguments().thenReturn(zooKeeperStateHandleStoreMock);
+		doReturn(checkpointsInZooKeeper).when(zooKeeperStateHandleStoreMock).getAllSortedByNameAndLock();
+
+		final int numCheckpointsToRetain = 1;
+
+		// Mocking for the delete operation on the CuratorFramework client
+		// It assures that the callback is executed synchronously
+
+		final EnsurePath ensurePathMock = mock(EnsurePath.class);
+		final CuratorEvent curatorEventMock = mock(CuratorEvent.class);
+		when(curatorEventMock.getType()).thenReturn(CuratorEventType.DELETE);
+		when(curatorEventMock.getResultCode()).thenReturn(0);
+		when(client.newNamespaceAwareEnsurePath(anyString())).thenReturn(ensurePathMock);
+
+		when(
+			client
+				.delete()
+				.inBackground(any(BackgroundCallback.class), any(Executor.class))
+		).thenAnswer(new Answer<ErrorListenerPathable<Void>>() {
+			@Override
+			public ErrorListenerPathable<Void> answer(InvocationOnMock invocation) throws Throwable {
+				final BackgroundCallback callback = (BackgroundCallback) invocation.getArguments()[0];
+
+				ErrorListenerPathable<Void> result = mock(ErrorListenerPathable.class);
+
+				when(result.forPath(anyString())).thenAnswer(new Answer<Void>() {
+					@Override
+					public Void answer(InvocationOnMock invocation) throws Throwable {
+
+						callback.processResult(client, curatorEventMock);
+
+						return null;
+					}
+				});
+
+				return result;
+			}
+		});
+
+		final String checkpointsPath = "foobar";
+		final RetrievableStateStorageHelper<CompletedCheckpoint> stateStorage = mock(RetrievableStateStorageHelper.class);
+
+		ZooKeeperCompletedCheckpointStore zooKeeperCompletedCheckpointStore = new ZooKeeperCompletedCheckpointStore(
+			numCheckpointsToRetain,
+			client,
+			checkpointsPath,
+			stateStorage,
+			Executors.directExecutor());
+
+		zooKeeperCompletedCheckpointStore.recover();
+
+		CompletedCheckpoint latestCompletedCheckpoint = zooKeeperCompletedCheckpointStore.getLatestCheckpoint();
+
+		// check that we return the latest checkpoint
+		assertEquals(completedCheckpoint2.getCheckpointID(), latestCompletedCheckpoint.getCheckpointID());
+
+		// this should fail, because at least one of the handles is broken
+		// this behaviour is very important because the logic for incremental checkpoints is
+		// rebuilding the internal dependencies in incremental checkpoints for this. If we restore
+		// but ignore broken handles or even drop them we would run into problems.
+		boolean failed = true;
+		try {
+			List<CompletedCheckpoint> completedCheckpoints = zooKeeperCompletedCheckpointStore.getAllCheckpoints();
+			failed = false;
+		} catch (FlinkException e) {
+			assertThat(e.getMessage(), containsString("Could not retrieve checkpoint"));
+		}
+
+		assertTrue(failed);
+
+		// check that we did not discard any of the state handles
+		verify(retrievableStateHandle1, never()).discardState();
+		verify(retrievableStateHandle2, never()).discardState();
+		verify(failingRetrievableStateHandle, never()).discardState();
+	}
+
+
 	/**
 	 * Tests that the checkpoint does not exist in the store when we fail to add
 	 * it into the store (i.e., there exists an exception thrown by the method).


### PR DESCRIPTION
This is a bit simpler now than described on the issue: We simply never delete checkpoints except when they are subsumed. We always fail completely when we try to retrieve a checkpoint handle, both in `getLatestCheckpoint()` and `getAllCheckpoints()`. The reason for this are incremental state handles: `getAllCheckpoints()` is used to rebuild the dependency information between the incremental state handles when restoring. If we only return a partial list of state handles from `getAllCheckpoints()` then this logic wouldn't work anymore, that's why we have to fail in this method as soon as one handle is not retrievable.

I could change `getLatestCheckpoint()` to ignore broken handles and return an older one (in fact I have the code for this ready) but it doesn't make sense because `getAllCheckpoints()` is also called when `getLatestCheckpoint()` is called, meaning that restoring will fail anyways.

R: @StefanRRichter AND/OR @tillrohrmann 

