### PR TITLE
[FLINK-4866]SourceFunction needn't extends Serializable again

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/SourceFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/SourceFunction.java
@@ -90,7 +90,7 @@ import java.io.Serializable;
  * @see org.apache.flink.streaming.api.TimeCharacteristic
  */
 @Public
-public interface SourceFunction<T> extends Function, Serializable {
+public interface SourceFunction<T> extends Function {
 
 	/**
 	 * Starts the source. Implementations can use the {@link SourceContext} emit


### PR DESCRIPTION
Function extends java.io.Serializable, so SourceFunction needn't extends Serializable again