### PR TITLE
[FLINK-7943] Make ParameterTool thread safe

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/api/common/ExecutionConfigTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/ExecutionConfigTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.java.typeutils.GenericTypeInfo;
 import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer;
 import org.apache.flink.core.testutils.CommonTestUtils;
 import org.apache.flink.util.SerializedValue;
+import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
 
@@ -37,7 +38,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-public class ExecutionConfigTest {
+public class ExecutionConfigTest extends TestLogger {
 
 	@Test
 	public void testDoubleTypeRegistration() {

--- a/flink-java/src/main/java/org/apache/flink/api/java/utils/RequiredParameters.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/utils/RequiredParameters.java
@@ -83,24 +83,28 @@ public class RequiredParameters {
 	 * <p>If any check fails, a RequiredParametersException is thrown
 	 *
 	 * @param parameterTool - parameters supplied by the user.
+	 * @return the updated ParameterTool containing all the required parameters
 	 * @throws RequiredParametersException if any of the specified checks fail
 	 */
-	public void applyTo(ParameterTool parameterTool) throws RequiredParametersException {
+	public ParameterTool applyTo(ParameterTool parameterTool) throws RequiredParametersException {
 		List<String> missingArguments = new LinkedList<>();
+
+		HashMap<String, String> newParameters = new HashMap<>(parameterTool.toMap());
+
 		for (Option o : data.values()) {
-			if (parameterTool.data.containsKey(o.getName())) {
-				if (Objects.equals(parameterTool.data.get(o.getName()), ParameterTool.NO_VALUE_KEY)) {
+			if (newParameters.containsKey(o.getName())) {
+				if (Objects.equals(newParameters.get(o.getName()), ParameterTool.NO_VALUE_KEY)) {
 					// the parameter has been passed, but no value, check if there is a default value
-					checkAndApplyDefaultValue(o, parameterTool.data);
+					checkAndApplyDefaultValue(o, newParameters);
 				} else {
 					// a value has been passed in the parameterTool, now check if it adheres to all constraints
-					checkAmbiguousValues(o, parameterTool.data);
-					checkIsCastableToDefinedType(o, parameterTool.data);
-					checkChoices(o, parameterTool.data);
+					checkAmbiguousValues(o, newParameters);
+					checkIsCastableToDefinedType(o, newParameters);
+					checkChoices(o, newParameters);
 				}
 			} else {
 				// check if there is a default name or a value passed for a possibly defined alternative name.
-				if (hasNoDefaultValueAndNoValuePassedOnAlternativeName(o, parameterTool.data)) {
+				if (hasNoDefaultValueAndNoValuePassedOnAlternativeName(o, newParameters)) {
 					missingArguments.add(o.getName());
 				}
 			}
@@ -108,6 +112,8 @@ public class RequiredParameters {
 		if (!missingArguments.isEmpty()) {
 			throw new RequiredParametersException(this.missingArgumentsText(missingArguments), missingArguments);
 		}
+
+		return ParameterTool.fromMap(newParameters);
 	}
 
 	// check if the given parameter has a default value and add it to the passed map if that is the case

--- a/flink-java/src/test/java/org/apache/flink/api/java/utils/ParameterToolTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/utils/ParameterToolTest.java
@@ -47,8 +47,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertEquals;
-
 /**
  * Tests for {@link ParameterTool}.
  */
@@ -67,21 +65,21 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 	@Test
 	public void testNoVal() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-berlin"});
-		assertEquals(1, parameter.getNumberOfParameters());
+		Assert.assertEquals(1, parameter.getNumberOfParameters());
 		Assert.assertTrue(parameter.has("berlin"));
 	}
 
 	@Test
 	public void testNoValDouble() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"--berlin"});
-		assertEquals(1, parameter.getNumberOfParameters());
+		Assert.assertEquals(1, parameter.getNumberOfParameters());
 		Assert.assertTrue(parameter.has("berlin"));
 	}
 
 	@Test
 	public void testMultipleNoVal() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"--a", "--b", "--c", "--d", "--e", "--f"});
-		assertEquals(6, parameter.getNumberOfParameters());
+		Assert.assertEquals(6, parameter.getNumberOfParameters());
 		Assert.assertTrue(parameter.has("a"));
 		Assert.assertTrue(parameter.has("b"));
 		Assert.assertTrue(parameter.has("c"));
@@ -93,7 +91,7 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 	@Test
 	public void testMultipleNoValMixed() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"--a", "-b", "-c", "-d", "--e", "--f"});
-		assertEquals(6, parameter.getNumberOfParameters());
+		Assert.assertEquals(6, parameter.getNumberOfParameters());
 		Assert.assertTrue(parameter.has("a"));
 		Assert.assertTrue(parameter.has("b"));
 		Assert.assertTrue(parameter.has("c"));
@@ -116,13 +114,13 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 	public void testFromCliArgs() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"--input", "myInput", "-expectedCount", "15", "--withoutValues",
 				"--negativeFloat", "-0.58", "-isWorking", "true", "--maxByte", "127", "-negativeShort", "-1024"});
-		assertEquals(7, parameter.getNumberOfParameters());
+		Assert.assertEquals(7, parameter.getNumberOfParameters());
 		validate(parameter);
 		Assert.assertTrue(parameter.has("withoutValues"));
-		assertEquals(-0.58, parameter.getFloat("negativeFloat"), 0.1);
+		Assert.assertEquals(-0.58, parameter.getFloat("negativeFloat"), 0.1);
 		Assert.assertTrue(parameter.getBoolean("isWorking"));
-		assertEquals(127, parameter.getByte("maxByte"));
-		assertEquals(-1024, parameter.getShort("negativeShort"));
+		Assert.assertEquals(127, parameter.getByte("maxByte"));
+		Assert.assertEquals(-1024, parameter.getShort("negativeShort"));
 	}
 
 	@Test
@@ -135,17 +133,17 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 			props.store(out, "Test properties");
 		}
 		ParameterTool parameter = ParameterTool.fromPropertiesFile(propertiesFile.getAbsolutePath());
-		assertEquals(2, parameter.getNumberOfParameters());
+		Assert.assertEquals(2, parameter.getNumberOfParameters());
 		validate(parameter);
 
 		parameter = ParameterTool.fromPropertiesFile(propertiesFile);
-		assertEquals(2, parameter.getNumberOfParameters());
+		Assert.assertEquals(2, parameter.getNumberOfParameters());
 		validate(parameter);
 
 		try (FileInputStream fis = new FileInputStream(propertiesFile)) {
 			parameter = ParameterTool.fromPropertiesFile(fis);
 		}
-		assertEquals(2, parameter.getNumberOfParameters());
+		Assert.assertEquals(2, parameter.getNumberOfParameters());
 		validate(parameter);
 	}
 
