### PR TITLE
[FLINK-7918] Run AbstractTestBase tests on Flip-6 MiniCluster

### DIFF
--- a/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/RollingSinkITCase.java
+++ b/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/RollingSinkITCase.java
@@ -121,6 +121,8 @@ public class RollingSinkITCase extends TestLogger {
 				new org.apache.flink.configuration.Configuration(),
 				1,
 				4));
+
+		miniClusterResource.before();
 	}
 
 	@AfterClass

--- a/flink-core/src/main/java/org/apache/flink/core/fs/FileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/FileSystem.java
@@ -752,7 +752,7 @@ public abstract class FileSystem {
 						return true;
 					} else {
 						// file may not be overwritten
-						throw new IOException("File or directory already exists. Existing files and directories " +
+						throw new IOException("File or directory " + outPath + " already exists. Existing files and directories " +
 								"are not overwritten in " + WriteMode.NO_OVERWRITE.name() + " mode. Use " +
 								WriteMode.OVERWRITE.name() + " mode to overwrite existing files and directories.");
 					}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/JobExecutorService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/JobExecutorService.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.minicluster;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Interface to control {@link JobExecutor}.
+ */
+public interface JobExecutorService extends JobExecutor {
+
+	/**
+	 * Terminate the given JobExecutorService.
+	 *
+	 * <p>This method can be implemented asynchronously. Therefore it returns a future
+	 * which is completed once the termination has been done.
+	 *
+	 * @return Termination future which can also contain an exception if the termination went wrong
+	 */
+	CompletableFuture<?> terminate();
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.blob.BlobServer;
 import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.clusterframework.FlinkResourceManager;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServicesUtils;
@@ -58,7 +59,7 @@ import static org.apache.flink.util.ExceptionUtils.firstOrSuppressed;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
 
-public class MiniCluster implements JobExecutor {
+public class MiniCluster implements JobExecutorService {
 
 	private static final Logger LOG = LoggerFactory.getLogger(MiniCluster.class);
 
@@ -458,6 +459,10 @@ public class MiniCluster implements JobExecutor {
 			dispatcher = this.jobDispatcher;
 		}
 
+		// we have to allow queued scheduling in Flip-6 mode because we need to request slots
+		// from the ResourceManager
+		job.setAllowQueuedScheduling(true);
+
 		return dispatcher.runJobBlocking(job);
 	}
 
@@ -591,6 +596,16 @@ public class MiniCluster implements JobExecutor {
 			}
 		}
 		return priorException;
+	}
+
+	@Override
+	public CompletableFuture<?> terminate() {
+		try {
+			shutdown();
+			return CompletableFuture.completedFuture(null);
+		} catch (Exception e) {
+			return FutureUtils.completedExceptionally(e);
+		}
 	}
 
 	private class TerminatingFatalErrorHandler implements FatalErrorHandler {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/registration/RegisteredRpcConnection.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/registration/RegisteredRpcConnection.java
@@ -27,6 +27,7 @@ import java.io.Serializable;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
@@ -46,6 +47,11 @@ import static org.apache.flink.util.Preconditions.checkState;
  */
 public abstract class RegisteredRpcConnection<F extends Serializable, G extends RpcGateway, S extends RegistrationResponse.Success> {
 
+	private static final AtomicReferenceFieldUpdater<RegisteredRpcConnection, RetryingRegistration> REGISTRATION_UPDATER = AtomicReferenceFieldUpdater.newUpdater(
+		RegisteredRpcConnection.class,
+		RetryingRegistration.class,
+		"pendingRegistration");
+
 	/** The logger for all log messages of this class. */
 	protected final Logger log;
 
@@ -59,7 +65,7 @@ public abstract class RegisteredRpcConnection<F extends Serializable, G extends 
 	private final Executor executor;
 
 	/** The Registration of this RPC connection. */
-	private RetryingRegistration<F, G, S> pendingRegistration;
+	private volatile RetryingRegistration<F, G, S> pendingRegistration;
 
 	/** The gateway to register, it's null until the registration is completed. */
 	private volatile G targetGateway;
@@ -85,27 +91,47 @@ public abstract class RegisteredRpcConnection<F extends Serializable, G extends 
 		checkState(!closed, "The RPC connection is already closed");
 		checkState(!isConnected() && pendingRegistration == null, "The RPC connection is already started");
 
-		pendingRegistration = checkNotNull(generateRegistration());
-		pendingRegistration.startRegistration();
+		final RetryingRegistration<F, G, S> newRegistration = createNewRegistration();
 
-		CompletableFuture<Tuple2<G, S>> future = pendingRegistration.getFuture();
+		if (REGISTRATION_UPDATER.compareAndSet(this, null, newRegistration)) {
+			newRegistration.startRegistration();
+		} else {
+			// concurrent start operation
+			newRegistration.cancel();
+		}
+	}
 
-		future.whenCompleteAsync(
-			(Tuple2<G, S> result, Throwable failure) -> {
-				if (failure != null) {
-					if (failure instanceof CancellationException) {
-						// we ignore cancellation exceptions because they originate from cancelling
-						// the RetryingRegistration
-						log.debug("Retrying registration towards {} was cancelled.", targetAddress);
-					} else {
-						// this future should only ever fail if there is a bug, not if the registration is declined
-						onRegistrationFailure(failure);
-					}
-				} else {
-					targetGateway = result.f0;
-					onRegistrationSuccess(result.f1);
-				}
-			}, executor);
+	public boolean tryReconnect() {
+		checkState(isConnected(), "Cannot reconnect to an unknown destination.");
+
+		if (closed) {
+			return false;
+		} else {
+			final RetryingRegistration<F, G, S> currentPendingRegistration = pendingRegistration;
+
+			if (currentPendingRegistration != null) {
+				currentPendingRegistration.cancel();
+			}
+
+			final RetryingRegistration<F, G, S> newRegistration = createNewRegistration();
+
+			if (REGISTRATION_UPDATER.compareAndSet(this, currentPendingRegistration, newRegistration)) {
+				newRegistration.startRegistration();
+			} else {
+				// concurrent modification
+				newRegistration.cancel();
+				return false;
+			}
+
+			// double check for concurrent close operations
+			if (closed) {
+				newRegistration.cancel();
+
+				return false;
+			} else {
+				return true;
+			}
+		}
 	}
 
 	/**
@@ -175,13 +201,42 @@ public abstract class RegisteredRpcConnection<F extends Serializable, G extends 
 		}
 
 		if (isClosed()) {
-			connectionInfo = connectionInfo + " is closed";
+			connectionInfo += " is closed";
 		} else if (isConnected()){
-			connectionInfo = connectionInfo + " is established";
+			connectionInfo += " is established";
 		} else {
-			connectionInfo = connectionInfo + " is connecting";
+			connectionInfo += " is connecting";
 		}
 
 		return connectionInfo;
+	}
+
+	// ------------------------------------------------------------------------
+	//  Internal methods
+	// ------------------------------------------------------------------------
+
+	private RetryingRegistration<F, G, S> createNewRegistration() {
+		RetryingRegistration<F, G, S> newRegistration = checkNotNull(generateRegistration());
+
+		CompletableFuture<Tuple2<G, S>> future = newRegistration.getFuture();
+
+		future.whenCompleteAsync(
+			(Tuple2<G, S> result, Throwable failure) -> {
+				if (failure != null) {
+					if (failure instanceof CancellationException) {
+						// we ignore cancellation exceptions because they originate from cancelling
+						// the RetryingRegistration
+						log.debug("Retrying registration towards {} was cancelled.", targetAddress);
+					} else {
+						// this future should only ever fail if there is a bug, not if the registration is declined
+						onRegistrationFailure(failure);
+					}
+				} else {
+					targetGateway = result.f0;
+					onRegistrationSuccess(result.f1);
+				}
+			}, executor);
+
+		return newRegistration;
 	}
 }

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/AbstractTestBase.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/AbstractTestBase.java
@@ -19,9 +19,11 @@
 package org.apache.flink.test.util;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.testutils.category.OldAndFlip6;
 import org.apache.flink.util.FileUtils;
 
 import org.junit.ClassRule;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
@@ -54,6 +56,7 @@ import java.io.IOException;
  *
  * </pre>
  */
+@Category(OldAndFlip6.class)
 public abstract class AbstractTestBase extends TestBaseUtils {
 
 	private static final int DEFAULT_PARALLELISM = 4;

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/JavaProgramTestBase.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/JavaProgramTestBase.java
@@ -210,7 +210,7 @@ public abstract class JavaProgramTestBase extends AbstractTestBase {
 			e.printStackTrace();
 			Assert.fail("Error while calling the test program: " + e.getMessage());
 		} finally {
-			CollectionTestEnvironment.unsetAsContext();
+			miniClusterResource.getTestEnvironment().setAsContext();
 		}
 
 		Assert.assertNotNull("The test program never triggered an execution.", this.latestExecutionResult);

--- a/flink-tests/src/test/java/org/apache/flink/test/example/java/PageRankITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/example/java/PageRankITCase.java
@@ -33,6 +33,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.io.File;
+import java.util.UUID;
 
 /**
  * Test for {@link PageRank}.
@@ -54,7 +55,10 @@ public class PageRankITCase extends MultipleProgramsTestBase {
 
 	@Before
 	public void before() throws Exception{
-		resultPath = tempFolder.newFile().toURI().toString();
+		final File folder = tempFolder.newFolder();
+		final File resultFile = new File(folder, UUID.randomUUID().toString());
+		resultPath = resultFile.toURI().toString();
+
 		File verticesFile = tempFolder.newFile();
 		FileUtils.writeFileUtf8(verticesFile, PageRankData.VERTICES);
 

--- a/flink-tests/src/test/java/org/apache/flink/test/iterative/aggregators/AggregatorsITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/iterative/aggregators/AggregatorsITCase.java
@@ -49,6 +49,7 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.util.Random;
+import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
 
@@ -78,9 +79,10 @@ public class AggregatorsITCase extends MultipleProgramsTestBase {
 
 	@Before
 	public void before() throws Exception{
-		File tempFile = tempFolder.newFile();
-		testPath = tempFile.toString();
-		resultPath = tempFile.toURI().toString();
+		final File folder = tempFolder.newFolder();
+		final File resultFile = new File(folder, UUID.randomUUID().toString());
+		testPath = resultFile.toString();
+		resultPath = resultFile.toURI().toString();
 	}
 
 	@After

--- a/flink-tests/src/test/java/org/apache/flink/test/operators/DataSinkITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/operators/DataSinkITCase.java
@@ -35,7 +35,9 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.util.Random;
+import java.util.UUID;
 
 import static org.junit.Assert.assertTrue;
 
@@ -57,7 +59,9 @@ public class DataSinkITCase extends MultipleProgramsTestBase {
 
 	@Before
 	public void before() throws Exception{
-		resultPath = tempFolder.newFile().toURI().toString();
+		final File folder = tempFolder.newFolder();
+		final File resultFile = new File(folder, UUID.randomUUID().toString());
+		resultPath = resultFile.toURI().toString();
 	}
 
 	@Test

--- a/flink-tests/src/test/java/org/apache/flink/test/operators/TypeHintITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/operators/TypeHintITCase.java
@@ -32,227 +32,196 @@ import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.api.java.typeutils.TupleTypeInfo;
 import org.apache.flink.test.operators.util.CollectionDataSets;
-import org.apache.flink.test.util.JavaProgramTestBase;
+import org.apache.flink.test.util.AbstractTestBase;
 import org.apache.flink.util.Collector;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.Test;
 
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
  * Integration tests for {@link org.apache.flink.api.common.typeinfo.TypeHint}.
  */
-@RunWith(Parameterized.class)
-public class TypeHintITCase extends JavaProgramTestBase {
+public class TypeHintITCase extends AbstractTestBase {
 
-	private static final int NUM_PROGRAMS = 9;
+	@Test
+	public void testIdentityMapWithMissingTypesAndStringTypeHint() throws Exception {
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		env.getConfig().disableSysoutLogging();
 
-	private final int curProgId;
+		DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.getSmall3TupleDataSet(env);
+		DataSet<Tuple3<Integer, Long, String>> identityMapDs = ds
+			.map(new Mapper<Tuple3<Integer, Long, String>, Tuple3<Integer, Long, String>>())
+			.returns("Tuple3<Integer, Long, String>");
+		List<Tuple3<Integer, Long, String>> result = identityMapDs.collect();
 
-	public TypeHintITCase(int curProgId) {
-		this.curProgId = curProgId;
+		String expectedResult = "(2,2,Hello)\n" +
+			"(3,2,Hello world)\n" +
+			"(1,1,Hi)\n";
+
+		compareResultAsText(result, expectedResult);
 	}
 
-	@Override
-	protected void testProgram() throws Exception {
-		TypeHintProgs.runProgram(curProgId);
+	@Test
+	public void testIdentityMapWithMissingTypesAndTypeInformationTypeHint() throws Exception {
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		env.getConfig().disableSysoutLogging();
+
+		DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.getSmall3TupleDataSet(env);
+		DataSet<Tuple3<Integer, Long, String>> identityMapDs = ds
+			// all following generics get erased during compilation
+			.map(new Mapper<Tuple3<Integer, Long, String>, Tuple3<Integer, Long, String>>())
+			.returns(new TupleTypeInfo<Tuple3<Integer, Long, String>>(BasicTypeInfo.INT_TYPE_INFO, BasicTypeInfo.LONG_TYPE_INFO, BasicTypeInfo.STRING_TYPE_INFO));
+		List<Tuple3<Integer, Long, String>> result = identityMapDs
+			.collect();
+
+		String expectedResult = "(2,2,Hello)\n" +
+			"(3,2,Hello world)\n" +
+			"(1,1,Hi)\n";
+
+		compareResultAsText(result, expectedResult);
 	}
 
-	@Parameters
-	public static Collection<Object[]> getConfigurations() {
+	@Test
+	public void testFlatMapWithClassTypeHint() throws Exception {
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		env.getConfig().disableSysoutLogging();
 
-		Collection<Object[]> parameters = new ArrayList<>(NUM_PROGRAMS);
+		DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.getSmall3TupleDataSet(env);
+		DataSet<Integer> identityMapDs = ds
+			.flatMap(new FlatMapper<Tuple3<Integer, Long, String>, Integer>())
+			.returns(Integer.class);
+		List<Integer> result = identityMapDs.collect();
 
-		for (int i = 1; i <= NUM_PROGRAMS; i++) {
-			parameters.add(new Object[]{i});
-		}
+		String expectedResult = "2\n" +
+			"3\n" +
+			"1\n";
 
-		return parameters;
+		compareResultAsText(result, expectedResult);
 	}
 
-	private static class TypeHintProgs {
+	@Test
+	public void testJoinWithTypeInformationTypeHint() throws Exception {
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		env.getConfig().disableSysoutLogging();
 
-		public static void runProgram(int progId) throws Exception {
-			switch(progId) {
-			// Test identity map with missing types and string type hint
-			case 1: {
-				final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple3<Integer, Long, String>> ds1 = CollectionDataSets.getSmall3TupleDataSet(env);
+		DataSet<Tuple3<Integer, Long, String>> ds2 = CollectionDataSets.getSmall3TupleDataSet(env);
+		DataSet<Integer> resultDs = ds1
+			.join(ds2)
+			.where(0)
+			.equalTo(0)
+			.with(new Joiner<Tuple3<Integer, Long, String>, Tuple3<Integer, Long, String>, Integer>())
+			.returns(BasicTypeInfo.INT_TYPE_INFO);
+		List<Integer> result = resultDs.collect();
 
-				DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.getSmall3TupleDataSet(env);
-				DataSet<Tuple3<Integer, Long, String>> identityMapDs = ds
-						.map(new Mapper<Tuple3<Integer, Long, String>, Tuple3<Integer, Long, String>>())
-						.returns("Tuple3<Integer, Long, String>");
-				List<Tuple3<Integer, Long, String>> result = identityMapDs.collect();
+		String expectedResult = "2\n" +
+			"3\n" +
+			"1\n";
 
-				String expectedResult = "(2,2,Hello)\n" +
-						"(3,2,Hello world)\n" +
-						"(1,1,Hi)\n";
+		compareResultAsText(result, expectedResult);
+	}
 
-				compareResultAsText(result, expectedResult);
-				break;
-			}
-			// Test identity map with missing types and type information type hint
-			case 2: {
-				final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+	@Test
+	public void testFlatJoinWithTypeInformationTypeHint() throws Exception {
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		env.getConfig().disableSysoutLogging();
 
-				DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.getSmall3TupleDataSet(env);
-				DataSet<Tuple3<Integer, Long, String>> identityMapDs = ds
-						// all following generics get erased during compilation
-						.map(new Mapper<Tuple3<Integer, Long, String>, Tuple3<Integer, Long, String>>())
-						.returns(new TupleTypeInfo<Tuple3<Integer, Long, String>>(BasicTypeInfo.INT_TYPE_INFO, BasicTypeInfo.LONG_TYPE_INFO, BasicTypeInfo.STRING_TYPE_INFO));
-				List<Tuple3<Integer, Long, String>> result = identityMapDs
-						.collect();
+		DataSet<Tuple3<Integer, Long, String>> ds1 = CollectionDataSets.getSmall3TupleDataSet(env);
+		DataSet<Tuple3<Integer, Long, String>> ds2 = CollectionDataSets.getSmall3TupleDataSet(env);
+		DataSet<Integer> resultDs = ds1
+			.join(ds2)
+			.where(0)
+			.equalTo(0)
+			.with(new FlatJoiner<Tuple3<Integer, Long, String>, Tuple3<Integer, Long, String>, Integer>())
+			.returns(BasicTypeInfo.INT_TYPE_INFO);
+		List<Integer> result = resultDs.collect();
 
-				String expectedResult = "(2,2,Hello)\n" +
-						"(3,2,Hello world)\n" +
-						"(1,1,Hi)\n";
+		String expectedResult = "2\n" +
+			"3\n" +
+			"1\n";
 
-				compareResultAsText(result, expectedResult);
-				break;
-			}
-			// Test flat map with class type hint
-			case 3: {
-				final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		compareResultAsText(result, expectedResult);
+	}
 
-				DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.getSmall3TupleDataSet(env);
-				DataSet<Integer> identityMapDs = ds
-						.flatMap(new FlatMapper<Tuple3<Integer, Long, String>, Integer>())
-						.returns(Integer.class);
-				List<Integer> result = identityMapDs.collect();
+	@Test
+	public void testUnsortedGroupReduceWithTypeInformationTypeHint() throws Exception {
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		env.getConfig().disableSysoutLogging();
 
-				String expectedResult = "2\n" +
-						"3\n" +
-						"1\n";
+		DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.getSmall3TupleDataSet(env);
+		DataSet<Integer> resultDs = ds
+			.groupBy(0)
+			.reduceGroup(new GroupReducer<Tuple3<Integer, Long, String>, Integer>())
+			.returns(BasicTypeInfo.INT_TYPE_INFO);
+		List<Integer> result = resultDs.collect();
 
-				compareResultAsText(result, expectedResult);
-				break;
-			}
-			// Test join with type information type hint
-			case 4: {
-				final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		String expectedResult = "2\n" +
+			"3\n" +
+			"1\n";
 
-				DataSet<Tuple3<Integer, Long, String>> ds1 = CollectionDataSets.getSmall3TupleDataSet(env);
-				DataSet<Tuple3<Integer, Long, String>> ds2 = CollectionDataSets.getSmall3TupleDataSet(env);
-				DataSet<Integer> resultDs = ds1
-						.join(ds2)
-						.where(0)
-						.equalTo(0)
-						.with(new Joiner<Tuple3<Integer, Long, String>, Tuple3<Integer, Long, String>, Integer>())
-						.returns(BasicTypeInfo.INT_TYPE_INFO);
-				List<Integer> result = resultDs.collect();
+		compareResultAsText(result, expectedResult);
+	}
 
-				String expectedResult = "2\n" +
-						"3\n" +
-						"1\n";
+	@Test
+	public void testSortedGroupReduceWithTypeInformationTypeHint() throws Exception {
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		env.getConfig().disableSysoutLogging();
 
-				compareResultAsText(result, expectedResult);
-				break;
-			}
-			// Test flat join with type information type hint
-			case 5: {
-				final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.getSmall3TupleDataSet(env);
+		DataSet<Integer> resultDs = ds
+			.groupBy(0)
+			.sortGroup(0, Order.ASCENDING)
+			.reduceGroup(new GroupReducer<Tuple3<Integer, Long, String>, Integer>())
+			.returns(BasicTypeInfo.INT_TYPE_INFO);
+		List<Integer> result = resultDs.collect();
 
-				DataSet<Tuple3<Integer, Long, String>> ds1 = CollectionDataSets.getSmall3TupleDataSet(env);
-				DataSet<Tuple3<Integer, Long, String>> ds2 = CollectionDataSets.getSmall3TupleDataSet(env);
-				DataSet<Integer> resultDs = ds1
-						.join(ds2)
-						.where(0)
-						.equalTo(0)
-						.with(new FlatJoiner<Tuple3<Integer, Long, String>, Tuple3<Integer, Long, String>, Integer>())
-						.returns(BasicTypeInfo.INT_TYPE_INFO);
-				List<Integer> result = resultDs.collect();
+		String expectedResult = "2\n" +
+			"3\n" +
+			"1\n";
 
-				String expectedResult = "2\n" +
-						"3\n" +
-						"1\n";
+		compareResultAsText(result, expectedResult);
+	}
 
-				compareResultAsText(result, expectedResult);
-				break;
-			}
-			// Test unsorted group reduce with type information type hint
-			case 6: {
-				final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+	@Test
+	public void testCombineGroupWithTypeInformationTypeHint() throws Exception {
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		env.getConfig().disableSysoutLogging();
 
-				DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.getSmall3TupleDataSet(env);
-				DataSet<Integer> resultDs = ds
-						.groupBy(0)
-						.reduceGroup(new GroupReducer<Tuple3<Integer, Long, String>, Integer>())
-						.returns(BasicTypeInfo.INT_TYPE_INFO);
-				List<Integer> result = resultDs.collect();
+		DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.getSmall3TupleDataSet(env);
+		DataSet<Integer> resultDs = ds
+			.groupBy(0)
+			.combineGroup(new GroupCombiner<Tuple3<Integer, Long, String>, Integer>())
+			.returns(BasicTypeInfo.INT_TYPE_INFO);
+		List<Integer> result = resultDs.collect();
 
-				String expectedResult = "2\n" +
-						"3\n" +
-						"1\n";
+		String expectedResult = "2\n" +
+			"3\n" +
+			"1\n";
 
-				compareResultAsText(result, expectedResult);
-				break;
-			}
-			// Test sorted group reduce with type information type hint
-			case 7: {
-				final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		compareResultAsText(result, expectedResult);
+	}
 
-				DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.getSmall3TupleDataSet(env);
-				DataSet<Integer> resultDs = ds
-						.groupBy(0)
-						.sortGroup(0, Order.ASCENDING)
-						.reduceGroup(new GroupReducer<Tuple3<Integer, Long, String>, Integer>())
-						.returns(BasicTypeInfo.INT_TYPE_INFO);
-				List<Integer> result = resultDs.collect();
+	@Test
+	public void testCoGroupWithTypeInformationTypeHint() throws Exception {
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		env.getConfig().disableSysoutLogging();
 
-				String expectedResult = "2\n" +
-						"3\n" +
-						"1\n";
+		DataSet<Tuple3<Integer, Long, String>> ds1 = CollectionDataSets.getSmall3TupleDataSet(env);
+		DataSet<Tuple3<Integer, Long, String>> ds2 = CollectionDataSets.getSmall3TupleDataSet(env);
+		DataSet<Integer> resultDs = ds1
+			.coGroup(ds2)
+			.where(0)
+			.equalTo(0)
+			.with(new CoGrouper<Tuple3<Integer, Long, String>, Tuple3<Integer, Long, String>, Integer>())
+			.returns(BasicTypeInfo.INT_TYPE_INFO);
+		List<Integer> result = resultDs.collect();
 
-				compareResultAsText(result, expectedResult);
-				break;
-			}
-			// Test combine group with type information type hint
-			case 8: {
-				final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		String expectedResult = "2\n" +
+			"3\n" +
+			"1\n";
 
-				DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.getSmall3TupleDataSet(env);
-				DataSet<Integer> resultDs = ds
-						.groupBy(0)
-						.combineGroup(new GroupCombiner<Tuple3<Integer, Long, String>, Integer>())
-						.returns(BasicTypeInfo.INT_TYPE_INFO);
-				List<Integer> result = resultDs.collect();
-
-				String expectedResult = "2\n" +
-						"3\n" +
-						"1\n";
-
-				compareResultAsText(result, expectedResult);
-				break;
-			}
-			// Test cogroup with type information type hint
-			case 9: {
-				final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-
-				DataSet<Tuple3<Integer, Long, String>> ds1 = CollectionDataSets.getSmall3TupleDataSet(env);
-				DataSet<Tuple3<Integer, Long, String>> ds2 = CollectionDataSets.getSmall3TupleDataSet(env);
-				DataSet<Integer> resultDs = ds1
-						.coGroup(ds2)
-						.where(0)
-						.equalTo(0)
-						.with(new CoGrouper<Tuple3<Integer, Long, String>, Tuple3<Integer, Long, String>, Integer>())
-						.returns(BasicTypeInfo.INT_TYPE_INFO);
-				List<Integer> result = resultDs.collect();
-
-				String expectedResult = "2\n" +
-						"3\n" +
-						"1\n";
-
-				compareResultAsText(result, expectedResult);
-				break;
-			}
-			default:
-				throw new IllegalArgumentException("Invalid program id");
-			}
-		}
+		compareResultAsText(result, expectedResult);
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,7 @@ under the License.
 		<!-- run all groups except flip6 by default -->
 		<test.groups></test.groups>
 		<test.excludedGroups>org.apache.flink.testutils.category.Flip6</test.excludedGroups>
+		<codebase>old</codebase>
 		<!--
 			Keeping the MiniKDC version fixed instead of taking hadoop version dependency
 			to support testing Kafka, ZK etc., modules that does not have Hadoop dependency
@@ -604,6 +605,7 @@ under the License.
 				<test.groups>org.apache.flink.testutils.category.Flip6, org.apache.flink.testutils.category.OldAndFlip6</test.groups>
 				<!-- clear the excluded groups list -->
 				<test.excludedGroups></test.excludedGroups>
+				<codebase>flip6</codebase>
 			</properties>
 		</profile>
 
@@ -1131,6 +1133,7 @@ under the License.
 					<systemPropertyVariables>
 						<forkNumber>0${surefire.forkNumber}</forkNumber>
 						<log4j.configuration>${log4j.configuration}</log4j.configuration>
+						<codebase>${codebase}</codebase>
 					</systemPropertyVariables>
 					<argLine>-Xms256m -Xmx2048m -Dmvn.forkNumber=${surefire.forkNumber} -XX:+UseG1GC</argLine>
 				</configuration>


### PR DESCRIPTION
## What is the purpose of the change

Extend `MiniClusterResource` to instantiate a Flip-6 `MiniCluster` if the system property `codebase` has been set to `flip6`. This allows to run all tests which are based on `AbstractTestBase` on the `Flip-6` code base.

This PR is based on #4896.

## Brief change log

- Use system property `codebase` to distinguish between Flip-6 and old code base
- Instantiate respective `MiniCluster` in `MiniClusterResource` depending on the system property

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
