### PR TITLE
[FLINK-8086][kafka] Ignore ProducerFencedException

### DIFF
--- a/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011.java
@@ -1022,7 +1022,12 @@ public class FlinkKafkaProducer011<IN>
 
 		@Override
 		public String toString() {
-			return String.format("%s [transactionalId=%s]", this.getClass().getSimpleName(), transactionalId);
+			return String.format(
+				"%s [transactionalId=%s, producerId=%s, epoch=%s]",
+				this.getClass().getSimpleName(),
+				transactionalId,
+				producerId,
+				epoch);
 		}
 
 		@Override

--- a/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/FlinkKafkaProducer.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/FlinkKafkaProducer.java
@@ -188,7 +188,7 @@ public class FlinkKafkaProducer<K, V> implements Producer<K, V> {
 	 */
 	public void resumeTransaction(long producerId, short epoch) {
 		Preconditions.checkState(producerId >= 0 && epoch >= 0, "Incorrect values for producerId {} and epoch {}", producerId, epoch);
-		LOG.info("Attempting to resume transaction with producerId {} and epoch {}", producerId, epoch);
+		LOG.info("Attempting to resume transaction {} with producerId {} and epoch {}", transactionalId, producerId, epoch);
 
 		Object transactionManager = getValue(kafkaProducer, "transactionManager");
 		synchronized (transactionManager) {


### PR DESCRIPTION
    ProducerFencedException can happen if we restore twice from the same checkpoint
    or if we restore from an old savepoint. In both cases transactional.ids that we
    want to recoverAndCommit have been already committed and reused. Reusing mean
    that they will be known by Kafka's brokers under newer producerId/epochId,
    which will result in ProducerFencedException if we try to commit again some
    old (and already committed) transaction.
    
    Ignoring this exception might hide some bugs/issues, because instead of failing
    we might have a semi silent (with a warning) data loss.

## Verifying this change

This change added a `testFailAndRecoverSameCheckpointTwice` for a scenario that was previously not tested (and was failing).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
