### PR TITLE
[FLINK-7574][build] POM Cleanup flink-clients

### DIFF
--- a/flink-annotations/pom.xml
+++ b/flink-annotations/pom.xml
@@ -34,4 +34,21 @@ under the License.
 
 	<packaging>jar</packaging>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>analyze</id>
+						<goals><goal>analyze-only</goal></goals>
+						<configuration>
+							<skip>true</skip>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/flink-clients/pom.xml
+++ b/flink-clients/pom.xml
@@ -64,8 +64,23 @@ under the License.
 		</dependency>
 
 		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-shaded-netty</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>commons-cli</groupId>
 			<artifactId>commons-cli</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.scala-lang</groupId>
+			<artifactId>scala-library</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.typesafe.akka</groupId>
+			<artifactId>akka-actor_${scala.binary.version}</artifactId>
 		</dependency>
 
 		<!-- test dependencies -->
@@ -88,6 +103,18 @@ under the License.
 		<dependency>
 			<groupId>com.typesafe.akka</groupId>
 			<artifactId>akka-testkit_${scala.binary.version}</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.powermock</groupId>
+			<artifactId>powermock-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.powermock</groupId>
+			<artifactId>powermock-reflect</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/flink-clients/pom.xml
+++ b/flink-clients/pom.xml
@@ -99,24 +99,6 @@ under the License.
 			<scope>test</scope>
 			<type>test-jar</type>
 		</dependency>
-		
-		<dependency>
-			<groupId>com.typesafe.akka</groupId>
-			<artifactId>akka-testkit_${scala.binary.version}</artifactId>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.powermock</groupId>
-			<artifactId>powermock-core</artifactId>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.powermock</groupId>
-			<artifactId>powermock-reflect</artifactId>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 
 	<!-- More information on this:

--- a/flink-connectors/pom.xml
+++ b/flink-connectors/pom.xml
@@ -103,6 +103,21 @@ under the License.
 
 	<build>
 		<plugins>
+			<!-- TODO: It will be removed after Cleanup dependencies(used but undeclared / declared but unused) -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>analyze</id>
+						<goals><goal>analyze-only</goal></goals>
+						<configuration>
+							<skip>true</skip>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-enforcer-plugin</artifactId>

--- a/flink-contrib/pom.xml
+++ b/flink-contrib/pom.xml
@@ -43,4 +43,23 @@ under the License.
 		<module>flink-connector-wikiedits</module>
 		<module>flink-statebackend-rocksdb</module>
 	</modules>
+
+	<build>
+		<plugins>
+			<!-- TODO: It will be removed after Cleanup dependencies(used but undeclared / declared but unused) -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>analyze</id>
+						<goals><goal>analyze-only</goal></goals>
+						<configuration>
+							<skip>true</skip>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -160,6 +160,21 @@ under the License.
 
 	<build>
 		<plugins>
+			<!-- TODO: It will be removed after Cleanup dependencies(used but undeclared / declared but unused) -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>analyze</id>
+						<goals><goal>analyze-only</goal></goals>
+						<configuration>
+							<skip>true</skip>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-checkstyle-plugin</artifactId>

--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -428,6 +428,21 @@ under the License.
 
 	<build>
 		<plugins>
+			<!-- TODO: It will be removed after Cleanup dependencies(used but undeclared / declared but unused) -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>analyze</id>
+						<goals><goal>analyze-only</goal></goals>
+						<configuration>
+							<skip>true</skip>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-enforcer-plugin</artifactId>

--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -428,7 +428,6 @@ under the License.
 
 	<build>
 		<plugins>
-			<!-- TODO: It will be removed after Cleanup dependencies(used but undeclared / declared but unused) -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-dependency-plugin</artifactId>

--- a/flink-end-to-end-tests/pom.xml
+++ b/flink-end-to-end-tests/pom.xml
@@ -49,6 +49,21 @@ under the License.
 
 	<build>
 		<plugins>
