### PR TITLE
[FLINK-5823] [checkpoints] State Backends also handle Checkpoint Metadata (part 1)

### DIFF
--- a/docs/dev/types_serialization.md
+++ b/docs/dev/types_serialization.md
@@ -38,7 +38,7 @@ Think about it like a database that infers the schema of tables. In most cases, 
 by itself. Having the type information allows Flink to do some cool things:
 
 * Using POJOs types and grouping / joining / aggregating them by referring to field names (like `dataSet.keyBy("username")`).
-  The type information allows Flink to check (for typos and type compatibility) early rather than failing later ar runtime.
+  The type information allows Flink to check (for typos and type compatibility) early rather than failing later at runtime.
 
 * The more Flink knows about data types, the better the serialization and data layout schemes are.
   That is quite important for the memory usage paradigm in Flink (work on serialized data inside/outside the heap where ever possible
@@ -330,7 +330,7 @@ Type information factories can be used in both the Java and Scala API.
 
 In a hierarchy of types the closest factory 
 will be chosen while traversing upwards, however, a built-in factory has highest precedence. A factory has 
-also higher precendence than Flink's built-in types, therefore you should know what you are doing.
+also higher precedence than Flink's built-in types, therefore you should know what you are doing.
 
 The following example shows how to annotate a custom type `MyTuple` and supply custom type information for it using a factory in Java.
 

--- a/docs/ops/deployment/aws.md
+++ b/docs/ops/deployment/aws.md
@@ -55,7 +55,7 @@ when creating an EMR cluster.
 
 After creating your cluster, you can [connect to the master node](http://docs.aws.amazon.com/ElasticMapReduce/latest/ManagementGuide/emr-connect-master-node.html) and install Flink:
 
-1. Go the [Downloads Page]({{ download_url}}) and **download a binary version of Flink matching the Hadoop version** of your EMR cluster, e.g. Hadoop 2.7 for EMR releases 4.3.0, 4.4.0, or 4.5.0.
+1. Go the [Downloads Page]({{ site.download_url }}) and **download a binary version of Flink matching the Hadoop version** of your EMR cluster, e.g. Hadoop 2.7 for EMR releases 4.3.0, 4.4.0, or 4.5.0.
 2. Extract the Flink distribution and you are ready to deploy [Flink jobs via YARN](yarn_setup.html) after **setting the Hadoop config directory**:
 
 ```bash

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
@@ -19,7 +19,7 @@
 package org.apache.flink.client.cli;
 
 import org.apache.flink.client.CliFrontend;
-import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.configuration.CheckpointingOptions;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
@@ -27,6 +27,7 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -94,7 +95,7 @@ public class CliFrontendParser {
 	static final Option CANCEL_WITH_SAVEPOINT_OPTION = new Option(
 			"s", "withSavepoint", true, "Trigger savepoint and cancel job. The target " +
 			"directory is optional. If no directory is specified, the configured default " +
-			"directory (" + CoreOptions.SAVEPOINT_DIRECTORY.key() + ") is used.");
+			"directory (" + CheckpointingOptions.SAVEPOINT_DIRECTORY.key() + ") is used.");
 
 	static {
 		HELP_OPTION.setRequired(false);

--- a/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/RollingSinkSecuredITCase.java
+++ b/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/RollingSinkSecuredITCase.java
@@ -18,9 +18,9 @@
 
 package org.apache.flink.streaming.connectors.fs;
 
+import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.runtime.security.SecurityConfiguration;
@@ -222,7 +222,7 @@ public class RollingSinkSecuredITCase extends RollingSinkITCase {
 			config.setBoolean(ConfigConstants.LOCAL_START_WEBSERVER, false);
 			config.setInteger(ConfigConstants.LOCAL_NUMBER_JOB_MANAGER, 3);
 			config.setString(HighAvailabilityOptions.HA_MODE, "zookeeper");
-			config.setString(CoreOptions.STATE_BACKEND, "filesystem");
+			config.setString(CheckpointingOptions.STATE_BACKEND, "filesystem");
 			config.setString(HighAvailabilityOptions.HA_ZOOKEEPER_CHECKPOINTS_PATH, hdfsURI + "/flink/checkpoints");
 			config.setString(HighAvailabilityOptions.HA_STORAGE_PATH, hdfsURI + "/flink/recovery");
 			config.setString("state.backend.fs.checkpointdir", hdfsURI + "/flink/checkpoints");

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
@@ -36,8 +36,11 @@ import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.DBOptions;
 import org.rocksdb.NativeLibraryLoader;
 import org.rocksdb.RocksDB;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
 
 import java.io.File;
 import java.io.IOException;
@@ -49,7 +52,7 @@ import java.util.List;
 import java.util.Random;
 import java.util.UUID;
 
-import static java.util.Objects.requireNonNull;
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * A State Backend that stores its state in {@code RocksDB}. This state backend can
@@ -76,42 +79,40 @@ public class RocksDBStateBackend extends AbstractStateBackend {
 	private static boolean rocksDbInitialized = false;
 
 	// ------------------------------------------------------------------------
-	//  Static configuration values
-	// ------------------------------------------------------------------------
+
+	// -- configuration values, set in the application / configuration
 
 	/** The state backend that we use for creating checkpoint streams. */
 	private final AbstractStateBackend checkpointStreamBackend;
 
-	/** Operator identifier that is used to uniqueify the RocksDB storage path. */
-	private String operatorIdentifier;
-
-	/** JobID for uniquifying backup paths. */
-	private JobID jobId;
-
-	// DB storage directories
-
 	/** Base paths for RocksDB directory, as configured. May be null. */
-	private Path[] configuredDbBasePaths;
-
-	/** Base paths for RocksDB directory, as initialized. */
-	private File[] initializedDbBasePaths;
-
-	private int nextDirectory;
-
-	// RocksDB options
+	@Nullable
+	private Path[] localRocksDbDirectories;
 
 	/** The pre-configured option settings. */
 	private PredefinedOptions predefinedOptions = PredefinedOptions.DEFAULT;
 
 	/** The options factory to create the RocksDB options in the cluster. */
+	@Nullable
 	private OptionsFactory optionsFactory;
-
-	/** Whether we already lazily initialized our local storage directories. */
-	private transient boolean isInitialized = false;
 
 	/** True if incremental checkpointing is enabled. */
 	private boolean enableIncrementalCheckpointing;
 
+	// -- runtime values, set on TaskManager when initializing / using the backend
+
+	/** Base paths for RocksDB directory, as initialized. */
+	private transient File[] initializedDbBasePaths;
+
+	/** JobID for uniquifying backup paths. */
+	private transient JobID jobId;
+
+	private transient int nextDirectory;
+	
+	/** Whether we already lazily initialized our local storage directories. */
+	private transient boolean isInitialized;
+
+	// ------------------------------------------------------------------------
 
 	/**
 	 * Creates a new {@code RocksDBStateBackend} that stores its checkpoint data in the
@@ -190,7 +191,7 @@ public class RocksDBStateBackend extends AbstractStateBackend {
 	 * @param checkpointStreamBackend The backend to store the
 	 */
 	public RocksDBStateBackend(AbstractStateBackend checkpointStreamBackend) {
-		this.checkpointStreamBackend = requireNonNull(checkpointStreamBackend);
+		this.checkpointStreamBackend = checkNotNull(checkpointStreamBackend);
 	}
 
 	/**
@@ -205,7 +206,7 @@ public class RocksDBStateBackend extends AbstractStateBackend {
 	 * @param enableIncrementalCheckpointing True if incremental checkponting is enabled
 	 */
 	public RocksDBStateBackend(AbstractStateBackend checkpointStreamBackend, boolean enableIncrementalCheckpointing) {
-		this.checkpointStreamBackend = requireNonNull(checkpointStreamBackend);
+		this.checkpointStreamBackend = checkNotNull(checkpointStreamBackend);
 		this.enableIncrementalCheckpointing = enableIncrementalCheckpointing;
 	}
 
@@ -221,19 +222,18 @@ public class RocksDBStateBackend extends AbstractStateBackend {
 			return;
 		}
 
-		this.operatorIdentifier = operatorIdentifier.replace(" ", "");
 		this.jobId = env.getJobID();
 
 		// initialize the paths where the local RocksDB files should be stored
-		if (configuredDbBasePaths == null) {
+		if (localRocksDbDirectories == null) {
 			// initialize from the temp directories
 			initializedDbBasePaths = env.getIOManager().getSpillingDirectories();
 		}
 		else {
-			List<File> dirs = new ArrayList<>(configuredDbBasePaths.length);
+			List<File> dirs = new ArrayList<>(localRocksDbDirectories.length);
 			String errorMessage = "";
 
-			for (Path path : configuredDbBasePaths) {
+			for (Path path : localRocksDbDirectories) {
 				File f = new File(path.toUri().getPath());
 				File testDir = new File(f, UUID.randomUUID().toString());
 				if (!testDir.mkdirs()) {
@@ -244,6 +244,7 @@ public class RocksDBStateBackend extends AbstractStateBackend {
 				} else {
 					dirs.add(f);
 				}
+				//noinspection ResultOfMethodCallIgnored
 				testDir.delete();
 			}
 
@@ -349,7 +350,7 @@ public class RocksDBStateBackend extends AbstractStateBackend {
 	 */
 	public void setDbStoragePaths(String... paths) {
 		if (paths == null) {
-			configuredDbBasePaths = null;
+			localRocksDbDirectories = null;
 		}
 		else if (paths.length == 0) {
 			throw new IllegalArgumentException("empty paths");
@@ -369,7 +370,7 @@ public class RocksDBStateBackend extends AbstractStateBackend {
 				}
 			}
 
-			configuredDbBasePaths = pp;
+			localRocksDbDirectories = pp;
 		}
 	}
 
@@ -378,12 +379,12 @@ public class RocksDBStateBackend extends AbstractStateBackend {
 	 * @return The configured DB storage paths, or null, if none were configured.
 	 */
 	public String[] getDbStoragePaths() {
-		if (configuredDbBasePaths == null) {
+		if (localRocksDbDirectories == null) {
 			return null;
 		} else {
-			String[] paths = new String[configuredDbBasePaths.length];
+			String[] paths = new String[localRocksDbDirectories.length];
 			for (int i = 0; i < paths.length; i++) {
-				paths[i] = configuredDbBasePaths[i].toString();
+				paths[i] = localRocksDbDirectories[i].toString();
 			}
 			return paths;
 		}
@@ -403,7 +404,7 @@ public class RocksDBStateBackend extends AbstractStateBackend {
 	 * @param options The options to set (must not be null).
 	 */
 	public void setPredefinedOptions(PredefinedOptions options) {
-		predefinedOptions = requireNonNull(options);
+		predefinedOptions = checkNotNull(options);
 	}
 
 	/**
@@ -496,7 +497,7 @@ public class RocksDBStateBackend extends AbstractStateBackend {
 	public String toString() {
 		return "RocksDB State Backend {" +
 			"isInitialized=" + isInitialized +
-			", configuredDbBasePaths=" + Arrays.toString(configuredDbBasePaths) +
+			", configuredDbBasePaths=" + Arrays.toString(localRocksDbDirectories) +
 			", initializedDbBasePaths=" + Arrays.toString(initializedDbBasePaths) +
 			", checkpointStreamBackend=" + checkpointStreamBackend +
 			'}';

--- a/flink-contrib/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBAsyncSnapshotTest.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBAsyncSnapshotTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.api.common.typeutils.base.VoidSerializer;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
@@ -61,9 +62,6 @@ import org.apache.flink.util.TestLogger;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.File;
 import java.io.IOException;
@@ -90,8 +88,6 @@ import static org.mockito.Mockito.verify;
 /**
  * Tests for asynchronous RocksDB Key/Value state checkpoints.
  */
-@RunWith(PowerMockRunner.class)
-@PowerMockIgnore({"javax.management.*", "com.sun.jndi.*", "org.apache.log4j.*"})
 @SuppressWarnings("serial")
 public class RocksDBAsyncSnapshotTest extends TestLogger {
 
@@ -405,6 +401,12 @@ public class RocksDBAsyncSnapshotTest extends TestLogger {
 		@Override
 		public CheckpointStreamFactory createStreamFactory(JobID jobId, String operatorIdentifier) throws IOException {
 			return blockerCheckpointStreamFactory;
+		}
+
+		@Override
+		public BlockingStreamMemoryStateBackend configure(Configuration config) {
+			// retain this instance, no re-configuration!
+			return this;
 		}
 	}
 

--- a/flink-contrib/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendFactoryTest.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendFactoryTest.java
@@ -18,14 +18,38 @@
 
 package org.apache.flink.contrib.streaming.state;
 
+import org.apache.flink.configuration.CheckpointingOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.runtime.state.StateBackendLoader;
+import org.apache.flink.runtime.state.filesystem.AbstractFileStateBackend;
+
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.HashSet;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for the RocksDBStateBackendFactory.
  */
 public class RocksDBStateBackendFactoryTest {
+
+	@Rule
+	public final TemporaryFolder tmp = new TemporaryFolder();
+
+	private final ClassLoader cl = getClass().getClassLoader();
+
+	private final String backendKey = CheckpointingOptions.STATE_BACKEND.key();
+
+	// ------------------------------------------------------------------------
 
 	@Test
 	public void testFactoryName() {
@@ -33,7 +57,120 @@ public class RocksDBStateBackendFactoryTest {
 		String factoryName = "org.apache.flink.contrib.streaming.state.Roc";
 		factoryName += "ksDBStateBackendFactory";
 
-		// !!! if this fails, the code in StreamTask.createStateBackend() must be adjusted
+		// !!! if this fails, the code in StateBackendLoader must be adjusted
 		assertEquals(factoryName, RocksDBStateBackendFactory.class.getName());
+	}
+
+	/**
+	 * Validates loading a file system state backend with additional parameters from the cluster configuration.
+	 */
+	@Test
+	public void testLoadFileSystemStateBackend() throws Exception {
+		final String checkpointDir = new Path(tmp.newFolder().toURI()).toString();
+		final String savepointDir = new Path(tmp.newFolder().toURI()).toString();
+		final String localDir1 = tmp.newFolder().getAbsolutePath();
+		final String localDir2 = tmp.newFolder().getAbsolutePath();
+		final String localDirs = localDir1 + File.pathSeparator + localDir2;
+		final boolean incremental = !CheckpointingOptions.ROCKSDB_INCREMENTAL_CHECKPOINTS.defaultValue();
+
+		final Path expectedCheckpointsPath = new Path(checkpointDir);
+		final Path expectedSavepointsPath = new Path(savepointDir);
+
+		// we configure with the explicit string (rather than AbstractStateBackend#X_STATE_BACKEND_NAME)
+		// to guard against config-breaking changes of the name
+		final Configuration config1 = new Configuration();
+		config1.setString(backendKey, "rocksdb");
+		config1.setString(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir);
+		config1.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir);
+		config1.setString(CheckpointingOptions.ROCKSDB_LOCAL_DIRECTORIES, localDirs);
+		config1.setBoolean(CheckpointingOptions.ROCKSDB_INCREMENTAL_CHECKPOINTS, incremental);
+
+		final Configuration config2 = new Configuration();
+		config2.setString(backendKey, RocksDBStateBackendFactory.class.getName());
+		config2.setString(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir);
+		config2.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir);
+		config2.setString(CheckpointingOptions.ROCKSDB_LOCAL_DIRECTORIES, localDirs);
+		config2.setBoolean(CheckpointingOptions.ROCKSDB_INCREMENTAL_CHECKPOINTS, incremental);
+
+		StateBackend backend1 = StateBackendLoader.loadStateBackendFromConfig(config1, cl, null);
+		StateBackend backend2 = StateBackendLoader.loadStateBackendFromConfig(config2, cl, null);
+
+		assertTrue(backend1 instanceof RocksDBStateBackend);
+		assertTrue(backend2 instanceof RocksDBStateBackend);
+
+		RocksDBStateBackend fs1 = (RocksDBStateBackend) backend1;
+		RocksDBStateBackend fs2 = (RocksDBStateBackend) backend2;
+
+		AbstractFileStateBackend fs1back = (AbstractFileStateBackend) fs1.getCheckpointBackend();
+		AbstractFileStateBackend fs2back = (AbstractFileStateBackend) fs2.getCheckpointBackend();
+
+		assertEquals(expectedCheckpointsPath, fs1back.getCheckpointPath());
+		assertEquals(expectedCheckpointsPath, fs2back.getCheckpointPath());
+		assertEquals(expectedSavepointsPath, fs1back.getSavepointPath());
+		assertEquals(expectedSavepointsPath, fs2back.getSavepointPath());
+		assertEquals(incremental, fs1.isIncrementalCheckpointsEnabled());
+		assertEquals(incremental, fs2.isIncrementalCheckpointsEnabled());
+		checkPaths(fs1.getDbStoragePaths(), localDir1, localDir2);
+		checkPaths(fs2.getDbStoragePaths(), localDir1, localDir2);
+	}
+
+	/**
+	 * Validates taking the application-defined file system state backend and adding with additional
+	 * parameters from the cluster configuration, but giving precedence to application-defined
+	 * parameters over configuration-defined parameters.
+	 */
+	@Test
+	public void testLoadFileSystemStateBackendMixed() throws Exception {
+		final String appCheckpointDir = new Path(tmp.newFolder().toURI()).toString();
+		final String checkpointDir = new Path(tmp.newFolder().toURI()).toString();
+		final String savepointDir = new Path(tmp.newFolder().toURI()).toString();
+
+		final String localDir1 = tmp.newFolder().getAbsolutePath();
+		final String localDir2 = tmp.newFolder().getAbsolutePath();
+		final String localDir3 = tmp.newFolder().getAbsolutePath();
+		final String localDir4 = tmp.newFolder().getAbsolutePath();
+
+		final boolean incremental = !CheckpointingOptions.ROCKSDB_INCREMENTAL_CHECKPOINTS.defaultValue();
+
+		final Path expectedCheckpointsPath = new Path(appCheckpointDir);
+		final Path expectedSavepointsPath = new Path(savepointDir);
+
+		final RocksDBStateBackend backend = new RocksDBStateBackend(appCheckpointDir, incremental);
+		backend.setDbStoragePaths(localDir1, localDir2);
+
+		final Configuration config = new Configuration();
+		config.setString(backendKey, "jobmanager"); // this should not be picked up
+		config.setString(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir); // this should not be picked up
+		config.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir);
+		config.setBoolean(CheckpointingOptions.ROCKSDB_INCREMENTAL_CHECKPOINTS, !incremental);  // this should not be picked up
+		config.setString(CheckpointingOptions.ROCKSDB_LOCAL_DIRECTORIES, localDir3 + ":" + localDir4);  // this should not be picked up
+
+		final StateBackend loadedBackend =
+				StateBackendLoader.fromApplicationOrConfigOrDefault(backend, config, cl, null);
+		assertTrue(loadedBackend instanceof RocksDBStateBackend);
+
+		final RocksDBStateBackend loadedRocks = (RocksDBStateBackend) loadedBackend;
+
+		assertEquals(incremental, loadedRocks.isIncrementalCheckpointsEnabled());
+		checkPaths(loadedRocks.getDbStoragePaths(), localDir1, localDir2);
+
+		AbstractFileStateBackend fsBackend = (AbstractFileStateBackend) loadedRocks.getCheckpointBackend();
+		assertEquals(expectedCheckpointsPath, fsBackend.getCheckpointPath());
+		assertEquals(expectedSavepointsPath, fsBackend.getSavepointPath());
+	}
+
+	// ------------------------------------------------------------------------
+
+	private static void checkPaths(String[] pathsArray, String... paths) {
+		assertNotNull(pathsArray);
+		assertNotNull(paths);
+
+		assertEquals(pathsArray.length, paths.length);
+
+		HashSet<String> pathsSet = new HashSet<>(Arrays.asList(pathsArray));
+
+		for (String path : paths) {
+			assertTrue(pathsSet.contains(path));
+		}
 	}
 }

--- a/flink-contrib/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendTest.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendTest.java
@@ -110,10 +110,10 @@ public class RocksDBStateBackendTest extends StateBackendTestBase<RocksDBStateBa
 	public boolean enableIncrementalCheckpointing;
 
 	@Rule
-	public TemporaryFolder tempFolder = new TemporaryFolder();
+	public final TemporaryFolder tempFolder = new TemporaryFolder();
 
 	// Store it because we need it for the cleanup test.
-	String dbPath;
+	private String dbPath;
 
 	@Override
 	protected RocksDBStateBackend getStateBackend() throws IOException {

--- a/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.configuration;
+
+/**
+ * A collection of all configuration options that relate to checkpoints
+ * and savepoints.
+ */
+public class CheckpointingOptions {
+
+	// ------------------------------------------------------------------------
+	//  general checkpoint and state backend options
+	// ------------------------------------------------------------------------
+
+	public static final ConfigOption<String> STATE_BACKEND = ConfigOptions
+			.key("state.backend")
+			.noDefaultValue();
+
+	/** The maximum number of completed checkpoint instances to retain.*/
+	public static final ConfigOption<Integer> MAX_RETAINED_CHECKPOINTS = ConfigOptions
+			.key("state.checkpoints.num-retained")
+			.defaultValue(1);
+
+	// ------------------------------------------------------------------------
+	//  Options specific to the file-system-based state backends
+	// ------------------------------------------------------------------------
+
+	/** The default directory for savepoints. Used by the state backends that write
+	 * savepoints to file systems (MemoryStateBackend, FsStateBackend, RocksDBStateBackend). */
+	public static final ConfigOption<String> SAVEPOINT_DIRECTORY = ConfigOptions
+			.key("state.savepoints.dir")
+			.noDefaultValue()
+			.withDeprecatedKeys("savepoints.state.backend.fs.dir");
+
+	/** The default directory used for checkpoints. Used by the state backends that write
+	 * checkpoints to file systems (MemoryStateBackend, FsStateBackend, RocksDBStateBackend). */
+	public static final ConfigOption<String> CHECKPOINTS_DIRECTORY = ConfigOptions
+			.key("state.checkpoints.dir")
+			.noDefaultValue();
+
+	/** Option whether the heap-based key/value data structures should use an asynchronous
+	 * snapshot method. Used by MemoryStateBackend and FsStateBackend. */
+	public static final ConfigOption<Boolean> HEAP_KV_ASYNC_SNAPSHOTS = ConfigOptions
+			.key("state.backend.heap.async")
+			.defaultValue(false);
+
+	/** The minimum size of state data files. All state chunks smaller than that
+	 * are stored inline in the root checkpoint metadata file. */
+	public static final ConfigOption<Integer> FS_SMALL_FILE_THRESHOLD = ConfigOptions
+			.key("state.backend.fs.memory-threshold")
+			.defaultValue(1024);
+}

--- a/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
@@ -65,4 +65,17 @@ public class CheckpointingOptions {
 	public static final ConfigOption<Integer> FS_SMALL_FILE_THRESHOLD = ConfigOptions
 			.key("state.backend.fs.memory-threshold")
 			.defaultValue(1024);
+
+	/** The minimum size of state data files. All state chunks smaller than that
+	 * are stored inline in the root checkpoint metadata file. */
+	public static final ConfigOption<String> ROCKSDB_LOCAL_DIRECTORIES = ConfigOptions
+			.key("state.backend.rocksdb.localdir")
+			.noDefaultValue()
+			.withDeprecatedKeys("state.backend.rocksdb.checkpointdir");
+
+	/** The minimum size of state data files. All state chunks smaller than that
+	 * are stored inline in the root checkpoint metadata file. */
+	public static final ConfigOption<Boolean> ROCKSDB_INCREMENTAL_CHECKPOINTS = ConfigOptions
+			.key("state.backend.rocksdb.incremental")
+			.defaultValue(false);
 }

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -651,7 +651,7 @@ public final class ConfigConstants {
 	/**
 	 * The port for the runtime monitor web-frontend server.
 	 *
-	 * @deprecated Use {@link JobManagerOptions#WEB_PORT} instead.
+	 * @deprecated Use {@link WebOptions#PORT} instead.
 	 */
 	@Deprecated
 	public static final String JOB_MANAGER_WEB_PORT_KEY = "jobmanager.web.port";
@@ -659,7 +659,7 @@ public final class ConfigConstants {
 	/**
 	 * Config parameter to override SSL support for the JobManager Web UI
 	 *
-	 * @deprecated Use {@link JobManagerOptions#WEB_SSL_ENABLED} instead.
+	 * @deprecated Use {@link WebOptions#SSL_ENABLED} instead.
 	 */
 	@Deprecated
 	public static final String JOB_MANAGER_WEB_SSL_ENABLED = "jobmanager.web.ssl.enabled";
@@ -667,7 +667,7 @@ public final class ConfigConstants {
 	/**
 	 * The config parameter defining the flink web directory to be used by the webmonitor.
 	 *
-	 * @deprecated Use {@link JobManagerOptions#WEB_TMP_DIR} instead.
+	 * @deprecated Use {@link WebOptions#TMP_DIR} instead.
 	 */
 	@Deprecated
 	public static final String JOB_MANAGER_WEB_TMPDIR_KEY = "jobmanager.web.tmpdir";
@@ -676,7 +676,7 @@ public final class ConfigConstants {
 	 * The config parameter defining the directory for uploading the job jars. If not specified a dynamic directory
 	 * will be used under the directory specified by JOB_MANAGER_WEB_TMPDIR_KEY.
 	 *
-	 * @deprecated Use {@link JobManagerOptions#WEB_UPLOAD_DIR} instead.
+	 * @deprecated Use {@link WebOptions#UPLOAD_DIR} instead.
 	 */
 	@Deprecated
 	public static final String JOB_MANAGER_WEB_UPLOAD_DIR_KEY = "jobmanager.web.upload.dir";
@@ -684,7 +684,7 @@ public final class ConfigConstants {
 	/**
 	 * The config parameter defining the number of archived jobs for the jobmanager
 	 *
-	 * @deprecated Use {@link JobManagerOptions#WEB_ARCHIVE_COUNT} instead.
+	 * @deprecated Use {@link WebOptions#ARCHIVE_COUNT} instead.
 	 */
 	@Deprecated
 	public static final String JOB_MANAGER_WEB_ARCHIVE_COUNT = "jobmanager.web.history";
@@ -692,7 +692,7 @@ public final class ConfigConstants {
 	/**
 	 * The log file location (may be in /log for standalone but under log directory when using YARN)
 	 *
-	 * @deprecated Use {@link JobManagerOptions#WEB_LOG_PATH} instead.
+	 * @deprecated Use {@link WebOptions#LOG_PATH} instead.
 	 */
 	@Deprecated
 	public static final String JOB_MANAGER_WEB_LOG_PATH_KEY = "jobmanager.web.log.path";
@@ -700,7 +700,7 @@ public final class ConfigConstants {
 	/**
 	 * Config parameter indicating whether jobs can be uploaded and run from the web-frontend.
 	 *
-	 * @deprecated Use {@link JobManagerOptions#WEB_SUBMIT_ENABLE} instead.
+	 * @deprecated Use {@link WebOptions#SUBMIT_ENABLE} instead.
 	 */
 	@Deprecated
 	public static final String JOB_MANAGER_WEB_SUBMIT_ENABLED_KEY = "jobmanager.web.submit.enable";
@@ -716,7 +716,7 @@ public final class ConfigConstants {
 	/**
 	 * Config parameter defining the number of checkpoints to remember for recent history.
 	 *
-	 * @deprecated Use {@link JobManagerOptions#WEB_CHECKPOINTS_HISTORY_SIZE} instead.
+	 * @deprecated Use {@link WebOptions#CHECKPOINTS_HISTORY_SIZE} instead.
 	 */
 	@Deprecated
 	public static final String JOB_MANAGER_WEB_CHECKPOINTS_HISTORY_SIZE = "jobmanager.web.checkpoints.history";
@@ -724,7 +724,7 @@ public final class ConfigConstants {
 	/**
 	 * Time after which cached stats are cleaned up if not accessed.
 	 *
-	 * @deprecated Use {@link JobManagerOptions#WEB_BACKPRESSURE_CLEANUP_INTERVAL} instead.
+	 * @deprecated Use {@link WebOptions#BACKPRESSURE_CLEANUP_INTERVAL} instead.
 	 */
 	@Deprecated
 	public static final String JOB_MANAGER_WEB_BACK_PRESSURE_CLEAN_UP_INTERVAL = "jobmanager.web.backpressure.cleanup-interval";
@@ -732,7 +732,7 @@ public final class ConfigConstants {
 	/**
 	 * Time after which available stats are deprecated and need to be refreshed (by resampling).
 	 *
-	 * @deprecated Use {@link JobManagerOptions#WEB_BACKPRESSURE_REFRESH_INTERVAL} instead.
+	 * @deprecated Use {@link WebOptions#BACKPRESSURE_REFRESH_INTERVAL} instead.
 	 */
 	@Deprecated
 	public static final String JOB_MANAGER_WEB_BACK_PRESSURE_REFRESH_INTERVAL = "jobmanager.web.backpressure.refresh-interval";
@@ -740,7 +740,7 @@ public final class ConfigConstants {
 	/**
 	 * Number of stack trace samples to take to determine back pressure.
 	 *
-	 * @deprecated Use {@link JobManagerOptions#WEB_BACKPRESSURE_NUM_SAMPLES} instead.
+	 * @deprecated Use {@link WebOptions#BACKPRESSURE_NUM_SAMPLES} instead.
 	 */
 	@Deprecated
 	public static final String JOB_MANAGER_WEB_BACK_PRESSURE_NUM_SAMPLES = "jobmanager.web.backpressure.num-samples";
@@ -748,7 +748,7 @@ public final class ConfigConstants {
 	/**
 	 * Delay between stack trace samples to determine back pressure.
 	 *
-	 * @deprecated Use {@link JobManagerOptions#WEB_BACKPRESSURE_DELAY} instead.
+	 * @deprecated Use {@link WebOptions#BACKPRESSURE_DELAY} instead.
 	 */
 	@Deprecated
 	public static final String JOB_MANAGER_WEB_BACK_PRESSURE_DELAY = "jobmanager.web.backpressure.delay-between-samples";
@@ -944,7 +944,7 @@ public final class ConfigConstants {
 	/**
 	 * State backend for checkpoints
 	 * 
-	 * @deprecated Use {@link CoreOptions#STATE_BACKEND} instead.
+	 * @deprecated Use {@link CheckpointingOptions#STATE_BACKEND} instead.
 	 */
 	@Deprecated
 	public static final String STATE_BACKEND = "state.backend";
@@ -1214,7 +1214,7 @@ public final class ConfigConstants {
 
 	/**
 	 * The default directory for savepoints.
-	 * @deprecated Use {@link CoreOptions#SAVEPOINT_DIRECTORY} instead.
+	 * @deprecated Use {@link CheckpointingOptions#SAVEPOINT_DIRECTORY} instead.
 	 */
 	@PublicEvolving
 	@Deprecated
@@ -1222,7 +1222,7 @@ public final class ConfigConstants {
 
 	/**
 	 * The default directory used for persistent checkpoints.
-	 * @deprecated Use {@link CoreOptions#CHECKPOINTS_DIRECTORY} instead.
+	 * @deprecated Use {@link CheckpointingOptions#CHECKPOINTS_DIRECTORY} instead.
 	 */
 	@PublicEvolving
 	@Deprecated
@@ -1231,7 +1231,7 @@ public final class ConfigConstants {
 	/**
 	 * @deprecated This key was used in Flink versions <= 1.1.X with the savepoint backend
 	 * configuration. We now always use the FileSystem for savepoints. For this,
-	 * the only relevant config key is {@link CoreOptions#SAVEPOINT_DIRECTORY}.
+	 * the only relevant config key is {@link CheckpointingOptions#SAVEPOINT_DIRECTORY}.
 	 */
 	@Deprecated
 	public static final String SAVEPOINT_FS_DIRECTORY_KEY = "savepoints.state.backend.fs.dir";
@@ -1540,7 +1540,7 @@ public final class ConfigConstants {
 	/**
 	 * The config key for the address of the JobManager web frontend.
 	 *
-	 * @deprecated use {@link JobManagerOptions#WEB_FRONTEND_ADDRESS} instead
+	 * @deprecated use {@link WebOptions#ADDRESS} instead
 	 */
 	@Deprecated
 	public static final ConfigOption<String> DEFAULT_JOB_MANAGER_WEB_FRONTEND_ADDRESS =
@@ -1551,7 +1551,7 @@ public final class ConfigConstants {
 	 * The config key for the port of the JobManager web frontend.
 	 * Setting this value to {@code -1} disables the web frontend.
 	 *
-	 * @deprecated use {@link JobManagerOptions#WEB_PORT} instead
+	 * @deprecated use {@link WebOptions#PORT} instead
 	 */
 	@Deprecated
 	public static final int DEFAULT_JOB_MANAGER_WEB_FRONTEND_PORT = 8081;
@@ -1559,7 +1559,7 @@ public final class ConfigConstants {
 	/**
 	 * Default value to override SSL support for the JobManager web UI
 	 *
-	 * @deprecated use {@link JobManagerOptions#WEB_SSL_ENABLED} instead
+	 * @deprecated use {@link WebOptions#SSL_ENABLED} instead
 	 */
 	@Deprecated
 	public static final boolean DEFAULT_JOB_MANAGER_WEB_SSL_ENABLED = true;
@@ -1567,7 +1567,7 @@ public final class ConfigConstants {
 	/**
 	 * The default number of archived jobs for the jobmanager
 	 *
-	 * @deprecated use {@link JobManagerOptions#WEB_ARCHIVE_COUNT} instead
+	 * @deprecated use {@link WebOptions#ARCHIVE_COUNT} instead
 	 */
 	@Deprecated
 	public static final int DEFAULT_JOB_MANAGER_WEB_ARCHIVE_COUNT = 5;
@@ -1575,7 +1575,7 @@ public final class ConfigConstants {
 	/**
 	 * By default, submitting jobs from the web-frontend is allowed.
 	 *
-	 * @deprecated use {@link JobManagerOptions#WEB_SUBMIT_ENABLE} instead
+	 * @deprecated use {@link WebOptions#SUBMIT_ENABLE} instead
 	 */
 	@Deprecated
 	public static final boolean DEFAULT_JOB_MANAGER_WEB_SUBMIT_ENABLED = true;
@@ -1587,7 +1587,7 @@ public final class ConfigConstants {
 	/**
 	 * Default number of checkpoints to remember for recent history.
 	 *
-	 * @deprecated use {@link JobManagerOptions#WEB_CHECKPOINTS_HISTORY_SIZE} instead
+	 * @deprecated use {@link WebOptions#CHECKPOINTS_HISTORY_SIZE} instead
 	 */
 	@Deprecated
 	public static final int DEFAULT_JOB_MANAGER_WEB_CHECKPOINTS_HISTORY_SIZE = 10;
@@ -1595,7 +1595,7 @@ public final class ConfigConstants {
 	/**
 	 * Time after which cached stats are cleaned up.
 	 *
-	 * @deprecated use {@link JobManagerOptions#WEB_BACKPRESSURE_CLEANUP_INTERVAL} instead
+	 * @deprecated use {@link WebOptions#BACKPRESSURE_CLEANUP_INTERVAL} instead
 	 */
 	@Deprecated
 	public static final int DEFAULT_JOB_MANAGER_WEB_BACK_PRESSURE_CLEAN_UP_INTERVAL = 10 * 60 * 1000;
@@ -1603,7 +1603,7 @@ public final class ConfigConstants {
 	/**
 	 * Time after which available stats are deprecated and need to be refreshed (by resampling).
 	 *
-	 * @deprecated use {@link JobManagerOptions#WEB_BACKPRESSURE_REFRESH_INTERVAL} instead
+	 * @deprecated use {@link WebOptions#BACKPRESSURE_REFRESH_INTERVAL} instead
 	 */
 	@Deprecated
 	public static final int DEFAULT_JOB_MANAGER_WEB_BACK_PRESSURE_REFRESH_INTERVAL = 60 * 1000;
@@ -1611,7 +1611,7 @@ public final class ConfigConstants {
 	/**
 	 * Number of samples to take to determine back pressure.
 	 *
-	 * @deprecated use {@link JobManagerOptions#WEB_BACKPRESSURE_NUM_SAMPLES} instead
+	 * @deprecated use {@link WebOptions#BACKPRESSURE_NUM_SAMPLES} instead
 	 */
 	@Deprecated
 	public static final int DEFAULT_JOB_MANAGER_WEB_BACK_PRESSURE_NUM_SAMPLES = 100;
@@ -1619,7 +1619,7 @@ public final class ConfigConstants {
 	/**
 	 * Delay between samples to determine back pressure.
 	 *
-	 * @deprecated use {@link JobManagerOptions#WEB_BACKPRESSURE_DELAY} instead
+	 * @deprecated use {@link WebOptions#BACKPRESSURE_DELAY} instead
 	 */
 	@Deprecated
 	public static final int DEFAULT_JOB_MANAGER_WEB_BACK_PRESSURE_DELAY = 50;

--- a/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
@@ -59,28 +59,4 @@ public class CoreOptions {
 	public static final ConfigOption<Integer> DEFAULT_PARALLELISM_KEY = ConfigOptions
 		.key("parallelism.default")
 		.defaultValue(-1);
-
-	// ------------------------------------------------------------------------
-	//  checkpoints / fault tolerance
-	// ------------------------------------------------------------------------
-
-	public static final ConfigOption<String> STATE_BACKEND = ConfigOptions
-		.key("state.backend")
-		.noDefaultValue();
-
-	/** The maximum number of completed checkpoint instances to retain.*/
-	public static final ConfigOption<Integer> MAX_RETAINED_CHECKPOINTS = ConfigOptions
-		.key("state.checkpoints.num-retained")
-		.defaultValue(1);
-
-	/** The default directory for savepoints. */
-	public static final ConfigOption<String> SAVEPOINT_DIRECTORY = ConfigOptions
-		.key("state.savepoints.dir")
-		.noDefaultValue()
-		.withDeprecatedKeys("savepoints.state.backend.fs.dir");
-
-	/** The default directory used for persistent checkpoints. */
-	public static final ConfigOption<String> CHECKPOINTS_DIRECTORY = ConfigOptions
-		.key("state.checkpoints.dir")
-		.noDefaultValue();
 }

--- a/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalFileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalFileSystem.java
@@ -148,6 +148,11 @@ public class LocalFileSystem extends FileSystem {
 		return new File(path.toUri().getPath());
 	}
 
+	@Override
+	public boolean exists(Path f) throws IOException {
+		final File path = pathToFile(f);
+		return path.exists();
+	}
 
 	@Override
 	public FileStatus[] listStatus(final Path f) throws IOException {
@@ -232,7 +237,7 @@ public class LocalFileSystem extends FileSystem {
 	public boolean mkdirs(final Path f) throws IOException {
 		final File p2f = pathToFile(f);
 
-		if(p2f.isDirectory()) {
+		if (p2f.isDirectory()) {
 			return true;
 		}
 

--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopFileSystem.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopFileSystem.java
@@ -74,7 +74,7 @@ public class HadoopFileSystem extends FileSystem {
 
 	@Override
 	public FileStatus getFileStatus(final Path f) throws IOException {
-		org.apache.hadoop.fs.FileStatus status = this.fs.getFileStatus(new org.apache.hadoop.fs.Path(f.toString()));
+		org.apache.hadoop.fs.FileStatus status = this.fs.getFileStatus(toHadoopPath(f));
 		return new HadoopFileStatus(status);
 	}
 
@@ -101,42 +101,52 @@ public class HadoopFileSystem extends FileSystem {
 
 	@Override
 	public HadoopDataInputStream open(final Path f, final int bufferSize) throws IOException {
-		final org.apache.hadoop.fs.Path path = new org.apache.hadoop.fs.Path(f.toString());
+		final org.apache.hadoop.fs.Path path = toHadoopPath(f);
 		final org.apache.hadoop.fs.FSDataInputStream fdis = this.fs.open(path, bufferSize);
 		return new HadoopDataInputStream(fdis);
 	}
 
 	@Override
 	public HadoopDataInputStream open(final Path f) throws IOException {
-		final org.apache.hadoop.fs.Path path = new org.apache.hadoop.fs.Path(f.toString());
+		final org.apache.hadoop.fs.Path path = toHadoopPath(f);
 		final org.apache.hadoop.fs.FSDataInputStream fdis = fs.open(path);
 		return new HadoopDataInputStream(fdis);
 	}
 
 	@Override
 	@SuppressWarnings("deprecation")
-	public HadoopDataOutputStream create(final Path f, final boolean overwrite, final int bufferSize,
-			final short replication, final long blockSize) throws IOException {
+	public HadoopDataOutputStream create(
+			final Path f,
+			final boolean overwrite,
+			final int bufferSize,
+			final short replication,
+			final long blockSize) throws IOException {
+
 		final org.apache.hadoop.fs.FSDataOutputStream fdos = this.fs.create(
-			new org.apache.hadoop.fs.Path(f.toString()), overwrite, bufferSize, replication, blockSize);
+				toHadoopPath(f), overwrite, bufferSize, replication, blockSize);
 		return new HadoopDataOutputStream(fdos);
 	}
 
 	@Override
 	public HadoopDataOutputStream create(final Path f, final WriteMode overwrite) throws IOException {
-		final org.apache.hadoop.fs.FSDataOutputStream fsDataOutputStream = this.fs
-			.create(new org.apache.hadoop.fs.Path(f.toString()), overwrite == WriteMode.OVERWRITE);
+		final org.apache.hadoop.fs.FSDataOutputStream fsDataOutputStream = 
+				this.fs.create(toHadoopPath(f), overwrite == WriteMode.OVERWRITE);
 		return new HadoopDataOutputStream(fsDataOutputStream);
 	}
 
 	@Override
 	public boolean delete(final Path f, final boolean recursive) throws IOException {
-		return this.fs.delete(new org.apache.hadoop.fs.Path(f.toString()), recursive);
+		return this.fs.delete(toHadoopPath(f), recursive);
+	}
+
+	@Override
+	public boolean exists(Path f) throws IOException {
+		return this.fs.exists(toHadoopPath(f));
 	}
 
 	@Override
 	public FileStatus[] listStatus(final Path f) throws IOException {
-		final org.apache.hadoop.fs.FileStatus[] hadoopFiles = this.fs.listStatus(new org.apache.hadoop.fs.Path(f.toString()));
+		final org.apache.hadoop.fs.FileStatus[] hadoopFiles = this.fs.listStatus(toHadoopPath(f));
 		final FileStatus[] files = new FileStatus[hadoopFiles.length];
 
 		// Convert types
@@ -149,13 +159,12 @@ public class HadoopFileSystem extends FileSystem {
 
 	@Override
 	public boolean mkdirs(final Path f) throws IOException {
-		return this.fs.mkdirs(new org.apache.hadoop.fs.Path(f.toString()));
+		return this.fs.mkdirs(toHadoopPath(f));
 	}
 
 	@Override
 	public boolean rename(final Path src, final Path dst) throws IOException {
-		return this.fs.rename(new org.apache.hadoop.fs.Path(src.toString()),
-			new org.apache.hadoop.fs.Path(dst.toString()));
+		return this.fs.rename(toHadoopPath(src), toHadoopPath(dst));
 	}
 
 	@SuppressWarnings("deprecation")
@@ -167,5 +176,13 @@ public class HadoopFileSystem extends FileSystem {
 	@Override
 	public boolean isDistributedFS() {
 		return true;
+	}
+
+	// ------------------------------------------------------------------------
+	//  Utilities
+	// ------------------------------------------------------------------------
+
+	private static org.apache.hadoop.fs.Path toHadoopPath(Path path) {
+		return new org.apache.hadoop.fs.Path(path.toUri());
 	}
 }

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitor.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitor.java
@@ -19,8 +19,8 @@
 package org.apache.flink.runtime.webmonitor;
 
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.WebOptions;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.jobmanager.MemoryArchivist;
@@ -245,7 +245,7 @@ public class WebRuntimeMonitor implements WebMonitor {
 		}
 		metricFetcher = new MetricFetcher(retriever, queryServiceRetriever, scheduledExecutor, timeout);
 
-		String defaultSavepointDir = config.getString(CoreOptions.SAVEPOINT_DIRECTORY);
+		String defaultSavepointDir = config.getString(CheckpointingOptions.SAVEPOINT_DIRECTORY);
 
 		JobCancellationWithSavepointHandlers cancelWithSavepoint = new JobCancellationWithSavepointHandlers(executionGraphCache, scheduledExecutor, defaultSavepointDir);
 		RuntimeMonitorHandler triggerHandler = handler(cancelWithSavepoint.getTriggerHandler());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -22,7 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.runtime.checkpoint.hooks.MasterHooks;
 import org.apache.flink.runtime.checkpoint.savepoint.SavepointLoader;
 import org.apache.flink.runtime.checkpoint.savepoint.SavepointStore;
@@ -208,7 +208,7 @@ public class CheckpointCoordinator {
 		if (externalizeSettings.externalizeCheckpoints() && checkpointDirectory == null) {
 			throw new IllegalStateException("CheckpointConfig says to persist periodic " +
 					"checkpoints, but no checkpoint directory has been configured. You can " +
-					"configure configure one via key '" + CoreOptions.CHECKPOINTS_DIRECTORY.key() + "'.");
+					"configure configure one via key '" + CheckpointingOptions.CHECKPOINTS_DIRECTORY.key() + "'.");
 		}
 
 		// max "in between duration" can be one year - this is to prevent numeric overflows

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -41,6 +41,7 @@ import org.apache.flink.runtime.messages.checkpoint.AcknowledgeCheckpoint;
 import org.apache.flink.runtime.messages.checkpoint.DeclineCheckpoint;
 import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.runtime.state.SharedStateRegistryFactory;
+import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.taskmanager.DispatcherThreadFactory;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.StringUtils;
@@ -115,6 +116,10 @@ public class CheckpointCoordinator {
 	/** Completed checkpoints. Implementations can be blocking. Make sure calls to methods
 	 * accessing this don't block the job manager actor and run asynchronously. */
 	private final CompletedCheckpointStore completedCheckpointStore;
+
+	/** The root checkpoint state backend, which is responsible for initializing the
+	 * checkpoint, storing the metadata, and cleaning up the checkpoint */
+	private final StateBackend checkpointStateBackend;
 
 	/** Default directory for persistent checkpoints; <code>null</code> if none configured.
 	 * THIS WILL BE REPLACED BY PROPER STATE-BACKEND METADATA WRITING */
@@ -196,6 +201,7 @@ public class CheckpointCoordinator {
 			CheckpointIDCounter checkpointIDCounter,
 			CompletedCheckpointStore completedCheckpointStore,
 			@Nullable String checkpointDirectory,
+			StateBackend checkpointStateBackend,
 			Executor executor,
 			SharedStateRegistryFactory sharedStateRegistryFactory) {
 
@@ -233,6 +239,7 @@ public class CheckpointCoordinator {
 		this.pendingCheckpoints = new LinkedHashMap<>();
 		this.checkpointIdCounter = checkNotNull(checkpointIDCounter);
 		this.completedCheckpointStore = checkNotNull(completedCheckpointStore);
+		this.checkpointStateBackend = checkNotNull(checkpointStateBackend);
 		this.checkpointDirectory = checkpointDirectory;
 		this.executor = checkNotNull(executor);
 		this.sharedStateRegistryFactory = checkNotNull(sharedStateRegistryFactory);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -453,7 +453,7 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 			CheckpointIDCounter checkpointIDCounter,
 			CompletedCheckpointStore checkpointStore,
 			String checkpointDir,
-			StateBackend metadataStore,
+			StateBackend checkpointStateBackend,
 			CheckpointStatsTracker statsTracker) {
 
 		// simple sanity checks
@@ -483,6 +483,7 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 			checkpointIDCounter,
 			checkpointStore,
 			checkpointDir,
+			checkpointStateBackend,
 			ioExecutor,
 			SharedStateRegistry.DEFAULT_FACTORY);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraphBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraphBuilder.java
@@ -115,16 +115,16 @@ public class ExecutionGraphBuilder {
 		final ExecutionGraph executionGraph;
 		try {
 			executionGraph = (prior != null) ? prior :
-                new ExecutionGraph(
-                    jobInformation,
-                    futureExecutor,
-                    ioExecutor,
-                    timeout,
-                    restartStrategy,
-                    failoverStrategy,
-                    slotProvider,
-                    classLoader,
-                    blobWriter);
+				new ExecutionGraph(
+					jobInformation,
+					futureExecutor,
+					ioExecutor,
+					timeout,
+					restartStrategy,
+					failoverStrategy,
+					slotProvider,
+					classLoader,
+					blobWriter);
 		} catch (IOException e) {
 			throw new JobException("Could not create the ExecutionGraph.", e);
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraphBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraphBuilder.java
@@ -21,8 +21,8 @@ package org.apache.flink.runtime.executiongraph;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.WebOptions;
 import org.apache.flink.metrics.MetricGroup;
@@ -50,8 +50,8 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.jsonplan.JsonPlanGenerator;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
 import org.apache.flink.runtime.jobgraph.tasks.JobCheckpointingSettings;
-import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.runtime.state.StateBackendLoader;
 import org.apache.flink.util.DynamicCodeLoadingException;
 import org.apache.flink.util.SerializedValue;
 
@@ -199,17 +199,17 @@ public class ExecutionGraphBuilder {
 			CheckpointIDCounter checkpointIdCounter;
 			try {
 				int maxNumberOfCheckpointsToRetain = jobManagerConfig.getInteger(
-					CoreOptions.MAX_RETAINED_CHECKPOINTS);
+						CheckpointingOptions.MAX_RETAINED_CHECKPOINTS);
 
 				if (maxNumberOfCheckpointsToRetain <= 0) {
 					// warning and use 1 as the default value if the setting in
 					// state.checkpoints.max-retained-checkpoints is not greater than 0.
 					log.warn("The setting for '{} : {}' is invalid. Using default value of {}",
-							CoreOptions.MAX_RETAINED_CHECKPOINTS.key(),
+							CheckpointingOptions.MAX_RETAINED_CHECKPOINTS.key(),
 							maxNumberOfCheckpointsToRetain,
-							CoreOptions.MAX_RETAINED_CHECKPOINTS.defaultValue());
+							CheckpointingOptions.MAX_RETAINED_CHECKPOINTS.defaultValue());
 
-					maxNumberOfCheckpointsToRetain = CoreOptions.MAX_RETAINED_CHECKPOINTS.defaultValue();
+					maxNumberOfCheckpointsToRetain = CheckpointingOptions.MAX_RETAINED_CHECKPOINTS.defaultValue();
 				}
 
 				completedCheckpoints = recoveryFactory.createCheckpointStore(jobId, maxNumberOfCheckpointsToRetain, classLoader);
@@ -229,29 +229,31 @@ public class ExecutionGraphBuilder {
 					metrics);
 
 			// The default directory for externalized checkpoints
-			String externalizedCheckpointsDir = jobManagerConfig.getString(CoreOptions.CHECKPOINTS_DIRECTORY);
+			String externalizedCheckpointsDir = jobManagerConfig.getString(CheckpointingOptions.CHECKPOINTS_DIRECTORY);
 
-			// load the state backend for checkpoint metadata.
-			// if specified in the application, use from there, otherwise load from configuration
-			final StateBackend metadataBackend;
+			// load the state backend from the application settings
+			final StateBackend applicationConfiguredBackend;
+			final SerializedValue<StateBackend> serializedAppConfigured = snapshotSettings.getDefaultStateBackend();
 
-			final SerializedValue<StateBackend> applicationConfiguredBackend = snapshotSettings.getDefaultStateBackend();
-			if (applicationConfiguredBackend != null) {
+			if (serializedAppConfigured == null) {
+				applicationConfiguredBackend = null;
+			}
+			else {
 				try {
-					metadataBackend = applicationConfiguredBackend.deserializeValue(classLoader);
+					applicationConfiguredBackend = serializedAppConfigured.deserializeValue(classLoader);
 				} catch (IOException | ClassNotFoundException e) {
-					throw new JobExecutionException(jobId, "Could not instantiate configured state backend.", e);
+					throw new JobExecutionException(jobId, 
+							"Could not deserialize application-defined state backend.", e);
 				}
+			}
 
-				log.info("Using application-defined state backend for checkpoint/savepoint metadata: {}.",
-					metadataBackend);
-			} else {
-				try {
-					metadataBackend = AbstractStateBackend
-							.loadStateBackendFromConfigOrCreateDefault(jobManagerConfig, classLoader, log);
-				} catch (IllegalConfigurationException | IOException | DynamicCodeLoadingException e) {
-					throw new JobExecutionException(jobId, "Could not instantiate configured state backend", e);
-				}
+			final StateBackend rootBackend;
+			try {
+				rootBackend = StateBackendLoader.fromApplicationOrConfigOrDefault(
+						applicationConfiguredBackend, jobManagerConfig, classLoader, log);
+			}
+			catch (IllegalConfigurationException | IOException | DynamicCodeLoadingException e) {
+				throw new JobExecutionException(jobId, "Could not instantiate configured state backend", e);
 			}
 
 			// instantiate the user-defined checkpoint hooks
@@ -301,7 +303,7 @@ public class ExecutionGraphBuilder {
 				checkpointIdCounter,
 				completedCheckpoints,
 				externalizedCheckpointsDir,
-				metadataBackend,
+				rootBackend,
 				checkpointStatsTracker);
 		}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/JobCancellationWithSavepointHandlers.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/JobCancellationWithSavepointHandlers.java
@@ -21,8 +21,8 @@ package org.apache.flink.runtime.rest.handler.legacy;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.ConfigConstants;
-import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
@@ -167,7 +167,7 @@ public class JobCancellationWithSavepointHandlers {
 									throw new IllegalStateException("No savepoint directory configured. " +
 										"You can either specify a directory when triggering this savepoint or " +
 										"configure a cluster-wide default via key '" +
-										CoreOptions.SAVEPOINT_DIRECTORY.key() + "'.");
+											CheckpointingOptions.SAVEPOINT_DIRECTORY.key() + "'.");
 								} else {
 									targetDirectory = defaultSavepointDirectory;
 								}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractStateBackend.java
@@ -21,45 +21,21 @@ package org.apache.flink.runtime.state;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.CoreOptions;
-import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
-import org.apache.flink.runtime.state.filesystem.FsStateBackend;
-import org.apache.flink.runtime.state.filesystem.FsStateBackendFactory;
-import org.apache.flink.runtime.state.memory.MemoryStateBackend;
-import org.apache.flink.util.DynamicCodeLoadingException;
-
-import org.slf4j.Logger;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
 
-import static org.apache.flink.util.Preconditions.checkNotNull;
-
 /**
  * An abstract base implementation of the {@link StateBackend} interface.
- * 
- * <p>
+ *
+ * <p>This class has currently no contents and only kept to not break the prior class hierarchy for users.
  */
 @PublicEvolving
 public abstract class AbstractStateBackend implements StateBackend, java.io.Serializable {
 
 	private static final long serialVersionUID = 4620415814639230247L;
-
-	// ------------------------------------------------------------------------
-	//  Configuration shortcut names
-	// ------------------------------------------------------------------------
-
-	/** The shortcut configuration name for the MemoryState backend that checkpoints to the JobManager */
-	public static final String MEMORY_STATE_BACKEND_NAME = "jobmanager";
-
-	/** The shortcut configuration name for the FileSystem State backend */ 
-	public static final String FS_STATE_BACKEND_NAME = "filesystem";
-
-	/** The shortcut configuration name for the RocksDB State Backend */
-	public static final String ROCKSDB_STATE_BACKEND_NAME = "rocksdb";
 
 	// ------------------------------------------------------------------------
 	//  State Backend - Persisting Byte Storage
@@ -94,141 +70,4 @@ public abstract class AbstractStateBackend implements StateBackend, java.io.Seri
 	public abstract OperatorStateBackend createOperatorStateBackend(
 			Environment env,
 			String operatorIdentifier) throws Exception;
-
-	// ------------------------------------------------------------------------
-	//  Loading the state backend from a configuration 
-	// ------------------------------------------------------------------------
-
-	/**
-	 * Loads the state backend from the configuration, from the parameter 'state.backend', as defined
-	 * in {@link CoreOptions#STATE_BACKEND}.
-	 * 
-	 * <p>The state backends can be specified either via their shortcut name, or via the class name
-	 * of a {@link StateBackendFactory}. If a StateBackendFactory class name is specified, the factory
-	 * is instantiated (via its zero-argument constructor) and its
-	 * {@link StateBackendFactory#createFromConfig(Configuration)} method is called.
-	 *
-	 * <p>Recognized shortcut names are '{@value AbstractStateBackend#MEMORY_STATE_BACKEND_NAME}',
-	 * '{@value AbstractStateBackend#FS_STATE_BACKEND_NAME}', and
-	 * '{@value AbstractStateBackend#ROCKSDB_STATE_BACKEND_NAME}'.
-	 * 
-	 * @param config The configuration to load the state backend from
-	 * @param classLoader The class loader that should be used to load the state backend
-	 * @param logger Optionally, a logger to log actions to (may be null)
-	 * 
-	 * @return The instantiated state backend.
-	 * 
-	 * @throws DynamicCodeLoadingException
-	 *             Thrown if a state backend factory is configured and the factory class was not
-	 *             found or the factory could not be instantiated
-	 * @throws IllegalConfigurationException
-	 *             May be thrown by the StateBackendFactory when creating / configuring the state
-	 *             backend in the factory
-	 * @throws IOException
-	 *             May be thrown by the StateBackendFactory when instantiating the state backend
-	 */
-	public static StateBackend loadStateBackendFromConfig(
-			Configuration config,
-			ClassLoader classLoader,
-			@Nullable Logger logger) throws IllegalConfigurationException, DynamicCodeLoadingException, IOException {
-
-		checkNotNull(config, "config");
-		checkNotNull(classLoader, "classLoader");
-
-		final String backendName = config.getString(CoreOptions.STATE_BACKEND);
-		if (backendName == null) {
-			return null;
-		}
-
-		// by default the factory class is the backend name 
-		String factoryClassName = backendName;
-
-		switch (backendName.toLowerCase()) {
-			case MEMORY_STATE_BACKEND_NAME:
-				if (logger != null) {
-					logger.info("State backend is set to heap memory (checkpoint to JobManager)");
-				}
-				return new MemoryStateBackend();
-
-			case FS_STATE_BACKEND_NAME:
-				FsStateBackend fsBackend = new FsStateBackendFactory().createFromConfig(config);
-				if (logger != null) {
-					logger.info("State backend is set to heap memory (checkpoints to filesystem \"{}\")",
-							fsBackend.getBasePath());
-				}
-				return fsBackend;
-
-			case ROCKSDB_STATE_BACKEND_NAME:
-				factoryClassName = "org.apache.flink.contrib.streaming.state.RocksDBStateBackendFactory";
-				// fall through to the 'default' case that uses reflection to load the backend
-				// that way we can keep RocksDB in a separate module
-
-			default:
-				if (logger != null) {
-					logger.info("Loading state backend via factory {}", factoryClassName);
-				}
-
-				StateBackendFactory<?> factory;
-				try {
-					@SuppressWarnings("rawtypes")
-					Class<? extends StateBackendFactory> clazz = 
-							Class.forName(factoryClassName, false, classLoader)
-									.asSubclass(StateBackendFactory.class);
-
-					factory = clazz.newInstance();
-				}
-				catch (ClassNotFoundException e) {
-					throw new DynamicCodeLoadingException(
-							"Cannot find configured state backend factory class: " + backendName, e);
-				}
-				catch (ClassCastException | InstantiationException | IllegalAccessException e) {
-					throw new DynamicCodeLoadingException("The class configured under '" +
-							CoreOptions.STATE_BACKEND.key() + "' is not a valid state backend factory (" +
-							backendName + ')', e);
-				}
-				
-				return factory.createFromConfig(config);
-		}
-	}
-
-	/**
-	 * Loads the state backend from the configuration, from the parameter 'state.backend', as defined
-	 * in {@link CoreOptions#STATE_BACKEND}. If no state backend is configures, this instantiates the
-	 * default state backend (the {@link MemoryStateBackend}). 
-	 *
-	 * <p>Refer to {@link #loadStateBackendFromConfig(Configuration, ClassLoader, Logger)} for details on
-	 * how the state backend is loaded from the configuration.
-	 *
-	 * @param config The configuration to load the state backend from
-	 * @param classLoader The class loader that should be used to load the state backend
-	 * @param logger Optionally, a logger to log actions to (may be null)
-	 *
-	 * @return The instantiated state backend.
-	 *
-	 * @throws DynamicCodeLoadingException
-	 *             Thrown if a state backend factory is configured and the factory class was not
-	 *             found or the factory could not be instantiated
-	 * @throws IllegalConfigurationException
-	 *             May be thrown by the StateBackendFactory when creating / configuring the state
-	 *             backend in the factory
-	 * @throws IOException
-	 *             May be thrown by the StateBackendFactory when instantiating the state backend
-	 */
-	public static StateBackend loadStateBackendFromConfigOrCreateDefault(
-			Configuration config,
-			ClassLoader classLoader,
-			@Nullable Logger logger) throws IllegalConfigurationException, DynamicCodeLoadingException, IOException {
-
-		final StateBackend fromConfig = loadStateBackendFromConfig(config, classLoader, logger);
-
-		if (fromConfig != null) {
-			return fromConfig;
-		}
-		else {
-			if (logger != null) {
-				logger.info("No state backend has been configured, using default state backend (Memory / JobManager)");
-			}
-			return new MemoryStateBackend();
-		}
-	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointStreamFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointStreamFactory.java
@@ -40,14 +40,6 @@ public interface CheckpointStreamFactory {
 			long timestamp) throws Exception;
 
 	/**
-	 * Closes the stream factory, releasing all internal resources, but does not delete any
-	 * persistent checkpoint data.
-	 *
-	 * @throws Exception Exceptions can be forwarded and will be logged by the system
-	 */
-	void close() throws Exception;
-
-	/**
 	 * A dedicated output stream that produces a {@link StreamStateHandle} when closed.
 	 *
 	 * <p>Note: This is an abstract class and not an interface because {@link OutputStream}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ConfigurableStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ConfigurableStateBackend.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.IllegalConfigurationException;
+
+/**
+ *An interface for state backends that pick up additional parameters from a configuration.
+ */
+public interface ConfigurableStateBackend {
+
+	/**
+	 * Creates a variant of the state backend that applies additional configuration parameters.
+	 *
+	 * <p>Settings that were directly done on the original state backend object in the application
+	 * program typically have precedence over setting picked up from the configuration.
+	 *
+	 * <p>If no configuration is applied, or if the method directly applies configuration values to
+	 * the (mutable) state backend object, this method may return the original state backend object.
+	 * Otherwise it typically returns a modified copy.
+	 *
+	 * @param config The configuration to pick the values from. 
+	 * @return A reconfigured state backend.
+	 *
+	 * @throws IllegalConfigurationException Thrown if the configuration contained invalid entries.
+	 */
+	StateBackend configure(Configuration config) throws IllegalConfigurationException;
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ManagedSnapshotContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ManagedSnapshotContext.java
@@ -33,7 +33,7 @@ public interface ManagedSnapshotContext {
 	 * 
 	 * <p>The checkpoint ID is guaranteed to be strictly monotonously increasing across checkpoints.
 	 * For two completed checkpoints <i>A</i> and <i>B</i>, {@code ID_B > ID_A} means that checkpoint
-	 * <i>B</i> subsumes checkpoint <i>A</i>, i.e., checkpoint <i>B</i>it contains a later state
+	 * <i>B</i> subsumes checkpoint <i>A</i>, i.e., checkpoint <i>B</i> contains a later state
 	 * than checkpoint <i>A</i>.
 	 */
 	long getCheckpointId();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackendLoader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackendLoader.java
@@ -1,0 +1,265 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.configuration.CheckpointingOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.HighAvailabilityOptions;
+import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
+import org.apache.flink.runtime.state.filesystem.FsStateBackend;
+import org.apache.flink.runtime.state.filesystem.FsStateBackendFactory;
+import org.apache.flink.runtime.state.memory.MemoryStateBackend;
+import org.apache.flink.runtime.state.memory.MemoryStateBackendFactory;
+import org.apache.flink.util.DynamicCodeLoadingException;
+
+import org.slf4j.Logger;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * This class contains utility methods to load state backends from configurations.
+ */
+public class StateBackendLoader {
+
+	// ------------------------------------------------------------------------
+	//  Configuration shortcut names
+	// ------------------------------------------------------------------------
+
+	/** The shortcut configuration name for the MemoryState backend that checkpoints to the JobManager */
+	public static final String MEMORY_STATE_BACKEND_NAME = "jobmanager";
+
+	/** The shortcut configuration name for the FileSystem State backend */
+	public static final String FS_STATE_BACKEND_NAME = "filesystem";
+
+	/** The shortcut configuration name for the RocksDB State Backend */
+	public static final String ROCKSDB_STATE_BACKEND_NAME = "rocksdb";
+
+	// ------------------------------------------------------------------------
+	//  Loading the state backend from a configuration 
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Loads the state backend from the configuration, from the parameter 'state.backend', as defined
+	 * in {@link CheckpointingOptions#STATE_BACKEND}.
+	 *
+	 * <p>The state backends can be specified either via their shortcut name, or via the class name
+	 * of a {@link StateBackendFactory}. If a StateBackendFactory class name is specified, the factory
+	 * is instantiated (via its zero-argument constructor) and its
+	 * {@link StateBackendFactory#createFromConfig(Configuration)} method is called.
+	 *
+	 * <p>Recognized shortcut names are '{@value StateBackendLoader#MEMORY_STATE_BACKEND_NAME}',
+	 * '{@value StateBackendLoader#FS_STATE_BACKEND_NAME}', and
+	 * '{@value StateBackendLoader#ROCKSDB_STATE_BACKEND_NAME}'.
+	 *
+	 * @param config The configuration to load the state backend from
+	 * @param classLoader The class loader that should be used to load the state backend
+	 * @param logger Optionally, a logger to log actions to (may be null)
+	 *
+	 * @return The instantiated state backend.
+	 *
+	 * @throws DynamicCodeLoadingException
+	 *             Thrown if a state backend factory is configured and the factory class was not
+	 *             found or the factory could not be instantiated
+	 * @throws IllegalConfigurationException
+	 *             May be thrown by the StateBackendFactory when creating / configuring the state
+	 *             backend in the factory
+	 * @throws IOException
+	 *             May be thrown by the StateBackendFactory when instantiating the state backend
+	 */
+	public static StateBackend loadStateBackendFromConfig(
+			Configuration config,
+			ClassLoader classLoader,
+			@Nullable Logger logger) throws IllegalConfigurationException, DynamicCodeLoadingException, IOException {
+
+		checkNotNull(config, "config");
+		checkNotNull(classLoader, "classLoader");
+
+		final String backendName = config.getString(CheckpointingOptions.STATE_BACKEND);
+		if (backendName == null) {
+			return null;
+		}
+
+		// by default the factory class is the backend name 
+		String factoryClassName = backendName;
+
+		switch (backendName.toLowerCase()) {
+			case MEMORY_STATE_BACKEND_NAME:
+				MemoryStateBackend memBackend = new MemoryStateBackendFactory().createFromConfig(config);
+
+				if (logger != null) {
+					Path memExternalized = memBackend.getCheckpointPath();
+					String extern = memExternalized == null ? "" :
+							" (externalized to " + memExternalized + ')';
+					logger.info("State backend is set to heap memory (checkpoint to JobManager) {}", extern);
+				}
+				return memBackend;
+
+			case FS_STATE_BACKEND_NAME:
+				FsStateBackend fsBackend = new FsStateBackendFactory().createFromConfig(config);
+				if (logger != null) {
+					logger.info("State backend is set to heap memory (checkpoints to filesystem \"{}\")",
+							fsBackend.getCheckpointPath());
+				}
+				return fsBackend;
+
+			case ROCKSDB_STATE_BACKEND_NAME:
+				factoryClassName = "org.apache.flink.contrib.streaming.state.RocksDBStateBackendFactory";
+				// fall through to the 'default' case that uses reflection to load the backend
+				// that way we can keep RocksDB in a separate module
+
+			default:
+				if (logger != null) {
+					logger.info("Loading state backend via factory {}", factoryClassName);
+				}
+
+				StateBackendFactory<?> factory;
+				try {
+					@SuppressWarnings("rawtypes")
+					Class<? extends StateBackendFactory> clazz =
+							Class.forName(factoryClassName, false, classLoader)
+									.asSubclass(StateBackendFactory.class);
+
+					factory = clazz.newInstance();
+				}
+				catch (ClassNotFoundException e) {
+					throw new DynamicCodeLoadingException(
+							"Cannot find configured state backend factory class: " + backendName, e);
+				}
+				catch (ClassCastException | InstantiationException | IllegalAccessException e) {
+					throw new DynamicCodeLoadingException("The class configured under '" +
+							CheckpointingOptions.STATE_BACKEND.key() + "' is not a valid state backend factory (" +
+							backendName + ')', e);
+				}
+
+				return factory.createFromConfig(config);
+		}
+	}
+
+	/**
+	 * Checks if an application-defined state backend is given, and if not, loads the state
+	 * backend from the configuration, from the parameter 'state.backend', as defined
+	 * in {@link CheckpointingOptions#STATE_BACKEND}. If no state backend is configured, this instantiates the
+	 * default state backend (the {@link MemoryStateBackend}). 
+	 *
+	 * <p>If an application-defined state backend is found, and the state backend is a
+	 * {@link ConfigurableStateBackend}, this methods calls {@link ConfigurableStateBackend#configure(Configuration)}
+	 * on the state backend.
+	 *
+	 * <p>Refer to {@link #loadStateBackendFromConfig(Configuration, ClassLoader, Logger)} for details on
+	 * how the state backend is loaded from the configuration.
+	 *
+	 * @param config The configuration to load the state backend from
+	 * @param classLoader The class loader that should be used to load the state backend
+	 * @param logger Optionally, a logger to log actions to (may be null)
+	 *
+	 * @return The instantiated state backend.
+	 *
+	 * @throws DynamicCodeLoadingException
+	 *             Thrown if a state backend factory is configured and the factory class was not
+	 *             found or the factory could not be instantiated
+	 * @throws IllegalConfigurationException
+	 *             May be thrown by the StateBackendFactory when creating / configuring the state
+	 *             backend in the factory
+	 * @throws IOException
+	 *             May be thrown by the StateBackendFactory when instantiating the state backend
+	 */
+	public static StateBackend fromApplicationOrConfigOrDefault(
+			@Nullable StateBackend fromApplication,
+			Configuration config,
+			ClassLoader classLoader,
+			@Nullable Logger logger) throws IllegalConfigurationException, DynamicCodeLoadingException, IOException {
+
+		checkNotNull(config, "config");
+		checkNotNull(classLoader, "classLoader");
+
+		final StateBackend backend;
+
+		// (1) the application defined state backend has precedence
+		if (fromApplication != null) {
+			if (logger != null) {
+				logger.info("Using application-defined state backend: {}", fromApplication);
+			}
+
+			// see if this is supposed to pick up additional configuration parameters
+			if (fromApplication instanceof ConfigurableStateBackend) {
+				// needs to pick up configuration
+				if (logger != null) {
+					logger.info("Configuring application-defined state backend with job/cluster config");
+				}
+
+				backend = ((ConfigurableStateBackend) fromApplication).configure(config);
+			}
+			else {
+				// keep as is!
+				backend = fromApplication;
+			}
+		}
+		else {
+			// (2) check if the config defines a state backend
+			final StateBackend fromConfig = loadStateBackendFromConfig(config, classLoader, logger);
+			if (fromConfig != null) {
+				backend = fromConfig;
+			}
+			else {
+				// (3) use the default
+				backend = new MemoryStateBackendFactory().createFromConfig(config);
+				if (logger != null) {
+					logger.info("No state backend has been configured, using default (Memory / JobManager) {}", backend);
+				}
+			}
+		}
+
+		// to keep supporting the old behavior where default (JobManager) Backend + HA mode = checkpoints in HA store
+		// we add the HA persistence dir as the checkpoint directory if none other is set
+
+		if (backend instanceof MemoryStateBackend) {
+			final MemoryStateBackend memBackend = (MemoryStateBackend) backend;
+
+			if (memBackend.getCheckpointPath() == null && HighAvailabilityMode.isHighAvailabilityModeActivated(config)) {
+				final String haStoragePath = config.getString(HighAvailabilityOptions.HA_STORAGE_PATH);
+
+				if (haStoragePath != null) {
+					try {
+						Path checkpointDirPath = new Path(haStoragePath, UUID.randomUUID().toString());
+						if (checkpointDirPath.toUri().getScheme() == null) {
+							checkpointDirPath = checkpointDirPath.makeQualified(checkpointDirPath.getFileSystem());
+						}
+						Configuration tempConfig = new Configuration(config);
+						tempConfig.setString(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDirPath.toString());
+						return memBackend.configure(tempConfig);
+					} catch (Exception ignored) {}
+				}
+			}
+		}
+
+		return backend;
+	}
+
+	// ------------------------------------------------------------------------
+
+	/** This class is not meant to be instantiated */
+	private StateBackendLoader() {}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/AbstractFileStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/AbstractFileStateBackend.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.filesystem;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.configuration.CheckpointingOptions;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.state.AbstractStateBackend;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import java.net.URI;
+
+/**
+ * A base class for all state backends that store their metadata (and data) in files.
+ * Examples that inherit from this are the {@link FsStateBackend}, the
+ * {@link org.apache.flink.runtime.state.memory.MemoryStateBackend MemoryStateBackend}, or the
+ * {@code RocksDBStateBackend}.
+ *
+ * <p>This class takes the base checkpoint- and savepoint directory paths, but also accepts null
+ * for both of then, in which case creating externalized checkpoint is not possible, and it is not
+ * possible to create a savepoint with a default path. Null is accepted to enable implementations
+ * that only optionally support default savepoints and externalized checkpoints.
+ *
+ * <h1>Checkpoint Layout</h1>
+ *
+ * The state backend is configured with a base directory and persists the checkpoint data of specific
+ * checkpoints in specific subdirectories. For example, if the base directory was set to 
+ * {@code hdfs://namenode:port/flink-checkpoints/}, the state backend will create a subdirectory with
+ * the job's ID that will contain the actual checkpoints:
+ * ({@code hdfs://namenode:port/flink-checkpoints/1b080b6e710aabbef8993ab18c6de98b})
+ *
+ * <p>Each checkpoint individually will store all its files in a subdirectory that includes the
+ * checkpoint number, such as {@code hdfs://namenode:port/flink-checkpoints/1b080b6e710aabbef8993ab18c6de98b/chk-17/}.
+ *
+ * <h1>Savepoint Layout</h1>
+ *
+ * A savepoint that is set to be stored in path {@code hdfs://namenode:port/flink-savepoints/}, will create
+ * a subdirectory {@code savepoint-jobId(0, 6)-randomDigits} in which it stores all savepoint data.
+ * The random digits are added as "entropy" to avoid directory collisions.
+ */
+@PublicEvolving
+public abstract class AbstractFileStateBackend extends AbstractStateBackend {
+
+	private static final long serialVersionUID = 1L;
+
+	private static final Logger LOG = LoggerFactory.getLogger(AbstractFileStateBackend.class);
+
+	// ------------------------------------------------------------------------
+	//  State Backend Properties
+	// ------------------------------------------------------------------------
+
+	/** The path where checkpoints will be stored, or null, if none has been configured. */
+	@Nullable
+	private final Path baseCheckpointPath;
+
+	/** The path where savepoints will be stored, or null, if none has been configured. */
+	@Nullable
+	private final Path baseSavepointPath;
+
+	/**
+	 * Creates a backend with the given optional checkpoint- and savepoint base directories.
+	 *
+	 * @param baseCheckpointPath The base directory for checkpoints, or null, if none is configured.
+	 * @param baseSavepointPath The default directory for savepoints, or null, if none is set.
+	 */
+	protected AbstractFileStateBackend(
+			@Nullable URI baseCheckpointPath,
+			@Nullable URI baseSavepointPath) {
+
+		this(baseCheckpointPath == null ? null : new Path(baseCheckpointPath),
+				baseSavepointPath == null ? null : new Path(baseSavepointPath));
+	}
+
+	/**
+	 * Creates a backend with the given optional checkpoint- and savepoint base directories.
+	 *
+	 * @param baseCheckpointPath The base directory for checkpoints, or null, if none is configured.
+	 * @param baseSavepointPath The default directory for savepoints, or null, if none is set.
+	 */
+	protected AbstractFileStateBackend(
+			@Nullable Path baseCheckpointPath,
+			@Nullable Path baseSavepointPath) {
+
+		this.baseCheckpointPath = baseCheckpointPath == null ? null : validatePath(baseCheckpointPath);
+		this.baseSavepointPath = baseSavepointPath == null ? null : validatePath(baseSavepointPath);
+	}
+
+	/**
+	 * Creates a new backend using the given checkpoint-/savepoint directories, or the values defined in
+	 * the given configuration. If a checkpoint-/savepoint parameter is not null, that value takes precedence
+	 * over the value in the configuration. If the configuration does not specify a value, it is possible
+	 * that the checkpoint-/savepoint directories in the backend will be null.
+	 *
+	 * <p>This constructor can be used to create a backend that is based partially on a given backend
+	 * and partially on a configuration.
+	 *
+	 * @param baseCheckpointPath The checkpoint base directory to use (or null).
+	 * @param baseSavepointPath The default savepoint directory to use (or null).
+	 * @param configuration The configuration to read values from 
+	 */
+	protected AbstractFileStateBackend(
+			@Nullable Path baseCheckpointPath,
+			@Nullable Path baseSavepointPath,
+			Configuration configuration) {
+
+		this(parameterOrConfigured(baseCheckpointPath, configuration, CheckpointingOptions.CHECKPOINTS_DIRECTORY),
+				parameterOrConfigured(baseSavepointPath, configuration, CheckpointingOptions.SAVEPOINT_DIRECTORY));
+	}
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Gets the checkpoint base directory. Jobs will create job-specific subdirectories
+	 * for checkpoints within this directory. May be null, if not configured.
+	 *
+	 * @return The checkpoint base directory
+	 */
+	@Nullable
+	public Path getCheckpointPath() {
+		return baseCheckpointPath;
+	}
+
+	/**
+	 * Gets the directory where savepoints are stored by default (when no custom path is given
+	 * to the savepoint trigger command).
+	 *
+	 * @return The default directory for savepoints, or null, if no default directory has been configured.
+	 */
+	@Nullable
+	public Path getSavepointPath() {
+		return baseSavepointPath;
+	}
+
+	// ------------------------------------------------------------------------
+	//  Utilities
+	// ------------------------------------------------------------------------
+
+	// 
+	/**
+	 * Checks the validity of the path's scheme and path.
+	 *
+	 * @param path The path to check.
+	 * @return The URI as a Path.
+	 *
+	 * @throws IllegalArgumentException Thrown, if the URI misses scheme or path.
+	 */
+	private static Path validatePath(Path path) {
+		final URI uri = path.toUri();
+		final String scheme = uri.getScheme();
+		final String pathPart = uri.getPath();
+
+		// some validity checks
+		if (scheme == null) {
+			throw new IllegalArgumentException("The scheme (hdfs://, file://, etc) is null. " +
+					"Please specify the file system scheme explicitly in the URI.");
+		}
+		if (pathPart == null) {
+			throw new IllegalArgumentException("The path to store the checkpoint data in is null. " +
+					"Please specify a directory path for the checkpoint data.");
+		}
+		if (pathPart.length() == 0 || pathPart.equals("/")) {
+			throw new IllegalArgumentException("Cannot use the root directory for checkpoints.");
+		}
+
+		return path;
+	}
+
+	@Nullable
+	private static Path parameterOrConfigured(@Nullable Path path, Configuration config, ConfigOption<String> option) {
+		if (path != null) {
+			return path;
+		}
+		else {
+			String configValue = config.getString(option);
+			try {
+				return configValue == null ? null : new Path(configValue);
+			}
+			catch (IllegalArgumentException e) {
+				throw new IllegalConfigurationException("Cannot parse value for " + option.key() +
+						" : " + configValue + " . Not a valid path.");
+			}
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStreamFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStreamFactory.java
@@ -106,9 +106,6 @@ public class FsCheckpointStreamFactory implements CheckpointStreamFactory {
 	}
 
 	@Override
-	public void close() throws Exception {}
-
-	@Override
 	public FsCheckpointStateOutputStream createCheckpointStateOutputStream(long checkpointID, long timestamp) throws Exception {
 		checkFileSystemInitialized();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackend.java
@@ -18,54 +18,92 @@
 
 package org.apache.flink.runtime.state.filesystem;
 
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.configuration.CheckpointingOptions;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
-import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
+import org.apache.flink.runtime.state.ConfigurableStateBackend;
 import org.apache.flink.runtime.state.DefaultOperatorStateBackend;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.OperatorStateBackend;
 import org.apache.flink.runtime.state.heap.HeapKeyedStateBackend;
 
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.net.URI;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
- * The file state backend is a state backend that stores the state of streaming jobs in a file system.
+ * This state backend holds the working state in the memory (JVM heap) of the TaskManagers.
+ * The state backend checkpoints state as files to a file system (hence the backend's name).
  *
- * <p>The state backend has one core directory into which it puts all checkpoint data. Inside that
- * directory, it creates a directory per job, inside which each checkpoint gets a directory, with
- * files for each state, for example:
+ * <p>Each checkpoint individually will store all its files in a subdirectory that includes the
+ * checkpoint number, such as {@code hdfs://namenode:port/flink-checkpoints/chk-17/}.
  *
- * {@code hdfs://namenode:port/flink-checkpoints/<job-id>/chk-17/6ba7b810-9dad-11d1-80b4-00c04fd430c8 }
+ * <h1>State Size Considerations</h1>
+ *
+ * Working state is kept on the TaskManager heap. If a TaskManager executes multiple
+ * tasks concurrently (if the TaskManager has multiple slots, or if slot-sharing is used)
+ * then the aggregate state of all tasks needs to fit into that TaskManager's memory.
+ *
+ * <p>This state backend stores small state chunks directly with the metadata, to avoid creating
+ * many small files. The threshold for that is configurable. When increasing this threshold, the
+ * size of the checkpoint metadata increases. The checkpoint metadata of all retained completed
+ * checkpoints needs to fit into the JobManager's heap memory. This is typically not a problem,
+ * unless the threshold {@link #getMinFileSizeThreshold()} is increased significantly.
+ *
+ * <h1>Persistence Guarantees</h1>
+ *
+ * Checkpoints from this state backend are as persistent and available as filesystem that is written to.
+ * If the file system is a persistent distributed file system, this state backend supports
+ * highly available setups. The backend additionally supports savepoints and externalized checkpoints.
+ *
+ * <h1>Configuration</h1>
+ *
+ * As for all state backends, this backend can either be configured within the application (by creating
+ * the backend with the respective constructor parameters and setting it on the execution environment)
+ * or by specifying it in the Flink configuration.
+ *
+ * <p>If the state backend was specified in the application, it may pick up additional configuration
+ * parameters from the Flink configuration. For example, if the backend if configured in the application
+ * without a default savepoint directory, it will pick up a default savepoint directory specified in the
+ * Flink configuration of the running job/cluster. That behavior is implemented via the
+ * {@link #configure(Configuration)} method.
  */
-public class FsStateBackend extends AbstractStateBackend {
+@PublicEvolving
+public class FsStateBackend extends AbstractFileStateBackend implements ConfigurableStateBackend {
 
 	private static final long serialVersionUID = -8191916350224044011L;
 
-	/** By default, state smaller than 1024 bytes will not be written to files, but
-	 * will be stored directly with the metadata */
-	public static final int DEFAULT_FILE_STATE_THRESHOLD = 1024;
+	/** Maximum size of state that is stored with the metadata, rather than in files (1 MiByte) */
+	public static final int MAX_FILE_STATE_THRESHOLD = 1024 * 1024;
 
-	/** Maximum size of state that is stored with the metadata, rather than in files */
-	private static final int MAX_FILE_STATE_THRESHOLD = 1024 * 1024;
-	
-	/** The path to the directory for the checkpoint data, including the file system
-	 * description via scheme and optional authority */
-	private final Path basePath;
+	// ------------------------------------------------------------------------
 
-	/** State below this size will be stored as part of the metadata, rather than in files */
-	private final int fileStateThreshold;
+	/** State below this size will be stored as part of the metadata, rather than in files.
+	 * Null if not yet configured, in which case the default will be used. */
+	@Nullable
+	private final Integer fileStateThreshold;
 
-	/** Switch to chose between synchronous and asynchronous snapshots */
-	private final boolean asynchronousSnapshots;
+	/** Switch to chose between synchronous and asynchronous snapshots.
+	 * Null if not yet configured, in which case the default will be used. */
+	@Nullable
+	private final Boolean asynchronousSnapshots;
+
+	// ------------------------------------------------------------------------
 
 	/**
 	 * Creates a new state backend that stores its checkpoint data in the file system and location
@@ -80,9 +118,8 @@ public class FsStateBackend extends AbstractStateBackend {
 	 *
 	 * @param checkpointDataUri The URI describing the filesystem (scheme and optionally authority),
 	 *                          and the path to the checkpoint data directory.
-	 * @throws IOException Thrown, if no file system can be found for the scheme in the URI.
 	 */
-	public FsStateBackend(String checkpointDataUri) throws IOException {
+	public FsStateBackend(String checkpointDataUri) {
 		this(new Path(checkpointDataUri));
 	}
 
@@ -100,10 +137,8 @@ public class FsStateBackend extends AbstractStateBackend {
 	 * @param checkpointDataUri The URI describing the filesystem (scheme and optionally authority),
 	 *                          and the path to the checkpoint data directory.
 	 * @param asynchronousSnapshots Switch to enable asynchronous snapshots.
-	 *
-	 * @throws IOException Thrown, if no file system can be found for the scheme in the URI.
 	 */
-	public FsStateBackend(String checkpointDataUri, boolean asynchronousSnapshots) throws IOException {
+	public FsStateBackend(String checkpointDataUri, boolean asynchronousSnapshots) {
 		this(new Path(checkpointDataUri), asynchronousSnapshots);
 	}
 
@@ -120,9 +155,8 @@ public class FsStateBackend extends AbstractStateBackend {
 	 *
 	 * @param checkpointDataUri The URI describing the filesystem (scheme and optionally authority),
 	 *                          and the path to the checkpoint data directory.
-	 * @throws IOException Thrown, if no file system can be found for the scheme in the URI.
 	 */
-	public FsStateBackend(Path checkpointDataUri) throws IOException {
+	public FsStateBackend(Path checkpointDataUri) {
 		this(checkpointDataUri.toUri());
 	}
 
@@ -140,10 +174,8 @@ public class FsStateBackend extends AbstractStateBackend {
 	 * @param checkpointDataUri The URI describing the filesystem (scheme and optionally authority),
 	 *                          and the path to the checkpoint data directory.
 	 * @param asynchronousSnapshots Switch to enable asynchronous snapshots.
-	 *
-	 * @throws IOException Thrown, if no file system can be found for the scheme in the URI.
 	 */
-	public FsStateBackend(Path checkpointDataUri, boolean asynchronousSnapshots) throws IOException {
+	public FsStateBackend(Path checkpointDataUri, boolean asynchronousSnapshots) {
 		this(checkpointDataUri.toUri(), asynchronousSnapshots);
 	}
 
@@ -160,10 +192,30 @@ public class FsStateBackend extends AbstractStateBackend {
 	 *
 	 * @param checkpointDataUri The URI describing the filesystem (scheme and optionally authority),
 	 *                          and the path to the checkpoint data directory.
-	 * @throws IOException Thrown, if no file system can be found for the scheme in the URI.
 	 */
-	public FsStateBackend(URI checkpointDataUri) throws IOException {
-		this(checkpointDataUri, DEFAULT_FILE_STATE_THRESHOLD, false);
+	public FsStateBackend(URI checkpointDataUri) {
+		this(checkpointDataUri, null, null, null);
+	}
+
+	/**
+	 * Creates a new state backend that stores its checkpoint data in the file system and location
+	 * defined by the given URI. Optionally, this constructor accepts a default savepoint storage
+	 * directory to which savepoints are stored when no custom target path is give to the savepoint
+	 * command.
+	 *
+	 * <p>A file system for the file system scheme in the URI (e.g., 'file://', 'hdfs://', or 'S3://')
+	 * must be accessible via {@link FileSystem#get(URI)}.
+	 *
+	 * <p>For a state backend targeting HDFS, this means that the URI must either specify the authority
+	 * (host and port), or that the Hadoop configuration that describes that information must be in the
+	 * classpath.
+	 *
+	 * @param checkpointDataUri The URI describing the filesystem (scheme and optionally authority),
+	 *                          and the path to the checkpoint data directory.
+	 * @param defaultSavepointDirectory The default directory to store savepoints to. May be null.
+	 */
+	public FsStateBackend(URI checkpointDataUri, @Nullable URI defaultSavepointDirectory) {
+		this(checkpointDataUri, defaultSavepointDirectory, null, null);
 	}
 
 	/**
@@ -180,11 +232,9 @@ public class FsStateBackend extends AbstractStateBackend {
 	 * @param checkpointDataUri The URI describing the filesystem (scheme and optionally authority),
 	 *                          and the path to the checkpoint data directory.
 	 * @param asynchronousSnapshots Switch to enable asynchronous snapshots.
-	 *
-	 * @throws IOException Thrown, if no file system can be found for the scheme in the URI.
 	 */
-	public FsStateBackend(URI checkpointDataUri, boolean asynchronousSnapshots) throws IOException {
-		this(checkpointDataUri, DEFAULT_FILE_STATE_THRESHOLD, asynchronousSnapshots);
+	public FsStateBackend(URI checkpointDataUri, boolean asynchronousSnapshots) {
+		this(checkpointDataUri, null, null, asynchronousSnapshots);
 	}
 
 	/**
@@ -202,13 +252,9 @@ public class FsStateBackend extends AbstractStateBackend {
 	 *                          and the path to the checkpoint data directory.
 	 * @param fileStateSizeThreshold State up to this size will be stored as part of the metadata,
 	 *                             rather than in files
-	 *
-	 * @throws IOException Thrown, if no file system can be found for the scheme in the URI.
-	 * @throws IllegalArgumentException Thrown, if the {@code fileStateSizeThreshold} is out of bounds.
 	 */
-	public FsStateBackend(URI checkpointDataUri, int fileStateSizeThreshold) throws IOException {
-
-		this(checkpointDataUri, fileStateSizeThreshold, false);
+	public FsStateBackend(URI checkpointDataUri, int fileStateSizeThreshold) {
+		this(checkpointDataUri, null, fileStateSizeThreshold, null);
 	}
 
 	/**
@@ -227,32 +273,116 @@ public class FsStateBackend extends AbstractStateBackend {
 	 * @param fileStateSizeThreshold State up to this size will be stored as part of the metadata,
 	 *                             rather than in files
 	 * @param asynchronousSnapshots Switch to enable asynchronous snapshots.
-	 *
-	 * @throws IOException Thrown, if no file system can be found for the scheme in the URI.
 	 */
 	public FsStateBackend(
 			URI checkpointDataUri,
 			int fileStateSizeThreshold,
-			boolean asynchronousSnapshots) throws IOException {
+			boolean asynchronousSnapshots) {
+		this(checkpointDataUri, null, fileStateSizeThreshold, asynchronousSnapshots);
+	}
 
-		checkArgument(fileStateSizeThreshold >= 0, "The threshold for file state size must be zero or larger.");
-		checkArgument(fileStateSizeThreshold <= MAX_FILE_STATE_THRESHOLD,
-				"The threshold for file state size cannot be larger than %s", MAX_FILE_STATE_THRESHOLD);
+	/**
+	 * Creates a new state backend that stores its checkpoint data in the file system and location
+	 * defined by the given URI.
+	 *
+	 * <p>A file system for the file system scheme in the URI (e.g., 'file://', 'hdfs://', or 'S3://')
+	 * must be accessible via {@link FileSystem#get(URI)}.
+	 *
+	 * <p>For a state backend targeting HDFS, this means that the URI must either specify the authority
+	 * (host and port), or that the Hadoop configuration that describes that information must be in the
+	 * classpath.
+	 *
+	 * @param checkpointDirectory        The path to write checkpoint metadata to.
+	 * @param defaultSavepointDirectory  The path to write savepoints to. If null, the value from
+	 *                                   the runtime configuration will be used, or savepoint
+	 *                                   target locations need to be passed when triggering a savepoint.
+	 * @param fileStateSizeThreshold     State below this size will be stored as part of the metadata,
+	 *                                   rather than in files. If null, the value configured in the
+	 *                                   runtime configuration will be used, or the default value (1KB)
+	 *                                   if nothing is configured. 
+	 * @param asynchronousSnapshots      Flag to switch between synchronous and asynchronous
+	 *                                   snapshot mode. If null, the value configured in the
+	 *                                   runtime configuration will be used.
+	 */
+	public FsStateBackend(
+			URI checkpointDirectory,
+			@Nullable URI defaultSavepointDirectory,
+			@Nullable Integer fileStateSizeThreshold,
+			@Nullable Boolean asynchronousSnapshots) {
+
+		super(checkNotNull(checkpointDirectory, "checkpoint directory is null"), defaultSavepointDirectory);
+
+		checkArgument(fileStateSizeThreshold == null || 
+					fileStateSizeThreshold >= 0 && fileStateSizeThreshold <= MAX_FILE_STATE_THRESHOLD,
+				"The threshold for file state size must be in [0, %s]", MAX_FILE_STATE_THRESHOLD);
 
 		this.fileStateThreshold = fileStateSizeThreshold;
-		this.basePath = validateAndNormalizeUri(checkpointDataUri);
-
 		this.asynchronousSnapshots = asynchronousSnapshots;
 	}
 
 	/**
-	 * Gets the base directory where all state-containing files are stored.
-	 * The job specific directory is created inside this directory.
+	 * Private constructor that creates a re-configured copy of the state backend.
 	 *
-	 * @return The base directory.
+	 * @param original The state backend to re-configure
+	 * @param configuration The configuration
 	 */
+	private FsStateBackend(FsStateBackend original, Configuration configuration) {
+		super(original.getCheckpointPath(), original.getSavepointPath(), configuration);
+
+		// if asynchronous snapshots were configured, use that setting,
+		// else check the configuration
+		this.asynchronousSnapshots = original.asynchronousSnapshots != null ?
+				original.asynchronousSnapshots :
+				configuration.getBoolean(CheckpointingOptions.HEAP_KV_ASYNC_SNAPSHOTS);
+
+		final int sizeThreshold = original.fileStateThreshold != null ?
+				original.fileStateThreshold :
+				configuration.getInteger(CheckpointingOptions.FS_SMALL_FILE_THRESHOLD);
+
+		if (sizeThreshold > 0 && sizeThreshold < MAX_FILE_STATE_THRESHOLD) {
+			this.fileStateThreshold = sizeThreshold;
+		}
+		else {
+			this.fileStateThreshold = CheckpointingOptions.FS_SMALL_FILE_THRESHOLD.defaultValue();
+
+			// because this is the only place we (unlikely) ever log, we lazily
+			// create the logger here
+			LoggerFactory.getLogger(AbstractFileStateBackend.class).warn(
+					"Ignoring invalid file size threshold value ({}): {} - using default value {} instead.",
+					CheckpointingOptions.FS_SMALL_FILE_THRESHOLD.key(), sizeThreshold,
+					CheckpointingOptions.FS_SMALL_FILE_THRESHOLD.defaultValue());
+		}
+	}
+
+	// ------------------------------------------------------------------------
+	//  Properties
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Gets the base directory where all the checkpoints are stored.
+	 * The job-specific checkpoint directory is created inside this directory.
+	 *
+	 * @return The base directory for checkpoints.
+	 *
+	 * @deprecated Deprecated in favor of {@link #getCheckpointPath()}.
+	 */
+	@Deprecated
 	public Path getBasePath() {
-		return basePath;
+		return getCheckpointPath();
+	}
+
+	/**
+	 * Gets the base directory where all the checkpoints are stored.
+	 * The job-specific checkpoint directory is created inside this directory.
+	 *
+	 * @return The base directory for checkpoints.
+	 */
+	@Nonnull
+	@Override
+	public Path getCheckpointPath() {
+		// we know that this can never be null by the way of constructor checks
+		//noinspection ConstantConditions
+		return super.getCheckpointPath();
 	}
 
 	/**
@@ -260,12 +390,43 @@ public class FsStateBackend extends AbstractStateBackend {
 	 * This threshold ensures that the backend does not create a large amount of very small files,
 	 * where potentially the file pointers are larger than the state itself.
 	 *
-	 * <p>By default, this threshold is {@value #DEFAULT_FILE_STATE_THRESHOLD}.
+	 * <p>If not explicitly configured, this is the default value of
+	 * {@link CheckpointingOptions#FS_SMALL_FILE_THRESHOLD}.
 	 *
 	 * @return The file size threshold, in bytes.
 	 */
 	public int getMinFileSizeThreshold() {
-		return fileStateThreshold;
+		return fileStateThreshold != null ?
+				fileStateThreshold :
+				CheckpointingOptions.FS_SMALL_FILE_THRESHOLD.defaultValue();
+	}
+
+	/**
+	 * Gets whether the key/value data structures are asynchronously snapshotted.
+	 * 
+	 * <p>If not explicitly configured, this is the default value of
+	 * {@link CheckpointingOptions#HEAP_KV_ASYNC_SNAPSHOTS}.
+	 */
+	public boolean isUsingAsynchronousSnapshots() {
+		return asynchronousSnapshots != null ?
+				asynchronousSnapshots :
+				CheckpointingOptions.HEAP_KV_ASYNC_SNAPSHOTS.defaultValue();
+	}
+
+	// ------------------------------------------------------------------------
+	//  Reconfiguration
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Creates a copy of this state backend that uses the values defined in the configuration
+	 * for fields where that were not specified in this state backend.
+	 *
+	 * @param config the configuration
+	 * @return The re-configured variant of the state backend
+	 */
+	@Override
+	public FsStateBackend configure(Configuration config) {
+		return new FsStateBackend(this, config);
 	}
 
 	// ------------------------------------------------------------------------
@@ -274,7 +435,7 @@ public class FsStateBackend extends AbstractStateBackend {
 
 	@Override
 	public CheckpointStreamFactory createStreamFactory(JobID jobId, String operatorIdentifier) throws IOException {
-		return new FsCheckpointStreamFactory(basePath, jobId, fileStateThreshold);
+		return new FsCheckpointStreamFactory(getCheckpointPath(), jobId, getMinFileSizeThreshold());
 	}
 
 	@Override
@@ -283,7 +444,7 @@ public class FsStateBackend extends AbstractStateBackend {
 			String operatorIdentifier,
 			String targetLocation) throws IOException {
 
-		return new FsSavepointStreamFactory(new Path(targetLocation), jobId, fileStateThreshold);
+		return new FsSavepointStreamFactory(new Path(targetLocation), jobId, getMinFileSizeThreshold());
 	}
 
 	@Override
@@ -302,7 +463,7 @@ public class FsStateBackend extends AbstractStateBackend {
 				env.getUserClassLoader(),
 				numberOfKeyGroups,
 				keyGroupRange,
-				asynchronousSnapshots,
+				isUsingAsynchronousSnapshots(),
 				env.getExecutionConfig());
 	}
 
@@ -314,45 +475,19 @@ public class FsStateBackend extends AbstractStateBackend {
 		return new DefaultOperatorStateBackend(
 			env.getUserClassLoader(),
 			env.getExecutionConfig(),
-			asynchronousSnapshots);
+				isUsingAsynchronousSnapshots());
 	}
+
+	// ------------------------------------------------------------------------
+	//  utilities
+	// ------------------------------------------------------------------------
 
 	@Override
 	public String toString() {
-		return "File State Backend @ " + basePath;
-	}
-
-	/**
-	 * Checks and normalizes the checkpoint data URI. This method first checks the validity of the
-	 * URI (scheme, path, availability of a matching file system) and then normalizes the URI
-	 * to a path.
-	 * 
-	 * <p>If the URI does not include an authority, but the file system configured for the URI has an
-	 * authority, then the normalized path will include this authority.
-	 * 
-	 * @param checkpointDataUri The URI to check and normalize.
-	 * @return A normalized URI as a Path.
-	 * 
-	 * @throws IllegalArgumentException Thrown, if the URI misses scheme or path. 
-	 * @throws IOException Thrown, if no file system can be found for the URI's scheme.
-	 */
-	private static Path validateAndNormalizeUri(URI checkpointDataUri) throws IOException {
-		final String scheme = checkpointDataUri.getScheme();
-		final String path = checkpointDataUri.getPath();
-
-		// some validity checks
-		if (scheme == null) {
-			throw new IllegalArgumentException("The scheme (hdfs://, file://, etc) is null. " +
-					"Please specify the file system scheme explicitly in the URI.");
-		}
-		if (path == null) {
-			throw new IllegalArgumentException("The path to store the checkpoint data in is null. " +
-					"Please specify a directory path for the checkpoint data.");
-		}
-		if (path.length() == 0 || path.equals("/")) {
-			throw new IllegalArgumentException("Cannot use the root directory for checkpoints.");
-		}
-
-		return new Path(checkpointDataUri);
+		return "File State Backend (" +
+				"checkpoints: '" + getCheckpointPath() +
+				"', savepoints: '" + getSavepointPath() +
+				"', asynchronous: " + asynchronousSnapshots +
+				", fileStateThreshold: " + fileStateThreshold + ")";
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackendFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackendFactory.java
@@ -18,44 +18,33 @@
 
 package org.apache.flink.runtime.state.filesystem;
 
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.IllegalConfigurationException;
-import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.state.StateBackendFactory;
 
-import java.io.IOException;
-
 /**
- * A factory that creates an {@link org.apache.flink.runtime.state.filesystem.FsStateBackend}
- * from a configuration.
+ * A factory that creates an {@link FsStateBackend} from a configuration.
  */
+@PublicEvolving
 public class FsStateBackendFactory implements StateBackendFactory<FsStateBackend> {
-	
-	/** The key under which the config stores the directory where checkpoints should be stored */
-	public static final String CHECKPOINT_DIRECTORY_URI_CONF_KEY = "state.backend.fs.checkpointdir";
-
-	/** The key under which the config stores the threshold for state to be store in memory,
-	 * rather than in files */
-	public static final String MEMORY_THRESHOLD_CONF_KEY = "state.backend.fs.memory-threshold";
-
 
 	@Override
 	public FsStateBackend createFromConfig(Configuration config) throws IllegalConfigurationException {
-		final String checkpointDirURI = config.getString(CHECKPOINT_DIRECTORY_URI_CONF_KEY, null);
-		final int memoryThreshold = config.getInteger(
-			MEMORY_THRESHOLD_CONF_KEY, FsStateBackend.DEFAULT_FILE_STATE_THRESHOLD);
-
-		if (checkpointDirURI == null) {
+		// we need to explicitly read the checkpoint directory here, because that
+		// is a required constructor parameter
+		final String checkpointDir = config.getString(CheckpointingOptions.CHECKPOINTS_DIRECTORY);
+		if (checkpointDir == null) {
 			throw new IllegalConfigurationException(
 					"Cannot create the file system state backend: The configuration does not specify the " +
-							"checkpoint directory '" + CHECKPOINT_DIRECTORY_URI_CONF_KEY + '\'');
+							"checkpoint directory '" + CheckpointingOptions.CHECKPOINTS_DIRECTORY.key() + '\'');
 		}
 
 		try {
-			Path path = new Path(checkpointDirURI);
-			return new FsStateBackend(path.toUri(), memoryThreshold);
+			return new FsStateBackend(checkpointDir).configure(config);
 		}
-		catch (IOException | IllegalArgumentException e) {
+		catch (IllegalArgumentException e) {
 			throw new IllegalConfigurationException("Invalid configuration for the state backend", e);
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemCheckpointStreamFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemCheckpointStreamFactory.java
@@ -45,9 +45,6 @@ public class MemCheckpointStreamFactory implements CheckpointStreamFactory {
 	}
 
 	@Override
-	public void close() throws Exception {}
-
-	@Override
 	public CheckpointStateOutputStream createCheckpointStateOutputStream(
 			long checkpointID, long timestamp) throws Exception
 	{

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryStateBackend.java
@@ -18,77 +18,267 @@
 
 package org.apache.flink.runtime.state.memory;
 
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.configuration.CheckpointingOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
-import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
+import org.apache.flink.runtime.state.ConfigurableStateBackend;
 import org.apache.flink.runtime.state.DefaultOperatorStateBackend;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.OperatorStateBackend;
+import org.apache.flink.runtime.state.filesystem.AbstractFileStateBackend;
 import org.apache.flink.runtime.state.heap.HeapKeyedStateBackend;
+
+import javax.annotation.Nullable;
 
 import java.io.IOException;
 
+import static org.apache.flink.util.Preconditions.checkArgument;
+
 /**
- * A {@link AbstractStateBackend} that stores all its data and checkpoints in memory and has no
- * capabilities to spill to disk. Checkpoints are serialized and the serialized data is
- * transferred
+ * This state backend holds the working state in the memory (JVM heap) of the TaskManagers.
+ * The state backend checkpoints state directly to the JobManager's memory (hence the backend's name),
+ * but the checkpoints will be persisted to a file system for high-availability setups and savepoints.
+ * The MemoryStateBackend is consequently a FileSystem-based backend that can work without a
+ * file system dependency in simple setups.
+ *
+ * <p>This state backend should be used only for experimentation, quick local setups,
+ * or for streaming applications that have very small state: Because it requires checkpoints to
+ * go through the JobManager's memory, larger state will occupy larger portions of the JobManager's  
+ * main memory, reducing operational stability.
+ * For any other setup, the {@link org.apache.flink.runtime.state.filesystem.FsStateBackend FsStateBackend}
+ * should be used. The {@code FsStateBackend} holds the working state on the TaskManagers in the same way, but
+ * checkpoints state directly to files rather then to the JobManager's memory, thus supporting
+ * large state sizes. 
+ *
+ * <h1>State Size Considerations</h1>
+ *
+ * State checkpointing with this state backend is subject to the following conditions:
+ * <ul>
+ *     <li>Each individual state must not exceed the configured maximum state size
+ *         (see {@link #getMaxStateSize()}.</li>
+ *
+ *     <li>All state from one task (i.e., the sum of all operator states and keyed states from all
+ *         chained operators of the task) must not exceed what the RPC system supports, which is
+ *         be default < 10 MB. That limit can be configured up, but that is typically not advised.</li>
+ *
+ *     <li>The sum of all states in the application times all retained checkpoints must comfortably
+ *         fit into the JobManager's JVM heap space.</li>
+ * </ul>
+ *
+ * <h1>Persistence Guarantees</h1>
+ *
+ * For the use cases where the state sizes can be handled by this backend, the backend does guarantee
+ * persistence for savepoints, externalized checkpoints (of configured), and checkpoints
+ * (when high-availability is configured).
+ *
+ * <h1>Configuration</h1>
+ *
+ * As for all state backends, this backend can either be configured within the application (by creating
+ * the backend with the respective constructor parameters and setting it on the execution environment)
+ * or by specifying it in the Flink configuration.
+ *
+ * <p>If the state backend was specified in the application, it may pick up additional configuration
+ * parameters from the Flink configuration. For example, if the backend if configured in the application
+ * without a default savepoint directory, it will pick up a default savepoint directory specified in the
+ * Flink configuration of the running job/cluster. That behavior is implemented via the
+ * {@link #configure(Configuration)} method.
  */
-public class MemoryStateBackend extends AbstractStateBackend {
+@PublicEvolving
+public class MemoryStateBackend extends AbstractFileStateBackend implements ConfigurableStateBackend {
 
 	private static final long serialVersionUID = 4109305377809414635L;
 
 	/** The default maximal size that the snapshotted memory state may have (5 MiBytes) */
-	private static final int DEFAULT_MAX_STATE_SIZE = 5 * 1024 * 1024;
+	public static final int DEFAULT_MAX_STATE_SIZE = 5 * 1024 * 1024;
 
 	/** The maximal size that the snapshotted memory state may have */
 	private final int maxStateSize;
 
-	/** Switch to chose between synchronous and asynchronous snapshots */
-	private final boolean asynchronousSnapshots;
+	/** Switch to chose between synchronous and asynchronous snapshots.
+	 * Null if not yet configured, in which case the default will be used. */
+	@Nullable
+	private final Boolean asynchronousSnapshots;
+
+	// ------------------------------------------------------------------------
 
 	/**
 	 * Creates a new memory state backend that accepts states whose serialized forms are
 	 * up to the default state size (5 MB).
+	 *
+	 * <p>Checkpoint and default savepoint locations are used as specified in the
+	 * runtime configuration.
 	 */
 	public MemoryStateBackend() {
-		this(DEFAULT_MAX_STATE_SIZE);
+		this(null, null, DEFAULT_MAX_STATE_SIZE, null);
 	}
 
 	/**
 	 * Creates a new memory state backend that accepts states whose serialized forms are
-	 * up to the given number of bytes.
+	 * up to the default state size (5 MB). The state backend uses asynchronous snapshots
+	 * or synchronous snapshots as configured.
 	 *
-	 * @param maxStateSize The maximal size of the serialized state
-	 */
-	public MemoryStateBackend(int maxStateSize) {
-		this(maxStateSize, false);
-	}
-
-	/**
-	 * Creates a new memory state backend that accepts states whose serialized forms are
-	 * up to the default state size (5 MB).
+	 * <p>Checkpoint and default savepoint locations are used as specified in the
+	 * runtime configuration.
 	 *
 	 * @param asynchronousSnapshots Switch to enable asynchronous snapshots.
 	 */
 	public MemoryStateBackend(boolean asynchronousSnapshots) {
-		this(DEFAULT_MAX_STATE_SIZE, asynchronousSnapshots);
+		this(null, null, DEFAULT_MAX_STATE_SIZE, asynchronousSnapshots);
 	}
 
 	/**
 	 * Creates a new memory state backend that accepts states whose serialized forms are
 	 * up to the given number of bytes.
 	 *
+	 * <p>Checkpoint and default savepoint locations are used as specified in the
+	 * runtime configuration.
+	 *
+	 * <p><b>WARNING:</b> Increasing the size of this value beyond the default value
+	 * ({@value #DEFAULT_MAX_STATE_SIZE}) should be done with care.
+	 * The checkpointed state needs to be send to the JobManager via limited size RPC messages, and there
+	 * and the JobManager needs to be able to hold all aggregated state in its memory.
+	 *
 	 * @param maxStateSize The maximal size of the serialized state
-	 * @param asynchronousSnapshots Switch to enable asynchronous snapshots.
+	 */
+	public MemoryStateBackend(int maxStateSize) {
+		this(null, null, maxStateSize, null);
+	}
+
+	/**
+	 * Creates a new memory state backend that accepts states whose serialized forms are
+	 * up to the given number of bytes and that uses asynchronous snashots as configured.
+	 *
+	 * <p>Checkpoint and default savepoint locations are used as specified in the
+	 * runtime configuration.
+	 *
+	 * <p><b>WARNING:</b> Increasing the size of this value beyond the default value
+	 * ({@value #DEFAULT_MAX_STATE_SIZE}) should be done with care.
+	 * The checkpointed state needs to be send to the JobManager via limited size RPC messages, and there
+	 * and the JobManager needs to be able to hold all aggregated state in its memory.
+	 *
+	 * @param maxStateSize The maximal size of the serialized state
+	 * @param asynchronousSnapshots Switch to enable asynchronous snapshots.   
 	 */
 	public MemoryStateBackend(int maxStateSize, boolean asynchronousSnapshots) {
+		this(null, null, maxStateSize, asynchronousSnapshots);
+	}
+
+	/**
+	 * Creates a new MemoryStateBackend, setting optionally the path to persist checkpoint metadata
+	 * to, and to persist savepoints to.
+	 *
+	 * @param checkpointPath The path to write checkpoint metadata to. If null, the value from
+	 *                       the runtime configuration will be used.
+	 * @param savepointPath  The path to write savepoints to. If null, the value from
+	 *                       the runtime configuration will be used.
+	 */
+	public MemoryStateBackend(@Nullable String checkpointPath, @Nullable String savepointPath) {
+		this(checkpointPath, savepointPath, DEFAULT_MAX_STATE_SIZE, null);
+	}
+
+	/**
+	 * Creates a new MemoryStateBackend, setting optionally the paths to persist checkpoint metadata
+	 * and savepoints to, as well as configuring state thresholds and asynchronous operations.
+	 *
+	 * <p><b>WARNING:</b> Increasing the size of this value beyond the default value
+	 * ({@value #DEFAULT_MAX_STATE_SIZE}) should be done with care.
+	 * The checkpointed state needs to be send to the JobManager via limited size RPC messages, and there
+	 * and the JobManager needs to be able to hold all aggregated state in its memory.
+	 *
+	 * @param checkpointPath The path to write checkpoint metadata to. If null, the value from
+	 *                       the runtime configuration will be used.
+	 * @param savepointPath  The path to write savepoints to. If null, the value from
+	 *                       the runtime configuration will be used.
+	 * @param maxStateSize   The maximal size of the serialized state.
+	 * @param asynchronousSnapshots Flag to switch between synchronous and asynchronous
+	 *                              snapshot mode. If null, the value configured in the
+	 *                              runtime configuration will be used.
+	 */
+	public MemoryStateBackend(
+			@Nullable String checkpointPath,
+			@Nullable String savepointPath,
+			int maxStateSize,
+			@Nullable Boolean asynchronousSnapshots) {
+
+		super(checkpointPath == null ? null : new Path(checkpointPath),
+				savepointPath == null ? null : new Path(savepointPath));
+
+		checkArgument(maxStateSize > 0, "maxStateSize must be > 0");
 		this.maxStateSize = maxStateSize;
+
 		this.asynchronousSnapshots = asynchronousSnapshots;
 	}
+
+	/**
+	 * Private constructor that creates a re-configured copy of the state backend.
+	 *
+	 * @param original The state backend to re-configure
+	 * @param configuration The configuration
+	 */
+	private MemoryStateBackend(MemoryStateBackend original, Configuration configuration) {
+		super(original.getCheckpointPath(), original.getSavepointPath(), configuration);
+
+		this.maxStateSize = original.maxStateSize;
+
+		// if asynchronous snapshots were configured, use that setting,
+		// else check the configuration
+		this.asynchronousSnapshots = original.asynchronousSnapshots != null ?
+				original.asynchronousSnapshots :
+				configuration.getBoolean(CheckpointingOptions.HEAP_KV_ASYNC_SNAPSHOTS);
+	}
+
+	// ------------------------------------------------------------------------
+	//  Properties
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Gets the maximum size that an individual state can have, as configured in the
+	 * constructor (by default {@value #DEFAULT_MAX_STATE_SIZE}).
+	 *
+	 * @return The maximum size that an individual state can have
+	 */
+	public int getMaxStateSize() {
+		return maxStateSize;
+	}
+
+	/**
+	 * Gets whether the key/value data structures are asynchronously snapshotted.
+	 *
+	 * <p>If not explicitly configured, this is the default value of
+	 * {@link CheckpointingOptions#HEAP_KV_ASYNC_SNAPSHOTS}.
+	 */
+	public boolean isUsingAsynchronousSnapshots() {
+		return asynchronousSnapshots != null ?
+				asynchronousSnapshots :
+				CheckpointingOptions.HEAP_KV_ASYNC_SNAPSHOTS.defaultValue();
+	}
+
+	// ------------------------------------------------------------------------
+	//  Reconfiguration
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Creates a copy of this state backend that uses the values defined in the configuration
+	 * for fields where that were not specified in this state backend.
+	 *
+	 * @param config the configuration
+	 * @return The re-configured variant of the state backend
+	 */
+	@Override
+	public MemoryStateBackend configure(Configuration config) {
+		return new MemoryStateBackend(this, config);
+	}
+
+	// ------------------------------------------------------------------------
+	//  checkpoint state persistence
+	// ------------------------------------------------------------------------
 
 	@Override
 	public OperatorStateBackend createOperatorStateBackend(
@@ -98,12 +288,7 @@ public class MemoryStateBackend extends AbstractStateBackend {
 		return new DefaultOperatorStateBackend(
 			env.getUserClassLoader(),
 			env.getExecutionConfig(),
-			asynchronousSnapshots);
-	}
-
-	@Override
-	public String toString() {
-		return "MemoryStateBackend (data in heap memory / checkpoints to JobManager)";
+			isUsingAsynchronousSnapshots());
 	}
 
 	@Override
@@ -121,6 +306,10 @@ public class MemoryStateBackend extends AbstractStateBackend {
 		return new MemCheckpointStreamFactory(maxStateSize);
 	}
 
+	// ------------------------------------------------------------------------
+	//  checkpoint state persistence
+	// ------------------------------------------------------------------------
+
 	@Override
 	public <K> AbstractKeyedStateBackend<K> createKeyedStateBackend(
 			Environment env, JobID jobID,
@@ -136,7 +325,20 @@ public class MemoryStateBackend extends AbstractStateBackend {
 				env.getUserClassLoader(),
 				numberOfKeyGroups,
 				keyGroupRange,
-				asynchronousSnapshots,
+				isUsingAsynchronousSnapshots(),
 				env.getExecutionConfig());
+	}
+
+	// ------------------------------------------------------------------------
+	//  utilities
+	// ------------------------------------------------------------------------
+
+	@Override
+	public String toString() {
+		return "MemoryStateBackend (data in heap memory / checkpoints to JobManager) " +
+				"(checkpoints: '" + getCheckpointPath() +
+				"', savepoints: '" + getSavepointPath() +
+				"', asynchronous: " + asynchronousSnapshots +
+				", maxStateSize: " + maxStateSize + ")";
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryStateBackendFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryStateBackendFactory.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.memory;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.state.StateBackendFactory;
+
+/**
+ * A factory that creates an {@link MemoryStateBackend} from a configuration.
+ */
+@PublicEvolving
+public class MemoryStateBackendFactory implements StateBackendFactory<MemoryStateBackend> {
+
+	@Override
+	public MemoryStateBackend createFromConfig(Configuration config) {
+		return new MemoryStateBackend().configure(config);
+	}
+}

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -168,7 +168,8 @@ class JobManager(
   var futuresToComplete: Option[Seq[Future[Unit]]] = None
 
   /** The default directory for savepoints. */
-  val defaultSavepointDir: String = flinkConfiguration.getString(CoreOptions.SAVEPOINT_DIRECTORY)
+  val defaultSavepointDir: String = 
+    flinkConfiguration.getString(CheckpointingOptions.SAVEPOINT_DIRECTORY)
 
   /** The resource manager actor responsible for allocating and managing task manager resources. */
   var currentResourceManager: Option[ActorRef] = None
@@ -586,7 +587,7 @@ class JobManager(
           sender ! decorateMessage(CancellationFailure(jobId, new IllegalStateException(
             "No savepoint directory configured. You can either specify a directory " +
               "while cancelling via -s :targetDirectory or configure a cluster-wide " +
-              "default via key '" + CoreOptions.SAVEPOINT_DIRECTORY.key() + "'.")))
+              "default via key '" + CheckpointingOptions.SAVEPOINT_DIRECTORY.key() + "'.")))
         } else {
           log.info(s"Trying to cancel job $jobId with savepoint to $targetDirectory")
 
@@ -772,13 +773,13 @@ class JobManager(
             val senderRef = sender()
             try {
               val targetDirectory : String = savepointDirectory.getOrElse(
-                flinkConfiguration.getString(CoreOptions.SAVEPOINT_DIRECTORY))
+                flinkConfiguration.getString(CheckpointingOptions.SAVEPOINT_DIRECTORY))
 
               if (targetDirectory == null) {
                 throw new IllegalStateException("No savepoint directory configured. " +
                   "You can either specify a directory when triggering this savepoint or " +
                   "configure a cluster-wide default via key '" +
-                  CoreOptions.SAVEPOINT_DIRECTORY.key() + "'.")
+                  CheckpointingOptions.SAVEPOINT_DIRECTORY.key() + "'.")
               }
 
               // Do this async, because checkpoint coordinator operations can

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorFailureTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorFailureTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.messages.checkpoint.AcknowledgeCheckpoint;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.runtime.state.SharedStateRegistry;
+import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
@@ -78,6 +79,7 @@ public class CheckpointCoordinatorFailureTest extends TestLogger {
 			new StandaloneCheckpointIDCounter(),
 			new FailingCompletedCheckpointStore(),
 			null,
+			new MemoryStateBackend(),
 			Executors.directExecutor(),
 			SharedStateRegistry.DEFAULT_FACTORY);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorMasterHooksTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorMasterHooksTest.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.jobgraph.tasks.ExternalizedCheckpointSettings;
 import org.apache.flink.runtime.messages.checkpoint.AcknowledgeCheckpoint;
 import org.apache.flink.runtime.state.SharedStateRegistry;
 
+import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -402,6 +403,7 @@ public class CheckpointCoordinatorMasterHooksTest {
 				new StandaloneCheckpointIDCounter(),
 				new StandaloneCompletedCheckpointStore(10),
 				null,
+				new MemoryStateBackend(),
 				Executors.directExecutor(),
 				SharedStateRegistry.DEFAULT_FACTORY);
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
@@ -49,6 +49,7 @@ import org.apache.flink.runtime.state.StateHandleID;
 import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.filesystem.FileStateHandle;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
+import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.runtime.testutils.RecoverableCompletedCheckpointStore;
 import org.apache.flink.runtime.util.TestByteStreamStateHandleDeepCompare;
@@ -141,6 +142,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 				new StandaloneCheckpointIDCounter(),
 				new StandaloneCompletedCheckpointStore(1),
 				null,
+				new MemoryStateBackend(),
 				Executors.directExecutor(),
 				SharedStateRegistry.DEFAULT_FACTORY);
 
@@ -202,6 +204,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 				new StandaloneCheckpointIDCounter(),
 				new StandaloneCompletedCheckpointStore(1),
 				null,
+				new MemoryStateBackend(),
 				Executors.directExecutor(),
 				SharedStateRegistry.DEFAULT_FACTORY);
 
@@ -254,6 +257,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 				new StandaloneCheckpointIDCounter(),
 				new StandaloneCompletedCheckpointStore(1),
 				null,
+				new MemoryStateBackend(),
 				Executors.directExecutor(),
 				SharedStateRegistry.DEFAULT_FACTORY);
 
@@ -307,6 +311,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 				new StandaloneCheckpointIDCounter(),
 				new StandaloneCompletedCheckpointStore(1),
 				null,
+				new MemoryStateBackend(),
 				Executors.directExecutor(),
 				SharedStateRegistry.DEFAULT_FACTORY);
 
@@ -410,6 +415,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 				new StandaloneCheckpointIDCounter(),
 				new StandaloneCompletedCheckpointStore(1),
 				null,
+				new MemoryStateBackend(),
 				Executors.directExecutor(),
 				SharedStateRegistry.DEFAULT_FACTORY);
 
@@ -530,6 +536,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 				new StandaloneCheckpointIDCounter(),
 				new StandaloneCompletedCheckpointStore(1),
 				null,
+				new MemoryStateBackend(),
 				Executors.directExecutor(),
 				SharedStateRegistry.DEFAULT_FACTORY);
 
@@ -698,6 +705,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 				new StandaloneCheckpointIDCounter(),
 				new StandaloneCompletedCheckpointStore(2),
 				null,
+				new MemoryStateBackend(),
 				Executors.directExecutor(),
 				SharedStateRegistry.DEFAULT_FACTORY);
 
@@ -829,6 +837,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 				new StandaloneCheckpointIDCounter(),
 				new StandaloneCompletedCheckpointStore(10),
 				null,
+				new MemoryStateBackend(),
 				Executors.directExecutor(),
 				SharedStateRegistry.DEFAULT_FACTORY);
 
@@ -994,6 +1003,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 				new StandaloneCheckpointIDCounter(),
 				new StandaloneCompletedCheckpointStore(2),
 				null,
+				new MemoryStateBackend(),
 				Executors.directExecutor(),
 				SharedStateRegistry.DEFAULT_FACTORY);
 
@@ -1072,6 +1082,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 				new StandaloneCheckpointIDCounter(),
 				new StandaloneCompletedCheckpointStore(2),
 				null,
+				new MemoryStateBackend(),
 				Executors.directExecutor(),
 				SharedStateRegistry.DEFAULT_FACTORY);
 
@@ -1136,6 +1147,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			new StandaloneCheckpointIDCounter(),
 			new StandaloneCompletedCheckpointStore(1),
 			null,
+			new MemoryStateBackend(),
 			Executors.directExecutor(),
 			SharedStateRegistry.DEFAULT_FACTORY);
 
@@ -1269,6 +1281,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 				new StandaloneCheckpointIDCounter(),
 				new StandaloneCompletedCheckpointStore(2),
 				null,
+				new MemoryStateBackend(),
 				Executors.directExecutor(),
 				SharedStateRegistry.DEFAULT_FACTORY);
 
@@ -1359,6 +1372,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 				new StandaloneCheckpointIDCounter(),
 				new StandaloneCompletedCheckpointStore(2),
 				"dummy-path",
+				new MemoryStateBackend(),
 				Executors.directExecutor(),
 				SharedStateRegistry.DEFAULT_FACTORY);
 
@@ -1433,6 +1447,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			new StandaloneCheckpointIDCounter(),
 			new StandaloneCompletedCheckpointStore(1),
 			null,
+			new MemoryStateBackend(),
 			Executors.directExecutor(),
 			SharedStateRegistry.DEFAULT_FACTORY);
 
@@ -1585,6 +1600,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			counter,
 			new StandaloneCompletedCheckpointStore(10),
 			null,
+			new MemoryStateBackend(),
 			Executors.directExecutor(),
 			SharedStateRegistry.DEFAULT_FACTORY);
 
@@ -1686,6 +1702,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 				new StandaloneCheckpointIDCounter(),
 				new StandaloneCompletedCheckpointStore(2),
 				null,
+				new MemoryStateBackend(),
 				Executors.directExecutor(),
 				SharedStateRegistry.DEFAULT_FACTORY);
 
@@ -1760,6 +1777,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 				new StandaloneCheckpointIDCounter(),
 				new StandaloneCompletedCheckpointStore(2),
 				null,
+				new MemoryStateBackend(),
 				Executors.directExecutor(),
 				SharedStateRegistry.DEFAULT_FACTORY);
 
@@ -1837,6 +1855,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 				new StandaloneCheckpointIDCounter(),
 				new StandaloneCompletedCheckpointStore(2),
 				null,
+				new MemoryStateBackend(),
 				Executors.directExecutor(),
 				SharedStateRegistry.DEFAULT_FACTORY);
 
@@ -1890,6 +1909,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			checkpointIDCounter,
 			new StandaloneCompletedCheckpointStore(2),
 			null,
+			new MemoryStateBackend(),
 			Executors.directExecutor(),
 			SharedStateRegistry.DEFAULT_FACTORY);
 
@@ -1944,6 +1964,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			new StandaloneCheckpointIDCounter(),
 			new StandaloneCompletedCheckpointStore(2),
 			null,
+			new MemoryStateBackend(),
 			Executors.directExecutor(),
 			SharedStateRegistry.DEFAULT_FACTORY);
 
@@ -2007,6 +2028,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			new StandaloneCheckpointIDCounter(),
 			store,
 			null,
+			new MemoryStateBackend(),
 			Executors.directExecutor(),
 			SharedStateRegistry.DEFAULT_FACTORY);
 
@@ -2122,6 +2144,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			new StandaloneCheckpointIDCounter(),
 			new StandaloneCompletedCheckpointStore(1),
 			null,
+			new MemoryStateBackend(),
 			Executors.directExecutor(),
 			SharedStateRegistry.DEFAULT_FACTORY);
 
@@ -2269,6 +2292,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			new StandaloneCheckpointIDCounter(),
 			new StandaloneCompletedCheckpointStore(1),
 			null,
+			new MemoryStateBackend(),
 			Executors.directExecutor(),
 			SharedStateRegistry.DEFAULT_FACTORY);
 
@@ -2553,6 +2577,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			new StandaloneCheckpointIDCounter(),
 			standaloneCompletedCheckpointStore,
 			null,
+			new MemoryStateBackend(),
 			Executors.directExecutor(),
 			SharedStateRegistry.DEFAULT_FACTORY);
 
@@ -2701,6 +2726,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 				new StandaloneCheckpointIDCounter(),
 				new StandaloneCompletedCheckpointStore(1),
 				"fake-directory",
+				new MemoryStateBackend(),
 				Executors.directExecutor(),
 				SharedStateRegistry.DEFAULT_FACTORY);
 
@@ -3177,6 +3203,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			new StandaloneCheckpointIDCounter(),
 			new StandaloneCompletedCheckpointStore(1),
 			null,
+			new MemoryStateBackend(),
 			Executors.directExecutor(),
 			SharedStateRegistry.DEFAULT_FACTORY);
 
@@ -3356,6 +3383,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			new StandaloneCheckpointIDCounter(),
 			new StandaloneCompletedCheckpointStore(1),
 			null,
+			new MemoryStateBackend(),
 			Executors.directExecutor(),
 			SharedStateRegistry.DEFAULT_FACTORY);
 
@@ -3395,6 +3423,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			new StandaloneCheckpointIDCounter(),
 			store,
 			null,
+			new MemoryStateBackend(),
 			Executors.directExecutor(),
 			SharedStateRegistry.DEFAULT_FACTORY);
 
@@ -3452,6 +3481,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			checkpointIDCounter,
 			completedCheckpointStore,
 			null,
+			new MemoryStateBackend(),
 			Executors.directExecutor(),
 			SharedStateRegistry.DEFAULT_FACTORY);
 
@@ -3545,6 +3575,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			new StandaloneCheckpointIDCounter(),
 			store,
 			null,
+			new MemoryStateBackend(),
 			Executors.directExecutor(),
 				deleteExecutor -> {
 					SharedStateRegistry instance = new SharedStateRegistry(deleteExecutor);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStateRestoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStateRestoreTest.java
@@ -33,6 +33,7 @@ import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.runtime.state.SharedStateRegistry;
+import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.util.SerializableObject;
 
 import org.hamcrest.BaseMatcher;
@@ -107,6 +108,7 @@ public class CheckpointStateRestoreTest {
 				new StandaloneCheckpointIDCounter(),
 				new StandaloneCompletedCheckpointStore(1),
 				null,
+				new MemoryStateBackend(),
 				Executors.directExecutor(),
 				SharedStateRegistry.DEFAULT_FACTORY);
 
@@ -184,6 +186,7 @@ public class CheckpointStateRestoreTest {
 				new StandaloneCheckpointIDCounter(),
 				new StandaloneCompletedCheckpointStore(1),
 				null,
+				new MemoryStateBackend(),
 				Executors.directExecutor(),
 				SharedStateRegistry.DEFAULT_FACTORY);
 
@@ -242,6 +245,7 @@ public class CheckpointStateRestoreTest {
 			new StandaloneCheckpointIDCounter(),
 			new StandaloneCompletedCheckpointStore(1),
 			null,
+			new MemoryStateBackend(),
 			Executors.directExecutor(),
 			SharedStateRegistry.DEFAULT_FACTORY);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ExecutionGraphCheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ExecutionGraphCheckpointCoordinatorTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobgraph.tasks.ExternalizedCheckpointSettings;
 import org.apache.flink.runtime.jobmanager.scheduler.Scheduler;
+import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 
 import org.junit.Test;
@@ -102,7 +103,7 @@ public class ExecutionGraphCheckpointCoordinatorTest {
 				counter,
 				store,
 				null,
-				null,
+				new MemoryStateBackend(),
 				CheckpointStatsTrackerTest.createTestTracker());
 
 		JobVertex jobVertex = new JobVertex("MockVertex");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
@@ -43,6 +43,7 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
 import org.apache.flink.runtime.jobgraph.tasks.ExternalizedCheckpointSettings;
+import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.TestLogger;
@@ -66,8 +67,6 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 public class ArchivedExecutionGraphTest extends TestLogger {
-	private static JobVertexID v1ID = new JobVertexID();
-	private static JobVertexID v2ID = new JobVertexID();
 
 	private static ExecutionGraph runtimeGraph;
 
@@ -77,8 +76,8 @@ public class ArchivedExecutionGraphTest extends TestLogger {
 		// Setup
 		// -------------------------------------------------------------------------------------------------------------
 
-		v1ID = new JobVertexID();
-		v2ID = new JobVertexID();
+		JobVertexID v1ID = new JobVertexID();
+		JobVertexID v2ID = new JobVertexID();
 
 		JobVertex v1 = new JobVertex("v1", v1ID);
 		JobVertex v2 = new JobVertex("v2", v2ID);
@@ -89,7 +88,7 @@ public class ArchivedExecutionGraphTest extends TestLogger {
 		v1.setInvokableClass(AbstractInvokable.class);
 		v2.setInvokableClass(AbstractInvokable.class);
 
-		List<JobVertex> vertices = new ArrayList<JobVertex>(Arrays.asList(v1, v2));
+		List<JobVertex> vertices = new ArrayList<>(Arrays.asList(v1, v2));
 
 		ExecutionConfig config = new ExecutionConfig();
 
@@ -135,7 +134,7 @@ public class ArchivedExecutionGraphTest extends TestLogger {
 			new StandaloneCheckpointIDCounter(),
 			new StandaloneCompletedCheckpointStore(1),
 			null,
-			null,
+			new MemoryStateBackend(),
 			statsTracker);
 
 		Map<String, Accumulator<?, ?>> userAccumulators = new HashMap<>();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphDeploymentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphDeploymentTest.java
@@ -23,8 +23,8 @@ import org.apache.flink.api.common.accumulators.Accumulator;
 import org.apache.flink.api.common.accumulators.IntCounter;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.runtime.accumulators.AccumulatorSnapshot;
 import org.apache.flink.runtime.akka.AkkaUtils;
@@ -468,7 +468,7 @@ public class ExecutionGraphDeploymentTest extends TestLogger {
 
 		final ExecutionGraph eg = createExecutionGraph(jobManagerConfig);
 
-		assertEquals(CoreOptions.MAX_RETAINED_CHECKPOINTS.defaultValue().intValue(),
+		assertEquals(CheckpointingOptions.MAX_RETAINED_CHECKPOINTS.defaultValue().intValue(),
 				eg.getCheckpointCoordinator().getCheckpointStore().getMaxNumberOfRetainedCheckpoints());
 	}
 
@@ -477,7 +477,7 @@ public class ExecutionGraphDeploymentTest extends TestLogger {
 
 		final int maxNumberOfCheckpointsToRetain = 10;
 		final Configuration jobManagerConfig = new Configuration();
-		jobManagerConfig.setInteger(CoreOptions.MAX_RETAINED_CHECKPOINTS,
+		jobManagerConfig.setInteger(CheckpointingOptions.MAX_RETAINED_CHECKPOINTS,
 			maxNumberOfCheckpointsToRetain);
 
 		final ExecutionGraph eg = createExecutionGraph(jobManagerConfig);
@@ -543,7 +543,7 @@ public class ExecutionGraphDeploymentTest extends TestLogger {
 		final int negativeMaxNumberOfCheckpointsToRetain = -10;
 
 		final Configuration jobManagerConfig = new Configuration();
-		jobManagerConfig.setInteger(CoreOptions.MAX_RETAINED_CHECKPOINTS,
+		jobManagerConfig.setInteger(CheckpointingOptions.MAX_RETAINED_CHECKPOINTS,
 			negativeMaxNumberOfCheckpointsToRetain);
 
 		final ExecutionGraph eg = createExecutionGraph(jobManagerConfig);
@@ -551,7 +551,7 @@ public class ExecutionGraphDeploymentTest extends TestLogger {
 		assertNotEquals(negativeMaxNumberOfCheckpointsToRetain,
 			eg.getCheckpointCoordinator().getCheckpointStore().getMaxNumberOfRetainedCheckpoints());
 
-		assertEquals(CoreOptions.MAX_RETAINED_CHECKPOINTS.defaultValue().intValue(),
+		assertEquals(CheckpointingOptions.MAX_RETAINED_CHECKPOINTS.defaultValue().intValue(),
 			eg.getCheckpointCoordinator().getCheckpointStore().getMaxNumberOfRetainedCheckpoints());
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerTest.java
@@ -20,9 +20,9 @@ package org.apache.flink.runtime.jobmanager;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.AkkaOptions;
+import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.queryablestate.KvStateID;
@@ -826,7 +826,7 @@ public class JobManagerTest extends TestLogger {
 
 		FiniteDuration timeout = new FiniteDuration(30, TimeUnit.SECONDS);
 		Configuration config = new Configuration();
-		config.setString(CoreOptions.SAVEPOINT_DIRECTORY, defaultSavepointDir.getAbsolutePath());
+		config.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY, defaultSavepointDir.getAbsolutePath());
 
 		ActorSystem actorSystem = null;
 		ActorGateway jobManager = null;
@@ -1149,7 +1149,7 @@ public class JobManagerTest extends TestLogger {
 
 		FiniteDuration timeout = new FiniteDuration(30, TimeUnit.SECONDS);
 		Configuration config = new Configuration();
-		config.setString(CoreOptions.SAVEPOINT_DIRECTORY, defaultSavepointDir.getAbsolutePath());
+		config.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY, defaultSavepointDir.getAbsolutePath());
 
 		ActorSystem actorSystem = null;
 		ActorGateway jobManager = null;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.queryablestate.KvStateID;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.akka.ListeningBehaviour;
@@ -147,16 +148,16 @@ import static org.apache.flink.runtime.testingUtils.TestingUtils.DEFAULT_AKKA_AS
 import static org.apache.flink.runtime.testingUtils.TestingUtils.TESTING_TIMEOUT;
 import static org.apache.flink.runtime.testingUtils.TestingUtils.startTestingCluster;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
 import static org.mockito.Mockito.mock;
 
 public class JobManagerTest extends TestLogger {
 
 	@Rule
-	public TemporaryFolder tmpFolder = new TemporaryFolder();
+	public final TemporaryFolder tmpFolder = new TemporaryFolder();
 
 	private static ActorSystem system;
 
@@ -826,7 +827,7 @@ public class JobManagerTest extends TestLogger {
 
 		FiniteDuration timeout = new FiniteDuration(30, TimeUnit.SECONDS);
 		Configuration config = new Configuration();
-		config.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY, defaultSavepointDir.getAbsolutePath());
+		config.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY, defaultSavepointDir.toURI().toString());
 
 		ActorSystem actorSystem = null;
 		ActorGateway jobManager = null;
@@ -926,13 +927,13 @@ public class JobManagerTest extends TestLogger {
 			}
 
 			// Verify savepoint path
-			assertNotEquals("Savepoint not triggered", null, savepointPath);
+			assertNotNull("Savepoint not triggered", savepointPath);
 
 			// Wait for job status change
 			Await.ready(cancelled, timeout);
 
-			File savepointFile = new File(savepointPath);
-			assertEquals(true, savepointFile.exists());
+			File savepointFile = new File(new Path(savepointPath).getPath());
+			assertTrue(savepointFile.exists());
 		} finally {
 			if (actorSystem != null) {
 				actorSystem.shutdown();
@@ -1149,7 +1150,7 @@ public class JobManagerTest extends TestLogger {
 
 		FiniteDuration timeout = new FiniteDuration(30, TimeUnit.SECONDS);
 		Configuration config = new Configuration();
-		config.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY, defaultSavepointDir.getAbsolutePath());
+		config.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY, defaultSavepointDir.toURI().toString());
 
 		ActorSystem actorSystem = null;
 		ActorGateway jobManager = null;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/JobCancellationWithSavepointHandlersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/JobCancellationWithSavepointHandlersTest.java
@@ -20,7 +20,7 @@ package org.apache.flink.runtime.rest.handler.legacy;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.runtime.concurrent.Executors;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
@@ -165,7 +165,7 @@ public class JobCancellationWithSavepointHandlersTest extends TestLogger {
 			fail("Did not throw expected test Exception");
 		} catch (Exception e) {
 			IllegalStateException cause = (IllegalStateException) e.getCause();
-			assertEquals(true, cause.getMessage().contains(CoreOptions.SAVEPOINT_DIRECTORY.key()));
+			assertEquals(true, cause.getMessage().contains(CheckpointingOptions.SAVEPOINT_DIRECTORY.key()));
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/MemoryStateBackendTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/MemoryStateBackendTest.java
@@ -93,7 +93,7 @@ public class MemoryStateBackendTest extends StateBackendTestBase<MemoryStateBack
 	@Test
 	public void testOversizedState() {
 		try {
-			MemoryStateBackend backend = new MemoryStateBackend(10);
+			MemoryStateBackend backend = new MemoryStateBackend(null, null, 10, true);
 			CheckpointStreamFactory streamFactory = backend.createStreamFactory(new JobID(), "test_op");
 
 			HashMap<String, Integer> state = new HashMap<>();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendLoadingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendLoadingTest.java
@@ -18,22 +18,27 @@
 
 package org.apache.flink.runtime.state;
 
+import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.CoreOptions;
-import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.configuration.HighAvailabilityOptions;
+import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.state.filesystem.FsStateBackend;
 import org.apache.flink.runtime.state.filesystem.FsStateBackendFactory;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
+import org.apache.flink.runtime.state.memory.MemoryStateBackendFactory;
 import org.apache.flink.util.DynamicCodeLoadingException;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.mockito.Mockito;
 
 import java.io.IOException;
+import java.net.URI;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -48,61 +53,199 @@ public class StateBackendLoadingTest {
 
 	private final ClassLoader cl = getClass().getClassLoader();
 
-	private final String backendKey = CoreOptions.STATE_BACKEND.key();
+	private final String backendKey = CheckpointingOptions.STATE_BACKEND.key();
 
+	// ------------------------------------------------------------------------
+	//  defaults
 	// ------------------------------------------------------------------------
 
 	@Test
 	public void testNoStateBackendDefined() throws Exception {
-		assertNull(AbstractStateBackend.loadStateBackendFromConfig(new Configuration(), cl, null));
+		assertNull(StateBackendLoader.loadStateBackendFromConfig(new Configuration(), cl, null));
 	}
 
 	@Test
 	public void testInstantiateMemoryBackendByDefault() throws Exception {
-		StateBackend backend = AbstractStateBackend
-				.loadStateBackendFromConfigOrCreateDefault(new Configuration(), cl, null);
+		StateBackend backend =
+				StateBackendLoader.fromApplicationOrConfigOrDefault(null, new Configuration(), cl, null);
 
 		assertTrue(backend instanceof MemoryStateBackend);
 	}
 
 	@Test
-	public void testLoadMemoryStateBackend() throws Exception {
-		// we configure with the explicit string (rather than AbstractStateBackend#X_STATE_BACKEND_NAME)
-		// to guard against config-breaking changes of the name 
+	public void testApplicationDefinedHasPrecedence() throws Exception {
+		final StateBackend appBackend = Mockito.mock(StateBackend.class);
+
 		final Configuration config = new Configuration();
 		config.setString(backendKey, "jobmanager");
 
-		StateBackend backend = AbstractStateBackend
-				.loadStateBackendFromConfigOrCreateDefault(new Configuration(), cl, null);
-
-		assertTrue(backend instanceof MemoryStateBackend);
+		StateBackend backend = StateBackendLoader.fromApplicationOrConfigOrDefault(appBackend, config, cl, null);
+		assertEquals(appBackend, backend);
 	}
 
+	// ------------------------------------------------------------------------
+	//  Memory State Backend
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Validates loading a memory state backend from the cluster configuration.
+	 */
+	@Test
+	public void testLoadMemoryStateBackendNoParameters() throws Exception {
+		// we configure with the explicit string (rather than AbstractStateBackend#X_STATE_BACKEND_NAME)
+		// to guard against config-breaking changes of the name
+
+		final Configuration config1 = new Configuration();
+		config1.setString(backendKey, "jobmanager");
+
+		final Configuration config2 = new Configuration();
+		config2.setString(backendKey, MemoryStateBackendFactory.class.getName());
+
+		StateBackend backend1 = StateBackendLoader.loadStateBackendFromConfig(config1, cl, null);
+		StateBackend backend2 = StateBackendLoader.loadStateBackendFromConfig(config2, cl, null);
+
+		assertTrue(backend1 instanceof MemoryStateBackend);
+		assertTrue(backend2 instanceof MemoryStateBackend);
+	}
+
+	/**
+	 * Validates loading a memory state backend with additional parameters from the cluster configuration.
+	 */
+	@Test
+	public void testLoadMemoryStateWithParameters() throws Exception {
+		final String checkpointDir = new Path(tmp.newFolder().toURI()).toString();
+		final String savepointDir = new Path(tmp.newFolder().toURI()).toString();
+		final Path expectedCheckpointPath = new Path(checkpointDir);
+		final Path expectedSavepointPath = new Path(savepointDir);
+
+		final boolean async = !CheckpointingOptions.HEAP_KV_ASYNC_SNAPSHOTS.defaultValue();
+
+		// we configure with the explicit string (rather than AbstractStateBackend#X_STATE_BACKEND_NAME)
+		// to guard against config-breaking changes of the name
+
+		final Configuration config1 = new Configuration();
+		config1.setString(backendKey, "jobmanager");
+		config1.setString(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir);
+		config1.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir);
+		config1.setBoolean(CheckpointingOptions.HEAP_KV_ASYNC_SNAPSHOTS, async);
+
+		final Configuration config2 = new Configuration();
+		config2.setString(backendKey, MemoryStateBackendFactory.class.getName());
+		config2.setString(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir);
+		config2.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir);
+		config2.setBoolean(CheckpointingOptions.HEAP_KV_ASYNC_SNAPSHOTS, async);
+
+		MemoryStateBackend backend1 = (MemoryStateBackend)
+				StateBackendLoader.loadStateBackendFromConfig(config1, cl, null);
+		MemoryStateBackend backend2 = (MemoryStateBackend)
+				StateBackendLoader.loadStateBackendFromConfig(config2, cl, null);
+
+		assertNotNull(backend1);
+		assertNotNull(backend2);
+
+		assertEquals(expectedCheckpointPath, backend1.getCheckpointPath());
+		assertEquals(expectedCheckpointPath, backend2.getCheckpointPath());
+		assertEquals(expectedSavepointPath, backend1.getSavepointPath());
+		assertEquals(expectedSavepointPath, backend2.getSavepointPath());
+		assertEquals(async, backend1.isUsingAsynchronousSnapshots());
+		assertEquals(async, backend2.isUsingAsynchronousSnapshots());
+	}
+
+	/**
+	 * Validates taking the application-defined memory state backend and adding additional
+	 * parameters from the cluster configuration.
+	 */
+	@Test
+	public void testConfigureMemoryStateBackend() throws Exception {
+		final String checkpointDir = new Path(tmp.newFolder().toURI()).toString();
+		final String savepointDir = new Path(tmp.newFolder().toURI()).toString();
+		final Path expectedCheckpointPath = new Path(checkpointDir);
+		final Path expectedSavepointPath = new Path(savepointDir);
+
+		final int maxSize = 100;
+		final boolean async = !CheckpointingOptions.HEAP_KV_ASYNC_SNAPSHOTS.defaultValue();
+
+		final MemoryStateBackend backend = new MemoryStateBackend(maxSize, async);
+
+		final Configuration config = new Configuration();
+		config.setString(backendKey, "filesystem"); // check that this is not accidentally picked up
+		config.setString(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir);
+		config.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir);
+		config.setBoolean(CheckpointingOptions.HEAP_KV_ASYNC_SNAPSHOTS, !async);
+
+		StateBackend loadedBackend = StateBackendLoader.fromApplicationOrConfigOrDefault(backend, config, cl, null);
+		assertTrue(loadedBackend instanceof MemoryStateBackend);
+
+		final MemoryStateBackend memBackend = (MemoryStateBackend) loadedBackend;
+		assertEquals(expectedCheckpointPath, memBackend.getCheckpointPath());
+		assertEquals(expectedSavepointPath, memBackend.getSavepointPath());
+		assertEquals(maxSize, memBackend.getMaxStateSize());
+		assertEquals(async, memBackend.isUsingAsynchronousSnapshots());
+	}
+
+	/**
+	 * Validates taking the application-defined memory state backend and adding additional
+	 * parameters from the cluster configuration, but giving precedence to application-defined
+	 * parameters over configuration-defined parameters.
+	 */
+	@Test
+	public void testConfigureMemoryStateBackendMixed() throws Exception {
+		final String appCheckpointDir = new Path(tmp.newFolder().toURI()).toString();
+		final String checkpointDir = new Path(tmp.newFolder().toURI()).toString();
+		final String savepointDir = new Path(tmp.newFolder().toURI()).toString();
+
+		final Path expectedCheckpointPath = new Path(appCheckpointDir);
+		final Path expectedSavepointPath = new Path(savepointDir);
+
+		final MemoryStateBackend backend = new MemoryStateBackend(appCheckpointDir, null);
+
+		final Configuration config = new Configuration();
+		config.setString(backendKey, "filesystem"); // check that this is not accidentally picked up
+		config.setString(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir); // this parameter should not be picked up
+		config.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir);
+
+		StateBackend loadedBackend = StateBackendLoader.fromApplicationOrConfigOrDefault(backend, config, cl, null);
+		assertTrue(loadedBackend instanceof MemoryStateBackend);
+
+		final MemoryStateBackend memBackend = (MemoryStateBackend) loadedBackend;
+		assertEquals(expectedCheckpointPath, memBackend.getCheckpointPath());
+		assertEquals(expectedSavepointPath, memBackend.getSavepointPath());
+	}
+
+	// ------------------------------------------------------------------------
+	//  File System State Backend
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Validates loading a file system state backend with additional parameters from the cluster configuration.
+	 */
 	@Test
 	public void testLoadFileSystemStateBackend() throws Exception {
-		final String checkpointDir = new Path(tmp.getRoot().toURI()).toString();
-		final Path expectedPath = new Path(checkpointDir);
+		final String checkpointDir = new Path(tmp.newFolder().toURI()).toString();
+		final String savepointDir = new Path(tmp.newFolder().toURI()).toString();
+		final Path expectedCheckpointsPath = new Path(checkpointDir);
+		final Path expectedSavepointsPath = new Path(savepointDir);
 		final int threshold = 1000000;
+		final boolean async = !CheckpointingOptions.HEAP_KV_ASYNC_SNAPSHOTS.defaultValue();
 
 		// we configure with the explicit string (rather than AbstractStateBackend#X_STATE_BACKEND_NAME)
 		// to guard against config-breaking changes of the name 
 		final Configuration config1 = new Configuration();
 		config1.setString(backendKey, "filesystem");
-		config1.setString("state.checkpoints.dir", checkpointDir);
-		config1.setString("state.backend.fs.checkpointdir", checkpointDir);
-		config1.setInteger("state.backend.fs.memory-threshold", threshold);
+		config1.setString(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir);
+		config1.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir);
+		config1.setInteger(CheckpointingOptions.FS_SMALL_FILE_THRESHOLD, threshold);
+		config1.setBoolean(CheckpointingOptions.HEAP_KV_ASYNC_SNAPSHOTS, async);
 
 		final Configuration config2 = new Configuration();
 		config2.setString(backendKey, FsStateBackendFactory.class.getName());
-		config2.setString("state.checkpoints.dir", checkpointDir);
-		config2.setString("state.backend.fs.checkpointdir", checkpointDir);
-		config2.setInteger("state.backend.fs.memory-threshold", threshold);
+		config2.setString(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir);
+		config2.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir);
+		config2.setInteger(CheckpointingOptions.FS_SMALL_FILE_THRESHOLD, threshold);
+		config2.setBoolean(CheckpointingOptions.HEAP_KV_ASYNC_SNAPSHOTS, async);
 
-		StateBackend backend1 = AbstractStateBackend
-				.loadStateBackendFromConfigOrCreateDefault(config1, cl, null);
-
-		StateBackend backend2 = AbstractStateBackend
-				.loadStateBackendFromConfigOrCreateDefault(config2, cl, null);
+		StateBackend backend1 = StateBackendLoader.loadStateBackendFromConfig(config1, cl, null);
+		StateBackend backend2 = StateBackendLoader.loadStateBackendFromConfig(config2, cl, null);
 
 		assertTrue(backend1 instanceof FsStateBackend);
 		assertTrue(backend2 instanceof FsStateBackend);
@@ -110,11 +253,53 @@ public class StateBackendLoadingTest {
 		FsStateBackend fs1 = (FsStateBackend) backend1;
 		FsStateBackend fs2 = (FsStateBackend) backend2;
 
-		assertEquals(expectedPath, fs1.getBasePath());
-		assertEquals(expectedPath, fs2.getBasePath());
+		assertEquals(expectedCheckpointsPath, fs1.getCheckpointPath());
+		assertEquals(expectedCheckpointsPath, fs2.getCheckpointPath());
+		assertEquals(expectedSavepointsPath, fs1.getSavepointPath());
+		assertEquals(expectedSavepointsPath, fs2.getSavepointPath());
 		assertEquals(threshold, fs1.getMinFileSizeThreshold());
 		assertEquals(threshold, fs2.getMinFileSizeThreshold());
+		assertEquals(async, fs1.isUsingAsynchronousSnapshots());
+		assertEquals(async, fs2.isUsingAsynchronousSnapshots());
 	}
+
+	/**
+	 * Validates taking the application-defined file system state backend and adding with additional
+	 * parameters from the cluster configuration, but giving precedence to application-defined
+	 * parameters over configuration-defined parameters.
+	 */
+	@Test
+	public void testLoadFileSystemStateBackendMixed() throws Exception {
+		final String appCheckpointDir = new Path(tmp.newFolder().toURI()).toString();
+		final String checkpointDir = new Path(tmp.newFolder().toURI()).toString();
+		final String savepointDir = new Path(tmp.newFolder().toURI()).toString();
+
+		final Path expectedCheckpointsPath = new Path(new URI(appCheckpointDir));
+		final Path expectedSavepointsPath = new Path(savepointDir);
+
+		final int threshold = 1000000;
+
+		final FsStateBackend backend = new FsStateBackend(new URI(appCheckpointDir), threshold);
+
+		final Configuration config = new Configuration();
+		config.setString(backendKey, "jobmanager"); // this should not be picked up 
+		config.setString(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir); // this should not be picked up
+		config.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir);
+		config.setInteger(CheckpointingOptions.FS_SMALL_FILE_THRESHOLD, 20); // this should not be picked up
+
+		final StateBackend loadedBackend =
+				StateBackendLoader.fromApplicationOrConfigOrDefault(backend, config, cl, null);
+		assertTrue(loadedBackend instanceof FsStateBackend);
+
+		final FsStateBackend fs = (FsStateBackend) loadedBackend;
+		assertEquals(expectedCheckpointsPath, fs.getCheckpointPath());
+		assertEquals(expectedSavepointsPath, fs.getSavepointPath());
+		assertEquals(threshold, fs.getMinFileSizeThreshold());
+	}
+
+	// ------------------------------------------------------------------------
+	//  Failures
+	// ------------------------------------------------------------------------
 
 	/**
 	 * This test makes sure that failures properly manifest when the state backend could not be loaded.
@@ -126,7 +311,7 @@ public class StateBackendLoadingTest {
 		// try a value that is neither recognized as a name, nor corresponds to a class
 		config.setString(backendKey, "does.not.exist");
 		try {
-			AbstractStateBackend.loadStateBackendFromConfigOrCreateDefault(config, cl, null);
+			StateBackendLoader.fromApplicationOrConfigOrDefault(null, config, cl, null);
 			fail("should fail with an exception");
 		} catch (DynamicCodeLoadingException ignored) {
 			// expected
@@ -135,7 +320,7 @@ public class StateBackendLoadingTest {
 		// try a class that is not a factory
 		config.setString(backendKey, java.io.File.class.getName());
 		try {
-			AbstractStateBackend.loadStateBackendFromConfigOrCreateDefault(config, cl, null);
+			StateBackendLoader.fromApplicationOrConfigOrDefault(null, config, cl, null);
 			fail("should fail with an exception");
 		} catch (DynamicCodeLoadingException ignored) {
 			// expected
@@ -144,7 +329,7 @@ public class StateBackendLoadingTest {
 		// a factory that fails
 		config.setString(backendKey, FailingFactory.class.getName());
 		try {
-			AbstractStateBackend.loadStateBackendFromConfigOrCreateDefault(config, cl, null);
+			StateBackendLoader.fromApplicationOrConfigOrDefault(null, config, cl, null);
 			fail("should fail with an exception");
 		} catch (IOException ignored) {
 			// expected
@@ -152,12 +337,103 @@ public class StateBackendLoadingTest {
 	}
 
 	// ------------------------------------------------------------------------
+	//  High-availability default
+	// ------------------------------------------------------------------------
+
+	/**
+	 * This tests that in the case of configured high-availability, the memory state backend
+	 * automatically grabs the HA persistence directory.
+	 */
+	@Test
+	public void testHighAvailabilityDefaultFallback() throws Exception {
+		final String haPersistenceDir = new Path(tmp.newFolder().toURI()).toString();
+		final Path expectedCheckpointPath = new Path(haPersistenceDir);
+
+		final Configuration config1 = new Configuration();
+		config1.setString(HighAvailabilityOptions.HA_MODE, "zookeeper");
+		config1.setString(HighAvailabilityOptions.HA_CLUSTER_ID, "myCluster");
+		config1.setString(HighAvailabilityOptions.HA_STORAGE_PATH, haPersistenceDir);
+
+		final Configuration config2 = new Configuration();
+		config2.setString(backendKey, "jobmanager");
+		config2.setString(HighAvailabilityOptions.HA_MODE, "zookeeper");
+		config2.setString(HighAvailabilityOptions.HA_CLUSTER_ID, "myCluster");
+		config2.setString(HighAvailabilityOptions.HA_STORAGE_PATH, haPersistenceDir);
+
+		final MemoryStateBackend appBackend = new MemoryStateBackend();
+
+		final StateBackend loaded1 = StateBackendLoader.fromApplicationOrConfigOrDefault(appBackend, config1, cl, null);
+		final StateBackend loaded2 = StateBackendLoader.fromApplicationOrConfigOrDefault(null, config1, cl, null);
+		final StateBackend loaded3 = StateBackendLoader.fromApplicationOrConfigOrDefault(null, config2, cl, null);
+
+		assertTrue(loaded1 instanceof MemoryStateBackend);
+		assertTrue(loaded2 instanceof MemoryStateBackend);
+		assertTrue(loaded3 instanceof MemoryStateBackend);
+
+		final MemoryStateBackend memBackend1 = (MemoryStateBackend) loaded1;
+		final MemoryStateBackend memBackend2 = (MemoryStateBackend) loaded2;
+		final MemoryStateBackend memBackend3 = (MemoryStateBackend) loaded3;
+
+		assertNotNull(memBackend1.getCheckpointPath());
+		assertNotNull(memBackend2.getCheckpointPath());
+		assertNotNull(memBackend3.getCheckpointPath());
+		assertNull(memBackend1.getSavepointPath());
+		assertNull(memBackend2.getSavepointPath());
+		assertNull(memBackend3.getSavepointPath());
+
+		assertEquals(expectedCheckpointPath, memBackend1.getCheckpointPath().getParent());
+		assertEquals(expectedCheckpointPath, memBackend2.getCheckpointPath().getParent());
+		assertEquals(expectedCheckpointPath, memBackend3.getCheckpointPath().getParent());
+	}
+
+	@Test
+	public void testHighAvailabilityDefaultFallbackLocalPaths() throws Exception {
+		final String haPersistenceDir = new Path(tmp.newFolder().getAbsolutePath()).toString();
+		final Path expectedCheckpointPath = new Path(haPersistenceDir).makeQualified(FileSystem.getLocalFileSystem());
+
+		final Configuration config1 = new Configuration();
+		config1.setString(HighAvailabilityOptions.HA_MODE, "zookeeper");
+		config1.setString(HighAvailabilityOptions.HA_CLUSTER_ID, "myCluster");
+		config1.setString(HighAvailabilityOptions.HA_STORAGE_PATH, haPersistenceDir);
+
+		final Configuration config2 = new Configuration();
+		config2.setString(backendKey, "jobmanager");
+		config2.setString(HighAvailabilityOptions.HA_MODE, "zookeeper");
+		config2.setString(HighAvailabilityOptions.HA_CLUSTER_ID, "myCluster");
+		config2.setString(HighAvailabilityOptions.HA_STORAGE_PATH, haPersistenceDir);
+
+		final MemoryStateBackend appBackend = new MemoryStateBackend();
+
+		final StateBackend loaded1 = StateBackendLoader.fromApplicationOrConfigOrDefault(appBackend, config1, cl, null);
+		final StateBackend loaded2 = StateBackendLoader.fromApplicationOrConfigOrDefault(null, config1, cl, null);
+		final StateBackend loaded3 = StateBackendLoader.fromApplicationOrConfigOrDefault(null, config2, cl, null);
+
+		assertTrue(loaded1 instanceof MemoryStateBackend);
+		assertTrue(loaded2 instanceof MemoryStateBackend);
+		assertTrue(loaded3 instanceof MemoryStateBackend);
+
+		final MemoryStateBackend memBackend1 = (MemoryStateBackend) loaded1;
+		final MemoryStateBackend memBackend2 = (MemoryStateBackend) loaded2;
+		final MemoryStateBackend memBackend3 = (MemoryStateBackend) loaded3;
+
+		assertNotNull(memBackend1.getCheckpointPath());
+		assertNotNull(memBackend2.getCheckpointPath());
+		assertNotNull(memBackend3.getCheckpointPath());
+		assertNull(memBackend1.getSavepointPath());
+		assertNull(memBackend2.getSavepointPath());
+		assertNull(memBackend3.getSavepointPath());
+
+		assertEquals(expectedCheckpointPath, memBackend1.getCheckpointPath().getParent());
+		assertEquals(expectedCheckpointPath, memBackend2.getCheckpointPath().getParent());
+		assertEquals(expectedCheckpointPath, memBackend3.getCheckpointPath().getParent());
+	}
+
+	// ------------------------------------------------------------------------
 
 	static final class FailingFactory implements StateBackendFactory<StateBackend> {
-		private static final long serialVersionUID = 1L;
 
 		@Override
-		public StateBackend createFromConfig(Configuration config) throws IllegalConfigurationException, IOException {
+		public StateBackend createFromConfig(Configuration config) throws IOException {
 			throw new IOException("fail!");
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/ZooKeeperTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/ZooKeeperTestUtils.java
@@ -19,12 +19,11 @@
 package org.apache.flink.runtime.testutils;
 
 import org.apache.flink.configuration.AkkaOptions;
+import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.WebOptions;
 import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
-import org.apache.flink.runtime.state.filesystem.FsStateBackendFactory;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -82,8 +81,8 @@ public class ZooKeeperTestUtils {
 		config.setInteger(HighAvailabilityOptions.ZOOKEEPER_SESSION_TIMEOUT, connTimeout);
 
 		// File system state backend
-		config.setString(CoreOptions.STATE_BACKEND, "FILESYSTEM");
-		config.setString(FsStateBackendFactory.CHECKPOINT_DIRECTORY_URI_CONF_KEY, fsStateHandlePath + "/checkpoints");
+		config.setString(CheckpointingOptions.STATE_BACKEND, "FILESYSTEM");
+		config.setString(CheckpointingOptions.CHECKPOINTS_DIRECTORY, fsStateHandlePath + "/checkpoints");
 		config.setString(HighAvailabilityOptions.HA_STORAGE_PATH, fsStateHandlePath + "/recovery");
 
 		// Akka failure detection and execution retries

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/BlockerCheckpointStreamFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/BlockerCheckpointStreamFactory.java
@@ -146,9 +146,4 @@ public class BlockerCheckpointStreamFactory implements CheckpointStreamFactory {
 
 		return lastCreatedStream;
 	}
-
-	@Override
-	public void close() throws Exception {
-
-	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamConfig.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamConfig.java
@@ -23,7 +23,7 @@ import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.operators.util.CorruptConfigurationException;
-import org.apache.flink.runtime.state.AbstractStateBackend;
+import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.util.ClassLoaderUtil;
 import org.apache.flink.streaming.api.CheckpointingMode;
 import org.apache.flink.streaming.api.TimeCharacteristic;
@@ -442,7 +442,7 @@ public class StreamConfig implements Serializable {
 	//  State backend
 	// ------------------------------------------------------------------------
 
-	public void setStateBackend(AbstractStateBackend backend) {
+	public void setStateBackend(StateBackend backend) {
 		if (backend != null) {
 			try {
 				InstantiationUtil.writeObjectToConfig(backend, this.config, STATE_BACKEND);
@@ -452,7 +452,7 @@ public class StreamConfig implements Serializable {
 		}
 	}
 
-	public AbstractStateBackend getStateBackend(ClassLoader cl) {
+	public StateBackend getStateBackend(ClassLoader cl) {
 		try {
 			return InstantiationUtil.readObjectFromConfig(this.config, STATE_BACKEND, cl);
 		} catch (Exception e) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -38,13 +38,13 @@ import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobgraph.tasks.StatefulTask;
 import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
-import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.OperatorStateBackend;
 import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.runtime.state.StateBackendLoader;
 import org.apache.flink.runtime.taskmanager.DispatcherThreadFactory;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.graph.StreamConfig;
@@ -690,19 +690,13 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 	// ------------------------------------------------------------------------
 
 	private StateBackend createStateBackend() throws Exception {
-		final StateBackend fromJob = configuration.getStateBackend(getUserCodeClassLoader());
+		final StateBackend fromApplication = configuration.getStateBackend(getUserCodeClassLoader());
 
-		if (fromJob != null) {
-			// backend has been configured on the environment
-			LOG.info("Using user-defined state backend: {}.", fromJob);
-			return fromJob;
-		}
-		else {
-			return AbstractStateBackend.loadStateBackendFromConfigOrCreateDefault(
-					getEnvironment().getTaskManagerInfo().getConfiguration(),
-					getUserCodeClassLoader(),
-					LOG);
-		}
+		return StateBackendLoader.fromApplicationOrConfigOrDefault(
+				fromApplication,
+				getEnvironment().getTaskManagerInfo().getConfiguration(),
+				getUserCodeClassLoader(),
+				LOG);
 	}
 
 	public OperatorStateBackend createOperatorStateBackend(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/BlockingCheckpointsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/BlockingCheckpointsTest.java
@@ -216,9 +216,6 @@ public class BlockingCheckpointsTest {
 		public CheckpointStateOutputStream createCheckpointStateOutputStream(long checkpointID, long timestamp) {
 			return new LockingOutputStream();
 		}
-
-		@Override
-		public void close() {}
 	}
 
 	private static final class LockingOutputStream extends CheckpointStateOutputStream {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -23,8 +23,8 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.TaskInfo;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.blob.BlobCacheService;
@@ -207,7 +207,7 @@ public class StreamTaskTest extends TestLogger {
 	@Test
 	public void testStateBackendLoadingAndClosing() throws Exception {
 		Configuration taskManagerConfig = new Configuration();
-		taskManagerConfig.setString(CoreOptions.STATE_BACKEND, MockStateBackend.class.getName());
+		taskManagerConfig.setString(CheckpointingOptions.STATE_BACKEND, MockStateBackend.class.getName());
 
 		StreamConfig cfg = new StreamConfig(new Configuration());
 		cfg.setOperatorID(new OperatorID(4711L, 42L));
@@ -232,7 +232,7 @@ public class StreamTaskTest extends TestLogger {
 	@Test
 	public void testStateBackendClosingOnFailure() throws Exception {
 		Configuration taskManagerConfig = new Configuration();
-		taskManagerConfig.setString(CoreOptions.STATE_BACKEND, MockStateBackend.class.getName());
+		taskManagerConfig.setString(CheckpointingOptions.STATE_BACKEND, MockStateBackend.class.getName());
 
 		StreamConfig cfg = new StreamConfig(new Configuration());
 		cfg.setOperatorID(new OperatorID(4711L, 42L));

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ExternalizedCheckpointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ExternalizedCheckpointITCase.java
@@ -22,9 +22,9 @@ import org.apache.flink.api.common.JobSubmissionResult;
 import org.apache.flink.api.common.functions.FilterFunction;
 import org.apache.flink.api.common.functions.ReduceFunction;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.contrib.streaming.state.RocksDBStateBackend;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
@@ -32,7 +32,6 @@ import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.runtime.state.filesystem.FsStateBackend;
-import org.apache.flink.runtime.state.filesystem.FsStateBackendFactory;
 import org.apache.flink.runtime.testingUtils.TestingCluster;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.environment.CheckpointConfig;
@@ -150,9 +149,9 @@ public class ExternalizedCheckpointITCase extends TestLogger {
 
 		final File savepointDir = temporaryFolder.newFolder();
 
-		config.setString(FsStateBackendFactory.CHECKPOINT_DIRECTORY_URI_CONF_KEY, checkpointDir.toURI().toString());
-		config.setString(CoreOptions.SAVEPOINT_DIRECTORY, savepointDir.toURI().toString());
-		config.setString(CoreOptions.CHECKPOINTS_DIRECTORY, checkpointDir.toURI().toString());
+		config.setString(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir.toURI().toString());
+		config.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir.toURI().toString());
+		config.setString(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir.toURI().toString());
 
 		// ZooKeeper recovery mode?
 		if (zooKeeperQuorum != null) {

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RescalingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RescalingITCase.java
@@ -28,9 +28,9 @@ import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.instance.ActorGateway;
@@ -40,7 +40,6 @@ import org.apache.flink.runtime.messages.JobManagerMessages;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
 import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
-import org.apache.flink.runtime.state.filesystem.FsStateBackendFactory;
 import org.apache.flink.runtime.testingUtils.TestingCluster;
 import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages;
 import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
@@ -127,9 +126,9 @@ public class RescalingITCase extends TestLogger {
 			final File checkpointDir = temporaryFolder.newFolder();
 			final File savepointDir = temporaryFolder.newFolder();
 
-			config.setString(CoreOptions.STATE_BACKEND, currentBackend);
-			config.setString(FsStateBackendFactory.CHECKPOINT_DIRECTORY_URI_CONF_KEY, checkpointDir.toURI().toString());
-			config.setString(CoreOptions.SAVEPOINT_DIRECTORY, savepointDir.toURI().toString());
+			config.setString(CheckpointingOptions.STATE_BACKEND, currentBackend);
+			config.setString(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir.toURI().toString());
+			config.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir.toURI().toString());
 
 			cluster = new TestingCluster(config);
 			cluster.start();

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
@@ -28,9 +28,9 @@ import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.akka.AkkaUtils;
@@ -55,8 +55,6 @@ import org.apache.flink.runtime.messages.JobManagerMessages.TriggerSavepoint;
 import org.apache.flink.runtime.messages.JobManagerMessages.TriggerSavepointSuccess;
 import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.runtime.state.filesystem.FileStateHandle;
-import org.apache.flink.runtime.state.filesystem.FsStateBackend;
-import org.apache.flink.runtime.state.filesystem.FsStateBackendFactory;
 import org.apache.flink.runtime.testingUtils.TestingCluster;
 import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages.RequestSavepoint;
 import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages.ResponseSavepoint;
@@ -123,7 +121,7 @@ public class SavepointITCase extends TestLogger {
 	private static final Logger LOG = LoggerFactory.getLogger(SavepointITCase.class);
 
 	@Rule
-	public TemporaryFolder folder = new TemporaryFolder();
+	public final TemporaryFolder folder = new TemporaryFolder();
 
 	/**
 	 * Triggers a savepoint for a job that uses the FsStateBackend. We expect
@@ -167,10 +165,10 @@ public class SavepointITCase extends TestLogger {
 			}
 
 			// Use file based checkpoints
-			config.setString(CoreOptions.STATE_BACKEND, "filesystem");
-			config.setString(FsStateBackendFactory.CHECKPOINT_DIRECTORY_URI_CONF_KEY, checkpointDir.toURI().toString());
-			config.setString(FsStateBackendFactory.MEMORY_THRESHOLD_CONF_KEY, "0");
-			config.setString(CoreOptions.SAVEPOINT_DIRECTORY, savepointRootDir.toURI().toString());
+			config.setString(CheckpointingOptions.STATE_BACKEND, "filesystem");
+			config.setString(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir.toURI().toString());
+			config.setInteger(CheckpointingOptions.FS_SMALL_FILE_THRESHOLD, 0);
+			config.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointRootDir.toURI().toString());
 
 			// Start Flink
 			flink = new TestingCluster(config);
@@ -434,8 +432,7 @@ public class SavepointITCase extends TestLogger {
 			final Configuration config = new Configuration();
 			config.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, numTaskManagers);
 			config.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, numSlotsPerTaskManager);
-			config.setString(CoreOptions.SAVEPOINT_DIRECTORY,
-				savepointDir.toURI().toString());
+			config.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir.toURI().toString());
 
 			LOG.info("Flink configuration: " + config + ".");
 
@@ -501,8 +498,7 @@ public class SavepointITCase extends TestLogger {
 		final Configuration config = new Configuration();
 		config.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, numTaskManagers);
 		config.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, numSlotsPerTaskManager);
-		config.setString(CoreOptions.SAVEPOINT_DIRECTORY,
-				savepointDir.toURI().toString());
+		config.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir.toURI().toString());
 
 		String savepointPath;
 
@@ -684,7 +680,7 @@ public class SavepointITCase extends TestLogger {
 			if (data == null) {
 				// We need this to be large, because we want to test with files
 				Random rand = new Random(getRuntimeContext().getIndexOfThisSubtask());
-				data = new byte[FsStateBackend.DEFAULT_FILE_STATE_THRESHOLD + 1];
+				data = new byte[CheckpointingOptions.FS_SMALL_FILE_THRESHOLD.defaultValue() + 1];
 				rand.nextBytes(data);
 			}
 		}
@@ -806,12 +802,10 @@ public class SavepointITCase extends TestLogger {
 			fail("Test setup failed: failed to create temporary directories.");
 		}
 
-		config.setString(CoreOptions.STATE_BACKEND, "filesystem");
-		config.setString(FsStateBackendFactory.CHECKPOINT_DIRECTORY_URI_CONF_KEY,
-				checkpointDir.toURI().toString());
-		config.setString(FsStateBackendFactory.MEMORY_THRESHOLD_CONF_KEY, "0");
-		config.setString(CoreOptions.SAVEPOINT_DIRECTORY,
-				savepointDir.toURI().toString());
+		config.setString(CheckpointingOptions.STATE_BACKEND, "filesystem");
+		config.setString(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir.toURI().toString());
+		config.setInteger(CheckpointingOptions.FS_SMALL_FILE_THRESHOLD, 0);
+		config.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir.toURI().toString());
 
 		TestingCluster cluster = new TestingCluster(config, false);
 		String savepointPath = null;

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/utils/SavepointMigrationTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/utils/SavepointMigrationTestBase.java
@@ -22,9 +22,9 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobSubmissionResult;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.client.program.StandaloneClusterClient;
+import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.runtime.checkpoint.savepoint.SavepointSerializers;
 import org.apache.flink.runtime.client.JobListeningContext;
 import org.apache.flink.runtime.instance.ActorGateway;
@@ -33,16 +33,17 @@ import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.runtime.messages.JobManagerMessages;
 import org.apache.flink.runtime.minicluster.LocalFlinkMiniCluster;
-import org.apache.flink.runtime.state.filesystem.FsStateBackendFactory;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.test.util.TestBaseUtils;
 
 import org.apache.commons.io.FileUtils;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -107,10 +108,10 @@ public class SavepointMigrationTestBase extends TestBaseUtils {
 		LOG.info("Created temporary checkpoint directory: " + checkpointDir + ".");
 		LOG.info("Created savepoint directory: " + savepointDir + ".");
 
-		config.setString(CoreOptions.STATE_BACKEND, "memory");
-		config.setString(FsStateBackendFactory.CHECKPOINT_DIRECTORY_URI_CONF_KEY, checkpointDir.toURI().toString());
-		config.setString(FsStateBackendFactory.MEMORY_THRESHOLD_CONF_KEY, "0");
-		config.setString("state.savepoints.dir", savepointDir.toURI().toString());
+		config.setString(CheckpointingOptions.STATE_BACKEND, "memory");
+		config.setString(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir.toURI().toString());
+		config.setInteger(CheckpointingOptions.FS_SMALL_FILE_THRESHOLD, 0);
+		config.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir.toURI().toString());
 
 		cluster = TestBaseUtils.startCluster(config, false);
 	}

--- a/flink-tests/src/test/java/org/apache/flink/test/classloading/ClassLoaderITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/classloading/ClassLoaderITCase.java
@@ -21,9 +21,9 @@ package org.apache.flink.test.classloading;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.client.program.PackagedProgram;
 import org.apache.flink.client.program.ProgramInvocationException;
+import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.client.JobCancellationException;
 import org.apache.flink.runtime.client.JobStatusMessage;
@@ -34,7 +34,6 @@ import org.apache.flink.runtime.messages.JobManagerMessages.DisposeSavepointFail
 import org.apache.flink.runtime.messages.JobManagerMessages.RunningJobsStatus;
 import org.apache.flink.runtime.messages.JobManagerMessages.TriggerSavepoint;
 import org.apache.flink.runtime.messages.JobManagerMessages.TriggerSavepointSuccess;
-import org.apache.flink.runtime.state.filesystem.FsStateBackendFactory;
 import org.apache.flink.runtime.testingUtils.TestingCluster;
 import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages.WaitForAllVerticesToBeRunning;
 import org.apache.flink.streaming.util.TestStreamEnvironment;
@@ -114,12 +113,12 @@ public class ClassLoaderITCase extends TestLogger {
 		parallelism = 4;
 
 		// we need to use the "filesystem" state backend to ensure FLINK-2543 is not happening again.
-		config.setString(CoreOptions.STATE_BACKEND, "filesystem");
-		config.setString(FsStateBackendFactory.CHECKPOINT_DIRECTORY_URI_CONF_KEY,
+		config.setString(CheckpointingOptions.STATE_BACKEND, "filesystem");
+		config.setString(CheckpointingOptions.CHECKPOINTS_DIRECTORY,
 				FOLDER.newFolder().getAbsoluteFile().toURI().toString());
 
 		// Savepoint path
-		config.setString(CoreOptions.SAVEPOINT_DIRECTORY,
+		config.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY,
 				FOLDER.newFolder().getAbsoluteFile().toURI().toString());
 
 		testCluster = new TestingCluster(config, false);

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/JobManagerHACheckpointRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/JobManagerHACheckpointRecoveryITCase.java
@@ -24,9 +24,9 @@ import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeinfo.TypeHint;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.contrib.streaming.state.RocksDBStateBackend;
 import org.apache.flink.runtime.akka.AkkaUtils;
@@ -360,11 +360,11 @@ public class JobManagerHACheckpointRecoveryITCase extends TestLogger {
 		try {
 			Configuration config = new Configuration();
 
-			config.setInteger(CoreOptions.MAX_RETAINED_CHECKPOINTS, retainedCheckpoints);
+			config.setInteger(CheckpointingOptions.MAX_RETAINED_CHECKPOINTS, retainedCheckpoints);
 			config.setInteger(ConfigConstants.LOCAL_NUMBER_JOB_MANAGER, numJMs);
 			config.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, numTMs);
 			config.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, numSlots);
-			config.setString(CoreOptions.CHECKPOINTS_DIRECTORY, temporaryFolder.newFolder().toString());
+			config.setString(CheckpointingOptions.CHECKPOINTS_DIRECTORY, temporaryFolder.newFolder().toString());
 
 			String tmpFolderString = temporaryFolder.newFolder().toString();
 			config.setString(HighAvailabilityOptions.HA_STORAGE_PATH, tmpFolderString);

--- a/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/keyed/KeyedJob.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/keyed/KeyedJob.java
@@ -25,8 +25,8 @@ import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.java.tuple.Tuple;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.streaming.api.CheckpointingMode;
 import org.apache.flink.streaming.api.checkpoint.ListCheckpointed;
@@ -59,7 +59,7 @@ public class KeyedJob {
 		String savepointsPath = pt.getRequired("savepoint-path");
 
 		Configuration config = new Configuration();
-		config.setString(CoreOptions.SAVEPOINT_DIRECTORY, savepointsPath);
+		config.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointsPath);
 
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.createLocalEnvironmentWithWebUI(config);
 		env.enableCheckpointing(500, CheckpointingMode.EXACTLY_ONCE);

--- a/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/unkeyed/NonKeyedJob.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/unkeyed/NonKeyedJob.java
@@ -22,8 +22,8 @@ import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.functions.RichMapFunction;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.streaming.api.CheckpointingMode;
 import org.apache.flink.streaming.api.checkpoint.ListCheckpointed;
@@ -52,7 +52,7 @@ public class NonKeyedJob {
 		String savepointsPath = pt.getRequired("savepoint-path");
 
 		Configuration config = new Configuration();
-		config.setString(CoreOptions.SAVEPOINT_DIRECTORY, savepointsPath);
+		config.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointsPath);
 
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.createLocalEnvironmentWithWebUI(config);
 		env.enableCheckpointing(500, CheckpointingMode.EXACTLY_ONCE);

--- a/flink-tests/src/test/java/org/apache/flink/test/typeserializerupgrade/PojoSerializerUpgradeTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/typeserializerupgrade/PojoSerializerUpgradeTest.java
@@ -32,15 +32,15 @@ import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeutils.base.LongSerializer;
 import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.core.testutils.CommonTestUtils;
 import org.apache.flink.runtime.operators.testutils.MockEnvironment;
 import org.apache.flink.runtime.operators.testutils.MockInputSplitProvider;
-import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
 import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.runtime.state.StateBackendLoader;
 import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.operators.StreamMap;
@@ -70,7 +70,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 
-import static org.apache.flink.runtime.state.filesystem.FsStateBackendFactory.CHECKPOINT_DIRECTORY_URI_CONF_KEY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -85,9 +84,9 @@ public class PojoSerializerUpgradeTest extends TestLogger {
 	@Parameterized.Parameters(name = "StateBackend: {0}")
 	public static Collection<String> parameters () {
 		return Arrays.asList(
-			AbstractStateBackend.MEMORY_STATE_BACKEND_NAME,
-			AbstractStateBackend.FS_STATE_BACKEND_NAME,
-			AbstractStateBackend.ROCKSDB_STATE_BACKEND_NAME);
+				StateBackendLoader.MEMORY_STATE_BACKEND_NAME,
+				StateBackendLoader.FS_STATE_BACKEND_NAME,
+				StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME);
 	}
 
 	@ClassRule
@@ -97,9 +96,9 @@ public class PojoSerializerUpgradeTest extends TestLogger {
 
 	public PojoSerializerUpgradeTest(String backendType) throws IOException, DynamicCodeLoadingException {
 		Configuration config = new Configuration();
-		config.setString(CoreOptions.STATE_BACKEND, backendType);
-		config.setString(CHECKPOINT_DIRECTORY_URI_CONF_KEY, temporaryFolder.newFolder().toURI().toString());
-		stateBackend = AbstractStateBackend.loadStateBackendFromConfig(config, Thread.currentThread().getContextClassLoader(), null);
+		config.setString(CheckpointingOptions.STATE_BACKEND, backendType);
+		config.setString(CheckpointingOptions.CHECKPOINTS_DIRECTORY, temporaryFolder.newFolder().toURI().toString());
+		stateBackend = StateBackendLoader.loadStateBackendFromConfig(config, Thread.currentThread().getContextClassLoader(), null);
 	}
 
 	private static final String POJO_NAME = "Pojo";

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/migration/StatefulJobSavepointMigrationITCase.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/migration/StatefulJobSavepointMigrationITCase.scala
@@ -35,14 +35,14 @@ import org.apache.flink.streaming.api.watermark.Watermark
 import org.apache.flink.test.checkpointing.utils.SavepointMigrationTestBase
 import org.apache.flink.util.Collector
 import org.apache.flink.api.java.tuple.Tuple2
-import org.apache.flink.runtime.state.{AbstractStateBackend, FunctionInitializationContext, FunctionSnapshotContext}
+import org.apache.flink.runtime.state.{StateBackendLoader, FunctionInitializationContext, FunctionSnapshotContext}
 import org.apache.flink.api.scala._
 import org.apache.flink.api.scala.migration.CustomEnum.CustomEnum
 import org.apache.flink.contrib.streaming.state.RocksDBStateBackend
 import org.apache.flink.streaming.util.migration.MigrationVersion
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
-import org.junit.{Assume, Ignore, Test}
+import org.junit.{Ignore, Test}
 
 import scala.util.{Failure, Properties, Try}
 
@@ -51,17 +51,17 @@ object StatefulJobSavepointMigrationITCase {
   @Parameterized.Parameters(name = "Migrate Savepoint / Backend: {0}")
   def parameters: util.Collection[(MigrationVersion, String)] = {
     util.Arrays.asList(
-      (MigrationVersion.v1_2, AbstractStateBackend.MEMORY_STATE_BACKEND_NAME),
-      (MigrationVersion.v1_2, AbstractStateBackend.ROCKSDB_STATE_BACKEND_NAME),
-      (MigrationVersion.v1_3, AbstractStateBackend.MEMORY_STATE_BACKEND_NAME),
-      (MigrationVersion.v1_3, AbstractStateBackend.ROCKSDB_STATE_BACKEND_NAME))
+      (MigrationVersion.v1_2, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
+      (MigrationVersion.v1_2, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME),
+      (MigrationVersion.v1_3, StateBackendLoader.MEMORY_STATE_BACKEND_NAME),
+      (MigrationVersion.v1_3, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME))
   }
 
   // TODO to generate savepoints for a specific Flink version / backend type,
   // TODO change these values accordingly, e.g. to generate for 1.3 with RocksDB,
-  // TODO set as (MigrationVersion.v1_3, AbstractStateBackend.ROCKSDB_STATE_BACKEND_NAME)
+  // TODO set as (MigrationVersion.v1_3, StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME)
   val GENERATE_SAVEPOINT_VER: MigrationVersion = MigrationVersion.v1_3
-  val GENERATE_SAVEPOINT_BACKEND_TYPE: String = AbstractStateBackend.ROCKSDB_STATE_BACKEND_NAME
+  val GENERATE_SAVEPOINT_BACKEND_TYPE: String = StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME
 
   val SCALA_VERSION: String = {
     val versionString = Properties.versionString.split(" ")(1)
@@ -86,9 +86,9 @@ class StatefulJobSavepointMigrationITCase(
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
 
     StatefulJobSavepointMigrationITCase.GENERATE_SAVEPOINT_BACKEND_TYPE match {
-      case AbstractStateBackend.ROCKSDB_STATE_BACKEND_NAME =>
+      case StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME =>
         env.setStateBackend(new RocksDBStateBackend(new MemoryStateBackend()))
-      case AbstractStateBackend.MEMORY_STATE_BACKEND_NAME =>
+      case StateBackendLoader.MEMORY_STATE_BACKEND_NAME =>
         env.setStateBackend(new MemoryStateBackend())
       case _ => throw new UnsupportedOperationException
     }
@@ -129,9 +129,9 @@ class StatefulJobSavepointMigrationITCase(
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
 
     migrationVersionAndBackend._2 match {
-      case AbstractStateBackend.ROCKSDB_STATE_BACKEND_NAME =>
+      case StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME =>
         env.setStateBackend(new RocksDBStateBackend(new MemoryStateBackend()))
-      case AbstractStateBackend.MEMORY_STATE_BACKEND_NAME =>
+      case StateBackendLoader.MEMORY_STATE_BACKEND_NAME =>
         env.setStateBackend(new MemoryStateBackend())
       case _ => throw new UnsupportedOperationException
     }

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNHighAvailabilityITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNHighAvailabilityITCase.java
@@ -20,9 +20,9 @@ package org.apache.flink.yarn;
 
 import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.runtime.akka.AkkaUtils;
@@ -32,13 +32,13 @@ import org.apache.flink.runtime.highavailability.HighAvailabilityServicesUtils;
 import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.instance.AkkaActorGateway;
 import org.apache.flink.runtime.messages.Acknowledge;
-import org.apache.flink.runtime.state.filesystem.FsStateBackendFactory;
 import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages;
 import org.apache.flink.runtime.util.LeaderRetrievalUtils;
 
 import akka.actor.ActorSystem;
 import akka.actor.PoisonPill;
 import akka.testkit.JavaTestKit;
+
 import org.apache.curator.test.TestingServer;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
@@ -121,8 +121,8 @@ public class YARNHighAvailabilityITCase extends YarnTestBase {
 
 		flinkYarnClient.setDynamicPropertiesEncoded("recovery.mode=zookeeper@@recovery.zookeeper.quorum=" +
 			zkServer.getConnectString() + "@@yarn.application-attempts=" + numberApplicationAttempts +
-			"@@" + CoreOptions.STATE_BACKEND + "=FILESYSTEM" +
-			"@@" + FsStateBackendFactory.CHECKPOINT_DIRECTORY_URI_CONF_KEY + "=" + fsStateHandlePath + "/checkpoints" +
+			"@@" + CheckpointingOptions.STATE_BACKEND.key() + "=FILESYSTEM" +
+			"@@" + CheckpointingOptions.CHECKPOINTS_DIRECTORY + "=" + fsStateHandlePath + "/checkpoints" +
 			"@@" + HighAvailabilityOptions.HA_STORAGE_PATH.key() + "=" + fsStateHandlePath + "/recovery");
 
 		ClusterClient yarnCluster = null;


### PR DESCRIPTION
This is an incremental (first part) rebuild of #3522 on the latest master.

For ease of review, broken down into small chunks.

## Part 1: Application-defined State Backends pick up additional values from the configuration

We need to keep supporting the scenario of setting a state backends in the user program, but configuring parameters like checkpoint directory in the cluster config. To support that, state backends may implement an additional interface which lets them pick up configuration values from the cluster configuration.

This also makes testing the checkpoint / savepoint configuration much easier.