### PR TITLE
[FLINK-8010][build] Bump remaining flink-shaded versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,7 @@ under the License.
 		<flink.forkCountTestPackage>${flink.forkCount}</flink.forkCountTestPackage>
 		<flink.reuseForks>true</flink.reuseForks>
 		<log4j.configuration>log4j-test.properties</log4j.configuration>
+		<flink.shaded.version>2.0</flink.shaded.version>
 		<guava.version>18.0</guava.version>
 		<akka.version>2.4.20</akka.version>
 		<java.version>1.8</java.version>
@@ -230,14 +231,34 @@ under the License.
 
 			<dependency>
 				<groupId>org.apache.flink</groupId>
+				<artifactId>flink-shaded-asm</artifactId>
+				<version>5.0.4-${flink.shaded.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.apache.flink</groupId>
 				<artifactId>flink-shaded-guava</artifactId>
-				<version>18.0-1.0</version>
+				<version>18.0-${flink.shaded.version}</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.apache.flink</groupId>
 				<artifactId>flink-shaded-jackson</artifactId>
-				<version>${jackson.version}-2.0</version>
+				<version>${jackson.version}-${flink.shaded.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.apache.flink</groupId>
+				<artifactId>flink-shaded-netty</artifactId>
+				<!-- Don't upgrade for now. Netty versions >= 4.0.28.Final
+				contain an improvement by Netty, which slices a Netty buffer
+				instead of doing a memory copy [1] in the
+				LengthFieldBasedFrameDecoder. In some situations, this
+				interacts badly with our Netty pipeline leading to OutOfMemory
+				errors.
+
+				[1] https://github.com/netty/netty/issues/3704 -->
+				<version>4.0.27.Final-${flink.shaded.version}</version>
 			</dependency>
 
 			<!-- This manages the 'javax.annotation' annotations (JSR305) -->
@@ -269,12 +290,6 @@ under the License.
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-lang3</artifactId>
 				<version>3.3.2</version>
-			</dependency>
-
-			<dependency>
-				<groupId>org.apache.flink</groupId>
-				<artifactId>flink-shaded-asm</artifactId>
-				<version>5.0.4-1.0</version>
 			</dependency>
 
 			<dependency>
@@ -484,20 +499,6 @@ under the License.
 						<artifactId>jline</artifactId>
 					</exclusion>
 				</exclusions>
-			</dependency>
-
-			<dependency>
-				<groupId>org.apache.flink</groupId>
-				<artifactId>flink-shaded-netty</artifactId>
-				<!-- Don't upgrade for now. Netty versions >= 4.0.28.Final
-				contain an improvement by Netty, which slices a Netty buffer
-				instead of doing a memory copy [1] in the
-				LengthFieldBasedFrameDecoder. In some situations, this
-				interacts badly with our Netty pipeline leading to OutOfMemory
-				errors.
-
-				[1] https://github.com/netty/netty/issues/3704 -->
-				<version>4.0.27.Final-1.0</version>
 			</dependency>
 
 			<!-- We have to define the versions for httpcore and httpclient here such that a consistent


### PR DESCRIPTION
## What is the purpose of the change

This PR bumps the remaining flink-shaded dependencies to 2.0.

## Brief change log

* add flink-shaded version property to root-pom (to prevent this issue in the future)
* group flink-shaded dependencies together
* replace dependency version with flink-shaded version property

## Verifying this change

If it compiles we're good.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
