### PR TITLE
[FLINK-8095][TableAPI & SQL] Introduce ProjectSetOpTransposeRule to F…

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/FlinkRuleSets.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/FlinkRuleSets.scala
@@ -54,6 +54,8 @@ object FlinkRuleSets {
     FilterAggregateTransposeRule.INSTANCE,
     // push filter through set operation
     FilterSetOpTransposeRule.INSTANCE,
+    // push project through set operation
+    ProjectSetOpTransposeRule.INSTANCE,
 
     // aggregation and projection rules
     AggregateProjectMergeRule.INSTANCE,

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/batch/table/SetOperatorsTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/batch/table/SetOperatorsTest.scala
@@ -215,4 +215,62 @@ class SetOperatorsTest extends TableTestBase {
 
     util.verifyTable(result, expected)
   }
+
+  @Test
+  def testProjectUnionTranspose(): Unit = {
+    val util = batchTestUtil()
+    val left = util.addTable[(Int, Long, String)]("left", 'a, 'b, 'c)
+    val right = util.addTable[(Int, Long, String)]("right", 'a, 'b, 'c)
+
+    val result = left.select('a, 'b, 'c)
+                 .unionAll(right.select('a, 'b, 'c))
+                 .select('b, 'c)
+
+    val expected = binaryNode(
+      "DataSetUnion",
+      unaryNode(
+        "DataSetCalc",
+        batchTableNode(0),
+        term("select", "b", "c")
+      ),
+      unaryNode(
+        "DataSetCalc",
+        batchTableNode(1),
+        term("select", "b", "c")
+      ),
+      term("union", "b", "c")
+    )
+
+    util.verifyTable(result, expected)
+
+  }
+
+  @Test
+  def testProjectMinusTranspose(): Unit = {
+    val util = batchTestUtil()
+    val left = util.addTable[(Int, Long, String)]("left", 'a, 'b, 'c)
+    val right = util.addTable[(Int, Long, String)]("right", 'a, 'b, 'c)
+
+    val result = left.select('a, 'b, 'c)
+                 .minusAll(right.select('a, 'b, 'c))
+                 .select('b, 'c)
+
+    val expected = binaryNode(
+      "DataSetMinus",
+      unaryNode(
+        "DataSetCalc",
+        batchTableNode(0),
+        term("select", "b", "c")
+      ),
+      unaryNode(
+        "DataSetCalc",
+        batchTableNode(1),
+        term("select", "b", "c")
+      ),
+      term("minus", "b", "c")
+    )
+
+    util.verifyTable(result, expected)
+
+  }
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/SetOperatorsTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/SetOperatorsTest.scala
@@ -65,4 +65,33 @@ class SetOperatorsTest extends TableTestBase {
 
     util.verifyTable(result, expected)
   }
+
+  @Test
+  def testProjectUnionTranspose(): Unit = {
+    val util = streamTestUtil()
+    val left = util.addTable[(Int, Long, String)]("left", 'a, 'b, 'c)
+    val right = util.addTable[(Int, Long, String)]("right", 'a, 'b, 'c)
+
+    val result = left.select('a, 'b, 'c)
+      .unionAll(right.select('a, 'b, 'c))
+      .select('b, 'c)
+
+    val expected = binaryNode(
+      "DataStreamUnion",
+      unaryNode(
+        "DataStreamCalc",
+        streamTableNode(0),
+        term("select", "b", "c")
+      ),
+      unaryNode(
+        "DataStreamCalc",
+        streamTableNode(1),
+        term("select", "b", "c")
+      ),
+      term("union all", "b", "c")
+    )
+
+    util.verifyTable(result, expected)
+  }
+
 }


### PR DESCRIPTION

## What is the purpose of the change

Introduce ProjectSetOpTransposeRule to Flink


## Brief change log

add `ProjectSetOpTransposeRule.INSTANCE` to `FlinkRuleSets`


## Verifying this change


This change is already covered by existing tests, such as *(org.apache.flink.table.api.stream.table.SetOpTransposeTest)*.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
