### PR TITLE
[FLINK-7922][Table API]make FlinkTypeFactory override leastRestrictive to work with Nullable composite types while using super class method to handle basic type 

### DIFF
--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/batch/sql/SetOperatorsTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/batch/sql/SetOperatorsTest.scala
@@ -212,7 +212,8 @@ class SetOperatorsTest extends TableTestBase {
   @Test
   def testUnionAnyType(): Unit = {
     val util = batchTestUtil()
-    val typeInfo = new RowTypeInfo(Seq(new GenericTypeInfo(classOf[NonPojo]), new GenericTypeInfo(classOf[NonPojo])): _*)
+    val typeInfo = new RowTypeInfo(Seq(new GenericTypeInfo(classOf[NonPojo]),
+      new GenericTypeInfo(classOf[NonPojo])): _*)
     util.addJavaTable(typeInfo, "A", "a, b")
 
     val expected = binaryNode(

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/batch/table/SetOperatorsTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/batch/table/SetOperatorsTest.scala
@@ -87,7 +87,8 @@ class SetOperatorsTest extends TableTestBase {
     val util = batchTestUtil()
     val t = util.addTable[((Int, String), (Int, String), Int)]("A", 'a, 'b, 'c)
 
-    val in = t.select('a).unionAll(t.select(('c > 0) ? ('b, Null(createTypeInformation[(Int, String)]))))
+    val in = t.select('a).unionAll(t.select(('c > 0)
+      ? ('b, Null(createTypeInformation[(Int, String)]))))
 
     val expected = binaryNode(
       "DataSetUnion",
@@ -110,7 +111,8 @@ class SetOperatorsTest extends TableTestBase {
   @Test
   def testUnionAnyType(): Unit = {
     val util = batchTestUtil()
-    val typeInfo = new RowTypeInfo(Seq(new GenericTypeInfo(classOf[NonPojo]), new GenericTypeInfo(classOf[NonPojo])): _*)
+    val typeInfo = new RowTypeInfo(Seq(new GenericTypeInfo(classOf[NonPojo]),
+      new GenericTypeInfo(classOf[NonPojo])): _*)
     val t = util.addJavaTable(typeInfo, "A", "a, b")
 
     val in = t.select('a).unionAll(t.select('b))

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarOperatorsTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarOperatorsTest.scala
@@ -211,7 +211,6 @@ class ScalarOperatorsTest extends ScalarOperatorsTestBase {
 
   @Test
   def testOtherExpressions(): Unit = {
-
     // nested field null type
     testSqlApi("CASE WHEN f13.f1 IS NULL THEN 'a' ELSE 'b' END", "a")
     testSqlApi("CASE WHEN f13.f1 IS NOT NULL THEN 'a' ELSE 'b' END", "b")
@@ -221,6 +220,10 @@ class ScalarOperatorsTest extends ScalarOperatorsTestBase {
     testAllApis('f13.get("f0").isNotNull, "f13.get('f0').isNotNull", "f13.f0 IS NOT NULL", "true")
     testAllApis('f13.get("f1").isNull, "f13.get('f1').isNull", "f13.f1 IS NULL", "true")
     testAllApis('f13.get("f1").isNotNull, "f13.get('f1').isNotNull", "f13.f1 IS NOT NULL", "false")
+
+    // array element access test
+    testSqlApi("CASE WHEN f18 IS NOT NULL THEN f18[1] ELSE NULL END", "1")
+    testSqlApi("CASE WHEN f19 IS NOT NULL THEN f19[1] ELSE NULL END", "(1,a)")
 
     // boolean literals
     testAllApis(

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/utils/ScalarOperatorsTestBase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/utils/ScalarOperatorsTestBase.scala
@@ -21,7 +21,8 @@ package org.apache.flink.table.expressions.utils
 import java.sql.Date
 
 import org.apache.flink.api.common.typeinfo.TypeInformation
-import org.apache.flink.api.java.typeutils.RowTypeInfo
+import org.apache.flink.api.java.typeutils.{ObjectArrayTypeInfo, RowTypeInfo}
+import org.apache.flink.api.scala.createTypeInformation
 import org.apache.flink.table.api.Types
 import org.apache.flink.table.functions.ScalarFunction
 import org.apache.flink.types.Row
@@ -29,7 +30,7 @@ import org.apache.flink.types.Row
 class ScalarOperatorsTestBase extends ExpressionTestBase {
 
   def testData: Row = {
-    val testData = new Row(18)
+    val testData = new Row(20)
     testData.setField(0, 1: Byte)
     testData.setField(1, 1: Short)
     testData.setField(2, 1)
@@ -48,6 +49,8 @@ class ScalarOperatorsTestBase extends ExpressionTestBase {
     testData.setField(15, Date.valueOf("1996-11-10"))
     testData.setField(16, BigDecimal("0.00000000").bigDecimal)
     testData.setField(17, BigDecimal("10.0").bigDecimal)
+    testData.setField(18, Array[Integer](1,2))
+    testData.setField(19, Array[(Int, String)]((1,"a"), (2, "b")))
     testData
   }
 
@@ -70,7 +73,9 @@ class ScalarOperatorsTestBase extends ExpressionTestBase {
       Types.STRING,
       Types.SQL_DATE,
       Types.DECIMAL,
-      Types.DECIMAL
+      Types.DECIMAL,
+      Types.OBJECT_ARRAY(Types.INT),
+      ObjectArrayTypeInfo.getInfoFor(createTypeInformation[(Int, String)])
       ).asInstanceOf[TypeInformation[Any]]
   }
 

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/SetOperatorsITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/SetOperatorsITCase.scala
@@ -95,8 +95,10 @@ class SetOperatorsITCase extends StreamingMultipleProgramsTestBase {
     val tEnv = TableEnvironment.getTableEnvironment(env)
 
     StreamITCase.testResults = mutable.MutableList()
-    val s1 = env.fromElements((1, new Tuple2[Int, String](1, "a")), (2, (2, "b"))).toTable(tEnv, 'a, 'b)
-    val s2 = env.fromElements((3, (3, "c")), (4, new Tuple2[Int, String](4, "d"))).toTable(tEnv, 'a, 'b)
+    val s1 = env.fromElements((1, new Tuple2[Int, String](1, "a")), (2, (2, "b")))
+      .toTable(tEnv, 'a, 'b)
+    val s2 = env.fromElements((3, (3, "c")), (4, new Tuple2[Int, String](4, "d")))
+      .toTable(tEnv, 'a, 'b)
 
     val result = s1.unionAll(s2).toAppendStream[Row]
     result.addSink(new StreamITCase.StringSink[Row])

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/SetOperatorsITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/SetOperatorsITCase.scala
@@ -23,6 +23,7 @@ import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.apache.flink.streaming.util.StreamingMultipleProgramsTestBase
 import org.apache.flink.table.api.TableEnvironment
 import org.apache.flink.table.api.scala._
+import org.apache.flink.table.runtime.utils.CommonTestData.NonPojo
 import org.apache.flink.table.runtime.utils.{StreamITCase, StreamTestData}
 import org.apache.flink.types.Row
 import org.junit.Assert._
@@ -88,9 +89,20 @@ class SetOperatorsITCase extends StreamingMultipleProgramsTestBase {
     assertEquals(expected.sorted, StreamITCase.testResults.sorted)
   }
 
-  class NonPojo {
-    val x = new java.util.HashMap[String, String]()
+  @Test
+  def testUnionWithCompositeType(): Unit = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env)
 
-    override def toString: String = x.toString
+    StreamITCase.testResults = mutable.MutableList()
+    val s1 = env.fromElements((1, new Tuple2[Int, String](1, "a")), (2, (2, "b"))).toTable(tEnv, 'a, 'b)
+    val s2 = env.fromElements((3, (3, "c")), (4, new Tuple2[Int, String](4, "d"))).toTable(tEnv, 'a, 'b)
+
+    val result = s1.unionAll(s2).toAppendStream[Row]
+    result.addSink(new StreamITCase.StringSink[Row])
+    env.execute()
+
+    val expected = mutable.MutableList("1,(1,a)", "2,(2,b)", "3,(3,c)", "4,(4,d)")
+    assertEquals(expected.sorted, StreamITCase.testResults.sorted)
   }
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/utils/CommonTestData.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/utils/CommonTestData.scala
@@ -174,4 +174,10 @@ object CommonTestData {
       this(null, null)
     }
   }
+
+  class NonPojo {
+    val x = new java.util.HashMap[String, String]()
+
+    override def toString: String = x.toString
+  }
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/utils/TableTestBase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/utils/TableTestBase.scala
@@ -190,6 +190,19 @@ case class BatchTableTestUtil() extends TableTestUtil {
       actual.split("\n").map(_.trim).mkString("\n"))
   }
 
+  def verifyJavaSql(query: String, expected: String): Unit = {
+    verifyJavaTable(javaTableEnv.sqlQuery(query), expected)
+  }
+
+  def verifyJavaTable(resultTable: Table, expected: String): Unit = {
+    val relNode = resultTable.getRelNode
+    val optimized = javaTableEnv.optimize(relNode)
+    val actual = RelOptUtil.toString(optimized)
+    assertEquals(
+      expected.split("\n").map(_.trim).mkString("\n"),
+      actual.split("\n").map(_.trim).mkString("\n"))
+  }
+
   def printTable(resultTable: Table): Unit = {
     val relNode = resultTable.getRelNode
     val optimized = tableEnv.optimize(relNode)
@@ -262,6 +275,19 @@ case class StreamTableTestUtil() extends TableTestUtil {
   def verifyTable(resultTable: Table, expected: String): Unit = {
     val relNode = resultTable.getRelNode
     val optimized = tableEnv.optimize(relNode, updatesAsRetraction = false)
+    val actual = RelOptUtil.toString(optimized)
+    assertEquals(
+      expected.split("\n").map(_.trim).mkString("\n"),
+      actual.split("\n").map(_.trim).mkString("\n"))
+  }
+
+  def verifyJavaSql(query: String, expected: String): Unit = {
+    verifyTable(javaTableEnv.sqlQuery(query), expected)
+  }
+
+  def verifyJavaTable(resultTable: Table, expected: String): Unit = {
+    val relNode = resultTable.getRelNode
+    val optimized = javaTableEnv.optimize(relNode, updatesAsRetraction = false)
     val actual = RelOptUtil.toString(optimized)
     assertEquals(
       expected.split("\n").map(_.trim).mkString("\n"),


### PR DESCRIPTION

## What is the purpose of the change

This pull request address usage of multiple composite type operation such as UNION or CASE WHEN where incorrect output RelDataType was generated due to the fact that Calcite automatically resolve result into basic type or Generic Relation Data Type with false nullability.

## Brief change log
Changed leastRestrictive function to resolve types with all identical typeinfomation directly instead of calling the super class method. 
Throw exception on ANY as we only support ANY with exact same types across all operands.
Invoke super class if not correctly resolved.


## Verifying this change
Integration test and unit test included to address UNION ALL and CASE WHEN.


## Does this pull request potentially affect one of the following parts:
no

## Documentation
no
