### PR TITLE
[FLINK-7717][flip6] Migrate TaskManagerMetricsHandler to new RestServerEndpoint

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherRestEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherRestEndpoint.java
@@ -46,6 +46,7 @@ import org.apache.flink.runtime.rest.handler.job.checkpoints.CheckpointStatsCach
 import org.apache.flink.runtime.rest.handler.job.checkpoints.CheckpointingStatisticsHandler;
 import org.apache.flink.runtime.rest.handler.job.checkpoints.TaskCheckpointStatisticDetailsHandler;
 import org.apache.flink.runtime.rest.handler.job.metrics.JobVertexMetricsHandler;
+import org.apache.flink.runtime.rest.handler.job.metrics.TaskManagerMetricsHandler;
 import org.apache.flink.runtime.rest.handler.legacy.ExecutionGraphCache;
 import org.apache.flink.runtime.rest.handler.legacy.files.StaticFileServerHandler;
 import org.apache.flink.runtime.rest.handler.legacy.files.WebContentHandlerSpecification;
@@ -69,6 +70,7 @@ import org.apache.flink.runtime.rest.messages.checkpoints.CheckpointingStatistic
 import org.apache.flink.runtime.rest.messages.checkpoints.TaskCheckpointStatisticsHeaders;
 import org.apache.flink.runtime.rest.messages.job.JobDetailsHeaders;
 import org.apache.flink.runtime.rest.messages.job.metrics.JobVertexMetricsHeaders;
+import org.apache.flink.runtime.rest.messages.job.metrics.TaskManagerMetricsHeaders;
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerDetailsHeaders;
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagersHeaders;
 import org.apache.flink.runtime.webmonitor.WebMonitorUtils;
@@ -315,6 +317,13 @@ public class DispatcherRestEndpoint extends RestServerEndpoint {
 			responseHeaders,
 			metricFetcher);
 
+		final TaskManagerMetricsHandler taskManagerMetricsHandler = new TaskManagerMetricsHandler(
+			restAddressFuture,
+			leaderRetriever,
+			timeout,
+			responseHeaders,
+			metricFetcher);
+
 		final File tmpDir = restConfiguration.getTmpDir();
 
 		Optional<StaticFileServerHandler<DispatcherGateway>> optWebContent;
