### PR TITLE
[FLINK-7873] [runtime] Introduce local recovery

### DIFF
--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
@@ -1566,7 +1566,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 					((CachedStreamStateHandle) remoteFileHandle).setCheckpointCache(stateBackend.cache);
 					((CachedStreamStateHandle) remoteFileHandle).reCache(!hasExtraKeys);
 				}
-				readStateData(new Path(restoreInstancePath, stateHandleID.toString()), remoteFileHandle);
+				readStateData(new Path(restoreInstancePath, getFileNameFromStateHanldeId(stateHandleID)), remoteFileHandle);
 			}
 		}
 
@@ -1575,11 +1575,16 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 			Path restoreInstancePath) throws IOException {
 
 			for (StateHandleID stateHandleID : stateHandleMap.keySet()) {
-				String newSstFileName = stateHandleID.toString();
+				String newSstFileName = getFileNameFromStateHanldeId(stateHandleID);
 				File restoreFile = new File(restoreInstancePath.getPath(), newSstFileName);
 				File targetFile = new File(stateBackend.instanceRocksDBPath, newSstFileName);
 				Files.createLink(targetFile.toPath(), restoreFile.toPath());
 			}
+		}
+
+		private String getFileNameFromStateHanldeId(StateHandleID handleID) {
+			final String[] arr = handleID.toString().split("\\$");
+			return arr[arr.length - 1];
 		}
 
 		void restore(Collection<KeyedStateHandle> restoreStateHandles) throws Exception {

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
@@ -1544,7 +1544,9 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 					stateBackend.lastCompletedCheckpointId = restoreStateHandle.getCheckpointId();
 
 					// commit re-cache
-					stateBackend.cache.commitCache(CheckpointCache.CHECKPOINT_ID_FOR_RESTORE, false);
+					if (stateBackend.cache != null) {
+						stateBackend.cache.commitCache(CheckpointCache.CHECKPOINT_ID_FOR_RESTORE, false);
+					}
 				}
 			} finally {
 				FileSystem restoreFileSystem = restoreInstancePath.getFileSystem();

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
@@ -30,7 +30,6 @@ import org.apache.flink.runtime.state.DefaultOperatorStateBackend;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.OperatorStateBackend;
 import org.apache.flink.runtime.state.filesystem.FsStateBackend;
-import org.apache.flink.runtime.taskmanager.RuntimeEnvironment;
 import org.apache.flink.util.AbstractID;
 
 import org.rocksdb.ColumnFamilyOptions;
@@ -285,13 +284,13 @@ public class RocksDBStateBackend extends AbstractStateBackend {
 
 	@Override
 	public <K> AbstractKeyedStateBackend<K> createKeyedStateBackend(
-			Environment env,
-			JobID jobID,
-			String operatorIdentifier,
-			TypeSerializer<K> keySerializer,
-			int numberOfKeyGroups,
-			KeyGroupRange keyGroupRange,
-			TaskKvStateRegistry kvStateRegistry) throws IOException {
+		Environment env,
+		JobID jobID,
+		String operatorIdentifier,
+		TypeSerializer<K> keySerializer,
+		int numberOfKeyGroups,
+		KeyGroupRange keyGroupRange,
+		TaskKvStateRegistry kvStateRegistry) throws IOException {
 
 		// first, make sure that the RocksDB JNI library is loaded
 		// we do this explicitly here to have better error handling
@@ -314,7 +313,7 @@ public class RocksDBStateBackend extends AbstractStateBackend {
 				numberOfKeyGroups,
 				keyGroupRange,
 				env.getExecutionConfig(),
-				((RuntimeEnvironment) env).getCheckpointCache(),
+				env.getCheckpointCache(),
 				enableIncrementalCheckpointing);
 	}
 

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.state.DefaultOperatorStateBackend;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.OperatorStateBackend;
 import org.apache.flink.runtime.state.filesystem.FsStateBackend;
+import org.apache.flink.runtime.taskmanager.RuntimeEnvironment;
 import org.apache.flink.util.AbstractID;
 
 import org.rocksdb.ColumnFamilyOptions;
@@ -313,6 +314,7 @@ public class RocksDBStateBackend extends AbstractStateBackend {
 				numberOfKeyGroups,
 				keyGroupRange,
 				env.getExecutionConfig(),
+				((RuntimeEnvironment) env).getCheckpointCache(),
 				enableIncrementalCheckpointing);
 	}
 

--- a/flink-contrib/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendTest.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.core.testutils.OneShotLatch;
+import org.apache.flink.runtime.checkpoint.CheckpointCache;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
@@ -231,6 +232,7 @@ public class RocksDBStateBackendTest extends StateBackendTestBase<RocksDBStateBa
 				1,
 				new KeyGroupRange(0, 0),
 				new ExecutionConfig(),
+				mock(CheckpointCache.class),
 				enableIncrementalCheckpointing);
 
 			verify(columnFamilyOptions, Mockito.times(1))

--- a/flink-mesos/src/main/scala/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManager.scala
+++ b/flink-mesos/src/main/scala/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManager.scala
@@ -18,6 +18,7 @@
 
 package org.apache.flink.mesos.runtime.clusterframework
 
+import org.apache.flink.runtime.checkpoint.CheckpointCacheManager
 import org.apache.flink.runtime.clusterframework.types.ResourceID
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices
 import org.apache.flink.runtime.io.disk.iomanager.IOManager
@@ -37,6 +38,7 @@ class MesosTaskManager(
     memoryManager: MemoryManager,
     ioManager: IOManager,
     network: NetworkEnvironment,
+    checkpointCacheManager: CheckpointCacheManager,
     numberOfSlots: Int,
     highAvailabilityServices: HighAvailabilityServices,
     taskManagerMetricGroup : TaskManagerMetricGroup)
@@ -47,6 +49,7 @@ class MesosTaskManager(
     memoryManager,
     ioManager,
     network,
+    checkpointCacheManager,
     numberOfSlots,
     highAvailabilityServices,
     taskManagerMetricGroup) {

--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/KVStateRequestSerializerRocksDBTest.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/KVStateRequestSerializerRocksDBTest.java
@@ -28,6 +28,7 @@ import org.apache.flink.contrib.streaming.state.PredefinedOptions;
 import org.apache.flink.contrib.streaming.state.RocksDBKeyedStateBackend;
 import org.apache.flink.queryablestate.client.VoidNamespace;
 import org.apache.flink.queryablestate.client.VoidNamespaceSerializer;
+import org.apache.flink.runtime.checkpoint.CheckpointCache;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.internal.InternalListState;
@@ -76,7 +77,9 @@ public final class KVStateRequestSerializerRocksDBTest {
 			super(operatorIdentifier, userCodeClassLoader,
 				instanceBasePath,
 				dbOptions, columnFamilyOptions, kvStateRegistry, keySerializer,
-				numberOfKeyGroups, keyGroupRange, executionConfig, false);
+				numberOfKeyGroups, keyGroupRange, executionConfig,
+				mock(CheckpointCache.class),
+				false);
 		}
 
 		@Override
@@ -152,6 +155,7 @@ public final class KVStateRequestSerializerRocksDBTest {
 				LongSerializer.INSTANCE,
 				1, new KeyGroupRange(0, 0),
 				new ExecutionConfig(),
+				mock(CheckpointCache.class),
 				false);
 		longHeapKeyedStateBackend.restore(null);
 		longHeapKeyedStateBackend.setCurrentKey(key);

--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/KvStateRequestSerializerTest.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/KvStateRequestSerializerTest.java
@@ -28,6 +28,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.queryablestate.client.VoidNamespace;
 import org.apache.flink.queryablestate.client.VoidNamespaceSerializer;
 import org.apache.flink.queryablestate.client.state.serialization.KvStateSerializer;
+import org.apache.flink.runtime.checkpoint.CheckpointCache;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.heap.HeapKeyedStateBackend;
@@ -194,7 +195,8 @@ public class KvStateRequestSerializerTest {
 				1,
 				new KeyGroupRange(0, 0),
 				async,
-				new ExecutionConfig()
+				new ExecutionConfig(),
+				mock(CheckpointCache.class)
 			);
 		longHeapKeyedStateBackend.setCurrentKey(key);
 
@@ -296,7 +298,8 @@ public class KvStateRequestSerializerTest {
 					1,
 					new KeyGroupRange(0, 0),
 					async,
-					new ExecutionConfig()
+					new ExecutionConfig(),
+					mock(CheckpointCache.class)
 			);
 		longHeapKeyedStateBackend.setCurrentKey(key);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CachedStreamStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CachedStreamStateHandle.java