@@ -155,7 +153,7 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 		props.setProperty("input", "myInput");
 		props.setProperty("expectedCount", "15");
 		ParameterTool parameter = ParameterTool.fromMap((Map) props);
-		assertEquals(2, parameter.getNumberOfParameters());
+		Assert.assertEquals(2, parameter.getNumberOfParameters());
 		validate(parameter);
 	}
 
@@ -184,38 +182,38 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 	@Test
 	public void testUnrequestedBoolean() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-boolean", "true"});
-		assertEquals(createHashSet("boolean"), parameter.getUnrequestedParameters());
+		Assert.assertEquals(createHashSet("boolean"), parameter.getUnrequestedParameters());
 
 		// test parameter access
 		Assert.assertTrue(parameter.getBoolean("boolean"));
-		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 
 		// test repeated access
 		Assert.assertTrue(parameter.getBoolean("boolean"));
-		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
 
 	@Test
 	public void testUnrequestedBooleanWithDefaultValue() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-boolean", "true"});
-		assertEquals(createHashSet("boolean"), parameter.getUnrequestedParameters());
+		Assert.assertEquals(createHashSet("boolean"), parameter.getUnrequestedParameters());
 
 		// test parameter access
 		Assert.assertTrue(parameter.getBoolean("boolean", false));
-		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 
 		// test repeated access
 		Assert.assertTrue(parameter.getBoolean("boolean", false));
-		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
 
 	@Test
 	public void testUnrequestedBooleanWithMissingValue() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-boolean"});
-		assertEquals(createHashSet("boolean"), parameter.getUnrequestedParameters());
+		Assert.assertEquals(createHashSet("boolean"), parameter.getUnrequestedParameters());
 
 		parameter.getBoolean("boolean");
-		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
 
 	// Byte
@@ -223,35 +221,35 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 	@Test
 	public void testUnrequestedByte() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-byte", "1"});
-		assertEquals(createHashSet("byte"), parameter.getUnrequestedParameters());
+		Assert.assertEquals(createHashSet("byte"), parameter.getUnrequestedParameters());
 
 		// test parameter access
-		assertEquals(1, parameter.getByte("byte"));
-		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		Assert.assertEquals(1, parameter.getByte("byte"));
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 
 		// test repeated access
-		assertEquals(1, parameter.getByte("byte"));
-		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		Assert.assertEquals(1, parameter.getByte("byte"));
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
 
 	@Test
 	public void testUnrequestedByteWithDefaultValue() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-byte", "1"});
-		assertEquals(createHashSet("byte"), parameter.getUnrequestedParameters());
+		Assert.assertEquals(createHashSet("byte"), parameter.getUnrequestedParameters());
 
 		// test parameter access
-		assertEquals(1, parameter.getByte("byte", (byte) 0));
-		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		Assert.assertEquals(1, parameter.getByte("byte", (byte) 0));
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 
 		// test repeated access
-		assertEquals(1, parameter.getByte("byte", (byte) 0));
-		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		Assert.assertEquals(1, parameter.getByte("byte", (byte) 0));
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
 
 	@Test
 	public void testUnrequestedByteWithMissingValue() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-byte"});
-		assertEquals(createHashSet("byte"), parameter.getUnrequestedParameters());
+		Assert.assertEquals(createHashSet("byte"), parameter.getUnrequestedParameters());
 
 		exception.expect(RuntimeException.class);
 		exception.expectMessage("For input string: \"__NO_VALUE_KEY\"");
@@ -264,35 +262,35 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 	@Test
 	public void testUnrequestedShort() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-short", "2"});
-		assertEquals(createHashSet("short"), parameter.getUnrequestedParameters());
+		Assert.assertEquals(createHashSet("short"), parameter.getUnrequestedParameters());
 
 		// test parameter access
-		assertEquals(2, parameter.getShort("short"));
-		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		Assert.assertEquals(2, parameter.getShort("short"));
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 
 		// test repeated access
-		assertEquals(2, parameter.getShort("short"));
-		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		Assert.assertEquals(2, parameter.getShort("short"));
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
 
 	@Test
 	public void testUnrequestedShortWithDefaultValue() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-short", "2"});
-		assertEquals(createHashSet("short"), parameter.getUnrequestedParameters());
+		Assert.assertEquals(createHashSet("short"), parameter.getUnrequestedParameters());
 
 		// test parameter access
-		assertEquals(2, parameter.getShort("short", (short) 0));
-		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		Assert.assertEquals(2, parameter.getShort("short", (short) 0));
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 
 		// test repeated access
-		assertEquals(2, parameter.getShort("short", (short) 0));
-		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		Assert.assertEquals(2, parameter.getShort("short", (short) 0));
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
 
 	@Test
 	public void testUnrequestedShortWithMissingValue() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-short"});
-		assertEquals(createHashSet("short"), parameter.getUnrequestedParameters());
+		Assert.assertEquals(createHashSet("short"), parameter.getUnrequestedParameters());
 
 		exception.expect(RuntimeException.class);
 		exception.expectMessage("For input string: \"__NO_VALUE_KEY\"");
@@ -305,35 +303,35 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 	@Test
 	public void testUnrequestedInt() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-int", "4"});
-		assertEquals(createHashSet("int"), parameter.getUnrequestedParameters());
+		Assert.assertEquals(createHashSet("int"), parameter.getUnrequestedParameters());
 
 		// test parameter access
-		assertEquals(4, parameter.getInt("int"));
-		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		Assert.assertEquals(4, parameter.getInt("int"));
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 
 		// test repeated access
-		assertEquals(4, parameter.getInt("int"));
-		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		Assert.assertEquals(4, parameter.getInt("int"));
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
 
 	@Test
 	public void testUnrequestedIntWithDefaultValue() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-int", "4"});
-		assertEquals(createHashSet("int"), parameter.getUnrequestedParameters());
+		Assert.assertEquals(createHashSet("int"), parameter.getUnrequestedParameters());
 
 		// test parameter access
-		assertEquals(4, parameter.getInt("int", 0));
-		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		Assert.assertEquals(4, parameter.getInt("int", 0));
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 
 		// test repeated access
-		assertEquals(4, parameter.getInt("int", 0));
-		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		Assert.assertEquals(4, parameter.getInt("int", 0));
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
 
 	@Test
 	public void testUnrequestedIntWithMissingValue() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-int"});
-		assertEquals(createHashSet("int"), parameter.getUnrequestedParameters());
+		Assert.assertEquals(createHashSet("int"), parameter.getUnrequestedParameters());
 
 		exception.expect(RuntimeException.class);
 		exception.expectMessage("For input string: \"__NO_VALUE_KEY\"");
@@ -346,35 +344,35 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 	@Test
 	public void testUnrequestedLong() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-long", "8"});
-		assertEquals(createHashSet("long"), parameter.getUnrequestedParameters());
+		Assert.assertEquals(createHashSet("long"), parameter.getUnrequestedParameters());
 
 		// test parameter access
