### PR TITLE
[hotfix] reorder the methods so they conform to their order in the interface

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/KeyedProcessOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/KeyedProcessOperator.java
@@ -127,7 +127,7 @@ public class KeyedProcessOperator<K, IN, OUT>
 			if (outputTag == null) {
 				throw new IllegalArgumentException("OutputTag must not be null.");
 			}
-			
+
 			output.collect(outputTag, new StreamRecord<>(value, element.getTimestamp()));
 		}
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/KeyedProcessOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/KeyedProcessOperator.java
@@ -127,6 +127,7 @@ public class KeyedProcessOperator<K, IN, OUT>
 			if (outputTag == null) {
 				throw new IllegalArgumentException("OutputTag must not be null.");
 			}
+			
 			output.collect(outputTag, new StreamRecord<>(value, element.getTimestamp()));
 		}
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/KeyedProcessOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/KeyedProcessOperator.java
@@ -118,16 +118,16 @@ public class KeyedProcessOperator<K, IN, OUT>
 		}
 
 		@Override
+		public TimerService timerService() {
+			return timerService;
+		}
+
+		@Override
 		public <X> void output(OutputTag<X> outputTag, X value) {
 			if (outputTag == null) {
 				throw new IllegalArgumentException("OutputTag must not be null.");
 			}
 			output.collect(outputTag, new StreamRecord<>(value, element.getTimestamp()));
-		}
-
-		@Override
-		public TimerService timerService() {
-			return timerService;
 		}
 	}
 
@@ -145,15 +145,14 @@ public class KeyedProcessOperator<K, IN, OUT>
 		}
 
 		@Override
-		public TimeDomain timeDomain() {
-			checkState(timeDomain != null);
-			return timeDomain;
-		}
-
-		@Override
 		public Long timestamp() {
 			checkState(timer != null);
 			return timer.getTimestamp();
+		}
+
+		@Override
+		public TimerService timerService() {
+			return timerService;
 		}
 
 		@Override
@@ -166,8 +165,9 @@ public class KeyedProcessOperator<K, IN, OUT>
 		}
 
 		@Override
-		public TimerService timerService() {
-			return timerService;
+		public TimeDomain timeDomain() {
+			checkState(timeDomain != null);
+			return timeDomain;
 		}
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/co/KeyedCoProcessOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/co/KeyedCoProcessOperator.java
@@ -162,12 +162,6 @@ public class KeyedCoProcessOperator<K, IN1, IN2, OUT>
 		}
 
 		@Override
-		public TimeDomain timeDomain() {
-			checkState(timeDomain != null);
-			return timeDomain;
-		}
-
-		@Override
 		public Long timestamp() {
 			checkState(timer != null);
 			return timer.getTimestamp();
@@ -185,6 +179,12 @@ public class KeyedCoProcessOperator<K, IN1, IN2, OUT>
 			}
 
 			output.collect(outputTag, new StreamRecord<>(value, timer.getTimestamp()));
+		}
+
+		@Override
+		public TimeDomain timeDomain() {
+			checkState(timeDomain != null);
+			return timeDomain;
 		}
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

As discussed with @aljoscha in https://github.com/apache/flink/pull/4881, I'm moving those unmerged changes to this PR. The purpose is to reorder the impl methods so they conform to their order in the interface

## Brief change log

- reorder the impl methods 

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

none

## Documentation

none