### PR TITLE
[FLINK-6245] [doc] Fix late side output documentation in Window documents.

### DIFF
--- a/docs/dev/stream/operators/windows.md
+++ b/docs/dev/stream/operators/windows.md
@@ -42,6 +42,7 @@ for the rest of the page.
           [.allowedLateness(...)]    <-  optional: "lateness" (else zero)
           [.sideOutputLateData(...)] <-  optional: "output tag" (else no side output for late data)
            .reduce/aggregate/fold/apply()      <-  required: "function"
+          [.getSideOutput(...)]      <-  optional: "output tag"
 
 **Non-Keyed Windows**
 
@@ -52,6 +53,7 @@ for the rest of the page.
           [.allowedLateness(...)]    <-  optional: "lateness" (else zero)
           [.sideOutputLateData(...)] <-  optional: "output tag" (else no side output for late data)
            .reduce/aggregate/fold/apply()      <-  required: "function"
+          [.getSideOutput(...)]      <-  optional: "output tag"
 
 In the above, the commands in square brackets ([...]) are optional. This reveals that Flink allows you to customize your
 windowing logic in many different ways so that it best fits your needs.
@@ -1235,7 +1237,7 @@ final OutputTag<T> lateOutputTag = new OutputTag<T>("late-data"){};
 
 DataStream<T> input = ...;
 
-DataStream<T> result = input
+SingleOutputStreamOperator<T> result = input
     .keyBy(<key selector>)
     .window(<window assigner>)
     .allowedLateness(<time>)


### PR DESCRIPTION
## What is the purpose of the change

There are two things that need to be done:

1) in the syntax description in the beginning of the page, we should also include the {{getSideOutput()}}

2) in the "Getting late data as a side output" section and for the Java example, it should not be a {{DataStream<T> result ...}} but a {{SingleOutputStreamOperator}}, if we want to get the late event side output.

## Brief change log

Fix docs

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

none

## Documentation

none

