### PR TITLE
[FLINK-4809] Operators should tolerate checkpoint failures.

### DIFF
--- a/docs/dev/stream/state/checkpointing.md
+++ b/docs/dev/stream/state/checkpointing.md
@@ -74,6 +74,8 @@ Other parameters for checkpointing include:
 
   - *externalized checkpoints*: You can configure periodic checkpoints to be persisted externally. Externalized checkpoints write their meta data out to persistent storage and are *not* automatically cleaned up when the job fails. This way, you will have a checkpoint around to resume from if your job fails. There are more details in the [deployment notes on externalized checkpoints]({{ site.baseurl }}/ops/state/checkpoints.html#externalized-checkpoints).
 
+  - *fail/continue task on checkpoint errors*: This determines if a task will be failed if an error occurs in the execution of the task's checkpoint procedure. This is the default behaviour. Alternatively, when this is disabled, the task will simply decline the checkpoint to the checkpoint coordinator and continue running.
+
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
 {% highlight java %}
@@ -117,6 +119,9 @@ env.getCheckpointConfig.setMinPauseBetweenCheckpoints(500)
 
 // checkpoints have to complete within one minute, or are discarded
 env.getCheckpointConfig.setCheckpointTimeout(60000)
+
+// prevent the tasks from failing if an error happens in their checkpointing, the checkpoint will just be declined.
+env.getCheckpointConfig.setFailTasksOnCheckpointingErrors(false)
 
 // allow only one checkpoint to be in progress at the same time
 env.getCheckpointConfig.setMaxConcurrentCheckpoints(1)

--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
@@ -150,6 +150,9 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 	/** This flag defines if we use compression for the state snapshot data or not. Default: false */
 	private boolean useSnapshotCompression = false;
 
+	/** Determines if a task fails or not if there is an error in writing its checkpoint data. Default: true */
+	private boolean failTaskOnCheckpointError = true;
+
 	// ------------------------------- User code values --------------------------------------------
 
 	private GlobalJobParameters globalJobParameters;
@@ -858,6 +861,26 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 
 	public void setUseSnapshotCompression(boolean useSnapshotCompression) {
 		this.useSnapshotCompression = useSnapshotCompression;
+	}
+
+	/**
+	 * This method is visible because of the way the configuration is currently forwarded from the checkpoint config to
+	 * the task. This should not be called by the user, please use CheckpointConfig.isFailTaskOnCheckpointError()
+	 * instead.
+	 */
+	@Internal
+	public boolean isFailTaskOnCheckpointError() {
+		return failTaskOnCheckpointError;
+	}
+
+	/**
+	 * This method is visible because of the way the configuration is currently forwarded from the checkpoint config to
+	 * the task. This should not be called by the user, please use CheckpointConfig.setFailOnCheckpointingErrors(...)
+	 * instead.
+	 */
+	@Internal
+	public void setFailTaskOnCheckpointError(boolean failTaskOnCheckpointError) {
+		this.failTaskOnCheckpointError = failTaskOnCheckpointError;
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DummyEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DummyEnvironment.java
@@ -53,6 +53,7 @@ public class DummyEnvironment implements Environment {
 	private final ExecutionConfig executionConfig = new ExecutionConfig();
 	private final TaskInfo taskInfo;
 	private KvStateRegistry kvStateRegistry = new KvStateRegistry();
+	private final AccumulatorRegistry accumulatorRegistry = new AccumulatorRegistry(jobId, executionId);
 
 	public DummyEnvironment(String taskName, int numSubTasks, int subTaskIndex) {
 		this.taskInfo = new TaskInfo(taskName, numSubTasks, subTaskIndex, numSubTasks, 0);
@@ -143,7 +144,7 @@ public class DummyEnvironment implements Environment {
 
 	@Override
 	public AccumulatorRegistry getAccumulatorRegistry() {
-		return null;
+		return accumulatorRegistry;
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/CheckpointConfig.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/CheckpointConfig.java
@@ -70,6 +70,9 @@ public class CheckpointConfig implements java.io.Serializable {
 	/** Cleanup behaviour for persistent checkpoints. */
 	private ExternalizedCheckpointCleanup externalizedCheckpointCleanup;
 
+	/** Determines if a tasks are failed or not if there is an error in their checkpointing. Default: true */
+	private boolean failOnCheckpointingErrors = true;
+
 	// ------------------------------------------------------------------------
 
 	/**
@@ -228,6 +231,23 @@ public class CheckpointConfig implements java.io.Serializable {
 	@PublicEvolving
 	public void setForceCheckpointing(boolean forceCheckpointing) {
 		this.forceCheckpointing = forceCheckpointing;
+	}
+
+	/**
+	 * This determines the behaviour of tasks if there is an error in their local checkpointing. If this returns true,
+	 * tasks will fail as a reaction. If this returns false, task will only decline the failed checkpoint.
+	 */
+	public boolean isFailOnCheckpointingErrors() {
+		return failOnCheckpointingErrors;
+	}
+
+	/**
+	 * Sets the expected behaviour for tasks in case that they encounter an error in their checkpointing procedure.
+	 * If this is set to true, the task will fail on checkpointing error. If this is set to false, the task will only
+	 * decline a the checkpoint and continue running. The default is true.
+	 */
+	public void setFailOnCheckpointingErrors(boolean failOnCheckpointingErrors) {
+		this.failOnCheckpointingErrors = failOnCheckpointingErrors;
 	}
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -18,6 +18,7 @@
 package org.apache.flink.streaming.api.graph;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.cache.DistributedCache;
 import org.apache.flink.api.common.functions.Function;
 import org.apache.flink.api.common.operators.ResourceSpec;
@@ -574,10 +575,15 @@ public class StreamingJobGraphGenerator {
 
 		long interval = cfg.getCheckpointInterval();
 		if (interval > 0) {
+
+			ExecutionConfig executionConfig = streamGraph.getExecutionConfig();
+			// propagate the expected behaviour for checkpoint errors to task.
+			executionConfig.setFailTaskOnCheckpointError(cfg.isFailOnCheckpointingErrors());
+
 			// check if a restart strategy has been set, if not then set the FixedDelayRestartStrategy
-			if (streamGraph.getExecutionConfig().getRestartStrategy() == null) {
+			if (executionConfig.getRestartStrategy() == null) {
 				// if the user enabled checkpointing, the default number of exec retries is infinite.
-				streamGraph.getExecutionConfig().setRestartStrategy(
+				executionConfig.setRestartStrategy(
 					RestartStrategies.fixedDelayRestart(Integer.MAX_VALUE, DEFAULT_RESTART_DELAY));
 			}
 		} else {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/CheckpointExceptionHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/CheckpointExceptionHandler.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
+
+/**
+ * Handler for exceptions that happen on checkpointing. The handler can reject and rethrow the offered exceptions.
+ */
+public interface CheckpointExceptionHandler {
+
+	/**
+	 * Offers the exception for handling. If the exception cannot be handled from this instance, it is rethrown.
+	 *
+	 * @param checkpointMetaData metadata for the checkpoint for which the exception occurred.
+	 * @param exception  the exception to handle.
+	 * @throws Exception rethrows the exception if it cannot be handled.
+	 */
+	void tryHandleCheckpointException(CheckpointMetaData checkpointMetaData, Exception exception) throws Exception;
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/CheckpointExceptionHandlerFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/CheckpointExceptionHandlerFactory.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.util.Preconditions;
+
+/**
+ * This factory produces {@link CheckpointExceptionHandler} instances that handle exceptions during checkpointing in a
+ * {@link StreamTask}.
+ */
+public class CheckpointExceptionHandlerFactory {
+
+	/**
+	 * Returns a {@link CheckpointExceptionHandler} that either causes a task to fail completely or to just declines
+	 * checkpoint on exception, depending on the parameter flag.
+	 */
+	public CheckpointExceptionHandler createCheckpointExceptionHandler(
+		boolean failTaskOnCheckpointException,
+		Environment environment) {
+
+		if (failTaskOnCheckpointException) {
+			return new FailingCheckpointExceptionHandler();
+		} else {
+			return new DecliningCheckpointExceptionHandler(environment);
+		}
+	}
+
+	/**
+	 * This handler makes the task fail by rethrowing a reported exception.
+	 */
+	static final class FailingCheckpointExceptionHandler implements CheckpointExceptionHandler {
+
+		@Override
+		public void tryHandleCheckpointException(
+			CheckpointMetaData checkpointMetaData,
+			Exception exception) throws Exception {
+
+			throw exception;
+		}
+	}
+
+	/**
+	 * This handler makes the task decline the checkpoint as reaction to the reported exception. The task is not failed.
+	 */
+	static final class DecliningCheckpointExceptionHandler implements CheckpointExceptionHandler {
+
+		final Environment environment;
+
+		DecliningCheckpointExceptionHandler(Environment environment) {
+			this.environment = Preconditions.checkNotNull(environment);
+		}
+
+		@Override
+		public void tryHandleCheckpointException(
+			CheckpointMetaData checkpointMetaData,
+			Exception exception) throws Exception {
+
+			environment.declineCheckpoint(checkpointMetaData.getCheckpointId(), exception);
+		}
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/CheckpointExceptionHandlerConfigurationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/CheckpointExceptionHandlerConfigurationTest.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.streaming.api.graph.StreamGraph;
+import org.apache.flink.streaming.api.graph.StreamingJobGraphGenerator;
+import org.apache.flink.util.SerializedValue;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test that the configuration mechanism for how tasks react on checkpoint errors works correctly.
+ */
+public class CheckpointExceptionHandlerConfigurationTest extends TestLogger {
+
+	@Test
+	public void testConfigurationFailOnException() throws Exception {
+		testConfigForwarding(true);
+	}
+
+	@Test
+	public void testConfigurationDeclineOnException() throws Exception {
+		testConfigForwarding(false);
+	}
+
+	@Test
+	public void testFailIsDefaultConfig() {
+		ExecutionConfig newExecutionConfig = new ExecutionConfig();
+		Assert.assertTrue(newExecutionConfig.isFailTaskOnCheckpointError());
+	}
+
+	private void testConfigForwarding(boolean failOnException) throws Exception {
+
+		final boolean expectedHandlerFlag = failOnException;
+		DummyEnvironment environment = new DummyEnvironment("test", 1, 0);
+		environment.getExecutionConfig().setFailTaskOnCheckpointError(expectedHandlerFlag);
+		final CheckpointExceptionHandlerFactory inspectingFactory = new CheckpointExceptionHandlerFactory() {
+
+			@Override
+			public CheckpointExceptionHandler createCheckpointExceptionHandler(
+				boolean failTaskOnCheckpointException,
+				Environment environment) {
+
+				Assert.assertEquals(expectedHandlerFlag, failTaskOnCheckpointException);
+				return super.createCheckpointExceptionHandler(failTaskOnCheckpointException, environment);
+			}
+		};
+
+		StreamTask streamTask = new StreamTask() {
+			@Override
+			protected void init() throws Exception {
+
+			}
+
+			@Override
+			protected void run() throws Exception {
+
+			}
+
+			@Override
+			protected void cleanup() throws Exception {
+
+			}
+
+			@Override
+			protected void cancelTask() throws Exception {
+
+			}
+
+			@Override
+			protected CheckpointExceptionHandlerFactory createCheckpointExceptionHandlerFactory() {
+				return inspectingFactory;
+			}
+		};
+
+		streamTask.setEnvironment(environment);
+		streamTask.invoke();
+	}
+
+	@Test
+	public void testCheckpointConfigDefault() throws Exception {
+		StreamExecutionEnvironment streamExecutionEnvironment = StreamExecutionEnvironment.getExecutionEnvironment();
+		Assert.assertTrue(streamExecutionEnvironment.getCheckpointConfig().isFailOnCheckpointingErrors());
+	}
+
+	@Test
+	public void testPropagationFailFromCheckpointConfig() throws Exception {
+		doTestPropagationFromCheckpointConfig(true);
+	}
+
+	@Test
+	public void testPropagationDeclineFromCheckpointConfig() throws Exception {
+		doTestPropagationFromCheckpointConfig(false);
+	}
+
+	public void doTestPropagationFromCheckpointConfig(boolean failTaskOnCheckpointErrors) throws Exception {
+		StreamExecutionEnvironment streamExecutionEnvironment = StreamExecutionEnvironment.getExecutionEnvironment();
+		streamExecutionEnvironment.setParallelism(1);
+		streamExecutionEnvironment.getCheckpointConfig().setCheckpointInterval(1000);
+		streamExecutionEnvironment.getCheckpointConfig().setFailOnCheckpointingErrors(failTaskOnCheckpointErrors);
+		streamExecutionEnvironment.addSource(new SourceFunction<Integer>() {
+
+			@Override
+			public void run(SourceContext<Integer> ctx) throws Exception {
+			}
+
+			@Override
+			public void cancel() {
+			}
+
+		}).addSink(new DiscardingSink<>());
+
+		StreamGraph streamGraph = streamExecutionEnvironment.getStreamGraph();
+		JobGraph jobGraph = StreamingJobGraphGenerator.createJobGraph(streamGraph);
+		SerializedValue<ExecutionConfig> serializedExecutionConfig = jobGraph.getSerializedExecutionConfig();
+		ExecutionConfig executionConfig =
+			serializedExecutionConfig.deserializeValue(Thread.currentThread().getContextClassLoader());
+
+		Assert.assertEquals(failTaskOnCheckpointErrors, executionConfig.isFailTaskOnCheckpointError());
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/CheckpointExceptionHandlerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/CheckpointExceptionHandlerTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
+import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test for the current implementations of {@link CheckpointExceptionHandler} and their factory.
+ */
+public class CheckpointExceptionHandlerTest extends TestLogger {
+
+	@Test
+	public void testRethrowingHandler() {
+		DeclineDummyEnvironment environment = new DeclineDummyEnvironment();
+		CheckpointExceptionHandlerFactory checkpointExceptionHandlerFactory = new CheckpointExceptionHandlerFactory();
+		CheckpointExceptionHandler exceptionHandler =
+			checkpointExceptionHandlerFactory.createCheckpointExceptionHandler(true, environment);
+
+		CheckpointMetaData failedCheckpointMetaData = new CheckpointMetaData(42L, 4711L);
+		Exception testException = new Exception("test");
+		try {
+			exceptionHandler.tryHandleCheckpointException(failedCheckpointMetaData, testException);
+			Assert.fail("Exception not rethrown.");
+		} catch (Exception e) {
+			Assert.assertEquals(testException, e);
+		}
+
+		Assert.assertNull(environment.getLastDeclinedCheckpointCause());
+	}
+
+	@Test
+	public void testDecliningHandler() {
+		DeclineDummyEnvironment environment = new DeclineDummyEnvironment();
+		CheckpointExceptionHandlerFactory checkpointExceptionHandlerFactory = new CheckpointExceptionHandlerFactory();
+		CheckpointExceptionHandler exceptionHandler =
+			checkpointExceptionHandlerFactory.createCheckpointExceptionHandler(false, environment);
+
+		CheckpointMetaData failedCheckpointMetaData = new CheckpointMetaData(42L, 4711L);
+		Exception testException = new Exception("test");
+		try {
+			exceptionHandler.tryHandleCheckpointException(failedCheckpointMetaData, testException);
+		} catch (Exception e) {
+			Assert.fail("Exception not handled, but rethrown.");
+		}
+
+		Assert.assertEquals(failedCheckpointMetaData.getCheckpointId(), environment.getLastDeclinedCheckpointId());
+		Assert.assertEquals(testException, environment.getLastDeclinedCheckpointCause());
+	}
+
+	static final class DeclineDummyEnvironment extends DummyEnvironment {
+
+		private long lastDeclinedCheckpointId;
+		private Throwable lastDeclinedCheckpointCause;
+
+		DeclineDummyEnvironment() {
+			super("test", 1, 0);
+			this.lastDeclinedCheckpointId = Long.MIN_VALUE;
+			this.lastDeclinedCheckpointCause = null;
+		}
+
+		@Override
+		public void declineCheckpoint(long checkpointId, Throwable cause) {
+			this.lastDeclinedCheckpointId = checkpointId;
+			this.lastDeclinedCheckpointCause = cause;
+		}
+
+		long getLastDeclinedCheckpointId() {
+			return lastDeclinedCheckpointId;
+		}
+
+		Throwable getLastDeclinedCheckpointCause() {
+			return lastDeclinedCheckpointCause;
+		}
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -344,10 +344,20 @@ public class StreamTaskTest extends TestLogger {
 		Whitebox.setInternalState(streamTask, "cancelables", new CloseableRegistry());
 		Whitebox.setInternalState(streamTask, "configuration", new StreamConfig(new Configuration()));
 
+		CheckpointExceptionHandlerFactory checkpointExceptionHandlerFactory = new CheckpointExceptionHandlerFactory();
+		CheckpointExceptionHandler checkpointExceptionHandler =
+			checkpointExceptionHandlerFactory.createCheckpointExceptionHandler(true, mockEnvironment);
+		Whitebox.setInternalState(streamTask, "synchronousCheckpointExceptionHandler", checkpointExceptionHandler);
+
+		StreamTask.AsyncCheckpointExceptionHandler asyncCheckpointExceptionHandler =
+			new StreamTask.AsyncCheckpointExceptionHandler(streamTask);
+		Whitebox.setInternalState(streamTask, "asynchronousCheckpointExceptionHandler", asyncCheckpointExceptionHandler);
+
 		try {
 			streamTask.triggerCheckpoint(checkpointMetaData, CheckpointOptions.forCheckpoint());
 			fail("Expected test exception here.");
 		} catch (Exception e) {
+			e.printStackTrace();
 			assertEquals(testException, e.getCause());
 		}
 
@@ -411,6 +421,15 @@ public class StreamTaskTest extends TestLogger {
 		Whitebox.setInternalState(streamTask, "cancelables", new CloseableRegistry());
 		Whitebox.setInternalState(streamTask, "asyncOperationsThreadPool", new DirectExecutorService());
 		Whitebox.setInternalState(streamTask, "configuration", new StreamConfig(new Configuration()));
+
+		CheckpointExceptionHandlerFactory checkpointExceptionHandlerFactory = new CheckpointExceptionHandlerFactory();
+		CheckpointExceptionHandler checkpointExceptionHandler =
+			checkpointExceptionHandlerFactory.createCheckpointExceptionHandler(true, mockEnvironment);
+		Whitebox.setInternalState(streamTask, "synchronousCheckpointExceptionHandler", checkpointExceptionHandler);
+
+		StreamTask.AsyncCheckpointExceptionHandler asyncCheckpointExceptionHandler =
+			new StreamTask.AsyncCheckpointExceptionHandler(streamTask);
+		Whitebox.setInternalState(streamTask, "asynchronousCheckpointExceptionHandler", asyncCheckpointExceptionHandler);
 
 		streamTask.triggerCheckpoint(checkpointMetaData, CheckpointOptions.forCheckpoint());
 


### PR DESCRIPTION
## What is the purpose of the change

This PR implements FLINK-4809 and allows tasks to tolerate errors that happen in their checkpointing procedure. This tolerance is optional and can activated through `CheckpointOptions`,  the default behaviour is to fail the task, as before this PR.

When fault tolerance is activated, an error will not fail the task. Instead, the task will decline the checkpoint to the checkpoint coordinator.

## Brief change log

  - *Feature configuration through `CheckpointOptions` and `ExecutionConfig`.*
  - *Introduced `CheckpointExceptionHandler` and integrated with StreamTask. This handler will either transform the exception to a `declineCheckpoint` or rethrow to fail the task. *
  - *Tests for configuration forwarding and functionality.*

## Verifying this change

This change added tests and can be verified as follows:

  - *`CheckpointExceptionHandlerTest`: Unit test for the implementations of `CheckpointExceptionHandlerTest` and their factory.*
  - *`TaskCheckpointingBehaviourTest`: Tests the functionality to either fail tasks or only decline checkpoints in case of failure.*
  - *`CheckpointExceptionHandlerConfigurationTest`: Checks everything about configuration and configuration forwarding for the feature.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs and JavaDocs)