### PR TITLE
[FLINK-8056][dist] Use 'web.port' instead of 'jobmanager.web.port'

### DIFF
--- a/flink-dist/src/main/resources/flink-conf.yaml
+++ b/flink-dist/src/main/resources/flink-conf.yaml
@@ -74,7 +74,7 @@ parallelism.default: 1
 # The port under which the web-based runtime monitor listens.
 # A value of -1 deactivates the web server.
 
-jobmanager.web.port: 8081
+web.port: 8081
 
 # Flag to specify whether job submission is enabled from the web-based
 # runtime monitor. Uncomment to disable.


### PR DESCRIPTION
## What is the purpose of the change

This PR modfiies the default `flink-conf.yaml` to no longer use the deprecated `jobmanager.web.port` key but `web.port` instead.

## Verifying this change

Configure a non-default port, start a cluster and verify the webUI is reachable under the configured port.
