### PR TITLE
[FLINK-7996] [table] Add support for (left.time = right.time) predicates to window join

### DIFF
--- a/docs/dev/table/sql.md
+++ b/docs/dev/table/sql.md
@@ -408,6 +408,7 @@ FROM Orders LEFT JOIN Product ON Orders.productId = Product.id
           </ul>
         </p>
 
+        <p>The range predicates <code>ltime >= rtime && ltime <= rtime</code> can be abbreviated with a single equi-predicate <code>ltime = rtime</code>.</p> 
         <p><b>Note:</b> Currently, only <code>INNER</code> time-windowed joins are supported.</p>
 
 {% highlight sql %}

--- a/docs/dev/table/tableApi.md
+++ b/docs/dev/table/tableApi.md
@@ -533,7 +533,8 @@ Table fullOuterResult = left.fullOuterJoin(right, "a = d").select("a, b, e");
             <li>The compared time attributes must be of the same type, i.e., both are processing time or event time.</li>
           </ul>
         </p>
-
+        
+        <p>The range predicates <code>ltime >= rtime && ltime <= rtime</code> can be abbreviated with a single equi-predicate <code>ltime = rtime</code>.</p> 
         <p><b>Note:</b> Currently, only <code>INNER</code> time-windowed joins are supported.</p>
 
 {% highlight java %}
@@ -651,6 +652,7 @@ val fullOuterResult = left.fullOuterJoin(right, 'a === 'd).select('a, 'b, 'e)
           </ul>
         </p>
 
+        <p>The range predicates <code>'ltime >= 'rtime && 'ltime <= 'rtime</code> can be abbreviated with a single equi-predicate <code>'ltime === 'rtime</code>.</p> 
         <p><b>Note:</b> Currently, only <code>INNER</code> time-windowed joins are supported.</p>
 
 {% highlight scala %}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/JoinTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/JoinTest.scala
@@ -185,6 +185,66 @@ class JoinTest extends TableTestBase {
   }
 
   @Test
+  def testJoinWithEuqiProcTime(): Unit = {
+    val sqlQuery =
+      """
+        |SELECT t1.a, t2.b
+        |FROM MyTable t1, MyTable2 t2
+        |WHERE t1.a = t2.a AND
+        |t1.proctime = t2.proctime
+        |""".stripMargin
+
+    val expected =
+      unaryNode("DataStreamCalc",
+        binaryNode("DataStreamWindowJoin",
+          unaryNode("DataStreamCalc",
+            streamTableNode(0),
+            term("select", "a", "proctime")
+          ),
+          unaryNode("DataStreamCalc",
+            streamTableNode(1),
+            term("select", "a", "b", "proctime")
+          ),
+          term("where", "AND(=(a, a0), =(proctime, proctime0))"),
+          term("join", "a", "proctime", "a0", "b", "proctime0"),
+          term("joinType", "InnerJoin")
+        ),
+        term("select", "a", "b0 AS b")
+      )
+    streamUtil.verifySql(sqlQuery, expected)
+  }
+
+  @Test
+  def testJoinWithEuqiRowTime(): Unit = {
+    val sqlQuery =
+      """
+        |SELECT t1.a, t2.b
+        |FROM MyTable t1, MyTable2 t2
+        |WHERE t1.a = t2.a AND
+        |t1.c = t2.c
+        |""".stripMargin
+
+    val expected =
+      unaryNode("DataStreamCalc",
+        binaryNode("DataStreamWindowJoin",
+          unaryNode("DataStreamCalc",
+            streamTableNode(0),
+            term("select", "a", "c")
+          ),
+          unaryNode("DataStreamCalc",
+            streamTableNode(1),
+            term("select", "a", "b", "c")
+          ),
+          term("where", "AND(=(a, a0), =(c, c0))"),
+          term("join", "a", "c", "a0", "b", "c0"),
+          term("joinType", "InnerJoin")
+        ),
+        term("select", "a", "b0 AS b")
+      )
+    streamUtil.verifySql(sqlQuery, expected)
+  }
+
+  @Test
   def testRowTimeInnerJoinAndWindowAggregationOnFirst(): Unit = {
 
     val sqlQuery =


### PR DESCRIPTION
## What is the purpose of the change

This PR adds `left.time = right.time` predicates support for time-windowed join in Table API and SQL.

## Brief change log

  - Change `WindowJoinUtil.extractWindowBoundsFromPredicate()` to accept single euqi-time predicate.
  - Add tests for the new predicate.
  - Update the documents.

## Verifying this change

This change can be verified by the added tests in `JoinTest` and `JoinITCase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (docs)
