### PR TITLE
[FLINK-4812][metrics] Expose currentLowWatermark for all operators

### DIFF
--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -1190,12 +1190,7 @@ Thus, in order to infer the metric identifier:
   </thead>
   <tbody>
     <tr>
-      <th rowspan="7"><strong>Task</strong></th>
-      <td>currentLowWatermark</td>
-      <td>The lowest watermark this task has received (in milliseconds).</td>
-      <td>Gauge</td>
-    </tr>
-    <tr>
+      <th rowspan="6"><strong>Task</strong></th>
       <td>numBytesInLocal</td>
       <td>The total number of bytes this task has read from a local source.</td>
       <td>Counter</td>
@@ -1252,7 +1247,38 @@ Thus, in order to infer the metric identifier:
       <td>Counter</td>
     </tr>
     <tr>
-      <th rowspan="2"><strong>Operator</strong></th>
+      <th rowspan="6"><strong>Operator</strong></th>
+      <td>currentInputWatermark</td>
+      <td>
+        The last watermark this operator has received (in milliseconds).
+        <p><strong>Note:</strong> For operators with 2 inputs this is the minimum of the last received watermarks.</p>
+      </td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>currentInput1Watermark</td>
+      <td>
+        The last watermark this operator has received in its first input (in milliseconds).
+        <p><strong>Note:</strong> Only for operators with 2 inputs.</p>
+      </td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>currentInput2Watermark</td>
+      <td>
+        The last watermark this operator has received in its second input (in milliseconds).
+        <p><strong>Note:</strong> Only for operators with 2 inputs.</p>
+      </td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>currentOutputWatermark</td>
+      <td>
+        The last watermark this operator has emitted (in milliseconds).
+      </td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
       <td>latency</td>
       <td>The latency distributions from all incoming sources (in milliseconds).</td>
       <td>Histogram</td>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
