### PR TITLE
[FLINK-7864] [DataStream API] Support side-outputs in CoProcessFunction

### DIFF
--- a/docs/dev/stream/side_output.md
+++ b/docs/dev/stream/side_output.md
@@ -58,6 +58,7 @@ contains.
 Emitting data to a side output is possible from the following functions:
 
 - [ProcessFunction]({{ site.baseurl }}/dev/stream/operators/process_function.html)
+- CoProcessFunction
 - [ProcessWindowFunction]({{ site.baseurl }}/dev/windows.html#processwindowfunction)
 - ProcessAllWindowFunction
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/co/CoProcessFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/co/CoProcessFunction.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.functions.AbstractRichFunction;
 import org.apache.flink.streaming.api.TimeDomain;
 import org.apache.flink.streaming.api.TimerService;
 import org.apache.flink.util.Collector;
+import org.apache.flink.util.OutputTag;
 
 /**
  * A function that processes elements of two streams and produces a single output one.
@@ -116,6 +117,14 @@ public abstract class CoProcessFunction<IN1, IN2, OUT> extends AbstractRichFunct
 		 * A {@link TimerService} for querying time and registering timers.
 		 */
 		public abstract TimerService timerService();
+
+		/**
+		 * Emits a record to the side output identified by the {@link OutputTag}.
+		 *
+		 * @param outputTag the {@code OutputTag} that identifies the side output to emit to.
+		 * @param value The record to emit.
+		 */
+		public abstract <X> void output(OutputTag<X> outputTag, X value);
 	}
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/KeyedProcessOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/KeyedProcessOperator.java
@@ -118,16 +118,16 @@ public class KeyedProcessOperator<K, IN, OUT>
 		}
 
 		@Override
+		public TimerService timerService() {
+			return timerService;
+		}
+
+		@Override
 		public <X> void output(OutputTag<X> outputTag, X value) {
 			if (outputTag == null) {
 				throw new IllegalArgumentException("OutputTag must not be null.");
 			}
 			output.collect(outputTag, new StreamRecord<>(value, element.getTimestamp()));
-		}
-
-		@Override
-		public TimerService timerService() {
-			return timerService;
 		}
 	}
 
@@ -145,25 +145,29 @@ public class KeyedProcessOperator<K, IN, OUT>
 		}
 
 		@Override
-		public TimeDomain timeDomain() {
-			checkState(timeDomain != null);
-			return timeDomain;
-		}
-
-		@Override
 		public Long timestamp() {
 			checkState(timer != null);
 			return timer.getTimestamp();
 		}
 
 		@Override
+		public TimerService timerService() {
+			return timerService;
+		}
+
+		@Override
 		public <X> void output(OutputTag<X> outputTag, X value) {
+			if (outputTag == null) {
+				throw new IllegalArgumentException("OutputTag must not be null.");
+			}
+
 			output.collect(outputTag, new StreamRecord<>(value, timer.getTimestamp()));
 		}
 
 		@Override
-		public TimerService timerService() {
-			return timerService;
+		public TimeDomain timeDomain() {
+			checkState(timeDomain != null);
+			return timeDomain;
 		}
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/co/CoProcessOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/co/CoProcessOperator.java
@@ -27,6 +27,7 @@ import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
+import org.apache.flink.util.OutputTag;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
@@ -130,6 +131,15 @@ public class CoProcessOperator<IN1, IN2, OUT>
 		@Override
 		public TimerService timerService() {
 			return this;
+		}
+
+		@Override
+		public <X> void output(OutputTag<X> outputTag, X value) {
+			if (outputTag == null) {
+				throw new IllegalArgumentException("OutputTag must not be null.");
+			}
+
+			output.collect(outputTag, new StreamRecord<>(value, element.getTimestamp()));
 		}
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/co/KeyedCoProcessOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/co/KeyedCoProcessOperator.java
@@ -31,6 +31,7 @@ import org.apache.flink.streaming.api.operators.TimestampedCollector;
 import org.apache.flink.streaming.api.operators.Triggerable;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.util.OutputTag;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
@@ -110,7 +111,7 @@ public class KeyedCoProcessOperator<K, IN1, IN2, OUT>
 		return collector;
 	}
 
