### PR TITLE
[FLINK-8162] [kinesis-connector] Emit Kinesis' millisBehindLatest metric

### DIFF
--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -1293,6 +1293,29 @@ Thus, in order to infer the metric identifier:
   </tbody>
 </table>
 
+#### Kinesis Connectors
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th class="text-left" style="width: 18%">Scope</th>
+      <th class="text-left" style="width: 26%">Metrics</th>
+      <th class="text-left" style="width: 48%">Description</th>
+      <th class="text-left" style="width: 8%">Type</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th rowspan="1">Operator</th>
+      <td>millisBehindLatest</td>
+      <td>The number of milliseconds the <a>GetRecords</a> response is from the tip of the stream,
+      indicating how far behind current time the consumer is. A value of zero indicates record
+      processing is caught up, and there are no new records to process at this moment.
+      </td>
+      <td>Counter</td>
+    </tr>
+  </tbody>
+</table>
+
 ## Latency tracking
 
 Flink allows to track the latency of records traveling through the system. To enable the latency tracking

--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -1307,7 +1307,7 @@ Thus, in order to infer the metric identifier:
     <tr>
       <th rowspan="1">Operator</th>
       <td>millisBehindLatest</td>
-      <td>The number of milliseconds the <a>GetRecords</a> response is from the tip of the stream,
+      <td>The number of milliseconds the <a>GetRecords</a> response is from the head of the stream,
       indicating how far behind current time the consumer is. A value of zero indicates record
       processing is caught up, and there are no new records to process at this moment.
       </td>

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
@@ -552,6 +552,7 @@ public class KinesisDataFetcher<T> {
 		return runtimeContext
 			.getMetricGroup()
 			.addGroup("Kinesis")
+			.addGroup("stream", shardState.getStreamShardHandle().getStreamName())
 			.addGroup("shardId", shardState.getStreamShardHandle().getShard().getShardId());
 	}
 

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
@@ -638,4 +638,8 @@ public class KinesisDataFetcher<T> {
 
 		return new StreamShardHandle(streamShardMetadata.getStreamName(), shard);
 	}
+
+	public RuntimeContext getRuntimeContext() {
+		return runtimeContext;
+	}
 }

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
@@ -274,7 +274,7 @@ public class KinesisDataFetcher<T> {
 						seededStateIndex,
 						subscribedShardsState.get(seededStateIndex).getStreamShardHandle(),
 						subscribedShardsState.get(seededStateIndex).getLastProcessedSequenceNum(),
-						buildMetricGroupForShard(subscribedShardsState.get(seededStateIndex))));
+						registerMetricGroupForShard(subscribedShardsState.get(seededStateIndex))));
 			}
 		}
 
@@ -321,7 +321,7 @@ public class KinesisDataFetcher<T> {
 						newStateIndex,
 						newShardState.getStreamShardHandle(),
 						newShardState.getLastProcessedSequenceNum(),
-						buildMetricGroupForShard(newShardState)));
+						registerMetricGroupForShard(newShardState)));
 			}
 
 			// we also check if we are running here so that we won't start the discovery sleep
