### PR TITLE
[FLINK-7979][minor] Use Log.*(Object, Throwable) overload to log exceptions

### DIFF
--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkBase.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkBase.java
@@ -405,7 +405,7 @@ public abstract class ElasticsearchSinkBase<T> extends RichSinkFunction<T> imple
 
 		@Override
 		public void afterBulk(long executionId, BulkRequest request, Throwable failure) {
-			LOG.error("Failed Elasticsearch bulk request: {}", failure.getMessage(), failure.getCause());
+			LOG.error("Failed Elasticsearch bulk request: ", failure);
 
 			try {
 				for (ActionRequest action : request.requests()) {

--- a/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011.java
@@ -959,7 +959,7 @@ public class FlinkKafkaProducer011<IN>
 		if (e != null) {
 			// prevent double throwing
 			asyncException = null;
-			throw new Exception("Failed to send data to Kafka: " + e.getMessage(), e);
+			throw new Exception("Failed to send data to Kafka: ", e);
 		}
 	}
 

--- a/flink-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/PeriodicOffsetCommitter.java
+++ b/flink-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/PeriodicOffsetCommitter.java
@@ -75,7 +75,7 @@ public class PeriodicOffsetCommitter extends Thread {
 		catch (Throwable t) {
 			if (running) {
 				errorHandler.reportError(
-						new Exception("The periodic offset committer encountered an error: " + t.getMessage(), t));
+						new Exception("The periodic offset committer encountered an error: ", t));
 			}
 		}
 	}

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerBase.java
@@ -250,7 +250,7 @@ public abstract class FlinkKafkaProducerBase<IN> extends RichSinkFunction<IN> im
 				@Override
 				public void onCompletion(RecordMetadata metadata, Exception e) {
 					if (e != null) {
-						LOG.error("Error while sending record to Kafka: " + e.getMessage(), e);
+						LOG.error("Error while sending record to Kafka: ", e);
 					}
 					acknowledgeMessage();
 				}
@@ -370,7 +370,7 @@ public abstract class FlinkKafkaProducerBase<IN> extends RichSinkFunction<IN> im
 		if (e != null) {
 			// prevent double throwing
 			asyncException = null;
-			throw new Exception("Failed to send data to Kafka: " + e.getMessage(), e);
+			throw new Exception("Failed to send data to Kafka: ", e);
 		}
 	}
 

--- a/flink-connectors/flink-hadoop-compatibility/src/main/java/org/apache/flink/api/java/hadoop/mapred/HadoopInputFormatBase.java
+++ b/flink-connectors/flink-hadoop-compatibility/src/main/java/org/apache/flink/api/java/hadoop/mapred/HadoopInputFormatBase.java
@@ -130,13 +130,11 @@ public abstract class HadoopInputFormatBase<K, V, T> extends HadoopInputFormatCo
 			return getFileStats(cachedFileStats, paths, new ArrayList<FileStatus>(1));
 		} catch (IOException ioex) {
 			if (LOG.isWarnEnabled()) {
-				LOG.warn("Could not determine statistics due to an io error: "
-						+ ioex.getMessage());
+				LOG.warn("Could not determine statistics due to an io error: ", ioex);
 			}
 		} catch (Throwable t) {
 			if (LOG.isErrorEnabled()) {
-				LOG.error("Unexpected problem while getting the file statistics: "
-						+ t.getMessage(), t);
+				LOG.error("Unexpected problem while getting the file statistics: ", t);
 			}
 		}
 

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCInputFormat.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCInputFormat.java
@@ -148,9 +148,9 @@ public class JDBCInputFormat extends RichInputFormat<Row, InputSplit> implements
 				statement.setFetchSize(fetchSize);
 			}
 		} catch (SQLException se) {
-			throw new IllegalArgumentException("open() failed." + se.getMessage(), se);
+			throw new IllegalArgumentException("open() failed.", se);
 		} catch (ClassNotFoundException cnfe) {
-			throw new IllegalArgumentException("JDBC-Class not found. - " + cnfe.getMessage(), cnfe);
+			throw new IllegalArgumentException("JDBC-Class not found. - ", cnfe);
 		}
 	}
 
