### PR TITLE
[FLINK-5506] [gelly] Fix CommunityDetection NullPointerException

### DIFF
--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/Graph.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/Graph.java
@@ -26,6 +26,7 @@ import org.apache.flink.api.common.functions.GroupReduceFunction;
 import org.apache.flink.api.common.functions.JoinFunction;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.typeinfo.TypeHint;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
@@ -569,6 +570,17 @@ public class Graph<K, VV, EV> {
 	}
 
 	/**
+	 * Apply a function to the attribute of each vertex in the graph.
+	 *
+	 * @param mapper the map function to apply.
+	 * @param returnType the explicit return type.
+	 * @return a new graph
+	 */
+	public <NV> Graph<K, NV, EV> mapVertices(final MapFunction<Vertex<K, VV>, NV> mapper, TypeHint<Vertex<K, NV>> returnType) {
+		return mapVertices(mapper, returnType.getTypeInfo());
+	}
+
+	/**
 	 * Apply a function to the attribute of each edge in the graph.
 	 *
 	 * @param mapper the map function to apply.
@@ -617,6 +629,17 @@ public class Graph<K, VV, EV> {
 				.name("Map edges");
 
 		return new Graph<>(this.vertices, mappedEdges, this.context);
+	}
+
+	/**
+	 * Apply a function to the attribute of each edge in the graph.
+	 *
+	 * @param mapper the map function to apply.
+	 * @param returnType the explicit return type.
+	 * @return a new graph
+	 */
+	public <NV> Graph<K, VV, NV> mapEdges(final MapFunction<Edge<K, EV>, NV> mapper, TypeHint<Edge<K, NV>> returnType) {
+		return mapEdges(mapper, returnType.getTypeInfo());
 	}
 
 	/**

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/CommunityDetection.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/CommunityDetection.java
@@ -144,7 +144,7 @@ public class CommunityDetection<K> implements GraphAlgorithm<K, Long, Double, Gr
 
 			if (receivedLabelsWithScores.size() > 0) {
 				// find the label with the highest score from the ones received
-				double maxScore = Double.MIN_VALUE;
+				double maxScore = -Double.MAX_VALUE;
 				long maxScoreLabel = vertex.getValue().f0;
 				for (long curLabel : receivedLabelsWithScores.keySet()) {
 

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/CommunityDetectionTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/library/CommunityDetectionTest.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.graph.library;
+
+import org.apache.flink.api.common.typeinfo.TypeHint;
+import org.apache.flink.graph.Edge;
+import org.apache.flink.graph.Graph;
+import org.apache.flink.graph.Vertex;
+import org.apache.flink.graph.asm.AsmTestBase;
+import org.apache.flink.graph.asm.dataset.ChecksumHashCode;
+import org.apache.flink.graph.asm.dataset.ChecksumHashCode.Checksum;
+import org.apache.flink.graph.generator.SingletonEdgeGraph;
+import org.apache.flink.test.util.TestBaseUtils;
+import org.apache.flink.types.IntValue;
+import org.apache.flink.types.LongValue;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link CommunityDetection}.
+ */
+public class CommunityDetectionTest extends AsmTestBase {
+
+	@Test
+	public void testWithSimpleGraph() throws Exception {
+		Graph<IntValue, Long, Double> result = undirectedSimpleGraph
+			.mapVertices(v -> (long) v.getId().getValue(),
+				new TypeHint<Vertex<IntValue, Long>>(){})
+			.mapEdges(e -> (double) e.getTarget().getValue() + e.getSource().getValue(),
+				new TypeHint<Edge<IntValue, Double>>(){})
+			.run(new CommunityDetection<>(10, 0.5));
+
+		String expectedResult =
+			"(0,3)\n" +
+			"(1,5)\n" +
+			"(2,5)\n" +
+			"(3,3)\n" +
+			"(4,5)\n" +
+			"(5,5)\n";
+
+		TestBaseUtils.compareResultAsText(result.getVertices().collect(), expectedResult);
+	}
+
+	@Test
+	public void testWithSingletonEdgeGraph() throws Exception {
+		Graph<LongValue, Long, Double> result = new SingletonEdgeGraph(env, 1)
+			.generate()
+			.mapVertices(v -> v.getId().getValue(),
+				new TypeHint<Vertex<LongValue, Long>>(){})
+			.mapEdges(e -> 1.0,
+				new TypeHint<Edge<LongValue, Double>>(){})
+			.run(new CommunityDetection<>(10, 0.5));
+
+		String expectedResult =
+			"(0,0)\n" +
+			"(1,1)\n";
+
+		TestBaseUtils.compareResultAsText(result.getVertices().collect(), expectedResult);
+	}
+
+	@Test
+	public void testWithEmptyGraphWithVertices() throws Exception {
+		emptyGraphWithVertices
+			.mapVertices(v -> 0L,
+				new TypeHint<Vertex<LongValue, Long>>(){})
+			.mapEdges(e -> 0.0,
+				new TypeHint<Edge<LongValue, Double>>(){})
+			.run(new CommunityDetection<>(10, 0.5));
+	}
+
+	@Test
+	public void testWithEmptyGraphWithoutVertices() throws Exception {
+		emptyGraphWithoutVertices
+			.mapVertices(v -> 0L,
+				new TypeHint<Vertex<LongValue, Long>>(){})
+			.mapEdges(e -> 0.0,
+				new TypeHint<Edge<LongValue, Double>>(){})
+			.run(new CommunityDetection<>(10, 0.5));
+	}
+
+	@Test
+	public void testWithRMatGraph() throws Exception {
+		Graph<LongValue, Long, Double> result = undirectedRMatGraph(8, 4)
+			.mapVertices(v -> v.getId().getValue(),
+				new TypeHint<Vertex<LongValue, Long>>(){})
+			.mapEdges(e -> (double) e.getTarget().getValue() - e.getSource().getValue(),
+				new TypeHint<Edge<LongValue, Double>>(){})
+			.run(new CommunityDetection<>(10, 0.5));
+
+		Checksum checksum = new ChecksumHashCode<Vertex<LongValue, Long>>()
+			.run(result.getVertices())
+			.execute();
+
+		assertEquals(184, checksum.getCount());
+		assertEquals(0x00000000000cdc96L, checksum.getChecksum());
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

This fixes a regression which can result in `NullPointerException` when running the `CommunityDetection` algorithm. When a new highest valued label had a negative summed value the lookup was performed on the old label value which did not necessarily exist in the dictionary.

## Brief change log

- replaced `Double.MIN_VALUE` with the intended (and original) `-Double.MAX_VALUE`
- added `Graph#mapVertices` and `Graph#mapEdges` variants accepting `TypeHint` rather than `TypeInformation`; this seemed useful when using Java 8 lambdas which require explicit type definition with OpenJDK
- added additional tests for `CommunityDetection`

## Verifying this change

`CommunityDetectionTest#testWithSingletonEdgeGraph` is a user supplied example which fails without the bug fix.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)