### PR TITLE
[FLINK-8176][flip6] Start SubmittedJobGraphStore in Dispatcher

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobSubmissionException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobSubmissionException.java
@@ -21,7 +21,7 @@ package org.apache.flink.runtime.client;
 import org.apache.flink.api.common.JobID;
 
 /**
- * This exception denotes an error while submitting a job to the JobManager
+ * This exception denotes an error while submitting a job to the JobManager.
  */
 public class JobSubmissionException extends JobExecutionException {
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -529,9 +529,7 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 				return;
 			}
 			runAsync(() -> {
-				if (!jobManagerRunners.containsKey(jobId)) {
-					submitJob(submittedJobGraph.getJobGraph(), RpcUtils.INF_TIMEOUT);
-				}
+				submitJob(submittedJobGraph.getJobGraph(), RpcUtils.INF_TIMEOUT);
 			});
 		});
 	}
@@ -539,12 +537,10 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 	@Override
 	public void onRemovedJobGraph(final JobID jobId) {
 		runAsync(() -> {
-			if (jobManagerRunners.containsKey(jobId)) {
-				try {
-					removeJob(jobId, false);
-				} catch (final Exception e) {
-					log.error("Could not remove job {}.", jobId, e);
-				}
+			try {
+				removeJob(jobId, false);
+			} catch (final Exception e) {
+				log.error("Could not remove job {}.", jobId, e);
 			}
 		});
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -61,7 +61,6 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.rules.TestName;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
 
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -127,8 +126,6 @@ public class DispatcherTest extends TestLogger {
 
 	@Before
 	public void setUp() throws Exception {
-		MockitoAnnotations.initMocks(this);
-
 		final JobVertex testVertex = new JobVertex("testVertex");
 		testVertex.setInvokableClass(NoOpInvokable.class);
 		jobGraph = new JobGraph(TEST_JOB_ID, "testJob", testVertex);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/TestingHighAvailabilityServices.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/TestingHighAvailabilityServices.java
@@ -52,6 +52,8 @@ public class TestingHighAvailabilityServices implements HighAvailabilityServices
 
 	private volatile SubmittedJobGraphStore submittedJobGraphStore;
 
+	private final RunningJobsRegistry runningJobsRegistry = new StandaloneRunningJobsRegistry();
+
 	// ------------------------------------------------------------------------
 	//  Setters for mock / testing implementations
 	// ------------------------------------------------------------------------
@@ -185,7 +187,7 @@ public class TestingHighAvailabilityServices implements HighAvailabilityServices
 
 	@Override
 	public RunningJobsRegistry getRunningJobsRegistry() {
-		return new StandaloneRunningJobsRegistry();
+		return runningJobsRegistry;
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerHARecoveryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerHARecoveryTest.java
@@ -73,6 +73,7 @@ import org.apache.flink.runtime.testingUtils.TestingMessages;
 import org.apache.flink.runtime.testingUtils.TestingTaskManager;
 import org.apache.flink.runtime.testingUtils.TestingTaskManagerMessages;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.apache.flink.runtime.testutils.InMemorySubmittedJobGraphStore;
 import org.apache.flink.runtime.testutils.RecoverableCompletedCheckpointStore;
 import org.apache.flink.runtime.util.TestByteStreamStateHandleDeepCompare;
 import org.apache.flink.util.InstantiationUtil;
@@ -169,7 +170,8 @@ public class JobManagerHARecoveryTest extends TestLogger {
 		try {
 			Scheduler scheduler = new Scheduler(TestingUtils.defaultExecutionContext());
 
-			MySubmittedJobGraphStore mySubmittedJobGraphStore = new MySubmittedJobGraphStore();
+			InMemorySubmittedJobGraphStore submittedJobGraphStore = new InMemorySubmittedJobGraphStore();
+			submittedJobGraphStore.start(null);
 			CompletedCheckpointStore checkpointStore = new RecoverableCompletedCheckpointStore();
 			CheckpointIDCounter checkpointCounter = new StandaloneCheckpointIDCounter();
 			CheckpointRecoveryFactory checkpointStateFactory = new MyCheckpointRecoveryFactory(checkpointStore, checkpointCounter);
@@ -203,7 +205,7 @@ public class JobManagerHARecoveryTest extends TestLogger {
 				new FixedDelayRestartStrategy.FixedDelayRestartStrategyFactory(Int.MaxValue(), 100),
 				timeout,
 				myLeaderElectionService,
-				mySubmittedJobGraphStore,
+				submittedJobGraphStore,
 				checkpointStateFactory,
 				jobRecoveryTimeout,
 				new JobManagerMetricGroup(new NoOpMetricRegistry(), "localhost"),
@@ -285,7 +287,7 @@ public class JobManagerHARecoveryTest extends TestLogger {
 			// check that the job gets removed from the JobManager
 			Await.ready(jobRemoved, deadline.timeLeft());
 			// but stays in the submitted job graph store
-			assertTrue(mySubmittedJobGraphStore.contains(jobGraph.getJobID()));
+			assertTrue(submittedJobGraphStore.contains(jobGraph.getJobID()));
 
 			Future<Object> jobRunning = gateway.ask(new TestingJobManagerMessages.NotifyWhenJobStatus(jobGraph.getJobID(), JobStatus.RUNNING), deadline.timeLeft());
 
@@ -305,7 +307,7 @@ public class JobManagerHARecoveryTest extends TestLogger {
 			Await.ready(jobFinished, deadline.timeLeft());
 
 			// check that the job has been removed from the submitted job graph store
-			assertFalse(mySubmittedJobGraphStore.contains(jobGraph.getJobID()));
+			assertFalse(submittedJobGraphStore.contains(jobGraph.getJobID()));
 
 			// Check that state has been recovered
 			long[] recoveredStates = BlockingStatefulInvokable.getRecoveredStates();
@@ -478,49 +480,6 @@ public class JobManagerHARecoveryTest extends TestLogger {
 		@Override
 		public CheckpointIDCounter createCheckpointIDCounter(JobID jobId) throws Exception {
 			return counter;
-		}
-	}
-
-	static class MySubmittedJobGraphStore implements SubmittedJobGraphStore {
-
-		Map<JobID, SubmittedJobGraph> storedJobs = new HashMap<>();
-
-		@Override
-		public void start(SubmittedJobGraphListener jobGraphListener) throws Exception {
-
-		}
-
-		@Override
-		public void stop() throws Exception {
-
-		}
-
-		@Override
-		public SubmittedJobGraph recoverJobGraph(JobID jobId) throws Exception {
-			if (storedJobs.containsKey(jobId)) {
-				return storedJobs.get(jobId);
-			} else {
-				return null;
-			}
-		}
-
-		@Override
-		public void putJobGraph(SubmittedJobGraph jobGraph) throws Exception {
-			storedJobs.put(jobGraph.getJobId(), jobGraph);
-		}
-
-		@Override
-		public void removeJobGraph(JobID jobId) throws Exception {
-			storedJobs.remove(jobId);
-		}
-
-		@Override
-		public Collection<JobID> getJobIds() throws Exception {
-			return storedJobs.keySet();
-		}
-
-		boolean contains(JobID jobId) {
-			return storedJobs.containsKey(jobId);
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionService.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionService.java
@@ -86,4 +86,13 @@ public class TestingLeaderElectionService implements LeaderElectionService {
 	public synchronized String getAddress() {
 		return contender.getAddress();
 	}
+
+	/**
+	 * Returns <code>true</code> if {@link #start(LeaderContender)} was called,
+	 * <code>false</code> otherwise.
+	 */
+	public synchronized boolean isStarted() {
+		return contender != null;
+	}
+
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/InMemorySubmittedJobGraphStore.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/InMemorySubmittedJobGraphStore.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.testutils;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.jobmanager.SubmittedJobGraph;
+import org.apache.flink.runtime.jobmanager.SubmittedJobGraphStore;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nullable;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * In-Memory implementation of {@link SubmittedJobGraphStore} for testing purposes.
+ */
+public class InMemorySubmittedJobGraphStore implements SubmittedJobGraphStore {
+
+	private final Map<JobID, SubmittedJobGraph> storedJobs = new HashMap<>();
+
+	private volatile boolean started;
+
+	@Override
+	public void start(@Nullable SubmittedJobGraphListener jobGraphListener) throws Exception {
+		started = true;
+	}
+
+	@Override
+	public void stop() throws Exception {
+		started = false;
+	}
+
+	@Override
+	public SubmittedJobGraph recoverJobGraph(JobID jobId) throws Exception {
+		verifyIsStarted();
+		return storedJobs.getOrDefault(jobId, null);
+	}
+
+	@Override
+	public void putJobGraph(SubmittedJobGraph jobGraph) throws Exception {
+		verifyIsStarted();
+		storedJobs.put(jobGraph.getJobId(), jobGraph);
+	}
+
+	@Override
+	public void removeJobGraph(JobID jobId) throws Exception {
+		verifyIsStarted();
+		storedJobs.remove(jobId);
+	}
+
+	@Override
+	public Collection<JobID> getJobIds() throws Exception {
+		verifyIsStarted();
+		return storedJobs.keySet();
+	}
+
+	public boolean contains(JobID jobId) {
+		verifyIsStarted();
+		return storedJobs.containsKey(jobId);
+	}
+
+	private void verifyIsStarted() {
+		Preconditions.checkState(started, "Not running. Forgot to call start()?");
+	}
+
+}


### PR DESCRIPTION
## What is the purpose of the change

The FLIP-6 dispatcher never calls `start()` on its SubmittedJobGraphStore instance. Hence, when a Job is submitted (YARN session mode with HA enabled), an IllegalStateException is thrown. This pull request adds the necessary changes so that jobs can be submitted.

## Brief change log

  - *Implement SubmittedJobGraphListener interface in Dispatcher*
 
## Verifying this change

  - *Added unit tests for new methods in Dispatcher class*
  - *Verified that jobs can be submitted in FLIP-6 YARN session mode with HA. Did not verify anything else.*


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)

CC: @tillrohrmann 
