### PR TITLE
[FLINK-7800] [table] Enable window joins without equi-join predicates

### DIFF
--- a/docs/dev/table/sql.md
+++ b/docs/dev/table/sql.md
@@ -394,21 +394,19 @@ FROM Orders LEFT JOIN Product ON Orders.productId = Product.id
     </tr>
     <tr>
       <td><strong>Time-windowed Join</strong><br>
-        <span class="label label-primary">Batch</span>
         <span class="label label-primary">Streaming</span>
       </td>
       <td>
-        <p><b>Note:</b> Time-windowed joins are a subset of regular joins that can be processed in a streaming fashion.</p>
-
-        <p>A time-windowed join requires at least one equi-join predicate and a special join 
-        condition that bounds the time on both sides. Such a condition can be defined by two appropriate range predicates (<code>&lt;, &lt;=, &gt;=, &gt;</code>) or a <code>BETWEEN</code> predicate (which is not available in Table API yet) that compares the <a href="streaming.html#time-attributes">time attributes</a> of both input tables. The following rules apply for time predicates:
+        <p>Time-windowed joins are a subset of regular joins that can be processed in a streaming fashion. It requires a special join condition that bounds the time on both sides. Such a condition can be defined by two appropriate range predicates (<code>&lt;, &lt;=, &gt;=, &gt;</code>) or a <code>BETWEEN</code> predicate that compares the <a href="streaming.html#time-attributes">time attributes</a> of both input tables. The following rules apply for time predicates:
           <ul>
             <li>The time attribute of a table must be compared to a bounded interval on a time attribute of the opposite table.</li>
             <li>The compared time attributes must be of the same type, i.e., both are processing time or event time.</li>
           </ul>
         </p>
-
-        <p><b>Note:</b> Currently, only <code>INNER</code> time-windowed joins are supported.</p>
+        
+        <p><b>Note:</b> Currently, only <code>INNER</code> time-windowed joins are supported,
+         and without equi-conditions, the join will be forcibly executed with <code>parallelism = 1</code>.
+        </p>
 
 {% highlight sql %}
 SELECT *

--- a/docs/dev/table/tableApi.md
+++ b/docs/dev/table/tableApi.md
@@ -521,20 +521,19 @@ Table fullOuterResult = left.fullOuterJoin(right, "a = d").select("a, b, e");
     </tr>
     <tr>
       <td><strong>Time-windowed Join</strong><br>
-        <span class="label label-primary">Batch</span>
         <span class="label label-primary">Streaming</span>
       </td>
       <td>
-        <p><b>Note:</b> Time-windowed joins are a subset of regular joins that can be processed in a streaming fashion.</p>
-
-        <p>A time-windowed join requires at least one equi-join predicate and a special join condition that bounds the time on both sides. Such a condition can be defined by two appropriate range predicates (<code>&lt;, &lt;=, &gt;=, &gt;</code>) or a <code>BETWEEN</code> predicate (which is not available in Table API yet) that compares the <a href="streaming.html#time-attributes">time attributes</a> of both input tables. The following rules apply for time predicates:
+        <p>Time-windowed joins are a subset of regular joins that can be processed in a streaming fashion. It requires a special join condition that bounds the time on both sides. Such a condition can be defined by two appropriate range predicates (<code>&lt;, &lt;=, &gt;=, &gt;</code>) or a <code>BETWEEN</code> predicate (which is not available in Table API yet)) that compares the <a href="streaming.html#time-attributes">time attributes</a> of both input tables. The following rules apply for time predicates:
           <ul>
             <li>The time attribute of a table must be compared to a bounded interval on a time attribute of the opposite table.</li>
             <li>The compared time attributes must be of the same type, i.e., both are processing time or event time.</li>
           </ul>
         </p>
-
-        <p><b>Note:</b> Currently, only <code>INNER</code> time-windowed joins are supported.</p>
+        
+        <p><b>Note:</b> Currently, only <code>INNER</code> time-windowed joins are supported,
+         and without equi-conditions, the join will be forcibly executed with <code>parallelism = 1</code>.
+        </p>
 
 {% highlight java %}
 Table left = tableEnv.fromDataSet(ds1, "a, b, c, ltime.rowtime");
