### PR TITLE
[FLINK-8220] Implement set of network benchmarks

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/ExceptionUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/ExceptionUtils.java
@@ -378,6 +378,31 @@ public final class ExceptionUtils {
 	}
 
 	// ------------------------------------------------------------------------
+	//  Lambda exception utilities
+	// ------------------------------------------------------------------------
+
+	public static void suppressExceptions(RunnableWithException action) {
+		try {
+			action.run();
+		}
+		catch (InterruptedException e) {
+			// restore interrupted state
+			Thread.currentThread().interrupt();
+		}
+		catch (Throwable t) {
+			if (isJvmFatalError(t)) {
+				rethrow(t);
+			}
+		}
+	}
+
+	@FunctionalInterface
+	public interface RunnableWithException {
+
+		void run() throws Exception;
+	}
+
+	// ------------------------------------------------------------------------
 
 	/** Private constructor to prevent instantiation. */
 	private ExceptionUtils() {}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/benchmark/DroppingNonDeserializingLongReceiver.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/benchmark/DroppingNonDeserializingLongReceiver.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.benchmark;
+
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
+import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
+
+/**
+ * {@link ReceiverThread} that drops all of the incoming messages.
+ */
+@SuppressWarnings("unused")
+public class DroppingNonDeserializingLongReceiver extends ReceiverThread {
+
+    private final InputGate inputGate;
+
+    public DroppingNonDeserializingLongReceiver(InputGate inputGate, int expectedRepetitionsOfExpectedRecord) {
+        super(expectedRepetitionsOfExpectedRecord);
+        this.inputGate = inputGate;
+    }
+
+    protected void readRecords(long remaining) throws Exception {
+        LOG.debug("readRecords(remaining = {})", remaining);
+        // assume LongValue instances here (4 bytes length, 8 bytes long)
+        final long expectedBytes = remaining * 12;
+
+        long readBytes = 0;
+
+        while (running && readBytes < expectedBytes) {
+            BufferOrEvent input = inputGate.getNextBufferOrEvent();
+            if (input.isBuffer()) {
+                Buffer buffer = input.getBuffer();
+                readBytes += buffer.getSize();
+                buffer.recycle();
+            }
+        }
+
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/benchmark/NetworkBenchmark.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/benchmark/NetworkBenchmark.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.benchmark;
+
+import org.apache.flink.types.LongValue;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Context for network benchmarks executed in flink-benchmark.
+ */
+public class NetworkBenchmark {
+	private static final long RECEIVER_TIMEOUT = 30_000;
+
+	protected NetworkBenchmarkEnvironment<LongValue> environment;
+	protected ReceiverThread receiver;
+	protected RecordWriterThread[] writerThreads;
+
+	public void executeThroughputBenchmark(long records) throws Exception {
+		final LongValue value = new LongValue();
+		value.setValue(0);
+
+		long lastRecord = records / writerThreads.length;
+		CompletableFuture<?> recordsReceived = receiver.setExpectedRecord(lastRecord);
+
+		for (RecordWriterThread writerThread : writerThreads) {
+			writerThread.setRecordsToSend(lastRecord);
+		}
+
+		recordsReceived.get(RECEIVER_TIMEOUT, TimeUnit.MILLISECONDS);
+	}
+
+	public void setUp(int recordWriters, int channels) throws Exception {
+		environment = new NetworkBenchmarkEnvironment<>();
+		environment.setUp(recordWriters, channels);
+		receiver = environment.createReceiver(SerializingLongReceiver.class);
+		writerThreads = new RecordWriterThread[recordWriters];
+		for (int writer = 0; writer < recordWriters; writer++) {
+			writerThreads[writer] = new RecordWriterThread(environment.createRecordWriter(writer));
+			writerThreads[writer].start();
+		}
+	}
+
+	public void tearDown() throws Exception {
+		for (RecordWriterThread writerThread : writerThreads) {
+			writerThread.shutdown();
+			writerThread.sync(5000);
+		}
+		environment.tearDown();
+		receiver.shutdown();
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/benchmark/NetworkBenchmarkEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/benchmark/NetworkBenchmarkEnvironment.java
@@ -1,0 +1,286 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.benchmark;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.core.io.IOReadableWritable;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.deployment.InputChannelDeploymentDescriptor;
+import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
+import org.apache.flink.runtime.deployment.ResultPartitionLocation;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+import org.apache.flink.runtime.io.disk.iomanager.IOManager.IOMode;
+import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
+import org.apache.flink.runtime.io.network.ConnectionID;
+import org.apache.flink.runtime.io.network.NetworkEnvironment;
+import org.apache.flink.runtime.io.network.TaskEventDispatcher;
+import org.apache.flink.runtime.io.network.api.writer.RecordWriter;
+import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
+import org.apache.flink.runtime.io.network.buffer.BufferPool;
+import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
+import org.apache.flink.runtime.io.network.netty.NettyConfig;
+import org.apache.flink.runtime.io.network.netty.NettyConnectionManager;
+import org.apache.flink.runtime.io.network.partition.ResultPartition;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionConsumableNotifier;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionManager;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
+import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
+import org.apache.flink.runtime.io.network.partition.consumer.UnionInputGate;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.operators.testutils.UnregisteredTaskMetricsGroup.DummyTaskIOMetricGroup;
+import org.apache.flink.runtime.query.KvStateRegistry;
+import org.apache.flink.runtime.taskmanager.TaskActions;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+
+import static org.apache.flink.util.ExceptionUtils.suppressExceptions;
+
+/**
+ * Context for network benchmarks executed in flink-benchmark.
+ */
+public class NetworkBenchmarkEnvironment<T extends IOReadableWritable> {
+
+	private static final int BUFFER_SIZE = TaskManagerOptions.MEMORY_SEGMENT_SIZE.defaultValue();
+
+	private static final int NUM_SLOTS_AND_THREADS = 1;
+
+	private static final InetAddress LOCAL_ADDRESS;
+
+	static {
+		try {
+			LOCAL_ADDRESS = InetAddress.getLocalHost();
+		} catch (UnknownHostException e) {
+			throw new Error(e);
+		}
+	}
+
+	protected final JobID jobId = new JobID();
+	protected final IntermediateDataSetID dataSetID = new IntermediateDataSetID();
+	protected final ExecutionAttemptID executionAttemptID = new ExecutionAttemptID();
+
+	protected NetworkEnvironment senderEnv;
+	protected NetworkEnvironment receiverEnv;
+	protected IOManager ioManager;
+
+	protected int channels;
+
+	protected ResultPartitionID[] partitionIds;
+
+	public void setUp(int writers, int channels) throws Exception {
+		this.channels = channels;
+		this.partitionIds = new ResultPartitionID[writers];
+
+		int bufferPoolSize = Math.max(2048, writers * channels * 4);
+		senderEnv = createNettyNetworkEnvironment(bufferPoolSize);
+		receiverEnv = createNettyNetworkEnvironment(bufferPoolSize);
+		ioManager = new IOManagerAsync();
+
+		senderEnv.start();
+		receiverEnv.start();
+
+		generatePartitionIds();
+	}
+
+	public void tearDown() {
+		suppressExceptions(senderEnv::shutdown);
+		suppressExceptions(receiverEnv::shutdown);
+		suppressExceptions(ioManager::shutdown);
+	}
+
+	public <C extends ReceiverThread> C createReceiver(Class<C> clazz) throws Exception {
+		TaskManagerLocation senderLocation = new TaskManagerLocation(
+			ResourceID.generate(),
+			LOCAL_ADDRESS,
+			senderEnv.getConnectionManager().getDataPort());
+
+		InputGate receiverGate = createInputGate(
+			jobId,
+			dataSetID,
+			executionAttemptID,
+			senderLocation,
+			receiverEnv,
+			channels);
+
+		final C receiver;
+		// avoid reflection or duplicates (as enum values) here
+		if (clazz == SerializingLongReceiver.class) {
+			receiver = (C) new SerializingLongReceiver(receiverGate, channels * partitionIds.length);
+		} else if (clazz == DroppingNonDeserializingLongReceiver.class) {
+			receiver = (C) new DroppingNonDeserializingLongReceiver(receiverGate, channels * partitionIds.length);
+		} else {
+			throw new UnsupportedOperationException("No receiver class " + clazz);
+		}
+
+		receiver.start();
+		return receiver;
+	}
+
+	public RecordWriter<T> createRecordWriter(int partitionIndex) throws Exception {
+		ResultPartitionWriter sender = createResultPartition(jobId, partitionIds[partitionIndex], senderEnv, channels);
+		return new RecordWriter<>(sender);
+	}
+
+	private void generatePartitionIds() throws Exception {
+		for (int writer = 0; writer < partitionIds.length; writer++) {
+			partitionIds[writer] = new ResultPartitionID();
+		}
+	}
+
+	private NetworkEnvironment createNettyNetworkEnvironment(
+			@SuppressWarnings("SameParameterValue") int bufferPoolSize) throws Exception {
+
+		final NetworkBufferPool bufferPool = new NetworkBufferPool(bufferPoolSize, BUFFER_SIZE);
+
+		final NettyConnectionManager nettyConnectionManager = new NettyConnectionManager(
+			new NettyConfig(LOCAL_ADDRESS, 0, BUFFER_SIZE, NUM_SLOTS_AND_THREADS, new Configuration()));
+
+		return new NetworkEnvironment(
+			bufferPool,
+			nettyConnectionManager,
+			new ResultPartitionManager(),
+			new TaskEventDispatcher(),
+			new KvStateRegistry(),
+			null,
+			null,
+			IOMode.SYNC,
+			TaskManagerOptions.NETWORK_REQUEST_BACKOFF_INITIAL.defaultValue(),
+			TaskManagerOptions.NETWORK_REQUEST_BACKOFF_MAX.defaultValue(),
+			TaskManagerOptions.NETWORK_BUFFERS_PER_CHANNEL.defaultValue(),
+			TaskManagerOptions.NETWORK_EXTRA_BUFFERS_PER_GATE.defaultValue());
+	}
+
+	protected ResultPartitionWriter createResultPartition(
+			JobID jobId,
+			ResultPartitionID partitionId,
+			NetworkEnvironment environment,
+			int channels) throws Exception {
+
+		ResultPartition resultPartition = new ResultPartition(
+			"sender task",
+			new NoOpTaskActions(),
+			jobId,
+			partitionId,
+			ResultPartitionType.PIPELINED_BOUNDED,
+			channels,
+			1,
+			environment.getResultPartitionManager(),
+			new NoOpResultPartitionConsumableNotifier(),
+			ioManager,
+			false);
+		ResultPartitionWriter partitionWriter = new ResultPartitionWriter(resultPartition);
+
+		// similar to NetworkEnvironment#registerTask()
+		int numBuffers = resultPartition.getNumberOfSubpartitions() *
+			TaskManagerOptions.NETWORK_BUFFERS_PER_CHANNEL.defaultValue() +
+			TaskManagerOptions.NETWORK_EXTRA_BUFFERS_PER_GATE.defaultValue();
+
+		BufferPool bufferPool = environment.getNetworkBufferPool().createBufferPool(channels, numBuffers);
+		resultPartition.registerBufferPool(bufferPool);
+
+		environment.getResultPartitionManager().registerResultPartition(resultPartition);
+
+		return partitionWriter;
+	}
+
+	private InputGate createInputGate(
+			JobID jobId,
+			IntermediateDataSetID dataSetID,
+			ExecutionAttemptID executionAttemptID,
+			final TaskManagerLocation senderLocation,
+			NetworkEnvironment environment,
+			final int channels) throws IOException {
+
+		InputGate[] gates = new InputGate[channels];
+		for (int channel = 0; channel < channels; ++channel) {
+			int finalChannel = channel;
+			InputChannelDeploymentDescriptor[] channelDescriptors = Arrays.stream(partitionIds)
+				.map(partitionId -> new InputChannelDeploymentDescriptor(
+					partitionId,
+					ResultPartitionLocation.createRemote(new ConnectionID(senderLocation, finalChannel))))
+				.toArray(InputChannelDeploymentDescriptor[]::new);
+
+			final InputGateDeploymentDescriptor gateDescriptor = new InputGateDeploymentDescriptor(
+				dataSetID,
+				ResultPartitionType.PIPELINED_BOUNDED,
+				channel,
+				channelDescriptors);
+
+			SingleInputGate gate = SingleInputGate.create(
+				"receiving task[" + channel + "]",
+				jobId,
+				executionAttemptID,
+				gateDescriptor,
+				environment,
+				new NoOpTaskActions(),
+				new DummyTaskIOMetricGroup());
+
+			// similar to NetworkEnvironment#registerTask()
+			int numBuffers = gate.getNumberOfInputChannels() *
+				TaskManagerOptions.NETWORK_BUFFERS_PER_CHANNEL.defaultValue() +
+				TaskManagerOptions.NETWORK_EXTRA_BUFFERS_PER_GATE.defaultValue();
+
+			BufferPool bufferPool =
+				environment.getNetworkBufferPool().createBufferPool(gate.getNumberOfInputChannels(), numBuffers);
+
+			gate.setBufferPool(bufferPool);
+			gates[channel] = gate;
+		}
+
+		if (channels > 1) {
+			return new UnionInputGate(gates);
+		} else {
+			return gates[0];
+		}
+	}
+
+	// ------------------------------------------------------------------------
+	//  Mocks
+	// ------------------------------------------------------------------------
+
+	/**
+	 * A dummy implementation of the {@link TaskActions}. We implement this here rather than using Mockito
+	 * to avoid using mockito in this benchmark class.
+	 */
+	private static final class NoOpTaskActions implements TaskActions {
+
+		@Override
+		public void triggerPartitionProducerStateCheck(
+			JobID jobId,
+			IntermediateDataSetID intermediateDataSetId,
+			ResultPartitionID resultPartitionId) {}
+
+		@Override
+		public void failExternally(Throwable cause) {}
+	}
+
+	private static final class NoOpResultPartitionConsumableNotifier implements ResultPartitionConsumableNotifier {
+
+		@Override
+		public void notifyPartitionConsumable(JobID j, ResultPartitionID p, TaskActions t) {}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/benchmark/NetworkBenchmarkTests.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/benchmark/NetworkBenchmarkTests.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.benchmark;
+
+import org.junit.Test;
+
+/**
+ * Tests for various network benchmarks based on {@link NetworkBenchmarkEnvironment}.
+ */
+public class NetworkBenchmarkTests {
+	@Test
+	public void pointToPointBenchmark() throws Exception {
+		NetworkBenchmark benchmark = new NetworkBenchmark();
+		benchmark.setUp(1, 1);
+		try {
+			benchmark.executeThroughputBenchmark(1_000);
+		}
+		finally {
+			benchmark.tearDown();
+		}
+	}
+
+	@Test
+	public void pointToMultiPointBenchmark() throws Exception {
+		NetworkBenchmark benchmark = new NetworkBenchmark();
+		benchmark.setUp(4,1000);
+		try {
+			benchmark.executeThroughputBenchmark(5000000);
+			benchmark.executeThroughputBenchmark(5000000);
+		}
+		finally {
+			benchmark.tearDown();
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/benchmark/ReceiverThread.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/benchmark/ReceiverThread.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.benchmark;
+
+import org.apache.flink.core.testutils.CheckedThread;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * This class waits for {@code expectedRepetitionsOfExpectedRecord} number of occurrences of the
+ * {@code expectedRecord}. {@code expectedRepetitionsOfExpectedRecord} is correlated with number of input channels.
+ */
+public abstract class ReceiverThread extends CheckedThread {
+    protected static final Logger LOG = LoggerFactory.getLogger(ReceiverThread.class);
+
+    protected final int expectedRepetitionsOfExpectedRecord;
+
+    protected int expectedRecordCounter;
+    protected CompletableFuture<Long> expectedRecord = new CompletableFuture<>();
+    protected CompletableFuture<?> recordsProcessed = new CompletableFuture<>();
+
+    protected volatile boolean running;
+
+    ReceiverThread(int expectedRepetitionsOfExpectedRecord) {
+        setName(this.getClass().getName());
+
+        this.expectedRepetitionsOfExpectedRecord = expectedRepetitionsOfExpectedRecord;
+        this.running = true;
+    }
+
+    public synchronized CompletableFuture<?> setExpectedRecord(long record) {
+        checkState(!expectedRecord.isDone());
+        checkState(!recordsProcessed.isDone());
+        expectedRecord.complete(record);
+        expectedRecordCounter = 0;
+        return recordsProcessed;
+    }
+
+    private synchronized CompletableFuture<Long> getExpectedRecord() {
+        return expectedRecord;
+    }
+
+    private synchronized void finishProcessingExpectedRecords() {
+        checkState(expectedRecord.isDone());
+        checkState(!recordsProcessed.isDone());
+
+        recordsProcessed.complete(null);
+        expectedRecord = new CompletableFuture<>();
+        recordsProcessed = new CompletableFuture<>();
+    }
+
+    @Override
+    public void go() throws Exception {
+        try {
+            while (running) {
+                readRecords(getExpectedRecord().get());
+                finishProcessingExpectedRecords();
+            }
+        }
+        catch (InterruptedException e) {
+            if (running) {
+                throw e;
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    protected abstract void readRecords(long lastExpectedRecord) throws Exception;
+
+    public void shutdown() {
+        running = false;
+        interrupt();
+        expectedRecord.complete(0L);
+    }
+
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/benchmark/RecordWriterThread.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/benchmark/RecordWriterThread.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.benchmark;
+
+import org.apache.flink.core.testutils.CheckedThread;
+import org.apache.flink.runtime.io.network.api.writer.RecordWriter;
+import org.apache.flink.types.LongValue;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * Wrapping thread around {@link RecordWriter} that sends requested number of records.
+ */
+public class RecordWriterThread extends CheckedThread {
+	private final RecordWriter<LongValue> recordWriter;
+
+	private CompletableFuture<Long> recordsToSend = new CompletableFuture<>();
+
+	private volatile boolean running = true;
+
+	public RecordWriterThread(RecordWriter<LongValue> recordWriter) {
+		this.recordWriter = checkNotNull(recordWriter);
+	}
+
+	public void shutdown() {
+		running = false;
+		recordsToSend.complete(0L);
+	}
+
+	public synchronized void setRecordsToSend(long records) {
+		checkState(!recordsToSend.isDone());
+		recordsToSend.complete(records);
+	}
+
+	private synchronized CompletableFuture<Long> getRecordsToSend() {
+		return recordsToSend;
+	}
+
+	private synchronized void finishSendingRecords() {
+		recordsToSend = new CompletableFuture<>();
+	}
+
+    @Override
+    public void go() throws Exception {
+		while (running) {
+			sendRecords(getRecordsToSend().get());
+		}
+    }
+
+	private void sendRecords(long records) throws IOException, InterruptedException {
+		LongValue value = new LongValue(0);
+
+		for (int i = 1; i < records; i++) {
+			recordWriter.emit(value);
+		}
+		value.setValue(records);
+		recordWriter.broadcastEmit(value);
+		recordWriter.flush();
+
+		finishSendingRecords();
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/benchmark/SerializingLongReceiver.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/benchmark/SerializingLongReceiver.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.benchmark;
+
+import org.apache.flink.runtime.io.network.api.reader.MutableRecordReader;
+import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
+import org.apache.flink.runtime.util.EnvironmentInformation;
+import org.apache.flink.types.LongValue;
+
+/**
+ * {@link ReceiverThread} that deserialize incoming messages.
+ */
+public class SerializingLongReceiver extends ReceiverThread {
+
+    private long maxLatency = Long.MIN_VALUE;
+    private long minLatency = Long.MAX_VALUE;
+    private long sumLatency;
+    private long sumLatencySquare;
+    private int numSamples;
+
+    private final MutableRecordReader<LongValue> reader;
+
+    public SerializingLongReceiver(InputGate inputGate, int expectedRepetitionsOfExpectedRecord) {
+        super(expectedRepetitionsOfExpectedRecord);
+        this.reader = new MutableRecordReader<>(
+            inputGate,
+            new String[]{
+                EnvironmentInformation.getTemporaryFileDirectory()
+            });
+    }
+
+    protected void readRecords(long lastExpectedRecord) throws Exception {
+        LOG.debug("readRecords(lastExpectedRecord = {})", lastExpectedRecord);
+        final LongValue value = new LongValue();
+
+        while (running && reader.next(value)) {
+            final long ts = value.getValue();
+            if (ts == lastExpectedRecord) {
+                expectedRecordCounter++;
+                if (expectedRecordCounter == expectedRepetitionsOfExpectedRecord) {
+                    break;
+                }
+            }
+            if (ts != 0) {
+                final long latencyNanos = System.nanoTime() - ts;
+
+                maxLatency = Math.max(maxLatency, latencyNanos);
+                minLatency = Math.min(minLatency, latencyNanos);
+                sumLatency += latencyNanos;
+                sumLatencySquare += latencyNanos * latencyNanos;
+                numSamples++;
+            }
+        }
+
+    }
+
+    public long getMaxLatency() {
+        return maxLatency == Long.MIN_VALUE ? 0 : maxLatency;
+    }
+
+    public long getMinLatency() {
+        return minLatency == Long.MAX_VALUE ? 0 : minLatency;
+    }
+
+    public long getAvgLatency() {
+        return numSamples == 0 ? 0 : sumLatency / numSamples;
+    }
+
+    public long getAvgLatencyNoExtremes() {
+        return (numSamples > 2) ? (sumLatency - maxLatency - minLatency) / (numSamples - 2) : 0;
+    }
+
+    public long getStandardDeviationLatency() {
+        return numSamples == 0 ? 0 : (long) Math.sqrt(
+            sumLatencySquare / numSamples - sumLatency * sumLatency /
+                (numSamples * numSamples));
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Receiver[avg=%d (%d), min=%d, max=%d, stddev=%d]",
+            getAvgLatency(), getAvgLatencyNoExtremes(), getMinLatency(), getMaxLatency(),
+            getStandardDeviationLatency());
+    }
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkBenchmarkEnvironment.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkBenchmarkEnvironment.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.io.benchmark;
+
+import org.apache.flink.core.io.IOReadableWritable;
+import org.apache.flink.runtime.io.network.api.writer.RecordWriter;
+import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
+import org.apache.flink.runtime.io.network.api.writer.RoundRobinChannelSelector;
+import org.apache.flink.runtime.io.network.benchmark.NetworkBenchmarkEnvironment;
+import org.apache.flink.streaming.runtime.io.StreamRecordWriter;
+
+/**
+ * Context for stream network benchmarks executed in flink-benchmark.
+ */
+public class StreamNetworkBenchmarkEnvironment<T extends IOReadableWritable> extends NetworkBenchmarkEnvironment<T> {
+
+	public RecordWriter<T> createStreamRecordWriter(int partitionIndex, long flushTimeout) throws Exception {
+		ResultPartitionWriter sender = createResultPartition(jobId, partitionIds[partitionIndex], senderEnv, channels);
+		return new StreamRecordWriter<T>(sender,  new RoundRobinChannelSelector<T>(), flushTimeout);
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkPointToPointBenchmark.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkPointToPointBenchmark.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.io.benchmark;
+
+import org.apache.flink.runtime.io.network.api.writer.RecordWriter;
+import org.apache.flink.runtime.io.network.benchmark.ReceiverThread;
+import org.apache.flink.runtime.io.network.benchmark.SerializingLongReceiver;
+import org.apache.flink.types.LongValue;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Context for network benchmarks executed in flink-benchmark.
+ */
+public class StreamNetworkPointToPointBenchmark {
+	private static final long RECEIVER_TIMEOUT = 2000;
+
+	protected StreamNetworkBenchmarkEnvironment<LongValue> environment;
+	protected ReceiverThread receiver;
+	protected RecordWriter recordWriter;
+
+	public void executeBenchmark(long records, boolean flushAfterLastEmit) throws Exception {
+		final LongValue value = new LongValue();
+		value.setValue(0);
+
+		CompletableFuture<?> recordsReceived = receiver.setExpectedRecord(records);
+
+		for (int i = 1; i < records; i++) {
+			recordWriter.emit(value);
+		}
+		value.setValue(records);
+		recordWriter.broadcastEmit(value);
+		if (flushAfterLastEmit) {
+			recordWriter.flush();
+		}
+
+		recordsReceived.get(RECEIVER_TIMEOUT, TimeUnit.MILLISECONDS);
+	}
+
+	public void setUp(long flushTimeout) throws Exception {
+		environment = new StreamNetworkBenchmarkEnvironment<>();
+		environment.setUp(1, 1);
+
+		receiver = environment.createReceiver(SerializingLongReceiver.class);
+		recordWriter = environment.createStreamRecordWriter(0, flushTimeout);
+	}
+
+	public void tearDown() {
+		environment.tearDown();
+
+		receiver.shutdown();
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkPointToPointBenchmarkTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkPointToPointBenchmarkTest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.io.benchmark;
+
+import org.junit.Test;
+
+/**
+ * Tests for {@link StreamNetworkPointToPointBenchmark}.
+ */
+public class StreamNetworkPointToPointBenchmarkTest {
+	@Test
+	public void test() throws Exception {
+		StreamNetworkPointToPointBenchmark benchmark = new StreamNetworkPointToPointBenchmark();
+		benchmark.setUp(10);
+		try {
+			benchmark.executeBenchmark(100, false);
+		}
+		finally {
+			benchmark.tearDown();
+		}
+	}
+}


### PR DESCRIPTION
This PR implements sets of network benchmarks that are intended to simulate various workloads for network stack. Benchmarks will be executed by `flink-benchmarks` (https://github.com/dataArtisans/flink-benchmarks/pull/3) project. We want to keep the code of the benchmarks here, since components they are using are not part of public api and we don't wont them braking unknowingly on changes in the flink code.

Example results (including performance fix #5104):
```
Benchmark                                   (channels)  (writers)   Mode  Cnt      Score      Error   Units
NetworkBenchmarkExecutor.networkThroughput           1          1  thrpt   10  23322.178 ±  261.931  ops/ms
NetworkBenchmarkExecutor.networkThroughput           1          4  thrpt   10  57279.697 ± 4152.714  ops/ms
NetworkBenchmarkExecutor.networkThroughput          50          1  thrpt   10  22927.629 ±  341.008  ops/ms
NetworkBenchmarkExecutor.networkThroughput          50          4  thrpt   10  60761.706 ± 1172.354  ops/ms
NetworkBenchmarkExecutor.networkThroughput        1000          1  thrpt   10  17765.148 ±  479.579  ops/ms
NetworkBenchmarkExecutor.networkThroughput        1000          4  thrpt   10  41030.963 ± 1149.041  ops/ms
```

## Verifying this change

This change adds two tests ensuring that benchmarks are compiling and executing as expected without an exceptions.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
