### PR TITLE
[FLINK-8099] Reduce default restart delay to 1 second

### DIFF
--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -231,9 +231,7 @@ The options are:
 - `restart-strategy.fixed-delay.attempts`: Number of restart attempts, used if the default restart strategy is set to "fixed-delay".
 Default value is 1, unless "fixed-delay" was activated by enabling checkpoints, in which case the default is `Integer.MAX_VALUE`.
 
-- `restart-strategy.fixed-delay.delay`: Delay between restart attempts, used if the default restart strategy is set to "fixed-delay".
-Default value is the `akka.ask.timeout`, unless "fixed-delay" was activated by enabling checkpoints, in which case
-the default is 10s.
+- `restart-strategy.fixed-delay.delay`: Delay between restart attempts, used if the default restart strategy is set to "fixed-delay". (default: `1 s`)
 
 - `restart-strategy.failure-rate.max-failures-per-interval`: Maximum number of restarts in given time interval before failing a job in "failure-rate" strategy.
 Default value is 1.

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -67,7 +67,8 @@ public final class ConfigConstants {
 	 * FiniteDuration notation: "1 min", "20 s"
 	 */
 	@PublicEvolving
-	public static final String RESTART_STRATEGY_FIXED_DELAY_DELAY = "restart-strategy.fixed-delay.delay";
+	public static final ConfigOption<String> RESTART_STRATEGY_FIXED_DELAY_DELAY =
+		key("restart-strategy.fixed-delay.delay").defaultValue("1 s");
 
 	/**
 	 * Maximum number of restarts in given time interval {@link #RESTART_STRATEGY_FAILURE_RATE_FAILURE_RATE_INTERVAL} before failing a job

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/FixedDelayRestartStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/FixedDelayRestartStrategy.java
@@ -80,10 +80,7 @@ public class FixedDelayRestartStrategy implements RestartStrategy {
 	public static FixedDelayRestartStrategyFactory createFactory(Configuration configuration) throws Exception {
 		int maxAttempts = configuration.getInteger(ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS, 1);
 
-		String delayString = configuration.getString(
-			ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_DELAY,
-			"1 s"
-		);
+		String delayString = configuration.getString(ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_DELAY);
 
 		long delay;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/FixedDelayRestartStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/FixedDelayRestartStrategy.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.executiongraph.restart;
 
-import org.apache.flink.configuration.AkkaOptions;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
@@ -81,12 +80,9 @@ public class FixedDelayRestartStrategy implements RestartStrategy {
 	public static FixedDelayRestartStrategyFactory createFactory(Configuration configuration) throws Exception {
 		int maxAttempts = configuration.getInteger(ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS, 1);
 
-		String timeoutString = configuration.getString(
-			AkkaOptions.WATCH_HEARTBEAT_INTERVAL);
-
 		String delayString = configuration.getString(
 			ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_DELAY,
-			timeoutString
+			"1 s"
 		);
 
 		long delay;
@@ -94,15 +90,9 @@ public class FixedDelayRestartStrategy implements RestartStrategy {
 		try {
 			delay = Duration.apply(delayString).toMillis();
 		} catch (NumberFormatException nfe) {
-			if (delayString.equals(timeoutString)) {
-				throw new Exception("Invalid config value for " +
-						AkkaOptions.WATCH_HEARTBEAT_INTERVAL.key() + ": " + timeoutString +
-						". Value must be a valid duration (such as '10 s' or '1 min')");
-			} else {
-				throw new Exception("Invalid config value for " +
-						ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_DELAY + ": " + delayString +
-						". Value must be a valid duration (such as '100 milli' or '10 s')");
-			}
+			throw new Exception("Invalid config value for " +
+					ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_DELAY + ": " + delayString +
+					". Value must be a valid duration (such as '100 milli' or '10 s')");
 		}
 
 		return new FixedDelayRestartStrategyFactory(maxAttempts, delay);


### PR DESCRIPTION
R: @tillrohrmann 

We could also introduce an extra entry in `ConfigConstants` for the `"1 s"` default but I opted against that. What do you think?