@@ -638,20 +637,19 @@ val fullOuterResult = left.fullOuterJoin(right, 'a === 'd).select('a, 'b, 'e)
     </tr>
     <tr>
       <td><strong>Time-windowed Join</strong><br>
-        <span class="label label-primary">Batch</span>
         <span class="label label-primary">Streaming</span>
       </td>
       <td>
-        <p><b>Note:</b> Time-windowed joins are a subset of regular joins that can be processed in a streaming fashion.</p>
-
-        <p>A time-windowed join requires at least one equi-join predicate and a special join condition that bounds the time on both sides. Such a condition can be defined by two appropriate range predicates (<code>&lt;, &lt;=, &gt;=, &gt;</code>) or a <code>BETWEEN</code> predicate (which is not available in Table API yet) that compares the <a href="streaming.html#time-attributes">time attributes</a> of both input tables. The following rules apply for time predicates:
+        <p>Time-windowed joins are a subset of regular joins that can be processed in a streaming fashion. It requires a special join condition that bounds the time on both sides. Such a condition can be defined by two appropriate range predicates (<code>&lt;, &lt;=, &gt;=, &gt;</code>) or a <code>BETWEEN</code> predicate (which is not available in Table API yet)) that compares the <a href="streaming.html#time-attributes">time attributes</a> of both input tables. The following rules apply for time predicates:
           <ul>
             <li>The time attribute of a table must be compared to a bounded interval on a time attribute of the opposite table.</li>
             <li>The compared time attributes must be of the same type, i.e., both are processing time or event time.</li>
           </ul>
         </p>
