### PR TITLE
[FLINK-8151][table]Map equality check to use entrySet equality

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/ScalarOperators.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/ScalarOperators.scala
@@ -188,6 +188,13 @@ object ScalarOperators {
         (leftTerm, rightTerm) => s"java.util.Arrays.equals($leftTerm, $rightTerm)"
       }
     }
+    // map types
+    else if (isMap(left.resultType) &&
+      left.resultType.getTypeClass == right.resultType.getTypeClass) {
+      generateOperatorIfNotNull(nullCheck, BOOLEAN_TYPE_INFO, left, right) {
+        (leftTerm, rightTerm) => s"$leftTerm.equals($rightTerm)"
+      }
+    }
     // comparable types of same type
     else if (isComparable(left.resultType) && left.resultType == right.resultType) {
       generateComparison("==", nullCheck, left, right)
@@ -227,6 +234,13 @@ object ScalarOperators {
         left.resultType.getTypeClass == right.resultType.getTypeClass) {
       generateOperatorIfNotNull(nullCheck, BOOLEAN_TYPE_INFO, left, right) {
         (leftTerm, rightTerm) => s"!java.util.Arrays.equals($leftTerm, $rightTerm)"
+      }
+    }
+    // map types
+    else if (isMap(left.resultType) &&
+      left.resultType.getTypeClass == right.resultType.getTypeClass) {
+      generateOperatorIfNotNull(nullCheck, BOOLEAN_TYPE_INFO, left, right) {
+        (leftTerm, rightTerm) => s"!($leftTerm.equals($rightTerm))"
       }
     }
     // comparable types

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/ScalarOperators.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/ScalarOperators.scala
@@ -188,13 +188,6 @@ object ScalarOperators {
         (leftTerm, rightTerm) => s"java.util.Arrays.equals($leftTerm, $rightTerm)"
       }
     }
