### PR TITLE
[FLINK-4822] Ensure that the Kafka 0.8 connector is compatible with k…

### DIFF
--- a/flink-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/PeriodicOffsetCommitter.java
+++ b/flink-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/PeriodicOffsetCommitter.java
@@ -45,14 +45,18 @@ public class PeriodicOffsetCommitter extends Thread {
 	/** Flag to mark the periodic committer as running. */
 	private volatile boolean running = true;
 
+	/** The task info to register in zk ownership path. */
+	private final String taskId;
+
 	PeriodicOffsetCommitter(ZookeeperOffsetHandler offsetHandler,
 			List<KafkaTopicPartitionState<TopicAndPartition>> partitionStates,
 			ExceptionProxy errorHandler,
-			long commitInterval) {
+			long commitInterval, String taskId) {
 		this.offsetHandler = checkNotNull(offsetHandler);
 		this.partitionStates = checkNotNull(partitionStates);
 		this.errorHandler = checkNotNull(errorHandler);
 		this.commitInterval = commitInterval;
+		this.taskId = taskId;
 
 		checkArgument(commitInterval > 0);
 	}
@@ -69,7 +73,7 @@ public class PeriodicOffsetCommitter extends Thread {
 					offsetsToCommit.put(partitionState.getKafkaTopicPartition(), partitionState.getOffset());
 				}
 
-				offsetHandler.prepareAndCommitOffsets(offsetsToCommit);
+				offsetHandler.prepareAndCommitOffsets(offsetsToCommit, taskId);
 			}
 		}
 		catch (Throwable t) {

--- a/flink-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/PeriodicOffsetCommitter.java
+++ b/flink-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/PeriodicOffsetCommitter.java
@@ -51,7 +51,8 @@ public class PeriodicOffsetCommitter extends Thread {
 	PeriodicOffsetCommitter(ZookeeperOffsetHandler offsetHandler,
 			List<KafkaTopicPartitionState<TopicAndPartition>> partitionStates,
 			ExceptionProxy errorHandler,
-			long commitInterval, String taskId) {
+			long commitInterval,
+			String taskId) {
 		this.offsetHandler = checkNotNull(offsetHandler);
 		this.partitionStates = checkNotNull(partitionStates);
 		this.errorHandler = checkNotNull(errorHandler);

--- a/flink-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/ZookeeperOffsetHandler.java
+++ b/flink-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/ZookeeperOffsetHandler.java
@@ -73,11 +73,11 @@ public class ZookeeperOffsetHandler {
 
 		// set consumerId to register ownership in zookeeper, just like kafka high level API
 		UUID uuid = UUID.randomUUID();
-		String hostName = "Unkonw";
+		String hostName = "Unkonwn";
 		try {
 			hostName = InetAddress.getLocalHost().getHostName();
 		} catch (UnknownHostException e) {
-			LOG.error("Can not get host name!");
+			LOG.error("Can not get host name", e);
 		}
 		String consumerUuid = String.format("%s-%d-%s",
 			hostName,
@@ -181,7 +181,7 @@ public class ZookeeperOffsetHandler {
 				curatorClient.create().creatingParentContainersIfNeeded().withMode(CreateMode.EPHEMERAL).forPath(path, info.getBytes());
 			}
 		} catch (KeeperException.NodeExistsException e) {
-			LOG.warn("NodeExists for {}", e);
+			LOG.warn("Node exists for {}", consumerId, e);
 		}
 	}
 }


### PR DESCRIPTION

## What is the purpose of the change

When we deploy the taskmanager in docker of our cluster, it's hard to locate which taskmanager cosnume the right partition of kafka except looking up the  log in docker, so I just add the owner in zk path when PeriodOffsetCommitter the offset.


## Brief change log

  - add the registerPartitionOwnership  when  commit the offset to zookeeper, and store the info like :  /consumers/[group_id]/owner/[topic]/[partition_id] 

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:no
  - The serializers:  no 
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not documented