@@ -152,7 +152,7 @@ public class CachedStreamStateHandle implements StreamStateHandle, CachedStateHa
 		@Override
 		public void close() throws IOException {
 			if (this.cacheOut != null) {
-				this.cacheOut.end();
+				this.cacheOut.closeAndGetHandle();
 			}
 			this.remoteInputStream.close();
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CachedStreamStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CachedStreamStateHandle.java
@@ -37,6 +37,8 @@ import java.io.IOException;
  */
 public class CachedStreamStateHandle implements StreamStateHandle, CachedStateHandle {
 
+	private static final long serialVersionUID = 350284443258002366L;
+
 	private static Logger LOG = LoggerFactory.getLogger(CachedStreamStateHandle.class);
 
 	private transient CheckpointCache cache;
@@ -137,12 +139,15 @@ public class CachedStreamStateHandle implements StreamStateHandle, CachedStateHa
 
 		@Override
 		public void seek(long desired) throws IOException {
-			throw new FlinkRuntimeException("Unsupported method in CachedSteamStateHandle.");
+			this.remoteInputStream.seek(desired);
+			if (cacheOut != null) {
+				cacheOut.discard();
+			}
 		}
 
 		@Override
 		public long getPos() throws IOException {
-			throw new FlinkRuntimeException("Unsupported method in CachedSteamStateHandle.");
+			return this.remoteInputStream.getPos();
 		}
 
 		@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CachedStreamStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CachedStreamStateHandle.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.checkpoint;
+
+import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.runtime.checkpoint.CheckpointCache.CachedOutputStream;
+import org.apache.flink.runtime.state.CachedStateHandle;
+import org.apache.flink.runtime.state.StateHandleID;
+import org.apache.flink.runtime.state.StreamStateHandle;
+import org.apache.flink.util.FlinkRuntimeException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+/**
+ * It mainly has two member fields:
+ * 1, cacheId {@link StateHandleID}
+ * 2, remoteHandle {@link StreamStateHandle}
+ * When building the input stream via {@link CachedStreamStateHandle}, it first try to build the local input stream from {@link CheckpointCache}
+ * based on the cache id, and use remoteHandle to build the input stream from the remote end only when building the local input stream failed.
+ */
+public class CachedStreamStateHandle implements StreamStateHandle, CachedStateHandle {
+
+	private static Logger LOG = LoggerFactory.getLogger(CachedStreamStateHandle.class);
+
+	private transient CheckpointCache cache;
+	private transient boolean reCache;
+
+	private final StateHandleID cacheId;
+	private final StreamStateHandle remoteHandle;
+
+	public CachedStreamStateHandle(StateHandleID cacheId, StreamStateHandle remoteHandle) {
+		this.cacheId = cacheId;
+		this.remoteHandle = remoteHandle;
+	}
+
+	@Override
+	public FSDataInputStream openInputStream() throws IOException {
+		FSDataInputStream in = cache.openInputStream(cacheId);
+		if (in != null) {
+			LOG.info("Open the local input stream.");
+			return in;
+		}
+
+		CachedOutputStream output = null;
+		if (reCache) {
+			output = cache.createOutputStream(CheckpointCache.CHECKPOINT_ID_FOR_RESTORE, cacheId);
+		}
+		LOG.info("Open the remote input stream, re-cache: {}.", reCache);
+		return new CachedInputStream(remoteHandle.openInputStream(), output);
+	}
+
+	@Override
+	public void discardState() throws Exception {
+		remoteHandle.discardState();
+	}
+
+	@Override
+	public long getStateSize() {
+		return remoteHandle.getStateSize();
+	}
+
+	public StreamStateHandle getRemoteHandle() {
+		return this.remoteHandle;
+	}
+
+	public void setCheckpointCache(CheckpointCache cache) {
+		this.cache = cache;
+	}
+
+	public void reCache(boolean reCache) {
+		this.reCache = reCache;
+	}
+
+	@Override
+	public StateHandleID getStateHandleId() {
+		return cacheId;
+	}
+
+	public static class CachedInputStream extends FSDataInputStream {
+
+		private final FSDataInputStream remoteInputStream ;
+		private final CachedOutputStream cacheOut;
+
+		public CachedInputStream(FSDataInputStream fsDataInputStream, CachedOutputStream output) {
+			this.cacheOut = output;
+			this.remoteInputStream = fsDataInputStream;
+		}
+
+		@Override
+		public int read() throws IOException {
+			int o = this.remoteInputStream.read();
+			if (o != -1) {
+				//re-cache and ignore exception
+				if (cacheOut != null && !cacheOut.isDiscarded()) {
+					try {
+						cacheOut.write(o);
+					} catch (Exception ignore) {
+						cacheOut.discard();
+					}
+				}
+			}
+			return o;
+		}
+
+		@Override
+		public int read(byte[] b) throws IOException {
+			int n = this.remoteInputStream.read(b);
+			if (n != -1) {
+				//re-cache and ignore exception
+				if (cacheOut != null && !cacheOut.isDiscarded()) {
+					try {
+						this.cacheOut.write(b, 0, n);
+					} catch (Exception ignore) {
+						cacheOut.discard();
+					}
+				}
+			}
+			return n;
+		}
+
+		@Override
+		public void seek(long desired) throws IOException {
+			throw new FlinkRuntimeException("Unsupported method in CachedSteamStateHandle.");
+		}
+
+		@Override
+		public long getPos() throws IOException {
+			throw new FlinkRuntimeException("Unsupported method in CachedSteamStateHandle.");
+		}
+
+		@Override
+		public void close() throws IOException {
+			if (this.cacheOut != null) {
+				this.cacheOut.end();
+			}
+			this.remoteInputStream.close();
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CachedStreamStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CachedStreamStateHandle.java
@@ -22,7 +22,6 @@ import org.apache.flink.runtime.checkpoint.CheckpointCache.CachedOutputStream;
 import org.apache.flink.runtime.state.CachedStateHandle;
 import org.apache.flink.runtime.state.StateHandleID;
 import org.apache.flink.runtime.state.StreamStateHandle;
-import org.apache.flink.util.FlinkRuntimeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCache.java
@@ -183,6 +183,7 @@ public class CheckpointCache {
 				}
 
 				this.completedCheckpointCaches.add(completedCheckpointCache);
+				pendingCheckpointCache.cancelCanceller();
 
 				if (dropUnRetainCheckpointCache) {
 					// only maintain the last complete checkpoint

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCache.java
@@ -346,7 +346,7 @@ public class CheckpointCache {
 						cacheBasePath,
 						cacheBasePath.getFileSystem(),
 						4096,
-						1024 * 1024);
+						2048);
 				} catch (Exception ignored) {
 					this.outputStream = null;
 				}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCache.java
@@ -1,0 +1,596 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.checkpoint;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.state.StateHandleID;
+import org.apache.flink.runtime.state.filesystem.FileStateHandle;
+import org.apache.flink.runtime.taskmanager.DispatcherThreadFactory;
+import org.apache.flink.util.FlinkRuntimeException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayDeque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Created from {@link CheckpointCacheManager} and used by {@link org.apache.flink.runtime.taskmanager.Task} to cache checkpoint data locally,
+ * it maintains the last success completed checkpoint cache and uses {@link SharedCacheRegistry}
+ * to manage the cache entry, backend uses the output stream to transmission data to both network and local,
+ * local data maintained by {@link PendingCheckpointCache}, we turn {@link PendingCheckpointCache} into {@link CompletedCheckpointCache}
+ * in notifyCheckpointComplete().
+ */
+public class CheckpointCache {
+
+	private static Logger LOG = LoggerFactory.getLogger(CheckpointCache.class);
+
+	// a special checkpoint id used when do re-cache for incremental checkpoint
+	public static final long CHECKPOINT_ID_FOR_RESTORE = -1L;
+
+	// max retain completed cache num
+	public static final int MAX_RETAIN_NUM = 1;
+
+	// cache manager
+	private final CheckpointCacheManager cacheManager;
+	private final JobID jobID;
+	private final Path basePath;
+	private final AtomicInteger reference;
+	private final Object lock = new Object();
+
+	// pending checkpoint cache timeout
+	private final long pendingCheckpointCacheTimeout;
+
+	//checkpoint cache lease ttl
+	private final long leaseTimeout;
+
+	// executor for dispose resource
+	private final Executor executor;
+
+	private final ScheduledThreadPoolExecutor timer;
+
+	// pending cache map
+	private final Map<Long, PendingCheckpointCache> pendingCacheMap;
+
+	// completed checkpoint cache map
+	private final ArrayDeque<CompletedCheckpointCache> completedCheckpointCaches;
+
+	// shared cache registry
+	private final SharedCacheRegistry sharedCacheRegistry;
+
+	public CheckpointCache(JobID jobID, String basePath, long pendingCheckpointCacheTimeout, long leaseTimeout, CheckpointCacheManager manager, Executor executor) {
+		this.basePath = new Path(basePath + File.separator + "checkpoint_cache" + File.separator + jobID);
+		try {
+			this.basePath.getFileSystem().mkdirs(this.basePath);
+		} catch (IOException e) {
+			throw new FlinkRuntimeException("init checkpoint cache manager failed:{}", e);
+		}
+		this.cacheManager = manager;
+		this.jobID = jobID;
+		this.reference = new AtomicInteger(0);
+		this.pendingCheckpointCacheTimeout = pendingCheckpointCacheTimeout;
+		this.leaseTimeout = leaseTimeout;
+		this.executor = executor;
+		this.timer = new ScheduledThreadPoolExecutor(1,
+			new DispatcherThreadFactory(Thread.currentThread().getThreadGroup(), "Checkpoint Cache Timer"));
+		this.pendingCacheMap = new ConcurrentHashMap<>();
+		this.completedCheckpointCaches = new ArrayDeque<>(MAX_RETAIN_NUM + 1);
+		this.sharedCacheRegistry = new SharedCacheRegistry(executor);
+
+		LOG.info("new checkpoint cache, pendingCacheTimeout: {}, leaseTimeout: {}", pendingCheckpointCacheTimeout, leaseTimeout);
+	}
+
+	protected void registerCacheEntry(long checkpointID, StateHandleID handleID, String filePath) {
+		synchronized (lock) {
+			LOG.debug("register cache entry: { cpkID:[{}] handleID:[{}] }", checkpointID, handleID);
+			PendingCheckpointCache pendingCheckpointCache = pendingCacheMap.get(checkpointID);
+			if (pendingCheckpointCache == null) {
+				PendingCheckpointCache newPendingCheckpointCache = new PendingCheckpointCache(executor, checkpointID);
+				LOG.debug("add pending cache map: { cpkID:[{}] }", checkpointID);
+				pendingCacheMap.put(checkpointID, newPendingCheckpointCache);
+				pendingCheckpointCache = newPendingCheckpointCache;
+
+				// schedule the timer that will clean up the expired checkpoints
+				ScheduledFuture<?> cancellerHandle = timer.schedule(
+					() -> {
+						synchronized (lock) {
+							if (!newPendingCheckpointCache.isDiscarded()) {
+								LOG.info("Checkpoint cache " + checkpointID + " expired before completing.");
+								newPendingCheckpointCache.abortExpired();
+								pendingCacheMap.remove(checkpointID);
+							}
+						}
+					},
+					pendingCheckpointCacheTimeout, TimeUnit.MILLISECONDS);
+
+				if (!newPendingCheckpointCache.setCancellerHandle(cancellerHandle)) {
+					cancellerHandle.cancel(false);
+				}
+			}
+
+			pendingCheckpointCache.addEntry(
+				new CacheKey(handleID),
+				new CacheEntry(new FileStateHandle(new Path(filePath), getFileSize(filePath))));
+		}
+	}
+
+	private long getFileSize(String filePath) {
+		File file = new File(filePath);
+		if (file.exists() && file.isFile()) {
+			return file.length();
+		} else {
+			return 0L;
+		}
+	}
+
+	protected void abortPendingCache(long checkpointID) {
+		LOG.info("abort pending cache: {}", checkpointID);
+		synchronized (lock) {
+			PendingCheckpointCache pendingCheckpointCache = pendingCacheMap.get(checkpointID);
+			if (pendingCheckpointCache != null) {
+				pendingCheckpointCache.abortSubsumed();
+			}
+		}
+	}
+
+	public void commitCache(long checkpointID) {
+		commitCache(checkpointID, true);
+	}
+
+	public void commitCache(long checkpointID, boolean dropUnRetainCheckpointCache) {
+		synchronized (lock) {
+			final PendingCheckpointCache pendingCheckpointCache;
+			pendingCheckpointCache = pendingCacheMap.remove(checkpointID);
+			if (pendingCheckpointCache != null) {
+				LOG.info("commit pending checkpoint cache: {}", checkpointID);
+				// here will build reference on cache entry
+				CompletedCheckpointCache completedCheckpointCache = new CompletedCheckpointCache(sharedCacheRegistry, checkpointID);
+				for (Map.Entry<CacheKey, CacheEntry> entry : pendingCheckpointCache.getEntryIterable()) {
+					completedCheckpointCache.addCacheEntry(entry.getKey(), entry.getValue());
+				}
+
+				this.completedCheckpointCaches.add(completedCheckpointCache);
+
+				if (dropUnRetainCheckpointCache) {
+					// only maintain the last complete checkpoint
+					dropUnRetainCheckpointCache(MAX_RETAIN_NUM);
+				}
+
+				// subsume pending checkpoint cache
+				dropSubsumedPendingCheckpointCache(checkpointID);
+			} else {
+				LOG.debug("{} pending checkpoint cache is not exists. This means it has been committed or expired", checkpointID);
+			}
+		}
+	}
+
+	public int getPendingCheckpointCacheSize() {
+		synchronized (lock) {
+			return pendingCacheMap.size();
+		}
+	}
+
+	public int getCompletedCheckpointCacheSize() {
+		synchronized (lock) {
+			return completedCheckpointCaches.size();
+		}
+	}
+
+	private void dropUnRetainCheckpointCache(int maxRetainNum) {
+		while (this.completedCheckpointCaches.size() > maxRetainNum) {
+			CompletedCheckpointCache completedCheckpointCache = completedCheckpointCaches.removeFirst();
+			LOG.debug("remove checkpoint cache:{}", completedCheckpointCache.getCheckpointID());
+			completedCheckpointCache.discard();
+		}
+	}
+
+	private void dropSubsumedPendingCheckpointCache(long checkpointID) {
+		Iterator<Map.Entry<Long, PendingCheckpointCache>> entries = this.pendingCacheMap.entrySet().iterator();
+		while (entries.hasNext()) {
+			PendingCheckpointCache p = entries.next().getValue();
+			// remove all pending checkpoints that are lesser than the current completed checkpoint
+			if (p.getCheckpointID() < checkpointID) {
+				LOG.debug("remove subsumed pending checkpoint: {} < {}", p.getCheckpointID(), checkpointID);
+				p.abortSubsumed();
+				entries.remove();
+			}
+		}
+	}
+
+	public String getBasePath() {
+		return basePath.getPath();
+	}
+
+	public void discard() {
+		cacheManager.unregisterCheckpointCache(jobID);
+	}
+
+	public void release() {
+		synchronized (lock) {
+			dropSubsumedPendingCheckpointCache(Long.MAX_VALUE);
+			dropUnRetainCheckpointCache(0);
+		}
+	}
+
+	@VisibleForTesting
+	protected SharedCacheRegistry getSharedCacheRegister() {
+		return this.sharedCacheRegistry;
+	}
+
+	public CachedOutputStream createOutputStream(long checkpointID, StateHandleID handleID) {
+		return createOutputStream(checkpointID, handleID, false);
+	}
+
+	public CachedOutputStream createOutputStream(long checkpointID, StateHandleID handleID, boolean placeholder) {
+		LOG.debug("create cache output: {} {}", checkpointID, placeholder);
+		try {
+			File basePathDir = new File(this.basePath.getPath());
+			//sanity check
+			if (!basePathDir.exists()) {
+				if (!basePathDir.mkdirs()) {
+					LOG.warn("init checkpoint cache base path {} failed.", this.basePath.getPath());
+					return null;
+				}
+			}
+			final String cacheFilePath = basePath + File.separator + handleID + "_" + UUID.randomUUID();
+			return new CachedOutputStream(checkpointID, handleID, cacheFilePath, this, placeholder);
+		} catch (Exception ignore) {
+			// warning
+			LOG.warn("create output stream failed: {}", ignore);
+		}
+		return null;
+	}
+
+	public FSDataInputStream openInputStream(StateHandleID cacheId) {
+		LOG.debug("try to open input stream from cache with cacheID:" + cacheId);
+		CacheEntry entry = sharedCacheRegistry.getCacheEntry(new CacheKey(cacheId));
+		if (entry != null) {
+			try {
+				LOG.debug("entry path: {}", entry.getHandle().getFilePath());
+				return entry.getHandle().openInputStream();
+			} catch (Exception ignore) {
+				entry.rot(true);
+				return null;
+			}
+		}
+		return null;
+	}
+
+	public int reference() {
+		return this.reference.incrementAndGet();
+	}
+
+	public int dereference() {
+		return this.reference.decrementAndGet();
+	}
+
+	public int getReference() {
+		return this.reference.get();
+	}
+
+	public static class CachedOutputStream extends OutputStream {
+
+		private final OutputStream outputStream;
+		private final StateHandleID cacheID;
+		private final long checkpointID;
+
+		private final String cacheFilePath;
+		private final CheckpointCache cache;
+		private boolean discarded;
+
+		public CachedOutputStream(
+			long checkpointID,
+			StateHandleID cacheID,
+			String cacheFilePath,
+			CheckpointCache cache,
+			boolean placeholder
+		) throws FileNotFoundException {
+			this.checkpointID = checkpointID;
+			this.cacheID = cacheID;
+			this.cacheFilePath = cacheFilePath;
+			if (!placeholder) {
+				this.outputStream = new FileOutputStream(cacheFilePath);
+			} else {
+				this.outputStream = null;
+			}
+			this.cache = cache;
+			this.discarded = false;
+		}
+
+		public long getCheckpointID() {
+			return this.checkpointID;
+		}
+
+		public StateHandleID getCacheID() {
+			return this.cacheID;
+		}
+
+		public boolean isDiscarded() {
+			return this.discarded;
+		}
+
+		public void discard() {
+			LOG.info("cache output stream discard: {}", checkpointID);
+			discarded = true;
+		}
+
+		@Override
+		public void write(int b) throws IOException {
+			if (!discarded && outputStream != null) {
+				outputStream.write(b);
+			}
+		}
+
+		@Override
+		public void write(byte[] b) throws IOException {
+			if (!discarded && outputStream != null) {
+				outputStream.write(b);
+			}
+		}
+
+		@Override
+		public void write(byte[] b, int off, int len) throws IOException {
+			if (!discarded && outputStream != null) {
+				outputStream.write(b, off, len);
+			}
+		}
+
+		@Override
+		public void flush() throws IOException {
+			if (!discarded && outputStream != null) {
+				outputStream.flush();
+			}
+		}
+
+		@Override
+		public void close() throws IOException {
+			if (outputStream != null) {
+				outputStream.close();
+			}
+		}
+
+		public void end() {
+			if (!discarded) {
+				this.cache.registerCacheEntry(checkpointID, cacheID, cacheFilePath);
+			} else {
+				this.cache.abortPendingCache(checkpointID);
+			}
+		}
+
+		public String getCacheFilePath() {
+			return cacheFilePath;
+		}
+	}
+
+	public long getLeaseTimeout() {
+		return leaseTimeout;
+	}
+
+	public static class CacheKey {
+		private StateHandleID handleID;
+		public CacheKey(StateHandleID handleID) {
+			this.handleID = handleID;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+
+			CacheKey cacheKey = (CacheKey) o;
+
+			return handleID != null ? handleID.equals(cacheKey.handleID) : cacheKey.handleID == null;
+		}
+
+		@Override
+		public int hashCode() {
+			int result = handleID != null ? handleID.hashCode() : 0;
+			return result;
+		}
+
+		@Override
+		public String toString() {
+			return handleID.toString();
+		}
+	}
+
+	public static class CacheEntry {
+		private final FileStateHandle handle;
+		private final AtomicInteger reference;
+
+		public boolean isRot() {
+			return rot;
+		}
+
+		public void rot(boolean isRot) {
+			this.rot = isRot;
+		}
+
+		private boolean rot;
+
+		public CacheEntry(FileStateHandle handle) {
+			this.handle = handle;
+			this.reference = new AtomicInteger(0);
+			this.rot = false;
+		}
+
+		public FileStateHandle getHandle() {
+			return handle;
+		}
+
+		public void discard() {
+			try {
+				//TODO: this should discard with future.
+				this.handle.discardState();
+			} catch (Exception e) {
+				LOG.warn("discard handle failed: {}", e);
+			}
+		}
+
+		public int increaseReferenceCount() {
+			return reference.incrementAndGet();
+		}
+
+		public int decreaseReferenceCount() {
+			return reference.decrementAndGet();
+		}
+
+		public int getReferenceCount() {
+			return reference.get();
+		}
+
+		public void setReference(int refer) {
+			reference.set(refer);
+		}
+	}
+
+	public static class CompletedCheckpointCache {
+		private final long checkpointID;
+		private final Set<CacheKey> cacheKeys;
+		private final SharedCacheRegistry registry;
+
+		public CompletedCheckpointCache(SharedCacheRegistry registry, long checkpointID) {
+			this.checkpointID = checkpointID;
+			this.cacheKeys = new HashSet<>();
+			this.registry = registry;
+		}
+
+		public void addCacheEntry(CacheKey key, CacheEntry value) {
+			registry.registerReference(key, value);
+			cacheKeys.add(key);
+		}
+
+		public long getCheckpointID() {
+			return checkpointID;
+		}
+
+		public void discard() {
+			for (CacheKey key : cacheKeys) {
+				registry.unregisterReference(key);
+			}
+		}
+	}
+
+	public static class PendingCheckpointCache {
+		private final long checkpointID;
+		private boolean discarded;
+		private final Map<CacheKey, CacheEntry> pendingEntry;
+		private ScheduledFuture<?> cancellerHandle;
+		private final Executor executor;
+
+		public PendingCheckpointCache(Executor executor, long checkpointID) {
+			this.checkpointID = checkpointID;
+			this.pendingEntry = new HashMap<>();
+			this.discarded = false;
+			this.executor = executor;
+		}
+
+		public void addEntry(CacheKey key, CacheEntry entry) {
+			if (!discarded) {
+				CacheEntry preEntry = pendingEntry.get(key);
+				if (preEntry != null) {
+					throw new FlinkRuntimeException("register twice in pending cache map with the same key: { "  + key.handleID + "}");
+				}
+				pendingEntry.put(key, entry);
+			}
+		}
+
+		public Iterable<Map.Entry<CacheKey, CacheEntry>> getEntryIterable() {
+			return discarded ? null : pendingEntry.entrySet();
+		}
+
+		public long getCheckpointID() {
+			return checkpointID;
+		}
+
+		public void abortSubsumed() {
+			dispose();
+		}
+
+		public void abortExpired() {
+			dispose();
+		}
+
+		public boolean isDiscarded() {
+			return discarded;
+		}
+
+		public boolean setCancellerHandle(ScheduledFuture<?> cancellerHandle) {
+			if (this.cancellerHandle == null) {
+				if (!discarded) {
+					this.cancellerHandle = cancellerHandle;
+					return true;
+				} else {
+					return false;
+				}
+			}
+			else {
+				throw new IllegalStateException("A canceller handle was already set");
+			}
+		}
+
+		private void cancelCanceller() {
+			try {
+				final ScheduledFuture<?> canceller = this.cancellerHandle;
+				if (canceller != null) {
+					canceller.cancel(false);
+				}
+			}
+			catch (Exception e) {
+				// this code should not throw exceptions
+				LOG.warn("Error while cancelling checkpoint cache timeout task", e);
+			}
+		}
+
+		private void dispose() {
+			try {
+				executor.execute(() -> {
+					for (CacheEntry entry : pendingEntry.values()) {
+						entry.discard();
+					}
+					pendingEntry.clear();
+				});
+			} finally {
+				discarded = true;
+				cancelCanceller();
+			}
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCacheManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCacheManager.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.checkpoint;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.core.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * It is responsible for managing all {@link CheckpointCache} instances on a TM,
+ * whenever the TM receives the task submit message, it registers a CheckpointCache
+ * from CheckpointCacheManager for the coming Task. It is initialized in the form of
+ * service during TM initialization and runs on TM until TM exits.
+ */
+public class CheckpointCacheManager {
+
+	private static Logger LOG = LoggerFactory.getLogger(CheckpointCacheManager.class);
+
+	private final Object lock = new Object();
+	private final Path basePath;
+	private final ScheduledExecutorService scheduledExecutorService;
+
+	private final Map<JobID, CheckpointCache> checkpointCaches;
+	private final Map<JobID, ScheduledFuture<?>> cacheClearFutures;
+
+	private final Executor executor;
+
+	public CheckpointCacheManager(ScheduledExecutorService scheduledExecutorService, Executor executor, String basePath) {
+		this.scheduledExecutorService = scheduledExecutorService;
+		this.executor = executor;
+		this.basePath = new Path(basePath);
+		this.checkpointCaches = new ConcurrentHashMap<>();
+		this.cacheClearFutures = new ConcurrentHashMap<>();
+	}
+
+	/** Reregister a {@linke CheckpointCache} from {@link CheckpointCacheManager}, create a new one or refer a exists one. */
+	public CheckpointCache registerCheckpointCache(JobID jobID, long pendingCheckpointCacheTimeout, long leaseTimeout) {
+		if (pendingCheckpointCacheTimeout == -1) {
+			return null;
+		}
+		synchronized (lock) {
+			CheckpointCache checkpointCache = checkpointCaches.get(jobID);
+			if (checkpointCache == null) {
+				LOG.info("jobID: {} create checkpoint cache", jobID);
+				checkpointCache = new CheckpointCache(jobID,
+					basePath.getPath(),
+					pendingCheckpointCacheTimeout,
+					leaseTimeout,
+					this,
+					executor);
+				checkpointCaches.put(jobID, checkpointCache);
+			} else {
+				ScheduledFuture<?> cacheClearRunner = cacheClearFutures.get(jobID);
+				if (cacheClearRunner != null && !cacheClearRunner.isDone()) {
+					LOG.info("checkpoint cache {}, reassign a lease", jobID);
+					cacheClearRunner.cancel(false);
+					cacheClearFutures.remove(jobID);
+				}
+			}
+			int reference = checkpointCache.reference();
+			LOG.info("jobID: {} registered, current reference: {}", jobID, reference);
+			return checkpointCache;
+		}
+	}
+
+	/** Unregister {@link CheckpointCache} with jobId, try to release it when it's reference equal zero. */
+	public void unregisterCheckpointCache(JobID jobID) {
+		synchronized (lock) {
+			final CheckpointCache checkpointCache = checkpointCaches.get(jobID);
+			int reference = checkpointCache.dereference();
+			if (reference <= 0) {
+				ScheduledFuture<?> cacheClearRunner = cacheClearFutures.get(jobID);
+				if (cacheClearRunner == null || cacheClearRunner.isDone()) {
+					cacheClearRunner = scheduledExecutorService.schedule(() -> {
+							synchronized (lock) {
+								LOG.info("try to remove checkpoint cache for jobID:{}", jobID);
+								if (checkpointCache.getReference() <= 0) {
+									checkpointCaches.remove(jobID);
+									checkpointCache.release();
+									cacheClearFutures.remove(jobID);
+									LOG.info("remove checkpoint cache for jobID:{}", jobID);
+								} else {
+									LOG.info("failed to remove checkpoint cache for jobID:{}", jobID);
+								}
+							}
+						}, checkpointCache.getLeaseTimeout(), TimeUnit.SECONDS
+					);
+					cacheClearFutures.put(jobID, cacheClearRunner);
+				}
+			}
+			LOG.info("jobID: {} unregistered, current reference: {}", jobID, reference);
+		}
+	}
+
+	/** Shutdown service, called when TM shutdown. */
+	public void shutdown() {
+		synchronized (lock) {
+			for (CheckpointCache checkpointCache : checkpointCaches.values()) {
+				checkpointCache.release();
+			}
+			checkpointCaches.clear();
+		}
+	}
+
+	@VisibleForTesting
+	protected CheckpointCache getCheckpointCache(JobID jobID) {
+		synchronized (lock) {
+			return checkpointCaches.get(jobID);
+		}
+	}
+
+	@VisibleForTesting
+	protected int getCheckpointCacheSize() {
+		synchronized (lock) {
+			return checkpointCaches.size();
+		}
+	}
+
+	@VisibleForTesting
+	protected ScheduledFuture getCacheClearFuture(JobID jobID) {
+		return cacheClearFutures.get(jobID);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCacheManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCacheManager.java
@@ -48,6 +48,7 @@ public class CheckpointCacheManager {
 	private final Map<JobID, ScheduledFuture<?>> cacheClearFutures;
 
 	private final Executor executor;
+	private boolean isShutdown;
 
 	public CheckpointCacheManager(ScheduledExecutorService scheduledExecutorService, Executor executor, String basePath) {
 		this.scheduledExecutorService = scheduledExecutorService;
@@ -55,6 +56,7 @@ public class CheckpointCacheManager {
 		this.basePath = new Path(basePath);
 		this.checkpointCaches = new ConcurrentHashMap<>();
 		this.cacheClearFutures = new ConcurrentHashMap<>();
+		this.isShutdown = false;
 	}
 
 	/** Reregister a {@linke CheckpointCache} from {@link CheckpointCacheManager}, create a new one or refer a exists one. */
@@ -123,6 +125,7 @@ public class CheckpointCacheManager {
 				checkpointCache.release();
 			}
 			checkpointCaches.clear();
+			isShutdown = true;
 		}
 	}
 
@@ -143,5 +146,9 @@ public class CheckpointCacheManager {
 	@VisibleForTesting
 	protected ScheduledFuture getCacheClearFuture(JobID jobID) {
 		return cacheClearFutures.get(jobID);
+	}
+
+	public boolean isShutdown() {
+		return this.isShutdown;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/SharedCacheRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/SharedCacheRegistry.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.checkpoint;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.runtime.checkpoint.CheckpointCache.CacheEntry;
+import org.apache.flink.runtime.checkpoint.CheckpointCache.CacheKey;
+import org.apache.flink.util.FlinkRuntimeException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+
+/**
+ * Used by {@link CheckpointCache} to support incremental Cache. SharedCacheRegistry maintains
+ * all CacheEntries, {@link CacheEntry} is deleted only if the reference count become zero.
+ */
+public class SharedCacheRegistry {
+
+	private static Logger LOG = LoggerFactory.getLogger(SharedCacheRegistry.class);
+	private final Map<CacheKey, CacheEntry> registeredCacheEntry;
+
+	/** Executor for async state deletion */
+	private final Executor asyncDisposalExecutor;
+
+	public SharedCacheRegistry(Executor asyncDisposalExecutor) {
+		this.registeredCacheEntry = new ConcurrentHashMap<>();
+		this.asyncDisposalExecutor = asyncDisposalExecutor;
+	}
+
+	public void registerReference(CacheKey key, CacheEntry value) {
+		synchronized (registeredCacheEntry) {
+			CacheEntry entry = registeredCacheEntry.get(key);
+			CacheEntry entryToDelete = null;
+			if (entry == null || entry.isRot()) {
+				if (entry != null) {
+					value.setReference(entry.getReferenceCount());
+					entryToDelete = entry;
+				}
+				entry = value;
+				registeredCacheEntry.put(key, value);
+			} else {
+				if (!Objects.equals(entry, value)) {
+					entryToDelete = value;
+				}
+			}
+			entry.increaseReferenceCount();
+
+			scheduleAsyncDelete(entryToDelete);
+		}
+	}
+
+	public void unregisterReference(CacheKey key) {
+		synchronized (registeredCacheEntry) {
+			CacheEntry entry = registeredCacheEntry.get(key);
+			if (entry.decreaseReferenceCount() <= 0) {
+				registeredCacheEntry.remove(key);
+				scheduleAsyncDelete(entry);
+			}
+		}
+	}
+
+	public CacheEntry getCacheEntry(CacheKey key) {
+		synchronized (registeredCacheEntry) {
+			return registeredCacheEntry.get(key);
+		}
+	}
+
+	private void scheduleAsyncDelete(CacheEntry entry) {
+		// We do the small optimization to not issue discards for placeholders, which are NOPs.
+		if (entry != null) {
+			LOG.trace("Scheduled delete of cache entry {}.", entry);
+			asyncDisposalExecutor.execute(() -> {
+				try {
+					entry.discard();
+				} catch (Exception e) {
+					LOG.warn("A problem occurred during asynchronous disposal of a cache entry: {}", entry, e);
+				}
+			});
+		}
+	}
+
+	@VisibleForTesting
+	protected Iterable<Map.Entry<CacheKey, CacheEntry>> getIterable() {
+		final Iterator<Map.Entry<CacheKey, CacheEntry>> iterator = registeredCacheEntry.entrySet().iterator();
+		return new Iterable<Map.Entry<CacheKey, CacheEntry>>() {
+			@Override
+			public Iterator<Map.Entry<CacheKey, CacheEntry>> iterator() {
+				return new Iterator<Map.Entry<CacheKey, CacheEntry>>()	{
+
+					@Override
+					public boolean hasNext() {
+						return iterator.hasNext();
+					}
+
+					@Override
+					public Map.Entry<CacheKey, CacheEntry> next() {
+						return iterator.next();
+					}
+
+					@Override
+					public void remove() {
+						throw new FlinkRuntimeException("unsupported method.");
+					}
+				};
+			}
+		};
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptor.java
@@ -148,6 +148,9 @@ public final class TaskDeploymentDescriptor implements Serializable {
 	/** checkpoint timeout. */
 	private final long checkpointTimeout;
 
+	/** checkpoint cache lease timeout. */
+	private final long leaseTimeout;
+
 	public TaskDeploymentDescriptor(
 			JobID jobId,
 			MaybeOffloaded<JobInformation> serializedJobInformation,
@@ -160,7 +163,8 @@ public final class TaskDeploymentDescriptor implements Serializable {
 			TaskStateSnapshot taskStateHandles,
 			Collection<ResultPartitionDeploymentDescriptor> resultPartitionDeploymentDescriptors,
 			Collection<InputGateDeploymentDescriptor> inputGateDeploymentDescriptors,
-			long checkpointTimeout) {
+			long checkpointTimeout,
+			long leaseTimeout) {
 
 		this.jobId = Preconditions.checkNotNull(jobId);
 
@@ -185,6 +189,7 @@ public final class TaskDeploymentDescriptor implements Serializable {
 		this.inputGates = Preconditions.checkNotNull(inputGateDeploymentDescriptors);
 
 		this.checkpointTimeout = checkpointTimeout;
+		this.leaseTimeout = leaseTimeout;
 	}
 
 	/**
@@ -330,6 +335,10 @@ public final class TaskDeploymentDescriptor implements Serializable {
 
 	public long getCheckpointTimeout() {
 		return this.checkpointTimeout;
+	}
+
+	public long getLeaseTimeout() {
+		return leaseTimeout;
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptor.java
@@ -145,6 +145,9 @@ public final class TaskDeploymentDescriptor implements Serializable {
 	/** State handles for the sub task. */
 	private final TaskStateSnapshot taskStateHandles;
 
+	/** checkpoint timeout. */
+	private final long checkpointTimeout;
+
 	public TaskDeploymentDescriptor(
 			JobID jobId,
 			MaybeOffloaded<JobInformation> serializedJobInformation,
@@ -156,7 +159,8 @@ public final class TaskDeploymentDescriptor implements Serializable {
 			int targetSlotNumber,
 			TaskStateSnapshot taskStateHandles,
 			Collection<ResultPartitionDeploymentDescriptor> resultPartitionDeploymentDescriptors,
-			Collection<InputGateDeploymentDescriptor> inputGateDeploymentDescriptors) {
+			Collection<InputGateDeploymentDescriptor> inputGateDeploymentDescriptors,
+			long checkpointTimeout) {
 
 		this.jobId = Preconditions.checkNotNull(jobId);
 
@@ -179,6 +183,8 @@ public final class TaskDeploymentDescriptor implements Serializable {
 
 		this.producedPartitions = Preconditions.checkNotNull(resultPartitionDeploymentDescriptors);
 		this.inputGates = Preconditions.checkNotNull(inputGateDeploymentDescriptors);
+
+		this.checkpointTimeout = checkpointTimeout;
 	}
 
 	/**
@@ -320,6 +326,10 @@ public final class TaskDeploymentDescriptor implements Serializable {
 		// make sure that the serialized job and task information fields are filled
 		Preconditions.checkNotNull(serializedJobInformation);
 		Preconditions.checkNotNull(serializedTaskInformation);
+	}
+
+	public long getCheckpointTimeout() {
+		return this.checkpointTimeout;
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/Environment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/Environment.java
@@ -25,6 +25,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
+import org.apache.flink.runtime.checkpoint.CheckpointCache;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
@@ -197,6 +198,12 @@ public interface Environment {
 	 * <p>This method never blocks.
 	 */
 	void failExternally(Throwable cause);
+
+	/**
+	 * Get the CheckpointCache for manage local checkpoint data.
+	 * @return The CheckpointCache instance
+	 */
+	CheckpointCache getCheckpointCache();
 
 	// --------------------------------------------------------------------------------------------
 	//  Fields relevant to the I/O system. Should go into Task

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -41,6 +41,7 @@ import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.jobgraph.JobEdge;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
 import org.apache.flink.runtime.jobmanager.scheduler.CoLocationConstraint;
 import org.apache.flink.runtime.jobmanager.scheduler.CoLocationGroup;
 import org.apache.flink.runtime.jobmanager.scheduler.LocationPreferenceConstraint;
@@ -824,6 +825,8 @@ public class ExecutionVertex implements AccessExecutionVertex, Archiveable<Archi
 			serializedTaskInformation = new TaskDeploymentDescriptor.Offloaded<>(taskInformationOrBlobKey.right());
 		}
 
+		// get jobCheckpointingSettings via job graph
+		CheckpointCoordinatorConfiguration checkpointCoordinatorConfiguration = this.getExecutionGraph().getCheckpointCoordinatorConfiguration();
 		return new TaskDeploymentDescriptor(
 			getJobId(),
 			serializedJobInformation,
@@ -835,7 +838,8 @@ public class ExecutionVertex implements AccessExecutionVertex, Archiveable<Archi
 			targetSlot.getRoot().getSlotNumber(),
 			taskStateHandles,
 			producedPartitions,
-			consumedPartitions);
+			consumedPartitions,
+			checkpointCoordinatorConfiguration == null ? -1L : checkpointCoordinatorConfiguration.getCheckpointTimeout());
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/FixedDelayRestartStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/restart/FixedDelayRestartStrategy.java
@@ -49,6 +49,10 @@ public class FixedDelayRestartStrategy implements RestartStrategy {
 		currentRestartAttempt = 0;
 	}
 
+	public long getDelayBetweenRestartAttempts() {
+		return this.delayBetweenRestartAttempts;
+	}
+
 	public int getCurrentRestartAttempt() {
 		return currentRestartAttempt;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/CachedCheckpointStreamFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/CachedCheckpointStreamFactory.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.runtime.checkpoint.CachedStreamStateHandle;
+import org.apache.flink.runtime.checkpoint.CheckpointCache;
+import org.apache.flink.runtime.checkpoint.CheckpointCache.CachedOutputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+/**
+ * {@link CachedCheckpointStreamFactory} is used to build an output stream that writes data to both remote end (e.g:DFS) and local end.
+ * Local data is managed by {@link CheckpointCache}. It simply wraps {@link CheckpointCache} and {@link CheckpointStreamFactory} and
+ * create a hybrid output stream by {@link CheckpointCache} and {@link CheckpointStreamFactory}, this hybrid output stream will write
+ * to both remote end and local end.
+ */
+public class CachedCheckpointStreamFactory implements CheckpointStreamFactory {
+
+	private static Logger LOG = LoggerFactory.getLogger(CachedCheckpointStreamFactory.class);
+
+	private final CheckpointCache cache;
+	private final CheckpointStreamFactory remoteFactory;
+
+	public CachedCheckpointStreamFactory(CheckpointCache cache, CheckpointStreamFactory factory) {
+		this.cache = cache;
+		this.remoteFactory = factory;
+	}
+
+	public CheckpointStateOutputStream createCheckpointStateOutputStream(long checkpointID, long timestamp, StateHandleID handleID) throws Exception {
+		return createCheckpointStateOutputStream(checkpointID, timestamp, handleID, false);
+	}
+
+	public CheckpointStateOutputStream createCheckpointStateOutputStream(long checkpointID, long timestamp, StateHandleID handleID, boolean placeholder) throws Exception {
+		if (LOG.isDebugEnabled()) {
+			LOG.debug("create cache output stream: cpkID:{} placeHolder:{}", checkpointID, placeholder);
+		}
+		CachedOutputStream cachedOut = cache.createOutputStream(checkpointID, handleID, placeholder);
+		CheckpointStateOutputStream remoteOut = null;
+		if (!placeholder) {
+			remoteOut = remoteFactory.createCheckpointStateOutputStream(checkpointID, timestamp);
+		}
+		CachedCheckpointStateOutputStream output = new CachedCheckpointStateOutputStream(cachedOut, remoteOut);
+		return output;
+	}
+
+	@Override
+	public CheckpointStateOutputStream createCheckpointStateOutputStream(long checkpointID, long timestamp) throws Exception {
+		LOG.warn("create output stream which is not cacheable.");
+		return remoteFactory.createCheckpointStateOutputStream(checkpointID, timestamp);
+	}
+
+	@Override
+	public void close() throws Exception {
+		remoteFactory.close();
+	}
+
+	/**
+	 * A hybrid checkpoint output stream which write data to both remote end and local end,
+	 * writing data locally failed won't stop writing to remote. This hybrid output stream
+	 * will return a {@link CachedStreamStateHandle} in closeAndGetHandle(), it can be used for read data locally.
+	 */
+	public static class CachedCheckpointStateOutputStream extends CheckpointStateOutputStream {
+
+		private CachedOutputStream cacheOut = null;
+		private CheckpointStateOutputStream remoteOut = null;
+
+		public CachedCheckpointStateOutputStream(CachedOutputStream cacheOut, CheckpointStateOutputStream remoteOut) {
+			this.cacheOut = cacheOut;
+			this.remoteOut = remoteOut;
+		}
+
+		@Override
+		public StreamStateHandle closeAndGetHandle() throws IOException {
+
+			// finalize cache data
+			StateHandleID cacheId = cacheOut.getCacheID();
+			cacheOut.end();
+
+			StreamStateHandle remoteHandle;
+			if (remoteOut != null) {
+				remoteHandle = remoteOut.closeAndGetHandle();
+			} else {
+				remoteHandle = new PlaceholderStreamStateHandle(cacheId);
+			}
+			return new CachedStreamStateHandle(cacheId, remoteHandle);
+		}
+
+		@Override
+		public long getPos() throws IOException {
+			return remoteOut != null ? remoteOut.getPos() :-1L;
+		}
+
+		@Override
+		public void write(int b) throws IOException {
+			// write to local
+			try {
+				cacheOut.write(b);
+			} catch (Exception e) {
+				//discard
+				cacheOut.discard();
+			}
+
+			// write to remote
+			if (remoteOut != null) {
+				remoteOut.write(b);
+			}
+		}
+
+		@Override
+		public void write(byte[] b, int off, int len) throws IOException {
+			// write to local
+			try {
+				cacheOut.write(b, off, len);
+			} catch (Exception e) {
+				//discard
+				cacheOut.discard();
+			}
+
+			// write to remote
+			if (remoteOut != null) {
+				remoteOut.write(b, off, len);
+			}
+		}
+
+		@Override
+		public void flush() throws IOException {
+			cacheOut.flush();
+			if (remoteOut != null) {
+				remoteOut.flush();
+			}
+		}
+
+		@Override
+		public void sync() throws IOException {
+			if (remoteOut != null) {
+				remoteOut.sync();
+			}
+		}
+
+		@Override
+		public void close() throws IOException {
+			cacheOut.close();
+			if (remoteOut != null) {
+				remoteOut.close();
+			}
+		}
+
+		@VisibleForTesting
+		public void setCacheOut(CachedOutputStream cacheOut) {
+			this.cacheOut = cacheOut;
+		}
+
+		@VisibleForTesting
+		public void setRemoteOut(CheckpointStateOutputStream remoteOut) {
+			this.remoteOut = remoteOut;
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/CachedCheckpointStreamFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/CachedCheckpointStreamFactory.java
@@ -106,7 +106,11 @@ public class CachedCheckpointStreamFactory implements CheckpointStreamFactory {
 				}
 				return new CachedStreamStateHandle(cacheId, remoteHandle);
 			} else {
-				return remoteOut.closeAndGetHandle();
+				if (remoteOut != null) {
+					return remoteOut.closeAndGetHandle();
+				} else {
+					return null;
+				}
 			}
 		}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/CachedStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/CachedStateHandle.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.state;
+
+/**
+ * Interface for StateHandle that can be cached.
+ */
+public interface CachedStateHandle {
+	StateHandleID getStateHandleId();
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyGroupsStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyGroupsStateHandle.java
@@ -20,6 +20,8 @@ package org.apache.flink.runtime.state;
 
 
 import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.runtime.checkpoint.CachedStreamStateHandle;
+import org.apache.flink.runtime.checkpoint.CheckpointCache;
 import org.apache.flink.util.Preconditions;
 
 import java.io.IOException;
@@ -85,6 +87,13 @@ public class KeyGroupsStateHandle implements StreamStateHandle, KeyedStateHandle
 	 */
 	public KeyGroupsStateHandle getIntersection(KeyGroupRange keyGroupRange) {
 		return new KeyGroupsStateHandle(groupRangeOffsets.getIntersection(keyGroupRange), stateHandle);
+	}
+
+	public void setCache(CheckpointCache cache) {
+		if (stateHandle instanceof CachedStreamStateHandle) {
+			((CachedStreamStateHandle) stateHandle).setCheckpointCache(cache);
+			((CachedStreamStateHandle) stateHandle).reCache(false);
+		}
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/PlaceholderStreamStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/PlaceholderStreamStateHandle.java
@@ -27,11 +27,18 @@ import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
  * case of {@link ByteStreamStateHandle}. This class is used in the referenced states of
  * {@link IncrementalKeyedStateHandle}.
  */
-public class PlaceholderStreamStateHandle implements StreamStateHandle {
+public class PlaceholderStreamStateHandle implements StreamStateHandle, CachedStateHandle {
 
 	private static final long serialVersionUID = 1L;
 
+	private final StateHandleID handleID;
+
+	public PlaceholderStreamStateHandle(StateHandleID handleID) {
+		this.handleID = handleID;
+	}
+
 	public PlaceholderStreamStateHandle() {
+		this(null);
 	}
 
 	@Override
@@ -48,5 +55,10 @@ public class PlaceholderStreamStateHandle implements StreamStateHandle {
 	@Override
 	public long getStateSize() {
 		return 0L;
+	}
+
+	@Override
+	public StateHandleID getStateHandleId() {
+		return this.handleID;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackend.java
@@ -288,13 +288,13 @@ public class FsStateBackend extends AbstractStateBackend {
 
 	@Override
 	public <K> AbstractKeyedStateBackend<K> createKeyedStateBackend(
-			Environment env,
-			JobID jobID,
-			String operatorIdentifier,
-			TypeSerializer<K> keySerializer,
-			int numberOfKeyGroups,
-			KeyGroupRange keyGroupRange,
-			TaskKvStateRegistry kvStateRegistry) throws IOException {
+		Environment env,
+		JobID jobID,
+		String operatorIdentifier,
+		TypeSerializer<K> keySerializer,
+		int numberOfKeyGroups,
+		KeyGroupRange keyGroupRange,
+		TaskKvStateRegistry kvStateRegistry) throws IOException {
 
 		return new HeapKeyedStateBackend<>(
 				kvStateRegistry,
@@ -303,7 +303,8 @@ public class FsStateBackend extends AbstractStateBackend {
 				numberOfKeyGroups,
 				keyGroupRange,
 				asynchronousSnapshots,
-				env.getExecutionConfig());
+				env.getExecutionConfig(),
+				env.getCheckpointCache());
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryStateBackend.java
@@ -123,12 +123,12 @@ public class MemoryStateBackend extends AbstractStateBackend {
 
 	@Override
 	public <K> AbstractKeyedStateBackend<K> createKeyedStateBackend(
-			Environment env, JobID jobID,
-			String operatorIdentifier,
-			TypeSerializer<K> keySerializer,
-			int numberOfKeyGroups,
-			KeyGroupRange keyGroupRange,
-			TaskKvStateRegistry kvStateRegistry) {
+		Environment env, JobID jobID,
+		String operatorIdentifier,
+		TypeSerializer<K> keySerializer,
+		int numberOfKeyGroups,
+		KeyGroupRange keyGroupRange,
+		TaskKvStateRegistry kvStateRegistry) {
 
 		return new HeapKeyedStateBackend<>(
 				kvStateRegistry,
@@ -137,6 +137,7 @@ public class MemoryStateBackend extends AbstractStateBackend {
 				numberOfKeyGroups,
 				keyGroupRange,
 				asynchronousSnapshots,
-				env.getExecutionConfig());
+				env.getExecutionConfig(),
+				env.getCheckpointCache());
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -21,9 +21,13 @@ package org.apache.flink.runtime.taskexecutor;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.accumulators.AccumulatorSnapshot;
 import org.apache.flink.runtime.blob.BlobCacheService;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
+import org.apache.flink.runtime.checkpoint.CheckpointCache;
+import org.apache.flink.runtime.checkpoint.CheckpointCacheManager;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
@@ -89,6 +93,7 @@ import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.Preconditions;
+import scala.concurrent.duration.Duration;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -165,6 +170,8 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 
 	private final JobLeaderService jobLeaderService;
 
+	private final CheckpointCacheManager checkpointCacheManager;
+
 	// ------------------------------------------------------------------------
 
 	private final HardwareDescription hardwareDescription;
@@ -176,6 +183,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 			MemoryManager memoryManager,
 			IOManager ioManager,
 			NetworkEnvironment networkEnvironment,
+			CheckpointCacheManager checkpointCacheManager,
 			HighAvailabilityServices haServices,
 			HeartbeatServices heartbeatServices,
 			TaskManagerMetricGroup taskManagerMetricGroup,
@@ -203,6 +211,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 		this.fileCache = checkNotNull(fileCache);
 		this.jobManagerTable = checkNotNull(jobManagerTable);
 		this.jobLeaderService = checkNotNull(jobLeaderService);
+		this.checkpointCacheManager = checkpointCacheManager;
 
 		this.jobManagerConnections = new HashMap<>(4);
 
@@ -277,6 +286,8 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 		networkEnvironment.shutdown();
 
 		fileCache.shutdown();
+
+		checkpointCacheManager.shutdown();
 
 		try {
 			super.postStop();
@@ -380,6 +391,23 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 			ResultPartitionConsumableNotifier resultPartitionConsumableNotifier = jobManagerConnection.getResultPartitionConsumableNotifier();
 			PartitionProducerStateChecker partitionStateChecker = jobManagerConnection.getPartitionStateChecker();
 
+			long checkpointCacheLeaseTimeout;
+			try {
+				Configuration configuration = jobInformation.getJobConfiguration();
+				String timeoutString = configuration.getString(
+					ConfigConstants.AKKA_WATCH_HEARTBEAT_INTERVAL,
+					ConfigConstants.DEFAULT_AKKA_ASK_TIMEOUT);
+				String delayString = configuration.getString(
+					ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_DELAY,
+					timeoutString
+				);
+				checkpointCacheLeaseTimeout = Duration.apply(delayString).toMillis() * 2;
+			} catch (Exception nfe) {
+				checkpointCacheLeaseTimeout = tdd.getCheckpointTimeout();
+			}
+
+			CheckpointCache checkpointCache = checkpointCacheManager.registerCheckpointCache(jobInformation.getJobId(), tdd.getCheckpointTimeout(), checkpointCacheLeaseTimeout);
+
 			Task task = new Task(
 				jobInformation,
 				taskInformation,
@@ -401,6 +429,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 				blobService,
 				libraryCache,
 				fileCache,
+				checkpointCache,
 				taskManagerConfiguration,
 				taskMetricGroup,
 				resultPartitionConsumableNotifier,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -286,6 +286,7 @@ public class TaskManagerRunner implements FatalErrorHandler {
 			taskManagerServices.getMemoryManager(),
 			taskManagerServices.getIOManager(),
 			taskManagerServices.getNetworkEnvironment(),
+			taskManagerServices.getCheckpointCacheManager(),
 			highAvailabilityServices,
 			heartbeatServices,
 			taskManagerMetricGroup,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
@@ -202,7 +202,7 @@ public class TaskManagerServices {
 		final CheckpointCacheManager checkpointCacheManager = new CheckpointCacheManager(
 			new ScheduledThreadPoolExecutor(1),
 			Executors.directExecutor(),
-			taskManagerServicesConfiguration.getTmpDirPaths()[0]);
+			taskManagerServicesConfiguration.getTmpDirPaths());
 
 		return new TaskManagerServices(
 			taskManagerLocation,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/RuntimeEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/RuntimeEnvironment.java
@@ -25,6 +25,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
+import org.apache.flink.runtime.checkpoint.CheckpointCache;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.execution.Environment;
@@ -81,6 +82,8 @@ public class RuntimeEnvironment implements Environment {
 
 	private final Task containingTask;
 
+	private final CheckpointCache checkpointCache;
+
 	// ------------------------------------------------------------------------
 
 	public RuntimeEnvironment(
@@ -104,6 +107,7 @@ public class RuntimeEnvironment implements Environment {
 			CheckpointResponder checkpointResponder,
 			TaskManagerRuntimeInfo taskManagerInfo,
 			TaskMetricGroup metrics,
+			CheckpointCache cache,
 			Task containingTask) {
 
 		this.jobId = checkNotNull(jobId);
@@ -127,6 +131,7 @@ public class RuntimeEnvironment implements Environment {
 		this.taskManagerInfo = checkNotNull(taskManagerInfo);
 		this.containingTask = containingTask;
 		this.metrics = metrics;
+		this.checkpointCache = cache;
 	}
 
 	// ------------------------------------------------------------------------
@@ -260,5 +265,9 @@ public class RuntimeEnvironment implements Environment {
 	@Override
 	public void failExternally(Throwable cause) {
 		this.containingTask.failExternally(cause);
+	}
+
+	public CheckpointCache getCheckpointCache() {
+		return checkpointCache;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/RuntimeEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/RuntimeEnvironment.java
@@ -267,6 +267,7 @@ public class RuntimeEnvironment implements Environment {
 		this.containingTask.failExternally(cause);
 	}
 
+	@Override
 	public CheckpointCache getCheckpointCache() {
 		return checkpointCache;
 	}

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/minicluster/LocalFlinkMiniCluster.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/minicluster/LocalFlinkMiniCluster.scala
@@ -27,7 +27,7 @@ import org.apache.flink.api.common.io.FileOutputFormat
 import org.apache.flink.configuration._
 import org.apache.flink.core.fs.Path
 import org.apache.flink.runtime.blob.BlobServer
-import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory
+import org.apache.flink.runtime.checkpoint.{CheckpointCacheManager, CheckpointRecoveryFactory}
 import org.apache.flink.runtime.clusterframework.FlinkResourceManager
 import org.apache.flink.runtime.clusterframework.standalone.StandaloneResourceManager
 import org.apache.flink.runtime.clusterframework.types.{ResourceID, ResourceIDRetrievable}
@@ -254,6 +254,7 @@ class LocalFlinkMiniCluster(
       taskManagerServices.getMemoryManager(),
       taskManagerServices.getIOManager(),
       taskManagerServices.getNetworkEnvironment,
+      taskManagerServices.getCheckpointCacheManager,
       taskManagerMetricGroup)
 
     system.actorOf(props, taskManagerActorName)
@@ -318,6 +319,7 @@ class LocalFlinkMiniCluster(
     memoryManager: MemoryManager,
     ioManager: IOManager,
     networkEnvironment: NetworkEnvironment,
+    checkpointCacheManager: CheckpointCacheManager,
     taskManagerMetricGroup: TaskManagerMetricGroup): Props = {
 
     TaskManager.getTaskManagerProps(
@@ -328,6 +330,7 @@ class LocalFlinkMiniCluster(
       memoryManager,
       ioManager,
       networkEnvironment,
+      checkpointCacheManager,
       highAvailabilityServices,
       taskManagerMetricGroup)
   }

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -37,6 +37,7 @@ import org.apache.flink.runtime.accumulators.AccumulatorSnapshot
 import org.apache.flink.runtime.akka.{AkkaUtils, DefaultQuarantineHandler, QuarantineMonitor}
 import org.apache.flink.runtime.blob.{BlobCacheService, BlobClient, BlobService}
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager
+import org.apache.flink.runtime.checkpoint.CheckpointCacheManager
 import org.apache.flink.runtime.clusterframework.BootstrapTools
 import org.apache.flink.runtime.clusterframework.messages.StopCluster
 import org.apache.flink.runtime.clusterframework.types.ResourceID
@@ -125,6 +126,7 @@ class TaskManager(
     protected val memoryManager: MemoryManager,
     protected val ioManager: IOManager,
     protected val network: NetworkEnvironment,
+    protected val checkpointCacheManager: CheckpointCacheManager,
     protected val numberOfSlots: Int,
     protected val highAvailabilityServices: HighAvailabilityServices,
     protected val taskManagerMetricGroup: TaskManagerMetricGroup)
@@ -258,6 +260,12 @@ class TaskManager(
     }
 
     taskManagerMetricGroup.close()
+
+    try {
+      checkpointCacheManager.shutdown();
+    } catch {
+      case t: Exception => log.error("CheckpointCacheManager did not shutdown properly", t)
+    }
 
     log.info(s"Task manager ${self.path} is completely shut down.")
   }
@@ -1176,6 +1184,28 @@ class TaskManager(
           config.getTimeout().getSize(),
           config.getTimeout().getUnit()))
 
+      var checkpointCacheLeaseTimeout: Long = {
+        try {
+          var configuration = jobInformation.getJobConfiguration()
+          var timeoutString = configuration.getString(
+            ConfigConstants.AKKA_WATCH_HEARTBEAT_INTERVAL,
+            ConfigConstants.DEFAULT_AKKA_ASK_TIMEOUT)
+          var delayString = configuration.getString(
+            ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_DELAY,
+            timeoutString
+          )
+          Duration.apply(delayString).toMillis * 2;
+        } catch {
+          case e: Exception =>
+            tdd.getCheckpointTimeout
+        }
+      }
+
+      var checkpointCache = checkpointCacheManager.registerCheckpointCache(
+        jobInformation.getJobId,
+        tdd.getCheckpointTimeout,
+        checkpointCacheLeaseTimeout)
+
       val task = new Task(
         jobInformation,
         taskInformation,
@@ -1197,6 +1227,7 @@ class TaskManager(
         blobCache,
         libCache,
         fileCache,
+        checkpointCache,
         config,
         taskMetricGroup,
         resultPartitionConsumableNotifier,
@@ -2018,6 +2049,7 @@ object TaskManager {
       taskManagerServices.getMemoryManager(),
       taskManagerServices.getIOManager(),
       taskManagerServices.getNetworkEnvironment(),
+      taskManagerServices.getCheckpointCacheManager(),
       highAvailabilityServices,
       taskManagerMetricGroup)
 
@@ -2035,6 +2067,7 @@ object TaskManager {
     memoryManager: MemoryManager,
     ioManager: IOManager,
     networkEnvironment: NetworkEnvironment,
+    checkpointCacheManager: CheckpointCacheManager,
     highAvailabilityServices: HighAvailabilityServices,
     taskManagerMetricGroup: TaskManagerMetricGroup
   ): Props = {
@@ -2046,6 +2079,7 @@ object TaskManager {
       memoryManager,
       ioManager,
       networkEnvironment,
+      checkpointCacheManager,
       taskManagerConfig.getNumberSlots(),
       highAvailabilityServices,
       taskManagerMetricGroup)

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -1184,27 +1184,10 @@ class TaskManager(
           config.getTimeout().getSize(),
           config.getTimeout().getUnit()))
 
-      var checkpointCacheLeaseTimeout: Long = {
-        try {
-          var configuration = jobInformation.getJobConfiguration()
-          var timeoutString = configuration.getString(
-            ConfigConstants.AKKA_WATCH_HEARTBEAT_INTERVAL,
-            ConfigConstants.DEFAULT_AKKA_ASK_TIMEOUT)
-          var delayString = configuration.getString(
-            ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_DELAY,
-            timeoutString
-          )
-          Duration.apply(delayString).toMillis * 2;
-        } catch {
-          case e: Exception =>
-            tdd.getCheckpointTimeout
-        }
-      }
-
       var checkpointCache = checkpointCacheManager.registerCheckpointCache(
         jobInformation.getJobId,
         tdd.getCheckpointTimeout,
-        checkpointCacheLeaseTimeout)
+        tdd.getLeaseTimeout)
 
       val task = new Task(
         jobInformation,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CachedCheckpointStreamFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CachedCheckpointStreamFactoryTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.checkpoint;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.concurrent.Executors;
+import org.apache.flink.runtime.state.CachedCheckpointStreamFactory;
+import org.apache.flink.runtime.state.CheckpointStreamFactory;
+import org.apache.flink.runtime.state.StateHandleID;
+import org.apache.flink.runtime.state.StreamStateHandle;
+import org.apache.flink.runtime.state.filesystem.FsCheckpointStreamFactory;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for the cached checkpoint stream factory.
+ */
+public class CachedCheckpointStreamFactoryTest {
+
+	@Rule
+	public final TemporaryFolder tmp = new TemporaryFolder();
+
+	@Test
+	public void testCachedCheckpointStateOutputStream() throws Exception {
+		JobID jobID = new JobID();
+
+		CheckpointCache checkpointCache = new CheckpointCache(
+			jobID,
+			tmp.newFolder().getAbsolutePath(),
+			1000L,
+			1000L,
+			mock(CheckpointCacheManager.class),
+			Executors.directExecutor()
+		);
+
+		CheckpointStreamFactory streamFactory = new FsCheckpointStreamFactory(
+			new Path(tmp.newFolder().getAbsolutePath()),
+			jobID,
+			1024);
+
+		CachedCheckpointStreamFactory factory = new CachedCheckpointStreamFactory(
+			checkpointCache,
+			streamFactory);
+		StateHandleID handleID = new StateHandleID("handleId");
+		CheckpointStreamFactory.CheckpointStateOutputStream outputStream = factory.createCheckpointStateOutputStream(1, 1, handleID);
+		Assert.assertTrue(outputStream instanceof CachedCheckpointStreamFactory.CachedCheckpointStateOutputStream);
+
+		String testStr = "hello";
+		outputStream.write(testStr.getBytes());
+		StreamStateHandle resultStateHandle = outputStream.closeAndGetHandle();
+		Assert.assertTrue(resultStateHandle instanceof CachedStreamStateHandle);
+		((CachedStreamStateHandle)resultStateHandle).setCheckpointCache(checkpointCache);
+
+		checkpointCache.commitCache(1);
+
+		byte[] buffer = new byte[1024];
+		int n = resultStateHandle.openInputStream().read(buffer);
+		Assert.assertEquals(testStr.length(), n);
+		Assert.assertEquals(new String(buffer, 0, testStr.length()), testStr);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCacheManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCacheManagerTest.java
@@ -45,7 +45,7 @@ public class CheckpointCacheManagerTest {
 
 	@Test
 	public void testCheckpointCacheManager() throws Exception {
-		CheckpointCacheManager cacheManager = new CheckpointCacheManager(new ScheduledThreadPoolExecutor(1), Executors.directExecutor(), tmp.newFolder().getAbsolutePath());
+		CheckpointCacheManager cacheManager = new CheckpointCacheManager(new ScheduledThreadPoolExecutor(1), Executors.directExecutor(), new String[] {tmp.newFolder().getAbsolutePath()});
 		JobID jobID1 = new JobID(1L, 1L);
 		cacheManager.registerCheckpointCache(jobID1, 10000, 5);
 		Assert.assertEquals(1, cacheManager.getCheckpointCacheSize());
@@ -57,7 +57,7 @@ public class CheckpointCacheManagerTest {
 	@Test
 	public void testCheckpointCacheRetouchFromRelease() throws Exception {
 
-		CheckpointCacheManager cacheManager = new CheckpointCacheManager(new ScheduledThreadPoolExecutor(1), Executors.directExecutor(), tmp.newFolder().getAbsolutePath());
+		CheckpointCacheManager cacheManager = new CheckpointCacheManager(new ScheduledThreadPoolExecutor(1), Executors.directExecutor(), new String[] {tmp.newFolder().getAbsolutePath()});
 		JobID jobID = new JobID(1L, 1L);
 		CheckpointCache cache1 = cacheManager.registerCheckpointCache(jobID, 10000, 5);
 
@@ -79,7 +79,7 @@ public class CheckpointCacheManagerTest {
 
 	@Test
 	public void testConcurrencyRequest() throws Exception {
-		CheckpointCacheManager cacheManager = new CheckpointCacheManager(new ScheduledThreadPoolExecutor(1), Executors.directExecutor(), tmp.newFolder().getAbsolutePath());
+		CheckpointCacheManager cacheManager = new CheckpointCacheManager(new ScheduledThreadPoolExecutor(1), Executors.directExecutor(), new String[] {tmp.newFolder().getAbsolutePath()});
 		// init jobs
 		int[] referenceCount = new int[10];
 		JobID[] jobIDS = new JobID[10];
@@ -130,7 +130,7 @@ public class CheckpointCacheManagerTest {
 
 	@Test
 	public void testShowdown() throws Exception {
-		CheckpointCacheManager cacheManager = new CheckpointCacheManager(new ScheduledThreadPoolExecutor(1), Executors.directExecutor(), tmp.newFolder().getAbsolutePath());
+		CheckpointCacheManager cacheManager = new CheckpointCacheManager(new ScheduledThreadPoolExecutor(1), Executors.directExecutor(), new String[] {tmp.newFolder().getAbsolutePath()});
 		JobID jobID1 = new JobID(1L, 1L);
 		cacheManager.registerCheckpointCache(jobID1, 10000, 5);
 		cacheManager.shutdown();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCacheManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCacheManagerTest.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.checkpoint;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.concurrent.Executors;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Tests for CheckpointCacheManager
+ */
+public class CheckpointCacheManagerTest {
+
+	@Rule
+	public final TemporaryFolder tmp = new TemporaryFolder();
+
+	@Test
+	public void testCheckpointCacheManager() throws Exception {
+		CheckpointCacheManager cacheManager = new CheckpointCacheManager(new ScheduledThreadPoolExecutor(1), Executors.directExecutor(), tmp.newFolder().getAbsolutePath());
+		JobID jobID1 = new JobID(1L, 1L);
+		cacheManager.registerCheckpointCache(jobID1, 10000, 5);
+		Assert.assertEquals(1, cacheManager.getCheckpointCacheSize());
+		cacheManager.unregisterCheckpointCache(jobID1);
+		TimeUnit.SECONDS.sleep(6);
+		Assert.assertEquals(0, cacheManager.getCheckpointCacheSize());
+	}
+
+	@Test
+	public void testCheckpointCacheRetouchFromRelease() throws Exception {
+
+		CheckpointCacheManager cacheManager = new CheckpointCacheManager(new ScheduledThreadPoolExecutor(1), Executors.directExecutor(), tmp.newFolder().getAbsolutePath());
+		JobID jobID = new JobID(1L, 1L);
+		CheckpointCache cache1 = cacheManager.registerCheckpointCache(jobID, 10000, 5);
+
+		// this should release the CheckpointCache in future.
+		cacheManager.unregisterCheckpointCache(jobID);
+		Assert.assertEquals(0, cache1.getReference());
+		ScheduledFuture<?> clearFuture = cacheManager.getCacheClearFuture(jobID);
+		TimeUnit.SECONDS.sleep(3);
+		Assert.assertTrue(!clearFuture.isDone());
+
+		// reassign a lease for CheckpointCache
+		CheckpointCache cache2 = cacheManager.registerCheckpointCache(jobID, 10000, 5);
+		TimeUnit.SECONDS.sleep(3);
+
+		Assert.assertTrue(clearFuture.isCancelled());
+		Assert.assertNull(cacheManager.getCacheClearFuture(jobID));
+		Assert.assertEquals(cache1, cache2);
+	}
+
+	@Test
+	public void testConcurrencyRequest() throws Exception {
+		CheckpointCacheManager cacheManager = new CheckpointCacheManager(new ScheduledThreadPoolExecutor(1), Executors.directExecutor(), tmp.newFolder().getAbsolutePath());
+		// init jobs
+		int[] referenceCount = new int[10];
+		JobID[] jobIDS = new JobID[10];
+		for (int i = 0; i < 10; ++i) {
+			jobIDS[i] = new JobID();
+			for (int j = 0; j < 50; ++j) {
+				cacheManager.registerCheckpointCache(jobIDS[i], 1, 1);
+			}
+			referenceCount[i] = 50;
+		}
+
+		// init runnables but dont submit immediately
+		Runnable[] runnables = new Runnable[50];
+		for (int i = 0; i < runnables.length; ++i) {
+			final int index = new Random().nextInt(jobIDS.length);
+			final int opType = new Random().nextInt(2);
+			if (opType == 0) {
+				referenceCount[index]--;
+			} else {
+				referenceCount[index]++;
+			}
+			runnables[i] = () -> {
+				if (opType == 0) {
+					cacheManager.unregisterCheckpointCache(jobIDS[index]);
+				} else {
+					cacheManager.registerCheckpointCache(jobIDS[index], 1, 1);
+				}
+			};
+		}
+
+		//submit all runnables
+		ExecutorService executor = java.util.concurrent.Executors.newFixedThreadPool(10);
+		Future[] futures = new Future[runnables.length];
+		for (int i = 0; i < futures.length; ++i) {
+			futures[i] = executor.submit(runnables[i]);
+		}
+
+		//wait all requests finished
+		for (int i = 0; i < futures.length; ++i) {
+			futures[i].get();
+		}
+
+		//valid result
+		for (int i = 0; i < jobIDS.length; ++i) {
+			Assert.assertEquals(referenceCount[i], cacheManager.getCheckpointCache(jobIDS[i]).getReference());
+		}
+	}
+
+	@Test
+	public void testShowdown() throws Exception {
+		CheckpointCacheManager cacheManager = new CheckpointCacheManager(new ScheduledThreadPoolExecutor(1), Executors.directExecutor(), tmp.newFolder().getAbsolutePath());
+		JobID jobID1 = new JobID(1L, 1L);
+		cacheManager.registerCheckpointCache(jobID1, 10000, 5);
+		cacheManager.shutdown();
+		Assert.assertEquals(0, cacheManager.getCheckpointCacheSize());
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCacheTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCacheTest.java
@@ -1,0 +1,297 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.checkpoint;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.concurrent.Executors;
+import org.apache.flink.runtime.state.StateHandleID;
+import org.apache.flink.runtime.state.filesystem.FileStateHandle;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStream;
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for CheckpointCache
+ */
+public class CheckpointCacheTest {
+
+	@Rule
+	public final TemporaryFolder tmp = new TemporaryFolder();
+
+	@Test
+	public void testCommitCache() throws Exception {
+		File tmpFolder = tmp.newFolder();
+		final CheckpointCache cache = new CheckpointCache(new JobID(), tmpFolder.getAbsolutePath(), 10000, 10000, mock(CheckpointCacheManager.class), Executors.directExecutor());
+
+		StateHandleID handleID1 = new StateHandleID("handle1");
+		StateHandleID handleID2 = new StateHandleID("handle2");
+
+		Assert.assertEquals(cache.getPendingCheckpointCacheSize(), 0);
+
+		cache.registerCacheEntry(1, handleID1, tmp.newFile().getAbsolutePath());
+		cache.registerCacheEntry(1, handleID2, tmp.newFile().getAbsolutePath());
+
+		Assert.assertEquals(cache.getPendingCheckpointCacheSize(), 1);
+
+		cache.commitCache(1);
+
+		Assert.assertEquals(cache.getPendingCheckpointCacheSize(), 0);
+		Assert.assertEquals(cache.getCompletedCheckpointCacheSize(), 1);
+
+		cache.release();
+	}
+
+	@Test
+	public void testOpenInputStream() throws Exception {
+		File tmpFolder = tmp.newFolder();
+		final CheckpointCache cache = new CheckpointCache(new JobID(), tmpFolder.getAbsolutePath(), 10000, 10000, mock(CheckpointCacheManager.class), Executors.directExecutor());
+
+		StateHandleID handleID1 = new StateHandleID("handle1");
+		cache.registerCacheEntry(1, handleID1, "handle1");
+
+		File handle2File = tmp.newFile("handle2");
+
+		final String testStr = "hello";
+
+		FileOutputStream outputStream = new FileOutputStream(handle2File);
+		outputStream.write(testStr.getBytes(), 0, testStr.getBytes().length);
+		outputStream.close();
+		StateHandleID handleID2 = new StateHandleID(handle2File.getAbsolutePath());
+		cache.registerCacheEntry(1, handleID2, handle2File.getAbsolutePath());
+
+		cache.commitCache(1);
+
+		Assert.assertNull(cache.openInputStream(handleID1));
+
+		//valid content
+		FSDataInputStream inputStream = cache.openInputStream(handleID2);
+		byte[] readBytes = new byte[testStr.length()];
+		inputStream.read(readBytes);
+		Assert.assertEquals(testStr, new String(readBytes));
+
+		cache.release();
+	}
+
+	@Test
+	public void testCreateOutputStream() throws Exception {
+		File tmpFolder = tmp.newFolder();
+		final CheckpointCache cache = new CheckpointCache(new JobID(), tmpFolder.getAbsolutePath(), 10000, 10000, mock(CheckpointCacheManager.class), Executors.directExecutor());
+
+		StateHandleID handleID1 = new StateHandleID("handle1");
+		CheckpointCache.CachedOutputStream outputStream = cache.createOutputStream(1, handleID1);
+
+		final String testStr = "hello";
+		outputStream.write(testStr.getBytes(), 0, testStr.length());
+		outputStream.end();
+
+		cache.commitCache(1);
+
+		FSDataInputStream inputStream = cache.openInputStream(handleID1);
+		byte[] readBytes = new byte[testStr.length()];
+		inputStream.read(readBytes);
+		Assert.assertEquals(testStr, new String(readBytes));
+
+		cache.release();
+	}
+
+	@Test
+	public void testDiscardOutputStream() throws Exception {
+		File tmpFolder = tmp.newFolder();
+		final CheckpointCache cache = new CheckpointCache(new JobID(), tmpFolder.getAbsolutePath(), 10000, 10000, mock(CheckpointCacheManager.class), Executors.directExecutor());
+
+		StateHandleID handleID1 = new StateHandleID("handle1");
+		CheckpointCache.CachedOutputStream outputStream = cache.createOutputStream(1, handleID1);
+
+		final String testStr = "test str";
+		outputStream.write(testStr.getBytes(), 0, testStr.length());
+		outputStream.discard();
+		outputStream.end();
+		Assert.assertEquals(cache.getPendingCheckpointCacheSize(), 0);
+
+		cache.release();
+	}
+
+	@Test
+	public void testOnlyMaintainTheLastCheckpointCache() throws Exception {
+		File tmpFolder = tmp.newFolder();
+		final CheckpointCache cache = new CheckpointCache(new JobID(), tmpFolder.getAbsolutePath(), 10000, 10000, mock(CheckpointCacheManager.class), Executors.directExecutor());
+
+		StateHandleID handleID1 = new StateHandleID("handle1");
+		CheckpointCache.CachedOutputStream outputStream = cache.createOutputStream(1, handleID1);
+		final String testStr = "test str";
+		outputStream.write(testStr.getBytes(), 0, testStr.length());
+		outputStream.end();
+		outputStream.close();
+		cache.commitCache(1);
+
+		Assert.assertEquals(cache.getCompletedCheckpointCacheSize(), 1);
+
+		StateHandleID handleID2 = new StateHandleID("handle2");
+		CheckpointCache.CachedOutputStream outputStream2 = cache.createOutputStream(2, handleID2);
+		final String testStr2 = "test str2";
+		outputStream2.write(testStr2.getBytes(), 0, testStr2.length());
+		outputStream2.end();
+		outputStream2.close();
+		cache.commitCache(2);
+
+		Assert.assertEquals(cache.getCompletedCheckpointCacheSize(), 1);
+
+		cache.release();
+	}
+
+	@Test
+	public void testClose() throws Exception {
+		File tmpFolder = tmp.newFolder();
+		final CheckpointCache cache = new CheckpointCache(new JobID(), tmpFolder.getAbsolutePath(), 10000, 10000, mock(CheckpointCacheManager.class), Executors.directExecutor());
+
+		for (int i = 0; i < 5; ++i) {
+			for (int j = 0; j < 10; ++j) {
+				final StateHandleID handleID = new StateHandleID("handle_" + i + "_" + j);
+				final CheckpointCache.CachedOutputStream output = cache.createOutputStream(i, handleID);
+				String testStr = "123";
+				output.write(testStr.getBytes(), 0, testStr.getBytes().length);
+				output.end();
+				output.close();
+			}
+		}
+
+		Assert.assertEquals(cache.getCompletedCheckpointCacheSize(), 0);;
+		Assert.assertEquals(cache.getPendingCheckpointCacheSize(), 5);
+
+		for (int i = 0; i < 3; ++i)  {
+			cache.commitCache(i);
+		}
+
+		Assert.assertEquals(1, cache.getCompletedCheckpointCacheSize() );
+		Assert.assertEquals(2, cache.getPendingCheckpointCacheSize());
+
+		cache.release();
+
+		Assert.assertEquals(0, cache.getCompletedCheckpointCacheSize());
+		Assert.assertEquals( 0, cache.getPendingCheckpointCacheSize());
+	}
+
+	@Test
+	public void testReCache() throws Exception {
+		File tmpFolder = tmp.newFolder();
+		final CheckpointCache cache = new CheckpointCache(new JobID(), tmpFolder.getAbsolutePath(), 10000, 10000, mock(CheckpointCacheManager.class), Executors.directExecutor());
+
+		CachedStreamStateHandle[] cachedHandles = new CachedStreamStateHandle[5];
+		final String testStr = "test re-cache logic.";
+		String[] cacheFilePaths = new String[5];
+
+		// checkpoint
+		for (int i = 0; i < 5; ++i) {
+			// cache stream
+			final StateHandleID handleID = new StateHandleID("cache_" + i);
+			final CheckpointCache.CachedOutputStream output = cache.createOutputStream(1, handleID);
+			output.write(testStr.getBytes(), 0, testStr.getBytes().length);
+			output.end();
+			cacheFilePaths[i] = output.getCacheFilePath();
+			output.close();
+
+			// remote output stream
+			final String remoteFilePath = tmp.newFile("remote_" + i).getAbsolutePath();
+			OutputStream outputStream = new FileOutputStream(remoteFilePath);
+			outputStream.write(testStr.getBytes(), 0, testStr.getBytes().length);
+			cachedHandles[i] = new CachedStreamStateHandle(handleID, new FileStateHandle(new Path(remoteFilePath), testStr.getBytes().length));
+		}
+		cache.commitCache(1);
+
+		// delete cache file
+		for (int i = 0; i < 5; ++i) {
+			new File(cacheFilePaths[i]).delete();
+		}
+
+		// read from cached handle, this should read from remote
+		for (int i = 0; i < 5; ++i) {
+			CachedStreamStateHandle cachedStreamStateHandle = cachedHandles[i];
+			cachedStreamStateHandle.setCheckpointCache(cache);
+			cachedStreamStateHandle.reCache(true);
+			FSDataInputStream inputStream = cachedStreamStateHandle.openInputStream();
+			byte[] bytes = new byte[1024];
+			int n = inputStream.read(bytes);
+			inputStream.close();
+			Assert.assertEquals(n, testStr.length());
+		}
+		cache.commitCache(CheckpointCache.CHECKPOINT_ID_FOR_RESTORE);
+
+		// read from cached handle again, this should read from cache
+		for (int i = 0; i < 5; ++i) {
+			CachedStreamStateHandle cachedStreamStateHandle = cachedHandles[i];
+			cachedStreamStateHandle.setCheckpointCache(cache);
+			cachedStreamStateHandle.reCache(true);
+			FSDataInputStream inputStream = cachedStreamStateHandle.openInputStream();
+			byte[] bytes = new byte[1024];
+			int n  = inputStream.read(bytes);
+			Assert.assertEquals(n, testStr.length());
+		}
+
+		// check refer count
+		SharedCacheRegistry register = cache.getSharedCacheRegister();
+		for (Map.Entry<CheckpointCache.CacheKey, CheckpointCache.CacheEntry> entry : register.getIterable()) {
+			Assert.assertEquals(1, entry.getValue().getReferenceCount());
+		}
+	}
+
+	@Test
+	public void testCacheRegister() throws Exception {
+
+		File tmpFolder = tmp.newFolder();
+		final CheckpointCache cache = new CheckpointCache(new JobID(), tmpFolder.getAbsolutePath(), 10000, 10000, mock(CheckpointCacheManager.class), Executors.directExecutor());
+		final String testStr = "test re-cache logic.";
+		String[] cacheFilePaths = new String[5];
+
+		// checkpoint
+		for (int i = 0; i < 5; ++i) {
+			// cache stream
+			final StateHandleID handleID = new StateHandleID("cache_" + i);
+			final CheckpointCache.CachedOutputStream output = cache.createOutputStream(1, handleID);
+			output.write(testStr.getBytes(), 0, testStr.getBytes().length);
+			output.end();
+			cacheFilePaths[i] = output.getCacheFilePath();
+			output.close();
+		}
+		cache.commitCache(1);
+
+		// checkpoint
+		for (int i = 4; i < 6; ++i) {
+			// cache stream
+			final StateHandleID handleID = new StateHandleID("cache_" + i);
+			final CheckpointCache.CachedOutputStream output = cache.createOutputStream(2, handleID);
+			output.write(testStr.getBytes(), 0, testStr.getBytes().length);
+			output.end();
+			output.close();
+		}
+		cache.commitCache(2);
+
+		for (int i = 0; i < 4; ++i) {
+			Assert.assertTrue(!new File(cacheFilePaths[i]).exists());
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCacheTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCacheTest.java
@@ -33,7 +33,6 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.file.Files;
 import java.util.Map;
 
 import static org.mockito.Mockito.mock;
@@ -267,7 +266,11 @@ public class CheckpointCacheTest {
 
 		File tmpFolder = tmp.newFolder();
 		final CheckpointCache cache = new CheckpointCache(new JobID(), tmpFolder.getAbsolutePath(), 10000, 10000, mock(CheckpointCacheManager.class), Executors.directExecutor());
-		final String testStr = "test re-cache logic.";
+		StringBuilder builder = new StringBuilder(4097);
+		for (int i = 0; i < 500; ++i) {
+			builder.append("1234567890");
+		}
+		final String testStr = builder.toString();
 		StreamStateHandle[] cacheHandles = new StreamStateHandle[5];
 
 		// checkpoint

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorTest.java
@@ -86,7 +86,8 @@ public class TaskDeploymentDescriptorTest {
 				targetSlotNumber,
 				taskStateHandles,
 				producedResults,
-				inputGates);
+				inputGates,
+				-1);
 
 			final TaskDeploymentDescriptor copy = CommonTestUtils.createCopySerializable(orig);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorTest.java
@@ -87,6 +87,7 @@ public class TaskDeploymentDescriptorTest {
 				taskStateHandles,
 				producedResults,
 				inputGates,
+				-1,
 				-1);
 
 			final TaskDeploymentDescriptor copy = CommonTestUtils.createCopySerializable(orig);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/TaskManagerMetricsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/TaskManagerMetricsTest.java
@@ -112,6 +112,7 @@ public class TaskManagerMetricsTest extends TestLogger {
 				taskManagerServices.getMemoryManager(),
 				taskManagerServices.getIOManager(),
 				taskManagerServices.getNetworkEnvironment(),
+				taskManagerServices.getCheckpointCacheManager(),
 				highAvailabilityServices,
 				taskManagerMetricGroup);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DummyEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DummyEnvironment.java
@@ -25,6 +25,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
+import org.apache.flink.runtime.checkpoint.CheckpointCache;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.execution.Environment;
@@ -168,6 +169,11 @@ public class DummyEnvironment implements Environment {
 	@Override
 	public void failExternally(Throwable cause) {
 		throw new UnsupportedOperationException("DummyEnvironment does not support external task failure.");
+	}
+
+	@Override
+	public CheckpointCache getCheckpointCache() {
+		return null;
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironment.java
@@ -26,6 +26,7 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
+import org.apache.flink.runtime.checkpoint.CheckpointCache;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.execution.Environment;
@@ -366,5 +367,10 @@ public class MockEnvironment implements Environment {
 	@Override
 	public void failExternally(Throwable cause) {
 		throw new UnsupportedOperationException("MockEnvironment does not support external task failure.");
+	}
+
+	@Override
+	public CheckpointCache getCheckpointCache() {
+		return mock(CheckpointCache.class);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/SharedCacheRegistryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/SharedCacheRegistryTest.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.runtime.checkpoint.CheckpointCache;
+import org.apache.flink.runtime.checkpoint.SharedCacheRegistry;
+import org.apache.flink.runtime.concurrent.Executors;
+import org.apache.flink.runtime.state.filesystem.FileStateHandle;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Random;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for SharedCacheRegistry
+ */
+public class SharedCacheRegistryTest {
+
+	@Test
+	public void testRegister() throws Exception {
+		SharedCacheRegistry registry = new SharedCacheRegistry(Executors.directExecutor());
+		CheckpointCache.CacheKey key = new CheckpointCache.CacheKey(new StateHandleID("hanleId1"));
+		CheckpointCache.CacheEntry entry1 = mock(CheckpointCache.CacheEntry.class);
+		CheckpointCache.CacheEntry entry2 = mock(CheckpointCache.CacheEntry.class);
+
+		registry.registerReference(key, entry1);
+		registry.registerReference(key, entry2);
+
+		TimeUnit.MILLISECONDS.sleep(500);
+		verify(entry2, times(1)).discard();
+		verify(entry1, times(2)).increaseReferenceCount();
+	}
+
+	@Test
+	public void testConcurrencyRequest() throws Exception {
+
+		ExecutorService executorService = java.util.concurrent.Executors.newFixedThreadPool(10);
+
+		SharedCacheRegistry registry = new SharedCacheRegistry(Executors.directExecutor());
+
+		CheckpointCache.CacheKey[] keys = new CheckpointCache.CacheKey[10];
+		int[] referCount = new int[keys.length];
+		for (int i = 0; i < keys.length; ++i) {
+			keys[i]	= new CheckpointCache.CacheKey(new StateHandleID("handleId" + i));
+			// for prevent unregister except
+			for (int j = 0; j < 100; ++j) {
+				CheckpointCache.CacheEntry entry = new CheckpointCache.CacheEntry(mock(FileStateHandle.class));
+				registry.registerReference(keys[i], entry);
+			}
+			Assert.assertEquals(100, registry.getCacheEntry(keys[i]).getReferenceCount());
+			referCount[i] = 100;
+		}
+
+		// init 100 runners
+		Runnable[] runnables = new Runnable[100];
+		for (int i = 0; i < runnables.length; ++i) {
+			final int index = new Random().nextInt(keys.length);
+			final int opType = new Random().nextInt(2);
+			if (opType == 0) {
+				referCount[index]--;
+			} else {
+				referCount[index]++;
+			}
+			runnables[i] = () -> {
+				if (opType == 0) {
+					registry.unregisterReference(keys[index]);
+				} else {
+					CheckpointCache.CacheEntry entry = new CheckpointCache.CacheEntry(mock(FileStateHandle.class));
+					registry.registerReference(keys[index], entry);
+				}
+			};
+		}
+
+		// submit runners
+		Future[] futures = new Future[runnables.length];
+		for (int i = 0; i < runnables.length; ++i) {
+			futures[i] = executorService.submit(runnables[i]);
+		}
+
+		// wait for finish
+		for (int i = 0; i < futures.length; ++i) {
+			futures[i].get();
+		}
+
+		// valid result
+		for (int i = 0; i < keys.length; ++i) {
+			if (referCount[i] == 0) {
+				Assert.assertNull(registry.getCacheEntry(keys[i]));
+			} else {
+				Assert.assertEquals(referCount[i], registry.getCacheEntry(keys[i]).getReferenceCount());
+			}
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateSnapshotCompressionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateSnapshotCompressionTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.state;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.runtime.checkpoint.CheckpointCache;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.heap.HeapKeyedStateBackend;
@@ -52,7 +53,8 @@ public class StateSnapshotCompressionTest extends TestLogger {
 			16,
 			new KeyGroupRange(0, 15),
 			true,
-			executionConfig);
+			executionConfig,
+			mock(CheckpointCache.class));
 
 		try {
 			Assert.assertTrue(
@@ -73,7 +75,8 @@ public class StateSnapshotCompressionTest extends TestLogger {
 			16,
 			new KeyGroupRange(0, 15),
 			true,
-			executionConfig);
+			executionConfig,
+			mock(CheckpointCache.class));
 
 		try {
 			Assert.assertTrue(
@@ -112,7 +115,8 @@ public class StateSnapshotCompressionTest extends TestLogger {
 			16,
 			new KeyGroupRange(0, 15),
 			true,
-			executionConfig);
+			executionConfig,
+			mock(CheckpointCache.class));
 
 		try {
 
@@ -153,7 +157,8 @@ public class StateSnapshotCompressionTest extends TestLogger {
 			16,
 			new KeyGroupRange(0, 15),
 			true,
-			executionConfig);
+			executionConfig,
+			mock(CheckpointCache.class));
 		try {
 
 			stateBackend.restore(Collections.singletonList(stateHandle));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/heap/HeapStateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/heap/HeapStateBackendTestBase.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.state.heap;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.runtime.checkpoint.CheckpointCache;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.junit.runner.RunWith;
@@ -54,6 +55,7 @@ public abstract class HeapStateBackendTestBase {
 			16,
 			new KeyGroupRange(0, 15),
 			async,
-			new ExecutionConfig());
+			new ExecutionConfig(),
+			mock(CheckpointCache.class));
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorITCase.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
+import org.apache.flink.runtime.checkpoint.CheckpointCacheManager;
 import org.apache.flink.runtime.clusterframework.FlinkResourceManager;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
@@ -151,6 +152,7 @@ public class TaskExecutorITCase extends TestLogger {
 			memoryManager,
 			ioManager,
 			networkEnvironment,
+			mock(CheckpointCacheManager.class),
 			testingHAServices,
 			heartbeatServices,
 			taskManagerMetricGroup,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.blob.BlobCacheService;
 import org.apache.flink.runtime.blob.PermanentBlobCache;
 import org.apache.flink.runtime.blob.TransientBlobCache;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
+import org.apache.flink.runtime.checkpoint.CheckpointCacheManager;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
@@ -212,6 +213,7 @@ public class TaskExecutorTest extends TestLogger {
 			mock(MemoryManager.class),
 			mock(IOManager.class),
 			mock(NetworkEnvironment.class),
+			mock(CheckpointCacheManager.class),
 			haServices,
 			heartbeatServices,
 			mock(TaskManagerMetricGroup.class),
@@ -317,6 +319,7 @@ public class TaskExecutorTest extends TestLogger {
 			mock(MemoryManager.class),
 			mock(IOManager.class),
 			mock(NetworkEnvironment.class),
+			mock(CheckpointCacheManager.class),
 			haServices,
 			heartbeatServices,
 			mock(TaskManagerMetricGroup.class),
@@ -434,6 +437,7 @@ public class TaskExecutorTest extends TestLogger {
 			mock(MemoryManager.class),
 			mock(IOManager.class),
 			mock(NetworkEnvironment.class),
+			mock(CheckpointCacheManager.class),
 			haServices,
 			heartbeatServices,
 			mock(TaskManagerMetricGroup.class),
@@ -526,6 +530,7 @@ public class TaskExecutorTest extends TestLogger {
 			mock(MemoryManager.class),
 			mock(IOManager.class),
 			mock(NetworkEnvironment.class),
+			mock(CheckpointCacheManager.class),
 			haServices,
 			mock(HeartbeatServices.class, RETURNS_MOCKS),
 			mock(TaskManagerMetricGroup.class),
@@ -608,6 +613,7 @@ public class TaskExecutorTest extends TestLogger {
 			mock(MemoryManager.class),
 			mock(IOManager.class),
 			mock(NetworkEnvironment.class),
+			mock(CheckpointCacheManager.class),
 			haServices,
 			mock(HeartbeatServices.class, RETURNS_MOCKS),
 			mock(TaskManagerMetricGroup.class),
@@ -694,7 +700,8 @@ public class TaskExecutorTest extends TestLogger {
 				0,
 				null,
 				Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
-				Collections.<InputGateDeploymentDescriptor>emptyList());
+				Collections.<InputGateDeploymentDescriptor>emptyList(),
+				-1);
 
 		final LibraryCacheManager libraryCacheManager = mock(LibraryCacheManager.class);
 		when(libraryCacheManager.getClassLoader(any(JobID.class))).thenReturn(ClassLoader.getSystemClassLoader());
@@ -749,6 +756,7 @@ public class TaskExecutorTest extends TestLogger {
 			mock(MemoryManager.class),
 			mock(IOManager.class),
 			networkEnvironment,
+			mock(CheckpointCacheManager.class),
 			haServices,
 			mock(HeartbeatServices.class, RETURNS_MOCKS),
 			taskManagerMetricGroup,
@@ -866,6 +874,7 @@ public class TaskExecutorTest extends TestLogger {
 			mock(MemoryManager.class),
 			mock(IOManager.class),
 			mock(NetworkEnvironment.class),
+			mock(CheckpointCacheManager.class),
 			haServices,
 			mock(HeartbeatServices.class, RETURNS_MOCKS),
 			mock(TaskManagerMetricGroup.class),
@@ -985,6 +994,7 @@ public class TaskExecutorTest extends TestLogger {
 			mock(MemoryManager.class),
 			mock(IOManager.class),
 			mock(NetworkEnvironment.class),
+			mock(CheckpointCacheManager.class),
 			haServices,
 			mock(HeartbeatServices.class, RETURNS_MOCKS),
 			mock(TaskManagerMetricGroup.class),
@@ -1079,6 +1089,7 @@ public class TaskExecutorTest extends TestLogger {
 			mock(MemoryManager.class),
 			mock(IOManager.class),
 			mock(NetworkEnvironment.class),
+			mock(CheckpointCacheManager.class),
 			haServices,
 			mock(HeartbeatServices.class, RETURNS_MOCKS),
 			mock(TaskManagerMetricGroup.class),
@@ -1254,6 +1265,7 @@ public class TaskExecutorTest extends TestLogger {
 			mock(MemoryManager.class),
 			mock(IOManager.class),
 			networkMock,
+			mock(CheckpointCacheManager.class),
 			haServices,
 			mock(HeartbeatServices.class, RETURNS_MOCKS),
 			taskManagerMetricGroup,
@@ -1304,7 +1316,8 @@ public class TaskExecutorTest extends TestLogger {
 				0,
 				null,
 				Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
-				Collections.<InputGateDeploymentDescriptor>emptyList());
+				Collections.<InputGateDeploymentDescriptor>emptyList(),
+				-1);
 
 			CompletableFuture<Collection<SlotOffer>> offerResultFuture = new CompletableFuture<>();
 
@@ -1376,6 +1389,7 @@ public class TaskExecutorTest extends TestLogger {
 			mock(MemoryManager.class),
 			mock(IOManager.class),
 			mock(NetworkEnvironment.class),
+			mock(CheckpointCacheManager.class),
 			haServicesMock,
 			heartbeatServicesMock,
 			mock(TaskManagerMetricGroup.class),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -701,6 +701,7 @@ public class TaskExecutorTest extends TestLogger {
 				null,
 				Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
 				Collections.<InputGateDeploymentDescriptor>emptyList(),
+				-1,
 				-1);
 
 		final LibraryCacheManager libraryCacheManager = mock(LibraryCacheManager.class);
@@ -1317,6 +1318,7 @@ public class TaskExecutorTest extends TestLogger {
 				null,
 				Collections.<ResultPartitionDeploymentDescriptor>emptyList(),
 				Collections.<InputGateDeploymentDescriptor>emptyList(),
+				-1,
 				-1);
 
 			CompletableFuture<Collection<SlotOffer>> offerResultFuture = new CompletableFuture<>();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.blob.BlobCacheService;
 import org.apache.flink.runtime.blob.PermanentBlobCache;
 import org.apache.flink.runtime.blob.TransientBlobCache;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
+import org.apache.flink.runtime.checkpoint.CheckpointCache;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
@@ -263,6 +264,7 @@ public class TaskAsyncCallTest {
 			blobService,
 			libCache,
 			mock(FileCache.class),
+			mock(CheckpointCache.class),
 			new TestingTaskManagerRuntimeInfo(),
 			taskMetricGroup,
 			consumableNotifier,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerComponentsStartupShutdownTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerComponentsStartupShutdownTest.java
@@ -24,9 +24,11 @@ import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.memory.MemoryType;
 import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.checkpoint.CheckpointCacheManager;
 import org.apache.flink.runtime.clusterframework.FlinkResourceManager;
 import org.apache.flink.runtime.clusterframework.standalone.StandaloneResourceManager;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.concurrent.Executors;
 import org.apache.flink.runtime.execution.librarycache.FlinkUserCodeClassLoaders;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.highavailability.nonha.embedded.EmbeddedHaServices;
@@ -155,6 +157,8 @@ public class TaskManagerComponentsStartupShutdownTest extends TestLogger {
 
 			network.start();
 
+			final CheckpointCacheManager checkpointCacheManager = new CheckpointCacheManager(java.util.concurrent.Executors.newSingleThreadScheduledExecutor(), Executors.directExecutor(), TMP_DIR[0]);
+
 			MetricRegistryConfiguration metricRegistryConfiguration = MetricRegistryConfiguration.fromConfiguration(config);
 
 			// create the task manager
@@ -166,6 +170,7 @@ public class TaskManagerComponentsStartupShutdownTest extends TestLogger {
 				memManager,
 				ioManager,
 				network,
+				checkpointCacheManager,
 				numberOfSlots,
 				highAvailabilityServices,
 				new TaskManagerMetricGroup(new NoOpMetricRegistry(), connectionInfo.getHostname(), connectionInfo.getResourceID().getResourceIdString()));
@@ -202,6 +207,7 @@ public class TaskManagerComponentsStartupShutdownTest extends TestLogger {
 			assertTrue(network.isShutdown());
 			assertTrue(ioManager.isProperlyShutDown());
 			assertTrue(memManager.isShutdown());
+			assertTrue(checkpointCacheManager.isShutdown());
 		} finally {
 			if (actorSystem != null) {
 				actorSystem.shutdown();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerComponentsStartupShutdownTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerComponentsStartupShutdownTest.java
@@ -157,7 +157,7 @@ public class TaskManagerComponentsStartupShutdownTest extends TestLogger {
 
 			network.start();
 
-			final CheckpointCacheManager checkpointCacheManager = new CheckpointCacheManager(java.util.concurrent.Executors.newSingleThreadScheduledExecutor(), Executors.directExecutor(), TMP_DIR[0]);
+			final CheckpointCacheManager checkpointCacheManager = new CheckpointCacheManager(java.util.concurrent.Executors.newSingleThreadScheduledExecutor(), Executors.directExecutor(), TMP_DIR);
 
 			MetricRegistryConfiguration metricRegistryConfiguration = MetricRegistryConfiguration.fromConfiguration(config);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
@@ -2159,7 +2159,8 @@ public class TaskManagerTest extends TestLogger {
 			targetSlotNumber,
 			null,
 			producedPartitions,
-			inputGates);
+			inputGates,
+			-1);
 
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
@@ -2160,6 +2160,7 @@ public class TaskManagerTest extends TestLogger {
 			null,
 			producedPartitions,
 			inputGates,
+			-1,
 			-1);
 
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.blob.BlobCacheService;
 import org.apache.flink.runtime.blob.PermanentBlobCache;
 import org.apache.flink.runtime.blob.TransientBlobCache;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
+import org.apache.flink.runtime.checkpoint.CheckpointCache;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.concurrent.Executors;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
@@ -1020,6 +1021,7 @@ public class TaskTest extends TestLogger {
 			blobService,
 			libCache,
 			mock(FileCache.class),
+			mock(CheckpointCache.class),
 			new TestingTaskManagerRuntimeInfo(taskManagerConfig),
 			taskMetricGroup,
 			consumableNotifier,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/JvmExitOnFatalErrorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/JvmExitOnFatalErrorTest.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.blob.BlobCacheService;
 import org.apache.flink.runtime.blob.PermanentBlobCache;
 import org.apache.flink.runtime.blob.TransientBlobCache;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
+import org.apache.flink.runtime.checkpoint.CheckpointCache;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
@@ -189,6 +190,7 @@ public class JvmExitOnFatalErrorTest {
 							FlinkUserCodeClassLoaders.ResolveOrder.CHILD_FIRST,
 							new String[0]),
 						new FileCache(tmInfo.getTmpDirectories()),
+						mock(CheckpointCache.class),
 						tmInfo,
 						new UnregisteredTaskMetricsGroup(),
 						new NoOpResultPartitionConsumableNotifier(),

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingTaskManager.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingTaskManager.scala
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.testingUtils
 
+import org.apache.flink.runtime.checkpoint.CheckpointCacheManager
 import org.apache.flink.runtime.clusterframework.types.ResourceID
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices
 import org.apache.flink.runtime.io.disk.iomanager.IOManager
@@ -38,6 +39,7 @@ class TestingTaskManager(
     memoryManager: MemoryManager,
     ioManager: IOManager,
     network: NetworkEnvironment,
+    checkpointCacheManager: CheckpointCacheManager,
     numberOfSlots: Int,
     highAvailabilityServices: HighAvailabilityServices,
     taskManagerMetricGroup : TaskManagerMetricGroup)
@@ -48,6 +50,7 @@ class TestingTaskManager(
     memoryManager,
     ioManager,
     network,
+    checkpointCacheManager,
     numberOfSlots,
     highAvailabilityServices,
     taskManagerMetricGroup)
@@ -59,6 +62,7 @@ class TestingTaskManager(
     memoryManager: MemoryManager,
     ioManager: IOManager,
     network: NetworkEnvironment,
+    checkpointCacheManager: CheckpointCacheManager,
     numberOfSlots: Int,
     highAvailabilityServices: HighAvailabilityServices,
     taskManagerMetricGroup : TaskManagerMetricGroup) {
@@ -69,6 +73,7 @@ class TestingTaskManager(
       memoryManager,
       ioManager,
       network,
+      checkpointCacheManager,
       numberOfSlots,
       highAvailabilityServices,
       taskManagerMetricGroup)

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.accumulators.Accumulator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.fs.FileSystemSafetyNet;
+import org.apache.flink.runtime.checkpoint.CheckpointCache;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
@@ -663,6 +664,10 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 					if (operator != null) {
 						operator.notifyOfCompletedCheckpoint(checkpointId);
 					}
+				}
+				final CheckpointCache checkpointCache = getEnvironment().getCheckpointCache();
+				if (checkpointCache != null) {
+					checkpointCache.commitCache(checkpointId);
 				}
 			}
 			else {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/InterruptSensitiveRestoreTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/InterruptSensitiveRestoreTest.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.blob.BlobCacheService;
 import org.apache.flink.runtime.blob.PermanentBlobCache;
 import org.apache.flink.runtime.blob.TransientBlobCache;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
+import org.apache.flink.runtime.checkpoint.CheckpointCache;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
@@ -268,6 +269,7 @@ public class InterruptSensitiveRestoreTest {
 				FlinkUserCodeClassLoaders.ResolveOrder.CHILD_FIRST,
 				new String[0]),
 			new FileCache(new String[] { EnvironmentInformation.getTemporaryFileDirectory() }),
+			mock(CheckpointCache.class),
 			new TestingTaskManagerRuntimeInfo(),
 			new UnregisteredTaskMetricsGroup(),
 			mock(ResultPartitionConsumableNotifier.class),

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamMockEnvironment.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamMockEnvironment.java
@@ -27,6 +27,7 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
+import org.apache.flink.runtime.checkpoint.CheckpointCache;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.event.AbstractEvent;
@@ -342,6 +343,11 @@ public class StreamMockEnvironment implements Environment {
 	@Override
 	public void failExternally(Throwable cause) {
 		this.wasFailedExternally = true;
+	}
+
+	@Override
+	public CheckpointCache getCheckpointCache() {
+		return mock(CheckpointCache.class);
 	}
 
 	public boolean wasFailedExternally() {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.blob.BlobCacheService;
 import org.apache.flink.runtime.blob.PermanentBlobCache;
 import org.apache.flink.runtime.blob.TransientBlobCache;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
+import org.apache.flink.runtime.checkpoint.CheckpointCache;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.concurrent.Executors;
@@ -164,6 +165,7 @@ public class StreamTaskTerminationTest extends TestLogger {
 				FlinkUserCodeClassLoaders.ResolveOrder.CHILD_FIRST,
 				new String[0]),
 			mock(FileCache.class),
+			mock(CheckpointCache.class),
 			taskManagerRuntimeInfo,
 			new UnregisteredTaskMetricsGroup(),
 			mock(ResultPartitionConsumableNotifier.class),

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.blob.BlobCacheService;
 import org.apache.flink.runtime.blob.PermanentBlobCache;
 import org.apache.flink.runtime.blob.TransientBlobCache;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
+import org.apache.flink.runtime.checkpoint.CheckpointCache;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
@@ -931,6 +932,7 @@ public class StreamTaskTest extends TestLogger {
 			blobService,
 			libCache,
 			mock(FileCache.class),
+			mock(CheckpointCache.class),
 			new TestingTaskManagerRuntimeInfo(taskManagerConfig, new String[] {System.getProperty("java.io.tmpdir")}),
 			new UnregisteredTaskMetricsGroup(),
 			consumableNotifier,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TaskCheckpointingBehaviourTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TaskCheckpointingBehaviourTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.blob.BlobCacheService;
 import org.apache.flink.runtime.blob.PermanentBlobCache;
 import org.apache.flink.runtime.blob.TransientBlobCache;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
+import org.apache.flink.runtime.checkpoint.CheckpointCache;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
@@ -240,6 +241,7 @@ public class TaskCheckpointingBehaviourTest extends TestLogger {
 					FlinkUserCodeClassLoaders.ResolveOrder.CHILD_FIRST,
 					new String[0]),
 				new FileCache(new String[] { EnvironmentInformation.getTemporaryFileDirectory() }),
+				mock(CheckpointCache.class),
 				new TestingTaskManagerRuntimeInfo(),
 				new UnregisteredTaskMetricsGroup(),
 				mock(ResultPartitionConsumableNotifier.class),

--- a/flink-yarn-tests/src/test/scala/org/apache/flink/yarn/TestingYarnTaskManager.scala
+++ b/flink-yarn-tests/src/test/scala/org/apache/flink/yarn/TestingYarnTaskManager.scala
@@ -18,6 +18,7 @@
 
 package org.apache.flink.yarn
 
+import org.apache.flink.runtime.checkpoint.CheckpointCacheManager
 import org.apache.flink.runtime.clusterframework.types.ResourceID
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices
 import org.apache.flink.runtime.io.disk.iomanager.IOManager
@@ -50,6 +51,7 @@ class TestingYarnTaskManager(
     memoryManager: MemoryManager,
     ioManager: IOManager,
     network: NetworkEnvironment,
+    checkpointCacheManager: CheckpointCacheManager,
     numberOfSlots: Int,
     highAvailabilityServices: HighAvailabilityServices,
     taskManagerMetricGroup : TaskManagerMetricGroup)
@@ -60,6 +62,7 @@ class TestingYarnTaskManager(
     memoryManager,
     ioManager,
     network,
+    checkpointCacheManager,
     numberOfSlots,
     highAvailabilityServices,
     taskManagerMetricGroup)

--- a/flink-yarn/src/main/scala/org/apache/flink/yarn/YarnTaskManager.scala
+++ b/flink-yarn/src/main/scala/org/apache/flink/yarn/YarnTaskManager.scala
@@ -18,6 +18,7 @@
 
 package org.apache.flink.yarn
 
+import org.apache.flink.runtime.checkpoint.CheckpointCacheManager
 import org.apache.flink.runtime.clusterframework.types.ResourceID
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices
 import org.apache.flink.runtime.io.disk.iomanager.IOManager
@@ -37,6 +38,7 @@ class YarnTaskManager(
     memoryManager: MemoryManager,
     ioManager: IOManager,
     network: NetworkEnvironment,
+    checkpointCacheManager: CheckpointCacheManager,
     numberOfSlots: Int,
     highAvailabilityServices: HighAvailabilityServices,
     taskManagerMetricGroup: TaskManagerMetricGroup)
@@ -47,6 +49,7 @@ class YarnTaskManager(
     memoryManager,
     ioManager,
     network,
+    checkpointCacheManager,
     numberOfSlots,
     highAvailabilityServices,
     taskManagerMetricGroup) {


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes [FLINK-7873](https://issues.apache.org/jira/browse/FLINK-7873). Current recover strategy will always read checkpoint data from remote FileStream (HDFS). This will cost a lot of bandwidth when the state is so big (e.g. 1T). What's worse, if this job performs recover again and again, it can eat up all network bandwidth and do a huge hurt to cluster. So, I proposed that we can cache the checkpoint data locally, and read checkpoint data from local cache as well as we can, we read the data from remote only if we fail locally. The advantage is that if a execution is assigned to the same TaskManager as before, it can save a lot of network, and obtain a faster recovery.

## Brief change log

  - *Add CheckpointCacheManager for TM to manage Local Checkpoint Data for each TM*
  - *Add CheckpointCache for Task to manage Local Checkpoint Data for each Task*
  - *Add CachedCheckpointStreamFactory to write checkpoint data to both DFS and local disk*
  - *Add CachedStreamStateHandle to read checkpoint data from local or remote*
  - Here is a doc for detail: [local_recovery.docx](https://docs.google.com/document/d/1-yZvTNV6_Nx1XUh3zwAFZqGgF2nkXckTGJy4tx-WzVQ/edit?usp=sharing)

## Verifying this change

This change added tests and can be verified as follows:
- Add tests in `CheckpointCacheManagerTest.java`, `CheckpointCacheTest.java`, `CachedCheckpointStreamFactoryTest.java`, `SharedCacheRegistryTest.java`.
- Compile this PR and deploy it on a cluster, trigger failure randomly. (I tested this on a yarn cluster and with `a naive Scheduler mechanism` that allocates slot only according to state.)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)

## Documentation

  - Does this pull request introduce a new feature? (Yes)
  - doc link :[local recovery](https://docs.google.com/document/d/1-yZvTNV6_Nx1XUh3zwAFZqGgF2nkXckTGJy4tx-WzVQ/edit?usp=sharing)