### PR TITLE
[FLINK-8133][REST][docs] Generate REST API documentation

### DIFF
--- a/docs/_includes/generated/rest_dispatcher.html
+++ b/docs/_includes/generated/rest_dispatcher.html
@@ -1,0 +1,1613 @@
+<table class="table table-bordered">
+  <tbody>
+    <tr>
+      <td class="text-left" colspan="2"><strong>/blobserver/port</strong></td>
+    </tr>
+    <tr>
+      <td class="text-left" style="width: 20%">Verb: <code>GET</code></td>
+      <td class="text-left">Response code: <code>200 OK</code></td>
+    </tr>
+    <tr>
+      <td colspan="2">description</td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#2130895547">Request</button>
+        <div id="2130895547" class="collapse">
+          <pre>
+            <code>
+{}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#-857861893">Response</button>
+        <div id="-857861893" class="collapse">
+          <pre>
+            <code>
+{
+  "type" : "object",
+  "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:BlobServerPortResponseBody",
+  "properties" : {
+    "port" : {
+      "type" : "integer"
+    }
+  }
+}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<table class="table table-bordered">
+  <tbody>
+    <tr>
+      <td class="text-left" colspan="2"><strong>/config</strong></td>
+    </tr>
+    <tr>
+      <td class="text-left" style="width: 20%">Verb: <code>GET</code></td>
+      <td class="text-left">Response code: <code>200 OK</code></td>
+    </tr>
+    <tr>
+      <td colspan="2">description</td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#-1640242453">Request</button>
+        <div id="-1640242453" class="collapse">
+          <pre>
+            <code>
+{}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#-925504791">Response</button>
+        <div id="-925504791" class="collapse">
+          <pre>
+            <code>
+{
+  "type" : "object",
+  "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:DashboardConfiguration",
+  "properties" : {
+    "refreshInterval" : {
+      "type" : "integer"
+    },
+    "timeZoneName" : {
+      "type" : "string"
+    },
+    "timeZoneOffset" : {
+      "type" : "integer"
+    },
+    "flinkVersion" : {
+      "type" : "string"
+    },
+    "flinkRevision" : {
+      "type" : "string"
+    }
+  }
+}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<table class="table table-bordered">
+  <tbody>
+    <tr>
+      <td class="text-left" colspan="2"><strong>/jobmanager/config</strong></td>
+    </tr>
+    <tr>
+      <td class="text-left" style="width: 20%">Verb: <code>GET</code></td>
+      <td class="text-left">Response code: <code>200 OK</code></td>
+    </tr>
+    <tr>
+      <td colspan="2">description</td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#-1636067508">Request</button>
+        <div id="-1636067508" class="collapse">
+          <pre>
+            <code>
+{}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#-1955506190">Response</button>
+        <div id="-1955506190" class="collapse">
+          <pre>
+            <code>
+{
+  "type" : "array",
+  "items" : {
+    "type" : "object",
+    "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:ClusterConfigurationInfoEntry",
+    "properties" : {
+      "key" : {
+        "type" : "string"
+      },
+      "value" : {
+        "type" : "string"
+      }
+    }
+  }
+}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<table class="table table-bordered">
+  <tbody>
+    <tr>
+      <td class="text-left" colspan="2"><strong>/jobs</strong></td>
+    </tr>
+    <tr>
+      <td class="text-left" style="width: 20%">Verb: <code>POST</code></td>
+      <td class="text-left">Response code: <code>202 Accepted</code></td>
+    </tr>
+    <tr>
+      <td colspan="2">description</td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#-2026599104">Request</button>
+        <div id="-2026599104" class="collapse">
+          <pre>
+            <code>
+{
+  "type" : "object",
+  "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:JobSubmitRequestBody",
+  "properties" : {
+    "serializedJobGraph" : {
+      "type" : "array",
+      "items" : {
+        "type" : "integer"
+      }
+    }
+  }
+}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#81703990">Response</button>
+        <div id="81703990" class="collapse">
+          <pre>
+            <code>
+{
+  "type" : "object",
+  "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:JobSubmitResponseBody",
+  "properties" : {
+    "jobUrl" : {
+      "type" : "string"
+    }
+  }
+}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<table class="table table-bordered">
+  <tbody>
+    <tr>
+      <td class="text-left" colspan="2"><strong>/jobs/overview</strong></td>
+    </tr>
+    <tr>
+      <td class="text-left" style="width: 20%">Verb: <code>GET</code></td>
+      <td class="text-left">Response code: <code>200 OK</code></td>
+    </tr>
+    <tr>
+      <td colspan="2">description</td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#-580225539">Request</button>
+        <div id="-580225539" class="collapse">
+          <pre>
+            <code>
+{}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#-657465645">Response</button>
+        <div id="-657465645" class="collapse">
+          <pre>
+            <code>
+{
+  "type" : "object",
+  "id" : "urn:jsonschema:org:apache:flink:runtime:messages:webmonitor:MultipleJobsDetails",
+  "properties" : {
+    "jobs" : {
+      "type" : "array",
+      "items" : {
+        "type" : "object",
+        "id" : "urn:jsonschema:org:apache:flink:runtime:messages:webmonitor:JobDetails",
+        "properties" : {
+          "jobId" : {
+            "type" : "object",
+            "id" : "urn:jsonschema:org:apache:flink:api:common:JobID",
+            "properties" : {
+              "upperPart" : {
+                "type" : "integer"
+              },
+              "lowerPart" : {
+                "type" : "integer"
+              },
+              "bytes" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
+          "jobName" : {
+            "type" : "string"
+          },
+          "startTime" : {
+            "type" : "integer"
+          },
+          "endTime" : {
+            "type" : "integer"
+          },
+          "duration" : {
+            "type" : "integer"
+          },
+          "status" : {
+            "type" : "string",
+            "enum" : [ "CREATED", "RUNNING", "FAILING", "FAILED", "CANCELLING", "CANCELED", "FINISHED", "RESTARTING", "SUSPENDED", "RECONCILING" ]
+          },
+          "lastUpdateTime" : {
+            "type" : "integer"
+          },
+          "tasksPerState" : {
+            "type" : "array",
+            "items" : {
+              "type" : "integer"
+            }
+          },
+          "numTasks" : {
+            "type" : "integer"
+          }
+        }
+      }
+    }
+  }
+}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<table class="table table-bordered">
+  <tbody>
+    <tr>
+      <td class="text-left" colspan="2"><strong>/jobs/:jobid</strong></td>
+    </tr>
+    <tr>
+      <td class="text-left" style="width: 20%">Verb: <code>PATCH</code></td>
+      <td class="text-left">Response code: <code>202 Accepted</code></td>
+    </tr>
+    <tr>
+      <td colspan="2">description</td>
+    </tr>
+    <tr>
+      <td colspan="2">Path parameters</td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <ul>
+<li><code>jobid</code> - description</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">Query parameters</td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <ul>
+<li><code>mode</code> (optional): description</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#-1387624156">Request</button>
+        <div id="-1387624156" class="collapse">
+          <pre>
+            <code>
+{}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#-1202641332">Response</button>
+        <div id="-1202641332" class="collapse">
+          <pre>
+            <code>
+{}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<table class="table table-bordered">
+  <tbody>
+    <tr>
+      <td class="text-left" colspan="2"><strong>/jobs/:jobid</strong></td>
+    </tr>
+    <tr>
+      <td class="text-left" style="width: 20%">Verb: <code>GET</code></td>
+      <td class="text-left">Response code: <code>200 OK</code></td>
+    </tr>
+    <tr>
+      <td colspan="2">description</td>
+    </tr>
+    <tr>
+      <td colspan="2">Path parameters</td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <ul>
+<li><code>jobid</code> - description</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#-1065339742">Request</button>
+        <div id="-1065339742" class="collapse">
+          <pre>
+            <code>
+{}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#2004396866">Response</button>
+        <div id="2004396866" class="collapse">
+          <pre>
+            <code>
+{
+  "type" : "any"
+}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<table class="table table-bordered">
+  <tbody>
+    <tr>
+      <td class="text-left" colspan="2"><strong>/jobs/:jobid/accumulators</strong></td>
+    </tr>
+    <tr>
+      <td class="text-left" style="width: 20%">Verb: <code>GET</code></td>
+      <td class="text-left">Response code: <code>200 OK</code></td>
+    </tr>
+    <tr>
+      <td colspan="2">description</td>
+    </tr>
+    <tr>
+      <td colspan="2">Path parameters</td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <ul>
+<li><code>jobid</code> - description</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#-1058407378">Request</button>
+        <div id="-1058407378" class="collapse">
+          <pre>
+            <code>
+{}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#-738243778">Response</button>
+        <div id="-738243778" class="collapse">
+          <pre>
+            <code>
+{
+  "type" : "any"
+}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<table class="table table-bordered">
+  <tbody>
+    <tr>
+      <td class="text-left" colspan="2"><strong>/jobs/:jobid/checkpoints</strong></td>
+    </tr>
+    <tr>
+      <td class="text-left" style="width: 20%">Verb: <code>GET</code></td>
+      <td class="text-left">Response code: <code>200 OK</code></td>
+    </tr>
+    <tr>
+      <td colspan="2">description</td>
+    </tr>
+    <tr>
+      <td colspan="2">Path parameters</td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <ul>
+<li><code>jobid</code> - description</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#-411676418">Request</button>
+        <div id="-411676418" class="collapse">
+          <pre>
+            <code>
+{}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#155229264">Response</button>
+        <div id="155229264" class="collapse">
+          <pre>
+            <code>
+{
+  "type" : "object",
+  "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:CheckpointingStatistics",
+  "properties" : {
+    "counts" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:CheckpointingStatistics:Counts",
+      "properties" : {
+        "numberRestoredCheckpoints" : {
+          "type" : "integer"
+        },
+        "totalNumberCheckpoints" : {
+          "type" : "integer"
+        },
+        "numberInProgressCheckpoints" : {
+          "type" : "integer"
+        },
+        "numberCompletedCheckpoints" : {
+          "type" : "integer"
+        },
+        "numberFailedCheckpoints" : {
+          "type" : "integer"
+        }
+      }
+    },
+    "summary" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:CheckpointingStatistics:Summary",
+      "properties" : {
+        "stateSize" : {
+          "type" : "object",
+          "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:MinMaxAvgStatistics",
+          "properties" : {
+            "minimum" : {
+              "type" : "integer"
+            },
+            "maximum" : {
+              "type" : "integer"
+            },
+            "average" : {
+              "type" : "integer"
+            }
+          }
+        },
+        "duration" : {
+          "type" : "object",
+          "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:MinMaxAvgStatistics"
+        },
+        "alignmentBuffered" : {
+          "type" : "object",
+          "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:MinMaxAvgStatistics"
+        }
+      }
+    },
+    "latestCheckpoints" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:CheckpointingStatistics:LatestCheckpoints",
+      "properties" : {
+        "completedCheckpointStatistics" : {
+          "type" : "object",
+          "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:CheckpointStatistics:CompletedCheckpointStatistics",
+          "properties" : {
+            "id" : {
+              "type" : "integer"
+            },
+            "status" : {
+              "type" : "string",
+              "enum" : [ "IN_PROGRESS", "COMPLETED", "FAILED" ]
+            },
+            "savepoint" : {
+              "type" : "boolean"
+            },
+            "triggerTimestamp" : {
+              "type" : "integer"
+            },
+            "latestAckTimestamp" : {
+              "type" : "integer"
+            },
+            "stateSize" : {
+              "type" : "integer"
+            },
+            "duration" : {
+              "type" : "integer"
+            },
+            "alignmentBuffered" : {
+              "type" : "integer"
+            },
+            "numSubtasks" : {
+              "type" : "integer"
+            },
+            "numAckSubtasks" : {
+              "type" : "integer"
+            },
+            "checkpointStatisticsPerTask" : {
+              "type" : "object",
+              "additionalProperties" : {
+                "type" : "object",
+                "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:TaskCheckpointStatistics",
+                "properties" : {
+                  "checkpointId" : {
+                    "type" : "integer"
+                  },
+                  "checkpointStatus" : {
+                    "type" : "string",
+                    "enum" : [ "IN_PROGRESS", "COMPLETED", "FAILED" ]
+                  },
+                  "latestAckTimestamp" : {
+                    "type" : "integer"
+                  },
+                  "stateSize" : {
+                    "type" : "integer"
+                  },
+                  "duration" : {
+                    "type" : "integer"
+                  },
+                  "alignmentBuffered" : {
+                    "type" : "integer"
+                  },
+                  "numSubtasks" : {
+                    "type" : "integer"
+                  },
+                  "numAckSubtasks" : {
+                    "type" : "integer"
+                  }
+                }
+              }
+            },
+            "externalPath" : {
+              "type" : "string"
+            },
+            "discarded" : {
+              "type" : "boolean"
+            }
+          }
+        },
+        "savepointStatistics" : {
+          "type" : "object",
+          "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:CheckpointStatistics:CompletedCheckpointStatistics"
+        },
+        "failedCheckpointStatistics" : {
+          "type" : "object",
+          "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:CheckpointStatistics:FailedCheckpointStatistics",
+          "properties" : {
+            "id" : {
+              "type" : "integer"
+            },
+            "status" : {
+              "type" : "string",
+              "enum" : [ "IN_PROGRESS", "COMPLETED", "FAILED" ]
+            },
+            "savepoint" : {
+              "type" : "boolean"
+            },
+            "triggerTimestamp" : {
+              "type" : "integer"
+            },
+            "latestAckTimestamp" : {
+              "type" : "integer"
+            },
+            "stateSize" : {
+              "type" : "integer"
+            },
+            "duration" : {
+              "type" : "integer"
+            },
+            "alignmentBuffered" : {
+              "type" : "integer"
+            },
+            "numSubtasks" : {
+              "type" : "integer"
+            },
+            "numAckSubtasks" : {
+              "type" : "integer"
+            },
+            "checkpointStatisticsPerTask" : {
+              "type" : "object",
+              "additionalProperties" : {
+                "type" : "object",
+                "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:TaskCheckpointStatistics"
+              }
+            },
+            "failureTimestamp" : {
+              "type" : "integer"
+            },
+            "failureMessage" : {
+              "type" : "string"
+            }
+          }
+        },
+        "restoredCheckpointStatistics" : {
+          "type" : "object",
+          "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:CheckpointingStatistics:RestoredCheckpointStatistics",
+          "properties" : {
+            "id" : {
+              "type" : "integer"
+            },
+            "restoreTimestamp" : {
+              "type" : "integer"
+            },
+            "savepoint" : {
+              "type" : "boolean"
+            },
+            "externalPath" : {
+              "type" : "string"
+            }
+          }
+        }
+      }
+    },
+    "history" : {
+      "type" : "array",
+      "items" : {
+        "type" : "object",
+        "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:CheckpointStatistics",
+        "properties" : {
+          "id" : {
+            "type" : "integer"
+          },
+          "status" : {
+            "type" : "string",
+            "enum" : [ "IN_PROGRESS", "COMPLETED", "FAILED" ]
+          },
+          "savepoint" : {
+            "type" : "boolean"
+          },
+          "triggerTimestamp" : {
+            "type" : "integer"
+          },
+          "latestAckTimestamp" : {
+            "type" : "integer"
+          },
+          "stateSize" : {
+            "type" : "integer"
+          },
+          "duration" : {
+            "type" : "integer"
+          },
+          "alignmentBuffered" : {
+            "type" : "integer"
+          },
+          "numSubtasks" : {
+            "type" : "integer"
+          },
+          "numAckSubtasks" : {
+            "type" : "integer"
+          },
+          "checkpointStatisticsPerTask" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "object",
+              "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:TaskCheckpointStatistics"
+            }
+          }
+        }
+      }
+    }
+  }
+}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<table class="table table-bordered">
+  <tbody>
+    <tr>
+      <td class="text-left" colspan="2"><strong>/jobs/:jobid/checkpoints/config</strong></td>
+    </tr>
+    <tr>
+      <td class="text-left" style="width: 20%">Verb: <code>GET</code></td>
+      <td class="text-left">Response code: <code>200 OK</code></td>
+    </tr>
+    <tr>
+      <td colspan="2">description</td>
+    </tr>
+    <tr>
+      <td colspan="2">Path parameters</td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <ul>
+<li><code>jobid</code> - description</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#-866337753">Request</button>
+        <div id="-866337753" class="collapse">
+          <pre>
+            <code>
+{}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#-1963480130">Response</button>
+        <div id="-1963480130" class="collapse">
+          <pre>
+            <code>
+{
+  "type" : "any"
+}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<table class="table table-bordered">
+  <tbody>
+    <tr>
+      <td class="text-left" colspan="2"><strong>/jobs/:jobid/checkpoints/details/:checkpointid/subtasks/:vertexid</strong></td>
+    </tr>
+    <tr>
+      <td class="text-left" style="width: 20%">Verb: <code>GET</code></td>
+      <td class="text-left">Response code: <code>200 OK</code></td>
+    </tr>
+    <tr>
+      <td colspan="2">description</td>
+    </tr>
+    <tr>
+      <td colspan="2">Path parameters</td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <ul>
+<li><code>jobid</code> - description</li>
+<li><code>checkpointid</code> - description</li>
+<li><code>vertexid</code> - description</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#1729939004">Request</button>
+        <div id="1729939004" class="collapse">
+          <pre>
+            <code>
+{}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#1670482062">Response</button>
+        <div id="1670482062" class="collapse">
+          <pre>
+            <code>
+{
+  "type" : "object",
+  "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:TaskCheckpointStatisticsWithSubtaskDetails",
+  "properties" : {
+    "checkpointId" : {
+      "type" : "integer"
+    },
+    "checkpointStatus" : {
+      "type" : "string",
+      "enum" : [ "IN_PROGRESS", "COMPLETED", "FAILED" ]
+    },
+    "latestAckTimestamp" : {
+      "type" : "integer"
+    },
+    "stateSize" : {
+      "type" : "integer"
+    },
+    "duration" : {
+      "type" : "integer"
+    },
+    "alignmentBuffered" : {
+      "type" : "integer"
+    },
+    "numSubtasks" : {
+      "type" : "integer"
+    },
+    "numAckSubtasks" : {
+      "type" : "integer"
+    },
+    "summary" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:TaskCheckpointStatisticsWithSubtaskDetails:Summary",
+      "properties" : {
+        "stateSize" : {
+          "type" : "object",
+          "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:MinMaxAvgStatistics",
+          "properties" : {
+            "minimum" : {
+              "type" : "integer"
+            },
+            "maximum" : {
+              "type" : "integer"
+            },
+            "average" : {
+              "type" : "integer"
+            }
+          }
+        },
+        "duration" : {
+          "type" : "object",
+          "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:MinMaxAvgStatistics"
+        },
+        "checkpointDuration" : {
+          "type" : "object",
+          "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:TaskCheckpointStatisticsWithSubtaskDetails:CheckpointDuration",
+          "properties" : {
+            "synchronousDuration" : {
+              "type" : "object",
+              "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:MinMaxAvgStatistics"
+            },
+            "asynchronousDuration" : {
+              "type" : "object",
+              "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:MinMaxAvgStatistics"
+            }
+          }
+        },
+        "checkpointAlignment" : {
+          "type" : "object",
+          "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:TaskCheckpointStatisticsWithSubtaskDetails:CheckpointAlignment",
+          "properties" : {
+            "bufferedData" : {
+              "type" : "object",
+              "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:MinMaxAvgStatistics"
+            },
+            "duration" : {
+              "type" : "object",
+              "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:MinMaxAvgStatistics"
+            }
+          }
+        }
+      }
+    },
+    "subtaskCheckpointStatistics" : {
+      "type" : "array",
+      "items" : {
+        "type" : "object",
+        "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:SubtaskCheckpointStatistics",
+        "properties" : {
+          "index" : {
+            "type" : "integer"
+          },
+          "checkpointStatus" : {
+            "type" : "string"
+          }
+        }
+      }
+    }
+  }
+}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<table class="table table-bordered">
+  <tbody>
+    <tr>
+      <td class="text-left" colspan="2"><strong>/jobs/:jobid/checkpoints/:checkpointid</strong></td>
+    </tr>
+    <tr>
+      <td class="text-left" style="width: 20%">Verb: <code>GET</code></td>
+      <td class="text-left">Response code: <code>200 OK</code></td>
+    </tr>
+    <tr>
+      <td colspan="2">description</td>
+    </tr>
+    <tr>
+      <td colspan="2">Path parameters</td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <ul>
+<li><code>jobid</code> - description</li>
+<li><code>checkpointid</code> - description</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#555198476">Request</button>
+        <div id="555198476" class="collapse">
+          <pre>
+            <code>
+{}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#-1467720266">Response</button>
+        <div id="-1467720266" class="collapse">
+          <pre>
+            <code>
+{
+  "type" : "object",
+  "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:CheckpointStatistics",
+  "properties" : {
+    "id" : {
+      "type" : "integer"
+    },
+    "status" : {
+      "type" : "string",
+      "enum" : [ "IN_PROGRESS", "COMPLETED", "FAILED" ]
+    },
+    "savepoint" : {
+      "type" : "boolean"
+    },
+    "triggerTimestamp" : {
+      "type" : "integer"
+    },
+    "latestAckTimestamp" : {
+      "type" : "integer"
+    },
+    "stateSize" : {
+      "type" : "integer"
+    },
+    "duration" : {
+      "type" : "integer"
+    },
+    "alignmentBuffered" : {
+      "type" : "integer"
+    },
+    "numSubtasks" : {
+      "type" : "integer"
+    },
+    "numAckSubtasks" : {
+      "type" : "integer"
+    },
+    "checkpointStatisticsPerTask" : {
+      "type" : "object",
+      "additionalProperties" : {
+        "type" : "object",
+        "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:TaskCheckpointStatistics",
+        "properties" : {
+          "checkpointId" : {
+            "type" : "integer"
+          },
+          "checkpointStatus" : {
+            "type" : "string",
+            "enum" : [ "IN_PROGRESS", "COMPLETED", "FAILED" ]
+          },
+          "latestAckTimestamp" : {
+            "type" : "integer"
+          },
+          "stateSize" : {
+            "type" : "integer"
+          },
+          "duration" : {
+            "type" : "integer"
+          },
+          "alignmentBuffered" : {
+            "type" : "integer"
+          },
+          "numSubtasks" : {
+            "type" : "integer"
+          },
+          "numAckSubtasks" : {
+            "type" : "integer"
+          }
+        }
+      }
+    }
+  }
+}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<table class="table table-bordered">
+  <tbody>
+    <tr>
+      <td class="text-left" colspan="2"><strong>/jobs/:jobid/config</strong></td>
+    </tr>
+    <tr>
+      <td class="text-left" style="width: 20%">Verb: <code>GET</code></td>
+      <td class="text-left">Response code: <code>200 OK</code></td>
+    </tr>
+    <tr>
+      <td colspan="2">description</td>
+    </tr>
+    <tr>
+      <td colspan="2">Path parameters</td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <ul>
+<li><code>jobid</code> - description</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#-1640089597">Request</button>
+        <div id="-1640089597" class="collapse">
+          <pre>
+            <code>
+{}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#-209393816">Response</button>
+        <div id="-209393816" class="collapse">
+          <pre>
+            <code>
+{
+  "type" : "object",
+  "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:JobConfigInfo",
+  "properties" : {
+    "jobId" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:api:common:JobID",
+      "properties" : {
+        "upperPart" : {
+          "type" : "integer"
+        },
+        "lowerPart" : {
+          "type" : "integer"
+        },
+        "bytes" : {
+          "type" : "array",
+          "items" : {
+            "type" : "integer"
+          }
+        }
+      }
+    },
+    "jobName" : {
+      "type" : "string"
+    },
+    "executionConfigInfo" : {
+      "type" : "any"
+    }
+  }
+}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<table class="table table-bordered">
+  <tbody>
+    <tr>
+      <td class="text-left" colspan="2"><strong>/jobs/:jobid/exceptions</strong></td>
+    </tr>
+    <tr>
+      <td class="text-left" style="width: 20%">Verb: <code>GET</code></td>
+      <td class="text-left">Response code: <code>200 OK</code></td>
+    </tr>
+    <tr>
+      <td colspan="2">description</td>
+    </tr>
+    <tr>
+      <td colspan="2">Path parameters</td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <ul>
+<li><code>jobid</code> - description</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#511742789">Request</button>
+        <div id="511742789" class="collapse">
+          <pre>
+            <code>
+{}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#-459132180">Response</button>
+        <div id="-459132180" class="collapse">
+          <pre>
+            <code>
+{
+  "type" : "any"
+}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<table class="table table-bordered">
+  <tbody>
+    <tr>
+      <td class="text-left" colspan="2"><strong>/jobs/:jobid/plan</strong></td>
+    </tr>
+    <tr>
+      <td class="text-left" style="width: 20%">Verb: <code>GET</code></td>
+      <td class="text-left">Response code: <code>200 OK</code></td>
+    </tr>
+    <tr>
+      <td colspan="2">description</td>
+    </tr>
+    <tr>
+      <td colspan="2">Path parameters</td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <ul>
+<li><code>jobid</code> - description</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#-1178135126">Request</button>
+        <div id="-1178135126" class="collapse">
+          <pre>
+            <code>
+{}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#314594358">Response</button>
+        <div id="314594358" class="collapse">
+          <pre>
+            <code>
+{
+  "type" : "object",
+  "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:JobPlanInfo",
+  "properties" : {
+    "jsonPlan" : {
+      "type" : "string"
+    }
+  }
+}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<table class="table table-bordered">
+  <tbody>
+    <tr>
+      <td class="text-left" colspan="2"><strong>/jobs/:jobid/vertices/:vertexid/accumulators</strong></td>
+    </tr>
+    <tr>
+      <td class="text-left" style="width: 20%">Verb: <code>GET</code></td>
+      <td class="text-left">Response code: <code>200 OK</code></td>
+    </tr>
+    <tr>
+      <td colspan="2">description</td>
+    </tr>
+    <tr>
+      <td colspan="2">Path parameters</td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <ul>
+<li><code>jobid</code> - description</li>
+<li><code>vertexid</code> - description</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#2008968300">Request</button>
+        <div id="2008968300" class="collapse">
+          <pre>
+            <code>
+{}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#453034240">Response</button>
+        <div id="453034240" class="collapse">
+          <pre>
+            <code>
+{
+  "type" : "any"
+}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<table class="table table-bordered">
+  <tbody>
+    <tr>
+      <td class="text-left" colspan="2"><strong>/jobs/:jobid/vertices/:vertexid/subtasktimes</strong></td>
+    </tr>
+    <tr>
+      <td class="text-left" style="width: 20%">Verb: <code>GET</code></td>
+      <td class="text-left">Response code: <code>200 OK</code></td>
+    </tr>
+    <tr>
+      <td colspan="2">description</td>
+    </tr>
+    <tr>
+      <td colspan="2">Path parameters</td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <ul>
+<li><code>jobid</code> - description</li>
+<li><code>vertexid</code> - description</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#-1464202656">Request</button>
+        <div id="-1464202656" class="collapse">
+          <pre>
+            <code>
+{}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#1808727934">Response</button>
+        <div id="1808727934" class="collapse">
+          <pre>
+            <code>
+{
+  "type" : "any"
+}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<table class="table table-bordered">
+  <tbody>
+    <tr>
+      <td class="text-left" colspan="2"><strong>/overview</strong></td>
+    </tr>
+    <tr>
+      <td class="text-left" style="width: 20%">Verb: <code>GET</code></td>
+      <td class="text-left">Response code: <code>200 OK</code></td>
+    </tr>
+    <tr>
+      <td colspan="2">description</td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#-1864315550">Request</button>
+        <div id="-1864315550" class="collapse">
+          <pre>
+            <code>
+{}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#-1614643076">Response</button>
+        <div id="-1614643076" class="collapse">
+          <pre>
+            <code>
+{
+  "type" : "object",
+  "id" : "urn:jsonschema:org:apache:flink:runtime:rest:handler:legacy:messages:ClusterOverviewWithVersion",
+  "properties" : {
+    "numJobsRunningOrPending" : {
+      "type" : "integer"
+    },
+    "numJobsFinished" : {
+      "type" : "integer"
+    },
+    "numJobsCancelled" : {
+      "type" : "integer"
+    },
+    "numJobsFailed" : {
+      "type" : "integer"
+    },
+    "numTaskManagersConnected" : {
+      "type" : "integer"
+    },
+    "numSlotsTotal" : {
+      "type" : "integer"
+    },
+    "numSlotsAvailable" : {
+      "type" : "integer"
+    },
+    "version" : {
+      "type" : "string"
+    },
+    "commitId" : {
+      "type" : "string"
+    }
+  }
+}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<table class="table table-bordered">
+  <tbody>
+    <tr>
+      <td class="text-left" colspan="2"><strong>/taskmanagers</strong></td>
+    </tr>
+    <tr>
+      <td class="text-left" style="width: 20%">Verb: <code>GET</code></td>
+      <td class="text-left">Response code: <code>200 OK</code></td>
+    </tr>
+    <tr>
+      <td colspan="2">description</td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#-1495435436">Request</button>
+        <div id="-1495435436" class="collapse">
+          <pre>
+            <code>
+{}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#1411286031">Response</button>
+        <div id="1411286031" class="collapse">
+          <pre>
+            <code>
+{
+  "type" : "object",
+  "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:taskmanager:TaskManagersInfo",
+  "properties" : {
+    "taskManagerInfos" : {
+      "type" : "array",
+      "items" : {
+        "type" : "object",
+        "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:taskmanager:TaskManagerInfo",
+        "properties" : {
+          "instanceId" : {
+            "type" : "object",
+            "id" : "urn:jsonschema:org:apache:flink:runtime:instance:InstanceID",
+            "properties" : {
+              "upperPart" : {
+                "type" : "integer"
+              },
+              "lowerPart" : {
+                "type" : "integer"
+              },
+              "bytes" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "integer"
+                }
+              }
+            }
+          },
+          "address" : {
+            "type" : "string"
+          },
+          "dataPort" : {
+            "type" : "integer"
+          },
+          "lastHeartbeat" : {
+            "type" : "integer"
+          },
+          "numberSlots" : {
+            "type" : "integer"
+          },
+          "numberAvailableSlots" : {
+            "type" : "integer"
+          },
+          "hardwareDescription" : {
+            "type" : "object",
+            "id" : "urn:jsonschema:org:apache:flink:runtime:instance:HardwareDescription",
+            "properties" : {
+              "numberOfCPUCores" : {
+                "type" : "integer"
+              },
+              "sizeOfPhysicalMemory" : {
+                "type" : "integer"
+              },
+              "sizeOfJvmHeap" : {
+                "type" : "integer"
+              },
+              "sizeOfManagedMemory" : {
+                "type" : "integer"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<table class="table table-bordered">
+  <tbody>
+    <tr>
+      <td class="text-left" colspan="2"><strong>/taskmanagers/:taskmanagerid</strong></td>
+    </tr>
+    <tr>
+      <td class="text-left" style="width: 20%">Verb: <code>GET</code></td>
+      <td class="text-left">Response code: <code>200 OK</code></td>
+    </tr>
+    <tr>
+      <td colspan="2">description</td>
+    </tr>
+    <tr>
+      <td colspan="2">Path parameters</td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <ul>
+<li><code>taskmanagerid</code> - description</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#-1492433800">Request</button>
+        <div id="-1492433800" class="collapse">
+          <pre>
+            <code>
+{}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#-2009840798">Response</button>
+        <div id="-2009840798" class="collapse">
+          <pre>
+            <code>
+{
+  "type" : "object",
+  "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:taskmanager:TaskManagerDetailsInfo",
+  "properties" : {
+    "instanceId" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:instance:InstanceID",
+      "properties" : {
+        "upperPart" : {
+          "type" : "integer"
+        },
+        "lowerPart" : {
+          "type" : "integer"
+        },
+        "bytes" : {
+          "type" : "array",
+          "items" : {
+            "type" : "integer"
+          }
+        }
+      }
+    },
+    "address" : {
+      "type" : "string"
+    },
+    "dataPort" : {
+      "type" : "integer"
+    },
+    "lastHeartbeat" : {
+      "type" : "integer"
+    },
+    "numberSlots" : {
+      "type" : "integer"
+    },
+    "numberAvailableSlots" : {
+      "type" : "integer"
+    },
+    "hardwareDescription" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:instance:HardwareDescription",
+      "properties" : {
+        "numberOfCPUCores" : {
+          "type" : "integer"
+        },
+        "sizeOfPhysicalMemory" : {
+          "type" : "integer"
+        },
+        "sizeOfJvmHeap" : {
+          "type" : "integer"
+        },
+        "sizeOfManagedMemory" : {
+          "type" : "integer"
+        }
+      }
+    }
+  }
+}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/docs/monitoring/rest_api.md
+++ b/docs/monitoring/rest_api.md
@@ -674,4 +674,12 @@ Response:
 {"jobid": "869a9868d49c679e7355700e0857af85"}
 ~~~
 
+## FLIP-6
+
+The following is the REST API documentation for FLIP-6.
+
+### Dispatcher
+
+{% include generated/rest_dispatcher.html %}
+
 {% top %}

--- a/flink-docs/README.md
+++ b/flink-docs/README.md
@@ -1,0 +1,36 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Documentation generators
+
+This module contains generators that create HTML files directly from Flinks source code.
+
+## REST API documentation
+
+The `RestAPIDocGenerator` can be used to generate a full reference of the REST API of a `RestServerEndpoint`. A separate file is generated for each endpoint.
+
+To integrate a new endpoint into the generator
+1. Add a new `DocumentingRestEndpoint` class to `RestAPIDocGenerator` that extends the new endpoint class
+2. Add another call to `createHtmlFile` in `RestAPIDocGenerator#main`
+3. Regenerate the documentation by running `mvn package -Dgenerate-rest-docs`
+4. Integrate the generated file into the REST API documentation using `{% include generated/<file-name>.html %}`
+
+The documentation must be regenerated whenever
+* a handler was added to/removed from a `RestServerEndpoint`
+* any used `MessageHeaders` class or any referenced `RequestBody`, `ResponseBody`, `MessageParameters` or `MessageParameter` class was modified.

--- a/flink-docs/pom.xml
+++ b/flink-docs/pom.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.apache.flink</groupId>
+		<artifactId>flink-parent</artifactId>
+		<version>1.5-SNAPSHOT</version>
+		<relativePath>..</relativePath>
+	</parent>
+
+	<artifactId>flink-docs</artifactId>
+	<name>flink-docs</name>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-core</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-java</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-shaded-netty</artifactId>
+		</dependency>
+
+		<dependency>
+			<!-- We use standard jackson since jackson-module-jsonSchema isn't part of flink-shaded-jackson -->
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-core</artifactId>
+			<version>${jackson.version}</version>
+		</dependency>
+		<dependency>
+			<!-- We use standard jackson since jackson-module-jsonSchema isn't part of flink-shaded-jackson -->
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>${jackson.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.module</groupId>
+			<artifactId>jackson-module-jsonSchema</artifactId>
+			<version>${jackson.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-log4j12</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>log4j</groupId>
+			<artifactId>log4j</artifactId>
+		</dependency>
+	</dependencies>
+
+	<profiles>
+		<profile>
+			<id>generate-rest-docs</id>
+			<activation>
+				<property>
+					<name>generate-rest-docs</name>
+				</property>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<artifactId>maven-antrun-plugin</artifactId>
+						<version>1.7</version>
+						<executions>
+							<execution>
+								<phase>package</phase>
+								<goals>
+									<goal>run</goal>
+								</goals>
+							</execution>
+						</executions>
+						<configuration>
+							<target>
+								<mkdir dir="${rootDir}/${generated.docs.dir}"/>
+								<java classname="org.apache.flink.docs.rest.RestAPIDocGenerator" fork="true">
+									<classpath refid="maven.compile.classpath"/>
+									<arg value="${rootDir}/${generated.docs.dir}/"/>
+								</java>
+							</target>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+
+</project>

--- a/flink-docs/src/main/java/org/apache/flink/docs/rest/RestAPIDocGenerator.java
+++ b/flink-docs/src/main/java/org/apache/flink/docs/rest/RestAPIDocGenerator.java
@@ -1,0 +1,315 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.docs.rest;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.concurrent.Executors;
+import org.apache.flink.runtime.dispatcher.DispatcherGateway;
+import org.apache.flink.runtime.dispatcher.DispatcherRestEndpoint;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
+import org.apache.flink.runtime.rest.RestServerEndpoint;
+import org.apache.flink.runtime.rest.RestServerEndpointConfiguration;
+import org.apache.flink.runtime.rest.handler.RestHandlerConfiguration;
+import org.apache.flink.runtime.rest.handler.RestHandlerSpecification;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.EmptyResponseBody;
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+import org.apache.flink.runtime.rest.messages.MessagePathParameter;
+import org.apache.flink.runtime.rest.messages.MessageQueryParameter;
+import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+import org.apache.flink.runtime.webmonitor.retriever.MetricQueryServiceRetriever;
+import org.apache.flink.util.ConfigurationException;
+
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelInboundHandler;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.module.jsonSchema.JsonSchema;
+import com.fasterxml.jackson.module.jsonSchema.JsonSchemaGenerator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.stream.Collectors;
+
+/**
+ * Generator for the Rest API documentation.
+ *
+ * <p>This class can be either invoked directly
+ *
+ * <p>One HTML file is generated for each {@link RestServerEndpoint} implementation
+ * that can be embedded into .md files using {@code {% include ${generated.docs.dir}/file.html %}}.
+ * Each file contains a series of HTML tables, one for each REST call.
+ *
+ * <p>The generated table for each REST call looks like this:
+ * ----------------------------------------------------------
+ * | URL                                                    |
+ * ----------------------------------------------------------
+ * | Verb: verb | Response code: responseCode               |
+ * ----------------------------------------------------------
+ * | Path parameters (if any are defined)                   |
+ * ----------------------------------------------------------
+ * |   - parameterName: description                         |
+ * |   ...                                                  |
+ * ----------------------------------------------------------
+ * | Query parameters (if any are defined)                  |
+ * ----------------------------------------------------------
+ * |   - parameterName (requisiteness): description         |
+ * |   ...                                                  |
+ * ----------------------------------------------------------
+ * | Request json schema (a collapsible "Request" button)   |
+ * ----------------------------------------------------------
+ * | Response json schema (a collapsible "Response" button) |
+ * ----------------------------------------------------------
+ */
+public class RestAPIDocGenerator {
+
+	private static final Logger LOG = LoggerFactory.getLogger(RestAPIDocGenerator.class);
+
+	private static final ObjectMapper mapper;
+	private static final JsonSchemaGenerator schemaGen;
+
+	static {
+		mapper = new ObjectMapper();
+		schemaGen = new JsonSchemaGenerator(mapper);
+	}
+
+	/**
+	 * Generates the REST API documentation.
+	 *
+	 * @param args args[0] contains the directory into which the generated files are placed
+	 * @throws IOException if any file operation failed
+	 */
+	public static void main(String[] args) throws IOException {
+		String outputDirectory = args[0];
+
+		createHtmlFile(new DocumentingDispatcherRestEndpoint(), Paths.get(outputDirectory, "rest_dispatcher.html"));
+	}
+
+	private static void createHtmlFile(DocumentingRestEndpoint restEndpoint, Path outputFile) throws IOException {
+		StringBuilder html = new StringBuilder();
+
+		List<MessageHeaders> specs = restEndpoint.getSpecs();
+		specs.forEach(spec -> html.append(createHtmlEntry(spec)));
+
+		if (Files.exists(outputFile)) {
+			Files.delete(outputFile);
+		}
+		Files.write(outputFile, html.toString().getBytes(StandardCharsets.UTF_8));
+	}
+
+	private static String createHtmlEntry(MessageHeaders<?, ?, ?> spec) {
+		String requestEntry = createMessageHtmlEntry(
+			spec.getRequestClass(),
+			EmptyRequestBody.class);
+		String responseEntry = createMessageHtmlEntry(
+			spec.getResponseClass(),
+			EmptyResponseBody.class);
+
+		String pathParameterList = createPathParameterHtmlList(spec.getUnresolvedMessageParameters().getPathParameters());
+		String queryParameterList = createQueryParameterHtmlList(spec.getUnresolvedMessageParameters().getQueryParameters());
+
+		StringBuilder sb = new StringBuilder();
+		{
+			sb.append("<table class=\"table table-bordered\">\n");
+			sb.append("  <tbody>\n");
+			sb.append("    <tr>\n");
+			sb.append("      <td class=\"text-left\" colspan=\"2\"><strong>" + spec.getTargetRestEndpointURL() + "</strong></td>\n");
+			sb.append("    </tr>\n");
+			sb.append("    <tr>\n");
+			sb.append("      <td class=\"text-left\" style=\"width: 20%\">Verb: <code>" + spec.getHttpMethod() + "</code></td>\n");
+			sb.append("      <td class=\"text-left\">Response code: <code>" + spec.getResponseStatusCode() + "</code></td>\n");
+			sb.append("    </tr>\n");
+			sb.append("    <tr>\n");
+			sb.append("      <td colspan=\"2\">" + "description" + "</td>\n");
+			sb.append("    </tr>\n");
+		}
+		if (!pathParameterList.isEmpty()) {
+			sb.append("    <tr>\n");
+			sb.append("      <td colspan=\"2\">Path parameters</td>\n");
+			sb.append("    </tr>\n");
+			sb.append("    <tr>\n");
+			sb.append("      <td colspan=\"2\">\n");
+			sb.append("        <ul>\n");
+			sb.append(pathParameterList);
+			sb.append("        </ul>\n");
+			sb.append("      </td>\n");
+			sb.append("    </tr>\n");
+		}
+		if (!queryParameterList.isEmpty()) {
+			sb.append("    <tr>\n");
+			sb.append("      <td colspan=\"2\">Query parameters</td>\n");
+			sb.append("    </tr>\n");
+			sb.append("    <tr>\n");
+			sb.append("      <td colspan=\"2\">\n");
+			sb.append("        <ul>\n");
+			sb.append(queryParameterList);
+			sb.append("        </ul>\n");
+			sb.append("      </td>\n");
+			sb.append("    </tr>\n");
+		}
+		int reqHash = spec.getTargetRestEndpointURL().hashCode() + spec.getHttpMethod().hashCode() + spec.getRequestClass().getCanonicalName().hashCode();
+		int resHash = spec.getTargetRestEndpointURL().hashCode() + spec.getHttpMethod().hashCode() + spec.getResponseClass().getCanonicalName().hashCode();
+		{
+			sb.append("    <tr>\n");
+			sb.append("      <td colspan=\"2\">\n");
+			sb.append("        <button data-toggle=\"collapse\" data-target=\"#" + reqHash + "\">Request</button>\n");
+			sb.append("        <div id=\"" + reqHash + "\" class=\"collapse\">\n");
+			sb.append("          <pre>\n");
+			sb.append("            <code>\n");
+			sb.append(requestEntry);
+			sb.append("            </code>\n");
+			sb.append("          </pre>\n");
+			sb.append("         </div>\n");
+			sb.append("      </td>\n");
+			sb.append("    </tr>\n");
+			sb.append("    <tr>\n");
+			sb.append("      <td colspan=\"2\">\n");
+			sb.append("        <button data-toggle=\"collapse\" data-target=\"#" + resHash + "\">Response</button>\n");
+			sb.append("        <div id=\"" + resHash + "\" class=\"collapse\">\n");
+			sb.append("          <pre>\n");
+			sb.append("            <code>\n");
+			sb.append(responseEntry);
+			sb.append("            </code>\n");
+			sb.append("          </pre>\n");
+			sb.append("         </div>\n");
+			sb.append("      </td>\n");
+			sb.append("    </tr>\n");
+			sb.append("  </tbody>\n");
+			sb.append("</table>\n");
+		}
+
+		return sb.toString();
+	}
+
+	private static String createPathParameterHtmlList(Collection<MessagePathParameter<?>> pathParameters) {
+		StringBuilder pathParameterList = new StringBuilder();
+		pathParameters.forEach(messagePathParameter ->
+			pathParameterList.append(
+				String.format("<li><code>%s</code> - %s</li>\n",
+					messagePathParameter.getKey(),
+					"description")
+			));
+		return pathParameterList.toString();
+	}
+
+	private static String createQueryParameterHtmlList(Collection<MessageQueryParameter<?>> queryParameters) {
+		StringBuilder queryParameterList = new StringBuilder();
+		queryParameters.stream()
+			.sorted((param1, param2) -> Boolean.compare(param1.isMandatory(), param2.isMandatory()))
+			.forEach(parameter ->
+				queryParameterList.append(
+					String.format("<li><code>%s</code> (%s): %s</li>\n",
+						parameter.getKey(),
+						parameter.isMandatory() ? "mandatory" : "optional",
+						"description")
+				));
+		return queryParameterList.toString();
+	}
+
+	private static String createMessageHtmlEntry(Class<?> messageClass, Class<?> emptyMessageClass) {
+		JsonSchema schema;
+		try {
+			schema = schemaGen.generateSchema(messageClass);
+		} catch (JsonProcessingException e) {
+			LOG.error("Failed to generate message schema for class {}.", messageClass, e);
+			throw new RuntimeException("Failed to generate message schema for class " + messageClass.getCanonicalName() + ".", e);
+		}
+
+		String json;
+		if (messageClass == emptyMessageClass) {
+			json = "{}";
+		} else {
+			try {
+				json = mapper.writerWithDefaultPrettyPrinter()
+					.writeValueAsString(schema);
+			} catch (JsonProcessingException e) {
+				LOG.error("Failed to write message schema for class {}.", messageClass.getCanonicalName(), e);
+				throw new RuntimeException("Failed to write message schema for class " + messageClass.getCanonicalName() + ".", e);
+			}
+		}
+
+		return json;
+	}
+
+	/**
+	 * Utility class to extract the {@link MessageHeaders} that hte {@link DispatcherRestEndpoint} supports.
+	 */
+	private static class DocumentingDispatcherRestEndpoint extends DispatcherRestEndpoint implements DocumentingRestEndpoint {
+
+		private static final Configuration config;
+		private static final RestServerEndpointConfiguration restConfig;
+		private static final RestHandlerConfiguration handlerConfig;
+		private static final Executor executor;
+		private static final GatewayRetriever<DispatcherGateway> dispatcherGatewayRetriever;
+		private static final GatewayRetriever<ResourceManagerGateway> resourceManagerGatewayRetriever;
+		private static final MetricQueryServiceRetriever metricQueryServiceRetriever;
+
+		static {
+			config = new Configuration();
+			try {
+				restConfig = RestServerEndpointConfiguration.fromConfiguration(config);
+			} catch (ConfigurationException e) {
+				throw new RuntimeException("Implementation error. RestServerEndpointConfiguration#fromConfiguration failed for default configuration.");
+			}
+			handlerConfig = RestHandlerConfiguration.fromConfiguration(config);
+			executor = Executors.directExecutor();
+
+			dispatcherGatewayRetriever = () -> null;
+			resourceManagerGatewayRetriever = () -> null;
+			metricQueryServiceRetriever = path -> null;
+		}
+
+		private DocumentingDispatcherRestEndpoint() {
+			super(restConfig, dispatcherGatewayRetriever, config, handlerConfig, resourceManagerGatewayRetriever, executor, metricQueryServiceRetriever);
+		}
+
+		@Override
+		public List<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> initializeHandlers(CompletableFuture<String> restAddressFuture) {
+			return super.initializeHandlers(restAddressFuture);
+		}
+	}
+
+	/**
+	 * Interface to expose the supported {@link MessageHeaders} of a {@link RestServerEndpoint}.
+	 */
+	private interface DocumentingRestEndpoint {
+		List<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> initializeHandlers(CompletableFuture<String> restAddressFuture);
+
+		default List<MessageHeaders> getSpecs() {
+			Comparator<String> comparator = new RestServerEndpoint.RestHandlerUrlComparator.CaseInsensitiveOrderComparator();
+			return initializeHandlers(CompletableFuture.completedFuture(null)).stream()
+				.map(tuple -> tuple.f0)
+				.filter(spec -> spec instanceof MessageHeaders)
+				.map(spec -> (MessageHeaders) spec)
+				.sorted((spec1, spec2) -> comparator.compare(spec1.getTargetRestEndpointURL(), spec2.getTargetRestEndpointURL()))
+				.collect(Collectors.toList());
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
@@ -302,7 +302,7 @@ public abstract class RestServerEndpoint {
 	 * <p>IMPORTANT: This comparator is highly specific to how Netty path parameter are encoded. Namely
 	 * via a preceding ':' character.
 	 */
-	static final class RestHandlerUrlComparator implements Comparator<Tuple2<RestHandlerSpecification, ChannelInboundHandler>>, Serializable {
+	public static final class RestHandlerUrlComparator implements Comparator<Tuple2<RestHandlerSpecification, ChannelInboundHandler>>, Serializable {
 
 		private static final long serialVersionUID = 2388466767835547926L;
 
@@ -317,7 +317,7 @@ public abstract class RestServerEndpoint {
 			return CASE_INSENSITIVE_ORDER.compare(o1.f0.getTargetRestEndpointURL(), o2.f0.getTargetRestEndpointURL());
 		}
 
-		static final class CaseInsensitiveOrderComparator implements Comparator<String>, Serializable {
+		public static final class CaseInsensitiveOrderComparator implements Comparator<String>, Serializable {
 			private static final long serialVersionUID = 8550835445193437027L;
 
 			@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
@@ -317,6 +317,20 @@ public abstract class RestServerEndpoint {
 			return CASE_INSENSITIVE_ORDER.compare(o1.f0.getTargetRestEndpointURL(), o2.f0.getTargetRestEndpointURL());
 		}
 
+		/**
+		 * Comparator for Rest URLs.
+		 *
+		 * <p>The comparator orders the Rest URLs such that URLs with path parameters are ordered behind
+		 * those without parameters. E.g.:
+		 * /jobs
+		 * /jobs/overview
+		 * /jobs/:jobid
+		 * /jobs/:jobid/config
+		 * /:*
+		 *
+		 * <p>IMPORTANT: This comparator is highly specific to how Netty path parameter are encoded. Namely
+		 * via a preceding ':' character.
+		 */
 		public static final class CaseInsensitiveOrderComparator implements Comparator<String>, Serializable {
 			private static final long serialVersionUID = 8550835445193437027L;
 

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,7 @@ under the License.
 		<module>flink-yarn</module>
 		<module>flink-yarn-tests</module>
 		<module>flink-fs-tests</module>
+		<module>flink-docs</module>
 	</modules>
 
 	<properties>


### PR DESCRIPTION
## What is the purpose of the change

This PR adds a generator for the REST API documentation. The generated has to be run manually (automatic integration is a bit tricky, in particular detecting changes & failing the build).

The generator can be called by either specifying either `-Pgenerate-rest-docs` or `-Dgenerate-rest-docs` when building `flink-docs`.

The generated content was added to the REST API documentation (`/monitoring/rest_api.md`).

Here's a preview of the result:
![snippet](https://user-images.githubusercontent.com/5725237/33132910-522eb2d2-cf9b-11e7-844c-613fdcd818c8.PNG)

## Brief change log

* modify URL comparator in RestServerEndpoint to be public
* add a new module `flink-docs` (to not pollute other modules with dependencies)
* implement generator
* generated dispatcher REST documentation
* integrated generated content into rest_api.md

## Verifying this change

Needs manual verification.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
