### PR TITLE
[FLINK-8275] [Security] fix keytab local path in YarnTaskManagerRunner

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/SecurityUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/SecurityUtils.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.security;
 
-import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.security.modules.SecurityModule;
 import org.apache.flink.runtime.security.modules.SecurityModuleFactory;
 
@@ -47,8 +46,7 @@ public class SecurityUtils {
 		return installedContext;
 	}
 
-	@VisibleForTesting
-	static List<SecurityModule> getInstalledModules() {
+	public static List<SecurityModule> getInstalledModules() {
 		return installedModules;
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/modules/HadoopModule.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/modules/HadoopModule.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.security.modules;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.security.SecurityConfiguration;
 import org.apache.flink.runtime.util.HadoopUtils;
 
@@ -56,6 +57,11 @@ public class HadoopModule implements SecurityModule {
 		Configuration hadoopConfiguration) {
 		this.securityConfig = checkNotNull(securityConfiguration);
 		this.hadoopConfiguration = checkNotNull(hadoopConfiguration);
+	}
+
+	@VisibleForTesting
+	public SecurityConfiguration getSecurityConfig() {
+		return securityConfig;
 	}
 
 	@Override

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/TestingYarnTaskManagerRunner.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/TestingYarnTaskManagerRunner.java
@@ -25,6 +25,7 @@ import java.io.IOException;
  */
 public class TestingYarnTaskManagerRunner {
 	public static void main(String[] args) throws IOException {
-		YarnTaskManagerRunner.runYarnTaskManager(args, TestingYarnTaskManager.class);
+		YarnTaskManagerRunner.runYarnTaskManager(
+				args, TestingYarnTaskManager.class, System.getenv(), null);
 	}
 }

--- a/flink-yarn-tests/src/test/scala/org/apache/flink/yarn/TestingYarnTaskManager.scala
+++ b/flink-yarn-tests/src/test/scala/org/apache/flink/yarn/TestingYarnTaskManager.scala
@@ -72,7 +72,8 @@ class TestingYarnTaskManager(
       * @param args The command line arguments.
       */
     def main(args: Array[String]): Unit = {
-      YarnTaskManagerRunner.runYarnTaskManager(args, classOf[TestingYarnTaskManager])
+      YarnTaskManagerRunner.runYarnTaskManager(
+        args, classOf[TestingYarnTaskManager], System.getenv(), null)
     }
 
   }

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnApplicationMasterRunner.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnApplicationMasterRunner.java
@@ -145,18 +145,8 @@ public class YarnApplicationMasterRunner {
 			require(currDir != null, "Current working directory variable (%s) not set", Environment.PWD.key());
 			LOG.debug("Current working Directory: {}", currDir);
 
-			final String remoteKeytabPath = ENV.get(YarnConfigKeys.KEYTAB_PATH);
-			LOG.debug("remoteKeytabPath obtained {}", remoteKeytabPath);
-
 			final String remoteKeytabPrincipal = ENV.get(YarnConfigKeys.KEYTAB_PRINCIPAL);
 			LOG.info("remoteKeytabPrincipal obtained {}", remoteKeytabPrincipal);
-
-			String keytabPath = null;
-			if (remoteKeytabPath != null) {
-				File f = new File(currDir, Utils.KEYTAB_FILE_NAME);
-				keytabPath = f.getAbsolutePath();
-				LOG.debug("keytabPath: {}", keytabPath);
-			}
 
 			UserGroupInformation currentUser = UserGroupInformation.getCurrentUser();
 
@@ -170,9 +160,10 @@ public class YarnApplicationMasterRunner {
 
 			final Configuration flinkConfig = createConfiguration(currDir, dynamicProperties);
 
-			// set keytab principal and replace path with the local path of the shipped keytab file in NodeManager
-			if (keytabPath != null && remoteKeytabPrincipal != null) {
-				flinkConfig.setString(SecurityOptions.KERBEROS_LOGIN_KEYTAB, keytabPath);
+			File f = new File(currDir, Utils.KEYTAB_FILE_NAME);
+			if (remoteKeytabPrincipal != null && f.exists()) {
+				// set keytab principal and replace path with the local path of the shipped keytab file in NodeManager
+				flinkConfig.setString(SecurityOptions.KERBEROS_LOGIN_KEYTAB, f.getAbsolutePath());
 				flinkConfig.setString(SecurityOptions.KERBEROS_LOGIN_PRINCIPAL, remoteKeytabPrincipal);
 			}
 
@@ -252,19 +243,11 @@ public class YarnApplicationMasterRunner {
 
 			LOG.info("YARN assigned hostname for application master: {}", appMasterHostname);
 
-			//Update keytab and principal path to reflect YARN container path location
-			final String remoteKeytabPath = ENV.get(YarnConfigKeys.KEYTAB_PATH);
-
 			final String remoteKeytabPrincipal = ENV.get(YarnConfigKeys.KEYTAB_PRINCIPAL);
 
-			String keytabPath = null;
-			if (remoteKeytabPath != null) {
-				File f = new File(currDir, Utils.KEYTAB_FILE_NAME);
-				keytabPath = f.getAbsolutePath();
-				LOG.info("keytabPath: {}", keytabPath);
-			}
-			if (keytabPath != null && remoteKeytabPrincipal != null) {
-				config.setString(SecurityOptions.KERBEROS_LOGIN_KEYTAB, keytabPath);
+			File f = new File(currDir, Utils.KEYTAB_FILE_NAME);
+			if (remoteKeytabPrincipal != null && f.exists()) {
+				config.setString(SecurityOptions.KERBEROS_LOGIN_KEYTAB, f.getAbsolutePath());
 				config.setString(SecurityOptions.KERBEROS_LOGIN_PRINCIPAL, remoteKeytabPrincipal);
 			}
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnTaskManagerRunner.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnTaskManagerRunner.java
@@ -113,6 +113,11 @@ public class YarnTaskManagerRunner {
 		final ResourceID resourceId = new ResourceID(containerID);
 		LOG.info("ResourceID assigned for this container: {}", resourceId);
 
+		// set keytab principal and replace path with the local path of the shipped keytab file in NodeManager
+		if (localKeytabPath != null && remoteKeytabPrincipal != null) {
+			configuration.setString(SecurityOptions.KERBEROS_LOGIN_KEYTAB, localKeytabPath);
+			configuration.setString(SecurityOptions.KERBEROS_LOGIN_PRINCIPAL, remoteKeytabPrincipal);
+		}
 		try {
 
 			SecurityConfiguration sc;
@@ -125,12 +130,6 @@ public class YarnTaskManagerRunner {
 				org.apache.hadoop.conf.Configuration hadoopConfiguration = new org.apache.hadoop.conf.Configuration();
 				hadoopConfiguration.set(CommonConfigurationKeysPublic.HADOOP_SECURITY_AUTHENTICATION, "kerberos");
 				hadoopConfiguration.set(CommonConfigurationKeysPublic.HADOOP_SECURITY_AUTHORIZATION, "true");
-
-				// set keytab principal and replace path with the local path of the shipped keytab file in NodeManager
-				if (localKeytabPath != null && remoteKeytabPrincipal != null) {
-					configuration.setString(SecurityOptions.KERBEROS_LOGIN_KEYTAB, localKeytabPath);
-					configuration.setString(SecurityOptions.KERBEROS_LOGIN_PRINCIPAL, remoteKeytabPrincipal);
-				}
 
 				sc = new SecurityConfiguration(configuration,
 					Collections.singletonList(securityConfig -> new HadoopModule(securityConfig, hadoopConfiguration)));

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnTaskManagerRunner.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnTaskManagerRunner.java
@@ -51,7 +51,29 @@ public class YarnTaskManagerRunner {
 
 	private static final Logger LOG = LoggerFactory.getLogger(YarnTaskManagerRunner.class);
 
-	public static void runYarnTaskManager(String[] args, final Class<? extends YarnTaskManager> taskManager) throws IOException {
+	private static Callable<Object> createMainRunner(
+			Configuration configuration,
+			ResourceID resourceId,
+			final Class<? extends YarnTaskManager> taskManager) {
+		return new Callable<Object>() {
+			@Override
+			public Integer call() {
+				try {
+					TaskManager.selectNetworkInterfaceAndRunTaskManager(
+							configuration, resourceId, taskManager);
+				} catch (Throwable t) {
+					LOG.error("Error while starting the TaskManager", t);
+					System.exit(TaskManager.STARTUP_FAILURE_RETURN_CODE());
+				}
+				return null;
+			}
+		};
+	}
+
+	public static void runYarnTaskManager(String[] args,
+																				final Class<? extends YarnTaskManager> taskManager,
+																				Map<String, String> envs,
+																				Callable<Object> mainRunner) throws IOException {
 		EnvironmentInformation.logEnvironmentInfo(LOG, "YARN TaskManager", args);
 		SignalHandler.register(LOG);
 		JvmShutdownSafeguard.installAsShutdownHook(LOG);
@@ -68,16 +90,12 @@ public class YarnTaskManagerRunner {
 		}
 
 		// read the environment variables for YARN
-		final Map<String, String> envs = System.getenv();
 		final String yarnClientUsername = envs.get(YarnConfigKeys.ENV_HADOOP_USER_NAME);
 		final String localDirs = envs.get(Environment.LOCAL_DIRS.key());
 		LOG.info("Current working/local Directory: {}", localDirs);
 
 		final String currDir = envs.get(Environment.PWD.key());
 		LOG.info("Current working Directory: {}", currDir);
-
-		final String remoteKeytabPath = envs.get(YarnConfigKeys.KEYTAB_PATH);
-		LOG.info("TM: remoteKeytabPath obtained {}", remoteKeytabPath);
 
 		final String remoteKeytabPrincipal = envs.get(YarnConfigKeys.KEYTAB_PRINCIPAL);
 		LOG.info("TM: remoteKeytabPrincipal obtained {}", remoteKeytabPrincipal);
@@ -96,13 +114,6 @@ public class YarnTaskManagerRunner {
 		// tell akka to die in case of an error
 		configuration.setBoolean(AkkaOptions.JVM_EXIT_ON_FATAL_ERROR, true);
 
-		String localKeytabPath = null;
-		if (remoteKeytabPath != null) {
-			File f = new File(currDir, Utils.KEYTAB_FILE_NAME);
-			localKeytabPath = f.getAbsolutePath();
-			LOG.info("localKeytabPath: {}", localKeytabPath);
-		}
-
 		UserGroupInformation currentUser = UserGroupInformation.getCurrentUser();
 
 		LOG.info("YARN daemon is running as: {} Yarn client user obtainer: {}",
@@ -113,9 +124,10 @@ public class YarnTaskManagerRunner {
 		final ResourceID resourceId = new ResourceID(containerID);
 		LOG.info("ResourceID assigned for this container: {}", resourceId);
 
-		// set keytab principal and replace path with the local path of the shipped keytab file in NodeManager
-		if (localKeytabPath != null && remoteKeytabPrincipal != null) {
-			configuration.setString(SecurityOptions.KERBEROS_LOGIN_KEYTAB, localKeytabPath);
+		File f = new File(currDir, Utils.KEYTAB_FILE_NAME);
+		if (remoteKeytabPrincipal != null && f.exists()) {
+			// set keytab principal and replace path with the local path of the shipped keytab file in NodeManager
+			configuration.setString(SecurityOptions.KERBEROS_LOGIN_KEYTAB, f.getAbsolutePath());
 			configuration.setString(SecurityOptions.KERBEROS_LOGIN_PRINCIPAL, remoteKeytabPrincipal);
 		}
 		try {
@@ -141,19 +153,10 @@ public class YarnTaskManagerRunner {
 
 			SecurityUtils.install(sc);
 
-			SecurityUtils.getInstalledContext().runSecured(new Callable<Object>() {
-				@Override
-				public Integer call() {
-					try {
-						TaskManager.selectNetworkInterfaceAndRunTaskManager(configuration, resourceId, taskManager);
-					}
-					catch (Throwable t) {
-						LOG.error("Error while starting the TaskManager", t);
-						System.exit(TaskManager.STARTUP_FAILURE_RETURN_CODE());
-					}
-					return null;
-				}
-			});
+			if (mainRunner == null) {
+				mainRunner = createMainRunner(configuration, resourceId, taskManager);
+			}
+			SecurityUtils.getInstalledContext().runSecured(mainRunner);
 		} catch (Exception e) {
 			LOG.error("Exception occurred while launching Task Manager", e);
 			throw new RuntimeException(e);

--- a/flink-yarn/src/main/scala/org/apache/flink/yarn/YarnTaskManager.scala
+++ b/flink-yarn/src/main/scala/org/apache/flink/yarn/YarnTaskManager.scala
@@ -62,7 +62,8 @@ class YarnTaskManager(
       * @param args The command line arguments.
       */
     def main(args: Array[String]): Unit = {
-      YarnTaskManagerRunner.runYarnTaskManager(args, classOf[YarnTaskManager])
+      YarnTaskManagerRunner.runYarnTaskManager(
+        args, classOf[YarnTaskManager], System.getenv(), null)
     }
 
 }

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnTaskManagerRunnerTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnTaskManagerRunnerTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.	See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.	The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.	You may obtain a copy of the License at
+ *
+ *		 http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.yarn;
+
+import org.apache.flink.runtime.security.SecurityUtils;
+import org.apache.flink.runtime.security.modules.HadoopModule;
+import org.apache.flink.runtime.security.modules.SecurityModule;
+
+import org.apache.hadoop.yarn.api.ApplicationConstants;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+
+/**
+ * Tests for {@link YarnTaskManagerRunner}.
+ */
+public class YarnTaskManagerRunnerTest {
+
+	@Test
+	public void testKerberosKeytabConfiguration() throws IOException {
+		final String resourceDirPath =
+				Paths.get("src", "test", "resources").toAbsolutePath().toString();
+		final Map<String, String> envs = new HashMap<>();
+		envs.put(YarnFlinkResourceManager.ENV_FLINK_CONTAINER_ID, "test_container_00001");
+		envs.put(YarnConfigKeys.KEYTAB_PRINCIPAL, "testuser1@domain");
+		envs.put(ApplicationConstants.Environment.PWD.key(), resourceDirPath);
+		YarnTaskManagerRunner.runYarnTaskManager(
+				new String[]{"--configDir", resourceDirPath},
+				YarnTaskManager.class,
+				envs,
+				new Callable<Object>() {
+					@Override
+					public Integer call() {
+						final List<SecurityModule> modules = SecurityUtils.getInstalledModules();
+						Optional<SecurityModule> moduleOpt =
+								modules.stream().filter(s -> s instanceof HadoopModule).findFirst();
+						if (moduleOpt.isPresent()) {
+							HadoopModule hadoopModule = (HadoopModule) moduleOpt.get();
+							assertEquals("testuser1@domain", hadoopModule.getSecurityConfig().getPrincipal());
+							assertEquals(resourceDirPath + "/krb5.keytab",
+									hadoopModule.getSecurityConfig().getKeytab());
+						} else {
+							fail("Can not find HadoopModule!");
+						}
+						return null;
+					}
+				});
+	}
+}

--- a/flink-yarn/src/test/resources/flink-conf.yaml
+++ b/flink-yarn/src/test/resources/flink-conf.yaml
@@ -1,0 +1,23 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+#
+# This is a test configuration for validation of YarnTaskManagerRunner.
+#
+
+taskmanager.tmp.dirs: /tmp

--- a/pom.xml
+++ b/pom.xml
@@ -1016,6 +1016,7 @@ under the License.
 						<exclude>flink-formats/flink-avro/src/test/resources/avro/*.avsc</exclude>
 						<exclude>out/test/flink-avro/avro/user.avsc</exclude>
 						<exclude>flink-libraries/flink-table/src/test/scala/resources/*.out</exclude>
+						<exclude>flink-yarn/src/test/resources/krb5.keytab</exclude>
 						<exclude>test-infra/end-to-end-test/test-data/*</exclude>
 
 						<!-- snapshots -->


### PR DESCRIPTION
## Brief change log

  - Set the local keytab path in YarnTaskManagerRunner to the correct local path.

## Verifying this change
  - Manually verified the change by running in a production secure cluser with 1 JobManager and 2 TaskManagers. Both the JobManager and the Taskmanagers can start, and verify through kerberos metrics.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