-		assertEquals(8, parameter.getLong("long"));
-		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		Assert.assertEquals(8, parameter.getLong("long"));
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 
 		// test repeated access
-		assertEquals(8, parameter.getLong("long"));
-		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		Assert.assertEquals(8, parameter.getLong("long"));
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
 
 	@Test
 	public void testUnrequestedLongWithDefaultValue() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-long", "8"});
-		assertEquals(createHashSet("long"), parameter.getUnrequestedParameters());
+		Assert.assertEquals(createHashSet("long"), parameter.getUnrequestedParameters());
 
 		// test parameter access
-		assertEquals(8, parameter.getLong("long", 0));
-		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		Assert.assertEquals(8, parameter.getLong("long", 0));
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 
 		// test repeated access
-		assertEquals(8, parameter.getLong("long", 0));
-		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		Assert.assertEquals(8, parameter.getLong("long", 0));
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
 
 	@Test
 	public void testUnrequestedLongWithMissingValue() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-long"});
-		assertEquals(createHashSet("long"), parameter.getUnrequestedParameters());
+		Assert.assertEquals(createHashSet("long"), parameter.getUnrequestedParameters());
 
 		exception.expect(RuntimeException.class);
 		exception.expectMessage("For input string: \"__NO_VALUE_KEY\"");
@@ -387,35 +385,35 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 	@Test
 	public void testUnrequestedFloat() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-float", "4"});
-		assertEquals(createHashSet("float"), parameter.getUnrequestedParameters());
+		Assert.assertEquals(createHashSet("float"), parameter.getUnrequestedParameters());
 
 		// test parameter access
-		assertEquals(4.0, parameter.getFloat("float"), 0.00001);
-		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		Assert.assertEquals(4.0, parameter.getFloat("float"), 0.00001);
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 
 		// test repeated access
-		assertEquals(4.0, parameter.getFloat("float"), 0.00001);
-		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		Assert.assertEquals(4.0, parameter.getFloat("float"), 0.00001);
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
 
 	@Test
 	public void testUnrequestedFloatWithDefaultValue() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-float", "4"});
-		assertEquals(createHashSet("float"), parameter.getUnrequestedParameters());
+		Assert.assertEquals(createHashSet("float"), parameter.getUnrequestedParameters());
 
 		// test parameter access
-		assertEquals(4.0, parameter.getFloat("float", 0.0f), 0.00001);
-		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		Assert.assertEquals(4.0, parameter.getFloat("float", 0.0f), 0.00001);
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 
 		// test repeated access
-		assertEquals(4.0, parameter.getFloat("float", 0.0f), 0.00001);
-		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		Assert.assertEquals(4.0, parameter.getFloat("float", 0.0f), 0.00001);
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
 
 	@Test
 	public void testUnrequestedFloatWithMissingValue() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-float"});
-		assertEquals(createHashSet("float"), parameter.getUnrequestedParameters());
+		Assert.assertEquals(createHashSet("float"), parameter.getUnrequestedParameters());
 
 		exception.expect(RuntimeException.class);
 		exception.expectMessage("For input string: \"__NO_VALUE_KEY\"");
@@ -428,35 +426,35 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 	@Test
 	public void testUnrequestedDouble() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-double", "8"});
-		assertEquals(createHashSet("double"), parameter.getUnrequestedParameters());
+		Assert.assertEquals(createHashSet("double"), parameter.getUnrequestedParameters());
 
 		// test parameter access
-		assertEquals(8.0, parameter.getDouble("double"), 0.00001);
-		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		Assert.assertEquals(8.0, parameter.getDouble("double"), 0.00001);
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 
 		// test repeated access
-		assertEquals(8.0, parameter.getDouble("double"), 0.00001);
-		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		Assert.assertEquals(8.0, parameter.getDouble("double"), 0.00001);
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
 
 	@Test
 	public void testUnrequestedDoubleWithDefaultValue() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-double", "8"});
-		assertEquals(createHashSet("double"), parameter.getUnrequestedParameters());
+		Assert.assertEquals(createHashSet("double"), parameter.getUnrequestedParameters());
 
 		// test parameter access
-		assertEquals(8.0, parameter.getDouble("double", 0.0), 0.00001);
-		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		Assert.assertEquals(8.0, parameter.getDouble("double", 0.0), 0.00001);
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 
 		// test repeated access
-		assertEquals(8.0, parameter.getDouble("double", 0.0), 0.00001);
-		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		Assert.assertEquals(8.0, parameter.getDouble("double", 0.0), 0.00001);
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
 
 	@Test
 	public void testUnrequestedDoubleWithMissingValue() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-double"});
-		assertEquals(createHashSet("double"), parameter.getUnrequestedParameters());
+		Assert.assertEquals(createHashSet("double"), parameter.getUnrequestedParameters());
 
 		exception.expect(RuntimeException.class);
 		exception.expectMessage("For input string: \"__NO_VALUE_KEY\"");
@@ -469,38 +467,38 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 	@Test
 	public void testUnrequestedString() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-string", "∞"});
-		assertEquals(createHashSet("string"), parameter.getUnrequestedParameters());
+		Assert.assertEquals(createHashSet("string"), parameter.getUnrequestedParameters());
 
 		// test parameter access
-		assertEquals("∞", parameter.get("string"));
-		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		Assert.assertEquals("∞", parameter.get("string"));
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 
 		// test repeated access
-		assertEquals("∞", parameter.get("string"));
-		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		Assert.assertEquals("∞", parameter.get("string"));
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
 
 	@Test
 	public void testUnrequestedStringWithDefaultValue() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-string", "∞"});
-		assertEquals(createHashSet("string"), parameter.getUnrequestedParameters());
+		Assert.assertEquals(createHashSet("string"), parameter.getUnrequestedParameters());
 
 		// test parameter access
-		assertEquals("∞", parameter.get("string", "0.0"));
-		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		Assert.assertEquals("∞", parameter.get("string", "0.0"));
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 
 		// test repeated access
-		assertEquals("∞", parameter.get("string", "0.0"));
-		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		Assert.assertEquals("∞", parameter.get("string", "0.0"));
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
 
 	@Test
 	public void testUnrequestedStringWithMissingValue() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-string"});
-		assertEquals(createHashSet("string"), parameter.getUnrequestedParameters());
+		Assert.assertEquals(createHashSet("string"), parameter.getUnrequestedParameters());
 
 		parameter.get("string");
-		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
 
 	// Additional methods
@@ -508,85 +506,85 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 	@Test
 	public void testUnrequestedHas() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-boolean"});
-		assertEquals(createHashSet("boolean"), parameter.getUnrequestedParameters());
+		Assert.assertEquals(createHashSet("boolean"), parameter.getUnrequestedParameters());
 
 		// test parameter access
 		Assert.assertTrue(parameter.has("boolean"));
