### PR TITLE
[FLINK-4812][metrics] Expose currentLowWatermark for all operators

### DIFF
--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -968,12 +968,7 @@ Thus, in order to infer the metric identifier:
   </thead>
   <tbody>
     <tr>
-      <th rowspan="7"><strong>Task</strong></th>
-      <td>currentLowWatermark</td>
-      <td>The lowest watermark this task has received (in milliseconds).</td>
-      <td>Gauge</td>
-    </tr>
-    <tr>
+      <th rowspan="6"><strong>Task</strong></th>
       <td>numBytesInLocal</td>
       <td>The total number of bytes this task has read from a local source.</td>
       <td>Counter</td>
@@ -1030,7 +1025,15 @@ Thus, in order to infer the metric identifier:
       <td>Counter</td>
     </tr>
     <tr>
-      <th rowspan="2"><strong>Operator</strong></th>
+      <th rowspan="3"><strong>Operator</strong></th>
+      <td>currentLowWatermark</td>
+      <td>
+        The lowest watermark this operator has received (in milliseconds).
+        <p><strong>Note:</strong> For sources and watermark assigners this is the lowest watermark this operator has emitted (in milliseconds).</p>
+      </td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
       <td>latency</td>
       <td>The latency distributions from all incoming sources (in milliseconds).</td>
       <td>Histogram</td>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
@@ -39,4 +39,6 @@ public class MetricNames {
 	public static final String IO_NUM_BYTES_IN_LOCAL_RATE = IO_NUM_BYTES_IN_LOCAL + SUFFIX_RATE;
 	public static final String IO_NUM_BYTES_IN_REMOTE_RATE = IO_NUM_BYTES_IN_REMOTE + SUFFIX_RATE;
 	public static final String IO_NUM_BYTES_OUT_RATE = IO_NUM_BYTES_OUT + SUFFIX_RATE;
+
+	public static final String IO_CURRENT_LOW_WATERMARK = "currentLowWatermark";
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileReaderOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileReaderOperator.java
@@ -137,7 +137,8 @@ public class ContinuousFileReaderOperator<OUT> extends AbstractStreamOperator<OU
 			getContainingTask().getStreamStatusMaintainer(),
 			output,
 			watermarkInterval,
-			-1);
+			-1,
+			this.watermarkGauge);
 
 		// and initialize the split reading thread
 		this.reader = new SplitReader<>(format, serializer, readerContext, checkpointLock, restoredReaderState);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSource.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSource.java
@@ -80,7 +80,8 @@ public class StreamSource<OUT, SRC extends SourceFunction<OUT>>
 			streamStatusMaintainer,
 			collector,
 			watermarkInterval,