+			<!-- TODO: It will be removed after Cleanup dependencies(used but undeclared / declared but unused) -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>analyze</id>
+						<goals><goal>analyze-only</goal></goals>
+						<configuration>
+							<skip>true</skip>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>

--- a/flink-examples/pom.xml
+++ b/flink-examples/pom.xml
@@ -73,6 +73,21 @@ under the License.
 
 	<build>
 		<plugins>
+			<!-- TODO: It will be removed after Cleanup dependencies(used but undeclared / declared but unused) -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>analyze</id>
+						<goals><goal>analyze-only</goal></goals>
+						<configuration>
+							<skip>true</skip>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-enforcer-plugin</artifactId>

--- a/flink-filesystems/pom.xml
+++ b/flink-filesystems/pom.xml
@@ -44,6 +44,21 @@ under the License.
 
 	<build>
 		<plugins>
+			<!-- TODO: It will be removed after Cleanup dependencies(used but undeclared / declared but unused) -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>analyze</id>
+						<goals><goal>analyze-only</goal></goals>
+						<configuration>
+							<skip>true</skip>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-enforcer-plugin</artifactId>

--- a/flink-formats/pom.xml
+++ b/flink-formats/pom.xml
@@ -39,4 +39,22 @@ under the License.
 		<module>flink-avro</module>
 	</modules>
 
+	<build>
+		<plugins>
+			<!-- TODO: It will be removed after Cleanup dependencies(used but undeclared / declared but unused) -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>analyze</id>
+						<goals><goal>analyze-only</goal></goals>
+						<configuration>
+							<skip>true</skip>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/flink-fs-tests/pom.xml
+++ b/flink-fs-tests/pom.xml
@@ -99,6 +99,21 @@ under the License.
 
 	<build>
 		<plugins>
+			<!-- TODO: It will be removed after Cleanup dependencies(used but undeclared / declared but unused) -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>analyze</id>
+						<goals><goal>analyze-only</goal></goals>
+						<configuration>
+							<skip>true</skip>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-enforcer-plugin</artifactId>

--- a/flink-java/pom.xml
+++ b/flink-java/pom.xml
@@ -71,6 +71,21 @@ under the License.
 
 	<build>
 		<plugins>
+			<!-- TODO: It will be removed after Cleanup dependencies(used but undeclared / declared but unused) -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>analyze</id>
+						<goals><goal>analyze-only</goal></goals>
+						<configuration>
+							<skip>true</skip>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
 			<!-- activate API compatibility checks -->
 			<plugin>
 				<groupId>com.github.siom79.japicmp</groupId>

--- a/flink-java8/pom.xml
+++ b/flink-java8/pom.xml
@@ -76,6 +76,21 @@ under the License.
 
 	<build>
 		<plugins>
+			<!-- TODO: It will be removed after Cleanup dependencies(used but undeclared / declared but unused) -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>analyze</id>
+						<goals><goal>analyze-only</goal></goals>
+						<configuration>
+							<skip>true</skip>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
 			<plugin>
 				<!-- just define the Java version to be used for compiling and plugins -->
 				<groupId>org.apache.maven.plugins</groupId>

--- a/flink-libraries/pom.xml
+++ b/flink-libraries/pom.xml
@@ -63,6 +63,21 @@ under the License.
 
 	<build>
 		<plugins>
+			<!-- TODO: It will be removed after Cleanup dependencies(used but undeclared / declared but unused) -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>analyze</id>
+						<goals><goal>analyze-only</goal></goals>
+						<configuration>
+							<skip>true</skip>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-enforcer-plugin</artifactId>

--- a/flink-mesos/pom.xml
+++ b/flink-mesos/pom.xml
@@ -144,6 +144,21 @@ under the License.
 
 	<build>
 		<plugins>