-		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 
 		// test repeated access
 		Assert.assertTrue(parameter.has("boolean"));
-		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
 
 	@Test
 	public void testUnrequestedRequired() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-required", "∞"});
-		assertEquals(createHashSet("required"), parameter.getUnrequestedParameters());
+		Assert.assertEquals(createHashSet("required"), parameter.getUnrequestedParameters());
 
 		// test parameter access
-		assertEquals("∞", parameter.getRequired("required"));
-		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		Assert.assertEquals("∞", parameter.getRequired("required"));
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 
 		// test repeated access
-		assertEquals("∞", parameter.getRequired("required"));
-		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		Assert.assertEquals("∞", parameter.getRequired("required"));
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
 
 	@Test
 	public void testUnrequestedMultiple() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-boolean", "true", "-byte", "1",
 			"-short", "2", "-int", "4", "-long", "8", "-float", "4.0", "-double", "8.0", "-string", "∞"});
-		assertEquals(createHashSet("boolean", "byte", "short", "int", "long", "float", "double", "string"),
+		Assert.assertEquals(createHashSet("boolean", "byte", "short", "int", "long", "float", "double", "string"),
 			parameter.getUnrequestedParameters());
 
 		Assert.assertTrue(parameter.getBoolean("boolean"));
-		assertEquals(createHashSet("byte", "short", "int", "long", "float", "double", "string"),
+		Assert.assertEquals(createHashSet("byte", "short", "int", "long", "float", "double", "string"),
 			parameter.getUnrequestedParameters());
 
-		assertEquals(1, parameter.getByte("byte"));
-		assertEquals(createHashSet("short", "int", "long", "float", "double", "string"),
+		Assert.assertEquals(1, parameter.getByte("byte"));
+		Assert.assertEquals(createHashSet("short", "int", "long", "float", "double", "string"),
 			parameter.getUnrequestedParameters());
 
-		assertEquals(2, parameter.getShort("short"));
-		assertEquals(createHashSet("int", "long", "float", "double", "string"),
+		Assert.assertEquals(2, parameter.getShort("short"));
+		Assert.assertEquals(createHashSet("int", "long", "float", "double", "string"),
 			parameter.getUnrequestedParameters());
 
-		assertEquals(4, parameter.getInt("int"));
-		assertEquals(createHashSet("long", "float", "double", "string"),
+		Assert.assertEquals(4, parameter.getInt("int"));
+		Assert.assertEquals(createHashSet("long", "float", "double", "string"),
 			parameter.getUnrequestedParameters());
 
-		assertEquals(8, parameter.getLong("long"));
-		assertEquals(createHashSet("float", "double", "string"),
+		Assert.assertEquals(8, parameter.getLong("long"));
+		Assert.assertEquals(createHashSet("float", "double", "string"),
 			parameter.getUnrequestedParameters());
 
-		assertEquals(4.0, parameter.getFloat("float"), 0.00001);
-		assertEquals(createHashSet("double", "string"),
+		Assert.assertEquals(4.0, parameter.getFloat("float"), 0.00001);
+		Assert.assertEquals(createHashSet("double", "string"),
 			parameter.getUnrequestedParameters());
 
-		assertEquals(8.0, parameter.getDouble("double"), 0.00001);
-		assertEquals(createHashSet("string"),
+		Assert.assertEquals(8.0, parameter.getDouble("double"), 0.00001);
+		Assert.assertEquals(createHashSet("string"),
 			parameter.getUnrequestedParameters());
 
-		assertEquals("∞", parameter.get("string"));
-		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		Assert.assertEquals("∞", parameter.get("string"));
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
 
 	@Test
 	public void testUnrequestedUnknown() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{});
-		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 
 		Assert.assertTrue(parameter.getBoolean("boolean", true));
-		assertEquals(0, parameter.getByte("byte", (byte) 0));
-		assertEquals(0, parameter.getShort("short", (short) 0));
-		assertEquals(0, parameter.getInt("int", 0));
-		assertEquals(0, parameter.getLong("long", 0));
-		assertEquals(0, parameter.getFloat("float", 0), 0.00001);
-		assertEquals(0, parameter.getDouble("double", 0), 0.00001);
-		assertEquals("0", parameter.get("string", "0"));
+		Assert.assertEquals(0, parameter.getByte("byte", (byte) 0));
+		Assert.assertEquals(0, parameter.getShort("short", (short) 0));
+		Assert.assertEquals(0, parameter.getInt("int", 0));
+		Assert.assertEquals(0, parameter.getLong("long", 0));
+		Assert.assertEquals(0, parameter.getFloat("float", 0), 0.00001);
+		Assert.assertEquals(0, parameter.getDouble("double", 0), 0.00001);
+		Assert.assertEquals("0", parameter.get("string", "0"));
 
-		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
 
 	/**

--- a/flink-java/src/test/java/org/apache/flink/api/java/utils/ParameterToolTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/utils/ParameterToolTest.java
@@ -23,16 +23,31 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Tests for {@link ParameterTool}.
@@ -52,21 +67,21 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 	@Test
 	public void testNoVal() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-berlin"});
-		Assert.assertEquals(1, parameter.getNumberOfParameters());
+		assertEquals(1, parameter.getNumberOfParameters());
 		Assert.assertTrue(parameter.has("berlin"));
 	}
 
 	@Test
 	public void testNoValDouble() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"--berlin"});
-		Assert.assertEquals(1, parameter.getNumberOfParameters());
+		assertEquals(1, parameter.getNumberOfParameters());
 		Assert.assertTrue(parameter.has("berlin"));
 	}
 
 	@Test
 	public void testMultipleNoVal() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"--a", "--b", "--c", "--d", "--e", "--f"});
-		Assert.assertEquals(6, parameter.getNumberOfParameters());
+		assertEquals(6, parameter.getNumberOfParameters());
 		Assert.assertTrue(parameter.has("a"));
 		Assert.assertTrue(parameter.has("b"));
 		Assert.assertTrue(parameter.has("c"));
@@ -78,7 +93,7 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 	@Test
 	public void testMultipleNoValMixed() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"--a", "-b", "-c", "-d", "--e", "--f"});
-		Assert.assertEquals(6, parameter.getNumberOfParameters());
+		assertEquals(6, parameter.getNumberOfParameters());
 		Assert.assertTrue(parameter.has("a"));
 		Assert.assertTrue(parameter.has("b"));
 		Assert.assertTrue(parameter.has("c"));
@@ -101,13 +116,13 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 	public void testFromCliArgs() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"--input", "myInput", "-expectedCount", "15", "--withoutValues",
 				"--negativeFloat", "-0.58", "-isWorking", "true", "--maxByte", "127", "-negativeShort", "-1024"});
-		Assert.assertEquals(7, parameter.getNumberOfParameters());
+		assertEquals(7, parameter.getNumberOfParameters());
 		validate(parameter);
 		Assert.assertTrue(parameter.has("withoutValues"));
-		Assert.assertEquals(-0.58, parameter.getFloat("negativeFloat"), 0.1);
+		assertEquals(-0.58, parameter.getFloat("negativeFloat"), 0.1);
 		Assert.assertTrue(parameter.getBoolean("isWorking"));
-		Assert.assertEquals(127, parameter.getByte("maxByte"));
-		Assert.assertEquals(-1024, parameter.getShort("negativeShort"));
+		assertEquals(127, parameter.getByte("maxByte"));
+		assertEquals(-1024, parameter.getShort("negativeShort"));
 	}
 
 	@Test
@@ -120,17 +135,17 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 			props.store(out, "Test properties");
 		}
 		ParameterTool parameter = ParameterTool.fromPropertiesFile(propertiesFile.getAbsolutePath());
-		Assert.assertEquals(2, parameter.getNumberOfParameters());
+		assertEquals(2, parameter.getNumberOfParameters());
 		validate(parameter);
 
 		parameter = ParameterTool.fromPropertiesFile(propertiesFile);
-		Assert.assertEquals(2, parameter.getNumberOfParameters());
+		assertEquals(2, parameter.getNumberOfParameters());
 		validate(parameter);
 
 		try (FileInputStream fis = new FileInputStream(propertiesFile)) {
 			parameter = ParameterTool.fromPropertiesFile(fis);
 		}
-		Assert.assertEquals(2, parameter.getNumberOfParameters());
+		assertEquals(2, parameter.getNumberOfParameters());
 		validate(parameter);
 	}
 
@@ -140,7 +155,7 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 		props.setProperty("input", "myInput");
 		props.setProperty("expectedCount", "15");
 		ParameterTool parameter = ParameterTool.fromMap((Map) props);
-		Assert.assertEquals(2, parameter.getNumberOfParameters());
+		assertEquals(2, parameter.getNumberOfParameters());
 		validate(parameter);
 	}
 
@@ -169,38 +184,38 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 	@Test
 	public void testUnrequestedBoolean() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-boolean", "true"});
-		Assert.assertEquals(createHashSet("boolean"), parameter.getUnrequestedParameters());
+		assertEquals(createHashSet("boolean"), parameter.getUnrequestedParameters());
 
 		// test parameter access
 		Assert.assertTrue(parameter.getBoolean("boolean"));
-		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 
 		// test repeated access
 		Assert.assertTrue(parameter.getBoolean("boolean"));
-		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
 
 	@Test
 	public void testUnrequestedBooleanWithDefaultValue() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-boolean", "true"});
-		Assert.assertEquals(createHashSet("boolean"), parameter.getUnrequestedParameters());
+		assertEquals(createHashSet("boolean"), parameter.getUnrequestedParameters());
 
 		// test parameter access
 		Assert.assertTrue(parameter.getBoolean("boolean", false));
-		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 
 		// test repeated access
 		Assert.assertTrue(parameter.getBoolean("boolean", false));
-		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
 
 	@Test
 	public void testUnrequestedBooleanWithMissingValue() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-boolean"});
-		Assert.assertEquals(createHashSet("boolean"), parameter.getUnrequestedParameters());
+		assertEquals(createHashSet("boolean"), parameter.getUnrequestedParameters());
 
 		parameter.getBoolean("boolean");
-		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
 
 	// Byte
@@ -208,35 +223,35 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 	@Test
 	public void testUnrequestedByte() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-byte", "1"});
-		Assert.assertEquals(createHashSet("byte"), parameter.getUnrequestedParameters());
+		assertEquals(createHashSet("byte"), parameter.getUnrequestedParameters());
 
 		// test parameter access
-		Assert.assertEquals(1, parameter.getByte("byte"));
-		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		assertEquals(1, parameter.getByte("byte"));
+		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 
 		// test repeated access
-		Assert.assertEquals(1, parameter.getByte("byte"));
-		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		assertEquals(1, parameter.getByte("byte"));
+		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
 
 	@Test
 	public void testUnrequestedByteWithDefaultValue() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-byte", "1"});
-		Assert.assertEquals(createHashSet("byte"), parameter.getUnrequestedParameters());
+		assertEquals(createHashSet("byte"), parameter.getUnrequestedParameters());
 
 		// test parameter access
-		Assert.assertEquals(1, parameter.getByte("byte", (byte) 0));
-		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		assertEquals(1, parameter.getByte("byte", (byte) 0));
+		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 
 		// test repeated access
-		Assert.assertEquals(1, parameter.getByte("byte", (byte) 0));
-		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		assertEquals(1, parameter.getByte("byte", (byte) 0));
+		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
 
 	@Test
 	public void testUnrequestedByteWithMissingValue() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-byte"});
-		Assert.assertEquals(createHashSet("byte"), parameter.getUnrequestedParameters());
+		assertEquals(createHashSet("byte"), parameter.getUnrequestedParameters());
 
 		exception.expect(RuntimeException.class);
 		exception.expectMessage("For input string: \"__NO_VALUE_KEY\"");
@@ -249,35 +264,35 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 	@Test
 	public void testUnrequestedShort() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-short", "2"});
-		Assert.assertEquals(createHashSet("short"), parameter.getUnrequestedParameters());
+		assertEquals(createHashSet("short"), parameter.getUnrequestedParameters());
 
 		// test parameter access
-		Assert.assertEquals(2, parameter.getShort("short"));
-		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		assertEquals(2, parameter.getShort("short"));
+		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 
 		// test repeated access
-		Assert.assertEquals(2, parameter.getShort("short"));
-		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		assertEquals(2, parameter.getShort("short"));
+		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
 
 	@Test
 	public void testUnrequestedShortWithDefaultValue() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-short", "2"});
-		Assert.assertEquals(createHashSet("short"), parameter.getUnrequestedParameters());
+		assertEquals(createHashSet("short"), parameter.getUnrequestedParameters());
 
 		// test parameter access
-		Assert.assertEquals(2, parameter.getShort("short", (short) 0));
-		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		assertEquals(2, parameter.getShort("short", (short) 0));
+		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 
 		// test repeated access
-		Assert.assertEquals(2, parameter.getShort("short", (short) 0));
-		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		assertEquals(2, parameter.getShort("short", (short) 0));
+		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
 
 	@Test
 	public void testUnrequestedShortWithMissingValue() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-short"});
-		Assert.assertEquals(createHashSet("short"), parameter.getUnrequestedParameters());
+		assertEquals(createHashSet("short"), parameter.getUnrequestedParameters());
 
 		exception.expect(RuntimeException.class);
 		exception.expectMessage("For input string: \"__NO_VALUE_KEY\"");
@@ -290,35 +305,35 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 	@Test
 	public void testUnrequestedInt() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-int", "4"});
-		Assert.assertEquals(createHashSet("int"), parameter.getUnrequestedParameters());
+		assertEquals(createHashSet("int"), parameter.getUnrequestedParameters());
 
 		// test parameter access
-		Assert.assertEquals(4, parameter.getInt("int"));
-		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		assertEquals(4, parameter.getInt("int"));
+		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 
 		// test repeated access
-		Assert.assertEquals(4, parameter.getInt("int"));
-		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		assertEquals(4, parameter.getInt("int"));
+		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
 
 	@Test
 	public void testUnrequestedIntWithDefaultValue() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-int", "4"});
-		Assert.assertEquals(createHashSet("int"), parameter.getUnrequestedParameters());
+		assertEquals(createHashSet("int"), parameter.getUnrequestedParameters());
 
 		// test parameter access
-		Assert.assertEquals(4, parameter.getInt("int", 0));
-		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		assertEquals(4, parameter.getInt("int", 0));
+		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 
 		// test repeated access
-		Assert.assertEquals(4, parameter.getInt("int", 0));
-		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		assertEquals(4, parameter.getInt("int", 0));
+		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
 
 	@Test
 	public void testUnrequestedIntWithMissingValue() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-int"});
-		Assert.assertEquals(createHashSet("int"), parameter.getUnrequestedParameters());
+		assertEquals(createHashSet("int"), parameter.getUnrequestedParameters());
 
 		exception.expect(RuntimeException.class);
 		exception.expectMessage("For input string: \"__NO_VALUE_KEY\"");
@@ -331,35 +346,35 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 	@Test
 	public void testUnrequestedLong() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-long", "8"});
-		Assert.assertEquals(createHashSet("long"), parameter.getUnrequestedParameters());
+		assertEquals(createHashSet("long"), parameter.getUnrequestedParameters());
 
 		// test parameter access
-		Assert.assertEquals(8, parameter.getLong("long"));
-		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		assertEquals(8, parameter.getLong("long"));
+		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 
 		// test repeated access
-		Assert.assertEquals(8, parameter.getLong("long"));
-		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		assertEquals(8, parameter.getLong("long"));
+		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
 
 	@Test
 	public void testUnrequestedLongWithDefaultValue() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-long", "8"});
-		Assert.assertEquals(createHashSet("long"), parameter.getUnrequestedParameters());
+		assertEquals(createHashSet("long"), parameter.getUnrequestedParameters());
 
 		// test parameter access
-		Assert.assertEquals(8, parameter.getLong("long", 0));
-		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		assertEquals(8, parameter.getLong("long", 0));
+		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 
 		// test repeated access
-		Assert.assertEquals(8, parameter.getLong("long", 0));
-		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		assertEquals(8, parameter.getLong("long", 0));
+		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
 
 	@Test
 	public void testUnrequestedLongWithMissingValue() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-long"});
-		Assert.assertEquals(createHashSet("long"), parameter.getUnrequestedParameters());
+		assertEquals(createHashSet("long"), parameter.getUnrequestedParameters());
 
 		exception.expect(RuntimeException.class);
 		exception.expectMessage("For input string: \"__NO_VALUE_KEY\"");
@@ -372,35 +387,35 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 	@Test
 	public void testUnrequestedFloat() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-float", "4"});
-		Assert.assertEquals(createHashSet("float"), parameter.getUnrequestedParameters());
+		assertEquals(createHashSet("float"), parameter.getUnrequestedParameters());
 
 		// test parameter access
-		Assert.assertEquals(4.0, parameter.getFloat("float"), 0.00001);
-		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		assertEquals(4.0, parameter.getFloat("float"), 0.00001);
+		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 
 		// test repeated access
-		Assert.assertEquals(4.0, parameter.getFloat("float"), 0.00001);
-		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		assertEquals(4.0, parameter.getFloat("float"), 0.00001);
+		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
 
 	@Test
 	public void testUnrequestedFloatWithDefaultValue() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-float", "4"});
-		Assert.assertEquals(createHashSet("float"), parameter.getUnrequestedParameters());
+		assertEquals(createHashSet("float"), parameter.getUnrequestedParameters());
 
 		// test parameter access
-		Assert.assertEquals(4.0, parameter.getFloat("float", 0.0f), 0.00001);
-		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		assertEquals(4.0, parameter.getFloat("float", 0.0f), 0.00001);
+		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 
 		// test repeated access
-		Assert.assertEquals(4.0, parameter.getFloat("float", 0.0f), 0.00001);
-		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		assertEquals(4.0, parameter.getFloat("float", 0.0f), 0.00001);
+		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
 
 	@Test
 	public void testUnrequestedFloatWithMissingValue() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-float"});
-		Assert.assertEquals(createHashSet("float"), parameter.getUnrequestedParameters());
+		assertEquals(createHashSet("float"), parameter.getUnrequestedParameters());
 
 		exception.expect(RuntimeException.class);
 		exception.expectMessage("For input string: \"__NO_VALUE_KEY\"");
@@ -413,35 +428,35 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 	@Test
 	public void testUnrequestedDouble() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-double", "8"});
-		Assert.assertEquals(createHashSet("double"), parameter.getUnrequestedParameters());
+		assertEquals(createHashSet("double"), parameter.getUnrequestedParameters());
 
 		// test parameter access
-		Assert.assertEquals(8.0, parameter.getDouble("double"), 0.00001);
-		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		assertEquals(8.0, parameter.getDouble("double"), 0.00001);
+		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 
 		// test repeated access
-		Assert.assertEquals(8.0, parameter.getDouble("double"), 0.00001);
-		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		assertEquals(8.0, parameter.getDouble("double"), 0.00001);
+		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
 
 	@Test
 	public void testUnrequestedDoubleWithDefaultValue() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-double", "8"});
-		Assert.assertEquals(createHashSet("double"), parameter.getUnrequestedParameters());
+		assertEquals(createHashSet("double"), parameter.getUnrequestedParameters());
 
 		// test parameter access
-		Assert.assertEquals(8.0, parameter.getDouble("double", 0.0), 0.00001);
-		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		assertEquals(8.0, parameter.getDouble("double", 0.0), 0.00001);
+		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 
 		// test repeated access
-		Assert.assertEquals(8.0, parameter.getDouble("double", 0.0), 0.00001);
-		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		assertEquals(8.0, parameter.getDouble("double", 0.0), 0.00001);
+		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
 
 	@Test
 	public void testUnrequestedDoubleWithMissingValue() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-double"});
-		Assert.assertEquals(createHashSet("double"), parameter.getUnrequestedParameters());
+		assertEquals(createHashSet("double"), parameter.getUnrequestedParameters());
 
 		exception.expect(RuntimeException.class);
 		exception.expectMessage("For input string: \"__NO_VALUE_KEY\"");
@@ -454,38 +469,38 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 	@Test
 	public void testUnrequestedString() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-string", "∞"});
-		Assert.assertEquals(createHashSet("string"), parameter.getUnrequestedParameters());
+		assertEquals(createHashSet("string"), parameter.getUnrequestedParameters());
 
 		// test parameter access
-		Assert.assertEquals("∞", parameter.get("string"));
-		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		assertEquals("∞", parameter.get("string"));
+		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 
 		// test repeated access
-		Assert.assertEquals("∞", parameter.get("string"));
-		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		assertEquals("∞", parameter.get("string"));
+		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
 
 	@Test
 	public void testUnrequestedStringWithDefaultValue() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-string", "∞"});
-		Assert.assertEquals(createHashSet("string"), parameter.getUnrequestedParameters());
+		assertEquals(createHashSet("string"), parameter.getUnrequestedParameters());
 
 		// test parameter access
-		Assert.assertEquals("∞", parameter.get("string", "0.0"));
-		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		assertEquals("∞", parameter.get("string", "0.0"));
+		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 
 		// test repeated access
-		Assert.assertEquals("∞", parameter.get("string", "0.0"));
-		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		assertEquals("∞", parameter.get("string", "0.0"));
+		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
 
 	@Test
 	public void testUnrequestedStringWithMissingValue() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-string"});
-		Assert.assertEquals(createHashSet("string"), parameter.getUnrequestedParameters());
+		assertEquals(createHashSet("string"), parameter.getUnrequestedParameters());
 
 		parameter.get("string");
-		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
 
 	// Additional methods
@@ -493,85 +508,157 @@ public class ParameterToolTest extends AbstractParameterToolTest {
 	@Test
 	public void testUnrequestedHas() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-boolean"});
-		Assert.assertEquals(createHashSet("boolean"), parameter.getUnrequestedParameters());
+		assertEquals(createHashSet("boolean"), parameter.getUnrequestedParameters());
 
 		// test parameter access
 		Assert.assertTrue(parameter.has("boolean"));
-		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 
 		// test repeated access
 		Assert.assertTrue(parameter.has("boolean"));
-		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
 
 	@Test
 	public void testUnrequestedRequired() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-required", "∞"});
-		Assert.assertEquals(createHashSet("required"), parameter.getUnrequestedParameters());
+		assertEquals(createHashSet("required"), parameter.getUnrequestedParameters());
 
 		// test parameter access
-		Assert.assertEquals("∞", parameter.getRequired("required"));
-		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		assertEquals("∞", parameter.getRequired("required"));
+		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 
 		// test repeated access
-		Assert.assertEquals("∞", parameter.getRequired("required"));
-		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		assertEquals("∞", parameter.getRequired("required"));
+		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
 
 	@Test
 	public void testUnrequestedMultiple() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{"-boolean", "true", "-byte", "1",
 			"-short", "2", "-int", "4", "-long", "8", "-float", "4.0", "-double", "8.0", "-string", "∞"});
-		Assert.assertEquals(createHashSet("boolean", "byte", "short", "int", "long", "float", "double", "string"),
+		assertEquals(createHashSet("boolean", "byte", "short", "int", "long", "float", "double", "string"),
 			parameter.getUnrequestedParameters());
 
 		Assert.assertTrue(parameter.getBoolean("boolean"));
-		Assert.assertEquals(createHashSet("byte", "short", "int", "long", "float", "double", "string"),
+		assertEquals(createHashSet("byte", "short", "int", "long", "float", "double", "string"),
 			parameter.getUnrequestedParameters());
 
-		Assert.assertEquals(1, parameter.getByte("byte"));
-		Assert.assertEquals(createHashSet("short", "int", "long", "float", "double", "string"),
+		assertEquals(1, parameter.getByte("byte"));
+		assertEquals(createHashSet("short", "int", "long", "float", "double", "string"),
 			parameter.getUnrequestedParameters());
 
-		Assert.assertEquals(2, parameter.getShort("short"));
-		Assert.assertEquals(createHashSet("int", "long", "float", "double", "string"),
+		assertEquals(2, parameter.getShort("short"));
+		assertEquals(createHashSet("int", "long", "float", "double", "string"),
 			parameter.getUnrequestedParameters());
 
-		Assert.assertEquals(4, parameter.getInt("int"));
-		Assert.assertEquals(createHashSet("long", "float", "double", "string"),
+		assertEquals(4, parameter.getInt("int"));
+		assertEquals(createHashSet("long", "float", "double", "string"),
 			parameter.getUnrequestedParameters());
 
-		Assert.assertEquals(8, parameter.getLong("long"));
-		Assert.assertEquals(createHashSet("float", "double", "string"),
+		assertEquals(8, parameter.getLong("long"));
+		assertEquals(createHashSet("float", "double", "string"),
 			parameter.getUnrequestedParameters());
 
-		Assert.assertEquals(4.0, parameter.getFloat("float"), 0.00001);
-		Assert.assertEquals(createHashSet("double", "string"),
+		assertEquals(4.0, parameter.getFloat("float"), 0.00001);
+		assertEquals(createHashSet("double", "string"),
 			parameter.getUnrequestedParameters());
 
-		Assert.assertEquals(8.0, parameter.getDouble("double"), 0.00001);
-		Assert.assertEquals(createHashSet("string"),
+		assertEquals(8.0, parameter.getDouble("double"), 0.00001);
+		assertEquals(createHashSet("string"),
 			parameter.getUnrequestedParameters());
 
-		Assert.assertEquals("∞", parameter.get("string"));
-		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		assertEquals("∞", parameter.get("string"));
+		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 	}
 
 	@Test
 	public void testUnrequestedUnknown() {
 		ParameterTool parameter = ParameterTool.fromArgs(new String[]{});
-		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
 
 		Assert.assertTrue(parameter.getBoolean("boolean", true));
-		Assert.assertEquals(0, parameter.getByte("byte", (byte) 0));
-		Assert.assertEquals(0, parameter.getShort("short", (short) 0));
-		Assert.assertEquals(0, parameter.getInt("int", 0));
-		Assert.assertEquals(0, parameter.getLong("long", 0));
-		Assert.assertEquals(0, parameter.getFloat("float", 0), 0.00001);
-		Assert.assertEquals(0, parameter.getDouble("double", 0), 0.00001);
-		Assert.assertEquals("0", parameter.get("string", "0"));
+		assertEquals(0, parameter.getByte("byte", (byte) 0));
+		assertEquals(0, parameter.getShort("short", (short) 0));
+		assertEquals(0, parameter.getInt("int", 0));
+		assertEquals(0, parameter.getLong("long", 0));
+		assertEquals(0, parameter.getFloat("float", 0), 0.00001);
+		assertEquals(0, parameter.getDouble("double", 0), 0.00001);
+		assertEquals("0", parameter.get("string", "0"));
 
-		Assert.assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+		assertEquals(Collections.emptySet(), parameter.getUnrequestedParameters());
+	}
+
+	/**
+	 * Tests that we can concurrently serialize and access the ParameterTool. See FLINK-7943
+	 */
+	@Test
+	public void testConcurrentExecutionConfigSerialization() throws ExecutionException, InterruptedException {
+
+		final int numInputs = 10;
+		Collection<String> input = new ArrayList<>(numInputs);
+
+		for (int i = 0; i < numInputs; i++) {
+			input.add("--" + UUID.randomUUID());
+			input.add(UUID.randomUUID().toString());
+		}
+
+		final String[] args = input.toArray(new String[0]);
+
+		final ParameterTool parameterTool = ParameterTool.fromArgs(args);
+
+		final int numThreads = 5;
+		final int numSerializations = 100;
+
+		final Collection<CompletableFuture<Void>> futures = new ArrayList<>(numSerializations);
+
+		final ExecutorService executorService = Executors.newFixedThreadPool(numThreads);
+
+		try {
+			for (int i = 0; i < numSerializations; i++) {
+				futures.add(
+					CompletableFuture.runAsync(
+						() -> {
+							try {
+								serializeDeserialize(parameterTool);
+							} catch (Exception e) {
+								throw new CompletionException(e);
+							}
+						},
+						executorService));
+			}
+
+			for (CompletableFuture<Void> future : futures) {
+				future.get();
+			}
+		} finally {
+			executorService.shutdownNow();
+			executorService.awaitTermination(1000L, TimeUnit.MILLISECONDS);
+		}
+	}
+
+	/**
+	 * Accesses parameter tool parameters and then serializes the given parameter tool and deserializes again.
+	 * @param parameterTool to serialize/deserialize
+	 */
+	private void serializeDeserialize(ParameterTool parameterTool) throws IOException, ClassNotFoundException {
+		// weirdly enough, this call has side effects making the ParameterTool serialization fail if not
+		// using a concurrent data structure.
+		parameterTool.get(UUID.randomUUID().toString());
+
+		try (
+			ByteArrayOutputStream baos = new ByteArrayOutputStream();
+			ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+			oos.writeObject(parameterTool);
+			oos.close();
+			baos.close();
+
+			ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+			ObjectInputStream ois = new ObjectInputStream(bais);
+
+			// this should work :-)
+			ParameterTool deserializedParameterTool = ((ParameterTool) ois.readObject());
+		}
 	}
 
 	private static <T> Set<T> createHashSet(T... elements) {

--- a/flink-java/src/test/java/org/apache/flink/api/java/utils/RequiredParametersTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/utils/RequiredParametersTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.api.java.utils;
 
+import org.apache.flink.util.TestLogger;
+
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -33,7 +35,7 @@ import static org.junit.Assert.fail;
 /**
  * Tests for RequiredParameter class and its interactions with ParameterTool.
  */
-public class RequiredParametersTest {
+public class RequiredParametersTest extends TestLogger {
 
 	@Rule
 	public ExpectedException expectedException = ExpectedException.none();

--- a/flink-java/src/test/java/org/apache/flink/api/java/utils/RequiredParametersTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/utils/RequiredParametersTest.java
@@ -124,7 +124,7 @@ public class RequiredParametersTest extends TestLogger {
 
 		try {
 			required.add(new Option("berlin").alt("b"));
-			required.applyTo(parameter);
+			parameter = required.applyTo(parameter);
 			Assert.assertEquals(parameter.data.get("berlin"), "value");
 			Assert.assertEquals(parameter.data.get("b"), "value");
 		} catch (RequiredParametersException e) {
@@ -139,7 +139,7 @@ public class RequiredParametersTest extends TestLogger {
 
 		try {
 			required.add(new Option("berlin").alt("b").defaultValue("something"));
-			required.applyTo(parameter);
+			parameter = required.applyTo(parameter);
 			Assert.assertEquals(parameter.data.get("berlin"), "value");
 			Assert.assertEquals(parameter.data.get("b"), "value");
 		} catch (RequiredParametersException e) {
@@ -166,7 +166,7 @@ public class RequiredParametersTest extends TestLogger {
 		RequiredParameters required = new RequiredParameters();
 		try {
 			required.add(new Option("berlin"));
-			required.applyTo(parameter);
+			parameter = required.applyTo(parameter);
 			Assert.assertEquals(parameter.data.get("berlin"), "value");
 		} catch (RequiredParametersException e) {
 			fail("Exception thrown " + e.getMessage());
@@ -179,7 +179,7 @@ public class RequiredParametersTest extends TestLogger {
 		RequiredParameters required = new RequiredParameters();
 		try {
 			required.add(new Option("berlin").defaultValue("value"));
-			required.applyTo(parameter);
+			parameter = required.applyTo(parameter);
 			Assert.assertEquals(parameter.data.get("berlin"), "value");
 		} catch (RequiredParametersException e) {
 			fail("Exception thrown " + e.getMessage());
@@ -192,7 +192,7 @@ public class RequiredParametersTest extends TestLogger {
 		RequiredParameters required = new RequiredParameters();
 		try {
 			required.add(new Option("berlin").alt("b").defaultValue("value"));
-			required.applyTo(parameter);
+			parameter = required.applyTo(parameter);
 			Assert.assertEquals(parameter.data.get("berlin"), "value");
 			Assert.assertEquals(parameter.data.get("b"), "value");
 		} catch (RequiredParametersException e) {
@@ -207,7 +207,7 @@ public class RequiredParametersTest extends TestLogger {
 		try {
 			rq.add("input");
 			rq.add(new Option("parallelism").alt("p").defaultValue("1").type(OptionType.INTEGER));
-			rq.applyTo(parameter);
+			parameter = rq.applyTo(parameter);
 			Assert.assertEquals(parameter.data.get("parallelism"), "1");
 			Assert.assertEquals(parameter.data.get("p"), "1");
 			Assert.assertEquals(parameter.data.get("input"), "abc");
@@ -225,7 +225,7 @@ public class RequiredParametersTest extends TestLogger {
 			required.add(new Option("count").defaultValue("15"));
 			required.add(new Option("someFlag").alt("sf").defaultValue("true"));
 
-			required.applyTo(parameter);
+			parameter = required.applyTo(parameter);
 
 			Assert.assertEquals(parameter.data.get("berlin"), "value");
 			Assert.assertEquals(parameter.data.get("count"), "15");


### PR DESCRIPTION
## What is the purpose of the change

This commit changes the serialization of the ParameterTool such that only the
data map is contained. The defaultData and the unrequestedParameters maps are
not serialized because they are only used on the client side. Additionally, the
defaultData and unrequestedParameters map are being made thread safe by using
ConcurrentHashMaps.

## Verifying this change

- Added `ParameterToolTest#testConcurrentExecutionConfigSerialization`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

