### PR TITLE
[FLINK-7984][build] Bump snappy-java to 1.1.4

### DIFF
--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -168,7 +168,6 @@ under the License.
 		<dependency>
 			<groupId>org.xerial.snappy</groupId>
 			<artifactId>snappy-java</artifactId>
-			<version>1.1.4</version>
 		</dependency>
 
 		<!--

--- a/pom.xml
+++ b/pom.xml
@@ -295,7 +295,7 @@ under the License.
 			<dependency>
 				<groupId>org.xerial.snappy</groupId>
 				<artifactId>snappy-java</artifactId>
-				<version>1.1.1.3</version>
+				<version>1.1.4</version>
 			</dependency>
 
 			<!-- Make sure we use a consistent avro version between Flink and Hadoop -->		


### PR DESCRIPTION
## What is the purpose of the change

This PR bumps the snappy-java version to 1.1.4.
snappy-java-1.1.4 (2017-05-22):
- Fix a 1% performance regression when snappy is used in PIE executables.
- Improve compression performance by 5%.
- Improve decompression performance by 20%.
- See more: [Snappy-java Release Notes](https://github.com/xerial/snappy-java/blob/master/Milestone.md)


## Verifying this change

This change should be covered by travis and the end-to-end tests.
