### PR TITLE
[hotfix][docs] Add type for numLateRecordsDropped metric in documentation

### DIFF
--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -999,6 +999,7 @@ Thus, in order to infer the metric identifier:
     <tr>
       <td>numLateRecordsDropped</td>
       <td>The number of records this operator/task has dropped due to arriving late.</td>
+      <td>Counter</td>
     </tr>
     <tr>
       <th rowspan="2"><strong>Operator</strong></th>


### PR DESCRIPTION
This "numLateRecordsDropped" metric missing type described in the document:

![image](https://user-images.githubusercontent.com/4133864/32472016-f5b095d8-c325-11e7-936a-c2eff6f6dfe9.png)
