### PR TITLE
[FLINK-8011][dist] Set flink-python to provided

### DIFF
--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -99,12 +99,6 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-python_${scala.binary.version}</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-scala-shell_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
 		</dependency>
@@ -263,6 +257,14 @@ under the License.
 		<!-- end optional Flink metrics reporters -->
 
 		<!-- start optional Flink libraries -->
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-python_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-cep_${scala.binary.version}</artifactId>
@@ -470,7 +472,6 @@ under the License.
 							</filters>
 							<artifactSet>
 								<excludes>
-									<exclude>org.apache.flink:flink-python_${scala.binary.version}</exclude>
 									<exclude>org.slf4j:slf4j-log4j12</exclude>
 									<exclude>log4j:log4j</exclude>
 								</excludes>

--- a/flink-dist/src/main/assemblies/bin.xml
+++ b/flink-dist/src/main/assemblies/bin.xml
@@ -39,7 +39,6 @@ under the License.
 			<useTransitiveFiltering>true</useTransitiveFiltering>
 
 			<includes>
-				<include>org.apache.flink:flink-python_${scala.binary.version}</include>
 				<include>org.slf4j:slf4j-log4j12</include>
 				<include>log4j:log4j</include>
 			</includes>
@@ -181,6 +180,16 @@ under the License.
 			<fileMode>0644</fileMode>
 			<includes>
 				<include>flink-gelly-examples_${scala.binary.version}-${project.version}.jar</include>
+			</includes>
+		</fileSet>
+
+		<!-- copy python jar -->
+		<fileSet>
+			<directory>../flink-libraries/flink-python/target</directory>
+			<outputDirectory>lib</outputDirectory>
+			<fileMode>0644</fileMode>
+			<includes>
+				<include>flink-python_${scala.binary.version}-${project.version}.jar</include>
 			</includes>
 		</fileSet>
 


### PR DESCRIPTION
## What is the purpose of the change

Minor clean-up in the flink-dist pom. flink-python is now set to provided, similar to other libraries, and the shading exclusion was removed.

## Verifying this change

Compile flink-dist and check that flink-python is correctly put in the /lib folder.