-	private static class ContextImpl<IN1, IN2, OUT> extends CoProcessFunction<IN1, IN2, OUT>.Context {
+	private class ContextImpl<IN1, IN2, OUT> extends CoProcessFunction<IN1, IN2, OUT>.Context {
 
 		private final TimerService timerService;
 
@@ -135,6 +136,15 @@ public class KeyedCoProcessOperator<K, IN1, IN2, OUT>
 		@Override
 		public TimerService timerService() {
 			return timerService;
+		}
+
+		@Override
+		public <X> void output(OutputTag<X> outputTag, X value) {
+			if (outputTag == null) {
+				throw new IllegalArgumentException("OutputTag must not be null.");
+			}
+
+			output.collect(outputTag, new StreamRecord<>(value, element.getTimestamp()));
 		}
 	}
 
@@ -167,6 +177,11 @@ public class KeyedCoProcessOperator<K, IN1, IN2, OUT>
 		@Override
 		public TimerService timerService() {
 			return timerService;
+		}
+
+		@Override
+		public <X> void output(OutputTag<X> outputTag, X value) {
+			output(outputTag, value);
 		}
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/co/KeyedCoProcessOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/co/KeyedCoProcessOperator.java
@@ -148,8 +148,7 @@ public class KeyedCoProcessOperator<K, IN1, IN2, OUT>
 		}
 	}
 
