### PR TITLE
[FLINK-8070][yarn][tests] Print errors found in log files

### DIFF
--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
@@ -69,6 +69,7 @@ import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.io.PrintWriter;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -307,6 +308,7 @@ public abstract class YarnTestBase extends TestLogger {
 		Assert.assertTrue("Expecting directory " + cwd.getAbsolutePath() + " to exist", cwd.exists());
 		Assert.assertTrue("Expecting directory " + cwd.getAbsolutePath() + " to be a directory", cwd.isDirectory());
 
+		List<String> prohibitedExcerpts = new ArrayList<>();
 		File foundFile = findFile(cwd.getAbsolutePath(), new FilenameFilter() {
 			@Override
 			public boolean accept(File dir, String name) {
@@ -331,6 +333,24 @@ public abstract class YarnTestBase extends TestLogger {
 								// logging in FATAL to see the actual message in TRAVIS tests.
 								Marker fatal = MarkerFactory.getMarker("FATAL");
 								LOG.error(fatal, "Prohibited String '{}' in line '{}'", aProhibited, lineFromFile);
+
+								StringBuilder logExcerpt = new StringBuilder();
+
+								logExcerpt.append(System.lineSeparator());
+								logExcerpt.append(lineFromFile);
+								logExcerpt.append(System.lineSeparator());
+								// extract potential stack trace from log
+								while (scanner.hasNextLine()) {
+									String line = scanner.nextLine();
+									if (!line.isEmpty() && (Character.isWhitespace(line.charAt(0))) || line.startsWith("Caused by")) {
+										logExcerpt.append(line);
+										logExcerpt.append(System.lineSeparator());
+									} else {
+										break;
+									}
+								}
+								prohibitedExcerpts.add(logExcerpt.toString());
+
 								return true;
 							}
 						}
@@ -355,7 +375,9 @@ public abstract class YarnTestBase extends TestLogger {
 			while (scanner.hasNextLine()) {
 				LOG.warn("LINE: " + scanner.nextLine());
 			}
-			Assert.fail("Found a file " + foundFile + " with a prohibited string: " + Arrays.toString(prohibited));
+			Assert.fail(
+				"Found a file " + foundFile + " with a prohibited string (one of " + Arrays.toString(prohibited) + "). " +
+				"Excerpts:" + System.lineSeparator() + prohibitedExcerpts);
 		}
 	}
 

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
@@ -342,7 +342,7 @@ public abstract class YarnTestBase extends TestLogger {
 								// extract potential stack trace from log
 								while (scanner.hasNextLine()) {
 									String line = scanner.nextLine();
-									if (!line.isEmpty() && (Character.isWhitespace(line.charAt(0))) || line.startsWith("Caused by")) {
+									if (!line.isEmpty() && (Character.isWhitespace(line.charAt(0)) || line.startsWith("Caused by"))) {
 										logExcerpt.append(line);
 										logExcerpt.append(System.lineSeparator());
 									} else {


### PR DESCRIPTION
## What is the purpose of the change

This PR modifies the `YarnTestBase` to print found exceptions in the test failure message.

The output now looks like this:

```
java.lang.AssertionError(Found a file /home/Zento/flink/flink-yarn-tests/target/flink-yarn-tests-fifo/flink-yarn-tests-fifo-logDir-nm-0_0/application_1510667711263_0001/container_1510667711263_0001_01_000001/jobmanager.log with a prohibited string (one of [Exception, Started SelectChannelConnector@0.0.0.0:8081]). Excerpts:
[
java.lang.Exception: Could not create actor system
        at org.apache.flink.runtime.clusterframework.BootstrapTools.startActorSystem(BootstrapTools.java:171)
        at org.apache.flink.runtime.clusterframework.BootstrapTools.startActorSystem(BootstrapTools.java:115)
        at org.apache.flink.yarn.YarnApplicationMasterRunner.runApplicationMaster(YarnApplicationMasterRunner.java:313)
        at org.apache.flink.yarn.YarnApplicationMasterRunner$1.call(YarnApplicationMasterRunner.java:199)
        at org.apache.flink.yarn.YarnApplicationMasterRunner$1.call(YarnApplicationMasterRunner.java:196)
        at java.security.AccessController.doPrivileged(Native Method)
        at javax.security.auth.Subject.doAs(Subject.java:422)
        at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1556)
        at org.apache.flink.runtime.security.HadoopSecurityContext.runSecured(HadoopSecurityContext.java:41)
        at org.apache.flink.yarn.YarnApplicationMasterRunner.run(YarnApplicationMasterRunner.java:196)
        at org.apache.flink.yarn.YarnApplicationMasterRunner.main(YarnApplicationMasterRunner.java:123)
Caused by: java.lang.VerifyError: Inconsistent stackmap frames at branch target 152
])
        at org.junit.runners.model.MultipleFailureException.assertEmpty(MultipleFailureException.java:67)
        at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:39)
        at org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:55)
        at org.junit.rules.RunRules.evaluate(RunRules.java:20)
        at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
        at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
        at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
        at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
        at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
        at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
        at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
        at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
        at org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:48)
        at org.junit.rules.RunRules.evaluate(RunRules.java:20)
        at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
        at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:283)
        at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:173)
        at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:153)
        at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:128)
        at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:203)
        at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:155)
        at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:103)
```

## Verifying this change

Create some failure condition in the yarn tests and check the test output. (I _luckily_ got one on hand locally due to FLINK-8071)
