### PR TITLE
[FLINK-8193][quickstart] Cleanup quickstart poms

### DIFF
--- a/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/pom.xml
+++ b/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/pom.xml
@@ -81,6 +81,13 @@ under the License.
 			<version>${flink.version}</version>
 		</dependency>
 		<dependency>
+			<!-- This dependency is required to actually execute jobs. It is currently pulled in by
+				flink-streaming-java, but we explicitly depend on it to safeguard against future changes. -->
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-clients_${scala.binary.version}</artifactId>
+			<version>${flink.version}</version>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
 			<version>${flink.version}</version>
@@ -119,6 +126,12 @@ under the License.
 				<dependency>
 					<groupId>org.apache.flink</groupId>
 					<artifactId>flink-java</artifactId>
+					<version>${flink.version}</version>
+					<scope>provided</scope>
+				</dependency>
+				<dependency>
+					<groupId>org.apache.flink</groupId>
+					<artifactId>flink-clients_${scala.binary.version}</artifactId>
 					<version>${flink.version}</version>
 					<scope>provided</scope>
 				</dependency>

--- a/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/pom.xml
+++ b/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/pom.xml
@@ -153,32 +153,6 @@ under the License.
 				</dependency>
 			</dependencies>
 		</profile>
-		<profile>
-			<id>print-warning</id>
-			<activation>
-				<activeByDefault>true</activeByDefault>
-			</activation>
-			<build>
-				<plugins>
-					<plugin>
-						<artifactId>maven-antrun-plugin</artifactId>
-						<executions>
-							<execution>
-								<phase>prepare-package</phase>
-								<goals>
-									<goal>run</goal>
-								</goals>
-								<configuration>
-									<tasks>
-										<echo>It is recommended use the "build-jar" profile to create a jar.</echo>
-									</tasks>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
 	</profiles>
 
 	<build>

--- a/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/pom.xml
+++ b/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/pom.xml
@@ -59,8 +59,6 @@ under the License.
 
 		a) Adding new dependencies:
 			You can add dependencies to the list below.
-			Please check if the maven-shade-plugin below is filtering out your dependency
-			and remove the exclude from there.
 
 		b) Build a jar for running on the cluster:
 

--- a/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/pom.xml
+++ b/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/pom.xml
@@ -152,52 +152,56 @@ under the License.
 					<scope>provided</scope>
 				</dependency>
 			</dependencies>
