### PR TITLE
[FLINK-8000] Sort Rest handler URLS in RestServerEndpoint

### DIFF
--- a/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
@@ -111,9 +111,9 @@ public class RestClusterClientTest extends TestLogger {
 
 		RestServerEndpoint rse = new RestServerEndpoint(rsec) {
 			@Override
-			protected Collection<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> initializeHandlers(CompletableFuture<String> restAddressFuture) {
+			protected List<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> initializeHandlers(CompletableFuture<String> restAddressFuture) {
 
-				Collection<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> handlers = new ArrayList<>();
+				List<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> handlers = new ArrayList<>();
 				handlers.add(Tuple2.of(portHandler.getMessageHeaders(), portHandler));
 				handlers.add(Tuple2.of(submitHandler.getMessageHeaders(), submitHandler));
 				handlers.add(Tuple2.of(terminationHandler.getMessageHeaders(), terminationHandler));
@@ -212,9 +212,9 @@ public class RestClusterClientTest extends TestLogger {
 
 		RestServerEndpoint rse = new RestServerEndpoint(rsec) {
 			@Override
-			protected Collection<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> initializeHandlers(CompletableFuture<String> restAddressFuture) {
+			protected List<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> initializeHandlers(CompletableFuture<String> restAddressFuture) {
 
-				Collection<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> handlers = new ArrayList<>();
+				List<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> handlers = new ArrayList<>();
 				handlers.add(Tuple2.of(triggerHandler.getMessageHeaders(), triggerHandler));
 				return handlers;
 			}
@@ -280,9 +280,9 @@ public class RestClusterClientTest extends TestLogger {
 
 		RestServerEndpoint rse = new RestServerEndpoint(rsec) {
 			@Override
-			protected Collection<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> initializeHandlers(CompletableFuture<String> restAddressFuture) {
+			protected List<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> initializeHandlers(CompletableFuture<String> restAddressFuture) {
 
-				Collection<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> handlers = new ArrayList<>();
+				List<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> handlers = new ArrayList<>();
 				handlers.add(Tuple2.of(listJobsHandler.getMessageHeaders(), listJobsHandler));
 				return handlers;
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherRestEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherRestEndpoint.java
@@ -85,7 +85,7 @@ import org.apache.flink.shaded.netty4.io.netty.channel.ChannelInboundHandler;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -137,7 +137,7 @@ public class DispatcherRestEndpoint extends RestServerEndpoint {
 	}
 
 	@Override
-	protected Collection<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> initializeHandlers(CompletableFuture<String> restAddressFuture) {
+	protected List<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> initializeHandlers(CompletableFuture<String> restAddressFuture) {
 		ArrayList<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> handlers = new ArrayList<>(3);
 
 		final Time timeout = restConfiguration.getTimeout();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestEndpointITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestEndpointITCase.java
@@ -57,6 +57,7 @@ import javax.annotation.Nonnull;
 import java.net.InetSocketAddress;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -205,8 +206,8 @@ public class RestEndpointITCase extends TestLogger {
 		}
 
 		@Override
-		protected Collection<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> initializeHandlers(CompletableFuture<String> restAddressFuture) {
-			return Collections.singleton(Tuple2.of(new TestHeaders(), testHandler));
+		protected List<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> initializeHandlers(CompletableFuture<String> restAddressFuture) {
+			return Collections.singletonList(Tuple2.of(new TestHeaders(), testHandler));
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest;
+
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test cases for the {@link RestServerEndpoint}.
+ */
+public class RestServerEndpointTest extends TestLogger {
+
+	/**
+	 * Tests that the REST handler URLs are properly sorted.
+	 */
+	@Test
+	public void testRestHandlerUrlSorting() {
+		final int numberHandlers = 5;
+
+		final List<String> handlerUrls = new ArrayList<>(numberHandlers);
+
+		handlerUrls.add("/jobs/overview");
+		handlerUrls.add("/jobs/:jobid");
+		handlerUrls.add("/jobs");
+		handlerUrls.add("/:*");
+		handlerUrls.add("/jobs/:jobid/config");
+
+		final List<String> expected = new ArrayList<>(numberHandlers);
+
+		expected.add("/jobs");
+		expected.add("/jobs/overview");
+		expected.add("/jobs/:jobid");
+		expected.add("/jobs/:jobid/config");
+		expected.add("/:*");
+
+		Collections.sort(handlerUrls, new RestServerEndpoint.RestHandlerUrlComparator.CaseInsensitiveOrderComparator());
+
+		assertEquals(expected, handlerUrls);
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

Introduce special `RestHandlerUrlComparator` to sort REST URLs such that
URLs with path parameters are sorted after those without or fewer.

E.g. the following order would be established

```
/jobs
/jobs/overview
/jobs/:jobid
/jobs/:jobid/config
/:*
```

## Brief change log

- Introduce `RestHandlerUrlComparator`
- Sort list of returned rest handlers in `RestServerEndpoint` before registering them

## Verifying this change

- `RestServerEndpointTest#testRestHandlerUrlSorting`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
