### PR TITLE
[FLINK-8124] Make Trigger implementations more generic

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/ContinuousEventTimeTrigger.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/ContinuousEventTimeTrigger.java
@@ -36,7 +36,7 @@ import org.apache.flink.streaming.api.windowing.windows.Window;
  * @param <W> The type of {@link Window Windows} on which this trigger can operate.
  */
 @PublicEvolving
-public class ContinuousEventTimeTrigger<W extends Window> extends Trigger<Object, W> {
+public class ContinuousEventTimeTrigger<T, W extends Window> extends Trigger<T, W> {
 	private static final long serialVersionUID = 1L;
 
 	private final long interval;
@@ -50,7 +50,7 @@ public class ContinuousEventTimeTrigger<W extends Window> extends Trigger<Object
 	}
 
 	@Override
-	public TriggerResult onElement(Object element, long timestamp, W window, TriggerContext ctx) throws Exception {
+	public TriggerResult onElement(T element, long timestamp, W window, TriggerContext ctx) throws Exception {
 
 		if (window.maxTimestamp() <= ctx.getCurrentWatermark()) {
 			// if the watermark is already past the window fire immediately
@@ -136,7 +136,7 @@ public class ContinuousEventTimeTrigger<W extends Window> extends Trigger<Object
 	 * @param interval The time interval at which to fire.
 	 * @param <W> The type of {@link Window Windows} on which this trigger can operate.
 	 */
-	public static <W extends Window> ContinuousEventTimeTrigger<W> of(Time interval) {
+	public static <T, W extends Window> ContinuousEventTimeTrigger<T, W> of(Time interval) {
 		return new ContinuousEventTimeTrigger<>(interval.toMilliseconds());
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/ContinuousProcessingTimeTrigger.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/ContinuousProcessingTimeTrigger.java
@@ -34,7 +34,7 @@ import org.apache.flink.streaming.api.windowing.windows.Window;
  * @param <W> The type of {@link Window Windows} on which this trigger can operate.
  */
 @PublicEvolving
-public class ContinuousProcessingTimeTrigger<W extends Window> extends Trigger<Object, W> {
+public class ContinuousProcessingTimeTrigger<T, W extends Window> extends Trigger<T, W> {
 	private static final long serialVersionUID = 1L;
 
 	private final long interval;
@@ -48,7 +48,7 @@ public class ContinuousProcessingTimeTrigger<W extends Window> extends Trigger<O
 	}
 
 	@Override
-	public TriggerResult onElement(Object element, long timestamp, W window, TriggerContext ctx) throws Exception {
+	public TriggerResult onElement(T element, long timestamp, W window, TriggerContext ctx) throws Exception {
 		ReducingState<Long> fireTimestamp = ctx.getPartitionedState(stateDesc);
 
 		timestamp = ctx.getCurrentProcessingTime();
@@ -116,9 +116,10 @@ public class ContinuousProcessingTimeTrigger<W extends Window> extends Trigger<O
 	 * Creates a trigger that continuously fires based on the given interval.
 	 *
 	 * @param interval The time interval at which to fire.
+	 * @param <T> The type of element on which this trigger can operate.
 	 * @param <W> The type of {@link Window Windows} on which this trigger can operate.
 	 */
-	public static <W extends Window> ContinuousProcessingTimeTrigger<W> of(Time interval) {
+	public static <T, W extends Window> ContinuousProcessingTimeTrigger<T, W> of(Time interval) {
 		return new ContinuousProcessingTimeTrigger<>(interval.toMilliseconds());
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/CountTrigger.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/CountTrigger.java
@@ -31,7 +31,7 @@ import org.apache.flink.streaming.api.windowing.windows.Window;
  * @param <W> The type of {@link Window Windows} on which this trigger can operate.
  */
 @PublicEvolving
-public class CountTrigger<W extends Window> extends Trigger<Object, W> {
+public class CountTrigger<T, W extends Window> extends Trigger<T, W> {
 	private static final long serialVersionUID = 1L;
 
 	private final long maxCount;
@@ -44,7 +44,7 @@ public class CountTrigger<W extends Window> extends Trigger<Object, W> {
 	}
 
 	@Override
-	public TriggerResult onElement(Object element, long timestamp, W window, TriggerContext ctx) throws Exception {
+	public TriggerResult onElement(T element, long timestamp, W window, TriggerContext ctx) throws Exception {
 		ReducingState<Long> count = ctx.getPartitionedState(stateDesc);
 		count.add(1L);
 		if (count.get() >= maxCount) {
@@ -90,7 +90,7 @@ public class CountTrigger<W extends Window> extends Trigger<Object, W> {
 	 * @param maxCount The count of elements at which to fire.
 	 * @param <W> The type of {@link Window Windows} on which this trigger can operate.
 	 */
-	public static <W extends Window> CountTrigger<W> of(long maxCount) {
+	public static <T, W extends Window> CountTrigger<T, W> of(long maxCount) {
 		return new CountTrigger<>(maxCount);
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/ProcessingTimeTrigger.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/ProcessingTimeTrigger.java
@@ -19,36 +19,36 @@
 package org.apache.flink.streaming.api.windowing.triggers;
 
 import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
+import org.apache.flink.streaming.api.windowing.windows.Window;
 
 /**
  * A {@link Trigger} that fires once the current system time passes the end of the window
  * to which a pane belongs.
  */
 @PublicEvolving
-public class ProcessingTimeTrigger extends Trigger<Object, TimeWindow> {
+public class ProcessingTimeTrigger<T, W extends Window> extends Trigger<T, W> {
 	private static final long serialVersionUID = 1L;
 
 	private ProcessingTimeTrigger() {}
 
 	@Override
-	public TriggerResult onElement(Object element, long timestamp, TimeWindow window, TriggerContext ctx) {
+	public TriggerResult onElement(T element, long timestamp, W window, TriggerContext ctx) {
 		ctx.registerProcessingTimeTimer(window.maxTimestamp());
 		return TriggerResult.CONTINUE;
 	}
 
 	@Override
-	public TriggerResult onEventTime(long time, TimeWindow window, TriggerContext ctx) throws Exception {
+	public TriggerResult onEventTime(long time, W window, TriggerContext ctx) throws Exception {
 		return TriggerResult.CONTINUE;
 	}
 
 	@Override
-	public TriggerResult onProcessingTime(long time, TimeWindow window, TriggerContext ctx) {
+	public TriggerResult onProcessingTime(long time, W window, TriggerContext ctx) {
 		return TriggerResult.FIRE;
 	}
 
 	@Override
-	public void clear(TimeWindow window, TriggerContext ctx) throws Exception {
+	public void clear(W window, TriggerContext ctx) throws Exception {
 		ctx.deleteProcessingTimeTimer(window.maxTimestamp());
 	}
 
@@ -58,7 +58,7 @@ public class ProcessingTimeTrigger extends Trigger<Object, TimeWindow> {
 	}
 
 	@Override
-	public void onMerge(TimeWindow window,
+	public void onMerge(W window,
 			OnMergeContext ctx) {
 		ctx.registerProcessingTimeTimer(window.maxTimestamp());
 	}
@@ -71,8 +71,8 @@ public class ProcessingTimeTrigger extends Trigger<Object, TimeWindow> {
 	/**
 	 * Creates a new trigger that fires once system time passes the end of the window.
 	 */
-	public static ProcessingTimeTrigger create() {
-		return new ProcessingTimeTrigger();
+	public static <T, W extends Window> ProcessingTimeTrigger<T, W> create() {
+		return new ProcessingTimeTrigger<>();
 	}
 
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/ContinuousEventTimeTriggerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/ContinuousEventTimeTriggerTest.java
@@ -46,7 +46,7 @@ public class ContinuousEventTimeTriggerTest {
 	@Test
 	public void testTriggerHandlesAllOnTimerCalls() throws Exception {
 		TriggerTestHarness<Object, TimeWindow> testHarness =
-				new TriggerTestHarness<>(ContinuousEventTimeTrigger.<TimeWindow>of(Time.milliseconds(5)), new TimeWindow.Serializer());
+				new TriggerTestHarness<>(ContinuousEventTimeTrigger.<Object, TimeWindow>of(Time.milliseconds(5)), new TimeWindow.Serializer());
 
 		assertEquals(0, testHarness.numStateEntries());
 		assertEquals(0, testHarness.numProcessingTimeTimers());
@@ -70,7 +70,7 @@ public class ContinuousEventTimeTriggerTest {
 	@Test
 	public void testWindowSeparationAndFiring() throws Exception {
 		TriggerTestHarness<Object, TimeWindow> testHarness =
-				new TriggerTestHarness<>(ContinuousEventTimeTrigger.<TimeWindow>of(Time.hours(1)), new TimeWindow.Serializer());
+				new TriggerTestHarness<>(ContinuousEventTimeTrigger.<Object, TimeWindow>of(Time.hours(1)), new TimeWindow.Serializer());
 
 		// inject several elements
 		assertEquals(TriggerResult.CONTINUE, testHarness.processElement(new StreamRecord<Object>(1), new TimeWindow(0, 2)));
@@ -123,7 +123,7 @@ public class ContinuousEventTimeTriggerTest {
 	@Test
 	public void testLateElementTriggersImmediately() throws Exception {
 		TriggerTestHarness<Object, TimeWindow> testHarness =
-				new TriggerTestHarness<>(ContinuousEventTimeTrigger.<TimeWindow>of(Time.hours(1)), new TimeWindow.Serializer());
+				new TriggerTestHarness<>(ContinuousEventTimeTrigger.<Object, TimeWindow>of(Time.hours(1)), new TimeWindow.Serializer());
 
 		testHarness.advanceWatermark(2);
 
@@ -141,7 +141,7 @@ public class ContinuousEventTimeTriggerTest {
 	@Test
 	public void testClear() throws Exception {
 		TriggerTestHarness<Object, TimeWindow> testHarness =
-				new TriggerTestHarness<>(ContinuousEventTimeTrigger.<TimeWindow>of(Time.hours(1)), new TimeWindow.Serializer());
+				new TriggerTestHarness<>(ContinuousEventTimeTrigger.<Object, TimeWindow>of(Time.hours(1)), new TimeWindow.Serializer());
 
 		assertEquals(TriggerResult.CONTINUE, testHarness.processElement(new StreamRecord<Object>(1), new TimeWindow(0, 2)));
 		assertEquals(TriggerResult.CONTINUE, testHarness.processElement(new StreamRecord<Object>(1), new TimeWindow(2, 4)));
@@ -170,9 +170,9 @@ public class ContinuousEventTimeTriggerTest {
 	@Test
 	public void testMergingWindows() throws Exception {
 		TriggerTestHarness<Object, TimeWindow> testHarness =
-				new TriggerTestHarness<>(ContinuousEventTimeTrigger.<TimeWindow>of(Time.hours(1)), new TimeWindow.Serializer());
+				new TriggerTestHarness<>(ContinuousEventTimeTrigger.<Object, TimeWindow>of(Time.hours(1)), new TimeWindow.Serializer());
 
-		assertTrue(ContinuousEventTimeTrigger.<TimeWindow>of(Time.hours(1)).canMerge());
+		assertTrue(ContinuousEventTimeTrigger.<Object, TimeWindow>of(Time.hours(1)).canMerge());
 
 		assertEquals(TriggerResult.CONTINUE, testHarness.processElement(new StreamRecord<Object>(1), new TimeWindow(0, 2)));
 		assertEquals(TriggerResult.CONTINUE, testHarness.processElement(new StreamRecord<Object>(1), new TimeWindow(2, 4)));

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/CountTriggerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/CountTriggerTest.java
@@ -40,7 +40,7 @@ public class CountTriggerTest {
 	@Test
 	public void testWindowSeparationAndFiring() throws Exception {
 		TriggerTestHarness<Object, TimeWindow> testHarness =
-				new TriggerTestHarness<>(CountTrigger.<TimeWindow>of(3), new TimeWindow.Serializer());
+				new TriggerTestHarness<>(CountTrigger.<Object, TimeWindow>of(3), new TimeWindow.Serializer());
 
 		assertEquals(TriggerResult.CONTINUE, testHarness.processElement(new StreamRecord<Object>(1), new TimeWindow(0, 2)));
 		assertEquals(TriggerResult.CONTINUE, testHarness.processElement(new StreamRecord<Object>(1), new TimeWindow(2, 4)));
@@ -75,7 +75,7 @@ public class CountTriggerTest {
 	@Test
 	public void testClear() throws Exception {
 		TriggerTestHarness<Object, TimeWindow> testHarness =
-				new TriggerTestHarness<>(CountTrigger.<TimeWindow>of(3), new TimeWindow.Serializer());
+				new TriggerTestHarness<>(CountTrigger.<Object, TimeWindow>of(3), new TimeWindow.Serializer());
 
 		assertEquals(TriggerResult.CONTINUE, testHarness.processElement(new StreamRecord<Object>(1), new TimeWindow(0, 2)));
 		assertEquals(TriggerResult.CONTINUE, testHarness.processElement(new StreamRecord<Object>(1), new TimeWindow(2, 4)));
@@ -104,7 +104,7 @@ public class CountTriggerTest {
 	@Test
 	public void testMergingWindows() throws Exception {
 		TriggerTestHarness<Object, TimeWindow> testHarness =
-				new TriggerTestHarness<>(CountTrigger.<TimeWindow>of(3), new TimeWindow.Serializer());
+				new TriggerTestHarness<>(CountTrigger.<Object, TimeWindow>of(3), new TimeWindow.Serializer());
 
 		assertEquals(TriggerResult.CONTINUE, testHarness.processElement(new StreamRecord<Object>(1), new TimeWindow(0, 2)));
 		assertEquals(TriggerResult.CONTINUE, testHarness.processElement(new StreamRecord<Object>(1), new TimeWindow(2, 4)));
@@ -142,7 +142,7 @@ public class CountTriggerTest {
 	@Test
 	public void testMergeSubsumingWindow() throws Exception {
 		TriggerTestHarness<Object, TimeWindow> testHarness =
-				new TriggerTestHarness<>(CountTrigger.<TimeWindow>of(3), new TimeWindow.Serializer());
+				new TriggerTestHarness<>(CountTrigger.<Object, TimeWindow>of(3), new TimeWindow.Serializer());
 
 		assertEquals(TriggerResult.CONTINUE, testHarness.processElement(new StreamRecord<Object>(1), new TimeWindow(2, 4)));
 		assertEquals(TriggerResult.CONTINUE, testHarness.processElement(new StreamRecord<Object>(1), new TimeWindow(4, 6)));

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/AllWindowTranslationTest.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/AllWindowTranslationTest.scala
@@ -26,7 +26,7 @@ import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
 import org.apache.flink.api.java.functions.KeySelector
 import org.apache.flink.streaming.api.TimeCharacteristic
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator
-import org.apache.flink.streaming.api.scala.function.{AllWindowFunction, ProcessAllWindowFunction, WindowFunction}
+import org.apache.flink.streaming.api.scala.function.{AllWindowFunction, ProcessAllWindowFunction}
 import org.apache.flink.streaming.api.transformations.OneInputTransformation
 import org.apache.flink.streaming.api.windowing.assigners._
 import org.apache.flink.streaming.api.windowing.evictors.CountEvictor
@@ -197,7 +197,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[EventTimeSessionWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
 
@@ -235,7 +235,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[SlidingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ReducingStateDescriptor[_]])
 
@@ -268,7 +268,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[SlidingProcessingTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ReducingStateDescriptor[_]])
 
@@ -301,7 +301,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[SlidingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ReducingStateDescriptor[_]])
 
@@ -340,7 +340,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ReducingStateDescriptor[_]])
 
@@ -379,7 +379,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingProcessingTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ReducingStateDescriptor[_]])
 
@@ -419,7 +419,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ReducingStateDescriptor[_]])
 
@@ -458,7 +458,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingProcessingTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ReducingStateDescriptor[_]])
 
@@ -497,7 +497,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ReducingStateDescriptor[_]])
 
@@ -532,7 +532,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ReducingStateDescriptor[_]])
 
@@ -569,7 +569,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[SlidingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[AggregatingStateDescriptor[_, _, _]])
 
@@ -602,7 +602,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[SlidingProcessingTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[AggregatingStateDescriptor[_, _, _]])
 
@@ -635,7 +635,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[AggregatingStateDescriptor[_, _, _]])
 
@@ -668,7 +668,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingProcessingTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[AggregatingStateDescriptor[_, _, _]])
 
@@ -701,7 +701,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[AggregatingStateDescriptor[_, _, _]])
 
@@ -734,7 +734,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingProcessingTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[AggregatingStateDescriptor[_, _, _]])
 
@@ -771,7 +771,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[AggregatingStateDescriptor[_, _, _]])
 
@@ -808,7 +808,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[SlidingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[FoldingStateDescriptor[_, _]])
 
@@ -841,7 +841,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[SlidingProcessingTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[FoldingStateDescriptor[_, _]])
 
@@ -874,7 +874,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[SlidingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[FoldingStateDescriptor[_, _]])
 
@@ -916,7 +916,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[FoldingStateDescriptor[_, _]])
 
@@ -957,7 +957,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingProcessingTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[FoldingStateDescriptor[_, _]])
 
@@ -998,7 +998,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[FoldingStateDescriptor[_, _]])
 
@@ -1039,7 +1039,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingProcessingTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[FoldingStateDescriptor[_, _]])
 
@@ -1081,7 +1081,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[FoldingStateDescriptor[_, _]])
 
@@ -1119,7 +1119,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[FoldingStateDescriptor[_, _]])
 
@@ -1162,7 +1162,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
 
@@ -1201,7 +1201,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingProcessingTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
 
@@ -1240,7 +1240,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
 
@@ -1279,7 +1279,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingProcessingTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
 
@@ -1314,7 +1314,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
 
@@ -1349,7 +1349,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[CountTrigger[_]])
+    assertTrue(winOperator.getTrigger.isInstanceOf[CountTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[SlidingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ReducingStateDescriptor[_]])
 
@@ -1383,7 +1383,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[CountTrigger[_]])
+    assertTrue(winOperator.getTrigger.isInstanceOf[CountTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[SlidingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[FoldingStateDescriptor[_, _]])
 
@@ -1423,7 +1423,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[CountTrigger[_]])
+    assertTrue(winOperator.getTrigger.isInstanceOf[CountTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
 
@@ -1463,7 +1463,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[CountTrigger[_]])
+    assertTrue(winOperator.getTrigger.isInstanceOf[CountTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
 
@@ -1498,7 +1498,7 @@ class AllWindowTranslationTest {
       .asInstanceOf[
       EvictingWindowOperator[String, (String, Int), (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator.getEvictor.isInstanceOf[CountEvictor[_]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[SlidingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
@@ -1534,7 +1534,7 @@ class AllWindowTranslationTest {
       .asInstanceOf[
       EvictingWindowOperator[String, (String, Int), (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator.getEvictor.isInstanceOf[CountEvictor[_]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[SlidingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
@@ -1579,7 +1579,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[EvictingWindowOperator[String, (String, Int), (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator.getEvictor.isInstanceOf[CountEvictor[_]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
@@ -1620,7 +1620,7 @@ class AllWindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[EvictingWindowOperator[String, (String, Int), (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator.getEvictor.isInstanceOf[CountEvictor[_]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/DataStreamTest.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/DataStreamTest.scala
@@ -21,7 +21,6 @@ package org.apache.flink.streaming.api.scala
 import java.lang
 
 import org.apache.flink.api.common.functions._
-import org.apache.flink.api.common.operators.ResourceSpec
 import org.apache.flink.api.java.typeutils.TypeExtractor
 import org.apache.flink.streaming.api.collector.selector.OutputSelector
 import org.apache.flink.streaming.api.functions.ProcessFunction
@@ -69,7 +68,7 @@ class DataStreamTest extends StreamingMultipleProgramsTestBase {
 
     val windowed = connected
       .windowAll(GlobalWindows.create())
-      .trigger(PurgingTrigger.of(CountTrigger.of[GlobalWindow](10)))
+      .trigger(PurgingTrigger.of(CountTrigger.of[(Long, Long), GlobalWindow](10)))
       .fold((0L, 0L))(func)
 
     windowed.name("testWindowFold")
@@ -248,7 +247,7 @@ class DataStreamTest extends StreamingMultipleProgramsTestBase {
     val map = src.map(x => (0L, 0L))
     val windowed: DataStream[(Long, Long)] = map
       .windowAll(GlobalWindows.create())
-      .trigger(PurgingTrigger.of(CountTrigger.of[GlobalWindow](10)))
+      .trigger(PurgingTrigger.of(CountTrigger.of[(Long, Long), GlobalWindow](10)))
       .fold((0L, 0L))((x: (Long, Long), y: (Long, Long)) => (0L, 0L))
 
     windowed.print()
@@ -379,14 +378,14 @@ class DataStreamTest extends StreamingMultipleProgramsTestBase {
 
     val window: DataStream[String] = map
       .windowAll(GlobalWindows.create())
-      .trigger(PurgingTrigger.of(CountTrigger.of[GlobalWindow](5)))
+      .trigger(PurgingTrigger.of(CountTrigger.of[(Integer, String), GlobalWindow](5)))
       .apply((w: GlobalWindow, x: Iterable[(Integer, String)], y: Collector[String]) => {})
 
     assert(TypeExtractor.getForClass(classOf[String]) == window.getType)
 
     val flatten: DataStream[Int] = window
       .windowAll(GlobalWindows.create())
-      .trigger(PurgingTrigger.of(CountTrigger.of[GlobalWindow](5)))
+      .trigger(PurgingTrigger.of(CountTrigger.of[String, GlobalWindow](5)))
       .fold(0)((accumulator: Int, value: String) => 0)
     assert(TypeExtractor.getForClass(classOf[Int]) == flatten.getType())
 

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/TimeWindowTranslationTest.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/TimeWindowTranslationTest.scala
@@ -106,7 +106,7 @@ class TimeWindowTranslationTest extends StreamingMultipleProgramsTestBase {
 
     val winOperator1 = operator1.asInstanceOf[WindowOperator[_, _, _, _, _]]
 
-    assertTrue(winOperator1.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator1.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator1.getWindowAssigner.isInstanceOf[SlidingEventTimeWindows])
     assertTrue(winOperator1.getStateDescriptor.isInstanceOf[ReducingStateDescriptor[_]])
   }
@@ -132,7 +132,7 @@ class TimeWindowTranslationTest extends StreamingMultipleProgramsTestBase {
 
     val winOperator1 = operator1.asInstanceOf[WindowOperator[_, _, _, _, _]]
 
-    assertTrue(winOperator1.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator1.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator1.getWindowAssigner.isInstanceOf[SlidingEventTimeWindows])
     assertTrue(winOperator1.getStateDescriptor.isInstanceOf[FoldingStateDescriptor[_, _]])
   }
@@ -164,7 +164,7 @@ class TimeWindowTranslationTest extends StreamingMultipleProgramsTestBase {
 
     val winOperator1 = operator1.asInstanceOf[WindowOperator[_, _, _, _, _]]
 
-    assertTrue(winOperator1.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator1.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator1.getWindowAssigner.isInstanceOf[SlidingEventTimeWindows])
     assertTrue(winOperator1.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
   }

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/WindowTranslationTest.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/WindowTranslationTest.scala
@@ -202,7 +202,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[EventTimeSessionWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
 
@@ -240,7 +240,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[SlidingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ReducingStateDescriptor[_]])
 
@@ -274,7 +274,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[SlidingProcessingTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ReducingStateDescriptor[_]])
 
@@ -308,7 +308,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[SlidingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ReducingStateDescriptor[_]])
 
@@ -349,7 +349,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ReducingStateDescriptor[_]])
 
@@ -390,7 +390,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingProcessingTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ReducingStateDescriptor[_]])
 
@@ -432,7 +432,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ReducingStateDescriptor[_]])
 
@@ -474,7 +474,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingProcessingTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ReducingStateDescriptor[_]])
 
@@ -515,7 +515,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ReducingStateDescriptor[_]])
 
@@ -558,7 +558,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
 
@@ -595,7 +595,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ReducingStateDescriptor[_]])
 
@@ -633,7 +633,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[SlidingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[AggregatingStateDescriptor[_, _, _]])
 
@@ -667,7 +667,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[SlidingProcessingTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[AggregatingStateDescriptor[_, _, _]])
 
@@ -701,7 +701,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[AggregatingStateDescriptor[_, _, _]])
 
@@ -735,7 +735,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingProcessingTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[AggregatingStateDescriptor[_, _, _]])
 
@@ -769,7 +769,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[AggregatingStateDescriptor[_, _, _]])
 
@@ -803,7 +803,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingProcessingTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[AggregatingStateDescriptor[_, _, _]])
 
@@ -840,7 +840,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[AggregatingStateDescriptor[_, _, _]])
 
@@ -878,7 +878,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[SlidingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[FoldingStateDescriptor[_, _]])
 
@@ -912,7 +912,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[SlidingProcessingTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[FoldingStateDescriptor[_, _]])
 
@@ -946,7 +946,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[SlidingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[FoldingStateDescriptor[_, _]])
 
@@ -990,7 +990,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[FoldingStateDescriptor[_, _]])
 
@@ -1033,7 +1033,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingProcessingTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[FoldingStateDescriptor[_, _]])
 
@@ -1076,7 +1076,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[FoldingStateDescriptor[_, _]])
 
@@ -1119,7 +1119,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingProcessingTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[FoldingStateDescriptor[_, _]])
 
@@ -1163,7 +1163,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[FoldingStateDescriptor[_, _]])
 
@@ -1208,7 +1208,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
 
@@ -1247,7 +1247,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[FoldingStateDescriptor[_, _]])
 
@@ -1292,7 +1292,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
 
@@ -1333,7 +1333,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingProcessingTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
 
@@ -1374,7 +1374,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
 
@@ -1415,7 +1415,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[ProcessingTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingProcessingTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
 
@@ -1451,7 +1451,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
 
@@ -1487,7 +1487,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[CountTrigger[_]])
+    assertTrue(winOperator.getTrigger.isInstanceOf[CountTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[SlidingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ReducingStateDescriptor[_]])
 
@@ -1522,7 +1522,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[CountTrigger[_]])
+    assertTrue(winOperator.getTrigger.isInstanceOf[CountTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[SlidingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[FoldingStateDescriptor[_, _]])
 
@@ -1564,7 +1564,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[CountTrigger[_]])
+    assertTrue(winOperator.getTrigger.isInstanceOf[CountTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
 
@@ -1606,7 +1606,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[CountTrigger[_]])
+    assertTrue(winOperator.getTrigger.isInstanceOf[CountTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
 
@@ -1643,7 +1643,7 @@ class WindowTranslationTest {
       .asInstanceOf[
       EvictingWindowOperator[String, (String, Int), (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator.getEvictor.isInstanceOf[CountEvictor[_]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[SlidingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
@@ -1680,7 +1680,7 @@ class WindowTranslationTest {
       .asInstanceOf[
       EvictingWindowOperator[String, (String, Int), (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator.getEvictor.isInstanceOf[CountEvictor[_]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[SlidingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
@@ -1716,7 +1716,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[SlidingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
 
@@ -1751,7 +1751,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[WindowOperator[String, (String, Int), _, (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[SlidingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
 
@@ -1787,7 +1787,7 @@ class WindowTranslationTest {
       .asInstanceOf[
       EvictingWindowOperator[String, (String, Int), (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator.getEvictor.isInstanceOf[CountEvictor[_]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[SlidingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
@@ -1828,7 +1828,7 @@ class WindowTranslationTest {
       .asInstanceOf[
       EvictingWindowOperator[String, (String, Int), (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator.getEvictor.isInstanceOf[CountEvictor[_]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[SlidingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
@@ -1876,7 +1876,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[EvictingWindowOperator[String, (String, Int), (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator.getEvictor.isInstanceOf[CountEvictor[_]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])
@@ -1919,7 +1919,7 @@ class WindowTranslationTest {
     val winOperator = operator
       .asInstanceOf[EvictingWindowOperator[String, (String, Int), (String, Int), _ <: Window]]
 
-    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger])
+    assertTrue(winOperator.getTrigger.isInstanceOf[EventTimeTrigger[_, _]])
     assertTrue(winOperator.getEvictor.isInstanceOf[CountEvictor[_]])
     assertTrue(winOperator.getWindowAssigner.isInstanceOf[TumblingEventTimeWindows])
     assertTrue(winOperator.getStateDescriptor.isInstanceOf[ListStateDescriptor[_]])


### PR DESCRIPTION
# What is the purpose of the change

Flink provides implementations of the `Trigger<T, W extend Window>` class that are unnecessarily
specific. `EventTimeTrigger`, for instance, extends `Trigger<Object, TimeWindow>`.

Since most window assigners provided also implement `WindowAssigner<Object, TimeWindow>` this
is usually not a problem. However, when implementing custom `WindowAssigner` it could be problematic:

```java
public class CustomWindowAssigner extends WindowAssigner<SomePojo, AnotherWindowImpl> {
    ...

	@Override
	public Trigger<SomePojo, AnotherWindowImpl> getDefaultTrigger(StreamExecutionEnvironment env) {
		return EventTimeTrigger.create(); // compiler complains about typing
	}

    ...
}
```

## Brief change log

This commit makes `Trigger` implementations generic, keeping them compatible with the current
windowing implementations as well as custom ones.

  - `EventTimeTrigger<T, W extends Window>`
  - `ProcessingTimeTrigger<T, W extends Window>`
  - `ContinuousEventTimeTrigger<T, W extends Window>`
  - `ContinuousProcessingTimeTrigger<T, W extends Window>`
  - `CountTrigger<T, W extends Window>`

## Verifying this change

This change is already covered by existing tests, such as `WindowTranslationTest` or `DataStreamTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
