### PR TITLE
[FLINK-7895][hotfix][docs]Fix error in example in get late message in window doc

### DIFF
--- a/docs/dev/stream/operators/windows.md
+++ b/docs/dev/stream/operators/windows.md
@@ -1043,7 +1043,7 @@ final OutputTag<T> lateOutputTag = new OutputTag<T>("late-data"){};
 
 DataStream<T> input = ...;
 
-DataStream<T> result = input
+SingleOutputStreamOperator<T> result = input
     .keyBy(<key selector>)
     .window(<window assigner>)
     .allowedLateness(<time>)


### PR DESCRIPTION
* getSideOutput api is only available in SingleOutputOperator class, and is not the part of the base class



