### PR TITLE
[FLINK-7898] [flip6] Don't propagate CancellationExceptions in RegisteredRpcConnection

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/registration/RegisteredRpcConnection.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/registration/RegisteredRpcConnection.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.rpc.RpcGateway;
 import org.slf4j.Logger;
 
 import java.io.Serializable;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
@@ -91,9 +92,15 @@ public abstract class RegisteredRpcConnection<F extends Serializable, G extends 
 
 		future.whenCompleteAsync(
 			(Tuple2<G, S> result, Throwable failure) -> {
-				// this future should only ever fail if there is a bug, not if the registration is declined
 				if (failure != null) {
-					onRegistrationFailure(failure);
+					if (failure instanceof CancellationException) {
+						// we ignore cancellation exceptions because the originate from cancelling
+						// the RetryingRegistration
+						log.debug("Retrying registration towards {} was cancelled.", targetAddress);
+					} else {
+						// this future should only ever fail if there is a bug, not if the registration is declined
+						onRegistrationFailure(failure);
+					}
 				} else {
 					targetGateway = result.f0;
 					onRegistrationSuccess(result.f1);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/registration/RetryingRegistration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/registration/RetryingRegistration.java
@@ -151,8 +151,8 @@ public abstract class RetryingRegistration<F extends Serializable, G extends Rpc
 	 * Cancels the registration procedure.
 	 */
 	public void cancel() {
-		completionFuture.cancel(false);
 		canceled = true;
+		completionFuture.cancel(false);
 	}
 
 	/**


### PR DESCRIPTION
## What is the purpose of the change

The RegisteredRpcConnection should not call the exception handler when the RetryingRegistration future failed with a cancellation exception, because this is how the future is completed in case of stopping the RetryingRegistration.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

