### PR TITLE
[FLINK-8049] [FLINK-8050] REST client/server report netty exceptions on shutdown.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
@@ -122,8 +122,14 @@ public class RestClient {
 		CompletableFuture<?> groupFuture = new CompletableFuture<>();
 		if (bootstrap != null) {
 			if (bootstrap.group() != null) {
-				bootstrap.group().shutdownGracefully(0, timeout.toMilliseconds(), TimeUnit.MILLISECONDS)
-					.addListener(ignored -> groupFuture.complete(null));
+				bootstrap.group().shutdownGracefully(0L, timeout.toMilliseconds(), TimeUnit.MILLISECONDS)
+					.addListener(finished -> {
+						if (finished.isSuccess()) {
+							groupFuture.complete(null);
+						} else {
+							groupFuture.completeExceptionally(finished.cause());
+						}
+					});
 			}
 		}
 


### PR DESCRIPTION
As described in the JIRAs, the rest client/server were swallowing exception without any message.
This PR changes the `shutdown()` methods of the `RestClient` and `RestServerEndpoint` to report these exceptions and log them.

R @zentol 