### PR TITLE
[FLINK-7692] [metrics] Support user-defined variables in Metrics

### DIFF
--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -263,7 +263,7 @@ You can configure which delimiter to use for the identifier (default: `.`) by se
 
 ### User Scope
 
-You can define a user scope by calling either `MetricGroup#addGroup(String name)` or `MetricGroup#addGroup(int name)`.
+You can define a user scope by calling `MetricGroup#addGroup(String name)`, `MetricGroup#addGroup(int name)` or `Metric#addGroup(String key, String value)`.
 
 {% highlight java %}
 
@@ -272,7 +272,15 @@ counter = getRuntimeContext()
   .addGroup("MyMetrics")
   .counter("myCounter");
 
+counter = getRuntimeContext()
+  .getMetricGroup()
+  .addGroup("MyMetricsKey", "MyMetricsValue")
+  .counter("myCounter");
+
 {% endhighlight %}
+
+**Important:** The behavior of `group.addGroup(String key, String value)` is like `group.addGroup(String string).addGroup(value)` when define user scope,
+but it is different when specify user-defined variables. 
 
 ### System Scope
 
@@ -323,6 +331,20 @@ or by assigning unique names to jobs and operators.
 - Operator: &lt;operator_id&gt;,&lt;operator_name&gt;, &lt;subtask_index&gt;
 
 **Important:** For the Batch API, &lt;operator_id&gt; is always equal to &lt;task_id&gt;.
+
+### User-Defined Variables
+
+You can define a user-defined variable by calling `MetricGroup#addGroup(String key, String value)`.
+It will create a key-value pair in the second group (i.e. the returned group),
+which has a variable name as `key` and corresponding value as `value`.
+
+{% highlight java %}
+
+group = getRuntimeContext()
+  .getMetricGroup()
+  .addGroup("MyVariable", "MyVariableValue");
+
+{% endhighlight %}
 
 ## Reporter
 

--- a/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/MetricGroup.java
+++ b/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/MetricGroup.java
@@ -151,10 +151,13 @@ public interface MetricGroup {
 	MetricGroup addGroup(String name);
 
 	/**
-	 * TODO: add javadoc.
-	 * @param key
-	 * @param value
-	 * @return
+	 * Creates two new MetricGroup and adds the first one to this groups sub-groups,
+	 * then add the second one to the first one's sub-groups. (i.e. {@code group.addGroup(key).addGroup(value)})
+	 * Moreover, the second group will be added a new user-defined variable, for example {@code {"<key>"="value"}}.
+	 *
+	 * @param key name of the first group
+	 * @param value name of the second group
+	 * @return the second created group
 	 */
 	MetricGroup addGroup(String key, String value);
 

--- a/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/MetricGroup.java
+++ b/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/MetricGroup.java
@@ -150,6 +150,14 @@ public interface MetricGroup {
 	 */
 	MetricGroup addGroup(String name);
 
+	/**
+	 * TODO: add javadoc.
+	 * @param key
+	 * @param value
+	 * @return
+	 */
+	MetricGroup addGroup(String key, String value);
+
 	// ------------------------------------------------------------------------
 	// Scope
 	// ------------------------------------------------------------------------

--- a/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/groups/UnregisteredMetricsGroup.java
+++ b/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/groups/UnregisteredMetricsGroup.java
@@ -96,6 +96,11 @@ public class UnregisteredMetricsGroup implements MetricGroup {
 	}
 
 	@Override
+	public MetricGroup addGroup(String key, String value) {
+		return new UnregisteredMetricsGroup();
+	}
+
+	@Override
 	public String[] getScopeComponents() {
 		return new String[0];
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroup.java
@@ -441,7 +441,7 @@ public abstract class AbstractMetricGroup<A extends AbstractMetricGroup<?>> impl
 			}
 			else {
 				// return a non-registered group that is immediately closed already
-				GenericMetricGroup closedGroup = createChildGroupInKeyedContext(name);
+				GenericMetricGroup closedGroup = new GenericMetricGroup(registry, this, name);
 				closedGroup.close();
 				return closedGroup;
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroup.java
@@ -427,7 +427,7 @@ public abstract class AbstractMetricGroup<A extends AbstractMetricGroup<?>> impl
 				}
 
 				AbstractMetricGroup newGroup = keyed
-					? createChildGroup(name)
+					? createChildGroupInKeyedContext(name)
 					: new GenericMetricGroup(registry, this, name);
 				AbstractMetricGroup prior = groups.put(name, newGroup);
 				if (prior == null) {
@@ -441,14 +441,14 @@ public abstract class AbstractMetricGroup<A extends AbstractMetricGroup<?>> impl
 			}
 			else {
 				// return a non-registered group that is immediately closed already
-				GenericMetricGroup closedGroup = createChildGroup(name);
+				GenericMetricGroup closedGroup = createChildGroupInKeyedContext(name);
 				closedGroup.close();
 				return closedGroup;
 			}
 		}
 	}
 