@@ -39,4 +39,9 @@ public class MetricNames {
 	public static final String IO_NUM_BYTES_IN_LOCAL_RATE = IO_NUM_BYTES_IN_LOCAL + SUFFIX_RATE;
 	public static final String IO_NUM_BYTES_IN_REMOTE_RATE = IO_NUM_BYTES_IN_REMOTE + SUFFIX_RATE;
 	public static final String IO_NUM_BYTES_OUT_RATE = IO_NUM_BYTES_OUT + SUFFIX_RATE;
+
+	public static final String IO_CURRENT_INPUT_WATERMARK = "currentInputWatermark";
+	public static final String IO_CURRENT_INPUT_1_WATERMARK = "currentInput1Watermark";
+	public static final String IO_CURRENT_INPUT_2_WATERMARK = "currentInput2Watermark";
+	public static final String IO_CURRENT_OUTPUT_WATERMARK = "currentOutputWatermark";
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/util/InterceptingOperatorMetricGroup.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/util/InterceptingOperatorMetricGroup.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.metrics.util;
+
+import org.apache.flink.metrics.Metric;
+import org.apache.flink.runtime.metrics.groups.OperatorMetricGroup;
+import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * An {@link OperatorMetricGroup} that exposes all registered metrics.
+ */
+public class InterceptingOperatorMetricGroup extends UnregisteredMetricGroups.UnregisteredOperatorMetricGroup {
+
+	private Map<String, Metric> intercepted;
+
+	/**
+	 * Returns the registered metric for the given name, or null if it was never registered.
+	 *
+	 * @param name metric name
+	 * @return registered metric for the given name, or null if it was never registered
+	 */
+	public Metric get(String name) {
+		return intercepted.get(name);
+	}
+
+	@Override
+	protected void addMetric(String name, Metric metric) {
+		if (intercepted == null) {
+			intercepted = new HashMap<>();
+		}
+		intercepted.put(name, metric);
+		super.addMetric(name, metric);
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/collector/selector/CopyingDirectedOutput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/collector/selector/CopyingDirectedOutput.java
@@ -36,7 +36,7 @@ public class CopyingDirectedOutput<OUT> extends DirectedOutput<OUT> {
 	@SuppressWarnings({"unchecked", "rawtypes"})
 	public CopyingDirectedOutput(
 			List<OutputSelector<OUT>> outputSelectors,
-			List<Tuple2<Output<StreamRecord<OUT>>, StreamEdge>> outputs) {
+			List<? extends Tuple2<? extends Output<StreamRecord<OUT>>, StreamEdge>> outputs) {
 		super(outputSelectors, outputs);
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/RecordWriterOutput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/RecordWriterOutput.java
@@ -19,17 +19,20 @@ package org.apache.flink.streaming.runtime.io;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.metrics.Gauge;
 import org.apache.flink.runtime.event.AbstractEvent;
 import org.apache.flink.runtime.io.network.api.writer.RecordWriter;
 import org.apache.flink.runtime.plugable.SerializationDelegate;
 import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.metrics.WatermarkGauge;
 import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
 import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
 import org.apache.flink.streaming.runtime.streamrecord.StreamElementSerializer;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.streamstatus.StreamStatus;
 import org.apache.flink.streaming.runtime.streamstatus.StreamStatusProvider;
+import org.apache.flink.streaming.runtime.tasks.OperatorChain;
 import org.apache.flink.util.OutputTag;
 
 import java.io.IOException;
@@ -40,7 +43,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * Implementation of {@link Output} that sends data using a {@link RecordWriter}.
  */
 @Internal
-public class RecordWriterOutput<OUT> implements Output<StreamRecord<OUT>> {
+public class RecordWriterOutput<OUT> implements OperatorChain.WatermarkGaugeExposingOutput<StreamRecord<OUT>> {
 
 	private StreamRecordWriter<SerializationDelegate<StreamElement>> recordWriter;
 
@@ -49,6 +52,8 @@ public class RecordWriterOutput<OUT> implements Output<StreamRecord<OUT>> {
 	private final StreamStatusProvider streamStatusProvider;
 
 	private final OutputTag outputTag;
+
+	private final WatermarkGauge watermarkGauge = new WatermarkGauge();
 
 	@SuppressWarnings("unchecked")
 	public RecordWriterOutput(
@@ -108,6 +113,7 @@ public class RecordWriterOutput<OUT> implements Output<StreamRecord<OUT>> {
 
 	@Override
 	public void emitWatermark(Watermark mark) {
+		watermarkGauge.setCurrentWatermark(mark.getTimestamp());
 		serializationDelegate.setInstance(mark);
 
 		if (streamStatusProvider.getStreamStatus().isActive()) {
@@ -157,5 +163,10 @@ public class RecordWriterOutput<OUT> implements Output<StreamRecord<OUT>> {
 
 	public void clearBuffers() {
 		recordWriter.clearBuffers();
+	}
+
+	@Override
+	public Gauge<Long> getWatermarkGauge() {
+		return watermarkGauge;
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessor.java
@@ -24,7 +24,6 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.metrics.Counter;
-import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.runtime.event.AbstractEvent;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
@@ -42,6 +41,7 @@ import org.apache.flink.runtime.plugable.NonReusingDeserializationDelegate;
 import org.apache.flink.streaming.api.CheckpointingMode;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
 import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.metrics.WatermarkGauge;
 import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
 import org.apache.flink.streaming.runtime.streamrecord.StreamElementSerializer;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
@@ -120,8 +120,8 @@ public class StreamTwoInputProcessor<IN1, IN2> {
 
 	// ---------------- Metrics ------------------
 
-	private long lastEmittedWatermark1;
-	private long lastEmittedWatermark2;
+	private final WatermarkGauge input1WatermarkGauge;
+	private final WatermarkGauge input2WatermarkGauge;
 
 	private Counter numRecordsIn;
 
@@ -139,7 +139,10 @@ public class StreamTwoInputProcessor<IN1, IN2> {
 			IOManager ioManager,
 			Configuration taskManagerConfig,
 			StreamStatusMaintainer streamStatusMaintainer,
-			TwoInputStreamOperator<IN1, IN2, ?> streamOperator) throws IOException {
+			TwoInputStreamOperator<IN1, IN2, ?> streamOperator,
+			TaskIOMetricGroup metrics,
+			WatermarkGauge input1WatermarkGauge,
+			WatermarkGauge input2WatermarkGauge) throws IOException {
 
 		final InputGate inputGate = InputGateUtil.createInputGate(inputGates1, inputGates2);
 
@@ -188,9 +191,6 @@ public class StreamTwoInputProcessor<IN1, IN2> {
 		this.numInputChannels1 = numInputChannels1;
 		this.numInputChannels2 = inputGate.getNumberOfInputChannels() - numInputChannels1;
 
-		this.lastEmittedWatermark1 = Long.MIN_VALUE;
-		this.lastEmittedWatermark2 = Long.MIN_VALUE;
-
 		this.firstStatus = StreamStatus.ACTIVE;
 		this.secondStatus = StreamStatus.ACTIVE;
 
@@ -200,6 +200,9 @@ public class StreamTwoInputProcessor<IN1, IN2> {
 		this.statusWatermarkValve1 = new StatusWatermarkValve(numInputChannels1, new ForwardingValveOutputHandler1(streamOperator, lock));
 		this.statusWatermarkValve2 = new StatusWatermarkValve(numInputChannels2, new ForwardingValveOutputHandler2(streamOperator, lock));
 
+		this.input1WatermarkGauge = input1WatermarkGauge;
+		this.input2WatermarkGauge = input2WatermarkGauge;
+		metrics.gauge("checkpointAlignmentTime", barrierHandler::getAlignmentDurationNanos);
 	}
 
 	public boolean processInput() throws Exception {
@@ -312,27 +315,6 @@ public class StreamTwoInputProcessor<IN1, IN2> {
 		}
 	}
 
-	/**
-	 * Sets the metric group for this StreamTwoInputProcessor.
-	 *
-	 * @param metrics metric group
-	 */
-	public void setMetricGroup(TaskIOMetricGroup metrics) {
-		metrics.gauge("currentLowWatermark", new Gauge<Long>() {
-			@Override
-			public Long getValue() {
-				return Math.min(lastEmittedWatermark1, lastEmittedWatermark2);
-			}
-		});
-
-		metrics.gauge("checkpointAlignmentTime", new Gauge<Long>() {
-			@Override
-			public Long getValue() {
-				return barrierHandler.getAlignmentDurationNanos();
-			}
-		});
-	}
-
 	public void cleanup() throws IOException {
 		// clear the buffers first. this part should not ever fail
 		for (RecordDeserializer<?> deserializer : recordDeserializers) {
@@ -360,7 +342,7 @@ public class StreamTwoInputProcessor<IN1, IN2> {
 		public void handleWatermark(Watermark watermark) {
 			try {
 				synchronized (lock) {
-					lastEmittedWatermark1 = watermark.getTimestamp();
+					input1WatermarkGauge.setCurrentWatermark(watermark.getTimestamp());
 					operator.processWatermark1(watermark);
 				}
 			} catch (Exception e) {
@@ -404,7 +386,7 @@ public class StreamTwoInputProcessor<IN1, IN2> {
 		public void handleWatermark(Watermark watermark) {
 			try {
 				synchronized (lock) {
-					lastEmittedWatermark2 = watermark.getTimestamp();
+					input2WatermarkGauge.setCurrentWatermark(watermark.getTimestamp());
 					operator.processWatermark2(watermark);
 				}
 			} catch (Exception e) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/metrics/MinWatermarkGauge.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/metrics/MinWatermarkGauge.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.metrics;
+
+import org.apache.flink.metrics.Gauge;
+
+/**
+ * A {@link Gauge} for exposing the minimum watermark of a {@link WatermarkGauge} pair.
+ */
+public class MinWatermarkGauge implements Gauge<Long> {
+
+	private WatermarkGauge watermarkGauge1;
+	private WatermarkGauge watermarkGauge2;
+
+	public MinWatermarkGauge(WatermarkGauge watermarkGauge1, WatermarkGauge watermarkGauge2) {
+		this.watermarkGauge1 = watermarkGauge1;
+		this.watermarkGauge2 = watermarkGauge2;
+	}
+
+	@Override
+	public Long getValue() {
+		return Math.min(watermarkGauge1.getValue(), watermarkGauge2.getValue());
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/metrics/WatermarkGauge.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/metrics/WatermarkGauge.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.metrics;
+
+import org.apache.flink.metrics.Gauge;
+
+/**
+ * A {@link Gauge} for exposing the current input/output watermark.
+ */
+public class WatermarkGauge implements Gauge<Long> {
+
+	private long currentWatermark = Long.MIN_VALUE;
+
+	public void setCurrentWatermark(long watermark) {
+		this.currentWatermark = watermark;
+	}
+
+	@Override
+	public Long getValue() {
+		return currentWatermark;
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/metrics/MinWatermarkGaugeTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/metrics/MinWatermarkGaugeTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.metrics;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for the {@link MinWatermarkGauge}.
+ */
+public class MinWatermarkGaugeTest {
+
+	@Test
+	public void testSetCurrentLowWatermark() {
+		WatermarkGauge metric1 = new WatermarkGauge();
+		WatermarkGauge metric2 = new WatermarkGauge();
+		MinWatermarkGauge metric = new MinWatermarkGauge(metric1, metric2);
+
+		Assert.assertEquals(Long.MIN_VALUE, metric.getValue().longValue());
+
+		metric1.setCurrentWatermark(1);
+		Assert.assertEquals(Long.MIN_VALUE, metric.getValue().longValue());
+
+		metric2.setCurrentWatermark(2);
+		Assert.assertEquals(1L, metric.getValue().longValue());
+
+		metric1.setCurrentWatermark(3);
+		Assert.assertEquals(2L, metric.getValue().longValue());
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/metrics/WatermarkGaugeTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/metrics/WatermarkGaugeTest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.metrics;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for the {@link WatermarkGauge}.
+ */
+public class WatermarkGaugeTest {
+
+	@Test
+	public void testSetCurrentLowWatermark() {
+		WatermarkGauge metric = new WatermarkGauge();
+
+		Assert.assertEquals(Long.MIN_VALUE, metric.getValue().longValue());
+
+		metric.setCurrentWatermark(64);
+		Assert.assertEquals(64, metric.getValue().longValue());
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTaskTest.java
@@ -18,12 +18,21 @@
 
 package org.apache.flink.streaming.runtime.tasks;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.metrics.Gauge;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.metrics.MetricNames;
+import org.apache.flink.runtime.metrics.groups.OperatorMetricGroup;
+import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
+import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
+import org.apache.flink.runtime.metrics.util.InterceptingOperatorMetricGroup;
+import org.apache.flink.runtime.operators.testutils.MockInputSplitProvider;
+import org.apache.flink.runtime.state.TestTaskStateManager;
 import org.apache.flink.streaming.api.functions.co.CoMapFunction;
 import org.apache.flink.streaming.api.functions.co.RichCoMapFunction;
 import org.apache.flink.streaming.api.graph.StreamConfig;
@@ -371,6 +380,91 @@ public class TwoInputStreamTaskTest {
 		TestHarnessUtil.assertOutputEquals("Output was not correct.",
 				expectedOutput,
 				testHarness.getOutput());
+	}
+
+	@Test
+	public void testWatermarkMetrics() throws Exception {
+		final TwoInputStreamTaskTestHarness<String, Integer, String> testHarness = new TwoInputStreamTaskTestHarness<>(TwoInputStreamTask::new, BasicTypeInfo.STRING_TYPE_INFO, BasicTypeInfo.INT_TYPE_INFO, BasicTypeInfo.STRING_TYPE_INFO);
+
+		CoStreamMap<String, Integer, String> headOperator = new CoStreamMap<>(new IdentityMap());
+		final OperatorID headOperatorId = new OperatorID();
+
+		OneInputStreamTaskTest.WatermarkMetricOperator chainedOperator = new OneInputStreamTaskTest.WatermarkMetricOperator();
+		OperatorID chainedOperatorId = new OperatorID();
+
+		testHarness.setupOperatorChain(headOperatorId, headOperator)
+			.chain(chainedOperatorId, chainedOperator, BasicTypeInfo.STRING_TYPE_INFO.createSerializer(new ExecutionConfig()))
+			.finish();
+
+		InterceptingOperatorMetricGroup headOperatorMetricGroup = new InterceptingOperatorMetricGroup();
+		InterceptingOperatorMetricGroup chainedOperatorMetricGroup = new InterceptingOperatorMetricGroup();
+		TaskMetricGroup taskMetricGroup = new UnregisteredMetricGroups.UnregisteredTaskMetricGroup() {
+			@Override
+			public OperatorMetricGroup addOperator(OperatorID id, String name) {
+				if (id.equals(headOperatorId)) {
+					return headOperatorMetricGroup;
+				} else if (id.equals(chainedOperatorId)) {
+					return chainedOperatorMetricGroup;
+				} else {
+					return super.addOperator(id, name);
+				}
+			}
+		};
+
+		StreamMockEnvironment env = new StreamMockEnvironment(
+			testHarness.jobConfig, testHarness.taskConfig, testHarness.memorySize, new MockInputSplitProvider(), testHarness.bufferSize, new TestTaskStateManager()) {
+			@Override
+			public TaskMetricGroup getMetricGroup() {
+				return taskMetricGroup;
+			}
+		};
+
+		testHarness.invoke(env);
+		testHarness.waitForTaskRunning();
+
+		Gauge<Long> headInput1WatermarkGauge = (Gauge<Long>) headOperatorMetricGroup.get(MetricNames.IO_CURRENT_INPUT_1_WATERMARK);
+		Gauge<Long> headInput2WatermarkGauge = (Gauge<Long>) headOperatorMetricGroup.get(MetricNames.IO_CURRENT_INPUT_2_WATERMARK);
+		Gauge<Long> headInputWatermarkGauge = (Gauge<Long>) headOperatorMetricGroup.get(MetricNames.IO_CURRENT_INPUT_WATERMARK);
+		Gauge<Long> headOutputWatermarkGauge = (Gauge<Long>) headOperatorMetricGroup.get(MetricNames.IO_CURRENT_OUTPUT_WATERMARK);
+		Gauge<Long> chainedInputWatermarkGauge = (Gauge<Long>) chainedOperatorMetricGroup.get(MetricNames.IO_CURRENT_INPUT_WATERMARK);
+		Gauge<Long> chainedOutputWatermarkGauge = (Gauge<Long>) chainedOperatorMetricGroup.get(MetricNames.IO_CURRENT_OUTPUT_WATERMARK);
+
+		Assert.assertEquals(Long.MIN_VALUE, headInputWatermarkGauge.getValue().longValue());
+		Assert.assertEquals(Long.MIN_VALUE, headInput1WatermarkGauge.getValue().longValue());
+		Assert.assertEquals(Long.MIN_VALUE, headInput2WatermarkGauge.getValue().longValue());
+		Assert.assertEquals(Long.MIN_VALUE, headOutputWatermarkGauge.getValue().longValue());
+		Assert.assertEquals(Long.MIN_VALUE, chainedInputWatermarkGauge.getValue().longValue());
+		Assert.assertEquals(Long.MIN_VALUE, chainedOutputWatermarkGauge.getValue().longValue());
+
+		testHarness.processElement(new Watermark(1L), 0, 0);
+		testHarness.waitForInputProcessing();
+		Assert.assertEquals(Long.MIN_VALUE, headInputWatermarkGauge.getValue().longValue());
+		Assert.assertEquals(1L, headInput1WatermarkGauge.getValue().longValue());
+		Assert.assertEquals(Long.MIN_VALUE, headInput2WatermarkGauge.getValue().longValue());
+		Assert.assertEquals(Long.MIN_VALUE, headOutputWatermarkGauge.getValue().longValue());
+		Assert.assertEquals(Long.MIN_VALUE, chainedInputWatermarkGauge.getValue().longValue());
+		Assert.assertEquals(Long.MIN_VALUE, chainedOutputWatermarkGauge.getValue().longValue());
+
+		testHarness.processElement(new Watermark(2L), 1, 0);
+		testHarness.waitForInputProcessing();
+		Assert.assertEquals(1L, headInputWatermarkGauge.getValue().longValue());
+		Assert.assertEquals(1L, headInput1WatermarkGauge.getValue().longValue());
+		Assert.assertEquals(2L, headInput2WatermarkGauge.getValue().longValue());
+		Assert.assertEquals(1L, headOutputWatermarkGauge.getValue().longValue());
+		Assert.assertEquals(1L, chainedInputWatermarkGauge.getValue().longValue());
+		Assert.assertEquals(2L, chainedOutputWatermarkGauge.getValue().longValue());
+
+		testHarness.processElement(new Watermark(3L), 0, 0);
+		testHarness.waitForInputProcessing();
+		Assert.assertEquals(2L, headInputWatermarkGauge.getValue().longValue());
+		Assert.assertEquals(3L, headInput1WatermarkGauge.getValue().longValue());
+		Assert.assertEquals(2L, headInput2WatermarkGauge.getValue().longValue());
+		Assert.assertEquals(2L, headOutputWatermarkGauge.getValue().longValue());
+		Assert.assertEquals(2L, chainedInputWatermarkGauge.getValue().longValue());
+		Assert.assertEquals(4L, chainedOutputWatermarkGauge.getValue().longValue());
+
+		testHarness.endInput();
+		testHarness.waitForTaskCompletion();
 	}
 
 	// This must only be used in one test, otherwise the static fields will be changed


### PR DESCRIPTION
Revised version of #5125.

## What is the purpose of the change

With this PR all operators expose the current input/output watermark through the metric system.

Input watermarks for the head operator are measured in the StreamInputProcessors.
Input watermarks for chained operators, and all output watermarks are measured in the output of each operator.

## Brief change log

* Introduce new `[Min]WatermarkGauge` classes to measure watermarks
* modified `Output`s used by the `OperatorChain` to create and expose a `WatermarkGauge`
* modified `Stream[Two]InputProcessor` to accept metrics through the constructor instead of a separate method
* added `getInputWatermarkGauge()` method to the `StreamTask` class; the retrieved gauge is given to the `OperatorChain` to register on the operator level

* added test utility `InterceptingOperatorMetricGroup` class to expose registered metrics
* added tests
* updated documentation

## Verifying this change

This change added tests and can be verified as follows:

Run
* WatermarkGaugeTest
* MinWatermarkGaugeTest
* OneInputStreamTaskTest
* TwoInputStreamTaskTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (yes (per-watermark codepaths))
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