@@ -162,7 +162,7 @@ public class JDBCInputFormat extends RichInputFormat<Row, InputSplit> implements
 				statement.close();
 			}
 		} catch (SQLException se) {
-			LOG.info("Inputformat Statement couldn't be closed - " + se.getMessage());
+			LOG.info("Inputformat Statement couldn't be closed - ", se);
 		} finally {
 			statement = null;
 		}
@@ -172,7 +172,7 @@ public class JDBCInputFormat extends RichInputFormat<Row, InputSplit> implements
 				dbConn.close();
 			}
 		} catch (SQLException se) {
-			LOG.info("Inputformat couldn't be closed - " + se.getMessage());
+			LOG.info("Inputformat couldn't be closed - ", se);
 		} finally {
 			dbConn = null;
 		}
@@ -238,7 +238,7 @@ public class JDBCInputFormat extends RichInputFormat<Row, InputSplit> implements
 			resultSet = statement.executeQuery();
 			hasNext = resultSet.next();
 		} catch (SQLException se) {
-			throw new IllegalArgumentException("open() failed." + se.getMessage(), se);
+			throw new IllegalArgumentException("open() failed.", se);
 		}
 	}
 
@@ -255,7 +255,7 @@ public class JDBCInputFormat extends RichInputFormat<Row, InputSplit> implements
 		try {
 			resultSet.close();
 		} catch (SQLException se) {
-			LOG.info("Inputformat ResultSet couldn't be closed - " + se.getMessage());
+			LOG.info("Inputformat ResultSet couldn't be closed - ", se);
 		}
 	}
 
@@ -290,7 +290,7 @@ public class JDBCInputFormat extends RichInputFormat<Row, InputSplit> implements
 			hasNext = resultSet.next();
 			return row;
 		} catch (SQLException se) {
-			throw new IOException("Couldn't read data - " + se.getMessage(), se);
+			throw new IOException("Couldn't read data - ", se);
 		} catch (NullPointerException npe) {
 			throw new IOException("Couldn't access resultSet", npe);
 		}

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCOutputFormat.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCOutputFormat.java
@@ -237,7 +237,7 @@ public class JDBCOutputFormat extends RichOutputFormat<Row> {
 			try {
 				upload.close();
 			} catch (SQLException e) {
-				LOG.info("JDBC statement could not be closed: " + e.getMessage());
+				LOG.info("JDBC statement could not be closed: ", e);
 			} finally {
 				upload = null;
 			}
@@ -247,7 +247,7 @@ public class JDBCOutputFormat extends RichOutputFormat<Row> {
 			try {
 				dbConn.close();
 			} catch (SQLException se) {
-				LOG.info("JDBC connection could not be closed: " + se.getMessage());
+				LOG.info("JDBC connection could not be closed: ", se);
 			} finally {
 				dbConn = null;
 			}

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractionUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractionUtils.java
@@ -158,8 +158,7 @@ public class TypeExtractionUtils {
 			throw new TypeExtractionException("No lambda method found.");
 		}
 		catch (Exception e) {
-			throw new TypeExtractionException("Could not extract lambda method out of function: " +
-				e.getClass().getSimpleName() + " - " + e.getMessage(), e);
+			throw new TypeExtractionException("Could not extract lambda method out of function: ", e);
 		}
 	}
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
@@ -1309,7 +1309,7 @@ public class TypeExtractor {
 			validateInfo(typeHierarchy, t, inType);
 		}
 		catch(InvalidTypesException e) {
-			throw new InvalidTypesException("Input mismatch: " + e.getMessage(), e);
+			throw new InvalidTypesException("Input mismatch: ", e);
 		}
 	}
 

