### PR TITLE
[FLINK-7784] [kafka-producer] Don't fail TwoPhaseCommitSinkFunction when failing to commit during job recovery

### DIFF
--- a/flink-connectors/flink-connector-kafka-0.11/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011StateSerializerTest.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011StateSerializerTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.connectors.kafka;
 import org.apache.flink.api.common.typeutils.SerializerTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.streaming.api.functions.sink.TwoPhaseCommitSinkFunction;
+import org.apache.flink.streaming.api.functions.sink.TwoPhaseCommitSinkFunction.TransactionHolder;
 
 import java.util.Collections;
 import java.util.Optional;
@@ -59,42 +60,43 @@ public class FlinkKafkaProducer011StateSerializerTest
 	protected TwoPhaseCommitSinkFunction.State<
 		FlinkKafkaProducer011.KafkaTransactionState,
 		FlinkKafkaProducer011.KafkaTransactionContext>[] getTestData() {
+		//noinspection unchecked
 		return new TwoPhaseCommitSinkFunction.State[] {
 			new TwoPhaseCommitSinkFunction.State<
 				FlinkKafkaProducer011.KafkaTransactionState,
 				FlinkKafkaProducer011.KafkaTransactionContext>(
-					new FlinkKafkaProducer011.KafkaTransactionState("fake", 1L, (short) 42, null),
+					new TransactionHolder(new FlinkKafkaProducer011.KafkaTransactionState("fake", 1L, (short) 42, null), 0),
 					Collections.emptyList(),
 					Optional.empty()),
 			new TwoPhaseCommitSinkFunction.State<
 				FlinkKafkaProducer011.KafkaTransactionState,
 				FlinkKafkaProducer011.KafkaTransactionContext>(
-				new FlinkKafkaProducer011.KafkaTransactionState("fake", 1L, (short) 42, null),
-				Collections.singletonList(new FlinkKafkaProducer011.KafkaTransactionState("fake", 1L, (short) 42, null)),
+				new TransactionHolder(new FlinkKafkaProducer011.KafkaTransactionState("fake", 1L, (short) 42, null), 2711),
+				Collections.singletonList(new TransactionHolder(new FlinkKafkaProducer011.KafkaTransactionState("fake", 1L, (short) 42, null), 42)),
 				Optional.empty()),
 			new TwoPhaseCommitSinkFunction.State<
 				FlinkKafkaProducer011.KafkaTransactionState,
 				FlinkKafkaProducer011.KafkaTransactionContext>(
-				new FlinkKafkaProducer011.KafkaTransactionState("fake", 1L, (short) 42, null),
+				new TransactionHolder(new FlinkKafkaProducer011.KafkaTransactionState("fake", 1L, (short) 42, null), 0),
 				Collections.emptyList(),
 				Optional.of(new FlinkKafkaProducer011.KafkaTransactionContext(Collections.emptySet()))),
 			new TwoPhaseCommitSinkFunction.State<
 				FlinkKafkaProducer011.KafkaTransactionState,
 				FlinkKafkaProducer011.KafkaTransactionContext>(
-				new FlinkKafkaProducer011.KafkaTransactionState("fake", 1L, (short) 42, null),
+				new TransactionHolder(new FlinkKafkaProducer011.KafkaTransactionState("fake", 1L, (short) 42, null), 0),
 				Collections.emptyList(),
 				Optional.of(new FlinkKafkaProducer011.KafkaTransactionContext(Collections.singleton("hello")))),
 			new TwoPhaseCommitSinkFunction.State<
 				FlinkKafkaProducer011.KafkaTransactionState,
 				FlinkKafkaProducer011.KafkaTransactionContext>(
-				new FlinkKafkaProducer011.KafkaTransactionState("fake", 1L, (short) 42, null),
-				Collections.singletonList(new FlinkKafkaProducer011.KafkaTransactionState("fake", 1L, (short) 42, null)),
+				new TransactionHolder(new FlinkKafkaProducer011.KafkaTransactionState("fake", 1L, (short) 42, null), 0),
+				Collections.singletonList(new TransactionHolder(new FlinkKafkaProducer011.KafkaTransactionState("fake", 1L, (short) 42, null), 0)),
 				Optional.of(new FlinkKafkaProducer011.KafkaTransactionContext(Collections.emptySet()))),
 			new TwoPhaseCommitSinkFunction.State<
 				FlinkKafkaProducer011.KafkaTransactionState,
 				FlinkKafkaProducer011.KafkaTransactionContext>(
-				new FlinkKafkaProducer011.KafkaTransactionState("fake", 1L, (short) 42, null),
-				Collections.singletonList(new FlinkKafkaProducer011.KafkaTransactionState("fake", 1L, (short) 42, null)),
+				new TransactionHolder(new FlinkKafkaProducer011.KafkaTransactionState("fake", 1L, (short) 42, null), 0),
+				Collections.singletonList(new TransactionHolder(new FlinkKafkaProducer011.KafkaTransactionState("fake", 1L, (short) 42, null), 0)),
 				Optional.of(new FlinkKafkaProducer011.KafkaTransactionContext(Collections.singleton("hello"))))
 		};
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/TransactionHolderTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/TransactionHolderTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.functions.sink;
+
+import org.apache.flink.streaming.api.functions.sink.TwoPhaseCommitSinkFunction.TransactionHolder;
+
+import org.junit.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Unit tests {@link TransactionHolder}.
+ */
+public class TransactionHolderTest {
+
+	@Test
+	public void testElapsedTime() {
+		final long elapsedTime = new TransactionHolder<>(new Object(), 0)
+			.elapsedTime(Clock.fixed(Instant.ofEpochMilli(1000), ZoneOffset.UTC));
+		assertThat(elapsedTime, equalTo(1000L));
+	}
+
+}


### PR DESCRIPTION
## What is the purpose of the change
This makes it possible to configure the TwoPhaseCommitSinkFunction's behaviour w.r.t. transaction timeouts.

## Brief change log
  - *Introduce transaction timeouts to TwoPhaseCommitSinkFunction.* 
  - *Timeout can be used to generate warnings if the transaction's age approaches the timeout.*
  - *If an exception is thrown during job recovery, the sink can be configured not to propagate the exception and instead log it on ERROR level.*


## Verifying this change
This change added tests and can be verified as follows:
  - *Extended unit tests for TwoPhaseCommitSinkFunction to test added functionality*
  - *Manually verified the change by running a job with a FlinkKafka011Producer with checkpoint interval 27000 and transaction.timeout.ms = 30000. Warnings were generated correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)