@@ -351,6 +360,7 @@ public class DispatcherRestEndpoint extends RestServerEndpoint {
 		handlers.add(Tuple2.of(TaskManagerDetailsHeaders.getInstance(), taskManagerDetailsHandler));
 		handlers.add(Tuple2.of(SubtasksTimesHeaders.getInstance(), subtasksTimesHandler));
 		handlers.add(Tuple2.of(JobVertexMetricsHeaders.getInstance(), jobVertexMetricsHandler));
+		handlers.add(Tuple2.of(TaskManagerMetricsHeaders.getInstance(), taskManagerMetricsHandler));
 
 		optWebContent.ifPresent(
 			webContent -> handlers.add(Tuple2.of(WebContentHandlerSpecification.getInstance(), webContent)));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/metrics/TaskManagerMetricsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/metrics/TaskManagerMetricsHandler.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.job.metrics;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.dispatcher.DispatcherGateway;
+import org.apache.flink.runtime.instance.InstanceID;
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.legacy.metrics.MetricFetcher;
+import org.apache.flink.runtime.rest.handler.legacy.metrics.MetricStore;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.job.metrics.TaskManagerMetricsHeaders;
+import org.apache.flink.runtime.rest.messages.job.metrics.TaskManagerMetricsMessageParameters;
+import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerIdPathParameter;
+import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+
+import javax.annotation.Nullable;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Handler that returns TaskManager metrics.
+ *
+ * @see MetricStore#getTaskManagerMetricStore(String)
+ */
+public class TaskManagerMetricsHandler extends AbstractMetricsHandler<TaskManagerMetricsMessageParameters> {
+
+	public TaskManagerMetricsHandler(
+			final CompletableFuture<String> localRestAddress,
+			final GatewayRetriever<DispatcherGateway> leaderRetriever,
+			final Time timeout,
+			final Map<String, String> headers,
+			final MetricFetcher metricFetcher) {
+		super(localRestAddress, leaderRetriever, timeout, headers, TaskManagerMetricsHeaders.getInstance(),
+			metricFetcher);
+	}
+
+	@Nullable
+	@Override
+	protected MetricStore.ComponentMetricStore getComponentMetricStore(
+			final HandlerRequest<EmptyRequestBody, TaskManagerMetricsMessageParameters> request,
+			final MetricStore metricStore) {
+		final InstanceID pathParameter = request.getPathParameter(TaskManagerIdPathParameter.class);
+		return metricStore.getTaskManagerMetricStore(pathParameter.toString());
+	}
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/TaskManagerMetricsHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/TaskManagerMetricsHeaders.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.job.metrics;
+
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerIdPathParameter;
+
+/**
+ * {@link MessageHeaders} for
+ * {@link org.apache.flink.runtime.rest.handler.job.metrics.TaskManagerMetricsHandler}.
+ */
+public final class TaskManagerMetricsHeaders extends
+	AbstractMetricsHeaders<TaskManagerMetricsMessageParameters> {
+
+	private static final TaskManagerMetricsHeaders INSTANCE = new TaskManagerMetricsHeaders();
+
+	private TaskManagerMetricsHeaders() {
+	}
+
+	@Override
+	public TaskManagerMetricsMessageParameters getUnresolvedMessageParameters() {
+		return new TaskManagerMetricsMessageParameters();
+	}
+
+	@Override
+	public String getTargetRestEndpointURL() {
+		return "/taskmanagers/:" + TaskManagerIdPathParameter.KEY + "/metrics";
+	}
+
+	public static TaskManagerMetricsHeaders getInstance() {
+		return INSTANCE;
+	}
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/TaskManagerMetricsMessageParameters.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/TaskManagerMetricsMessageParameters.java
@@ -16,31 +16,26 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.rest.messages.taskmanager;
+package org.apache.flink.runtime.rest.messages.job.metrics;
 
-import org.apache.flink.runtime.instance.InstanceID;
-import org.apache.flink.runtime.rest.messages.ConversionException;
-import org.apache.flink.runtime.rest.messages.MessagePathParameter;
-import org.apache.flink.util.StringUtils;
+import org.apache.flink.runtime.rest.messages.MessageParameters;
+import org.apache.flink.runtime.rest.messages.MessageQueryParameter;
+import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerMessageParameters;
+
+import java.util.Collection;
+import java.util.Collections;
 
 /**
- * TaskManager id path parameter used by TaskManager related handlers.
+ * {@link MessageParameters} for
+ * {@link org.apache.flink.runtime.rest.handler.job.metrics.TaskManagerMetricsHandler}.
  */
-public class TaskManagerIdPathParameter extends MessagePathParameter<InstanceID> {
+public class TaskManagerMetricsMessageParameters extends TaskManagerMessageParameters {
 
-	public static final String KEY = "taskmanagerid";
-
-	public TaskManagerIdPathParameter() {
-		super(KEY);
-	}
+	private final MetricsFilterParameter metricsFilterParameter = new MetricsFilterParameter();
 
 	@Override
-	protected InstanceID convertFromString(String value) throws ConversionException {
-		return new InstanceID(StringUtils.hexStringToByte(value));
+	public Collection<MessageQueryParameter<?>> getQueryParameters() {
+		return Collections.singletonList(metricsFilterParameter);
 	}
 
-	@Override
-	protected String convertToString(InstanceID value) {
-		return StringUtils.byteToHexString(value.getBytes());
-	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/metrics/TaskManagerMetricsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/metrics/TaskManagerMetricsHandlerTest.java
@@ -16,31 +16,40 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.rest.messages.taskmanager;
+package org.apache.flink.runtime.rest.handler.job.metrics;
 
 import org.apache.flink.runtime.instance.InstanceID;
-import org.apache.flink.runtime.rest.messages.ConversionException;
-import org.apache.flink.runtime.rest.messages.MessagePathParameter;
-import org.apache.flink.util.StringUtils;
+import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
+
+import java.util.Collections;
+import java.util.Map;
 
 /**
- * TaskManager id path parameter used by TaskManager related handlers.
+ * Tests for {@link TaskManagerMetricsHandler}.
  */
-public class TaskManagerIdPathParameter extends MessagePathParameter<InstanceID> {
+public class TaskManagerMetricsHandlerTest extends
+	MetricsHandlerTestBase<TaskManagerMetricsHandler> {
 
-	public static final String KEY = "taskmanagerid";
+	private static final String TEST_TASK_MANAGER_ID = new InstanceID().toString();
 
-	public TaskManagerIdPathParameter() {
-		super(KEY);
+	@Override
+	TaskManagerMetricsHandler getMetricsHandler() {
+		return new TaskManagerMetricsHandler(
+			TEST_REST_ADDRESS,
+			leaderRetriever,
+			TIMEOUT,
+			TEST_HEADERS,
+			mockMetricFetcher);
 	}
 
 	@Override
-	protected InstanceID convertFromString(String value) throws ConversionException {
-		return new InstanceID(StringUtils.hexStringToByte(value));
+	QueryScopeInfo getQueryScopeInfo() {
+		return new QueryScopeInfo.TaskManagerQueryScopeInfo(TEST_TASK_MANAGER_ID);
 	}
 
 	@Override
-	protected String convertToString(InstanceID value) {
-		return StringUtils.byteToHexString(value.getBytes());
+	Map<String, String> getPathParameters() {
+		return Collections.singletonMap("taskmanagerid", TEST_TASK_MANAGER_ID);
 	}
+
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/metrics/TaskManagerMetricsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/metrics/TaskManagerMetricsHandlerTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.rest.handler.job.metrics;
 
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
+import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerIdPathParameter;
 
 import java.util.Collections;
 import java.util.Map;
@@ -49,7 +50,7 @@ public class TaskManagerMetricsHandlerTest extends
 
 	@Override
 	Map<String, String> getPathParameters() {
-		return Collections.singletonMap("taskmanagerid", TEST_TASK_MANAGER_ID);
+		return Collections.singletonMap(TaskManagerIdPathParameter.KEY, TEST_TASK_MANAGER_ID);
 	}
 
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/metrics/TaskManagerMetricsHeadersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/metrics/TaskManagerMetricsHeadersTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.job.metrics;
+
+import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerIdPathParameter;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for {@link TaskManagerMetricsHeaders}.
+ */
+public class TaskManagerMetricsHeadersTest {
+
+	private final TaskManagerMetricsHeaders taskManagerMetricsHeaders =
+		TaskManagerMetricsHeaders.getInstance();
+
+	@Test
+	public void testUrl() {
+		assertThat(taskManagerMetricsHeaders.getTargetRestEndpointURL(),
+			equalTo("/taskmanagers/:" + TaskManagerIdPathParameter.KEY + "/metrics"));
+	}
+
+	@Test
+	public void testMessageParameters() {
+		assertThat(taskManagerMetricsHeaders.getUnresolvedMessageParameters(),
+			instanceOf(TaskManagerMetricsMessageParameters.class));
+	}
+
+}


### PR DESCRIPTION
## What is the purpose of the change

*FLIP-6 efforts: Migrating HTTP handlers*

## Brief change log
  - Migrate logic from `org.apache.flink.runtime.rest.handler.legacy.metrics.TaskManagerMetricsHandler to` new handler.
  - Add new handler to `DispatcherRestEndpoint`.

## Verifying this change

  - *Added unit tests for all new classes and modified existing classes except for DispatcherRestEndpoint.*
  - *Manually deployed a job locally and verified with `curl` that TaskManager metrics can be queried in FLIP-6 standalone mode. Note that the task manager ids exposed by the WebUI in FLIP-6 mode are currently broken (https://issues.apache.org/jira/browse/FLINK-8150). I had to obtain valid ids by setting a breakpoint in `ResourceManager`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)

CC: @tillrohrmann 