### PR TITLE
[FLINK-7993][kafka] Sync curator shading patterns

### DIFF
--- a/flink-connectors/flink-connector-kafka-0.8/pom.xml
+++ b/flink-connectors/flink-connector-kafka-0.8/pom.xml
@@ -213,15 +213,11 @@ under the License.
 							<goal>shade</goal>
 						</goals>
 						<configuration>
-							<artifactSet>
-								<includes combine.children="append">
-									<include>org.apache.flink:flink-shaded-curator</include>
-								</includes>
-							</artifactSet>
 							<relocations combine.children="append">
 								<relocation>
 									<pattern>org.apache.curator</pattern>
-									<shadedPattern>org.apache.flink.shaded.org.apache.curator</shadedPattern>
+									<!-- IMPORTANT: This must be kept in sync with flink-runtime -->
+									<shadedPattern>org.apache.flink.shaded.curator.org.apache.curator</shadedPattern>
 								</relocation>
 							</relocations>
 						</configuration>

--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -454,6 +454,7 @@ under the License.
 								</relocation>
 								<relocation>
 									<pattern>org.apache.curator</pattern>
+									<!-- IMPORTANT: This must be kept in sync with flink-connector-kafka-0.8 -->
 									<shadedPattern>org.apache.flink.shaded.curator.org.apache.curator</shadedPattern>
 									<excludes>
 										<!-- Do not relocate curator-test. This leads to problems for downstream


### PR DESCRIPTION
## What is the purpose of the change

This PR syncs the curator shading patterns in flink-runtime and flink-connector-kafka-0.8.

Further changes:
* added a note that the patterns have to be kept in sync
* removed an ineffective artifact inclusion from the kafka shading configuration
  * since curator was set to provided it was never included anyway

## Verifying this change

Create a simple kafka/zk setup as per https://kafka.apache.org/082/documentation.html#quickstart and run an example job that contains a kafka consumer, with checkpointing enabled.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

