### PR TITLE
[Hotfix for State doc in 1.4 and 1.5] update State's doc and javaDoc to clarify replacement of foldingstate

### DIFF
--- a/docs/dev/stream/state/state.md
+++ b/docs/dev/stream/state/state.md
@@ -119,7 +119,7 @@ views for mappings, keys and values can be retrieved using `entries()`, `keys()`
 All types of state also have a method `clear()` that clears the state for the currently
 active key, i.e. the key of the input element.
 
-<span class="label label-danger">Attention</span> `FoldingState` and `FoldingStateDescriptor` have been deprecated in Flink 1.4 and will be completely removed in the future. A more general alternative will be provided.
+<span class="label label-danger">Attention</span> `FoldingState` and `FoldingStateDescriptor` have been deprecated in Flink 1.4 and will be completely removed in the future. Please use `AggregatingState` and `AggregatingStateDescriptor` instead.
 
 It is important to keep in mind that these state objects are only used for interfacing
 with state. The state is not necessarily stored inside but might reside on disk or somewhere else.

--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/RuntimeContext.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/RuntimeContext.java
@@ -441,7 +441,7 @@ public interface RuntimeContext {
 	 * @throws UnsupportedOperationException Thrown, if no partitioned state is available for the
 	 *                                       function (function is not part of a KeyedStream).
 	 *
-	 * @deprecated will be removed in a future version
+	 * @deprecated will be removed in a future version in favor of {@link AggregatingState}
 	 */
 	@PublicEvolving
 	@Deprecated

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/FoldingState.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/FoldingState.java
@@ -36,7 +36,7 @@ import org.apache.flink.annotation.PublicEvolving;
  * @param <T> Type of the values folded into the state
  * @param <ACC> Type of the value in the state
  *
- * @deprecated will be removed in a future version
+ * @deprecated will be removed in a future version in favor of {@link AggregatingState}
  */
 @PublicEvolving
 @Deprecated

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/KeyedStateStore.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/KeyedStateStore.java
@@ -237,7 +237,7 @@ public interface KeyedStateStore {
 	 * @throws UnsupportedOperationException Thrown, if no partitioned state is available for the
 	 *                                       function (function is not part of a KeyedStream).
 	 *
-	 * @deprecated will be removed in a future version
+	 * @deprecated will be removed in a future version in favor of {@link AggregatingState}
 	 */
 	@PublicEvolving
 	@Deprecated

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/StateBinder.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/StateBinder.java
@@ -69,7 +69,7 @@ public interface StateBinder {
 	 * @param <T> Type of the values folded into the state
 	 * @param <ACC> Type of the value in the state
 	 *
-	 * @deprecated will be removed in a future version
+	 * @deprecated will be removed in a future version in favor of {@link AggregatingState}
 	 */
 	@Deprecated
 	<T, ACC> FoldingState<T, ACC> createFoldingState(FoldingStateDescriptor<T, ACC> stateDesc) throws Exception;


### PR DESCRIPTION
## What is the purpose of the change

Clarify that `aggregatingstate` is the replacement of `foldingstate` rather than giving users ambiguous hint in both Flink doc and javaDoc

**Please merge this back to 1.4 as well!**

## Brief change log

- updated Flink's State doc
- added "in favor of {@link AggregatingState}" to deprecated APIs, making them similar to javaDocs of `FoldingStateDescriptor.java`

## Verifying this change

none

## Does this pull request potentially affect one of the following parts:

none

## Documentation

  - If yes, how is the feature documented? (docs / java docs)
