### PR TITLE
[FLINK-7951] Load YarnConfiguration with default Hadoop configuration

### DIFF
--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/util/HadoopUtils.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/util/HadoopUtils.java
@@ -21,11 +21,11 @@ package org.apache.flink.runtime.util;
 import org.apache.flink.configuration.ConfigConstants;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.security.token.TokenIdentifier;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,7 +44,9 @@ public class HadoopUtils {
 
 	public static Configuration getHadoopConfiguration(org.apache.flink.configuration.Configuration flinkConfiguration) {
 
-		Configuration result = new Configuration();
+		// the HdfsConfiguration adds per default hdfs-site.xml and hdfs-default.xml
+		// as a default resource which is read from the class path
+		Configuration result = new HdfsConfiguration();
 		boolean foundHadoopConfiguration = false;
 
 		// We need to load both core-site.xml and hdfs-site.xml to determine the default fs path and

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
+import org.apache.flink.runtime.util.HadoopUtils;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.yarn.configuration.YarnConfigOptions;
 
@@ -107,7 +108,7 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 	private static final int MIN_JM_MEMORY = 768; // the minimum memory should be higher than the min heap cutoff
 	private static final int MIN_TM_MEMORY = 768;
 
-	private Configuration conf = new YarnConfiguration();
+	private final Configuration conf;
 
 	/**
 	 * If the user has specified a different number of slots, we store them here
@@ -144,6 +145,11 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 	public AbstractYarnClusterDescriptor(
 		org.apache.flink.configuration.Configuration flinkConfiguration,
 		String configurationDirectory) {
+
+		Configuration hadoopConfiguration = HadoopUtils.getHadoopConfiguration(flinkConfiguration);
+
+		conf = new YarnConfiguration(hadoopConfiguration);
+
 		// for unit tests only
 		if (System.getenv("IN_TESTS") != null) {
 			try {

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnApplicationMasterRunner.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnApplicationMasterRunner.java
@@ -43,6 +43,7 @@ import org.apache.flink.runtime.security.modules.HadoopModule;
 import org.apache.flink.runtime.taskmanager.TaskManager;
 import org.apache.flink.runtime.util.EnvironmentInformation;
 import org.apache.flink.runtime.util.ExecutorThreadFactory;
+import org.apache.flink.runtime.util.HadoopUtils;
 import org.apache.flink.runtime.util.Hardware;
 import org.apache.flink.runtime.util.JvmShutdownSafeguard;
 import org.apache.flink.runtime.util.SignalHandler;
@@ -265,7 +266,8 @@ public class YarnApplicationMasterRunner {
 			}
 
 			// Hadoop/Yarn configuration (loads config data automatically from classpath files)
-			final YarnConfiguration yarnConfig = new YarnConfiguration();
+			final org.apache.hadoop.conf.Configuration hadoopConfiguration = HadoopUtils.getHadoopConfiguration(config);
+			final YarnConfiguration yarnConfig = new YarnConfiguration(hadoopConfiguration);
 
 			final int taskManagerContainerMemory;
 			final int numInitialTaskManagers;

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
@@ -36,6 +36,7 @@ import org.apache.flink.runtime.resourcemanager.exceptions.ResourceManagerExcept
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.runtime.util.HadoopUtils;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.yarn.configuration.YarnConfigOptions;
 
@@ -131,7 +132,10 @@ public class YarnResourceManager extends ResourceManager<ResourceID> implements 
 			jobLeaderIdService,
 			fatalErrorHandler);
 		this.flinkConfig  = flinkConfig;
-		this.yarnConfig = new YarnConfiguration();
+
+		final org.apache.hadoop.conf.Configuration hadoopConfiguration = HadoopUtils.getHadoopConfiguration(flinkConfig);
+		this.yarnConfig = new YarnConfiguration(hadoopConfiguration);
+
 		this.env = env;
 		final int yarnHeartbeatIntervalMS = flinkConfig.getInteger(
 				YarnConfigOptions.HEARTBEAT_DELAY_SECONDS) * 1000;


### PR DESCRIPTION
## What is the purpose of the change

This PR loads the default Hadoop configuration via HadoopUtils.
getHadoopConfiguration and initializes the YarnConfiguration with
it.

R @aljoscha 

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

