### PR TITLE
[FLINK-7797] [table] Add support for windowed outer joins for streaming tables

### DIFF
--- a/docs/dev/table/sql.md
+++ b/docs/dev/table/sql.md
@@ -408,8 +408,6 @@ FROM Orders LEFT JOIN Product ON Orders.productId = Product.id
           <li><code>ltime &gt;= rtime AND ltime &lt; rtime + INTERVAL '10' MINUTE</code></li>
           <li><code>ltime BETWEEN rtime - INTERVAL '10' SECOND AND rtime + INTERVAL '5' SECOND</code></li>
         </ul>
-                
-        <p><b>Note:</b> Currently, only <code>INNER</code> time-windowed joins are supported.</p>
 
 {% highlight sql %}
 SELECT *

--- a/docs/dev/table/tableApi.md
+++ b/docs/dev/table/tableApi.md
@@ -535,8 +535,6 @@ Table fullOuterResult = left.fullOuterJoin(right, "a = d").select("a, b, e");
           <li><code>ltime &gt;= rtime &amp;&amp; ltime &lt; rtime + 10.minutes</code></li>
         </ul>
         
-        <p><b>Note:</b> Currently, only <code>INNER</code> time-windowed joins are supported.</p>
-
 {% highlight java %}
 Table left = tableEnv.fromDataSet(ds1, "a, b, c, ltime.rowtime");
 Table right = tableEnv.fromDataSet(ds2, "d, e, f, rtime.rowtime");
