### PR TITLE
[FLINK-7958][metrics] Allow reporters to define default delimiter

### DIFF
--- a/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/reporter/DelimiterProvider.java
+++ b/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/reporter/DelimiterProvider.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.metrics.reporter;
+
+/**
+ * Interface for reporters that define their own default delimiter.
+ */
+public interface DelimiterProvider {
+
+	/**
+	 * Returns the default delimiter for the reporter.
+	 *
+	 * @return default delimiter
+	 */
+	char getDelimiter();
+}

--- a/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/reporter/MetricReporter.java
+++ b/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/reporter/MetricReporter.java
@@ -25,6 +25,8 @@ import org.apache.flink.metrics.MetricGroup;
 /**
  * Reporters are used to export {@link Metric Metrics} to an external backend.
  *
+ * <p>Implementations may also implement {@link DelimiterProvider} to define a default delimiter.
+ *
  * <p>Reporters are instantiated via reflection and must be public, non-abstract, and have a
  * public no-argument constructor.
  */

--- a/flink-metrics/flink-metrics-jmx/src/main/java/org/apache/flink/metrics/jmx/JMXReporter.java
+++ b/flink-metrics/flink-metrics-jmx/src/main/java/org/apache/flink/metrics/jmx/JMXReporter.java
@@ -26,6 +26,7 @@ import org.apache.flink.metrics.Meter;
 import org.apache.flink.metrics.Metric;
 import org.apache.flink.metrics.MetricConfig;
 import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.metrics.reporter.DelimiterProvider;
 import org.apache.flink.metrics.reporter.MetricReporter;
 import org.apache.flink.runtime.metrics.groups.AbstractMetricGroup;
 import org.apache.flink.runtime.metrics.groups.FrontMetricGroup;
@@ -62,7 +63,7 @@ import java.util.Map;
  * <p>Largely based on the JmxReporter class of the dropwizard metrics library
  * https://github.com/dropwizard/metrics/blob/master/metrics-core/src/main/java/io/dropwizard/metrics/JmxReporter.java
  */
