### PR TITLE
[FLINK-7978][kafka] Ensure that transactional ids will never clash

### DIFF
--- a/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011.java
@@ -791,6 +791,7 @@ public class FlinkKafkaProducer011<IN>
 		transactionalIdsGenerator = new TransactionalIdsGenerator(
 			getRuntimeContext().getTaskName(),
 			getRuntimeContext().getIndexOfThisSubtask(),
+			getRuntimeContext().getNumberOfParallelSubtasks(),
 			kafkaProducersPoolSize,
 			SAFE_SCALE_DOWN_FACTOR);
 

--- a/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/TransactionalIdsGenerator.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/TransactionalIdsGenerator.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kafka.internal;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Class responsible for generating transactional ids to use when communicating with Kafka.
+ */
+public class TransactionalIdsGenerator {
+	private final String prefix;
+	private final int subtaskIndex;
+	private final int poolSize;
+	private final int safeScaleDownFactor;
+
+	public TransactionalIdsGenerator(
+			String prefix,
+			int subtaskIndex,
+			int poolSize,
+			int safeScaleDownFactor) {
+		this.prefix = checkNotNull(prefix);
+		this.subtaskIndex = subtaskIndex;
+		this.poolSize = poolSize;
+		this.safeScaleDownFactor = safeScaleDownFactor;
+	}
+
+	/**
+	 * Range of available transactional ids to use is:
+	 * [nextFreeTransactionalId, nextFreeTransactionalId + parallelism * kafkaProducersPoolSize)
+	 * loop below picks in a deterministic way a subrange of those available transactional ids based on index of
+	 * this subtask.
+	 */
+	public Set<String> generateIdsToUse(long nextFreeTransactionalId) {
+		Set<String> transactionalIds = new HashSet<>();
+		for (int i = 0; i < poolSize; i++) {
+			long transactionalId = nextFreeTransactionalId + subtaskIndex * poolSize + i;
+			transactionalIds.add(generateTransactionalId(transactionalId));
+		}
+		return transactionalIds;
+	}
+
+	/**
+	 *  If we have to abort previous transactional id in case of restart after a failure BEFORE first checkpoint
+	 *  completed, we don't know what was the parallelism used in previous attempt. In that case we must guess the ids
+	 *  range to abort based on current configured pool size, current parallelism and safeScaleDownFactor.
+	 */
+	public Set<String> generateIdsToAbort() {
+		long abortTransactionalIdStart = subtaskIndex;
+		long abortTransactionalIdEnd = abortTransactionalIdStart + 1;
+
+		abortTransactionalIdStart *= poolSize * safeScaleDownFactor;
+		abortTransactionalIdEnd *= poolSize * safeScaleDownFactor;
+		return LongStream.range(abortTransactionalIdStart, abortTransactionalIdEnd)
+			.mapToObj(this::generateTransactionalId)
+			.collect(Collectors.toSet());
+	}
+
+	private String generateTransactionalId(long transactionalId) {
+		return String.format(prefix + "-%d", transactionalId);
+	}
+}

--- a/flink-connectors/flink-connector-kafka-0.11/src/test/java/org/apache/flink/streaming/connectors/kafka/internal/TransactionalIdsGeneratorTest.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/test/java/org/apache/flink/streaming/connectors/kafka/internal/TransactionalIdsGeneratorTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kafka.internal;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link TransactionalIdsGenerator}.
+ */
+public class TransactionalIdsGeneratorTest {
+	private static final int POOL_SIZE = 3;
+	private static final int SAFE_SCALE_DOWN_FACTOR = 3;
+	private static final int SUBTASKS_COUNT = 5;
+
+	@Test
+	public void testGenerateIdsToUse() {
+		TransactionalIdsGenerator generator = new TransactionalIdsGenerator("test", 2, SUBTASKS_COUNT, POOL_SIZE, SAFE_SCALE_DOWN_FACTOR);
+
+		assertEquals(
+			new HashSet<>(Arrays.asList("test-42", "test-43", "test-44")),
+			generator.generateIdsToUse(36));
+	}
+
+	/**
+	 * Ids to abort and to use should never clash between subtasks.
+	 */
+	@Test
+	public void testGeneratedIdsDoNotClash() {
+		List<Set<String>> idsToAbort = new ArrayList<>();
+		List<Set<String>> idsToUse = new ArrayList<>();
+
+		for (int subtask = 0; subtask < SUBTASKS_COUNT; subtask++) {
+			TransactionalIdsGenerator generator = new TransactionalIdsGenerator("test", subtask, SUBTASKS_COUNT, POOL_SIZE, SAFE_SCALE_DOWN_FACTOR);
+			idsToUse.add(generator.generateIdsToUse(0));
+			idsToAbort.add(generator.generateIdsToAbort());
+		}
+
+		for (int subtask1 = 0; subtask1 < SUBTASKS_COUNT; subtask1++) {
+			for (int subtask2 = 0; subtask2 < SUBTASKS_COUNT; subtask2++) {
+				if (subtask2 == subtask1) {
+					continue;
+				}
+				assertDisjoint(idsToAbort.get(subtask2), idsToAbort.get(subtask1));
+				assertDisjoint(idsToUse.get(subtask2), idsToUse.get(subtask1));
+				assertDisjoint(idsToAbort.get(subtask2), idsToUse.get(subtask1));
+			}
+		}
+	}
+
+	private <T> void assertDisjoint(Set<T> first, Set<T> second) {
+		HashSet<T> actual = new HashSet<>(first);
+		actual.retainAll(second);
+		assertEquals(Collections.emptySet(), actual);
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

Previously transactional ids to use and to abort could clash between subtasks. This could lead to a race condition between initialization and writting the data, where one subtask is still initializing/aborting some transactional id while different subtask is already trying to write the data using the same transactional id.

## Brief change log

First commit extracts `TransactionalIdsGenerator` logic and is a pure refactor, without any functional change. Second one is the actual fix. I would like to merge those two commits as they are, without squashing, so that a bug fix is actually easier to understand/read in the commit history.

## Verifying this change

This fixes a bug and adds test coverage (`TransactionalIdsGeneratorTest`) for future regressions.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
