### PR TITLE
[hotfix][docs][javadocs] Remove double "of"

### DIFF
--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -316,7 +316,7 @@ The following parameters configure Flink's JobManager and TaskManagers.
 
 - `taskmanager.exit-on-fatal-akka-error`: Whether the TaskManager shall be terminated in case of a fatal Akka error (quarantining event). (DEFAULT: **false**)
 
-- `jobmanager.tdd.offload.minsize`: Maximum size of of the `TaskDeploymentDescriptor`'s serialized task and job information to still transmit them via RPC. Larger blobs may be offloaded to the BLOB server. (DEFAULT: **1 KiB**).
+- `jobmanager.tdd.offload.minsize`: Maximum size of the `TaskDeploymentDescriptor`'s serialized task and job information to still transmit them via RPC. Larger blobs may be offloaded to the BLOB server. (DEFAULT: **1 KiB**).
 
 ### Distributed Coordination (via Akka)
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -420,7 +420,7 @@ public final class ConfigConstants {
 	 * The maximum number of failed YARN containers before entirely stopping
 	 * the YARN session / job on YARN.
 	 *
-	 * By default, we take the number of of initially requested containers.
+	 * By default, we take the number of initially requested containers.
 	 * @deprecated in favor of {@code YarnConfigOptions#MAX_FAILED_CONTAINERS}.
 	 */
 	@Deprecated
@@ -523,7 +523,7 @@ public final class ConfigConstants {
 	 * The maximum number of failed Mesos tasks before entirely stopping
 	 * the Mesos session / job on Mesos.
 	 *
-	 * By default, we take the number of of initially requested tasks.
+	 * By default, we take the number of initially requested tasks.
 	 * @deprecated in favor of {@code MesosOptions#MAX_FAILED_TASKS}.
 	 */
 	@Deprecated

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/schema/RowSchema.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/schema/RowSchema.scala
@@ -48,7 +48,7 @@ class RowSchema(private val logicalRowType: RelDataType) {
   def relDataType: RelDataType = logicalRowType
 
   /**
-    * Returns the [[TypeInformation]] of of the schema
+    * Returns the [[TypeInformation]] of the schema
     */
   def typeInfo: TypeInformation[Row] = physicalRowTypeInfo
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/BootstrapTools.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/BootstrapTools.java
@@ -288,7 +288,7 @@ public class BootstrapTools {
 	}
 
 	/**
-	* Sets the value of of a new config key to the value of a deprecated config key. Taking into
+	* Sets the value of a new config key to the value of a deprecated config key. Taking into
 	* account the changed prefix.
 	* @param config Config to write
 	* @param deprecatedPrefix Old prefix of key

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/instance/SlotSharingGroupAssignment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/instance/SlotSharingGroupAssignment.java
@@ -53,7 +53,7 @@ import org.slf4j.LoggerFactory;
  * the {@link SimpleSlot}s.</p>
  * 
  * <p>An exception are the co-location-constraints, that define that the i-th subtask of one
- * vertex needs to be scheduled strictly together with the i-th subtasks of of the vertices
+ * vertex needs to be scheduled strictly together with the i-th subtasks of the vertices
  * that share the co-location-constraint. To manage that, a co-location-constraint gets its
  * own shared slot inside the shared slots of a sharing group.</p>
  * 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyClient.java
@@ -208,7 +208,7 @@ class NettyClient {
 			{
 				throw new ChannelException(
 						"The operating system does not offer enough file handles to open the network connection. " +
-								"Please increase the number of of available file handles.", e.getCause());
+								"Please increase the number of available file handles.", e.getCause());
 			}
 			else {
 				throw e;

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
@@ -62,7 +62,7 @@ public class YarnConfigOptions {
 	/**
 	 * The maximum number of failed YARN containers before entirely stopping
 	 * the YARN session / job on YARN.
-	 * By default, we take the number of of initially requested containers.
+	 * By default, we take the number of initially requested containers.
 	 *
 	 * <p>Note: This option returns a String since Integer options must have a static default value.
 	 */


### PR DESCRIPTION
Remove double "of" word in document and java docs.