### PR TITLE
[FLINK-8013] [table] Support aggregate functions with generic arrays

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractionUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractionUtils.java
@@ -18,7 +18,9 @@
 
 package org.apache.flink.api.java.typeutils;
 
+import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;
+import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
@@ -321,5 +323,19 @@ public class TypeExtractionUtils {
 			}
 		}
 		return false;
+	}
+
+	/**
+	 * Returns the raw class of both parameterized types and generic arrays.
+	 * Returns java.lang.Object for all other types.
+	 */
+	public static Class<?> getRawClass(Type t) {
+		if (isClassType(t)) {
+			return typeToClass(t);
+		} else if (t instanceof GenericArrayType) {
+			Type component = ((GenericArrayType)t).getGenericComponentType();
+			return Array.newInstance(getRawClass(component), 0).getClass();
+		}
+		return Object.class;
 	}
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/aggregations.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/aggregations.scala
@@ -245,8 +245,10 @@ case class AggFunctionCall(
       ValidationFailure(s"Given parameters do not match any signature. \n" +
                           s"Actual: ${signatureToString(signature)} \n" +
                           s"Expected: ${
-                            getMethodSignatures(aggregateFunction, "accumulate").drop(1)
-                              .map(signatureToString).mkString(", ")}")
+                            getMethodSignatures(aggregateFunction, "accumulate")
+                              .map(_.drop(1))
+                              .map(signatureToString)
+                              .mkString(", ")}")
     } else {
       ValidationSuccess
     }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/utils/UserDefinedFunctionUtils.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/utils/UserDefinedFunctionUtils.scala
