### PR TITLE
[FLINK-8090] [DataStream] Improve the error message for duplicate state name

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultKeyedStateStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultKeyedStateStore.java
@@ -35,6 +35,7 @@ import org.apache.flink.api.common.state.State;
 import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.runtime.state.util.DuplicateStateNameException;
 import org.apache.flink.util.Preconditions;
 
 import static java.util.Objects.requireNonNull;
@@ -57,17 +58,16 @@ public class DefaultKeyedStateStore implements KeyedStateStore {
 		try {
 			return getPartitionedState(stateProperties);
 		} catch (ClassCastException cce) {
-			throw new RuntimeException("Duplicate state name: " + stateProperties.getName());
+			throw new DuplicateStateNameException("Duplicate state name: " + stateProperties, cce);
 		}
 	}
 
 	@Override
 	public <T> ListState<T> getListState(ListStateDescriptor<T> stateProperties) {
 		try {
-			ListState<T> originalState = getPartitionedState(stateProperties);
-			return new UserFacingListState<>(originalState);
+			return new UserFacingListState<>(getPartitionedState(stateProperties));
 		} catch (ClassCastException cce) {
-			throw new RuntimeException("Duplicate state name: " + stateProperties.getName());
+			throw new DuplicateStateNameException("Duplicate state name: " + stateProperties, cce);
 		}
 	}
 
@@ -76,7 +76,7 @@ public class DefaultKeyedStateStore implements KeyedStateStore {
 		try {
 			return getPartitionedState(stateProperties);
 		} catch (ClassCastException cce) {
-			throw new RuntimeException("Duplicate state name: " + stateProperties.getName());
+			throw new DuplicateStateNameException("Duplicate state name: " + stateProperties, cce);
 		}
 	}
 
@@ -85,7 +85,7 @@ public class DefaultKeyedStateStore implements KeyedStateStore {
 		try {
 			return getPartitionedState(stateProperties);
 		} catch (ClassCastException cce) {
-			throw new RuntimeException("Duplicate state name: " + stateProperties.getName());
+			throw new DuplicateStateNameException("Duplicate state name: " + stateProperties, cce);
 		}
 	}
 
@@ -94,17 +94,16 @@ public class DefaultKeyedStateStore implements KeyedStateStore {
 		try {
 			return getPartitionedState(stateProperties);
 		} catch (ClassCastException cce) {
-			throw new RuntimeException("Duplicate state name: " + stateProperties.getName());
+			throw new DuplicateStateNameException("Duplicate state name: " + stateProperties, cce);
 		}
 	}
 
 	@Override
 	public <UK, UV> MapState<UK, UV> getMapState(MapStateDescriptor<UK, UV> stateProperties) {
 		try {
-			MapState<UK, UV> originalState = getPartitionedState(stateProperties);
-			return new UserFacingMapState<>(originalState);
+			return new UserFacingMapState<>(getPartitionedState(stateProperties));
 		} catch (ClassCastException cce) {
-			throw new RuntimeException("Duplicate state name: " + stateProperties.getName());
+			throw new DuplicateStateNameException("Duplicate state name: " + stateProperties, cce);
 		}
 	}
 
@@ -116,6 +115,8 @@ public class DefaultKeyedStateStore implements KeyedStateStore {
 					VoidNamespace.INSTANCE,
 					VoidNamespaceSerializer.INSTANCE,
 					stateDescriptor);
