### PR TITLE
[FLINK-8297] [flink-rocksdb] Optionally store elements of ListState as multiple key-values in rocksdb

### DIFF
--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBListState.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBListState.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.state;
+
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.state.internal.InternalListState;
+
+import org.rocksdb.ColumnFamilyHandle;
+
+import java.util.List;
+
+/**
+ * A parent class for {@link RockDBListState} and {@link LargeRocksDBListState}.
+ */
+public abstract class AbstractRocksDBListState<K, N, V>
+		extends AbstractRocksDBState<K, N, ListState<V>, ListStateDescriptor<V>, List<V>>
+		implements InternalListState<N, V> {
+
+	/** Serializer for the values. */
+	final TypeSerializer<V> valueSerializer;
+
+	/**
+	 * Separator of StringAppendTestOperator in RocksDB.
+	 */
+	static final byte DELIMITER = ',';
+
+	/**
+	 * Creates a new {@code RocksDBListState}.
+	 *
+	 * @param namespaceSerializer The serializer for the namespace.
+	 * @param stateDesc The state identifier for the state. This contains name
+	 *                     and can create a default state value.
+	 */
+	public AbstractRocksDBListState(ColumnFamilyHandle columnFamily,
+			TypeSerializer<N> namespaceSerializer,
+			ListStateDescriptor<V> stateDesc,
+			RocksDBKeyedStateBackend<K> backend) {
+
+		super(columnFamily, namespaceSerializer, stateDesc, backend);
+		this.valueSerializer = stateDesc.getElementSerializer();
+
+		writeOptions.setDisableWAL(true);
+	}
+
+}

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBState.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBState.java
@@ -70,7 +70,7 @@ public abstract class AbstractRocksDBState<K, N, S extends State, SD extends Sta
 	/**
 	 * We disable writes to the write-ahead-log here.
 	 */