+			<!-- TODO: It will be removed after Cleanup dependencies(used but undeclared / declared but unused) -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>analyze</id>
+						<goals><goal>analyze-only</goal></goals>
+						<configuration>
+							<skip>true</skip>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
 			<!-- Scala Compiler -->
 			<plugin>
 				<groupId>net.alchim31.maven</groupId>

--- a/flink-metrics/pom.xml
+++ b/flink-metrics/pom.xml
@@ -62,4 +62,22 @@ under the License.
 		</dependency>
 	</dependencies>
 
+	<build>
+		<plugins>
+			<!-- TODO: It will be removed after Cleanup dependencies(used but undeclared / declared but unused) -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>analyze</id>
+						<goals><goal>analyze-only</goal></goals>
+						<configuration>
+							<skip>true</skip>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/flink-optimizer/pom.xml
+++ b/flink-optimizer/pom.xml
@@ -79,6 +79,21 @@ under the License.
 	<!-- Because flink-tests needs the CompilerTestBsae -->
 	<build>
 		<plugins>
+			<!-- TODO: It will be removed after Cleanup dependencies(used but undeclared / declared but unused) -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>analyze</id>
+						<goals><goal>analyze-only</goal></goals>
+						<configuration>
+							<skip>true</skip>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-checkstyle-plugin</artifactId>

--- a/flink-queryable-state/pom.xml
+++ b/flink-queryable-state/pom.xml
@@ -52,4 +52,23 @@ under the License.
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>
+
+	<build>
+		<plugins>
+			<!-- TODO: It will be removed after Cleanup dependencies(used but undeclared / declared but unused) -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>analyze</id>
+						<goals><goal>analyze-only</goal></goals>
+						<configuration>
+							<skip>true</skip>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/flink-quickstart/pom.xml
+++ b/flink-quickstart/pom.xml
@@ -55,6 +55,21 @@ under the License.
 			</plugins>
 		</pluginManagement>
 		<plugins>
+			<!-- TODO: It will be removed after Cleanup dependencies(used but undeclared / declared but unused) -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>analyze</id>
+						<goals><goal>analyze-only</goal></goals>
+						<configuration>
+							<skip>true</skip>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
 			<plugin>
 				<artifactId>maven-archetype-plugin</artifactId>
 				<version>2.2</version><!--$NO-MVN-MAN-VER$-->

--- a/flink-runtime-web/pom.xml
+++ b/flink-runtime-web/pom.xml
@@ -128,6 +128,21 @@ under the License.
 		</resources>
 
 		<plugins>
+			<!-- TODO: It will be removed after Cleanup dependencies(used but undeclared / declared but unused) -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>analyze</id>
+						<goals><goal>analyze-only</goal></goals>
+						<configuration>
+							<skip>true</skip>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>

--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -241,6 +241,21 @@ under the License.
 
 	<build>
 		<plugins>
+			<!-- TODO: It will be removed after Cleanup dependencies(used but undeclared / declared but unused) -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>analyze</id>
+						<goals><goal>analyze-only</goal></goals>
+						<configuration>
+							<skip>true</skip>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-enforcer-plugin</artifactId>

--- a/flink-scala-shell/pom.xml
+++ b/flink-scala-shell/pom.xml
@@ -91,6 +91,21 @@ under the License.
 
 	<build>
 		<plugins>
+			<!-- TODO: It will be removed after Cleanup dependencies(used but undeclared / declared but unused) -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>analyze</id>
+						<goals><goal>analyze-only</goal></goals>
+						<configuration>
+							<skip>true</skip>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
 			<!-- Scala Compiler -->
 			<plugin>
 				<groupId>net.alchim31.maven</groupId>

--- a/flink-scala/pom.xml
+++ b/flink-scala/pom.xml
@@ -111,6 +111,21 @@ under the License.
 
 	<build>
 		<plugins>
+			<!-- TODO: It will be removed after Cleanup dependencies(used but undeclared / declared but unused) -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>analyze</id>
+						<goals><goal>analyze-only</goal></goals>
+						<configuration>
+							<skip>true</skip>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-enforcer-plugin</artifactId>

