### PR TITLE
[FLINK-8071][build] Bump shade-plugin asm version to 5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1317,6 +1317,24 @@ under the License.
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-shade-plugin</artifactId>
 					<version>2.4.1</version>
+					<dependencies>
+						<!-- bump asm to 5.1 to avoid a bug in the shading of akka -->
+						<dependency>
+							<groupId>org.ow2.asm</groupId>
+							<artifactId>asm</artifactId>
+							<version>5.1</version>
+						</dependency>
+						<dependency>
+							<groupId>org.ow2.asm</groupId>
+							<artifactId>asm-commons</artifactId>
+							<version>5.1</version>
+						</dependency>
+						<dependency>
+							<groupId>org.ow2.asm</groupId>
+							<artifactId>asm-tree</artifactId>
+							<version>5.1</version>
+						</dependency>
+					</dependencies>
 				</plugin>
 
 				<!-- Disable certain plugins in Eclipse -->


### PR DESCRIPTION
## What is the purpose of the change

This PR bumps the ASM dependency of the `maven-shade-plugin` to 5.1 as a workaround to a bug in ASM. This bug causes some error during the shading of akka, making it unusable.

## Verifying this change

I can't guarantee 100% that this fixes the issue, since the shading issue only manifests sometimes. This means a simple recompilation of flink-runtime _can_ resolve the issue temporarily.

I've compiled flink-runtime, flink-dist and ran the flink-yarn-tests in a loop and switched the version bump on and off. It only failed with the old ASM version,

To verify that the `maven-shade-plugin` uses ASM 5.1, run `mvn -X package` in an arbitrary module and check the dependency tree.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