--- a/flink-core/src/main/java/org/apache/flink/types/Record.java
+++ b/flink-core/src/main/java/org/apache/flink/types/Record.java
@@ -632,8 +632,7 @@ public final class Record implements Value, CopyableValue<Record> {
 					}
 				}
 			} catch (Exception ioex) {
-				throw new RuntimeException("Error creating field union of record data" + 
-							ioex.getMessage() == null ? "." : ": " + ioex.getMessage(), ioex);
+				throw new RuntimeException("Error creating field union of record data: ", ioex);
 			}
 		}
 		else {
@@ -700,8 +699,7 @@ public final class Record implements Value, CopyableValue<Record> {
 					}
 				}
 			} catch (Exception ioex) {
-				throw new RuntimeException("Error creating field union of record data" + 
-							ioex.getMessage() == null ? "." : ": " + ioex.getMessage(), ioex);
+				throw new RuntimeException("Error creating field union of record data: ", ioex);
 			}
 		}
 		
@@ -995,7 +993,7 @@ public final class Record implements Value, CopyableValue<Record> {
 				}
 			}
 			catch (Exception e) {
-				throw new RuntimeException("Error in data type serialization: " + e.getMessage(), e); 
+				throw new RuntimeException("Error in data type serialization: ", e);
 			}
 		}
 		
@@ -1074,7 +1072,7 @@ public final class Record implements Value, CopyableValue<Record> {
 			serializer.writeValLenIntBackwards(numFields);
 		}
 		catch (Exception e) {
-			throw new RuntimeException("Error serializing Record header: " + e.getMessage(), e);
+			throw new RuntimeException("Error serializing Record header: ", e);
 		}
 	}
 	

--- a/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
@@ -979,7 +979,7 @@ public abstract class ExecutionEnvironment {
 		try {
 			registerCachedFilesWithPlan(plan);
 		} catch (Exception e) {
-			throw new RuntimeException("Error while registering cached files: " + e.getMessage(), e);
+			throw new RuntimeException("Error while registering cached files: ", e);
 		}
 
 		// clear all the sinks such that the next execution does not redo everything

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/net/ConnectionUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/net/ConnectionUtils.java
@@ -225,7 +225,7 @@ public class ConnectionUtils {
 			try {
 				localhostName = InetAddress.getLocalHost();
 			} catch (UnknownHostException uhe) {
-				LOG.warn("Could not resolve local hostname to an IP address: {}", uhe.getMessage());
+				LOG.warn("Could not resolve local hostname to an IP address: ", uhe);
 				return null;
 			}
 

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -1235,7 +1235,7 @@ class JobManager(
         catch {
           case t: Throwable =>
             throw new JobSubmissionException(jobId,
-              "Cannot set up the user code libraries: " + t.getMessage, t)
+              "Cannot set up the user code libraries: ", t)
         }
 
         val userCodeLoader = libraryCacheManager.getClassLoader(jobGraph.getJobID)

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/RemoteStreamEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/RemoteStreamEnvironment.java
@@ -205,7 +205,7 @@ public class RemoteStreamEnvironment extends StreamExecutionEnvironment {
 			client.setPrintStatusDuringExecution(getConfig().isSysoutLoggingEnabled());
 		}
 		catch (Exception e) {
-			throw new ProgramInvocationException("Cannot establish connection to JobManager: " + e.getMessage(), e);
+			throw new ProgramInvocationException("Cannot establish connection to JobManager: ", e);
 		}
 
 		try {
@@ -215,8 +215,7 @@ public class RemoteStreamEnvironment extends StreamExecutionEnvironment {
 			throw e;
 		}
 		catch (Exception e) {
-			String term = e.getMessage() == null ? "." : (": " + e.getMessage());
-			throw new ProgramInvocationException("The program execution failed" + term, e);
+			throw new ProgramInvocationException("The program execution failed: ", e);
 		}
 		finally {
 			try {


### PR DESCRIPTION
## What is the purpose of the change

When logging an exception, we often convert the exception to string or call `.getMessage()`. Instead we can use the log method overloads which take `Throwable` as a parameter.


## Brief change log

-  *Remove unnecessary `e.getMessage()`, logging exception use LOG.\*(Object, Throwable)*


## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)