--- a/flink-shaded-curator/pom.xml
+++ b/flink-shaded-curator/pom.xml
@@ -47,6 +47,20 @@ under the License.
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>analyze</id>
+						<goals><goal>analyze-only</goal></goals>
+						<configuration>
+							<skip>true</skip>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
 				<executions>
 					<execution>

--- a/flink-shaded-hadoop/pom.xml
+++ b/flink-shaded-hadoop/pom.xml
@@ -58,6 +58,20 @@ under the License.
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>analyze</id>
+						<goals><goal>analyze-only</goal></goals>
+						<configuration>
+							<skip>true</skip>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-enforcer-plugin</artifactId>
 				<executions>
 					<execution>

--- a/flink-streaming-java/pom.xml
+++ b/flink-streaming-java/pom.xml
@@ -93,6 +93,20 @@ under the License.
 
 	<build>
 		<plugins>
+			<!-- TODO: It will be removed after Cleanup dependencies(used but undeclared / declared but unused) -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>analyze</id>
+						<goals><goal>analyze-only</goal></goals>
+						<configuration>
+							<skip>true</skip>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 
 			<!-- activate API compatibility checks -->
 			<plugin>

--- a/flink-streaming-scala/pom.xml
+++ b/flink-streaming-scala/pom.xml
@@ -106,6 +106,21 @@ under the License.
 
 	<build>
 		<plugins>
+			<!-- TODO: It will be removed after Cleanup dependencies(used but undeclared / declared but unused) -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>analyze</id>
+						<goals><goal>analyze-only</goal></goals>
+						<configuration>
+							<skip>true</skip>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-enforcer-plugin</artifactId>

--- a/flink-test-utils-parent/pom.xml
+++ b/flink-test-utils-parent/pom.xml
@@ -40,4 +40,22 @@ under the License.
 		<module>flink-test-utils</module>
 	</modules>
 
+	<build>
+		<plugins>
+			<!-- TODO: It will be removed after Cleanup dependencies(used but undeclared / declared but unused) -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>analyze</id>
+						<goals><goal>analyze-only</goal></goals>
+						<configuration>
+							<skip>true</skip>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/flink-tests/pom.xml
+++ b/flink-tests/pom.xml
@@ -236,6 +236,21 @@ under the License.
 
 	<build>
 		<plugins>
+			<!-- TODO: It will be removed after Cleanup dependencies(used but undeclared / declared but unused) -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>analyze</id>
+						<goals><goal>analyze-only</goal></goals>
+						<configuration>
+							<skip>true</skip>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-enforcer-plugin</artifactId>

--- a/flink-yarn-tests/pom.xml
+++ b/flink-yarn-tests/pom.xml
@@ -138,6 +138,21 @@ under the License.
 
 	<build>
 		<plugins>
+			<!-- TODO: It will be removed after Cleanup dependencies(used but undeclared / declared but unused) -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>analyze</id>
+						<goals><goal>analyze-only</goal></goals>
+						<configuration>
+							<skip>true</skip>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-enforcer-plugin</artifactId>

--- a/flink-yarn/pom.xml
+++ b/flink-yarn/pom.xml
@@ -220,6 +220,21 @@ under the License.
 
 	<build>
 		<plugins>
+			<!-- TODO: It will be removed after Cleanup dependencies(used but undeclared / declared but unused) -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>analyze</id>
+						<goals><goal>analyze-only</goal></goals>
+						<configuration>
+							<skip>true</skip>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-enforcer-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -581,6 +581,20 @@ under the License.
 				<version>0.9.10</version>
 				<scope>test</scope>
 			</dependency>
