### PR TITLE
[FLINK-8081][metrics] Annotate 'MetricRegistry#getReporters' with '@V…

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricRegistryImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricRegistryImpl.java
@@ -214,6 +214,7 @@ public class MetricRegistryImpl implements MetricRegistry {
 		return reporters.size();
 	}
 
+	@VisibleForTesting
 	public List<MetricReporter> getReporters() {
 		return reporters;
 	}


### PR DESCRIPTION
## What is the purpose of the change

`MetricRegistry#getReporters()` is only used for testing purposes to provide access to instantiated reporters. We should annotate this method with `@VisibleForTesting`.
