### PR TITLE
[FLINK-8181] [kafka] Make FlinkFixedPartitioner insensitive to topic rescaling

### DIFF
--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkFixedPartitionerTest.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkFixedPartitionerTest.java
@@ -103,7 +103,75 @@ public class FlinkFixedPartitionerTest {
 
 		part.open(2, 3);
 		Assert.assertEquals(0, part.partition("abc1", null, null, null, partitions));
+	}
 
+	/**
+	 * Tests that the determined target partition is independently calculated for different topics.
+	 */
+	@Test
+	public void testDifferentTopics() {
+		final String topic1 = "topic-1";
+		final String topic2 = "topic-2";
+
+		final int[] partitionsTopic1 = new int[]{0, 1, 2};
+		final int[] partitionsTopic2 = new int[]{0, 1};
+
+		final FlinkFixedPartitioner<String> partitioner1 = new FlinkFixedPartitioner<>();
+		partitioner1.open(0, 3);
+		Assert.assertEquals(0, partitioner1.partition("abc1", null, null, topic1, partitionsTopic1));
+		Assert.assertEquals(0, partitioner1.partition("abc1", null, null, topic2, partitionsTopic2));
+
+		final FlinkFixedPartitioner<String> partitioner2 = new FlinkFixedPartitioner<>();
+		partitioner2.open(1, 3);
+		Assert.assertEquals(1, partitioner2.partition("abc1", null, null, topic1, partitionsTopic1));
+		Assert.assertEquals(1, partitioner2.partition("abc1", null, null, topic2, partitionsTopic2));
+
+		final FlinkFixedPartitioner<String> partitioner3 = new FlinkFixedPartitioner<>();
+		partitioner3.open(2, 3);
+		Assert.assertEquals(2, partitioner3.partition("abc1", null, null, topic1, partitionsTopic1));
+		Assert.assertEquals(0, partitioner3.partition("abc1", null, null, topic2, partitionsTopic2));
+	}
+
+	/**
+	 * Tests that the determined target partition for individual topics remains identical in the case of new partitions.
+	 */
+	@Test
+	public void testIncreasingPartitions() {
+		final String topic1 = "topic-1";
+		final String topic2 = "topic-2";
+
+		final int[] initialPartitionsTopic1 = new int[]{0, 1};
+		final int[] increasedPartitionsTopic1 = new int[]{0, 1, 2, 3};
+
+		final int[] initialPartitionsTopic2 = new int[]{0, 1, 2};
+		final int[] increasedPartitionsTopic2 = new int[]{0, 1, 2, 3, 4};
+
+		final FlinkFixedPartitioner<String> partitioner1 = new FlinkFixedPartitioner<>();
+		partitioner1.open(0, 3);
+		Assert.assertEquals(
+			partitioner1.partition("abc1", null, null, topic1, initialPartitionsTopic1),
+			partitioner1.partition("abc1", null, null, topic1, increasedPartitionsTopic1));
+		Assert.assertEquals(
+			partitioner1.partition("abc1", null, null, topic2, initialPartitionsTopic2),
+			partitioner1.partition("abc1", null, null, topic2, increasedPartitionsTopic2));
+
+		final FlinkFixedPartitioner<String> partitioner2 = new FlinkFixedPartitioner<>();
+		partitioner2.open(1, 3);
+		Assert.assertEquals(
+			partitioner2.partition("abc1", null, null, topic1, initialPartitionsTopic1),
+			partitioner2.partition("abc1", null, null, topic1, increasedPartitionsTopic1));
+		Assert.assertEquals(
+			partitioner2.partition("abc1", null, null, topic2, initialPartitionsTopic2),
+			partitioner2.partition("abc1", null, null, topic2, increasedPartitionsTopic2));
+
+		final FlinkFixedPartitioner<String> partitioner3 = new FlinkFixedPartitioner<>();
+		partitioner3.open(2, 3);
+		Assert.assertEquals(
+			partitioner3.partition("abc1", null, null, topic1, initialPartitionsTopic1),
+			partitioner3.partition("abc1", null, null, topic1, increasedPartitionsTopic1));
+		Assert.assertEquals(
+			partitioner3.partition("abc1", null, null, topic2, initialPartitionsTopic2),
+			partitioner3.partition("abc1", null, null, topic2, increasedPartitionsTopic2));
 	}
 
 }

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkFixedPartitionerTest.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkFixedPartitionerTest.java
@@ -40,22 +40,24 @@ public class FlinkFixedPartitionerTest {
 	 */
 	@Test
 	public void testMoreFlinkThanBrokers() {
-		FlinkFixedPartitioner<String> part = new FlinkFixedPartitioner<>();
+		final int[] partitions = new int[]{0};
 
-		int[] partitions = new int[]{0};
+		final FlinkFixedPartitioner<String> partitioner1 = new FlinkFixedPartitioner<>();
+		partitioner1.open(0, 4);
+		Assert.assertEquals(0, partitioner1.partition("abc1", null, null, null, partitions));
 
-		part.open(0, 4);
-		Assert.assertEquals(0, part.partition("abc1", null, null, null, partitions));
+		final FlinkFixedPartitioner<String> partitioner2 = new FlinkFixedPartitioner<>();
+		partitioner2.open(1, 4);
+		Assert.assertEquals(0, partitioner2.partition("abc2", null, null, null, partitions));
 
-		part.open(1, 4);
-		Assert.assertEquals(0, part.partition("abc2", null, null, null, partitions));
+		final FlinkFixedPartitioner<String> partitioner3 = new FlinkFixedPartitioner<>();
+		partitioner3.open(2, 4);
+		Assert.assertEquals(0, partitioner3.partition("abc3", null, null, null, partitions));
+		Assert.assertEquals(0, partitioner3.partition("abc3", null, null, null, partitions)); // check if it is changing ;)
 
-		part.open(2, 4);
-		Assert.assertEquals(0, part.partition("abc3", null, null, null, partitions));
-		Assert.assertEquals(0, part.partition("abc3", null, null, null, partitions)); // check if it is changing ;)
-
-		part.open(3, 4);
-		Assert.assertEquals(0, part.partition("abc4", null, null, null, partitions));
+		final FlinkFixedPartitioner<String> partitioner4 = new FlinkFixedPartitioner<>();
+		partitioner4.open(3, 4);
+		Assert.assertEquals(0, partitioner4.partition("abc4", null, null, null, partitions));
 	}
 
 	/**
@@ -72,16 +74,17 @@ public class FlinkFixedPartitionerTest {
 	 */
 	@Test
 	public void testFewerPartitions() {
-		FlinkFixedPartitioner<String> part = new FlinkFixedPartitioner<>();
+		final int[] partitions = new int[]{0, 1, 2, 3, 4};
 
-		int[] partitions = new int[]{0, 1, 2, 3, 4};
-		part.open(0, 2);
-		Assert.assertEquals(0, part.partition("abc1", null, null, null, partitions));
-		Assert.assertEquals(0, part.partition("abc1", null, null, null, partitions));
+		final FlinkFixedPartitioner<String> partitioner1 = new FlinkFixedPartitioner<>();
+		partitioner1.open(0, 2);
+		Assert.assertEquals(0, partitioner1.partition("abc1", null, null, null, partitions));
+		Assert.assertEquals(0, partitioner1.partition("abc1", null, null, null, partitions));
 
-		part.open(1, 2);
-		Assert.assertEquals(1, part.partition("abc1", null, null, null, partitions));
-		Assert.assertEquals(1, part.partition("abc1", null, null, null, partitions));
+		final FlinkFixedPartitioner<String> partitioner2 = new FlinkFixedPartitioner<>();
+		partitioner2.open(1, 2);
+		Assert.assertEquals(1, partitioner2.partition("abc1", null, null, null, partitions));
+		Assert.assertEquals(1, partitioner2.partition("abc1", null, null, null, partitions));
 	}
 
 	/*
@@ -92,17 +95,19 @@ public class FlinkFixedPartitionerTest {
 	 */
 	@Test
 	public void testMixedCase() {
-		FlinkFixedPartitioner<String> part = new FlinkFixedPartitioner<>();
-		int[] partitions = new int[]{0, 1};
+		final int[] partitions = new int[]{0, 1};
 
-		part.open(0, 3);
-		Assert.assertEquals(0, part.partition("abc1", null, null, null, partitions));
+		final FlinkFixedPartitioner<String> partitioner1 = new FlinkFixedPartitioner<>();
+		partitioner1.open(0, 3);
+		Assert.assertEquals(0, partitioner1.partition("abc1", null, null, null, partitions));
 
-		part.open(1, 3);
-		Assert.assertEquals(1, part.partition("abc1", null, null, null, partitions));
+		final FlinkFixedPartitioner<String> partitioner2 = new FlinkFixedPartitioner<>();
+		partitioner2.open(1, 3);
+		Assert.assertEquals(1, partitioner2.partition("abc1", null, null, null, partitions));
 
-		part.open(2, 3);
-		Assert.assertEquals(0, part.partition("abc1", null, null, null, partitions));
+		final FlinkFixedPartitioner<String> partitioner3 = new FlinkFixedPartitioner<>();
+		partitioner3.open(2, 3);
+		Assert.assertEquals(0, partitioner3.partition("abc1", null, null, null, partitions));
 	}
 
 	/**


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes a behavioral regression caused by 9ed9b68397b51bfd2b0f6e532212a82f771641bd.
In that commit, the new `FlinkFixedPartitioner` no longer returns identical target partitions once a target topic is rescaled. 

With this PR, the `FlinkFixedPartitioner` returns identical target Kafka partitions for a given target Kafka topic when rescaling happens. A cache is maintained in the partitioner to remember the determined target partition for each target topic, calculated at the time of the topic's first appearance at the partitioner.

## Brief change log

- Make the `FlinkFixedPartitioner` insensitive to topic rescaling
- Add new test `FlinkFixedPartitionerTest#testIncreasingPartitions()`.
- Minor hotfix to properly use independent partitioner instances in all tests of `FlinkFixedPartitionerTest`.


## Verifying this change

Covered by new test `FlinkFixedPartitionerTest#testIncreasingPartitions()`. The test fails without the fix.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): **yes**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? n/a
