### PR TITLE
[FLINK-7914] Introduce AkkaOptions.RETRY_GATE_CLOSED_FOR

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/AkkaOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/AkkaOptions.java
@@ -139,4 +139,11 @@ public class AkkaOptions {
 	public static final ConfigOption<Boolean> JVM_EXIT_ON_FATAL_ERROR = ConfigOptions
 		.key("akka.jvm-exit-on-fatal-error")
 		.defaultValue(true);
+
+	/**
+	 * Milliseconds a gate should be closed for after a remote connection was disconnected.
+	 */
+	public static final ConfigOption<Long> RETRY_GATE_CLOSED_FOR = ConfigOptions
+		.key("akka.retry-gate-closed-for")
+		.defaultValue(50L);
 }

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
@@ -304,6 +304,8 @@ object AkkaUtils {
     val akkaEnableSSLConfig = configuration.getBoolean(AkkaOptions.SSL_ENABLED) &&
           SSLUtils.getSSLEnabled(configuration)
 
+    val retryGateClosedFor = configuration.getLong(AkkaOptions.RETRY_GATE_CLOSED_FOR)
+
     val akkaEnableSSL = if (akkaEnableSSLConfig) "on" else "off"
 
     val akkaSSLKeyStore = configuration.getString(SecurityOptions.SSL_KEYSTORE)
@@ -355,6 +357,8 @@ object AkkaUtils {
          |    }
          |
          |    log-remote-lifecycle-events = $logLifecycleEvents
+         |
+         |    retry-gate-closed-for = ${retryGateClosedFor + " ms"}
          |  }
          |}
        """.stripMargin

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/jobmanager/JobManagerFailsITCase.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/jobmanager/JobManagerFailsITCase.scala
@@ -20,15 +20,15 @@ package org.apache.flink.api.scala.runtime.jobmanager
 
 import akka.actor.ActorSystem
 import akka.testkit.{ImplicitSender, TestKit}
-import org.apache.flink.configuration.{ConfigConstants, Configuration}
+import org.apache.flink.configuration.{ConfigConstants, Configuration, JobManagerOptions}
 import org.apache.flink.runtime.akka.{AkkaUtils, ListeningBehaviour}
 import org.apache.flink.runtime.jobgraph.{JobGraph, JobVertex}
-import org.apache.flink.runtime.testtasks.{BlockingNoOpInvokable, NoOpInvokable}
 import org.apache.flink.runtime.messages.Acknowledge
 import org.apache.flink.runtime.messages.JobManagerMessages._
 import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages.NotifyWhenAtLeastNumTaskManagerAreRegistered
 import org.apache.flink.runtime.testingUtils.TestingMessages.DisableDisconnect
 import org.apache.flink.runtime.testingUtils.{ScalaTestingUtils, TestingCluster, TestingUtils}
+import org.apache.flink.runtime.testtasks.{BlockingNoOpInvokable, NoOpInvokable}
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
@@ -51,7 +51,7 @@ class JobManagerFailsITCase(_system: ActorSystem)
   "A TaskManager" should {
     "detect a lost connection to the JobManager and try to reconnect to it" in {
 
-      val num_slots = 13
+      val num_slots = 4
       val cluster = startDeathwatchCluster(num_slots, 1)
 
       try {
@@ -83,7 +83,7 @@ class JobManagerFailsITCase(_system: ActorSystem)
     }
 
     "go into a clean state in case of a JobManager failure" in {
-      val num_slots = 36
+      val num_slots = 4
 
       val sender = new JobVertex("BlockingSender")
       sender.setParallelism(num_slots)
@@ -135,6 +135,9 @@ class JobManagerFailsITCase(_system: ActorSystem)
     val config = new Configuration()
     config.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, numSlots)
     config.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, numTaskmanagers)
+    config.setInteger(JobManagerOptions.PORT, 0)
+    config.setString(ConfigConstants.TASK_MANAGER_INITIAL_REGISTRATION_PAUSE, "50 ms")
+    config.setString(ConfigConstants.TASK_MANAGER_MAX_REGISTARTION_PAUSE, "100 ms")
 
     val cluster = new TestingCluster(config, singleActorSystem = false)
 


### PR DESCRIPTION
## What is the purpose of the change

The AkkaOptions.RETRY_GATE_CLOSED_FOR allows to configure how long a remote
ActorSystem is gated in case of a connection loss. The default value is set
to 50 ms.

## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