-			-1);
+			-1,
+			this.watermarkGauge);
 
 		try {
 			userFunction.run(ctx);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperator.java
@@ -230,6 +230,7 @@ public class AsyncWaitOperator<IN, OUT>
 
 	@Override
 	public void processWatermark(Watermark mark) throws Exception {
+		watermarkGauge.setCurrentLowWatermark(mark.getTimestamp());
 		WatermarkQueueEntry watermarkBufferEntry = new WatermarkQueueEntry(mark);
 
 		addAsyncBufferEntry(watermarkBufferEntry);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessor.java
@@ -112,11 +112,6 @@ public class StreamTwoInputProcessor<IN1, IN2> {
 
 	private final TwoInputStreamOperator<IN1, IN2, ?> streamOperator;
 
-	// ---------------- Metrics ------------------
-
-	private long lastEmittedWatermark1;
-	private long lastEmittedWatermark2;
-
 	private Counter numRecordsIn;
 
 	private boolean isFinished;
@@ -181,9 +176,6 @@ public class StreamTwoInputProcessor<IN1, IN2> {
 
 		this.numInputChannels1 = numInputChannels1;
 		this.numInputChannels2 = inputGate.getNumberOfInputChannels() - numInputChannels1;
-
-		this.lastEmittedWatermark1 = Long.MIN_VALUE;
-		this.lastEmittedWatermark2 = Long.MIN_VALUE;
 
 		this.firstStatus = StreamStatus.ACTIVE;
 		this.secondStatus = StreamStatus.ACTIVE;
@@ -307,13 +299,6 @@ public class StreamTwoInputProcessor<IN1, IN2> {
 	 * @param metrics metric group
 	 */
 	public void setMetricGroup(TaskIOMetricGroup metrics) {
-		metrics.gauge("currentLowWatermark", new Gauge<Long>() {
-			@Override
-			public Long getValue() {
-				return Math.min(lastEmittedWatermark1, lastEmittedWatermark2);
-			}
-		});
-
 		metrics.gauge("checkpointAlignmentTime", new Gauge<Long>() {
 			@Override
 			public Long getValue() {
@@ -349,7 +334,6 @@ public class StreamTwoInputProcessor<IN1, IN2> {
 		public void handleWatermark(Watermark watermark) {
 			try {
 				synchronized (lock) {
-					lastEmittedWatermark1 = watermark.getTimestamp();
 					operator.processWatermark1(watermark);
 				}
 			} catch (Exception e) {
@@ -393,7 +377,6 @@ public class StreamTwoInputProcessor<IN1, IN2> {
 		public void handleWatermark(Watermark watermark) {
 			try {
 				synchronized (lock) {
-					lastEmittedWatermark2 = watermark.getTimestamp();
 					operator.processWatermark2(watermark);
 				}
 			} catch (Exception e) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/metrics/WatermarkGauge.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/metrics/WatermarkGauge.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.metrics;
+
+import org.apache.flink.metrics.Gauge;
+
+/**
+ * A {@link Gauge} for exposing the current low watermark.
+ */
+public class WatermarkGauge implements Gauge<Long> {
+
+	private long currentLowWatermark = Long.MIN_VALUE;
+
+	public void setCurrentLowWatermark(long watermark) {
+		this.currentLowWatermark = watermark;
+	}
+
+	@Override
+	public Long getValue() {
+		return currentLowWatermark;
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/TimestampsAndPeriodicWatermarksOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/TimestampsAndPeriodicWatermarksOperator.java
@@ -75,6 +75,7 @@ public class TimestampsAndPeriodicWatermarksOperator<T>
 			currentWatermark = newWatermark.getTimestamp();
 			// emit watermark
 			output.emitWatermark(newWatermark);
+			watermarkGauge.setCurrentLowWatermark(currentWatermark);
 		}
 
 		long now = getProcessingTimeService().getCurrentProcessingTime();
@@ -93,6 +94,7 @@ public class TimestampsAndPeriodicWatermarksOperator<T>
 		if (mark.getTimestamp() == Long.MAX_VALUE && currentWatermark != Long.MAX_VALUE) {
 			currentWatermark = Long.MAX_VALUE;
 			output.emitWatermark(mark);
+			watermarkGauge.setCurrentLowWatermark(currentWatermark);
 		}
 	}
 
@@ -106,6 +108,7 @@ public class TimestampsAndPeriodicWatermarksOperator<T>
 			currentWatermark = newWatermark.getTimestamp();
 			// emit watermark
 			output.emitWatermark(newWatermark);
+			watermarkGauge.setCurrentLowWatermark(currentWatermark);
 		}
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/TimestampsAndPunctuatedWatermarksOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/TimestampsAndPunctuatedWatermarksOperator.java
@@ -55,6 +55,7 @@ public class TimestampsAndPunctuatedWatermarksOperator<T>
 		if (nextWatermark != null && nextWatermark.getTimestamp() > currentWatermark) {
 			currentWatermark = nextWatermark.getTimestamp();
 			output.emitWatermark(nextWatermark);
+			watermarkGauge.setCurrentLowWatermark(currentWatermark);
 		}
 	}
 
@@ -70,6 +71,7 @@ public class TimestampsAndPunctuatedWatermarksOperator<T>
 		if (mark.getTimestamp() == Long.MAX_VALUE && currentWatermark != Long.MAX_VALUE) {
 			currentWatermark = Long.MAX_VALUE;
 			output.emitWatermark(mark);
+			watermarkGauge.setCurrentLowWatermark(currentWatermark);
 		}
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamSourceContextIdleDetectionTests.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamSourceContextIdleDetectionTests.java
@@ -21,6 +21,7 @@ package org.apache.flink.streaming.api.operators;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.metrics.WatermarkGauge;
 import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.streamstatus.StreamStatus;
@@ -88,6 +89,7 @@ public class StreamSourceContextIdleDetectionTests {
 		processingTimeService.setCurrentTime(initialTime);
 
 		final List<StreamElement> output = new ArrayList<>();
+		WatermarkGauge watermarkGauge = new WatermarkGauge();
 
 		MockStreamStatusMaintainer mockStreamStatusMaintainer = new MockStreamStatusMaintainer();
 
@@ -98,7 +100,8 @@ public class StreamSourceContextIdleDetectionTests {
 			mockStreamStatusMaintainer,
 			new CollectorOutput<String>(output),
 			0,
-			idleTimeout);
+			idleTimeout,
+			watermarkGauge);
 
 		// -------------------------- begin test scenario --------------------------
 
@@ -186,7 +189,8 @@ public class StreamSourceContextIdleDetectionTests {
 			mockStreamStatusMaintainer,
 			new CollectorOutput<String>(output),
 			watermarkInterval,
-			idleTimeout);
+			idleTimeout,
+			new WatermarkGauge());
 
 		// -------------------------- begin test scenario --------------------------
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorTest.java
@@ -288,6 +288,8 @@ public class AsyncWaitOperatorTest extends TestLogger {
 		expectedOutput.add(new Watermark(initialTime + 2));
 		expectedOutput.add(new StreamRecord<>(6, initialTime + 3));
 
+		Assert.assertEquals(initialTime + 2, operator.getWatermarkGauge().getValue().longValue());
+
 		if (AsyncDataStream.OutputMode.ORDERED == mode) {
 			TestHarnessUtil.assertOutputEquals("Output with watermark was not correct.", expectedOutput, testHarness.getOutput());
 		}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/metrics/StreamOperatorWatermarkMetricsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/metrics/StreamOperatorWatermarkMetricsTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.metrics;
+
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.streaming.util.TwoInputStreamOperatorTestHarness;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests to verify that {@link AbstractStreamOperator} properly updates the {@link WatermarkGauge}.
+ */
+public class StreamOperatorWatermarkMetricsTest {
+
+	@Test
+	public void testOneInputWatermarkReporting() throws Exception {
+		TestOneInputStreamOperator operator = new TestOneInputStreamOperator();
+		try (OneInputStreamOperatorTestHarness<Integer, Integer> harness = new OneInputStreamOperatorTestHarness<>(operator)) {
+			harness.setup();
+			WatermarkGauge watermarkGauge = operator.getWatermarkGauge();
+
+			Assert.assertEquals(Long.MIN_VALUE, watermarkGauge.getValue().longValue());
+
+			harness.processWatermark(new Watermark(64L));
+			Assert.assertEquals(64L, watermarkGauge.getValue().longValue());
+			harness.processWatermark(new Watermark(128L));
+			Assert.assertEquals(128L, watermarkGauge.getValue().longValue());
+		}
+	}
+
+	@Test
+	public void testTwoInputWatermarkReporting() throws Exception {
+		TestTwoInputStreamOperator operator = new TestTwoInputStreamOperator();
+		try (TwoInputStreamOperatorTestHarness<Integer, Integer, Integer> harness = new TwoInputStreamOperatorTestHarness<>(operator)) {
+			harness.setup();
+			WatermarkGauge watermarkGauge = operator.getWatermarkGauge();
+
+			Assert.assertEquals(Long.MIN_VALUE, watermarkGauge.getValue().longValue());
+
+			harness.processWatermark1(new Watermark(64L));
+			Assert.assertEquals(Long.MIN_VALUE, watermarkGauge.getValue().longValue());
+
+			harness.processWatermark2(new Watermark(128L));
+			Assert.assertEquals(64L, watermarkGauge.getValue().longValue());
+
+			harness.processWatermark1(new Watermark(128L));
+			Assert.assertEquals(128L, watermarkGauge.getValue().longValue());
+
+			harness.processWatermark1(new Watermark(256L));
+			Assert.assertEquals(128L, watermarkGauge.getValue().longValue());
+		}
+	}
+
+	private static class TestOneInputStreamOperator extends AbstractStreamOperator<Integer> implements OneInputStreamOperator<Integer, Integer> {
+
+		@Override
+		public void processElement(StreamRecord<Integer> element) throws Exception {
+			output.collect(element);
+		}
+	}
+
+	private static class TestTwoInputStreamOperator extends AbstractStreamOperator<Integer> implements TwoInputStreamOperator<Integer, Integer, Integer> {
+
+		@Override
+		public void processElement1(StreamRecord<Integer> element) throws Exception {
+			output.collect(element);
+		}
+
+		@Override
+		public void processElement2(StreamRecord<Integer> element) throws Exception {
+			output.collect(element);
+		}
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/metrics/WatermarkGaugeTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/metrics/WatermarkGaugeTest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.metrics;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for the {@link WatermarkGauge}.
+ */
+public class WatermarkGaugeTest {
+
+	@Test
+	public void testSetCurrentLowWatermark() {
+		WatermarkGauge metric = new WatermarkGauge();
+
+		Assert.assertEquals(Long.MIN_VALUE, metric.getValue().longValue());
+
+		metric.setCurrentLowWatermark(64);
+		Assert.assertEquals(64, metric.getValue().longValue());
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/TimestampsAndPeriodicWatermarksOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/TimestampsAndPeriodicWatermarksOperatorTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.streaming.runtime.operators;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
 import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.metrics.WatermarkGauge;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 
@@ -52,9 +53,12 @@ public class TimestampsAndPeriodicWatermarksOperatorTest {
 
 		testHarness.open();
 
+		WatermarkGauge watermarkGauge = operator.getWatermarkGauge();
+
 		testHarness.processElement(new StreamRecord<>(1L, 1));
 		testHarness.processElement(new StreamRecord<>(2L, 1));
 		testHarness.processWatermark(new Watermark(2)); // this watermark should be ignored
+		assertEquals(Long.MIN_VALUE, watermarkGauge.getValue().longValue());
 		testHarness.processElement(new StreamRecord<>(3L, 3));
 		testHarness.processElement(new StreamRecord<>(4L, 3));
 
@@ -80,6 +84,7 @@ public class TimestampsAndPeriodicWatermarksOperatorTest {
 					testHarness.setProcessingTime(currentTime);
 				}
 			}
+			assertEquals(3L, watermarkGauge.getValue().longValue());
 
 			output.clear();
 		}
@@ -118,6 +123,7 @@ public class TimestampsAndPeriodicWatermarksOperatorTest {
 
 		testHarness.processWatermark(new Watermark(Long.MAX_VALUE));
 		assertEquals(Long.MAX_VALUE, ((Watermark) testHarness.getOutput().poll()).getTimestamp());
+		assertEquals(Long.MAX_VALUE, watermarkGauge.getValue().longValue());
 	}
 
 	@Test

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/TimestampsAndPunctuatedWatermarksOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/TimestampsAndPunctuatedWatermarksOperatorTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.streaming.runtime.operators;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.streaming.api.functions.AssignerWithPunctuatedWatermarks;
 import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.metrics.WatermarkGauge;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 
@@ -47,18 +48,31 @@ public class TimestampsAndPunctuatedWatermarksOperatorTest {
 
 		testHarness.open();
 
+		WatermarkGauge watermarkGauge = operator.getWatermarkGauge();
+
 		testHarness.processElement(new StreamRecord<>(new Tuple2<>(3L, true), 0L));
+		assertEquals(3L, watermarkGauge.getValue().longValue());
 		testHarness.processElement(new StreamRecord<>(new Tuple2<>(5L, false), 0L));
+		assertEquals(3L, watermarkGauge.getValue().longValue());
 		testHarness.processElement(new StreamRecord<>(new Tuple2<>(4L, false), 0L));
+		assertEquals(3L, watermarkGauge.getValue().longValue());
 		testHarness.processWatermark(new Watermark(10)); // this watermark should be ignored
+		assertEquals(3L, watermarkGauge.getValue().longValue());
 		testHarness.processElement(new StreamRecord<>(new Tuple2<>(4L, false), 0L));
+		assertEquals(3L, watermarkGauge.getValue().longValue());
 		testHarness.processElement(new StreamRecord<>(new Tuple2<>(4L, true), 0L));
+		assertEquals(4L, watermarkGauge.getValue().longValue());
 		testHarness.processElement(new StreamRecord<>(new Tuple2<>(9L, false), 0L));
+		assertEquals(4L, watermarkGauge.getValue().longValue());
 		testHarness.processElement(new StreamRecord<>(new Tuple2<>(5L, false), 0L));
+		assertEquals(4L, watermarkGauge.getValue().longValue());
 		testHarness.processElement(new StreamRecord<>(new Tuple2<>(7L, true), 0L));
+		assertEquals(7L, watermarkGauge.getValue().longValue());
 		testHarness.processElement(new StreamRecord<>(new Tuple2<>(10L, false), 0L));
+		assertEquals(7L, watermarkGauge.getValue().longValue());
 
 		testHarness.processWatermark(new Watermark(Long.MAX_VALUE));
+		assertEquals(Long.MAX_VALUE, watermarkGauge.getValue().longValue());
 
 		ConcurrentLinkedQueue<Object> output = testHarness.getOutput();
 


### PR DESCRIPTION
## What is the purpose of the change

This PR makes all operators expose the current low watermark through the metric system. As mentioned in the documentation, the currentLowWatermark is the lowest watermark an operator has received, with the exception for sources and watermark assigners for which it is the lowest emitted watermark.

## Brief change log

* remove watermark metric logic from `Stream[Two]InputProcessor`
  * this implies that this metric is no longer measured at the task level at all
* introduce `WatermarkGauge` class to decouple metric from local state of operator classes (i.e. some currentLowWatermark field)
* measure the lowest watermark received by operators in 
  * `AbstractStreamOperator#processWatermark`
  * `AsyncWaitOperator#processWatermark`
* measure the lowest watermark emitted by sources their `SourceContext`
* measure the lowest watermark emitted by `TimestampsAndPeriodicWatermarksOperator` and `TimestampsAndPunctuatedWatermarksOperator`
* update metrics reference in the documentation


## Verifying this change

This change modified the following tests:
* `TimestampsAndPunctuatedWatermarksOperatorTest#testTimestampsAndPeriodicWatermarksOperator`
* `TimestampsAndPeriodicWatermarksOperatorTest#testTimestampsAndPeriodicWatermarksOperator`
* `StreamSourceOperatorTest#testAutomaticWatermarkContext`
* `AsyncWaitOperatorTest#testEventTime`

This change added the following tests:

* `WatermarkGaugeTest`
* `StreamOperatorWatermarkMetricsTest`
* `StreamSourceOperatorTest#testManualWatermarkContextWatermarkMetric`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (**yes**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
