### PR TITLE
[FLINK-7967] [config] Deprecate Hadoop specific Flink configuration o…

### DIFF
--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -72,7 +72,7 @@ definition. As another example, if this is set to `hdfs://localhost:9000/`, then
 without explicit scheme definition, such as `/user/USERNAME/in.txt`, is going to be transformed into
 `hdfs://localhost:9000/user/USERNAME/in.txt`. This scheme is used **ONLY** if no other scheme is specified (explicitly) in the user-provided `URI`.
 
-- `fs.hdfs.hadoopconf`: The absolute path to the Hadoop File System's (HDFS) configuration **directory** (OPTIONAL VALUE). Specifying this value allows programs to reference HDFS files using short URIs (`hdfs:///path/to/files`, without including the address and port of the NameNode in the file URI). Without this option, HDFS files can be accessed, but require fully qualified URIs like `hdfs://address:port/path/to/files`. This option also causes file writers to pick up the HDFS's default values for block sizes and replication factors. Flink will look for the "core-site.xml" and "hdfs-site.xml" files in the specified directory.
+- `fs.hdfs.hadoopconf`: (deprecated, recommend using `HADOOP_CONF_DIR`): The absolute path to the Hadoop File System's (HDFS) configuration **directory** (OPTIONAL VALUE). Specifying this value allows programs to reference HDFS files using short URIs (`hdfs:///path/to/files`, without including the address and port of the NameNode in the file URI). Without this option, HDFS files can be accessed, but require fully qualified URIs like `hdfs://address:port/path/to/files`. This option also causes file writers to pick up the HDFS's default values for block sizes and replication factors. Flink will look for the "core-site.xml" and "hdfs-site.xml" files in the specified directory.
 
 - `classloader.resolve-order`: Whether Flink should use a child-first `ClassLoader` when loading
 user-code classes or a parent-first `ClassLoader`. Can be one of `parent-first` or `child-first`. (default: `child-first`)
@@ -247,6 +247,10 @@ Default value is the `akka.ask.timeout`.
 ## Full Reference
 
 ### HDFS
+
+<div class="alert alert-warning">
+  <strong>Note:</strong> This way of configuring the Hadoop configuration directory is deprecated. Recommend using the environment variable *HADOOP_CONF_DIR* instead.
+</div>
 
 These parameters configure the default HDFS used by Flink. Setups that do not specify a HDFS configuration have to specify the full path to HDFS files (`hdfs://address:port/path/to/files`) Files will also be written with default HDFS parameters (block size, replication factor).
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -594,19 +594,28 @@ public final class ConfigConstants {
 
 	/**
 	 * Path to hdfs-defaul.xml file
+	 *
+	 * @deprecated Use environment variable HADOOP_CONF_DIR instead.
 	 */
+	@Deprecated
 	public static final String HDFS_DEFAULT_CONFIG = "fs.hdfs.hdfsdefault";
 	
 	/**
 	 * Path to hdfs-site.xml file
+	 *
+	 * @deprecated Use environment variable HADOOP_CONF_DIR instead.
 	 */
+	@Deprecated
 	public static final String HDFS_SITE_CONFIG = "fs.hdfs.hdfssite";
 	
 	/**
 	 * Path to Hadoop configuration
+	 *
+	 * @deprecated Use environment variable HADOOP_CONF_DIR instead.
 	 */
+	@Deprecated
 	public static final String PATH_HADOOP_CONFIG = "fs.hdfs.hadoopconf";
-	
+
 	// ------------------------ File System Behavior ------------------------
 
 	/**

--- a/flink-dist/src/main/resources/flink-conf.yaml
+++ b/flink-dist/src/main/resources/flink-conf.yaml
@@ -151,6 +151,9 @@ jobmanager.web.port: 8081
 
 # Path to the Hadoop configuration directory.
 #
+# Warning: these keys are deprecated and recommend using environment variable 'HADOOP_CONF_DIR'
+# looking for hadoop configuration.
+#
 # This configuration is used when writing into HDFS. Unless specified otherwise,
 # HDFS file creation will use HDFS default settings with respect to block-size,
 # replication factor, etc.


### PR DESCRIPTION
## What is the purpose of the change

This PR is mainly for deprecated hadoop specific Flink configuration options. We hope people use environment variable HADOOP_CONF_DIR as a replacement.


## Brief change log
  - Add a warning message to hadoop configuration in ```flink-conf.yaml``` file.
  - Add @Deprecated annotation to ```HDFS_DEFAULT_CONFIG```, ```HDFS_SITE_CONFIG```, ```PATH_HADOOP_CONFIG```  three fields which in ```ConfigConstants.java```.


## Verifying this change
This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (JavaDocs)

