### PR TITLE
[FLINK-6101] [table] Support select GroupBy fields with arithmetic ex…

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/ProjectionTranslator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/ProjectionTranslator.scala
@@ -203,6 +203,20 @@ object ProjectionTranslator {
                   complexGroupKeys))
           c.makeCopy(Array(newArgs))
 
+        // map constructor
+        case c@MapConstructor(args) =>
+          val newArgs = c.elements
+            .map(
+              (exp: Expression) =>
+                replaceAggregationsAndProperties(
+                  exp,
+                  tableEnv,
+                  aggNames,
+                  propNames,
+                  projectedNames,
+                  complexGroupKeys))
+          c.makeCopy(Array(newArgs))
+
         // General expression
         case e: Expression =>
           val newArgs = e.productIterator.map {
@@ -216,21 +230,7 @@ object ProjectionTranslator {
                 complexGroupKeys)
           }
           e.makeCopy(newArgs.toArray)
-
-      // map constructor
-      case c @ MapConstructor(args) =>
-        val newArgs = c.elements
-          .map((exp: Expression) =>
-            replaceAggregationsAndProperties(exp, tableEnv, aggNames, propNames, projectedNames))
-        c.makeCopy(Array(newArgs))
-
-      // General expression
-      case e: Expression =>
-        val newArgs = e.productIterator.map {
-          case arg: Expression =>
-            replaceAggregationsAndProperties(arg, tableEnv, aggNames, propNames, projectedNames)
-        }
-        e.makeCopy(newArgs.toArray)
+      }
     }
   }
 

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/batch/table/CalcTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/batch/table/CalcTest.scala
@@ -248,7 +248,7 @@ class CalcTest extends TableTestBase {
   def testSelectFromGroupedTableWithNonTrivialKey(): Unit = {
     val util = batchTestUtil()
     val sourceTable = util.addTable[(Int, Long, String, Double)]("MyTable", 'a, 'b, 'c, 'd)
-    val resultTable = sourceTable.groupBy(Upper('c) as 'k).select('a.sum)
+    val resultTable = sourceTable.groupBy(Upper('c)).select('a.sum)
 
     val expected =
       unaryNode(
@@ -258,10 +258,10 @@ class CalcTest extends TableTestBase {
           unaryNode(
             "DataSetCalc",
             batchTableNode(0),
-            term("select", "a", "c", "UPPER(c) AS k")
+            term("select", "a", "c", "UPPER(c) AS TMP_1")
           ),
-          term("groupBy", "k"),
-          term("select", "k", "SUM(a) AS TMP_0")
+          term("groupBy", "TMP_1"),
+          term("select", "TMP_1", "SUM(a) AS TMP_0")
         ),
         term("select", "TMP_0")
       )
@@ -273,7 +273,7 @@ class CalcTest extends TableTestBase {
   def testSelectFromGroupedTableWithFunctionKey(): Unit = {
     val util = batchTestUtil()
     val sourceTable = util.addTable[(Int, Long, String, Double)]("MyTable", 'a, 'b, 'c, 'd)
-    val resultTable = sourceTable.groupBy(MyHashCode('c) as 'k).select('a.sum)
+    val resultTable = sourceTable.groupBy(MyHashCode('c)).select('a.sum)
 
     val expected =
       unaryNode(
@@ -283,10 +283,10 @@ class CalcTest extends TableTestBase {
           unaryNode(
             "DataSetCalc",
             batchTableNode(0),
-            term("select", "a", "c", "MyHashCode$(c) AS k")
+            term("select", "a", "c", "MyHashCode$(c) AS TMP_1")
           ),
-          term("groupBy", "k"),
-          term("select", "k", "SUM(a) AS TMP_0")
+          term("groupBy", "TMP_1"),
+          term("select", "TMP_1", "SUM(a) AS TMP_0")
         ),
         term("select", "TMP_0")
       )

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/batch/sql/AggregateITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/batch/sql/AggregateITCase.scala
@@ -231,6 +231,26 @@ class AggregateITCase(
   }
 
   @Test
+  def testGroupedAggregateWithExpression(): Unit = {
+
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+
+    val sqlQuery =
+      "SELECT _2 + 1, avg(distinct _1) as a, count(_3) as b FROM MyTable GROUP BY _2 + 1"
+
+    val ds = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv)
+    tEnv.registerTable("MyTable", ds)
+
+    val result = tEnv.sqlQuery(sqlQuery)
+
+    val expected =
+      "7,18,6\n6,13,5\n5,8,4\n4,5,3\n3,2,2\n2,1,1"
+    val results = result.toDataSet[Row].collect()
+    TestBaseUtils.compareResultAsText(results.asJava, expected)
+  }
+
+  @Test
   def testGroupingSetAggregate(): Unit = {
 
     val env = ExecutionEnvironment.getExecutionEnvironment

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/utils/UserDefinedFunctions.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/utils/UserDefinedFunctions.scala
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.utils
+
+import org.apache.flink.table.functions.ScalarFunction
+
+object UDFMod extends ScalarFunction {
+  def eval(src: Int, m: Int): Int = {
+    src % m
+  }
+
+  def eval(src: Long, m: Int): Long = {
+    src % m
+  }
+}


### PR DESCRIPTION
## What is the purpose of the change

Support select GroupBy fields with arithmetic expressions(include UDF)

## Brief change log
- Using an internal alias for groupBy fields with arithmetic expressions(include UDF) in groupBy().

## Verifying this change
`AggregateITCase` verifies
- select GroupBy fields with arithmetic expression/UDF
  
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