-	private final WriteOptions writeOptions;
+	final WriteOptions writeOptions;
 
 	protected final ByteArrayOutputStreamWithPos keySerializationStream;
 	protected final DataOutputView keySerializationDataOutputView;

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/LargeRocksDBListState.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/LargeRocksDBListState.java
@@ -40,6 +40,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 
@@ -106,15 +107,17 @@ public class LargeRocksDBListState<K, N, V>
 
 	@Override
 	public void add(V value) throws IOException {
-		Integer index = this.indexState.value();
-		if (index == null) {
-			index = 0;
-		}
-		try {
-			put(index++, value);
-			this.indexState.update(index);
-		} catch (Exception e) {
-			throw new RuntimeException("Error while adding data to RocksDB", e);
+		if (value != null) {
+			Integer index = this.indexState.value();
+			if (index == null) {
+				index = 0;
+			}
+			try {
+				put(index++, value);
+				this.indexState.update(index);
+			} catch (Exception e) {
+				throw new RuntimeException("Error while adding data to RocksDB", e);
+			}
 		}
 	}
 
@@ -174,6 +177,21 @@ public class LargeRocksDBListState<K, N, V>
 	public void clear() {
 		super.clear();
 		this.indexState.clear();
+	}
+
+	@Override
+	public void update(List<V> list) throws Exception {
+		clear();
+		addAll(list);
+	}
+
+	@Override
+	public void addAll(List<V> list) throws Exception {
+		if (list != null) {
+			for (V value : list) {
+				add(value);
+			}
+		}
 	}
 
 }

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/LargeRocksDBListState.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/LargeRocksDBListState.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.state;
+
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.core.memory.ByteArrayInputStreamWithPos;
+import org.apache.flink.core.memory.DataInputViewStreamWrapper;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.runtime.state.internal.InternalListState;
+
+import org.apache.flink.shaded.guava18.com.google.common.base.Function;
+import org.apache.flink.shaded.guava18.com.google.common.collect.Iterators;
+
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.RocksDBException;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+
+
+/**
+ * {@link ListState} implementation that stores state in RocksDB using
+ * {@link RocksDBMapState}.
+ *
+ * @param <K> The type of the key.
+ * @param <N> The type of the namespace.
+ * @param <V> The type of the values in the list state.
+ */
+public class LargeRocksDBListState<K, N, V>
+	extends RocksDBMapState<K, N, Integer, V>
+	implements InternalListState<N, V> {
+
+	/** State for current list index. */
+	private final RocksDBValueState<K, N, Integer> indexState;
+
+	/**
+	 * Creates a new {@code LargeRocksDBListState}.
+	 *
+	 * @param namespaceSerializer The serializer for the namespace.
+	 * @param stateDesc The state identifier for the state. This contains name
+	 *                     and can create a default state value.
+	 * @param backend the rocksdb backend
+	 */
+	public LargeRocksDBListState(ColumnFamilyHandle columnFamily,
+			TypeSerializer<N> namespaceSerializer,
+			ListStateDescriptor<V> stateDesc,
+			RocksDBKeyedStateBackend<K> backend) {
+
+		super(columnFamily, namespaceSerializer, new MapStateDescriptor<Integer, V>(
+						stateDesc.getName() + "::map", new IntSerializer(), stateDesc.getElementSerializer()),
+						backend);
+		this.indexState = new RocksDBValueState(columnFamily, namespaceSerializer,
+						new ValueStateDescriptor<>(stateDesc.getName() + "::index",
+										userKeySerializer), backend);
+	}
+
+	@Override
+	public Iterable<V> get() {
+		try {
+			Iterator<Map.Entry<Integer, V>> i = this.iterator();
+			if (!i.hasNext()) {
+				// required by contract and tests
+				return null;
+			}
+			return new Iterable<V>() {
+				@Override
+				public Iterator<V> iterator() {
+					return Iterators.transform(
+						i, new Function<Map.Entry<Integer, V>, V>() {
+								@Override
+								public V apply(Map.Entry<Integer, V> f) {
+									return f.getValue();
+								}
+							});
+				}
+			};
+		} catch (IOException | RocksDBException ex) {
+			throw new RuntimeException(ex);
+		}
+	}
+
+	@Override
+	public void add(V value) throws IOException {
+		Integer index = this.indexState.value();
+		if (index == null) {
+			index = 0;
+		}
+		try {
+			put(index++, value);
+			this.indexState.update(index);
+		} catch (Exception e) {
+			throw new RuntimeException("Error while adding data to RocksDB", e);
+		}
+	}
+
+	@Override
+	public void mergeNamespaces(N target, Collection<N> sources) throws Exception {
+		for (N source : sources) {
+			this.setCurrentNamespace(source);
+			Iterable<V> values = get();
+			if (values != null) {
+				this.setCurrentNamespace(target);
+				for (V v : values) {
+					add(v);
+				}
+				this.setCurrentNamespace(source);
+				clear();
+			}
+		}
+	}
+
+	@Override
+	public byte[] getSerializedValue(byte[] serializedKeyAndNamespace) throws Exception {
+		// serialize the list as single byte blob
+		try (ByteArrayInputStreamWithPos bais = new ByteArrayInputStreamWithPos(serializedKeyAndNamespace);
+				DataInputViewStreamWrapper in = new DataInputViewStreamWrapper(bais)) {
+
+			Tuple3<Integer, K, N> ns = readKeyWithGroupAndNamespace(bais, in);
+			setCurrentNamespace(ns.f2);
+		}
+
+		Iterable<V> values = get();
+		if (values == null) {
+			return null;
+		}
+		try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+				DataOutputViewStreamWrapper out = new DataOutputViewStreamWrapper(baos)) {
+			byte[] separator = null;
+			for (V v : values) {
+				if (separator != null) {
+					out.write(separator);
+				} else {
+					separator = new byte[] { 0 };
+				}
+				this.userValueSerializer.serialize(v, out);
+			}
+			baos.flush();
+			return baos.toByteArray();
+		}
+	}
+
+	@Override
+	public void setCurrentNamespace(N namespace) {
+		super.setCurrentNamespace(namespace);
+		this.indexState.setCurrentNamespace(namespace);
+	}
+
+	@Override
+	public void clear() {
+		super.clear();
+		this.indexState.clear();
+	}
+
+}

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBListState.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBListState.java
@@ -27,7 +27,6 @@ import org.apache.flink.runtime.state.internal.InternalListState;
 
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.RocksDBException;
-import org.rocksdb.WriteOptions;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -47,22 +46,8 @@ import java.util.List;
  * @param <V> The type of the values in the list state.
  */
 public class RocksDBListState<K, N, V>
