### PR TITLE
[FLINK-7991][examples][kafka] Cleanup kafka10 example jar

### DIFF
--- a/flink-examples/flink-examples-streaming/pom.xml
+++ b/flink-examples/flink-examples-streaming/pom.xml
@@ -514,14 +514,8 @@ under the License.
 									<artifact>*</artifact>
 									<includes>
 										<include>org/apache/flink/streaming/examples/kafka/**</include>
-										<include>org/apache/flink/streaming/**</include>
+										<include>org/apache/flink/streaming/connectors/kafka/**</include>
 										<include>org/apache/kafka/**</include>
-										<include>org/apache/curator/**</include>
-										<include>org/apache/zookeeper/**</include>
-										<include>org/apache/jute/**</include>
-										<include>org/I0Itec/**</include>
-										<include>jline/**</include>
-										<include>com/yammer/**</include>
 										<include>kafka/**</include>
 									</includes>
 								</filter>

--- a/flink-examples/flink-examples-streaming/pom.xml
+++ b/flink-examples/flink-examples-streaming/pom.xml
@@ -509,14 +509,18 @@ under the License.
 							</transformers>
 							<finalName>Kafka010Example</finalName>
 							<!-- <outputFile>Kafka.jar</outputFile> -->
+							<artifactSet>
+								<includes>
+									<include>org.apache.kafka:*</include>
+									<include>org.apache.flink:flink-connector-kafka*</include>
+									<include>org.apache.flink:flink-examples-streaming*</include>
+								</includes>
+							</artifactSet>
 							<filters>
 								<filter>
-									<artifact>*</artifact>
+									<artifact>org.apache.flink:flink-examples-streaming*</artifact>
 									<includes>
 										<include>org/apache/flink/streaming/examples/kafka/**</include>
-										<include>org/apache/flink/streaming/connectors/kafka/**</include>
-										<include>org/apache/kafka/**</include>
-										<include>kafka/**</include>
 									</includes>
 								</filter>
 							</filters>


### PR DESCRIPTION
## What is the purpose of the change

This PR cleans up the kafka example shading configuration, removing plenty of unnecessary classes from the resulting jar along with several ineffective inclusions.

## Brief change log

* remove inclusions for zk, curator, jute, I0Itex, jline and jammer as they are ineffective
* narrow down `org.apache.flink.streaming` inclusion to only include the kafka connector

## Verifying this change

* Build jar before and after and compare contents