### PR TITLE
[FLINK-8292] Remove unnecessary force cast in DataStreamSource

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSource.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSource.java
@@ -54,7 +54,8 @@ public class DataStreamSource<T> extends SingleOutputStreamOperator<T> {
 		if (parallelism > 1 && !isParallel) {
 			throw new IllegalArgumentException("Source: " + transformation.getId() + " is not a parallel source");
 		} else {
-			return (DataStreamSource<T>) super.setParallelism(parallelism);
+			super.setParallelism(parallelism);
+			return this;
 		}
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

Remove unnecessary force cast in DataStreamSource

## Verifying this change

This change is already covered by existing tests, such as DataStreamTest.testParallelism()

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