-	extends AbstractRocksDBState<K, N, ListState<V>, ListStateDescriptor<V>, List<V>>
+	extends AbstractRocksDBListState<K, N, V>
 	implements InternalListState<N, V> {
-
-	/** Serializer for the values. */
-	private final TypeSerializer<V> valueSerializer;
-
-	/**
-	 * We disable writes to the write-ahead-log here. We can't have these in the base class
-	 * because JNI segfaults for some reason if they are.
-	 */
-	private final WriteOptions writeOptions;
-
-	/**
-	 * Separator of StringAppendTestOperator in RocksDB.
-	 */
-	private static final byte DELIMITER = ',';
 
 	/**
 	 * Creates a new {@code RocksDBListState}.
@@ -77,10 +62,6 @@ public class RocksDBListState<K, N, V>
 			RocksDBKeyedStateBackend<K> backend) {
 
 		super(columnFamily, namespaceSerializer, stateDesc, backend);
-		this.valueSerializer = stateDesc.getElementSerializer();
-
-		writeOptions = new WriteOptions();
-		writeOptions.setDisableWAL(true);
 	}
 
 	@Override

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBPrefixIterator.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBPrefixIterator.java
@@ -1,0 +1,285 @@
+/*
+ * Copyright 2018 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.state;
+
+import org.rocksdb.RocksDBException;
+import org.rocksdb.RocksIterator;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.function.Function;
+
+
+/**
+ * Auxiliary class for scanning RocksDB with given prefix.
+ */
+public abstract class RocksDBPrefixIterator<K, V> implements Iterator<Map.Entry<K, V>> {
+
+	static final int CACHE_SIZE_BASE = 1;
+	static final int CACHE_SIZE_LIMIT = 128;
+
+	/** A map entry in RocksDBMapState. */
+	class RocksDBPrefixEntry<K, V> implements Map.Entry<K, V> {
+
+		/** Deserializer of raw bytes to key type. */
+		private final Function<byte[], K> keyDeserializer;
+
+		/** Deserializer of raw bytes to value type. */
+		private final Function<byte[], V> valueDeserializer;
+
+		/** Serializer of value to raw bytes. */
+		private final Function<V, byte[]> valueSerializer;
+
+		/** The raw bytes of the key stored in RocksDB. Each user key is stored in RocksDB
+		 * with the format #KeyGroup#Key#Namespace#UserKey. */
+		private final byte[] rawKeyBytes;
+
+		/** The raw bytes of the value stored in RocksDB. */
+		private byte[] rawValueBytes;
+
+		/** True if the entry has been deleted. */
+		private boolean deleted;
+
+		/** Deserialized key (cached). */
+		@Nullable
+		K key;
+
+		/** Deserialized value (cached). */
+		@Nullable
+		V value;
+
+		RocksDBPrefixEntry(
+						final byte[] rawKeyBytes, final byte[] rawValueBytes,
+						final Function<byte[], K> keyDeserializer,
+						final Function<byte[], V> valueDeserializer,
+						final Function<V, byte[]> valueSerializer) {
+
+			this.keyDeserializer = keyDeserializer;
+			this.valueDeserializer = valueDeserializer;
+			this.valueSerializer = valueSerializer;
+			this.rawKeyBytes = rawKeyBytes;
+			this.rawValueBytes = rawValueBytes;
+			this.deleted = false;
+		}
+
+		public void remove() {
+			deleted = true;
+			rawValueBytes = null;
+
+			try {
+				state.backend.db.delete(state.columnFamily, state.writeOptions, rawKeyBytes);
+			} catch (RocksDBException e) {
+				throw new RuntimeException("Error while removing data from RocksDB.", e);
+			}
+		}
+
+		@Override
+		public K getKey() {
+			if (key == null) {
+				key = keyDeserializer.apply(rawKeyBytes);
+			}
+			return key;
+		}
+
+		@Override
+		public V getValue() {
+			if (deleted) {
+				return null;
+			} else {
+				if (value == null) {
+					value = valueDeserializer.apply(rawValueBytes);
+				}
+				return value;
+			}
+		}
+
+		@Override
+		public V setValue(V value) {
+			if (deleted) {
+				throw new IllegalStateException("The value has already been deleted.");
+			}
+
+			V oldValue = getValue();
+			try {
+				rawValueBytes = valueSerializer.apply(value);
+				state.backend.db.put(
+								state.columnFamily, state.writeOptions, rawKeyBytes, rawValueBytes);
+			} catch (RocksDBException e) {
+				throw new RuntimeException("Error while putting data into RocksDB.", e);
+			}
+
+			return oldValue;
+		}
+
+		@Override
+		public String toString() {
+			return "RocksDBMapEntry("
+							+ "key=" + Arrays.toString(rawKeyBytes)
+							+ ", value=" + Arrays.toString(rawValueBytes)
+							+ ")";
+		}
+
+	}
+
+	private final AbstractRocksDBState state;
+
+	/**
+	 * The prefix bytes of the key being accessed. All entries under the same key
+	 * has the same prefix, hence we can stop the iterating once coming across an
+	 * entry with a different prefix.
+	 */
+	private final byte[] keyPrefixBytes;
+
+	/**
+	 * True if all entries have been accessed or the iterator has come across an
+	 * entry with a different prefix.
+	 */
+	private boolean expired = false;
+
+	/** A in-memory cache for the entries in the rocksdb. */
+	private final ArrayList<RocksDBPrefixEntry<K, V>> cacheEntries = new ArrayList<>();
+	private int cacheIndex = 0;
+
+	RocksDBPrefixIterator(
+					final AbstractRocksDBState state,
+					final byte[] keyPrefixBytes) {
+
+		this.state = state;
+		this.keyPrefixBytes = keyPrefixBytes;
+	}
+
+	@Override
+	public boolean hasNext() {
+		loadCache();
+
+		return (cacheIndex < cacheEntries.size());
+	}
+
+	@Override
+	public void remove() {
+		if (cacheIndex == 0 || cacheIndex > cacheEntries.size()) {
+			throw new IllegalStateException(
+							"The remove operation must be called after an valid next operation.");
+		}
+
+		RocksDBPrefixEntry<K, V> lastEntry = cacheEntries.get(cacheIndex - 1);
+		lastEntry.remove();
+	}
+
+	@Override
+	public Map.Entry<K, V> next() {
+		loadCache();
+
+		if (cacheIndex == cacheEntries.size()) {
+			if (!expired) {
+				throw new IllegalStateException();
+			}
+
+			return null;
+		}
+
+		RocksDBPrefixEntry entry = cacheEntries.get(cacheIndex);
+		cacheIndex++;
+
+		return entry;
+	}
+
+	private void loadCache() {
+		if (cacheIndex > cacheEntries.size()) {
+			throw new IllegalStateException();
+		}
+
+		// Load cache entries only when the cache is empty and there still exist unread entries
+		if (cacheIndex < cacheEntries.size() || expired) {
+			return;
+		}
+
+		try (RocksIterator iterator = state.backend.db.newIterator(state.columnFamily)) {
+
+			/*
+			* The iteration starts from the prefix bytes at the first loading. The cache then is
+			* reloaded when the next entry to return is the last one in the cache. At that time,
+			* we will start the iterating from the last returned entry.
+			*/
+			RocksDBPrefixEntry lastEntry = cacheEntries.isEmpty() ? null : cacheEntries.get(cacheEntries.size() - 1);
+			byte[] startBytes = (lastEntry == null ? keyPrefixBytes : lastEntry.rawKeyBytes);
+			int numEntries = (lastEntry == null ? CACHE_SIZE_BASE : Math.min(cacheEntries.size() * 2, CACHE_SIZE_LIMIT));
+
+			cacheEntries.clear();
+			cacheIndex = 0;
+
+			iterator.seek(startBytes);
+
+			/*
+			* If the last returned entry is not deleted, it will be the first entry in the
+			* iterating. Skip it to avoid redundant access in such cases.
+			*/
+			if (lastEntry != null && !lastEntry.deleted) {
+				iterator.next();
+			}
+
+			while (true) {
+				if (!iterator.isValid() || !underSameKey(iterator.key())) {
+					expired = true;
+					break;
+				}
+
+				if (cacheEntries.size() >= numEntries) {
+					break;
+				}
+
+				RocksDBPrefixEntry<K, V> entry = new RocksDBPrefixEntry<>(
+								iterator.key(), iterator.value(), this::deserializeKey,
+								this::deserializeValue, this::serializeValue);
+				// skip any entry that doesn't have suffix
+				if (entry.rawKeyBytes.length > this.keyPrefixBytes.length) {
+					cacheEntries.add(entry);
+				}
+
+				iterator.next();
+			}
+		}
+	}
+
+	private boolean underSameKey(byte[] rawKeyBytes) {
+		if (rawKeyBytes.length < keyPrefixBytes.length) {
+			return false;
+		}
+
+		for (int i = 0; i < keyPrefixBytes.length; ++i) {
+			if (rawKeyBytes[i] != keyPrefixBytes[i]) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/** Deserialize key from raw bytes. */
+	abstract K deserializeKey(byte[] bytes);
+
+	/** Deserialize value from raw bytes. */
+	abstract V deserializeValue(byte[] bytes);
+
+	/** Serialize value to bytes. */
+	abstract byte[] serializeValue(V value);
+
+}

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
@@ -300,7 +300,7 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 	@Override
 	public RocksDBStateBackend configure(Configuration config) {
 		return new RocksDBStateBackend(this, config);
-        }
+	}
 
 	// ------------------------------------------------------------------------
 	//  State backend methods

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
@@ -122,6 +122,9 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 	/** Whether we already lazily initialized our local storage directories. */
 	private transient boolean isInitialized;
 
+	/** True if large lists per single value should be supported. */
+	private boolean enableLargeListsPerKey;
+
 	// ------------------------------------------------------------------------
 
 	/**
@@ -297,11 +300,21 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 	@Override
 	public RocksDBStateBackend configure(Configuration config) {
 		return new RocksDBStateBackend(this, config);
-	}
+        }
 
 	// ------------------------------------------------------------------------
 	//  State backend methods
 	// ------------------------------------------------------------------------
+
+	/**
+	 * Enable storing large lists per single key. The list need not fit into memory
+	 * but the backend might have a slightly higher overhead in some cases.
+	 * @return this
+	 */
+	public RocksDBStateBackend enableLargeListsPerKey() {
+		this.enableLargeListsPerKey = true;
+		return this;
+	}
 
 	/**
 	 * Gets the state backend that this RocksDB state backend uses to persist
@@ -418,7 +431,8 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 				numberOfKeyGroups,
 				keyGroupRange,
 				env.getExecutionConfig(),
-				isIncrementalCheckpointsEnabled());
+				isIncrementalCheckpointsEnabled(),
+				enableLargeListsPerKey);
 	}
 
 	@Override

--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/KVStateRequestSerializerRocksDBTest.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/KVStateRequestSerializerRocksDBTest.java
@@ -36,10 +36,14 @@ import org.apache.flink.runtime.state.internal.InternalMapState;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.DBOptions;
 
 import java.io.File;
+import java.util.Arrays;
+import java.util.Collection;
 
 import static org.mockito.Mockito.mock;
 
@@ -47,10 +51,19 @@ import static org.mockito.Mockito.mock;
  * Additional tests for the serialization and deserialization using
  * the KvStateSerializer with a RocksDB state back-end.
  */
+@RunWith(Parameterized.class)
 public final class KVStateRequestSerializerRocksDBTest {
 
 	@Rule
 	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	@Parameterized.Parameters
+	public static Collection<Boolean> parameters() {
+		return Arrays.asList(true, false);
+	}
+
+	@Parameterized.Parameter
+	public boolean enableLargeListsPerKey;
 
 	/**
 	 * Extension of {@link RocksDBKeyedStateBackend} to make {@link
@@ -59,7 +72,7 @@ public final class KVStateRequestSerializerRocksDBTest {
 	 *
 	 * @param <K> key type
 	 */
-	static final class RocksDBKeyedStateBackend2<K> extends RocksDBKeyedStateBackend<K> {
+	final class RocksDBKeyedStateBackend2<K> extends RocksDBKeyedStateBackend<K> {
 
 		RocksDBKeyedStateBackend2(
 				final String operatorIdentifier,
@@ -76,7 +89,8 @@ public final class KVStateRequestSerializerRocksDBTest {
 			super(operatorIdentifier, userCodeClassLoader,
 				instanceBasePath,
 				dbOptions, columnFamilyOptions, kvStateRegistry, keySerializer,
-				numberOfKeyGroups, keyGroupRange, executionConfig, false);
+				numberOfKeyGroups, keyGroupRange, executionConfig, false,
+				enableLargeListsPerKey);
 		}
 
 		@Override
@@ -152,7 +166,9 @@ public final class KVStateRequestSerializerRocksDBTest {
 				LongSerializer.INSTANCE,
 				1, new KeyGroupRange(0, 0),
 				new ExecutionConfig(),
-				false);
+				false,
+				enableLargeListsPerKey);
+
 		longHeapKeyedStateBackend.restore(null);
 		longHeapKeyedStateBackend.setCurrentKey(key);
 


### PR DESCRIPTION
## What is the purpose of the change

Enable storing lists not fitting to memory per single key.

## Brief change log

## Verifying this change

This change added tests and can be verified as follows:
  passes additional tests for RocksDBStateBackend.enableLargeListsPerKey()

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no, backward compatible
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
