### PR TITLE
[FLINK-7878] [api] make resource type extendible in ResourceSpec

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/operators/ResourceSpec.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/operators/ResourceSpec.java
@@ -328,11 +328,11 @@ public class ResourceSpec implements Serializable {
 	 */
 	public static class GPUResource extends Resource {
 
-		GPUResource(double value) {
+		public GPUResource(double value) {
 			this(value, ResourceAggregateType.AGGREGATE_TYPE_SUM);
 		}
 
-		GPUResource(double value, ResourceAggregateType type) {
+		public GPUResource(double value, ResourceAggregateType type) {
 			super("GPU", value, type);
 		}
 
@@ -347,11 +347,11 @@ public class ResourceSpec implements Serializable {
 	 */
 	public static class FPGAResource extends Resource {
 
-		FPGAResource(double value) {
+		public FPGAResource(double value) {
 			this(value, ResourceAggregateType.AGGREGATE_TYPE_SUM);
 		}
 
-		FPGAResource(double value, ResourceAggregateType type) {
+		public FPGAResource(double value, ResourceAggregateType type) {
 			super("FPGA", value, type);
 		}
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/operators/ResourceSpec.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/operators/ResourceSpec.java
@@ -314,13 +314,13 @@ public class ResourceSpec implements Serializable {
 		}
 
 		/**
-		 * create a resource of the sub resource type
+		 * create a resource of the same resource type
 		 *
 		 * @param value the value of the resource
 		 * @param type the aggregate type of the resource
 		 * @return a new instance of the sub resource
 		 */
-		abstract Resource create(double value, ResourceAggregateType type);
+		protected abstract Resource create(double value, ResourceAggregateType type);
 	}
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/api/common/operators/ResourceSpec.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/operators/ResourceSpec.java
@@ -19,9 +19,14 @@
 package org.apache.flink.api.common.operators;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nonnull;
 import java.io.Serializable;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
 
 /**
  * Describe the different resource factors of the operator with UDF.
@@ -37,10 +42,23 @@ import java.io.Serializable;
  *     <li>Direct Memory Size</li>
  *     <li>Native Memory Size</li>
  *     <li>State Size</li>
+ *     <li>Extended resources</li>
  * </ol>
  */
 @Internal
 public class ResourceSpec implements Serializable {
+
+	public enum ResourceAggregateType {
+		/**
+		 * Denotes keeping the sum of the values with same name when merging two resource specs for operator chaining
+		 */
+		AGGREGATE_TYPE_SUM,
+
+		/**
+		 * Denotes keeping the max of the values with same name when merging two resource specs for operator chaining
+		 */
+		AGGREGATE_TYPE_MAX
+	}
 
 	private static final long serialVersionUID = 1L;
 
@@ -61,18 +79,17 @@ public class ResourceSpec implements Serializable {
 	/** How many state size in mb are used */
 	private final int stateSizeInMB;
 
+	private final Map<String, Resource> extendedResources = new HashMap<>(1);
+
 	/**
 	 * Creates a new ResourceSpec with basic common resources.
 	 *
 	 * @param cpuCores The number of CPU cores (possibly fractional, i.e., 0.2 cores)
 	 * @param heapMemoryInMB The size of the java heap memory, in megabytes.
+	 * @param extendedResources The extended resources, associated with the resource manager used
 	 */
-	public ResourceSpec(double cpuCores, int heapMemoryInMB) {
-		this.cpuCores = cpuCores;
-		this.heapMemoryInMB = heapMemoryInMB;
-		this.directMemoryInMB = 0;
-		this.nativeMemoryInMB = 0;
-		this.stateSizeInMB = 0;
+	public ResourceSpec(double cpuCores, int heapMemoryInMB, Resource... extendedResources) {
+		this(cpuCores, heapMemoryInMB, 0, 0, 0, extendedResources);
 	}
 
 	/**
@@ -83,18 +100,23 @@ public class ResourceSpec implements Serializable {
 	 * @param directMemoryInMB The size of the java nio direct memory, in megabytes.
 	 * @param nativeMemoryInMB The size of the native memory, in megabytes.
 	 * @param stateSizeInMB The state size for storing in checkpoint.
+	 * @param extendedResources The extended resources, associated with the resource manager used
 	 */
 	public ResourceSpec(
 			double cpuCores,
 			int heapMemoryInMB,
 			int directMemoryInMB,
 			int nativeMemoryInMB,
-			int stateSizeInMB) {
+			int stateSizeInMB,
+			Resource... extendedResources) {
 		this.cpuCores = cpuCores;
 		this.heapMemoryInMB = heapMemoryInMB;
 		this.directMemoryInMB = directMemoryInMB;
 		this.nativeMemoryInMB = nativeMemoryInMB;
 		this.stateSizeInMB = stateSizeInMB;
+		for (Resource resource : extendedResources) {
+			this.extendedResources.put(resource.name, resource);
+		}
 	}
 
 	/**
@@ -105,12 +127,17 @@ public class ResourceSpec implements Serializable {
 	 * @return The new resource with merged values.
 	 */
 	public ResourceSpec merge(ResourceSpec other) {
-		return new ResourceSpec(
+		ResourceSpec target = new ResourceSpec(
 				Math.max(this.cpuCores, other.cpuCores),
 				this.heapMemoryInMB + other.heapMemoryInMB,
 				this.directMemoryInMB + other.directMemoryInMB,
 				this.nativeMemoryInMB + other.nativeMemoryInMB,
 				this.stateSizeInMB + other.stateSizeInMB);
+		target.extendedResources.putAll(extendedResources);
+		for (Resource resource : other.extendedResources.values()) {
+			target.extendedResources.merge(resource.name, resource, (v1, v2) -> v1.merge(v2));
+		}
+		return target;
 	}
 
 	public double getCpuCores() {
@@ -133,14 +160,31 @@ public class ResourceSpec implements Serializable {
 		return this.stateSizeInMB;
 	}
 
+	public Map<String, Double> getExtendedResources() {
+		Map<String, Double> resources = new HashMap<>(extendedResources.size());
+		for (Resource resource : extendedResources.values()) {
+			resources.put(resource.name, resource.value);
+		}
+		return Collections.unmodifiableMap(resources);
+	}
+
 	/**
 	 * Check whether all the field values are valid.
 	 *
 	 * @return True if all the values are equal or greater than 0, otherwise false.
 	 */
 	public boolean isValid() {
-		return (this.cpuCores >= 0 && this.heapMemoryInMB >= 0 && this.directMemoryInMB >= 0 &&
-				this.nativeMemoryInMB >= 0 && this.stateSizeInMB >= 0);
+		if (this.cpuCores >= 0 && this.heapMemoryInMB >= 0 && this.directMemoryInMB >= 0 &&
+				this.nativeMemoryInMB >= 0 && this.stateSizeInMB >= 0) {
+			for (Resource resource : extendedResources.values()) {
+				if (resource.value.doubleValue() < 0) {
+					return false;
+				}
+			}
+			return true;
+		} else {
+			return false;
+		}
 	}
 
 	/**
@@ -156,7 +200,17 @@ public class ResourceSpec implements Serializable {
 		int cmp3 = Integer.compare(this.directMemoryInMB, other.directMemoryInMB);
 		int cmp4 = Integer.compare(this.nativeMemoryInMB, other.nativeMemoryInMB);
 		int cmp5 = Integer.compare(this.stateSizeInMB, other.stateSizeInMB);
-		return (cmp1 <= 0 && cmp2 <= 0 && cmp3 <= 0 && cmp4 <= 0 && cmp5 <= 0);
+		if (cmp1 <= 0 && cmp2 <= 0 && cmp3 <= 0 && cmp4 <= 0 && cmp5 <= 0) {
+			for (Resource resource : extendedResources.values()) {
+				if (!other.extendedResources.containsKey(resource.name) ||
+						!other.extendedResources.get(resource.name).type.equals(resource.type) ||
+						other.extendedResources.get(resource.name).value.compareTo(resource.value) < 0) {
+					return false;
+				}
+			}
+			return true;
+		}
+		return false;
 	}
 
 	@Override
@@ -169,7 +223,8 @@ public class ResourceSpec implements Serializable {
 					this.heapMemoryInMB == that.heapMemoryInMB &&
 					this.directMemoryInMB == that.directMemoryInMB &&
 					this.nativeMemoryInMB == that.nativeMemoryInMB &&
-					this.stateSizeInMB == that.stateSizeInMB;
+					this.stateSizeInMB == that.stateSizeInMB &&
+					Objects.equals(this.extendedResources, that.extendedResources);
 		} else {
 			return false;
 		}
@@ -183,17 +238,81 @@ public class ResourceSpec implements Serializable {
 		result = 31 * result + directMemoryInMB;
 		result = 31 * result + nativeMemoryInMB;
 		result = 31 * result + stateSizeInMB;
+		result = 31 * result + extendedResources.hashCode();
 		return result;
 	}
 
 	@Override
 	public String toString() {
+		String extend = "";
+		for (Resource resource : extendedResources.values()) {
+			extend += ", " + resource.name + "=" + resource.value;
+		}
 		return "ResourceSpec{" +
 				"cpuCores=" + cpuCores +
 				", heapMemoryInMB=" + heapMemoryInMB +
 				", directMemoryInMB=" + directMemoryInMB +
 				", nativeMemoryInMB=" + nativeMemoryInMB +
-				", stateSizeInMB=" + stateSizeInMB +
+				", stateSizeInMB=" + stateSizeInMB + extend +
 				'}';
+	}
+
+	private void addResource(String name, double value, ResourceAggregateType type) {
+		extendedResources.put(name, new Resource(name, type, value));
+	}
+
+	public static class Resource {
+		private String name;
+		private ResourceAggregateType type;
+		private Double value;
+
+		public Resource(String name, double value) {
+			this(name, ResourceAggregateType.AGGREGATE_TYPE_SUM, value);
+		}
+
+		public Resource(String name, ResourceAggregateType type, double value) {
+			this.name = name;
+			this.type = type;
+			this.value = Double.valueOf(value);
+		}
+
+		Resource merge(Resource other) {
+			Preconditions.checkArgument(this.name.equals(other.name), "Merge with different aggregate name");
+			Preconditions.checkArgument(this.type.equals(other.type), "Merge with different aggregate type");
+
+			Resource resource = new Resource(name, type, value);
+			switch (type) {
+				case AGGREGATE_TYPE_MAX :
+					resource.value = other.value.compareTo(this.value) > 0 ? other.value : this.value;
+					break;
+
+				case AGGREGATE_TYPE_SUM:
+				default:
+					resource.value += other.value;
+			}
+
+			return resource;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			} else if (o != null && getClass() == o.getClass()) {
+				Resource other = (Resource) o;
+
+				return name.equals(other.name) && type.equals(other.type) && value.equals(other.value);
+			} else {
+				return false;
+			}
+		}
+
+		@Override
+		public int hashCode() {
+			int result = name != null ? name.hashCode() : 0;
+			result = 31 * result + type.ordinal();
+			result = 31 * result + value.hashCode();
+			return result;
+		}
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/operators/ResourceSpec.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/operators/ResourceSpec.java
@@ -275,8 +275,8 @@ public class ResourceSpec implements Serializable {
 			return this;
 		}
 
-		public Builder setGPUResource(GPUResource gpuResource) {
-			this.gpuResource = gpuResource;
+		public Builder setGPUResource(double gpu) {
+			this.gpuResource = new GPUResource(gpu);
 			return this;
 		}
 

--- a/flink-core/src/test/java/org/apache/flink/api/common/operators/ResourceSpecTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/operators/ResourceSpecTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.api.common.operators;
 
+import org.apache.flink.util.InstantiationUtil;
+import org.apache.flink.util.TestLogger;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -25,17 +27,20 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-public class ResourceSpecTest {
+/**
+ * Tests for ResourceSpec class, including its all public api: isValid, lessThanOrEqual, equals, hashCode and merge.
+ */
+public class ResourceSpecTest extends TestLogger {
 
 	@Test
 	public void testIsValid() throws Exception {
 		ResourceSpec rs = new ResourceSpec(1.0, 100);
 		assertTrue(rs.isValid());
 
-		rs = new ResourceSpec(1.0, 100, new ResourceSpec.Resource("GPU", 1));
+		rs = new ResourceSpec(1.0, 100, new ResourceSpec.GPUResource(1));
 		assertTrue(rs.isValid());
 
-		rs = new ResourceSpec(1.0, 100, new ResourceSpec.Resource("GPU", -1));
+		rs = new ResourceSpec(1.0, 100, new ResourceSpec.GPUResource(-1));
 		assertFalse(rs.isValid());
 	}
 
@@ -46,19 +51,19 @@ public class ResourceSpecTest {
 		assertTrue(rs1.lessThanOrEqual(rs2));
 		assertTrue(rs2.lessThanOrEqual(rs1));
 
-		rs2 = new ResourceSpec(1.0, 100, new ResourceSpec.Resource("FPGA", 1));
+		rs2 = new ResourceSpec(1.0, 100, new ResourceSpec.FPGAResource(1));
 		assertTrue(rs1.lessThanOrEqual(rs2));
 		assertFalse(rs2.lessThanOrEqual(rs1));
 
-		rs1 = new ResourceSpec(1.0, 100, new ResourceSpec.Resource("FPGA", 2));
-		assertFalse(rs1.lessThanOrEqual(rs2));
-		assertTrue(rs2.lessThanOrEqual(rs1));
+		ResourceSpec rs3 = new ResourceSpec(1.0, 100, new ResourceSpec.FPGAResource(2));
+		assertFalse(rs3.lessThanOrEqual(rs2));
+		assertTrue(rs2.lessThanOrEqual(rs3));
 
-		rs2 = new ResourceSpec(1.0, 100,
-				new ResourceSpec.Resource("FPGA", 1),
-				new ResourceSpec.Resource("GPU", 1));
-		assertFalse(rs1.lessThanOrEqual(rs2));
-		assertFalse(rs2.lessThanOrEqual(rs1));
+		ResourceSpec rs4 = new ResourceSpec(1.0, 100,
+				new ResourceSpec.FPGAResource(1),
+				new ResourceSpec.GPUResource( 1));
+		assertFalse(rs3.lessThanOrEqual(rs4));
+		assertFalse(rs4.lessThanOrEqual(rs3));
 	}
 
 	@Test
@@ -68,20 +73,20 @@ public class ResourceSpecTest {
 		assertTrue(rs1.equals(rs2));
 		assertTrue(rs2.equals(rs1));
 
-		rs1 = new ResourceSpec(1.0, 100, new ResourceSpec.Resource("FPGA", 2.2));
-		rs2 = new ResourceSpec(1.0, 100, new ResourceSpec.Resource("FPGA", 1));
-		assertFalse(rs1.equals(rs2));
+		ResourceSpec rs3 = new ResourceSpec(1.0, 100, new ResourceSpec.FPGAResource(2.2));
+		ResourceSpec rs4 = new ResourceSpec(1.0, 100, new ResourceSpec.FPGAResource( 1));
+		assertFalse(rs3.equals(rs4));
 
-		rs2 = new ResourceSpec(1.0, 100, new ResourceSpec.Resource("FPGA", 2.2));
-		assertTrue(rs1.equals(rs2));
+		ResourceSpec rs5 = new ResourceSpec(1.0, 100, new ResourceSpec.FPGAResource(2.2));
+		assertTrue(rs3.equals(rs5));
 
-		rs1 = new ResourceSpec(1.0, 100,
-				new ResourceSpec.Resource("FPGA", 2),
-				new ResourceSpec.Resource("GPU", 0.5));
-		rs2 = new ResourceSpec(1.0, 100,
-				new ResourceSpec.Resource("FPGA", 2),
-				new ResourceSpec.Resource("GPU", ResourceSpec.ResourceAggregateType.AGGREGATE_TYPE_MAX, 0.5));
-		assertFalse(rs1.equals(rs2));
+		ResourceSpec rs6 = new ResourceSpec(1.0, 100,
+				new ResourceSpec.FPGAResource(2),
+				new ResourceSpec.GPUResource( 0.5));
+		ResourceSpec rs7 = new ResourceSpec(1.0, 100,
+				new ResourceSpec.FPGAResource( 2),
+				new ResourceSpec.GPUResource(0.5, ResourceSpec.ResourceAggregateType.AGGREGATE_TYPE_MAX));
+		assertFalse(rs6.equals(rs7));
 	}
 
 	@Test
@@ -90,25 +95,25 @@ public class ResourceSpecTest {
 		ResourceSpec rs2 = new ResourceSpec(1.0, 100);
 		assertEquals(rs1.hashCode(), rs2.hashCode());
 
-		rs1 = new ResourceSpec(1.0, 100, new ResourceSpec.Resource("FPGA", 2.2));
-		rs2 = new ResourceSpec(1.0, 100, new ResourceSpec.Resource("FPGA", 1));
-		assertFalse(rs1.hashCode() == rs2.hashCode());
+		ResourceSpec rs3 = new ResourceSpec(1.0, 100, new ResourceSpec.FPGAResource(2.2));
+		ResourceSpec rs4 = new ResourceSpec(1.0, 100, new ResourceSpec.FPGAResource(1));
+		assertFalse(rs3.hashCode() == rs4.hashCode());
 
-		rs2 = new ResourceSpec(1.0, 100, new ResourceSpec.Resource("FPGA", 2.2));
-		assertEquals(rs1.hashCode(), rs2.hashCode());
+		ResourceSpec rs5 = new ResourceSpec(1.0, 100, new ResourceSpec.FPGAResource( 2.2));
+		assertEquals(rs3.hashCode(), rs5.hashCode());
 
-		rs1 = new ResourceSpec(1.0, 100,
-				new ResourceSpec.Resource("FPGA", 2),
-				new ResourceSpec.Resource("GPU", 0.5));
-		rs2 = new ResourceSpec(1.0, 100,
-				new ResourceSpec.Resource("FPGA", 2),
-				new ResourceSpec.Resource("GPU", ResourceSpec.ResourceAggregateType.AGGREGATE_TYPE_MAX, 0.5));
-		assertFalse(rs1.hashCode() == rs2.hashCode());
+		ResourceSpec rs6 = new ResourceSpec(1.0, 100,
+				new ResourceSpec.FPGAResource( 2),
+				new ResourceSpec.GPUResource(0.5));
+		ResourceSpec rs7 = new ResourceSpec(1.0, 100,
+				new ResourceSpec.FPGAResource(2),
+				new ResourceSpec.GPUResource(0.5, ResourceSpec.ResourceAggregateType.AGGREGATE_TYPE_MAX));
+		assertFalse(rs6.hashCode() == rs7.hashCode());
 	}
 
 	@Test
 	public void testMerge() throws Exception {
-		ResourceSpec rs1 = new ResourceSpec(1.0, 100, new ResourceSpec.Resource("FPGA", 1.1));
+		ResourceSpec rs1 = new ResourceSpec(1.0, 100, new ResourceSpec.FPGAResource(1.1));
 		ResourceSpec rs2 = new ResourceSpec(1.0, 100);
 
 		ResourceSpec rs3 = rs1.merge(rs2);
@@ -117,28 +122,34 @@ public class ResourceSpecTest {
 		ResourceSpec rs4 = rs1.merge(rs3);
 		assertEquals(2.2, rs4.getExtendedResources().get("FPGA").doubleValue(), 0.000001);
 
-		rs1 = new ResourceSpec(1.0, 100,
-				new ResourceSpec.Resource("FPGA", 2),
-				new ResourceSpec.Resource("GPU", 0.5));
-		ResourceSpec rs5 = rs1.merge(rs2);
+		ResourceSpec rs6 = new ResourceSpec(1.0, 100,
+				new ResourceSpec.FPGAResource(2),
+				new ResourceSpec.GPUResource(0.5));
+		ResourceSpec rs5 = rs6.merge(rs2);
 		assertEquals(2, rs5.getExtendedResources().get("FPGA").doubleValue(), 0.000001);
 		assertEquals(0.5, rs5.getExtendedResources().get("GPU").doubleValue(), 0.000001);
 
-		rs2 = new ResourceSpec(1.0, 100,
-				new ResourceSpec.Resource("GPU", ResourceSpec.ResourceAggregateType.AGGREGATE_TYPE_MAX, 0.5));
+		ResourceSpec rs7 = new ResourceSpec(1.0, 100,
+				new ResourceSpec.GPUResource( 0.5, ResourceSpec.ResourceAggregateType.AGGREGATE_TYPE_MAX));
 		try {
-			rs1.merge(rs2);
+			rs6.merge(rs7);
 			fail("Merge with different aggregate type should fail");
-		} catch (IllegalArgumentException e) {
+		} catch (IllegalArgumentException ignored) {
 		}
 
-		rs1 = new ResourceSpec(1.0, 100,
-				new ResourceSpec.Resource("FPGA", 2),
-				new ResourceSpec.Resource("GPU", ResourceSpec.ResourceAggregateType.AGGREGATE_TYPE_MAX, 1.5));
-		ResourceSpec rs6 = rs1.merge(rs2);
-		assertEquals(2, rs6.getExtendedResources().get("FPGA").doubleValue(), 0.000001);
-		assertEquals(1.5, rs6.getExtendedResources().get("GPU").doubleValue(), 0.000001);
+		ResourceSpec rs8 = new ResourceSpec(1.0, 100,
+				new ResourceSpec.FPGAResource(2),
+				new ResourceSpec.GPUResource(1.5, ResourceSpec.ResourceAggregateType.AGGREGATE_TYPE_MAX));
+		ResourceSpec rs9 = rs8.merge(rs7);
+		assertEquals(2, rs9.getExtendedResources().get("FPGA").doubleValue(), 0.000001);
+		assertEquals(1.5, rs9.getExtendedResources().get("GPU").doubleValue(), 0.000001);
 
 	}
 
+	@Test
+	public void testSerializable() throws Exception {
+		ResourceSpec rs = new ResourceSpec(1.0, 100, new ResourceSpec.FPGAResource(1.1));
+		byte[] buffer = InstantiationUtil.serializeObject(rs);
+		InstantiationUtil.deserializeObject(buffer, ClassLoader.getSystemClassLoader());
+	}
 }

--- a/flink-core/src/test/java/org/apache/flink/api/common/operators/ResourceSpecTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/operators/ResourceSpecTest.java
@@ -148,8 +148,9 @@ public class ResourceSpecTest extends TestLogger {
 
 	@Test
 	public void testSerializable() throws Exception {
-		ResourceSpec rs = new ResourceSpec(1.0, 100, new ResourceSpec.FPGAResource(1.1));
-		byte[] buffer = InstantiationUtil.serializeObject(rs);
-		InstantiationUtil.deserializeObject(buffer, ClassLoader.getSystemClassLoader());
+		ResourceSpec rs1 = new ResourceSpec(1.0, 100, new ResourceSpec.FPGAResource(1.1));
+		byte[] buffer = InstantiationUtil.serializeObject(rs1);
+		ResourceSpec rs2 = InstantiationUtil.deserializeObject(buffer, ClassLoader.getSystemClassLoader());
+		assertTrue(rs1.equals(rs2));
 	}
 }

--- a/flink-core/src/test/java/org/apache/flink/api/common/operators/ResourceSpecTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/operators/ResourceSpecTest.java
@@ -34,123 +34,153 @@ public class ResourceSpecTest extends TestLogger {
 
 	@Test
 	public void testIsValid() throws Exception {
-		ResourceSpec rs = new ResourceSpec(1.0, 100);
+		ResourceSpec rs = ResourceSpec.newBuilder().setCpuCores(1.0).setHeapMemoryInMB(100).build();
 		assertTrue(rs.isValid());
 
-		rs = new ResourceSpec(1.0, 100, new ResourceSpec.GPUResource(1));
+		rs = ResourceSpec.newBuilder().
+				setCpuCores(1.0).
+				setHeapMemoryInMB(100).
+				setGPUResource(new ResourceSpec.GPUResource(1)).
+				build();
 		assertTrue(rs.isValid());
 
-		rs = new ResourceSpec(1.0, 100, new ResourceSpec.GPUResource(-1));
+		rs = ResourceSpec.newBuilder().
+				setCpuCores(1.0).
+				setHeapMemoryInMB(100).
+				setGPUResource(new ResourceSpec.GPUResource(-1)).
+				build();
 		assertFalse(rs.isValid());
 	}
 
 	@Test
 	public void testLessThanOrEqual() throws Exception {
-		ResourceSpec rs1 = new ResourceSpec(1.0, 100);
-		ResourceSpec rs2 = new ResourceSpec(1.0, 100);
+		ResourceSpec rs1 = ResourceSpec.newBuilder().setCpuCores(1.0).setHeapMemoryInMB(100).build();
+		ResourceSpec rs2 = ResourceSpec.newBuilder().setCpuCores(1.0).setHeapMemoryInMB(100).build();
 		assertTrue(rs1.lessThanOrEqual(rs2));
 		assertTrue(rs2.lessThanOrEqual(rs1));
 
-		rs2 = new ResourceSpec(1.0, 100, new ResourceSpec.FPGAResource(1));
-		assertTrue(rs1.lessThanOrEqual(rs2));
-		assertFalse(rs2.lessThanOrEqual(rs1));
+		ResourceSpec rs3 = ResourceSpec.newBuilder().
+				setCpuCores(1.0).
+				setHeapMemoryInMB(100).
+				setGPUResource(new ResourceSpec.GPUResource(1.1)).
+				build();
+		assertTrue(rs1.lessThanOrEqual(rs3));
+		assertFalse(rs3.lessThanOrEqual(rs1));
 
-		ResourceSpec rs3 = new ResourceSpec(1.0, 100, new ResourceSpec.FPGAResource(2));
-		assertFalse(rs3.lessThanOrEqual(rs2));
-		assertTrue(rs2.lessThanOrEqual(rs3));
-
-		ResourceSpec rs4 = new ResourceSpec(1.0, 100,
-				new ResourceSpec.FPGAResource(1),
-				new ResourceSpec.GPUResource( 1));
-		assertFalse(rs3.lessThanOrEqual(rs4));
+		ResourceSpec rs4 = ResourceSpec.newBuilder().
+				setCpuCores(1.0).
+				setHeapMemoryInMB(100).
+				setGPUResource(new ResourceSpec.GPUResource(2.2)).
+				build();
 		assertFalse(rs4.lessThanOrEqual(rs3));
+		assertTrue(rs3.lessThanOrEqual(rs4));
 	}
 
 	@Test
 	public void testEquals() throws Exception {
-		ResourceSpec rs1 = new ResourceSpec(1.0, 100);
-		ResourceSpec rs2 = new ResourceSpec(1.0, 100);
+		ResourceSpec rs1 = ResourceSpec.newBuilder().setCpuCores(1.0).setHeapMemoryInMB(100).build();
+		ResourceSpec rs2 = ResourceSpec.newBuilder().setCpuCores(1.0).setHeapMemoryInMB(100).build();
 		assertTrue(rs1.equals(rs2));
 		assertTrue(rs2.equals(rs1));
 
-		ResourceSpec rs3 = new ResourceSpec(1.0, 100, new ResourceSpec.FPGAResource(2.2));
-		ResourceSpec rs4 = new ResourceSpec(1.0, 100, new ResourceSpec.FPGAResource( 1));
+		ResourceSpec rs3 = ResourceSpec.newBuilder().
+				setCpuCores(1.0).
+				setHeapMemoryInMB(100).
+				setGPUResource(new ResourceSpec.GPUResource(2.2)).
+				build();
+		ResourceSpec rs4 = ResourceSpec.newBuilder().
+				setCpuCores(1.0).
+				setHeapMemoryInMB(100).
+				setGPUResource(new ResourceSpec.GPUResource(1)).
+				build();
 		assertFalse(rs3.equals(rs4));
 
-		ResourceSpec rs5 = new ResourceSpec(1.0, 100, new ResourceSpec.FPGAResource(2.2));
+		ResourceSpec rs5 = ResourceSpec.newBuilder().
+				setCpuCores(1.0).
+				setHeapMemoryInMB(100).
+				setGPUResource(new ResourceSpec.GPUResource(2.2)).
+				build();
 		assertTrue(rs3.equals(rs5));
-
-		ResourceSpec rs6 = new ResourceSpec(1.0, 100,
-				new ResourceSpec.FPGAResource(2),
-				new ResourceSpec.GPUResource( 0.5));
-		ResourceSpec rs7 = new ResourceSpec(1.0, 100,
-				new ResourceSpec.FPGAResource( 2),
-				new ResourceSpec.GPUResource(0.5, ResourceSpec.ResourceAggregateType.AGGREGATE_TYPE_MAX));
-		assertFalse(rs6.equals(rs7));
 	}
 
 	@Test
 	public void testHashCode() throws Exception {
-		ResourceSpec rs1 = new ResourceSpec(1.0, 100);
-		ResourceSpec rs2 = new ResourceSpec(1.0, 100);
+		ResourceSpec rs1 = ResourceSpec.newBuilder().setCpuCores(1.0).setHeapMemoryInMB(100).build();
+		ResourceSpec rs2 = ResourceSpec.newBuilder().setCpuCores(1.0).setHeapMemoryInMB(100).build();
 		assertEquals(rs1.hashCode(), rs2.hashCode());
 
-		ResourceSpec rs3 = new ResourceSpec(1.0, 100, new ResourceSpec.FPGAResource(2.2));
-		ResourceSpec rs4 = new ResourceSpec(1.0, 100, new ResourceSpec.FPGAResource(1));
+		ResourceSpec rs3 = ResourceSpec.newBuilder().
+				setCpuCores(1.0).
+				setHeapMemoryInMB(100).
+				setGPUResource(new ResourceSpec.GPUResource(2.2)).
+				build();
+		ResourceSpec rs4 = ResourceSpec.newBuilder().
+				setCpuCores(1.0).
+				setHeapMemoryInMB(100).
+				setGPUResource(new ResourceSpec.GPUResource(1)).
+				build();
 		assertFalse(rs3.hashCode() == rs4.hashCode());
 
-		ResourceSpec rs5 = new ResourceSpec(1.0, 100, new ResourceSpec.FPGAResource( 2.2));
+		ResourceSpec rs5 = ResourceSpec.newBuilder().
+				setCpuCores(1.0).
+				setHeapMemoryInMB(100).
+				setGPUResource(new ResourceSpec.GPUResource(2.2)).
+				build();
 		assertEquals(rs3.hashCode(), rs5.hashCode());
 
-		ResourceSpec rs6 = new ResourceSpec(1.0, 100,
-				new ResourceSpec.FPGAResource( 2),
-				new ResourceSpec.GPUResource(0.5));
-		ResourceSpec rs7 = new ResourceSpec(1.0, 100,
-				new ResourceSpec.FPGAResource(2),
-				new ResourceSpec.GPUResource(0.5, ResourceSpec.ResourceAggregateType.AGGREGATE_TYPE_MAX));
-		assertFalse(rs6.hashCode() == rs7.hashCode());
+		ResourceSpec rs6 = ResourceSpec.newBuilder().
+				setCpuCores(1.0).
+				setHeapMemoryInMB(100).
+				setGPUResource(new ResourceSpec.GPUResource(2.2, ResourceSpec.Resource.ResourceAggregateType.AGGREGATE_TYPE_MAX)).
+				build();
+		assertFalse(rs6.hashCode() == rs5.hashCode());
 	}
 
 	@Test
 	public void testMerge() throws Exception {
-		ResourceSpec rs1 = new ResourceSpec(1.0, 100, new ResourceSpec.FPGAResource(1.1));
-		ResourceSpec rs2 = new ResourceSpec(1.0, 100);
+		ResourceSpec rs1 = ResourceSpec.newBuilder().
+				setCpuCores(1.0).
+				setHeapMemoryInMB(100).
+				setGPUResource(new ResourceSpec.GPUResource(1.1)).
+				build();
+		ResourceSpec rs2 = ResourceSpec.newBuilder().setCpuCores(1.0).setHeapMemoryInMB(100).build();
 
 		ResourceSpec rs3 = rs1.merge(rs2);
-		assertEquals(1.1, rs3.getExtendedResources().get("FPGA").doubleValue(), 0.000001);
+		assertEquals(1.1, rs3.getGPUResource(), 0.000001);
 
 		ResourceSpec rs4 = rs1.merge(rs3);
-		assertEquals(2.2, rs4.getExtendedResources().get("FPGA").doubleValue(), 0.000001);
+		assertEquals(2.2, rs4.getGPUResource(), 0.000001);
 
-		ResourceSpec rs6 = new ResourceSpec(1.0, 100,
-				new ResourceSpec.FPGAResource(2),
-				new ResourceSpec.GPUResource(0.5));
-		ResourceSpec rs5 = rs6.merge(rs2);
-		assertEquals(2, rs5.getExtendedResources().get("FPGA").doubleValue(), 0.000001);
-		assertEquals(0.5, rs5.getExtendedResources().get("GPU").doubleValue(), 0.000001);
-
-		ResourceSpec rs7 = new ResourceSpec(1.0, 100,
-				new ResourceSpec.GPUResource( 0.5, ResourceSpec.ResourceAggregateType.AGGREGATE_TYPE_MAX));
+		ResourceSpec rs5 = ResourceSpec.newBuilder().
+				setCpuCores(1.0).
+				setHeapMemoryInMB(100).
+				setGPUResource(new ResourceSpec.GPUResource(1.1, ResourceSpec.Resource.ResourceAggregateType.AGGREGATE_TYPE_MAX)).
+				build();
 		try {
-			rs6.merge(rs7);
+			rs4.merge(rs5);
 			fail("Merge with different aggregate type should fail");
 		} catch (IllegalArgumentException ignored) {
 		}
 
-		ResourceSpec rs8 = new ResourceSpec(1.0, 100,
-				new ResourceSpec.FPGAResource(2),
-				new ResourceSpec.GPUResource(1.5, ResourceSpec.ResourceAggregateType.AGGREGATE_TYPE_MAX));
-		ResourceSpec rs9 = rs8.merge(rs7);
-		assertEquals(2, rs9.getExtendedResources().get("FPGA").doubleValue(), 0.000001);
-		assertEquals(1.5, rs9.getExtendedResources().get("GPU").doubleValue(), 0.000001);
+		ResourceSpec rs6 = ResourceSpec.newBuilder().
+				setCpuCores(1.0).
+				setHeapMemoryInMB(100).
+				setGPUResource(new ResourceSpec.GPUResource(1.5, ResourceSpec.Resource.ResourceAggregateType.AGGREGATE_TYPE_MAX)).
+				build();
+		ResourceSpec rs7 = rs5.merge(rs6);
+		assertEquals(1.5, rs7.getGPUResource(), 0.000001);
 
 	}
 
 	@Test
 	public void testSerializable() throws Exception {
-		ResourceSpec rs1 = new ResourceSpec(1.0, 100, new ResourceSpec.FPGAResource(1.1));
+		ResourceSpec rs1 = ResourceSpec.newBuilder().
+				setCpuCores(1.0).
+				setHeapMemoryInMB(100).
+				setGPUResource(new ResourceSpec.GPUResource(1.1)).
+				build();
 		byte[] buffer = InstantiationUtil.serializeObject(rs1);
 		ResourceSpec rs2 = InstantiationUtil.deserializeObject(buffer, ClassLoader.getSystemClassLoader());
-		assertTrue(rs1.equals(rs2));
+		assertEquals(rs1, rs2);
 	}
 }

--- a/flink-core/src/test/java/org/apache/flink/api/common/operators/ResourceSpecTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/operators/ResourceSpecTest.java
@@ -25,7 +25,6 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * Tests for ResourceSpec class, including its all public api: isValid, lessThanOrEqual, equals, hashCode and merge.
@@ -40,14 +39,14 @@ public class ResourceSpecTest extends TestLogger {
 		rs = ResourceSpec.newBuilder().
 				setCpuCores(1.0).
 				setHeapMemoryInMB(100).
-				setGPUResource(new ResourceSpec.GPUResource(1)).
+				setGPUResource(1).
 				build();
 		assertTrue(rs.isValid());
 
 		rs = ResourceSpec.newBuilder().
 				setCpuCores(1.0).
 				setHeapMemoryInMB(100).
-				setGPUResource(new ResourceSpec.GPUResource(-1)).
+				setGPUResource(-1).
 				build();
 		assertFalse(rs.isValid());
 	}
@@ -62,7 +61,7 @@ public class ResourceSpecTest extends TestLogger {
 		ResourceSpec rs3 = ResourceSpec.newBuilder().
 				setCpuCores(1.0).
 				setHeapMemoryInMB(100).
-				setGPUResource(new ResourceSpec.GPUResource(1.1)).
+				setGPUResource(1.1).
 				build();
 		assertTrue(rs1.lessThanOrEqual(rs3));
 		assertFalse(rs3.lessThanOrEqual(rs1));
@@ -70,7 +69,7 @@ public class ResourceSpecTest extends TestLogger {
 		ResourceSpec rs4 = ResourceSpec.newBuilder().
 				setCpuCores(1.0).
 				setHeapMemoryInMB(100).
-				setGPUResource(new ResourceSpec.GPUResource(2.2)).
+				setGPUResource(2.2).
 				build();
 		assertFalse(rs4.lessThanOrEqual(rs3));
 		assertTrue(rs3.lessThanOrEqual(rs4));
@@ -86,19 +85,19 @@ public class ResourceSpecTest extends TestLogger {
 		ResourceSpec rs3 = ResourceSpec.newBuilder().
 				setCpuCores(1.0).
 				setHeapMemoryInMB(100).
-				setGPUResource(new ResourceSpec.GPUResource(2.2)).
+				setGPUResource(2.2).
 				build();
 		ResourceSpec rs4 = ResourceSpec.newBuilder().
 				setCpuCores(1.0).
 				setHeapMemoryInMB(100).
-				setGPUResource(new ResourceSpec.GPUResource(1)).
+				setGPUResource(1).
 				build();
 		assertFalse(rs3.equals(rs4));
 
 		ResourceSpec rs5 = ResourceSpec.newBuilder().
 				setCpuCores(1.0).
 				setHeapMemoryInMB(100).
-				setGPUResource(new ResourceSpec.GPUResource(2.2)).
+				setGPUResource(2.2).
 				build();
 		assertTrue(rs3.equals(rs5));
 	}
@@ -112,28 +111,21 @@ public class ResourceSpecTest extends TestLogger {
 		ResourceSpec rs3 = ResourceSpec.newBuilder().
 				setCpuCores(1.0).
 				setHeapMemoryInMB(100).
-				setGPUResource(new ResourceSpec.GPUResource(2.2)).
+				setGPUResource(2.2).
 				build();
 		ResourceSpec rs4 = ResourceSpec.newBuilder().
 				setCpuCores(1.0).
 				setHeapMemoryInMB(100).
-				setGPUResource(new ResourceSpec.GPUResource(1)).
+				setGPUResource(1).
 				build();
 		assertFalse(rs3.hashCode() == rs4.hashCode());
 
 		ResourceSpec rs5 = ResourceSpec.newBuilder().
 				setCpuCores(1.0).
 				setHeapMemoryInMB(100).
-				setGPUResource(new ResourceSpec.GPUResource(2.2)).
+				setGPUResource(2.2).
 				build();
 		assertEquals(rs3.hashCode(), rs5.hashCode());
-
-		ResourceSpec rs6 = ResourceSpec.newBuilder().
-				setCpuCores(1.0).
-				setHeapMemoryInMB(100).
-				setGPUResource(new ResourceSpec.GPUResource(2.2, ResourceSpec.Resource.ResourceAggregateType.AGGREGATE_TYPE_MAX)).
-				build();
-		assertFalse(rs6.hashCode() == rs5.hashCode());
 	}
 
 	@Test
@@ -141,7 +133,7 @@ public class ResourceSpecTest extends TestLogger {
 		ResourceSpec rs1 = ResourceSpec.newBuilder().
 				setCpuCores(1.0).
 				setHeapMemoryInMB(100).
-				setGPUResource(new ResourceSpec.GPUResource(1.1)).
+				setGPUResource(1.1).
 				build();
 		ResourceSpec rs2 = ResourceSpec.newBuilder().setCpuCores(1.0).setHeapMemoryInMB(100).build();
 
@@ -150,26 +142,6 @@ public class ResourceSpecTest extends TestLogger {
 
 		ResourceSpec rs4 = rs1.merge(rs3);
 		assertEquals(2.2, rs4.getGPUResource(), 0.000001);
-
-		ResourceSpec rs5 = ResourceSpec.newBuilder().
-				setCpuCores(1.0).
-				setHeapMemoryInMB(100).
-				setGPUResource(new ResourceSpec.GPUResource(1.1, ResourceSpec.Resource.ResourceAggregateType.AGGREGATE_TYPE_MAX)).
-				build();
-		try {
-			rs4.merge(rs5);
-			fail("Merge with different aggregate type should fail");
-		} catch (IllegalArgumentException ignored) {
-		}
-
-		ResourceSpec rs6 = ResourceSpec.newBuilder().
-				setCpuCores(1.0).
-				setHeapMemoryInMB(100).
-				setGPUResource(new ResourceSpec.GPUResource(1.5, ResourceSpec.Resource.ResourceAggregateType.AGGREGATE_TYPE_MAX)).
-				build();
-		ResourceSpec rs7 = rs5.merge(rs6);
-		assertEquals(1.5, rs7.getGPUResource(), 0.000001);
-
 	}
 
 	@Test
@@ -177,7 +149,7 @@ public class ResourceSpecTest extends TestLogger {
 		ResourceSpec rs1 = ResourceSpec.newBuilder().
 				setCpuCores(1.0).
 				setHeapMemoryInMB(100).
-				setGPUResource(new ResourceSpec.GPUResource(1.1)).
+				setGPUResource(1.1).
 				build();
 		byte[] buffer = InstantiationUtil.serializeObject(rs1);
 		ResourceSpec rs2 = InstantiationUtil.deserializeObject(buffer, ClassLoader.getSystemClassLoader());

--- a/flink-core/src/test/java/org/apache/flink/api/common/operators/ResourceSpecTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/operators/ResourceSpecTest.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.operators;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class ResourceSpecTest {
+
+	@Test
+	public void testIsValid() throws Exception {
+		ResourceSpec rs = new ResourceSpec(1.0, 100);
+		assertTrue(rs.isValid());
+
+		rs = new ResourceSpec(1.0, 100, new ResourceSpec.Resource("GPU", 1));
+		assertTrue(rs.isValid());
+
+		rs = new ResourceSpec(1.0, 100, new ResourceSpec.Resource("GPU", -1));
+		assertFalse(rs.isValid());
+	}
+
+	@Test
+	public void testLessThanOrEqual() throws Exception {
+		ResourceSpec rs1 = new ResourceSpec(1.0, 100);
+		ResourceSpec rs2 = new ResourceSpec(1.0, 100);
+		assertTrue(rs1.lessThanOrEqual(rs2));
+		assertTrue(rs2.lessThanOrEqual(rs1));
+
+		rs2 = new ResourceSpec(1.0, 100, new ResourceSpec.Resource("FPGA", 1));
+		assertTrue(rs1.lessThanOrEqual(rs2));
+		assertFalse(rs2.lessThanOrEqual(rs1));
+
+		rs1 = new ResourceSpec(1.0, 100, new ResourceSpec.Resource("FPGA", 2));
+		assertFalse(rs1.lessThanOrEqual(rs2));
+		assertTrue(rs2.lessThanOrEqual(rs1));
+
+		rs2 = new ResourceSpec(1.0, 100,
+				new ResourceSpec.Resource("FPGA", 1),
+				new ResourceSpec.Resource("GPU", 1));
+		assertFalse(rs1.lessThanOrEqual(rs2));
+		assertFalse(rs2.lessThanOrEqual(rs1));
+	}
+
+	@Test
+	public void testEquals() throws Exception {
+		ResourceSpec rs1 = new ResourceSpec(1.0, 100);
+		ResourceSpec rs2 = new ResourceSpec(1.0, 100);
+		assertTrue(rs1.equals(rs2));
+		assertTrue(rs2.equals(rs1));
+
+		rs1 = new ResourceSpec(1.0, 100, new ResourceSpec.Resource("FPGA", 2.2));
+		rs2 = new ResourceSpec(1.0, 100, new ResourceSpec.Resource("FPGA", 1));
+		assertFalse(rs1.equals(rs2));
+
+		rs2 = new ResourceSpec(1.0, 100, new ResourceSpec.Resource("FPGA", 2.2));
+		assertTrue(rs1.equals(rs2));
+
+		rs1 = new ResourceSpec(1.0, 100,
+				new ResourceSpec.Resource("FPGA", 2),
+				new ResourceSpec.Resource("GPU", 0.5));
+		rs2 = new ResourceSpec(1.0, 100,
+				new ResourceSpec.Resource("FPGA", 2),
+				new ResourceSpec.Resource("GPU", ResourceSpec.ResourceAggregateType.AGGREGATE_TYPE_MAX, 0.5));
+		assertFalse(rs1.equals(rs2));
+	}
+
+	@Test
+	public void testHashCode() throws Exception {
+		ResourceSpec rs1 = new ResourceSpec(1.0, 100);
+		ResourceSpec rs2 = new ResourceSpec(1.0, 100);
+		assertEquals(rs1.hashCode(), rs2.hashCode());
+
+		rs1 = new ResourceSpec(1.0, 100, new ResourceSpec.Resource("FPGA", 2.2));
+		rs2 = new ResourceSpec(1.0, 100, new ResourceSpec.Resource("FPGA", 1));
+		assertFalse(rs1.hashCode() == rs2.hashCode());
+
+		rs2 = new ResourceSpec(1.0, 100, new ResourceSpec.Resource("FPGA", 2.2));
+		assertEquals(rs1.hashCode(), rs2.hashCode());
+
+		rs1 = new ResourceSpec(1.0, 100,
+				new ResourceSpec.Resource("FPGA", 2),
+				new ResourceSpec.Resource("GPU", 0.5));
+		rs2 = new ResourceSpec(1.0, 100,
+				new ResourceSpec.Resource("FPGA", 2),
+				new ResourceSpec.Resource("GPU", ResourceSpec.ResourceAggregateType.AGGREGATE_TYPE_MAX, 0.5));
+		assertFalse(rs1.hashCode() == rs2.hashCode());
+	}
+
+	@Test
+	public void testMerge() throws Exception {
+		ResourceSpec rs1 = new ResourceSpec(1.0, 100, new ResourceSpec.Resource("FPGA", 1.1));
+		ResourceSpec rs2 = new ResourceSpec(1.0, 100);
+
+		ResourceSpec rs3 = rs1.merge(rs2);
+		assertEquals(1.1, rs3.getExtendedResources().get("FPGA").doubleValue(), 0.000001);
+
+		ResourceSpec rs4 = rs1.merge(rs3);
+		assertEquals(2.2, rs4.getExtendedResources().get("FPGA").doubleValue(), 0.000001);
+
+		rs1 = new ResourceSpec(1.0, 100,
+				new ResourceSpec.Resource("FPGA", 2),
+				new ResourceSpec.Resource("GPU", 0.5));
+		ResourceSpec rs5 = rs1.merge(rs2);
+		assertEquals(2, rs5.getExtendedResources().get("FPGA").doubleValue(), 0.000001);
+		assertEquals(0.5, rs5.getExtendedResources().get("GPU").doubleValue(), 0.000001);
+
+		rs2 = new ResourceSpec(1.0, 100,
+				new ResourceSpec.Resource("GPU", ResourceSpec.ResourceAggregateType.AGGREGATE_TYPE_MAX, 0.5));
+		try {
+			rs1.merge(rs2);
+			fail("Merge with different aggregate type should fail");
+		} catch (IllegalArgumentException e) {
+		}
+
+		rs1 = new ResourceSpec(1.0, 100,
+				new ResourceSpec.Resource("FPGA", 2),
+				new ResourceSpec.Resource("GPU", ResourceSpec.ResourceAggregateType.AGGREGATE_TYPE_MAX, 1.5));
+		ResourceSpec rs6 = rs1.merge(rs2);
+		assertEquals(2, rs6.getExtendedResources().get("FPGA").doubleValue(), 0.000001);
+		assertEquals(1.5, rs6.getExtendedResources().get("GPU").doubleValue(), 0.000001);
+
+	}
+
+}

--- a/flink-java/src/test/java/org/apache/flink/api/java/operator/OperatorTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/operator/OperatorTest.java
@@ -60,8 +60,8 @@ public class OperatorTest {
 		opMethod.setAccessible(true);
 
 		// verify explicit change in resources
-		ResourceSpec minResources = new ResourceSpec(1.0, 100);
-		ResourceSpec preferredResources = new ResourceSpec(2.0, 200);
+		ResourceSpec minResources = ResourceSpec.newBuilder().setCpuCores(1.0).setHeapMemoryInMB(100).build();
+		ResourceSpec preferredResources = ResourceSpec.newBuilder().setCpuCores(2.0).setHeapMemoryInMB(200).build();
 		opMethod.invoke(operator, minResources, preferredResources);
 
 		assertEquals(minResources, operator.getMinResources());

--- a/flink-optimizer/src/test/java/org/apache/flink/optimizer/plantranslate/JobGraphGeneratorTest.java
+++ b/flink-optimizer/src/test/java/org/apache/flink/optimizer/plantranslate/JobGraphGeneratorTest.java
@@ -50,13 +50,13 @@ public class JobGraphGeneratorTest {
 	 */
 	@Test
 	public void testResourcesForChainedOperators() throws Exception {
-		ResourceSpec resource1 = new ResourceSpec(0.1, 100);
-		ResourceSpec resource2 = new ResourceSpec(0.2, 200);
-		ResourceSpec resource3 = new ResourceSpec(0.3, 300);
-		ResourceSpec resource4 = new ResourceSpec(0.4, 400);
-		ResourceSpec resource5 = new ResourceSpec(0.5, 500);
-		ResourceSpec resource6 = new ResourceSpec(0.6, 600);
-		ResourceSpec resource7 = new ResourceSpec(0.7, 700);
+		ResourceSpec resource1 = ResourceSpec.newBuilder().setCpuCores(0.1).setHeapMemoryInMB(100).build();
+		ResourceSpec resource2 = ResourceSpec.newBuilder().setCpuCores(0.2).setHeapMemoryInMB(200).build();
+		ResourceSpec resource3 = ResourceSpec.newBuilder().setCpuCores(0.3).setHeapMemoryInMB(300).build();
+		ResourceSpec resource4 = ResourceSpec.newBuilder().setCpuCores(0.4).setHeapMemoryInMB(400).build();
+		ResourceSpec resource5 = ResourceSpec.newBuilder().setCpuCores(0.5).setHeapMemoryInMB(500).build();
+		ResourceSpec resource6 = ResourceSpec.newBuilder().setCpuCores(0.6).setHeapMemoryInMB(600).build();
+		ResourceSpec resource7 = ResourceSpec.newBuilder().setCpuCores(0.7).setHeapMemoryInMB(700).build();
 
 		Method opMethod = Operator.class.getDeclaredMethod("setResources", ResourceSpec.class);
 		opMethod.setAccessible(true);
@@ -129,12 +129,12 @@ public class JobGraphGeneratorTest {
 	 */
 	@Test
 	public void testResourcesForDeltaIteration() throws Exception{
-		ResourceSpec resource1 = new ResourceSpec(0.1, 100);
-		ResourceSpec resource2 = new ResourceSpec(0.2, 200);
-		ResourceSpec resource3 = new ResourceSpec(0.3, 300);
-		ResourceSpec resource4 = new ResourceSpec(0.4, 400);
-		ResourceSpec resource5 = new ResourceSpec(0.5, 500);
-		ResourceSpec resource6 = new ResourceSpec(0.6, 600);
+		ResourceSpec resource1 = ResourceSpec.newBuilder().setCpuCores(0.1).setHeapMemoryInMB(100).build();
+		ResourceSpec resource2 = ResourceSpec.newBuilder().setCpuCores(0.2).setHeapMemoryInMB(200).build();
+		ResourceSpec resource3 = ResourceSpec.newBuilder().setCpuCores(0.3).setHeapMemoryInMB(300).build();
+		ResourceSpec resource4 = ResourceSpec.newBuilder().setCpuCores(0.4).setHeapMemoryInMB(400).build();
+		ResourceSpec resource5 = ResourceSpec.newBuilder().setCpuCores(0.5).setHeapMemoryInMB(500).build();
+		ResourceSpec resource6 = ResourceSpec.newBuilder().setCpuCores(0.6).setHeapMemoryInMB(600).build();
 
 		Method opMethod = Operator.class.getDeclaredMethod("setResources", ResourceSpec.class);
 		opMethod.setAccessible(true);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/DataStreamTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/DataStreamTest.java
@@ -531,26 +531,26 @@ public class DataStreamTest {
 	public void testResources() throws Exception{
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
-		ResourceSpec minResource1 = new ResourceSpec(1.0, 100);
-		ResourceSpec preferredResource1 = new ResourceSpec(2.0, 200);
+		ResourceSpec minResource1 = ResourceSpec.newBuilder().setCpuCores(1.0).setHeapMemoryInMB(100).build();
+		ResourceSpec preferredResource1 = ResourceSpec.newBuilder().setCpuCores(2.0).setHeapMemoryInMB(200).build();
 
-		ResourceSpec minResource2 = new ResourceSpec(1.0, 200);
-		ResourceSpec preferredResource2 = new ResourceSpec(2.0, 300);
+		ResourceSpec minResource2 = ResourceSpec.newBuilder().setCpuCores(1.0).setHeapMemoryInMB(200).build();
+		ResourceSpec preferredResource2 = ResourceSpec.newBuilder().setCpuCores(2.0).setHeapMemoryInMB(300).build();
 
-		ResourceSpec minResource3 = new ResourceSpec(1.0, 300);
-		ResourceSpec preferredResource3 = new ResourceSpec(2.0, 400);
+		ResourceSpec minResource3 = ResourceSpec.newBuilder().setCpuCores(1.0).setHeapMemoryInMB(300).build();
+		ResourceSpec preferredResource3 = ResourceSpec.newBuilder().setCpuCores(2.0).setHeapMemoryInMB(400).build();
 
-		ResourceSpec minResource4 = new ResourceSpec(1.0, 400);
-		ResourceSpec preferredResource4 = new ResourceSpec(2.0, 500);
+		ResourceSpec minResource4 = ResourceSpec.newBuilder().setCpuCores(1.0).setHeapMemoryInMB(400).build();
+		ResourceSpec preferredResource4 = ResourceSpec.newBuilder().setCpuCores(2.0).setHeapMemoryInMB(500).build();
 
-		ResourceSpec minResource5 = new ResourceSpec(1.0, 500);
-		ResourceSpec preferredResource5 = new ResourceSpec(2.0, 600);
+		ResourceSpec minResource5 = ResourceSpec.newBuilder().setCpuCores(1.0).setHeapMemoryInMB(500).build();
+		ResourceSpec preferredResource5 = ResourceSpec.newBuilder().setCpuCores(2.0).setHeapMemoryInMB(600).build();
 
-		ResourceSpec minResource6 = new ResourceSpec(1.0, 600);
-		ResourceSpec preferredResource6 = new ResourceSpec(2.0, 700);
+		ResourceSpec minResource6 = ResourceSpec.newBuilder().setCpuCores(1.0).setHeapMemoryInMB(600).build();
+		ResourceSpec preferredResource6 = ResourceSpec.newBuilder().setCpuCores(2.0).setHeapMemoryInMB(700).build();
 
-		ResourceSpec minResource7 = new ResourceSpec(1.0, 700);
-		ResourceSpec preferredResource7 = new ResourceSpec(2.0, 800);
+		ResourceSpec minResource7 = ResourceSpec.newBuilder().setCpuCores(1.0).setHeapMemoryInMB(700).build();
+		ResourceSpec preferredResource7 = ResourceSpec.newBuilder().setCpuCores(2.0).setHeapMemoryInMB(800).build();
 
 		Method opMethod = SingleOutputStreamOperator.class.getDeclaredMethod("setResources", ResourceSpec.class, ResourceSpec.class);
 		opMethod.setAccessible(true);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
@@ -165,11 +165,11 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
 	 */
 	@Test
 	public void testResourcesForChainedSourceSink() throws Exception {
-		ResourceSpec resource1 = new ResourceSpec(0.1, 100);
-		ResourceSpec resource2 = new ResourceSpec(0.2, 200);
-		ResourceSpec resource3 = new ResourceSpec(0.3, 300);
-		ResourceSpec resource4 = new ResourceSpec(0.4, 400);
-		ResourceSpec resource5 = new ResourceSpec(0.5, 500);
+		ResourceSpec resource1 = ResourceSpec.newBuilder().setCpuCores(0.1).setHeapMemoryInMB(100).build();
+		ResourceSpec resource2 = ResourceSpec.newBuilder().setCpuCores(0.2).setHeapMemoryInMB(200).build();
+		ResourceSpec resource3 = ResourceSpec.newBuilder().setCpuCores(0.3).setHeapMemoryInMB(300).build();
+		ResourceSpec resource4 = ResourceSpec.newBuilder().setCpuCores(0.4).setHeapMemoryInMB(400).build();
+		ResourceSpec resource5 = ResourceSpec.newBuilder().setCpuCores(0.5).setHeapMemoryInMB(500).build();
 
 		Method opMethod = SingleOutputStreamOperator.class.getDeclaredMethod("setResources", ResourceSpec.class);
 		opMethod.setAccessible(true);
@@ -237,11 +237,11 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
 	 */
 	@Test
 	public void testResourcesForIteration() throws Exception {
-		ResourceSpec resource1 = new ResourceSpec(0.1, 100);
-		ResourceSpec resource2 = new ResourceSpec(0.2, 200);
-		ResourceSpec resource3 = new ResourceSpec(0.3, 300);
-		ResourceSpec resource4 = new ResourceSpec(0.4, 400);
-		ResourceSpec resource5 = new ResourceSpec(0.5, 500);
+		ResourceSpec resource1 = ResourceSpec.newBuilder().setCpuCores(0.1).setHeapMemoryInMB(100).build();
+		ResourceSpec resource2 = ResourceSpec.newBuilder().setCpuCores(0.2).setHeapMemoryInMB(200).build();
+		ResourceSpec resource3 = ResourceSpec.newBuilder().setCpuCores(0.3).setHeapMemoryInMB(300).build();
+		ResourceSpec resource4 = ResourceSpec.newBuilder().setCpuCores(0.4).setHeapMemoryInMB(400).build();
+		ResourceSpec resource5 = ResourceSpec.newBuilder().setCpuCores(0.5).setHeapMemoryInMB(500).build();
 
 		Method opMethod = SingleOutputStreamOperator.class.getDeclaredMethod("setResources", ResourceSpec.class);
 		opMethod.setAccessible(true);


### PR DESCRIPTION
Summary:
Now, flink only support user define CPU and MEM,
but some user need to specify the GPU, FPGA and so on resources.
So it need to make the resource type extendible in the ResourceSpec.
Add a extend field for new resources.

## What is the purpose of the change

This pull request adds a extensible filed to the ResourceSpec, so user can define variable resources only if supported by their resource manager.

*(for example:)*
user can use 
_text.flatMap().setResource(new ResourceSpce(1, 100, new ResourceSpce.Resource("GPU", 0.5)));_
to define their GPU requirement for the operator.

## Verifying this change
This change added tests and can be verified as follows:
  - *Added unit tests ResourceSpecTest to verify.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

