### PR TITLE
[Flink-7945][Metrics&connector]Fix per partition-lag metric lost in kafka connector 

### DIFF
--- a/flink-connectors/flink-connector-kafka-0.10/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumer010.java
+++ b/flink-connectors/flink-connector-kafka-0.10/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumer010.java
@@ -136,6 +136,7 @@ public class FlinkKafkaConsumer010<T> extends FlinkKafkaConsumer09<T> {
 			OffsetCommitMode offsetCommitMode) throws Exception {
 
 		boolean useMetrics = !PropertiesUtil.getBoolean(properties, KEY_DISABLE_METRICS, false);
+		int tryRegisterKafkaMetricCounts = PropertiesUtil.getInt(properties, KEY_REGISTER_TIMES, 100);
 
 		// make sure that auto commit is disabled when our offset commit mode is ON_CHECKPOINTS;
 		// this overwrites whatever setting the user configured in the properties
@@ -156,7 +157,8 @@ public class FlinkKafkaConsumer010<T> extends FlinkKafkaConsumer09<T> {
 				deserializer,
 				properties,
 				pollTimeout,
-				useMetrics);
+				useMetrics,
+				tryRegisterKafkaMetricCounts);
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-kafka-0.10/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/Kafka010Fetcher.java
+++ b/flink-connectors/flink-connector-kafka-0.10/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/Kafka010Fetcher.java
@@ -57,7 +57,8 @@ public class Kafka010Fetcher<T> extends Kafka09Fetcher<T> {
 			KeyedDeserializationSchema<T> deserializer,
 			Properties kafkaProperties,
 			long pollTimeout,
-			boolean useMetrics) throws Exception {
+			boolean useMetrics,
+			int tryRegisterKafkaMetricCounts) throws Exception {
 		super(
 				sourceContext,
 				assignedPartitionsWithInitialOffsets,
@@ -71,7 +72,8 @@ public class Kafka010Fetcher<T> extends Kafka09Fetcher<T> {
 				deserializer,
 				kafkaProperties,
 				pollTimeout,
-				useMetrics);
+				useMetrics,
+				tryRegisterKafkaMetricCounts);
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-kafka-0.10/src/test/java/org/apache/flink/streaming/connectors/kafka/internal/Kafka010FetcherTest.java
+++ b/flink-connectors/flink-connector-kafka-0.10/src/test/java/org/apache/flink/streaming/connectors/kafka/internal/Kafka010FetcherTest.java
@@ -130,7 +130,8 @@ public class Kafka010FetcherTest {
 				schema,
 				new Properties(),
 				0L,
-				false);
+				false,
+				100);
 
 		// ----- run the fetcher -----
 
@@ -266,7 +267,8 @@ public class Kafka010FetcherTest {
 				schema,
 				new Properties(),
 				0L,
-				false);
+				false,
+				100);
 
 		// ----- run the fetcher -----
 
@@ -380,7 +382,8 @@ public class Kafka010FetcherTest {
 				schema,
 				new Properties(),
 				0L,
-				false);
+				false,
+				100);
 
 		// ----- run the fetcher -----
 

--- a/flink-connectors/flink-connector-kafka-0.9/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumer09.java
+++ b/flink-connectors/flink-connector-kafka-0.9/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumer09.java
@@ -72,6 +72,9 @@ public class FlinkKafkaConsumer09<T> extends FlinkKafkaConsumerBase<T> {
 	/**  Configuration key to change the polling timeout. **/
 	public static final String KEY_POLL_TIMEOUT = "flink.poll-timeout";
 
+	/** Configuration key to change the register kafka metrics. */
+	public static final String KEY_REGISTER_TIMES = "flink.register-kafka-metric.times";
+
 	/** From Kafka's Javadoc: The time, in milliseconds, spent waiting in poll if data is not
 	 * available. If 0, returns immediately with any records that are available now. */
 	public static final long DEFAULT_POLL_TIMEOUT = 100L;
@@ -175,6 +178,7 @@ public class FlinkKafkaConsumer09<T> extends FlinkKafkaConsumerBase<T> {
 			OffsetCommitMode offsetCommitMode) throws Exception {
 
 		boolean useMetrics = !PropertiesUtil.getBoolean(properties, KEY_DISABLE_METRICS, false);
+		int tryRegisterKafkaMetricCounts = PropertiesUtil.getInt(properties, KEY_REGISTER_TIMES, 100);
 
 		// make sure that auto commit is disabled when our offset commit mode is ON_CHECKPOINTS;
 		// this overwrites whatever setting the user configured in the properties
@@ -195,7 +199,8 @@ public class FlinkKafkaConsumer09<T> extends FlinkKafkaConsumerBase<T> {
 				deserializer,
 				properties,
 				pollTimeout,
-				useMetrics);
+				useMetrics,
+				tryRegisterKafkaMetricCounts);
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-kafka-0.9/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/Kafka09Fetcher.java
+++ b/flink-connectors/flink-connector-kafka-0.9/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/Kafka09Fetcher.java
@@ -82,7 +82,8 @@ public class Kafka09Fetcher<T> extends AbstractFetcher<T, TopicPartition> {
 			KeyedDeserializationSchema<T> deserializer,
 			Properties kafkaProperties,
 			long pollTimeout,
-			boolean useMetrics) throws Exception {
+			boolean useMetrics,
+			int tryRegisterKafkaMetricCounts) throws Exception {
 		super(
 				sourceContext,
 				assignedPartitionsWithInitialOffsets,
@@ -108,7 +109,8 @@ public class Kafka09Fetcher<T> extends AbstractFetcher<T, TopicPartition> {
 				createCallBridge(),
 				getFetcherName() + " for " + taskNameWithSubtasks,
 				pollTimeout,
-				useMetrics);
+				useMetrics,
+				tryRegisterKafkaMetricCounts);
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/internal/Kafka09FetcherTest.java
+++ b/flink-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/internal/Kafka09FetcherTest.java
@@ -130,7 +130,8 @@ public class Kafka09FetcherTest {
 				schema,
 				new Properties(),
 				0L,
-				false);
+				false,
+				100);
 
 		// ----- run the fetcher -----
 
@@ -265,7 +266,8 @@ public class Kafka09FetcherTest {
 				schema,
 				new Properties(),
 				0L,
-				false);
+				false,
+				100);
 
 		// ----- run the fetcher -----
 
@@ -379,7 +381,8 @@ public class Kafka09FetcherTest {
 				schema,
 				new Properties(),
 				0L,
-				false);
+				false,
+				100);
 
 		// ----- run the fetcher -----
 

--- a/flink-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/internal/KafkaConsumerThreadTest.java
+++ b/flink-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/internal/KafkaConsumerThreadTest.java
@@ -720,7 +720,8 @@ public class KafkaConsumerThreadTest {
 					new KafkaConsumerCallBridge(),
 					"test-kafka-consumer-thread",
 					0,
-					false);
+					false,
+					100);
 
 			this.mockConsumer = mockConsumer;
 		}


### PR DESCRIPTION
## What is the purpose of the change

*When used KafkaConnector, we cant get per partition lag metric. But it has been exposed after kafka 0.10.2 [https://issues.apache.org/jira/browse/KAFKA-4381](url). After read the kafka code, i found that the per partition lag is register after `KafkaConsumer#poll` method be invoked, so i change the metric register time in flink , and after this, with kafka-connector10 and kafka-connector11 we can see the correct lag metric. *

## Brief change log

  - *Change the kafka metric register time in Flink kafka-connector*


## Verifying this change

This change is already run through the test case

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (yes)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)


