### PR TITLE
 [FLINK-7781][metrics][REST] Support on-demand aggregations 

### DIFF
--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -992,9 +992,9 @@ up an automated clock synchronisation service (like NTP) to avoid false latency 
 
 ## REST API integration
 
-Metrics can also be queried through the [Monitoring REST API]({{ site.baseurl }}/monitoring/rest_api.html).
+Metrics can be queried through the [Monitoring REST API]({{ site.baseurl }}/monitoring/rest_api.html).
 
-Below is a list of available requests, with a sample JSON response. All requests are of the sample form `http://hostname:8081/jobmanager/metrics`, below we list only the *path* part of the URLs.
+Below is a list of available endpoints, with a sample JSON response. All endpoints are of the sample form `http://hostname:8081/jobmanager/metrics`, below we list only the *path* part of the URLs.
 
 Values in angle brackets are variables, for example `http://hostname:8081/jobs/<jobid>/metrics` will have to be requested for example as `http://hostname:8081/jobs/7684be6004e4e955c2a558a9bc463f65/metrics`.
 
@@ -1010,6 +1010,12 @@ Request metrics aggregated across all entities of the respective type:
   - `/taskmanagers/metrics`
   - `/jobs/metrics`
   - `/jobs/<jobid>/vertices/<vertexid>/subtasks/metrics`
+
+Request metrics aggregated over a subset of all entities of the respective type:
+
+  - `/taskmanagers/metrics?taskmanagers=A,B,C`
+  - `/jobs/metrics?jobs=D,E,F`
+  - `/jobs/<jobid>/vertices/<vertexid>/subtasks/metrics?subtask=1,2,3`
 
 Request a list of available metrics:
 

--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -990,6 +990,101 @@ latency issues caused by individual machines.
 Currently, Flink assumes that the clocks of all machines in the cluster are in sync. We recommend setting
 up an automated clock synchronisation service (like NTP) to avoid false latency results.
 
