### PR TITLE
[FLINK-7704][hotfix][flip6] Fix JobPlanInfoTest package path

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/JobPlanInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/JobPlanInfoTest.java
@@ -16,11 +16,9 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.rest.handler.legacy.messages;
+package org.apache.flink.runtime.rest.messages;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.runtime.rest.messages.JobPlanInfo;
-import org.apache.flink.runtime.rest.messages.RestResponseMarshallingTestBase;
 
 /**
  * Tests that the {@link JobPlanInfo} can be marshalled and unmarshalled.


### PR DESCRIPTION
This PR fix the package path of  `JobPlanInfoTest`, consistent with the
JobPlanInfo  `org.apache.flink.runtime.rest.messages`.
