### PR TITLE
[FLINK-8106] [cep] Optimize the timer logic in AbstractKeyedCEPPatternOperator

### DIFF
--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/CEPOperatorUtils.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/CEPOperatorUtils.java
@@ -74,7 +74,8 @@ public class CEPOperatorUtils {
 					nfaFactory,
 					comparator,
 					skipStrategy,
-					selectFunction
+					selectFunction,
+					pattern.getWindowTime() != null ? pattern.getWindowTime().toMilliseconds() : -1
 				);
 			}
 
@@ -121,7 +122,8 @@ public class CEPOperatorUtils {
 					nfaFactory,
 					comparator,
 					skipStrategy,
-					selectFunction
+					selectFunction,
+					pattern.getWindowTime() != null ? pattern.getWindowTime().toMilliseconds() : -1
 				);
 			}
 
@@ -177,7 +179,8 @@ public class CEPOperatorUtils {
 					skipStrategy,
 					selectFunction,
 					timeoutFunction,
-					outputTag
+					outputTag,
+					pattern.getWindowTime() != null ? pattern.getWindowTime().toMilliseconds() : -1
 				);
 			}
 
@@ -233,7 +236,8 @@ public class CEPOperatorUtils {
 					skipStrategy,
 					selectFunction,
 					timeoutFunction,
-					outputTag
+					outputTag,
+					pattern.getWindowTime() != null ? pattern.getWindowTime().toMilliseconds() : -1
 				);
 			}
 

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/FlatSelectCepOperator.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/FlatSelectCepOperator.java
@@ -45,8 +45,9 @@ public class FlatSelectCepOperator<IN, KEY, OUT>
 		NFACompiler.NFAFactory<IN> nfaFactory,
 		EventComparator<IN> comparator,
 		AfterMatchSkipStrategy skipStrategy,
-		PatternFlatSelectFunction<IN, OUT> function) {
-		super(inputSerializer, isProcessingTime, nfaFactory, comparator, skipStrategy, function);
+		PatternFlatSelectFunction<IN, OUT> function,
+		long patternTimeoutMs) {
+		super(inputSerializer, isProcessingTime, nfaFactory, comparator, skipStrategy, function, patternTimeoutMs);
 	}
 
 	private transient TimestampedCollector<OUT> collector;

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/FlatSelectTimeoutCepOperator.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/FlatSelectTimeoutCepOperator.java
@@ -61,14 +61,16 @@ public class FlatSelectTimeoutCepOperator<IN, OUT1, OUT2, KEY> extends
 		AfterMatchSkipStrategy skipStrategy,
 		PatternFlatSelectFunction<IN, OUT1> flatSelectFunction,
 		PatternFlatTimeoutFunction<IN, OUT2> flatTimeoutFunction,
-		OutputTag<OUT2> outputTag) {
+		OutputTag<OUT2> outputTag,
+		long patternTimeoutMs) {
 		super(
 			inputSerializer,
 			isProcessingTime,
 			nfaFactory,
 			comparator,
 			skipStrategy,
-			new FlatSelectWrapper<>(flatSelectFunction, flatTimeoutFunction));
+			new FlatSelectWrapper<>(flatSelectFunction, flatTimeoutFunction),
+			patternTimeoutMs);
 		this.timedOutOutputTag = outputTag;
 	}
 

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/SelectCepOperator.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/SelectCepOperator.java
@@ -43,8 +43,9 @@ public class SelectCepOperator<IN, KEY, OUT>
 		NFACompiler.NFAFactory<IN> nfaFactory,
 		EventComparator<IN> comparator,
 		AfterMatchSkipStrategy skipStrategy,
-		PatternSelectFunction<IN, OUT> function) {
-		super(inputSerializer, isProcessingTime, nfaFactory, comparator, skipStrategy, function);
+		PatternSelectFunction<IN, OUT> function,
+		long patternTimeoutMs) {
+		super(inputSerializer, isProcessingTime, nfaFactory, comparator, skipStrategy, function, patternTimeoutMs);
 	}
 
 	@Override

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/SelectTimeoutCepOperator.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/SelectTimeoutCepOperator.java
@@ -56,14 +56,16 @@ public class SelectTimeoutCepOperator<IN, OUT1, OUT2, KEY>
 		AfterMatchSkipStrategy skipStrategy,
 		PatternSelectFunction<IN, OUT1> flatSelectFunction,
 		PatternTimeoutFunction<IN, OUT2> flatTimeoutFunction,
