### PR TITLE
[FLINK-8110][dist] Relocate jackson services in flink-dist

### DIFF
--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -462,6 +462,11 @@ under the License.
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
+
+				<!-- we need to explicitly override this version, because the -->
+				<!-- earlier versions of the shade plugin have a bug relocating services -->
+				<version>3.0.0</version>
+
 				<executions>
 					<execution>
 						<phase>package</phase>
@@ -495,6 +500,11 @@ under the License.
 								<relocation>
 									<pattern>org.codehaus.jackson</pattern>
 									<shadedPattern>org.apache.flink.formats.avro.shaded.org.codehaus.jackson</shadedPattern>
+								</relocation>
+								<relocation>
+									<!-- relocate jackson services, which isn't done by flink-shaded-jackson -->
+									<pattern>com.fasterxml.jackson</pattern>
+									<shadedPattern>org.apache.flink.shaded.jackson2.com.fasterxml.jackson</shadedPattern>
 								</relocation>
 							</relocations>
 							<transformers>


### PR DESCRIPTION
## What is the purpose of the change

This PR introduces a com.fasterxml.jackson relocation to flink-dist in order to relocate the jackson services contained in flink-shaded-jackson. The flink-shaded project still uses shade-plugin 2.4.1 which doesn't relocate services.

Since flink also doesn't use 3.0.0 yet we have to manually bump the version in flink-dist.

## Brief change log

* bump maven-shade-plugin version in flink-dist to 3.0.0
* add com.fasterxml.jackson relocation


## Verifying this change

* build flink-dist and check the contents of META-INF/services
  * it should contain the following files:
    `org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonFactory` and    `org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.ObjectCodec`
  * the contents of these files should also be relocated
* wait for travis end-to-end tests to verify general functionality

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
