### PR TITLE
[FLINK-8136] [table] Fix code generation with JodaTime shading

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
@@ -44,6 +44,7 @@ import org.apache.flink.table.functions.utils.UserDefinedFunctionUtils
 import org.apache.flink.table.typeutils.TimeIndicatorTypeInfo
 import org.apache.flink.table.functions.{FunctionContext, UserDefinedFunction}
 import org.apache.flink.table.typeutils.TypeCheckUtils._
+import org.joda.time.format.DateTimeFormatter
 
 import scala.collection.JavaConversions._
 import scala.collection.mutable
@@ -1467,7 +1468,7 @@ abstract class CodeGenerator(
 
     val field =
       s"""
-         |final org.joda.time.format.DateTimeFormatter $fieldTerm;
+         |final ${classOf[DateTimeFormatter].getCanonicalName} $fieldTerm;
          |""".stripMargin
     reusableMemberStatements.add(field)
 


### PR DESCRIPTION
## What is the purpose of the change

Fix `DATE_FORMAT` with shaded JodaTime.


## Brief change log

Do not use hard-coded class name in code generation.


## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
