### PR TITLE
[FLINK-8283] [kafka] Fix mock verification on final method in FlinkKafkaConsumerBaseTest

### DIFF
--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractFetcher.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractFetcher.java
@@ -243,7 +243,7 @@ public abstract class AbstractFetcher<T, KPH> {
 	 * @param commitCallback The callback that the user should trigger when a commit request completes or fails.
 	 * @throws Exception This method forwards exceptions.
 	 */
-	public final void commitInternalOffsetsToKafka(
+	public void commitInternalOffsetsToKafka(
 			Map<KafkaTopicPartition, Long> offsets,
 			@Nonnull KafkaCommitCallback commitCallback) throws Exception {
 		// Ignore sentinels. They might appear here if snapshot has started before actual offsets values


### PR DESCRIPTION
## What is the purpose of the change

Prior to this PR,
`FlinkKafkaConsumerBaseTest::testSnapshotStateWithCommitOnCheckpointsEnabled()`
was incorrectly mock verifying the `AbstractFetcher::commitInternalOffsetsToKafka()` method, which is final and cannot be mocked. This commit PR fixes this by making the method non-final.
This seems to cause instabilities spanning several tests in the `FlinkKafkaConsumerBaseTest`.

Note that ideally, that method should be final to prevent accidental overrides, but we actually have a lot of methods in the `AbstractFetcher` that should actually be best as final, but are not and mocked in the unit tests (e.g., `AbstractFetcher::snapshotState`, `AbstractFetcher::emitRecord`, etc).

## Brief change log

- Make `AbstractFetcher::commitInternalOffsetsToKafka` non-final, so that it can be properly mocked in unit tests.

## Verifying this change

This change is already covered by existing tests in `FlinkKafkaConsumerBaseTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? n/a