@@ -652,8 +650,6 @@ val fullOuterResult = left.fullOuterJoin(right, 'a === 'd).select('a, 'b, 'e)
           <li><code>'ltime === 'rtime</code></li>
           <li><code>'ltime &gt;= 'rtime &amp;&amp; 'ltime &lt; 'rtime + 10.minutes</code></li>
         </ul>
-        
-        <p><b>Note:</b> Currently, only <code>INNER</code> time-windowed joins are supported.</p>
 
 {% highlight scala %}
 val left = ds1.toTable(tableEnv, 'a, 'b, 'c, 'ltime.rowtime);

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/join/JoinAwareCollector.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/join/JoinAwareCollector.scala
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.join
+
+import org.apache.flink.table.runtime.types.CRow
+import org.apache.flink.types.Row
+import org.apache.flink.util.Collector
+
+/**
+  * Collector to track whether there's a joined result.
+  */
+class JoinAwareCollector extends Collector[Row]{
+
+  private var emitted = false
+  private var emittedThisTurn = false
+  private var innerCollector: Collector[CRow] = _
+  private val cRow: CRow = new CRow()
+
+  def setCollector(collector: Collector[CRow]): Unit = {
+    this.innerCollector = collector
+  }
+
+  def reset(): Unit = {
+    emitted = false
+    emittedThisTurn = false
+  }
+
+  def resetThisTurn(): Unit = {
+    emittedThisTurn = false
+  }
+
+  def everEmitted: Boolean = emitted
+
+  def everEmittedThisTurn: Boolean = emittedThisTurn
+
+  /** Collects a record without notifying the collector. **/
+  def collectWithoutNotifying(record: Row): Unit = {
+    cRow.row = record
+    innerCollector.collect(cRow)
+  }
+
+  override def collect(record: Row): Unit = {
+    emittedThisTurn = true
+    emitted = true
+    cRow.row = record
+    innerCollector.collect(cRow)
+  }
+
+  override def close(): Unit = {
+    innerCollector.close()
+  }
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/join/OuterJoinPaddingUtil.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/join/OuterJoinPaddingUtil.scala
@@ -23,7 +23,7 @@ import org.apache.flink.types.Row
 /**
   * An utility to generate reusable padding results for outer joins.
   */
-class OuterJoinPaddingUtil(leftArity: Int, rightArity: Int) {
+class OuterJoinPaddingUtil(leftArity: Int, rightArity: Int) extends java.io.Serializable{
 
   private val resultArity = leftArity + rightArity
   private val leftNullPaddingResult = new Row(resultArity)

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/join/OuterJoinPaddingUtil.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/join/OuterJoinPaddingUtil.scala
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.join
+
+import org.apache.flink.types.Row
+
+/**
+  * An utility to generate reusable padding results for outer joins.
+  */
+class OuterJoinPaddingUtil(leftArity: Int, rightArity: Int) {
+
+  private val resultArity = leftArity + rightArity
+  private val leftNullPaddingResult = new Row(resultArity)
+  private val rightNullPaddingResult = new Row(resultArity)
+
+  // Initialize the two reusable padding results.
+  var i = 0
+  while (i < leftArity) {
+    leftNullPaddingResult.setField(i, null)
+    i = i + 1
+  }
+  i = 0
+  while (i < rightArity) {
+    rightNullPaddingResult.setField(i + leftArity, null)
+    i = i + 1
+  }
+
+  /**
+    * Returns a padding result with the given right row.
+    * @param rightRow the right row to pad
+    * @return the reusable null padding result
+    */
+  final def padRight(rightRow: Row): Row = {
+    var i = 0
+    while (i < rightArity) {
+      leftNullPaddingResult.setField(leftArity + i, rightRow.getField(i))
+      i = i + 1
+    }
+    leftNullPaddingResult
+  }
+
+  /**
+    * Returns a padding result with the given left row.
+    * @param leftRow the left row to pad
+    * @return the reusable null padding result
+    */
+  final def padLeft(leftRow: Row): Row = {
+    var i = 0
+    while (i < leftArity) {
+      rightNullPaddingResult.setField(i, leftRow.getField(i))
+      i = i + 1
+    }
+    rightNullPaddingResult
+  }
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/StreamWindowJoinHarnessTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/StreamWindowJoinHarnessTest.scala
@@ -20,20 +20,25 @@ package org.apache.flink.table.runtime.harness
 import java.lang.{Long => JLong}
 import java.util.concurrent.ConcurrentLinkedQueue
 
+import org.apache.flink.api.java.operators.join.JoinType
 import org.apache.flink.streaming.api.operators.co.KeyedCoProcessOperator
 import org.apache.flink.streaming.api.watermark.Watermark
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord
 import org.apache.flink.streaming.util.KeyedTwoInputStreamOperatorTestHarness
 import org.apache.flink.table.api.Types
 import org.apache.flink.table.runtime.harness.HarnessTestBase.{RowResultSortComparator, RowResultSortComparatorWithWatermarks, TupleRowKeySelector}
-import org.apache.flink.table.runtime.join.{ProcTimeBoundedStreamInnerJoin, RowTimeBoundedStreamInnerJoin}
+import org.apache.flink.table.runtime.join.{ProcTimeBoundedStreamJoin, RowTimeBoundedStreamJoin}
 import org.apache.flink.table.runtime.operators.KeyedCoProcessOperatorWithWatermarkDelay
 import org.apache.flink.table.runtime.types.CRow
 import org.apache.flink.types.Row
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
-class JoinHarnessTest extends HarnessTestBase {
+/**
+  * Since the runtime logic for different stream window joins are identical, we only test on
+  * inner join.
+  */
+class StreamWindowJoinHarnessTest extends HarnessTestBase {
 
   private val rowType = Types.ROW(
     Types.LONG,
@@ -75,8 +80,8 @@ class JoinHarnessTest extends HarnessTestBase {
   @Test
   def testProcTimeJoinWithCommonBounds() {
 
-    val joinProcessFunc = new ProcTimeBoundedStreamInnerJoin(
-      -10, 20, rowType, rowType, "TestJoinFunction", funcCode)
+    val joinProcessFunc = new ProcTimeBoundedStreamJoin(
+      JoinType.INNER, -10, 20, rowType, rowType, "TestJoinFunction", funcCode)
 
     val operator: KeyedCoProcessOperator[Integer, CRow, CRow, CRow] =
       new KeyedCoProcessOperator[Integer, CRow, CRow, CRow](joinProcessFunc)
@@ -165,8 +170,8 @@ class JoinHarnessTest extends HarnessTestBase {
   @Test
   def testProcTimeJoinWithNegativeBounds() {
 
-    val joinProcessFunc = new ProcTimeBoundedStreamInnerJoin(
-      -10, -5, rowType, rowType, "TestJoinFunction", funcCode)
+    val joinProcessFunc = new ProcTimeBoundedStreamJoin(
+      JoinType.INNER, -10, -5, rowType, rowType, "TestJoinFunction", funcCode)
 
     val operator: KeyedCoProcessOperator[Integer, CRow, CRow, CRow] =
       new KeyedCoProcessOperator[Integer, CRow, CRow, CRow](joinProcessFunc)
@@ -247,8 +252,8 @@ class JoinHarnessTest extends HarnessTestBase {
   @Test
   def testRowTimeJoinWithCommonBounds() {
 
-    val joinProcessFunc = new RowTimeBoundedStreamInnerJoin(
-      -10, 20, 0, rowType, rowType, "TestJoinFunction", funcCode, 0, 0)
+    val joinProcessFunc = new RowTimeBoundedStreamJoin(
+      JoinType.INNER, -10, 20, 0, rowType, rowType, "TestJoinFunction", funcCode, 0, 0)
 
     val operator: KeyedCoProcessOperator[String, CRow, CRow, CRow] =
       new KeyedCoProcessOperatorWithWatermarkDelay[String, CRow, CRow, CRow](
@@ -346,8 +351,8 @@ class JoinHarnessTest extends HarnessTestBase {
   @Test
   def testRowTimeJoinWithNegativeBounds() {
 
-    val joinProcessFunc = new RowTimeBoundedStreamInnerJoin(
-      -10, -7, 0, rowType, rowType, "TestJoinFunction", funcCode, 0, 0)
+    val joinProcessFunc = new RowTimeBoundedStreamJoin(
+      JoinType.INNER, -10, -7, 0, rowType, rowType, "TestJoinFunction", funcCode, 0, 0)
 
     val operator: KeyedCoProcessOperator[String, CRow, CRow, CRow] =
       new KeyedCoProcessOperatorWithWatermarkDelay[String, CRow, CRow, CRow](


### PR DESCRIPTION
## What is the purpose of the change

This PR adds support for windowed outer joins for streaming tables.

## Brief change log

  - Adjusts the plan translation logic to accept stream window outer join.
  - Adheres an ever emitted flag to each row. When a row is removed from the cache (or detected as not cached), a null padding join result will be emitted if necessary.
  - Adds a custom `JoinAwareCollector` to track whether there's a successfully joined result for both sides in each join loop.
  - Adds table/SQL translation tests, and also join integration tests. Since the runtime logic is built on the existing window inner join, no new harness tests are added.
 - Updates the SQL/Table API docs.

## Verifying this change

This PR can be verified by the cases added in `JoinTest` and `JoinITCase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (**yes**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (**yes**)
  - If yes, how is the feature documented? (**remove the restriction notes**)
