### PR TITLE
[FLINK-7907][docs] The metrics documentation missing scala snippets

### DIFF
--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -45,7 +45,7 @@ You can create and register a `Counter` by calling `counter(String name)` on a `
 <div data-lang="java" markdown="1">
 {% highlight java %}
 
-RichMapFunction<String, String> {
+class MyMapper extends RichMapFunction<String, String> {
   private transient Counter counter;
 
   @Override
@@ -68,7 +68,7 @@ RichMapFunction<String, String> {
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
 
-RichMapFunction[String,String] {
+class MyMapper extends RichMapFunction[String,String] {
   @transient private var counter: Counter
 
   override def open(parameters: Configuration): Unit = {
@@ -94,7 +94,7 @@ Alternatively you can also use your own `Counter` implementation:
 <div data-lang="java" markdown="1">
 {% highlight java %}
 
-RichMapFunction<String, String> {
+class MyMapper extends RichMapFunction<String, String> {
   private transient Counter counter;
 
   @Override
@@ -118,7 +118,7 @@ RichMapFunction<String, String> {
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
 
-RichMapFunction[String,String] {
+class MyMapper extends RichMapFunction[String,String] {
   @transient private var counter: Counter
 
   override def open(parameters: Configuration): Unit = {
@@ -148,7 +148,7 @@ You can register a gauge by calling `gauge(String name, Gauge gauge)` on a `Metr
 <div data-lang="java" markdown="1">
 {% highlight java %}
 
