### PR TITLE
[FLINK-8046] [flink-streaming-java] Have filter of timestamp compare with strictly SMALLER (NOT smaller or equal)

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileMonitoringFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileMonitoringFunction.java
@@ -325,7 +325,7 @@ public class ContinuousFileMonitoringFunction<OUT>
 	 */
 	private boolean shouldIgnore(Path filePath, long modificationTime) {
 		assert (Thread.holdsLock(checkpointLock));
-		boolean shouldIgnore = modificationTime <= globalModificationTime;
+		boolean shouldIgnore = modificationTime < globalModificationTime;
 		if (shouldIgnore && LOG.isDebugEnabled()) {
 			LOG.debug("Ignoring " + filePath + ", with mod time= " + modificationTime +
 				" and global mod time= " + globalModificationTime);


### PR DESCRIPTION
## What is the purpose of the change

This change fixes the wrong ignoring of files with same exact timestamp. This change also matches the doc header of the method (`shouldIgnore`): "...if the modification time of the file is smaller than...".

Without this change, some files with same exact timestamp (because they were written at the same exact long time) will be ignored, which is unexpected by the user.

Also you would find the funny log of `Ignoring file:/XXX, with mod time= 1510321363000 and global mod time= 1510321363000`

## Brief change log

* Comparison is done with strictly SMALLER (<)

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? JavaDocs