### PR TITLE
[FLINK-8279][blob] fall back to TaskManager temp directories first

### DIFF
--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -203,6 +203,8 @@ will be used under the directory specified by jobmanager.web.tmpdir.
 - `high-availability.zookeeper.storageDir`: Required for HA. Directory for storing JobManager metadata; this is persisted in the state backend and only a pointer to this state is stored in ZooKeeper. Exactly like the checkpoint directory it must be accessible from the JobManager and a local filesystem should only be used for local deployments. Previously this key was named `recovery.zookeeper.storageDir`.
 
 - `blob.storage.directory`: Directory for storing blobs (such as user JARs) on the TaskManagers.
+If not set or empty, Flink will fall back to `taskmanager.tmp.dirs` and select one temp directory
+at random.
 
 - `blob.service.cleanup.interval`: Cleanup interval (in seconds) of transient blobs at server and caches as well as permanent blobs at the caches (DEFAULT: 1 hour).
 Whenever a job is not referenced at the cache anymore, we set a TTL for its permanent blob files and

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -209,7 +209,10 @@ public final class ConfigConstants {
 	/**
 	 * The config parameter defining the directories for temporary files, separated by
 	 * ",", "|", or the system's {@link java.io.File#pathSeparator}.
+	 *
+	 * @deprecated Use {@link CoreOptions#TMP_DIRS} instead
 	 */
+	@Deprecated
 	public static final String TASK_MANAGER_TMP_DIR_KEY = "taskmanager.tmp.dirs";
 
 	/**
@@ -1338,7 +1341,10 @@ public final class ConfigConstants {
 
 	/**
 	 * The default directory for temporary files of the task manager.
+	 *
+	 * @deprecated {@link CoreOptions#TMP_DIRS} provides the default value now
 	 */
+	@Deprecated
 	public static final String DEFAULT_TASK_MANAGER_TMP_PATH = System.getProperty("java.io.tmpdir");
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -207,7 +207,8 @@ public final class ConfigConstants {
 	public static final String TASK_MANAGER_DATA_SSL_ENABLED = "taskmanager.data.ssl.enabled";
 
 	/**
-	 * The config parameter defining the directories for temporary files.
+	 * The config parameter defining the directories for temporary files, separated by
+	 * ",", "|", or the system's {@link java.io.File#pathSeparator}.
 	 */
 	public static final String TASK_MANAGER_TMP_DIR_KEY = "taskmanager.tmp.dirs";
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
@@ -20,6 +20,8 @@ package org.apache.flink.configuration;
 
 import org.apache.flink.annotation.PublicEvolving;
 
+import static org.apache.flink.configuration.ConfigOptions.key;
+
 /**
  * The set of configuration options for core parameters.
  */
@@ -95,6 +97,19 @@ public class CoreOptions {
 	public static final ConfigOption<String> FLINK_TM_JVM_OPTIONS = ConfigOptions
 		.key("env.java.opts.taskmanager")
 		.defaultValue("");
+
+	// ------------------------------------------------------------------------
+	//  generic io
+	// ------------------------------------------------------------------------
+
+	/**
+	 * The config parameter defining the directories for temporary files, separated by
+	 * ",", "|", or the system's {@link java.io.File#pathSeparator}.
+	 */
+	public static final ConfigOption<String> TMP_DIRS =
+		key("io.tmp.dirs")
+			.defaultValue(System.getProperty("java.io.tmpdir"))
+			.withDeprecatedKeys("taskmanager.tmp.dirs");
 
 	// ------------------------------------------------------------------------
 	//  program

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosJobClusterEntrypoint.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosJobClusterEntrypoint.java
@@ -19,7 +19,6 @@
 package org.apache.flink.mesos.entrypoint;
 
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.mesos.runtime.clusterframework.MesosResourceManager;
 import org.apache.flink.mesos.runtime.clusterframework.MesosTaskManagerParameters;
@@ -218,7 +217,7 @@ public class MesosJobClusterEntrypoint extends JobClusterEntrypoint {
 		}
 
 		Configuration dynamicProperties = BootstrapTools.parseDynamicProperties(cmd);
-		Configuration configuration = GlobalConfiguration.loadConfigurationWithDynamicProperties(dynamicProperties);
+		Configuration configuration = MesosEntrypointUtils.loadConfiguration(dynamicProperties, LOG);
 
 		MesosJobClusterEntrypoint clusterEntrypoint = new MesosJobClusterEntrypoint(configuration, dynamicProperties);
 

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosSessionClusterEntrypoint.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosSessionClusterEntrypoint.java
@@ -19,7 +19,6 @@
 package org.apache.flink.mesos.entrypoint;
 
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.mesos.runtime.clusterframework.MesosResourceManager;
 import org.apache.flink.mesos.runtime.clusterframework.MesosTaskManagerParameters;
@@ -192,10 +191,11 @@ public class MesosSessionClusterEntrypoint extends SessionClusterEntrypoint {
 		}
 
 		Configuration dynamicProperties = BootstrapTools.parseDynamicProperties(cmd);
-		Configuration configuration = GlobalConfiguration.loadConfigurationWithDynamicProperties(dynamicProperties);
+		Configuration configuration = MesosEntrypointUtils.loadConfiguration(dynamicProperties, LOG);
 
 		MesosSessionClusterEntrypoint clusterEntrypoint = new MesosSessionClusterEntrypoint(configuration, dynamicProperties);
 
 		clusterEntrypoint.startCluster();
 	}
+
 }

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosTaskExecutorRunner.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosTaskExecutorRunner.java
@@ -20,8 +20,6 @@ package org.apache.flink.mesos.entrypoint;
 
 import org.apache.flink.configuration.AkkaOptions;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.CoreOptions;
-import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.mesos.runtime.clusterframework.MesosConfigKeys;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
@@ -76,7 +74,7 @@ public class MesosTaskExecutorRunner {
 			Configuration dynamicProperties = BootstrapTools.parseDynamicProperties(cmd);
 			LOG.debug("Mesos dynamic properties: {}", dynamicProperties);
 
-			configuration = GlobalConfiguration.loadConfigurationWithDynamicProperties(dynamicProperties);
+			configuration = MesosEntrypointUtils.loadConfiguration(dynamicProperties, LOG);
 		}
 		catch (Throwable t) {
 			LOG.error("Failed to load the TaskManager configuration and dynamic properties.", t);
@@ -84,19 +82,7 @@ public class MesosTaskExecutorRunner {
 			return;
 		}
 
-		// read the environment variables
 		final Map<String, String> envs = System.getenv();
-		final String tmpDirs = envs.get(MesosConfigKeys.ENV_FLINK_TMP_DIR);
-
-		// configure local directory
-		if (configuration.contains(CoreOptions.TMP_DIRS)) {
-			LOG.info("Overriding Mesos' temporary file directories with those " +
-				"specified in the Flink config: " + configuration.getValue(CoreOptions.TMP_DIRS));
-		}
-		else if (tmpDirs != null) {
-			LOG.info("Setting directories for temporary files to: {}", tmpDirs);
-			configuration.setString(CoreOptions.TMP_DIRS, tmpDirs);
-		}
 
 		// configure the filesystems
 		try {

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosTaskExecutorRunner.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosTaskExecutorRunner.java
@@ -19,8 +19,8 @@
 package org.apache.flink.mesos.entrypoint;
 
 import org.apache.flink.configuration.AkkaOptions;
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.mesos.runtime.clusterframework.MesosConfigKeys;
@@ -89,14 +89,13 @@ public class MesosTaskExecutorRunner {
 		final String tmpDirs = envs.get(MesosConfigKeys.ENV_FLINK_TMP_DIR);
 
 		// configure local directory
-		String flinkTempDirs = configuration.getString(ConfigConstants.TASK_MANAGER_TMP_DIR_KEY, null);
-		if (flinkTempDirs != null) {
-			LOG.info("Overriding Mesos temporary file directories with those " +
-				"specified in the Flink config: {}", flinkTempDirs);
+		if (configuration.contains(CoreOptions.TMP_DIRS)) {
+			LOG.info("Overriding Mesos' temporary file directories with those " +
+				"specified in the Flink config: " + configuration.getValue(CoreOptions.TMP_DIRS));
 		}
 		else if (tmpDirs != null) {
 			LOG.info("Setting directories for temporary files to: {}", tmpDirs);
-			configuration.setString(ConfigConstants.TASK_MANAGER_TMP_DIR_KEY, tmpDirs);
+			configuration.setString(CoreOptions.TMP_DIRS, tmpDirs);
 		}
 
 		// configure the filesystems

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosApplicationMasterRunner.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosApplicationMasterRunner.java
@@ -20,7 +20,6 @@ package org.apache.flink.mesos.runtime.clusterframework;
 
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.WebOptions;
 import org.apache.flink.core.fs.FileSystem;
@@ -157,7 +156,7 @@ public class MesosApplicationMasterRunner {
 			CommandLine cmd = parser.parse(ALL_OPTIONS, args);
 
 			final Configuration dynamicProperties = BootstrapTools.parseDynamicProperties(cmd);
-			final Configuration config = GlobalConfiguration.loadConfigurationWithDynamicProperties(dynamicProperties);
+			final Configuration config = MesosEntrypointUtils.loadConfiguration(dynamicProperties, LOG);
 
 			// configure the filesystems
 			try {

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerRunner.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerRunner.java
@@ -19,8 +19,8 @@
 package org.apache.flink.mesos.runtime.clusterframework;
 
 import org.apache.flink.configuration.AkkaOptions;
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
@@ -89,14 +89,13 @@ public class MesosTaskManagerRunner {
 		final String tmpDirs = envs.get(MesosConfigKeys.ENV_FLINK_TMP_DIR);
 
 		// configure local directory
-		String flinkTempDirs = configuration.getString(ConfigConstants.TASK_MANAGER_TMP_DIR_KEY, null);
-		if (flinkTempDirs != null) {
-			LOG.info("Overriding Mesos temporary file directories with those " +
-				"specified in the Flink config: {}", flinkTempDirs);
+		if (configuration.contains(CoreOptions.TMP_DIRS)) {
+			LOG.info("Overriding Mesos' temporary file directories with those " +
+				"specified in the Flink config: " + configuration.getValue(CoreOptions.TMP_DIRS));
 		}
 		else if (tmpDirs != null) {
 			LOG.info("Setting directories for temporary files to: {}", tmpDirs);
-			configuration.setString(ConfigConstants.TASK_MANAGER_TMP_DIR_KEY, tmpDirs);
+			configuration.setString(CoreOptions.TMP_DIRS, tmpDirs);
 		}
 
 		// configure the filesystems

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerRunner.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerRunner.java
@@ -20,9 +20,8 @@ package org.apache.flink.mesos.runtime.clusterframework;
 
 import org.apache.flink.configuration.AkkaOptions;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.CoreOptions;
-import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.mesos.entrypoint.MesosEntrypointUtils;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.security.SecurityConfiguration;
@@ -76,7 +75,7 @@ public class MesosTaskManagerRunner {
 			final Configuration dynamicProperties = BootstrapTools.parseDynamicProperties(cmd);
 			LOG.debug("Mesos dynamic properties: {}", dynamicProperties);
 
-			configuration = GlobalConfiguration.loadConfigurationWithDynamicProperties(dynamicProperties);
+			configuration = MesosEntrypointUtils.loadConfiguration(dynamicProperties, LOG);
 		}
 		catch (Throwable t) {
 			LOG.error("Failed to load the TaskManager configuration and dynamic properties.", t);
@@ -84,19 +83,7 @@ public class MesosTaskManagerRunner {
 			return;
 		}
 
-		// read the environment variables
 		final Map<String, String> envs = System.getenv();
-		final String tmpDirs = envs.get(MesosConfigKeys.ENV_FLINK_TMP_DIR);
-
-		// configure local directory
-		if (configuration.contains(CoreOptions.TMP_DIRS)) {
-			LOG.info("Overriding Mesos' temporary file directories with those " +
-				"specified in the Flink config: " + configuration.getValue(CoreOptions.TMP_DIRS));
-		}
-		else if (tmpDirs != null) {
-			LOG.info("Setting directories for temporary files to: {}", tmpDirs);
-			configuration.setString(CoreOptions.TMP_DIRS, tmpDirs);
-		}
 
 		// configure the filesystems
 		try {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/AbstractBlobCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/AbstractBlobCache.java
@@ -103,8 +103,7 @@ public abstract class AbstractBlobCache implements Closeable {
 		this.readWriteLock = new ReentrantReadWriteLock();
 
 		// configure and create the storage directory
-		String storageDirectory = blobClientConfig.getString(BlobServerOptions.STORAGE_DIRECTORY);
-		this.storageDir = BlobUtils.initLocalStorageDirectory(storageDirectory);
+		this.storageDir = BlobUtils.initLocalStorageDirectory(blobClientConfig);
 		log.info("Created BLOB cache storage directory " + storageDir);
 
 		// configure the number of fetch retries

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
@@ -139,8 +139,7 @@ public class BlobServer extends Thread implements BlobService, BlobWriter, Perma
 		this.readWriteLock = new ReentrantReadWriteLock();
 
 		// configure and create the storage directory
-		String storageDirectory = config.getString(BlobServerOptions.STORAGE_DIRECTORY);
-		this.storageDir = BlobUtils.initLocalStorageDirectory(storageDirectory);
+		this.storageDir = BlobUtils.initLocalStorageDirectory(config);
 		LOG.info("Created BLOB server storage directory {}", storageDir);
 
 		// configure the maximum number of concurrent connections

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobUtils.java
@@ -134,7 +134,7 @@ public class BlobUtils {
 	/**
 	 * Creates a local storage directory for a blob service under the configuration parameter given
 	 * by {@link BlobServerOptions#STORAGE_DIRECTORY}. If this is <tt>null</tt> or empty, we will
-	 * fall back to the TaskManager temp directories (given by
+	 * fall back to Flink's temp directories (given by
 	 * {@link org.apache.flink.configuration.CoreOptions#TMP_DIRS}) and choose one among them at
 	 * random.
 	 *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobUtils.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.blob;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.BlobServerOptions;
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.IllegalConfigurationException;
@@ -136,9 +135,8 @@ public class BlobUtils {
 	 * Creates a local storage directory for a blob service under the configuration parameter given
 	 * by {@link BlobServerOptions#STORAGE_DIRECTORY}. If this is <tt>null</tt> or empty, we will
 	 * fall back to the TaskManager temp directories (given by
-	 * {@link ConfigConstants#TASK_MANAGER_TMP_DIR_KEY}; which in turn falls back to
-	 * {@link ConfigConstants#DEFAULT_TASK_MANAGER_TMP_PATH} currently set to
-	 * <tt>java.io.tmpdir</tt>) and choose one among them at random.
+	 * {@link org.apache.flink.configuration.CoreOptions#TMP_DIRS}) and choose one among them at
+	 * random.
 	 *
 	 * @param config
 	 * 		Flink configuration

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerConfiguration.java
@@ -36,8 +36,6 @@ import org.slf4j.LoggerFactory;
 
 import scala.concurrent.duration.Duration;
 
-import java.io.File;
-
 /**
  * Configuration object for {@link TaskExecutor}.
  */
@@ -149,9 +147,7 @@ public class TaskManagerConfiguration implements TaskManagerRuntimeInfo {
 			numberSlots = 1;
 		}
 
-		final String[] tmpDirPaths = configuration.getString(
-			ConfigConstants.TASK_MANAGER_TMP_DIR_KEY,
-			ConfigConstants.DEFAULT_TASK_MANAGER_TMP_PATH).split(",|" + File.pathSeparator);
+		final String[] tmpDirPaths = TaskManagerServicesConfiguration.parseTempDirectories(configuration);
 
 		final Time timeout;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfiguration.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.taskexecutor;
 
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.QueryableStateOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
@@ -436,15 +437,13 @@ public class TaskManagerServicesConfiguration {
 
 	/**
 	 * Extracts the task manager directories for temporary files as defined by
-	 * {@link ConfigConstants#TASK_MANAGER_TMP_DIR_KEY}.
+	 * {@link org.apache.flink.configuration.CoreOptions#TMP_DIRS}.
 	 *
 	 * @param configuration configuration object
 	 * @return array of configured directories (in order)
 	 */
 	public static String[] parseTempDirectories(Configuration configuration) {
-		return configuration.getString(
-			ConfigConstants.TASK_MANAGER_TMP_DIR_KEY,
-			ConfigConstants.DEFAULT_TASK_MANAGER_TMP_PATH).split(",|" + File.pathSeparator);
+		return configuration.getString(CoreOptions.TMP_DIRS).split(",|" + File.pathSeparator);
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfiguration.java
@@ -184,9 +184,7 @@ public class TaskManagerServicesConfiguration {
 			slots = 1;
 		}
 
-		final String[] tmpDirs = configuration.getString(
-			ConfigConstants.TASK_MANAGER_TMP_DIR_KEY,
-			ConfigConstants.DEFAULT_TASK_MANAGER_TMP_PATH).split(",|" + File.pathSeparator);
+		final String[] tmpDirs = parseTempDirectories(configuration);
 
 		final NetworkEnvironmentConfiguration networkConfig = parseNetworkEnvironmentConfiguration(
 			configuration,
@@ -434,6 +432,19 @@ public class TaskManagerServicesConfiguration {
 				numProxyServerQueryThreads,
 				numStateServerNetworkThreads,
 				numStateServerQueryThreads);
+	}
+
+	/**
+	 * Extracts the task manager directories for temporary files as defined by
+	 * {@link ConfigConstants#TASK_MANAGER_TMP_DIR_KEY}.
+	 *
+	 * @param configuration configuration object
+	 * @return array of configured directories (in order)
+	 */
+	public static String[] parseTempDirectories(Configuration configuration) {
+		return configuration.getString(
+			ConfigConstants.TASK_MANAGER_TMP_DIR_KEY,
+			ConfigConstants.DEFAULT_TASK_MANAGER_TMP_PATH).split(",|" + File.pathSeparator);
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobUtilsNonWritableTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobUtilsNonWritableTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.blob;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.BlobServerOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.OperatingSystem;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+
+/**
+ * Tests for {@link BlobUtils} working on non-writable directories.
+ */
+public class BlobUtilsNonWritableTest extends TestLogger {
+
+	private static final String CANNOT_CREATE_THIS = "cannot-create-this";
+
+	private File blobUtilsTestDirectory;
+
+	@Rule
+	public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	@Before
+	public void before() throws IOException {
+		assumeTrue(!OperatingSystem.isWindows()); //setWritable doesn't work on Windows.
+
+		// Prepare test directory
+		blobUtilsTestDirectory = temporaryFolder.newFolder();
+		assertTrue(blobUtilsTestDirectory.setExecutable(true, false));
+		assertTrue(blobUtilsTestDirectory.setReadable(true, false));
+		assertTrue(blobUtilsTestDirectory.setWritable(false, false));
+	}
+
+	@After
+	public void after() {
+		// Cleanup test directory, ensure it was empty
+		assertTrue(blobUtilsTestDirectory.delete());
+	}
+
+	@Test(expected = IOException.class)
+	public void testExceptionOnCreateStorageDirectoryFailure() throws IOException {
+		Configuration config = new Configuration();
+		config.setString(BlobServerOptions.STORAGE_DIRECTORY,
+			new File(blobUtilsTestDirectory, CANNOT_CREATE_THIS).getAbsolutePath());
+		// Should throw an Exception
+		BlobUtils.initLocalStorageDirectory(config);
+	}
+
+	@Test(expected = IOException.class)
+	public void testExceptionOnCreateCacheDirectoryFailureNoJob() throws IOException {
+		// Should throw an Exception
+		BlobUtils.getStorageLocation(new File(blobUtilsTestDirectory, CANNOT_CREATE_THIS), null, new TransientBlobKey());
+	}
+
+	@Test(expected = IOException.class)
+	public void testExceptionOnCreateCacheDirectoryFailureForJobTransient() throws IOException {
+		// Should throw an Exception
+		BlobUtils.getStorageLocation(new File(blobUtilsTestDirectory, CANNOT_CREATE_THIS), new JobID(), new TransientBlobKey());
+	}
+
+	@Test(expected = IOException.class)
+	public void testExceptionOnCreateCacheDirectoryFailureForJobPermanent() throws IOException {
+		// Should throw an Exception
+		BlobUtils.getStorageLocation(new File(blobUtilsTestDirectory, CANNOT_CREATE_THIS), new JobID(), new PermanentBlobKey());
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobUtilsTest.java
@@ -18,12 +18,10 @@
 
 package org.apache.flink.runtime.blob;
 
-import org.apache.flink.api.common.JobID;
-import org.apache.flink.util.OperatingSystem;
-import org.apache.flink.util.TestLogger;
+import org.apache.flink.configuration.BlobServerOptions;
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
 
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -31,60 +29,87 @@ import org.junit.rules.TemporaryFolder;
 import java.io.File;
 import java.io.IOException;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeTrue;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Tests for {@link BlobUtils}.
  */
-public class BlobUtilsTest extends TestLogger {
-
-	private static final String CANNOT_CREATE_THIS = "cannot-create-this";
-
-	private File blobUtilsTestDirectory;
+public class BlobUtilsTest {
 
 	@Rule
 	public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
-	@Before
-	public void before() throws IOException {
-		assumeTrue(!OperatingSystem.isWindows()); //setWritable doesn't work on Windows.
+	/**
+	 * Tests {@link BlobUtils#initLocalStorageDirectory} using
+	 * {@link BlobServerOptions#STORAGE_DIRECTORY} per default.
+	 */
+	@Test
+	public void testDefaultBlobStorageDirectory() throws IOException {
+		Configuration config = new Configuration();
+		String blobStorageDir = temporaryFolder.newFolder().getAbsolutePath();
+		config.setString(BlobServerOptions.STORAGE_DIRECTORY, blobStorageDir);
+		config.setString(ConfigConstants.TASK_MANAGER_TMP_DIR_KEY,
+			temporaryFolder.newFolder().getAbsolutePath());
 
-		// Prepare test directory
-		blobUtilsTestDirectory = temporaryFolder.newFolder();
-		assertTrue(blobUtilsTestDirectory.setExecutable(true, false));
-		assertTrue(blobUtilsTestDirectory.setReadable(true, false));
-		assertTrue(blobUtilsTestDirectory.setWritable(false, false));
+		File dir = BlobUtils.initLocalStorageDirectory(config);
+		assertThat(dir.getAbsolutePath(), startsWith(blobStorageDir));
 	}
 
-	@After
-	public void after() {
-		// Cleanup test directory, ensure it was empty
-		assertTrue(blobUtilsTestDirectory.delete());
+	/**
+	 * Tests {@link BlobUtils#initLocalStorageDirectory}'s fallback to
+	 * {@link ConfigConstants#TASK_MANAGER_TMP_DIR_KEY} with a single temp directory.
+	 */
+	@Test
+	public void testTaskManagerFallbackBlobStorageDirectory1() throws IOException {
+		Configuration config = new Configuration();
+		String blobStorageDir = temporaryFolder.getRoot().getAbsolutePath();
+		config.setString(ConfigConstants.TASK_MANAGER_TMP_DIR_KEY, blobStorageDir);
+
+		File dir = BlobUtils.initLocalStorageDirectory(config);
+		assertThat(dir.getAbsolutePath(), startsWith(blobStorageDir));
 	}
 
-	@Test(expected = IOException.class)
-	public void testExceptionOnCreateStorageDirectoryFailure() throws
-		IOException {
-		// Should throw an Exception
-		BlobUtils.initLocalStorageDirectory(new File(blobUtilsTestDirectory, CANNOT_CREATE_THIS).getAbsolutePath());
+	/**
+	 * Tests {@link BlobUtils#initLocalStorageDirectory}'s fallback to
+	 * {@link ConfigConstants#TASK_MANAGER_TMP_DIR_KEY} having multiple temp directories.
+	 */
+	@Test
+	public void testTaskManagerFallbackBlobStorageDirectory2a() throws IOException {
+		Configuration config = new Configuration();
+		String blobStorageDirs = temporaryFolder.newFolder().getAbsolutePath() + "," +
+			temporaryFolder.newFolder().getAbsolutePath();
+		config.setString(ConfigConstants.TASK_MANAGER_TMP_DIR_KEY, blobStorageDirs);
+
+		File dir = BlobUtils.initLocalStorageDirectory(config);
+		assertThat(dir.getAbsolutePath(), startsWith(temporaryFolder.getRoot().getAbsolutePath()));
 	}
 
-	@Test(expected = IOException.class)
-	public void testExceptionOnCreateCacheDirectoryFailureNoJob() throws IOException {
-		// Should throw an Exception
-		BlobUtils.getStorageLocation(new File(blobUtilsTestDirectory, CANNOT_CREATE_THIS), null, new TransientBlobKey());
+	/**
+	 * Tests {@link BlobUtils#initLocalStorageDirectory}'s fallback to
+	 * {@link ConfigConstants#TASK_MANAGER_TMP_DIR_KEY} having multiple temp directories.
+	 */
+	@Test
+	public void testTaskManagerFallbackBlobStorageDirectory2b() throws IOException {
+		Configuration config = new Configuration();
+		String blobStorageDirs = temporaryFolder.newFolder().getAbsolutePath() + File.pathSeparator +
+			temporaryFolder.newFolder().getAbsolutePath();
+		config.setString(ConfigConstants.TASK_MANAGER_TMP_DIR_KEY, blobStorageDirs);
+
+		File dir = BlobUtils.initLocalStorageDirectory(config);
+		assertThat(dir.getAbsolutePath(), startsWith(temporaryFolder.getRoot().getAbsolutePath()));
 	}
 
-	@Test(expected = IOException.class)
-	public void testExceptionOnCreateCacheDirectoryFailureForJobTransient() throws IOException {
-		// Should throw an Exception
-		BlobUtils.getStorageLocation(new File(blobUtilsTestDirectory, CANNOT_CREATE_THIS), new JobID(), new TransientBlobKey());
-	}
+	/**
+	 * Tests {@link BlobUtils#initLocalStorageDirectory}'s fallback to
+	 * {@link ConfigConstants#DEFAULT_TASK_MANAGER_TMP_PATH}.
+	 */
+	@Test
+	public void testTaskManagerFallbackFallbackBlobStorageDirectory1() throws IOException {
+		Configuration config = new Configuration();
 
-	@Test(expected = IOException.class)
-	public void testExceptionOnCreateCacheDirectoryFailureForJobPermanent() throws IOException {
-		// Should throw an Exception
-		BlobUtils.getStorageLocation(new File(blobUtilsTestDirectory, CANNOT_CREATE_THIS), new JobID(), new PermanentBlobKey());
+		File dir = BlobUtils.initLocalStorageDirectory(config);
+		assertThat(dir.getAbsolutePath(),
+			startsWith(ConfigConstants.DEFAULT_TASK_MANAGER_TMP_PATH));
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobUtilsTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.blob;
 import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -49,8 +50,7 @@ public class BlobUtilsTest {
 		Configuration config = new Configuration();
 		String blobStorageDir = temporaryFolder.newFolder().getAbsolutePath();
 		config.setString(BlobServerOptions.STORAGE_DIRECTORY, blobStorageDir);
-		config.setString(ConfigConstants.TASK_MANAGER_TMP_DIR_KEY,
-			temporaryFolder.newFolder().getAbsolutePath());
+		config.setString(CoreOptions.TMP_DIRS, temporaryFolder.newFolder().getAbsolutePath());
 
 		File dir = BlobUtils.initLocalStorageDirectory(config);
 		assertThat(dir.getAbsolutePath(), startsWith(blobStorageDir));
@@ -58,13 +58,13 @@ public class BlobUtilsTest {
 
 	/**
 	 * Tests {@link BlobUtils#initLocalStorageDirectory}'s fallback to
-	 * {@link ConfigConstants#TASK_MANAGER_TMP_DIR_KEY} with a single temp directory.
+	 * {@link CoreOptions#TMP_DIRS} with a single temp directory.
 	 */
 	@Test
 	public void testTaskManagerFallbackBlobStorageDirectory1() throws IOException {
 		Configuration config = new Configuration();
 		String blobStorageDir = temporaryFolder.getRoot().getAbsolutePath();
-		config.setString(ConfigConstants.TASK_MANAGER_TMP_DIR_KEY, blobStorageDir);
+		config.setString(CoreOptions.TMP_DIRS, blobStorageDir);
 
 		File dir = BlobUtils.initLocalStorageDirectory(config);
 		assertThat(dir.getAbsolutePath(), startsWith(blobStorageDir));
@@ -72,14 +72,14 @@ public class BlobUtilsTest {
 
 	/**
 	 * Tests {@link BlobUtils#initLocalStorageDirectory}'s fallback to
-	 * {@link ConfigConstants#TASK_MANAGER_TMP_DIR_KEY} having multiple temp directories.
+	 * {@link CoreOptions#TMP_DIRS} having multiple temp directories.
 	 */
 	@Test
 	public void testTaskManagerFallbackBlobStorageDirectory2a() throws IOException {
 		Configuration config = new Configuration();
 		String blobStorageDirs = temporaryFolder.newFolder().getAbsolutePath() + "," +
 			temporaryFolder.newFolder().getAbsolutePath();
-		config.setString(ConfigConstants.TASK_MANAGER_TMP_DIR_KEY, blobStorageDirs);
+		config.setString(CoreOptions.TMP_DIRS, blobStorageDirs);
 
 		File dir = BlobUtils.initLocalStorageDirectory(config);
 		assertThat(dir.getAbsolutePath(), startsWith(temporaryFolder.getRoot().getAbsolutePath()));
@@ -87,22 +87,22 @@ public class BlobUtilsTest {
 
 	/**
 	 * Tests {@link BlobUtils#initLocalStorageDirectory}'s fallback to
-	 * {@link ConfigConstants#TASK_MANAGER_TMP_DIR_KEY} having multiple temp directories.
+	 * {@link CoreOptions#TMP_DIRS} having multiple temp directories.
 	 */
 	@Test
 	public void testTaskManagerFallbackBlobStorageDirectory2b() throws IOException {
 		Configuration config = new Configuration();
 		String blobStorageDirs = temporaryFolder.newFolder().getAbsolutePath() + File.pathSeparator +
 			temporaryFolder.newFolder().getAbsolutePath();
-		config.setString(ConfigConstants.TASK_MANAGER_TMP_DIR_KEY, blobStorageDirs);
+		config.setString(CoreOptions.TMP_DIRS, blobStorageDirs);
 
 		File dir = BlobUtils.initLocalStorageDirectory(config);
 		assertThat(dir.getAbsolutePath(), startsWith(temporaryFolder.getRoot().getAbsolutePath()));
 	}
 
 	/**
-	 * Tests {@link BlobUtils#initLocalStorageDirectory}'s fallback to
-	 * {@link ConfigConstants#DEFAULT_TASK_MANAGER_TMP_PATH}.
+	 * Tests {@link BlobUtils#initLocalStorageDirectory}'s fallback to the default value of
+	 * {@link CoreOptions#TMP_DIRS}.
 	 */
 	@Test
 	public void testTaskManagerFallbackFallbackBlobStorageDirectory1() throws IOException {
@@ -110,6 +110,6 @@ public class BlobUtilsTest {
 
 		File dir = BlobUtils.initLocalStorageDirectory(config);
 		assertThat(dir.getAbsolutePath(),
-			startsWith(ConfigConstants.DEFAULT_TASK_MANAGER_TMP_PATH));
+			startsWith(CoreOptions.TMP_DIRS.defaultValue()));
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerComponentsStartupShutdownTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerComponentsStartupShutdownTest.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.taskmanager;
 
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.AkkaOptions;
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.memory.MemoryType;
 import org.apache.flink.runtime.akka.AkkaUtils;
@@ -46,6 +45,7 @@ import org.apache.flink.runtime.metrics.NoOpMetricRegistry;
 import org.apache.flink.runtime.metrics.groups.TaskManagerMetricGroup;
 import org.apache.flink.runtime.query.KvStateRegistry;
 import org.apache.flink.runtime.taskexecutor.TaskManagerConfiguration;
+import org.apache.flink.runtime.taskexecutor.TaskManagerServicesConfiguration;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.util.TestLogger;
 
@@ -73,7 +73,6 @@ public class TaskManagerComponentsStartupShutdownTest extends TestLogger {
 	@Test
 	public void testComponentsStartupShutdown() throws Exception {
 
-		final String[] TMP_DIR = new String[] { ConfigConstants.DEFAULT_TASK_MANAGER_TMP_PATH };
 		final Time timeout = Time.seconds(100);
 		final int BUFFER_SIZE = 32 * 1024;
 
@@ -81,6 +80,8 @@ public class TaskManagerComponentsStartupShutdownTest extends TestLogger {
 		config.setString(AkkaOptions.WATCH_HEARTBEAT_INTERVAL, "200 ms");
 		config.setString(AkkaOptions.WATCH_HEARTBEAT_PAUSE, "1 s");
 		config.setInteger(AkkaOptions.WATCH_THRESHOLD, 1);
+
+		final String[] TMP_DIR = TaskManagerServicesConfiguration.parseTempDirectories(config);
 
 		ActorSystem actorSystem = null;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerStartupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerStartupTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.*;
 import org.apache.commons.io.FileUtils;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
@@ -142,7 +143,7 @@ public class TaskManagerStartupTest extends TestLogger {
 
 		try {
 			Configuration cfg = new Configuration();
-			cfg.setString(ConfigConstants.TASK_MANAGER_TMP_DIR_KEY, nonWritable.getAbsolutePath());
+			cfg.setString(CoreOptions.TMP_DIRS, nonWritable.getAbsolutePath());
 			cfg.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, 4L);
 			cfg.setString(JobManagerOptions.ADDRESS, "localhost");
 			cfg.setInteger(JobManagerOptions.PORT, 21656);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerStartupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerStartupTest.java
@@ -36,8 +36,12 @@ import org.apache.flink.util.NetUtils;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.After;
+import org.junit.Assume;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
 import scala.Option;
 
 import java.io.File;
@@ -47,13 +51,14 @@ import java.net.BindException;
 import java.net.ServerSocket;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 
 /**
  * Tests that check how the TaskManager behaves when encountering startup
  * problems.
  */
 public class TaskManagerStartupTest extends TestLogger {
+	@Rule
+	public TemporaryFolder tempFolder = new TemporaryFolder();
 
 	private HighAvailabilityServices highAvailabilityServices;
 
@@ -131,13 +136,9 @@ public class TaskManagerStartupTest extends TestLogger {
 	 */
 	@Test
 	public void testIODirectoryNotWritable() throws Exception {
-		File tempDir = new File(ConfigConstants.DEFAULT_TASK_MANAGER_TMP_PATH);
-		File nonWritable = new File(tempDir, UUID.randomUUID().toString());
-
-		if (!nonWritable.mkdirs() || !nonWritable.setWritable(false, false)) {
-			System.err.println("Cannot create non-writable temporary file directory. Skipping test.");
-			return;
-		}
+		File nonWritable = tempFolder.newFolder();
+		Assume.assumeTrue("Cannot create non-writable temporary file directory. Skipping test.",
+			nonWritable.setWritable(false, false));
 
 		try {
 			Configuration cfg = new Configuration();

--- a/flink-tests/src/test/java/org/apache/flink/test/optimizer/jsonplan/JsonJobGraphGenerationTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/optimizer/jsonplan/JsonJobGraphGenerationTest.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.ExecutionEnvironmentFactory;
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.examples.java.clustering.KMeans;
 import org.apache.flink.examples.java.graph.ConnectedComponents;
@@ -42,7 +41,9 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.Arra
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.OutputStream;
 import java.io.PrintStream;
@@ -59,6 +60,8 @@ import static org.junit.Assert.fail;
  * Test job graph generation in JSON format.
  */
 public class JsonJobGraphGenerationTest {
+	@Rule
+	public TemporaryFolder tempFolder = new TemporaryFolder();
 
 	private PrintStream out;
 	private PrintStream err;
@@ -106,7 +109,7 @@ public class JsonJobGraphGenerationTest {
 				JsonValidator validator = new GenericValidator(parallelism, 3);
 				TestingExecutionEnvironment.setAsNext(validator, parallelism);
 
-				String tmpDir = ConfigConstants.DEFAULT_TASK_MANAGER_TMP_PATH;
+				String tmpDir = tempFolder.newFolder().getAbsolutePath();
 				WordCount.main(new String[] {
 						"--input", tmpDir,
 						"--output", tmpDir});
@@ -139,7 +142,7 @@ public class JsonJobGraphGenerationTest {
 				JsonValidator validator = new GenericValidator(parallelism, 6);
 				TestingExecutionEnvironment.setAsNext(validator, parallelism);
 
-				String tmpDir = ConfigConstants.DEFAULT_TASK_MANAGER_TMP_PATH;
+				String tmpDir = tempFolder.newFolder().getAbsolutePath();
 				WebLogAnalysis.main(new String[] {
 						"--documents", tmpDir,
 						"--ranks", tmpDir,
@@ -174,7 +177,7 @@ public class JsonJobGraphGenerationTest {
 				JsonValidator validator = new GenericValidator(parallelism, 9);
 				TestingExecutionEnvironment.setAsNext(validator, parallelism);
 
-				String tmpDir = ConfigConstants.DEFAULT_TASK_MANAGER_TMP_PATH;
+				String tmpDir = tempFolder.newFolder().getAbsolutePath();
 				KMeans.main(new String[] {
 					"--points", tmpDir,
 					"--centroids", tmpDir,
@@ -210,7 +213,7 @@ public class JsonJobGraphGenerationTest {
 				JsonValidator validator = new GenericValidator(parallelism, 9);
 				TestingExecutionEnvironment.setAsNext(validator, parallelism);
 
-				String tmpDir = ConfigConstants.DEFAULT_TASK_MANAGER_TMP_PATH;
+				String tmpDir = tempFolder.newFolder().getAbsolutePath();
 				ConnectedComponents.main(
 						"--vertices", tmpDir,
 						"--edges", tmpDir,

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/TaskManagerProcessFailureStreamingRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/TaskManagerProcessFailureStreamingRecoveryITCase.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.functions.RichMapFunction;
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.state.filesystem.FsStateBackend;
 import org.apache.flink.streaming.api.checkpoint.ListCheckpointed;
@@ -33,14 +32,13 @@ import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunctio
 
 import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
-import java.util.UUID;
-
-import static org.junit.Assert.assertTrue;
 
 /**
  * Test for streaming program behaviour in case of TaskManager failure
@@ -57,16 +55,15 @@ import static org.junit.Assert.assertTrue;
  */
 @SuppressWarnings("serial")
 public class TaskManagerProcessFailureStreamingRecoveryITCase extends AbstractTaskManagerProcessFailureRecoveryTest {
+	@Rule
+	public TemporaryFolder tempFolder = new TemporaryFolder();
 
 	private static final int DATA_COUNT = 10000;
 
 	@Override
 	public void testTaskManagerFailure(int jobManagerPort, final File coordinateDir) throws Exception {
 
-		final File tempCheckpointDir = new File(new File(ConfigConstants.DEFAULT_TASK_MANAGER_TMP_PATH),
-				UUID.randomUUID().toString());
-
-		assertTrue("Cannot create directory for checkpoints", tempCheckpointDir.mkdirs());
+		final File tempCheckpointDir = tempFolder.newFolder();
 
 		StreamExecutionEnvironment env = StreamExecutionEnvironment
 				.createRemoteEnvironment("localhost", jobManagerPort);

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnApplicationMasterRunner.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnApplicationMasterRunner.java
@@ -21,6 +21,7 @@ package org.apache.flink.yarn;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.JobManagerOptions;
@@ -168,7 +169,7 @@ public class YarnApplicationMasterRunner {
 				FlinkYarnSessionCli.getDynamicProperties(ENV.get(YarnConfigKeys.ENV_DYNAMIC_PROPERTIES));
 			LOG.debug("YARN dynamic properties: {}", dynamicProperties);
 
-			final Configuration flinkConfig = createConfiguration(currDir, dynamicProperties);
+			final Configuration flinkConfig = createConfiguration(currDir, dynamicProperties, LOG);
 
 			// set keytab principal and replace path with the local path of the shipped keytab file in NodeManager
 			if (keytabPath != null && remoteKeytabPrincipal != null) {
@@ -512,11 +513,12 @@ public class YarnApplicationMasterRunner {
 	 *
 	 * @param baseDirectory directory to load the configuration from
 	 * @param additional additional parameters to be included in the configuration
+	 * @param log logger instance
 	 *
 	 * @return The configuration to be used by the TaskManagers.
 	 */
 	@SuppressWarnings("deprecation")
-	private static Configuration createConfiguration(String baseDirectory, Map<String, String> additional) {
+	private static Configuration createConfiguration(String baseDirectory, Map<String, String> additional, Logger log) {
 		LOG.info("Loading config from directory " + baseDirectory);
 
 		Configuration configuration = GlobalConfiguration.loadConfiguration(baseDirectory);
@@ -548,6 +550,17 @@ public class YarnApplicationMasterRunner {
 		BootstrapTools.substituteDeprecatedConfigPrefix(configuration,
 			ConfigConstants.YARN_TASK_MANAGER_ENV_PREFIX,
 			ResourceManagerOptions.CONTAINERIZED_TASK_MANAGER_ENV_PREFIX);
+
+		// configure local directory
+		if (configuration.contains(CoreOptions.TMP_DIRS)) {
+			log.info("Overriding YARN's temporary file directories with those " +
+				"specified in the Flink config: " + configuration.getValue(CoreOptions.TMP_DIRS));
+		}
+		else {
+			final String localDirs = ENV.get(Environment.LOCAL_DIRS.key());
+			log.info("Setting directories for temporary files to: {}", localDirs);
+			configuration.setString(CoreOptions.TMP_DIRS, localDirs);
+		}
 
 		return configuration;
 	}

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnTaskExecutorRunner.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnTaskExecutorRunner.java
@@ -21,6 +21,7 @@ package org.apache.flink.yarn;
 import org.apache.flink.configuration.AkkaOptions;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.core.fs.FileSystem;
@@ -103,14 +104,13 @@ public class YarnTaskExecutorRunner {
 			FileSystem.initialize(configuration);
 
 			// configure local directory
-			String flinkTempDirs = configuration.getString(ConfigConstants.TASK_MANAGER_TMP_DIR_KEY, null);
-			if (flinkTempDirs == null) {
-				LOG.info("Setting directories for temporary file " + localDirs);
-				configuration.setString(ConfigConstants.TASK_MANAGER_TMP_DIR_KEY, localDirs);
+			if (configuration.contains(CoreOptions.TMP_DIRS)) {
+				LOG.info("Overriding YARN's temporary file directories with those " +
+					"specified in the Flink config: " + configuration.getValue(CoreOptions.TMP_DIRS));
 			}
 			else {
-				LOG.info("Overriding YARN's temporary file directories with those " +
-						"specified in the Flink config: " + flinkTempDirs);
+				LOG.info("Setting directories for temporary files to: {}", localDirs);
+				configuration.setString(CoreOptions.TMP_DIRS, localDirs);
 			}
 
 			// tell akka to die in case of an error

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnTaskManagerRunner.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnTaskManagerRunner.java
@@ -19,8 +19,8 @@
 package org.apache.flink.yarn;
 
 import org.apache.flink.configuration.AkkaOptions;
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.security.SecurityConfiguration;
@@ -83,14 +83,13 @@ public class YarnTaskManagerRunner {
 		LOG.info("TM: remoteKeytabPrincipal obtained {}", remoteKeytabPrincipal);
 
 		// configure local directory
-		String flinkTempDirs = configuration.getString(ConfigConstants.TASK_MANAGER_TMP_DIR_KEY, null);
-		if (flinkTempDirs == null) {
-			LOG.info("Setting directories for temporary file " + localDirs);
-			configuration.setString(ConfigConstants.TASK_MANAGER_TMP_DIR_KEY, localDirs);
+		if (configuration.contains(CoreOptions.TMP_DIRS)) {
+			LOG.info("Overriding YARN's temporary file directories with those " +
+				"specified in the Flink config: " + configuration.getValue(CoreOptions.TMP_DIRS));
 		}
 		else {
-			LOG.info("Overriding YARN's temporary file directories with those " +
-				"specified in the Flink config: " + flinkTempDirs);
+			LOG.info("Setting directories for temporary files to: {}", localDirs);
+			configuration.setString(CoreOptions.TMP_DIRS, localDirs);
 		}
 
 		// tell akka to die in case of an error

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnEntrypointUtils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnEntrypointUtils.java
@@ -20,6 +20,7 @@ package org.apache.flink.yarn.entrypoint;
 
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.JobManagerOptions;
@@ -76,7 +77,7 @@ public class YarnEntrypointUtils {
 		return SecurityUtils.getInstalledContext();
 	}
 
-	public static Configuration loadConfiguration(String workingDirectory, Map<String, String> env) {
+	public static Configuration loadConfiguration(String workingDirectory, Map<String, String> env, Logger log) {
 		Configuration configuration = GlobalConfiguration.loadConfiguration(workingDirectory);
 
 		final String remoteKeytabPrincipal = env.get(YarnConfigKeys.KEYTAB_PRINCIPAL);
@@ -136,6 +137,17 @@ public class YarnEntrypointUtils {
 		if (keytabPath != null && remoteKeytabPrincipal != null) {
 			configuration.setString(SecurityOptions.KERBEROS_LOGIN_KEYTAB, keytabPath);
 			configuration.setString(SecurityOptions.KERBEROS_LOGIN_PRINCIPAL, remoteKeytabPrincipal);
+		}
+
+		// configure local directory
+		if (configuration.contains(CoreOptions.TMP_DIRS)) {
+			log.info("Overriding YARN's temporary file directories with those " +
+				"specified in the Flink config: " + configuration.getValue(CoreOptions.TMP_DIRS));
+		}
+		else {
+			final String localDirs = env.get(ApplicationConstants.Environment.LOCAL_DIRS.key());
+			log.info("Setting directories for temporary files to: {}", localDirs);
+			configuration.setString(CoreOptions.TMP_DIRS, localDirs);
 		}
 
 		return configuration;

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnJobClusterEntrypoint.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnJobClusterEntrypoint.java
@@ -142,7 +142,7 @@ public class YarnJobClusterEntrypoint extends JobClusterEntrypoint {
 			LOG.warn("Could not log YARN environment information.", e);
 		}
 
-		Configuration configuration = YarnEntrypointUtils.loadConfiguration(workingDirectory, env);
+		Configuration configuration = YarnEntrypointUtils.loadConfiguration(workingDirectory, env, LOG);
 
 		YarnJobClusterEntrypoint yarnJobClusterEntrypoint = new YarnJobClusterEntrypoint(
 			configuration,

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnSessionClusterEntrypoint.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnSessionClusterEntrypoint.java
@@ -116,7 +116,7 @@ public class YarnSessionClusterEntrypoint extends SessionClusterEntrypoint {
 			LOG.warn("Could not log YARN environment information.", e);
 		}
 
-		Configuration configuration = YarnEntrypointUtils.loadConfiguration(workingDirectory, env);
+		Configuration configuration = YarnEntrypointUtils.loadConfiguration(workingDirectory, env, LOG);
 
 		YarnSessionClusterEntrypoint yarnSessionClusterEntrypoint = new YarnSessionClusterEntrypoint(
 			configuration,


### PR DESCRIPTION
## What is the purpose of the change

Instead of falling back to `java.io.tmpdir` directly, the BLOB server and cache processes should fall back to the TaskManager temp directories (given by `ConfigConstants#TASK_MANAGER_TMP_DIR_KEY}` directly, before falling back
to `ConfigConstants#DEFAULT_TASK_MANAGER_TMP_PATH` (set to `java.io.tmpdir`).

In a Mesos/YARN environment, this means that we will use the designated temp directories for our jobs instead of the system-wide `java.io.tmpdir`. These directories may also offer some more space.

## Brief change log

- change `BlobUtils#initLocalStorageDirectory()` storage directory initialisation to use temporary directories in this order (and fall back to the next if not available):
  - `BlobServerOptions.STORAGE_DIRECTORY`
  - `ConfigConstants.TASK_MANAGER_TMP_DIR_KEY` (and randomly select one among them)
  - `ConfigConstants.DEFAULT_TASK_MANAGER_TMP_PATH`

## Verifying this change

This change added tests and can be verified as follows:

- added tests verifying the fallbacks

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **Docs, JavaDocs**
