### PR TITLE
[FLINK-4812][metrics] Expose currentLowWatermark for all operators

### DIFF
--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -968,12 +968,7 @@ Thus, in order to infer the metric identifier:
   </thead>
   <tbody>
     <tr>
-      <th rowspan="7"><strong>Task</strong></th>
-      <td>currentLowWatermark</td>
-      <td>The lowest watermark this task has received (in milliseconds).</td>
-      <td>Gauge</td>
-    </tr>
-    <tr>
+      <th rowspan="6"><strong>Task</strong></th>
       <td>numBytesInLocal</td>
       <td>The total number of bytes this task has read from a local source.</td>
       <td>Counter</td>
@@ -1030,7 +1025,23 @@ Thus, in order to infer the metric identifier:
       <td>Counter</td>
     </tr>
     <tr>
-      <th rowspan="2"><strong>Operator</strong></th>
+      <th rowspan="4"><strong>Operator</strong></th>
+      <td>currentInputWatermark</td>
+      <td>
+        The lowest watermark this operator has received (in milliseconds).
+        <p><strong>Note:</strong> For sources and watermark assigners this is identical to currentOutputWatermark.</p>
+      </td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>currentOutputWatermark</td>
+      <td>
+        The last watermark this operator has emitted (in milliseconds).
+        <p><strong>Note:</strong> For sources and watermark assigners this is identical to currentInputWatermark.</p>
+      </td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
       <td>latency</td>
       <td>The latency distributions from all incoming sources (in milliseconds).</td>
       <td>Histogram</td>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
@@ -39,4 +39,7 @@ public class MetricNames {
 	public static final String IO_NUM_BYTES_IN_LOCAL_RATE = IO_NUM_BYTES_IN_LOCAL + SUFFIX_RATE;
 	public static final String IO_NUM_BYTES_IN_REMOTE_RATE = IO_NUM_BYTES_IN_REMOTE + SUFFIX_RATE;
 	public static final String IO_NUM_BYTES_OUT_RATE = IO_NUM_BYTES_OUT + SUFFIX_RATE;
+
+	public static final String IO_CURRENT_INPUT_WATERMARK = "currentInputWatermark";
+	public static final String IO_CURRENT_OUTPUT_WATERMARK = "currentOutputWatermark";
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileReaderOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileReaderOperator.java
@@ -116,6 +116,11 @@ public class ContinuousFileReaderOperator<OUT> extends AbstractStreamOperator<OU
 	}
 
 	@Override
+	protected boolean useSeparateWatermarkGauges() {
+		return false;
+	}
+
+	@Override
 	public void open() throws Exception {
 		super.open();
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSink.java
@@ -70,6 +70,11 @@ public class StreamSink<IN> extends AbstractUdfStreamOperator<Object, SinkFuncti
 		this.currentWatermark = mark.getTimestamp();
 	}
 
+	@Override
+	protected boolean useSeparateWatermarkGauges() {
+		return false;
+	}
+
 	private class SimpleContext<IN> implements SinkFunction.Context<IN> {
 
 		private StreamRecord<IN> element;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSource.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSource.java
@@ -131,6 +131,10 @@ public class StreamSource<OUT, SRC extends SourceFunction<OUT>>
 		return canceledOrStopped;
 	}
 