-	private static class OnTimerContextImpl<IN1, IN2, OUT>
-			extends CoProcessFunction<IN1, IN2, OUT>.OnTimerContext {
+	private class OnTimerContextImpl<IN1, IN2, OUT> extends CoProcessFunction<IN1, IN2, OUT>.OnTimerContext {
 
 		private final TimerService timerService;
 
@@ -160,12 +159,6 @@ public class KeyedCoProcessOperator<K, IN1, IN2, OUT>
 		OnTimerContextImpl(CoProcessFunction<IN1, IN2, OUT> function, TimerService timerService) {
 			function.super();
 			this.timerService = checkNotNull(timerService);
-		}
-
-		@Override
-		public TimeDomain timeDomain() {
-			checkState(timeDomain != null);
-			return timeDomain;
 		}
 
 		@Override
@@ -181,7 +174,17 @@ public class KeyedCoProcessOperator<K, IN1, IN2, OUT>
 
 		@Override
 		public <X> void output(OutputTag<X> outputTag, X value) {
-			output(outputTag, value);
+			if (outputTag == null) {
+				throw new IllegalArgumentException("OutputTag must not be null.");
+			}
+
+			output.collect(outputTag, new StreamRecord<>(value, timer.getTimestamp()));
+		}
+
+		@Override
+		public TimeDomain timeDomain() {
+			checkState(timeDomain != null);
+			return timeDomain;
 		}
 	}
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SideOutputITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SideOutputITCase.java
@@ -498,7 +498,7 @@ public class SideOutputITCase extends StreamingMultipleProgramsTestBase implemen
 	}
 
 	/**
-	 * Test CoProcessFunction side output on keyed streams.
+	 * Test keyed CoProcessFunction side output.
 	 */
 	@Test
 	public void testKeyedCoProcessFunctionSideOutput() throws Exception {
@@ -543,7 +543,7 @@ public class SideOutputITCase extends StreamingMultipleProgramsTestBase implemen
 	}
 
 	/**
-	 * Test CoProcessFunction side output on keyed streams with multiple consumers.
+	 * Test keyed CoProcessFunction side output with multiple consumers.
 	 */
 	@Test
 	public void testKeyedCoProcessFunctionSideOutputWithMultipleConsumers() throws Exception {

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SideOutputITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SideOutputITCase.java
@@ -498,7 +498,7 @@ public class SideOutputITCase extends StreamingMultipleProgramsTestBase implemen
 	}
 
 	/**
-	 * Test KeyedCoProcessFunction side output.
+	 * Test CoProcessFunction side output on keyed streams.
 	 */
 	@Test
 	public void testKeyedCoProcessFunctionSideOutput() throws Exception {
@@ -543,7 +543,7 @@ public class SideOutputITCase extends StreamingMultipleProgramsTestBase implemen
 	}
 
 	/**
-	 * Test KeyedCoProcessFunction side output with multiple consumers.
+	 * Test CoProcessFunction side output on keyed streams with multiple consumers.
 	 */
 	@Test
 	public void testKeyedCoProcessFunctionSideOutputWithMultipleConsumers() throws Exception {

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SideOutputITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SideOutputITCase.java
@@ -27,6 +27,7 @@ import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.AssignerWithPunctuatedWatermarks;
 import org.apache.flink.streaming.api.functions.ProcessFunction;
+import org.apache.flink.streaming.api.functions.co.CoProcessFunction;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.api.functions.windowing.AllWindowFunction;
 import org.apache.flink.streaming.api.functions.windowing.ProcessAllWindowFunction;
@@ -362,6 +363,98 @@ public class SideOutputITCase extends StreamingMultipleProgramsTestBase implemen
 	}
 
 	/**
+	 * Test CoProcessFunction side output.
+	 */
+	@Test
+	public void testCoProcessFunctionSideOutput() throws Exception {
+		final OutputTag<String> sideOutputTag = new OutputTag<String>("side"){};
+
+		TestListResultSink<String> sideOutputResultSink = new TestListResultSink<>();
+		TestListResultSink<Integer> resultSink = new TestListResultSink<>();
+
+		StreamExecutionEnvironment see = StreamExecutionEnvironment.getExecutionEnvironment();
+		see.setParallelism(3);
+
+		DataStream<Integer> ds1 = see.fromCollection(elements);
+		DataStream<Integer> ds2 = see.fromCollection(elements);
+
+		SingleOutputStreamOperator<Integer> passThroughtStream = ds1
+				.connect(ds2)
+				.process(new CoProcessFunction<Integer, Integer, Integer>() {
+					@Override
+					public void processElement1(Integer value, Context ctx, Collector<Integer> out) throws Exception {
+						if (value < 3) {
+							out.collect(value);
+							ctx.output(sideOutputTag, "sideout1-" + String.valueOf(value));
+						}
+					}
+
+					@Override
+					public void processElement2(Integer value, Context ctx, Collector<Integer> out) throws Exception {
+						if (value >= 3) {
+							out.collect(value);
+							ctx.output(sideOutputTag, "sideout2-" + String.valueOf(value));
+						}
+					}
+				});
+
+		passThroughtStream.getSideOutput(sideOutputTag).addSink(sideOutputResultSink);
+		passThroughtStream.addSink(resultSink);
+		see.execute();
+
+		assertEquals(Arrays.asList("sideout1-1", "sideout1-2", "sideout2-3", "sideout2-4", "sideout2-5"), sideOutputResultSink.getSortedResult());
+		assertEquals(Arrays.asList(1, 2, 3, 4, 5), resultSink.getSortedResult());
+	}
+
+	/**
+	 * Test CoProcessFunction side output with multiple consumers.
+	 */
+	@Test
+	public void testCoProcessFunctionSideOutputWithMultipleConsumers() throws Exception {
+		final OutputTag<String> sideOutputTag1 = new OutputTag<String>("side1"){};
+		final OutputTag<String> sideOutputTag2 = new OutputTag<String>("side2"){};
+
+		TestListResultSink<String> sideOutputResultSink1 = new TestListResultSink<>();
+		TestListResultSink<String> sideOutputResultSink2 = new TestListResultSink<>();
+		TestListResultSink<Integer> resultSink = new TestListResultSink<>();
+
+		StreamExecutionEnvironment see = StreamExecutionEnvironment.getExecutionEnvironment();
+		see.setParallelism(3);
+
+		DataStream<Integer> ds1 = see.fromCollection(elements);
+		DataStream<Integer> ds2 = see.fromCollection(elements);
+
+		SingleOutputStreamOperator<Integer> passThroughtStream = ds1
+				.connect(ds2)
+				.process(new CoProcessFunction<Integer, Integer, Integer>() {
+					@Override
+					public void processElement1(Integer value, Context ctx, Collector<Integer> out) throws Exception {
+						if (value < 4) {
+							out.collect(value);
+							ctx.output(sideOutputTag1, "sideout1-" + String.valueOf(value));
+						}
+					}
+
+					@Override
+					public void processElement2(Integer value, Context ctx, Collector<Integer> out) throws Exception {
+						if (value >= 4) {
+							out.collect(value);
+							ctx.output(sideOutputTag2, "sideout2-" + String.valueOf(value));
+						}
+					}
+				});
+
+		passThroughtStream.getSideOutput(sideOutputTag1).addSink(sideOutputResultSink1);
+		passThroughtStream.getSideOutput(sideOutputTag2).addSink(sideOutputResultSink2);
+		passThroughtStream.addSink(resultSink);
+		see.execute();
+
+		assertEquals(Arrays.asList("sideout1-1", "sideout1-2", "sideout1-3"), sideOutputResultSink1.getSortedResult());
+		assertEquals(Arrays.asList("sideout2-4", "sideout2-5"), sideOutputResultSink2.getSortedResult());
+		assertEquals(Arrays.asList(1, 2, 3, 4, 5), resultSink.getSortedResult());
+	}
+
+	/**
 	 * Test keyed ProcessFunction side output.
 	 */
 	@Test
@@ -401,6 +494,100 @@ public class SideOutputITCase extends StreamingMultipleProgramsTestBase implemen
 		see.execute();
 
 		assertEquals(Arrays.asList("sideout-1", "sideout-2", "sideout-3", "sideout-4", "sideout-5"), sideOutputResultSink.getSortedResult());
