### PR TITLE
[FLINK-8104][Table API] fixing ROW type value constructor for SQL API. 

### DIFF
--- a/docs/dev/table/sql.md
+++ b/docs/dev/table/sql.md
@@ -2257,12 +2257,34 @@ tableName.compositeType.*
 <table class="table table-bordered">
   <thead>
     <tr>
-      <th class="text-left" style="width: 40%">Array functions</th>
+      <th class="text-left" style="width: 40%">Value constructor functions</th>
       <th class="text-center">Description</th>
     </tr>
   </thead>
 
   <tbody>
+
+    <tr>
+      <td>
+        {% highlight text %}
+(value, [, value]*)
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Creates a row from a list of values. </p>
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        {% highlight text %}
+ROW(value, [, value]*)
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Creates a row from a list of literals. </p>
+      </td>
+    </tr>
 
     <tr>
       <td>
@@ -2274,6 +2296,30 @@ ARRAY ‘[’ value [, value ]* ‘]’
         <p>Creates an array from a list of values.</p>
       </td>
     </tr>
+
+    <tr>
+      <td>
+        {% highlight text %}
+MAP ‘[’ key, value [, key, value ]* ‘]’
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Creates a map from a list of key-value pairs.</p>
+      </td>
+    </tr>
+
+  </tbody>
+</table>
+
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th class="text-left" style="width: 40%">Array functions</th>
+      <th class="text-center">Description</th>
+    </tr>
+  </thead>
+
+  <tbody>
 
     <tr>
       <td>
@@ -2323,17 +2369,6 @@ ELEMENT(ARRAY)
     <tr>
       <td>
         {% highlight text %}
-MAP ‘[’ key, value [, key, value ]* ‘]’
-{% endhighlight %}
-      </td>
-      <td>
-        <p>Creates a map from a list of key-value pairs.</p>
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        {% highlight text %}
 CARDINALITY(MAP)
 {% endhighlight %}
       </td>
@@ -2352,41 +2387,6 @@ map ‘[’ key ‘]’
         <p>Returns the value specified by a particular key in a map.</p>
       </td>
     </tr>
-  </tbody>
-</table>
-
-<table class="table table-bordered">
-  <thead>
-    <tr>
-      <th class="text-left" style="width: 40%">Row functions</th>
-      <th class="text-center">Description</th>
-    </tr>
-  </thead>
-
-  <tbody>
-
-    <tr>
-      <td>
-        {% highlight text %}
-(value, [, value]*)
-{% endhighlight %}
-      </td>
-      <td>
-        <p>Creates a row from a list of values. </p>
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        {% highlight text %}
-ROW(value, [, value]*)
-{% endhighlight %}
-      </td>
-      <td>
-        <p>Creates a row from a list of literals. </p>
-      </td>
-    </tr>
-
   </tbody>
 </table>
 

--- a/docs/dev/table/sql.md
+++ b/docs/dev/table/sql.md
@@ -2355,6 +2355,41 @@ map ‘[’ key ‘]’
   </tbody>
 </table>
 
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th class="text-left" style="width: 40%">Row functions</th>
+      <th class="text-center">Description</th>
+    </tr>
+  </thead>
+
+  <tbody>
+
+    <tr>
+      <td>
+        {% highlight text %}
+(value, [, value]*)
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Creates a row from a list of values. </p>
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        {% highlight text %}
+ROW(value, [, value]*)
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Creates a row from a list of literals. </p>
+      </td>
+    </tr>
+
+  </tbody>
+</table>
+
 ### Unsupported Functions
 
 The following functions are not supported yet:

--- a/docs/dev/table/tableApi.md
+++ b/docs/dev/table/tableApi.md
@@ -4314,6 +4314,52 @@ ARRAY.element()
 <table class="table table-bordered">
   <thead>
     <tr>
