### PR TITLE
[FLINK-8249] [KinesisConnector] [hotfix] aws region is never setted in KinesisProducer

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtil.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtil.java
@@ -191,6 +191,7 @@ public class KinesisConfigUtil {
 		}
 
 		KinesisProducerConfiguration kpc = KinesisProducerConfiguration.fromProperties(config);
+		kpc.setRegion(config.getProperty(AWSConfigConstants.AWS_REGION));
 
 		kpc.setCredentialsProvider(AWSUtil.getCredentialsProvider(config));
 

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtilTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtilTest.java
@@ -131,6 +131,16 @@ public class KinesisConfigUtilTest {
 		assertEquals("2", replacedConfig.getProperty(KinesisConfigUtil.COLLECTION_MAX_COUNT));
 	}
 
+	@Test
+	public void testCorrectlySetRegionInProducerConfiguration() {
+		String region = "us-east-1";
+		Properties testConfig = new Properties();
+		testConfig.setProperty(AWSConfigConstants.AWS_REGION, region);
+		KinesisProducerConfiguration kpc = KinesisConfigUtil.getValidatedProducerConfiguration(testConfig);
+
+		assertEquals("region not expected", region, kpc.getRegion());
+	}
+
 	// ----------------------------------------------------------------------
 	// validateAwsConfiguration() tests
 	// ----------------------------------------------------------------------

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtilTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtilTest.java
@@ -138,7 +138,7 @@ public class KinesisConfigUtilTest {
 		testConfig.setProperty(AWSConfigConstants.AWS_REGION, region);
 		KinesisProducerConfiguration kpc = KinesisConfigUtil.getValidatedProducerConfiguration(testConfig);
 
-		assertEquals("region not expected", region, kpc.getRegion());
+		assertEquals("incorrect region", region, kpc.getRegion());
 	}
 
 	// ----------------------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change

solve the issue related, adding aws region to kinesis producer configuration

## Verifying this change

This change added tests and can be verified as follows:
  - Added test that validates that region is correctly setted

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)