-	protected GenericMetricGroup createChildGroup(String name) {
+	protected GenericMetricGroup createChildGroupInKeyedContext(String name) {
 		return new GenericKeyMetricGroup(registry, this, name);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroup.java
@@ -395,11 +395,6 @@ public abstract class AbstractMetricGroup<A extends AbstractMetricGroup<?>> impl
 	// ------------------------------------------------------------------------
 
 	@Override
-	public MetricGroup addGroup(String key, String value) {
-		return addGroup(key, true).addGroup(value);
-	}
-
-	@Override
 	public MetricGroup addGroup(int name) {
 		return addGroup(String.valueOf(name), false);
 	}
@@ -407,6 +402,22 @@ public abstract class AbstractMetricGroup<A extends AbstractMetricGroup<?>> impl
 	@Override
 	public MetricGroup addGroup(String name) {
 		return addGroup(name, false);
+	}
+
+	@Override
+	public MetricGroup addGroup(String key, String value) {
+		MetricGroup metricGroup;
+		if (this instanceof GenericKeyMetricGroup) {
+			metricGroup = addGroup(key);
+		} else {
+			metricGroup = addGroup(key, true);
+		}
+		if (metricGroup instanceof GenericKeyMetricGroup) {
+			return ((AbstractMetricGroup) metricGroup).addGroup(value, true);
+		}
+		else {
+			return metricGroup.addGroup(value);
+		}
 	}
 
 	private MetricGroup addGroup(String name, boolean keyed) {
@@ -421,8 +432,8 @@ public abstract class AbstractMetricGroup<A extends AbstractMetricGroup<?>> impl
 				}
 
 				AbstractMetricGroup newGroup = keyed
-					? new GenericKeyMetricGroup(registry, this, name)
-					: createChildGroup(name);
+					? createChildGroup(name)
+					: new GenericMetricGroup(registry, this, name);
 				AbstractMetricGroup prior = groups.put(name, newGroup);
 				if (prior == null) {
 					// no prior group with that name
@@ -443,6 +454,6 @@ public abstract class AbstractMetricGroup<A extends AbstractMetricGroup<?>> impl
 	}
 
 	protected GenericMetricGroup createChildGroup(String name) {
-		return new GenericMetricGroup(registry, this, name);
+		return new GenericKeyMetricGroup(registry, this, name);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroup.java
@@ -450,7 +450,10 @@ public abstract class AbstractMetricGroup<A extends AbstractMetricGroup<?>> impl
 	}
 
 	/**
-	 * TODO: add javadoc.
+	 * Enum for indicating which child group should be created.
+	 * `KEY` is used to create {@link GenericKeyMetricGroup}.
+	 * `VALUE` is used to create {@link GenericValueMetricGroup}.
+	 * `GENERIC` is used to create {@link GenericMetricGroup}.
 	 */
 	protected enum ChildType {
 		KEY,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroup.java
@@ -406,12 +406,7 @@ public abstract class AbstractMetricGroup<A extends AbstractMetricGroup<?>> impl
 
 	@Override
 	public MetricGroup addGroup(String key, String value) {
-		MetricGroup metricGroup;
-		if (this instanceof GenericKeyMetricGroup) {
-			metricGroup = addGroup(key);
-		} else {
-			metricGroup = addGroup(key, true);
-		}
+		MetricGroup metricGroup = addGroup(key, true);
 		if (metricGroup instanceof GenericKeyMetricGroup) {
 			return ((AbstractMetricGroup) metricGroup).addGroup(value, true);
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/GenericKeyMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/GenericKeyMetricGroup.java
@@ -19,9 +19,7 @@
 package org.apache.flink.runtime.metrics.groups;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.metrics.CharacterFilter;
 import org.apache.flink.runtime.metrics.MetricRegistry;
-import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
 
 /**
  * A simple named {@link org.apache.flink.metrics.MetricGroup} that is used to hold

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/GenericKeyMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/GenericKeyMetricGroup.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.metrics.groups;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 
 /**
@@ -30,6 +31,11 @@ public class GenericKeyMetricGroup extends GenericMetricGroup {
 
 	GenericKeyMetricGroup(MetricRegistry registry, AbstractMetricGroup parent, String name) {
 		super(registry, parent, name);
+	}
+
+	@Override
+	public MetricGroup addGroup(String key, String value) {
+		return addGroup(key).addGroup(value);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/GenericKeyMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/GenericKeyMetricGroup.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.metrics.groups;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.metrics.CharacterFilter;
+import org.apache.flink.runtime.metrics.MetricRegistry;
+import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
+
+/**
+ * A simple named {@link org.apache.flink.metrics.MetricGroup} that is used to hold
+ * subgroups of metrics.
+ */
+@Internal
+public class GenericKeyMetricGroup extends GenericMetricGroup {
+
+	GenericKeyMetricGroup(MetricRegistry registry, AbstractMetricGroup parent, String name) {
+		super(registry, parent, name);
+	}
+
+	@Override
+	protected GenericMetricGroup createChildGroup(String name) {
+		return new GenericValueMetricGroup(registry, this, name);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/GenericKeyMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/GenericKeyMetricGroup.java
@@ -39,7 +39,7 @@ public class GenericKeyMetricGroup extends GenericMetricGroup {
 	}
 
 	@Override
-	protected GenericMetricGroup createChildGroup(String name) {
+	protected GenericMetricGroup createChildGroupInKeyedContext(String name) {
 		return new GenericValueMetricGroup(registry, this, name);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/GenericKeyMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/GenericKeyMetricGroup.java
@@ -39,7 +39,12 @@ public class GenericKeyMetricGroup extends GenericMetricGroup {
 	}
 
 	@Override
-	protected GenericMetricGroup createChildGroupInKeyedContext(String name) {
-		return new GenericValueMetricGroup(registry, this, name);
+	protected GenericMetricGroup createChildGroup(String name, ChildType childType) {
+		switch (childType) {
+			case VALUE:
+				return new GenericValueMetricGroup(registry, this, name);
+			default:
+				return new GenericMetricGroup(registry, this, name);
+		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/GenericValueMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/GenericValueMetricGroup.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.metrics.groups;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.metrics.CharacterFilter;
+import org.apache.flink.runtime.metrics.MetricRegistry;
+import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
+import org.apache.flink.runtime.metrics.scope.ScopeFormat;
+
+import java.util.Map;
+
+/**
+ * A simple named {@link org.apache.flink.metrics.MetricGroup} that is used to hold
+ * subgroups of metrics.
+ */
+@Internal
+public class GenericValueMetricGroup extends GenericMetricGroup {
+	private String key;
+	private final String value;
+
+	GenericValueMetricGroup(MetricRegistry registry, GenericKeyMetricGroup parent, String value) {
+		super(registry, parent, value);
+		this.key = parent.getGroupName(name -> name);
+		this.value = value;
+	}
+
+	// ------------------------------------------------------------------------
+
+	@Override
+	protected void putVariables(Map<String, String> variables) {
+		variables.put(ScopeFormat.asVariable(this.key), value);
+	}
+
+	@Override
+	public String getLogicalScope(CharacterFilter filter, char delimiter) {
+		return parent.getLogicalScope(filter, delimiter);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/GenericValueMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/GenericValueMetricGroup.java
@@ -21,7 +21,6 @@ package org.apache.flink.runtime.metrics.groups;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.metrics.CharacterFilter;
 import org.apache.flink.runtime.metrics.MetricRegistry;
-import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
 import org.apache.flink.runtime.metrics.scope.ScopeFormat;
 
 import java.util.Map;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/ProxyMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/ProxyMetricGroup.java
@@ -103,6 +103,11 @@ public class ProxyMetricGroup<P extends MetricGroup> implements MetricGroup {
 	}
 
 	@Override
+	public final MetricGroup addGroup(String key, String value) {
+		return parentMetricGroup.addGroup(key, value);
+	}
+
+	@Override
 	public String[] getScopeComponents() {
 		return parentMetricGroup.getScopeComponents();
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStatsTrackerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStatsTrackerTest.java
@@ -385,6 +385,11 @@ public class CheckpointStatsTrackerTest {
 			}
 
 			@Override
+			public MetricGroup addGroup(String key, String value) {
+				throw new UnsupportedOperationException("Not expected in this test");
+			}
+
+			@Override
 			public String[] getScopeComponents() {
 				throw new UnsupportedOperationException("Not expected in this test");
 			}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/MetricGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/MetricGroupTest.java
@@ -92,8 +92,8 @@ public class MetricGroupTest extends TestLogger {
 		Map<String, String> variables1 = subgroup1.getAllVariables();
 
 		assertNotNull(subgroup1);
-		assertTrue(subgroup1 instanceof GenericValueMetricGroup);
-		assertTrue(((AbstractMetricGroup) subgroup1).parent instanceof GenericKeyMetricGroup);
+		assertEquals(GenericValueMetricGroup.class, subgroup1.getClass());
+		assertEquals(GenericKeyMetricGroup.class, ((AbstractMetricGroup) subgroup1).parent.getClass());
 		assertTrue(variables1.containsKey(ScopeFormat.asVariable(keyName)));
 		assertEquals(valueName1, variables1.get(ScopeFormat.asVariable(keyName)));
 
@@ -102,7 +102,7 @@ public class MetricGroupTest extends TestLogger {
 		Map<String, String> variables2 = subgroup2.getAllVariables();
 
 		assertNotNull(subgroup2);
-		assertTrue(subgroup2 instanceof GenericValueMetricGroup);
+		assertEquals(GenericValueMetricGroup.class, subgroup2.getClass());
 		assertEquals(((AbstractMetricGroup) subgroup1).parent, ((AbstractMetricGroup) subgroup2).parent);
 		assertTrue(variables2.containsKey(ScopeFormat.asVariable(keyName)));
 		assertEquals(valueName2, variables2.get(ScopeFormat.asVariable(keyName)));
@@ -121,8 +121,10 @@ public class MetricGroupTest extends TestLogger {
 		String valueName2 = "somevaluename2";
 		MetricGroup subgroup = group.addGroup(keyName).addGroup(keyName2, valueName2);
 
-		assertTrue(((AbstractMetricGroup) subgroup).parent instanceof GenericMetricGroup);
-		assertTrue(subgroup instanceof GenericMetricGroup);
+		// Is is illegal to call `MetricGroup#addGroup(String key, String value)` after `GenericKeyMetricGroup`.
+		// The behavior will fall back to `group.addGroup(key).addGroup(value)`.
+		assertEquals(GenericMetricGroup.class, ((AbstractMetricGroup) subgroup).parent.getClass());
+		assertEquals(GenericMetricGroup.class, subgroup.getClass());
 	}
 
 	@Test
@@ -136,7 +138,9 @@ public class MetricGroupTest extends TestLogger {
 		String valueName = "somevaluename";
 		MetricGroup subgroup = group.addGroup(groupName, valueName);
 
-		assertTrue(subgroup instanceof  GenericMetricGroup);
+		// Is is illegal to call `MetricGroup#addGroup(String key, String value)` when there is already a
+		// `GenericMetricGroup` named as `key`. The behavior will fall back to `group.addGroup(key).addGroup(value)`.
+		assertEquals(GenericMetricGroup.class, subgroup.getClass());
 	}
 
 	@Test
@@ -146,16 +150,16 @@ public class MetricGroupTest extends TestLogger {
 
 		String groupName = "sometestname";
 		MetricGroup group1 = group.addGroup(groupName);
-		assertTrue(group1 instanceof GenericMetricGroup);
+		assertEquals(GenericMetricGroup.class, group1.getClass());
 
 		String keyName = "somekeyname";
 		String valueName = "somevaluename";
 		MetricGroup valueGroup = group.addGroup(keyName, valueName);
 		MetricGroup group2 = group.addGroup(keyName).addGroup(groupName);
-		assertTrue(group2 instanceof GenericMetricGroup);
+		assertEquals(GenericMetricGroup.class, group2.getClass());
 
 		MetricGroup group3 = valueGroup.addGroup(groupName);
-		assertTrue(group3 instanceof GenericMetricGroup);
+		assertEquals(GenericMetricGroup.class, group3.getClass());
 	}
 
 	@Test
@@ -169,7 +173,7 @@ public class MetricGroupTest extends TestLogger {
 		MetricGroup subgroup2 = group.addGroup(groupName, valueName);
 
 		assertEquals(subgroup1, ((AbstractMetricGroup) subgroup2).parent);
-		assertTrue(subgroup2 instanceof GenericMetricGroup);
+		assertEquals(GenericMetricGroup.class, subgroup2.getClass());
 
 		String groupName2 = "sometestname2";
 		String valueName2 = "somevaluename2";
@@ -178,7 +182,7 @@ public class MetricGroupTest extends TestLogger {
 		MetricGroup subgroup4 = group.addGroup(groupName2, valueName2);
 
 		assertEquals(subgroup3, subgroup4);
-		assertTrue(subgroup4 instanceof GenericMetricGroup);
+		assertEquals(GenericMetricGroup.class, subgroup4.getClass());
 	}
 
 	@Test
@@ -192,7 +196,7 @@ public class MetricGroupTest extends TestLogger {
 		MetricGroup subgroup2 = group.addGroup(keyName);
 
 		assertEquals(((AbstractMetricGroup) subgroup1).parent, subgroup2);
-		assertTrue(subgroup2 instanceof GenericKeyMetricGroup);
+		assertEquals(GenericKeyMetricGroup.class, subgroup2.getClass());
 	}
 
 	@Test
@@ -206,7 +210,7 @@ public class MetricGroupTest extends TestLogger {
 		MetricGroup subgroup2 = group.addGroup(keyName).addGroup(valueName);
 
 		assertEquals(subgroup1, subgroup2);
-		assertTrue(subgroup2 instanceof GenericValueMetricGroup);
+		assertEquals(GenericValueMetricGroup.class, subgroup2.getClass());
 	}
 
 	@Test


### PR DESCRIPTION
## What is the purpose of the change

This pull request makes user can create his own `MetricGroup` with user-defined variables.
The way to create user-defined variables is to use a new public method `MetricGroup#addGroup(String key, String value)`, which is almost same as `group.addGroup(key).addGroup(value)` but the former will return a group with one more variable: `{"<key>":"value"}`.

## Brief change log

  - Added a new public method: `MetricGroup#addGroup(String key, String value)`.
  - Introduce two new class: `GenericKeyMetricGroup` and `GenericValueMetricGroup`.
  - The child group of `GenericKeyMetricGroup` will be either `GenericMetricGroup` or `GenericValueMetricGroup`.
  - The child group of `GenericMetricGroup` and `GenericValueMetricGroup` will be either `GenericMetricGroup` or `GenericKeyMetricGroup`.
  - `GenericValueMetricGroup` doesn't have logical scope and have a user-defined variable, whose name is its parent's group name and value is its group name.


## Verifying this change

This change added tests and can be verified as follows:

  - Added test that verify the behavior of `MetricGroup#addGroup(String key, String value)`
  - Manually verfied the new method works by rewriting the committed offset metric in kafka connector and monitoring it through prometheus reporter.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: don't know
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs and JavaDocs
