### PR TITLE
[FLINK-7941][flip6] Port SubtasksTimesHandler to new REST endpoint

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherRestEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherRestEndpoint.java
@@ -34,6 +34,7 @@ import org.apache.flink.runtime.rest.handler.job.JobPlanHandler;
 import org.apache.flink.runtime.rest.handler.job.JobSubmitHandler;
 import org.apache.flink.runtime.rest.handler.job.JobTerminationHandler;
 import org.apache.flink.runtime.rest.handler.job.JobVertexAccumulatorsHandler;
+import org.apache.flink.runtime.rest.handler.job.SubtasksTimesHandler;
 import org.apache.flink.runtime.rest.handler.job.checkpoints.CheckpointConfigHandler;
 import org.apache.flink.runtime.rest.handler.job.checkpoints.CheckpointStatisticDetailsHandler;
 import org.apache.flink.runtime.rest.handler.job.checkpoints.CheckpointStatsCache;
@@ -59,6 +60,7 @@ import org.apache.flink.runtime.rest.messages.JobExceptionsHeaders;
 import org.apache.flink.runtime.rest.messages.JobPlanHeaders;
 import org.apache.flink.runtime.rest.messages.JobTerminationHeaders;
 import org.apache.flink.runtime.rest.messages.JobVertexAccumulatorsHeaders;
+import org.apache.flink.runtime.rest.messages.SubtasksTimesHeaders;
 import org.apache.flink.runtime.rest.messages.checkpoints.CheckpointConfigHeaders;
 import org.apache.flink.runtime.rest.messages.checkpoints.CheckpointStatisticDetailsHeaders;
 import org.apache.flink.runtime.rest.messages.checkpoints.CheckpointingStatisticsHeaders;
@@ -227,6 +229,14 @@ public class DispatcherRestEndpoint extends RestServerEndpoint {
 			executionGraphCache,
 			executor);
 
+		SubtasksTimesHandler subtasksTimesHandler = new SubtasksTimesHandler(
+			restAddressFuture,
+			leaderRetriever,
+			timeout,
+			SubtasksTimesHeaders.getInstance(),
+			executionGraphCache,
+			executor);
+
 		final File tmpDir = restConfiguration.getTmpDir();
 
 		Optional<StaticFileServerHandler<DispatcherGateway>> optWebContent;
