### PR TITLE
[FLINK-7762, FLINK-8167] Clean up and harden WikipediaEditsSource

### DIFF
--- a/flink-contrib/flink-connector-wikiedits/pom.xml
+++ b/flink-contrib/flink-connector-wikiedits/pom.xml
@@ -40,11 +40,16 @@ under the License.
 			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-
 		<dependency>
 			<groupId>org.schwering</groupId>
 			<artifactId>irclib</artifactId>
 			<version>1.10</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-test-utils-junit</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 </project>

--- a/flink-contrib/flink-connector-wikiedits/src/main/java/org/apache/flink/streaming/connectors/wikiedits/WikipediaEditsSource.java
+++ b/flink-contrib/flink-connector-wikiedits/src/main/java/org/apache/flink/streaming/connectors/wikiedits/WikipediaEditsSource.java
@@ -18,9 +18,9 @@
 
 package org.apache.flink.streaming.connectors.wikiedits;
 
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.functions.source.RichSourceFunction;
 
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -43,8 +43,6 @@ public class WikipediaEditsSource extends RichSourceFunction<WikipediaEditEvent>
 	private final String channel;
 
 	private volatile boolean isRunning = true;
-
-	private WikipediaEditEventIrcStream ircStream;
 
 	/**
 	 * Creates a source reading {@link WikipediaEditEvent} instances from the
@@ -72,33 +70,27 @@ public class WikipediaEditsSource extends RichSourceFunction<WikipediaEditEvent>
 	public WikipediaEditsSource(String host, int port, String channel) {
 		this.host = host;
 		this.port = port;
-		this.channel = channel;
+		this.channel = Objects.requireNonNull(channel);
 	}
 
 	@Override
-	public void open(Configuration parameters) throws Exception {
-		ircStream = new WikipediaEditEventIrcStream(host, port);
-		ircStream.start();
-		ircStream.join(channel);
-	}
+	public void run(SourceContext<WikipediaEditEvent> ctx) throws Exception {
+		try (WikipediaEditEventIrcStream ircStream = new WikipediaEditEventIrcStream(host, port)) {
+			// Open connection and join channel
+			ircStream.connect();
+			ircStream.join(channel);
 
-	@Override
-	public void close() throws Exception {
-		if (ircStream != null) {
-			ircStream.leave(channel);
-			ircStream.stop();
-		}
-	}
+			try {
+				while (isRunning) {
+					// Query for the next edit event
+					WikipediaEditEvent edit = ircStream.getEdits().poll(100, TimeUnit.MILLISECONDS);
 
-	@Override
-	public void run(SourceContext ctx) throws Exception {
-		while (isRunning) {
-			// Query for the next edit event
-			WikipediaEditEvent edit = ircStream.getEdits()
-					.poll(100, TimeUnit.MILLISECONDS);
-
-			if (edit != null) {
-				ctx.collect(edit);
+					if (edit != null) {
+						ctx.collect(edit);
+					}
+				}
+			} finally {
+				ircStream.leave(channel);
 			}
 		}
 	}

--- a/flink-contrib/flink-connector-wikiedits/src/test/java/org/apache/flink/streaming/connectors/wikiedits/WikipediaEditsSourceTest.java
+++ b/flink-contrib/flink-connector-wikiedits/src/test/java/org/apache/flink/streaming/connectors/wikiedits/WikipediaEditsSourceTest.java
@@ -18,19 +18,29 @@
 
 package org.apache.flink.streaming.connectors.wikiedits;
 
-import org.apache.flink.streaming.api.datastream.DataStream;
-import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.functions.sink.SinkFunction;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.testutils.junit.RetryOnFailure;
+import org.apache.flink.testutils.junit.RetryRule;
 
+import org.junit.Rule;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.InetSocketAddress;
 import java.net.Socket;
+import java.util.Objects;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
@@ -40,71 +50,127 @@ public class WikipediaEditsSourceTest {
 
 	private static final Logger LOG = LoggerFactory.getLogger(WikipediaEditsSourceTest.class);
 
+	@Rule
+	public RetryRule retryRule = new RetryRule();
+
 	/**
-	 * NOTE: if you are behind a firewall you may need to use a SOCKS Proxy for this test.
-	 *
-	 * <p>We first check the connection to the IRC server. If it fails, this test
-	 * is effectively ignored.
-	 *
-	 * @see <a href="http://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html">Socks Proxy</a>
+	 * We first check the connection to the IRC server. If it fails, this test is ignored.
 	 */
