### PR TITLE
[FLINK-8226] [cep] Dangling reference generated after NFA clean up timed out SharedBufferEntry

### DIFF
--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/SharedBuffer.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/SharedBuffer.java
@@ -208,7 +208,6 @@ public class SharedBuffer<K extends Serializable, V> implements Serializable {
 			for (Map.Entry<K, SharedBufferPage<K, V>> entry : pages.entrySet()) {
 				entry.getValue().removeEdges(prunedEntries);
 			}
-			prunedEntries.clear();
 			return true;
 		} else {
 			return false;

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/SharedBuffer.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/SharedBuffer.java
@@ -82,12 +82,9 @@ public class SharedBuffer<K extends Serializable, V> implements Serializable {
 
 	private transient Map<K, SharedBufferPage<K, V>> pages;
 
-	private final transient List<SharedBufferEntry<K, V>> prunedEntries;
-
 	public SharedBuffer(final TypeSerializer<V> valueSerializer) {
 		this.valueSerializer = valueSerializer;
 		this.pages = new HashMap<>();
-		this.prunedEntries = new ArrayList<>();
 	}
 
 	public TypeSerializer<V> getValueSerializer() {
@@ -194,6 +191,7 @@ public class SharedBuffer<K extends Serializable, V> implements Serializable {
 	 */
 	public boolean prune(long pruningTimestamp) {
 		Iterator<Map.Entry<K, SharedBufferPage<K, V>>> iter = pages.entrySet().iterator();
+		List<SharedBufferEntry<K, V>> prunedEntries = new ArrayList<>();
 
 		while (iter.hasNext()) {
 			SharedBufferPage<K, V> page = iter.next().getValue();
@@ -339,7 +337,6 @@ public class SharedBuffer<K extends Serializable, V> implements Serializable {
 		Map<K, SharedBufferPage<K, V>> pages) {
 		this.valueSerializer = valueSerializer;
 		this.pages = pages;
-		this.prunedEntries = new ArrayList<>();
 	}
 
 	private SharedBufferEntry<K, V> get(


### PR DESCRIPTION
## What is the purpose of the change

*This pull request fix the issue that dangling reference generated after NFA clean up timed out SharedBufferEntry. Exception will be thrown when serializing NFA.*


## Verifying this change

This change added tests and can be verified as follows:

*(example:)*
  - *Added tests NFATest#testTimeoutWindowPruning2*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)