### PR TITLE
[FLINK-8186] Exclude flink-avro from flink-dist; fix AvroUtils loading

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/AvroUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/AvroUtils.java
@@ -37,12 +37,14 @@ public abstract class AvroUtils {
 
 	private static final String AVRO_KRYO_UTILS = "org.apache.flink.formats.avro.utils.AvroKryoSerializerUtils";
 
-	private static final AvroUtils INSTANCE = loadAvroKryoUtils();
-
-	private static AvroUtils loadAvroKryoUtils() {
+	/**
+	 * Returns either the default {@link AvroUtils} which throw an exception in cases where Avro
+	 * would be needed or loads the specific utils for Avro from flink-avro.
+	 */
+	public static AvroUtils getAvroUtils() {
 		// try and load the special AvroUtils from the flink-avro package
 		try {
-			Class<?> clazz = Class.forName(AVRO_KRYO_UTILS, false, AvroUtils.class.getClassLoader());
+			Class<?> clazz = Class.forName(AVRO_KRYO_UTILS, false, Thread.currentThread().getContextClassLoader());
 			return clazz.asSubclass(AvroUtils.class).getConstructor().newInstance();
 		} catch (ClassNotFoundException e) {
 			// cannot find the utils, return the default implementation
@@ -50,14 +52,6 @@ public abstract class AvroUtils {
 		} catch (Exception e) {
 			throw new RuntimeException("Could not instantiate " + AVRO_KRYO_UTILS + ".", e);
 		}
-	}
-
-	/**
-	 * Returns either the default {@link AvroUtils} which throw an exception in cases where Avro
-	 * would be needed or loads the specific utils for Avro from flink-avro.
-	 */
-	public static AvroUtils getAvroUtils() {
-		return INSTANCE;
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -81,12 +81,6 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-avro</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
 		</dependency>
@@ -497,10 +491,6 @@ under the License.
 								</excludes>
 							</artifactSet>
 							<relocations>
-								<relocation>
-									<pattern>org.codehaus.jackson</pattern>
-									<shadedPattern>org.apache.flink.formats.avro.shaded.org.codehaus.jackson</shadedPattern>
-								</relocation>
 								<relocation>
 									<!-- relocate jackson services, which isn't done by flink-shaded-jackson -->
 									<pattern>com.fasterxml.jackson</pattern>


### PR DESCRIPTION
Before, AvroUtils were loaded when the class was loaded which didn't
take into account the user-code ClassLoader. Now, we try loading avro
utils with the Thread context ClassLoader.

R: @StephanEwen 