### PR TITLE
[FLINK-4877] About SourceFunction extends Serializable

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/SourceFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/SourceFunction.java
@@ -90,7 +90,7 @@ import java.io.Serializable;
  * @see org.apache.flink.streaming.api.TimeCharacteristic
  */
 @Public
-public interface SourceFunction<T> extends Function, Serializable {
+public interface SourceFunction<T> extends Function {
 
 	/**
 	 * Starts the source. Implementations can use the {@link SourceContext} emit


### PR DESCRIPTION
SourceFunction extends Function and Serializable, but Function has been extends Serializable, so SourceFunction needn't extends Serializable again.