### PR TITLE
[FLINK-8264] [core] Add 'scala.' to the 'parent-first' classloading patterns

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
@@ -36,7 +36,7 @@ public class CoreOptions {
 
 	public static final ConfigOption<String> ALWAYS_PARENT_FIRST_LOADER = ConfigOptions
 		.key("classloader.parent-first-patterns")
-		.defaultValue("java.;org.apache.flink.;javax.annotation;org.slf4j;org.apache.log4j;org.apache.logging.log4j;ch.qos.logback");
+		.defaultValue("java.;scala.;org.apache.flink.;javax.annotation;org.slf4j;org.apache.log4j;org.apache.logging.log4j;ch.qos.logback");
 
 
 	// ------------------------------------------------------------------------


### PR DESCRIPTION
**BACKPORT of #5166 to release-1.4**

## What is the purpose of the change

Adding `scala.` to the "parent-first-patterns" makes sure that Scala classes are not duplicated through "child-first" classloading when users accidentally package the Scala Library into the application jar.

Since Scala classes traverse the boundary between core and user space, they should never be duplicated.

## Brief change log

  - Adds `scala.` to the default value of `classloader.parent-first-patterns`.

## Verifying this change

This change can be verified as follows:
  - Create a very simple quickstart Scala project using a Scala lambda for a filter function (`_ => true`).
  - Package it such that the Scala library is in the user code jar
  - Without the fix, you get a weird class cast exception during deserialization, with this fix, everything is fine.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no)**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
