### PR TITLE
[FLINK-8200] RocksDBAsyncSnapshotTest should use temp fold instead of fold with fixed name

### DIFF
--- a/flink-contrib/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBAsyncSnapshotTest.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBAsyncSnapshotTest.java
@@ -96,7 +96,7 @@ import static org.mockito.Mockito.verify;
 public class RocksDBAsyncSnapshotTest extends TestLogger {
 
 	/**
-	 * Temporary fold for test
+	 * Temporary fold for test.
 	 */
 	@Rule
 	public TemporaryFolder temporaryFolder = new TemporaryFolder();

--- a/flink-contrib/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBAsyncSnapshotTest.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBAsyncSnapshotTest.java
@@ -25,7 +25,6 @@ import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.api.common.typeutils.base.VoidSerializer;
 import org.apache.flink.api.java.functions.KeySelector;
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
@@ -60,7 +59,9 @@ import org.apache.flink.util.IOUtils;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -70,7 +71,6 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RunnableFuture;
@@ -96,6 +96,12 @@ import static org.mockito.Mockito.verify;
 public class RocksDBAsyncSnapshotTest extends TestLogger {
 
 	/**
+	 * Temporary fold for test
+	 */
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	/**
 	 * This ensures that asynchronous state handles are actually materialized asynchronously.
 	 *
 	 * <p>We use latches to block at various stages and see if the code still continues through
@@ -119,7 +125,7 @@ public class RocksDBAsyncSnapshotTest extends TestLogger {
 
 		StreamConfig streamConfig = testHarness.getStreamConfig();
 
-		File dbDir = new File(new File(ConfigConstants.DEFAULT_TASK_MANAGER_TMP_PATH, UUID.randomUUID().toString()), "state");
+		File dbDir = temporaryFolder.newFolder();
 
 		RocksDBStateBackend backend = new RocksDBStateBackend(new MemoryStateBackend());
 		backend.setDbStoragePath(dbDir.getAbsolutePath());
@@ -225,7 +231,7 @@ public class RocksDBAsyncSnapshotTest extends TestLogger {
 
 		StreamConfig streamConfig = testHarness.getStreamConfig();
 
-		File dbDir = new File(new File(ConfigConstants.DEFAULT_TASK_MANAGER_TMP_PATH, UUID.randomUUID().toString()), "state");
+		File dbDir = temporaryFolder.newFolder();
 
 		BlockingStreamMemoryStateBackend memoryStateBackend = new BlockingStreamMemoryStateBackend();
 
@@ -333,7 +339,7 @@ public class RocksDBAsyncSnapshotTest extends TestLogger {
 
 		RocksDBStateBackend backend = new RocksDBStateBackend(stateBackend);
 
-		backend.setDbStoragePath("file:///tmp/foobar");
+		backend.setDbStoragePath("file://" + temporaryFolder.newFolder().getAbsolutePath());
 
 		AbstractKeyedStateBackend<Void> keyedStateBackend = backend.createKeyedStateBackend(
 			env,

--- a/flink-contrib/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBAsyncSnapshotTest.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBAsyncSnapshotTest.java
@@ -339,7 +339,7 @@ public class RocksDBAsyncSnapshotTest extends TestLogger {
 
 		RocksDBStateBackend backend = new RocksDBStateBackend(stateBackend);
 
-		backend.setDbStoragePath("file://" + temporaryFolder.newFolder().getAbsolutePath());
+		backend.setDbStoragePath(temporaryFolder.newFolder().toURI().toString());
 
 		AbstractKeyedStateBackend<Void> keyedStateBackend = backend.createKeyedStateBackend(
 			env,


### PR DESCRIPTION
Using fixed folder in test makes test fail when different users run the test in the same machine. We should TemporaryFolder instead to avoid the conflicts and make the test folder be cleared automaticlly when execution finished.