### PR TITLE
[hotfix] [docs] Fix broken link to FLINK-7811

### DIFF
--- a/docs/start/building.md
+++ b/docs/start/building.md
@@ -109,7 +109,7 @@ Flink has APIs, libraries, and runtime modules written in [Scala](http://scala-l
 
 Flink 1.4 currently builds only with Scala version 2.11.
 
-We are working on supporting Scala 2.12, but certain breaking changes in Scala 2.12 make this a more involved effort. Please check out (this JIRA issue)[https://issues.apache.org/jira/browse/FLINK-7811] for updates.
+We are working on supporting Scala 2.12, but certain breaking changes in Scala 2.12 make this a more involved effort. Please check out [this JIRA issue](https://issues.apache.org/jira/browse/FLINK-7811) for updates.
 
 {% top %}
 


### PR DESCRIPTION
This fixes a broken hyperlink on page https://ci.apache.org/projects/flink/flink-docs-release-1.4/start/building.html#scala-versions

![image](https://user-images.githubusercontent.com/1681921/32661415-3205d53a-c627-11e7-8f15-3ff6c52c7bf0.png)
