### PR TITLE
[FLINK-8001] [kafka] Prevent PeriodicWatermarkEmitter from violating IDLE status

### DIFF
--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractFetcher.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractFetcher.java
@@ -648,6 +648,7 @@ public abstract class AbstractFetcher<T, KPH> {
 		public void onProcessingTime(long timestamp) throws Exception {
 
 			long minAcrossAll = Long.MAX_VALUE;
+			boolean isEffectiveMinAggregation = false;
 			for (KafkaTopicPartitionState<?> state : allPartitions) {
 
 				// we access the current watermark for the periodic assigners under the state
@@ -659,10 +660,11 @@ public abstract class AbstractFetcher<T, KPH> {
 				}
 
 				minAcrossAll = Math.min(minAcrossAll, curr);
+				isEffectiveMinAggregation = true;
 			}
 
 			// emit next watermark, if there is one
-			if (minAcrossAll > lastWatermarkTimestamp) {
+			if (isEffectiveMinAggregation && minAcrossAll > lastWatermarkTimestamp) {
 				lastWatermarkTimestamp = minAcrossAll;
 				emitter.emitWatermark(new Watermark(minAcrossAll));
 			}


### PR DESCRIPTION
## What is the purpose of the change

Prior to this PR, a bug exists such that if a Kafka consumer subtask initially marks itself as idle because it didn't have any partitions to subscribe to, that idleness status will be violated when the `PeriodicWatermarkEmitter` is fired.

The problem is that the PeriodicWatermarkEmitter incorrectly yields a `Long.MAX_VALUE` watermark even when there are no partitions to subscribe to. This commit fixes this by additionally ensuring that the aggregated watermark in the `PeriodicWatermarkEmitter` is an effective one (i.e., is really aggregated from some partition).

## Brief change log

Only contains one commit, which addresses the above described issue.

## Verifying this change

A new test is added to `AbstractFetcherTest`, that verifies when there is no subscribed partitions and the periodic watermark emitter fires, no watermark is emitted.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? n/a