+
+			<dependency>
+				<groupId>org.powermock</groupId>
+				<artifactId>powermock-core</artifactId>
+				<version>${powermock.version}</version>
+				<scope>test</scope>
+			</dependency>
+
+			<dependency>
+				<groupId>org.powermock</groupId>
+				<artifactId>powermock-reflect</artifactId>
+				<version>${powermock.version}</version>
+				<scope>test</scope>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 
@@ -891,6 +905,41 @@ under the License.
 
 	<build>
 		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<version>3.0.2</version>
+				<executions>
+					<execution>
+						<id>analyze</id>
+						<goals>
+							<goal>analyze-only</goal>
+						</goals>
+						<configuration>
+							<!-- Ignore runtime-only dependencies in analysis -->
+							<ignoreNonCompile>true</ignoreNonCompile>
+							<outputXML>true</outputXML>
+							<failOnWarning>true</failOnWarning>
+							<ignoredUnusedDeclaredDependencies>
+								<!-- Ignore inherited from the root POM -->
+								<ignoredUnusedDeclaredDependency>org.apache.flink:force-shading</ignoredUnusedDeclaredDependency>
+								<ignoredUnusedDeclaredDependency>com.google.code.findbugs:jsr305</ignoredUnusedDeclaredDependency>
+								<ignoredUnusedDeclaredDependency>junit:junit:jar</ignoredUnusedDeclaredDependency>
+								<ignoredUnusedDeclaredDependency>org.mockito:mockito-all</ignoredUnusedDeclaredDependency>
+								<ignoredUnusedDeclaredDependency>org.powermock:powermock-module-junit4</ignoredUnusedDeclaredDependency>
+								<ignoredUnusedDeclaredDependency>org.powermock:powermock-api-mockito</ignoredUnusedDeclaredDependency>
+								<ignoredUnusedDeclaredDependency>org.powermock:powermock-core</ignoredUnusedDeclaredDependency>
+								<ignoredUnusedDeclaredDependency>org.powermock:powermock-reflect</ignoredUnusedDeclaredDependency>
+								<ignoredUnusedDeclaredDependency>org.hamcrest:hamcrest-all</ignoredUnusedDeclaredDependency>
+								<ignoredUnusedDeclaredDependency>org.slf4j:slf4j-api</ignoredUnusedDeclaredDependency>
+								<ignoredUnusedDeclaredDependency>org.slf4j:slf4j-log4j12</ignoredUnusedDeclaredDependency>
+								<ignoredUnusedDeclaredDependency>log4j:log4j:jar</ignoredUnusedDeclaredDependency>
+							</ignoredUnusedDeclaredDependencies>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
 			<!--
 			We need to include this here because some of our modules have transitive dependencies
 			on jdbm1, which is of type "bundle". This only works if you include the
@@ -1292,6 +1341,12 @@ under the License.
 
 		<pluginManagement>
 			<plugins>
+
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-dependency-plugin</artifactId>
+					<version>3.0.2</version>
+				</plugin>
 
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -581,20 +581,6 @@ under the License.
 				<version>0.9.10</version>
 				<scope>test</scope>
 			</dependency>
-
-			<dependency>
-				<groupId>org.powermock</groupId>
-				<artifactId>powermock-core</artifactId>
-				<version>${powermock.version}</version>
-				<scope>test</scope>
-			</dependency>
-
-			<dependency>
-				<groupId>org.powermock</groupId>
-				<artifactId>powermock-reflect</artifactId>
-				<version>${powermock.version}</version>
-				<scope>test</scope>
-			</dependency>
 		</dependencies>
 	</dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -908,7 +908,6 @@ under the License.
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-dependency-plugin</artifactId>
-				<version>3.0.2</version>
 				<executions>
 					<execution>
 						<id>analyze</id>
@@ -928,8 +927,6 @@ under the License.
 								<ignoredUnusedDeclaredDependency>org.mockito:mockito-all</ignoredUnusedDeclaredDependency>
 								<ignoredUnusedDeclaredDependency>org.powermock:powermock-module-junit4</ignoredUnusedDeclaredDependency>
 								<ignoredUnusedDeclaredDependency>org.powermock:powermock-api-mockito</ignoredUnusedDeclaredDependency>
