### PR TITLE
[FLINK-8006] [Startup Shell Scripts] Enclosing $pid in quotes

### DIFF
--- a/flink-dist/src/main/flink-bin/bin/flink-daemon.sh
+++ b/flink-dist/src/main/flink-bin/bin/flink-daemon.sh
@@ -84,7 +84,7 @@ fi
 
 # Ascending ID depending on number of lines in pid file.
 # This allows us to start multiple daemon of each type.
-id=$([ -f "$pid" ] && echo $(wc -l < $pid) || echo "0")
+id=$([ -f "$pid" ] && echo $(wc -l < "$pid") || echo "0")
 
 FLINK_LOG_PREFIX="${FLINK_LOG_DIR}/flink-${FLINK_IDENT_STRING}-${DAEMON}-${id}-${HOSTNAME}"
 log="${FLINK_LOG_PREFIX}.log"
@@ -144,16 +144,16 @@ case $STARTSTOP in
     (stop)
         if [ -f "$pid" ]; then
             # Remove last in pid file
-            to_stop=$(tail -n 1 $pid)
+            to_stop=$(tail -n 1 "$pid")
 
             if [ -z $to_stop ]; then
                 rm "$pid" # If all stopped, clean up pid file
                 echo "No $DAEMON daemon to stop on host $HOSTNAME."
             else
-                sed \$d "$pid" > $pid.tmp # all but last line
+                sed \$d "$pid" > "$pid.tmp" # all but last line
 
                 # If all stopped, clean up pid file
-                [ $(wc -l < $pid.tmp) -eq 0 ] && rm "$pid" $pid.tmp || mv $pid.tmp $pid
+                [ $(wc -l < "$pid.tmp") -eq 0 ] && rm "$pid" "$pid.tmp" || mv "$pid.tmp" "$pid"
 
                 if kill -0 $to_stop > /dev/null 2>&1; then
                     echo "Stopping $DAEMON daemon (pid: $to_stop) on host $HOSTNAME."
@@ -169,7 +169,7 @@ case $STARTSTOP in
 
     (stop-all)
         if [ -f "$pid" ]; then
-            mv "$pid" ${pid}.tmp
+            mv "$pid" "${pid}.tmp"
 
             while read to_stop; do
                 if kill -0 $to_stop > /dev/null 2>&1; then

--- a/flink-dist/src/main/flink-bin/bin/flink-daemon.sh
+++ b/flink-dist/src/main/flink-bin/bin/flink-daemon.sh
@@ -108,7 +108,7 @@ case $STARTSTOP in
         rotateLogFilesWithPrefix "$FLINK_LOG_DIR" "$FLINK_LOG_PREFIX"
 
         # Print a warning if daemons are already running on host
-        if [ -f $pid ]; then
+        if [ -f "$pid" ]; then
           active=()
           while IFS='' read -r p || [[ -n "$p" ]]; do
             kill -0 $p >/dev/null 2>&1
@@ -134,7 +134,7 @@ case $STARTSTOP in
 
         # Add to pid file if successful start
         if [[ ${mypid} =~ ${IS_NUMBER} ]] && kill -0 $mypid > /dev/null 2>&1 ; then
-            echo $mypid >> $pid
+            echo $mypid >> "$pid"
         else
             echo "Error starting $DAEMON daemon."
             exit 1
@@ -142,18 +142,18 @@ case $STARTSTOP in
     ;;
 
     (stop)
-        if [ -f $pid ]; then
+        if [ -f "$pid" ]; then
             # Remove last in pid file
             to_stop=$(tail -n 1 $pid)
 
             if [ -z $to_stop ]; then
-                rm $pid # If all stopped, clean up pid file
+                rm "$pid" # If all stopped, clean up pid file
                 echo "No $DAEMON daemon to stop on host $HOSTNAME."
             else
-                sed \$d $pid > $pid.tmp # all but last line
+                sed \$d "$pid" > $pid.tmp # all but last line
 
                 # If all stopped, clean up pid file
-                [ $(wc -l < $pid.tmp) -eq 0 ] && rm $pid $pid.tmp || mv $pid.tmp $pid
+                [ $(wc -l < $pid.tmp) -eq 0 ] && rm "$pid" $pid.tmp || mv $pid.tmp $pid
 
                 if kill -0 $to_stop > /dev/null 2>&1; then
                     echo "Stopping $DAEMON daemon (pid: $to_stop) on host $HOSTNAME."
@@ -168,8 +168,8 @@ case $STARTSTOP in
     ;;
 
     (stop-all)
-        if [ -f $pid ]; then
-            mv $pid ${pid}.tmp
+        if [ -f "$pid" ]; then
+            mv "$pid" ${pid}.tmp
 
             while read to_stop; do
                 if kill -0 $to_stop > /dev/null 2>&1; then

--- a/flink-dist/src/main/flink-bin/bin/flink-daemon.sh
+++ b/flink-dist/src/main/flink-bin/bin/flink-daemon.sh
@@ -178,8 +178,8 @@ case $STARTSTOP in
                 else
                     echo "Skipping $DAEMON daemon (pid: $to_stop), because it is not running anymore on $HOSTNAME."
                 fi
-            done < ${pid}.tmp
-            rm ${pid}.tmp
+            done < "${pid}.tmp"
+            rm "${pid}.tmp"
         fi
     ;;
 


### PR DESCRIPTION
## What is the purpose of the change

When executing `./bin/start-local.sh` The following errors appears:

flink-1.3.2/bin/flink-daemon.sh: line 79: $pid: ambiguous redirect

This is because $pid contains spaces, so to fix it I've enclose I replaced all $pid by "$pid"

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

No

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
