### PR TITLE
[FLINK-8117] [runtime] [streaming] Eliminate modulo operation from round robin partitioners

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/RoundRobinChannelSelector.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/RoundRobinChannelSelector.java
@@ -46,7 +46,10 @@ public class RoundRobinChannelSelector<T extends IOReadableWritable> implements 
 	@Override
 	public int[] selectChannels(final T record, final int numberOfOutputChannels) {
 
-		this.nextChannelToSendTo[0] = (this.nextChannelToSendTo[0] + 1) % numberOfOutputChannels;
+		int newChannel = ++this.nextChannelToSendTo[0];
+		if (newChannel >= numberOfOutputChannels) {
+			this.nextChannelToSendTo[0] = 0;
+		}
 
 		return this.nextChannelToSendTo;
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/CustomPartitionerWrapper.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/CustomPartitionerWrapper.java
@@ -35,7 +35,7 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 public class CustomPartitionerWrapper<K, T> extends StreamPartitioner<T> {
 	private static final long serialVersionUID = 1L;
 
-	private int[] returnArray = new int[1];
+	private final int[] returnArray = new int[1];
 	Partitioner<K> partitioner;
 	KeySelector<T, K> keySelector;
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/ForwardPartitioner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/ForwardPartitioner.java
@@ -30,7 +30,7 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 public class ForwardPartitioner<T> extends StreamPartitioner<T> {
 	private static final long serialVersionUID = 1L;
 
-	private int[] returnArray = new int[] {0};
+	private final int[] returnArray = new int[] {0};
 
 	@Override
 	public int[] selectChannels(SerializationDelegate<StreamRecord<T>> record, int numberOfOutputChannels) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/GlobalPartitioner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/GlobalPartitioner.java
@@ -30,7 +30,7 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 public class GlobalPartitioner<T> extends StreamPartitioner<T> {
 	private static final long serialVersionUID = 1L;
 
-	private int[] returnArray = new int[] { 0 };
+	private final int[] returnArray = new int[] { 0 };
 
 	@Override
 	public int[] selectChannels(SerializationDelegate<StreamRecord<T>> record,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/RebalancePartitioner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/RebalancePartitioner.java
@@ -31,12 +31,15 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 public class RebalancePartitioner<T> extends StreamPartitioner<T> {
 	private static final long serialVersionUID = 1L;
 
-	private int[] returnArray = new int[] {-1};
+	private final int[] returnArray = new int[] {-1};
 
 	@Override
 	public int[] selectChannels(SerializationDelegate<StreamRecord<T>> record,
 			int numberOfOutputChannels) {
-		this.returnArray[0] = (this.returnArray[0] + 1) % numberOfOutputChannels;
+		int newChannel = ++this.returnArray[0];
+		if (newChannel >= numberOfOutputChannels) {
+			this.returnArray[0] = 0;
+		}
 		return this.returnArray;
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/RescalePartitioner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/RescalePartitioner.java
@@ -48,11 +48,14 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 public class RescalePartitioner<T> extends StreamPartitioner<T> {
 	private static final long serialVersionUID = 1L;
 
-	private int[] returnArray = new int[] {-1};
+	private final int[] returnArray = new int[] {-1};
 
 	@Override
 	public int[] selectChannels(SerializationDelegate<StreamRecord<T>> record, int numberOfOutputChannels) {
-		this.returnArray[0] = (this.returnArray[0] + 1) % numberOfOutputChannels;
+		int newChannel = ++this.returnArray[0];
+		if (newChannel >= numberOfOutputChannels) {
+			this.returnArray[0] = 0;
+		}
 		return this.returnArray;
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/ShufflePartitioner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/ShufflePartitioner.java
@@ -36,7 +36,7 @@ public class ShufflePartitioner<T> extends StreamPartitioner<T> {
 
 	private Random random = new Random();
 
-	private int[] returnArray = new int[1];
+	private final int[] returnArray = new int[1];
 
 	@Override
 	public int[] selectChannels(SerializationDelegate<StreamRecord<T>> record,


### PR DESCRIPTION

## What is the purpose of the change

This PR changes `RebalancePartitioner`, `RescalePartitioner`, and `RoundRobinChannelSelector` to not use `%` for wrapping around when reaching the number of channels, but use an `if`-statement instead.

## Brief change log

- Make the above change in `RebalancePartitioner`, `RescalePartitioner`, and `RoundRobinChannelSelector`
- Additionally, I added `final` to the field that is holding the reused return array in `RebalancePartitioner`, `RoundRobinChannelSelector`, `ShufflePartitioner`, `ForwardPartitioner`, `GlobalPartitioner`, `CustomPartitionerWrapper`.

## Verifying this change

This change is already covered by existing tests, such as `RebalancePartitionerTest`, `RescalePartitionerTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): **yes**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
