### PR TITLE
[FLINK-8145][tests] fix various IOManagerAsync instances not being shut down

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/iomanager/AsynchronousBufferFileWriterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/iomanager/AsynchronousBufferFileWriterTest.java
@@ -20,6 +20,8 @@ package org.apache.flink.runtime.io.disk.iomanager;
 
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.util.TestNotificationListener;
+
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -44,6 +46,11 @@ public class AsynchronousBufferFileWriterTest {
 	private static final Buffer mockBuffer = mock(Buffer.class);
 
 	private AsynchronousBufferFileWriter writer;
+
+	@AfterClass
+	public static void shutdown() {
+		ioManager.shutdown();
+	}
 
 	@Before
 	public void setUp() throws IOException {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/iomanager/BufferFileWriterFileSegmentReaderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/iomanager/BufferFileWriterFileSegmentReaderTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.io.network.buffer.BufferRecycler;
 import org.apache.flink.runtime.testutils.DiscardingRecycler;
 import org.apache.flink.runtime.util.event.NotificationListener;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -54,6 +55,11 @@ public class BufferFileWriterFileSegmentReaderTest {
 	private AsynchronousBufferFileSegmentReader reader;
 
 	private LinkedBlockingQueue<FileSegment> returnedFileSegments = new LinkedBlockingQueue<>();
+
+	@AfterClass
+	public static void shutdown() {
+		ioManager.shutdown();
+	}
 
 	@Before
 	public void setUpWriterAndReader() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/iomanager/BufferFileWriterReaderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/iomanager/BufferFileWriterReaderTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferRecycler;
 import org.apache.flink.runtime.testutils.DiscardingRecycler;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -51,6 +52,11 @@ public class BufferFileWriterReaderTest {
 	private BufferFileReader reader;
 
 	private LinkedBlockingQueue<Buffer> returnedBuffers = new LinkedBlockingQueue<>();
+
+	@AfterClass
+	public static void shutdown() {
+		ioManager.shutdown();
+	}
 
 	@Before
 	public void setUpWriterAndReader() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/HashTableITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/HashTableITCase.java
@@ -806,11 +806,8 @@ public class HashTableITCase extends TestLogger {
 			return;
 		}
 		
-		// create the I/O access for spilling
-		final IOManager ioManager = new IOManagerAsync();
-		
 		// ----------------------------------------------------------------------------------------
-		
+
 		final MutableHashTable<IntPair, IntPair> join = new MutableHashTable<IntPair, IntPair>(
 			this.pairBuildSideAccesssor, this.pairProbeSideAccesssor, 
 			this.pairBuildSideComparator, this.pairProbeSideComparator, this.pairComparator,
@@ -906,9 +903,6 @@ public class HashTableITCase extends TestLogger {
 			fail("Memory for the Join could not be provided.");
 			return;
 		}
-		
-		// create the I/O access for spilling
-		IOManager ioManager = new IOManagerAsync();
 		
 		// create the map for validating the results
 		HashMap<Integer, Long> map = new HashMap<Integer, Long>(NUM_KEYS);
@@ -1021,9 +1015,6 @@ public class HashTableITCase extends TestLogger {
 			fail("Memory for the Join could not be provided.");
 			return;
 		}
-		
-		// create the I/O access for spilling
-		IOManager ioManager = new IOManagerAsync();
 		
 		// create the map for validating the results
 		HashMap<Integer, Long> map = new HashMap<Integer, Long>(NUM_KEYS);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/HashTablePerformanceComparison.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/HashTablePerformanceComparison.java
@@ -55,13 +55,6 @@ public class HashTablePerformanceComparison {
 	
 	private final TypePairComparator<IntPair, IntPair> pairComparator = new IntPairPairComparator();
 	
-	private static final IOManager ioManager = new IOManagerAsync();
-
-	@AfterClass
-	public static void shutdown() {
-		ioManager.shutdown();
-	}
-	
 	@Test
 	public void testCompactingHashMapPerformance() {
 		
@@ -138,6 +131,7 @@ public class HashTablePerformanceComparison {
 	
 	@Test
 	public void testMutableHashMapPerformance() {
+		final IOManager ioManager = new IOManagerAsync();
 		try {
 			final int NUM_MEM_PAGES = SIZE * NUM_PAIRS / PAGE_SIZE;
 			
@@ -213,6 +207,8 @@ public class HashTablePerformanceComparison {
 		catch (Exception e) {
 			e.printStackTrace();
 			fail("Error: " + e.getMessage());
+		} finally {
+			ioManager.shutdown();
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/HashTablePerformanceComparison.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/HashTablePerformanceComparison.java
@@ -36,6 +36,7 @@ import org.apache.flink.runtime.operators.testutils.types.IntPairPairComparator;
 import org.apache.flink.runtime.operators.testutils.types.IntPairSerializer;
 import org.apache.flink.util.MutableObjectIterator;
 
+import org.junit.AfterClass;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -54,7 +55,12 @@ public class HashTablePerformanceComparison {
 	
 	private final TypePairComparator<IntPair, IntPair> pairComparator = new IntPairPairComparator();
 	
-	private IOManager ioManager = new IOManagerAsync();
+	private static final IOManager ioManager = new IOManagerAsync();
+
+	@AfterClass
+	public static void shutdown() {
+		ioManager.shutdown();
+	}
 	
 	@Test
 	public void testCompactingHashMapPerformance() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/HashTableTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/hash/HashTableTest.java
@@ -205,54 +205,58 @@ public class HashTableTest {
 	public void testSpillingWhenBuildingTableWithoutOverflow() throws Exception {
 		final IOManager ioMan = new IOManagerAsync();
 
-		final TypeSerializer<byte[]> serializer = BytePrimitiveArraySerializer.INSTANCE;
-		final TypeComparator<byte[]> buildComparator = new BytePrimitiveArrayComparator(true);
-		final TypeComparator<byte[]> probeComparator = new BytePrimitiveArrayComparator(true);
+		try {
+			final TypeSerializer<byte[]> serializer = BytePrimitiveArraySerializer.INSTANCE;
+			final TypeComparator<byte[]> buildComparator = new BytePrimitiveArrayComparator(true);
+			final TypeComparator<byte[]> probeComparator = new BytePrimitiveArrayComparator(true);
 
-		@SuppressWarnings("unchecked")
-		final TypePairComparator<byte[], byte[]> pairComparator = new GenericPairComparator<>(
-			new BytePrimitiveArrayComparator(true), new BytePrimitiveArrayComparator(true));
+			@SuppressWarnings("unchecked") final TypePairComparator<byte[], byte[]> pairComparator =
+				new GenericPairComparator<>(
+					new BytePrimitiveArrayComparator(true), new BytePrimitiveArrayComparator(true));
 
-		final int pageSize = 128;
-		final int numSegments = 33;
+			final int pageSize = 128;
+			final int numSegments = 33;
 
-		List<MemorySegment> memory = getMemory(numSegments, pageSize);
+			List<MemorySegment> memory = getMemory(numSegments, pageSize);
 
-		MutableHashTable<byte[], byte[]> table = new MutableHashTable<byte[], byte[]>(
-			serializer,
-			serializer,
-			buildComparator,
-			probeComparator,
-			pairComparator,
-			memory,
-			ioMan,
-			1,
-			false);
+			MutableHashTable<byte[], byte[]> table = new MutableHashTable<byte[], byte[]>(
+				serializer,
+				serializer,
+				buildComparator,
+				probeComparator,
+				pairComparator,
+				memory,
+				ioMan,
+				1,
+				false);
 
-		int numElements = 9;
+			int numElements = 9;
 
-		table.open(
-			new CombiningIterator<byte[]>(
-				new ByteArrayIterator(numElements, 128,(byte) 0),
-				new ByteArrayIterator(numElements, 128,(byte) 1)),
-			new CombiningIterator<byte[]>(
-				new ByteArrayIterator(1, 128,(byte) 0),
-				new ByteArrayIterator(1, 128,(byte) 1)));
+			table.open(
+				new CombiningIterator<byte[]>(
+					new ByteArrayIterator(numElements, 128, (byte) 0),
+					new ByteArrayIterator(numElements, 128, (byte) 1)),
+				new CombiningIterator<byte[]>(
+					new ByteArrayIterator(1, 128, (byte) 0),
+					new ByteArrayIterator(1, 128, (byte) 1)));
 
-		while(table.nextRecord()) {
-			MutableObjectIterator<byte[]> iterator = table.getBuildSideIterator();
+			while (table.nextRecord()) {
+				MutableObjectIterator<byte[]> iterator = table.getBuildSideIterator();
 
-			int counter = 0;
+				int counter = 0;
 
-			while(iterator.next() != null) {
-				counter++;
+				while (iterator.next() != null) {
+					counter++;
+				}
+
+				// check that we retrieve all our elements
+				Assert.assertEquals(numElements, counter);
 			}
 
-			// check that we retrieve all our elements
-			Assert.assertEquals(numElements, counter);
+			table.close();
+		} finally {
+			ioMan.shutdown();
 		}
-
-		table.close();
 	}
 	
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/AbstractSortMergeOuterJoinIteratorITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/AbstractSortMergeOuterJoinIteratorITCase.java
@@ -300,9 +300,6 @@ public abstract class AbstractSortMergeOuterJoinIteratorITCase extends TestLogge
 
 		TypePairComparator<Tuple2<Integer, String>, Tuple2<Integer, String>> pairComparator = new GenericPairComparator<>(comparator1, comparator2);
 
-		this.memoryManager = new MemoryManager(MEMORY_SIZE, 1);
-		this.ioManager = new IOManagerAsync();
-
 		final int DUPLICATE_KEY = 13;
 
 		try {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/FixedLengthRecordSorterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/sort/FixedLengthRecordSorterTest.java
@@ -77,6 +77,11 @@ public class FixedLengthRecordSorterTest {
 		if (!this.memoryManager.verifyEmpty()) {
 			Assert.fail("Memory Leak: Some memory has not been returned to the memory manager.");
 		}
+
+		if (this.ioManager != null) {
+			ioManager.shutdown();
+			ioManager = null;
+		}
 		
 		if (this.memoryManager != null) {
 			this.memoryManager.shutdown();

--- a/flink-tests/src/test/java/org/apache/flink/test/manual/MassiveStringSorting.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/manual/MassiveStringSorting.java
@@ -82,10 +82,12 @@ public class MassiveStringSorting {
 			UnilateralSortMerger<String> sorter = null;
 			BufferedReader reader = null;
 			BufferedReader verifyReader = null;
+			MemoryManager mm = null;
+			IOManager ioMan = null;
 
 			try {
-				MemoryManager mm = new MemoryManager(1024 * 1024, 1);
-				IOManager ioMan = new IOManagerAsync();
+				mm = new MemoryManager(1024 * 1024, 1);
+				ioMan = new IOManagerAsync();
 
 				TypeSerializer<String> serializer = StringSerializer.INSTANCE;
 				TypeComparator<String> comparator = new StringComparator(true);
@@ -121,6 +123,12 @@ public class MassiveStringSorting {
 				}
 				if (sorter != null) {
 					sorter.close();
+				}
+				if (mm != null) {
+					mm.shutdown();
+				}
+				if (ioMan != null) {
+					ioMan.shutdown();
 				}
 			}
 		}
@@ -173,10 +181,12 @@ public class MassiveStringSorting {
 			UnilateralSortMerger<Tuple2<String, String[]>> sorter = null;
 			BufferedReader reader = null;
 			BufferedReader verifyReader = null;
+			MemoryManager mm = null;
+			IOManager ioMan = null;
 
 			try {
-				MemoryManager mm = new MemoryManager(1024 * 1024, 1);
-				IOManager ioMan = new IOManagerAsync();
+				mm = new MemoryManager(1024 * 1024, 1);
+				ioMan = new IOManagerAsync();
 
 				TupleTypeInfo<Tuple2<String, String[]>> typeInfo = (TupleTypeInfo<Tuple2<String, String[]>>)
 						TypeInfoParser.<Tuple2<String, String[]>>parse("Tuple2<String, String[]>");
@@ -242,6 +252,12 @@ public class MassiveStringSorting {
 				}
 				if (sorter != null) {
 					sorter.close();
+				}
+				if (mm != null) {
+					mm.shutdown();
+				}
+				if (ioMan != null) {
+					ioMan.shutdown();
 				}
 			}
 		}

--- a/flink-tests/src/test/java/org/apache/flink/test/manual/MassiveStringValueSorting.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/manual/MassiveStringValueSorting.java
@@ -83,10 +83,12 @@ public class MassiveStringValueSorting {
 			UnilateralSortMerger<StringValue> sorter = null;
 			BufferedReader reader = null;
 			BufferedReader verifyReader = null;
+			MemoryManager mm = null;
+			IOManager ioMan = null;
 
 			try {
-				MemoryManager mm = new MemoryManager(1024 * 1024, 1);
-				IOManager ioMan = new IOManagerAsync();
+				mm = new MemoryManager(1024 * 1024, 1);
+				ioMan = new IOManagerAsync();
 
 				TypeSerializer<StringValue> serializer = new CopyableValueSerializer<StringValue>(StringValue.class);
 				TypeComparator<StringValue> comparator = new CopyableValueComparator<StringValue>(true, StringValue.class);
@@ -123,6 +125,12 @@ public class MassiveStringValueSorting {
 				}
 				if (sorter != null) {
 					sorter.close();
+				}
+				if (mm != null) {
+					mm.shutdown();
+				}
+				if (ioMan != null) {
+					ioMan.shutdown();
 				}
 			}
 		}
@@ -177,10 +185,12 @@ public class MassiveStringValueSorting {
 			UnilateralSortMerger<Tuple2<StringValue, StringValue[]>> sorter = null;
 			BufferedReader reader = null;
 			BufferedReader verifyReader = null;
+			MemoryManager mm = null;
+			IOManager ioMan = null;
 
 			try {
-				MemoryManager mm = new MemoryManager(1024 * 1024, 1);
-				IOManager ioMan = new IOManagerAsync();
+				mm = new MemoryManager(1024 * 1024, 1);
+				ioMan = new IOManagerAsync();
 
 				TupleTypeInfo<Tuple2<StringValue, StringValue[]>> typeInfo = (TupleTypeInfo<Tuple2<StringValue, StringValue[]>>)
 						TypeInfoParser.<Tuple2<StringValue, StringValue[]>>parse("Tuple2<org.apache.flink.types.StringValue, org.apache.flink.types.StringValue[]>");
@@ -246,6 +256,12 @@ public class MassiveStringValueSorting {
 				}
 				if (sorter != null) {
 					sorter.close();
+				}
+				if (mm != null) {
+					mm.shutdown();
+				}
+				if (ioMan != null) {
+					ioMan.shutdown();
 				}
 			}
 		}


### PR DESCRIPTION
## What is the purpose of the change

Fix several unit tests using `IOManagerAsync` but not shutting it down afterwards (not even in the failure-free case). The only thing cleaning them up seems to be a shutdown handler attached to the JVM. Since each IOManagerAsync is spawning a number of reader and writer threads, this may put a significant burden on the tests.

## Brief change log

- add shutdown handlers via `@AfterClass` to `AsynchronousBufferFileWriterTest`, `BufferFileWriterFileSegmentReaderTest`, `BufferFileWriterReaderTest`, `HashTablePerformanceComparison`, `FixedLengthRecordSorterTest`
- let `HashTableITCase`, `AbstractSortMergeOuterJoinIteratorITCase` test methods use the static `ioManager` instead of creating new instances in some test methods
- clean up manually in `HashTableTest`, `MassiveStringSorting`, `MassiveStringValueSorting` (similar cleanup for the `MemoryManager` there)

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? (not applicable)