+      <th class="text-left" style="width: 40%">Map functions</th>
+      <th class="text-center">Description</th>
+    </tr>
+  </thead>
+
+  <tbody>
+
+    <tr>
+      <td>
+        {% highlight scala %}
+map(ANY, ANY [, ANY, ANY ]*)
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Creates a map from a list of key-value pairs.</p>
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        {% highlight scala %}
+MAP.cardinality()
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Returns the number of entries of a map.</p>
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        {% highlight scala %}
+MAP.at(ANY)
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Returns the value specified by a particular key in a map.</p>
+      </td>
+    </tr>
+
+  </tbody>
+</table>
+
+<table class="table table-bordered">
+  <thead>
+    <tr>
       <th class="text-left" style="width: 40%">Row functions</th>
       <th class="text-center">Description</th>
     </tr>

--- a/docs/dev/table/tableApi.md
+++ b/docs/dev/table/tableApi.md
@@ -2996,6 +2996,30 @@ MAP.at(ANY)
 <table class="table table-bordered">
   <thead>
     <tr>
+      <th class="text-left" style="width: 40%">Row functions</th>
+      <th class="text-center">Description</th>
+    </tr>
+  </thead>
+
+  <tbody>
+
+    <tr>
+      <td>
+        {% highlight java %}
+row(ANY, [, ANY]*)
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Creates a row from a list of values. row can be access via <a href="tableApi.html#built-in-functions">built-in functions</a> (see Value access functions section) </p>
+      </td>
+    </tr>
+
+  </tbody>
+</table>
+
+<table class="table table-bordered">
+  <thead>
+    <tr>
       <th class="text-left" style="width: 40%">Auxiliary functions</th>
       <th class="text-center">Description</th>
     </tr>

--- a/docs/dev/table/tableApi.md
+++ b/docs/dev/table/tableApi.md
@@ -3010,7 +3010,7 @@ row(ANY, [, ANY]*)
 {% endhighlight %}
       </td>
       <td>
-        <p>Creates a row from a list of values. row can be access via <a href="tableApi.html#built-in-functions">built-in functions</a> (see Value access functions section) </p>
+        <p>Creates a row from a list of values. Row is composite type and can be access via <a href="tableApi.html#built-in-functions">value access functions</a>. </p>
       </td>
     </tr>
 
@@ -4311,7 +4311,29 @@ ARRAY.element()
   </tbody>
 </table>
 
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th class="text-left" style="width: 40%">Row functions</th>
+      <th class="text-center">Description</th>
+    </tr>
+  </thead>
 