-
-        <p><b>Note:</b> Currently, only <code>INNER</code> time-windowed joins are supported.</p>
+        
+        <p><b>Note:</b> Currently, only <code>INNER</code> time-windowed joins are supported,
+         and without equi-conditions, the join will be forcibly executed with <code>parallelism = 1</code>.
+        </p>
 
 {% highlight scala %}
 val left = ds1.toTable(tableEnv, 'a, 'b, 'c, 'ltime.rowtime);

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/dataset/DataSetJoin.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/dataset/DataSetJoin.scala
@@ -38,6 +38,7 @@ import org.apache.flink.table.api.{BatchTableEnvironment, TableConfig, TableExce
 import org.apache.flink.table.calcite.FlinkTypeFactory
 import org.apache.flink.table.codegen.{FunctionCodeGenerator, GeneratedFunction}
 import org.apache.flink.table.plan.nodes.CommonJoin
+import org.apache.flink.table.plan.util.JoinPlanUtil
 import org.apache.flink.table.runtime._
 import org.apache.flink.types.Row
 import org.apache.flink.util.Collector
@@ -124,7 +125,7 @@ class DataSetJoin(
     // get the equality keys
     val leftKeys = ArrayBuffer.empty[Int]
     val rightKeys = ArrayBuffer.empty[Int]
-    if (keyPairs.isEmpty) {
+    if (!JoinPlanUtil.hasEqualityPredicates(joinInfo)) {
       // if no equality keys => not supported
       throw TableException(
         "Joins should have at least one equality condition.\n" +

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamWindowJoin.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamWindowJoin.scala
@@ -233,6 +233,7 @@ class DataStreamWindowJoin(
         .name(operatorName)
         .returns(returnTypeInfo)
     } else {
+      // Without keys for grouping, the join operator's parallelism can only be 1.
       leftDataStream.connect(rightDataStream)
         .keyBy(new NullByteKeySelector[CRow](), new NullByteKeySelector[CRow]())
         .process(procInnerJoinFunc)
@@ -278,6 +279,7 @@ class DataStreamWindowJoin(
             rowTimeInnerJoinFunc.getMaxOutputDelay)
         )
     } else {
+      // Without keys for grouping, the join operator's parallelism can only be 1.
       leftDataStream.connect(rightDataStream)
         .keyBy(new NullByteKeySelector[CRow](), new NullByteKeySelector[CRow])
         .transform(

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/logical/FlinkLogicalJoin.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/logical/FlinkLogicalJoin.scala
@@ -19,7 +19,6 @@
 package org.apache.flink.table.plan.nodes.logical
 
 import org.apache.calcite.plan._
-import org.apache.calcite.plan.volcano.RelSubset
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.convert.ConverterRule
 import org.apache.calcite.rel.core._
@@ -27,6 +26,7 @@ import org.apache.calcite.rel.logical.LogicalJoin
 import org.apache.calcite.rel.metadata.RelMetadataQuery
 import org.apache.calcite.rex.RexNode
 import org.apache.flink.table.plan.nodes.FlinkConventions
+import org.apache.flink.table.plan.util.JoinPlanUtil
 
 import scala.collection.JavaConverters._
 
@@ -74,10 +74,17 @@ private class FlinkLogicalJoinConverter
     "FlinkLogicalJoinConverter") {
 
   override def matches(call: RelOptRuleCall): Boolean = {
-    val join: LogicalJoin = call.rel(0).asInstanceOf[LogicalJoin]
-    val joinInfo = join.analyzeCondition
-
-    hasEqualityPredicates(joinInfo) || isSingleRowJoin(join)
+    val logicalJoin = call.rels(0).asInstanceOf[LogicalJoin]
+    val joinInfo = logicalJoin.analyzeCondition()
+    JoinPlanUtil.hasEqualityPredicates(joinInfo) ||
+      JoinPlanUtil.isSingleRowJoin(
+        logicalJoin.getJoinType,
+        logicalJoin.getLeft,
+        logicalJoin.getRight) ||
+      // When there's no equi-join predicate and it's not single row, we must ensure that the
+      // predicates cannot be replaced with some equi-ones.
+      !JoinPlanUtil.canBeReplacedWithEquiPreds(
+        joinInfo.getRemaining(logicalJoin.getCluster.getRexBuilder))
   }
 
   override def convert(rel: RelNode): RelNode = {
@@ -93,35 +100,6 @@ private class FlinkLogicalJoinConverter
       newRight,
       join.getCondition,
       join.getJoinType)
-  }
-
-  private def hasEqualityPredicates(joinInfo: JoinInfo): Boolean = {
-    // joins require an equi-condition or a conjunctive predicate with at least one equi-condition
-    !joinInfo.pairs().isEmpty
-  }
-
-  private def isSingleRowJoin(join: LogicalJoin): Boolean = {
-    join.getJoinType match {
-      case JoinRelType.INNER if isSingleRow(join.getRight) || isSingleRow(join.getLeft) => true
-      case JoinRelType.LEFT if isSingleRow(join.getRight) => true
-      case JoinRelType.RIGHT if isSingleRow(join.getLeft) => true
-      case _ => false
-    }
-  }
-
-  /**
-    * Recursively checks if a [[RelNode]] returns at most a single row.
-    * Input must be a global aggregation possibly followed by projections or filters.
-    */
-  private def isSingleRow(node: RelNode): Boolean = {
-    node match {
-      case ss: RelSubset => isSingleRow(ss.getOriginal)
-      case lp: Project => isSingleRow(lp.getInput)
-      case lf: Filter => isSingleRow(lf.getInput)
-      case lc: Calc => isSingleRow(lc.getInput)
-      case la: Aggregate => la.getGroupSet.isEmpty
-      case _ => false
-    }
   }
 }
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/dataSet/DataSetJoinRule.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/dataSet/DataSetJoinRule.scala
@@ -21,10 +21,10 @@ package org.apache.flink.table.plan.rules.dataSet
 import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall, RelTraitSet}
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.convert.ConverterRule
-import org.apache.calcite.rel.core.JoinRelType
 import org.apache.flink.table.plan.nodes.FlinkConventions
 import org.apache.flink.table.plan.nodes.dataset.DataSetJoin
 import org.apache.flink.table.plan.nodes.logical.FlinkLogicalJoin
+import org.apache.flink.table.plan.util.JoinPlanUtil
 
 import scala.collection.JavaConversions._
 
@@ -41,7 +41,9 @@ class DataSetJoinRule
     val joinInfo = join.analyzeCondition
 
     // joins require an equi-condition or a conjunctive predicate with at least one equi-condition
-    !joinInfo.pairs().isEmpty
+    JoinPlanUtil.hasEqualityPredicates(joinInfo)
+    // We need to support single row join without equi-condition in the future.
+    // JoinPlanUtil.isSingleRowJoin(join.getJoinType, join.getLeft, join.getRight)
   }
 
   override def convert(rel: RelNode): RelNode = {

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/util/JoinPlanUtil.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/util/JoinPlanUtil.scala
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.util
+
+import scala.collection.JavaConverters._
+import org.apache.calcite.plan.volcano.RelSubset
+import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rel.core._
+import org.apache.calcite.rel.core.{JoinInfo, JoinRelType, Project}
+import org.apache.calcite.rex.{RexCall, RexInputRef, RexLiteral, RexNode}
+import org.apache.calcite.sql.fun.{SqlMonotonicBinaryOperator, SqlStdOperatorTable}
+
+/**
+  * Utilities for join plan translation.
+  */
+object JoinPlanUtil {
+
+  /** Checks whether a join has equi-conditions. */
+  def hasEqualityPredicates(joinInfo: JoinInfo): Boolean = {
+    !joinInfo.pairs().isEmpty
+  }
+
+  /**
+    * Checks whether the predicates can be replaced with a Calc followed by an equi-join.
+    * (e.g., replace =($1, -($0, 1)) with $2=[-($0, 1)] and =($2, $1))
+    * @param remainCond the join remaining conditions
+    * @return true if the conditions can be replaced with equi-ones.
+    */
+  def canBeReplacedWithEquiPreds(remainCond: RexNode): Boolean = {
+    var canBeReplaced: Boolean = false
+
+    def checkCond(call: RexNode, andBranch: Boolean): Unit = call match {
+      case x: RexCall if x.op == SqlStdOperatorTable.OR =>
+        x.operands.asScala.foreach(checkCond(_, andBranch = false))
+      case x: RexCall if x.op == SqlStdOperatorTable.AND =>
+        x.operands.asScala.foreach(checkCond(_, andBranch))
+      case x: RexCall if x.op == SqlStdOperatorTable.EQUALS =>
+        // Found a predicate with "=" comparator.
+        x.operands.asScala.foreach {
+          case _: RexCall if andBranch => canBeReplaced = true
+          case _ =>
+        }
+      case _ => // Just omit others.
+    }
+
+    checkCond(remainCond, andBranch = true)
+    canBeReplaced
+  }
+
+  /** Checks whether joining with a single row. */
+  def isSingleRowJoin(joinType: JoinRelType, left: RelNode, right: RelNode): Boolean = {
+    joinType match {
+      case JoinRelType.INNER if isSingleRow(right) || isSingleRow(left) => true
+      case JoinRelType.LEFT if isSingleRow(right) => true
+      case JoinRelType.RIGHT if isSingleRow(left) => true
+      case _ => false
+    }
+  }
+
+  /**
+    * Recursively checks if a [[RelNode]] returns a single row.
+    * The input must be a global aggregation possibly followed by projections or filters.
+    */
+  private def isSingleRow(node: RelNode): Boolean = {
+    node match {
+      case ss: RelSubset => isSingleRow(ss.getOriginal)
+      case lp: Project => isSingleRow(lp.getInput)
+      case lf: Filter => isSingleRow(lf.getInput)
+      case lc: Calc => isSingleRow(lc.getInput)
+      case la: Aggregate => la.getGroupSet.isEmpty
+      case _ => false
+    }
+  }
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/validation/JoinValidationTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/validation/JoinValidationTest.scala
@@ -30,23 +30,6 @@ import org.junit.Test
 class JoinValidationTest extends TableTestBase {
 
   /**
-    * At least one equi-join predicate required.
-    */
-  @Test(expected = classOf[TableException])
-  def testInnerJoinWithoutEquiPredicate(): Unit = {
-    val util = streamTestUtil()
-    val left = util.addTable[(Long, Int, String)]('a, 'b, 'c, 'ltime.rowtime)
-    val right = util.addTable[(Long, Int, String)]('d, 'e, 'f, 'rtime.rowtime)
-
-    val resultTable = left.join(right)
-      .where('ltime >= 'rtime - 5.minutes && 'ltime < 'rtime + 3.seconds)
-      .select('a, 'e, 'ltime)
-
-    val expected = ""
-    util.verifyTable(resultTable, expected)
-  }
-
-  /**
     * There must be complete window-bounds.
     */
   @Test(expected = classOf[TableException])

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/sql/JoinITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/sql/JoinITCase.scala
@@ -187,6 +187,59 @@ class JoinITCase extends StreamingWithStateTestBase {
     StreamITCase.compareWithList(expected)
   }
 
+  /** test rowtime inner join without equi-conditions **/
+  @Test
+  def testRowTimeInnerJoinWithoutEquiCond(): Unit = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env)
+    env.setStateBackend(getStateBackend)
+    env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
+    StreamITCase.clear
+
+    val sqlQuery =
+      """
+        |SELECT t2.key, t2.id, t1.id
+        |FROM T1 as t1 join T2 as t2 ON
+        |  t1.rt BETWEEN t2.rt - INTERVAL '5' SECOND AND
+        |    t2.rt + INTERVAL '6' SECOND
+        |""".stripMargin
+
+    val data1 = new mutable.MutableList[(String, String, Long)]
+    // for boundary test
+    data1.+=(("A", "LEFT0.999", 999L))
+    data1.+=(("A", "LEFT1", 1000L))
+    data1.+=(("A", "LEFT2", 2000L))
+    data1.+=(("B", "LEFT4", 4000L))
+    data1.+=(("A", "LEFT6", 6000L))
+
+    val data2 = new mutable.MutableList[(String, String, Long)]
+    data2.+=(("A", "RIGHT6", 6000L))
+    data2.+=(("B", "RIGHT7", 7000L))
+
+    val t1 = env.fromCollection(data1)
+      .assignTimestampsAndWatermarks(new Row3WatermarkExtractor2)
+      .toTable(tEnv, 'key, 'id, 'rt.rowtime)
+    val t2 = env.fromCollection(data2)
+      .assignTimestampsAndWatermarks(new Row3WatermarkExtractor2)
+      .toTable(tEnv, 'key, 'id, 'rt.rowtime)
+
+    tEnv.registerTable("T1", t1)
+    tEnv.registerTable("T2", t2)
+
+    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    result.addSink(new StreamITCase.StringSink[Row])
+    env.execute()
+    val expected = new java.util.ArrayList[String]
+    expected.add("A,RIGHT6,LEFT1")
+    expected.add("A,RIGHT6,LEFT2")
+    expected.add("A,RIGHT6,LEFT4")
+    expected.add("A,RIGHT6,LEFT6")
+    expected.add("B,RIGHT7,LEFT2")
+    expected.add("B,RIGHT7,LEFT4")
+    expected.add("B,RIGHT7,LEFT6")
+    StreamITCase.compareWithList(expected)
+  }
+
   /** test rowtime inner join with other conditions **/
   @Test
   def testRowTimeInnerJoinWithOtherConditions(): Unit = {


### PR DESCRIPTION
## What is the purpose of the change

This PR enables the stream window joins without equi-join predicates.

## Brief change log

  - Push down all predicate checks, except for the priority-related one below, from `FlinkLogicalRule` to DataSet/DataStream rules, so that we can organize them in a flat mode. 
  - Create a `JoinPlanUtil` tool to provide utilities (e.g., equi-predicate checker) for join plan translation.
  - Give priority to join plans with equi-join predicates by forbidding equi-conditions on `RexCall` operands in `FlinkLogicalRule`.
  - Enable stream joins without euqi-predicates for Table API by checking the table environment in `Join.testJoinCondition` (`operators.scala`).
  - Add related tests.
  - Update the documents.

## Verifying this change

This change can be verified by the added tests in `JoinTest` and `JoinITCase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**no**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive): (**yes**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (**yes**)
  - If yes, how is the feature documented? (**docs**)