### PR TITLE
[hotfix][docs] Change mailing list link in quickstart to flink-user

### DIFF
--- a/docs/quickstart/java_api_quickstart.md
+++ b/docs/quickstart/java_api_quickstart.md
@@ -197,6 +197,11 @@ public static final class LineSplitter implements FlatMapFunction<String, Tuple2
 
 {% gh_link /flink-examples/flink-examples-batch/src/main/java/org/apache/flink/examples/java/wordcount/WordCount.java "Check GitHub" %} for the full example code.
 
-For a complete overview over our API, have a look at the [DataStream API]({{ site.baseurl }}/dev/datastream_api.html) and [DataSet API]({{ site.baseurl }}/dev/batch/index.html) sections. If you have any trouble, ask on our [Mailing List](http://mail-archives.apache.org/mod_mbox/flink-dev/). We are happy to provide help.
+For a complete overview over our API, have a look at the
+[DataStream API]({{ site.baseurl }}/dev/datastream_api.html) and
+[DataSet API]({{ site.baseurl }}/dev/batch/index.html) sections.
+If you have any trouble, ask on our
+[Mailing List](http://mail-archives.apache.org/mod_mbox/flink-user/).
+We are happy to provide help.
 
 {% top %}

--- a/docs/quickstart/scala_api_quickstart.md
+++ b/docs/quickstart/scala_api_quickstart.md
@@ -263,7 +263,7 @@ For a complete overview over our API, have a look at the
 [DataSet API]({{ site.baseurl }}/dev/batch/index.html), and
 [Scala API Extensions]({{ site.baseurl }}/dev/scala_api_extensions.html)
 sections. If you have any trouble, ask on our
-[Mailing List](http://mail-archives.apache.org/mod_mbox/flink-dev/).
+[Mailing List](http://mail-archives.apache.org/mod_mbox/flink-user/).
 We are happy to provide help.
 
 {% top %}


### PR DESCRIPTION
Change mailing list link in quickstart to flink-user. Previously it was pointing to flink-dev.

This change only fixes minor bug in documentation and doesn't touch source code.
