### PR TITLE
[FLINK-8156][build] Bump commons-beanutils version to 1.9.3

### DIFF
--- a/flink-shaded-hadoop/flink-shaded-hadoop2/pom.xml
+++ b/flink-shaded-hadoop/flink-shaded-hadoop2/pom.xml
@@ -171,7 +171,8 @@ under the License.
 		commons-collections dependency-->
 		<dependency>
 			<groupId>commons-beanutils</groupId>
-			<artifactId>commons-beanutils-bean-collections</artifactId>
+			<artifactId>commons-beanutils</artifactId>
+			<version>1.9.3</version>
 		</dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -368,13 +368,6 @@ under the License.
 				<version>3.2.2</version>
 			</dependency>
 
-			<!-- common-beanutils-bean-collections is used by flink-shaded-hadoop2 -->
-			<dependency>
-				<groupId>commons-beanutils</groupId>
-				<artifactId>commons-beanutils-bean-collections</artifactId>
-				<version>1.8.3</version>
-			</dependency>
-
 			<!--We have to bump the commons-configuration to version 1.7 because Hadoop uses per
 			default 1.6. This version has the problem that it depends on commons-beanutils-core and
 			commons-digester. Commons-digester depends on commons-beanutils. Both dependencies are


### PR DESCRIPTION
## What is the purpose of the change
Commons-beanutils v1.8.0 dependency is not security compliant. See [CVE-2014-0114](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-0114)

> Apache Commons BeanUtils, as distributed in lib/commons-beanutils-1.8.0.jar in Apache Struts 1.x through 1.3.10 and in other products requiring commons-beanutils through 1.9.2, does not suppress the class property, which allows remote attackers to "manipulate" the ClassLoader and execute arbitrary code via the class parameter, as demonstrated by the passing of this parameter to the getClass method of the ActionForm object in Struts 1.

the version commons-beanutils 1.9.2 in turn has a CVE in its dependency commons-collections ([CVE-2015-6420](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-6420), see [BEANUTILS-488](https://issues.apache.org/jira/browse/BEANUTILS-488)), which is fixed in 1.9.3.

We should upgrade commons-beanutils from 1.8.3 to 1.9.3.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**yes** / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
