### PR TITLE
[FLINK-7419][build][avro] Relocate jackson in flink-dist

### DIFF
--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -491,6 +491,12 @@ under the License.
 									<exclude>log4j:log4j</exclude>
 								</excludes>
 							</artifactSet>
+							<relocations>
+								<relocation>
+									<pattern>org.codehaus.jackson</pattern>
+									<shadedPattern>org.apache.flink.formats.avro.shaded.org.codehaus.jackson</shadedPattern>
+								</relocation>
+							</relocations>
 							<transformers>
 								<transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
 									<resource>reference.conf</resource>

--- a/flink-formats/flink-avro/pom.xml
+++ b/flink-formats/flink-avro/pom.xml
@@ -171,24 +171,6 @@ under the License.
 					</execution>
 				</executions>
 			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-shade-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>shade-flink</id>
-						<phase>package</phase>
-						<goals>
-							<goal>shade</goal>
-						</goals>
-						<configuration combine.self="override">
-							<dependencyReducedPomLocation>${project.basedir}/target/dependency-reduced-pom.xml</dependencyReducedPomLocation>
-							<promoteTransitiveDependencies>true</promoteTransitiveDependencies>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
 		</plugins>
 
 		<pluginManagement>

--- a/flink-formats/flink-avro/pom.xml
+++ b/flink-formats/flink-avro/pom.xml
@@ -185,17 +185,6 @@ under the License.
 						<configuration combine.self="override">
 							<dependencyReducedPomLocation>${project.basedir}/target/dependency-reduced-pom.xml</dependencyReducedPomLocation>
 							<promoteTransitiveDependencies>true</promoteTransitiveDependencies>
-							<artifactSet>
-								<includes>
-									<include>org.codehaus.jackson:*</include>
-								</includes>
-							</artifactSet>
-							<relocations>
-								<relocation>
-									<pattern>org.codehaus.jackson</pattern>
-									<shadedPattern>org.apache.flink.avro.shaded.org.codehaus.jackson</shadedPattern>
-								</relocation>
-							</relocations>
 						</configuration>
 					</execution>
 				</executions>

--- a/pom.xml
+++ b/pom.xml
@@ -1317,6 +1317,24 @@ under the License.
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-shade-plugin</artifactId>
 					<version>2.4.1</version>
+					<dependencies>
+						<!-- bump asm to 5.1 to avoid a bug in the shading of akka -->
+						<dependency>
+							<groupId>org.ow2.asm</groupId>
+							<artifactId>asm</artifactId>
+							<version>5.1</version>
+						</dependency>
+						<dependency>
+							<groupId>org.ow2.asm</groupId>
+							<artifactId>asm-commons</artifactId>
+							<version>5.1</version>
+						</dependency>
+						<dependency>
+							<groupId>org.ow2.asm</groupId>
+							<artifactId>asm-tree</artifactId>
+							<version>5.1</version>
+						</dependency>
+					</dependencies>
 				</plugin>
 
 				<!-- Disable certain plugins in Eclipse -->

--- a/tools/travis_mvn_watchdog.sh
+++ b/tools/travis_mvn_watchdog.sh
@@ -301,6 +301,22 @@ check_shaded_artifacts() {
 		return 1
 	fi
 
+	CODEHAUS_JACKSON=`cat allClasses | grep '^org/codehaus/jackson' | wc -l`
+	if [ "$CODEHAUS_JACKSON" != "0" ]; then
+		echo "=============================================================================="
+		echo "Detected '$CODEHAUS_JACKSON' unshaded org.codehaus.jackson classes in fat jar"
+		echo "=============================================================================="
+		return 1
+	fi
+
+	FASTERXML_JACKSON=`cat allClasses | grep '^com/fasterxml/jackson' | wc -l`
+	if [ "$FASTERXML_JACKSON" != "0" ]; then
+		echo "=============================================================================="
+		echo "Detected '$FASTERXML_JACKSON' unshaded com.fasterxml.jackson classes in fat jar"
+		echo "=============================================================================="
+		return 1
+	fi
+
 	SNAPPY=`cat allClasses | grep '^org/xerial/snappy' | wc -l`
 	if [ "$SNAPPY" == "0" ]; then
 		echo "=============================================================================="


### PR DESCRIPTION
## What is the purpose of the change

This PR relocates avros jackson dependency in flink-dist.

## Brief change log

* remove ineffective jackson shading configuration from flink-avro
* relocate org.codehaus.jackson in flink-dist
  * this way, we keep flink-dist clean, and avro+jackson is still added to the fat user-jar
* add dist shading checks to travis watchdog

## Verifying this change

I have not tested this yet with an actual job.
I did check that the relocation is applied and flink-dist is free or codehaus.jackson.

Since the relocation is done in flink-dist this change is not covered by tests, and could only be covered by an end-to-end test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (on)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
