### PR TITLE
[FLINK-7973] disable JNI bridge for relocated hadoop classes in s3-fs-*

### DIFF
--- a/flink-filesystems/flink-s3-fs-hadoop/README.md
+++ b/flink-filesystems/flink-s3-fs-hadoop/README.md
@@ -13,12 +13,21 @@ relocated class names of classes loaded via reflection
 If you want to change the Hadoop version this project depends on, the following
 steps are required to keep the shading correct:
 
-1. copy `org/apache/hadoop/conf/Configuration.java` from the respective Hadoop jar file to this project
-  - adapt the `Configuration` class by replacing `core-default.xml` with `core-default-shaded.xml`.
-2. copy `core-default.xml` from the respective Hadoop jar file to this project as
-  - `src/main/resources/core-default-shaded.xml` (replacing every occurence of `org.apache.hadoop` with `org.apache.flink.fs.s3hadoop.shaded.org.apache.hadoop`)
-  - `src/test/resources/core-site.xml` (as is)
-3. verify the shaded jar:
+1. from the respective Hadoop jar (currently 2.8.1 as of the `s3hadoop.hadoop.version` property our `pom.xml`),
+  - copy `org/apache/hadoop/conf/Configuration.java` to `src/main/java/org/apache/hadoop/conf/` and
+    - replace `core-default.xml` with `core-default-shaded.xml`.
+  - copy `org/apache/hadoop/util/NativeCodeLoader.java` to `src/main/java/org/apache/hadoop/util/` and
+    - replace the static initializer with
+    ```
+  static {
+    LOG.info("Skipping native-hadoop library for flink-s3-fs-hadoop's relocated Hadoop... " +
+             "using builtin-java classes where applicable");
+  }
+```
+  - copy `core-default.xml` to `src/main/resources/core-default-shaded.xml` and
+    - change every occurence of `org.apache.hadoop` into `org.apache.flink.fs.s3hadoop.shaded.org.apache.hadoop`
+  - copy `core-site.xml` to `src/test/resources/core-site.xml` (as is)
+2. verify the shaded jar:
   - does not contain any unshaded classes except for `org.apache.flink.fs.s3hadoop.S3FileSystemFactory`
   - all other classes should be under `org.apache.flink.fs.s3hadoop.shaded`
   - there should be a `META-INF/services/org.apache.flink.fs.s3hadoop.S3FileSystemFactory` file pointing to the `org.apache.flink.fs.s3hadoop.S3FileSystemFactory` class

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/java/org/apache/hadoop/util/NativeCodeLoader.java
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/java/org/apache/hadoop/util/NativeCodeLoader.java
@@ -1,0 +1,94 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.util;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.CommonConfigurationKeys;
+
+/**
+ * A helper to load the native hadoop code i.e. libhadoop.so.
+ * This handles the fallback to either the bundled libhadoop-Linux-i386-32.so
+ * or the default java implementations where appropriate.
+ *  
+ */
+@InterfaceAudience.Private
+@InterfaceStability.Unstable
+public class NativeCodeLoader {
+
+  private static final Log LOG =
+    LogFactory.getLog(NativeCodeLoader.class);
+  
+  private static boolean nativeCodeLoaded = false;
+  
+  static {
+    LOG.info("Skipping native-hadoop library for flink-s3-fs-hadoop's relocated Hadoop... " +
+             "using builtin-java classes where applicable");
+  }
+
+  /**
+   * Check if native-hadoop code is loaded for this platform.
+   * 
+   * @return <code>true</code> if native-hadoop is loaded, 
+   *         else <code>false</code>
+   */
+  public static boolean isNativeCodeLoaded() {
+    return nativeCodeLoaded;
+  }
+
+  /**
+   * Returns true only if this build was compiled with support for snappy.
+   */
+  public static native boolean buildSupportsSnappy();
+  
+  /**
+   * Returns true only if this build was compiled with support for openssl.
+   */
+  public static native boolean buildSupportsOpenssl();
+
+  public static native String getLibraryName();
+
+  /**
+   * Return if native hadoop libraries, if present, can be used for this job.
+   * @param conf configuration
+   * 
+   * @return <code>true</code> if native hadoop libraries, if present, can be 
+   *         used for this job; <code>false</code> otherwise.
+   */
+  public boolean getLoadNativeLibraries(Configuration conf) {
+    return conf.getBoolean(CommonConfigurationKeys.IO_NATIVE_LIB_AVAILABLE_KEY, 
+                           CommonConfigurationKeys.IO_NATIVE_LIB_AVAILABLE_DEFAULT);
+  }
+  
+  /**
+   * Set if native hadoop libraries, if present, can be used for this job.
+   * 
+   * @param conf configuration
+   * @param loadNativeLibraries can native hadoop libraries be loaded
+   */
+  public void setLoadNativeLibraries(Configuration conf, 
+                                     boolean loadNativeLibraries) {
+    conf.setBoolean(CommonConfigurationKeys.IO_NATIVE_LIB_AVAILABLE_KEY,
+                    loadNativeLibraries);
+  }
+
+}

