### PR TITLE
[FLINK-8113][build] Bump maven-shade-plugin to 3.0.0

### DIFF
--- a/flink-connectors/flink-connector-cassandra/pom.xml
+++ b/flink-connectors/flink-connector-cassandra/pom.xml
@@ -55,7 +55,6 @@ under the License.
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-				<version>2.4.1</version>
 				<executions>
 					<!-- Run shade goal on package phase -->
 					<execution>

--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -462,11 +462,6 @@ under the License.
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-
-				<!-- we need to explicitly override this version, because the -->
-				<!-- earlier versions of the shade plugin have a bug relocating services -->
-				<version>3.0.0</version>
-
 				<executions>
 					<execution>
 						<phase>package</phase>

--- a/flink-filesystems/flink-s3-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-s3-fs-hadoop/pom.xml
@@ -214,11 +214,6 @@ under the License.
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-
-				<!-- we need to explicitly override this version, because the -->
-				<!-- earlier versions of the shade plugin have a bug relocating services -->
-				<version>3.0.0</version>
-
 				<executions>
 					<execution>
 						<id>shade-flink</id>

--- a/flink-filesystems/flink-s3-fs-presto/pom.xml
+++ b/flink-filesystems/flink-s3-fs-presto/pom.xml
@@ -214,11 +214,6 @@ under the License.
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-
-				<!-- we need to explicitly override this version, because the -->
-				<!-- earlier versions of the shade plugin have a bug relocating services -->
-				<version>3.0.0</version>
-
 				<executions>
 					<execution>
 						<id>shade-flink</id>

--- a/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/pom.xml
+++ b/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/pom.xml
@@ -154,7 +154,7 @@ under the License.
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-shade-plugin</artifactId>
-						<version>2.4.1</version>
+						<version>3.0.0</version>
 						<executions>
 							<execution>
 								<phase>package</phase>
@@ -182,7 +182,7 @@ under the License.
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-				<version>2.4.1</version>
+				<version>3.0.0</version>
 				<executions>
 					<!-- Run shade goal on package phase -->
 					<execution>

--- a/flink-quickstart/flink-quickstart-scala/src/main/resources/archetype-resources/pom.xml
+++ b/flink-quickstart/flink-quickstart-scala/src/main/resources/archetype-resources/pom.xml
@@ -153,7 +153,7 @@ under the License.
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-shade-plugin</artifactId>
-						<version>2.4.1</version>
+						<version>3.0.0</version>
 						<executions>
 							<execution>
 								<phase>package</phase>
@@ -184,7 +184,7 @@ under the License.
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-				<version>2.4.1</version>
+				<version>3.0.0</version>
 				<executions>
 					<!-- Run shade goal on package phase -->
 					<execution>

--- a/pom.xml
+++ b/pom.xml
@@ -1314,25 +1314,7 @@ under the License.
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-shade-plugin</artifactId>
-					<version>2.4.1</version>
-					<dependencies>
-						<!-- bump asm to 5.1 to avoid a bug in the shading of akka -->
-						<dependency>
-							<groupId>org.ow2.asm</groupId>
-							<artifactId>asm</artifactId>
-							<version>5.1</version>
-						</dependency>
-						<dependency>
-							<groupId>org.ow2.asm</groupId>
-							<artifactId>asm-commons</artifactId>
-							<version>5.1</version>
-						</dependency>
-						<dependency>
-							<groupId>org.ow2.asm</groupId>
-							<artifactId>asm-tree</artifactId>
-							<version>5.1</version>
-						</dependency>
-					</dependencies>
+					<version>3.0.0</version>
 				</plugin>
 
 				<!-- Disable certain plugins in Eclipse -->


### PR DESCRIPTION
## What is the purpose of the change

This PR bumps the maven-shade-plugin version to 3.0.0.
Benefits:
* all modules now use the same version again
  * currently, some modules set it to 3.0.0 already to fix a problem with relocating services
* we no longer need to bump the ASM version of the plugin

## Verifying this change

This change should be covered by travis and the end-to-end tests.
