### PR TITLE
(release-1.3) [FLINK-8001] [kafka] Mark subtask as IDLE instead of emitting Long.MAX_VALUE watermark

### DIFF
--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBase.java
@@ -483,9 +483,9 @@ public abstract class FlinkKafkaConsumerBase<T> extends RichParallelSourceFuncti
 			fetcher.runFetchLoop();
 		}
 		else {
-			// this source never completes, so emit a Long.MAX_VALUE watermark
-			// to not block watermark forwarding
-			sourceContext.emitWatermark(new Watermark(Long.MAX_VALUE));
+			// this source never emits any records (and therefore also no watermarks),
+			// so we mark this subtask as idle to not block watermark forwarding
+			sourceContext.markAsTemporarilyIdle();
 
 			// wait until this is canceled
 			final Object waitLock = new Object();

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractFetcherTest.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractFetcherTest.java
@@ -318,6 +318,28 @@ public class AbstractFetcherTest {
 		assertTrue(watermarkTs >= 13L && watermarkTs <= 15L);
 	}
 
+	@Test
+	public void testPeriodicWatermarksWithNoSubscribedPartitionsShouldYieldNoWatermarks() throws Exception {
+		Map<KafkaTopicPartition, Long> originalPartitions = new HashMap<>();
+
+		TestSourceContext<Long> sourceContext = new TestSourceContext<>();
+
+		TestProcessingTimeService processingTimeProvider = new TestProcessingTimeService();
+
+		TestFetcher<Long> fetcher = new TestFetcher<>(
+			sourceContext,
+			originalPartitions,
+			new SerializedValue<AssignerWithPeriodicWatermarks<Long>>(new PeriodicTestExtractor()),
+			null, /* punctuated watermarks assigner*/
+			processingTimeProvider,
+			10);
+
+		processingTimeProvider.setCurrentTime(10);
+		// no partitions; when the periodic watermark emitter fires, no watermark should be emitted
+		assertFalse(sourceContext.hasWatermark());
+	}
+
+
 	// ------------------------------------------------------------------------
 	//  Test mocks
 	// ------------------------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change

This is a backport of #4967 to `release-1.3`.
The additional change, compared to #4967, is that instead of emitting the `Long.MAX_VALUE` watermark when a subtask has no Kafka partitions, `sourceContext.markAsTemporarilyIdle()` is used instead.

Technically speaking, this backport for `release-1.3` doesn't fix any bug, since in the case for 1.3 where there is no partition discovery, emitting `Long.MAX_VALUE` and `sourceContext.markAsTemporarilyIdle()` is semantically the same.
However, in custom implementations of `FlinkKafkaConsumerBase` / `AbstractFetcher` where some idleness detection logic is implemented and some subtasks mark themselves as IDLE, emitting `Long.MAX_VALUE` would directly advance any downstream time operators to the max event-time.

## Brief change log

Only contains one commit, which addresses the above described issue.

## Verifying this change

A new test is added to AbstractFetcherTest, that verifies when there is no subscribed partitions and the periodic watermark emitter fires, no watermark is emitted.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? n/a