+		assertEquals(Arrays.asList(1, 2, 3, 4, 5), resultSink.getSortedResult());
+	}
+
+	/**
+	 * Test KeyedCoProcessFunction side output.
+	 */
+	@Test
+	public void testKeyedCoProcessFunctionSideOutput() throws Exception {
+		final OutputTag<String> sideOutputTag = new OutputTag<String>("side"){};
+
+		TestListResultSink<String> sideOutputResultSink = new TestListResultSink<>();
+		TestListResultSink<Integer> resultSink = new TestListResultSink<>();
+
+		StreamExecutionEnvironment see = StreamExecutionEnvironment.getExecutionEnvironment();
+		see.setParallelism(3);
+
+		DataStream<Integer> ds1 = see.fromCollection(elements);
+		DataStream<Integer> ds2 = see.fromCollection(elements);
+
+		SingleOutputStreamOperator<Integer> passThroughtStream = ds1
+				.keyBy(i -> i)
+				.connect(ds2.keyBy(i -> i))
+				.process(new CoProcessFunction<Integer, Integer, Integer>() {
+					@Override
+					public void processElement1(Integer value, Context ctx, Collector<Integer> out) throws Exception {
+						if (value < 3) {
+							out.collect(value);
+							ctx.output(sideOutputTag, "sideout1-" + String.valueOf(value));
+						}
+					}
+
+					@Override
+					public void processElement2(Integer value, Context ctx, Collector<Integer> out) throws Exception {
+						if (value >= 3) {
+							out.collect(value);
+							ctx.output(sideOutputTag, "sideout2-" + String.valueOf(value));
+						}
+					}
+				});
+
+		passThroughtStream.getSideOutput(sideOutputTag).addSink(sideOutputResultSink);
+		passThroughtStream.addSink(resultSink);
+		see.execute();
+
+		assertEquals(Arrays.asList("sideout1-1", "sideout1-2", "sideout2-3", "sideout2-4", "sideout2-5"), sideOutputResultSink.getSortedResult());
+		assertEquals(Arrays.asList(1, 2, 3, 4, 5), resultSink.getSortedResult());
+	}
+
+	/**
+	 * Test KeyedCoProcessFunction side output with multiple consumers.
+	 */
+	@Test
+	public void testKeyedCoProcessFunctionSideOutputWithMultipleConsumers() throws Exception {
+		final OutputTag<String> sideOutputTag1 = new OutputTag<String>("side1"){};
+		final OutputTag<String> sideOutputTag2 = new OutputTag<String>("side2"){};
+
+		TestListResultSink<String> sideOutputResultSink1 = new TestListResultSink<>();
+		TestListResultSink<String> sideOutputResultSink2 = new TestListResultSink<>();
+		TestListResultSink<Integer> resultSink = new TestListResultSink<>();
+
+		StreamExecutionEnvironment see = StreamExecutionEnvironment.getExecutionEnvironment();
+		see.setParallelism(3);
+
+		DataStream<Integer> ds1 = see.fromCollection(elements);
+		DataStream<Integer> ds2 = see.fromCollection(elements);
+
+		SingleOutputStreamOperator<Integer> passThroughtStream = ds1
+				.keyBy(i -> i)
+				.connect(ds2.keyBy(i -> i))
+				.process(new CoProcessFunction<Integer, Integer, Integer>() {
+					@Override
+					public void processElement1(Integer value, Context ctx, Collector<Integer> out) throws Exception {
+						if (value < 4) {
+							out.collect(value);
+							ctx.output(sideOutputTag1, "sideout1-" + String.valueOf(value));
+						}
+					}
+
+					@Override
+					public void processElement2(Integer value, Context ctx, Collector<Integer> out) throws Exception {
+						if (value >= 4) {
+							out.collect(value);
+							ctx.output(sideOutputTag2, "sideout2-" + String.valueOf(value));
+						}
+					}
+				});
+
+		passThroughtStream.getSideOutput(sideOutputTag1).addSink(sideOutputResultSink1);
+		passThroughtStream.getSideOutput(sideOutputTag2).addSink(sideOutputResultSink2);
+		passThroughtStream.addSink(resultSink);
+		see.execute();
+
+		assertEquals(Arrays.asList("sideout1-1", "sideout1-2", "sideout1-3"), sideOutputResultSink1.getSortedResult());
+		assertEquals(Arrays.asList("sideout2-4", "sideout2-5"), sideOutputResultSink2.getSortedResult());
 		assertEquals(Arrays.asList(1, 2, 3, 4, 5), resultSink.getSortedResult());
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

Support side-outputs in CoProcessFunction

## Brief change log

- Support side-outputs in CoProcessFunction
- Added integration tests

## Verifying this change

This change added tests and can be verified as follows:

  - *Added integration tests for CoProcessFunction*

## Does this pull request potentially affect one of the following parts:

  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