@@ -607,13 +607,14 @@ object UserDefinedFunctionUtils {
     candidate == expected ||
     expected == classOf[Object] ||
     expected.isPrimitive && Primitives.wrap(expected) == candidate ||
+    // time types
     candidate == classOf[Date] && (expected == classOf[Int] || expected == classOf[JInt])  ||
     candidate == classOf[Time] && (expected == classOf[Int] || expected == classOf[JInt]) ||
     candidate == classOf[Timestamp] && (expected == classOf[Long] || expected == classOf[JLong]) ||
-    (candidate.isArray &&
-      expected.isArray &&
-      candidate.getComponentType.isInstanceOf[Object] &&
-      expected.getComponentType == classOf[Object])
+    // arrays
+    (candidate.isArray && expected.isArray &&
+      (candidate.getComponentType == expected.getComponentType ||
+        expected.getComponentType == classOf[Object]))
 
   @throws[Exception]
   def serialize(function: UserDefinedFunction): String = {

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/batch/table/AggregateITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/batch/table/AggregateITCase.scala
@@ -22,12 +22,13 @@ import java.math.BigDecimal
 
 import org.apache.flink.api.scala._
 import org.apache.flink.api.scala.util.CollectionDataSets
-import org.apache.flink.table.api.TableEnvironment
+import org.apache.flink.table.api.{TableEnvironment, Types}
 import org.apache.flink.table.runtime.utils.JavaUserDefinedAggFunctions.{CountDistinctWithMergeAndReset, WeightedAvgWithMergeAndReset}
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.functions.aggfunctions.CountAggFunction
 import org.apache.flink.table.runtime.utils.TableProgramsCollectionTestBase
 import org.apache.flink.table.runtime.utils.TableProgramsTestBase.TableConfigMode
+import org.apache.flink.table.utils.Top10
 import org.apache.flink.test.util.TestBaseUtils
 import org.apache.flink.types.Row
 import org.junit._
@@ -390,6 +391,28 @@ class AggregationsITCase(
         "1,1,1," +
         "1,0.5,0.5,0.5"
     val results = res.toDataSet[Row].collect()
+    TestBaseUtils.compareResultAsText(results.asJava, expected)
+  }
+
+  @Test
+  def testComplexAggregate(): Unit = {
+
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    val top10Fun = new Top10
+
+    val t = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv, 'a, 'b, 'c)
+      .groupBy('b)
+      .select('b, top10Fun('b.cast(Types.INT), 'a.cast(Types.FLOAT)))
+
+    val expected =
+      "1,[(1,1.0), null, null, null, null, null, null, null, null, null]\n" +
+      "2,[(2,3.0), (2,2.0), null, null, null, null, null, null, null, null]\n" +
+      "3,[(3,6.0), (3,5.0), (3,4.0), null, null, null, null, null, null, null]\n" +
+      "4,[(4,10.0), (4,9.0), (4,8.0), (4,7.0), null, null, null, null, null, null]\n" +
+      "5,[(5,15.0), (5,14.0), (5,13.0), (5,12.0), (5,11.0), null, null, null, null, null]\n" +
+      "6,[(6,21.0), (6,20.0), (6,19.0), (6,18.0), (6,17.0), (6,16.0), null, null, null, null]"
+    val results = t.toDataSet[Row].collect()
     TestBaseUtils.compareResultAsText(results.asJava, expected)
   }
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/utils/UserDefinedAggFunctions.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/utils/UserDefinedAggFunctions.scala
@@ -1,0 +1,107 @@
+package org.apache.flink.table.utils
+
+import org.apache.flink.table.functions.AggregateFunction
+import org.apache.flink.api.java.tuple.{Tuple2 => JTuple2}
+import java.lang.{Integer => JInt}
+import java.lang.{Float => JFloat}
+import java.util
+
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.typeutils.{ObjectArrayTypeInfo, TupleTypeInfo}
+import org.apache.flink.table.api.Types
+
+/**
+  * User-defined aggregation function to compute the TOP 10 most visited pages.
+  * We use and Array[Tuple2[Int, Float]] as accumulator to store the 10 most visited pages.
+  *
+  * The result is emitted as Array as well.
+  */
+class Top10 extends AggregateFunction[Array[JTuple2[JInt, JFloat]], Array[JTuple2[JInt, JFloat]]] {
+
+  @Override
+  def createAccumulator(): Array[JTuple2[JInt, JFloat]] = {
+    new Array[JTuple2[JInt, JFloat]](10)
+  }
+
+  /**
+    * Adds a new pages and count to the Top10 pages if necessary.
+    *
+    * @param acc The current top 10
+    * @param adId The id of the ad
+    * @param revenue The revenue for the ad
+    */
+  def accumulate(acc: Array[JTuple2[JInt, JFloat]], adId: Int, revenue: Float) {
+
+    var i = 9
+    var skipped = 0
+
+    // skip positions without records
+    while (i >= 0 && acc(i) == null) {
+      if (acc(i) == null) {
+        // continue until first entry in the top10 list
+        i -= 1
+      }
+    }
+    // backward linear search for insert position
+    while (i >= 0 && revenue > acc(i).f1) {
+      // check next entry
+      skipped += 1
+      i -= 1
+    }
+
+    // set if necessary
+    if (i < 9) {
+      // move entries with lower count by one position
+      if (i < 8 && skipped > 0) {
+        System.arraycopy(acc, i + 1, acc, i + 2, skipped)
+      }
+
+      // add page to top10 list
+      acc(i + 1) = JTuple2.of(adId, revenue)
+    }
+  }
+
+  override def getValue(acc: Array[JTuple2[JInt, JFloat]]): Array[JTuple2[JInt, JFloat]] = acc
+
+  def resetAccumulator(acc: Array[JTuple2[JInt, JFloat]]): Unit = {
+    util.Arrays.fill(acc.asInstanceOf[Array[Object]], null)
+  }
+
+  def merge(
+      acc: Array[JTuple2[JInt, JFloat]],
+      its: java.lang.Iterable[Array[JTuple2[JInt, JFloat]]]): Unit = {
+
+    val it = its.iterator()
+    while(it.hasNext) {
+      val acc2 = it.next()
+
+      var i = 0
+      var i2 = 0
+      while (i < 10 && i2 < 10 && acc2(i2) != null) {
+        if (acc(i) == null) {
+          // copy to empty place
+          acc(i) = acc2(i2)
+          i += 1
+          i2 += 1
+        } else if (acc(i).f1.asInstanceOf[Float] >= acc2(i2).f1.asInstanceOf[Float]) {
+          // forward to next
+          i += 1
+        } else {
+          // shift and copy
+          System.arraycopy(acc, i, acc, i + 1, 9 - i)
+          acc(i) = acc2(i2)
+          i += 1
+          i2 += 1
+        }
+      }
+    }
+  }
+
+  override def getAccumulatorType: TypeInformation[Array[JTuple2[JInt, JFloat]]] = {
+    ObjectArrayTypeInfo.getInfoFor(new TupleTypeInfo[JTuple2[JInt, JFloat]](Types.INT, Types.FLOAT))
+  }
+
+  override def getResultType: TypeInformation[Array[JTuple2[JInt, JFloat]]] = {
+    ObjectArrayTypeInfo.getInfoFor(new TupleTypeInfo[JTuple2[JInt, JFloat]](Types.INT, Types.FLOAT))
+  }
+}

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/util/CollectionDataSets.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/util/CollectionDataSets.scala
@@ -55,7 +55,6 @@ object CollectionDataSets {
     data.+=((19, 6L, "Comment#13"))
     data.+=((20, 6L, "Comment#14"))
     data.+=((21, 6L, "Comment#15"))
-    Random.shuffle(data)
     env.fromCollection(Random.shuffle(data))
   }
 


### PR DESCRIPTION
## What is the purpose of the change

Adds supports for aggregate functions with generic arrays and fixes other bugs.

## Brief change log

- Changes to the type extraction at several locations.

## Verifying this change

Complex aggregation function added.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
