### PR TITLE
[FLINK-7856][flip6] Port JobVertexBackPressureHandler to REST endpoint

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherRestEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherRestEndpoint.java
@@ -38,6 +38,7 @@ import org.apache.flink.runtime.rest.handler.job.JobPlanHandler;
 import org.apache.flink.runtime.rest.handler.job.JobSubmitHandler;
 import org.apache.flink.runtime.rest.handler.job.JobTerminationHandler;
 import org.apache.flink.runtime.rest.handler.job.JobVertexAccumulatorsHandler;
+import org.apache.flink.runtime.rest.handler.job.JobVertexBackPressureHandler;
 import org.apache.flink.runtime.rest.handler.job.JobsOverviewHandler;
 import org.apache.flink.runtime.rest.handler.job.SubtasksTimesHandler;
 import org.apache.flink.runtime.rest.handler.job.checkpoints.CheckpointConfigHandler;
@@ -60,6 +61,7 @@ import org.apache.flink.runtime.rest.messages.JobExceptionsHeaders;
 import org.apache.flink.runtime.rest.messages.JobPlanHeaders;
 import org.apache.flink.runtime.rest.messages.JobTerminationHeaders;
 import org.apache.flink.runtime.rest.messages.JobVertexAccumulatorsHeaders;
+import org.apache.flink.runtime.rest.messages.JobVertexBackPressureHeaders;
 import org.apache.flink.runtime.rest.messages.JobsOverviewHeaders;
 import org.apache.flink.runtime.rest.messages.SubtasksTimesHeaders;
 import org.apache.flink.runtime.rest.messages.checkpoints.CheckpointConfigHeaders;
@@ -306,6 +308,13 @@ public class DispatcherRestEndpoint extends RestServerEndpoint {
 			executionGraphCache,
 			executor);
 
+		JobVertexBackPressureHandler jobVertexBackPressureHandler = new JobVertexBackPressureHandler(
+			restAddressFuture,
+			leaderRetriever,
+			timeout,
+			responseHeaders,
+			JobVertexBackPressureHeaders.getInstance());
+
 		final File tmpDir = restConfiguration.getTmpDir();
 
 		Optional<StaticFileServerHandler<DispatcherGateway>> optWebContent;
