### PR TITLE
[FLINK-8118] [table] Allow specifying reading offsets of KafkaTableSources

### DIFF
--- a/docs/dev/table/sourceSinks.md
+++ b/docs/dev/table/sourceSinks.md
@@ -144,7 +144,7 @@ val source: TableSource[_] = Kafka010JsonTableSource.builder()
 </div>
 </div>
 
-* **Missing Field Handling** By default, a missing JSON field is set to `null`. You can enable strict JSON parsing that will cancel the source (and query) if a field is missing.
+* **Missing Field Handling:** By default, a missing JSON field is set to `null`. You can enable strict JSON parsing that will cancel the source (and query) if a field is missing.
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
@@ -163,6 +163,30 @@ val source: TableSource[_] = Kafka010JsonTableSource.builder()
   // ...
   // configure missing field behavior
   .failOnMissingField(true)
+  .build()
+{% endhighlight %}
+</div>
+</div>
+
+* **Specify the start reading position:** By default, the table source will start reading data from the committed group offsets in Zookeeper or Kafka brokers. You can specify other start positions via the builder's methods, which correspond to the configurations in section [Kafka Consumers Start Position Configuration](../connectors/kafka.html#kafka-consumers-start-position-configuration).
+
+<div class="codetabs" markdown="1">
+<div data-lang="java" markdown="1">
+{% highlight java %}
+TableSource source = Kafka010JsonTableSource.builder()
+  // ...
+  // start reading from the earliest offset
+  .startReadingFromEarliest()
+  .build();
+{% endhighlight %}
+</div>
+
+<div data-lang="scala" markdown="1">
+{% highlight scala %}
+val source: TableSource[_] = Kafka010JsonTableSource.builder()
+  // ...
+  // start reading from the earliest offset
+  .startReadingFromEarliest()
   .build()
 {% endhighlight %}
 </div>
@@ -259,6 +283,30 @@ val source: TableSource[_] = Kafka010AvroTableSource.builder()
   .withTableToJsonMapping(Map(
     "sensorId" -> "id", 
     "temperature" -> "temp").asJava)
+  .build()
+{% endhighlight %}
+</div>
+</div>
+
+* **Specify the start reading position:** By default, the table source will start reading data from the committed group offsets in Zookeeper or Kafka brokers. You can specify other start positions via the builder's methods, which correspond to the configurations in section [Kafka Consumers Start Position Configuration](../connectors/kafka.html#kafka-consumers-start-position-configuration).
+
+<div class="codetabs" markdown="1">
+<div data-lang="java" markdown="1">
+{% highlight java %}
+TableSource source = Kafka010JsonTableSource.builder()
+  // ...
+  // start reading from the earliest offset
+  .startReadingFromEarliest()
+  .build();
+{% endhighlight %}
+</div>
+
+<div data-lang="scala" markdown="1">
+{% highlight scala %}
+val source: TableSource[_] = Kafka010JsonTableSource.builder()
+  // ...
+  // start reading from the earliest offset
+  .startReadingFromEarliest()
   .build()
 {% endhighlight %}
 </div>

--- a/flink-connectors/flink-connector-kafka-0.10/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka010AvroTableSource.java
+++ b/flink-connectors/flink-connector-kafka-0.10/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka010AvroTableSource.java
@@ -94,7 +94,7 @@ public class Kafka010AvroTableSource extends KafkaAvroTableSource {
 	}
 
 	@Override
