### PR TITLE
[FLINK-8224] [runtime] shutdown application when job terminated in job mode

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/JobClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/JobClusterEntrypoint.java
@@ -203,7 +203,7 @@ public abstract class JobClusterEntrypoint extends ClusterEntrypoint {
 		public void jobFinishedByOther() {
 			LOG.info("Job({}) was finished by another JobManager.", jobId);
 
-			shutDownAndTerminate(false, ApplicationStatus.UNKNOWN, "Job was finished by other another master");
+			shutDownAndTerminate(false, ApplicationStatus.UNKNOWN, "Job was finished by another master");
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/JobClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/JobClusterEntrypoint.java
@@ -203,7 +203,7 @@ public abstract class JobClusterEntrypoint extends ClusterEntrypoint {
 		public void jobFinishedByOther() {
 			LOG.info("Job({}) was finished by another JobManager.", jobId);
 
-			shutDownAndTerminate(false, ApplicationStatus.UNKNOWN, "Job finish by other another master");
+			shutDownAndTerminate(false, ApplicationStatus.UNKNOWN, "Job was finished by other another master");
 		}
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

This current job cluster entrypoint doesn't call resource manage to shutdown the application. So resource manger has no change to set the application status to the outer resource management system such as YARN/Mesos. This may make the YARN still consider the application as running even the job is finished.

## Verifying this change

This change is tested manually.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
