### PR TITLE
[hotfix][metrics] Cleanup ScopeFormats

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricRegistryConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricRegistryConfiguration.java
@@ -97,7 +97,7 @@ public class MetricRegistryConfiguration {
 			scopeFormats = ScopeFormats.fromConfig(configuration);
 		} catch (Exception e) {
 			LOG.warn("Failed to parse scope format, using default scope formats", e);
-			scopeFormats = new ScopeFormats();
+			scopeFormats = ScopeFormats.fromConfig(new Configuration());
 		}
 
 		char delim;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricRegistryConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricRegistryConfiguration.java
@@ -94,7 +94,7 @@ public class MetricRegistryConfiguration {
 	public static MetricRegistryConfiguration fromConfiguration(Configuration configuration) {
 		ScopeFormats scopeFormats;
 		try {
-			scopeFormats = createScopeConfig(configuration);
+			scopeFormats = ScopeFormats.fromConfig(configuration);
 		} catch (Exception e) {
 			LOG.warn("Failed to parse scope format, using default scope formats", e);
 			scopeFormats = new ScopeFormats();
@@ -128,23 +128,6 @@ public class MetricRegistryConfiguration {
 		}
 
 		return new MetricRegistryConfiguration(scopeFormats, delim, reporterConfigurations);
-	}
-
-	/**
-	 *	Create the scope formats from the given {@link Configuration}.
-	 *
-	 * @param configuration to extract the scope formats from
-	 * @return Scope formats extracted from the given configuration
-	 */
-	static ScopeFormats createScopeConfig(Configuration configuration) {
-		String jmFormat = configuration.getString(MetricOptions.SCOPE_NAMING_JM);
-		String jmJobFormat = configuration.getString(MetricOptions.SCOPE_NAMING_JM_JOB);
-		String tmFormat = configuration.getString(MetricOptions.SCOPE_NAMING_TM);
-		String tmJobFormat = configuration.getString(MetricOptions.SCOPE_NAMING_TM_JOB);
-		String taskFormat = configuration.getString(MetricOptions.SCOPE_NAMING_TASK);
-		String operatorFormat = configuration.getString(MetricOptions.SCOPE_NAMING_OPERATOR);
-
-		return new ScopeFormats(jmFormat, jmJobFormat, tmFormat, tmJobFormat, taskFormat, operatorFormat);
 	}
 
 	public static MetricRegistryConfiguration defaultMetricRegistryConfiguration() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/scope/ScopeFormats.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/scope/ScopeFormats.java
@@ -38,7 +38,7 @@ public class ScopeFormats {
 	/**
 	 * Creates all scope formats, based on the given scope format strings.
 	 */
-	public ScopeFormats(
+	private ScopeFormats(
 			String jobManagerFormat,
 			String jobManagerJobFormat,
 			String taskManagerFormat,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/scope/ScopeFormats.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/scope/ScopeFormats.java
@@ -24,7 +24,7 @@ import org.apache.flink.configuration.MetricOptions;
 /**
  * A container for component scope formats.
  */
-public class ScopeFormats {
+public final class ScopeFormats {
 
 	private final JobManagerScopeFormat jobManagerFormat;
 	private final JobManagerJobScopeFormat jobManagerJobFormat;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/scope/ScopeFormats.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/scope/ScopeFormats.java
@@ -21,8 +21,6 @@ package org.apache.flink.runtime.metrics.scope;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MetricOptions;
 
-import static org.apache.flink.util.Preconditions.checkNotNull;
-
 /**
  * A container for component scope formats.
  */
@@ -74,24 +72,6 @@ public class ScopeFormats {
 		this.taskManagerJobFormat = new TaskManagerJobScopeFormat(taskManagerJobFormat, this.taskManagerFormat);
 		this.taskFormat = new TaskScopeFormat(taskFormat, this.taskManagerJobFormat);
 		this.operatorFormat = new OperatorScopeFormat(operatorFormat, this.taskFormat);
-	}
-
-	/**
-	 * Creates a {@code ScopeFormats} with the given scope formats.
-	 */
-	public ScopeFormats(
-			JobManagerScopeFormat jobManagerFormat,
-			JobManagerJobScopeFormat jobManagerJobFormat,
-			TaskManagerScopeFormat taskManagerFormat,
-			TaskManagerJobScopeFormat taskManagerJobFormat,
-			TaskScopeFormat taskFormat,
-			OperatorScopeFormat operatorFormat) {
-		this.jobManagerFormat = checkNotNull(jobManagerFormat);
-		this.jobManagerJobFormat = checkNotNull(jobManagerJobFormat);
-		this.taskManagerFormat = checkNotNull(taskManagerFormat);
-		this.taskManagerJobFormat = checkNotNull(taskManagerJobFormat);
-		this.taskFormat = checkNotNull(taskFormat);
-		this.operatorFormat = checkNotNull(operatorFormat);
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/scope/ScopeFormats.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/scope/ScopeFormats.java
@@ -36,27 +36,6 @@ public class ScopeFormats {
 	// ------------------------------------------------------------------------
 
 	/**
-	 * Creates all default scope formats.
-	 */
-	public ScopeFormats() {
-		this.jobManagerFormat = new JobManagerScopeFormat(MetricOptions.SCOPE_NAMING_JM.defaultValue());
-
-		this.jobManagerJobFormat = new JobManagerJobScopeFormat(
-			MetricOptions.SCOPE_NAMING_JM_JOB.defaultValue(), this.jobManagerFormat);
-
-		this.taskManagerFormat = new TaskManagerScopeFormat(MetricOptions.SCOPE_NAMING_TM.defaultValue());
-
-		this.taskManagerJobFormat = new TaskManagerJobScopeFormat(
-			MetricOptions.SCOPE_NAMING_TM_JOB.defaultValue(), this.taskManagerFormat);
-
-		this.taskFormat = new TaskScopeFormat(
-				MetricOptions.SCOPE_NAMING_TASK.defaultValue(), this.taskManagerJobFormat);
-
-		this.operatorFormat = new OperatorScopeFormat(
-			MetricOptions.SCOPE_NAMING_OPERATOR.defaultValue(), this.taskFormat);
-	}
-
-	/**
 	 * Creates all scope formats, based on the given scope format strings.
 	 */
 	public ScopeFormats(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/MetricRegistryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/MetricRegistryTest.java
@@ -331,7 +331,7 @@ public class MetricRegistryTest extends TestLogger {
 		config.setString(MetricOptions.SCOPE_NAMING_TASK, "C");
 		config.setString(MetricOptions.SCOPE_NAMING_OPERATOR, "D");
 
-		ScopeFormats scopeConfig = MetricRegistryConfiguration.createScopeConfig(config);
+		ScopeFormats scopeConfig = ScopeFormats.fromConfig(config);
 
 		assertEquals("A", scopeConfig.getTaskManagerFormat().format());
 		assertEquals("B", scopeConfig.getTaskManagerJobFormat().format());


### PR DESCRIPTION
## What is the purpose of the change

 This PR cleans up a few things related to `ScopeFormats`.

## Brief change log

* remove unused constructor
* remove redundant `MetricRegistryConfiguration#createScopeConfig`
* remove unnecessary default constructor (passing an empty configuration instead is easier to maintain)
* limit visibility of constructor

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