+  <tbody>
+
+    <tr>
+      <td>
+        {% highlight scala %}
+row(ANY, [, ANY]*)
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Creates a row from a list of values. Row is composite type and can be access via <a href="tableApi.html#built-in-functions">value access functions</a>. </p>
+      </td>
+    </tr>
+
+  </tbody>
+</table>
 
 <table class="table table-bordered">
   <thead>

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
@@ -960,6 +960,19 @@ object array {
 }
 
 /**
+  * Creates an row of literals.
+  */
+object row {
+
+  /**
+    * Creates a row of literals.
+    */
+  def apply(head: Expression, tail: Expression*): Expression = {
+    RowConstructor(head +: tail.toSeq)
+  }
+}
+
+/**
   * Creates a map of literals. The map will be a map between two objects (not primitives).
   */
 object map {

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
@@ -960,12 +960,12 @@ object array {
 }
 
 /**
-  * Creates an row of literals.
+  * Creates a row of expressions.
   */
 object row {
 
   /**
-    * Creates a row of literals.
+    * Creates a row of expressions.
     */
   def apply(head: Expression, tail: Expression*): Expression = {
     RowConstructor(head +: tail.toSeq)
@@ -973,12 +973,12 @@ object row {
 }
 
 /**
-  * Creates a map of literals. The map will be a map between two objects (not primitives).
+  * Creates a map of expressions. The map will be a map between two objects (not primitives).
   */
 object map {
 
   /**
-    * Creates a map of literals. The map will be a map between two objects (not primitives).
+    * Creates a map of expressions. The map will be a map between two objects (not primitives).
     */
   def apply(key: Expression, value: Expression, tail: Expression*): Expression = {
     MapConstructor(Seq(key, value) ++ tail.toSeq)

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/calcite/FlinkTypeFactory.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/calcite/FlinkTypeFactory.scala
@@ -434,6 +434,10 @@ object FlinkTypeFactory {
       val compositeRelDataType = relDataType.asInstanceOf[CompositeRelDataType]
       compositeRelDataType.compositeType
 
+    case ROW if relDataType.isInstanceOf[RelRecordType] =>
+      val relRecordType = relDataType.asInstanceOf[RelRecordType]
+      new RowSchema(relRecordType).typeInfo
+
     // ROW and CURSOR for UDTF case, whose type info will never be used, just a placeholder
     case ROW | CURSOR => new NothingTypeInfo
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/calcite/FlinkTypeFactory.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/calcite/FlinkTypeFactory.scala
@@ -438,8 +438,8 @@ object FlinkTypeFactory {
       val relRecordType = relDataType.asInstanceOf[RelRecordType]
       new RowSchema(relRecordType).typeInfo
 
-    // ROW and CURSOR for UDTF case, whose type info will never be used, just a placeholder
-    case ROW | CURSOR => new NothingTypeInfo
+    // CURSOR for UDTF case, whose type info will never be used, just a placeholder
+    case CURSOR => new NothingTypeInfo
 
     case ARRAY if relDataType.isInstanceOf[ArrayRelDataType] =>
       val arrayRelDataType = relDataType.asInstanceOf[ArrayRelDataType]

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
@@ -1313,11 +1313,12 @@ abstract class CodeGenerator(
     }
   }
 
-  private[flink] def generateBoxedElementWithNullableSupport(
+  private[flink] def generateNullableOutputBoxing(
       element: GeneratedExpression,
-      boxedTypeTerm: String)
+      typeInfo: TypeInformation[_])
     : GeneratedExpression = {
     val boxedExpr = generateOutputFieldBoxing(element)
+    val boxedTypeTerm = boxedTypeTermForTypeInfo(typeInfo)
     val exprOrNull: String = if (nullCheck) {
       s"${boxedExpr.nullTerm} ? null : ($boxedTypeTerm) ${boxedExpr.resultTerm}"
     } else {
@@ -1575,10 +1576,10 @@ abstract class CodeGenerator(
   }
 
   /**
-    * Add a reusable [[org.apache.flink.types.Row]]
+    * Adds a reusable [[org.apache.flink.types.Row]]
     * to the member area of the generated [[Function]].
     */
-  def addReusableRow(arity: Int, size: Int): String = {
+  def addReusableRow(arity: Int): String = {
     val fieldTerm = newName("row")
     val fieldRow =
       s"""

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
@@ -1313,6 +1313,19 @@ abstract class CodeGenerator(
     }
   }
 
+  private[flink] def generateBoxedElementWithNullableSupport(
+      element: GeneratedExpression,
+      boxedTypeTerm: String)
+    : GeneratedExpression = {
+    val boxedExpr = generateOutputFieldBoxing(element)
+    val exprOrNull: String = if (nullCheck) {
+      s"${boxedExpr.nullTerm} ? null : ($boxedTypeTerm) ${boxedExpr.resultTerm}"
+    } else {
+      boxedExpr.resultTerm
+    }
+    boxedExpr.copy(resultTerm = exprOrNull)
+  }
+
   private[flink] def generateStreamRecordRowtimeAccess(): GeneratedExpression = {
     val resultTerm = newName("result")
     val nullTerm = newName("isNull")

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/collection.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/collection.scala
@@ -23,12 +23,41 @@ import org.apache.calcite.sql.fun.SqlStdOperatorTable
 import org.apache.calcite.tools.RelBuilder
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo.INT_TYPE_INFO
 import org.apache.flink.api.common.typeinfo.{BasicArrayTypeInfo, BasicTypeInfo, PrimitiveArrayTypeInfo, TypeInformation}
-import org.apache.flink.api.java.typeutils.{GenericTypeInfo, MapTypeInfo, ObjectArrayTypeInfo}
+import org.apache.flink.api.java.typeutils.{GenericTypeInfo, MapTypeInfo, ObjectArrayTypeInfo, RowTypeInfo}
 import org.apache.flink.table.calcite.FlinkRelBuilder
 import org.apache.flink.table.typeutils.TypeCheckUtils.{isArray, isMap}
 import org.apache.flink.table.validate.{ValidationFailure, ValidationResult, ValidationSuccess}
 
 import scala.collection.JavaConverters._
+
+case class RowConstructor(elements: Seq[Expression]) extends Expression {
+
+  override private[flink] def children: Seq[Expression] = elements
+
+  override private[flink] def toRexNode(implicit relBuilder: RelBuilder): RexNode = {
+    val relDataType = relBuilder
+      .asInstanceOf[FlinkRelBuilder]
+      .getTypeFactory
+      .createTypeFromTypeInfo(resultType, isNullable = false)
+    val values = elements.map(_.toRexNode).toList.asJava
+    relBuilder
+      .getRexBuilder
+      .makeCall(relDataType, SqlStdOperatorTable.ROW, values)
+  }
+
+  override def toString = s"row(${elements.mkString(", ")})"
+
+  override private[flink] def resultType: TypeInformation[_] = new RowTypeInfo(
+    elements.map(e => e.resultType):_*
+  )
+
+  override private[flink] def validateInput(): ValidationResult = {
+    if (elements.isEmpty) {
+      return ValidationFailure("Empty rows are not supported yet.")
+    }
+    ValidationSuccess
+  }
+}
 
 case class ArrayConstructor(elements: Seq[Expression]) extends Expression {
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
@@ -250,6 +250,9 @@ object FunctionCatalog {
     // map
     "map" -> classOf[MapConstructor],
 
+    // row
+    "row" -> classOf[RowConstructor],
+
     // window properties
     "start" -> classOf[WindowStart],
     "end" -> classOf[WindowEnd],

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/RowTypeTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/RowTypeTest.scala
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.expressions
+
+import java.sql.Date
+
+import org.apache.flink.table.api.Types
+import org.apache.flink.table.api.scala._
+import org.apache.flink.table.expressions.utils.RowTypeTestBase
+import org.junit.Test
+
+class RowTypeTest extends RowTypeTestBase {
+
+  @Test
+  def testRowLiteral(): Unit = {
+
+    // primitive literal
+    testAllApis(
+      row(1, "foo", true),
+      "row(1, 'foo', true)",
+      "ROW(1, 'foo', true)",
+      "1,foo,true")
+
+    // special literal
+    testAllApis(
+      row(Date.valueOf("1985-04-11"),
+        BigDecimal("0.1").bigDecimal,
+        array(1, 2, 3),
+        map("foo", "bar"),
+        row(1, true)
+      ),
+      "row('1985-04-11'.toDate, 0.1p, Array(1, 2, 3), " +
+        "Map('foo', 'bar'), row(1, true))",
+      "ROW(DATE '1985-04-11', CAST(0.1 AS DECIMAL), ARRAY[1, 2, 3], " +
+        "MAP['foo', 'bar'], row(1, true))",
+      "1985-04-11,0.1,[1, 2, 3],{foo=bar},1,true") // string faltten
+
+    testAllApis(
+      row(1 + 1, 2 * 3, Null(Types.STRING)),
+      "row(1 + 1, 2 * 3, Null(STRING))",
+      "ROW(1 + 1, 2 * 3, NULLIF(1,1))",
+      "2,6,null"
+    )
+
+    testSqlApi("(1, 'foo', true)", "1,foo,true")
+  }
+
+  @Test
+  def testRowField(): Unit = {
+    testAllApis(
+      row('f0, 'f1),
+      "row(f0, f1)",
+      "(f0, f1)",
+      "null,1"
+    )
+
+    testAllApis(
+      'f2,
+      "f2",
+      "f2",
+      "2,foo,true"
+    )
+
+    testAllApis(
+      row('f2, 'f5),
+      "row(f2, f5)",
+      "(f2, f5)",
+      "2,foo,true,foo,null"
+    )
+
+    testAllApis(
+      'f4,
+      "f4",
+      "f4",
+      "1984-03-12,0E-8,[1, 2, 3]"
+    )
+
+    testAllApis(
+      row('f1, "foo", true),
+      "row(f1, 'foo', true)",
+      "(f1, 'foo',true)",
+      "1,foo,true"
+    )
+  }
+
+  @Test
+  def testRowOperations(): Unit = {
+    testAllApis(
+      'f5.get("f0"),
+      "f5.get('f0')",
+      "f5.f0",
+      "foo"
+    )
+
+    testAllApis(
+      'f3.get("f1").get("f2"),
+      "f3.get('f1').get('f2')",
+      "f3.f1.f2",
+      "true"
+    )
+
+    // SQL API for row value constructor follow by field access is not supported
+    testTableApi(
+      row('f1, 'f6, 'f2).get("f1").get("f1"),
+      "row(f1, f6, f2).get('f1').get('f1')",
+      "null"
+    )
+  }
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/SqlExpressionTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/SqlExpressionTest.scala
@@ -151,9 +151,9 @@ class SqlExpressionTest extends ExpressionTestBase {
 
   @Test
   def testValueConstructorFunctions(): Unit = {
-    // TODO we need a special code path that flattens ROW types
-    // testSqlApi("ROW('hello world', 12)", "hello world") // test base only returns field 0
-    // testSqlApi("('hello world', 12)", "hello world") // test base only returns field 0
+    testSqlApi("ROW('hello world', 12)", "hello world,12")
+    testSqlApi("('hello world', 12)", "hello world,12")
+    testSqlApi("('foo', ('bar', 12))", "foo,bar,12")
     testSqlApi("ARRAY[TRUE, FALSE][2]", "false")
     testSqlApi("ARRAY[TRUE, TRUE]", "[true, true]")
     testSqlApi("MAP['k1', 'v1', 'k2', 'v2']['k2']", "v2")

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/utils/RowTypeTestBase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/utils/RowTypeTestBase.scala
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.expressions.utils
+
+import java.sql.Date
+
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.typeutils.{ObjectArrayTypeInfo, RowTypeInfo}
+import org.apache.flink.table.api.Types
+import org.apache.flink.types.Row
+
+class RowTypeTestBase extends ExpressionTestBase {
+
+  override def testData: Any = {
+    val row = new Row(3)
+    row.setField(0, 2)
+    row.setField(1, "foo")
+    row.setField(2, true)
+    val nestedRow = new Row(2)
+    nestedRow.setField(0, 3)
+    nestedRow.setField(1, row)
+    val specialTypeRow = new Row(3)
+    specialTypeRow.setField(0, Date.valueOf("1984-03-12"))
+    specialTypeRow.setField(1, BigDecimal("0.00000000").bigDecimal)
+    specialTypeRow.setField(2, Array(1, 2, 3))
+    val testData = new Row(7)
+    testData.setField(0, null)
+    testData.setField(1, 1)
+    testData.setField(2, row)
+    testData.setField(3, nestedRow)
+    testData.setField(4, specialTypeRow)
+    testData.setField(5, Row.of("foo", null))
+    testData.setField(6, Row.of(null, null))
+    testData
+  }
+
+  override def typeInfo: TypeInformation[Any] = {
+    new RowTypeInfo(
+      Types.STRING,
+      Types.INT,
+      Types.ROW(Types.INT, Types.STRING, Types.BOOLEAN),
+      Types.ROW(Types.INT, Types.ROW(Types.INT, Types.STRING, Types.BOOLEAN)),
+      Types.ROW(Types.SQL_DATE, Types.DECIMAL, ObjectArrayTypeInfo.getInfoFor(Types.INT)),
+      Types.ROW(Types.STRING, Types.BOOLEAN),
+      Types.ROW(Types.STRING, Types.STRING)
+    ).asInstanceOf[TypeInformation[Any]]
+  }
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/validation/RowTypeValidationTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/validation/RowTypeValidationTest.scala
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.expressions.validation
+
+import org.apache.flink.table.api.ValidationException
+import org.apache.flink.table.api.scala._
+import org.apache.flink.table.expressions.utils.RowTypeTestBase
+import org.junit.Test
+
+class RowTypeValidationTest extends RowTypeTestBase {
+
+  @Test(expected = classOf[ValidationException])
+  def testEmptyRowType(): Unit = {
+    testAllApis("FAIL", "row()", "Row()", "FAIL")
+  }
+
+  @Test(expected = classOf[ValidationException])
+  def testNullRowType(): Unit = {
+    testAllApis("FAIL", "row(null)", "Row(NULL)", "FAIL")
+  }
+
+  @Test(expected = classOf[ValidationException])
+  def testSqlRowIllegalAccess(): Unit = {
+    testAllApis('f5.get("f2"), "f5.get('f2')", "f5.f2", "FAIL")
+  }
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/batch/sql/CalcITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/batch/sql/CalcITCase.scala
@@ -309,6 +309,27 @@ class CalcITCase(
   }
 
   @Test
+  def testValueConstructor(): Unit = {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+
+    val sqlQuery = "SELECT (a, b, c), ARRAY[b, b] FROM MyTable"
+
+    val ds = env.fromElements((
+      "foo",
+      12,
+      Timestamp.valueOf("1984-07-12 14:34:24")))
+    tEnv.registerDataSet("MyTable", ds, 'a, 'b, 'c)
+
+    val result = tEnv.sqlQuery(sqlQuery)
+
+    val expected = "foo,12,1984-07-12 14:34:24.0,[12, 12]"
+    val results = result.toDataSet[Row].collect()
+    TestBaseUtils.compareResultAsText(results.asJava, expected)
+
+  }
+
+  @Test
   def testUserDefinedScalarFunction(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
     val tEnv = TableEnvironment.getTableEnvironment(env, config)

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/batch/sql/CalcITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/batch/sql/CalcITCase.scala
@@ -32,6 +32,7 @@ import org.apache.flink.table.runtime.utils.{TableProgramsCollectionTestBase, Ta
 import org.apache.flink.test.util.TestBaseUtils
 import org.apache.flink.types.Row
 import org.junit._
+import org.junit.Assert.assertEquals
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
@@ -313,20 +314,24 @@ class CalcITCase(
     val env = ExecutionEnvironment.getExecutionEnvironment
     val tEnv = TableEnvironment.getTableEnvironment(env, config)
 
-    val sqlQuery = "SELECT (a, b, c), ARRAY[b, b] FROM MyTable"
+    val sqlQuery = "SELECT (a, b, c), ARRAY[12, b], MAP[a, c] FROM MyTable"
+    val rowValue = ("foo", 12, Timestamp.valueOf("1984-07-12 14:34:24"))
 
-    val ds = env.fromElements((
-      "foo",
-      12,
-      Timestamp.valueOf("1984-07-12 14:34:24")))
+    val ds = env.fromElements(rowValue)
     tEnv.registerDataSet("MyTable", ds, 'a, 'b, 'c)
 
     val result = tEnv.sqlQuery(sqlQuery)
 
-    val expected = "foo,12,1984-07-12 14:34:24.0,[12, 12]"
+    val expected = "foo,12,1984-07-12 14:34:24.0,[12, 12],{foo=1984-07-12 14:34:24.0}"
     val results = result.toDataSet[Row].collect()
     TestBaseUtils.compareResultAsText(results.asJava, expected)
 
+    // Compare actual object to avoid undetected Calcite flattening
+    val resultRow = results.asJava.get(0)
+    assertEquals(rowValue._1, resultRow.getField(0).asInstanceOf[Row].getField(0))
+    assertEquals(rowValue._2, resultRow.getField(1).asInstanceOf[Array[Integer]](1))
+    assertEquals(rowValue._3,
+      resultRow.getField(2).asInstanceOf[util.Map[String, Timestamp]].get(rowValue._1))
   }
 
   @Test


### PR DESCRIPTION
 ## What is the purpose of the change

Supports creation of a ROW literal constructor: `ROW('hello', 12, true)` or simply `('hello', 12, true)` and support for ROW value constructors: `(int_field, string_field, 123, 'string_literal')`.

- Casting is not supported at this moment as it depends on how fieldNames are set, see FLINK-8003 for more details

## Brief change log

  - Added in `generateRow` for Row type generation
  - Fix FlinkTypeFactory not able to recognize `RelRecordType` by resolving it through `RowSchema` class.
  - Added in `row` keyword support on Table API.
  - Support for non-literal support for ROW value constructor as `(expr [, expr]*)` and literal constructor as `ROW(value [, value*])` or `(value [, value]*)`

## Verifying this change

This change added tests and can be verified as follows:

  - Added unit test for both Table and SQL expression and integration test for value constructor

## Does this pull request potentially affect one of the following parts:

No

## Documentation

  - Does this pull request introduce a new feature? Yes
  - Documentations? Not yet, will add soon.
