### PR TITLE
[FLINK-8148][yarn/s3] fix test instability in YarnFileStageTestS3ITCase

### DIFF
--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnFileStageTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnFileStageTest.java
@@ -139,7 +139,7 @@ public class YarnFileStageTest extends TestLogger {
 	 * @param addSchemeToLocalPath
 	 * 		whether add the <tt>file://</tt> scheme to the local path to copy from
 	 */
-	public static void testCopyFromLocalRecursive(
+	static void testCopyFromLocalRecursive(
 			FileSystem targetFileSystem,
 			Path targetDir,
 			TemporaryFolder tempFolder,

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnFileStageTestS3ITCase.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnFileStageTestS3ITCase.java
@@ -166,9 +166,6 @@ public class YarnFileStageTestS3ITCase extends TestLogger {
 
 			YarnFileStageTest.testCopyFromLocalRecursive(fs.getHadoopFileSystem(),
 				new org.apache.hadoop.fs.Path(directory.toUri()), tempFolder, true);
-
-			// now directory must be gone
-			assertFalse(fs.exists(directory));
 		} finally {
 			// clean up
 			fs.delete(basePath, true);


### PR DESCRIPTION
## What is the purpose of the change

`YarnFileStageTestS3ITCase.testRecursiveUploadForYarn` verifies that the test directory used is cleaned up by `YarnFileStageTest.testCopyFromLocalRecursive` which should clean up the directory (in a `finally` block). However, for S3, we may not always see our own deletes.

Quoting from https://aws.amazon.com/s3/faqs/ here:

> Q: What data consistency model does Amazon S3 employ?
> Amazon S3 buckets in all Regions provide read-after-write consistency for PUTS of new objects and eventual consistency for overwrite PUTS and DELETES.

## Brief change log

- Remove a check for a deleted directory since we may not see our own delete yet
with S3.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
