### PR TITLE
[FLINK-8228][cleanup] Code cleanup - pointless bitwise expressions

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/types/Record.java
+++ b/flink-core/src/main/java/org/apache/flink/types/Record.java
@@ -1321,7 +1321,7 @@ public final class Record implements Value, CopyableValue<Record> {
 		@Override
 		public char readChar() throws IOException {
 			if (this.position < this.end - 1) {
-				return (char) (((this.memory[this.position++] & 0xff) << 8) | ((this.memory[this.position++] & 0xff) << 0));
+				return (char) (((this.memory[this.position++] & 0xff) << 8) | ((this.memory[this.position++] & 0xff)));
 			} else {
 				throw new EOFException();
 			}
@@ -1417,7 +1417,7 @@ public final class Record implements Value, CopyableValue<Record> {
 		@Override
 		public short readShort() throws IOException {
 			if (position >= 0 && position < this.end - 1) {
-				return (short) ((((this.memory[position++]) & 0xff) << 8) | (((this.memory[position++]) & 0xff) << 0));
+				return (short) ((((this.memory[position++]) & 0xff) << 8) | (((this.memory[position++]) & 0xff)));
 			} else {
 				throw new EOFException();
 			}
@@ -1483,7 +1483,7 @@ public final class Record implements Value, CopyableValue<Record> {
 					if (((char2 & 0xC0) != 0x80) || ((char3 & 0xC0) != 0x80)) {
 						throw new UTFDataFormatException("malformed input around byte " + (count - 1));
 					}
-					chararr[chararr_count++] = (char) (((c & 0x0F) << 12) | ((char2 & 0x3F) << 6) | ((char3 & 0x3F) << 0));
+					chararr[chararr_count++] = (char) (((c & 0x0F) << 12) | ((char2 & 0x3F) << 6) | ((char3 & 0x3F)));
 					break;
 				default:
 					/* 10xx xxxx, 1111 xxxx */
@@ -1506,7 +1506,7 @@ public final class Record implements Value, CopyableValue<Record> {
 		@Override
 		public int readUnsignedShort() throws IOException {
 			if (this.position < this.end - 1) {
-				return ((this.memory[this.position++] & 0xff) << 8) | ((this.memory[this.position++] & 0xff) << 0);
+				return ((this.memory[this.position++] & 0xff) << 8) | ((this.memory[this.position++] & 0xff));
 			} else {
 				throw new EOFException();
 			}
@@ -1681,7 +1681,7 @@ public final class Record implements Value, CopyableValue<Record> {
 				resize(2);
 			}
 			this.memory[this.position++] = (byte) ((v >>> 8) & 0xff);
-			this.memory[this.position++] = (byte) ((v >>> 0) & 0xff);
+			this.memory[this.position++] = (byte) ((v) & 0xff);
 		}
 
 		@Override
@@ -1712,7 +1712,7 @@ public final class Record implements Value, CopyableValue<Record> {
 			int count = this.position;
 
 			bytearr[count++] = (byte) ((utflen >>> 8) & 0xFF);
-			bytearr[count++] = (byte) ((utflen >>> 0) & 0xFF);
+			bytearr[count++] = (byte) ((utflen) & 0xFF);
 
 			int i = 0;
 			for (i = 0; i < strlen; i++) {
@@ -1731,10 +1731,10 @@ public final class Record implements Value, CopyableValue<Record> {
 				} else if (c > 0x07FF) {
 					bytearr[count++] = (byte) (0xE0 | ((c >> 12) & 0x0F));
 					bytearr[count++] = (byte) (0x80 | ((c >> 6) & 0x3F));
-					bytearr[count++] = (byte) (0x80 | ((c >> 0) & 0x3F));
+					bytearr[count++] = (byte) (0x80 | ((c) & 0x3F));
 				} else {
 					bytearr[count++] = (byte) (0xC0 | ((c >> 6) & 0x1F));
-					bytearr[count++] = (byte) (0x80 | ((c >> 0) & 0x3F));
+					bytearr[count++] = (byte) (0x80 | ((c) & 0x3F));
 				}
 			}
 

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/TestDataOutputSerializer.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/TestDataOutputSerializer.java
@@ -193,7 +193,7 @@ public final class TestDataOutputSerializer implements DataOutputView {
 			resize(2);
 		}
 		this.buffer[this.position++] = (byte) ((v >>> 8) & 0xff);
-		this.buffer[this.position++] = (byte) ((v >>> 0) & 0xff);
+		this.buffer[this.position++] = (byte) ((v) & 0xff);
 	}
 
 	@Override
@@ -225,7 +225,7 @@ public final class TestDataOutputSerializer implements DataOutputView {
 		int count = this.position;
 
 		bytearr[count++] = (byte) ((utflen >>> 8) & 0xFF);
-		bytearr[count++] = (byte) ((utflen >>> 0) & 0xFF);
+		bytearr[count++] = (byte) ((utflen) & 0xFF);
 
 		int i = 0;
 		for (i = 0; i < strlen; i++) {
@@ -244,10 +244,10 @@ public final class TestDataOutputSerializer implements DataOutputView {
 			} else if (c > 0x07FF) {
 				bytearr[count++] = (byte) (0xE0 | ((c >> 12) & 0x0F));
 				bytearr[count++] = (byte) (0x80 | ((c >> 6) & 0x3F));
-				bytearr[count++] = (byte) (0x80 | ((c >> 0) & 0x3F));
+				bytearr[count++] = (byte) (0x80 | ((c) & 0x3F));
 			} else {
 				bytearr[count++] = (byte) (0xC0 | ((c >> 6) & 0x1F));
-				bytearr[count++] = (byte) (0x80 | ((c >> 0) & 0x3F));
+				bytearr[count++] = (byte) (0x80 | ((c) & 0x3F));
 			}
 		}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/AdaptiveSpanningRecordDeserializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/AdaptiveSpanningRecordDeserializer.java
@@ -349,7 +349,7 @@ public class AdaptiveSpanningRecordDeserializer<T extends IOReadableWritable> im
 						if (((char2 & 0xC0) != 0x80) || ((char3 & 0xC0) != 0x80)) {
 							throw new UTFDataFormatException("malformed input around byte " + (count - 1));
 						}
-						chararr[chararr_count++] = (char) (((c & 0x0F) << 12) | ((char2 & 0x3F) << 6) | ((char3 & 0x3F) << 0));
+						chararr[chararr_count++] = (char) (((c & 0x0F) << 12) | ((char2 & 0x3F) << 6) | ((char3 & 0x3F)));
 						break;
 					default:
 						throw new UTFDataFormatException("malformed input around byte " + count);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/memory/AbstractPagedInputView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/memory/AbstractPagedInputView.java
@@ -480,7 +480,7 @@ public abstract class AbstractPagedInputView implements DataInputView {
 				if (((char2 & 0xC0) != 0x80) || ((char3 & 0xC0) != 0x80)) {
 					throw new UTFDataFormatException("malformed input around byte " + (count - 1));
 				}
-				chararr[chararrCount++] = (char) (((c & 0x0F) << 12) | ((char2 & 0x3F) << 6) | ((char3 & 0x3F) << 0));
+				chararr[chararrCount++] = (char) (((c & 0x0F) << 12) | ((char2 & 0x3F) << 6) | ((char3 & 0x3F)));
 				break;
 			default:
 				/* 10xx xxxx, 1111 xxxx */


### PR DESCRIPTION
## Brief change log

Remove pointless bitwise expressions, Such expressions include anding with zero, oring by zero, and shifting by zero.



## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
