### PR TITLE
[FLINK-8022][kafka] Bump at-least-once timeout in tests

### DIFF
--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaProducerTestBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaProducerTestBase.java
@@ -68,6 +68,8 @@ import static org.junit.Assert.fail;
 @SuppressWarnings("serial")
 public abstract class KafkaProducerTestBase extends KafkaTestBase {
 
+	private static final long KAFKA_READ_TIMEOUT = 60_000L;
+
 	/**
 	 * This tests verifies that custom partitioning works correctly, with a default topic
 	 * and dynamic topic. The number of partitions for each topic is deliberately different.
@@ -291,7 +293,7 @@ public abstract class KafkaProducerTestBase extends KafkaTestBase {
 				topic,
 				partition,
 				Collections.unmodifiableSet(new HashSet<>(getIntegersSequence(BrokerRestartingMapper.numElementsBeforeSnapshot))),
-				30000L);
+				KAFKA_READ_TIMEOUT);
 
 		deleteTestTopic(topic);
 	}
@@ -367,7 +369,7 @@ public abstract class KafkaProducerTestBase extends KafkaTestBase {
 			topic,
 			partition,
 			expectedElements,
-			30000L);
+			KAFKA_READ_TIMEOUT);
 
 		deleteTestTopic(topic);
 	}


### PR DESCRIPTION
Increasing timeout for reading the records from 30s to 60s seems to solve the issue
for failing at-least-one tests.

This is a minor fix in tests that intends to increase tests stability.