### PR TITLE
[FLINK-7666] Close TimeService after closing operators.

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/ProcessingTimeService.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/ProcessingTimeService.java
@@ -29,7 +29,7 @@ import java.util.concurrent.ScheduledFuture;
  * <p>The registration of timers follows a life cycle of three phases:
  * <ol>
  *     <li>In the initial state, it accepts timer registrations and triggers when the time is reached.</li>
- *     <li>After calling {@link #quiesceAndAwaitPending()}, further calls to
+ *     <li>After calling {@link #quiesce()}, further calls to
  *         {@link #registerTimer(long, ProcessingTimeCallback)} will not register any further timers, and will
  *         return a "dummy" future as a result. This is used for clean shutdown, where currently firing
  *         timers are waited for and no future timers can be scheduled, without causing hard exceptions.</li>
@@ -73,14 +73,19 @@ public abstract class ProcessingTimeService {
 	/**
 	 * This method puts the service into a state where it does not register new timers, but
 	 * returns for each call to {@link #registerTimer(long, ProcessingTimeCallback)} only a "mock" future.
-	 * Furthermore, the method clears all not yet started timers, and awaits the completion
-	 * of currently executing timers.
+	 * Furthermore, the method clears all not yet started timers.
 	 *
 	 * <p>This method can be used to cleanly shut down the timer service. The using components
 	 * will not notice that the service is shut down (as for example via exceptions when registering
 	 * a new timer), but the service will simply not fire any timer any more.
 	 */
-	public abstract void quiesceAndAwaitPending() throws InterruptedException;
+	public abstract void quiesce() throws InterruptedException;
+
+	/**
+	 * This method can be used after calling {@link #quiesce()}, and awaits the completion
+	 * of currently executing timers.
+	 */
+	public abstract void awaitPendingAfterQuiesce() throws InterruptedException;
 
 	/**
 	 * Shuts down and clean up the timer service provider hard and immediately. This does not wait

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SystemProcessingTimeService.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SystemProcessingTimeService.java
@@ -108,7 +108,7 @@ public class SystemProcessingTimeService extends ProcessingTimeService {
 		// that way we save unnecessary volatile accesses for each timer
 		try {
 			return timerService.schedule(
-					new TriggerTask(task, checkpointLock, target, timestamp), delay, TimeUnit.MILLISECONDS);
+					new TriggerTask(status, task, checkpointLock, target, timestamp), delay, TimeUnit.MILLISECONDS);
 		}
 		catch (RejectedExecutionException e) {
 			final int status = this.status.get();
@@ -133,7 +133,7 @@ public class SystemProcessingTimeService extends ProcessingTimeService {
 		// that way we save unnecessary volatile accesses for each timer
 		try {
 			return timerService.scheduleAtFixedRate(
-				new RepeatedTriggerTask(task, checkpointLock, callback, nextTimestamp, period),
+				new RepeatedTriggerTask(status, task, checkpointLock, callback, nextTimestamp, period),
 				initialDelay,
 				period,
 				TimeUnit.MILLISECONDS);
@@ -152,18 +152,34 @@ public class SystemProcessingTimeService extends ProcessingTimeService {
 		}
 	}
 
+	/**
+	 * @return {@code true} is the status of the service
+	 * is {@link #STATUS_ALIVE}, {@code false} otherwise.
+	 */
+	@VisibleForTesting
+	boolean isAlive() {
+		return status.get() == STATUS_ALIVE;
+	}
+
 	@Override
 	public boolean isTerminated() {
 		return status.get() == STATUS_SHUTDOWN;
 	}
 
 	@Override
-	public void quiesceAndAwaitPending() throws InterruptedException {
+	public void quiesce() throws InterruptedException {
 		if (status.compareAndSet(STATUS_ALIVE, STATUS_QUIESCED)) {
 			timerService.shutdown();
+		}
+	}
+
+	@Override
+	public void awaitPendingAfterQuiesce() throws InterruptedException {
+		if (!timerService.isTerminated()) {
+			Preconditions.checkState(timerService.isTerminating() || timerService.isShutdown());
 
 			// await forever (almost)
-			timerService.awaitTermination(365, TimeUnit.DAYS);
+			timerService.awaitTermination(365L, TimeUnit.DAYS);
 		}
 	}
 
@@ -199,15 +215,23 @@ public class SystemProcessingTimeService extends ProcessingTimeService {
 	 */
 	private static final class TriggerTask implements Runnable {
 
+		private final AtomicInteger serviceStatus;
 		private final Object lock;
 		private final ProcessingTimeCallback target;
 		private final long timestamp;
 		private final AsyncExceptionHandler exceptionHandler;
 
-		TriggerTask(AsyncExceptionHandler exceptionHandler, final Object lock, ProcessingTimeCallback target, long timestamp) {
-			this.exceptionHandler = exceptionHandler;
-			this.lock = lock;
-			this.target = target;
+		private TriggerTask(
+				final AtomicInteger serviceStatus,
+				final AsyncExceptionHandler exceptionHandler,
+				final Object lock,
+				final ProcessingTimeCallback target,
+				final long timestamp) {
+
+			this.serviceStatus = Preconditions.checkNotNull(serviceStatus);
+			this.exceptionHandler = Preconditions.checkNotNull(exceptionHandler);
+			this.lock = Preconditions.checkNotNull(lock);
+			this.target = Preconditions.checkNotNull(target);
 			this.timestamp = timestamp;
 		}
 
@@ -215,7 +239,9 @@ public class SystemProcessingTimeService extends ProcessingTimeService {
 		public void run() {
 			synchronized (lock) {
 				try {
-					target.onProcessingTime(timestamp);
+					if (serviceStatus.get() == STATUS_ALIVE) {
+						target.onProcessingTime(timestamp);
+					}
 				} catch (Throwable t) {
 					TimerException asyncException = new TimerException(t);
 					exceptionHandler.handleAsyncException("Caught exception while processing timer.", asyncException);
@@ -228,6 +254,8 @@ public class SystemProcessingTimeService extends ProcessingTimeService {
 	 * Internal task which is repeatedly called by the processing time service.
 	 */
 	private static final class RepeatedTriggerTask implements Runnable {
+
+		private final AtomicInteger serviceStatus;
 		private final Object lock;
 		private final ProcessingTimeCallback target;
 		private final long period;
@@ -236,11 +264,14 @@ public class SystemProcessingTimeService extends ProcessingTimeService {
 		private long nextTimestamp;
 
 		private RepeatedTriggerTask(
-				AsyncExceptionHandler exceptionHandler,
-				Object lock,
-				ProcessingTimeCallback target,
-				long nextTimestamp,
-				long period) {
+				final AtomicInteger serviceStatus,
+				final AsyncExceptionHandler exceptionHandler,
+				final Object lock,
+				final ProcessingTimeCallback target,
+				final long nextTimestamp,
+				final long period) {
+
+			this.serviceStatus = Preconditions.checkNotNull(serviceStatus);
 			this.lock = Preconditions.checkNotNull(lock);
 			this.target = Preconditions.checkNotNull(target);
 			this.period = period;
@@ -251,15 +282,17 @@ public class SystemProcessingTimeService extends ProcessingTimeService {
 
 		@Override
 		public void run() {
-			try {
-				synchronized (lock) {
-					target.onProcessingTime(nextTimestamp);
-				}
+			synchronized (lock) {
+				try {
+					if (serviceStatus.get() == STATUS_ALIVE) {
+						target.onProcessingTime(nextTimestamp);
+					}
 
-				nextTimestamp += period;
-			} catch (Throwable t) {
-				TimerException asyncException = new TimerException(t);
-				exceptionHandler.handleAsyncException("Caught exception while processing repeated timer task.", asyncException);
+					nextTimestamp += period;
+				} catch (Throwable t) {
+					TimerException asyncException = new TimerException(t);
+					exceptionHandler.handleAsyncException("Caught exception while processing repeated timer task.", asyncException);
+				}
 			}
 		}
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TestProcessingTimeService.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TestProcessingTimeService.java
@@ -117,11 +117,16 @@ public class TestProcessingTimeService extends ProcessingTimeService {
 	}
 
 	@Override
-	public void quiesceAndAwaitPending() {
+	public void quiesce() {
 		if (!isTerminated) {
 			isQuiesced = true;
 			priorityQueue.clear();
 		}
+	}
+
+	@Override
+	public void awaitPendingAfterQuiesce() throws InterruptedException {
+		// do nothing.
 	}
 
 	@Override


### PR DESCRIPTION

R @aljoscha 

**(The sections below can be removed for hotfixes of typos)**

## What is the purpose of the change

*Breaks the `quiesceAndWait` of the `TimeService` into 2 methods, `quiesce` and `wait`, and calls them **after** closing the operators. The `quiesce()` is called while having the `checkpointLock`, while the `wait()` no.

The original problem was that the StreamTask was calling the `quiesceAndAwaitPending()` of the
`TimerService` before the close() of the operator. In the case  of the continuous file reading process, this meant that with a periodic watermark emitter and a small file (e.g. one split), the timer service would be closed before even starting to read (as soon as the reader received the first split), and no timers would be registered to emit watermarks.

## Verifying this change

Added test in the `OneInputStreamTaskTest`.

## Documentation

  - Does this pull request introduce a new feature? NO