+	protected boolean useSeparateWatermarkGauges() {
+		return false;
+	}
+
 	private static class LatencyMarksEmitter<OUT> {
 		private final ScheduledFuture<?> latencyMarkTimer;
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperator.java
@@ -230,6 +230,7 @@ public class AsyncWaitOperator<IN, OUT>
 
 	@Override
 	public void processWatermark(Watermark mark) throws Exception {
+		inputWatermarkGauge.setCurrentWatermark(mark.getTimestamp());
 		WatermarkQueueEntry watermarkBufferEntry = new WatermarkQueueEntry(mark);
 
 		addAsyncBufferEntry(watermarkBufferEntry);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessor.java
@@ -112,11 +112,6 @@ public class StreamTwoInputProcessor<IN1, IN2> {
 
 	private final TwoInputStreamOperator<IN1, IN2, ?> streamOperator;
 
-	// ---------------- Metrics ------------------
-
-	private long lastEmittedWatermark1;
-	private long lastEmittedWatermark2;
-
 	private Counter numRecordsIn;
 
 	private boolean isFinished;
@@ -181,9 +176,6 @@ public class StreamTwoInputProcessor<IN1, IN2> {
 
 		this.numInputChannels1 = numInputChannels1;
 		this.numInputChannels2 = inputGate.getNumberOfInputChannels() - numInputChannels1;
-
-		this.lastEmittedWatermark1 = Long.MIN_VALUE;
-		this.lastEmittedWatermark2 = Long.MIN_VALUE;
 
 		this.firstStatus = StreamStatus.ACTIVE;
 		this.secondStatus = StreamStatus.ACTIVE;
@@ -307,13 +299,6 @@ public class StreamTwoInputProcessor<IN1, IN2> {
 	 * @param metrics metric group
 	 */
 	public void setMetricGroup(TaskIOMetricGroup metrics) {
-		metrics.gauge("currentLowWatermark", new Gauge<Long>() {
-			@Override
-			public Long getValue() {
-				return Math.min(lastEmittedWatermark1, lastEmittedWatermark2);
-			}
-		});
-
 		metrics.gauge("checkpointAlignmentTime", new Gauge<Long>() {
 			@Override
 			public Long getValue() {
@@ -349,7 +334,6 @@ public class StreamTwoInputProcessor<IN1, IN2> {
 		public void handleWatermark(Watermark watermark) {
 			try {
 				synchronized (lock) {
-					lastEmittedWatermark1 = watermark.getTimestamp();
 					operator.processWatermark1(watermark);
 				}
 			} catch (Exception e) {
@@ -393,7 +377,6 @@ public class StreamTwoInputProcessor<IN1, IN2> {
 		public void handleWatermark(Watermark watermark) {
 			try {
 				synchronized (lock) {
-					lastEmittedWatermark2 = watermark.getTimestamp();
 					operator.processWatermark2(watermark);
 				}
 			} catch (Exception e) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/metrics/WatermarkGauge.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/metrics/WatermarkGauge.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.metrics;
+
+import org.apache.flink.metrics.Gauge;
+
+/**
+ * A {@link Gauge} for exposing the current input/output watermark.
+ */
+public class WatermarkGauge implements Gauge<Long> {
+
+	private long currentWatermark = Long.MIN_VALUE;
+
+	public void setCurrentWatermark(long watermark) {
+		this.currentWatermark = watermark;
+	}
+
+	@Override
+	public Long getValue() {
+		return currentWatermark;
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/TimestampsAndPeriodicWatermarksOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/TimestampsAndPeriodicWatermarksOperator.java
@@ -108,4 +108,9 @@ public class TimestampsAndPeriodicWatermarksOperator<T>
 			output.emitWatermark(newWatermark);
 		}
 	}
+
+	@Override
+	protected boolean useSeparateWatermarkGauges() {
+		return false;
+	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/TimestampsAndPunctuatedWatermarksOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/TimestampsAndPunctuatedWatermarksOperator.java
@@ -72,4 +72,9 @@ public class TimestampsAndPunctuatedWatermarksOperator<T>
 			output.emitWatermark(mark);
 		}
 	}
+
+	@Override
+	protected boolean useSeparateWatermarkGauges() {
+		return false;
+	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/metrics/StreamOperatorWatermarkMetricsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/metrics/StreamOperatorWatermarkMetricsTest.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.metrics;
+
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.streaming.util.TwoInputStreamOperatorTestHarness;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests to verify that {@link AbstractStreamOperator} properly updates the {@link WatermarkGauge}.
+ */
+public class StreamOperatorWatermarkMetricsTest {
+
+	@Test
+	public void testOneInputWatermarkReporting() throws Exception {
+		TestOneInputStreamOperator operator = new TestOneInputStreamOperator();
+		try (OneInputStreamOperatorTestHarness<Integer, Integer> harness = new OneInputStreamOperatorTestHarness<>(operator)) {
+			harness.setup();
+			WatermarkGauge inputWatermarkGauge = operator.getInputWatermarkGauge();
+			WatermarkGauge outputWatermarkGauge = operator.getOutputWatermarkGauge();
+
+			Assert.assertEquals(Long.MIN_VALUE, outputWatermarkGauge.getValue().longValue());
+
+			harness.processWatermark(new Watermark(64L));
+			Assert.assertEquals(64L, inputWatermarkGauge.getValue().longValue());
+			Assert.assertEquals(64L, outputWatermarkGauge.getValue().longValue());
+			harness.processWatermark(new Watermark(128L));
+			Assert.assertEquals(128L, inputWatermarkGauge.getValue().longValue());
+			Assert.assertEquals(128L, outputWatermarkGauge.getValue().longValue());
+			harness.processWatermark(Watermark.MAX_WATERMARK);
+			Assert.assertEquals(Watermark.MAX_WATERMARK.getTimestamp(), inputWatermarkGauge.getValue().longValue());
+			Assert.assertEquals(Watermark.MAX_WATERMARK.getTimestamp(), outputWatermarkGauge.getValue().longValue());
+		}
+	}
+
+	@Test
+	public void testTwoInputWatermarkReporting() throws Exception {
+		TestTwoInputStreamOperator operator = new TestTwoInputStreamOperator();
+		try (TwoInputStreamOperatorTestHarness<Integer, Integer, Integer> harness = new TwoInputStreamOperatorTestHarness<>(operator)) {
+			harness.setup();
+			WatermarkGauge inputWatermarkGauge = operator.getInputWatermarkGauge();
+			WatermarkGauge outputWatermarkGauge = operator.getOutputWatermarkGauge();
+
+			Assert.assertEquals(Long.MIN_VALUE, outputWatermarkGauge.getValue().longValue());
+
+			harness.processWatermark1(new Watermark(64L));
+			Assert.assertEquals(Long.MIN_VALUE, inputWatermarkGauge.getValue().longValue());
+			Assert.assertEquals(Long.MIN_VALUE, outputWatermarkGauge.getValue().longValue());
+
+			harness.processWatermark2(new Watermark(128L));
+			Assert.assertEquals(64L, inputWatermarkGauge.getValue().longValue());
+			Assert.assertEquals(64L, outputWatermarkGauge.getValue().longValue());
+
+			harness.processWatermark1(new Watermark(128L));
+			Assert.assertEquals(128L, inputWatermarkGauge.getValue().longValue());
+			Assert.assertEquals(128L, outputWatermarkGauge.getValue().longValue());
+
+			harness.processWatermark1(new Watermark(256L));
+			Assert.assertEquals(128L, inputWatermarkGauge.getValue().longValue());
+			Assert.assertEquals(128L, outputWatermarkGauge.getValue().longValue());
+
+			harness.processWatermark1(Watermark.MAX_WATERMARK);
+			Assert.assertEquals(128L, inputWatermarkGauge.getValue().longValue());
+			Assert.assertEquals(128L, outputWatermarkGauge.getValue().longValue());
+
+			harness.processWatermark2(Watermark.MAX_WATERMARK);
+			Assert.assertEquals(Watermark.MAX_WATERMARK.getTimestamp(), inputWatermarkGauge.getValue().longValue());
+			Assert.assertEquals(Watermark.MAX_WATERMARK.getTimestamp(), outputWatermarkGauge.getValue().longValue());
+		}
+	}
+
+	private static class TestOneInputStreamOperator extends AbstractStreamOperator<Integer> implements OneInputStreamOperator<Integer, Integer> {
+
+		@Override
+		public void processElement(StreamRecord<Integer> element) throws Exception {
+			output.collect(element);
+		}
+	}
+
+	private static class TestTwoInputStreamOperator extends AbstractStreamOperator<Integer> implements TwoInputStreamOperator<Integer, Integer, Integer> {
+
+		@Override
+		public void processElement1(StreamRecord<Integer> element) throws Exception {
+			output.collect(element);
+		}
+
+		@Override
+		public void processElement2(StreamRecord<Integer> element) throws Exception {
+			output.collect(element);
+		}
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/metrics/WatermarkGaugeTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/metrics/WatermarkGaugeTest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.metrics;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for the {@link WatermarkGauge}.
+ */
+public class WatermarkGaugeTest {
+
+	@Test
+	public void testSetCurrentLowWatermark() {
+		WatermarkGauge metric = new WatermarkGauge();
+
+		Assert.assertEquals(Long.MIN_VALUE, metric.getValue().longValue());
+
+		metric.setCurrentWatermark(64);
+		Assert.assertEquals(64, metric.getValue().longValue());
+	}
+}


### PR DESCRIPTION
This is an alternative version of #5092.

## What is the purpose of the change

This PR makes all operators expose the current input/output watermark through the metric system.

Generally, watermarks are measured separately; input watermarks are measured in `AbstractStreamOperator#processWatermark(Watermark)` and output are measured in the `Output` of the respective operator.

Sub-classes may specify to expose the same watermark as input/output by overriding `AbstractStreamOperator#useSeparateWatermarkGauges`, which is used for sources, sink and watermark assigners.

## Brief change log

* remove watermark metric logic from `Stream[Two]InputProcessor`
  * this implies that this metric is no longer measured at the task level at all
* introduce `WatermarkGauge` class to decouple metric from local state of operator classes (i.e. some currentLowWatermark field)
* setup `WatermarkGauge`s in `AbstractStreamOperator#setup`
  * introduce `AbstractStreamOperator#useSeparateWatermarkGauges` to control re-use behavior
* measure the input watermark received by operators in 
  * `AbstractStreamOperator#processWatermark`
  * `AsyncWaitOperator#processWatermark`
  * `ContinuousFileReaderOperator#processWatermark`
* measure the output watermark emitted by operators in the `Output`
  * rename `CountingOutput` to `OutputWithMetrics`
* update metrics reference in the documentation


## Verifying this change

This change modified the following tests:
* `TimestampsAndPunctuatedWatermarksOperatorTest#testTimestampsAndPeriodicWatermarksOperator`
* `TimestampsAndPeriodicWatermarksOperatorTest#testTimestampsAndPeriodicWatermarksOperator`
* `AsyncWaitOperatorTest#testEventTime`

This change added the following tests:

* `WatermarkGaugeTest`
* `StreamOperatorWatermarkMetricsTest`
* `StreamSourceOperatorTest#testWatermarkMetrics`
* `StreamSinkOperatorTest#testWatermarkMetrics`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (**yes**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
