### PR TITLE
[FLINK-8171] [flip6] Remove work arounds from Flip6LocalStreamEnvironment

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
@@ -98,7 +98,7 @@ public class RestClusterClient extends ClusterClient {
 	protected JobSubmissionResult submitJob(JobGraph jobGraph, ClassLoader classLoader) throws ProgramInvocationException {
 		log.info("Submitting job.");
 		try {
-			// temporary hack for FLIP-6 since slot-sharing isn't implemented yet
+			// we have to enable queued scheduling because slot will be allocated lazily
 			jobGraph.setAllowQueuedScheduling(true);
 			submitJob(jobGraph);
 		} catch (JobSubmissionException e) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/environment/LocalStreamEnvironmentITCase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/environment/LocalStreamEnvironmentITCase.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.streaming.api.environment;
 
-import org.apache.flink.api.common.functions.FilterFunction;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.util.TestLogger;
 
@@ -63,23 +62,11 @@ public class LocalStreamEnvironmentITCase extends TestLogger {
 	// ------------------------------------------------------------------------
 
 	private static void addSmallBoundedJob(StreamExecutionEnvironment env, int parallelism) {
-		DataStream<Long> stream = env
-				.generateSequence(1, 100)
-					.setParallelism(parallelism)
-					.slotSharingGroup("group_1");
+		DataStream<Long> stream = env.generateSequence(1, 100).setParallelism(parallelism);
 
 		stream
-				.filter(new FilterFunction<Long>() {
-					@Override
-					public boolean filter(Long value) {
-						return false;
-					}
-				})
-					.setParallelism(parallelism)
+				.filter(ignored -> false).setParallelism(parallelism)
 					.startNewChain()
-					.slotSharingGroup("group_2")
-
-				.print()
-					.setParallelism(parallelism);
+					.print().setParallelism(parallelism);
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

It is no longer needed to wait for the registration of task managers and
to not use slot sharing when submitting jobs to the Flip-6 MiniCluster.
Therefore, we can remove these work arounds from the
Flip6LocalStreamEnvironment.

This PR is based on #5091.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
