### PR TITLE
[FLINK-8295][cassandra][build] properly shade netty for the datastax driver

### DIFF
--- a/flink-connectors/flink-connector-cassandra/pom.xml
+++ b/flink-connectors/flink-connector-cassandra/pom.xml
@@ -84,9 +84,9 @@ under the License.
 									</excludes>
 								</relocation>
 								<!--
-									For the details of relocation pattern, refer the discussion at
-									https://github.com/apache/flink/pull/4545
-									FLINK-6805
+									Relocate to datastax' package where it
+									expects shaded netty versions; see
+									https://issues.apache.org/jira/browse/FLINK-8295
 								-->
 								<relocation>
 									<pattern>io.netty</pattern>

--- a/flink-connectors/flink-connector-cassandra/pom.xml
+++ b/flink-connectors/flink-connector-cassandra/pom.xml
@@ -90,7 +90,7 @@ under the License.
 								-->
 								<relocation>
 									<pattern>io.netty</pattern>
-									<shadedPattern>org.apache.flink.cassandra.shaded.io.netty</shadedPattern>
+									<shadedPattern>com.datastax.shaded.netty</shadedPattern>
 								</relocation>
 							</relocations>
 						</configuration>


### PR DESCRIPTION
## What is the purpose of the change

`com.datastax.driver.core.NettyUtil` expects netty to be present either at its original package (`io.netty`) or relocated to `com.datastax.shaded.netty`. By relocating it to this package we make sure the driver follows its designated path and is able to connect at all.

## Brief change log

- relocate netty to  `com.datastax.shaded.netty` instead of our own namespace

## Verifying this change

This change added tests and can be verified as follows:

- verified the build jar contains netty (only) in `com.datastax.shaded.netty` and not under `org.apache.flink.cassandra.shaded.io.netty`
- run a job that uses cassandra (should not have worked without adding netty before and should work now - haven't tested it yet - @twalthr can you jump in here?)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**