### PR TITLE
[FLINK-8158] [table] Fix rowtime window inner join emits late data bug

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamWindowJoin.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamWindowJoin.scala
@@ -275,7 +275,7 @@ class DataStreamWindowJoin(
           returnTypeInfo,
           new KeyedCoProcessOperatorWithWatermarkDelay[Tuple, CRow, CRow, CRow](
             rowTimeInnerJoinFunc,
-            rowTimeInnerJoinFunc.getMaxOutputDelay)
+            rowTimeInnerJoinFunc.getMaxOutputDelay + 1) // WatermarkDelay = MaxOutputDelay + 1
         )
     } else {
       leftDataStream.connect(rightDataStream)
@@ -285,7 +285,7 @@ class DataStreamWindowJoin(
           returnTypeInfo,
           new KeyedCoProcessOperatorWithWatermarkDelay[java.lang.Byte, CRow, CRow, CRow](
             rowTimeInnerJoinFunc,
-            rowTimeInnerJoinFunc.getMaxOutputDelay)
+            rowTimeInnerJoinFunc.getMaxOutputDelay + 1) // WatermarkDelay = MaxOutputDelay + 1
         )
         .setParallelism(1)
         .setMaxParallelism(1)


### PR DESCRIPTION

## What is the purpose of the change

This pull request fixes rowtime window inner join emits late data bug. When executing the join, the join operator needs to make sure that no late data is emitted. However, the window border is not handled correctly.


## Brief change log

  - Set `WatermarkDelay` to `MaxOutputDelay + 1` instead of `MaxOutputDelay`
  - Add tests in `JoinHarnessTest`


## Verifying this change

This change added tests and can be verified as follows:

  - *Added tests in `JoinHarnessTest` to check if late data is outputted*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