-								<ignoredUnusedDeclaredDependency>org.powermock:powermock-core</ignoredUnusedDeclaredDependency>
-								<ignoredUnusedDeclaredDependency>org.powermock:powermock-reflect</ignoredUnusedDeclaredDependency>
 								<ignoredUnusedDeclaredDependency>org.hamcrest:hamcrest-all</ignoredUnusedDeclaredDependency>
 								<ignoredUnusedDeclaredDependency>org.slf4j:slf4j-api</ignoredUnusedDeclaredDependency>
 								<ignoredUnusedDeclaredDependency>org.slf4j:slf4j-log4j12</ignoredUnusedDeclaredDependency>

--- a/tools/travis_mvn_watchdog.sh
+++ b/tools/travis_mvn_watchdog.sh
@@ -119,25 +119,25 @@ case $TEST in
 	(core)
 		MVN_COMPILE_MODULES="-pl $MODULES_CORE -am"
 		MVN_TEST_MODULES="-pl $MODULES_CORE"
-		MVN_COMPILE_OPTIONS="-Dcheckstyle.skip=true -Djapicmp.skip=true -Drat.skip=true"
+		MVN_COMPILE_OPTIONS="-Dcheckstyle.skip=true -Djapicmp.skip=true -Drat.skip=true -Dmdep.analyze.skip=true"
 		MVN_TEST_OPTIONS="-Dcheckstyle.skip=true"
 	;;
 	(libraries)
 		MVN_COMPILE_MODULES="-pl $MODULES_LIBRARIES -am"
 		MVN_TEST_MODULES="-pl $MODULES_LIBRARIES"
-		MVN_COMPILE_OPTIONS="-Dcheckstyle.skip=true -Djapicmp.skip=true -Drat.skip=true"
+		MVN_COMPILE_OPTIONS="-Dcheckstyle.skip=true -Djapicmp.skip=true -Drat.skip=true -Dmdep.analyze.skip=true"
 		MVN_TEST_OPTIONS="-Dcheckstyle.skip=true"
 	;;
 	(connectors)
 		MVN_COMPILE_MODULES="-pl $MODULES_CONNECTORS -am"
 		MVN_TEST_MODULES="-pl $MODULES_CONNECTORS"
-		MVN_COMPILE_OPTIONS="-Dcheckstyle.skip=true -Djapicmp.skip=true -Drat.skip=true"
+		MVN_COMPILE_OPTIONS="-Dcheckstyle.skip=true -Djapicmp.skip=true -Drat.skip=true -Dmdep.analyze.skip=true"
 		MVN_TEST_OPTIONS="-Dcheckstyle.skip=true"
 	;;
 	(tests)
 		MVN_COMPILE_MODULES="-pl $MODULES_TESTS -am"
 		MVN_TEST_MODULES="-pl $MODULES_TESTS"
-		MVN_COMPILE_OPTIONS="-Dcheckstyle.skip=true -Djapicmp.skip=true -Drat.skip=true"
+		MVN_COMPILE_OPTIONS="-Dcheckstyle.skip=true -Djapicmp.skip=true -Drat.skip=true -Dmdep.analyze.skip=true"
 		MVN_TEST_OPTIONS="-Dcheckstyle.skip=true"
 	;;
 	(misc)


### PR DESCRIPTION
Re-created #4712.

## What is the purpose of the change

This PR changes the `flink-clients` pom to

-  contain unused dependencies
-  contain all used dependencies


## Brief change log

- *Define the `maven-dependency-plugin` plugin version in root POM pluginManagement*
- *Enable `dependency:analyze-only` at root POM plugins*
- *Disable the dependency analysis of flink submodules, except the `flink-clients`*
- *Cleanup`flink-clients` dependencies(used but undeclared / declared but unused)*
- *[travis] Only execute `dependency:analyze-only` in "Misc" profile*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**yes** / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)