### PR TITLE
[FLINK-8278] [doc] Fix the private member init problem for Scala examples in docs

### DIFF
--- a/docs/dev/stream/state/state.md
+++ b/docs/dev/stream/state/state.md
@@ -397,7 +397,7 @@ class BufferingSink(threshold: Int = 0)
     with CheckpointedRestoring[List[(String, Int)]] {
 
   @transient
-  private var checkpointedState: ListState[(String, Int)] = null
+  private var checkpointedState: ListState[(String, Int)] = _
 
   private val bufferedElements = ListBuffer[(String, Int)]()
 

--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -69,7 +69,7 @@ public class MyMapper extends RichMapFunction<String, String> {
 {% highlight scala %}
 
 class MyMapper extends RichMapFunction[String,String] {
-  @transient private var counter: Counter
+  @transient private var counter: Counter = _
 
   override def open(parameters: Configuration): Unit = {
     counter = getRuntimeContext()
@@ -119,7 +119,7 @@ public class MyMapper extends RichMapFunction<String, String> {
 {% highlight scala %}
 
 class MyMapper extends RichMapFunction[String,String] {
-  @transient private var counter: Counter
+  @transient private var counter: Counter = _
 
   override def open(parameters: Configuration): Unit = {
     counter = getRuntimeContext()
@@ -229,7 +229,7 @@ public class MyMapper extends RichMapFunction<Long, Long> {
 {% highlight scala %}
 
 class MyMapper extends RichMapFunction[Long,Long] {
-  @transient private var histogram: Histogram
+  @transient private var histogram: Histogram = _
 
   override def open(parameters: Configuration): Unit = {
     histogram = getRuntimeContext()
@@ -289,7 +289,7 @@ public class MyMapper extends RichMapFunction<Long, Long> {
 {% highlight scala %}
 
 class MyMapper extends RichMapFunction[Long, Long] {
-  @transient private var histogram: Histogram
+  @transient private var histogram: Histogram = _
 
   override def open(config: Configuration): Unit = {
     com.codahale.metrics.Histogram dropwizardHistogram =
@@ -342,7 +342,7 @@ public class MyMapper extends RichMapFunction<Long, Long> {
 {% highlight scala %}
 
 class MyMapper extends RichMapFunction[Long,Long] {
-  @transient private var meter: Meter
+  @transient private var meter: Meter = _
 
   override def open(config: Configuration): Unit = {
     meter = getRuntimeContext()
@@ -401,7 +401,7 @@ public class MyMapper extends RichMapFunction<Long, Long> {
 {% highlight scala %}
 
 class MyMapper extends RichMapFunction[Long,Long] {
-  @transient private var meter: Meter
+  @transient private var meter: Meter = _
 
   override def open(config: Configuration): Unit = {
     com.codahale.metrics.Meter dropwizardMeter = new com.codahale.metrics.Meter()


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes the improper initialization problem for Scala private members in docs.

## Brief change log

  - Assigns the private members with the proper value `_`.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