+
+			<build>
+				<plugins>
+					<!-- We use the maven-shade plugin to create a fat jar that contains all dependencies
+                    	except flink and its transitive dependencies. The resulting fat-jar can be executed
+                    	on a cluster. Change the value of Program-Class if your program entry point changes. -->
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-shade-plugin</artifactId>
+						<version>3.0.0</version>
+						<executions>
+							<!-- Run shade goal on package phase -->
+							<execution>
+								<phase>package</phase>
+								<goals>
+									<goal>shade</goal>
+								</goals>
+								<configuration>
+									<filters>
+										<filter>
+											<!-- Do not copy the signatures in the META-INF folder.
+                                            Otherwise, this might cause SecurityExceptions when using the JAR. -->
+											<artifact>*:*</artifact>
+											<excludes>
+												<exclude>META-INF/*.SF</exclude>
+												<exclude>META-INF/*.DSA</exclude>
+												<exclude>META-INF/*.RSA</exclude>
+											</excludes>
+										</filter>
+									</filters>
+									<!-- If you want to use ./bin/flink run <quickstart jar> uncomment the following lines.
+                             			This will add a Main-Class entry to the manifest file -->
+									<!--
+                             		<transformers>
+                             			<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                             			<mainClass>${package}.StreamingJob</mainClass>
+                             			</transformer>
+                            		</transformers>
+                             		-->
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
 		</profile>
 	</profiles>
 
 	<build>
 		<plugins>
-			<!-- We use the maven-shade plugin to create a fat jar that contains all dependencies
-			except flink and its transitive dependencies. The resulting fat-jar can be executed
-			on a cluster. Change the value of Program-Class if your program entry point changes. -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-shade-plugin</artifactId>
-				<version>3.0.0</version>
-				<executions>
-					<!-- Run shade goal on package phase -->
-					<execution>
-						<phase>package</phase>
-						<goals>
-							<goal>shade</goal>
-						</goals>
-						<configuration>
-							<filters>
-								<filter>
-									<!-- Do not copy the signatures in the META-INF folder.
-									Otherwise, this might cause SecurityExceptions when using the JAR. -->
-									<artifact>*:*</artifact>
-									<excludes>
-										<exclude>META-INF/*.SF</exclude>
-										<exclude>META-INF/*.DSA</exclude>
-										<exclude>META-INF/*.RSA</exclude>
-									</excludes>
-								</filter>
-							</filters>
-							<!-- If you want to use ./bin/flink run <quickstart jar> uncomment the following lines.
-							This will add a Main-Class entry to the manifest file -->
-							<!--
-							<transformers>
-								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-									<mainClass>${package}.StreamingJob</mainClass>
-								</transformer>
-							</transformers>
-						    -->
-							<createDependencyReducedPom>false</createDependencyReducedPom>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
 
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/pom.xml
+++ b/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/pom.xml
@@ -78,17 +78,17 @@ under the License.
 		<!-- Apache Flink dependencies -->
 		<dependency>
 			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-core</artifactId>
+			<version>${flink.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-java</artifactId>
 			<version>${flink.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
-			<version>${flink.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-clients_${scala.binary.version}</artifactId>
 			<version>${flink.version}</version>
 		</dependency>
 
@@ -118,6 +118,12 @@ under the License.
 			<dependencies>
 				<dependency>
 					<groupId>org.apache.flink</groupId>
+					<artifactId>flink-core</artifactId>
+					<version>${flink.version}</version>
+					<scope>provided</scope>
+				</dependency>
+				<dependency>
+					<groupId>org.apache.flink</groupId>
 					<artifactId>flink-java</artifactId>
 					<version>${flink.version}</version>
 					<scope>provided</scope>
@@ -125,12 +131,6 @@ under the License.
 				<dependency>
 					<groupId>org.apache.flink</groupId>
 					<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
-					<version>${flink.version}</version>
-					<scope>provided</scope>
-				</dependency>
-				<dependency>
-					<groupId>org.apache.flink</groupId>
-					<artifactId>flink-clients_${scala.binary.version}</artifactId>
 					<version>${flink.version}</version>
 					<scope>provided</scope>
 				</dependency>

--- a/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/pom.xml
+++ b/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/pom.xml
@@ -153,6 +153,32 @@ under the License.
 				</dependency>
 			</dependencies>
 		</profile>
+		<profile>
+			<id>print-warning</id>
+			<activation>
+				<activeByDefault>true</activeByDefault>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<artifactId>maven-antrun-plugin</artifactId>
+						<executions>
+							<execution>
+								<phase>prepare-package</phase>
+								<goals>
+									<goal>run</goal>
+								</goals>
+								<configuration>
+									<tasks>
+										<echo>It is recommended use the "build-jar" profile to create a jar.</echo>
+									</tasks>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 	</profiles>
 
 	<build>

--- a/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/pom.xml
+++ b/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/pom.xml
@@ -63,7 +63,7 @@ under the License.
 		b) Build a jar for running on the cluster:
 
 			"mvn clean package -Pbuild-jar"
-			This will create a fat-jar which contain all dependencies necessary for running the created jar in a cluster.
+			This will create a fat-jar which contains all dependencies necessary for running the created jar in a cluster.
 	-->
 
 	<dependencies>

--- a/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/pom.xml
+++ b/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/pom.xml
@@ -63,15 +63,9 @@ under the License.
 			and remove the exclude from there.
 
 		b) Build a jar for running on the cluster:
-			There are two options for creating a jar from this project
 
-			b.1) "mvn clean package" -> this will create a fat jar which contains all
-					dependencies necessary for running the jar created by this pom in a cluster.
-					The "maven-shade-plugin" excludes everything that is provided on a running Flink cluster.
-
-			b.2) "mvn clean package -Pbuild-jar" -> This will also create a fat-jar, but with much
-					nicer dependency exclusion handling. This approach is preferred and leads to
-					much cleaner jar files.
+			"mvn clean package -Pbuild-jar"
+			This will create a fat-jar which contain all dependencies necessary for running the created jar in a cluster.
 	-->
 
 	<dependencies>
@@ -147,30 +141,6 @@ under the License.
 					<scope>provided</scope>
 				</dependency>
 			</dependencies>
-
-			<build>
-				<plugins>
-					<!-- disable the exclusion rules -->
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-shade-plugin</artifactId>
-						<version>3.0.0</version>
-						<executions>
-							<execution>
-								<phase>package</phase>
-								<goals>
-									<goal>shade</goal>
-								</goals>
-								<configuration>
-									<artifactSet>
-										<excludes combine.self="override"></excludes>
-									</artifactSet>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
 		</profile>
 	</profiles>
 
@@ -191,89 +161,7 @@ under the License.
 							<goal>shade</goal>
 						</goals>
 						<configuration>
-							<artifactSet>
-								<excludes>
-									<!-- This list contains all dependencies of flink-dist
-									Everything else will be packaged into the fat-jar
-									-->
-									<exclude>org.apache.flink:flink-annotations</exclude>
-									<exclude>org.apache.flink:flink-shaded-hadoop2</exclude>
-									<exclude>org.apache.flink:flink-shaded-curator</exclude>
-									<exclude>org.apache.flink:flink-core</exclude>
-									<exclude>org.apache.flink:flink-java</exclude>
-									<exclude>org.apache.flink:flink-scala_${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-runtime_${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-optimizer_${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-clients_${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-avro</exclude>
-									<exclude>org.apache.flink:flink-examples-batch_${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-examples-streaming_${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-streaming-java_${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-streaming-scala_${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-scala-shell_${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-python</exclude>
-									<exclude>org.apache.flink:flink-metrics-core</exclude>
-									<exclude>org.apache.flink:flink-metrics-jmx</exclude>
-									<exclude>org.apache.flink:flink-statebackend-rocksdb_${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-shaded-jackson</exclude>
-
-									<!-- Also exclude very big transitive dependencies of Flink
-
-									WARNING: You have to remove these excludes if your code relies on other
-									versions of these dependencies.
-
-									-->
-
-									<exclude>log4j:log4j</exclude>
-									<exclude>org.scala-lang:scala-library</exclude>
-									<exclude>org.scala-lang:scala-compiler</exclude>
-									<exclude>org.scala-lang:scala-reflect</exclude>
-									<exclude>com.typesafe.akka:akka-actor_*</exclude>
-									<exclude>com.typesafe.akka:akka-remote_*</exclude>
-									<exclude>com.typesafe.akka:akka-slf4j_*</exclude>
-									<exclude>io.netty:netty-all</exclude>
-									<exclude>io.netty:netty</exclude>
-									<exclude>commons-fileupload:commons-fileupload</exclude>
-									<exclude>org.apache.avro:avro</exclude>
-									<exclude>commons-collections:commons-collections</exclude>
-									<exclude>org.codehaus.jackson:jackson-core-asl</exclude>
-									<exclude>org.codehaus.jackson:jackson-mapper-asl</exclude>
-									<exclude>com.thoughtworks.paranamer:paranamer</exclude>
-									<exclude>org.xerial.snappy:snappy-java</exclude>
-									<exclude>org.apache.commons:commons-compress</exclude>
-									<exclude>org.tukaani:xz</exclude>
-									<exclude>com.esotericsoftware.kryo:kryo</exclude>
-									<exclude>com.esotericsoftware.minlog:minlog</exclude>
-									<exclude>org.objenesis:objenesis</exclude>
-									<exclude>com.twitter:chill_*</exclude>
-									<exclude>com.twitter:chill-java</exclude>
-									<exclude>commons-lang:commons-lang</exclude>
-									<exclude>junit:junit</exclude>
-									<exclude>org.apache.commons:commons-lang3</exclude>
-									<exclude>org.slf4j:slf4j-api</exclude>
-									<exclude>org.slf4j:slf4j-log4j12</exclude>
-									<exclude>log4j:log4j</exclude>
-									<exclude>org.apache.commons:commons-math</exclude>
-									<exclude>org.apache.sling:org.apache.sling.commons.json</exclude>
-									<exclude>commons-logging:commons-logging</exclude>
-									<exclude>commons-codec:commons-codec</exclude>
-									<exclude>stax:stax-api</exclude>
-									<exclude>com.typesafe:config</exclude>
-									<exclude>org.uncommons.maths:uncommons-maths</exclude>
-									<exclude>com.github.scopt:scopt_*</exclude>
-									<exclude>commons-io:commons-io</exclude>
-									<exclude>commons-cli:commons-cli</exclude>
-								</excludes>
-							</artifactSet>
 							<filters>
-								<filter>
-									<artifact>org.apache.flink:*</artifact>
-									<excludes>
-										<!-- exclude shaded google but include shaded curator -->
-										<exclude>org/apache/flink/shaded/com/**</exclude>
-										<exclude>web-docs/**</exclude>
-									</excludes>
-								</filter>
 								<filter>
 									<!-- Do not copy the signatures in the META-INF folder.
 									Otherwise, this might cause SecurityExceptions when using the JAR. -->

--- a/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/pom.xml
+++ b/flink-quickstart/flink-quickstart-java/src/main/resources/archetype-resources/pom.xml
@@ -170,6 +170,13 @@ under the License.
 									<goal>shade</goal>
 								</goals>
 								<configuration>
+									<artifactSet>
+										<excludes>
+											<exclude>org.apache.flink:force-shading</exclude>
+											<exclude>com.google.code.findbgs:jsr305</exclude>
+											<exclude>org.slf4j:slf4j-api</exclude>
+										</excludes>
+									</artifactSet>
 									<filters>
 										<filter>
 											<!-- Do not copy the signatures in the META-INF folder.

--- a/flink-quickstart/flink-quickstart-scala/src/main/resources/archetype-resources/pom.xml
+++ b/flink-quickstart/flink-quickstart-scala/src/main/resources/archetype-resources/pom.xml
@@ -61,8 +61,6 @@ under the License.
 
 		a) Adding new dependencies:
 			You can add dependencies to the list below.
-			Please check if the maven-shade-plugin below is filtering out your dependency
-			and remove the exclude from there.
 
 		b) Build a jar for running on the cluster:
 

--- a/flink-quickstart/flink-quickstart-scala/src/main/resources/archetype-resources/pom.xml
+++ b/flink-quickstart/flink-quickstart-scala/src/main/resources/archetype-resources/pom.xml
@@ -49,6 +49,7 @@ under the License.
 		<slf4j.version>@slf4j.version@</slf4j.version>
 		<log4j.version>@log4j.version@</log4j.version>
 		<scala.binary.version>2.11</scala.binary.version>
+		<scala.version>2.11.11</scala.version>
 	</properties>
 
 	<!-- 
@@ -79,6 +80,11 @@ under the License.
 		<!-- Apache Flink dependencies -->
 		<dependency>
 			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-core</artifactId>
+			<version>${flink.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-scala_${scala.binary.version}</artifactId>
 			<version>${flink.version}</version>
 		</dependency>
@@ -87,10 +93,11 @@ under the License.
 			<artifactId>flink-streaming-scala_${scala.binary.version}</artifactId>
 			<version>${flink.version}</version>
 		</dependency>
+
 		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-clients_${scala.binary.version}</artifactId>
-			<version>${flink.version}</version>
+			<groupId>org.scala-lang</groupId>
+			<artifactId>scala-library</artifactId>
+			<version>${scala.version}</version>
 		</dependency>
 
 		<!-- explicitly add a standard logging framework, as Flink does not have
@@ -131,6 +138,12 @@ under the License.
 					<groupId>org.apache.flink</groupId>
 					<artifactId>flink-clients_${scala.binary.version}</artifactId>
 					<version>${flink.version}</version>
+					<scope>provided</scope>
+				</dependency>
+				<dependency>
+					<groupId>org.scala-lang</groupId>
+					<artifactId>scala-library</artifactId>
+					<version>${scala.version}</version>
 					<scope>provided</scope>
 				</dependency>
 				<dependency>

--- a/flink-quickstart/flink-quickstart-scala/src/main/resources/archetype-resources/pom.xml
+++ b/flink-quickstart/flink-quickstart-scala/src/main/resources/archetype-resources/pom.xml
@@ -65,7 +65,7 @@ under the License.
 		b) Build a jar for running on the cluster:
 
 			"mvn clean package -Pbuild-jar"
-			This will create a fat-jar which contain all dependencies necessary for running the created jar in a cluster.
+			This will create a fat-jar which contains all dependencies necessary for running the created jar in a cluster.
 	-->
 
 	<dependencies>

--- a/flink-quickstart/flink-quickstart-scala/src/main/resources/archetype-resources/pom.xml
+++ b/flink-quickstart/flink-quickstart-scala/src/main/resources/archetype-resources/pom.xml
@@ -78,6 +78,13 @@ under the License.
 			<version>${flink.version}</version>
 		</dependency>
 		<dependency>
+			<!-- This dependency is required to actually execute jobs. It is currently pulled in by
+				flink-streaming-java, but we explicitly depend on it to safeguard against future changes. -->
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-clients_${scala.binary.version}</artifactId>
+			<version>${flink.version}</version>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-scala_${scala.binary.version}</artifactId>
 			<version>${flink.version}</version>
@@ -118,6 +125,17 @@ under the License.
 			<dependencies>
 				<dependency>
 					<groupId>org.apache.flink</groupId>
+					<artifactId>flink-core</artifactId>
+					<version>${flink.version}</version>
+				</dependency>
+				<dependency>
+					<groupId>org.apache.flink</groupId>
+					<artifactId>flink-clients_${scala.binary.version}</artifactId>
+					<version>${flink.version}</version>
+					<scope>provided</scope>
+				</dependency>
+				<dependency>
+					<groupId>org.apache.flink</groupId>
 					<artifactId>flink-scala_${scala.binary.version}</artifactId>
 					<version>${flink.version}</version>
 					<scope>provided</scope>
@@ -125,12 +143,6 @@ under the License.
 				<dependency>
 					<groupId>org.apache.flink</groupId>
 					<artifactId>flink-streaming-scala_${scala.binary.version}</artifactId>
-					<version>${flink.version}</version>
-					<scope>provided</scope>
-				</dependency>
-				<dependency>
-					<groupId>org.apache.flink</groupId>
-					<artifactId>flink-clients_${scala.binary.version}</artifactId>
 					<version>${flink.version}</version>
 					<scope>provided</scope>
 				</dependency>

--- a/flink-quickstart/flink-quickstart-scala/src/main/resources/archetype-resources/pom.xml
+++ b/flink-quickstart/flink-quickstart-scala/src/main/resources/archetype-resources/pom.xml
@@ -65,15 +65,9 @@ under the License.
 			and remove the exclude from there.
 
 		b) Build a jar for running on the cluster:
-			There are two options for creating a jar from this project
 
-			b.1) "mvn clean package" -> this will create a fat jar which contains all
-					dependencies necessary for running the jar created by this pom in a cluster.
-					The "maven-shade-plugin" excludes everything that is provided on a running Flink cluster.
-
-			b.2) "mvn clean package -Pbuild-jar" -> This will also create a fat-jar, but with much
-					nicer dependency exclusion handling. This approach is preferred and leads to
-					much cleaner jar files.
+			"mvn clean package -Pbuild-jar"
+			This will create a fat-jar which contain all dependencies necessary for running the created jar in a cluster.
 	-->
 
 	<dependencies>
@@ -159,36 +153,9 @@ under the License.
 					<scope>provided</scope>
 				</dependency>
 			</dependencies>
-
-			<build>
-				<plugins>
-					<!-- disable the exclusion rules -->
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-shade-plugin</artifactId>
-						<version>3.0.0</version>
-						<executions>
-							<execution>
-								<phase>package</phase>
-								<goals>
-									<goal>shade</goal>
-								</goals>
-								<configuration>
-									<artifactSet>
-										<excludes combine.self="override"></excludes>
-									</artifactSet>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
 		</profile>
 	</profiles>
 
-	<!-- We use the maven-assembly plugin to create a fat jar that contains all dependencies
-		except flink and its transitive dependencies. The resulting fat-jar can be executed
-		on a cluster. Change the value of Program-Class if your program entry point changes. -->
 	<build>
 		<plugins>
 			<!-- We use the maven-shade plugin to create a fat jar that contains all dependencies
@@ -206,87 +173,7 @@ under the License.
 							<goal>shade</goal>
 						</goals>
 						<configuration>
-							<artifactSet>
-								<excludes>
-									<!-- This list contains all dependencies of flink-dist
-									Everything else will be packaged into the fat-jar
-									-->
-									<exclude>org.apache.flink:flink-annotations</exclude>
-									<exclude>org.apache.flink:flink-shaded-hadoop2</exclude>
-									<exclude>org.apache.flink:flink-shaded-curator</exclude>
-									<exclude>org.apache.flink:flink-core</exclude>
-									<exclude>org.apache.flink:flink-java</exclude>
-									<exclude>org.apache.flink:flink-scala_${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-runtime_${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-optimizer_${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-clients_${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-avro</exclude>
-									<exclude>org.apache.flink:flink-examples-batch_${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-examples-streaming_${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-streaming-java_${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-streaming-scala_${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-scala-shell_${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-python</exclude>
-									<exclude>org.apache.flink:flink-metrics-core</exclude>
-									<exclude>org.apache.flink:flink-metrics-jmx</exclude>
-									<exclude>org.apache.flink:flink-statebackend-rocksdb_${scala.binary.version}</exclude>
-									<exclude>org.apache.flink:flink-shaded-jackson</exclude>
-
-									<!-- Also exclude very big transitive dependencies of Flink
-
-									WARNING: You have to remove these excludes if your code relies on other
-									versions of these dependencies.
-
-									-->
-
-									<exclude>log4j:log4j</exclude>
-									<exclude>org.scala-lang:scala-library</exclude>
-									<exclude>org.scala-lang:scala-compiler</exclude>
-									<exclude>org.scala-lang:scala-reflect</exclude>
-									<exclude>com.typesafe.akka:akka-actor_*</exclude>
-									<exclude>com.typesafe.akka:akka-remote_*</exclude>
-									<exclude>com.typesafe.akka:akka-slf4j_*</exclude>
-									<exclude>io.netty:netty-all</exclude>
-									<exclude>io.netty:netty</exclude>
-									<exclude>commons-fileupload:commons-fileupload</exclude>
-									<exclude>org.apache.avro:avro</exclude>
-									<exclude>commons-collections:commons-collections</exclude>
-									<exclude>com.thoughtworks.paranamer:paranamer</exclude>
-									<exclude>org.xerial.snappy:snappy-java</exclude>
-									<exclude>org.apache.commons:commons-compress</exclude>
-									<exclude>org.tukaani:xz</exclude>
-									<exclude>com.esotericsoftware.kryo:kryo</exclude>
-									<exclude>com.esotericsoftware.minlog:minlog</exclude>
-									<exclude>org.objenesis:objenesis</exclude>
-									<exclude>com.twitter:chill_*</exclude>
-									<exclude>com.twitter:chill-java</exclude>
-									<exclude>commons-lang:commons-lang</exclude>
-									<exclude>junit:junit</exclude>
-									<exclude>org.apache.commons:commons-lang3</exclude>
-									<exclude>org.slf4j:slf4j-api</exclude>
-									<exclude>org.slf4j:slf4j-log4j12</exclude>
-									<exclude>log4j:log4j</exclude>
-									<exclude>org.apache.commons:commons-math</exclude>
-									<exclude>org.apache.sling:org.apache.sling.commons.json</exclude>
-									<exclude>commons-logging:commons-logging</exclude>
-									<exclude>commons-codec:commons-codec</exclude>
-									<exclude>stax:stax-api</exclude>
-									<exclude>com.typesafe:config</exclude>
-									<exclude>org.uncommons.maths:uncommons-maths</exclude>
-									<exclude>com.github.scopt:scopt_*</exclude>
-									<exclude>commons-io:commons-io</exclude>
-									<exclude>commons-cli:commons-cli</exclude>
-								</excludes>
-							</artifactSet>
 							<filters>
-								<filter>
-									<artifact>org.apache.flink:*</artifact>
-									<excludes>
-										<!-- exclude shaded google but include shaded curator -->
-										<exclude>org/apache/flink/shaded/com/**</exclude>
-										<exclude>web-docs/**</exclude>
-									</excludes>
-								</filter>
 								<filter>
 									<!-- Do not copy the signatures in the META-INF folder.
 									Otherwise, this might cause SecurityExceptions when using the JAR. -->

--- a/flink-quickstart/flink-quickstart-scala/src/main/resources/archetype-resources/pom.xml
+++ b/flink-quickstart/flink-quickstart-scala/src/main/resources/archetype-resources/pom.xml
@@ -164,6 +164,32 @@ under the License.
 				</dependency>
 			</dependencies>
 		</profile>
+		<profile>
+			<id>print-warning</id>
+			<activation>
+				<activeByDefault>true</activeByDefault>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<artifactId>maven-antrun-plugin</artifactId>
+						<executions>
+							<execution>
+								<phase>prepare-package</phase>
+								<goals>
+									<goal>run</goal>
+								</goals>
+								<configuration>
+									<tasks>
+										<echo>It is recommended use the "build-jar" profile to create a jar.</echo>
+									</tasks>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 	</profiles>
 
 	<build>

--- a/flink-quickstart/flink-quickstart-scala/src/main/resources/archetype-resources/pom.xml
+++ b/flink-quickstart/flink-quickstart-scala/src/main/resources/archetype-resources/pom.xml
@@ -181,6 +181,13 @@ under the License.
 									<goal>shade</goal>
 								</goals>
 								<configuration>
+									<artifactSet>
+										<excludes>
+											<exclude>org.apache.flink:force-shading</exclude>
+											<exclude>com.google.code.findbgs:jsr305</exclude>
+											<exclude>org.slf4j:slf4j-api</exclude>
+										</excludes>
+									</artifactSet>
 									<filters>
 										<filter>
 											<!-- Do not copy the signatures in the META-INF folder.

--- a/flink-quickstart/flink-quickstart-scala/src/main/resources/archetype-resources/pom.xml
+++ b/flink-quickstart/flink-quickstart-scala/src/main/resources/archetype-resources/pom.xml
@@ -164,32 +164,6 @@ under the License.
 				</dependency>
 			</dependencies>
 		</profile>
-		<profile>
-			<id>print-warning</id>
-			<activation>
-				<activeByDefault>true</activeByDefault>
-			</activation>
-			<build>
-				<plugins>
-					<plugin>
-						<artifactId>maven-antrun-plugin</artifactId>
-						<executions>
-							<execution>
-								<phase>prepare-package</phase>
-								<goals>
-									<goal>run</goal>
-								</goals>
-								<configuration>
-									<tasks>
-										<echo>It is recommended use the "build-jar" profile to create a jar.</echo>
-									</tasks>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
 	</profiles>
 
 	<build>

--- a/flink-quickstart/flink-quickstart-scala/src/main/resources/archetype-resources/pom.xml
+++ b/flink-quickstart/flink-quickstart-scala/src/main/resources/archetype-resources/pom.xml
@@ -163,53 +163,56 @@ under the License.
 					<scope>provided</scope>
 				</dependency>
 			</dependencies>
+
+			<build>
+				<plugins>
+					<!-- We use the maven-shade plugin to create a fat jar that contains all dependencies
+						except flink and its transitive dependencies. The resulting fat-jar can be executed
+						on a cluster. Change the value of Program-Class if your program entry point changes. -->
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-shade-plugin</artifactId>
+						<version>3.0.0</version>
+						<executions>
+							<!-- Run shade goal on package phase -->
+							<execution>
+								<phase>package</phase>
+								<goals>
+									<goal>shade</goal>
+								</goals>
+								<configuration>
+									<filters>
+										<filter>
+											<!-- Do not copy the signatures in the META-INF folder.
+											Otherwise, this might cause SecurityExceptions when using the JAR. -->
+											<artifact>*:*</artifact>
+											<excludes>
+												<exclude>META-INF/*.SF</exclude>
+												<exclude>META-INF/*.DSA</exclude>
+												<exclude>META-INF/*.RSA</exclude>
+											</excludes>
+										</filter>
+									</filters>
+									<!-- If you want to use ./bin/flink run <quickstart jar> uncomment the following lines.
+										This will add a Main-Class entry to the manifest file -->
+									<!--
+									<transformers>
+										<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+										<mainClass>${package}.StreamingJob</mainClass>
+										</transformer>
+									</transformers>
+									-->
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
 		</profile>
 	</profiles>
 
 	<build>
 		<plugins>
-			<!-- We use the maven-shade plugin to create a fat jar that contains all dependencies
-			except flink and it's transitive dependencies. The resulting fat-jar can be executed
-			on a cluster. Change the value of Program-Class if your program entry point changes. -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-shade-plugin</artifactId>
-				<version>3.0.0</version>
-				<executions>
-					<!-- Run shade goal on package phase -->
-					<execution>
-						<phase>package</phase>
-						<goals>
-							<goal>shade</goal>
-						</goals>
-						<configuration>
-							<filters>
-								<filter>
-									<!-- Do not copy the signatures in the META-INF folder.
-									Otherwise, this might cause SecurityExceptions when using the JAR. -->
-									<artifact>*:*</artifact>
-									<excludes>
-										<exclude>META-INF/*.SF</exclude>
-										<exclude>META-INF/*.DSA</exclude>
-										<exclude>META-INF/*.RSA</exclude>
-									</excludes>
-								</filter>
-							</filters>
-							<!-- If you want to use ./bin/flink run <quickstart jar> uncomment the following lines.
-							This will add a Main-Class entry to the manifest file -->
-							<!--
-							<transformers>
-								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-									<mainClass>${package}.StreamingJob</mainClass>
-								</transformer>
-							</transformers>
-						    -->
-							<createDependencyReducedPom>false</createDependencyReducedPom>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
## What is the purpose of the change

This PR addresses 2 problems in the quick start poms:

1) The poms declared unused dependencies (flink-clients), and were missing used dependencies (flink-core, scala-library).
2) The manual dependency exclusion using the maven-shade-plugin was prone to being out-dated.

This PR fixes the missing/unused dependencies, and removes the manual exclusion so there is now only one correct way of building the jar, which is using the `build-jar` profile.

## Verifying this change

This change was verified locally. I installed the archetypes locally and created new projects from them.
For verification I executed the programs in the IDE and packaged the jar with the `build-jar` profile and checked whether that they don't contain any dependencies.

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (docs)