@@ -548,7 +548,7 @@ public class KinesisDataFetcher<T> {
 	/**
 	 * Registers a metric group associated with the shard id of the provided {@link KinesisStreamShardState shardState}.
 	 */
-	private MetricGroup buildMetricGroupForShard(KinesisStreamShardState shardState) {
+	private MetricGroup registerMetricGroupForShard(KinesisStreamShardState shardState) {
 		return runtimeContext
 			.getMetricGroup()
 			.addGroup("Kinesis")

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
@@ -552,7 +552,7 @@ public class KinesisDataFetcher<T> {
 		return runtimeContext
 			.getMetricGroup()
 			.addGroup("Kinesis")
-			.addGroup("shard_id", shardState.getStreamShardHandle().getShard().getShardId());
+			.addGroup("shardId", shardState.getStreamShardHandle().getShard().getShardId());
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumer.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumer.java
@@ -17,7 +17,6 @@
 
 package org.apache.flink.streaming.connectors.kinesis.internals;
 
-import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants;
@@ -102,12 +101,13 @@ public class ShardConsumer<T> implements Runnable {
 		this.fetcherRef = checkNotNull(fetcherRef);
 		MetricGroup kinesisMetricGroup = fetcherRef.getRuntimeContext()
 			.getMetricGroup()
-			.addGroup("Kinesis");
+			.addGroup("Kinesis")
+			.addGroup("<shard_id>", subscribedShard.getShard().getShardId());
 		kinesisMetricGroup
 			.getAllVariables()
 			.put("<shard_id>", subscribedShard.getShard().getShardId());
 
-		kinesisMetricGroup.gauge("millisBehindLatest", (Gauge<Long>) () -> millisBehindLatest);
+		kinesisMetricGroup.gauge("millisBehindLatest", () -> millisBehindLatest);
 		this.subscribedShardStateIndex = checkNotNull(subscribedShardStateIndex);
 		this.subscribedShard = checkNotNull(subscribedShard);
 		this.lastSequenceNum = checkNotNull(lastSequenceNum);

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumer.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumer.java
@@ -107,8 +107,8 @@ public class ShardConsumer<T> implements Runnable {
 		this.subscribedShard = checkNotNull(subscribedShard);
 		this.lastSequenceNum = checkNotNull(lastSequenceNum);
 
-		checkNotNull(kinesisMetricGroup)
-			.gauge("millisBehindLatest", () -> millisBehindLatest);
+		checkNotNull(kinesisMetricGroup);
+		kinesisMetricGroup.gauge("millisBehindLatest", () -> millisBehindLatest);
 
 		checkArgument(
 			!lastSequenceNum.equals(SentinelSequenceNumber.SENTINEL_SHARD_ENDING_SEQUENCE_NUM.get()),

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumerTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumerTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.streaming.connectors.kinesis.internals;
 
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.streaming.connectors.kinesis.model.KinesisStreamShardState;
 import org.apache.flink.streaming.connectors.kinesis.model.SentinelSequenceNumber;
 import org.apache.flink.streaming.connectors.kinesis.model.SequenceNumber;
@@ -77,7 +78,7 @@ public class ShardConsumerTest {
 			0,
 			subscribedShardsStateUnderTest.get(0).getStreamShardHandle(),
 			subscribedShardsStateUnderTest.get(0).getLastProcessedSequenceNum(),
-			FakeKinesisBehavioursFactory.totalNumOfRecordsAfterNumOfGetRecordsCalls(1000, 9)).run();
+			FakeKinesisBehavioursFactory.totalNumOfRecordsAfterNumOfGetRecordsCalls(1000, 9), new UnregisteredMetricsGroup()).run();
 
 		assertTrue(fetcher.getNumOfElementsCollected() == 1000);
 		assertTrue(subscribedShardsStateUnderTest.get(0).getLastProcessedSequenceNum().equals(
@@ -118,7 +119,7 @@ public class ShardConsumerTest {
 			subscribedShardsStateUnderTest.get(0).getLastProcessedSequenceNum(),
 			// Get a total of 1000 records with 9 getRecords() calls,
 			// and the 7th getRecords() call will encounter an unexpected expired shard iterator
-			FakeKinesisBehavioursFactory.totalNumOfRecordsAfterNumOfGetRecordsCallsWithUnexpectedExpiredIterator(1000, 9, 7)).run();
+			FakeKinesisBehavioursFactory.totalNumOfRecordsAfterNumOfGetRecordsCallsWithUnexpectedExpiredIterator(1000, 9, 7), new UnregisteredMetricsGroup()).run();
 
 		assertTrue(fetcher.getNumOfElementsCollected() == 1000);
 		assertTrue(subscribedShardsStateUnderTest.get(0).getLastProcessedSequenceNum().equals(

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/FakeKinesisBehavioursFactory.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/FakeKinesisBehavioursFactory.java
@@ -116,6 +116,7 @@ public class FakeKinesisBehavioursFactory {
 				// assuming that the maxRecordsToGet is always large enough
 				return new GetRecordsResult()
 					.withRecords(shardItrToRecordBatch.get(shardIterator))
+					.withMillisBehindLatest(500L)
 					.withNextShardIterator(
 						(Integer.valueOf(shardIterator) == totalNumOfGetRecordsCalls - 1)
 							? null : String.valueOf(Integer.valueOf(shardIterator) + 1)); // last next shard iterator is null
@@ -176,6 +177,7 @@ public class FakeKinesisBehavioursFactory {
 			// assuming that the maxRecordsToGet is always large enough
 			return new GetRecordsResult()
 				.withRecords(shardItrToRecordBatch.get(shardIterator))
+				.withMillisBehindLatest(500L)
 				.withNextShardIterator(
 					(Integer.valueOf(shardIterator) == totalNumOfGetRecordsCalls - 1)
 						? null : String.valueOf(Integer.valueOf(shardIterator) + 1)); // last next shard iterator is null

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/TestableKinesisDataFetcher.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/TestableKinesisDataFetcher.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.connectors.kinesis.testutils;
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.api.common.serialization.SimpleStringSchema;
 import org.apache.flink.core.testutils.OneShotLatch;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.connectors.kinesis.internals.KinesisDataFetcher;
 import org.apache.flink.streaming.connectors.kinesis.model.KinesisStreamShardState;
@@ -135,6 +136,8 @@ public class TestableKinesisDataFetcher extends KinesisDataFetcher<String> {
 				return "Fake Task (" + fakeTndexOfThisSubtask + "/" + fakeTotalCountOfSubtasks + ")";
 			}
 		});
+
+		Mockito.when(mockedRuntimeContext.getMetricGroup()).thenReturn(new UnregisteredMetricsGroup());
 
 		return mockedRuntimeContext;
 	}

--- a/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/groups/UnregisteredMetricsGroup.java
+++ b/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/groups/UnregisteredMetricsGroup.java
@@ -26,7 +26,7 @@ import org.apache.flink.metrics.Meter;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.SimpleCounter;
 
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -107,7 +107,7 @@ public class UnregisteredMetricsGroup implements MetricGroup {
 
 	@Override
 	public Map<String, String> getAllVariables() {
-		return Collections.emptyMap();
+		return new HashMap<>();
 	}
 
 	@Override

--- a/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/groups/UnregisteredMetricsGroup.java
+++ b/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/groups/UnregisteredMetricsGroup.java
@@ -26,7 +26,7 @@ import org.apache.flink.metrics.Meter;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.SimpleCounter;
 
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -107,7 +107,7 @@ public class UnregisteredMetricsGroup implements MetricGroup {
 
 	@Override
 	public Map<String, String> getAllVariables() {
-		return new HashMap<>();
+		return Collections.emptyMap();
 	}
 
 	@Override


### PR DESCRIPTION
## What is the purpose of the change

- Emits [Kinesis' millisBehindLatest](http://docs.aws.amazon.com/kinesis/latest/APIReference/API_GetRecords.html) metric, which can be used to detect delays in the pipeline

## Brief change log

  - Publish `millisBehindLatest` as a gauge metric under the `Kinesis` group using `<shard_id>` as parameter
  - Updated metrics documentation


## Verifying this change

This change is already covered by existing tests, such as `ShardConsumerTest`.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? `metrics.md` file
