### PR TITLE
[FLINK-8201] YarnResourceManagerTest causes license checking failure

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
@@ -418,6 +418,7 @@ public final class Utils {
 				homeDirPath,
 				"").f1;
 
+			taskManagerConfigFile.delete();
 			log.info("Prepared local resource for modified yaml: {}", flinkConf);
 		}
 

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
@@ -54,7 +54,6 @@ import org.apache.flink.util.TestLogger;
 
 import org.apache.flink.shaded.guava18.com.google.common.collect.ImmutableList;
 
-import org.apache.hadoop.yarn.api.ApplicationConstants;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.Container;
@@ -130,7 +129,6 @@ public class YarnResourceManagerTest extends TestLogger {
 		env.put(ENV_FLINK_CLASSPATH, "");
 		env.put(ENV_HADOOP_USER_NAME, "foo");
 		env.put(FLINK_JAR_PATH, root.toURI().toString());
-		env.put(ApplicationConstants.Environment.PWD.key(), home.getAbsolutePath());
 	}
 
 	@After

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
@@ -130,7 +130,7 @@ public class YarnResourceManagerTest extends TestLogger {
 		env.put(ENV_FLINK_CLASSPATH, "");
 		env.put(ENV_HADOOP_USER_NAME, "foo");
 		env.put(FLINK_JAR_PATH, root.toURI().toString());
-		// env.put(ApplicationConstants.Environment.PWD.key(), home.getAbsolutePath());
+		env.put(ApplicationConstants.Environment.PWD.key(), home.getAbsolutePath());
 	}
 
 	@After

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
@@ -54,6 +54,7 @@ import org.apache.flink.util.TestLogger;
 
 import org.apache.flink.shaded.guava18.com.google.common.collect.ImmutableList;
 
+import org.apache.hadoop.yarn.api.ApplicationConstants;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.Container;
@@ -129,6 +130,7 @@ public class YarnResourceManagerTest extends TestLogger {
 		env.put(ENV_FLINK_CLASSPATH, "");
 		env.put(ENV_HADOOP_USER_NAME, "foo");
 		env.put(FLINK_JAR_PATH, root.toURI().toString());
+		// env.put(ApplicationConstants.Environment.PWD.key(), home.getAbsolutePath());
 	}
 
 	@After


### PR DESCRIPTION
YarnResourceManagerTest generates a temporary taskmanager config file in flink-yarn module 
root folder and never clear it, which makes license checking fail when we run mvn clean verify multiple times in the same source folder.

this pr adds PWD env variable to make sure the temporary file created in the temporary folder which will be cleared automatically when case finished.