@@ -341,6 +350,7 @@ public class DispatcherRestEndpoint extends RestServerEndpoint {
 		handlers.add(Tuple2.of(TaskManagersHeaders.getInstance(), taskManagersHandler));
 		handlers.add(Tuple2.of(TaskManagerDetailsHeaders.getInstance(), taskManagerDetailsHandler));
 		handlers.add(Tuple2.of(SubtasksTimesHeaders.getInstance(), subtasksTimesHandler));
+		handlers.add(Tuple2.of(JobVertexBackPressureHeaders.getInstance(), jobVertexBackPressureHandler));
 
 		optWebContent.ifPresent(
 			webContent -> handlers.add(Tuple2.of(WebContentHandlerSpecification.getInstance(), webContent)));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobVertexBackPressureHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobVertexBackPressureHandler.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.job;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.dispatcher.DispatcherGateway;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.rest.handler.AbstractRestHandler;
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.RestHandlerException;
+import org.apache.flink.runtime.rest.messages.EmptyJobVertexBackPressureInfo;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.JobIDPathParameter;
+import org.apache.flink.runtime.rest.messages.JobVertexBackPressureInfo;
+import org.apache.flink.runtime.rest.messages.JobVertexIdPathParameter;
+import org.apache.flink.runtime.rest.messages.JobVertexMessageParameters;
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+
+import javax.annotation.Nonnull;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Request handler for the job vertex back pressure.
+ */
+public class JobVertexBackPressureHandler extends AbstractRestHandler<DispatcherGateway, EmptyRequestBody, JobVertexBackPressureInfo, JobVertexMessageParameters> {
+
+	public JobVertexBackPressureHandler(
+			CompletableFuture<String> localRestAddress,
+			GatewayRetriever<DispatcherGateway> leaderRetriever,
+			Time timeout,
+			Map<String, String> responseHeaders,
+			MessageHeaders<EmptyRequestBody, JobVertexBackPressureInfo, JobVertexMessageParameters> messageHeaders) {
+		super(localRestAddress, leaderRetriever, timeout, responseHeaders, messageHeaders);
+	}
+
+	@Override
+	protected CompletableFuture<JobVertexBackPressureInfo> handleRequest(@Nonnull HandlerRequest<EmptyRequestBody, JobVertexMessageParameters> request, @Nonnull DispatcherGateway gateway) throws RestHandlerException {
+		JobID jobId = request.getPathParameter(JobIDPathParameter.class);
+		JobVertexID jobVertexID = request.getPathParameter(JobVertexIdPathParameter.class);
+		///TODO Get JobVertexBackPressureInfo from DispatcherGateway with JobID and JobVertexID here
+
+		return CompletableFuture.completedFuture(EmptyJobVertexBackPressureInfo.getInstance());
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/EmptyJobVertexBackPressureInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/EmptyJobVertexBackPressureInfo.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages;
+
+import org.apache.flink.runtime.rest.handler.job.JobVertexBackPressureHandler;
+
+import java.util.ArrayList;
+
+/**
+ * Empty response of the {@link JobVertexBackPressureHandler}.
+ */
+public class EmptyJobVertexBackPressureInfo extends JobVertexBackPressureInfo {
+
+	private static final EmptyJobVertexBackPressureInfo INSTANCE = new EmptyJobVertexBackPressureInfo();
+
+	private EmptyJobVertexBackPressureInfo() {
+		super(null, null, System.currentTimeMillis(), new ArrayList<>());
+	}
+
+	public static EmptyJobVertexBackPressureInfo getInstance() {
+		return INSTANCE;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobVertexBackPressureHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobVertexBackPressureHeaders.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages;
+
+import org.apache.flink.runtime.rest.HttpMethodWrapper;
+import org.apache.flink.runtime.rest.handler.job.JobVertexBackPressureHandler;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+/**
+ * Message headers for the {@link JobVertexBackPressureHandler}.
+ */
+public class JobVertexBackPressureHeaders implements MessageHeaders<EmptyRequestBody, JobVertexBackPressureInfo, JobVertexMessageParameters> {
+
+	private static final JobVertexBackPressureHeaders INSTANCE = new JobVertexBackPressureHeaders();
+
+	private static final String URL = "/jobs/:" + JobIDPathParameter.KEY + "/vertices/:" + JobVertexIdPathParameter.KEY + "/backpressure";
+
+	@Override
+	public Class<EmptyRequestBody> getRequestClass() {
+		return EmptyRequestBody.class;
+	}
+
+	@Override
+	public Class<JobVertexBackPressureInfo> getResponseClass() {
+		return JobVertexBackPressureInfo.class;
+	}
+
+	@Override
+	public HttpResponseStatus getResponseStatusCode() {
+		return HttpResponseStatus.OK;
+	}
+
+	@Override
+	public JobVertexMessageParameters getUnresolvedMessageParameters() {
+		return new JobVertexMessageParameters();
+	}
+
+	@Override
+	public HttpMethodWrapper getHttpMethod() {
+		return HttpMethodWrapper.GET;
+	}
+
+	@Override
+	public String getTargetRestEndpointURL() {
+		return URL;
+	}
+
+	public static JobVertexBackPressureHeaders getInstance() {
+		return INSTANCE;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobVertexBackPressureInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobVertexBackPressureInfo.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages;
+
+import org.apache.flink.runtime.rest.handler.job.JobVertexBackPressureHandler;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Objects;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Response type of the {@link JobVertexBackPressureHandler}.
+ */
+public class JobVertexBackPressureInfo implements ResponseBody {
+
+	public static final String FIELD_NAME_STATUS = "status";
+	public static final String FIELD_NAME_BACKPRESSURE_LEVEL = "backpressure-level";
+	public static final String FIELD_NAME_END_TIMESTAMP = "end-timestamp";
+	public static final String FIELD_NAME_SUBTASKS = "subtasks";
+
+	@JsonProperty(FIELD_NAME_STATUS)
+	private final VertexBackPressureStatus status;
+
+	@JsonProperty(FIELD_NAME_BACKPRESSURE_LEVEL)
+	private final VertexBackPressureLevel backpressureLevel;
+
+	@JsonProperty(FIELD_NAME_END_TIMESTAMP)
+	private final long endTimestamp;
+
+	@JsonProperty(FIELD_NAME_SUBTASKS)
+	protected final List<SubtaskBackPressureInfo> subtasks;
+
+	@JsonCreator
+	public JobVertexBackPressureInfo(
+		@JsonProperty(FIELD_NAME_STATUS) VertexBackPressureStatus status,
+		@JsonProperty(FIELD_NAME_BACKPRESSURE_LEVEL) VertexBackPressureLevel backpressureLevel,
+		@JsonProperty(FIELD_NAME_END_TIMESTAMP) long endTimestamp,
+		@JsonProperty(FIELD_NAME_SUBTASKS) List<SubtaskBackPressureInfo> subtasks) {
+		this.status = status;
+		this.backpressureLevel = backpressureLevel;
+		this.endTimestamp = endTimestamp;
+		this.subtasks = checkNotNull(subtasks);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		JobVertexBackPressureInfo that = (JobVertexBackPressureInfo) o;
+		return Objects.equals(status, that.status) &&
+			Objects.equals(backpressureLevel, that.backpressureLevel) &&
+			Objects.equals(endTimestamp, that.endTimestamp) &&
+			Objects.equals(subtasks, that.subtasks);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(status, backpressureLevel, endTimestamp, subtasks);
+	}
+
+	//---------------------------------------------------------------------------------
+	// Static helper classes
+	//---------------------------------------------------------------------------------
+
+	/**
+	 * Nested class to encapsulate the sub tasks back pressure.
+	 */
+	public static final class SubtaskBackPressureInfo {
+
+		public static final String FIELD_NAME_SUBTASK = "subtask";
+		public static final String FIELD_NAME_BACKPRESSURE_LEVEL = "backpressure-level";
+		public static final String FIELD_NAME_RATIO = "ratio";
+
+		@JsonProperty(FIELD_NAME_SUBTASK)
+		private final int subtask;
+
+		@JsonProperty(FIELD_NAME_BACKPRESSURE_LEVEL)
+		private final VertexBackPressureLevel backpressureLevel;
+
+		@JsonProperty(FIELD_NAME_RATIO)
+		private final double ratio;
+
+		public SubtaskBackPressureInfo(
+			@JsonProperty(FIELD_NAME_SUBTASK) int subtask,
+			@JsonProperty(FIELD_NAME_BACKPRESSURE_LEVEL) VertexBackPressureLevel backpressureLevel,
+			@JsonProperty(FIELD_NAME_RATIO) double ratio) {
+			this.subtask = subtask;
+			this.backpressureLevel = checkNotNull(backpressureLevel);
+			this.ratio = ratio;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+			SubtaskBackPressureInfo that = (SubtaskBackPressureInfo) o;
+			return subtask == that.subtask &&
+				ratio == that.ratio &&
+				Objects.equals(backpressureLevel, that.backpressureLevel);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(subtask, backpressureLevel, ratio);
+		}
+	}
+
+	/**
+	 * Status of vertex back-pressure.
+	 */
+	public enum VertexBackPressureStatus {
+		DEPRECATED("deprecated"), OK("ok");
+
+		private String status;
+
+		VertexBackPressureStatus(String status) {
+			this.status = status;
+		}
+
+		@Override
+		public String toString() {
+			return status;
+		}
+	}
+
+	/**
+	 * Level of vertex back-pressure.
+	 */
+	public enum VertexBackPressureLevel {
+		OK("ok"), LOW("low"), HIGH("high");
+
+		private String level;
+
+		VertexBackPressureLevel(String level) {
+			this.level = level;
+		}
+
+		@Override
+		public String toString() {
+			return level;
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/JobVertexBackPressureInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/JobVertexBackPressureInfoTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Tests that the {@link JobVertexBackPressureInfo} can be marshalled and unmarshalled.
+ */
+public class JobVertexBackPressureInfoTest extends RestResponseMarshallingTestBase<JobVertexBackPressureInfo> {
+	@Override
+	protected Class<JobVertexBackPressureInfo> getTestResponseClass() {
+		return JobVertexBackPressureInfo.class;
+	}
+
+	@Override
+	protected JobVertexBackPressureInfo getTestResponseInstance() throws Exception {
+		List<JobVertexBackPressureInfo.SubtaskBackPressureInfo> subtaskList = new ArrayList<>();
+		subtaskList.add(new JobVertexBackPressureInfo.SubtaskBackPressureInfo(0, JobVertexBackPressureInfo.VertexBackPressureLevel.LOW, 0.1));
+		subtaskList.add(new JobVertexBackPressureInfo.SubtaskBackPressureInfo(1, JobVertexBackPressureInfo.VertexBackPressureLevel.OK, 0.4));
+		subtaskList.add(new JobVertexBackPressureInfo.SubtaskBackPressureInfo(2, JobVertexBackPressureInfo.VertexBackPressureLevel.HIGH, 0.9));
+		return new JobVertexBackPressureInfo(
+					JobVertexBackPressureInfo.VertexBackPressureStatus.OK,
+					JobVertexBackPressureInfo.VertexBackPressureLevel.LOW,
+					System.currentTimeMillis(),
+					subtaskList);
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

Port JobVertexBackPressureHandler to REST endpoint

## Brief change log

  - *Add JobVertexBackPressureInfo class to describe the json format response*
  - *Add JobVertexBackPressureHandler to deal with back pressure in rest server*


## Verifying this change
This change added tests and can be verified as follows:

  - *Added test case JobVertexBackPressureInfoTest*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)

