### PR TITLE
[FLINK-6909] [FLINK-7450] [types] Improve the handling of POJOs and clean-up type extraction

### DIFF
--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -101,7 +101,7 @@ under the License.
 			<scope>test</scope>
 		</dependency>
 
-		<!-- Joda and jackson are used to test that serialization and type extraction
+		<!-- Joda, jackson, and lombok are used to test that serialization and type extraction
 			work with types from those libraries -->
 
 		<dependency>
@@ -119,6 +119,13 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-shaded-jackson</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<version>1.16.18</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeInfoParser.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeInfoParser.java
@@ -293,7 +293,7 @@ public class TypeInfoParser {
 					String fieldName = fieldMatcher.group(1);
 					sb.delete(0, fieldName.length() + 1);
 
-					Field field = TypeExtractor.getDeclaredField(clazz, fieldName);
+					Field field = TypeExtractionUtils.getDeclaredField(clazz, fieldName);
 					if (field == null) {
 						throw new IllegalArgumentException("Field '" + fieldName + "'could not be accessed.");
 					}

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/PojoTypeExtractionTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/PojoTypeExtractionTest.java
@@ -18,13 +18,6 @@
 
 package org.apache.flink.api.java.typeutils;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.typeinfo.BasicArrayTypeInfo;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
@@ -35,8 +28,23 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.api.java.typeutils.TypeInfoParserTest.MyValue;
 
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  *  Pojo Type tests
@@ -55,7 +63,7 @@ public class PojoTypeExtractionTest {
 	@Test
 	public void testDuplicateFieldException() {
 		TypeInformation<?> ti = TypeExtractor.createTypeInfo(HasDuplicateField.class);
-		Assert.assertTrue(ti instanceof GenericTypeInfo<?>);
+		assertTrue(ti instanceof GenericTypeInfo<?>);
 	}
 
 	// test with correct pojo types
@@ -163,7 +171,7 @@ public class PojoTypeExtractionTest {
 	public void testPojoWithGenericFields() {
 		TypeInformation<?> typeForClass = TypeExtractor.createTypeInfo(PojoWithGenericFields.class);
 
-		Assert.assertTrue(typeForClass instanceof PojoTypeInfo<?>);
+		assertTrue(typeForClass instanceof PojoTypeInfo<?>);
 	}
 
 
@@ -183,19 +191,19 @@ public class PojoTypeExtractionTest {
 	@Test
 	public void testIncorrectPojos() {
 		TypeInformation<?> typeForClass = TypeExtractor.createTypeInfo(IncorrectPojo.class);
-		Assert.assertTrue(typeForClass instanceof GenericTypeInfo<?>);
+		assertTrue(typeForClass instanceof GenericTypeInfo<?>);
 
 		typeForClass = TypeExtractor.createTypeInfo(WrongCtorPojo.class);
-		Assert.assertTrue(typeForClass instanceof GenericTypeInfo<?>);
+		assertTrue(typeForClass instanceof GenericTypeInfo<?>);
 	}
 
 	@Test
 	public void testCorrectPojos() {
 		TypeInformation<?> typeForClass = TypeExtractor.createTypeInfo(BeanStylePojo.class);
-		Assert.assertTrue(typeForClass instanceof PojoTypeInfo<?>);
+		assertTrue(typeForClass instanceof PojoTypeInfo<?>);
 
 		typeForClass = TypeExtractor.createTypeInfo(TypedPojoGetterSetterCheck.class);
-		Assert.assertTrue(typeForClass instanceof PojoTypeInfo<?>);
+		assertTrue(typeForClass instanceof PojoTypeInfo<?>);
 	}
 
 	@Test
@@ -213,11 +221,11 @@ public class PojoTypeExtractionTest {
 	private void checkWCPojoAsserts(TypeInformation<?> typeInfo) {
 		Assert.assertFalse(typeInfo.isBasicType());
 		Assert.assertFalse(typeInfo.isTupleType());
-		Assert.assertEquals(10, typeInfo.getTotalFields());
-		Assert.assertTrue(typeInfo instanceof PojoTypeInfo);
+		assertEquals(10, typeInfo.getTotalFields());
+		assertTrue(typeInfo instanceof PojoTypeInfo);
 		PojoTypeInfo<?> pojoType = (PojoTypeInfo<?>) typeInfo;
 
-		List<FlatFieldDescriptor> ffd = new ArrayList<FlatFieldDescriptor>();
+		List<FlatFieldDescriptor> ffd = new ArrayList<>();
 		String[] fields = {"count",
 				"complex.date",
 				"complex.collection",
@@ -238,96 +246,96 @@ public class PojoTypeExtractionTest {
 				6,
 				7,
 				8};
-		Assert.assertEquals(fields.length, positions.length);
+		assertEquals(fields.length, positions.length);
 		for(int i = 0; i < fields.length; i++) {
 			pojoType.getFlatFields(fields[i], 0, ffd);
-			Assert.assertEquals("Too many keys returned", 1, ffd.size());
-			Assert.assertEquals("position of field "+fields[i]+" wrong", positions[i], ffd.get(0).getPosition());
+			assertEquals("Too many keys returned", 1, ffd.size());
+			assertEquals("position of field "+fields[i]+" wrong", positions[i], ffd.get(0).getPosition());
 			ffd.clear();
 		}
 
 		pojoType.getFlatFields("complex.word.*", 0, ffd);
-		Assert.assertEquals(3, ffd.size());
+		assertEquals(3, ffd.size());
 		// check if it returns 5,6,7
 		for(FlatFieldDescriptor ffdE : ffd) {
 			final int pos = ffdE.getPosition();
-			Assert.assertTrue(pos <= 8 );
-			Assert.assertTrue(6 <= pos );
+			assertTrue(pos <= 8 );
+			assertTrue(6 <= pos );
 			if(pos == 6) {
-				Assert.assertEquals(Long.class, ffdE.getType().getTypeClass());
+				assertEquals(Long.class, ffdE.getType().getTypeClass());
 			}
 			if(pos == 7) {
-				Assert.assertEquals(Long.class, ffdE.getType().getTypeClass());
+				assertEquals(Long.class, ffdE.getType().getTypeClass());
 			}
 			if(pos == 8) {
-				Assert.assertEquals(String.class, ffdE.getType().getTypeClass());
+				assertEquals(String.class, ffdE.getType().getTypeClass());
 			}
 		}
 		ffd.clear();
 
 		// scala style full tuple selection for pojos
 		pojoType.getFlatFields("complex.word._", 0, ffd);
-		Assert.assertEquals(3, ffd.size());
+		assertEquals(3, ffd.size());
 		ffd.clear();
 
 		pojoType.getFlatFields("complex.*", 0, ffd);
-		Assert.assertEquals(9, ffd.size());
+		assertEquals(9, ffd.size());
 		// check if it returns 0-7
 		for(FlatFieldDescriptor ffdE : ffd) {
 			final int pos = ffdE.getPosition();
-			Assert.assertTrue(ffdE.getPosition() <= 8 );
-			Assert.assertTrue(0 <= ffdE.getPosition() );
+			assertTrue(ffdE.getPosition() <= 8 );
+			assertTrue(0 <= ffdE.getPosition() );
 
 			if(pos == 0) {
-				Assert.assertEquals(List.class, ffdE.getType().getTypeClass());
+				assertEquals(List.class, ffdE.getType().getTypeClass());
 			}
 			if(pos == 1) {
-				Assert.assertEquals(Date.class, ffdE.getType().getTypeClass());
+				assertEquals(Date.class, ffdE.getType().getTypeClass());
 			}
 			if(pos == 2) {
-				Assert.assertEquals(Object.class, ffdE.getType().getTypeClass());
+				assertEquals(Object.class, ffdE.getType().getTypeClass());
 			}
 			if(pos == 3) {
-				Assert.assertEquals(Float.class, ffdE.getType().getTypeClass());
+				assertEquals(Float.class, ffdE.getType().getTypeClass());
 			}
 			if(pos == 4) {
-				Assert.assertEquals(Integer.class, ffdE.getType().getTypeClass());
+				assertEquals(Integer.class, ffdE.getType().getTypeClass());
 			}
 			if(pos == 5) {
-				Assert.assertEquals(MyValue.class, ffdE.getType().getTypeClass());
+				assertEquals(MyValue.class, ffdE.getType().getTypeClass());
 			}
 			if(pos == 6) {
-				Assert.assertEquals(Long.class, ffdE.getType().getTypeClass());
+				assertEquals(Long.class, ffdE.getType().getTypeClass());
 			}
 			if(pos == 7) {
-				Assert.assertEquals(Long.class, ffdE.getType().getTypeClass());
+				assertEquals(Long.class, ffdE.getType().getTypeClass());
 			}
 			if(pos == 8) {
-				Assert.assertEquals(String.class, ffdE.getType().getTypeClass());
+				assertEquals(String.class, ffdE.getType().getTypeClass());
 			}
 			if(pos == 9) {
-				Assert.assertEquals(Integer.class, ffdE.getType().getTypeClass());
+				assertEquals(Integer.class, ffdE.getType().getTypeClass());
 			}
 		}
 		ffd.clear();
 
 		pojoType.getFlatFields("*", 0, ffd);
-		Assert.assertEquals(10, ffd.size());
+		assertEquals(10, ffd.size());
 		// check if it returns 0-8
 		for(FlatFieldDescriptor ffdE : ffd) {
-			Assert.assertTrue(ffdE.getPosition() <= 9 );
-			Assert.assertTrue(0 <= ffdE.getPosition() );
+			assertTrue(ffdE.getPosition() <= 9 );
+			assertTrue(0 <= ffdE.getPosition() );
 			if(ffdE.getPosition() == 9) {
-				Assert.assertEquals(Integer.class, ffdE.getType().getTypeClass());
+				assertEquals(Integer.class, ffdE.getType().getTypeClass());
 			}
 		}
 		ffd.clear();
 
 		TypeInformation<?> typeComplexNested = pojoType.getTypeAt(0); // ComplexNestedClass complex
-		Assert.assertTrue(typeComplexNested instanceof PojoTypeInfo);
+		assertTrue(typeComplexNested instanceof PojoTypeInfo);
 
-		Assert.assertEquals(7, typeComplexNested.getArity());
-		Assert.assertEquals(9, typeComplexNested.getTotalFields());
+		assertEquals(7, typeComplexNested.getArity());
+		assertEquals(9, typeComplexNested.getTotalFields());
 		PojoTypeInfo<?> pojoTypeComplexNested = (PojoTypeInfo<?>) typeComplexNested;
 
 		boolean dateSeen = false, intSeen = false, floatSeen = false,
@@ -335,77 +343,86 @@ public class PojoTypeExtractionTest {
 		for(int i = 0; i < pojoTypeComplexNested.getArity(); i++) {
 			PojoField field = pojoTypeComplexNested.getPojoFieldAt(i);
 			String name = field.getField().getName();
-			if(name.equals("date")) {
-				if(dateSeen) {
-					Assert.fail("already seen");
-				}
-				dateSeen = true;
-				Assert.assertEquals(BasicTypeInfo.DATE_TYPE_INFO, field.getTypeInformation());
-				Assert.assertEquals(Date.class, field.getTypeInformation().getTypeClass());
-			} else if(name.equals("someNumberWithÜnicödeNäme")) {
-				if(intSeen) {
-					Assert.fail("already seen");
-				}
-				intSeen = true;
-				Assert.assertEquals(BasicTypeInfo.INT_TYPE_INFO, field.getTypeInformation());
-				Assert.assertEquals(Integer.class, field.getTypeInformation().getTypeClass());
-			} else if(name.equals("someFloat")) {
-				if(floatSeen) {
-					Assert.fail("already seen");
-				}
-				floatSeen = true;
-				Assert.assertEquals(BasicTypeInfo.FLOAT_TYPE_INFO, field.getTypeInformation());
-				Assert.assertEquals(Float.class, field.getTypeInformation().getTypeClass());
-			} else if(name.equals("word")) {
-				if(tupleSeen) {
-					Assert.fail("already seen");
-				}
-				tupleSeen = true;
-				Assert.assertTrue(field.getTypeInformation() instanceof TupleTypeInfo<?>);
-				Assert.assertEquals(Tuple3.class, field.getTypeInformation().getTypeClass());
-				// do some more advanced checks on the tuple
-				TupleTypeInfo<?> tupleTypeFromComplexNested = (TupleTypeInfo<?>) field.getTypeInformation();
-				Assert.assertEquals(BasicTypeInfo.LONG_TYPE_INFO, tupleTypeFromComplexNested.getTypeAt(0));
-				Assert.assertEquals(BasicTypeInfo.LONG_TYPE_INFO, tupleTypeFromComplexNested.getTypeAt(1));
-				Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tupleTypeFromComplexNested.getTypeAt(2));
-			} else if(name.equals("nothing")) {
-				if(objectSeen) {
-					Assert.fail("already seen");
-				}
-				objectSeen = true;
-				Assert.assertEquals(new GenericTypeInfo<Object>(Object.class), field.getTypeInformation());
-				Assert.assertEquals(Object.class, field.getTypeInformation().getTypeClass());
-			} else if(name.equals("valueType")) {
-				if(writableSeen) {
-					Assert.fail("already seen");
-				}
-				writableSeen = true;
-				Assert.assertEquals(new ValueTypeInfo<>(MyValue.class), field.getTypeInformation());
-				Assert.assertEquals(MyValue.class, field.getTypeInformation().getTypeClass());
-			} else if(name.equals("collection")) {
-				if(collectionSeen) {
-					Assert.fail("already seen");
-				}
-				collectionSeen = true;
-				Assert.assertEquals(new GenericTypeInfo(List.class), field.getTypeInformation());
+			switch (name) {
+				case "date":
+					if (dateSeen) {
+						fail("already seen");
+					}
+					dateSeen = true;
+					assertEquals(BasicTypeInfo.DATE_TYPE_INFO, field.getTypeInformation());
+					assertEquals(Date.class, field.getTypeInformation().getTypeClass());
+					break;
+				case "someNumberWithÜnicödeNäme":
+					if (intSeen) {
+						fail("already seen");
+					}
+					intSeen = true;
+					assertEquals(BasicTypeInfo.INT_TYPE_INFO, field.getTypeInformation());
+					assertEquals(Integer.class, field.getTypeInformation().getTypeClass());
+					break;
+				case "someFloat":
+					if (floatSeen) {
+						fail("already seen");
+					}
+					floatSeen = true;
+					assertEquals(BasicTypeInfo.FLOAT_TYPE_INFO, field.getTypeInformation());
+					assertEquals(Float.class, field.getTypeInformation().getTypeClass());
+					break;
+				case "word":
+					if (tupleSeen) {
+						fail("already seen");
+					}
+					tupleSeen = true;
+					assertTrue(field.getTypeInformation() instanceof TupleTypeInfo<?>);
+					assertEquals(Tuple3.class, field.getTypeInformation().getTypeClass());
+					// do some more advanced checks on the tuple
+					TupleTypeInfo<?> tupleTypeFromComplexNested = (TupleTypeInfo<?>) field.getTypeInformation();
+					assertEquals(BasicTypeInfo.LONG_TYPE_INFO, tupleTypeFromComplexNested.getTypeAt(0));
+					assertEquals(BasicTypeInfo.LONG_TYPE_INFO, tupleTypeFromComplexNested.getTypeAt(1));
+					assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tupleTypeFromComplexNested.getTypeAt(2));
+					break;
+				case "nothing":
+					if (objectSeen) {
+						fail("already seen");
+					}
+					objectSeen = true;
+					assertEquals(new GenericTypeInfo<>(Object.class), field.getTypeInformation());
+					assertEquals(Object.class, field.getTypeInformation().getTypeClass());
+					break;
+				case "valueType":
+					if (writableSeen) {
+						fail("already seen");
+					}
+					writableSeen = true;
+					assertEquals(new ValueTypeInfo<>(MyValue.class), field.getTypeInformation());
+					assertEquals(MyValue.class, field.getTypeInformation().getTypeClass());
+					break;
+				case "collection":
+					if (collectionSeen) {
+						fail("already seen");
+					}
+					collectionSeen = true;
+					assertEquals(new GenericTypeInfo(List.class), field.getTypeInformation());
 
-			} else {
-				Assert.fail("field "+field+" is not expected");
+					break;
+				default:
+					fail("field " + field + " is not expected");
+					break;
 			}
 		}
-		Assert.assertTrue("Field was not present", dateSeen);
-		Assert.assertTrue("Field was not present", intSeen);
-		Assert.assertTrue("Field was not present", floatSeen);
-		Assert.assertTrue("Field was not present", tupleSeen);
-		Assert.assertTrue("Field was not present", objectSeen);
-		Assert.assertTrue("Field was not present", writableSeen);
-		Assert.assertTrue("Field was not present", collectionSeen);
+		assertTrue("Field was not present", dateSeen);
+		assertTrue("Field was not present", intSeen);
+		assertTrue("Field was not present", floatSeen);
+		assertTrue("Field was not present", tupleSeen);
+		assertTrue("Field was not present", objectSeen);
+		assertTrue("Field was not present", writableSeen);
+		assertTrue("Field was not present", collectionSeen);
 
 		TypeInformation<?> typeAtOne = pojoType.getTypeAt(1); // int count
-		Assert.assertTrue(typeAtOne instanceof BasicTypeInfo);
+		assertTrue(typeAtOne instanceof BasicTypeInfo);
 
-		Assert.assertEquals(typeInfo.getTypeClass(), WC.class);
-		Assert.assertEquals(typeInfo.getArity(), 2);
+		assertEquals(typeInfo.getTypeClass(), WC.class);
+		assertEquals(typeInfo.getArity(), 2);
 	}
 
 	@Test
@@ -418,46 +435,44 @@ public class PojoTypeExtractionTest {
 	}
 
 	private void checkAllPublicAsserts(TypeInformation<?> typeInformation) {
-		Assert.assertTrue(typeInformation instanceof PojoTypeInfo);
-		Assert.assertEquals(10, typeInformation.getArity());
-		Assert.assertEquals(12, typeInformation.getTotalFields());
+		assertTrue(typeInformation instanceof PojoTypeInfo);
+		assertEquals(10, typeInformation.getArity());
+		assertEquals(12, typeInformation.getTotalFields());
 		// check if the three additional fields are identified correctly
 		boolean arrayListSeen = false, multisetSeen = false, strArraySeen = false;
 		PojoTypeInfo<?> pojoTypeForClass = (PojoTypeInfo<?>) typeInformation;
 		for(int i = 0; i < pojoTypeForClass.getArity(); i++) {
 			PojoField field = pojoTypeForClass.getPojoFieldAt(i);
 			String name = field.getField().getName();
-			if(name.equals("somethingFancy")) {
-				if(arrayListSeen) {
-					Assert.fail("already seen");
+			if (name.equals("somethingFancy")) {
+				if (arrayListSeen) {
+					fail("already seen");
 				}
 				arrayListSeen = true;
-				Assert.assertTrue(field.getTypeInformation() instanceof GenericTypeInfo);
-				Assert.assertEquals(ArrayList.class, field.getTypeInformation().getTypeClass());
-			} else if(name.equals("fancyIds")) {
+				assertTrue(field.getTypeInformation() instanceof GenericTypeInfo);
+				assertEquals(ArrayList.class, field.getTypeInformation().getTypeClass());
+			} else if (name.equals("fancyIds")) {
 				if(multisetSeen) {
-					Assert.fail("already seen");
+					fail("already seen");
 				}
 				multisetSeen = true;
-				Assert.assertTrue(field.getTypeInformation() instanceof GenericTypeInfo);
-				Assert.assertEquals(FancyCollectionSubtype.class, field.getTypeInformation().getTypeClass());
-			} else if(name.equals("fancyArray")) {
+				assertTrue(field.getTypeInformation() instanceof GenericTypeInfo);
+				assertEquals(FancyCollectionSubtype.class, field.getTypeInformation().getTypeClass());
+			} else if (name.equals("fancyArray")) {
 				if(strArraySeen) {
-					Assert.fail("already seen");
+					fail("already seen");
 				}
 				strArraySeen = true;
-				Assert.assertEquals(BasicArrayTypeInfo.STRING_ARRAY_TYPE_INFO, field.getTypeInformation());
-				Assert.assertEquals(String[].class, field.getTypeInformation().getTypeClass());
-			} else if(Arrays.asList("date", "someNumberWithÜnicödeNäme", "someFloat", "word", "nothing", "valueType", "collection").contains(name)) {
+				assertEquals(BasicArrayTypeInfo.STRING_ARRAY_TYPE_INFO, field.getTypeInformation());
+				assertEquals(String[].class, field.getTypeInformation().getTypeClass());
+			} else if (!Arrays.asList("date", "someNumberWithÜnicödeNäme", "someFloat", "word", "nothing", "valueType", "collection").contains(name)) {
 				// ignore these, they are inherited from the ComplexNestedClass
-			}
-			else {
-				Assert.fail("field "+field+" is not expected");
+				fail("field "+field+" is not expected");
 			}
 		}
-		Assert.assertTrue("Field was not present", arrayListSeen);
-		Assert.assertTrue("Field was not present", multisetSeen);
-		Assert.assertTrue("Field was not present", strArraySeen);
+		assertTrue("Field was not present", arrayListSeen);
+		assertTrue("Field was not present", multisetSeen);
+		assertTrue("Field was not present", strArraySeen);
 	}
 
 	@Test
@@ -472,20 +487,26 @@ public class PojoTypeExtractionTest {
 	}
 
 	private void checkFromTuplePojo(TypeInformation<?> typeInformation) {
-		Assert.assertTrue(typeInformation instanceof PojoTypeInfo<?>);
-		Assert.assertEquals(4, typeInformation.getTotalFields());
+		assertTrue(typeInformation instanceof PojoTypeInfo<?>);
+		assertEquals(4, typeInformation.getTotalFields());
 		PojoTypeInfo<?> pojoTypeForClass = (PojoTypeInfo<?>) typeInformation;
 		for(int i = 0; i < pojoTypeForClass.getArity(); i++) {
 			PojoField field = pojoTypeForClass.getPojoFieldAt(i);
 			String name = field.getField().getName();
-			if(name.equals("special")) {
-				Assert.assertEquals(BasicTypeInfo.INT_TYPE_INFO, field.getTypeInformation());
-			} else if(name.equals("f0") || name.equals("f1")) {
-				Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, field.getTypeInformation());
-			} else if(name.equals("f2")) {
-				Assert.assertEquals(BasicTypeInfo.LONG_TYPE_INFO, field.getTypeInformation());
-			} else {
-				Assert.fail("unexpected field");
+			switch (name) {
+				case "special":
+					assertEquals(BasicTypeInfo.INT_TYPE_INFO, field.getTypeInformation());
+					break;
+				case "f0":
+				case "f1":
+					assertEquals(BasicTypeInfo.STRING_TYPE_INFO, field.getTypeInformation());
+					break;
+				case "f2":
+					assertEquals(BasicTypeInfo.LONG_TYPE_INFO, field.getTypeInformation());
+					break;
+				default:
+					fail("unexpected field");
+					break;
 			}
 		}
 	}
@@ -493,21 +514,27 @@ public class PojoTypeExtractionTest {
 	@Test
 	public void testPojoWithGenerics() {
 		TypeInformation<?> typeForClass = TypeExtractor.createTypeInfo(ParentSettingGenerics.class);
-		Assert.assertTrue(typeForClass instanceof PojoTypeInfo<?>);
+		assertTrue(typeForClass instanceof PojoTypeInfo<?>);
 		PojoTypeInfo<?> pojoTypeForClass = (PojoTypeInfo<?>) typeForClass;
 		for(int i = 0; i < pojoTypeForClass.getArity(); i++) {
 			PojoField field = pojoTypeForClass.getPojoFieldAt(i);
 			String name = field.getField().getName();
-			if(name.equals("field1")) {
-				Assert.assertEquals(BasicTypeInfo.INT_TYPE_INFO, field.getTypeInformation());
-			} else if (name.equals("field2")) {
-				Assert.assertEquals(BasicTypeInfo.LONG_TYPE_INFO, field.getTypeInformation());
-			} else if (name.equals("field3")) {
-				Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, field.getTypeInformation());
-			} else if (name.equals("key")) {
-				Assert.assertEquals(BasicTypeInfo.INT_TYPE_INFO, field.getTypeInformation());
-			} else {
-				Assert.fail("Unexpected field "+field);
+			switch (name) {
+				case "field1":
+					assertEquals(BasicTypeInfo.INT_TYPE_INFO, field.getTypeInformation());
+					break;
+				case "field2":
+					assertEquals(BasicTypeInfo.LONG_TYPE_INFO, field.getTypeInformation());
+					break;
+				case "field3":
+					assertEquals(BasicTypeInfo.STRING_TYPE_INFO, field.getTypeInformation());
+					break;
+				case "key":
+					assertEquals(BasicTypeInfo.INT_TYPE_INFO, field.getTypeInformation());
+					break;
+				default:
+					fail("Unexpected field " + field);
+					break;
 			}
 		}
 	}
@@ -519,19 +546,24 @@ public class PojoTypeExtractionTest {
 	@Test
 	public void testPojoWithGenericsSomeFieldsGeneric() {
 		TypeInformation<?> typeForClass = TypeExtractor.createTypeInfo(PojoWithGenerics.class);
-		Assert.assertTrue(typeForClass instanceof PojoTypeInfo<?>);
+		assertTrue(typeForClass instanceof PojoTypeInfo<?>);
 		PojoTypeInfo<?> pojoTypeForClass = (PojoTypeInfo<?>) typeForClass;
 		for(int i = 0; i < pojoTypeForClass.getArity(); i++) {
 			PojoField field = pojoTypeForClass.getPojoFieldAt(i);
 			String name = field.getField().getName();
-			if(name.equals("field1")) {
-				Assert.assertEquals(new GenericTypeInfo<Object>(Object.class), field.getTypeInformation());
-			} else if (name.equals("field2")) {
-				Assert.assertEquals(new GenericTypeInfo<Object>(Object.class), field.getTypeInformation());
-			} else if (name.equals("key")) {
-				Assert.assertEquals(BasicTypeInfo.INT_TYPE_INFO, field.getTypeInformation());
-			} else {
-				Assert.fail("Unexpected field "+field);
+			switch (name) {
+				case "field1":
+					assertEquals(new GenericTypeInfo<>(Object.class), field.getTypeInformation());
+					break;
+				case "field2":
+					assertEquals(new GenericTypeInfo<>(Object.class), field.getTypeInformation());
+					break;
+				case "key":
+					assertEquals(BasicTypeInfo.INT_TYPE_INFO, field.getTypeInformation());
+					break;
+				default:
+					fail("Unexpected field " + field);
+					break;
 			}
 		}
 	}
@@ -540,20 +572,25 @@ public class PojoTypeExtractionTest {
 	@Test
 	public void testPojoWithComplexHierarchy() {
 		TypeInformation<?> typeForClass = TypeExtractor.createTypeInfo(ComplexHierarchyTop.class);
-		Assert.assertTrue(typeForClass instanceof PojoTypeInfo<?>);
+		assertTrue(typeForClass instanceof PojoTypeInfo<?>);
 		PojoTypeInfo<?> pojoTypeForClass = (PojoTypeInfo<?>) typeForClass;
 		for(int i = 0; i < pojoTypeForClass.getArity(); i++) {
 			PojoField field = pojoTypeForClass.getPojoFieldAt(i);
 			String name = field.getField().getName();
-			if(name.equals("field1")) {
-				Assert.assertTrue(field.getTypeInformation() instanceof PojoTypeInfo<?>); // From tuple is pojo (not tuple type!)
-			} else if (name.equals("field2")) {
-				Assert.assertTrue(field.getTypeInformation() instanceof TupleTypeInfo<?>);
-				Assert.assertTrue( ((TupleTypeInfo<?>)field.getTypeInformation()).getTypeAt(0).equals(BasicTypeInfo.STRING_TYPE_INFO) );
-			} else if (name.equals("key")) {
-				Assert.assertEquals(BasicTypeInfo.INT_TYPE_INFO, field.getTypeInformation());
-			} else {
-				Assert.fail("Unexpected field "+field);
+			switch (name) {
+				case "field1":
+					assertTrue(field.getTypeInformation() instanceof PojoTypeInfo<?>); // From tuple is pojo (not tuple type!)
+					break;
+				case "field2":
+					assertTrue(field.getTypeInformation() instanceof TupleTypeInfo<?>);
+					assertTrue(((TupleTypeInfo<?>) field.getTypeInformation()).getTypeAt(0).equals(BasicTypeInfo.STRING_TYPE_INFO));
+					break;
+				case "key":
+					assertEquals(BasicTypeInfo.INT_TYPE_INFO, field.getTypeInformation());
+					break;
+				default:
+					fail("Unexpected field " + field);
+					break;
 			}
 		}
 	}
@@ -576,19 +613,24 @@ public class PojoTypeExtractionTest {
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, (TypeInformation)
 				TypeInfoParser.parse("org.apache.flink.api.java.typeutils.PojoTypeExtractionTest$PojoWithGenerics<key=int,field1=Long,field2=String>"));
 		
-		Assert.assertTrue(ti instanceof PojoTypeInfo<?>);
+		assertTrue(ti instanceof PojoTypeInfo<?>);
 		PojoTypeInfo<?> pti = (PojoTypeInfo<?>) ti;
 		for(int i = 0; i < pti.getArity(); i++) {
 			PojoField field = pti.getPojoFieldAt(i);
 			String name = field.getField().getName();
-			if(name.equals("field1")) {
-				Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, field.getTypeInformation());
-			} else if (name.equals("field2")) {
-				Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, field.getTypeInformation());
-			} else if (name.equals("key")) {
-				Assert.assertEquals(BasicTypeInfo.INT_TYPE_INFO, field.getTypeInformation());
-			} else {
-				Assert.fail("Unexpected field "+field);
+			switch (name) {
+				case "field1":
+					assertEquals(BasicTypeInfo.STRING_TYPE_INFO, field.getTypeInformation());
+					break;
+				case "field2":
+					assertEquals(BasicTypeInfo.STRING_TYPE_INFO, field.getTypeInformation());
+					break;
+				case "key":
+					assertEquals(BasicTypeInfo.INT_TYPE_INFO, field.getTypeInformation());
+					break;
+				default:
+					fail("Unexpected field " + field);
+					break;
 			}
 		}
 	}
@@ -615,21 +657,27 @@ public class PojoTypeExtractionTest {
 
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, (TypeInformation)
 				TypeInfoParser.parse("Tuple2<Character,Boolean>"));
-		Assert.assertTrue(ti instanceof PojoTypeInfo<?>);
+		assertTrue(ti instanceof PojoTypeInfo<?>);
 		PojoTypeInfo<?> pti = (PojoTypeInfo<?>) ti;
 		for(int i = 0; i < pti.getArity(); i++) {
 			PojoField field = pti.getPojoFieldAt(i);
 			String name = field.getField().getName();
-			if(name.equals("extraField")) {
-				Assert.assertEquals(BasicTypeInfo.CHAR_TYPE_INFO, field.getTypeInformation());
-			} else if (name.equals("f0")) {
-				Assert.assertEquals(BasicTypeInfo.BOOLEAN_TYPE_INFO, field.getTypeInformation());
-			} else if (name.equals("f1")) {
-				Assert.assertEquals(BasicTypeInfo.BOOLEAN_TYPE_INFO, field.getTypeInformation());
-			} else if (name.equals("f2")) {
-				Assert.assertEquals(BasicTypeInfo.LONG_TYPE_INFO, field.getTypeInformation());
-			} else {
-				Assert.fail("Unexpected field "+field);
+			switch (name) {
+				case "extraField":
+					assertEquals(BasicTypeInfo.CHAR_TYPE_INFO, field.getTypeInformation());
+					break;
+				case "f0":
+					assertEquals(BasicTypeInfo.BOOLEAN_TYPE_INFO, field.getTypeInformation());
+					break;
+				case "f1":
+					assertEquals(BasicTypeInfo.BOOLEAN_TYPE_INFO, field.getTypeInformation());
+					break;
+				case "f2":
+					assertEquals(BasicTypeInfo.LONG_TYPE_INFO, field.getTypeInformation());
+					break;
+				default:
+					fail("Unexpected field " + field);
+					break;
 			}
 		}
 	}
@@ -651,10 +699,10 @@ public class PojoTypeExtractionTest {
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, (TypeInformation)
 				TypeInfoParser.parse("org.apache.flink.api.java.typeutils.PojoTypeExtractionTest$PojoTuple<extraField=char,f0=boolean,f1=boolean,f2=long>"));
 		
-		Assert.assertTrue(ti instanceof TupleTypeInfo<?>);
+		assertTrue(ti instanceof TupleTypeInfo<?>);
 		TupleTypeInfo<?> tti = (TupleTypeInfo<?>) ti;
-		Assert.assertEquals(BasicTypeInfo.CHAR_TYPE_INFO, tti.getTypeAt(0));
-		Assert.assertEquals(BasicTypeInfo.BOOLEAN_TYPE_INFO, tti.getTypeAt(1));
+		assertEquals(BasicTypeInfo.CHAR_TYPE_INFO, tti.getTypeAt(0));
+		assertEquals(BasicTypeInfo.BOOLEAN_TYPE_INFO, tti.getTypeAt(1));
 	}
 
 	public static class PojoWithParameterizedFields1<Z> {
@@ -676,7 +724,7 @@ public class PojoTypeExtractionTest {
 
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, (TypeInformation)
 				TypeInfoParser.parse("org.apache.flink.api.java.typeutils.PojoTypeExtractionTest$PojoWithParameterizedFields1<field=Tuple2<byte,byte>>"));
-		Assert.assertEquals(BasicTypeInfo.BYTE_TYPE_INFO, ti);
+		assertEquals(BasicTypeInfo.BYTE_TYPE_INFO, ti);
 	}
 
 	public static class PojoWithParameterizedFields2<Z> {
@@ -700,7 +748,7 @@ public class PojoTypeExtractionTest {
 				TypeInfoParser.parse("org.apache.flink.api.java.typeutils.PojoTypeExtractionTest$PojoWithParameterizedFields2<"
 						+ "field=org.apache.flink.api.java.typeutils.PojoTypeExtractionTest$PojoWithGenerics<key=int,field1=byte,field2=byte>"
 						+ ">"));
-		Assert.assertEquals(BasicTypeInfo.BYTE_TYPE_INFO, ti);
+		assertEquals(BasicTypeInfo.BYTE_TYPE_INFO, ti);
 	}
 	
 	public static class PojoWithParameterizedFields3<Z> {
@@ -724,7 +772,7 @@ public class PojoTypeExtractionTest {
 				TypeInfoParser.parse("org.apache.flink.api.java.typeutils.PojoTypeExtractionTest$PojoWithParameterizedFields3<"
 						+ "field=int[]"
 						+ ">"));
-		Assert.assertEquals(BasicTypeInfo.INT_TYPE_INFO, ti);
+		assertEquals(BasicTypeInfo.INT_TYPE_INFO, ti);
 	}
 
 	public static class MyMapper7<A> implements MapFunction<PojoWithParameterizedFields4<A>, A> {
@@ -748,7 +796,7 @@ public class PojoTypeExtractionTest {
 				TypeInfoParser.parse("org.apache.flink.api.java.typeutils.PojoTypeExtractionTest$PojoWithParameterizedFields4<"
 						+ "field=Tuple1<int>[]"
 						+ ">"));
-		Assert.assertEquals(BasicTypeInfo.INT_TYPE_INFO, ti);
+		assertEquals(BasicTypeInfo.INT_TYPE_INFO, ti);
 	}
 
 	public static class RecursivePojo1 {
@@ -770,26 +818,26 @@ public class PojoTypeExtractionTest {
 	@Test
 	public void testRecursivePojo1() {
 		TypeInformation<?> ti = TypeExtractor.createTypeInfo(RecursivePojo1.class);
-		Assert.assertTrue(ti instanceof PojoTypeInfo);
-		Assert.assertEquals(GenericTypeInfo.class, ((PojoTypeInfo) ti).getPojoFieldAt(0).getTypeInformation().getClass());
+		assertTrue(ti instanceof PojoTypeInfo);
+		assertEquals(GenericTypeInfo.class, ((PojoTypeInfo) ti).getPojoFieldAt(0).getTypeInformation().getClass());
 	}
 
 	@Test
 	public void testRecursivePojo2() {
 		TypeInformation<?> ti = TypeExtractor.createTypeInfo(RecursivePojo2.class);
-		Assert.assertTrue(ti instanceof PojoTypeInfo);
+		assertTrue(ti instanceof PojoTypeInfo);
 		PojoField pf = ((PojoTypeInfo) ti).getPojoFieldAt(0);
-		Assert.assertTrue(pf.getTypeInformation() instanceof TupleTypeInfo);
-		Assert.assertEquals(GenericTypeInfo.class, ((TupleTypeInfo) pf.getTypeInformation()).getTypeAt(0).getClass());
+		assertTrue(pf.getTypeInformation() instanceof TupleTypeInfo);
+		assertEquals(GenericTypeInfo.class, ((TupleTypeInfo) pf.getTypeInformation()).getTypeAt(0).getClass());
 	}
 
 	@Test
 	public void testRecursivePojo3() {
 		TypeInformation<?> ti = TypeExtractor.createTypeInfo(RecursivePojo3.class);
-		Assert.assertTrue(ti instanceof PojoTypeInfo);
+		assertTrue(ti instanceof PojoTypeInfo);
 		PojoField pf = ((PojoTypeInfo) ti).getPojoFieldAt(0);
-		Assert.assertTrue(pf.getTypeInformation() instanceof PojoTypeInfo);
-		Assert.assertEquals(GenericTypeInfo.class, ((PojoTypeInfo) pf.getTypeInformation()).getPojoFieldAt(0).getTypeInformation().getClass());
+		assertTrue(pf.getTypeInformation() instanceof PojoTypeInfo);
+		assertEquals(GenericTypeInfo.class, ((PojoTypeInfo) pf.getTypeInformation()).getPojoFieldAt(0).getTypeInformation().getClass());
 	}
 
 	public static class FooBarPojo {
@@ -804,14 +852,15 @@ public class PojoTypeExtractionTest {
 		}
 	}
 
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testDualUseOfPojo() {
 		MapFunction<?, ?> function = new DuplicateMapper();
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, (TypeInformation) TypeExtractor.createTypeInfo(FooBarPojo.class));
-		Assert.assertTrue(ti instanceof TupleTypeInfo);
+		assertTrue(ti instanceof TupleTypeInfo);
 		TupleTypeInfo<?> tti = ((TupleTypeInfo) ti);
-		Assert.assertTrue(tti.getTypeAt(0) instanceof PojoTypeInfo);
-		Assert.assertTrue(tti.getTypeAt(1) instanceof PojoTypeInfo);
+		assertTrue(tti.getTypeAt(0) instanceof PojoTypeInfo);
+		assertTrue(tti.getTypeAt(1) instanceof PojoTypeInfo);
 	}
 
 	public static class PojoWithRecursiveGenericField<K,V> {
@@ -822,8 +871,8 @@ public class PojoTypeExtractionTest {
 	@Test
 	public void testPojoWithRecursiveGenericField() {
 		TypeInformation<?> ti = TypeExtractor.createTypeInfo(PojoWithRecursiveGenericField.class);
-		Assert.assertTrue(ti instanceof PojoTypeInfo);
-		Assert.assertEquals(GenericTypeInfo.class, ((PojoTypeInfo) ti).getPojoFieldAt(0).getTypeInformation().getClass());
+		assertTrue(ti instanceof PojoTypeInfo);
+		assertEquals(GenericTypeInfo.class, ((PojoTypeInfo) ti).getPojoFieldAt(0).getTypeInformation().getClass());
 	}
 
 	public static class MutualPojoA {
@@ -837,10 +886,10 @@ public class PojoTypeExtractionTest {
 	@Test
 	public void testPojosWithMutualRecursion() {
 		TypeInformation<?> ti = TypeExtractor.createTypeInfo(MutualPojoB.class);
-		Assert.assertTrue(ti instanceof PojoTypeInfo);
+		assertTrue(ti instanceof PojoTypeInfo);
 		TypeInformation<?> pti = ((PojoTypeInfo) ti).getPojoFieldAt(0).getTypeInformation();
-		Assert.assertTrue(pti instanceof PojoTypeInfo);
-		Assert.assertEquals(GenericTypeInfo.class, ((PojoTypeInfo) pti).getPojoFieldAt(0).getTypeInformation().getClass());
+		assertTrue(pti instanceof PojoTypeInfo);
+		assertEquals(GenericTypeInfo.class, ((PojoTypeInfo) pti).getPojoFieldAt(0).getTypeInformation().getClass());
 	}
 
 	public static class Container<T> {
@@ -852,10 +901,104 @@ public class PojoTypeExtractionTest {
 	@Test
 	public void testRecursivePojoWithTypeVariable() {
 		TypeInformation<?> ti = TypeExtractor.createTypeInfo(MyType.class);
-		Assert.assertTrue(ti instanceof PojoTypeInfo);
+		assertTrue(ti instanceof PojoTypeInfo);
 		TypeInformation<?> pti = ((PojoTypeInfo) ti).getPojoFieldAt(0).getTypeInformation();
-		Assert.assertTrue(pti instanceof PojoTypeInfo);
-		Assert.assertEquals(GenericTypeInfo.class, ((PojoTypeInfo) pti).getPojoFieldAt(0).getTypeInformation().getClass());
+		assertTrue(pti instanceof PojoTypeInfo);
+		assertEquals(GenericTypeInfo.class, ((PojoTypeInfo) pti).getPojoFieldAt(0).getTypeInformation().getClass());
 	}
 
+	public static class PojoTuple2 extends Tuple2<Integer, String> {
+		private int myField0;
+		private String myField1;
+
+		public int getMyField0() {
+			return myField0;
+		}
+
+		public void setMyField0(int myField0) {
+			this.myField0 = myField0;
+		}
+
+		public String getMyField1() {
+			return myField1;
+		}
+
+		public void setMyField1(String myField1) {
+			this.myField1 = myField1;
+		}
+	}
+
+	@Test
+	public void testPojoTupleWithEqualArity() {
+		TypeInformation<?> ti = TypeExtractor.createTypeInfo(PojoTuple2.class);
+		assertTrue(ti instanceof PojoTypeInfo);
+
+		PojoTypeInfo<?> pti = (PojoTypeInfo<?>) ti;
+		assertEquals(BasicTypeInfo.INT_TYPE_INFO, pti.getTypeAt(0));
+		assertEquals(BasicTypeInfo.STRING_TYPE_INFO, pti.getTypeAt(1));
+		assertEquals(BasicTypeInfo.INT_TYPE_INFO, pti.getTypeAt(2));
+		assertEquals(BasicTypeInfo.STRING_TYPE_INFO, pti.getTypeAt(3));
+	}
+
+	@Getter
+	@Setter
+	@NoArgsConstructor
+	public static class TestLombok{
+		private int age = 10;
+		private String name;
+	}
+
+	@Test
+	public void testTestLombokPojos() {
+		TypeInformation<TestLombok> ti = TypeExtractor.getForClass(TestLombok.class);
+		assertTrue(ti instanceof PojoTypeInfo);
+
+		PojoTypeInfo<TestLombok> pti = (PojoTypeInfo<TestLombok>) ti;
+		assertEquals(BasicTypeInfo.INT_TYPE_INFO, pti.getTypeAt(0));
+		assertEquals(BasicTypeInfo.STRING_TYPE_INFO, pti.getTypeAt(1));
+	}
+
+	public static class BoundedPojo<T extends Tuple2<Integer, String>> {
+
+		public T someKey;
+
+		public BoundedPojo() {}
+
+		public BoundedPojo(T someKey) {
+			this.someKey = someKey;
+		}
+	}
+
+	@Test
+	public void testBoundedPojos() {
+		TypeInformation<?> ti = TypeExtractor.createTypeInfo(BoundedPojo.class);
+		assertTrue(ti instanceof PojoTypeInfo);
+		PojoTypeInfo<?> pti = (PojoTypeInfo<?>) ti;
+		assertEquals(BoundedPojo.class, pti.getTypeClass());
+		assertTrue(pti.getPojoFieldAt(0).getTypeInformation() instanceof GenericTypeInfo);
+		TypeInformation<?> fti = pti.getPojoFieldAt(0).getTypeInformation();
+		assertEquals(Tuple2.class, fti.getTypeClass());
+	}
+
+	public static class MultiBoundedPojo<T extends Tuple2<Integer, String> & Serializable> {
+
+		public T someKey;
+
+		public MultiBoundedPojo() {}
+
+		public MultiBoundedPojo(T someKey) {
+			this.someKey = someKey;
+		}
+	}
+
+	@Test
+	public void testMultiBoundedPojos() {
+		TypeInformation<?> ti = TypeExtractor.createTypeInfo(MultiBoundedPojo.class);
+		assertTrue(ti instanceof PojoTypeInfo);
+		PojoTypeInfo<?> pti = (PojoTypeInfo<?>) ti;
+		assertEquals(MultiBoundedPojo.class, pti.getTypeClass());
+		assertTrue(pti.getPojoFieldAt(0).getTypeInformation() instanceof GenericTypeInfo);
+		TypeInformation<?> fti = pti.getPojoFieldAt(0).getTypeInformation();
+		assertEquals(Tuple2.class, fti.getTypeClass());
+	}
 }

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/PojoTypeInfoTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/PojoTypeInfoTest.java
@@ -18,7 +18,10 @@
 
 package org.apache.flink.api.java.typeutils;
 
+import org.apache.flink.api.common.functions.InvalidTypesException;
 import org.apache.flink.api.common.typeutils.TypeInformationTestBase;
+
+import org.junit.Test;
 
 /**
  * Test for {@link PojoTypeInfo}.
@@ -33,6 +36,25 @@ public class PojoTypeInfoTest extends TypeInformationTestBase<PojoTypeInfo<?>>{
 			(PojoTypeInfo<?>) TypeExtractor.getForClass(PrimitivePojo.class),
 			(PojoTypeInfo<?>) TypeExtractor.getForClass(UnderscorePojo.class)
 		};
+	}
+
+	@Test
+	public void testEnsurePojo() {
+		PojoTypeInfo.ensurePojo(TestPojo.class);
+	}
+
+	@Test(expected = InvalidTypesException.class)
+	public void testEnsurePojoException() {
+		PojoTypeInfo.ensurePojo(InvalidPojo.class);
+	}
+
+	public static final class InvalidPojo {
+		public int test;
+
+		// default constructor is missing
+		public InvalidPojo(int test) {
+			this.test = test;
+		}
 	}
 
 	public static final class TestPojo {

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/TypeExtractorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/TypeExtractorTest.java
@@ -18,16 +18,6 @@
 
 package org.apache.flink.api.java.typeutils;
 
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.sql.Date;
-import java.sql.Time;
-import java.sql.Timestamp;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-
-import java.util.Map;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.InvalidTypesException;
 import org.apache.flink.api.common.functions.JoinFunction;
@@ -55,22 +45,34 @@ import org.apache.flink.api.java.tuple.Tuple1;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.api.java.tuple.Tuple9;
-import org.apache.flink.types.Either;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.types.DoubleValue;
+import org.apache.flink.types.Either;
 import org.apache.flink.types.IntValue;
+import org.apache.flink.types.Row;
 import org.apache.flink.types.StringValue;
 import org.apache.flink.types.Value;
-import org.apache.flink.types.Row;
 import org.apache.flink.util.Collector;
 
 import org.junit.Assert;
 import org.junit.Test;
 
-@SuppressWarnings("serial")
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@SuppressWarnings({"serial", "AssertEqualsBetweenInconvertibleTypes", "Convert2Lambda"})
 public class TypeExtractorTest {
 
-	
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Test
 	public void testBasicType() {
@@ -86,16 +88,16 @@ public class TypeExtractorTest {
 
 		TypeInformation<?> ti = TypeExtractor.getGroupReduceReturnTypes(function, (TypeInformation) TypeInfoParser.parse("Boolean"));
 
-		Assert.assertTrue(ti.isBasicType());
-		Assert.assertEquals(BasicTypeInfo.BOOLEAN_TYPE_INFO, ti);
-		Assert.assertEquals(Boolean.class, ti.getTypeClass());
+		assertTrue(ti.isBasicType());
+		assertEquals(BasicTypeInfo.BOOLEAN_TYPE_INFO, ti);
+		assertEquals(Boolean.class, ti.getTypeClass());
 
 		// use getForClass()
-		Assert.assertTrue(TypeExtractor.getForClass(Boolean.class).isBasicType());
-		Assert.assertEquals(ti, TypeExtractor.getForClass(Boolean.class));
+		assertTrue(TypeExtractor.getForClass(Boolean.class).isBasicType());
+		assertEquals(ti, TypeExtractor.getForClass(Boolean.class));
 
 		// use getForObject()
-		Assert.assertEquals(BasicTypeInfo.BOOLEAN_TYPE_INFO, TypeExtractor.getForObject(true));
+		assertEquals(BasicTypeInfo.BOOLEAN_TYPE_INFO, TypeExtractor.getForObject(true));
 	}
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })
@@ -115,47 +117,46 @@ public class TypeExtractorTest {
 
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, (TypeInformation) TypeInfoParser.parse("Tuple9<Integer, Long, Double, Float, Boolean, String, Character, Short, Byte>"));
 
-		Assert.assertTrue(ti.isTupleType());
-		Assert.assertEquals(9, ti.getArity());
-		Assert.assertTrue(ti instanceof TupleTypeInfo);
-		List<FlatFieldDescriptor> ffd = new ArrayList<FlatFieldDescriptor>();
+		assertTrue(ti.isTupleType());
+		assertEquals(9, ti.getArity());
+		assertTrue(ti instanceof TupleTypeInfo);
+		List<FlatFieldDescriptor> ffd = new ArrayList<>();
 		((TupleTypeInfo) ti).getFlatFields("f3", 0, ffd);
-		Assert.assertTrue(ffd.size() == 1);
-		Assert.assertEquals(3, ffd.get(0).getPosition() );
+		assertTrue(ffd.size() == 1);
+		assertEquals(3, ffd.get(0).getPosition() );
 
 		TupleTypeInfo<?> tti = (TupleTypeInfo<?>) ti;
-		Assert.assertEquals(Tuple9.class, tti.getTypeClass());
+		assertEquals(Tuple9.class, tti.getTypeClass());
 		
 		for (int i = 0; i < 9; i++) {
-			Assert.assertTrue(tti.getTypeAt(i) instanceof BasicTypeInfo);
+			assertTrue(tti.getTypeAt(i) instanceof BasicTypeInfo);
 		}
 
-		Assert.assertEquals(BasicTypeInfo.INT_TYPE_INFO, tti.getTypeAt(0));
-		Assert.assertEquals(BasicTypeInfo.LONG_TYPE_INFO, tti.getTypeAt(1));
-		Assert.assertEquals(BasicTypeInfo.DOUBLE_TYPE_INFO, tti.getTypeAt(2));
-		Assert.assertEquals(BasicTypeInfo.FLOAT_TYPE_INFO, tti.getTypeAt(3));
-		Assert.assertEquals(BasicTypeInfo.BOOLEAN_TYPE_INFO, tti.getTypeAt(4));
-		Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tti.getTypeAt(5));
-		Assert.assertEquals(BasicTypeInfo.CHAR_TYPE_INFO, tti.getTypeAt(6));
-		Assert.assertEquals(BasicTypeInfo.SHORT_TYPE_INFO, tti.getTypeAt(7));
-		Assert.assertEquals(BasicTypeInfo.BYTE_TYPE_INFO, tti.getTypeAt(8));
+		assertEquals(BasicTypeInfo.INT_TYPE_INFO, tti.getTypeAt(0));
+		assertEquals(BasicTypeInfo.LONG_TYPE_INFO, tti.getTypeAt(1));
+		assertEquals(BasicTypeInfo.DOUBLE_TYPE_INFO, tti.getTypeAt(2));
+		assertEquals(BasicTypeInfo.FLOAT_TYPE_INFO, tti.getTypeAt(3));
+		assertEquals(BasicTypeInfo.BOOLEAN_TYPE_INFO, tti.getTypeAt(4));
+		assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tti.getTypeAt(5));
+		assertEquals(BasicTypeInfo.CHAR_TYPE_INFO, tti.getTypeAt(6));
+		assertEquals(BasicTypeInfo.SHORT_TYPE_INFO, tti.getTypeAt(7));
+		assertEquals(BasicTypeInfo.BYTE_TYPE_INFO, tti.getTypeAt(8));
 
 		// use getForObject()
-		Tuple9<Integer, Long, Double, Float, Boolean, String, Character, Short, Byte> t = new Tuple9<Integer, Long, Double, Float, Boolean, String, Character, Short, Byte>(
-				1, 1L, 1.0, 1.0F, false, "Hello World", 'w', (short) 1, (byte) 1);
+		Tuple9<Integer, Long, Double, Float, Boolean, String, Character, Short, Byte> t = new Tuple9<>(1, 1L, 1.0, 1.0F, false, "Hello World", 'w', (short) 1, (byte) 1);
 
-		Assert.assertTrue(TypeExtractor.getForObject(t) instanceof TupleTypeInfo);
+		assertTrue(TypeExtractor.getForObject(t) instanceof TupleTypeInfo);
 		TupleTypeInfo<?> tti2 = (TupleTypeInfo<?>) TypeExtractor.getForObject(t);
 
-		Assert.assertEquals(BasicTypeInfo.INT_TYPE_INFO, tti2.getTypeAt(0));
-		Assert.assertEquals(BasicTypeInfo.LONG_TYPE_INFO, tti2.getTypeAt(1));
-		Assert.assertEquals(BasicTypeInfo.DOUBLE_TYPE_INFO, tti2.getTypeAt(2));
-		Assert.assertEquals(BasicTypeInfo.FLOAT_TYPE_INFO, tti2.getTypeAt(3));
-		Assert.assertEquals(BasicTypeInfo.BOOLEAN_TYPE_INFO, tti2.getTypeAt(4));
-		Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tti2.getTypeAt(5));
-		Assert.assertEquals(BasicTypeInfo.CHAR_TYPE_INFO, tti2.getTypeAt(6));
-		Assert.assertEquals(BasicTypeInfo.SHORT_TYPE_INFO, tti2.getTypeAt(7));
-		Assert.assertEquals(BasicTypeInfo.BYTE_TYPE_INFO, tti2.getTypeAt(8));
+		assertEquals(BasicTypeInfo.INT_TYPE_INFO, tti2.getTypeAt(0));
+		assertEquals(BasicTypeInfo.LONG_TYPE_INFO, tti2.getTypeAt(1));
+		assertEquals(BasicTypeInfo.DOUBLE_TYPE_INFO, tti2.getTypeAt(2));
+		assertEquals(BasicTypeInfo.FLOAT_TYPE_INFO, tti2.getTypeAt(3));
+		assertEquals(BasicTypeInfo.BOOLEAN_TYPE_INFO, tti2.getTypeAt(4));
+		assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tti2.getTypeAt(5));
+		assertEquals(BasicTypeInfo.CHAR_TYPE_INFO, tti2.getTypeAt(6));
+		assertEquals(BasicTypeInfo.SHORT_TYPE_INFO, tti2.getTypeAt(7));
+		assertEquals(BasicTypeInfo.BYTE_TYPE_INFO, tti2.getTypeAt(8));
 		
 		// test that getForClass does not work
 		try {
@@ -181,58 +182,57 @@ public class TypeExtractorTest {
 		};
 
 		TypeInformation<?> ti = TypeExtractor.getFlatMapReturnTypes(function, (TypeInformation) TypeInfoParser.parse("Tuple3<Tuple1<String>, Tuple1<Integer>, Tuple2<Long, Long>>"));
-		Assert.assertTrue(ti.isTupleType());
-		Assert.assertEquals(3, ti.getArity());
-		Assert.assertTrue(ti instanceof TupleTypeInfo);
-		List<FlatFieldDescriptor> ffd = new ArrayList<FlatFieldDescriptor>();
+		assertTrue(ti.isTupleType());
+		assertEquals(3, ti.getArity());
+		assertTrue(ti instanceof TupleTypeInfo);
+		List<FlatFieldDescriptor> ffd = new ArrayList<>();
 		
 		((TupleTypeInfo) ti).getFlatFields("f0.f0", 0, ffd);
-		Assert.assertEquals(0, ffd.get(0).getPosition() );
+		assertEquals(0, ffd.get(0).getPosition() );
 		ffd.clear();
 		
 		((TupleTypeInfo) ti).getFlatFields("f0.f0", 0, ffd);
-		Assert.assertTrue( ffd.get(0).getType() instanceof BasicTypeInfo );
-		Assert.assertTrue( ffd.get(0).getType().getTypeClass().equals(String.class) );
+		assertTrue( ffd.get(0).getType() instanceof BasicTypeInfo );
+		assertTrue( ffd.get(0).getType().getTypeClass().equals(String.class) );
 		ffd.clear();
 		
 		((TupleTypeInfo) ti).getFlatFields("f1.f0", 0, ffd);
-		Assert.assertEquals(1, ffd.get(0).getPosition() );
+		assertEquals(1, ffd.get(0).getPosition() );
 		ffd.clear();
 
 		TupleTypeInfo<?> tti = (TupleTypeInfo<?>) ti;
-		Assert.assertEquals(Tuple3.class, tti.getTypeClass());
+		assertEquals(Tuple3.class, tti.getTypeClass());
 
-		Assert.assertTrue(tti.getTypeAt(0).isTupleType());
-		Assert.assertTrue(tti.getTypeAt(1).isTupleType());
-		Assert.assertTrue(tti.getTypeAt(2).isTupleType());
+		assertTrue(tti.getTypeAt(0).isTupleType());
+		assertTrue(tti.getTypeAt(1).isTupleType());
+		assertTrue(tti.getTypeAt(2).isTupleType());
 		
-		Assert.assertEquals(Tuple1.class, tti.getTypeAt(0).getTypeClass());
-		Assert.assertEquals(Tuple1.class, tti.getTypeAt(1).getTypeClass());
-		Assert.assertEquals(Tuple2.class, tti.getTypeAt(2).getTypeClass());
+		assertEquals(Tuple1.class, tti.getTypeAt(0).getTypeClass());
+		assertEquals(Tuple1.class, tti.getTypeAt(1).getTypeClass());
+		assertEquals(Tuple2.class, tti.getTypeAt(2).getTypeClass());
 
-		Assert.assertEquals(1, tti.getTypeAt(0).getArity());
-		Assert.assertEquals(1, tti.getTypeAt(1).getArity());
-		Assert.assertEquals(2, tti.getTypeAt(2).getArity());
+		assertEquals(1, tti.getTypeAt(0).getArity());
+		assertEquals(1, tti.getTypeAt(1).getArity());
+		assertEquals(2, tti.getTypeAt(2).getArity());
 
-		Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, ((TupleTypeInfo<?>) tti.getTypeAt(0)).getTypeAt(0));
-		Assert.assertEquals(BasicTypeInfo.INT_TYPE_INFO, ((TupleTypeInfo<?>) tti.getTypeAt(1)).getTypeAt(0));
-		Assert.assertEquals(BasicTypeInfo.LONG_TYPE_INFO, ((TupleTypeInfo<?>) tti.getTypeAt(2)).getTypeAt(0));
-		Assert.assertEquals(BasicTypeInfo.LONG_TYPE_INFO, ((TupleTypeInfo<?>) tti.getTypeAt(2)).getTypeAt(1));
+		assertEquals(BasicTypeInfo.STRING_TYPE_INFO, ((TupleTypeInfo<?>) tti.getTypeAt(0)).getTypeAt(0));
+		assertEquals(BasicTypeInfo.INT_TYPE_INFO, ((TupleTypeInfo<?>) tti.getTypeAt(1)).getTypeAt(0));
+		assertEquals(BasicTypeInfo.LONG_TYPE_INFO, ((TupleTypeInfo<?>) tti.getTypeAt(2)).getTypeAt(0));
+		assertEquals(BasicTypeInfo.LONG_TYPE_INFO, ((TupleTypeInfo<?>) tti.getTypeAt(2)).getTypeAt(1));
 
 		// use getForObject()
-		Tuple3<Tuple1<String>, Tuple1<Integer>, Tuple2<Long, Long>> t = new Tuple3<Tuple1<String>, Tuple1<Integer>, Tuple2<Long, Long>>(
-				new Tuple1<String>("hello"), new Tuple1<Integer>(1), new Tuple2<Long, Long>(2L, 3L));
-		Assert.assertTrue(TypeExtractor.getForObject(t) instanceof TupleTypeInfo);
+		Tuple3<Tuple1<String>, Tuple1<Integer>, Tuple2<Long, Long>> t = new Tuple3<>(new Tuple1<>("hello"), new Tuple1<>(1), new Tuple2<>(2L, 3L));
+		assertTrue(TypeExtractor.getForObject(t) instanceof TupleTypeInfo);
 		TupleTypeInfo<?> tti2 = (TupleTypeInfo<?>) TypeExtractor.getForObject(t);
 
-		Assert.assertEquals(1, tti2.getTypeAt(0).getArity());
-		Assert.assertEquals(1, tti2.getTypeAt(1).getArity());
-		Assert.assertEquals(2, tti2.getTypeAt(2).getArity());
+		assertEquals(1, tti2.getTypeAt(0).getArity());
+		assertEquals(1, tti2.getTypeAt(1).getArity());
+		assertEquals(2, tti2.getTypeAt(2).getArity());
 
-		Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, ((TupleTypeInfo<?>) tti2.getTypeAt(0)).getTypeAt(0));
-		Assert.assertEquals(BasicTypeInfo.INT_TYPE_INFO, ((TupleTypeInfo<?>) tti2.getTypeAt(1)).getTypeAt(0));
-		Assert.assertEquals(BasicTypeInfo.LONG_TYPE_INFO, ((TupleTypeInfo<?>) tti2.getTypeAt(2)).getTypeAt(0));
-		Assert.assertEquals(BasicTypeInfo.LONG_TYPE_INFO, ((TupleTypeInfo<?>) tti2.getTypeAt(2)).getTypeAt(1));
+		assertEquals(BasicTypeInfo.STRING_TYPE_INFO, ((TupleTypeInfo<?>) tti2.getTypeAt(0)).getTypeAt(0));
+		assertEquals(BasicTypeInfo.INT_TYPE_INFO, ((TupleTypeInfo<?>) tti2.getTypeAt(1)).getTypeAt(0));
+		assertEquals(BasicTypeInfo.LONG_TYPE_INFO, ((TupleTypeInfo<?>) tti2.getTypeAt(2)).getTypeAt(0));
+		assertEquals(BasicTypeInfo.LONG_TYPE_INFO, ((TupleTypeInfo<?>) tti2.getTypeAt(2)).getTypeAt(1));
 	}
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })
@@ -251,9 +251,9 @@ public class TypeExtractorTest {
 		TypeInformation<?> ti = TypeExtractor.getFlatMapReturnTypes(function,
 				(TypeInformation) TypeInfoParser.parse("Tuple0"));
 
-		Assert.assertTrue(ti.isTupleType());
-		Assert.assertEquals(0, ti.getArity());
-		Assert.assertTrue(ti instanceof TupleTypeInfo);
+		assertTrue(ti.isTupleType());
+		assertEquals(0, ti.getArity());
+		assertTrue(ti instanceof TupleTypeInfo);
 	}
 	
 	@SuppressWarnings({ "unchecked", "rawtypes" })
@@ -269,27 +269,31 @@ public class TypeExtractorTest {
 			}			
 		};
 
-		TypeInformation<?> ti = TypeExtractor.getFlatJoinReturnTypes(function, (TypeInformation) TypeInfoParser.parse("Tuple2<String, Integer>"), (TypeInformation) TypeInfoParser.parse("String"));
+		TypeInformation<?> ti = TypeExtractor.getFlatJoinReturnTypes(function, TypeInfoParser.parse("Tuple2<String, Integer>"), TypeInfoParser.parse("String"));
 
-		Assert.assertTrue(ti.isTupleType());
-		Assert.assertEquals(2, ti.getArity());
-		Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, ((TupleTypeInfo<?>) ti).getTypeAt(0));
-		Assert.assertEquals(BasicTypeInfo.INT_TYPE_INFO, ((TupleTypeInfo<?>) ti).getTypeAt(1));
-		Assert.assertEquals(CustomTuple.class, ((TupleTypeInfo<?>) ti).getTypeClass());
+		assertTrue(ti.isTupleType());
+		assertEquals(2, ti.getArity());
+		assertEquals(BasicTypeInfo.STRING_TYPE_INFO, ((TupleTypeInfo<?>) ti).getTypeAt(0));
+		assertEquals(BasicTypeInfo.INT_TYPE_INFO, ((TupleTypeInfo<?>) ti).getTypeAt(1));
+		assertEquals(CustomTuple.class, ((TupleTypeInfo<?>) ti).getTypeClass());
 
 		// use getForObject()
 		CustomTuple t = new CustomTuple("hello", 1);
 		TypeInformation<?> ti2 = TypeExtractor.getForObject(t);
 
-		Assert.assertTrue(ti2.isTupleType());
-		Assert.assertEquals(2, ti2.getArity());
-		Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, ((TupleTypeInfo<?>) ti2).getTypeAt(0));
-		Assert.assertEquals(BasicTypeInfo.INT_TYPE_INFO, ((TupleTypeInfo<?>) ti2).getTypeAt(1));
-		Assert.assertEquals(CustomTuple.class, ((TupleTypeInfo<?>) ti2).getTypeClass());
+		assertTrue(ti2.isTupleType());
+		assertEquals(2, ti2.getArity());
+		assertEquals(BasicTypeInfo.STRING_TYPE_INFO, ((TupleTypeInfo<?>) ti2).getTypeAt(0));
+		assertEquals(BasicTypeInfo.INT_TYPE_INFO, ((TupleTypeInfo<?>) ti2).getTypeAt(1));
+		assertEquals(CustomTuple.class, ((TupleTypeInfo<?>) ti2).getTypeClass());
 	}
 
 	public static class CustomTuple extends Tuple2<String, Integer> {
 		private static final long serialVersionUID = 1L;
+
+		public CustomTuple() {
+			// default constructor
+		}
 
 		public CustomTuple(String myField1, Integer myField2) {
 			this.setFields(myField1, myField2);
@@ -322,18 +326,16 @@ public class TypeExtractorTest {
 			}			
 		};
 
-		TypeInformation<?> ti = TypeExtractor.getCrossReturnTypes(function, 
-				(TypeInformation) TypeInfoParser.parse("org.apache.flink.api.java.typeutils.TypeExtractorTest$CustomType"),
-				(TypeInformation) TypeInfoParser.parse("Integer"));
+		TypeInformation<?> ti = TypeExtractor.getCrossReturnTypes(function, TypeInfoParser.parse("org.apache.flink.api.java.typeutils.TypeExtractorTest$CustomType"), TypeInfoParser.parse("Integer"));
 
 		Assert.assertFalse(ti.isBasicType());
 		Assert.assertFalse(ti.isTupleType());
-		Assert.assertTrue(ti instanceof PojoTypeInfo);
-		Assert.assertEquals(ti.getTypeClass(), CustomType.class);
+		assertTrue(ti instanceof PojoTypeInfo);
+		assertEquals(ti.getTypeClass(), CustomType.class);
 
 		// use getForClass()
-		Assert.assertTrue(TypeExtractor.getForClass(CustomType.class) instanceof PojoTypeInfo);
-		Assert.assertEquals(TypeExtractor.getForClass(CustomType.class).getTypeClass(), ti.getTypeClass());
+		assertTrue(TypeExtractor.getForClass(CustomType.class) instanceof PojoTypeInfo);
+		assertEquals(TypeExtractor.getForClass(CustomType.class).getTypeClass(), ti.getTypeClass());
 
 		// use getForObject()
 		CustomType t = new CustomType("World", 1);
@@ -341,8 +343,8 @@ public class TypeExtractorTest {
 
 		Assert.assertFalse(ti2.isBasicType());
 		Assert.assertFalse(ti2.isTupleType());
-		Assert.assertTrue(ti2 instanceof PojoTypeInfo);
-		Assert.assertEquals(ti2.getTypeClass(), CustomType.class);
+		assertTrue(ti2 instanceof PojoTypeInfo);
+		assertEquals(ti2.getTypeClass(), CustomType.class);
 
 		Assert.assertFalse(TypeExtractor.getForClass(PojoWithNonPublicDefaultCtor.class) instanceof PojoTypeInfo);
 	}
@@ -353,9 +355,9 @@ public class TypeExtractorTest {
 		row.setField(0, "string");
 		row.setField(1, 15);
 		TypeInformation<Row> rowInfo = TypeExtractor.getForObject(row);
-		Assert.assertEquals(rowInfo.getClass(), RowTypeInfo.class);
-		Assert.assertEquals(2, rowInfo.getArity());
-		Assert.assertEquals(
+		assertEquals(rowInfo.getClass(), RowTypeInfo.class);
+		assertEquals(2, rowInfo.getArity());
+		assertEquals(
 			new RowTypeInfo(
 				BasicTypeInfo.STRING_TYPE_INFO,
 				BasicTypeInfo.INT_TYPE_INFO),
@@ -363,7 +365,7 @@ public class TypeExtractorTest {
 
 		Row nullRow = new Row(2);
 		TypeInformation<Row> genericRowInfo = TypeExtractor.getForObject(nullRow);
-		Assert.assertEquals(genericRowInfo, new GenericTypeInfo<>(Row.class));
+		assertEquals(genericRowInfo, new GenericTypeInfo<>(Row.class));
 	}
 	
 	public static class CustomType {
@@ -396,46 +398,46 @@ public class TypeExtractorTest {
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, 
 				(TypeInformation) TypeInfoParser.parse("Tuple2<Long,org.apache.flink.api.java.typeutils.TypeExtractorTest$CustomType>"));
 
-		Assert.assertTrue(ti.isTupleType());
-		Assert.assertEquals(2, ti.getArity());
+		assertTrue(ti.isTupleType());
+		assertEquals(2, ti.getArity());
 		
 		TupleTypeInfo<?> tti = (TupleTypeInfo<?>) ti;
-		Assert.assertEquals(Tuple2.class, tti.getTypeClass());
-		List<FlatFieldDescriptor> ffd = new ArrayList<FlatFieldDescriptor>();
+		assertEquals(Tuple2.class, tti.getTypeClass());
+		List<FlatFieldDescriptor> ffd = new ArrayList<>();
 		
 		tti.getFlatFields("f0", 0, ffd);
-		Assert.assertEquals(1, ffd.size());
-		Assert.assertEquals(0, ffd.get(0).getPosition() ); // Long
-		Assert.assertTrue( ffd.get(0).getType().getTypeClass().equals(Long.class) );
+		assertEquals(1, ffd.size());
+		assertEquals(0, ffd.get(0).getPosition() ); // Long
+		assertTrue( ffd.get(0).getType().getTypeClass().equals(Long.class) );
 		ffd.clear();
 		
 		tti.getFlatFields("f1.myField1", 0, ffd);
-		Assert.assertEquals(1, ffd.get(0).getPosition() );
-		Assert.assertTrue( ffd.get(0).getType().getTypeClass().equals(String.class) );
+		assertEquals(1, ffd.get(0).getPosition() );
+		assertTrue( ffd.get(0).getType().getTypeClass().equals(String.class) );
 		ffd.clear();
 		
 		
 		tti.getFlatFields("f1.myField2", 0, ffd);
-		Assert.assertEquals(2, ffd.get(0).getPosition() );
-		Assert.assertTrue( ffd.get(0).getType().getTypeClass().equals(Integer.class) );
+		assertEquals(2, ffd.get(0).getPosition() );
+		assertTrue( ffd.get(0).getType().getTypeClass().equals(Integer.class) );
 		
 		
-		Assert.assertEquals(Long.class, tti.getTypeAt(0).getTypeClass());
-		Assert.assertTrue(tti.getTypeAt(1) instanceof PojoTypeInfo);
-		Assert.assertEquals(CustomType.class, tti.getTypeAt(1).getTypeClass());
+		assertEquals(Long.class, tti.getTypeAt(0).getTypeClass());
+		assertTrue(tti.getTypeAt(1) instanceof PojoTypeInfo);
+		assertEquals(CustomType.class, tti.getTypeAt(1).getTypeClass());
 
 		// use getForObject()
-		Tuple2<?, ?> t = new Tuple2<Long, CustomType>(1L, new CustomType("Hello", 1));
+		Tuple2<?, ?> t = new Tuple2<>(1L, new CustomType("Hello", 1));
 		TypeInformation<?> ti2 = TypeExtractor.getForObject(t);
 
-		Assert.assertTrue(ti2.isTupleType());
-		Assert.assertEquals(2, ti2.getArity());
+		assertTrue(ti2.isTupleType());
+		assertEquals(2, ti2.getArity());
 		TupleTypeInfo<?> tti2 = (TupleTypeInfo<?>) ti2;
 		
-		Assert.assertEquals(Tuple2.class, tti2.getTypeClass());
-		Assert.assertEquals(Long.class, tti2.getTypeAt(0).getTypeClass());
-		Assert.assertTrue(tti2.getTypeAt(1) instanceof PojoTypeInfo);
-		Assert.assertEquals(CustomType.class, tti2.getTypeAt(1).getTypeClass());
+		assertEquals(Tuple2.class, tti2.getTypeClass());
+		assertEquals(Long.class, tti2.getTypeAt(0).getTypeClass());
+		assertTrue(tti2.getTypeAt(1) instanceof PojoTypeInfo);
+		assertEquals(CustomType.class, tti2.getTypeAt(1).getTypeClass());
 	}
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })
@@ -455,17 +457,17 @@ public class TypeExtractorTest {
 
 		Assert.assertFalse(ti.isBasicType());
 		Assert.assertFalse(ti.isTupleType());
-		Assert.assertTrue(ti instanceof ValueTypeInfo);
-		Assert.assertEquals(ti.getTypeClass(), StringValue.class);
+		assertTrue(ti instanceof ValueTypeInfo);
+		assertEquals(ti.getTypeClass(), StringValue.class);
 
 		// use getForClass()
-		Assert.assertTrue(TypeExtractor.getForClass(StringValue.class) instanceof ValueTypeInfo);
-		Assert.assertEquals(TypeExtractor.getForClass(StringValue.class).getTypeClass(), ti.getTypeClass());
+		assertTrue(TypeExtractor.getForClass(StringValue.class) instanceof ValueTypeInfo);
+		assertEquals(TypeExtractor.getForClass(StringValue.class).getTypeClass(), ti.getTypeClass());
 
 		// use getForObject()
 		StringValue v = new StringValue("Hello");
-		Assert.assertTrue(TypeExtractor.getForObject(v) instanceof ValueTypeInfo);
-		Assert.assertEquals(TypeExtractor.getForObject(v).getTypeClass(), ti.getTypeClass());
+		assertTrue(TypeExtractor.getForObject(v) instanceof ValueTypeInfo);
+		assertEquals(TypeExtractor.getForObject(v).getTypeClass(), ti.getTypeClass());
 	}
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })
@@ -484,22 +486,26 @@ public class TypeExtractorTest {
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, (TypeInformation) TypeInfoParser.parse("Tuple2<StringValue, IntValue>"));
 
 		Assert.assertFalse(ti.isBasicType());
-		Assert.assertTrue(ti.isTupleType());
-		Assert.assertEquals(StringValue.class, ((TupleTypeInfo<?>) ti).getTypeAt(0).getTypeClass());
-		Assert.assertEquals(IntValue.class, ((TupleTypeInfo<?>) ti).getTypeAt(1).getTypeClass());
+		assertTrue(ti.isTupleType());
+		assertEquals(StringValue.class, ((TupleTypeInfo<?>) ti).getTypeAt(0).getTypeClass());
+		assertEquals(IntValue.class, ((TupleTypeInfo<?>) ti).getTypeAt(1).getTypeClass());
 
 		// use getForObject()
-		Tuple2<StringValue, IntValue> t = new Tuple2<StringValue, IntValue>(new StringValue("x"), new IntValue(1));
+		Tuple2<StringValue, IntValue> t = new Tuple2<>(new StringValue("x"), new IntValue(1));
 		TypeInformation<?> ti2 = TypeExtractor.getForObject(t);
 
 		Assert.assertFalse(ti2.isBasicType());
-		Assert.assertTrue(ti2.isTupleType());
-		Assert.assertEquals(((TupleTypeInfo<?>) ti2).getTypeAt(0).getTypeClass(), StringValue.class);
-		Assert.assertEquals(((TupleTypeInfo<?>) ti2).getTypeAt(1).getTypeClass(), IntValue.class);
+		assertTrue(ti2.isTupleType());
+		assertEquals(((TupleTypeInfo<?>) ti2).getTypeAt(0).getTypeClass(), StringValue.class);
+		assertEquals(((TupleTypeInfo<?>) ti2).getTypeAt(1).getTypeClass(), IntValue.class);
 	}
 
 	public static class LongKeyValue<V> extends Tuple2<Long, V> {
 		private static final long serialVersionUID = 1L;
+
+		public LongKeyValue() {
+			// default constructor
+		}
 
 		public LongKeyValue(Long field1, V field2) {
 			this.f0 = field1;
@@ -522,18 +528,22 @@ public class TypeExtractorTest {
 
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, (TypeInformation) TypeInfoParser.parse("Tuple2<Long, String>"));
 
-		Assert.assertTrue(ti.isTupleType());
-		Assert.assertEquals(2, ti.getArity());
+		assertTrue(ti.isTupleType());
+		assertEquals(2, ti.getArity());
 		
 		TupleTypeInfo<?> tti = (TupleTypeInfo<?>) ti;
-		Assert.assertEquals(LongKeyValue.class, tti.getTypeClass());
+		assertEquals(LongKeyValue.class, tti.getTypeClass());
 		
-		Assert.assertEquals(BasicTypeInfo.LONG_TYPE_INFO, tti.getTypeAt(0));
-		Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tti.getTypeAt(1));
+		assertEquals(BasicTypeInfo.LONG_TYPE_INFO, tti.getTypeAt(0));
+		assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tti.getTypeAt(1));
 	}
 
 	public static class ChainedOne<X, Y> extends Tuple3<X, Long, Y> {
 		private static final long serialVersionUID = 1L;
+
+		public ChainedOne() {
+			// default constructor
+		}
 
 		public ChainedOne(X field0, Long field1, Y field2) {
 			this.f0 = field0;
@@ -544,6 +554,10 @@ public class TypeExtractorTest {
 
 	public static class ChainedTwo<V> extends ChainedOne<String, V> {
 		private static final long serialVersionUID = 1L;
+
+		public ChainedTwo() {
+			// default constructor
+		}
 
 		public ChainedTwo(String field0, Long field1, V field2) {
 			super(field0, field1, field2);
@@ -565,19 +579,23 @@ public class TypeExtractorTest {
 
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, (TypeInformation) TypeInfoParser.parse("Tuple3<String, Long, Integer>"));
 
-		Assert.assertTrue(ti.isTupleType());
-		Assert.assertEquals(3, ti.getArity());
+		assertTrue(ti.isTupleType());
+		assertEquals(3, ti.getArity());
 		
 		TupleTypeInfo<?> tti = (TupleTypeInfo<?>) ti;
-		Assert.assertEquals(ChainedTwo.class, tti.getTypeClass());
+		assertEquals(ChainedTwo.class, tti.getTypeClass());
 		
-		Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tti.getTypeAt(0));
-		Assert.assertEquals(BasicTypeInfo.LONG_TYPE_INFO, tti.getTypeAt(1));
-		Assert.assertEquals(BasicTypeInfo.INT_TYPE_INFO, tti.getTypeAt(2));
+		assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tti.getTypeAt(0));
+		assertEquals(BasicTypeInfo.LONG_TYPE_INFO, tti.getTypeAt(1));
+		assertEquals(BasicTypeInfo.INT_TYPE_INFO, tti.getTypeAt(2));
 	}
 
 	public static class ChainedThree extends ChainedTwo<String> {
 		private static final long serialVersionUID = 1L;
+
+		public ChainedThree() {
+			// default constructor
+		}
 
 		public ChainedThree(String field0, Long field1, String field2) {
 			super(field0, field1, field2);
@@ -586,6 +604,10 @@ public class TypeExtractorTest {
 
 	public static class ChainedFour extends ChainedThree {
 		private static final long serialVersionUID = 1L;
+
+		public ChainedFour() {
+			// default constructor
+		}
 
 		public ChainedFour(String field0, Long field1, String field2) {
 			super(field0, field1, field2);
@@ -607,15 +629,15 @@ public class TypeExtractorTest {
 
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, (TypeInformation) TypeInfoParser.parse("Tuple3<String, Long, String>"));
 
-		Assert.assertTrue(ti.isTupleType());
-		Assert.assertEquals(3, ti.getArity());
+		assertTrue(ti.isTupleType());
+		assertEquals(3, ti.getArity());
 		
 		TupleTypeInfo<?> tti = (TupleTypeInfo<?>) ti;
-		Assert.assertEquals(ChainedThree.class, tti.getTypeClass());
+		assertEquals(ChainedThree.class, tti.getTypeClass());
 		
-		Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tti.getTypeAt(0));
-		Assert.assertEquals(BasicTypeInfo.LONG_TYPE_INFO, tti.getTypeAt(1));
-		Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tti.getTypeAt(2));
+		assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tti.getTypeAt(0));
+		assertEquals(BasicTypeInfo.LONG_TYPE_INFO, tti.getTypeAt(1));
+		assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tti.getTypeAt(2));
 	}
 	
 	@SuppressWarnings({ "unchecked", "rawtypes" })
@@ -633,15 +655,15 @@ public class TypeExtractorTest {
 
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, (TypeInformation) TypeInfoParser.parse("Tuple3<String, Long, String>"));
 
-		Assert.assertTrue(ti.isTupleType());
-		Assert.assertEquals(3, ti.getArity());
+		assertTrue(ti.isTupleType());
+		assertEquals(3, ti.getArity());
 		
 		TupleTypeInfo<?> tti = (TupleTypeInfo<?>) ti;
-		Assert.assertEquals(ChainedFour.class, tti.getTypeClass());
+		assertEquals(ChainedFour.class, tti.getTypeClass());
 		
-		Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tti.getTypeAt(0));
-		Assert.assertEquals(BasicTypeInfo.LONG_TYPE_INFO, tti.getTypeAt(1));
-		Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tti.getTypeAt(2));
+		assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tti.getTypeAt(0));
+		assertEquals(BasicTypeInfo.LONG_TYPE_INFO, tti.getTypeAt(1));
+		assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tti.getTypeAt(2));
 	}
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })
@@ -657,7 +679,7 @@ public class TypeExtractorTest {
 		};
 
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, (TypeInformation) TypeInfoParser.parse("String"), "name", true);
-		Assert.assertTrue(ti instanceof MissingTypeInfo);
+		assertTrue(ti instanceof MissingTypeInfo);
 		
 		try {
 			TypeExtractor.getMapReturnTypes(function, (TypeInformation) TypeInfoParser.parse("String"));
@@ -681,7 +703,7 @@ public class TypeExtractorTest {
 		};
 
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, (TypeInformation) TypeInfoParser.parse("String"), "name", true);
-		Assert.assertTrue(ti instanceof MissingTypeInfo);
+		assertTrue(ti instanceof MissingTypeInfo);
 		
 		try {
 			TypeExtractor.getMapReturnTypes(function, (TypeInformation) TypeInfoParser.parse("String"));
@@ -694,6 +716,10 @@ public class TypeExtractorTest {
 
 	public static class SameTypeVariable<X> extends Tuple2<X, X> {
 		private static final long serialVersionUID = 1L;
+
+		public SameTypeVariable() {
+			// default constructor
+		}
 
 		public SameTypeVariable(X field0, X field1) {
 			super(field0, field1);
@@ -714,18 +740,22 @@ public class TypeExtractorTest {
 
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, (TypeInformation) TypeInfoParser.parse("Tuple2<String, String>"));
 
-		Assert.assertTrue(ti.isTupleType());
-		Assert.assertEquals(2, ti.getArity());
+		assertTrue(ti.isTupleType());
+		assertEquals(2, ti.getArity());
 		
 		TupleTypeInfo<?> tti = (TupleTypeInfo<?>) ti;
-		Assert.assertEquals(SameTypeVariable.class, tti.getTypeClass());
+		assertEquals(SameTypeVariable.class, tti.getTypeClass());
 		
-		Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tti.getTypeAt(0));
-		Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tti.getTypeAt(1));
+		assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tti.getTypeAt(0));
+		assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tti.getTypeAt(1));
 	}
 
 	public static class Nested<V, T> extends Tuple2<V, Tuple2<T, T>> {
 		private static final long serialVersionUID = 1L;
+
+		public Nested() {
+			// default constructor
+		}
 
 		public Nested(V field0, Tuple2<T, T> field1) {
 			super(field0, field1);
@@ -746,25 +776,29 @@ public class TypeExtractorTest {
 
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, (TypeInformation) TypeInfoParser.parse("Tuple2<String, Tuple2<Integer, Integer>>"));
 
-		Assert.assertTrue(ti.isTupleType());
-		Assert.assertEquals(2, ti.getArity());
+		assertTrue(ti.isTupleType());
+		assertEquals(2, ti.getArity());
 		
 		TupleTypeInfo<?> tti = (TupleTypeInfo<?>) ti;
-		Assert.assertEquals(Nested.class, tti.getTypeClass());
+		assertEquals(Nested.class, tti.getTypeClass());
 		
-		Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tti.getTypeAt(0));
-		Assert.assertTrue(tti.getTypeAt(1).isTupleType());
-		Assert.assertEquals(2, tti.getTypeAt(1).getArity());
+		assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tti.getTypeAt(0));
+		assertTrue(tti.getTypeAt(1).isTupleType());
+		assertEquals(2, tti.getTypeAt(1).getArity());
 
 		// Nested
 		TupleTypeInfo<?> tti2 = (TupleTypeInfo<?>) tti.getTypeAt(1);
-		Assert.assertEquals(Tuple2.class, tti2.getTypeClass());
-		Assert.assertEquals(BasicTypeInfo.INT_TYPE_INFO, tti2.getTypeAt(0));
-		Assert.assertEquals(BasicTypeInfo.INT_TYPE_INFO, tti2.getTypeAt(1));
+		assertEquals(Tuple2.class, tti2.getTypeClass());
+		assertEquals(BasicTypeInfo.INT_TYPE_INFO, tti2.getTypeAt(0));
+		assertEquals(BasicTypeInfo.INT_TYPE_INFO, tti2.getTypeAt(1));
 	}
 
 	public static class Nested2<T> extends Nested<T, Nested<Integer, T>> {
 		private static final long serialVersionUID = 1L;
+
+		public Nested2() {
+			// default constructor
+		}
 
 		public Nested2(T field0, Tuple2<Nested<Integer, T>, Nested<Integer, T>> field1) {
 			super(field0, field1);
@@ -789,26 +823,26 @@ public class TypeExtractorTest {
 		// Tuple2<Boolean, Tuple2<Tuple2<Integer, Tuple2<Boolean, Boolean>>, Tuple2<Integer, Tuple2<Boolean, Boolean>>>>
 
 		// 1st nested level
-		Assert.assertTrue(ti.isTupleType());
-		Assert.assertEquals(2, ti.getArity());
+		assertTrue(ti.isTupleType());
+		assertEquals(2, ti.getArity());
 		TupleTypeInfo<?> tti = (TupleTypeInfo<?>) ti;
-		Assert.assertEquals(BasicTypeInfo.BOOLEAN_TYPE_INFO, tti.getTypeAt(0));
-		Assert.assertTrue(tti.getTypeAt(1).isTupleType());
+		assertEquals(BasicTypeInfo.BOOLEAN_TYPE_INFO, tti.getTypeAt(0));
+		assertTrue(tti.getTypeAt(1).isTupleType());
 
 		// 2nd nested level
 		TupleTypeInfo<?> tti2 = (TupleTypeInfo<?>) tti.getTypeAt(1);
-		Assert.assertTrue(tti2.getTypeAt(0).isTupleType());
-		Assert.assertTrue(tti2.getTypeAt(1).isTupleType());
+		assertTrue(tti2.getTypeAt(0).isTupleType());
+		assertTrue(tti2.getTypeAt(1).isTupleType());
 
 		// 3rd nested level
 		TupleTypeInfo<?> tti3 = (TupleTypeInfo<?>) tti2.getTypeAt(0);
-		Assert.assertEquals(BasicTypeInfo.INT_TYPE_INFO, tti3.getTypeAt(0));
-		Assert.assertTrue(tti3.getTypeAt(1).isTupleType());
+		assertEquals(BasicTypeInfo.INT_TYPE_INFO, tti3.getTypeAt(0));
+		assertTrue(tti3.getTypeAt(1).isTupleType());
 
 		// 4th nested level
 		TupleTypeInfo<?> tti4 = (TupleTypeInfo<?>) tti3.getTypeAt(1);
-		Assert.assertEquals(BasicTypeInfo.BOOLEAN_TYPE_INFO, tti4.getTypeAt(0));
-		Assert.assertEquals(BasicTypeInfo.BOOLEAN_TYPE_INFO, tti4.getTypeAt(1));
+		assertEquals(BasicTypeInfo.BOOLEAN_TYPE_INFO, tti4.getTypeAt(0));
+		assertEquals(BasicTypeInfo.BOOLEAN_TYPE_INFO, tti4.getTypeAt(1));
 	}
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })
@@ -824,7 +858,7 @@ public class TypeExtractorTest {
 		};
 
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, TypeInfoParser.parse("String"), "name", true);
-		Assert.assertTrue(ti instanceof MissingTypeInfo);
+		assertTrue(ti instanceof MissingTypeInfo);
 		
 		try {
 			TypeExtractor.getMapReturnTypes(function, TypeInfoParser.parse("String"));
@@ -844,8 +878,8 @@ public class TypeExtractorTest {
 
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, (TypeInformation) TypeInfoParser.parse("Boolean"));
 
-		Assert.assertTrue(ti.isBasicType());
-		Assert.assertEquals(BasicTypeInfo.BOOLEAN_TYPE_INFO, ti);
+		assertTrue(ti.isBasicType());
+		assertEquals(BasicTypeInfo.BOOLEAN_TYPE_INFO, ti);
 	}
 
 	public class IdentityMapper<T> extends RichMapFunction<T, T> {
@@ -859,17 +893,17 @@ public class TypeExtractorTest {
 
 	@Test
 	public void testFunctionDependingOnInputFromInput() {
-		IdentityMapper<Boolean> function = new IdentityMapper<Boolean>();
+		IdentityMapper<Boolean> function = new IdentityMapper<>();
 
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, BasicTypeInfo.BOOLEAN_TYPE_INFO);
 
-		Assert.assertTrue(ti.isBasicType());
-		Assert.assertEquals(BasicTypeInfo.BOOLEAN_TYPE_INFO, ti);
+		assertTrue(ti.isBasicType());
+		assertEquals(BasicTypeInfo.BOOLEAN_TYPE_INFO, ti);
 	}
 	
 	@Test
 	public void testFunctionDependingOnInputWithMissingInput() {
-		IdentityMapper<Boolean> function = new IdentityMapper<Boolean>();
+		IdentityMapper<Boolean> function = new IdentityMapper<>();
 
 		try {
 			TypeExtractor.getMapReturnTypes(function, null);
@@ -890,29 +924,28 @@ public class TypeExtractorTest {
 
 	@Test
 	public void testFunctionDependingOnInputWithTupleInput() {
-		IdentityMapper2<Boolean> function = new IdentityMapper2<Boolean>();
+		IdentityMapper2<Boolean> function = new IdentityMapper2<>();
 
-		TypeInformation<Tuple2<Boolean, String>> inputType = new TupleTypeInfo<Tuple2<Boolean, String>>(BasicTypeInfo.BOOLEAN_TYPE_INFO,
-				BasicTypeInfo.STRING_TYPE_INFO);
+		TypeInformation<Tuple2<Boolean, String>> inputType = new TupleTypeInfo<>(BasicTypeInfo.BOOLEAN_TYPE_INFO, BasicTypeInfo.STRING_TYPE_INFO);
 
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, inputType);
 
-		Assert.assertTrue(ti.isBasicType());
-		Assert.assertEquals(BasicTypeInfo.BOOLEAN_TYPE_INFO, ti);
+		assertTrue(ti.isBasicType());
+		assertEquals(BasicTypeInfo.BOOLEAN_TYPE_INFO, ti);
 	}
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Test
 	public void testFunctionDependingOnInputWithCustomTupleInput() {
-		IdentityMapper<SameTypeVariable<String>> function = new IdentityMapper<SameTypeVariable<String>>();
+		IdentityMapper<SameTypeVariable<String>> function = new IdentityMapper<>();
 
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, (TypeInformation) TypeInfoParser.parse("Tuple2<String, String>"));
 
-		Assert.assertTrue(ti.isTupleType());
-		Assert.assertEquals(2, ti.getArity());
+		assertTrue(ti.isTupleType());
+		assertEquals(2, ti.getArity());
 		TupleTypeInfo<?> tti = (TupleTypeInfo<?>) ti;
-		Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tti.getTypeAt(0));
-		Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tti.getTypeAt(1));
+		assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tti.getTypeAt(0));
+		assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tti.getTypeAt(1));
 	}
 
 	public class IdentityMapper3<T, V> extends RichMapFunction<T, V> {
@@ -926,10 +959,10 @@ public class TypeExtractorTest {
 
 	@Test
 	public void testFunctionDependingOnUnknownInput() {
-		IdentityMapper3<Boolean, String> function = new IdentityMapper3<Boolean, String>();
+		IdentityMapper3<Boolean, String> function = new IdentityMapper3<>();
 
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, BasicTypeInfo.BOOLEAN_TYPE_INFO, "name", true);
-		Assert.assertTrue(ti instanceof MissingTypeInfo);
+		assertTrue(ti instanceof MissingTypeInfo);
 		
 		try {
 			TypeExtractor.getMapReturnTypes(function, BasicTypeInfo.BOOLEAN_TYPE_INFO);
@@ -946,11 +979,11 @@ public class TypeExtractorTest {
 
 	@Test
 	public void testFunctionDependingOnInputWithFunctionHierarchy() {
-		IdentityMapper4<String> function = new IdentityMapper4<String>();
+		IdentityMapper4<String> function = new IdentityMapper4<>();
 
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, BasicTypeInfo.STRING_TYPE_INFO);
 
-		Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, ti);
+		assertEquals(BasicTypeInfo.STRING_TYPE_INFO, ti);
 	}
 
 	public class IdentityMapper5<D> extends IdentityMapper<Tuple2<D, D>> {
@@ -959,16 +992,16 @@ public class TypeExtractorTest {
 
 	@Test
 	public void testFunctionDependingOnInputWithFunctionHierarchy2() {
-		IdentityMapper5<String> function = new IdentityMapper5<String>();
+		IdentityMapper5<String> function = new IdentityMapper5<>();
 
 		@SuppressWarnings({ "rawtypes", "unchecked" })
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, new TupleTypeInfo(BasicTypeInfo.STRING_TYPE_INFO,
 				BasicTypeInfo.STRING_TYPE_INFO));
 
-		Assert.assertTrue(ti.isTupleType());
+		assertTrue(ti.isTupleType());
 		TupleTypeInfo<?> tti = (TupleTypeInfo<?>) ti;
-		Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tti.getTypeAt(0));
-		Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tti.getTypeAt(1));
+		assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tti.getTypeAt(0));
+		assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tti.getTypeAt(1));
 	}
 
 	public class Mapper extends IdentityMapper<String> {
@@ -996,15 +1029,15 @@ public class TypeExtractorTest {
 
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, (TypeInformation) TypeInfoParser.parse("String"));
 
-		Assert.assertTrue(ti.isBasicType());
-		Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, ti);
+		assertTrue(ti.isBasicType());
+		assertEquals(BasicTypeInfo.STRING_TYPE_INFO, ti);
 	}
 
 	public class OneAppender<T> extends RichMapFunction<T, Tuple2<T, Integer>> {
 		private static final long serialVersionUID = 1L;
 
 		public Tuple2<T, Integer> map(T value) {
-			return new Tuple2<T, Integer>(value, 1);
+			return new Tuple2<>(value, 1);
 		}
 	}
 
@@ -1017,80 +1050,79 @@ public class TypeExtractorTest {
 
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, (TypeInformation) TypeInfoParser.parse("DoubleValue"));
 
-		Assert.assertTrue(ti.isTupleType());
-		Assert.assertEquals(2, ti.getArity());
+		assertTrue(ti.isTupleType());
+		assertEquals(2, ti.getArity());
 		TupleTypeInfo<?> tti = (TupleTypeInfo<?>) ti;
 
-		Assert.assertTrue(tti.getTypeAt(0) instanceof ValueTypeInfo<?>);
+		assertTrue(tti.getTypeAt(0) instanceof ValueTypeInfo<?>);
 		ValueTypeInfo<?> vti = (ValueTypeInfo<?>) tti.getTypeAt(0);
-		Assert.assertEquals(DoubleValue.class, vti.getTypeClass());
+		assertEquals(DoubleValue.class, vti.getTypeClass());
 		
-		Assert.assertTrue(tti.getTypeAt(1).isBasicType());
-		Assert.assertEquals(Integer.class , tti.getTypeAt(1).getTypeClass());
+		assertTrue(tti.getTypeAt(1).isBasicType());
+		assertEquals(Integer.class , tti.getTypeAt(1).getTypeClass());
 	}
 
 	@Test
 	public void testFunctionDependingPartialOnInput2() {
-		RichMapFunction<DoubleValue, ?> function = new OneAppender<DoubleValue>();
+		RichMapFunction<DoubleValue, ?> function = new OneAppender<>();
 
-		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, new ValueTypeInfo<DoubleValue>(DoubleValue.class));
+		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, new ValueTypeInfo<>(DoubleValue.class));
 
-		Assert.assertTrue(ti.isTupleType());
-		Assert.assertEquals(2, ti.getArity());
+		assertTrue(ti.isTupleType());
+		assertEquals(2, ti.getArity());
 		TupleTypeInfo<?> tti = (TupleTypeInfo<?>) ti;
 
-		Assert.assertTrue(tti.getTypeAt(0) instanceof ValueTypeInfo<?>);
+		assertTrue(tti.getTypeAt(0) instanceof ValueTypeInfo<?>);
 		ValueTypeInfo<?> vti = (ValueTypeInfo<?>) tti.getTypeAt(0);
-		Assert.assertEquals(DoubleValue.class, vti.getTypeClass());
+		assertEquals(DoubleValue.class, vti.getTypeClass());
 		
-		Assert.assertTrue(tti.getTypeAt(1).isBasicType());
-		Assert.assertEquals(Integer.class , tti.getTypeAt(1).getTypeClass());
+		assertTrue(tti.getTypeAt(1).isBasicType());
+		assertEquals(Integer.class , tti.getTypeAt(1).getTypeClass());
 	}
 
 	public class FieldDuplicator<T> extends RichMapFunction<T, Tuple2<T, T>> {
 		private static final long serialVersionUID = 1L;
 
 		public Tuple2<T, T> map(T value) {
-			return new Tuple2<T, T>(value, value);
+			return new Tuple2<>(value, value);
 		}
 	}
 
 	@Test
 	public void testFunctionInputInOutputMultipleTimes() {
-		RichMapFunction<Float, ?> function = new FieldDuplicator<Float>();
+		RichMapFunction<Float, ?> function = new FieldDuplicator<>();
 
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, BasicTypeInfo.FLOAT_TYPE_INFO);
 
-		Assert.assertTrue(ti.isTupleType());
-		Assert.assertEquals(2, ti.getArity());
+		assertTrue(ti.isTupleType());
+		assertEquals(2, ti.getArity());
 		TupleTypeInfo<?> tti = (TupleTypeInfo<?>) ti;
-		Assert.assertEquals(BasicTypeInfo.FLOAT_TYPE_INFO, tti.getTypeAt(0));
-		Assert.assertEquals(BasicTypeInfo.FLOAT_TYPE_INFO, tti.getTypeAt(1));
+		assertEquals(BasicTypeInfo.FLOAT_TYPE_INFO, tti.getTypeAt(0));
+		assertEquals(BasicTypeInfo.FLOAT_TYPE_INFO, tti.getTypeAt(1));
 	}
 
 	@Test
 	public void testFunctionInputInOutputMultipleTimes2() {
-		RichMapFunction<Tuple2<Float, Float>, ?> function = new FieldDuplicator<Tuple2<Float, Float>>();
+		RichMapFunction<Tuple2<Float, Float>, ?> function = new FieldDuplicator<>();
 
-		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, new TupleTypeInfo<Tuple2<Float, Float>>(
-				BasicTypeInfo.FLOAT_TYPE_INFO, BasicTypeInfo.FLOAT_TYPE_INFO));
+		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, new TupleTypeInfo<>(BasicTypeInfo.FLOAT_TYPE_INFO, BasicTypeInfo.FLOAT_TYPE_INFO));
 
 		// should be
 		// Tuple2<Tuple2<Float, Float>, Tuple2<Float, Float>>
 
-		Assert.assertTrue(ti.isTupleType());
-		Assert.assertEquals(2, ti.getArity());
+		assertTrue(ti.isTupleType());
+		assertEquals(2, ti.getArity());
 		TupleTypeInfo<?> tti = (TupleTypeInfo<?>) ti;
 
 		// 2nd nested level	
-		Assert.assertTrue(tti.getTypeAt(0).isTupleType());
+		assertTrue(tti.getTypeAt(0).isTupleType());
 		TupleTypeInfo<?> tti2 = (TupleTypeInfo<?>) tti.getTypeAt(0);
-		Assert.assertEquals(BasicTypeInfo.FLOAT_TYPE_INFO, tti2.getTypeAt(0));
-		Assert.assertEquals(BasicTypeInfo.FLOAT_TYPE_INFO, tti2.getTypeAt(1));
-		Assert.assertTrue(tti.getTypeAt(0).isTupleType());
+		assertEquals(BasicTypeInfo.FLOAT_TYPE_INFO, tti2.getTypeAt(0));
+		assertEquals(BasicTypeInfo.FLOAT_TYPE_INFO, tti2.getTypeAt(1));
+		assertTrue(tti.getTypeAt(0).isTupleType());
 		TupleTypeInfo<?> tti3 = (TupleTypeInfo<?>) tti.getTypeAt(1);
-		Assert.assertEquals(BasicTypeInfo.FLOAT_TYPE_INFO, tti3.getTypeAt(0));
-		Assert.assertEquals(BasicTypeInfo.FLOAT_TYPE_INFO, tti3.getTypeAt(1));
+		assertEquals(BasicTypeInfo.FLOAT_TYPE_INFO, tti3.getTypeAt(0));
+		assertEquals(BasicTypeInfo.FLOAT_TYPE_INFO, tti3.getTypeAt(1));
 	}
 
 	public interface Testable {}
@@ -1115,7 +1147,7 @@ public class TypeExtractorTest {
 		};
 
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, BasicTypeInfo.STRING_TYPE_INFO);
-		Assert.assertTrue(ti instanceof GenericTypeInfo);
+		assertTrue(ti instanceof GenericTypeInfo);
 
 		// abstract class with out class member
 		RichMapFunction<String, ?> function2 = new RichMapFunction<String, AbstractClassWithoutMember>() {
@@ -1128,7 +1160,7 @@ public class TypeExtractorTest {
 		};
 
 		ti = TypeExtractor.getMapReturnTypes(function2, BasicTypeInfo.STRING_TYPE_INFO);
-		Assert.assertTrue(ti instanceof GenericTypeInfo);
+		assertTrue(ti instanceof GenericTypeInfo);
 
 		// abstract class with class member
 		RichMapFunction<String, ?> function3 = new RichMapFunction<String, AbstractClassWithMember>() {
@@ -1141,7 +1173,7 @@ public class TypeExtractorTest {
 		};
 
 		ti = TypeExtractor.getMapReturnTypes(function3, BasicTypeInfo.STRING_TYPE_INFO);
-		Assert.assertTrue(ti instanceof PojoTypeInfo);
+		assertTrue(ti instanceof PojoTypeInfo);
 	}
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })
@@ -1157,7 +1189,7 @@ public class TypeExtractorTest {
 		};
 
 		TypeInformation<?> ti =TypeExtractor.getMapReturnTypes(function, (TypeInformation)TypeInfoParser.parse("StringValue"), "name", true);
-		Assert.assertTrue(ti instanceof MissingTypeInfo);
+		assertTrue(ti instanceof MissingTypeInfo);
 		
 		try {
 			TypeExtractor.getMapReturnTypes(function, (TypeInformation)TypeInfoParser.parse("StringValue"));
@@ -1181,32 +1213,32 @@ public class TypeExtractorTest {
 			}
 		};
 
-		TypeInformation<?> ti = TypeExtractor.getCoGroupReturnTypes(function, (TypeInformation) TypeInfoParser.parse("String[]"), (TypeInformation) TypeInfoParser.parse("String[]"));
+		TypeInformation<?> ti = TypeExtractor.getCoGroupReturnTypes(function, TypeInfoParser.parse("String[]"), TypeInfoParser.parse("String[]"));
 
 		Assert.assertFalse(ti.isBasicType());
 		Assert.assertFalse(ti.isTupleType());
 		
 		// Due to a Java 6 bug the classification can be slightly wrong
-		Assert.assertTrue(ti instanceof BasicArrayTypeInfo<?,?> || ti instanceof ObjectArrayTypeInfo<?,?>);
+		assertTrue(ti instanceof BasicArrayTypeInfo<?,?> || ti instanceof ObjectArrayTypeInfo<?,?>);
 		
 		if(ti instanceof BasicArrayTypeInfo<?,?>) {
-			Assert.assertEquals(BasicArrayTypeInfo.STRING_ARRAY_TYPE_INFO, ti);
+			assertEquals(BasicArrayTypeInfo.STRING_ARRAY_TYPE_INFO, ti);
 		}
 		else {
-			Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, ((ObjectArrayTypeInfo<?,?>) ti).getComponentInfo());
+			assertEquals(BasicTypeInfo.STRING_TYPE_INFO, ((ObjectArrayTypeInfo<?,?>) ti).getComponentInfo());
 		}		
 	}
 
 	@Test
 	public void testBasicArray2() {
-		RichMapFunction<Boolean[], ?> function = new IdentityMapper<Boolean[]>();
+		RichMapFunction<Boolean[], ?> function = new IdentityMapper<>();
 
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, BasicArrayTypeInfo.BOOLEAN_ARRAY_TYPE_INFO);
 
-		Assert.assertTrue(ti instanceof BasicArrayTypeInfo<?, ?>);
+		assertTrue(ti instanceof BasicArrayTypeInfo<?, ?>);
 		BasicArrayTypeInfo<?, ?> bati = (BasicArrayTypeInfo<?, ?>) ti;
-		Assert.assertTrue(bati.getComponentInfo().isBasicType());
-		Assert.assertEquals(BasicTypeInfo.BOOLEAN_TYPE_INFO, bati.getComponentInfo());
+		assertTrue(bati.getComponentInfo().isBasicType());
+		assertEquals(BasicTypeInfo.BOOLEAN_TYPE_INFO, bati.getComponentInfo());
 	}
 
 	public static class CustomArrayObject {}
@@ -1226,8 +1258,8 @@ public class TypeExtractorTest {
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function,
 				(TypeInformation) TypeInfoParser.parse("org.apache.flink.api.java.typeutils.TypeExtractorTest$CustomArrayObject[]"));
 
-		Assert.assertTrue(ti instanceof ObjectArrayTypeInfo<?, ?>);
-		Assert.assertEquals(CustomArrayObject.class, ((ObjectArrayTypeInfo<?, ?>) ti).getComponentInfo().getTypeClass());
+		assertTrue(ti instanceof ObjectArrayTypeInfo<?, ?>);
+		assertEquals(CustomArrayObject.class, ((ObjectArrayTypeInfo<?, ?>) ti).getComponentInfo().getTypeClass());
 	}
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })
@@ -1244,12 +1276,12 @@ public class TypeExtractorTest {
 		
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, (TypeInformation) TypeInfoParser.parse("Tuple2<String, String>[]"));
 
-		Assert.assertTrue(ti instanceof ObjectArrayTypeInfo<?, ?>);
+		assertTrue(ti instanceof ObjectArrayTypeInfo<?, ?>);
 		ObjectArrayTypeInfo<?, ?> oati = (ObjectArrayTypeInfo<?, ?>) ti;
-		Assert.assertTrue(oati.getComponentInfo().isTupleType());
+		assertTrue(oati.getComponentInfo().isTupleType());
 		TupleTypeInfo<?> tti = (TupleTypeInfo<?>) oati.getComponentInfo();
-		Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tti.getTypeAt(0));
-		Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tti.getTypeAt(1));
+		assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tti.getTypeAt(0));
+		assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tti.getTypeAt(1));
 	}
 
 	public class CustomArrayObject2<F> extends Tuple1<F> {
@@ -1260,15 +1292,15 @@ public class TypeExtractorTest {
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Test
 	public void testCustomArrayWithTypeVariable() {
-		RichMapFunction<CustomArrayObject2<Boolean>[], ?> function = new IdentityMapper<CustomArrayObject2<Boolean>[]>();
+		RichMapFunction<CustomArrayObject2<Boolean>[], ?> function = new IdentityMapper<>();
 
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, (TypeInformation) TypeInfoParser.parse("Tuple1<Boolean>[]"));
 
-		Assert.assertTrue(ti instanceof ObjectArrayTypeInfo<?, ?>);
+		assertTrue(ti instanceof ObjectArrayTypeInfo<?, ?>);
 		ObjectArrayTypeInfo<?, ?> oati = (ObjectArrayTypeInfo<?, ?>) ti;
-		Assert.assertTrue(oati.getComponentInfo().isTupleType());
+		assertTrue(oati.getComponentInfo().isTupleType());
 		TupleTypeInfo<?> tti = (TupleTypeInfo<?>) oati.getComponentInfo();
-		Assert.assertEquals(BasicTypeInfo.BOOLEAN_TYPE_INFO, tti.getTypeAt(0));
+		assertEquals(BasicTypeInfo.BOOLEAN_TYPE_INFO, tti.getTypeAt(0));
 	}
 	
 	public class GenericArrayClass<T> extends RichMapFunction<T[], T[]> {
@@ -1288,9 +1320,9 @@ public class TypeExtractorTest {
 		};
 		
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, (TypeInformation) TypeInfoParser.parse("Boolean[]"));
-		Assert.assertTrue(ti instanceof ObjectArrayTypeInfo<?,?>);
+		assertTrue(ti instanceof ObjectArrayTypeInfo<?,?>);
 		ObjectArrayTypeInfo<?, ?> oati = (ObjectArrayTypeInfo<?, ?>) ti;
-		Assert.assertEquals(BasicTypeInfo.BOOLEAN_TYPE_INFO, oati.getComponentInfo());
+		assertEquals(BasicTypeInfo.BOOLEAN_TYPE_INFO, oati.getComponentInfo());
 	}
 	
 	public static class MyObject<T> {
@@ -1311,15 +1343,14 @@ public class TypeExtractorTest {
 		};
 		TypeInformation<?> inType = TypeExtractor.createTypeInfo(InType.class);
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, (TypeInformation) inType);
-		Assert.assertTrue(ti instanceof PojoTypeInfo);
+		assertTrue(ti instanceof PojoTypeInfo);
 	}
 	
 	@Test
 	public void testFunctionDependingOnInputWithTupleInputWithTypeMismatch() {
-		IdentityMapper2<Boolean> function = new IdentityMapper2<Boolean>();
+		IdentityMapper2<Boolean> function = new IdentityMapper2<>();
 
-		TypeInformation<Tuple2<Boolean, String>> inputType = new TupleTypeInfo<Tuple2<Boolean, String>>(BasicTypeInfo.BOOLEAN_TYPE_INFO,
-				BasicTypeInfo.INT_TYPE_INFO);
+		TypeInformation<Tuple2<Boolean, String>> inputType = new TupleTypeInfo<>(BasicTypeInfo.BOOLEAN_TYPE_INFO, BasicTypeInfo.INT_TYPE_INFO);
 		
 		// input is: Tuple2<Boolean, Integer>
 		// allowed: Tuple2<?, String>
@@ -1406,7 +1437,7 @@ public class TypeExtractorTest {
 	public void testTypeErasure() {
 		TypeInformation<?> ti = TypeExtractor.getFlatMapReturnTypes(new DummyFlatMapFunction<String, Integer, String, Boolean>(), 
 					(TypeInformation) TypeInfoParser.parse("Tuple2<String, Integer>"), "name", true);
-		Assert.assertTrue(ti instanceof MissingTypeInfo);
+		assertTrue(ti instanceof MissingTypeInfo);
 		
 		try {
 			TypeExtractor.getFlatMapReturnTypes(new DummyFlatMapFunction<String, Integer, String, Boolean>(), 
@@ -1437,7 +1468,7 @@ public class TypeExtractorTest {
 	@Test
 	public void testResultTypeQueryable() {
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(new MyQueryableMapper<Integer>(), BasicTypeInfo.STRING_TYPE_INFO);
-		Assert.assertEquals(BasicTypeInfo.INT_TYPE_INFO, ti);
+		assertEquals(BasicTypeInfo.INT_TYPE_INFO, ti);
 	}
 	
 	@Test
@@ -1453,15 +1484,15 @@ public class TypeExtractorTest {
 		
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, BasicTypeInfo.INT_TYPE_INFO);
 		TupleTypeInfo<?> tti = (TupleTypeInfo<?>) ti;
-		Assert.assertEquals(PrimitiveArrayTypeInfo.INT_PRIMITIVE_ARRAY_TYPE_INFO, tti.getTypeAt(0));
-		Assert.assertEquals(PrimitiveArrayTypeInfo.DOUBLE_PRIMITIVE_ARRAY_TYPE_INFO, tti.getTypeAt(1));
-		Assert.assertEquals(PrimitiveArrayTypeInfo.LONG_PRIMITIVE_ARRAY_TYPE_INFO, tti.getTypeAt(2));
-		Assert.assertEquals(PrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO, tti.getTypeAt(3));
-		Assert.assertEquals(PrimitiveArrayTypeInfo.CHAR_PRIMITIVE_ARRAY_TYPE_INFO, tti.getTypeAt(4));
-		Assert.assertEquals(PrimitiveArrayTypeInfo.FLOAT_PRIMITIVE_ARRAY_TYPE_INFO, tti.getTypeAt(5));
-		Assert.assertEquals(PrimitiveArrayTypeInfo.SHORT_PRIMITIVE_ARRAY_TYPE_INFO, tti.getTypeAt(6));
-		Assert.assertEquals(PrimitiveArrayTypeInfo.BOOLEAN_PRIMITIVE_ARRAY_TYPE_INFO, tti.getTypeAt(7));
-		Assert.assertEquals(BasicArrayTypeInfo.STRING_ARRAY_TYPE_INFO, tti.getTypeAt(8));
+		assertEquals(PrimitiveArrayTypeInfo.INT_PRIMITIVE_ARRAY_TYPE_INFO, tti.getTypeAt(0));
+		assertEquals(PrimitiveArrayTypeInfo.DOUBLE_PRIMITIVE_ARRAY_TYPE_INFO, tti.getTypeAt(1));
+		assertEquals(PrimitiveArrayTypeInfo.LONG_PRIMITIVE_ARRAY_TYPE_INFO, tti.getTypeAt(2));
+		assertEquals(PrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO, tti.getTypeAt(3));
+		assertEquals(PrimitiveArrayTypeInfo.CHAR_PRIMITIVE_ARRAY_TYPE_INFO, tti.getTypeAt(4));
+		assertEquals(PrimitiveArrayTypeInfo.FLOAT_PRIMITIVE_ARRAY_TYPE_INFO, tti.getTypeAt(5));
+		assertEquals(PrimitiveArrayTypeInfo.SHORT_PRIMITIVE_ARRAY_TYPE_INFO, tti.getTypeAt(6));
+		assertEquals(PrimitiveArrayTypeInfo.BOOLEAN_PRIMITIVE_ARRAY_TYPE_INFO, tti.getTypeAt(7));
+		assertEquals(BasicArrayTypeInfo.STRING_ARRAY_TYPE_INFO, tti.getTypeAt(8));
 	}
 	
 	@Test
@@ -1496,7 +1527,7 @@ public class TypeExtractorTest {
 		};
 		
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(mapInterface, BasicTypeInfo.STRING_TYPE_INFO);
-		Assert.assertEquals(BasicTypeInfo.BOOLEAN_TYPE_INFO, ti);
+		assertEquals(BasicTypeInfo.BOOLEAN_TYPE_INFO, ti);
 	}
 
 	@Test
@@ -1511,7 +1542,7 @@ public class TypeExtractorTest {
 		};
 
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(mapInterface, BasicTypeInfo.STRING_TYPE_INFO);
-		Assert.assertEquals(BasicTypeInfo.BOOLEAN_TYPE_INFO, ti);
+		assertEquals(BasicTypeInfo.BOOLEAN_TYPE_INFO, ti);
 	}
 
 	@Test
@@ -1523,7 +1554,7 @@ public class TypeExtractorTest {
 			}
 		};
 		TypeInformation<?> ti = TypeExtractor.createTypeInfo(instance, null, null, 0);
-		Assert.assertEquals(BasicTypeInfo.LONG_TYPE_INFO, ti);
+		assertEquals(BasicTypeInfo.LONG_TYPE_INFO, ti);
 
 		// method also needs to work for instances that do not implement ResultTypeQueryable
 		MapFunction<Integer, Long> func = new MapFunction<Integer, Long>() {
@@ -1533,7 +1564,7 @@ public class TypeExtractorTest {
 			}
 		};
 		ti = TypeExtractor.createTypeInfo(func, MapFunction.class, func.getClass(), 0);
-		Assert.assertEquals(BasicTypeInfo.INT_TYPE_INFO, ti);
+		assertEquals(BasicTypeInfo.INT_TYPE_INFO, ti);
 	}
 	
 	@SuppressWarnings({ "serial", "unchecked", "rawtypes" })
@@ -1545,7 +1576,7 @@ public class TypeExtractorTest {
 		};
 
 		TypeInformation<?> ti = TypeExtractor.getKeySelectorTypes(selector, BasicTypeInfo.STRING_TYPE_INFO);
-		Assert.assertEquals(BasicTypeInfo.INT_TYPE_INFO, ti);
+		assertEquals(BasicTypeInfo.INT_TYPE_INFO, ti);
 		
 		try {
 			TypeExtractor.getKeySelectorTypes((KeySelector) selector, BasicTypeInfo.BOOLEAN_TYPE_INFO);
@@ -1564,7 +1595,7 @@ public class TypeExtractorTest {
 
 		@Override
 		public Tuple2<T, T> map(Tuple1<T> vertex) {
-			return new Tuple2<T, T>(vertex.f0, vertex.f0);
+			return new Tuple2<>(vertex.f0, vertex.f0);
 		}
 	}
 	
@@ -1572,11 +1603,11 @@ public class TypeExtractorTest {
 	@Test
 	public void testDuplicateValue() {
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes((MapFunction) new DuplicateValue<String>(), TypeInfoParser.parse("Tuple1<String>"));
-		Assert.assertTrue(ti.isTupleType());
-		Assert.assertEquals(2, ti.getArity());
+		assertTrue(ti.isTupleType());
+		assertEquals(2, ti.getArity());
 		TupleTypeInfo<?> tti = (TupleTypeInfo<?>) ti;
-		Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tti.getTypeAt(0));
-		Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tti.getTypeAt(1));
+		assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tti.getTypeAt(0));
+		assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tti.getTypeAt(1));
 	}
 	
 	public static class DuplicateValueNested<T> implements MapFunction<Tuple1<Tuple1<T>>, Tuple2<T, T>> {
@@ -1584,7 +1615,7 @@ public class TypeExtractorTest {
 
 		@Override
 		public Tuple2<T, T> map(Tuple1<Tuple1<T>> vertex) {
-			return new Tuple2<T, T>(null, null);
+			return new Tuple2<>(null, null);
 		}
 	}
 	
@@ -1592,11 +1623,11 @@ public class TypeExtractorTest {
 	@Test
 	public void testDuplicateValueNested() {
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes((MapFunction) new DuplicateValueNested<String>(), TypeInfoParser.parse("Tuple1<Tuple1<String>>"));
-		Assert.assertTrue(ti.isTupleType());
-		Assert.assertEquals(2, ti.getArity());
+		assertTrue(ti.isTupleType());
+		assertEquals(2, ti.getArity());
 		TupleTypeInfo<?> tti = (TupleTypeInfo<?>) ti;
-		Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tti.getTypeAt(0));
-		Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tti.getTypeAt(1));
+		assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tti.getTypeAt(0));
+		assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tti.getTypeAt(1));
 	}
 	
 	public static class Edge<K, V> extends Tuple3<K, K, V> {
@@ -1617,14 +1648,14 @@ public class TypeExtractorTest {
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@Test
 	public void testInputInference1() {
-		EdgeMapper<String, Double> em = new EdgeMapper<String, Double>();
+		EdgeMapper<String, Double> em = new EdgeMapper<>();
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes((MapFunction) em, TypeInfoParser.parse("Tuple3<String, String, Double>"));
-		Assert.assertTrue(ti.isTupleType());
-		Assert.assertEquals(3, ti.getArity());
+		assertTrue(ti.isTupleType());
+		assertEquals(3, ti.getArity());
 		TupleTypeInfo<?> tti = (TupleTypeInfo<?>) ti;
-		Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tti.getTypeAt(0));
-		Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tti.getTypeAt(1));
-		Assert.assertEquals(BasicTypeInfo.DOUBLE_TYPE_INFO, tti.getTypeAt(2));
+		assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tti.getTypeAt(0));
+		assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tti.getTypeAt(1));
+		assertEquals(BasicTypeInfo.DOUBLE_TYPE_INFO, tti.getTypeAt(2));
 	}
 	
 	public static class EdgeMapper2<V> implements MapFunction<V, Edge<Long, V>> {
@@ -1640,14 +1671,14 @@ public class TypeExtractorTest {
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@Test
 	public void testInputInference2() {
-		EdgeMapper2<Boolean> em = new EdgeMapper2<Boolean>();
+		EdgeMapper2<Boolean> em = new EdgeMapper2<>();
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes((MapFunction) em, TypeInfoParser.parse("Boolean"));
-		Assert.assertTrue(ti.isTupleType());
-		Assert.assertEquals(3, ti.getArity());
+		assertTrue(ti.isTupleType());
+		assertEquals(3, ti.getArity());
 		TupleTypeInfo<?> tti = (TupleTypeInfo<?>) ti;
-		Assert.assertEquals(BasicTypeInfo.LONG_TYPE_INFO, tti.getTypeAt(0));
-		Assert.assertEquals(BasicTypeInfo.LONG_TYPE_INFO, tti.getTypeAt(1));
-		Assert.assertEquals(BasicTypeInfo.BOOLEAN_TYPE_INFO, tti.getTypeAt(2));
+		assertEquals(BasicTypeInfo.LONG_TYPE_INFO, tti.getTypeAt(0));
+		assertEquals(BasicTypeInfo.LONG_TYPE_INFO, tti.getTypeAt(1));
+		assertEquals(BasicTypeInfo.BOOLEAN_TYPE_INFO, tti.getTypeAt(2));
 	}
 	
 	public static class EdgeMapper3<K, V> implements MapFunction<Edge<K, V>, V> {
@@ -1662,10 +1693,10 @@ public class TypeExtractorTest {
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@Test
 	public void testInputInference3() {
-		EdgeMapper3<Boolean, String> em = new EdgeMapper3<Boolean, String>();
+		EdgeMapper3<Boolean, String> em = new EdgeMapper3<>();
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes((MapFunction) em, TypeInfoParser.parse("Tuple3<Boolean,Boolean,String>"));
-		Assert.assertTrue(ti.isBasicType());
-		Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, ti);
+		assertTrue(ti.isBasicType());
+		assertEquals(BasicTypeInfo.STRING_TYPE_INFO, ti);
 	}
 	
 	public static class EdgeMapper4<K, V> implements MapFunction<Edge<K, V>[], V> {
@@ -1680,10 +1711,10 @@ public class TypeExtractorTest {
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@Test
 	public void testInputInference4() {
-		EdgeMapper4<Boolean, String> em = new EdgeMapper4<Boolean, String>();
+		EdgeMapper4<Boolean, String> em = new EdgeMapper4<>();
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes((MapFunction) em, TypeInfoParser.parse("Tuple3<Boolean,Boolean,String>[]"));
-		Assert.assertTrue(ti.isBasicType());
-		Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, ti);
+		assertTrue(ti.isBasicType());
+		assertEquals(BasicTypeInfo.STRING_TYPE_INFO, ti);
 	}
 
 	public static class CustomTuple2WithArray<K> extends Tuple2<K[], K> {
@@ -1710,19 +1741,19 @@ public class TypeExtractorTest {
 			new TypeHint<CustomTuple2WithArray<Long>>(){}.getTypeInfo(),
 			new TypeHint<CustomTuple2WithArray<Long>>(){}.getTypeInfo());
 
-		Assert.assertTrue(ti.isTupleType());
+		assertTrue(ti.isTupleType());
 		TupleTypeInfo<?> tti = (TupleTypeInfo<?>) ti;
-		Assert.assertEquals(BasicTypeInfo.LONG_TYPE_INFO, tti.getTypeAt(1));
+		assertEquals(BasicTypeInfo.LONG_TYPE_INFO, tti.getTypeAt(1));
 
-		Assert.assertTrue(tti.getTypeAt(0) instanceof ObjectArrayTypeInfo<?, ?>);
+		assertTrue(tti.getTypeAt(0) instanceof ObjectArrayTypeInfo<?, ?>);
 		ObjectArrayTypeInfo<?, ?> oati = (ObjectArrayTypeInfo<?, ?>) tti.getTypeAt(0);
-		Assert.assertEquals(BasicTypeInfo.LONG_TYPE_INFO, oati.getComponentInfo());
+		assertEquals(BasicTypeInfo.LONG_TYPE_INFO, oati.getComponentInfo());
 	}
 
-	public static enum MyEnum {
+	public enum MyEnum {
 		ONE, TWO, THREE
 	}
-	
+
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@Test
 	public void testEnumType() {
@@ -1735,9 +1766,9 @@ public class TypeExtractorTest {
 			}
 		};
 		
-		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes((MapFunction) mf, new EnumTypeInfo(MyEnum.class));
-		Assert.assertTrue(ti instanceof EnumTypeInfo);
-		Assert.assertEquals(ti.getTypeClass(), MyEnum.class);
+		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(mf, new EnumTypeInfo(MyEnum.class));
+		assertTrue(ti instanceof EnumTypeInfo);
+		assertEquals(ti.getTypeClass(), MyEnum.class);
 	}
 	
 	public static class MapperWithMultiDimGenericArray<T> implements MapFunction<T[][][], Tuple1<T>[][][]> {
@@ -1763,7 +1794,7 @@ public class TypeExtractorTest {
 			}
 		};
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes((MapFunction)function, TypeInfoParser.parse("Tuple2<Integer, Double>[][]"));
-		Assert.assertEquals("ObjectArrayTypeInfo<ObjectArrayTypeInfo<Java Tuple2<Integer, Double>>>", ti.toString());
+		assertEquals("ObjectArrayTypeInfo<ObjectArrayTypeInfo<Java Tuple2<Integer, Double>>>", ti.toString());
 
 		// primitive array
 		function = new MapFunction<int[][][], int[][][]>() {
@@ -1776,7 +1807,7 @@ public class TypeExtractorTest {
 			}
 		};
 		ti = TypeExtractor.getMapReturnTypes((MapFunction)function, TypeInfoParser.parse("int[][][]"));
-		Assert.assertEquals("ObjectArrayTypeInfo<ObjectArrayTypeInfo<int[]>>", ti.toString());
+		assertEquals("ObjectArrayTypeInfo<ObjectArrayTypeInfo<int[]>>", ti.toString());
 
 		// basic array
 		function = new MapFunction<Integer[][][], Integer[][][]>() {
@@ -1789,7 +1820,7 @@ public class TypeExtractorTest {
 			}
 		};
 		ti = TypeExtractor.getMapReturnTypes((MapFunction)function, TypeInfoParser.parse("Integer[][][]"));
-		Assert.assertEquals("ObjectArrayTypeInfo<ObjectArrayTypeInfo<BasicArrayTypeInfo<Integer>>>", ti.toString());
+		assertEquals("ObjectArrayTypeInfo<ObjectArrayTypeInfo<BasicArrayTypeInfo<Integer>>>", ti.toString());
 
 		// pojo array
 		function = new MapFunction<CustomType[][][], CustomType[][][]>() {
@@ -1806,13 +1837,13 @@ public class TypeExtractorTest {
 					+ "myField1=String,myField2=int"
 					+ ">[][][]"));
 		
-		Assert.assertEquals("ObjectArrayTypeInfo<ObjectArrayTypeInfo<ObjectArrayTypeInfo<"
+		assertEquals("ObjectArrayTypeInfo<ObjectArrayTypeInfo<ObjectArrayTypeInfo<"
 				+ "PojoType<org.apache.flink.api.java.typeutils.TypeExtractorTest$CustomType, fields = [myField1: String, myField2: Integer]>"
 				+ ">>>", ti.toString());
 		
 		// generic array
 		ti = TypeExtractor.getMapReturnTypes((MapFunction) new MapperWithMultiDimGenericArray<String>(), TypeInfoParser.parse("String[][][]"));
-		Assert.assertEquals("ObjectArrayTypeInfo<ObjectArrayTypeInfo<ObjectArrayTypeInfo<Java Tuple1<String>>>>", ti.toString());
+		assertEquals("ObjectArrayTypeInfo<ObjectArrayTypeInfo<ObjectArrayTypeInfo<Java Tuple1<String>>>>", ti.toString());
 	}
 
 	@SuppressWarnings("rawtypes")
@@ -1836,7 +1867,7 @@ public class TypeExtractorTest {
 		MapFunction<?, ?> function = new MapWithResultTypeQueryable();
 
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes((MapFunction)function, BasicTypeInfo.INT_TYPE_INFO);
-		Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, ti);
+		assertEquals(BasicTypeInfo.STRING_TYPE_INFO, ti);
 	}
 
 	public static class Either1<T> extends Either<String, T> {
@@ -1876,6 +1907,7 @@ public class TypeExtractorTest {
 		}
 	}
 
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testEither() {
 		MapFunction<?, ?> function = new MapFunction<Either<String, Boolean>, Either<String, Boolean>>() {
@@ -1886,28 +1918,29 @@ public class TypeExtractorTest {
 		};
 		TypeInformation<?> expected = new EitherTypeInfo(BasicTypeInfo.STRING_TYPE_INFO, BasicTypeInfo.BOOLEAN_TYPE_INFO);
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes((MapFunction) function, expected);
-		Assert.assertEquals(expected, ti);
+		assertEquals(expected, ti);
 	}
 
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testEitherHierarchy() {
 		MapFunction<?, ?> function = new EitherMapper<Boolean>();
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes((MapFunction) function, BasicTypeInfo.BOOLEAN_TYPE_INFO);
 		TypeInformation<?> expected = new EitherTypeInfo(BasicTypeInfo.STRING_TYPE_INFO, BasicTypeInfo.BOOLEAN_TYPE_INFO);
-		Assert.assertEquals(expected, ti);
+		assertEquals(expected, ti);
 
 		function = new EitherMapper2();
 		ti = TypeExtractor.getMapReturnTypes((MapFunction) function, BasicTypeInfo.STRING_TYPE_INFO);
 		expected = new EitherTypeInfo(BasicTypeInfo.STRING_TYPE_INFO, new TupleTypeInfo(BasicTypeInfo.INT_TYPE_INFO));
-		Assert.assertEquals(expected, ti);
+		assertEquals(expected, ti);
 
 		function = new EitherMapper3();
 		ti = TypeExtractor.getMapReturnTypes((MapFunction) function, expected);
-		Assert.assertEquals(expected, ti);
+		assertEquals(expected, ti);
 
 		Either<String, Tuple1<Integer>> either = new Either2();
 		ti = TypeExtractor.getForObject(either);
-		Assert.assertEquals(expected, ti);
+		assertEquals(expected, ti);
 	}
 
 	@Test(expected=InvalidTypesException.class)
@@ -1933,7 +1966,7 @@ public class TypeExtractorTest {
 
 		TypeInformation<?> ti = TypeExtractor.getMapReturnTypes(function, (TypeInformation) inputType);
 		TypeInformation<?> expected = TypeExtractor.createTypeInfo(Map.class);
-		Assert.assertEquals(expected, ti);
+		assertEquals(expected, ti);
 	}
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })
@@ -2039,20 +2072,20 @@ public class TypeExtractorTest {
 			(TypeInformation) TypeInformation.of(new TypeHint<Tuple2<BigInteger, BigDecimal>>() {
 		}));
 
-		Assert.assertTrue(ti.isTupleType());
+		assertTrue(ti.isTupleType());
 		TupleTypeInfo<?> tti = (TupleTypeInfo<?>) ti;
-		Assert.assertEquals(BasicTypeInfo.BIG_INT_TYPE_INFO, tti.getTypeAt(0));
-		Assert.assertEquals(BasicTypeInfo.BIG_DEC_TYPE_INFO, tti.getTypeAt(1));
+		assertEquals(BasicTypeInfo.BIG_INT_TYPE_INFO, tti.getTypeAt(0));
+		assertEquals(BasicTypeInfo.BIG_DEC_TYPE_INFO, tti.getTypeAt(1));
 
 		// use getForClass()
-		Assert.assertTrue(TypeExtractor.getForClass(BigInteger.class).isBasicType());
-		Assert.assertTrue(TypeExtractor.getForClass(BigDecimal.class).isBasicType());
-		Assert.assertEquals(tti.getTypeAt(0), TypeExtractor.getForClass(BigInteger.class));
-		Assert.assertEquals(tti.getTypeAt(1), TypeExtractor.getForClass(BigDecimal.class));
+		assertTrue(TypeExtractor.getForClass(BigInteger.class).isBasicType());
+		assertTrue(TypeExtractor.getForClass(BigDecimal.class).isBasicType());
+		assertEquals(tti.getTypeAt(0), TypeExtractor.getForClass(BigInteger.class));
+		assertEquals(tti.getTypeAt(1), TypeExtractor.getForClass(BigDecimal.class));
 
 		// use getForObject()
-		Assert.assertEquals(BasicTypeInfo.BIG_INT_TYPE_INFO, TypeExtractor.getForObject(new BigInteger("42")));
-		Assert.assertEquals(BasicTypeInfo.BIG_DEC_TYPE_INFO, TypeExtractor.getForObject(new BigDecimal("42.42")));
+		assertEquals(BasicTypeInfo.BIG_INT_TYPE_INFO, TypeExtractor.getForObject(new BigInteger("42")));
+		assertEquals(BasicTypeInfo.BIG_DEC_TYPE_INFO, TypeExtractor.getForObject(new BigDecimal("42.42")));
 	}
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })
@@ -2070,20 +2103,64 @@ public class TypeExtractorTest {
 			(TypeInformation) TypeInformation.of(new TypeHint<Tuple3<Date, Time, Timestamp>>() {
 		}));
 
-		Assert.assertTrue(ti.isTupleType());
+		assertTrue(ti.isTupleType());
 		TupleTypeInfo<?> tti = (TupleTypeInfo<?>) ti;
-		Assert.assertEquals(SqlTimeTypeInfo.DATE, tti.getTypeAt(0));
-		Assert.assertEquals(SqlTimeTypeInfo.TIME, tti.getTypeAt(1));
-		Assert.assertEquals(SqlTimeTypeInfo.TIMESTAMP, tti.getTypeAt(2));
+		assertEquals(SqlTimeTypeInfo.DATE, tti.getTypeAt(0));
+		assertEquals(SqlTimeTypeInfo.TIME, tti.getTypeAt(1));
+		assertEquals(SqlTimeTypeInfo.TIMESTAMP, tti.getTypeAt(2));
 
 		// use getForClass()
-		Assert.assertEquals(tti.getTypeAt(0), TypeExtractor.getForClass(Date.class));
-		Assert.assertEquals(tti.getTypeAt(1), TypeExtractor.getForClass(Time.class));
-		Assert.assertEquals(tti.getTypeAt(2), TypeExtractor.getForClass(Timestamp.class));
+		assertEquals(tti.getTypeAt(0), TypeExtractor.getForClass(Date.class));
+		assertEquals(tti.getTypeAt(1), TypeExtractor.getForClass(Time.class));
+		assertEquals(tti.getTypeAt(2), TypeExtractor.getForClass(Timestamp.class));
 
 		// use getForObject()
-		Assert.assertEquals(SqlTimeTypeInfo.DATE, TypeExtractor.getForObject(Date.valueOf("1998-12-12")));
-		Assert.assertEquals(SqlTimeTypeInfo.TIME, TypeExtractor.getForObject(Time.valueOf("12:37:45")));
-		Assert.assertEquals(SqlTimeTypeInfo.TIMESTAMP, TypeExtractor.getForObject(Timestamp.valueOf("1998-12-12 12:37:45")));
+		assertEquals(SqlTimeTypeInfo.DATE, TypeExtractor.getForObject(Date.valueOf("1998-12-12")));
+		assertEquals(SqlTimeTypeInfo.TIME, TypeExtractor.getForObject(Time.valueOf("12:37:45")));
+		assertEquals(SqlTimeTypeInfo.TIMESTAMP, TypeExtractor.getForObject(Timestamp.valueOf("1998-12-12 12:37:45")));
+	}
+
+	public class InvalidExtendingTuple1 extends Tuple1<Integer> { // not static
+		// empty
+	}
+
+	public static class InvalidExtendingTuple2 extends Tuple1<Integer> {
+		private InvalidExtendingTuple2() { // no default constructor
+			super();
+		} // private default constructor
+	}
+
+	@Test
+	public void testInvalidExtendingTuple() {
+		TypeInformation<?> ti = TypeExtractor.createTypeInfo(InvalidExtendingTuple1.class);
+		assertTrue(ti instanceof GenericTypeInfo);
+		ti = TypeExtractor.getForClass(InvalidExtendingTuple2.class);
+		assertTrue(ti instanceof GenericTypeInfo);
+	}
+
+	public static class PositionEvent extends Tuple2<Integer, String> {
+
+		public PositionEvent() {
+			// default constructor
+		}
+
+		public PositionEvent(int f0, String f1) {
+			this.f0 = f0;
+			this.f1 = f1;
+		}
+	}
+
+	@Test
+	public void testNamedTupleObject() {
+		TypeInformation<?> ti = TypeExtractor.getForObject(new PositionEvent(12, "hello"));
+		assertTrue(ti instanceof TupleTypeInfo);
+		TupleTypeInfo<?> tti = (TupleTypeInfo<?>) ti;
+		assertEquals(tti.getTypeAt(0), TypeExtractor.getForClass(Integer.class));
+		assertEquals(tti.getTypeAt(1), TypeExtractor.getForClass(String.class));
+	}
+
+	@Test(expected = InvalidTypesException.class)
+	public void testNamedTupleObjectWithNull() {
+		TypeInformation<?> ti = TypeExtractor.getForObject(new PositionEvent());
 	}
 }

--- a/flink-examples/flink-examples-batch/src/main/java/org/apache/flink/examples/java/relational/TPCHQuery3.java
+++ b/flink-examples/flink-examples-batch/src/main/java/org/apache/flink/examples/java/relational/TPCHQuery3.java
@@ -238,7 +238,10 @@ public class TPCHQuery3 {
 		}
 	}
 
-	private static class ShippingPriorityItem extends Tuple4<Long, Double, String, Long> {
+	/**
+	 * ShippingPriorityItem.
+	 */
+	public static class ShippingPriorityItem extends Tuple4<Long, Double, String, Long> {
 
 		public ShippingPriorityItem() {}
 

--- a/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
@@ -702,7 +702,7 @@ public abstract class ExecutionEnvironment {
 		catch (Exception e) {
 			throw new RuntimeException("Could not create TypeInformation for type " + data[0].getClass().getName()
 					+ "; please specify the TypeInformation manually via "
-					+ "ExecutionEnvironment#fromElements(Collection, TypeInformation)");
+					+ "ExecutionEnvironment#fromElements(Collection, TypeInformation)", e);
 		}
 
 		return fromCollection(Arrays.asList(data), typeInfo, Utils.getCallLocationName());

--- a/flink-java/src/test/java/org/apache/flink/api/java/io/CSVReaderTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/io/CSVReaderTest.java
@@ -304,19 +304,31 @@ public class CSVReaderTest {
 	// Custom types for testing
 	// --------------------------------------------------------------------------------------------
 
-	private static class Item extends Tuple4<Integer, String, Double, String> {
+	/**
+	 * Tuple subclass for testing.
+	 */
+	public static class Item extends Tuple4<Integer, String, Double, String> {
 		private static final long serialVersionUID = -7444437337392053502L;
 	}
 
-	private static class SubItem extends Item {
+	/**
+	 * Tuple subclass for testing.
+	 */
+	public static class SubItem extends Item {
 		private static final long serialVersionUID = 1L;
 	}
 
-	private static class PartialItem<A, B, C> extends Tuple5<Integer, A, Double, B, C> {
+	/**
+	 * Tuple subclass for testing.
+	 */
+	public static class PartialItem<A, B, C> extends Tuple5<Integer, A, Double, B, C> {
 		private static final long serialVersionUID = 1L;
 	}
 
-	private static class FinalItem extends PartialItem<String, StringValue, LongValue> {
+	/**
+	 * Tuple subclass for testing.
+	 */
+	public static class FinalItem extends PartialItem<String, StringValue, LongValue> {
 		private static final long serialVersionUID = 1L;
 	}
 

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/degree/annotate/directed/VertexDegrees.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/asm/degree/annotate/directed/VertexDegrees.java
@@ -245,7 +245,7 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Vertex<K, Degrees>> {
 	extends Tuple3<LongValue, LongValue, LongValue> {
 		private static final int HASH_SEED = 0x3a12fc31;
 
-		private MurmurHash hasher = new MurmurHash(HASH_SEED);
+		private final MurmurHash hasher = new MurmurHash(HASH_SEED);
 
 		public Degrees() {
 			this(new LongValue(), new LongValue(), new LongValue());

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenUtils.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenUtils.scala
@@ -26,7 +26,7 @@ import org.apache.flink.api.common.typeinfo.BasicTypeInfo._
 import org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo._
 import org.apache.flink.api.common.typeinfo.{FractionalTypeInfo, SqlTimeTypeInfo, TypeInformation}
 import org.apache.flink.api.common.typeutils.CompositeType
-import org.apache.flink.api.java.typeutils.{PojoTypeInfo, RowTypeInfo, TupleTypeInfo, TypeExtractor}
+import org.apache.flink.api.java.typeutils._
 import org.apache.flink.api.scala.typeutils.CaseClassTypeInfo
 import org.apache.flink.table.typeutils.{TimeIndicatorTypeInfo, TimeIntervalTypeInfo, TypeCheckUtils}
 
@@ -258,7 +258,7 @@ object CodeGenUtils {
   }
 
   def getFieldAccessor(clazz: Class[_], fieldName: String): FieldAccessor = {
-    val field = TypeExtractor.getDeclaredField(clazz, fieldName)
+    val field = TypeExtractionUtils.getDeclaredField(clazz, fieldName)
     if (field.isAccessible) {
       ObjectFieldAccessor(field)
     }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
@@ -1381,7 +1381,7 @@ abstract class CodeGenerator(
     val fieldExtraction =
       s"""
         |final java.lang.reflect.Field $fieldTerm =
-        |    org.apache.flink.api.java.typeutils.TypeExtractor.getDeclaredField(
+        |    ${classOf[TypeExtractionUtils].getCanonicalName}.getDeclaredField(
         |      ${clazz.getCanonicalName}.class, "$fieldName");
         |""".stripMargin
     reusableMemberStatements.add(fieldExtraction)

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -701,7 +701,7 @@ public abstract class StreamExecutionEnvironment {
 		catch (Exception e) {
 			throw new RuntimeException("Could not create TypeInformation for type " + data[0].getClass().getName()
 					+ "; please specify the TypeInformation manually via "
-					+ "StreamExecutionEnvironment#fromElements(Collection, TypeInformation)");
+					+ "StreamExecutionEnvironment#fromElements(Collection, TypeInformation)", e);
 		}
 		return fromCollection(Arrays.asList(data), typeInfo);
 	}


### PR DESCRIPTION
## Contribution Checklist

This PR solves a variety of issues that are related to the type extraction of POJOs and tuples.

## What is the purpose of the change

Make the type extraction more stable and help users with more detailed exceptions.

## Brief change log

- Until now, subclasses of tuples where not properly checked for additional fields and serializability: Non-static subclasses of tuples or classes with no default constructor were valid types.
- Even existing tests and Gelly classes where not implemented correctly.
- I fixed bugs related to bounded generic fields in POJOs.
- The type extractor has been refactored and simplified in order to have more consistent behavior. E.g., getForClass was unable to determine subclasses of tuples.
- Type extraction tests have been refactored to remove all warnings that were present.
- I tested generated Lombok POJOs. 
- Class cast execeptions in CSV reader have been fixed as well.
- I added a utility method `PojoTypeInfo.ensurePojo(MyPojo.class)` that validates if a type is a POJO and throws an exception with reasons why the given field is no POJO. I think this can help users a lot to avoid common mistakes.


## Verifying this change

Tests have been added to `TypeExtractorTest`, `PojoTypeExtractionTest`. Existing tests still run.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