-    // map types
-    else if (isMap(left.resultType) &&
-      left.resultType.getTypeClass == right.resultType.getTypeClass) {
-      generateOperatorIfNotNull(nullCheck, BOOLEAN_TYPE_INFO, left, right) {
-        (leftTerm, rightTerm) => s"java.util.Map.equals($leftTerm, $rightTerm)"
-      }
-    }
     // comparable types of same type
     else if (isComparable(left.resultType) && left.resultType == right.resultType) {
       generateComparison("==", nullCheck, left, right)
@@ -234,13 +227,6 @@ object ScalarOperators {
         left.resultType.getTypeClass == right.resultType.getTypeClass) {
       generateOperatorIfNotNull(nullCheck, BOOLEAN_TYPE_INFO, left, right) {
         (leftTerm, rightTerm) => s"!java.util.Arrays.equals($leftTerm, $rightTerm)"
-      }
-    }
-    // map types
-    else if (isMap(left.resultType) &&
-      left.resultType.getTypeClass == right.resultType.getTypeClass) {
-      generateOperatorIfNotNull(nullCheck, BOOLEAN_TYPE_INFO, left, right) {
-        (leftTerm, rightTerm) => s"!java.util.Map.equals($leftTerm, $rightTerm)"
       }
     }
     // comparable types

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/collection.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/collection.scala
@@ -65,10 +65,6 @@ case class ArrayConstructor(elements: Seq[Expression]) extends Expression {
 case class MapConstructor(elements: Seq[Expression]) extends Expression {
   override private[flink] def children: Seq[Expression] = elements
 
-  private[flink] var mapResultType: TypeInformation[_] = new MapTypeInfo(
-    new GenericTypeInfo[AnyRef](classOf[AnyRef]),
-    new GenericTypeInfo[AnyRef](classOf[AnyRef]))
-
   override private[flink] def toRexNode(implicit relBuilder: RelBuilder): RexNode = {
     val typeFactory = relBuilder.asInstanceOf[FlinkRelBuilder].getTypeFactory
     val relDataType = typeFactory.createMapType(

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/MapTypeTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/MapTypeTest.scala
@@ -141,6 +141,18 @@ class MapTypeTest extends MapTypeTestBase {
 
     // comparison
     testAllApis(
+      'f1 === 'f2,
+      "f1 === f2",
+      "f1 = f2",
+      "false")
+
+    testAllApis(
+      'f3 === 'f7,
+      "f3 === f7",
+      "f3 = f7",
+      "true")
+
+    testAllApis(
       'f5 === 'f2.at("a"),
       "f5 === f2.at('a')",
       "f5 = f2['a']",

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/MapTypeTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/MapTypeTest.scala
@@ -146,13 +146,6 @@ class MapTypeTest extends MapTypeTestBase {
       "f5 = f2['a']",
       "true")
 
-    // comparison
-    testAllApis(
-      'f5 === 'f2.at("a"),
-      "f5 === f2.at('a')",
-      "f5 = f2['a']",
-      "true")
-
     testAllApis(
       'f0.at("map is null"),
       "f0.at('map is null')",

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/utils/MapTypeTestBase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/utils/MapTypeTestBase.scala
@@ -20,6 +20,7 @@ package org.apache.flink.table.expressions.utils
 
 import java.util.{HashMap => JHashMap}
 
+import com.google.common.collect.ImmutableMap
 import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
 import org.apache.flink.api.java.typeutils.{MapTypeInfo, RowTypeInfo}
 import org.apache.flink.table.api.Types
@@ -34,7 +35,7 @@ class MapTypeTestBase extends ExpressionTestBase {
     val map2 = new JHashMap[Int, String]()
     map2.put(12, "a")
     map2.put(13, "b")
-    val testData = new Row(7)
+    val testData = new Row(8)
     testData.setField(0, null)
     testData.setField(1, new JHashMap[String, Int]())
     testData.setField(2, map1)
@@ -42,6 +43,7 @@ class MapTypeTestBase extends ExpressionTestBase {
     testData.setField(4, "foo")
     testData.setField(5, 12)
     testData.setField(6, Array(1.2, 1.3))
+    testData.setField(7, ImmutableMap.of(12, "a", 13, "b"))
     testData
   }
 
@@ -53,7 +55,8 @@ class MapTypeTestBase extends ExpressionTestBase {
       new MapTypeInfo(BasicTypeInfo.INT_TYPE_INFO, BasicTypeInfo.STRING_TYPE_INFO),
       Types.STRING,
       Types.INT,
-      Types.OBJECT_ARRAY(Types.DOUBLE)
+      Types.OBJECT_ARRAY(Types.DOUBLE),
+      new MapTypeInfo(BasicTypeInfo.INT_TYPE_INFO, BasicTypeInfo.STRING_TYPE_INFO)
     ).asInstanceOf[TypeInformation[Any]]
   }
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/validation/MapTypeValidationTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/validation/MapTypeValidationTest.scala
@@ -19,6 +19,7 @@
 package org.apache.flink.table.expressions.validation
 
 import org.apache.flink.table.api.ValidationException
+import org.apache.flink.table.api.scala._
 import org.apache.flink.table.expressions.utils.MapTypeTestBase
 import org.junit.Test
 
@@ -26,6 +27,21 @@ class MapTypeValidationTest extends MapTypeTestBase {
 
   @Test(expected = classOf[ValidationException])
   def testWrongKeyType(): Unit = {
-    testSqlApi("f2[12]", "FAIL")
+    testAllApis('f2.at(12), "f2.at(12)", "f2[12]", "FAIL")
+  }
+
+  @Test(expected = classOf[ValidationException])
+  def testIncorrectMapTypeComparison(): Unit = {
+    testAllApis('f1 === 'f3, "f1 === f3", "f1 = f3", "FAIL")
+  }
+
+  @Test(expected = classOf[ValidationException])
+  def testUnsupportedComparisonType(): Unit = {
+    testAllApis('f6 !== 'f2, "f6 !== f2", "f6 != f2", "FAIL")
+  }
+
+  @Test(expected = classOf[ValidationException])
+  def testEmptyMap(): Unit = {
+    testAllApis("FAIL", "map()", "MAP[]", "FAIL")
   }
 }


### PR DESCRIPTION
Remove map type equality support as unlike java array, there's no element-wise equality check on Map type. 

Also small clean up on map value constructor code.