+		} catch (ClassCastException cce) {
+			throw cce;
 		} catch (Exception e) {
 			throw new RuntimeException("Error while getting state", e);
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultKeyedStateStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultKeyedStateStore.java
@@ -54,76 +54,70 @@ public class DefaultKeyedStateStore implements KeyedStateStore {
 
 	@Override
 	public <T> ValueState<T> getState(ValueStateDescriptor<T> stateProperties) {
-		requireNonNull(stateProperties, "The state properties must not be null");
 		try {
-			stateProperties.initializeSerializerUnlessSet(executionConfig);
 			return getPartitionedState(stateProperties);
-		} catch (Exception e) {
-			throw new RuntimeException("Error while getting state", e);
+		} catch (ClassCastException cce) {
+			throw new RuntimeException("Duplicate state name: " + stateProperties.getName());
 		}
 	}
 
 	@Override
 	public <T> ListState<T> getListState(ListStateDescriptor<T> stateProperties) {
-		requireNonNull(stateProperties, "The state properties must not be null");
 		try {
-			stateProperties.initializeSerializerUnlessSet(executionConfig);
 			ListState<T> originalState = getPartitionedState(stateProperties);
 			return new UserFacingListState<>(originalState);
-		} catch (Exception e) {
-			throw new RuntimeException("Error while getting state", e);
+		} catch (ClassCastException cce) {
+			throw new RuntimeException("Duplicate state name: " + stateProperties.getName());
 		}
 	}
 
 	@Override
 	public <T> ReducingState<T> getReducingState(ReducingStateDescriptor<T> stateProperties) {
-		requireNonNull(stateProperties, "The state properties must not be null");
 		try {
-			stateProperties.initializeSerializerUnlessSet(executionConfig);
 			return getPartitionedState(stateProperties);
-		} catch (Exception e) {
-			throw new RuntimeException("Error while getting state", e);
+		} catch (ClassCastException cce) {
+			throw new RuntimeException("Duplicate state name: " + stateProperties.getName());
 		}
 	}
 
 	@Override
 	public <IN, ACC, OUT> AggregatingState<IN, OUT> getAggregatingState(AggregatingStateDescriptor<IN, ACC, OUT> stateProperties) {
-		requireNonNull(stateProperties, "The state properties must not be null");
 		try {
-			stateProperties.initializeSerializerUnlessSet(executionConfig);
 			return getPartitionedState(stateProperties);
-		} catch (Exception e) {
-			throw new RuntimeException("Error while getting state", e);
+		} catch (ClassCastException cce) {
+			throw new RuntimeException("Duplicate state name: " + stateProperties.getName());
 		}
 	}
 
 	@Override
 	public <T, ACC> FoldingState<T, ACC> getFoldingState(FoldingStateDescriptor<T, ACC> stateProperties) {
-		requireNonNull(stateProperties, "The state properties must not be null");
 		try {
-			stateProperties.initializeSerializerUnlessSet(executionConfig);
 			return getPartitionedState(stateProperties);
-		} catch (Exception e) {
-			throw new RuntimeException("Error while getting state", e);
+		} catch (ClassCastException cce) {
+			throw new RuntimeException("Duplicate state name: " + stateProperties.getName());
 		}
 	}
 
 	@Override
 	public <UK, UV> MapState<UK, UV> getMapState(MapStateDescriptor<UK, UV> stateProperties) {
-		requireNonNull(stateProperties, "The state properties must not be null");
 		try {
-			stateProperties.initializeSerializerUnlessSet(executionConfig);
 			MapState<UK, UV> originalState = getPartitionedState(stateProperties);
 			return new UserFacingMapState<>(originalState);
-		} catch (Exception e) {
-			throw new RuntimeException("Error while getting state", e);
+		} catch (ClassCastException cce) {
+			throw new RuntimeException("Duplicate state name: " + stateProperties.getName());
 		}
 	}
 
-	private <S extends State> S getPartitionedState(StateDescriptor<S, ?> stateDescriptor) throws Exception {
-		return keyedStateBackend.getPartitionedState(
-				VoidNamespace.INSTANCE,
-				VoidNamespaceSerializer.INSTANCE,
-				stateDescriptor);
+	private <S extends State> S getPartitionedState(StateDescriptor<S, ?> stateDescriptor) {
+		requireNonNull(stateDescriptor, "The state properties must not be null");
+		try {
+			stateDescriptor.initializeSerializerUnlessSet(executionConfig);
+			return keyedStateBackend.getPartitionedState(
+					VoidNamespace.INSTANCE,
+					VoidNamespaceSerializer.INSTANCE,
+					stateDescriptor);
+		} catch (Exception e) {
+			throw new RuntimeException("Error while getting state", e);
+		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/util/DuplicateStateNameException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/util/DuplicateStateNameException.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.util;
+
+/**
+ * Exception for states with duplicate name but different types.
+ *
+ */
+public class DuplicateStateNameException extends RuntimeException{
+	public DuplicateStateNameException(String message) {
+		super(message);
+	}
+
+	public DuplicateStateNameException(String message, Throwable t) {
+		super(message, t);
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContextTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContextTest.java
@@ -50,6 +50,7 @@ import org.apache.flink.runtime.state.KeyedStateBackend;
 import org.apache.flink.runtime.state.VoidNamespace;
 import org.apache.flink.runtime.state.VoidNamespaceSerializer;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
+import org.apache.flink.runtime.state.util.DuplicateStateNameException;
 
 import org.junit.Test;
 import org.mockito.Matchers;
@@ -268,6 +269,20 @@ public class StreamingRuntimeContextTest {
 		Iterable<Map.Entry<Integer, String>> value = state.entries();
 		assertNotNull(value);
 		assertFalse(value.iterator().hasNext());
+	}
+
+	@Test(expected = DuplicateStateNameException.class)
+	public void testDuplicateStateName() throws Exception {
+		StreamingRuntimeContext context = new StreamingRuntimeContext(
+				createMapPlainMockOp(),
+				createMockEnvironment(),
+				Collections.emptyMap());
+		MapStateDescriptor<Integer, String> mapStateDesc =
+				new MapStateDescriptor<>("name", Integer.class, String.class);
+		ListStateDescriptor<String> listStateDesc =
+				new ListStateDescriptor<>("name", String.class);
+		context.getMapState(mapStateDesc);
+		context.getListState(listStateDesc);
 	}
 
 	// ------------------------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change

This PR improves the error message when users trying to access two states of different types, but with an identical name. However, it cannot detect two states of the same type and name, but are registered via two descriptors.

## Brief change log

Refactor `DefaultKeyedStateStore.java` to raise an error message when the required state type does not match the real state type.

## Verifying this change

The change can be verified by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
