### PR TITLE
[FLINK-7977][build] bump version of compatibility check for Flink 1.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1419,7 +1419,7 @@ under the License.
 							<dependency>
 								<groupId>org.apache.flink</groupId>
 								<artifactId>${project.artifactId}</artifactId>
-								<version>1.1.4</version>
+								<version>1.2.1</version>
 								<type>${project.packaging}</type>
 							</dependency>
 						</oldVersion>


### PR DESCRIPTION
## What is the purpose of the change

Since Flink maintains backward compatibility check for 2 versions, Flink 1.4 should check compatibility with 1.2

## Brief change log

bump compatible version from 1.1 to 1.2

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

none

## Documentation

none
