### PR TITLE
[Flink-7871] [flip6] SlotPool should release unused slots to RM

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
@@ -113,6 +113,26 @@ public class JobManagerOptions {
 		.defaultValue(60L * 60L)
 		.withDescription("The time in seconds after which a completed job expires and is purged from the job store.");
 
+	public static final ConfigOption<Long> SLOT_REQUEST_TIMEOUT =
+		key("slot.request.timeout")
+		.defaultValue(10 * 60 * 1000L)
+		.withDescription("The timeout in milliseconds for requesting a slot from Slot Pool.");
+
+	public static final ConfigOption<Long> SLOT_REQUEST_RM_TIMEOUT =
+		key("slot.request.resourcemanager.timeout")
+			.defaultValue(10 * 1000L)
+			.withDescription("The timeout in milliseconds for sending a request to Resource Manager.");
+
+	public static final ConfigOption<Long> SLOT_ALLOCATION_RM_TIMEOUT =
+		key("slot.allocation.resourcemanager.timeout")
+			.defaultValue(5 * 60 * 1000L)
+			.withDescription("The timeout in milliseconds for allocation a slot from Resource Manager.");
+
+	public static final ConfigOption<Long> SLOT_IDLE_TIMEOUT =
+		key("slot.idle.timeout")
+			.defaultValue(5 * 60 * 1000L)
+			.withDescription("The timeout in milliseconds for a idle slot in Slot Pool.");
+
 	// ---------------------------------------------------------------------------------------------
 
 	private JobManagerOptions() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolRpcTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolRpcTest.java
@@ -112,7 +112,8 @@ public class SlotPoolRpcTest extends TestLogger {
 			SystemClock.getInstance(),
 			TestingUtils.infiniteTime(),
 			TestingUtils.infiniteTime(),
-			Time.milliseconds(10L) // this is the timeout for the request tested here
+			Time.milliseconds(10L), // this is the timeout for the request tested here
+			TestingUtils.infiniteTime()
 		);
 
 		try {
@@ -145,6 +146,7 @@ public class SlotPoolRpcTest extends TestLogger {
 			rpcService,
 			jid,
 			SystemClock.getInstance(),
+			TestingUtils.infiniteTime(),
 			TestingUtils.infiniteTime(),
 			TestingUtils.infiniteTime(),
 			TestingUtils.infiniteTime());
@@ -187,6 +189,7 @@ public class SlotPoolRpcTest extends TestLogger {
 			rpcService,
 			jid,
 			SystemClock.getInstance(),
+			TestingUtils.infiniteTime(),
 			TestingUtils.infiniteTime(),
 			TestingUtils.infiniteTime(),
 			TestingUtils.infiniteTime());
@@ -234,6 +237,7 @@ public class SlotPoolRpcTest extends TestLogger {
 			rpcService,
 			jid,
 			SystemClock.getInstance(),
+			TestingUtils.infiniteTime(),
 			TestingUtils.infiniteTime(),
 			TestingUtils.infiniteTime(),
 			TestingUtils.infiniteTime());
@@ -305,6 +309,7 @@ public class SlotPoolRpcTest extends TestLogger {
 			SystemClock.getInstance(),
 			Time.milliseconds(10L),
 			TestingUtils.infiniteTime(),
+			TestingUtils.infiniteTime(),
 			TestingUtils.infiniteTime());
 
 		final CompletableFuture<SlotRequestId> releaseSlotFuture = new CompletableFuture<>();
@@ -354,14 +359,16 @@ public class SlotPoolRpcTest extends TestLogger {
 				Clock clock,
 				Time slotRequestTimeout,
 				Time resourceManagerAllocationTimeout,
-				Time resourceManagerRequestTimeout) {
+				Time resourceManagerRequestTimeout,
+				Time idleSlotTimeout) {
 			super(
 				rpcService,
 				jobId,
 				clock,
 				slotRequestTimeout,
 				resourceManagerAllocationTimeout,
-				resourceManagerRequestTimeout);
+				resourceManagerRequestTimeout,
+				idleSlotTimeout);
 
 			releaseSlotConsumer = null;
 		}


### PR DESCRIPTION
## What is the purpose of the change

* This pull request makes SlotPool release unused slots back to RM if a slot is idle for some time

## Brief change log

* Add a new method `checkIdleSlot()` in `SlotPool`
* Check all the available slots periodically, if a slot is expired, release it with TM gateway

## Verifying this change

This change added tests in `SlotPoolTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no, but add a new `@Public(Evolving)` class SlotOptions)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
