### PR TITLE
[FLINK-7845] Make NettyMessage public

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyMessage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyMessage.java
@@ -52,8 +52,11 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * A simple and generic interface to serialize messages to Netty's buffer space.
+ *
+ * <p>This class must be public as long as we are using a Netty version prior to 4.0.45. Please check FLINK-7845 for
+ * more information.
  */
-abstract class NettyMessage {
+public abstract class NettyMessage {
 
 	// ------------------------------------------------------------------------
 	// Note: Every NettyMessage subtype needs to have a public 0-argument


### PR DESCRIPTION
This a walkaround strange javaassist bug. The issue should go away
once we upgrade netty dependency.

Please check the [ticket](https://issues.apache.org/jira/browse/FLINK-7845) for more information.

This change was manually tested on this example: https://github.com/okkam-it/flink-memory-leak

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
