### PR TITLE
[FLINK-8235][build] Spotbugs exclusion file path now absolute

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -616,7 +616,7 @@ under the License.
 							<threshold>Low</threshold>
 							<effort>default</effort>
 							<findbugsXmlOutputDirectory>${project.build.directory}/spotbugs</findbugsXmlOutputDirectory>
-							<excludeFilterFile>tools/maven/spotbugs-exclude.xml</excludeFilterFile>
+							<excludeFilterFile>${rootDir}/tools/maven/spotbugs-exclude.xml</excludeFilterFile>
 							<failOnError>true</failOnError>
 						</configuration>
 					</plugin>


### PR DESCRIPTION
## What is the purpose of the change

With this PR the spotbugs plugin can now be run on a single sub-module. The path to the exclusion file is now absolute and no longer relies on in which module it is executed.

## Verifying this change

Run {{mvn package -Dspotbugs}} in any sub-module.
