### PR TITLE
[FLINK-7974][FLINK-7975][QS] Wait for shutdown in QS client and servers.

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
@@ -48,6 +48,7 @@ import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointMessagePar
 import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointTriggerHeaders;
 import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointTriggerResponseBody;
 import org.apache.flink.runtime.util.ExecutorThreadFactory;
+import org.apache.flink.util.ExecutorUtils;
 
 import javax.annotation.Nullable;
 
@@ -90,7 +91,7 @@ public class RestClusterClient extends ClusterClient {
 			log.error("An error occurred during the client shutdown.", e);
 		}
 		this.restClient.shutdown(Time.seconds(5));
-		org.apache.flink.runtime.concurrent.Executors.gracefulShutdown(5, TimeUnit.SECONDS, this.executorService);
+		ExecutorUtils.gracefulShutdown(5, TimeUnit.SECONDS, this.executorService);
 	}
 
 	@Override

--- a/flink-core/src/main/java/org/apache/flink/util/ExecutorUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/ExecutorUtils.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Utilities for {@link java.util.concurrent.Executor Executors}.
+ */
+public class ExecutorUtils {
+
+	private static final Logger LOG = LoggerFactory.getLogger(ExecutorUtils.class);
+
+	/**
+	 * Gracefully shutdown the given {@link ExecutorService}. The call waits the given timeout that
+	 * all ExecutorServices terminate. If the ExecutorServices do not terminate in this time,
+	 * they will be shut down hard.
+	 *
+	 * @param timeout to wait for the termination of all ExecutorServices
+	 * @param unit of the timeout
+	 * @param executorServices to shut down
+	 */
+	public static void gracefulShutdown(long timeout, TimeUnit unit, ExecutorService... executorServices) {
+		for (ExecutorService executorService: executorServices) {
+			executorService.shutdown();
+		}
+
+		boolean wasInterrupted = false;
+		final long endTime = unit.toMillis(timeout) + System.currentTimeMillis();
+		long timeLeft = unit.toMillis(timeout);
+		boolean hasTimeLeft = timeLeft > 0L;
+
+		for (ExecutorService executorService: executorServices) {
+			if (wasInterrupted || !hasTimeLeft) {
+				executorService.shutdownNow();
+			} else {
+				try {
+					if (!executorService.awaitTermination(timeLeft, TimeUnit.MILLISECONDS)) {
+						LOG.warn("ExecutorService did not terminate in time. Shutting it down now.");
+						executorService.shutdownNow();
+					}
+				} catch (InterruptedException e) {
+					LOG.warn("Interrupted while shutting down executor services. Shutting all " +
+							"remaining ExecutorServices down now.", e);
+					executorService.shutdownNow();
+
+					wasInterrupted = true;
+
+					Thread.currentThread().interrupt();
+				}
+
+				timeLeft = endTime - System.currentTimeMillis();
+				hasTimeLeft = timeLeft > 0L;
+			}
+		}
+	}
+}

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosApplicationMasterRunner.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosApplicationMasterRunner.java
@@ -52,6 +52,7 @@ import org.apache.flink.runtime.util.SignalHandler;
 import org.apache.flink.runtime.webmonitor.WebMonitor;
 import org.apache.flink.runtime.webmonitor.retriever.impl.AkkaJobManagerRetriever;
 import org.apache.flink.runtime.webmonitor.retriever.impl.AkkaQueryServiceRetriever;
+import org.apache.flink.util.ExecutorUtils;
 
 import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
@@ -439,7 +440,7 @@ public class MesosApplicationMasterRunner {
 			}
 		}
 
