### PR TITLE
[FLINK-7986][TableAPI & SQL] Introduce FilterSetOpTransposeRule to Flink

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/FlinkRuleSets.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/FlinkRuleSets.scala
@@ -52,6 +52,8 @@ object FlinkRuleSets {
     FilterJoinRule.JOIN,
     // push filter through an aggregation
     FilterAggregateTransposeRule.INSTANCE,
+    // push filter through set operation
+    FilterSetOpTransposeRule.INSTANCE,
 
     // aggregation and projection rules
     AggregateProjectMergeRule.INSTANCE,

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/batch/table/SetOpTransposeTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/batch/table/SetOpTransposeTest.scala
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api.batch.table
+
+import org.apache.flink.api.scala._
+import org.apache.flink.table.api.scala._
+import org.apache.flink.table.utils.TableTestBase
+import org.apache.flink.table.utils.TableTestUtil.{binaryNode, batchTableNode, term, unaryNode}
+import org.junit.Test
+
+class SetOpTransposeTest extends TableTestBase {
+
+  @Test
+  def testFilterUnionTranspose(): Unit = {
+    val util = batchTestUtil()
+    val left = util.addTable[(Int, Long, String)]("left", 'a, 'b, 'c)
+    val right = util.addTable[(Int, Long, String)]("right", 'a, 'b, 'c)
+
+    val result = left.unionAll(right)
+                 .where('a > 0)
+                 .groupBy('b)
+                 .select('a.sum as 'a, 'b as 'b, 'c.count as 'c)
+
+    val expected = unaryNode(
+      "DataSetCalc",
+      unaryNode(
+        "DataSetAggregate",
+        binaryNode(
+          "DataSetUnion",
+          unaryNode(
+            "DataSetCalc",
+            batchTableNode(0),
+            term("select", "a", "b", "c"),
+            term("where", ">(a, 0)")
+          ),
+          unaryNode(
+            "DataSetCalc",
+            batchTableNode(1),
+            term("select", "a", "b", "c"),
+            term("where", ">(a, 0)")
+          ),
+          term("union", "a", "b", "c")
+        ),
+        term("groupBy", "b"),
+        term("select", "b", "SUM(a) AS TMP_0", "COUNT(c) AS TMP_1")
+      ),
+      term("select", "TMP_0 AS a", "b", "TMP_1 AS c")
+    )
+
+    util.verifyTable(result, expected)
+  }
+
+  @Test
+  def testFilterMinusTranspose(): Unit = {
+    val util = batchTestUtil()
+    val left = util.addTable[(Int, Long, String)]("left", 'a, 'b, 'c)
+    val right = util.addTable[(Int, Long, String)]("right", 'a, 'b, 'c)
+
+    val result = left.minusAll(right)
+                 .where('a > 0)
+                 .groupBy('b)
+                 .select('a.sum as 'a, 'b as 'b, 'c.count as 'c)
+
+    val expected = unaryNode(
+      "DataSetCalc",
+      unaryNode(
+        "DataSetAggregate",
+        binaryNode(
+          "DataSetMinus",
+          unaryNode(
+            "DataSetCalc",
+            batchTableNode(0),
+            term("select", "a", "b", "c"),
+            term("where", ">(a, 0)")
+          ),
+          unaryNode(
+            "DataSetCalc",
+            batchTableNode(1),
+            term("select", "a", "b", "c"),
+            term("where", ">(a, 0)")
+          ),
+          term("minus", "a", "b", "c")
+        ),
+        term("groupBy", "b"),
+        term("select", "b", "SUM(a) AS TMP_0", "COUNT(c) AS TMP_1")
+      ),
+      term("select", "TMP_0 AS a", "b", "TMP_1 AS c")
+    )
+
+    util.verifyTable(result, expected)
+  }
+
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/SetOpTransposeTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/SetOpTransposeTest.scala
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api.stream.table
+
+import org.apache.flink.api.scala._
+import org.apache.flink.table.api.scala._
+import org.apache.flink.table.utils.TableTestBase
+import org.apache.flink.table.utils.TableTestUtil.{binaryNode, streamTableNode, term, unaryNode}
+import org.junit.Test
+
+class SetOpTransposeTest extends TableTestBase {
+
+  @Test
+  def testFilterUnionTranspose(): Unit = {
+    val util = streamTestUtil()
+    val left = util.addTable[(Int, Long, String)]("left", 'a, 'b, 'c)
+    val right = util.addTable[(Int, Long, String)]("right", 'a, 'b, 'c)
+
+    val result = left.unionAll(right)
+      .where('a > 0)
+      .groupBy('b)
+      .select('a.sum as 'a, 'b as 'b, 'c.count as 'c)
+
+    val expected = unaryNode(
+      "DataStreamCalc",
+        unaryNode(
+          "DataStreamGroupAggregate",
+          binaryNode(
+            "DataStreamUnion",
+            unaryNode(
+              "DataStreamCalc",
+              streamTableNode(0),
+              term("select", "a", "b", "c"),
+              term("where", ">(a, 0)")
+            ),
+            unaryNode(
+              "DataStreamCalc",
+              streamTableNode(1),
+              term("select", "a", "b", "c"),
+              term("where", ">(a, 0)")
+            ),
+            term("union all", "a", "b", "c")
+          ),
+          term("groupBy", "b"),
+          term("select", "b", "SUM(a) AS TMP_0", "COUNT(c) AS TMP_1")
+        ),
+      term("select", "TMP_0 AS a", "b", "TMP_1 AS c")
+    )
+
+    util.verifyTable(result, expected)
+  }
+
+}


### PR DESCRIPTION


## What is the purpose of the change

Introduce FilterSetOpTransposeRule to Flink


## Brief change log

add `FilterSetOpTransposeRule.INSTANCE` to `FlinkRuleSets`


## Verifying this change


This change is already covered by existing tests, such as *(org.apache.flink.table.api.stream.table.SetOpTransposeTest)*.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
