### PR TITLE
[FLINK-7950][build] add flink-queryable-state-runtime as a dependency to flink-dist

### DIFF
--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -260,6 +260,13 @@ under the License.
 			<version>${project.version}</version>
 			<scope>provided</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-queryable-state-runtime_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
 		<!-- end optional Flink metrics reporters -->
 
 		<!-- start optional Flink libraries -->


### PR DESCRIPTION
## What is the purpose of the change

Since #4906, `flink-queryable-state-runtime`'s jar file was put into the `opt/`
folder of `flink-dist` and is thus required to build as well.

## Brief change log

- add `flink-queryable-state-runtime` as a (provided) dependency to `flink-dist`

## Verifying this change

This change can be verified by building the `flink-dist` sub-project: `mvn install -pl flink-dist -am` and verifying that it builds as well as that `org.apache.flink.queryablestate.client.proxy.KvStateClientProxyHandler` is not part of the `flink-dist` uber jar.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (not to Flink itself)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