-public class JMXReporter implements MetricReporter {
+public class JMXReporter implements MetricReporter, DelimiterProvider {
 
 	static final String JMX_DOMAIN_PREFIX = "org.apache.flink.";
 
@@ -91,6 +92,11 @@ public class JMXReporter implements MetricReporter {
 	public JMXReporter() {
 		this.mBeanServer = ManagementFactory.getPlatformMBeanServer();
 		this.registeredMetrics = new HashMap<>();
+	}
+
+	@Override
+	public char getDelimiter() {
+		return '.';
 	}
 
 	// ------------------------------------------------------------------------
@@ -231,7 +237,7 @@ public class JMXReporter implements MetricReporter {
 	}
 
 	static String generateJmxDomain(String metricName, MetricGroup group) {
-		return JMX_DOMAIN_PREFIX + ((FrontMetricGroup<AbstractMetricGroup<?>>) group).getLogicalScope(CHARACTER_FILTER, '.') + '.' + metricName;
+		return JMX_DOMAIN_PREFIX + ((FrontMetricGroup<AbstractMetricGroup<?>>) group).getLogicalScope(CHARACTER_FILTER) + '.' + metricName;
 	}
 
 	/**

--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/AbstractPrometheusReporter.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/AbstractPrometheusReporter.java
@@ -28,6 +28,7 @@ import org.apache.flink.metrics.Meter;
 import org.apache.flink.metrics.Metric;
 import org.apache.flink.metrics.MetricConfig;
 import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.metrics.reporter.DelimiterProvider;
 import org.apache.flink.metrics.reporter.MetricReporter;
 import org.apache.flink.runtime.metrics.groups.AbstractMetricGroup;
 import org.apache.flink.runtime.metrics.groups.FrontMetricGroup;
@@ -53,7 +54,7 @@ import static org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterO
  * base prometheus reporter for prometheus metrics.
  */
 @PublicEvolving
-public abstract class AbstractPrometheusReporter implements MetricReporter {
+public abstract class AbstractPrometheusReporter implements MetricReporter, DelimiterProvider {
 
 	protected final Logger log = LoggerFactory.getLogger(getClass());
 
@@ -78,6 +79,11 @@ public abstract class AbstractPrometheusReporter implements MetricReporter {
 	}
 
 	private CharacterFilter labelValueCharactersFilter = CHARACTER_FILTER;
+
+	@Override
+	public char getDelimiter() {
+		return SCOPE_SEPARATOR;
+	}
 
 	@Override
 	public void open(MetricConfig config) {
@@ -213,7 +219,7 @@ public abstract class AbstractPrometheusReporter implements MetricReporter {
 
 	@SuppressWarnings("unchecked")
 	private static String getLogicalScope(MetricGroup group) {
-		return ((FrontMetricGroup<AbstractMetricGroup<?>>) group).getLogicalScope(CHARACTER_FILTER, SCOPE_SEPARATOR);
+		return ((FrontMetricGroup<AbstractMetricGroup<?>>) group).getLogicalScope(CHARACTER_FILTER);
 	}
 
 	@VisibleForTesting

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroup.java
@@ -141,19 +141,11 @@ public abstract class AbstractMetricGroup<A extends AbstractMetricGroup<?>> impl
 		return getLogicalScope(filter, registry.getDelimiter());
 	}
 
-	String getLogicalScope(CharacterFilter filter, char delimiter) {
-		return createLogicalScope(filter, delimiter);
-	}
-
 	String getLogicalScope(CharacterFilter filter, int reporterIndex) {
-		if (logicalScopeStrings.length == 0 || (reporterIndex < 0 || reporterIndex >= logicalScopeStrings.length)) {
-			return createLogicalScope(filter, registry.getDelimiter());
-		} else {
-			if (logicalScopeStrings[reporterIndex] == null) {
-				logicalScopeStrings[reporterIndex] = createLogicalScope(filter, registry.getDelimiter(reporterIndex));
-			}
-			return logicalScopeStrings[reporterIndex];
-		}
+		final char delimiter = reporterIndex < 0 || reporterIndex >= logicalScopeStrings.length
+			? registry.getDelimiter()
+			: registry.getDelimiter(reporterIndex);
+		return getLogicalScope(filter, delimiter, reporterIndex);
 	}
 
 	/**
@@ -165,16 +157,18 @@ public abstract class AbstractMetricGroup<A extends AbstractMetricGroup<?>> impl
 	 * @param reporterIndex index of the reporter
 	 * @return logical scope
 	 */
-	@Deprecated
 	String getLogicalScope(CharacterFilter filter, char delimiter, int reporterIndex) {
-		if (logicalScopeStrings.length == 0 || (reporterIndex < 0 || reporterIndex >= logicalScopeStrings.length)) {
-			return createLogicalScope(filter, delimiter);
-		} else {
+		final String logicalScope = getLogicalScope(filter, delimiter);
+		if (reporterIndex < 0 || reporterIndex >= logicalScopeStrings.length) {
 			if (logicalScopeStrings[reporterIndex] == null) {
-				logicalScopeStrings[reporterIndex] = createLogicalScope(filter, delimiter);
+				logicalScopeStrings[reporterIndex] = logicalScope;
 			}
-			return logicalScopeStrings[reporterIndex];
 		}
+		return logicalScope;
+	}
+
+	private String getLogicalScope(CharacterFilter filter, char delimiter) {
+		return createLogicalScope(filter, delimiter);
 	}
 
 	private String createLogicalScope(CharacterFilter filter, char delimiter) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroup.java
@@ -151,6 +151,8 @@ public abstract class AbstractMetricGroup<A extends AbstractMetricGroup<?>> impl
 	/**
 	 * Returns the logical scope of this group, for example
 	 * {@code "taskmanager.job.task"}.
+	 * 
+	 * This method is necessary for backwards compatibility, see the usage in {@link FrontMetricGroup}.
 	 *
 	 * @param filter character filter which is applied to the scope components
 	 * @param delimiter delimiter to use for concatenating scope components

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroup.java
@@ -151,8 +151,8 @@ public abstract class AbstractMetricGroup<A extends AbstractMetricGroup<?>> impl
 	/**
 	 * Returns the logical scope of this group, for example
 	 * {@code "taskmanager.job.task"}.
-	 * 
-	 * This method is necessary for backwards compatibility, see the usage in {@link FrontMetricGroup}.
+	 *
+	 * <p>This method is necessary for backwards compatibility, see the usage in {@link FrontMetricGroup}.
 	 *
 	 * @param filter character filter which is applied to the scope components
 	 * @param delimiter delimiter to use for concatenating scope components

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroup.java
@@ -138,7 +138,7 @@ public abstract class AbstractMetricGroup<A extends AbstractMetricGroup<?>> impl
 	 * @return logical scope
 	 */
 	public String getLogicalScope(CharacterFilter filter) {
-		return getLogicalScope(filter, registry.getDelimiter());
+		return createLogicalScope(filter, registry.getDelimiter());
 	}
 
 	String getLogicalScope(CharacterFilter filter, int reporterIndex) {
@@ -160,17 +160,13 @@ public abstract class AbstractMetricGroup<A extends AbstractMetricGroup<?>> impl
 	 * @return logical scope
 	 */
 	String getLogicalScope(CharacterFilter filter, char delimiter, int reporterIndex) {
-		final String logicalScope = getLogicalScope(filter, delimiter);
+		final String logicalScope = createLogicalScope(filter, delimiter);
 		if (reporterIndex < 0 || reporterIndex >= logicalScopeStrings.length) {
 			if (logicalScopeStrings[reporterIndex] == null) {
 				logicalScopeStrings[reporterIndex] = logicalScope;
 			}
 		}
 		return logicalScope;
-	}
-
-	private String getLogicalScope(CharacterFilter filter, char delimiter) {
-		return createLogicalScope(filter, delimiter);
 	}
 
 	private String createLogicalScope(CharacterFilter filter, char delimiter) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/FrontMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/FrontMetricGroup.java
@@ -48,9 +48,16 @@ public class FrontMetricGroup<P extends AbstractMetricGroup<?>> extends ProxyMet
 	}
 
 	public String getLogicalScope(CharacterFilter filter) {
-		return parentMetricGroup.getLogicalScope(filter);
+		return parentMetricGroup.getLogicalScope(filter, this.reporterIndex);
 	}
 
+	/**
+	 * This method only exists for backwards compatibility, and should only be removed once a public alternative was
+	 * provided, see FLINK-7957.
+	 *
+	 * @deprecated Use {@link #getLogicalScope(CharacterFilter)} instead
+	 */
+	@Deprecated
 	public String getLogicalScope(CharacterFilter filter, char delimiter) {
 		return parentMetricGroup.getLogicalScope(filter, delimiter, this.reporterIndex);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/GenericValueMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/GenericValueMetricGroup.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.metrics.groups;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.metrics.CharacterFilter;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.metrics.scope.ScopeFormat;
@@ -51,7 +50,7 @@ public class GenericValueMetricGroup extends GenericMetricGroup {
 	}
 
 	@Override
-	protected String createLogicalScope(CharacterFilter filter, char delimiter) {
-		return parent.getLogicalScope(filter, delimiter);
+	protected boolean includeInLogicalScope() {
+		return false;
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroupTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.core.testutils.BlockerSync;
 import org.apache.flink.metrics.CharacterFilter;
 import org.apache.flink.metrics.Metric;
 import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.metrics.reporter.DelimiterProvider;
 import org.apache.flink.metrics.reporter.MetricReporter;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
@@ -207,7 +208,7 @@ public class AbstractMetricGroupTest {
 	/**
 	 * Reporter that verifies the logical-scope caching behavior.
 	 */
-	public static final class LogicalScopeReporter1 extends ScopeCheckingTestReporter {
+	public static final class LogicalScopeReporter1 extends ScopeCheckingTestReporter implements DelimiterProvider {
 		@Override
 		public String filterCharacters(String input) {
 			return FILTER_B.filterCharacters(input);
@@ -215,15 +216,20 @@ public class AbstractMetricGroupTest {
 
 		@Override
 		public void checkScopes(Metric metric, String metricName, MetricGroup group) {
-			final String logicalScope = ((FrontMetricGroup<AbstractMetricGroup<?>>) group).getLogicalScope(this, '-');
+			final String logicalScope = ((FrontMetricGroup<AbstractMetricGroup<?>>) group).getLogicalScope(this);
 			assertEquals("taskmanager-X-C", logicalScope);
+		}
+
+		@Override
+		public char getDelimiter() {
+			return '-';
 		}
 	}
 
 	/**
 	 * Reporter that verifies the logical-scope caching behavior.
 	 */
-	public static final class LogicalScopeReporter2 extends ScopeCheckingTestReporter {
+	public static final class LogicalScopeReporter2 extends ScopeCheckingTestReporter implements DelimiterProvider {
 		@Override
 		public String filterCharacters(String input) {
 			return FILTER_C.filterCharacters(input);
@@ -231,8 +237,13 @@ public class AbstractMetricGroupTest {
 
 		@Override
 		public void checkScopes(Metric metric, String metricName, MetricGroup group) {
-			final String logicalScope = ((FrontMetricGroup<AbstractMetricGroup<?>>) group).getLogicalScope(this, ',');
+			final String logicalScope = ((FrontMetricGroup<AbstractMetricGroup<?>>) group).getLogicalScope(this);
 			assertEquals("taskmanager,B,X", logicalScope);
+		}
+
+		@Override
+		public char getDelimiter() {
+			return ',';
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/MetricGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/MetricGroupTest.java
@@ -223,7 +223,7 @@ public class MetricGroupTest extends TestLogger {
 	}
 
 	/**
-	 * Verifies that calling {@link AbstractMetricGroup#getLogicalScope(CharacterFilter, char, int)} on {@link GenericValueMetricGroup}
+	 * Verifies that calling {@link AbstractMetricGroup#getLogicalScope(CharacterFilter, int)} on {@link GenericValueMetricGroup}
 	 * should ignore value as well.
 	 */
 	@Test
@@ -241,7 +241,7 @@ public class MetricGroupTest extends TestLogger {
 			MetricGroup group = root.addGroup(key, value);
 
 			String logicalScope = ((AbstractMetricGroup) group)
-				.getLogicalScope(new DummyCharacterFilter(), registry.getDelimiter(), 0);
+				.getLogicalScope(new DummyCharacterFilter(), 0);
 			assertThat("Key is missing from logical scope.", logicalScope, containsString(key));
 			assertThat("Value is present in logical scope.", logicalScope, not(containsString(value)));
 		} finally {


### PR DESCRIPTION
## What is the purpose of the change

This PR allows reporters to define their default delimiter. Previously we always defaulted to `.`.

Reporters may now implement the `DelimiterProvider` interface with which they may define a delimiter. This delimiter is used if no delimiter was explicitly configured for the reporter.

## Brief change log

* Add DelimiterProvider interface
* modify Prometheus&JmxReporter to define the default delimiter
* modify delimiter setup in the MetricRegistry
* add a test to the MetricRegistryTest to verify functionality

## Verifying this change

This change added tests and can be verified as follows:

Run MetricRegistryTest#testDelimiterOverride.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (javadoc)

