### PR TITLE
[FLINK-8222] [build] Update Scala version

### DIFF
--- a/flink-quickstart/flink-quickstart-scala/src/main/resources/archetype-resources/pom.xml
+++ b/flink-quickstart/flink-quickstart-scala/src/main/resources/archetype-resources/pom.xml
@@ -49,7 +49,7 @@ under the License.
 		<slf4j.version>@slf4j.version@</slf4j.version>
 		<log4j.version>@log4j.version@</log4j.version>
 		<scala.binary.version>2.11</scala.binary.version>
-		<scala.version>2.11.11</scala.version>
+		<scala.version>2.11.12</scala.version>
 	</properties>
 
 	<!-- 

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@ under the License.
 		<maven.compiler.target>${java.version}</maven.compiler.target>
 		<scala.macros.version>2.1.0</scala.macros.version>
 		<!-- Default scala versions, may be overwritten by build profiles -->
-		<scala.version>2.11.11</scala.version>
+		<scala.version>2.11.12</scala.version>
 		<scala.binary.version>2.11</scala.binary.version>
 		<chill.version>0.7.4</chill.version>
 		<zookeeper.version>3.4.10</zookeeper.version>


### PR DESCRIPTION
## What is the purpose of the change

This is an incremental upgrade to the Scala security release 2.11.12.

"A privilege escalation vulnerability (CVE-2017-15288) has been identified in the Scala compilation daemon."

https://www.scala-lang.org/news/security-update-nov17.html

## Brief change log

Updated scala version in both parent `pom.xml` and in flink-quickstart-scala `pom.xml`.

## Verifying this change

This change is already covered by existing tests, such as Scala tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**yes** / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)