### PR TITLE
[FLINK-8017] Fix High availability cluster-id key in documentation

### DIFF
--- a/docs/ops/jobmanager_high_availability.md
+++ b/docs/ops/jobmanager_high_availability.md
@@ -80,7 +80,7 @@ In order to start an HA-cluster add the following configuration keys to `conf/fl
 
 - **ZooKeeper cluster-id** (recommended): The *cluster-id ZooKeeper node*, under which all required coordination data for a cluster is placed.
 
-  <pre>high-availability.zookeeper.path.cluster-id: /default_ns # important: customize per cluster</pre>
+  <pre>high-availability.cluster-id: /default_ns # important: customize per cluster</pre>
 
   **Important**: You should not set this value manually when runnig a YARN
   cluster, a per-job YARN session, or on another cluster manager. In those
@@ -108,7 +108,7 @@ After configuring the masters and the ZooKeeper quorum, you can use the provided
 high-availability: zookeeper
 high-availability.zookeeper.quorum: localhost:2181
 high-availability.zookeeper.path.root: /flink
-high-availability.zookeeper.path.cluster-id: /cluster_one # important: customize per cluster
+high-availability.cluster-id: /cluster_one # important: customize per cluster
 high-availability.zookeeper.storageDir: hdfs:///flink/recovery</pre>
 
 2. **Configure masters** in `conf/masters`:


### PR DESCRIPTION
## What is the purpose of the change

Fixes documentation for a property key that is incorrect


## Brief change log
- Update documentation to match the high-availability.cluster-id property key

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