-RichMapFunction<String, String> {
+class MyMapper extends RichMapFunction<String, String> {
   private transient int valueToExpose = 0;
 
   @Override
@@ -176,7 +176,7 @@ RichMapFunction<String, String> {
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
 
-new RichMapFunction[String,String] {
+new class MyMapper extends RichMapFunction[String,String] {
   @transient private var valueToExpose = 0
 
   override def open(parameters: Configuration): Unit = {
@@ -206,7 +206,7 @@ You can register one by calling `histogram(String name, Histogram histogram)` on
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
 {% highlight java %}
-RichMapFunction<Long, Long> {
+class MyMapper extends RichMapFunction<Long, Long> {
   private transient Histogram histogram;
 
   @Override
@@ -228,7 +228,7 @@ RichMapFunction<Long, Long> {
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
 
-RichMapFunction[Long,Long] {
+class MyMapper extends RichMapFunction[Long,Long] {
   @transient private var histogram: Histogram
 
   override def open(parameters: Configuration): Unit = {
@@ -263,7 +263,7 @@ You can then register a Codahale/DropWizard histogram like this:
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
 {% highlight java %}
-RichMapFunction<Long, Long> {
+class MyMapper extends RichMapFunction<Long, Long> {
   private transient Histogram histogram;
 
   @Override
@@ -288,7 +288,7 @@ RichMapFunction<Long, Long> {
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
 
-RichMapFunction[Long, Long] {
+class MyMapper extends RichMapFunction[Long, Long] {
   @transient private var histogram: Histogram
 
   override def open(config: Configuration): Unit = {
@@ -319,7 +319,7 @@ You can register a meter by calling `meter(String name, Meter meter)` on a `Metr
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
 {% highlight java %}
-RichMapFunction<Long, Long> {
+class MyMapper extends RichMapFunction<Long, Long> {
   private transient Meter meter;
 
   @Override
@@ -341,7 +341,7 @@ RichMapFunction<Long, Long> {
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
 
-RichMapFunction[Long,Long] {
+class MyMapper extends RichMapFunction[Long,Long] {
   @transient private var meter: Meter
 
   override def open(config: Configuration): Unit = {
@@ -376,7 +376,7 @@ You can then register a Codahale/DropWizard meter like this:
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
 {% highlight java %}
-RichMapFunction<Long, Long> {
+class MyMapper extends RichMapFunction<Long, Long> {
   private transient Meter meter;
 
   @Override
@@ -400,7 +400,7 @@ RichMapFunction<Long, Long> {
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
 
-RichMapFunction[Long,Long] {
+class MyMapper extends RichMapFunction[Long,Long] {
   @transient private var meter: Meter
 
   override def open(config: Configuration): Unit = {

--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -45,8 +45,8 @@ You can create and register a `Counter` by calling `counter(String name)` on a `
 <div data-lang="java" markdown="1">
 {% highlight java %}
 
-public class MyMapper extends RichMapFunction<String, String> {
-  private Counter counter;
+RichMapFunction<String, String> {
+  private transient Counter counter;
 
   @Override
   public void open(Configuration config) {
@@ -68,8 +68,8 @@ public class MyMapper extends RichMapFunction<String, String> {
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
 
-public class MyMapper extends RichMapFunction[String,String] {
-  var counter: Counter
+RichMapFunction[String,String] {
+  @transient private var counter: Counter
 
   override def open(parameters: Configuration): Unit = {
     counter = getRuntimeContext()
@@ -94,8 +94,8 @@ Alternatively you can also use your own `Counter` implementation:
 <div data-lang="java" markdown="1">
 {% highlight java %}
 
-public class MyMapper extends RichMapFunction<String, String> {
-  private Counter counter;
+RichMapFunction<String, String> {
+  private transient Counter counter;
 
   @Override
   public void open(Configuration config) {
@@ -118,8 +118,8 @@ public class MyMapper extends RichMapFunction<String, String> {
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
 
-public class MyMapper extends RichMapFunction[String,String] {
-  var counter: Counter
+RichMapFunction[String,String] {
+  @transient private var counter: Counter
 
   override def open(parameters: Configuration): Unit = {
     counter = getRuntimeContext()
@@ -148,8 +148,8 @@ You can register a gauge by calling `gauge(String name, Gauge gauge)` on a `Metr
 <div data-lang="java" markdown="1">
 {% highlight java %}
 
-public class MyMapper extends RichMapFunction<String, String> {
-  private int valueToExpose = 0;
+RichMapFunction<String, String> {
+  private transient int valueToExpose = 0;
 
   @Override
   public void open(Configuration config) {
@@ -176,8 +176,8 @@ public class MyMapper extends RichMapFunction<String, String> {
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
 
-public class MyMapper extends RichMapFunction[String,String] {
-  val valueToExpose = 0
+new RichMapFunction[String,String] {
+  @transient private var valueToExpose = 0
 
   override def open(parameters: Configuration): Unit = {
     getRuntimeContext()
@@ -206,8 +206,8 @@ You can register one by calling `histogram(String name, Histogram histogram)` on
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
 {% highlight java %}
-public class MyMapper extends RichMapFunction<Long, Long> {
-  private Histogram histogram;
+RichMapFunction<Long, Long> {
+  private transient Histogram histogram;
 
   @Override
   public void open(Configuration config) {
@@ -228,8 +228,8 @@ public class MyMapper extends RichMapFunction<Long, Long> {
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
 
-public class MyMapper extends RichMapFunction[Long,Long] {
-  var histogram: Histogram
+RichMapFunction[Long,Long] {
+  @transient private var histogram: Histogram
 
   override def open(parameters: Configuration): Unit = {
     histogram = getRuntimeContext()
@@ -263,8 +263,8 @@ You can then register a Codahale/DropWizard histogram like this:
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
 {% highlight java %}
-public class MyMapper extends RichMapFunction<Long, Long> {
-  private Histogram histogram;
+RichMapFunction<Long, Long> {
+  private transient Histogram histogram;
 
   @Override
   public void open(Configuration config) {
@@ -288,8 +288,8 @@ public class MyMapper extends RichMapFunction<Long, Long> {
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
 
-public class MyMapper extends RichMapFunction[Long, Long] {
-  var histogram: Histogram
+RichMapFunction[Long, Long] {
+  @transient private var histogram: Histogram
 
   override def open(config: Configuration): Unit = {
     com.codahale.metrics.Histogram dropwizardHistogram =
@@ -319,8 +319,8 @@ You can register a meter by calling `meter(String name, Meter meter)` on a `Metr
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
 {% highlight java %}
-public class MyMapper extends RichMapFunction<Long, Long> {
-  private Meter meter;
+RichMapFunction<Long, Long> {
+  private transient Meter meter;
 
   @Override
   public void open(Configuration config) {
@@ -341,8 +341,8 @@ public class MyMapper extends RichMapFunction<Long, Long> {
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
 
-public class MyMapper extends RichMapFunction[Long,Long] {
-  var meter: Meter
+RichMapFunction[Long,Long] {
+  @transient private var meter: Meter
 
   override def open(config: Configuration): Unit = {
     meter = getRuntimeContext()
@@ -376,8 +376,8 @@ You can then register a Codahale/DropWizard meter like this:
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
 {% highlight java %}
-public class MyMapper extends RichMapFunction<Long, Long> {
-  private Meter meter;
+RichMapFunction<Long, Long> {
+  private transient Meter meter;
 
   @Override
   public void open(Configuration config) {
@@ -400,8 +400,8 @@ public class MyMapper extends RichMapFunction<Long, Long> {
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
 
-public class MyMapper extends RichMapFunction[Long,Long] {
-  var meter: Meter
+RichMapFunction[Long,Long] {
+  @transient private var meter: Meter
 
   override def open(config: Configuration): Unit = {
     com.codahale.metrics.Meter dropwizardMeter = new com.codahale.metrics.Meter()


### PR DESCRIPTION
## What is the purpose of the change

*The metrics documentation is missing Scala examples for many of the metrics types. To be consistent there should be Scala examples for all the types.*

## Brief change log

  - *Add scala snippets for  `Counter` , `Histogram `, `Meter` types of metrics*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
