### PR TITLE
[FLINK-7992][docs] extend the PR template asking for any S3 relation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -63,9 +63,9 @@ This change added tests and can be verified as follows:
   - The serializers: (yes / no / don't know)
   - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
   - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / no / don't know)
+  - The S3 file system connector: (yes / no / don't know)
 
 ## Documentation
 
   - Does this pull request introduce a new feature? (yes / no)
   - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
-


### PR DESCRIPTION
## What is the purpose of the change

This adds a question to the PR template whether a PR is S3-related because this needs special tests (run in the committer's Travis CI with proper AWS credentials set up) before merging for the following reason:

S3 file system tests are only run if AWS credentials are specified, i.e. ARTIFACTS_AWS_BUCKET, ARTIFACTS_AWS_ACCESS_KEY, and ARTIFACTS_AWS_SECRET_KEY. Since these must remain secret, they are only set in Apache Flink's Travis CI configuration and not available in the Travis runs on pull requests (PR) to not leak them in any way. This however means that if a contributor changes something S3-related, the PR's test results will not reflect the actual changes and if something breaks there, we will only see it once merged.

## Brief change log

- extend the PR template

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
