### PR TITLE
[hotfix] [docs] Update checkstyle version in documentation

### DIFF
--- a/docs/internals/ide_setup.md
+++ b/docs/internals/ide_setup.md
@@ -87,7 +87,7 @@ IntelliJ supports checkstyle within the IDE using the Checkstyle-IDEA plugin.
 1. Install the "Checkstyle-IDEA" plugin from the IntelliJ plugin repository.
 2. Configure the plugin by going to Settings -> Other Settings -> Checkstyle.
 3. Set the "Scan Scope" to "Only Java sources (including tests)".
-4. Select _6.19_ in the "Checkstyle Version" dropdown and click apply. **This step is important,
+4. Select _8.4_ in the "Checkstyle Version" dropdown and click apply. **This step is important,
    don't skip it!**
 5. In the "Configuration File" pane, add a new configuration using the plus icon:
     1. Set the "Description" to "Flink".

--- a/pom.xml
+++ b/pom.xml
@@ -1061,6 +1061,7 @@ under the License.
 					<dependency>
 						<groupId>com.puppycrawl.tools</groupId>
 						<artifactId>checkstyle</artifactId>
+						<!-- Note: match version with docs/internals/ide_setup.md -->
 						<version>8.4</version>
 					</dependency>
 				</dependencies>


### PR DESCRIPTION
## What is the purpose of the change

Update the recommended checkstyle version in the documentation to match the active version from FLINK-8126.