--- a/flink-filesystems/flink-s3-fs-presto/src/main/java/org/apache/hadoop/util/NativeCodeLoader.java
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/java/org/apache/hadoop/util/NativeCodeLoader.java
@@ -1,0 +1,94 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.util;
+
+import com.facebook.presto.hadoop.$internal.org.apache.commons.logging.Log;
+import com.facebook.presto.hadoop.$internal.org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.CommonConfigurationKeys;
+
+/**
+ * A helper to load the native hadoop code i.e. libhadoop.so.
+ * This handles the fallback to either the bundled libhadoop-Linux-i386-32.so
+ * or the default java implementations where appropriate.
+ *  
+ */
+@InterfaceAudience.Private
+@InterfaceStability.Unstable
+public class NativeCodeLoader {
+
+  private static final Log LOG =
+    LogFactory.getLog(NativeCodeLoader.class);
+  
+  private static boolean nativeCodeLoaded = false;
+  
+  static {
+    LOG.info("Skipping native-hadoop library for flink-s3-fs-presto's relocated Hadoop... " +
+             "using builtin-java classes where applicable");
+  }
+
+  /**
+   * Check if native-hadoop code is loaded for this platform.
+   * 
+   * @return <code>true</code> if native-hadoop is loaded, 
+   *         else <code>false</code>
+   */
+  public static boolean isNativeCodeLoaded() {
+    return nativeCodeLoaded;
+  }
+
+  /**
+   * Returns true only if this build was compiled with support for snappy.
+   */
+  public static native boolean buildSupportsSnappy();
+  
+  /**
+   * Returns true only if this build was compiled with support for openssl.
+   */
+  public static native boolean buildSupportsOpenssl();
+
+  public static native String getLibraryName();
+
+  /**
+   * Return if native hadoop libraries, if present, can be used for this job.
+   * @param conf configuration
+   * 
+   * @return <code>true</code> if native hadoop libraries, if present, can be 
+   *         used for this job; <code>false</code> otherwise.
+   */
+  public boolean getLoadNativeLibraries(Configuration conf) {
+    return conf.getBoolean(CommonConfigurationKeys.IO_NATIVE_LIB_AVAILABLE_KEY, 
+                           CommonConfigurationKeys.IO_NATIVE_LIB_AVAILABLE_DEFAULT);
+  }
+  
+  /**
+   * Set if native hadoop libraries, if present, can be used for this job.
+   * 
+   * @param conf configuration
+   * @param loadNativeLibraries can native hadoop libraries be loaded
+   */
+  public void setLoadNativeLibraries(Configuration conf, 
+                                     boolean loadNativeLibraries) {
+    conf.setBoolean(CommonConfigurationKeys.IO_NATIVE_LIB_AVAILABLE_KEY,
+                    loadNativeLibraries);
+  }
+
+}

--- a/tools/maven/suppressions.xml
+++ b/tools/maven/suppressions.xml
@@ -35,8 +35,11 @@ under the License.
 		<suppress
 			files="FlinkKinesisProducer.java|FlinkKinesisProducerTest.java"
 			checks="IllegalImport"/>
-		<!-- Configuration class copied from Hadoop -->
+		<!-- Classes copied from Hadoop -->
 		<suppress
 			files="org[\\/]apache[\\/]hadoop[\\/]conf[\\/]Configuration.java"
+			checks=".*"/>
+		<suppress
+			files="org[\\/]apache[\\/]hadoop[\\/]util[\\/]NativeCodeLoader.java"
 			checks=".*"/>
 </suppressions>


### PR DESCRIPTION
## What is the purpose of the change

If some Hadoop's JNI library is in the classpath, it will be loaded by our shaded, relocated hadoop classes in the `flink-s3-fs-*` filesystems as well. Then, however, `NativeCodeLoader#isNativeCodeLoaded` will return `true` and native code libraries will be tried although our relocated namespaces have no JNI mapping leading to errors like `java.lang.UnsatisfiedLinkError: org.apache.flink.fs.s3hadoop.shaded.org.apache.hadoop.security.JniBasedUnixGroupsMapping.anchorNative()V`.

## Brief change log

- disable native code loading (there are more users than the shown `JniBasedUnixGroupsMapping`) via copies of the respective `NativeCodeLoader` class

## Verifying this change

This change added tests and can be verified as follows:

  - Manually verified the change by running a 3 node cluster with 1 JobManagers and 2 TaskManagers on EMR executing the `WordCount` example with an S3 input source:
  ```
cp ./opt/flink-s3-fs-hadoop-1.4-SNAPSHOT.jar ./lib/
./bin/flink run -m yarn-cluster -yn 2 -ys 1 -yjm 768 -ytm 1024 ./examples/batch/WordCount.jar --input s3://<bucket>/<path-to-intput-file>
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **yes** -- actually, the shaded and relocated Hadoop classes may not use (potentially faster) JNI implementations for certain functions; depending on their use, this may be per record but since this only applies to the S3 filesystem access, performance penalties should be hidden by its access times anyway
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **yes**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **docs**