-	FlinkKafkaConsumerBase<Row> getKafkaConsumer(String topic, Properties properties, DeserializationSchema<Row> deserializationSchema) {
+	protected FlinkKafkaConsumerBase<Row> createKafkaConsumer(String topic, Properties properties, DeserializationSchema<Row> deserializationSchema) {
 		return new FlinkKafkaConsumer010<>(topic, deserializationSchema, properties);
 	}
 

--- a/flink-connectors/flink-connector-kafka-0.10/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka010JsonTableSource.java
+++ b/flink-connectors/flink-connector-kafka-0.10/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka010JsonTableSource.java
@@ -93,7 +93,7 @@ public class Kafka010JsonTableSource extends KafkaJsonTableSource {
 	}
 
 	@Override
-	FlinkKafkaConsumerBase<Row> getKafkaConsumer(String topic, Properties properties, DeserializationSchema<Row> deserializationSchema) {
+	protected FlinkKafkaConsumerBase<Row> createKafkaConsumer(String topic, Properties properties, DeserializationSchema<Row> deserializationSchema) {
 		return new FlinkKafkaConsumer010<>(topic, deserializationSchema, properties);
 	}
 

--- a/flink-connectors/flink-connector-kafka-0.10/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka010TableSource.java
+++ b/flink-connectors/flink-connector-kafka-0.10/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka010TableSource.java
@@ -61,7 +61,7 @@ public abstract class Kafka010TableSource extends KafkaTableSource {
 	}
 
 	@Override
-	FlinkKafkaConsumerBase<Row> getKafkaConsumer(String topic, Properties properties, DeserializationSchema<Row> deserializationSchema) {
+	protected FlinkKafkaConsumerBase<Row> createKafkaConsumer(String topic, Properties properties, DeserializationSchema<Row> deserializationSchema) {
 		return new FlinkKafkaConsumer010<>(topic, deserializationSchema, properties);
 	}
 }

--- a/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka011AvroTableSource.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka011AvroTableSource.java
@@ -94,7 +94,7 @@ public class Kafka011AvroTableSource extends KafkaAvroTableSource {
 	}
 
 	@Override
-	FlinkKafkaConsumerBase<Row> getKafkaConsumer(String topic, Properties properties, DeserializationSchema<Row> deserializationSchema) {
+	protected FlinkKafkaConsumerBase<Row> createKafkaConsumer(String topic, Properties properties, DeserializationSchema<Row> deserializationSchema) {
 		return new FlinkKafkaConsumer011<>(topic, deserializationSchema, properties);
 	}
 

--- a/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka011JsonTableSource.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka011JsonTableSource.java
@@ -93,7 +93,7 @@ public class Kafka011JsonTableSource extends KafkaJsonTableSource {
 	}
 
 	@Override
-	FlinkKafkaConsumerBase<Row> getKafkaConsumer(String topic, Properties properties, DeserializationSchema<Row> deserializationSchema) {
+	protected FlinkKafkaConsumerBase<Row> createKafkaConsumer(String topic, Properties properties, DeserializationSchema<Row> deserializationSchema) {
 		return new FlinkKafkaConsumer011<>(topic, deserializationSchema, properties);
 	}
 

--- a/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka011TableSource.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka011TableSource.java
@@ -61,7 +61,7 @@ public abstract class Kafka011TableSource extends KafkaTableSource {
 	}
 
 	@Override
-	FlinkKafkaConsumerBase<Row> getKafkaConsumer(String topic, Properties properties, DeserializationSchema<Row> deserializationSchema) {
+	protected FlinkKafkaConsumerBase<Row> createKafkaConsumer(String topic, Properties properties, DeserializationSchema<Row> deserializationSchema) {
 		return new FlinkKafkaConsumer011<>(topic, deserializationSchema, properties);
 	}
 

--- a/flink-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka08AvroTableSource.java
+++ b/flink-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka08AvroTableSource.java
@@ -94,7 +94,7 @@ public class Kafka08AvroTableSource extends KafkaAvroTableSource {
 	}
 
 	@Override
-	FlinkKafkaConsumerBase<Row> getKafkaConsumer(String topic, Properties properties, DeserializationSchema<Row> deserializationSchema) {
+	protected FlinkKafkaConsumerBase<Row> createKafkaConsumer(String topic, Properties properties, DeserializationSchema<Row> deserializationSchema) {
 		return new FlinkKafkaConsumer08<>(topic, deserializationSchema, properties);
 	}
 

--- a/flink-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka08JsonTableSource.java
+++ b/flink-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka08JsonTableSource.java
@@ -93,7 +93,7 @@ public class Kafka08JsonTableSource extends KafkaJsonTableSource {
 	}
 
 	@Override
-	FlinkKafkaConsumerBase<Row> getKafkaConsumer(String topic, Properties properties, DeserializationSchema<Row> deserializationSchema) {
+	protected FlinkKafkaConsumerBase<Row> createKafkaConsumer(String topic, Properties properties, DeserializationSchema<Row> deserializationSchema) {
 		return new FlinkKafkaConsumer08<>(topic, deserializationSchema, properties);
 	}
 

--- a/flink-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka08TableSource.java
+++ b/flink-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka08TableSource.java
@@ -61,7 +61,7 @@ public abstract class Kafka08TableSource extends KafkaTableSource {
 	}
 
 	@Override
-	FlinkKafkaConsumerBase<Row> getKafkaConsumer(String topic, Properties properties, DeserializationSchema<Row> deserializationSchema) {
+	protected FlinkKafkaConsumerBase<Row> createKafkaConsumer(String topic, Properties properties, DeserializationSchema<Row> deserializationSchema) {
 		return new FlinkKafkaConsumer08<>(topic, deserializationSchema, properties);
 	}
 }

--- a/flink-connectors/flink-connector-kafka-0.9/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka09AvroTableSource.java
+++ b/flink-connectors/flink-connector-kafka-0.9/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka09AvroTableSource.java
@@ -94,7 +94,7 @@ public class Kafka09AvroTableSource extends KafkaAvroTableSource {
 	}
 
 	@Override
-	FlinkKafkaConsumerBase<Row> getKafkaConsumer(String topic, Properties properties, DeserializationSchema<Row> deserializationSchema) {
+	protected FlinkKafkaConsumerBase<Row> createKafkaConsumer(String topic, Properties properties, DeserializationSchema<Row> deserializationSchema) {
 		return new FlinkKafkaConsumer09<>(topic, deserializationSchema, properties);
 	}
 

--- a/flink-connectors/flink-connector-kafka-0.9/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka09JsonTableSource.java
+++ b/flink-connectors/flink-connector-kafka-0.9/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka09JsonTableSource.java
@@ -93,7 +93,7 @@ public class Kafka09JsonTableSource extends KafkaJsonTableSource {
 	}
 
 	@Override
-	FlinkKafkaConsumerBase<Row> getKafkaConsumer(String topic, Properties properties, DeserializationSchema<Row> deserializationSchema) {
+	protected FlinkKafkaConsumerBase<Row> createKafkaConsumer(String topic, Properties properties, DeserializationSchema<Row> deserializationSchema) {
 		return new FlinkKafkaConsumer09<>(topic, deserializationSchema, properties);
 	}
 

--- a/flink-connectors/flink-connector-kafka-0.9/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka09TableSource.java
+++ b/flink-connectors/flink-connector-kafka-0.9/src/main/java/org/apache/flink/streaming/connectors/kafka/Kafka09TableSource.java
@@ -61,7 +61,7 @@ public abstract class Kafka09TableSource extends KafkaTableSource {
 	}
 
 	@Override
-	FlinkKafkaConsumerBase<Row> getKafkaConsumer(String topic, Properties properties, DeserializationSchema<Row> deserializationSchema) {
+	protected FlinkKafkaConsumerBase<Row> createKafkaConsumer(String topic, Properties properties, DeserializationSchema<Row> deserializationSchema) {
 		return new FlinkKafkaConsumer09<>(topic, deserializationSchema, properties);
 	}
 }

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaAvroTableSource.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaAvroTableSource.java
@@ -44,7 +44,7 @@ import java.util.Properties;
  * A version-agnostic Kafka Avro {@link StreamTableSource}.
  *
  * <p>The version-specific Kafka consumers need to extend this class and
- * override {@link #getKafkaConsumer(String, Properties, DeserializationSchema)}}.
+ * override {@link #createKafkaConsumer(String, Properties, DeserializationSchema)}}.
  */
 public abstract class KafkaAvroTableSource extends KafkaTableSource implements DefinedFieldMapping {
 

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaJsonTableSource.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaJsonTableSource.java
@@ -32,7 +32,7 @@ import java.util.Properties;
  * A version-agnostic Kafka JSON {@link StreamTableSource}.
  *
  * <p>The version-specific Kafka consumers need to extend this class and
- * override {@link #getKafkaConsumer(String, Properties, DeserializationSchema)}}.
+ * override {@link #createKafkaConsumer(String, Properties, DeserializationSchema)}}.
  *
  * <p>The field names are used to parse the JSON file and so are the types.
  */

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSource.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSource.java
@@ -22,6 +22,8 @@ import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.connectors.kafka.config.StartupMode;
+import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartition;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.Types;
 import org.apache.flink.table.api.ValidationException;
@@ -37,6 +39,7 @@ import org.apache.flink.util.Preconditions;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 import scala.Option;
@@ -45,7 +48,7 @@ import scala.Option;
  * A version-agnostic Kafka {@link StreamTableSource}.
  *
  * <p>The version-specific Kafka consumers need to extend this class and
- * override {@link #getKafkaConsumer(String, Properties, DeserializationSchema)}}.
+ * override {@link #createKafkaConsumer(String, Properties, DeserializationSchema)}}.
  */
 public abstract class KafkaTableSource
 	implements StreamTableSource<Row>, DefinedProctimeAttribute, DefinedRowtimeAttributes {
@@ -67,6 +70,12 @@ public abstract class KafkaTableSource
 
 	/** Descriptor for a rowtime attribute. */
 	private List<RowtimeAttributeDescriptor> rowtimeAttributeDescriptors;
+
+	/** The startup mode for the contained consumer (default is {@link StartupMode#GROUP_OFFSETS}). */
+	protected StartupMode startupMode;
+
+	/** Specific startup offsets; only relevant when startup mode is {@link StartupMode#SPECIFIC_OFFSETS}. */
+	protected Map<KafkaTopicPartition, Long> specificStartupOffsets;
 
 	/**
 	 * Creates a generic Kafka {@link StreamTableSource}.
@@ -121,6 +130,37 @@ public abstract class KafkaTableSource
 		return rowtimeAttributeDescriptors;
 	}
 
+	/**
+	 * Returns a version-specific Kafka consumer with the start position configured.
+	 *
+	 * @param topic                 Kafka topic to consume.
+	 * @param properties            Properties for the Kafka consumer.
+	 * @param deserializationSchema Deserialization schema to use for Kafka records.
+	 * @return The version-specific Kafka consumer
+	 */
+	public FlinkKafkaConsumerBase<Row> getKafkaConsumer(
+			String topic,
+			Properties properties,
+			DeserializationSchema<Row> deserializationSchema) {
+		FlinkKafkaConsumerBase<Row> kafkaConsumer =
+				createKafkaConsumer(topic, properties, deserializationSchema);
+		switch (startupMode) {
+			case EARLIEST:
+				kafkaConsumer.setStartFromEarliest();
+				break;
+			case LATEST:
+				kafkaConsumer.setStartFromLatest();
+				break;
+			case GROUP_OFFSETS:
+				kafkaConsumer.setStartFromGroupOffsets();
+				break;
+			case SPECIFIC_OFFSETS:
+				kafkaConsumer.setStartFromSpecificOffsets(specificStartupOffsets);
+				break;
+		}
+		return kafkaConsumer;
+	}
+
 	//////// SETTERS FOR OPTIONAL PARAMETERS
 
 	/**
@@ -163,14 +203,14 @@ public abstract class KafkaTableSource
 	//////// ABSTRACT METHODS FOR SUBCLASSES
 
 	/**
-	 * Returns the version-specific Kafka consumer.
+	 * Create a version-specific Kafka consumer.
 	 *
 	 * @param topic                 Kafka topic to consume.
 	 * @param properties            Properties for the Kafka consumer.
 	 * @param deserializationSchema Deserialization schema to use for Kafka records.
 	 * @return The version-specific Kafka consumer
 	 */
-	abstract FlinkKafkaConsumerBase<Row> getKafkaConsumer(
+	protected abstract FlinkKafkaConsumerBase<Row> createKafkaConsumer(
 			String topic,
 			Properties properties,
 			DeserializationSchema<Row> deserializationSchema);
@@ -200,6 +240,13 @@ public abstract class KafkaTableSource
 		private String proctimeAttribute;
 
 		private RowtimeAttributeDescriptor rowtimeAttributeDescriptor;
+
+		/** The startup mode for the contained consumer (default is {@link StartupMode#GROUP_OFFSETS}). */
+		private StartupMode startupMode = StartupMode.GROUP_OFFSETS;
+
+		/** Specific startup offsets; only relevant when startup mode is {@link StartupMode#SPECIFIC_OFFSETS}. */
+		private Map<KafkaTopicPartition, Long> specificStartupOffsets = null;
+
 
 		/**
 		 * Sets the topic from which the table is read.
@@ -310,6 +357,51 @@ public abstract class KafkaTableSource
 		}
 
 		/**
+		 * Configures the TableSource to start reading from the earliest offset for all partitions.
+		 *
+		 * @see FlinkKafkaConsumerBase#setStartFromEarliest()
+		 */
+		public B startReadingFromEarliest() {
+			this.startupMode = StartupMode.EARLIEST;
+			this.specificStartupOffsets = null;
+			return builder();
+		}
+
+		/**
+		 * Configures the TableSource to start reading from the latest offset for all partitions.
+		 *
+		 * @see FlinkKafkaConsumerBase#setStartFromLatest()
+		 */
+		public B startReadingFromLatest() {
+			this.startupMode = StartupMode.LATEST;
+			this.specificStartupOffsets = null;
+			return builder();
+		}
+
+		/**
+		 * Configures the TableSource to start reading from any committed group offsets found in Zookeeper / Kafka brokers.
+		 *
+		 * @see FlinkKafkaConsumerBase#setStartFromGroupOffsets()
+		 */
+		public B startReadingFromGroupOffsets() {
+			this.startupMode = StartupMode.GROUP_OFFSETS;
+			this.specificStartupOffsets = null;
+			return builder();
+		}
+
+		/**
+		 * Configures the TableSource to start reading partitions from specific offsets, set independently for each partition.
+		 *
+		 * @param specificStartupOffsets the specified offsets for partitions
+		 * @see FlinkKafkaConsumerBase#setStartFromSpecificOffsets(Map)
+		 */
+		public B startReadingFromSpecificOffsets(Map<KafkaTopicPartition, Long> specificStartupOffsets) {
+			this.startupMode = StartupMode.SPECIFIC_OFFSETS;
+			this.specificStartupOffsets = Preconditions.checkNotNull(specificStartupOffsets);
+			return builder();
+		}
+
+		/**
 		 * Returns the configured topic.
 		 *
 		 * @return the configured topic.
@@ -356,6 +448,16 @@ public abstract class KafkaTableSource
 				tableSource.setRowtimeAttributeDescriptors(Collections.emptyList());
 			} else {
 				tableSource.setRowtimeAttributeDescriptors(Collections.singletonList(rowtimeAttributeDescriptor));
+			}
+			tableSource.startupMode = startupMode;
+			switch (startupMode) {
+				case EARLIEST:
+				case LATEST:
+				case GROUP_OFFSETS:
+					break;
+				case SPECIFIC_OFFSETS:
+					tableSource.specificStartupOffsets = specificStartupOffsets;
+					break;
 			}
 		}
 

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceTestBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceTestBase.java
@@ -32,6 +32,7 @@ import org.apache.flink.types.Row;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
@@ -44,6 +45,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Abstract test base for all Kafka table sources.
@@ -186,6 +188,48 @@ public abstract class KafkaTableSourceTestBase {
 				fail();
 			}
 		}
+	}
+
+	@Test
+	public void testKafkaTSSetConsumeOffsets() {
+		KafkaTableSource.Builder b = getBuilder();
+		configureBuilder(b);
+
+		// test the default behavior
+		KafkaTableSource source = spy(b.build());
+		when(source.createKafkaConsumer(TOPIC, PROPS, null))
+				.thenReturn(mock(getFlinkKafkaConsumer()));
+
+		verify(source.getKafkaConsumer(TOPIC, PROPS, null)).setStartFromGroupOffsets();
+
+		// test reading from earliest
+		b.startReadingFromEarliest();
+		source = spy(b.build());
+		when(source.createKafkaConsumer(TOPIC, PROPS, null))
+				.thenReturn(mock(getFlinkKafkaConsumer()));
+
+		verify(source.getKafkaConsumer(TOPIC, PROPS, null)).setStartFromEarliest();
+
+		// test reading from latest
+		b.startReadingFromLatest();
+		source = spy(b.build());
+		when(source.createKafkaConsumer(TOPIC, PROPS, null))
+				.thenReturn(mock(getFlinkKafkaConsumer()));
+		verify(source.getKafkaConsumer(TOPIC, PROPS, null)).setStartFromLatest();
+
+		// test reading from group offsets
+		b.startReadingFromGroupOffsets();
+		source = spy(b.build());
+		when(source.createKafkaConsumer(TOPIC, PROPS, null))
+				.thenReturn(mock(getFlinkKafkaConsumer()));
+		verify(source.getKafkaConsumer(TOPIC, PROPS, null)).setStartFromGroupOffsets();
+
+		// test reading from given offsets
+		b.startReadingFromSpecificOffsets(mock(Map.class));
+		source = spy(b.build());
+		when(source.createKafkaConsumer(TOPIC, PROPS, null))
+				.thenReturn(mock(getFlinkKafkaConsumer()));
+		verify(source.getKafkaConsumer(TOPIC, PROPS, null)).setStartFromSpecificOffsets(any(Map.class));
 	}
 
 	protected abstract KafkaTableSource.Builder getBuilder();

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceTestBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceTestBase.java
@@ -203,7 +203,7 @@ public abstract class KafkaTableSourceTestBase {
 		verify(source.getKafkaConsumer(TOPIC, PROPS, null)).setStartFromGroupOffsets();
 
 		// test reading from earliest
-		b.startReadingFromEarliest();
+		b.fromEarliest();
 		source = spy(b.build());
 		when(source.createKafkaConsumer(TOPIC, PROPS, null))
 				.thenReturn(mock(getFlinkKafkaConsumer()));
@@ -211,21 +211,21 @@ public abstract class KafkaTableSourceTestBase {
 		verify(source.getKafkaConsumer(TOPIC, PROPS, null)).setStartFromEarliest();
 
 		// test reading from latest
-		b.startReadingFromLatest();
+		b.fromLatest();
 		source = spy(b.build());
 		when(source.createKafkaConsumer(TOPIC, PROPS, null))
 				.thenReturn(mock(getFlinkKafkaConsumer()));
 		verify(source.getKafkaConsumer(TOPIC, PROPS, null)).setStartFromLatest();
 
 		// test reading from group offsets
-		b.startReadingFromGroupOffsets();
+		b.fromGroupOffsets();
 		source = spy(b.build());
 		when(source.createKafkaConsumer(TOPIC, PROPS, null))
 				.thenReturn(mock(getFlinkKafkaConsumer()));
 		verify(source.getKafkaConsumer(TOPIC, PROPS, null)).setStartFromGroupOffsets();
 
 		// test reading from given offsets
-		b.startReadingFromSpecificOffsets(mock(Map.class));
+		b.fromSpecificOffsets(mock(Map.class));
 		source = spy(b.build());
 		when(source.createKafkaConsumer(TOPIC, PROPS, null))
 				.thenReturn(mock(getFlinkKafkaConsumer()));


### PR DESCRIPTION
## What is the purpose of the change

This PR enables the kafka table source builder to specify start reading offsets for the `KafkaTableSource`.

## Brief change log

  - Add offset specifying methods (reading from latest, earliest, group offsets and specified offsets) to the builder.
  - Configure the offset option in a new `getKafkaConsumer` and change the old `getKafkaConsumer` to `createKafkaConsumer`.
  - Add a related test and update the documents.


## Verifying this change

The change can be verified by `KafkaTableSourceTestBase. testKafkaTSSetConsumeOffsets`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