-		org.apache.flink.runtime.concurrent.Executors.gracefulShutdown(
+		ExecutorUtils.gracefulShutdown(
 			AkkaUtils.getTimeout(config).toMillis(),
 			TimeUnit.MILLISECONDS,
 			futureExecutor,

--- a/flink-queryable-state/flink-queryable-state-client-java/src/main/java/org/apache/flink/queryablestate/network/AbstractServerHandler.java
+++ b/flink-queryable-state/flink-queryable-state-client-java/src/main/java/org/apache/flink/queryablestate/network/AbstractServerHandler.java
@@ -183,9 +183,16 @@ public abstract class AbstractServerHandler<REQ extends MessageBody, RESP extend
 	public abstract CompletableFuture<RESP> handleRequest(final long requestId, final REQ request);
 
 	/**
-	 * Shuts down any handler specific resources, e.g. thread pools etc.
+	 * Shuts down any handler-specific resources, e.g. thread pools etc and returns
+	 * a {@link CompletableFuture}.
+	 *
+	 * <p>If an exception is thrown during the shutdown process, then that exception
+	 * will be included in the returned future.
+	 *
+	 * @return A {@link CompletableFuture} that will be completed when the shutdown
+	 * process actually finishes.
 	 */
-	public abstract CompletableFuture<Boolean> shutdown();
+	public abstract CompletableFuture<?> shutdown();
 
 	/**
 	 * Task to execute the actual query against the state instance.

--- a/flink-queryable-state/flink-queryable-state-client-java/src/main/java/org/apache/flink/queryablestate/network/AbstractServerHandler.java
+++ b/flink-queryable-state/flink-queryable-state-client-java/src/main/java/org/apache/flink/queryablestate/network/AbstractServerHandler.java
@@ -185,7 +185,7 @@ public abstract class AbstractServerHandler<REQ extends MessageBody, RESP extend
 	/**
 	 * Shuts down any handler specific resources, e.g. thread pools etc.
 	 */
-	public abstract void shutdown();
+	public abstract CompletableFuture<Boolean> shutdown();
 
 	/**
 	 * Task to execute the actual query against the state instance.

--- a/flink-queryable-state/flink-queryable-state-runtime/src/main/java/org/apache/flink/queryablestate/client/proxy/KvStateClientProxyHandler.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/main/java/org/apache/flink/queryablestate/client/proxy/KvStateClientProxyHandler.java
@@ -219,7 +219,7 @@ public class KvStateClientProxyHandler extends AbstractServerHandler<KvStateRequ
 	}
 
 	@Override
-	public void shutdown() {
-		kvStateClient.shutdown();
+	public CompletableFuture<Boolean> shutdown() {
+		return kvStateClient.shutdown();
 	}
 }

--- a/flink-queryable-state/flink-queryable-state-runtime/src/main/java/org/apache/flink/queryablestate/client/proxy/KvStateClientProxyHandler.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/main/java/org/apache/flink/queryablestate/client/proxy/KvStateClientProxyHandler.java
@@ -219,7 +219,7 @@ public class KvStateClientProxyHandler extends AbstractServerHandler<KvStateRequ
 	}
 
 	@Override
-	public CompletableFuture<Boolean> shutdown() {
+	public CompletableFuture<?> shutdown() {
 		return kvStateClient.shutdown();
 	}
 }

--- a/flink-queryable-state/flink-queryable-state-runtime/src/main/java/org/apache/flink/queryablestate/client/proxy/KvStateClientProxyImpl.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/main/java/org/apache/flink/queryablestate/client/proxy/KvStateClientProxyImpl.java
@@ -19,6 +19,7 @@
 package org.apache.flink.queryablestate.client.proxy;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.time.Time;
 import org.apache.flink.queryablestate.exceptions.UnknownJobManagerException;
 import org.apache.flink.queryablestate.messages.KvStateRequest;
 import org.apache.flink.queryablestate.messages.KvStateResponse;
@@ -35,6 +36,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.Iterator;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
 /**
  * The default implementation of the {@link KvStateClientProxy}.
@@ -96,7 +98,13 @@ public class KvStateClientProxyImpl extends AbstractServerBase<KvStateRequest, K
 
 	@Override
 	public void shutdown() {
-		super.shutdown();
+		try {
+			Time timeout = Time.seconds(10L);
+			shutdownServer(timeout).get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+			log.info("{} was shutdown successfully.", getServerName());
+		} catch (Exception e) {
+			log.warn("{} shutdown failed: {}", getServerName(), e);
+		}
 	}
 
 	@Override

--- a/flink-queryable-state/flink-queryable-state-runtime/src/main/java/org/apache/flink/queryablestate/server/KvStateServerHandler.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/main/java/org/apache/flink/queryablestate/server/KvStateServerHandler.java
@@ -101,7 +101,7 @@ public class KvStateServerHandler extends AbstractServerHandler<KvStateInternalR
 	}
 
 	@Override
-	public void shutdown() {
-		// do nothing
+	public CompletableFuture<Boolean> shutdown() {
+		return CompletableFuture.completedFuture(true);
 	}
 }

--- a/flink-queryable-state/flink-queryable-state-runtime/src/main/java/org/apache/flink/queryablestate/server/KvStateServerHandler.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/main/java/org/apache/flink/queryablestate/server/KvStateServerHandler.java
@@ -101,7 +101,7 @@ public class KvStateServerHandler extends AbstractServerHandler<KvStateInternalR
 	}
 
 	@Override
-	public CompletableFuture<Boolean> shutdown() {
-		return CompletableFuture.completedFuture(true);
+	public CompletableFuture<?> shutdown() {
+		return CompletableFuture.completedFuture(null);
 	}
 }

--- a/flink-queryable-state/flink-queryable-state-runtime/src/main/java/org/apache/flink/queryablestate/server/KvStateServerImpl.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/main/java/org/apache/flink/queryablestate/server/KvStateServerImpl.java
@@ -19,6 +19,7 @@
 package org.apache.flink.queryablestate.server;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.time.Time;
 import org.apache.flink.queryablestate.messages.KvStateInternalRequest;
 import org.apache.flink.queryablestate.messages.KvStateResponse;
 import org.apache.flink.queryablestate.network.AbstractServerBase;
@@ -35,6 +36,7 @@ import org.slf4j.LoggerFactory;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.Iterator;
+import java.util.concurrent.TimeUnit;
 
 /**
  * The default implementation of the {@link KvStateServer}.
@@ -106,6 +108,12 @@ public class KvStateServerImpl extends AbstractServerBase<KvStateInternalRequest
 
 	@Override
 	public void shutdown() {
-		super.shutdown();
+		try {
+			Time timeout = Time.seconds(10L);
+			shutdownServer(timeout).get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+			log.info("{} was shutdown successfully.", getServerName());
+		} catch (Exception e) {
+			log.warn("{} shutdown failed: {}", getServerName(), e);
+		}
 	}
 }

--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/AbstractQueryableStateTestBase.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/AbstractQueryableStateTestBase.java
@@ -1410,7 +1410,7 @@ public abstract class AbstractQueryableStateTestBase extends TestLogger {
 		return resultFuture;
 	}
 
-	public static <T> void retryWithDelay(
+	private static <T> void retryWithDelay(
 			final CompletableFuture<T> resultFuture,
 			final Supplier<CompletableFuture<T>> operation,
 			final int retries,

--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/HAAbstractQueryableStateTestBase.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/HAAbstractQueryableStateTestBase.java
@@ -65,7 +65,7 @@ public abstract class HAAbstractQueryableStateTestBase extends AbstractQueryable
 			config.setString(HighAvailabilityOptions.HA_MODE, "zookeeper");
 
 			cluster = new TestingCluster(config, false);
-			cluster.start();
+			cluster.start(true);
 
 			client = new QueryableStateClient("localhost", proxyPortRangeStart);
 

--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/HAAbstractQueryableStateTestBase.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/HAAbstractQueryableStateTestBase.java
@@ -88,11 +88,10 @@ public abstract class HAAbstractQueryableStateTestBase extends AbstractQueryable
 		try {
 			zkServer.stop();
 			zkServer.close();
-		} catch (Exception e) {
+			client.shutdownAndWait();
+		} catch (Throwable e) {
 			e.printStackTrace();
 			fail(e.getMessage());
 		}
-
-		client.shutdown();
 	}
 }

--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/NonHAAbstractQueryableStateTestBase.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/NonHAAbstractQueryableStateTestBase.java
@@ -69,10 +69,10 @@ public abstract class NonHAAbstractQueryableStateTestBase extends AbstractQuerya
 	public static void tearDown() {
 		try {
 			cluster.stop();
-		} catch (Exception e) {
+			client.shutdownAndWait();
+		} catch (Throwable e) {
 			e.printStackTrace();
 			fail(e.getMessage());
 		}
-		client.shutdown();
 	}
 }

--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/AbstractServerTest.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/AbstractServerTest.java
@@ -174,23 +174,21 @@ public class AbstractServerTest {
 				}
 
 				@Override
-				public CompletableFuture<Boolean> shutdown() {
-					return CompletableFuture.completedFuture(true);
+				public CompletableFuture<?> shutdown() {
+					return CompletableFuture.completedFuture(null);
 				}
 			};
 		}
 
 		@Override
 		public void close() throws Exception {
-			shutdownServer(Time.seconds(10L)).join();
-
+			shutdownServer(Time.seconds(10L)).get();
 			if (requestStats instanceof AtomicKvStateRequestStats) {
 				AtomicKvStateRequestStats stats = (AtomicKvStateRequestStats) requestStats;
 				Assert.assertEquals(0L, stats.getNumConnections());
 			}
-
 			Assert.assertTrue(getQueryExecutor().isTerminated());
-			Assert.assertTrue(getQueryExecutor().isTerminated());
+			Assert.assertTrue(isEventGroupShutdown());
 		}
 	}
 

--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/AbstractServerTest.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/AbstractServerTest.java
@@ -18,11 +18,14 @@
 
 package org.apache.flink.queryablestate.network;
 
+import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.queryablestate.network.messages.MessageBody;
 import org.apache.flink.queryablestate.network.messages.MessageDeserializer;
 import org.apache.flink.queryablestate.network.messages.MessageSerializer;
+import org.apache.flink.queryablestate.network.stats.AtomicKvStateRequestStats;
 import org.apache.flink.queryablestate.network.stats.DisabledKvStateRequestStats;
+import org.apache.flink.queryablestate.network.stats.KvStateRequestStats;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.Preconditions;
 
@@ -58,25 +61,19 @@ public class AbstractServerTest {
 
 		// the expected exception along with the adequate message
 		expectedEx.expect(FlinkRuntimeException.class);
-		expectedEx.expectMessage("Unable to start the Test Server 2. All ports in provided range are occupied.");
+		expectedEx.expectMessage("Unable to start Test Server 2. All ports in provided range are occupied.");
 
-		TestServer server1 = null;
-		TestServer server2 = null;
-		try {
+		List<Integer> portList = new ArrayList<>();
+		portList.add(7777);
 
-			server1 = startServer("Test Server 1", 7777);
+		try (
+				TestServer server1 = new TestServer("Test Server 1", new DisabledKvStateRequestStats(), portList.iterator());
+				TestServer server2 = new TestServer("Test Server 2", new DisabledKvStateRequestStats(), portList.iterator())
+		) {
+			server1.start();
 			Assert.assertEquals(7777L, server1.getServerAddress().getPort());
 
-			server2 = startServer("Test Server 2", 7777);
-		} finally {
-
-			if (server1 != null) {
-				server1.shutdown();
-			}
-
-			if (server2 != null) {
-				server2.shutdown();
-			}
+			server2.start();
 		}
 	}
 
@@ -86,69 +83,80 @@ public class AbstractServerTest {
 	 */
 	@Test
 	public void testPortRangeSuccess() throws Throwable {
-		TestServer server1 = null;
-		TestServer server2 = null;
-		Client<TestMessage, TestMessage> client = null;
 
-		try {
-			server1 = startServer("Test Server 1", 7777, 7778, 7779);
+		// this is shared between the two servers.
+		AtomicKvStateRequestStats serverStats = new AtomicKvStateRequestStats();
+		AtomicKvStateRequestStats clientStats = new AtomicKvStateRequestStats();
+
+		List<Integer> portList = new ArrayList<>();
+		portList.add(7777);
+		portList.add(7778);
+		portList.add(7779);
+
+		try (
+				TestServer server1 = new TestServer("Test Server 1", serverStats, portList.iterator());
+				TestServer server2 = new TestServer("Test Server 2", serverStats, portList.iterator());
+				TestClient client = new TestClient(
+						"Test Client",
+						1,
+						new MessageSerializer<>(new TestMessage.TestMessageDeserializer(), new TestMessage.TestMessageDeserializer()),
+						clientStats
+				)
+		) {
+			server1.start();
 			Assert.assertEquals(7777L, server1.getServerAddress().getPort());
 
-			server2 = startServer("Test Server 2", 7777, 7778, 7779);
+			server2.start();
 			Assert.assertEquals(7778L, server2.getServerAddress().getPort());
-
-			client = new Client<>(
-					"Test Client",
-					1,
-					new MessageSerializer<>(new TestMessage.TestMessageDeserializer(), new TestMessage.TestMessageDeserializer()),
-					new DisabledKvStateRequestStats());
 
 			TestMessage response1 = client.sendRequest(server1.getServerAddress(), new TestMessage("ping")).join();
 			Assert.assertEquals(server1.getServerName() + "-ping", response1.getMessage());
 
 			TestMessage response2 = client.sendRequest(server2.getServerAddress(), new TestMessage("pong")).join();
 			Assert.assertEquals(server2.getServerName() + "-pong", response2.getMessage());
-		} finally {
 
-			if (server1 != null) {
-				server1.shutdown();
-			}
+			// the client connects to both servers and the stats object is shared.
+			Assert.assertEquals(2L, serverStats.getNumConnections());
 
-			if (server2 != null) {
-				server2.shutdown();
-			}
-
-			if (client != null) {
-				client.shutdown();
-			}
+			Assert.assertEquals(2L, clientStats.getNumConnections());
+			Assert.assertEquals(0L, clientStats.getNumFailed());
+			Assert.assertEquals(2L, clientStats.getNumSuccessful());
+			Assert.assertEquals(2L, clientStats.getNumRequests());
 		}
+
+		Assert.assertEquals(0L, clientStats.getNumConnections());
+		Assert.assertEquals(0L, clientStats.getNumFailed());
+		Assert.assertEquals(2L, clientStats.getNumSuccessful());
+		Assert.assertEquals(2L, clientStats.getNumRequests());
 	}
 
-	/**
-	 * Initializes a {@link TestServer} with the given port range.
-	 * @param serverName the name of the server.
-	 * @param ports a range of ports.
-	 * @return A test server with the given name.
-	 */
-	private TestServer startServer(String serverName, int... ports) throws Throwable {
-		List<Integer> portList = new ArrayList<>(ports.length);
-		for (int p : ports) {
-			portList.add(p);
+	private static class TestClient extends Client<TestMessage, TestMessage> implements AutoCloseable {
+
+		TestClient(
+				String clientName,
+				int numEventLoopThreads,
+				MessageSerializer<TestMessage, TestMessage> serializer,
+				KvStateRequestStats stats) {
+			super(clientName, numEventLoopThreads, serializer, stats);
 		}
 
-		final TestServer server = new TestServer(serverName, portList.iterator());
-		server.start();
-		return server;
+		@Override
+		public void close() throws Exception {
+			shutdown().join();
+		}
 	}
 
 	/**
 	 * A server that receives a {@link TestMessage test message} and returns another test
 	 * message containing the same string as the request with the name of the server prepended.
 	 */
-	private class TestServer extends AbstractServerBase<TestMessage, TestMessage> {
+	private static class TestServer extends AbstractServerBase<TestMessage, TestMessage> implements AutoCloseable {
 
-		protected TestServer(String name, Iterator<Integer> bindPort) throws UnknownHostException {
+		private final KvStateRequestStats requestStats;
+
+		TestServer(String name, KvStateRequestStats stats, Iterator<Integer> bindPort) throws UnknownHostException {
 			super(name, InetAddress.getLocalHost(), bindPort, 1, 1);
+			this.requestStats = stats;
 		}
 
 		@Override
@@ -156,7 +164,7 @@ public class AbstractServerTest {
 			return new AbstractServerHandler<TestMessage, TestMessage>(
 					this,
 					new MessageSerializer<>(new TestMessage.TestMessageDeserializer(), new TestMessage.TestMessageDeserializer()),
-					new DisabledKvStateRequestStats()) {
+					requestStats) {
 
 				@Override
 				public CompletableFuture<TestMessage> handleRequest(long requestId, TestMessage request) {
@@ -165,10 +173,23 @@ public class AbstractServerTest {
 				}
 
 				@Override
-				public void shutdown() {
-					// do nothing
+				public CompletableFuture<Boolean> shutdown() {
+					return CompletableFuture.completedFuture(true);
 				}
 			};
+		}
+
+		@Override
+		public void close() throws Exception {
+			shutdownServer(Time.seconds(10L)).join();
+
+			if (requestStats instanceof AtomicKvStateRequestStats) {
+				AtomicKvStateRequestStats stats = (AtomicKvStateRequestStats) requestStats;
+				Assert.assertEquals(0L, stats.getNumConnections());
+			}
+
+			Assert.assertTrue(getQueryExecutor().isTerminated());
+			Assert.assertTrue(getQueryExecutor().isTerminated());
 		}
 	}
 

--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/AbstractServerTest.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/AbstractServerTest.java
@@ -143,6 +143,7 @@ public class AbstractServerTest {
 		@Override
 		public void close() throws Exception {
 			shutdown().join();
+			Assert.assertTrue(isEventGroupShutdown());
 		}
 	}
 

--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/ClientTest.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/ClientTest.java
@@ -217,8 +217,9 @@ public class ClientTest {
 			assertEquals(expectedRequests, stats.getNumSuccessful());
 			assertEquals(expectedRequests, stats.getNumFailed());
 		} finally {
+
 			if (client != null) {
-				client.shutdown();
+				client.shutdown().join();
 			}
 
 			if (serverChannel != null) {
@@ -366,7 +367,7 @@ public class ClientTest {
 			}
 
 			if (client != null) {
-				client.shutdown();
+				client.shutdown().join();
 			}
 
 			assertEquals("Channel leak", 0L, stats.getNumConnections());
@@ -467,7 +468,7 @@ public class ClientTest {
 			assertEquals(2L, stats.getNumFailed());
 		} finally {
 			if (client != null) {
-				client.shutdown();
+				client.shutdown().join();
 			}
 
 			if (serverChannel != null) {
@@ -548,7 +549,7 @@ public class ClientTest {
 			assertEquals(1L, stats.getNumFailed());
 		} finally {
 			if (client != null) {
-				client.shutdown();
+				client.shutdown().join();
 			}
 
 			if (serverChannel != null) {
@@ -701,7 +702,7 @@ public class ClientTest {
 			}
 
 			// Shut down
-			client.shutdown();
+			client.shutdown().join();
 
 			for (Future<Void> future : taskFutures) {
 				try {
@@ -739,7 +740,7 @@ public class ClientTest {
 			}
 		} finally {
 			if (client != null) {
-				client.shutdown();
+				client.shutdown().join();
 			}
 
 			for (int i = 0; i < numServers; i++) {

--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/ClientTest.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/ClientTest.java
@@ -54,7 +54,9 @@ import org.apache.flink.shaded.netty4.io.netty.channel.socket.SocketChannel;
 import org.apache.flink.shaded.netty4.io.netty.channel.socket.nio.NioServerSocketChannel;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.LengthFieldBasedFrameDecoder;
 
-import org.junit.AfterClass;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -95,15 +97,20 @@ public class ClientTest {
 
 	private static final Logger LOG = LoggerFactory.getLogger(ClientTest.class);
 
+	private static final FiniteDuration TEST_TIMEOUT = new FiniteDuration(20L, TimeUnit.SECONDS);
+
 	// Thread pool for client bootstrap (shared between tests)
-	private static final NioEventLoopGroup NIO_GROUP = new NioEventLoopGroup();
+	private NioEventLoopGroup nioGroup;
 
-	private static final FiniteDuration TEST_TIMEOUT = new FiniteDuration(10L, TimeUnit.SECONDS);
+	@Before
+	public void setUp() throws Exception {
+		nioGroup = new NioEventLoopGroup();
+	}
 
-	@AfterClass
-	public static void tearDown() throws Exception {
-		if (NIO_GROUP != null) {
-			NIO_GROUP.shutdownGracefully();
+	@After
+	public void tearDown() throws Exception {
+		if (nioGroup != null) {
+			nioGroup.shutdownGracefully();
 		}
 	}
 
@@ -217,9 +224,19 @@ public class ClientTest {
 			assertEquals(expectedRequests, stats.getNumSuccessful());
 			assertEquals(expectedRequests, stats.getNumFailed());
 		} finally {
-
 			if (client != null) {
-				client.shutdown().join();
+				try {
+
+					// todo here we were seeing this problem:
+					// https://github.com/netty/netty/issues/4357 if we do a get().
+					// this is why we now simply wait a bit so that everything is
+					// shut down and then we check
+
+					client.shutdown().get(10L, TimeUnit.SECONDS);
+				} catch (Exception e) {
+					e.printStackTrace();
+				}
+				Assert.assertTrue(client.isEventGroupShutdown());
 			}
 
 			if (serverChannel != null) {
@@ -266,7 +283,12 @@ public class ClientTest {
 			}
 		} finally {
 			if (client != null) {
-				client.shutdown();
+				try {
+					client.shutdown().get(10L, TimeUnit.SECONDS);
+				} catch (Exception e) {
+					e.printStackTrace();
+				}
+				Assert.assertTrue(client.isEventGroupShutdown());
 			}
 
 			assertEquals("Channel leak", 0L, stats.getNumConnections());
@@ -367,7 +389,12 @@ public class ClientTest {
 			}
 
 			if (client != null) {
-				client.shutdown().join();
+				try {
+					client.shutdown().get(10L, TimeUnit.SECONDS);
+				} catch (Exception e) {
+					e.printStackTrace();
+				}
+				Assert.assertTrue(client.isEventGroupShutdown());
 			}
 
 			assertEquals("Channel leak", 0L, stats.getNumConnections());
@@ -468,7 +495,12 @@ public class ClientTest {
 			assertEquals(2L, stats.getNumFailed());
 		} finally {
 			if (client != null) {
-				client.shutdown().join();
+				try {
+					client.shutdown().get(10L, TimeUnit.SECONDS);
+				} catch (Exception e) {
+					e.printStackTrace();
+				}
+				Assert.assertTrue(client.isEventGroupShutdown());
 			}
 
 			if (serverChannel != null) {
@@ -549,7 +581,11 @@ public class ClientTest {
 			assertEquals(1L, stats.getNumFailed());
 		} finally {
 			if (client != null) {
-				client.shutdown().join();
+				try {
+					client.shutdown().get(10L, TimeUnit.SECONDS);
+				} catch (Exception e) {
+					e.printStackTrace();
+				}
 			}
 
 			if (serverChannel != null) {
@@ -662,7 +698,7 @@ public class ClientTest {
 					Collections.shuffle(random);
 
 					// Dispatch queries
-					List<Future<KvStateResponse>> futures = new ArrayList<>(batchSize);
+					List<CompletableFuture<KvStateResponse>> futures = new ArrayList<>(batchSize);
 
 					for (int j = 0; j < batchSize; j++) {
 						int targetServer = random.get(j) % numServers;
@@ -701,8 +737,12 @@ public class ClientTest {
 				LOG.info("Number of requests {}/100_000", numRequests);
 			}
 
-			// Shut down
-			client.shutdown().join();
+			try {
+				client.shutdown().get(10L, TimeUnit.SECONDS);
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+			Assert.assertTrue(client.isEventGroupShutdown());
 
 			for (Future<Void> future : taskFutures) {
 				try {
@@ -740,7 +780,12 @@ public class ClientTest {
 			}
 		} finally {
 			if (client != null) {
-				client.shutdown().join();
+				try {
+					client.shutdown().get(10L, TimeUnit.SECONDS);
+				} catch (Exception e) {
+					e.printStackTrace();
+				}
+				Assert.assertTrue(client.isEventGroupShutdown());
 			}
 
 			for (int i = 0; i < numServers; i++) {
@@ -762,7 +807,7 @@ public class ClientTest {
 				// Bind address and port
 				.localAddress(InetAddress.getLocalHost(), 0)
 				// NIO server channels
-				.group(NIO_GROUP)
+				.group(nioGroup)
 				.channel(NioServerSocketChannel.class)
 				// See initializer for pipeline details
 				.childHandler(new ChannelInitializer<SocketChannel>() {

--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/KvStateServerHandlerTest.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/KvStateServerHandlerTest.java
@@ -391,7 +391,7 @@ public class KvStateServerHandlerTest extends TestLogger {
 
 		localTestServer.start();
 		localTestServer.shutdown();
-		assertTrue(localTestServer.isExecutorShutdown());
+		assertTrue(localTestServer.getQueryExecutor().isTerminated());
 
 		MessageSerializer<KvStateInternalRequest, KvStateResponse> serializer =
 				new MessageSerializer<>(new KvStateInternalRequest.KvStateInternalRequestDeserializer(), new KvStateResponse.KvStateResponseDeserializer());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/Executors.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/Executors.java
@@ -22,14 +22,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
+
 import java.util.concurrent.Executor;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.TimeUnit;
 
 import scala.concurrent.ExecutionContext;
 
 /**
- * Collection of {@link Executor} implementations
+ * Collection of {@link Executor} implementations.
  */
 public class Executors {
 
@@ -92,50 +91,6 @@ public class Executors {
 		@Override
 		public ExecutionContext prepare() {
 			return this;
-		}
-	}
-
-	/**
-	 * Gracefully shutdown the given {@link ExecutorService}. The call waits the given timeout that
-	 * all ExecutorServices terminate. If the ExecutorServices do not terminate in this time,
-	 * they will be shut down hard.
-	 *
-	 * @param timeout to wait for the termination of all ExecutorServices
-	 * @param unit of the timeout
-	 * @param executorServices to shut down
-	 */
-	public static void gracefulShutdown(long timeout, TimeUnit unit, ExecutorService... executorServices) {
-		for (ExecutorService executorService: executorServices) {
-			executorService.shutdown();
-		}
-
-		boolean wasInterrupted = false;
-		final long endTime = unit.toMillis(timeout) + System.currentTimeMillis();
-		long timeLeft = unit.toMillis(timeout);
-		boolean hasTimeLeft = timeLeft > 0L;
-
-		for (ExecutorService executorService: executorServices) {
-			if (wasInterrupted || !hasTimeLeft) {
-				executorService.shutdownNow();
-			} else {
-				try {
-					if (!executorService.awaitTermination(timeLeft, TimeUnit.MILLISECONDS)) {
-						LOG.warn("ExecutorService did not terminate in time. Shutting it down now.");
-						executorService.shutdownNow();
-					}
-				} catch (InterruptedException e) {
-					LOG.warn("Interrupted while shutting down executor services. Shutting all " +
-						"remaining ExecutorServices down now.", e);
-					executorService.shutdownNow();
-
-					wasInterrupted = true;
-
-					Thread.currentThread().interrupt();
-				}
-
-				timeLeft = endTime - System.currentTimeMillis();
-				hasTimeLeft = timeLeft > 0L;
-			}
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -25,7 +25,6 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
-import org.apache.flink.runtime.concurrent.Executors;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServicesUtils;
@@ -47,6 +46,7 @@ import org.apache.flink.runtime.util.JvmShutdownSafeguard;
 import org.apache.flink.runtime.util.LeaderRetrievalUtils;
 import org.apache.flink.runtime.util.SignalHandler;
 import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.ExecutorUtils;
 import org.apache.flink.util.Preconditions;
 
 import akka.actor.ActorSystem;
@@ -88,7 +88,7 @@ public class TaskManagerRunner implements FatalErrorHandler {
 
 	private final MetricRegistryImpl metricRegistry;
 
-	/** Executor used to run future callbacks */
+	/** Executor used to run future callbacks. */
 	private final ExecutorService executor;
 
 	private final TaskExecutor taskManager;
@@ -165,7 +165,7 @@ public class TaskManagerRunner implements FatalErrorHandler {
 				exception = ExceptionUtils.firstOrSuppressed(e, exception);
 			}
 
-			Executors.gracefulShutdown(timeout.toMilliseconds(), TimeUnit.MILLISECONDS, executor);
+			ExecutorUtils.gracefulShutdown(timeout.toMilliseconds(), TimeUnit.MILLISECONDS, executor);
 
 			if (exception != null) {
 				throw exception;

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -45,7 +45,7 @@ import org.apache.flink.runtime.clusterframework.{BootstrapTools, FlinkResourceM
 import org.apache.flink.runtime.clusterframework.messages._
 import org.apache.flink.runtime.clusterframework.standalone.StandaloneResourceManager
 import org.apache.flink.runtime.clusterframework.types.ResourceID
-import org.apache.flink.runtime.concurrent.{FutureUtils, ScheduledExecutorServiceAdapter, Executors => FlinkExecutors}
+import org.apache.flink.runtime.concurrent.{FutureUtils, ScheduledExecutorServiceAdapter}
 import org.apache.flink.runtime.execution.SuppressRestartsException
 import org.apache.flink.runtime.execution.librarycache.FlinkUserCodeClassLoaders.ResolveOrder
 import org.apache.flink.runtime.execution.librarycache.{BlobLibraryCacheManager, LibraryCacheManager}
@@ -84,7 +84,7 @@ import org.apache.flink.runtime.util._
 import org.apache.flink.runtime.webmonitor.retriever.impl.{AkkaJobManagerRetriever, AkkaQueryServiceRetriever}
 import org.apache.flink.runtime.webmonitor.{WebMonitor, WebMonitorUtils}
 import org.apache.flink.runtime.{FlinkActor, LeaderSessionMessageFilter, LogMessages}
-import org.apache.flink.util.{FlinkException, InstantiationUtil, NetUtils, SerializedThrowable}
+import org.apache.flink.util._
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
@@ -2065,7 +2065,7 @@ object JobManager {
         LOG.warn("Could not properly shut down the metric registry.", t)
     }
 
-    FlinkExecutors.gracefulShutdown(
+    ExecutorUtils.gracefulShutdown(
       timeout.toMillis,
       TimeUnit.MILLISECONDS,
       futureExecutor,

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/minicluster/FlinkMiniCluster.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/minicluster/FlinkMiniCluster.scala
@@ -32,7 +32,7 @@ import org.apache.flink.configuration._
 import org.apache.flink.core.fs.Path
 import org.apache.flink.runtime.akka.{AkkaJobManagerGateway, AkkaUtils}
 import org.apache.flink.runtime.client.{JobClient, JobExecutionException}
-import org.apache.flink.runtime.concurrent.{FutureUtils, ScheduledExecutorServiceAdapter, Executors => FlinkExecutors}
+import org.apache.flink.runtime.concurrent.{FutureUtils, ScheduledExecutorServiceAdapter}
 import org.apache.flink.runtime.execution.librarycache.FlinkUserCodeClassLoaders
 import org.apache.flink.runtime.highavailability.{HighAvailabilityServices, HighAvailabilityServicesUtils}
 import org.apache.flink.runtime.instance.{ActorGateway, AkkaActorGateway}
@@ -44,7 +44,7 @@ import org.apache.flink.runtime.metrics.{MetricRegistryConfiguration, MetricRegi
 import org.apache.flink.runtime.util.{ExecutorThreadFactory, Hardware}
 import org.apache.flink.runtime.webmonitor.retriever.impl.{AkkaJobManagerRetriever, AkkaQueryServiceRetriever}
 import org.apache.flink.runtime.webmonitor.{WebMonitor, WebMonitorUtils}
-import org.apache.flink.util.NetUtils
+import org.apache.flink.util.{ExecutorUtils, NetUtils}
 import org.slf4j.LoggerFactory
 
 import scala.concurrent.duration.{Duration, FiniteDuration}
@@ -440,7 +440,7 @@ abstract class FlinkMiniCluster(
 
     isRunning = false
 
-    FlinkExecutors.gracefulShutdown(
+    ExecutorUtils.gracefulShutdown(
       timeout.toMillis,
       TimeUnit.MILLISECONDS,
       futureExecutor,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotProtocolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotProtocolTest.java
@@ -33,6 +33,7 @@ import org.apache.flink.runtime.taskexecutor.SlotReport;
 import org.apache.flink.runtime.taskexecutor.SlotStatus;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.apache.flink.util.ExecutorUtils;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.AfterClass;
@@ -64,7 +65,7 @@ public class SlotProtocolTest extends TestLogger {
 
 	@AfterClass
 	public static void afterClass() {
-		Executors.gracefulShutdown(timeout, TimeUnit.MILLISECONDS, scheduledExecutorService);
+		ExecutorUtils.gracefulShutdown(timeout, TimeUnit.MILLISECONDS, scheduledExecutorService);
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/ExecutionGraphCacheTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/ExecutionGraphCacheTest.java
@@ -23,7 +23,6 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.accumulators.StringifiedAccumulatorResult;
-import org.apache.flink.runtime.concurrent.Executors;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
@@ -33,6 +32,7 @@ import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobmanager.JobManager;
 import org.apache.flink.runtime.jobmaster.JobManagerGateway;
 import org.apache.flink.runtime.messages.FlinkJobNotFoundException;
+import org.apache.flink.util.ExecutorUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
 
@@ -233,7 +233,7 @@ public class ExecutionGraphCacheTest extends TestLogger {
 
 			verify(jobManagerGateway, times(1)).requestJob(eq(jobId), any(Time.class));
 		} finally {
-			Executors.gracefulShutdown(5000L, TimeUnit.MILLISECONDS, executor);
+			ExecutorUtils.gracefulShutdown(5000L, TimeUnit.MILLISECONDS, executor);
 		}
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/query/AbstractQueryableStateOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/query/AbstractQueryableStateOperator.java
@@ -36,6 +36,8 @@ abstract class AbstractQueryableStateOperator<S extends State, IN>
 		extends AbstractStreamOperator<IN>
 		implements OneInputStreamOperator<IN, IN> {
 
+	private static final long serialVersionUID = 7842489558298787382L;
+
 	/** State descriptor for the queryable state instance. */
 	protected final StateDescriptor<? extends S, ?> stateDescriptor;
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnApplicationMasterRunner.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnApplicationMasterRunner.java
@@ -51,6 +51,7 @@ import org.apache.flink.runtime.util.SignalHandler;
 import org.apache.flink.runtime.webmonitor.WebMonitor;
 import org.apache.flink.runtime.webmonitor.retriever.impl.AkkaJobManagerRetriever;
 import org.apache.flink.runtime.webmonitor.retriever.impl.AkkaQueryServiceRetriever;
+import org.apache.flink.util.ExecutorUtils;
 import org.apache.flink.yarn.cli.FlinkYarnSessionCli;
 import org.apache.flink.yarn.configuration.YarnConfigOptions;
 
@@ -472,7 +473,7 @@ public class YarnApplicationMasterRunner {
 			}
 		}
 
-		org.apache.flink.runtime.concurrent.Executors.gracefulShutdown(
+		ExecutorUtils.gracefulShutdown(
 			AkkaUtils.getTimeout(config).toMillis(),
 			TimeUnit.MILLISECONDS,
 			futureExecutor,


### PR DESCRIPTION
## What is the purpose of the change

Previously we were freeing the resources held by the QS client and servers on `shutdown()`, but we were not waiting for this to complete. Now we are waiting for everything to be freed.

## Brief change log

The `Client` and the `AbstractServerBase` contain the biggest changes. The actual implementations (`KvStateClientProxyImpl`, `KvStateServerImpl`, and `QueryableStateClient`) build on that.

## Verifying this change

Some tests were also adjusted but mainly the changes are tested in `AbstractServerTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): NO
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: NO
  - The serializers: NO
  - The runtime per-record code paths (performance sensitive): NO
  - Anything that affects deployment or recovery: NO
  - The S3 file system connector: NO

## Documentation

  - Does this pull request introduce a new feature? NO
  - If yes, how is the feature documented? not applicable

R @aljoscha or @tillrohrmann 