+## REST API integration
+
+Metrics can also be queried through the [Monitoring REST API]({{ site.baseurl }}/monitoring/rest_api.html).
+
+Below is a list of available requests, with a sample JSON response. All requests are of the sample form `http://hostname:8081/jobmanager/metrics`, below we list only the *path* part of the URLs.
+
+Values in angle brackets are variables, for example `http://hostname:8081/jobs/<jobid>/metrics` will have to be requested for example as `http://hostname:8081/jobs/7684be6004e4e955c2a558a9bc463f65/metrics`.
+
+Request metrics for a specific entity:
+
+  - `/jobmanager/metrics`
+  - `/taskmanagers/<taskmanagerid>/metrics`
+  - `/jobs/<jobid>/metrics`
+  - `/jobs/<jobid>/vertices/<vertexid>/subtasks/<subtaskindex>`
+
+Request metrics aggregated across all entities of the respective type:
+
+  - `/taskmanagers/metrics`
+  - `/jobs/metrics`
+  - `/jobs/<jobid>/vertices/<vertexid>/subtasks/metrics`
+
+Request a list of available metrics:
+
+`GET /jobmanager/metrics`
+
+~~~
+[
+  {
+    "id": "metric1"
+  },
+  {
+    "id": "metric2"
+  }
+]
+~~~
+
+Request the values for specific (unaggregated) metrics:
+
+`GET taskmanagers/ABCDE/metrics?get=metric1,metric2`
+
+~~~
+[
+  {
+    "id": "metric1",
+    "value": "34"
+  },
+  {
+    "id": "metric2",
+    "value": "2"
+  }
+]
+~~~
+
+Request aggregated values for specific metrics:
+
+`GET /taskmanagers/metrics?get=metric1,metric2`
+
+~~~
+[
+  {
+    "id": "metric1",
+    "min": 1,
+    "max": 34,
+    "avg": 15,
+    "sum": 45
+  },
+  {
+    "id": "metric2",
+    "min": 2,
+    "max": 14,
+    "avg": 7,
+    "sum": 16
+  }
+]
+~~~
+
+Request specific aggregated values for specific metrics:
+
+`GET /taskmanagers/metrics?get=metric1,metric2&agg=min,max`
+
+~~~
+[
+  {
+    "id": "metric1",
+    "min": 1,
+    "max": 34,
+  },
+  {
+    "id": "metric2",
+    "min": 2,
+    "max": 14,
+  }
+]
+~~~
+
 ## Dashboard integration
 
 Metrics that were gathered for each task or operator can also be visualized in the Dashboard. On the main page for a

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/SubtaskExecutionAttemptDetailsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/SubtaskExecutionAttemptDetailsHandler.java
@@ -51,6 +51,7 @@ import static org.apache.flink.runtime.rest.handler.legacy.SubtaskCurrentAttempt
  */
 public class SubtaskExecutionAttemptDetailsHandler extends AbstractSubtaskAttemptRequestHandler {
 
+	public static final String PARAMETER_SUBTASK_INDEX = "subtasknum";
 	private static final String SUBTASK_ATTEMPT_DETAILS_REST_PATH = "/jobs/:jobid/vertices/:vertexid/subtasks/:subtasknum/attempts/:attempt";
 
 	private final MetricFetcher fetcher;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/AbstractAggregatingMetricsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/AbstractAggregatingMetricsHandler.java
@@ -1,0 +1,223 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.legacy.metrics;
+
+import org.apache.flink.runtime.jobmaster.JobManagerGateway;
+import org.apache.flink.runtime.rest.handler.legacy.AbstractJsonRequestHandler;
+import org.apache.flink.runtime.rest.handler.legacy.JsonFactory;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.Preconditions;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executor;
+
+/**
+ * Abstract request handler for querying metrics. Subclasses may either that returns a list of all available metrics or
+ * the values for a set of metrics for a specific entity, or aggregate them across several entities.
+ *
+ * <p>If the query parameters do not contain a "get" parameter the list of all metrics is returned.
+ * {@code [ { "id" : "X" } ] }
+ *
+ * <p>If the query parameters do contain a "get" parameter, a comma-separated list of metric names is expected as a value.
+ * {@code /metrics?get=X,Y}
+ * The handler will then return a list containing the values of the requested metrics.
+ * {@code [ { "id" : "X", "value" : "S" }, { "id" : "Y", "value" : "T" } ] }
+ *
+ * <p>If the query parameters do contain a "get" parameter a comma-separate list of metric names is expected as a value.
+ * The "agg" query parameter is used to define which aggregates should be calculated. Available aggregations are
+ * "sum", "max", "min" and "avg". If the parameter is not specified all aggregations will be returned.
+ * {@code /metrics?get=X,Y&agg=min,max}
+ * The handler will then return an object containing the aggregations for the requested metrics.
+ * {@code [ { "id" : "X", "min", "1", "max", "2" }, { "id" : "Y", "min", "4", "max", "10"}]}
+ */
+abstract class AbstractAggregatingMetricsHandler extends AbstractJsonRequestHandler {
+
+	protected final Logger log = LoggerFactory.getLogger(getClass());
+
+	private static final String PARAMETER_AGGREGATION = "agg";
+
+	private final MetricFetcher fetcher;
+
+	AbstractAggregatingMetricsHandler(Executor executor, MetricFetcher fetcher) {
+		super(executor);
+		this.fetcher = Preconditions.checkNotNull(fetcher);
+	}
+
+	protected abstract Collection<? extends MetricStore.ComponentMetricStore> getStores(MetricStore store, Map<String, String> pathParameters, Map<String, String> queryParameters);
+
+	@Override
+	public CompletableFuture<String> handleJsonRequest(Map<String, String> pathParams, Map<String, String> queryParams, JobManagerGateway jobManagerGateway) {
+		return CompletableFuture.supplyAsync(
+			() -> {
+				try {
+					fetcher.update();
+					String requestedMetricsList = queryParams.get(AbstractMetricsHandler.PARAMETER_METRICS);
+					String aggTypeList = queryParams.get(PARAMETER_AGGREGATION);
+					MetricStore store = fetcher.getMetricStore();
+
+					if (requestedMetricsList == null) {
+						Collection<? extends MetricStore.ComponentMetricStore> stores = getStores(store, pathParams, queryParams);
+						if (stores == null) {
+							return "[]";
+						}
+						Collection<String> list = getAvailableMetrics(stores);
+						return mapMetricListToJson(list);
+					}
+
+					if (requestedMetricsList.isEmpty()) {
+						/*
+						 * The WebInterface doesn't check whether the list of available metrics was empty. This can lead to a
+						 * request for which the "get" parameter is an empty string.
+						 */
+						return "[]";
+					}
+
+					String[] requestedMetrics = requestedMetricsList.split(",");
+
+					List<DoubleAccumulator.DoubleAccumulatorFactory<?>> requestedAggregationsFactories = new ArrayList<>();
+					// by default we return all aggregations
+					if (aggTypeList == null || aggTypeList.isEmpty()) {
+						requestedAggregationsFactories.add(DoubleAccumulator.DoubleMinimumFactory.get());
+						requestedAggregationsFactories.add(DoubleAccumulator.DoubleMaximumFactory.get());
+						requestedAggregationsFactories.add(DoubleAccumulator.DoubleSumFactory.get());
+						requestedAggregationsFactories.add(DoubleAccumulator.DoubleAverageFactory.get());
+					} else {
+						for (String aggregation : aggTypeList.split(",")) {
+							switch (aggregation.toLowerCase()) {
+								case DoubleAccumulator.DoubleMinimum.NAME:
+									requestedAggregationsFactories.add(DoubleAccumulator.DoubleMinimumFactory.get());
+									break;
+								case DoubleAccumulator.DoubleMaximum.NAME:
+									requestedAggregationsFactories.add(DoubleAccumulator.DoubleMaximumFactory.get());
+									break;
+								case DoubleAccumulator.DoubleSum.NAME:
+									requestedAggregationsFactories.add(DoubleAccumulator.DoubleSumFactory.get());
+									break;
+								case DoubleAccumulator.DoubleAverage.NAME:
+									requestedAggregationsFactories.add(DoubleAccumulator.DoubleAverageFactory.get());
+									break;
+								default:
+									log.warn("Invalid aggregation specified: {}", aggregation.toLowerCase());
+							}
+						}
+					}
+					Collection<? extends MetricStore.ComponentMetricStore> stores = getStores(store, pathParams, queryParams);
+					if (stores == null){
+						return "[]";
+					}
+					return getAggregatedMetricValues(stores, requestedMetrics, requestedAggregationsFactories);
+				} catch (Exception e) {
+					throw new CompletionException(new FlinkException("Could not retrieve metrics.", e));
+				}
+			},
+			executor);
+	}
+
+	/**
+	 * Returns a JSON string containing a list of all available metrics in the given stores. Effectively this method maps
+	 * the union of all key-sets to JSON.
+	 *
+	 * @param stores metrics
+	 * @return JSON string containing a list of all available metrics
+	 */
+	private static Collection<String> getAvailableMetrics(Collection<? extends MetricStore.ComponentMetricStore> stores) {
+		Set<String> uniqueMetrics = new HashSet<>();
+		for (MetricStore.ComponentMetricStore store : stores) {
+			uniqueMetrics.addAll(store.metrics.keySet());
+		}
+		return uniqueMetrics;
+	}
+
+	private static String mapMetricListToJson(Collection<String> metrics) throws IOException {
+		StringWriter writer = new StringWriter();
+		JsonGenerator gen = JsonFactory.JACKSON_FACTORY.createGenerator(writer);
+
+		gen.writeStartArray();
+		for (String m : metrics) {
+			gen.writeStartObject();
+			gen.writeStringField("id", m);
+			gen.writeEndObject();
+		}
+		gen.writeEndArray();
+
+		gen.close();
+		return writer.toString();
+	}
+
+	/**
+	 * Extracts and aggregates all requested metrics from the given metric stores, and maps the result to a JSON string.
+	 *
+	 * @param stores available metrics
+	 * @param requestedMetrics ids of requested metrics
+	 * @param requestedAggregationsFactories requested aggregations
+	 * @return JSON string containing the requested metrics
+	 * @throws IOException
+	 */
+	private String getAggregatedMetricValues(Collection<? extends MetricStore.ComponentMetricStore> stores, String[] requestedMetrics, List<DoubleAccumulator.DoubleAccumulatorFactory<?>> requestedAggregationsFactories) throws IOException {
+		StringWriter writer = new StringWriter();
+		JsonGenerator gen = JsonFactory.JACKSON_FACTORY.createGenerator(writer);
+
+		gen.writeStartArray();
+		for (String requestedMetric : requestedMetrics) {
+			final Collection<Double> values = new ArrayList<>();
+			try {
+				for (MetricStore.ComponentMetricStore store : stores) {
+					String stringValue = store.metrics.get(requestedMetric);
+					if (stringValue != null) {
+						values.add(Double.valueOf(stringValue));
+					}
+				}
+			} catch (NumberFormatException nfe) {
+				// metric is not numeric so we can't perform aggregations => ignore it
+				continue;
+			}
+			if (!values.isEmpty()) {
+
+				gen.writeStartObject();
+				gen.writeStringField("id", requestedMetric);
+				for (DoubleAccumulator.DoubleAccumulatorFactory<?> accFactory : requestedAggregationsFactories) {
+					Iterator<Double> valuesIterator = values.iterator();
+					DoubleAccumulator acc = accFactory.get(valuesIterator.next());
+					valuesIterator.forEachRemaining(acc::add);
+
+					gen.writeStringField(acc.getName(), String.valueOf(acc.getValue()));
+				}
+				gen.writeEndObject();
+			}
+		}
+		gen.writeEndArray();
+
+		gen.close();
+		return writer.toString();
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/AbstractMetricsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/AbstractMetricsHandler.java
@@ -39,12 +39,15 @@ import java.util.concurrent.Executor;
  * <p>If the query parameters do not contain a "get" parameter the list of all metrics is returned.
  * {@code [ { "id" : "X" } ] }
  *
- * <p>If the query parameters do contain a "get" parameter a comma-separate list of metric names is expected as a value.
- * {@code /get?X,Y}
+ * <p>If the query parameters do contain a "get" parameter, a comma-separated list of metric names is expected as a value.
+ * {@code /metrics?get=X,Y}
  * The handler will then return a list containing the values of the requested metrics.
  * {@code [ { "id" : "X", "value" : "S" }, { "id" : "Y", "value" : "T" } ] }
  */
 public abstract class AbstractMetricsHandler extends AbstractJsonRequestHandler {
+
+	public static final String PARAMETER_METRICS = "get";
+
 	private final MetricFetcher fetcher;
 
 	public AbstractMetricsHandler(Executor executor, MetricFetcher fetcher) {
@@ -57,7 +60,7 @@ public abstract class AbstractMetricsHandler extends AbstractJsonRequestHandler 
 		return CompletableFuture.supplyAsync(
 			() -> {
 				fetcher.update();
-				String requestedMetricsList = queryParams.get("get");
+				String requestedMetricsList = queryParams.get(PARAMETER_METRICS);
 				try {
 					return requestedMetricsList != null
 						? getMetricsValues(pathParams, requestedMetricsList)

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/AggregatingJobsMetricsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/AggregatingJobsMetricsHandler.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.legacy.metrics;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.Executor;
+
+/**
+ * Request handler that returns, aggregated across all jobs, a list of all available metrics or the values
+ * for a set of metrics.
+ */
+public class AggregatingJobsMetricsHandler extends AbstractAggregatingMetricsHandler {
+	public AggregatingJobsMetricsHandler(Executor executor, MetricFetcher fetcher) {
+		super(executor, fetcher);
+	}
+
+	@Override
+	protected Collection<? extends MetricStore.ComponentMetricStore> getStores(MetricStore store, Map<String, String> pathParameters, Map<String, String> queryParameters) {
+		String jobsList = queryParameters.get("jobs");
+		if (jobsList == null || jobsList.isEmpty()) {
+			return store.getJobs().values();
+		} else {
+			String[] jobs = jobsList.split(",");
+			Collection<MetricStore.ComponentMetricStore> jobStores = new ArrayList<>();
+			for (String job : jobs) {
+				jobStores.add(store.getJobMetricStore(job));
+			}
+			return jobStores;
+		}
+	}
+
+	@Override
+	public String[] getPaths() {
+		return new String[]{"/jobs/metrics"};
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/AggregatingJobsMetricsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/AggregatingJobsMetricsHandler.java
@@ -26,6 +26,9 @@ import java.util.concurrent.Executor;
 /**
  * Request handler that returns, aggregated across all jobs, a list of all available metrics or the values
  * for a set of metrics.
+ *
+ * <p>Specific jobs can be selected for aggregation by specifying a comma-separated list of job IDs.
+ * {@code /metrics?get=X,Y&jobs=A,B}
  */
 public class AggregatingJobsMetricsHandler extends AbstractAggregatingMetricsHandler {
 	public AggregatingJobsMetricsHandler(Executor executor, MetricFetcher fetcher) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/AggregatingSubtasksMetricsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/AggregatingSubtasksMetricsHandler.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.legacy.metrics;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.Executor;
+
+import static org.apache.flink.runtime.rest.handler.legacy.metrics.JobMetricsHandler.PARAMETER_JOB_ID;
+import static org.apache.flink.runtime.rest.handler.legacy.metrics.JobVertexMetricsHandler.PARAMETER_VERTEX_ID;
+
+/**
+ * Request handler that returns, aggregated across all subtasks, a list of all available metrics or the values
+ * for a set of metrics.
+ */
+public class AggregatingSubtasksMetricsHandler extends AbstractAggregatingMetricsHandler {
+	public AggregatingSubtasksMetricsHandler(Executor executor, MetricFetcher fetcher) {
+		super(executor, fetcher);
+	}
+
+	@Override
+	protected Collection<? extends MetricStore.ComponentMetricStore> getStores(MetricStore store, Map<String, String> pathParameters, Map<String, String> queryParameters) {
+		String jobID = pathParameters.get(PARAMETER_JOB_ID);
+		String taskID = pathParameters.get(PARAMETER_VERTEX_ID);
+		if (taskID == null) {
+			return Collections.emptyList();
+		}
+		String subtasksList = queryParameters.get("subtasks");
+		if (subtasksList == null || subtasksList.isEmpty()) {
+			return store.getTaskMetricStore(jobID, taskID).getAllSubtaskMetricStores();
+		} else {
+			String[] subtasks = subtasksList.split(",");
+			Collection<MetricStore.ComponentMetricStore> subtaskStores = new ArrayList<>();
+			for (String subtask : subtasks) {
+				int subtaskNum;
+				try {
+					subtaskNum = Integer.valueOf(subtask);
+				} catch (NumberFormatException nfe) {
+					log.warn("Invalid subtask index specified {}. Not a number.", subtask, nfe);
+					continue;
+				}
+				subtaskStores.add(store.getSubtaskMetricStore(jobID, taskID, subtaskNum));
+			}
+			return subtaskStores;
+		}
+	}
+
+	@Override
+	public String[] getPaths() {
+		return new String[]{"/jobs/:jobid/vertices/:vertexid/subtasks/metrics"};
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/AggregatingSubtasksMetricsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/AggregatingSubtasksMetricsHandler.java
@@ -25,6 +25,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.concurrent.Executor;
 
 import static org.apache.flink.runtime.rest.handler.legacy.metrics.JobMetricsHandler.PARAMETER_JOB_ID;
@@ -70,7 +71,7 @@ public class AggregatingSubtasksMetricsHandler extends AbstractAggregatingMetric
 		return new String[]{"/jobs/:jobid/vertices/:vertexid/subtasks/metrics"};
 	}
 
-	private Iterable<Integer> getIntegerRangeFromString(String rangeDefinition) throws NumberFormatException {
+	private Iterable<Integer> getIntegerRangeFromString(String rangeDefinition) {
 		final String[] ranges = rangeDefinition.trim().split(",");
 
 		UnionIterator<Integer> iterators = new UnionIterator<>();
@@ -97,7 +98,11 @@ public class AggregatingSubtasksMetricsHandler extends AbstractAggregatingMetric
 
 						@Override
 						public Integer next() {
-							return i++;
+							if (hasNext()) {
+								return i++;
+							} else {
+								throw new NoSuchElementException();
+							}
 						}
 
 						@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/AggregatingTaskManagersMetricsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/AggregatingTaskManagersMetricsHandler.java
@@ -26,6 +26,9 @@ import java.util.concurrent.Executor;
 /**
  * Request handler that returns, aggregated across all task managers, a list of all available metrics or the values for
  * a set of metrics.
+ *
+ * <p>Specific taskmanagers can be selected for aggregation by specifying a comma-separated list of taskmanager IDs.
+ * {@code /metrics?get=X,Y&taskmanagers=A,B}
  */
 public class AggregatingTaskManagersMetricsHandler extends AbstractAggregatingMetricsHandler {
 	public AggregatingTaskManagersMetricsHandler(Executor executor, MetricFetcher fetcher) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/AggregatingTaskManagersMetricsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/AggregatingTaskManagersMetricsHandler.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.legacy.metrics;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.Executor;
+
+/**
+ * Request handler that returns, aggregated across all task managers, a list of all available metrics or the values for
+ * a set of metrics.
+ */
+public class AggregatingTaskManagersMetricsHandler extends AbstractAggregatingMetricsHandler {
+	public AggregatingTaskManagersMetricsHandler(Executor executor, MetricFetcher fetcher) {
+		super(executor, fetcher);
+	}
+
+	@Override
+	protected Collection<? extends MetricStore.ComponentMetricStore> getStores(MetricStore store, Map<String, String> pathParameters, Map<String, String> queryParameters) {
+		String taskmanagersList = queryParameters.get("taskmanagers");
+		if (taskmanagersList == null || taskmanagersList.isEmpty()) {
+			return store.getTaskManagers().values();
+		} else {
+			String[] taskmanagers = taskmanagersList.split(",");
+			Collection<MetricStore.TaskManagerMetricStore> taskmanagerStores = new ArrayList<>();
+			for (String taskmanager : taskmanagers) {
+				taskmanagerStores.add(store.getTaskManagerMetricStore(taskmanager));
+			}
+			return taskmanagerStores;
+		}
+	}
+
+	@Override
+	public String[] getPaths() {
+		return new String[]{"/taskmanagers/metrics"};
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/DoubleAccumulator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/DoubleAccumulator.java
@@ -246,9 +246,6 @@ interface DoubleAccumulator {
 
 		@Override
 		public double getValue() {
-			if (count == 0) {
-				return 0;
-			}
 			return sum / count;
 		}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/DoubleAccumulator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/DoubleAccumulator.java
@@ -1,0 +1,260 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.legacy.metrics;
+
+/**
+ * An interface for accumulating double values.
+ */
+interface DoubleAccumulator {
+
+	/**
+	 * Adds the given value to this accumulator.
+	 *
+	 * @param value value to add
+	 */
+	void add(double value);
+
+	/**
+	 * Returns the current value of this accumulator.
+	 *
+	 * @return current value of this accumulator
+	 */
+	double getValue();
+
+	/**
+	 * Returns the name of this accumulator type. This name is used as a suffix for exposed metrics.
+	 *
+	 * @return name of this accumulator type
+	 */
+	String getName();
+
+	/**
+	 * A factory for {@link DoubleAccumulator}s. This allows us to regenerate a new set of accumulators for each metrics
+	 * without re-evaluating the "agg" query parameter or re-using existing accumulators.
+	 *
+	 * @param <A> DoubleAccumulator subclass
+	 */
+	interface DoubleAccumulatorFactory<A extends DoubleAccumulator> {
+		/**
+		 * Creates a new accumulator with the given initial value.
+		 *
+		 * @param init initial value
+		 * @return new accumulator with the given initial value
+		 */
+		A get(double init);
+	}
+
+	/**
+	 * Factory for {@link DoubleMaximum}.
+	 */
+	final class DoubleMaximumFactory implements DoubleAccumulatorFactory<DoubleMaximum> {
+		private static final DoubleMaximumFactory INSTANCE = new DoubleMaximumFactory();
+
+		private DoubleMaximumFactory(){
+		}
+
+		@Override
+		public DoubleMaximum get(double init) {
+			return new DoubleMaximum(init);
+		}
+
+		public static DoubleMaximumFactory get() {
+			return INSTANCE;
+		}
+	}
+
+	/**
+	 * Factory for {@link DoubleMinimum}.
+	 */
+	final class DoubleMinimumFactory implements DoubleAccumulatorFactory<DoubleMinimum> {
+		private static final DoubleMinimumFactory INSTANCE = new DoubleMinimumFactory();
+
+		private DoubleMinimumFactory(){
+		}
+
+		@Override
+		public DoubleMinimum get(double init) {
+			return new DoubleMinimum(init);
+		}
+
+		public static DoubleMinimumFactory get() {
+			return INSTANCE;
+		}
+	}
+
+	/**
+	 * Factory for {@link DoubleSum}.
+	 */
+	final class DoubleSumFactory implements DoubleAccumulatorFactory<DoubleSum> {
+		private static final DoubleSumFactory INSTANCE = new DoubleSumFactory();
+
+		private DoubleSumFactory(){
+		}
+
+		@Override
+		public DoubleSum get(double init) {
+			return new DoubleSum(init);
+		}
+
+		public static DoubleSumFactory get() {
+			return INSTANCE;
+		}
+	}
+
+	/**
+	 * Factory for {@link DoubleAverage}.
+	 */
+	final class DoubleAverageFactory implements DoubleAccumulatorFactory<DoubleAverage> {
+		private static final DoubleAverageFactory INSTANCE = new DoubleAverageFactory();
+
+		private DoubleAverageFactory(){
+		}
+
+		@Override
+		public DoubleAverage get(double init) {
+			return new DoubleAverage(init);
+		}
+
+		public static DoubleAverageFactory get() {
+			return INSTANCE;
+		}
+	}
+
+	/**
+	 * {@link DoubleAccumulator} that returns the maximum value.
+	 */
+	final class DoubleMaximum implements DoubleAccumulator {
+
+		public static final String NAME = "max";
+
+		private double value;
+
+		private DoubleMaximum(double init) {
+			value = init;
+		}
+
+		@Override
+		public void add(double value) {
+			this.value = Math.max(this.value, value);
+		}
+
+		@Override
+		public double getValue() {
+			return value;
+		}
+
+		@Override
+		public String getName() {
+			return NAME;
+		}
+	}
+
+	/**
+	 * {@link DoubleAccumulator} that returns the minimum value.
+	 */
+	final class DoubleMinimum implements DoubleAccumulator {
+
+		public static final String NAME = "min";
+
+		private double value;
+
+		private DoubleMinimum(double init) {
+			value = init;
+		}
+
+		@Override
+		public void add(double value) {
+			this.value = Math.min(this.value, value);
+		}
+
+		@Override
+		public double getValue() {
+			return value;
+		}
+
+		@Override
+		public String getName() {
+			return NAME;
+		}
+	}
+
+	/**
+	 * {@link DoubleAccumulator} that returns the sum of all values.
+	 */
+	final class DoubleSum implements DoubleAccumulator {
+
+		public static final String NAME = "sum";
+
+		private double value;
+
+		private DoubleSum(double init) {
+			value = init;
+		}
+
+		@Override
+		public void add(double value) {
+			this.value += value;
+		}
+
+		@Override
+		public double getValue() {
+			return value;
+		}
+
+		@Override
+		public String getName() {
+			return NAME;
+		}
+	}
+
+	/**
+	 * {@link DoubleAccumulator} that returns the average over all values.
+	 */
+	final class DoubleAverage implements DoubleAccumulator {
+
+		public static final String NAME = "avg";
+
+		private double sum;
+		private int count;
+
+		private DoubleAverage(double init) {
+			sum = init;
+			count = 1;
+		}
+
+		@Override
+		public void add(double value) {
+			this.sum += value;
+			this.count++;
+		}
+
+		@Override
+		public double getValue() {
+			if (count == 0) {
+				return 0;
+			}
+			return sum / count;
+		}
+
+		@Override
+		public String getName() {
+			return NAME;
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/JobManagerMetricsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/JobManagerMetricsHandler.java
@@ -27,7 +27,7 @@ import java.util.concurrent.Executor;
  * <p>If the query parameters do not contain a "get" parameter the list of all metrics is returned.
  * {@code {"available": [ { "name" : "X", "id" : "X" } ] } }
  *
- * <p>If the query parameters do contain a "get" parameter a comma-separate list of metric names is expected as a value.
+ * <p>If the query parameters do contain a "get" parameter, a comma-separated list of metric names is expected as a value.
  * {@code /metrics?get=X,Y}
  * The handler will then return a list containing the values of the requested metrics.
  * {@code [ { "id" : "X", "value" : "S" }, { "id" : "Y", "value" : "T" } ] }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/JobManagerMetricsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/JobManagerMetricsHandler.java
@@ -28,7 +28,7 @@ import java.util.concurrent.Executor;
  * {@code {"available": [ { "name" : "X", "id" : "X" } ] } }
  *
  * <p>If the query parameters do contain a "get" parameter a comma-separate list of metric names is expected as a value.
- * {@code /get?X,Y}
+ * {@code /metrics?get=X,Y}
  * The handler will then return a list containing the values of the requested metrics.
  * {@code [ { "id" : "X", "value" : "S" }, { "id" : "Y", "value" : "T" } ] }
  */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/JobMetricsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/JobMetricsHandler.java
@@ -27,7 +27,7 @@ import java.util.concurrent.Executor;
  * <p>If the query parameters do not contain a "get" parameter the list of all metrics is returned.
  * {@code {"available": [ { "name" : "X", "id" : "X" } ] } }
  *
- * <p>If the query parameters do contain a "get" parameter a comma-separate list of metric names is expected as a value.
+ * <p>If the query parameters do contain a "get" parameter, a comma-separated list of metric names is expected as a value.
  * {@code /metrics?get=X,Y}
  * The handler will then return a list containing the values of the requested metrics.
  * {@code [ { "id" : "X", "value" : "S" }, { "id" : "Y", "value" : "T" } ] }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/JobMetricsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/JobMetricsHandler.java
@@ -28,7 +28,7 @@ import java.util.concurrent.Executor;
  * {@code {"available": [ { "name" : "X", "id" : "X" } ] } }
  *
  * <p>If the query parameters do contain a "get" parameter a comma-separate list of metric names is expected as a value.
- * {@code /get?X,Y}
+ * {@code /metrics?get=X,Y}
  * The handler will then return a list containing the values of the requested metrics.
  * {@code [ { "id" : "X", "value" : "S" }, { "id" : "Y", "value" : "T" } ] }
  */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/JobVertexMetricsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/JobVertexMetricsHandler.java
@@ -27,11 +27,14 @@ import java.util.concurrent.Executor;
  * <p>If the query parameters do not contain a "get" parameter the list of all metrics is returned.
  * {@code {"available": [ { "name" : "X", "id" : "X" } ] } }
  *
- * <p>If the query parameters do contain a "get" parameter a comma-separate list of metric names is expected as a value.
+ * <p>If the query parameters do contain a "get" parameter, a comma-separated list of metric names is expected as a value.
  * {@code /metrics?get=X,Y}
  * The handler will then return a list containing the values of the requested metrics.
  * {@code [ { "id" : "X", "value" : "S" }, { "id" : "Y", "value" : "T" } ] }
+ *
+ * @deprecated This class is subsumed by {@link SubtaskMetricsHandler} and is only kept for backwards-compatibility.
  */
+@Deprecated
 public class JobVertexMetricsHandler extends AbstractMetricsHandler {
 	public static final String PARAMETER_VERTEX_ID = "vertexid";
 	private static final String JOB_VERTEX_METRICS_REST_PATH = "/jobs/:jobid/vertices/:vertexid/metrics";

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/JobVertexMetricsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/JobVertexMetricsHandler.java
@@ -28,7 +28,7 @@ import java.util.concurrent.Executor;
  * {@code {"available": [ { "name" : "X", "id" : "X" } ] } }
  *
  * <p>If the query parameters do contain a "get" parameter a comma-separate list of metric names is expected as a value.
- * {@code /get?X,Y}
+ * {@code /metrics?get=X,Y}
  * The handler will then return a list containing the values of the requested metrics.
  * {@code [ { "id" : "X", "value" : "S" }, { "id" : "Y", "value" : "T" } ] }
  */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/MetricStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/MetricStore.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.concurrent.ThreadSafe;
 
 import java.util.List;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -125,12 +126,12 @@ public class MetricStore {
 	 * @param taskID task ID
 	 * @return ComponentMetricStore for given IDs, or null if no store for the given arguments exists
 	 */
-	public synchronized ComponentMetricStore getTaskMetricStore(String jobID, String taskID) {
+	public synchronized TaskMetricStore getTaskMetricStore(String jobID, String taskID) {
 		JobMetricStore job = jobID == null ? null : jobs.get(jobID);
 		if (job == null || taskID == null) {
 			return null;
 		}
-		return ComponentMetricStore.unmodifiable(job.getTaskMetricStore(taskID));
+		return TaskMetricStore.unmodifiable(job.getTaskMetricStore(taskID));
 	}
 
 	/**
@@ -218,11 +219,13 @@ public class MetricStore {
 					QueryScopeInfo.OperatorQueryScopeInfo operatorInfo = (QueryScopeInfo.OperatorQueryScopeInfo) info;
 					job = jobs.computeIfAbsent(operatorInfo.jobID, k -> new JobMetricStore());
 					task = job.tasks.computeIfAbsent(operatorInfo.vertexID, k -> new TaskMetricStore());
+					subtask = task.subtasks.computeIfAbsent(operatorInfo.subtaskIndex, k -> new ComponentMetricStore());
 					/**
 					 * As the WebInterface does not account for operators (because it can't) we don't
 					 * divide by operator and instead use the concatenation of subtask index, operator name and metric name
 					 * as the name.
 					 */
+					addMetric(subtask.metrics, operatorInfo.operatorName + "." + name, metric);
 					addMetric(task.metrics, operatorInfo.subtaskIndex + "." + operatorInfo.operatorName + "." + name, metric);
 					break;
 				default:
@@ -348,11 +351,33 @@ public class MetricStore {
 	 * Sub-structure containing metrics of a single Task.
 	 */
 	@ThreadSafe
-	private static class TaskMetricStore extends ComponentMetricStore {
-		private final Map<Integer, ComponentMetricStore> subtasks = new ConcurrentHashMap<>();
+	public static class TaskMetricStore extends ComponentMetricStore {
+		private final Map<Integer, ComponentMetricStore> subtasks;
+
+		private TaskMetricStore() {
+			this(new ConcurrentHashMap<>(), new ConcurrentHashMap<>());
+		}
+
+		private TaskMetricStore(Map<String, String> metrics, Map<Integer, ComponentMetricStore> subtasks) {
+			super(metrics);
+			this.subtasks = checkNotNull(subtasks);
+		}
 
 		public ComponentMetricStore getSubtaskMetricStore(int subtaskIndex) {
 			return subtasks.get(subtaskIndex);
+		}
+
+		public Collection<ComponentMetricStore> getAllSubtaskMetricStores() {
+			return subtasks.values();
+		}
+
+		private static TaskMetricStore unmodifiable(TaskMetricStore source) {
+			if (source == null) {
+				return null;
+			}
+			return new TaskMetricStore(
+				unmodifiableMap(source.metrics),
+				unmodifiableMap(source.subtasks));
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/MetricStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/MetricStore.java
@@ -27,8 +27,8 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.concurrent.ThreadSafe;
 
-import java.util.List;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/TaskManagerMetricsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/TaskManagerMetricsHandler.java
@@ -30,7 +30,7 @@ import java.util.concurrent.Executor;
  * {@code {"available": [ { "name" : "X", "id" : "X" } ] } }
  *
  * <p>If the query parameters do contain a "get" parameter a comma-separate list of metric names is expected as a value.
- * {@code /get?X,Y}
+ * {@code /metrics?get=X,Y}
  * The handler will then return a list containing the values of the requested metrics.
  * {@code [ { "id" : "X", "value" : "S" }, { "id" : "Y", "value" : "T" } ] }
  */

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/metrics/AbstractAggregatingMetricsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/metrics/AbstractAggregatingMetricsHandlerTest.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.legacy.metrics;
+
+import org.apache.flink.runtime.concurrent.Executors;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+import org.apache.flink.runtime.webmonitor.retriever.MetricQueryServiceRetriever;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.powermock.api.mockito.PowerMockito.mock;
+
+/**
+ * Tests for the {@link AbstractAggregatingMetricsHandler}.
+ */
+public class AbstractAggregatingMetricsHandlerTest {
+	private static final ObjectMapper mapper = new ObjectMapper();
+
+	private static AggregatingTaskManagersMetricsHandler handler;
+
+	@BeforeClass
+	public static void setupHandler() {
+		MetricFetcher fetcher = new MetricFetcher(
+			mock(GatewayRetriever.class),
+			mock(MetricQueryServiceRetriever.class),
+			Executors.directExecutor(),
+			TestingUtils.TIMEOUT());
+		MetricStoreTest.setupStore(fetcher.getMetricStore());
+
+		handler = new AggregatingTaskManagersMetricsHandler(Executors.directExecutor(), fetcher);
+	}
+
+	@Test
+	public void testListMetrics() throws Exception {
+		String response = handler.handleJsonRequest(Collections.emptyMap(), Collections.emptyMap(), null)
+			.get();
+
+		Assert.assertEquals("[{\"id\":\"abc.metric22\"},{\"id\":\"abc.metric2b\"},{\"id\":\"abc.metric2\"}]", response);
+	}
+
+	@Test
+	public void testMinAggregation() throws Exception {
+		Map<String, String> queryParams = new HashMap<>();
+		queryParams.put("get", "abc.metric2");
+		queryParams.put("agg", "min");
+		String response = handler.handleJsonRequest(Collections.emptyMap(), queryParams, null)
+			.get();
+
+		JsonNode responseObject = mapper.readTree(response);
+		Assert.assertEquals(1, responseObject.size());
+		JsonNode metricInfo = responseObject.get(0);
+		Assert.assertEquals("abc.metric2", metricInfo.get("id").asText());
+		Assert.assertEquals(1, metricInfo.get("min").asDouble(), 0.01);
+	}
+
+	@Test
+	public void testMaxAggregation() throws Exception {
+		Map<String, String> queryParams = new HashMap<>();
+		queryParams.put("get", "abc.metric2");
+		queryParams.put("agg", "max");
+		String response = handler.handleJsonRequest(Collections.emptyMap(), queryParams, null)
+			.get();
+
+		JsonNode responseObject = mapper.readTree(response);
+		Assert.assertEquals(1, responseObject.size());
+		JsonNode metricInfo = responseObject.get(0);
+		Assert.assertEquals("abc.metric2", metricInfo.get("id").asText());
+		Assert.assertEquals(10, metricInfo.get("max").asDouble(), 0.01);
+	}
+
+	@Test
+	public void testAvgAggregation() throws Exception {
+		Map<String, String> queryParams = new HashMap<>();
+		queryParams.put("get", "abc.metric2");
+		queryParams.put("agg", "avg");
+		String response = handler.handleJsonRequest(Collections.emptyMap(), queryParams, null)
+			.get();
+
+		JsonNode responseObject = mapper.readTree(response);
+		Assert.assertEquals(1, responseObject.size());
+		JsonNode metricInfo = responseObject.get(0);
+		Assert.assertEquals("abc.metric2", metricInfo.get("id").asText());
+		Assert.assertEquals(5.5, metricInfo.get("avg").asDouble(), 0.01);
+	}
+
+	@Test
+	public void testSumAggregation() throws Exception {
+		Map<String, String> queryParams = new HashMap<>();
+		queryParams.put("get", "abc.metric2");
+		queryParams.put("agg", "sum");
+		String response = handler.handleJsonRequest(Collections.emptyMap(), queryParams, null)
+			.get();
+
+		JsonNode responseObject = mapper.readTree(response);
+		Assert.assertEquals(1, responseObject.size());
+		JsonNode metricInfo = responseObject.get(0);
+		Assert.assertEquals("abc.metric2", metricInfo.get("id").asText());
+		Assert.assertEquals(11, metricInfo.get("sum").asDouble(), 0.01);
+	}
+
+	@Test
+	public void testMultipleAggregations() throws Exception {
+		Map<String, String> queryParams = new HashMap<>();
+		queryParams.put("get", "abc.metric2");
+		queryParams.put("agg", "sum,max,min,avg");
+		String response = handler.handleJsonRequest(Collections.emptyMap(), queryParams, null)
+			.get();
+
+		JsonNode array = mapper.readTree(response);
+		Assert.assertEquals(1, array.size());
+
+		FullMetricInfo mappedResponse = mapper.treeToValue(array.get(0), FullMetricInfo.class);
+		Assert.assertEquals("abc.metric2", mappedResponse.id);
+		Assert.assertEquals(11, mappedResponse.sum, 0.01);
+		Assert.assertEquals(1, mappedResponse.min, 0.01);
+		Assert.assertEquals(10, mappedResponse.max, 0.01);
+		Assert.assertEquals(5.5, mappedResponse.avg, 0.01);
+	}
+
+	@Test
+	public void testDefaultAggregations() throws Exception {
+		Map<String, String> queryParams = new HashMap<>();
+		queryParams.put("get", "abc.metric2");
+		String response = handler.handleJsonRequest(Collections.emptyMap(), queryParams, null)
+			.get();
+
+		JsonNode array = mapper.readTree(response);
+		Assert.assertEquals(1, array.size());
+
+		FullMetricInfo mappedResponse = mapper.treeToValue(array.get(0), FullMetricInfo.class);
+		Assert.assertEquals("abc.metric2", mappedResponse.id);
+		Assert.assertEquals(11, mappedResponse.sum, 0.01);
+		Assert.assertEquals(1, mappedResponse.min, 0.01);
+		Assert.assertEquals(10, mappedResponse.max, 0.01);
+		Assert.assertEquals(5.5, mappedResponse.avg, 0.01);
+	}
+
+	private static class FullMetricInfo {
+		private final String id;
+		private final double min;
+		private final double max;
+		private final double avg;
+		private final double sum;
+
+		@JsonCreator
+		private FullMetricInfo(
+			@JsonProperty("id") String id,
+			@JsonProperty("min") double min,
+			@JsonProperty("max") double max,
+			@JsonProperty("avg") double avg,
+			@JsonProperty("sum") double sum) {
+			this.id = id;
+			this.min = min;
+			this.max = max;
+			this.avg = avg;
+			this.sum = sum;
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/metrics/AbstractMetricsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/metrics/AbstractMetricsHandlerTest.java
@@ -63,6 +63,8 @@ public class AbstractMetricsHandlerTest extends TestLogger {
 		assertEquals("[" +
 				"{\"id\":\"8.opname.abc.metric6\"}," +
 				"{\"id\":\"8.opname.abc.metric7\"}," +
+				"{\"id\":\"1.opname.abc.metric6\"}," +
+				"{\"id\":\"1.opname.abc.metric7\"}," +
 				"{\"id\":\"8.abc.metric5\"}" +
 				"]",
 			availableList);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/metrics/AggregatingJobsMetricsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/metrics/AggregatingJobsMetricsHandlerTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.legacy.metrics;
+
+import org.apache.flink.runtime.concurrent.Executors;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+import org.apache.flink.runtime.webmonitor.retriever.MetricQueryServiceRetriever;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.powermock.api.mockito.PowerMockito.mock;
+
+/**
+ * Tests for the {@link AggregatingJobsMetricsHandler}.
+ */
+public class AggregatingJobsMetricsHandlerTest extends TestLogger {
+	@Test
+	public void testGetPaths() {
+		AggregatingJobsMetricsHandler handler = new AggregatingJobsMetricsHandler(Executors.directExecutor(), mock(MetricFetcher.class));
+		String[] paths = handler.getPaths();
+		assertEquals(1, paths.length);
+		assertEquals("/jobs/metrics", paths[0]);
+	}
+
+	@Test
+	public void getStores() throws Exception {
+		MetricFetcher fetcher = new MetricFetcher(
+			mock(GatewayRetriever.class),
+			mock(MetricQueryServiceRetriever.class),
+			Executors.directExecutor(),
+			TestingUtils.TIMEOUT());
+		MetricStore store = MetricStoreTest.setupStore(fetcher.getMetricStore());
+
+		AggregatingJobsMetricsHandler handler = new AggregatingJobsMetricsHandler(Executors.directExecutor(), fetcher);
+
+		Map<String, String> pathParams = new HashMap<>();
+		Map<String, String> queryParams = new HashMap<>();
+
+		Collection<? extends MetricStore.ComponentMetricStore> stores = handler.getStores(store, pathParams, queryParams);
+
+		assertEquals(2, stores.size());
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/metrics/AggregatingSubtasksMetricsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/metrics/AggregatingSubtasksMetricsHandlerTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.legacy.metrics;
+
+import org.apache.flink.runtime.concurrent.Executors;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+import org.apache.flink.runtime.webmonitor.retriever.MetricQueryServiceRetriever;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.flink.runtime.rest.handler.legacy.metrics.JobMetricsHandler.PARAMETER_JOB_ID;
+import static org.apache.flink.runtime.rest.handler.legacy.metrics.JobVertexMetricsHandler.PARAMETER_VERTEX_ID;
+import static org.junit.Assert.assertEquals;
+import static org.powermock.api.mockito.PowerMockito.mock;
+
+/**
+ * Tests for the {@link AggregatingSubtasksMetricsHandler}.
+ */
+public class AggregatingSubtasksMetricsHandlerTest extends TestLogger {
+	@Test
+	public void testGetPaths() {
+		AggregatingSubtasksMetricsHandler handler = new AggregatingSubtasksMetricsHandler(Executors.directExecutor(), mock(MetricFetcher.class));
+		String[] paths = handler.getPaths();
+		assertEquals(1, paths.length);
+		assertEquals("/jobs/:jobid/vertices/:vertexid/subtasks/metrics", paths[0]);
+	}
+
+	@Test
+	public void getStores() throws Exception {
+		MetricFetcher fetcher = new MetricFetcher(
+			mock(GatewayRetriever.class),
+			mock(MetricQueryServiceRetriever.class),
+			Executors.directExecutor(),
+			TestingUtils.TIMEOUT());
+		MetricStore store = MetricStoreTest.setupStore(fetcher.getMetricStore());
+
+		AggregatingSubtasksMetricsHandler handler = new AggregatingSubtasksMetricsHandler(Executors.directExecutor(), fetcher);
+
+		Map<String, String> pathParams = new HashMap<>();
+		pathParams.put(PARAMETER_JOB_ID, "jobid");
+		pathParams.put(PARAMETER_VERTEX_ID, "taskid");
+		Map<String, String> queryParams = new HashMap<>();
+
+		Collection<? extends MetricStore.ComponentMetricStore> stores = handler.getStores(store, pathParams, queryParams);
+
+		assertEquals(2, stores.size());
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/metrics/AggregatingTaskManagersMetricsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/metrics/AggregatingTaskManagersMetricsHandlerTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.legacy.metrics;
+
+import org.apache.flink.runtime.concurrent.Executors;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+import org.apache.flink.runtime.webmonitor.retriever.MetricQueryServiceRetriever;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.powermock.api.mockito.PowerMockito.mock;
+
+/**
+ * Tests for the {@link AggregatingTaskManagersMetricsHandler}.
+ */
+public class AggregatingTaskManagersMetricsHandlerTest extends TestLogger {
+	@Test
+	public void testGetPaths() {
+		AggregatingTaskManagersMetricsHandler handler = new AggregatingTaskManagersMetricsHandler(Executors.directExecutor(), mock(MetricFetcher.class));
+		String[] paths = handler.getPaths();
+		assertEquals(1, paths.length);
+		assertEquals("/taskmanagers/metrics", paths[0]);
+	}
+
+	@Test
+	public void getStores() throws Exception {
+		MetricFetcher fetcher = new MetricFetcher(
+			mock(GatewayRetriever.class),
+			mock(MetricQueryServiceRetriever.class),
+			Executors.directExecutor(),
+			TestingUtils.TIMEOUT());
+		MetricStore store = MetricStoreTest.setupStore(fetcher.getMetricStore());
+
+		AggregatingTaskManagersMetricsHandler handler = new AggregatingTaskManagersMetricsHandler(Executors.directExecutor(), fetcher);
+
+		Map<String, String> pathParams = new HashMap<>();
+		Map<String, String> queryParams = new HashMap<>();
+
+		Collection<? extends MetricStore.ComponentMetricStore> stores = handler.getStores(store, pathParams, queryParams);
+
+		assertEquals(2, stores.size());
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/metrics/MetricStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/metrics/MetricStoreTest.java
@@ -69,10 +69,19 @@ public class MetricStoreTest extends TestLogger {
 
 		QueryScopeInfo.TaskManagerQueryScopeInfo tm = new QueryScopeInfo.TaskManagerQueryScopeInfo("tmid", "abc");
 		MetricDump.CounterDump cd2 = new MetricDump.CounterDump(tm, "metric2", 1);
+		MetricDump.CounterDump cd2a = new MetricDump.CounterDump(tm, "metric22", 1);
+
+		QueryScopeInfo.TaskManagerQueryScopeInfo tm2 = new QueryScopeInfo.TaskManagerQueryScopeInfo("tmid2", "abc");
+		MetricDump.CounterDump cd22 = new MetricDump.CounterDump(tm2, "metric2", 10);
+		MetricDump.CounterDump cd22a = new MetricDump.CounterDump(tm2, "metric2b", 10);
 
 		QueryScopeInfo.JobQueryScopeInfo job = new QueryScopeInfo.JobQueryScopeInfo("jobid", "abc");
 		MetricDump.CounterDump cd3 = new MetricDump.CounterDump(job, "metric3", 2);
 		MetricDump.CounterDump cd4 = new MetricDump.CounterDump(job, "metric4", 3);
+
+		QueryScopeInfo.JobQueryScopeInfo job2 = new QueryScopeInfo.JobQueryScopeInfo("jobid2", "abc");
+		MetricDump.CounterDump cd32 = new MetricDump.CounterDump(job2, "metric3", 2);
+		MetricDump.CounterDump cd42 = new MetricDump.CounterDump(job2, "metric4", 3);
 
 		QueryScopeInfo.TaskQueryScopeInfo task = new QueryScopeInfo.TaskQueryScopeInfo("jobid", "taskid", 8, "abc");
 		MetricDump.CounterDump cd5 = new MetricDump.CounterDump(task, "metric5", 4);
@@ -81,13 +90,25 @@ public class MetricStoreTest extends TestLogger {
 		MetricDump.CounterDump cd6 = new MetricDump.CounterDump(operator, "metric6", 5);
 		MetricDump.CounterDump cd7 = new MetricDump.CounterDump(operator, "metric7", 6);
 
+		QueryScopeInfo.OperatorQueryScopeInfo operator2 = new QueryScopeInfo.OperatorQueryScopeInfo("jobid", "taskid", 1, "opname", "abc");
+		MetricDump.CounterDump cd62 = new MetricDump.CounterDump(operator2, "metric6", 5);
+		MetricDump.CounterDump cd72 = new MetricDump.CounterDump(operator2, "metric7", 6);
+
 		store.add(cd1);
 		store.add(cd2);
+		store.add(cd2a);
 		store.add(cd3);
 		store.add(cd4);
 		store.add(cd5);
 		store.add(cd6);
 		store.add(cd7);
+
+		store.add(cd62);
+		store.add(cd72);
+		store.add(cd22);
+		store.add(cd22a);
+		store.add(cd32);
+		store.add(cd42);
 
 		return store;
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/metrics/SubtaskMetricsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/metrics/SubtaskMetricsHandlerTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.legacy.metrics;
+
+import org.apache.flink.runtime.concurrent.Executors;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+import org.apache.flink.runtime.webmonitor.retriever.MetricQueryServiceRetriever;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.flink.runtime.rest.handler.legacy.SubtaskExecutionAttemptDetailsHandler.PARAMETER_SUBTASK_INDEX;
+import static org.apache.flink.runtime.rest.handler.legacy.metrics.JobMetricsHandler.PARAMETER_JOB_ID;
+import static org.apache.flink.runtime.rest.handler.legacy.metrics.JobVertexMetricsHandler.PARAMETER_VERTEX_ID;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.powermock.api.mockito.PowerMockito.mock;
+
+/**
+ * Tests for the {@link SubtaskMetricsHandler}.
+ */
+public class SubtaskMetricsHandlerTest extends TestLogger {
+	@Test
+	public void testGetPaths() {
+		SubtaskMetricsHandler handler = new SubtaskMetricsHandler(Executors.directExecutor(), mock(MetricFetcher.class));
+		String[] paths = handler.getPaths();
+		Assert.assertEquals(1, paths.length);
+		Assert.assertEquals("/jobs/:jobid/vertices/:vertexid/subtasks/:subtasknum/metrics", paths[0]);
+	}
+
+	@Test
+	public void getMapFor() throws Exception {
+		MetricFetcher fetcher = new MetricFetcher(
+			mock(GatewayRetriever.class),
+			mock(MetricQueryServiceRetriever.class),
+			Executors.directExecutor(),
+			TestingUtils.TIMEOUT());
+		MetricStore store = MetricStoreTest.setupStore(fetcher.getMetricStore());
+
+		SubtaskMetricsHandler handler = new SubtaskMetricsHandler(Executors.directExecutor(), fetcher);
+
+		Map<String, String> pathParams = new HashMap<>();
+		pathParams.put(PARAMETER_JOB_ID, "jobid");
+		pathParams.put(PARAMETER_VERTEX_ID, "taskid");
+		pathParams.put(PARAMETER_SUBTASK_INDEX, "8");
+
+		Map<String, String> metrics = handler.getMapFor(pathParams, store);
+
+		assertEquals("4", metrics.get("abc.metric5"));
+		assertEquals("5", metrics.get("opname.abc.metric6"));
+		assertEquals("6", metrics.get("opname.abc.metric7"));
+	}
+
+	@Test
+	public void getMapForNull() {
+		MetricFetcher fetcher = new MetricFetcher(
+			mock(GatewayRetriever.class),
+			mock(MetricQueryServiceRetriever.class),
+			Executors.directExecutor(),
+			TestingUtils.TIMEOUT());
+		MetricStore store = fetcher.getMetricStore();
+
+		SubtaskMetricsHandler handler = new SubtaskMetricsHandler(Executors.directExecutor(), fetcher);
+
+		Map<String, String> pathParams = new HashMap<>();
+
+		Map<String, String> metrics = handler.getMapFor(pathParams, store);
+
+		assertNull(metrics);
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR adds on-demand aggregation support to the metrics REST API. It allows aggregating
* taskmanagers metrics across all taskmanagers
* job metrics across all jobs
* subtask metrics across all subtasks

Task metrics can't be aggregated since we simply don't have any; all task related metrics are scoped by sutbask.

The aggregation is handled by new endpoints as described in the documentation. Additionally, a subtask metric handler was added to subsume the existing JobVertexMetricsHandler to expose subtask metrics in a more idiomatic way. The JobVertexMetricsHandler was not removed for backwards compatibility (with the webUI in particular):

## Brief change log

* fix the requests examples in the metric handler javadocs
* implement aggregation handlers
  * expose all subtask stores in TaskMetricStore for easier access
  * extend MetricStoreTest#setupMetricStore to contain metrics for multiple entities
* integrate aggregation handlers into WebRuntimeMonitor
* document the metrics REST API

## Verifying this change

This change added tests for each Aggregating*MetricsHandler and for the abstract base class (AbstractAggregatingMetricsHandlerTest).

This change can be verified manually by running multiple taskmanagers/jobs/subtasks in the cluster and querying the rest endpoints as described in the documentation.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)