@@ -255,6 +265,7 @@ public class DispatcherRestEndpoint extends RestServerEndpoint {
 		handlers.add(Tuple2.of(TaskCheckpointStatisticsHeaders.getInstance(), taskCheckpointStatisticDetailsHandler));
 		handlers.add(Tuple2.of(JobExceptionsHeaders.getInstance(), jobExceptionsHandler));
 		handlers.add(Tuple2.of(JobVertexAccumulatorsHeaders.getInstance(), jobVertexAccumulatorsHandler));
+		handlers.add(Tuple2.of(SubtasksTimesHeaders.getInstance(), subtasksTimesHandler));
 
 		BlobServerPortHandler blobServerPortHandler = new BlobServerPortHandler(restAddressFuture, leaderRetriever, timeout);
 		handlers.add(Tuple2.of(blobServerPortHandler.getMessageHeaders(), blobServerPortHandler));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/SubtasksTimesHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/SubtasksTimesHandler.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.job;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
+import org.apache.flink.runtime.executiongraph.AccessExecutionJobVertex;
+import org.apache.flink.runtime.executiongraph.AccessExecutionVertex;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.legacy.ExecutionGraphCache;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.JobVertexIdPathParameter;
+import org.apache.flink.runtime.rest.messages.JobVertexMessageParameters;
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+import org.apache.flink.runtime.rest.messages.SubtasksTimesInfo;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+import org.apache.flink.runtime.webmonitor.RestfulGateway;
+import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+/**
+ * Request handler for the subtasks times info.
+ */
+public class SubtasksTimesHandler extends AbstractExecutionGraphHandler<SubtasksTimesInfo, JobVertexMessageParameters>  {
+	public SubtasksTimesHandler(
+			CompletableFuture<String> localRestAddress,
+			GatewayRetriever<? extends RestfulGateway> leaderRetriever,
+			Time timeout,
+			MessageHeaders<EmptyRequestBody, SubtasksTimesInfo, JobVertexMessageParameters> messageHeaders,
+			ExecutionGraphCache executionGraphCache,
+			Executor executor) {
+		super(localRestAddress, leaderRetriever, timeout, messageHeaders, executionGraphCache, executor);
+	}
+
+	@Override
+	protected SubtasksTimesInfo handleRequest(HandlerRequest<EmptyRequestBody, JobVertexMessageParameters> request, AccessExecutionGraph executionGraph) {
+		JobVertexID jobVertexID = request.getPathParameter(JobVertexIdPathParameter.class);
+		AccessExecutionJobVertex jobVertex = executionGraph.getJobVertex(jobVertexID);
+
+		final String id = jobVertex.getJobVertexId().toString();
+		final String name = jobVertex.getName();
+		final long now = System.currentTimeMillis();
+		final List<SubtasksTimesInfo.SubtaskTimeInfo> subtasks = new ArrayList<>();
+
+		int num = 0;
+		for (AccessExecutionVertex vertex : jobVertex.getTaskVertices()) {
+
+			long[] timestamps = vertex.getCurrentExecutionAttempt().getStateTimestamps();
+			ExecutionState status = vertex.getExecutionState();
+
+			long scheduledTime = timestamps[ExecutionState.SCHEDULED.ordinal()];
+
+			long start = scheduledTime > 0 ? scheduledTime : -1;
+			long end = status.isTerminal() ? timestamps[status.ordinal()] : now;
+			long duration = start >= 0 ? end - start : -1L;
+
+			TaskManagerLocation location = vertex.getCurrentAssignedResourceLocation();
+			String locationString = location == null ? "(unassigned)" : location.getHostname();
+
+			Map<String, Long> timestampMap = new HashMap<>();
+			for (ExecutionState state : ExecutionState.values()) {
+				timestampMap.put(state.name(), timestamps[state.ordinal()]);
+			}
+
+			subtasks.add(new SubtasksTimesInfo.SubtaskTimeInfo(
+				num++,
+				locationString,
+				duration,
+				timestampMap));
+		}
+		return new SubtasksTimesInfo(id, name, now, subtasks);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/SubtasksTimesHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/SubtasksTimesHeaders.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages;
+
+import org.apache.flink.runtime.rest.HttpMethodWrapper;
+import org.apache.flink.runtime.rest.handler.job.SubtasksTimesHandler;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+/**
+ * Message headers for the {@link SubtasksTimesHandler}.
+ */
+public class SubtasksTimesHeaders implements MessageHeaders<EmptyRequestBody, SubtasksTimesInfo, JobVertexMessageParameters> {
+
+	private static final SubtasksTimesHeaders INSTANCE = new SubtasksTimesHeaders();
+
+	public static final String URL = "/jobs/:" + JobIDPathParameter.KEY +
+		"/vertices/:" + JobVertexIdPathParameter.KEY + "/subtasktimes";
+
+	@Override
+	public Class<EmptyRequestBody> getRequestClass() {
+		return EmptyRequestBody.class;
+	}
+
+	@Override
+	public Class<SubtasksTimesInfo> getResponseClass() {
+		return SubtasksTimesInfo.class;
+	}
+
+	@Override
+	public HttpResponseStatus getResponseStatusCode() {
+		return HttpResponseStatus.OK;
+	}
+
+	@Override
+	public JobVertexMessageParameters getUnresolvedMessageParameters() {
+		return new JobVertexMessageParameters();
+	}
+
+	@Override
+	public HttpMethodWrapper getHttpMethod() {
+		return HttpMethodWrapper.GET;
+	}
+
+	@Override
+	public String getTargetRestEndpointURL() {
+		return URL;
+	}
+
+	public static SubtasksTimesHeaders getInstance() {
+		return INSTANCE;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/SubtasksTimesInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/SubtasksTimesInfo.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages;
+
+import org.apache.flink.runtime.rest.handler.job.SubtasksTimesHandler;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Response type of the {@link SubtasksTimesHandler}.
+ */
+public class SubtasksTimesInfo implements ResponseBody {
+
+	public static final String FIELD_NAME_ID = "id";
+	public static final String FIELD_NAME_NAME = "name";
+	public static final String FIELD_NAME_NOW = "now";
+	public static final String FIELD_NAME_SUBTASKS = "subtasks";
+
+	@JsonProperty(FIELD_NAME_ID)
+	private final String id;
+
+	@JsonProperty(FIELD_NAME_NAME)
+	private final String name;
+
+	@JsonProperty(FIELD_NAME_NOW)
+	private final long now;
+
+	@JsonProperty(FIELD_NAME_SUBTASKS)
+	private final List<SubtaskTimeInfo> subtasks;
+
+	@JsonCreator
+	public SubtasksTimesInfo(
+			@JsonProperty(FIELD_NAME_ID) String id,
+			@JsonProperty(FIELD_NAME_NAME) String name,
+			@JsonProperty(FIELD_NAME_NOW) long now,
+			@JsonProperty(FIELD_NAME_SUBTASKS) List<SubtaskTimeInfo> subtasks) {
+		this.id = checkNotNull(id);
+		this.name = checkNotNull(name);
+		this.now = now;
+		this.subtasks = checkNotNull(subtasks);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+
+		if (o == null || this.getClass() != o.getClass()) {
+			return false;
+		}
+
+		SubtasksTimesInfo that = (SubtasksTimesInfo) o;
+		return Objects.equals(id, that.id) &&
+			Objects.equals(name, that.name) &&
+			now == that.now &&
+			Objects.equals(subtasks, that.subtasks);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(id, name, now, subtasks);
+	}
+
+	//---------------------------------------------------------------------------------
+	// Static helper classes
+	//---------------------------------------------------------------------------------
+
+	/**
+	 * Nested class to encapsulate the sub task times info.
+	 */
+	public static final class SubtaskTimeInfo {
+
+		public static final String FIELD_NAME_SUBTASK = "subtask";
+		public static final String FIELD_NAME_HOST = "host";
+		public static final String FIELD_NAME_DURATION = "duration";
+		public static final String FIELD_NAME_TIMESTAMPS = "timestamps";
+
+		@JsonProperty(FIELD_NAME_SUBTASK)
+		private final int subtask;
+
+		@JsonProperty(FIELD_NAME_HOST)
+		private final String host;
+
+		@JsonProperty(FIELD_NAME_DURATION)
+		private final long duration;
+
+		@JsonProperty(FIELD_NAME_TIMESTAMPS)
+		private final Map<String, Long> timestamps;
+
+		public SubtaskTimeInfo(
+				@JsonProperty(FIELD_NAME_SUBTASK) int subtask,
+				@JsonProperty(FIELD_NAME_HOST) String host,
+				@JsonProperty(FIELD_NAME_DURATION) long duration,
+				@JsonProperty(FIELD_NAME_TIMESTAMPS) Map<String, Long> timestamps) {
+			this.subtask = subtask;
+			this.host = checkNotNull(host);
+			this.duration = duration;
+			this.timestamps = checkNotNull(timestamps);
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+
+			if (null == o || this.getClass() != o.getClass()) {
+				return false;
+			}
+
+			SubtaskTimeInfo that = (SubtaskTimeInfo) o;
+			return subtask == that.subtask &&
+				Objects.equals(host, that.host) &&
+				duration == that.duration &&
+				Objects.equals(timestamps, that.timestamps);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(subtask, host, duration, timestamps);
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/SubtasksTimesInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/SubtasksTimesInfoTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Tests that the {@link SubtasksTimesInfo} can be marshalled and unmarshalled.
+ */
+public class SubtasksTimesInfoTest extends RestResponseMarshallingTestBase<SubtasksTimesInfo> {
+
+	@Override
+	protected Class<SubtasksTimesInfo> getTestResponseClass() {
+		return SubtasksTimesInfo.class;
+	}
+
+	@Override
+	protected SubtasksTimesInfo getTestResponseInstance() throws Exception {
+		List<SubtasksTimesInfo.SubtaskTimeInfo> subtasks = new ArrayList<>();
+
+		Map<String, Long> subTimeMap1 = new HashMap<>();
+		subTimeMap1.put("state11", System.currentTimeMillis());
+		subTimeMap1.put("state12", System.currentTimeMillis());
+		subTimeMap1.put("state13", System.currentTimeMillis());
+		subtasks.add(new SubtasksTimesInfo.SubtaskTimeInfo(0, "local1", 1L, subTimeMap1));
+
+		Map<String, Long> subTimeMap2 = new HashMap<>();
+		subTimeMap1.put("state21", System.currentTimeMillis());
+		subTimeMap1.put("state22", System.currentTimeMillis());
+		subTimeMap1.put("state23", System.currentTimeMillis());
+		subtasks.add(new SubtasksTimesInfo.SubtaskTimeInfo(1, "local2", 2L, subTimeMap2));
+
+		Map<String, Long> subTimeMap3 = new HashMap<>();
+		subTimeMap1.put("state31", System.currentTimeMillis());
+		subTimeMap1.put("state32", System.currentTimeMillis());
+		subTimeMap1.put("state33", System.currentTimeMillis());
+		subtasks.add(new SubtasksTimesInfo.SubtaskTimeInfo(2, "local3", 3L, subTimeMap3));
+
+		return new SubtasksTimesInfo("testId", "testName", System.currentTimeMillis(), subtasks);
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

Port SubtasksTimesHandler to new REST endpoint

## Brief change log
  - *Add new SubtasksTimesHandler class*
  - *Add SubtasksTimesInfo/SubtaskTimesHeaders*

## Verifying this change

This change added tests and can be verified as follows:

  - *Add SubtasksTimesInfoTest for testing json response*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)

