### PR TITLE
[hotfix] Fix typo in AkkaUtils method

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
@@ -304,7 +304,7 @@ public abstract class ClusterClient {
 					highAvailabilityServices.getJobManagerLeaderRetriever(HighAvailabilityServices.DEFAULT_JOB_ID),
 					timeout);
 
-			return AkkaUtils.getInetSockeAddressFromAkkaURL(leaderConnectionInfo.getAddress());
+			return AkkaUtils.getInetSocketAddressFromAkkaURL(leaderConnectionInfo.getAddress());
 		} catch (Exception e) {
 			throw new RuntimeException("Failed to retrieve JobManager address", e);
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/net/ConnectionUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/net/ConnectionUtils.java
@@ -389,7 +389,7 @@ public class ConnectionUtils {
 										"while waiting for the leader retrieval.");
 							}
 						} else if (retrievalState == LeaderRetrievalState.NEWLY_RETRIEVED) {
-							targetAddress = AkkaUtils.getInetSockeAddressFromAkkaURL(akkaURL);
+							targetAddress = AkkaUtils.getInetSocketAddressFromAkkaURL(akkaURL);
 
 							LOG.info("Retrieved new target address {}.", targetAddress);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceUtils.java
@@ -38,7 +38,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.InetAddress;
-import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -199,20 +198,6 @@ public class AkkaRpcServiceUtils {
 		} while (!nextNameOffset.compareAndSet(nameOffset, nameOffset + 1L));
 
 		return prefix + '_' + nameOffset;
-	}
-
-	/**
-	 * Extracts the hostname and the port of the remote actor system from the given Akka URL. The
-	 * result is an {@link InetSocketAddress} instance containing the extracted hostname and port. If
-	 * the Akka URL does not contain the hostname and port information, e.g. a local Akka URL is
-	 * provided, then an {@link Exception} is thrown.
-	 *
-	 * @param akkaURL The URL to extract the host and port from.
-	 * @return The InetSocketAddress with teh extracted host and port.
-	 * @throws Exception Thrown, if the given string does not represent a proper url
-	 */
-	public static InetSocketAddress createInetSocketAddressFromAkkaURL(String akkaURL) throws Exception {
-		return AkkaUtils.getInetSockeAddressFromAkkaURL(akkaURL);
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
@@ -694,7 +694,7 @@ object AkkaUtils {
     * @return The InetSocketAddress with teh extracted host and port.
     */
   @throws(classOf[Exception])
-  def getInetSockeAddressFromAkkaURL(akkaURL: String): InetSocketAddress = {
+  def getInetSocketAddressFromAkkaURL(akkaURL: String): InetSocketAddress = {
     // AkkaURLs have the form schema://systemName@host:port/.... if it's a remote Akka URL
     try {
       // we need to manually strip the protocol, because "akka.tcp" is not

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/akka/AkkaUtilsTest.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/akka/AkkaUtilsTest.scala
@@ -68,7 +68,7 @@ class AkkaUtilsTest
       AddressResolution.NO_ADDRESS_RESOLUTION,
       AkkaProtocol.TCP)
 
-    val result = AkkaUtils.getInetSockeAddressFromAkkaURL(remoteAkkaUrl)
+    val result = AkkaUtils.getInetSocketAddressFromAkkaURL(remoteAkkaUrl)
 
     result should equal(address)
   }
@@ -78,7 +78,7 @@ class AkkaUtilsTest
     val localAkkaURL = AkkaUtils.getLocalAkkaURL("actor")
 
     intercept[Exception] {
-      AkkaUtils.getInetSockeAddressFromAkkaURL(localAkkaURL)
+      AkkaUtils.getInetSocketAddressFromAkkaURL(localAkkaURL)
     }
   }
 
@@ -86,7 +86,7 @@ class AkkaUtilsTest
     val url = "akka://flink@localhost:1234/user/jobmanager"
     val expected = new InetSocketAddress("localhost", 1234)
 
-    val result = AkkaUtils.getInetSockeAddressFromAkkaURL(url)
+    val result = AkkaUtils.getInetSocketAddressFromAkkaURL(url)
 
     result should equal(expected)
   }
@@ -95,7 +95,7 @@ class AkkaUtilsTest
     val url = "akka.tcp://flink@localhost:1234/user/jobmanager"
     val expected = new InetSocketAddress("localhost", 1234)
 
-    val result = AkkaUtils.getInetSockeAddressFromAkkaURL(url)
+    val result = AkkaUtils.getInetSocketAddressFromAkkaURL(url)
 
     result should equal(expected)
   }
@@ -104,7 +104,7 @@ class AkkaUtilsTest
     val url = "akka.ssl.tcp://flink@localhost:1234/user/jobmanager"
     val expected = new InetSocketAddress("localhost", 1234)
 
-    val result = AkkaUtils.getInetSockeAddressFromAkkaURL(url)
+    val result = AkkaUtils.getInetSocketAddressFromAkkaURL(url)
 
     result should equal(expected)
   }
@@ -116,7 +116,7 @@ class AkkaUtilsTest
     
     val url = s"akka://flink@$IPv4AddressString:$port/user/jobmanager"
 
-    val result = AkkaUtils.getInetSockeAddressFromAkkaURL(url)
+    val result = AkkaUtils.getInetSocketAddressFromAkkaURL(url)
 
     result should equal(address)
   }
@@ -128,7 +128,7 @@ class AkkaUtilsTest
 
     val url = s"akka://flink@[$IPv6AddressString]:$port/user/jobmanager"
 
-    val result = AkkaUtils.getInetSockeAddressFromAkkaURL(url)
+    val result = AkkaUtils.getInetSocketAddressFromAkkaURL(url)
 
     result should equal(address)
   }
@@ -140,7 +140,7 @@ class AkkaUtilsTest
 
     val url = s"akka.tcp://flink@[$IPv6AddressString]:$port/user/jobmanager"
 
-    val result = AkkaUtils.getInetSockeAddressFromAkkaURL(url)
+    val result = AkkaUtils.getInetSocketAddressFromAkkaURL(url)
 
     result should equal(address)
   }
@@ -152,7 +152,7 @@ class AkkaUtilsTest
 
     val url = s"akka.ssl.tcp://flink@[$IPv6AddressString]:$port/user/jobmanager"
 
-    val result = AkkaUtils.getInetSockeAddressFromAkkaURL(url)
+    val result = AkkaUtils.getInetSocketAddressFromAkkaURL(url)
 
     result should equal(address)
   }


### PR DESCRIPTION
Also, removed unused code:

- `StandaloneHaServices#RESOURCE_MANAGER_RPC_ENDPOINT_NAME`, since `ResourceManager#RESOURCE_MANAGER_NAME` is used instead
- AkkaRpcServiceUtils#createInetSocketAddressFromAkkaURL()