-	@Test(timeout = 120 * 1000)
+	@Test
+	@RetryOnFailure(times = 1)
 	public void testWikipediaEditsSource() throws Exception {
-		final int numRetries = 5;
-		final int waitBetweenRetriesMillis = 2000;
-		final int connectTimeout = 1000;
+		if (canConnect(1, TimeUnit.SECONDS)) {
+			final Time testTimeout = Time.seconds(60);
+			final WikipediaEditsSource wikipediaEditsSource = new WikipediaEditsSource();
 
-		boolean success = false;
+			ExecutorService executorService = null;
+			try {
+				executorService = Executors.newSingleThreadExecutor();
+				BlockingQueue<Object> collectedEvents = new ArrayBlockingQueue<>(1);
+				AtomicReference<Exception> asyncError = new AtomicReference<>();
 
-		for (int i = 0; i < numRetries && !success; i++) {
-			// Check connection
-			boolean canConnect = false;
+				// Execute the source in a different thread and collect events into the queue.
+				// We do this in a separate thread in order to not block the main test thread
+				// indefinitely in case that somethign bad happens (like not receiving any
+				// events)
+				executorService.execute(() -> {
+					try {
+						wikipediaEditsSource.run(new CollectingSourceContext<>(collectedEvents));
+					} catch (Exception e) {
+						boolean interrupted = e instanceof InterruptedException;
+						if (!interrupted) {
+							LOG.warn("Failure in WikipediaEditsSource", e);
+						}
 
-			String host = WikipediaEditsSource.DEFAULT_HOST;
-			int port = WikipediaEditsSource.DEFAULT_PORT;
-
-			try (Socket s = new Socket()) {
-				s.connect(new InetSocketAddress(host, port), connectTimeout);
-				canConnect = s.isConnected();
-			} catch (Throwable ignored) {
-			}
-
-			if (canConnect) {
-				StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-				env.getConfig().disableSysoutLogging();
-
-				DataStream<WikipediaEditEvent> edits = env.addSource(new WikipediaEditsSource());
-
-				edits.addSink(new SinkFunction<WikipediaEditEvent>() {
-					@Override
-					public void invoke(WikipediaEditEvent value) throws Exception {
-						throw new Exception("Expected test exception");
+						asyncError.compareAndSet(null, e);
 					}
 				});
 
-				try {
-					env.execute();
-					fail("Did not throw expected Exception.");
-				} catch (Exception e) {
-					assertNotNull(e.getCause());
-					assertEquals("Expected test exception", e.getCause().getMessage());
+				long deadline = deadlineNanos(testTimeout);
+
+				Object event = null;
+				Exception error = null;
+
+				// Check event or error
+				while (event == null && error == null && System.nanoTime() < deadline) {
+					event = collectedEvents.poll(1, TimeUnit.SECONDS);
+					error = asyncError.get();
 				}
 
-				success = true;
-			} else {
-				LOG.info("Failed to connect to IRC server ({}/{}). Retrying in {} ms.",
-						i + 1,
-						numRetries,
-						waitBetweenRetriesMillis);
+				if (error != null) {
+					// We don't use assertNull, because we want to include the error message
+					fail("Failure in WikipediaEditsSource: " + error.getMessage());
+				}
 
-				Thread.sleep(waitBetweenRetriesMillis);
+				assertNotNull("Did not receive a WikipediaEditEvent within the desired timeout", event);
+				assertTrue("Received unexpected event " + event, event instanceof WikipediaEditEvent);
+			} finally {
+				wikipediaEditsSource.cancel();
+
+				if (executorService != null) {
+					executorService.shutdownNow();
+					executorService.awaitTermination(1, TimeUnit.SECONDS);
+				}
 			}
+		} else {
+			LOG.info("Skipping test, because not able to connect to IRC server.");
+		}
+	}
+
+	private long deadlineNanos(Time testTimeout) {
+		return System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(testTimeout.toMilliseconds());
+	}
+
+	private static class CollectingSourceContext<T> implements SourceFunction.SourceContext<T> {
+
+		private final BlockingQueue<Object> events;
+
+		private CollectingSourceContext(BlockingQueue<Object> events) {
+			this.events = Objects.requireNonNull(events, "events");
 		}
 
-		if (success) {
-			LOG.info("Successfully ran test.");
-		} else {
-			LOG.info("Skipped test, because not able to connect to IRC server.");
+		@Override
+		public void collect(T element) {
+			events.offer(element);
 		}
+
+		@Override
+		public void collectWithTimestamp(T element, long timestamp) {
+			throw new UnsupportedOperationException();
+
+		}
+
+		@Override
+		public void emitWatermark(Watermark mark) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void markAsTemporarilyIdle() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public Object getCheckpointLock() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void close() {
+		}
+
+	}
+
+	private static boolean canConnect(int timeout, TimeUnit unit) {
+		String host = WikipediaEditsSource.DEFAULT_HOST;
+		int port = WikipediaEditsSource.DEFAULT_PORT;
+
+		try (Socket s = new Socket()) {
+			s.connect(new InetSocketAddress(host, port), (int) unit.toMillis(timeout));
+			return s.isConnected();
+		} catch (Throwable ignored) {
+		}
+
+		return false;
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

This pull requests addresses two related issues with the WikipediaEditsSource. It makes the WikipediaEditsSourceTest a proper test instead of unnecessarily starting a FlinkMiniCluster and addresses a potential test instability.

In general, the WikipediaEditsSource is not in good shape and could benefit from further refactoring. One potential area for improvement is integration with the asynchronous channel listener that reports events like errors or being kicked out of a channel, etc.

I did not do this due to time constraints and the fact that this is not a production source. In general, it is questionable whether we should keep the test as is or remove it since it depends on connectivity to an IRC channel.

## Brief change log
- Harden WikipediaEditsSource with eager sanity checks
- Make WikipediaEditsSourceTest proper test

## Verifying this change

This change is a rework/code cleanup without any new test coverage.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): yes, but only to `flink-test-utils-junit`
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable
