### PR TITLE
[FLINK-7783] Don't always remove checkpoints in ZooKeeperCompletedCheckpointStore#recover()

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpoint.java
@@ -302,4 +302,28 @@ public class CompletedCheckpoint implements Serializable {
 	public String toString() {
 		return String.format("Checkpoint %d @ %d for %s", checkpointID, timestamp, job);
 	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+
+		CompletedCheckpoint that = (CompletedCheckpoint) o;
+
+		if (checkpointID != that.checkpointID) {
+			return false;
+		}
+		return job.equals(that.job);
+	}
+
+	@Override
+	public int hashCode() {
+		int result = job.hashCode();
+		result = 31 * result + (int) (checkpointID ^ (checkpointID >>> 32));
+		return result;
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/zookeeper/ZooKeeperStateHandleStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/zookeeper/ZooKeeperStateHandleStore.java
@@ -326,7 +326,8 @@ public class ZooKeeperStateHandleStore<T extends Serializable> {
 
 	/**
 	 * Gets all available state handles from ZooKeeper sorted by name (ascending) and locks the
-	 * respective state nodes.
+	 * respective state nodes. The result tuples contain the retrieved state and the path to the
+	 * node in ZooKeeper.
 	 *
 	 * <p>If there is a concurrent modification, the operation is retried until it succeeds.
 	 *


### PR DESCRIPTION
I think this will be the final version for what I started in #4863.

Now, the code will retrieve checkpoints and succeed if either all of them area read or of two successive tries read the same set of checkpoints.

This doesn't duplicate the test anymore but still leaves the questionable (lack of) separation of concerns in the store.

R: @StefanRRichter, @tillrohrmann 