### PR TITLE
[FLINK-7940] Add FutureUtils.orTimeout

### DIFF
--- a/flink-queryable-state/flink-queryable-state-runtime/src/main/java/org/apache/flink/queryablestate/client/proxy/KvStateClientProxyHandler.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/main/java/org/apache/flink/queryablestate/client/proxy/KvStateClientProxyHandler.java
@@ -169,7 +169,7 @@ public class KvStateClientProxyHandler extends AbstractServerHandler<KvStateRequ
 
 					final InetSocketAddress serverAddress = location.getKvStateServerAddress(keyGroupIndex);
 					if (serverAddress == null) {
-						return FutureUtils.getFailedFuture(new UnknownKvStateKeyGroupLocationException(getServerName()));
+						return FutureUtils.completedExceptionally(new UnknownKvStateKeyGroupLocationException(getServerName()));
 					} else {
 						// Query server
 						final KvStateID kvStateId = location.getKvStateID(keyGroupIndex);

--- a/flink-queryable-state/flink-queryable-state-runtime/src/main/java/org/apache/flink/queryablestate/client/proxy/KvStateClientProxyImpl.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/main/java/org/apache/flink/queryablestate/client/proxy/KvStateClientProxyImpl.java
@@ -43,7 +43,7 @@ import java.util.concurrent.CompletableFuture;
 public class KvStateClientProxyImpl extends AbstractServerBase<KvStateRequest, KvStateResponse> implements KvStateClientProxy {
 
 	private static final CompletableFuture<ActorGateway> UNKNOWN_JOB_MANAGER =
-			FutureUtils.getFailedFuture(new UnknownJobManagerException());
+			FutureUtils.completedExceptionally(new UnknownJobManagerException());
 
 	/** Number of threads used to process incoming requests. */
 	private final int queryExecutorThreads;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.concurrent;
 
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.util.ExecutorThreadFactory;
 import org.apache.flink.util.Preconditions;
 
 import akka.dispatch.OnComplete;
@@ -31,7 +32,9 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
@@ -444,5 +447,69 @@ public class FutureUtils {
 		}, Executors.directExecutionContext());
 
 		return result;
+	}
+
+	/**
+	 * Times the given future out after the timeout.
+	 *
+	 * @param future to time out
+	 * @param timeout after which the given future is timed out
+	 * @param timeUnit time unit of the timeout
+	 * @param <T> type of the given future
+	 * @return The timeout enriched future
+	 */
+	public static <T> CompletableFuture<T> orTimeout(CompletableFuture<T> future, long timeout, TimeUnit timeUnit) {
+		final ScheduledFuture<?> timeoutFuture = Delayer.delay(new Timeout(future), timeout, timeUnit);
+
+		future.whenComplete((T value, Throwable throwable) -> {
+			if (!timeoutFuture.isDone()) {
+				timeoutFuture.cancel(false);
+			}
+		});
+
+		return future;
+	}
+
+	/**
+	 * Runnable to complete the given future with a {@link TimeoutException}.
+	 */
+	private static final class Timeout implements Runnable {
+
+		private final CompletableFuture<?> future;
+
+		private Timeout(CompletableFuture<?> future) {
+			this.future = Preconditions.checkNotNull(future);
+		}
+
+		@Override
+		public void run() {
+			future.completeExceptionally(new TimeoutException());
+		}
+	}
+
+	/**
+	 * Delay scheduler used to timeout futures.
+	 *
+	 * <p>This class creates a singleton scheduler used to run the provided actions.
+	 */
+	private static final class Delayer {
+		static final ScheduledThreadPoolExecutor delayer = new ScheduledThreadPoolExecutor(
+			1,
+			new ExecutorThreadFactory("FlinkCompletableFutureDelayScheduler"));
+
+		/**
+		 * Delay the given action by the given delay.
+		 *
+		 * @param runnable to execute after the given delay
+		 * @param delay after which to execute the runnable
+		 * @param timeUnit time unit of the delay
+		 * @return Future of the scheduled action
+		 */
+		private static ScheduledFuture<?> delay(Runnable runnable, long delay, TimeUnit timeUnit) {
+			Preconditions.checkNotNull(runnable);
+			Preconditions.checkNotNull(timeUnit);
+
+			return delayer.schedule(runnable, delay, timeUnit);
+		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
@@ -445,20 +445,4 @@ public class FutureUtils {
 
 		return result;
 	}
-
-	// ------------------------------------------------------------------------
-	//  Future Completed with an exception.
-	// ------------------------------------------------------------------------
-
-	/**
-	 * Returns a {@link CompletableFuture} that has failed with the exception
-	 * provided as argument.
-	 * @param throwable the exception to fail the future with.
-	 * @return The failed future.
-	 */
-	public static <T> CompletableFuture<T> getFailedFuture(Throwable throwable) {
-		CompletableFuture<T> failedAttempt = new CompletableFuture<>();
-		failedAttempt.completeExceptionally(throwable);
-		return failedAttempt;
-	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/FutureUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/FutureUtilsTest.java
@@ -33,6 +33,7 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -222,5 +223,22 @@ public class FutureUtilsTest extends TestLogger {
 
 		assertTrue(retryFuture.isCancelled());
 		verify(scheduledFutureMock).cancel(anyBoolean());
+	}
+
+	/**
+	 * Tests that a future is timed out after the specified timeout.
+	 */
+	@Test
+	public void testOrTimeout() throws Exception {
+		final CompletableFuture<String> future = new CompletableFuture<>();
+		final long timeout = 10L;
+
+		FutureUtils.orTimeout(future, timeout, TimeUnit.MILLISECONDS);
+
+		try {
+			future.get();
+		} catch (ExecutionException e) {
+			assertTrue(ExceptionUtils.stripExecutionException(e) instanceof TimeoutException);
+		}
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

This commit adds a convenience function `FutureUtils#orTimeout` which allows to easily add a timeout to a CompletableFuture.

## Verifying this change

- Added `FutureUtilsTest#testOrTimeout`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

