### PR TITLE
[FLINK-8161] [tests] Harden YARNSessionCapacitySchedulerITCase

### DIFF
--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
@@ -109,13 +109,14 @@ public abstract class YarnTestBase extends TestLogger {
 
 	/** These strings are white-listed, overriding teh prohibited strings. */
 	protected static final String[] WHITELISTED_STRINGS = {
-			"akka.remote.RemoteTransportExceptionNoStackTrace",
-			// workaround for annoying InterruptedException logging:
-			// https://issues.apache.org/jira/browse/YARN-1022
-			"java.lang.InterruptedException",
-			// very specific on purpose
-			"Remote connection to [null] failed with java.net.ConnectException: Connection refused",
-			"java.io.IOException: Connection reset by peer"
+		"akka.remote.RemoteTransportExceptionNoStackTrace",
+		// workaround for annoying InterruptedException logging:
+		// https://issues.apache.org/jira/browse/YARN-1022
+		"java.lang.InterruptedException",
+		// very specific on purpose
+		"Remote connection to [null] failed with java.net.ConnectException: Connection refused",
+		"Remote connection to [null] failed with java.nio.channels.NotYetConnectedException",
+		"java.io.IOException: Connection reset by peer"
 	};
 
 	// Temp directory which is deleted after the unit test.


### PR DESCRIPTION
## What is the purpose of the change

Add "Remote connection to [null] failed with java.nio.channels.NotYetConnectedException"
to the list of whitelisted log statements in YarnTestBase. This logging statement
seems to appear since we moved from Flakka to Akka 2.4.0.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
