### PR TITLE
[FLINK-7933][metrics] Improve PrometheusReporter tests

### DIFF
--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusReporter.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusReporter.java
@@ -32,6 +32,7 @@ import org.apache.flink.metrics.reporter.MetricReporter;
 import org.apache.flink.runtime.metrics.groups.AbstractMetricGroup;
 import org.apache.flink.runtime.metrics.groups.FrontMetricGroup;
 import org.apache.flink.util.NetUtils;
+import org.apache.flink.util.Preconditions;
 
 import io.prometheus.client.Collector;
 import io.prometheus.client.CollectorRegistry;
@@ -73,7 +74,14 @@ public class PrometheusReporter implements MetricReporter {
 	private static final String SCOPE_PREFIX = "flink" + SCOPE_SEPARATOR;
 
 	private HTTPServer httpServer;
+	private int port;
 	private final Map<String, AbstractMap.SimpleImmutableEntry<Collector, Integer>> collectorsWithCountByMetricName = new HashMap<>();
+
+	@VisibleForTesting
+	public int getPort() {
+		Preconditions.checkState(httpServer != null, "Server has not been initialized.");
+		return port;
+	}
 
 	@VisibleForTesting
 	static String replaceInvalidChars(final String input) {
@@ -91,6 +99,7 @@ public class PrometheusReporter implements MetricReporter {
 			int port = ports.next();
 			try {
 				httpServer = new HTTPServer(port);
+				this.port = port;
 				LOG.info("Started PrometheusReporter HTTP server on port {}.", port);
 				break;
 			} catch (IOException ioe) { //assume port conflict

--- a/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTaskScopeTest.java
+++ b/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTaskScopeTest.java
@@ -37,6 +37,7 @@ import org.apache.flink.util.AbstractID;
 import com.mashape.unirest.http.exceptions.UnirestException;
 import io.prometheus.client.CollectorRegistry;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -62,7 +63,6 @@ public class PrometheusReporterTaskScopeTest {
 	private static final int SUBTASK_INDEX_1 = 0;
 	private static final int SUBTASK_INDEX_2 = 1;
 
-	private final MetricRegistry registry = new MetricRegistry(MetricRegistryConfiguration.fromConfiguration(createConfigWithOneReporter("test1", "9429")));
 
 	private final JobID jobId = new JobID();
 	private final JobVertexID taskId1 = new JobVertexID();
@@ -72,10 +72,30 @@ public class PrometheusReporterTaskScopeTest {
 	private final AbstractID taskAttemptId2 = new AbstractID();
 	private final String[] labelValues2 = {jobId.toString(), taskId2.toString(), taskAttemptId2.toString(), TASK_MANAGER_HOST, TASK_NAME, "" + ATTEMPT_NUMBER, JOB_NAME, TASK_MANAGER_ID, "" + SUBTASK_INDEX_2};
 
-	private final TaskManagerMetricGroup tmMetricGroup = new TaskManagerMetricGroup(registry, TASK_MANAGER_HOST, TASK_MANAGER_ID);
-	private final TaskManagerJobMetricGroup tmJobMetricGroup = new TaskManagerJobMetricGroup(registry, tmMetricGroup, jobId, JOB_NAME);
-	private final TaskMetricGroup taskMetricGroup1 = new TaskMetricGroup(registry, tmJobMetricGroup, taskId1, taskAttemptId1, TASK_NAME, SUBTASK_INDEX_1, ATTEMPT_NUMBER);
-	private final TaskMetricGroup taskMetricGroup2 = new TaskMetricGroup(registry, tmJobMetricGroup, taskId2, taskAttemptId2, TASK_NAME, SUBTASK_INDEX_2, ATTEMPT_NUMBER);
+	private TaskMetricGroup taskMetricGroup1;
+	private TaskMetricGroup taskMetricGroup2;
+
+	private MetricRegistry registry;
+	private int port;
+
+	@Before
+	public void setupReporter() {
+		registry = new MetricRegistry(MetricRegistryConfiguration.fromConfiguration(createConfigWithOneReporter("test1", "9400-9500")));
+		PrometheusReporter reporter = (PrometheusReporter) registry.getReporters().get(0);
+		port = reporter.getPort();
+
+		TaskManagerMetricGroup tmMetricGroup = new TaskManagerMetricGroup(registry, TASK_MANAGER_HOST, TASK_MANAGER_ID);
+		TaskManagerJobMetricGroup tmJobMetricGroup = new TaskManagerJobMetricGroup(registry, tmMetricGroup, jobId, JOB_NAME);
+		taskMetricGroup1 = new TaskMetricGroup(registry, tmJobMetricGroup, taskId1, taskAttemptId1, TASK_NAME, SUBTASK_INDEX_1, ATTEMPT_NUMBER);
+		taskMetricGroup2 = new TaskMetricGroup(registry, tmJobMetricGroup, taskId2, taskAttemptId2, TASK_NAME, SUBTASK_INDEX_2, ATTEMPT_NUMBER);
+	}
+
+	@After
+	public void shutdownRegistry() {
+		if (registry != null) {
+			registry.shutdown();
+		}
+	}
 
 	@Test
 	public void countersCanBeAddedSeveralTimesIfTheyDifferInLabels() throws UnirestException {
@@ -137,7 +157,7 @@ public class PrometheusReporterTaskScopeTest {
 		taskMetricGroup1.histogram("my_histogram", histogram);
 		taskMetricGroup2.histogram("my_histogram", histogram);
 
-		final String exportedMetrics = pollMetrics().getBody();
+		final String exportedMetrics = pollMetrics(port).getBody();
 		assertThat(exportedMetrics, containsString("subtask_index=\"0\",quantile=\"0.5\",} 0.5")); // histogram
 		assertThat(exportedMetrics, containsString("subtask_index=\"1\",quantile=\"0.5\",} 0.5")); // histogram
 
@@ -179,10 +199,4 @@ public class PrometheusReporterTaskScopeTest {
 		labelNames[LABEL_NAMES.length] = element;
 		return labelNames;
 	}
-
-	@After
-	public void shutdownRegistry() {
-		registry.shutdown();
-	}
-
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR resolves the test instabilities of the prometheus reporter.

## Brief change log

* use a port range instead of a single hard-coded port
  * required the exposure of the bound port by the reporter
* move registry/reporter initialization into an `@Before` method (guarantees execution order)
* shutdown registry in `PrometheusReporterTest`

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