-		OutputTag<OUT2> outputTag) {
+		OutputTag<OUT2> outputTag,
+		long patternTimeoutMs) {
 		super(
 			inputSerializer,
 			isProcessingTime,
 			nfaFactory,
 			comparator,
 			skipStrategy,
-			new SelectWrapper<>(flatSelectFunction, flatTimeoutFunction));
+			new SelectWrapper<>(flatSelectFunction, flatTimeoutFunction),
+			patternTimeoutMs);
 		this.timedOutOutputTag = outputTag;
 	}
 

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPMigrationTest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPMigrationTest.java
@@ -61,6 +61,8 @@ import static org.junit.Assert.assertTrue;
 @RunWith(Parameterized.class)
 public class CEPMigrationTest {
 
+	private static final long PATTERN_TIMEOUT_MS = 10L;
+
 	/**
 	 * TODO change this to the corresponding savepoint version to be written (e.g. {@link MigrationVersion#v1_3} for 1.3)
 	 * TODO and remove all @Ignore annotations on write*Snapshot() methods to generate savepoints
@@ -100,7 +102,7 @@ public class CEPMigrationTest {
 
 		OneInputStreamOperatorTestHarness<Event, Map<String, List<Event>>> harness =
 				new KeyedOneInputStreamOperatorTestHarness<>(
-					getKeyedCepOpearator(false, new NFAFactory()),
+					getKeyedCepOpearator(false, new NFAFactory(), PATTERN_TIMEOUT_MS),
 						keySelector,
 						BasicTypeInfo.INT_TYPE_INFO);
 
@@ -145,7 +147,7 @@ public class CEPMigrationTest {
 
 		OneInputStreamOperatorTestHarness<Event, Map<String, List<Event>>> harness =
 				new KeyedOneInputStreamOperatorTestHarness<>(
-						getKeyedCepOpearator(false, new NFAFactory()),
+						getKeyedCepOpearator(false, new NFAFactory(), PATTERN_TIMEOUT_MS),
 						keySelector,
 						BasicTypeInfo.INT_TYPE_INFO);
 
@@ -209,7 +211,7 @@ public class CEPMigrationTest {
 			harness.close();
 
 			harness = new KeyedOneInputStreamOperatorTestHarness<>(
-				getKeyedCepOpearator(false, new NFAFactory()),
+				getKeyedCepOpearator(false, new NFAFactory(), PATTERN_TIMEOUT_MS),
 				keySelector,
 				BasicTypeInfo.INT_TYPE_INFO);
 
@@ -264,7 +266,7 @@ public class CEPMigrationTest {
 
 		OneInputStreamOperatorTestHarness<Event, Map<String, List<Event>>> harness =
 				new KeyedOneInputStreamOperatorTestHarness<>(
-					getKeyedCepOpearator(false, new NFAFactory()),
+					getKeyedCepOpearator(false, new NFAFactory(), PATTERN_TIMEOUT_MS),
 						keySelector,
 						BasicTypeInfo.INT_TYPE_INFO);
 
@@ -307,7 +309,7 @@ public class CEPMigrationTest {
 
 		OneInputStreamOperatorTestHarness<Event, Map<String, List<Event>>> harness =
 				new KeyedOneInputStreamOperatorTestHarness<>(
-					getKeyedCepOpearator(false, new NFAFactory()),
+					getKeyedCepOpearator(false, new NFAFactory(), PATTERN_TIMEOUT_MS),
 						keySelector,
 						BasicTypeInfo.INT_TYPE_INFO);
 
@@ -385,7 +387,7 @@ public class CEPMigrationTest {
 			harness.close();
 
 			harness = new KeyedOneInputStreamOperatorTestHarness<>(
-				getKeyedCepOpearator(false, new NFAFactory()),
+				getKeyedCepOpearator(false, new NFAFactory(), PATTERN_TIMEOUT_MS),
 				keySelector,
 				BasicTypeInfo.INT_TYPE_INFO);
 
@@ -439,7 +441,7 @@ public class CEPMigrationTest {
 
 		OneInputStreamOperatorTestHarness<Event, Map<String, List<Event>>> harness =
 				new KeyedOneInputStreamOperatorTestHarness<>(
-						getKeyedCepOpearator(false, new SinglePatternNFAFactory()),
+						getKeyedCepOpearator(false, new SinglePatternNFAFactory(), PATTERN_TIMEOUT_MS),
 						keySelector,
 						BasicTypeInfo.INT_TYPE_INFO);
 
@@ -473,7 +475,7 @@ public class CEPMigrationTest {
 
 		OneInputStreamOperatorTestHarness<Event, Map<String, List<Event>>> harness =
 				new KeyedOneInputStreamOperatorTestHarness<>(
-						getKeyedCepOpearator(false, new SinglePatternNFAFactory()),
+						getKeyedCepOpearator(false, new SinglePatternNFAFactory(), PATTERN_TIMEOUT_MS),
 						keySelector,
 						BasicTypeInfo.INT_TYPE_INFO);
 
@@ -529,7 +531,7 @@ public class CEPMigrationTest {
 		public NFA<Event> createNFA() {
 
 			Pattern<Event, ?> pattern = Pattern.<Event>begin("start").where(new StartFilter())
-					.within(Time.milliseconds(10L));
+					.within(Time.milliseconds(PATTERN_TIMEOUT_MS));
 
 			return NFACompiler.compile(pattern, Event.createTypeSerializer(), handleTimeout);
 		}
@@ -560,7 +562,7 @@ public class CEPMigrationTest {
 					.where(new EndFilter())
 					// add a window timeout to test whether timestamps of elements in the
 					// priority queue in CEP operator are correctly checkpointed/restored
-					.within(Time.milliseconds(10L));
+					.within(Time.milliseconds(PATTERN_TIMEOUT_MS));
 
 			return NFACompiler.compile(pattern, Event.createTypeSerializer(), handleTimeout);
 		}

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPRescalingTest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPRescalingTest.java
@@ -50,6 +50,8 @@ import static org.junit.Assert.assertTrue;
  */
 public class CEPRescalingTest {
 
+	private static final long PATTERN_TIMEOUT_MS = 10L;
+
 	@Test
 	public void testCEPFunctionScalingUp() throws Exception {
 		int maxParallelism = 10;
@@ -374,7 +376,8 @@ public class CEPRescalingTest {
 		return new KeyedOneInputStreamOperatorTestHarness<>(
 			getKeyedCepOpearator(
 				false,
-				new NFAFactory()),
+				new NFAFactory(),
+				PATTERN_TIMEOUT_MS),
 			keySelector,
 			BasicTypeInfo.INT_TYPE_INFO,
 			maxParallelism,
@@ -425,7 +428,7 @@ public class CEPRescalingTest {
 				})
 				// add a window timeout to test whether timestamps of elements in the
 				// priority queue in CEP operator are correctly checkpointed/restored
-				.within(Time.milliseconds(10L));
+				.within(Time.milliseconds(PATTERN_TIMEOUT_MS));
 
 			return NFACompiler.compile(pattern, Event.createTypeSerializer(), handleTimeout);
 		}

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CepOperatorTestUtilities.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CepOperatorTestUtilities.java
@@ -57,15 +57,17 @@ public class CepOperatorTestUtilities {
 
 	public static <K> SelectCepOperator<Event, K, Map<String, List<Event>>> getKeyedCepOpearator(
 		boolean isProcessingTime,
-		NFACompiler.NFAFactory<Event> nfaFactory) {
+		NFACompiler.NFAFactory<Event> nfaFactory,
+		long patternTimeoutMs) {
 
-		return getKeyedCepOpearator(isProcessingTime, nfaFactory, null);
+		return getKeyedCepOpearator(isProcessingTime, nfaFactory, null, patternTimeoutMs);
 	}
 
 	public static <K> SelectCepOperator<Event, K, Map<String, List<Event>>> getKeyedCepOpearator(
 		boolean isProcessingTime,
 		NFACompiler.NFAFactory<Event> nfaFactory,
-		EventComparator<Event> comparator) {
+		EventComparator<Event> comparator,
+		long patternTimeoutMs) {
 		return new SelectCepOperator<>(
 			Event.createTypeSerializer(),
 			isProcessingTime,
@@ -77,7 +79,8 @@ public class CepOperatorTestUtilities {
 				public Map<String, List<Event>> select(Map<String, List<Event>> pattern) throws Exception {
 					return pattern;
 				}
-			});
+			},
+			patternTimeoutMs);
 	}
 
 	private CepOperatorTestUtilities() {


### PR DESCRIPTION
## What is the purpose of the change

*This pull request optimize the performance of AbstractKeyedCEPPatternOperator*

## Verifying this change
  - *Existing tests*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
