### PR TITLE
 [FLINK-7637] [kinesis] Fix at-least-once guarantee in FlinkKinesisProducer

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisProducer.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisProducer.java
@@ -54,6 +54,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  */
 public class FlinkKinesisProducer<OUT> extends RichSinkFunction<OUT> implements CheckpointedFunction {
 
+	private static final long serialVersionUID = 6447077318449477846L;
+
 	private static final Logger LOG = LoggerFactory.getLogger(FlinkKinesisProducer.class);
 
 	/** Properties to parametrize settings such as AWS service region, access key etc. */

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisProducerTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisProducerTest.java
@@ -18,10 +18,6 @@
 
 package org.apache.flink.streaming.connectors.kinesis;
 
-import com.amazonaws.services.kinesis.producer.KinesisProducer;
-import com.amazonaws.services.kinesis.producer.KinesisProducerConfiguration;
-import com.amazonaws.services.kinesis.producer.UserRecordResult;
-import com.google.common.util.concurrent.SettableFuture;
 import org.apache.flink.core.testutils.CheckedThread;
 import org.apache.flink.core.testutils.MultiShotLatch;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
@@ -34,6 +30,12 @@ import org.apache.flink.streaming.util.serialization.SerializationSchema;
 import org.apache.flink.streaming.util.serialization.SimpleStringSchema;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.InstantiationUtil;
+
+import org.apache.flink.shaded.guava18.com.google.common.util.concurrent.SettableFuture;
+
+import com.amazonaws.services.kinesis.producer.KinesisProducer;
+import com.amazonaws.services.kinesis.producer.KinesisProducerConfiguration;
+import com.amazonaws.services.kinesis.producer.UserRecordResult;
 
 import org.junit.Assert;
 import org.junit.Rule;

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisProducerTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisProducerTest.java
@@ -18,19 +18,41 @@
 
 package org.apache.flink.streaming.connectors.kinesis;
 
+import com.amazonaws.services.kinesis.producer.KinesisProducer;
+import com.amazonaws.services.kinesis.producer.KinesisProducerConfiguration;
+import com.amazonaws.services.kinesis.producer.UserRecordResult;
+import com.google.common.util.concurrent.SettableFuture;
+import org.apache.flink.core.testutils.CheckedThread;
+import org.apache.flink.core.testutils.MultiShotLatch;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.streaming.api.operators.StreamSink;
 import org.apache.flink.streaming.connectors.kinesis.config.AWSConfigConstants;
 import org.apache.flink.streaming.connectors.kinesis.serialization.KinesisSerializationSchema;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.streaming.util.serialization.SerializationSchema;
 import org.apache.flink.streaming.util.serialization.SimpleStringSchema;
+import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.InstantiationUtil;
 
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 import java.nio.ByteBuffer;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Properties;
 
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Suite of {@link FlinkKinesisProducer} tests.
@@ -49,22 +71,12 @@ public class FlinkKinesisProducerTest {
 		exception.expect(IllegalArgumentException.class);
 		exception.expectMessage("The provided serialization schema is not serializable");
 
-		Properties testConfig = new Properties();
-		testConfig.setProperty(AWSConfigConstants.AWS_REGION, "us-east-1");
-		testConfig.setProperty(AWSConfigConstants.AWS_ACCESS_KEY_ID, "accessKeyId");
-		testConfig.setProperty(AWSConfigConstants.AWS_SECRET_ACCESS_KEY, "secretKey");
-
-		new FlinkKinesisProducer<>(new NonSerializableSerializationSchema(), testConfig);
+		new FlinkKinesisProducer<>(new NonSerializableSerializationSchema(), getStandardProperties());
 	}
 
 	@Test
 	public void testCreateWithSerializableDeserializer() {
-		Properties testConfig = new Properties();
-		testConfig.setProperty(AWSConfigConstants.AWS_REGION, "us-east-1");
-		testConfig.setProperty(AWSConfigConstants.AWS_ACCESS_KEY_ID, "accessKeyId");
-		testConfig.setProperty(AWSConfigConstants.AWS_SECRET_ACCESS_KEY, "secretKey");
-
-		new FlinkKinesisProducer<>(new SerializableSerializationSchema(), testConfig);
+		new FlinkKinesisProducer<>(new SerializableSerializationSchema(), getStandardProperties());
 	}
 
 	@Test
@@ -72,35 +84,189 @@ public class FlinkKinesisProducerTest {
 		exception.expect(IllegalArgumentException.class);
 		exception.expectMessage("The provided custom partitioner is not serializable");
 
-		Properties testConfig = new Properties();
-		testConfig.setProperty(AWSConfigConstants.AWS_REGION, "us-east-1");
-		testConfig.setProperty(AWSConfigConstants.AWS_ACCESS_KEY_ID, "accessKeyId");
-		testConfig.setProperty(AWSConfigConstants.AWS_SECRET_ACCESS_KEY, "secretKey");
-
-		new FlinkKinesisProducer<>(new SimpleStringSchema(), testConfig)
+		new FlinkKinesisProducer<>(new SimpleStringSchema(), getStandardProperties())
 			.setCustomPartitioner(new NonSerializableCustomPartitioner());
 	}
 
 	@Test
 	public void testConfigureWithSerializableCustomPartitioner() {
-		Properties testConfig = new Properties();
-		testConfig.setProperty(AWSConfigConstants.AWS_REGION, "us-east-1");
-		testConfig.setProperty(AWSConfigConstants.AWS_ACCESS_KEY_ID, "accessKeyId");
-		testConfig.setProperty(AWSConfigConstants.AWS_SECRET_ACCESS_KEY, "secretKey");
-
-		new FlinkKinesisProducer<>(new SimpleStringSchema(), testConfig)
+		new FlinkKinesisProducer<>(new SimpleStringSchema(), getStandardProperties())
 			.setCustomPartitioner(new SerializableCustomPartitioner());
 	}
 
 	@Test
 	public void testConsumerIsSerializable() {
-		Properties testConfig = new Properties();
-		testConfig.setProperty(AWSConfigConstants.AWS_REGION, "us-east-1");
-		testConfig.setProperty(AWSConfigConstants.AWS_ACCESS_KEY_ID, "accessKeyId");
-		testConfig.setProperty(AWSConfigConstants.AWS_SECRET_ACCESS_KEY, "secretKey");
-
-		FlinkKinesisProducer<String> consumer = new FlinkKinesisProducer<>(new SimpleStringSchema(), testConfig);
+		FlinkKinesisProducer<String> consumer = new FlinkKinesisProducer<>(new SimpleStringSchema(), getStandardProperties());
 		assertTrue(InstantiationUtil.isSerializable(consumer));
+	}
+
+	// ----------------------------------------------------------------------
+	// Tests to verify at-least-once guarantee
+	// ----------------------------------------------------------------------
+
+	/**
+	 * Test ensuring that if an invoke call happens right after an async exception is caught, it should be rethrown.
+	 */
+	@SuppressWarnings("ResultOfMethodCallIgnored")
+	@Test
+	public void testAsyncErrorRethrownOnInvoke() throws Throwable {
+		final DummyFlinkKinesisProducer<String> producer = new DummyFlinkKinesisProducer<>(new SimpleStringSchema());
+
+		OneInputStreamOperatorTestHarness<String, Object> testHarness =
+			new OneInputStreamOperatorTestHarness<>(new StreamSink<>(producer));
+
+		testHarness.open();
+
+		testHarness.processElement(new StreamRecord<>("msg-1"));
+
+		producer.getPendingRecordFutures().get(0).setException(new Exception("artificial async exception"));
+
+		try {
+			testHarness.processElement(new StreamRecord<>("msg-2"));
+		} catch (Exception e) {
+			// the next invoke should rethrow the async exception
+			Assert.assertTrue(ExceptionUtils.findThrowableWithMessage(e, "artificial async exception").isPresent());
+
+			// test succeeded
+			return;
+		}
+
+		Assert.fail();
+	}
+
+	/**
+	 * Test ensuring that if a snapshot call happens right after an async exception is caught, it should be rethrown.
+	 */
+	@SuppressWarnings("ResultOfMethodCallIgnored")
+	@Test
+	public void testAsyncErrorRethrownOnCheckpoint() throws Throwable {
+		final DummyFlinkKinesisProducer<String> producer = new DummyFlinkKinesisProducer<>(new SimpleStringSchema());
+
+		OneInputStreamOperatorTestHarness<String, Object> testHarness =
+			new OneInputStreamOperatorTestHarness<>(new StreamSink<>(producer));
+
+		testHarness.open();
+
+		testHarness.processElement(new StreamRecord<>("msg-1"));
+
+		producer.getPendingRecordFutures().get(0).setException(new Exception("artificial async exception"));
+
+		try {
+			testHarness.snapshot(123L, 123L);
+		} catch (Exception e) {
+			// the next invoke should rethrow the async exception
+			Assert.assertTrue(ExceptionUtils.findThrowableWithMessage(e, "artificial async exception").isPresent());
+
+			// test succeeded
+			return;
+		}
+
+		Assert.fail();
+	}
+
+	/**
+	 * Test ensuring that if an async exception is caught for one of the flushed requests on checkpoint,
+	 * it should be rethrown; we set a timeout because the test will not finish if the logic is broken.
+	 *
+	 * <p>Note that this test does not test the snapshot method is blocked correctly when there are pending recorrds.
+	 * The test for that is covered in testAtLeastOnceProducer.
+	 */
+	@SuppressWarnings("ResultOfMethodCallIgnored")
+	@Test
+	public void testAsyncErrorRethrownAfterFlush() throws Throwable {
+		final DummyFlinkKinesisProducer<String> producer = new DummyFlinkKinesisProducer<>(new SimpleStringSchema());
+
+		OneInputStreamOperatorTestHarness<String, Object> testHarness =
+			new OneInputStreamOperatorTestHarness<>(new StreamSink<>(producer));
+
+		testHarness.open();
+
+		testHarness.processElement(new StreamRecord<>("msg-1"));
+		testHarness.processElement(new StreamRecord<>("msg-2"));
+		testHarness.processElement(new StreamRecord<>("msg-3"));
+
+		// only let the first record succeed for now
+		UserRecordResult result = mock(UserRecordResult.class);
+		when(result.isSuccessful()).thenReturn(true);
+		producer.getPendingRecordFutures().get(0).set(result);
+
+		CheckedThread snapshotThread = new CheckedThread() {
+			@Override
+			public void go() throws Exception {
+				// this should block at first, since there are still two pending records that needs to be flushed
+				testHarness.snapshot(123L, 123L);
+			}
+		};
+		snapshotThread.start();
+
+		// let the 2nd message fail with an async exception
+		producer.getPendingRecordFutures().get(1).setException(new Exception("artificial async failure for 2nd message"));
+		producer.getPendingRecordFutures().get(2).set(mock(UserRecordResult.class));
+
+		try {
+			snapshotThread.sync();
+		} catch (Exception e) {
+			// the next invoke should rethrow the async exception
+			e.printStackTrace();
+			Assert.assertTrue(ExceptionUtils.findThrowableWithMessage(e, "artificial async failure for 2nd message").isPresent());
+
+			// test succeeded
+			return;
+		}
+
+		Assert.fail();
+	}
+
+	/**
+	 * Test ensuring that the producer is not dropping buffered records;
+	 * we set a timeout because the test will not finish if the logic is broken.
+	 */
+	@SuppressWarnings("unchecked")
+	@Test(timeout = 10000)
+	public void testAtLeastOnceProducer() throws Throwable {
+		final DummyFlinkKinesisProducer<String> producer = new DummyFlinkKinesisProducer<>(new SimpleStringSchema());
+
+		OneInputStreamOperatorTestHarness<String, Object> testHarness =
+			new OneInputStreamOperatorTestHarness<>(new StreamSink<>(producer));
+
+		testHarness.open();
+
+		testHarness.processElement(new StreamRecord<>("msg-1"));
+		testHarness.processElement(new StreamRecord<>("msg-2"));
+		testHarness.processElement(new StreamRecord<>("msg-3"));
+
+		// start a thread to perform checkpointing
+		CheckedThread snapshotThread = new CheckedThread() {
+			@Override
+			public void go() throws Exception {
+				// this should block until all records are flushed;
+				// if the snapshot implementation returns before pending records are flushed,
+				testHarness.snapshot(123L, 123L);
+			}
+		};
+		snapshotThread.start();
+
+		// before proceeding, make sure that flushing has started and that the snapshot is still blocked;
+		// this would block forever if the snapshot didn't perform a flush
+		producer.waitUntilFlushStarted();
+		Assert.assertTrue("Snapshot returned before all records were flushed", snapshotThread.isAlive());
+
+		// now, complete the callbacks
+		UserRecordResult result = mock(UserRecordResult.class);
+		when(result.isSuccessful()).thenReturn(true);
+
+		producer.getPendingRecordFutures().get(0).set(result);
+		Assert.assertTrue("Snapshot returned before all records were flushed", snapshotThread.isAlive());
+
+		producer.getPendingRecordFutures().get(1).set(result);
+		Assert.assertTrue("Snapshot returned before all records were flushed", snapshotThread.isAlive());
+
+		producer.getPendingRecordFutures().get(2).set(result);
+
+		// this would fail with an exception if flushing wasn't completed before the snapshot method returned
+		snapshotThread.sync();
+
+		testHarness.close();
 	}
 
 	// ----------------------------------------------------------------------
@@ -157,5 +323,119 @@ public class FlinkKinesisProducerTest {
 		public String getPartitionId(String element) {
 			return "test-partition";
 		}
+	}
+
+	private static class DummyFlinkKinesisProducer<T> extends FlinkKinesisProducer<T> {
+
+		private static final long serialVersionUID = -1212425318784651817L;
+
+		private static final String DUMMY_STREAM = "dummy-stream";
+		private static final String DUMMY_PARTITION = "dummy-partition";
+
+		private transient KinesisProducer mockProducer;
+		private List<SettableFuture<UserRecordResult>> pendingRecordFutures = new LinkedList<>();
+
+		private transient MultiShotLatch flushLatch;
+		private boolean isFlushed;
+
+		DummyFlinkKinesisProducer(SerializationSchema<T> schema) {
+			super(schema, getStandardProperties());
+
+			setDefaultStream(DUMMY_STREAM);
+			setDefaultPartition(DUMMY_PARTITION);
+			setFailOnError(true);
+
+			// set up mock producer
+			this.mockProducer = mock(KinesisProducer.class);
+
+			when(mockProducer.addUserRecord(anyString(), anyString(), anyString(), any(ByteBuffer.class))).thenAnswer(new Answer<Object>() {
+				@Override
+				public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
+					SettableFuture<UserRecordResult> future = SettableFuture.create();
+					pendingRecordFutures.add(future);
+					return future;
+				}
+			});
+
+			when(mockProducer.getOutstandingRecordsCount()).thenAnswer(new Answer<Object>() {
+				@Override
+				public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
+					return getNumPendingRecordFutures();
+				}
+			});
+
+			doAnswer(new Answer() {
+				@Override
+				public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
+					flushLatch.trigger();
+
+					while (!isAllRecordFuturesCompleted()) {
+						Thread.sleep(50);
+					}
+
+					isFlushed = true;
+
+					return null;
+				}
+			}).when(mockProducer).flush();
+
+			this.flushLatch = new MultiShotLatch();
+		}
+
+		@Override
+		protected KinesisProducer getKinesisProducer(KinesisProducerConfiguration producerConfig) {
+			return mockProducer;
+		}
+
+		@Override
+		public void snapshotState(FunctionSnapshotContext context) throws Exception {
+			isFlushed = false;
+
+			super.snapshotState(context);
+
+			// if the snapshot implementation doesn't wait until all pending records are flushed, we should fail the test
+			if (!isFlushed) {
+				throw new RuntimeException("Flushing is enabled; snapshots should be blocked until all pending records are flushed");
+			}
+		}
+
+		List<SettableFuture<UserRecordResult>> getPendingRecordFutures() {
+			return pendingRecordFutures;
+		}
+
+		void waitUntilFlushStarted() throws Exception {
+			flushLatch.await();
+		}
+
+		private boolean isAllRecordFuturesCompleted() {
+			for (SettableFuture<UserRecordResult> future : pendingRecordFutures) {
+				if (!future.isDone()) {
+					return false;
+				}
+			}
+
+			return true;
+		}
+
+		private int getNumPendingRecordFutures() {
+			int numPending = 0;
+
+			for (SettableFuture<UserRecordResult> future : pendingRecordFutures) {
+				if (!future.isDone()) {
+					numPending++;
+				}
+			}
+
+			return numPending;
+		}
+	}
+
+	private static Properties getStandardProperties() {
+		Properties standardProps = new Properties();
+		standardProps.setProperty(AWSConfigConstants.AWS_REGION, "us-east-1");
+		standardProps.setProperty(AWSConfigConstants.AWS_ACCESS_KEY_ID, "accessKeyId");
+		standardProps.setProperty(AWSConfigConstants.AWS_SECRET_ACCESS_KEY, "secretKey");
+
+		return standardProps;
 	}
 }

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisProducerTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisProducerTest.java
@@ -154,7 +154,7 @@ public class FlinkKinesisProducerTest {
 		try {
 			testHarness.snapshot(123L, 123L);
 		} catch (Exception e) {
-			// the next invoke should rethrow the async exception
+			// the next checkpoint should rethrow the async exception
 			Assert.assertTrue(ExceptionUtils.findThrowableWithMessage(e, "artificial async exception").isPresent());
 
 			// test succeeded
@@ -172,7 +172,7 @@ public class FlinkKinesisProducerTest {
 	 * The test for that is covered in testAtLeastOnceProducer.
 	 */
 	@SuppressWarnings("ResultOfMethodCallIgnored")
-	@Test
+	@Test(timeout = 10000)
 	public void testAsyncErrorRethrownAfterFlush() throws Throwable {
 		final DummyFlinkKinesisProducer<String> producer = new DummyFlinkKinesisProducer<>(new SimpleStringSchema());
 
@@ -206,8 +206,7 @@ public class FlinkKinesisProducerTest {
 		try {
 			snapshotThread.sync();
 		} catch (Exception e) {
-			// the next invoke should rethrow the async exception
-			e.printStackTrace();
+			// after the flush, the async exception should have been rethrown
 			Assert.assertTrue(ExceptionUtils.findThrowableWithMessage(e, "artificial async failure for 2nd message").isPresent());
 
 			// test succeeded
@@ -221,7 +220,7 @@ public class FlinkKinesisProducerTest {
 	 * Test ensuring that the producer is not dropping buffered records;
 	 * we set a timeout because the test will not finish if the logic is broken.
 	 */
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({"unchecked", "ResultOfMethodCallIgnored"})
 	@Test(timeout = 10000)
 	public void testAtLeastOnceProducer() throws Throwable {
 		final DummyFlinkKinesisProducer<String> producer = new DummyFlinkKinesisProducer<>(new SimpleStringSchema());

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisProducerTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisProducerTest.java
@@ -278,6 +278,9 @@ public class FlinkKinesisProducerTest {
 	 * to the enclosing class, which is not serializable) used for testing.
 	 */
 	private final class NonSerializableSerializationSchema implements KinesisSerializationSchema<String> {
+
+		private static final long serialVersionUID = 3361337188490178780L;
+
 		@Override
 		public ByteBuffer serialize(String element) {
 			return ByteBuffer.wrap(element.getBytes());
@@ -293,6 +296,9 @@ public class FlinkKinesisProducerTest {
 	 * A static, serializable {@link KinesisSerializationSchema}.
 	 */
 	private static final class SerializableSerializationSchema implements KinesisSerializationSchema<String> {
+
+		private static final long serialVersionUID = 6298573834520052886L;
+
 		@Override
 		public ByteBuffer serialize(String element) {
 			return ByteBuffer.wrap(element.getBytes());
@@ -309,6 +315,9 @@ public class FlinkKinesisProducerTest {
 	 * to the enclosing class, which is not serializable) used for testing.
 	 */
 	private final class NonSerializableCustomPartitioner extends KinesisPartitioner<String> {
+
+		private static final long serialVersionUID = -5961578876056779161L;
+
 		@Override
 		public String getPartitionId(String element) {
 			return "test-partition";
@@ -319,6 +328,9 @@ public class FlinkKinesisProducerTest {
 	 * A static, serializable {@link KinesisPartitioner}.
 	 */
 	private static final class SerializableCustomPartitioner extends KinesisPartitioner<String> {
+
+		private static final long serialVersionUID = -4996071893997035695L;
+
 		@Override
 		public String getPartitionId(String element) {
 			return "test-partition";

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisProducerTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisProducerTest.java
@@ -95,7 +95,7 @@ public class FlinkKinesisProducerTest {
 	}
 
 	@Test
-	public void testConsumerIsSerializable() {
+	public void testProducerIsSerializable() {
 		FlinkKinesisProducer<String> consumer = new FlinkKinesisProducer<>(new SimpleStringSchema(), getStandardProperties());
 		assertTrue(InstantiationUtil.isSerializable(consumer));
 	}

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisProducerTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisProducerTest.java
@@ -31,11 +31,11 @@ import org.apache.flink.streaming.util.serialization.SimpleStringSchema;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.InstantiationUtil;
 
-import org.apache.flink.shaded.guava18.com.google.common.util.concurrent.SettableFuture;
-
 import com.amazonaws.services.kinesis.producer.KinesisProducer;
 import com.amazonaws.services.kinesis.producer.KinesisProducerConfiguration;
 import com.amazonaws.services.kinesis.producer.UserRecordResult;
+
+import com.google.common.util.concurrent.SettableFuture;
 
 import org.junit.Assert;
 import org.junit.Rule;

--- a/flink-core/src/main/java/org/apache/flink/util/ExceptionUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/ExceptionUtils.java
@@ -302,6 +302,30 @@ public final class ExceptionUtils {
 	}
 
 	/**
+	 * Checks whether a throwable chain contains a specific error message and returns the corresponding throwable.
+	 *
+	 * @param throwable the throwable chain to check.
+	 * @param searchMessage the error message to search for in the chain.
+	 * @return Optional throwable containing the search message if available, otherwise empty
+	 */
+	public static Optional<Throwable> findThrowableWithMessage(Throwable throwable, String searchMessage) {
+		if (throwable == null || searchMessage == null) {
+			return Optional.empty();
+		}
+
+		Throwable t = throwable;
+		while (t != null) {
+			if (t.getMessage().contains(searchMessage)) {
+				return Optional.of(t);
+			} else {
+				t = t.getCause();
+			}
+		}
+
+		return Optional.empty();
+	}
+
+	/**
 	 * Unpacks an {@link ExecutionException} and returns its cause. Otherwise the given
 	 * Throwable is returned.
 	 *

--- a/tools/maven/suppressions.xml
+++ b/tools/maven/suppressions.xml
@@ -34,6 +34,6 @@ under the License.
 			checks="IllegalImport"/>
 		<!-- Kinesis producer has to use guava directly -->
 		<suppress
-			files="FlinkKinesisProducer.java"
+			files="FlinkKinesisProducer.java|FlinkKinesisProducerTest.java"
 			checks="IllegalImport"/>
 </suppressions>


### PR DESCRIPTION
## What is the purpose of the change

Prior to this PR, there is no flushing of KPL outstanding records on checkpoints in the `FlinkKinesisProducer`. Likewise to the at-least-once issue on the Flink Kafka producer before, this may lead to data loss if there are asynchronous failing records after a checkpoint which the records was part of was completed.

## Brief change log

- Fix at-least-once in the Kinesis producer by properly flushing on checkpoints.
- Minor fixes (last 2 commits) that cleans up the code.

## Verifying this change

New unit tests are added to `FlinkKinesisProducerTest` to verify at-least-once.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? n/a

