### PR TITLE
 [FLINK-8283] [kafka] Introduce KafkaOffsetCommitter interface

### DIFF
--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBase.java
@@ -882,4 +882,9 @@ public abstract class FlinkKafkaConsumerBase<T> extends RichParallelSourceFuncti
 	OffsetCommitMode getOffsetCommitMode() {
 		return offsetCommitMode;
 	}
+
+	@VisibleForTesting
+	LinkedMap getPendingOffsetsToCommit() {
+		return pendingOffsetsToCommit;
+	}
 }

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBase.java
@@ -43,6 +43,7 @@ import org.apache.flink.streaming.connectors.kafka.config.StartupMode;
 import org.apache.flink.streaming.connectors.kafka.internals.AbstractFetcher;
 import org.apache.flink.streaming.connectors.kafka.internals.AbstractPartitionDiscoverer;
 import org.apache.flink.streaming.connectors.kafka.internals.KafkaCommitCallback;
+import org.apache.flink.streaming.connectors.kafka.internals.KafkaOffsetCommitter;
 import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartition;
 import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartitionAssigner;
 import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartitionStateSentinel;
@@ -158,6 +159,11 @@ public abstract class FlinkKafkaConsumerBase<T> extends RichParallelSourceFuncti
 
 	/** The partition discoverer, used to find new partitions. */
 	private transient volatile AbstractPartitionDiscoverer partitionDiscoverer;
+
+	/**
+	 * The offset committer service that commits offsets back to Kafka's brokers / Zookeeper.
+	 */
+	private transient volatile KafkaOffsetCommitter kafkaOffsetCommitter;
 
 	/**
 	 * The offsets to restore to, if the consumer restores state from a checkpoint.
@@ -559,6 +565,7 @@ public abstract class FlinkKafkaConsumerBase<T> extends RichParallelSourceFuncti
 		//            the fetchers 'snapshotCurrentState()' method return at least
 		//            the restored offsets
 		this.kafkaFetcher = fetcher;
+		this.kafkaOffsetCommitter = createOffsetCommitter();
 
 		if (!running) {
 			return;
@@ -770,8 +777,8 @@ public abstract class FlinkKafkaConsumerBase<T> extends RichParallelSourceFuncti
 			return;
 		}
 
-		final AbstractFetcher<?, ?> fetcher = this.kafkaFetcher;
-		if (fetcher == null) {
+		final KafkaOffsetCommitter offsetCommitter = this.kafkaOffsetCommitter;
+		if (offsetCommitter == null) {
 			LOG.debug("notifyCheckpointComplete() called on uninitialized source");
 			return;
 		}
@@ -803,7 +810,7 @@ public abstract class FlinkKafkaConsumerBase<T> extends RichParallelSourceFuncti
 					return;
 				}
 
-				fetcher.commitInternalOffsetsToKafka(offsets, offsetCommitCallback);
+				offsetCommitter.commitInternalOffsetsToKafka(offsets, offsetCommitCallback);
 			} catch (Exception e) {
 				if (running) {
 					throw e;
@@ -886,5 +893,10 @@ public abstract class FlinkKafkaConsumerBase<T> extends RichParallelSourceFuncti
 	@VisibleForTesting
 	LinkedMap getPendingOffsetsToCommit() {
 		return pendingOffsetsToCommit;
+	}
+
+	@VisibleForTesting
+	KafkaOffsetCommitter createOffsetCommitter() {
+		return this.kafkaFetcher;
 	}
 }

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractFetcher.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractFetcher.java
@@ -24,7 +24,6 @@ import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
 import org.apache.flink.streaming.api.functions.AssignerWithPunctuatedWatermarks;
 import org.apache.flink.streaming.api.functions.source.SourceFunction.SourceContext;
 import org.apache.flink.streaming.api.watermark.Watermark;
-import org.apache.flink.streaming.connectors.kafka.config.OffsetCommitMode;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeCallback;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.util.SerializedValue;
@@ -51,7 +50,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  *            the Flink data streams.
  * @param <KPH> The type of topic/partition identifier used by Kafka in the specific version.
  */
-public abstract class AbstractFetcher<T, KPH> {
+public abstract class AbstractFetcher<T, KPH> implements KafkaOffsetCommitter {
 
 	protected static final int NO_TIMESTAMPS_WATERMARKS = 0;
 	protected static final int PERIODIC_WATERMARKS = 1;
@@ -229,20 +228,6 @@ public abstract class AbstractFetcher<T, KPH> {
 	//  Kafka version specifics
 	// ------------------------------------------------------------------------
 
-	/**
-	 * Commits the given partition offsets to the Kafka brokers (or to ZooKeeper for
-	 * older Kafka versions). This method is only ever called when the offset commit mode of
-	 * the consumer is {@link OffsetCommitMode#ON_CHECKPOINTS}.
-	 *
-	 * <p>The given offsets are the internal checkpointed offsets, representing
-	 * the last processed record of each partition. Version-specific implementations of this method
-	 * need to hold the contract that the given offsets must be incremented by 1 before
-	 * committing them, so that committed offsets to Kafka represent "the next record to process".
-	 *
-	 * @param offsets The offsets to commit to Kafka (implementations must increment offsets by 1 before committing).
-	 * @param commitCallback The callback that the user should trigger when a commit request completes or fails.
-	 * @throws Exception This method forwards exceptions.
-	 */
 	public final void commitInternalOffsetsToKafka(
 			Map<KafkaTopicPartition, Long> offsets,
 			@Nonnull KafkaCommitCallback commitCallback) throws Exception {

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/KafkaOffsetCommitter.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/KafkaOffsetCommitter.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kafka.internals;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.streaming.connectors.kafka.config.OffsetCommitMode;
+
+import javax.annotation.Nonnull;
+
+import java.util.Map;
+
+/**
+ * The offset committer service that commits offsets back to Kafka's brokers / Zookeeper.
+ * Committed offsets serves only as a means to expose the consumer progress to the outside world, and
+ * is not used for Flink's exactly-once guarantees.
+ */
+@Internal
+public interface KafkaOffsetCommitter {
+
+	/**
+	 * Commits the given partition offsets to the Kafka brokers (or to ZooKeeper for
+	 * older Kafka versions). This method is only ever called when the offset commit mode of
+	 * the consumer is {@link OffsetCommitMode#ON_CHECKPOINTS}.
+	 *
+	 * <p>The given offsets are the internal checkpointed offsets, representing
+	 * the last processed record of each partition. Version-specific implementations of this method
+	 * need to hold the contract that the given offsets must be incremented by 1 before
+	 * committing them, so that committed offsets to Kafka represent "the next record to process".
+	 *
+	 * @param offsets The offsets to commit to Kafka (implementations must increment offsets by 1 before committing).
+	 * @param commitCallback The callback that the user should trigger when a commit request completes or fails.
+	 * @throws Exception This method forwards exceptions.
+	 */
+	void commitInternalOffsetsToKafka(
+			Map<KafkaTopicPartition, Long> offsets,
+			@Nonnull KafkaCommitCallback commitCallback) throws Exception;
+}

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBaseTest.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBaseTest.java
@@ -38,6 +38,7 @@ import org.apache.flink.streaming.connectors.kafka.config.OffsetCommitMode;
 import org.apache.flink.streaming.connectors.kafka.internals.AbstractFetcher;
 import org.apache.flink.streaming.connectors.kafka.internals.AbstractPartitionDiscoverer;
 import org.apache.flink.streaming.connectors.kafka.internals.KafkaCommitCallback;
+import org.apache.flink.streaming.connectors.kafka.internals.KafkaOffsetCommitter;
 import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartition;
 import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicsDescriptor;
 import org.apache.flink.streaming.connectors.kafka.testutils.TestPartitionDiscoverer;
@@ -46,11 +47,14 @@ import org.apache.flink.streaming.util.AbstractStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.serialization.KeyedDeserializationSchema;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.SerializedValue;
+import org.apache.flink.util.TestLogger;
 
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Matchers;
 import org.mockito.Mockito;
+
+import javax.annotation.Nonnull;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -71,16 +75,13 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.anyMap;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
  * Tests for the {@link FlinkKafkaConsumerBase}.
  */
-public class FlinkKafkaConsumerBaseTest {
+public class FlinkKafkaConsumerBaseTest extends TestLogger {
 
 	/**
 	 * Tests that not both types of timestamp extractors / watermark generators can be used.
@@ -89,13 +90,19 @@ public class FlinkKafkaConsumerBaseTest {
 	@SuppressWarnings("unchecked")
 	public void testEitherWatermarkExtractor() {
 		try {
-			new DummyFlinkKafkaConsumer<String>(mock(AbstractFetcher.class), mock(AbstractPartitionDiscoverer.class))
+			new DummyFlinkKafkaConsumer<String>(
+					mock(AbstractFetcher.class),
+					mock(AbstractPartitionDiscoverer.class),
+					mock(KafkaOffsetCommitter.class))
 				.assignTimestampsAndWatermarks((AssignerWithPeriodicWatermarks<String>) null);
 			fail();
 		} catch (NullPointerException ignored) {}
 
 		try {
-			new DummyFlinkKafkaConsumer<String>(mock(AbstractFetcher.class), mock(AbstractPartitionDiscoverer.class))
+			new DummyFlinkKafkaConsumer<String>(
+					mock(AbstractFetcher.class),
+					mock(AbstractPartitionDiscoverer.class),
+					mock(KafkaOffsetCommitter.class))
 				.assignTimestampsAndWatermarks((AssignerWithPunctuatedWatermarks<String>) null);
 			fail();
 		} catch (NullPointerException ignored) {}
@@ -103,16 +110,20 @@ public class FlinkKafkaConsumerBaseTest {
 		final AssignerWithPeriodicWatermarks<String> periodicAssigner = mock(AssignerWithPeriodicWatermarks.class);
 		final AssignerWithPunctuatedWatermarks<String> punctuatedAssigner = mock(AssignerWithPunctuatedWatermarks.class);
 
-		DummyFlinkKafkaConsumer<String> c1 =
-			new DummyFlinkKafkaConsumer<>(mock(AbstractFetcher.class), mock(AbstractPartitionDiscoverer.class));
+		DummyFlinkKafkaConsumer<String> c1 = new DummyFlinkKafkaConsumer<>(
+				mock(AbstractFetcher.class),
+				mock(AbstractPartitionDiscoverer.class),
+				mock(KafkaOffsetCommitter.class));
 		c1.assignTimestampsAndWatermarks(periodicAssigner);
 		try {
 			c1.assignTimestampsAndWatermarks(punctuatedAssigner);
 			fail();
 		} catch (IllegalStateException ignored) {}
 
-		DummyFlinkKafkaConsumer<String> c2 =
-			new DummyFlinkKafkaConsumer<>(mock(AbstractFetcher.class), mock(AbstractPartitionDiscoverer.class));
+		DummyFlinkKafkaConsumer<String> c2 = new DummyFlinkKafkaConsumer<>(
+				mock(AbstractFetcher.class),
+				mock(AbstractPartitionDiscoverer.class),
+				mock(KafkaOffsetCommitter.class));
 		c2.assignTimestampsAndWatermarks(punctuatedAssigner);
 		try {
 			c2.assignTimestampsAndWatermarks(periodicAssigner);
@@ -125,9 +136,13 @@ public class FlinkKafkaConsumerBaseTest {
 	 */
 	@Test
 	public void ignoreCheckpointWhenNotRunning() throws Exception {
+		final DummyKafkaOffsetCommitter offsetCommitter = new DummyKafkaOffsetCommitter();
+
 		@SuppressWarnings("unchecked")
-		final FlinkKafkaConsumerBase<String> consumer =
-			new DummyFlinkKafkaConsumer<>(mock(AbstractFetcher.class), mock(AbstractPartitionDiscoverer.class));
+		final FlinkKafkaConsumerBase<String> consumer = new DummyFlinkKafkaConsumer<>(
+				mock(AbstractFetcher.class),
+				mock(AbstractPartitionDiscoverer.class),
+				offsetCommitter);
 
 		final TestingListState<Tuple2<KafkaTopicPartition, Long>> listState = new TestingListState<>();
 		setupConsumer(consumer, false, listState, true, 0, 1);
@@ -137,6 +152,11 @@ public class FlinkKafkaConsumerBaseTest {
 
 		// no state should have been checkpointed
 		assertFalse(listState.get().iterator().hasNext());
+
+		// acknowledgement of the checkpoint should also not result in any offset commits
+		consumer.notifyCheckpointComplete(66L);
+		assertEquals(null, offsetCommitter.getLastCommittedOffsets());
+		assertEquals(0, offsetCommitter.getCommitCount());
 	}
 
 	/**
@@ -146,8 +166,10 @@ public class FlinkKafkaConsumerBaseTest {
 	@Test
 	public void checkRestoredCheckpointWhenFetcherNotReady() throws Exception {
 		@SuppressWarnings("unchecked")
-		final FlinkKafkaConsumerBase<String> consumer =
-			new DummyFlinkKafkaConsumer<>(mock(AbstractFetcher.class), mock(AbstractPartitionDiscoverer.class));
+		final FlinkKafkaConsumerBase<String> consumer = new DummyFlinkKafkaConsumer<>(
+				mock(AbstractFetcher.class),
+				mock(AbstractPartitionDiscoverer.class),
+				mock(KafkaOffsetCommitter.class));
 
 		final TestingListState<Tuple2<KafkaTopicPartition, Long>> restoredListState = new TestingListState<>();
 		setupConsumer(consumer, true, restoredListState, true, 0, 1);
@@ -178,8 +200,10 @@ public class FlinkKafkaConsumerBaseTest {
 	@Test
 	public void testConfigureOnCheckpointsCommitMode() throws Exception {
 		@SuppressWarnings("unchecked")
-		final DummyFlinkKafkaConsumer<String> consumer =
-			new DummyFlinkKafkaConsumer<>(mock(AbstractFetcher.class), mock(AbstractPartitionDiscoverer.class));
+		final DummyFlinkKafkaConsumer<String> consumer = new DummyFlinkKafkaConsumer<>(
+				mock(AbstractFetcher.class),
+				mock(AbstractPartitionDiscoverer.class),
+				mock(KafkaOffsetCommitter.class));
 		consumer.setIsAutoCommitEnabled(true); // this should be ignored
 
 		setupConsumer(
@@ -196,8 +220,10 @@ public class FlinkKafkaConsumerBaseTest {
 	@Test
 	public void testConfigureAutoCommitMode() throws Exception {
 		@SuppressWarnings("unchecked")
-		final DummyFlinkKafkaConsumer<String> consumer =
-			new DummyFlinkKafkaConsumer<>(mock(AbstractFetcher.class), mock(AbstractPartitionDiscoverer.class));
+		final DummyFlinkKafkaConsumer<String> consumer = new DummyFlinkKafkaConsumer<>(
+				mock(AbstractFetcher.class),
+				mock(AbstractPartitionDiscoverer.class),
+				mock(KafkaOffsetCommitter.class));
 		consumer.setIsAutoCommitEnabled(true);
 
 		setupConsumer(
@@ -214,8 +240,10 @@ public class FlinkKafkaConsumerBaseTest {
 	@Test
 	public void testConfigureDisableOffsetCommitWithCheckpointing() throws Exception {
 		@SuppressWarnings("unchecked")
-		final DummyFlinkKafkaConsumer<String> consumer =
-			new DummyFlinkKafkaConsumer<>(mock(AbstractFetcher.class), mock(AbstractPartitionDiscoverer.class));
+		final DummyFlinkKafkaConsumer<String> consumer = new DummyFlinkKafkaConsumer<>(
+				mock(AbstractFetcher.class),
+				mock(AbstractPartitionDiscoverer.class),
+				mock(KafkaOffsetCommitter.class));
 		consumer.setIsAutoCommitEnabled(true); // this should be ignored
 		consumer.setCommitOffsetsOnCheckpoints(false); // disabling offset committing should override everything
 
@@ -233,8 +261,10 @@ public class FlinkKafkaConsumerBaseTest {
 	@Test
 	public void testConfigureDisableOffsetCommitWithoutCheckpointing() throws Exception {
 		@SuppressWarnings("unchecked")
-		final DummyFlinkKafkaConsumer<String> consumer =
-			new DummyFlinkKafkaConsumer<>(mock(AbstractFetcher.class), mock(AbstractPartitionDiscoverer.class));
+		final DummyFlinkKafkaConsumer<String> consumer = new DummyFlinkKafkaConsumer<>(
+				mock(AbstractFetcher.class),
+				mock(AbstractPartitionDiscoverer.class),
+				mock(KafkaOffsetCommitter.class));
 		consumer.setIsAutoCommitEnabled(false);
 
 		setupConsumer(
@@ -268,14 +298,24 @@ public class FlinkKafkaConsumerBaseTest {
 		state3.put(new KafkaTopicPartition("abc", 13), 16780L);
 		state3.put(new KafkaTopicPartition("def", 7), 987654377L);
 
+		final HashMap<KafkaTopicPartition, Long> state4 = new HashMap<>();
+		state4.put(new KafkaTopicPartition("abc", 13), 16790L);
+		state4.put(new KafkaTopicPartition("def", 7), 987654479L);
+
 		// --------------------------------------------------------------------
 
 		final OneShotLatch runLatch = new OneShotLatch();
 		final OneShotLatch stopLatch = new OneShotLatch();
 		final AbstractFetcher<String, ?> fetcher = getRunnableMockFetcher(runLatch, stopLatch);
-		when(fetcher.snapshotCurrentState()).thenReturn(state1, state2, state3);
+		when(fetcher.snapshotCurrentState()).thenReturn(state1, state2, state3, state4);
 
-		final FlinkKafkaConsumerBase<String> consumer = new DummyFlinkKafkaConsumer<>(fetcher, mock(AbstractPartitionDiscoverer.class));
+		final DummyKafkaOffsetCommitter offsetCommitter = new DummyKafkaOffsetCommitter();
+
+		final FlinkKafkaConsumerBase<String> consumer = new DummyFlinkKafkaConsumer<>(
+				fetcher,
+				mock(AbstractPartitionDiscoverer.class),
+				offsetCommitter);
+		consumer.setCommitOffsetsOnCheckpoints(true); // enable offset committing
 
 		final TestingListState<Serializable> listState = new TestingListState<>();
 
@@ -331,6 +371,8 @@ public class FlinkKafkaConsumerBaseTest {
 		consumer.notifyCheckpointComplete(138L);
 		assertEquals(1, consumer.getPendingOffsetsToCommit().size());
 		assertTrue(consumer.getPendingOffsetsToCommit().containsKey(140L));
+		assertEquals(state1, offsetCommitter.getLastCommittedOffsets());
+		assertEquals(1, offsetCommitter.getCommitCount());
 
 		// checkpoint 3
 		consumer.snapshotState(new StateSnapshotContextSynchronousImpl(141, 141));
@@ -349,9 +391,13 @@ public class FlinkKafkaConsumerBaseTest {
 		// ack checkpoint 3, subsumes number 2
 		consumer.notifyCheckpointComplete(141L);
 		assertEquals(0, consumer.getPendingOffsetsToCommit().size());
+		assertEquals(state3, offsetCommitter.getLastCommittedOffsets());
+		assertEquals(2, offsetCommitter.getCommitCount()); // commits for checkpoint 2 should have been skipped completely
 
-		consumer.notifyCheckpointComplete(666); // invalid checkpoint
+		// acknowledge invalid checkpoint; should not commit any offsets
+		consumer.notifyCheckpointComplete(666);
 		assertEquals(0, consumer.getPendingOffsetsToCommit().size());
+		assertEquals(state3, offsetCommitter.getLastCommittedOffsets());
 
 		// create 500 snapshots
 		for (int i = 100; i < 600; i++) {
@@ -363,13 +409,18 @@ public class FlinkKafkaConsumerBaseTest {
 		// commit only the second last
 		consumer.notifyCheckpointComplete(598);
 		assertEquals(1, consumer.getPendingOffsetsToCommit().size());
+		assertEquals(state4, offsetCommitter.getLastCommittedOffsets());
+		assertEquals(3, offsetCommitter.getCommitCount()); // commits for all previous checkpoints should have been skipped completely
 
 		// access invalid checkpoint
 		consumer.notifyCheckpointComplete(590);
+		assertEquals(state4, offsetCommitter.getLastCommittedOffsets());
 
 		// and the last
 		consumer.notifyCheckpointComplete(599);
 		assertEquals(0, consumer.getPendingOffsetsToCommit().size());
+		assertEquals(state4, offsetCommitter.getLastCommittedOffsets()); // mock stub returns state4 for all remaining calls
+		assertEquals(4, offsetCommitter.getCommitCount());
 
 		runThread.sync();
 	}
@@ -400,7 +451,12 @@ public class FlinkKafkaConsumerBaseTest {
 		final AbstractFetcher<String, ?> fetcher = getRunnableMockFetcher(runLatch, stopLatch);
 		when(fetcher.snapshotCurrentState()).thenReturn(state1, state2, state3);
 
-		final FlinkKafkaConsumerBase<String> consumer = new DummyFlinkKafkaConsumer<>(fetcher, mock(AbstractPartitionDiscoverer.class));
+		final DummyKafkaOffsetCommitter offsetCommitter = new DummyKafkaOffsetCommitter();
+
+		final FlinkKafkaConsumerBase<String> consumer = new DummyFlinkKafkaConsumer<>(
+				fetcher,
+				mock(AbstractPartitionDiscoverer.class),
+				offsetCommitter);
 		consumer.setCommitOffsetsOnCheckpoints(false); // disable offset committing
 
 		final TestingListState<Serializable> listState = new TestingListState<>();
@@ -453,7 +509,8 @@ public class FlinkKafkaConsumerBaseTest {
 
 		// ack checkpoint 1
 		consumer.notifyCheckpointComplete(138L);
-		verify(fetcher, never()).commitInternalOffsetsToKafka(anyMap(), Matchers.any(KafkaCommitCallback.class)); // no offsets should be committed
+		assertEquals(null, offsetCommitter.getLastCommittedOffsets());
+		assertEquals(0, offsetCommitter.getCommitCount()); // no offsets should have been committed
 
 		// checkpoint 3
 		consumer.snapshotState(new StateSnapshotContextSynchronousImpl(141, 141));
@@ -470,10 +527,12 @@ public class FlinkKafkaConsumerBaseTest {
 
 		// ack checkpoint 3, subsumes number 2
 		consumer.notifyCheckpointComplete(141L);
-		verify(fetcher, never()).commitInternalOffsetsToKafka(anyMap(), Matchers.any(KafkaCommitCallback.class)); // no offsets should be committed
+		assertEquals(null, offsetCommitter.getLastCommittedOffsets());
+		assertEquals(0, offsetCommitter.getCommitCount()); // no offsets should have been committed
 
 		consumer.notifyCheckpointComplete(666); // invalid checkpoint
-		verify(fetcher, never()).commitInternalOffsetsToKafka(anyMap(), Matchers.any(KafkaCommitCallback.class)); // no offsets should be committed
+		assertEquals(null, offsetCommitter.getLastCommittedOffsets());
+		assertEquals(0, offsetCommitter.getCommitCount()); // no offsets should have been committed
 
 		// create 500 snapshots
 		for (int i = 100; i < 600; i++) {
@@ -484,15 +543,18 @@ public class FlinkKafkaConsumerBaseTest {
 
 		// commit only the second last
 		consumer.notifyCheckpointComplete(598);
-		verify(fetcher, never()).commitInternalOffsetsToKafka(anyMap(), Matchers.any(KafkaCommitCallback.class)); // no offsets should be committed
+		assertEquals(null, offsetCommitter.getLastCommittedOffsets());
+		assertEquals(0, offsetCommitter.getCommitCount()); // no offsets should have been committed
 
 		// access invalid checkpoint
 		consumer.notifyCheckpointComplete(590);
-		verify(fetcher, never()).commitInternalOffsetsToKafka(anyMap(), Matchers.any(KafkaCommitCallback.class)); // no offsets should be committed
+		assertEquals(null, offsetCommitter.getLastCommittedOffsets());
+		assertEquals(0, offsetCommitter.getCommitCount()); // no offsets should have been committed
 
 		// and the last
 		consumer.notifyCheckpointComplete(599);
-		verify(fetcher, never()).commitInternalOffsetsToKafka(anyMap(), Matchers.any(KafkaCommitCallback.class)); // no offsets should be committed
+		assertEquals(null, offsetCommitter.getLastCommittedOffsets());
+		assertEquals(0, offsetCommitter.getCommitCount()); // no offsets should have been committed
 	}
 
 	@Test
@@ -542,7 +604,7 @@ public class FlinkKafkaConsumerBaseTest {
 				TestPartitionDiscoverer.createMockGetAllTopicsSequenceFromFixedReturn(Collections.singletonList("test-topic")),
 				TestPartitionDiscoverer.createMockGetAllPartitionsFromTopicsSequenceFromFixedReturn(mockFetchedPartitionsOnStartup));
 
-			consumers[i] = new DummyFlinkKafkaConsumer<>(mock(AbstractFetcher.class), partitionDiscoverer);
+			consumers[i] = new DummyFlinkKafkaConsumer<>(mock(AbstractFetcher.class), partitionDiscoverer, mock(KafkaOffsetCommitter.class));
 			testHarnesses[i] = createTestHarness(consumers[i], initialParallelism, i);
 
 			// initializeState() is always called, null signals that we didn't restore
@@ -596,7 +658,7 @@ public class FlinkKafkaConsumerBaseTest {
 				TestPartitionDiscoverer.createMockGetAllTopicsSequenceFromFixedReturn(Collections.singletonList("test-topic")),
 				TestPartitionDiscoverer.createMockGetAllPartitionsFromTopicsSequenceFromFixedReturn(mockFetchedPartitionsAfterRestore));
 
-			restoredConsumers[i] = new DummyFlinkKafkaConsumer<>(mock(AbstractFetcher.class), partitionDiscoverer);
+			restoredConsumers[i] = new DummyFlinkKafkaConsumer<>(mock(AbstractFetcher.class), partitionDiscoverer, mock(KafkaOffsetCommitter.class));
 			restoredTestHarnesses[i] = createTestHarness(restoredConsumers[i], restoredParallelism, i);
 
 			// initializeState() is always called, null signals that we didn't restore
@@ -645,9 +707,14 @@ public class FlinkKafkaConsumerBaseTest {
 
 		private AbstractFetcher<T, ?> testFetcher;
 		private AbstractPartitionDiscoverer testPartitionDiscoverer;
+		private KafkaOffsetCommitter testOffsetCommitter;
 
 		@SuppressWarnings("unchecked")
-		DummyFlinkKafkaConsumer(AbstractFetcher<T, ?> testFetcher, AbstractPartitionDiscoverer testPartitionDiscoverer) {
+		DummyFlinkKafkaConsumer(
+				AbstractFetcher<T, ?> testFetcher,
+				AbstractPartitionDiscoverer testPartitionDiscoverer,
+				KafkaOffsetCommitter testOffsetCommitter) {
+
 			super(
 					Collections.singletonList("dummy-topic"),
 					null,
@@ -656,6 +723,7 @@ public class FlinkKafkaConsumerBaseTest {
 
 			this.testFetcher = testFetcher;
 			this.testPartitionDiscoverer = testPartitionDiscoverer;
+			this.testOffsetCommitter = testOffsetCommitter;
 		}
 
 		@Override
@@ -679,12 +747,40 @@ public class FlinkKafkaConsumerBaseTest {
 		}
 
 		@Override
+		KafkaOffsetCommitter createOffsetCommitter() {
+			return this.testOffsetCommitter;
+		}
+
+		@Override
 		protected boolean getIsAutoCommitEnabled() {
 			return isAutoCommitEnabled;
 		}
 
 		void setIsAutoCommitEnabled(boolean isAutoCommitEnabled) {
 			this.isAutoCommitEnabled = isAutoCommitEnabled;
+		}
+	}
+
+	private static class DummyKafkaOffsetCommitter implements KafkaOffsetCommitter {
+
+		private Map<KafkaTopicPartition, Long> lastCommittedOffsets;
+		private int commitCount = 0;
+
+		@Override
+		public void commitInternalOffsetsToKafka(
+			Map<KafkaTopicPartition, Long> offsets,
+			@Nonnull KafkaCommitCallback commitCallback) throws Exception {
+
+			this.lastCommittedOffsets = offsets;
+			this.commitCount++;
+		}
+
+		Map<KafkaTopicPartition, Long> getLastCommittedOffsets() {
+			return lastCommittedOffsets;
+		}
+
+		int getCommitCount() {
+			return commitCount;
 		}
 	}
 

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBaseTest.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBaseTest.java
@@ -23,7 +23,10 @@ import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.state.OperatorStateStore;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.core.testutils.CheckedThread;
+import org.apache.flink.core.testutils.OneShotLatch;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.StateSnapshotContextSynchronousImpl;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
@@ -44,16 +47,13 @@ import org.apache.flink.streaming.util.serialization.KeyedDeserializationSchema;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.SerializedValue;
 
-import org.apache.commons.collections.map.LinkedMap;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Matchers;
 import org.mockito.Mockito;
 
 import java.io.Serializable;
-import java.lang.reflect.Field;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -86,30 +86,33 @@ public class FlinkKafkaConsumerBaseTest {
 	 * Tests that not both types of timestamp extractors / watermark generators can be used.
 	 */
 	@Test
+	@SuppressWarnings("unchecked")
 	public void testEitherWatermarkExtractor() {
 		try {
-			new DummyFlinkKafkaConsumer<>().assignTimestampsAndWatermarks((AssignerWithPeriodicWatermarks<Object>) null);
+			new DummyFlinkKafkaConsumer<String>(mock(AbstractFetcher.class), mock(AbstractPartitionDiscoverer.class))
+				.assignTimestampsAndWatermarks((AssignerWithPeriodicWatermarks<String>) null);
 			fail();
 		} catch (NullPointerException ignored) {}
 
 		try {
-			new DummyFlinkKafkaConsumer<>().assignTimestampsAndWatermarks((AssignerWithPunctuatedWatermarks<Object>) null);
+			new DummyFlinkKafkaConsumer<String>(mock(AbstractFetcher.class), mock(AbstractPartitionDiscoverer.class))
+				.assignTimestampsAndWatermarks((AssignerWithPunctuatedWatermarks<String>) null);
 			fail();
 		} catch (NullPointerException ignored) {}
 
-		@SuppressWarnings("unchecked")
 		final AssignerWithPeriodicWatermarks<String> periodicAssigner = mock(AssignerWithPeriodicWatermarks.class);
-		@SuppressWarnings("unchecked")
 		final AssignerWithPunctuatedWatermarks<String> punctuatedAssigner = mock(AssignerWithPunctuatedWatermarks.class);
 
-		DummyFlinkKafkaConsumer<String> c1 = new DummyFlinkKafkaConsumer<>();
+		DummyFlinkKafkaConsumer<String> c1 =
+			new DummyFlinkKafkaConsumer<>(mock(AbstractFetcher.class), mock(AbstractPartitionDiscoverer.class));
 		c1.assignTimestampsAndWatermarks(periodicAssigner);
 		try {
 			c1.assignTimestampsAndWatermarks(punctuatedAssigner);
 			fail();
 		} catch (IllegalStateException ignored) {}
 
-		DummyFlinkKafkaConsumer<String> c2 = new DummyFlinkKafkaConsumer<>();
+		DummyFlinkKafkaConsumer<String> c2 =
+			new DummyFlinkKafkaConsumer<>(mock(AbstractFetcher.class), mock(AbstractPartitionDiscoverer.class));
 		c2.assignTimestampsAndWatermarks(punctuatedAssigner);
 		try {
 			c2.assignTimestampsAndWatermarks(periodicAssigner);
@@ -123,17 +126,17 @@ public class FlinkKafkaConsumerBaseTest {
 	@Test
 	public void ignoreCheckpointWhenNotRunning() throws Exception {
 		@SuppressWarnings("unchecked")
-		final AbstractFetcher<String, ?> fetcher = mock(AbstractFetcher.class);
+		final FlinkKafkaConsumerBase<String> consumer =
+			new DummyFlinkKafkaConsumer<>(mock(AbstractFetcher.class), mock(AbstractPartitionDiscoverer.class));
 
-		FlinkKafkaConsumerBase<String> consumer = getConsumer(fetcher, new LinkedMap(), false);
-		OperatorStateStore operatorStateStore = mock(OperatorStateStore.class);
-		TestingListState<Tuple2<KafkaTopicPartition, Long>> listState = new TestingListState<>();
-		when(operatorStateStore.getListState(Matchers.any(ListStateDescriptor.class))).thenReturn(listState);
+		final TestingListState<Tuple2<KafkaTopicPartition, Long>> listState = new TestingListState<>();
+		setupConsumer(consumer, false, listState, true, 0, 1);
 
+		// snapshot before the fetcher starts running
 		consumer.snapshotState(new StateSnapshotContextSynchronousImpl(1, 1));
 
+		// no state should have been checkpointed
 		assertFalse(listState.get().iterator().hasNext());
-		consumer.notifyCheckpointComplete(66L);
 	}
 
 	/**
@@ -142,32 +145,14 @@ public class FlinkKafkaConsumerBaseTest {
 	 */
 	@Test
 	public void checkRestoredCheckpointWhenFetcherNotReady() throws Exception {
-		OperatorStateStore operatorStateStore = mock(OperatorStateStore.class);
+		@SuppressWarnings("unchecked")
+		final FlinkKafkaConsumerBase<String> consumer =
+			new DummyFlinkKafkaConsumer<>(mock(AbstractFetcher.class), mock(AbstractPartitionDiscoverer.class));
 
-		TestingListState<Serializable> restoredListState = new TestingListState<>();
-		restoredListState.add(Tuple2.of(new KafkaTopicPartition("abc", 13), 16768L));
-		restoredListState.add(Tuple2.of(new KafkaTopicPartition("def", 7), 987654321L));
+		final TestingListState<Tuple2<KafkaTopicPartition, Long>> restoredListState = new TestingListState<>();
+		setupConsumer(consumer, true, restoredListState, true, 0, 1);
 
-		FlinkKafkaConsumerBase<String> consumer = getConsumer(null, new LinkedMap(), true);
-		StreamingRuntimeContext context = mock(StreamingRuntimeContext.class);
-		when(context.getNumberOfParallelSubtasks()).thenReturn(1);
-		when(context.getIndexOfThisSubtask()).thenReturn(0);
-		consumer.setRuntimeContext(context);
-
-		// mock old 1.2 state (empty)
-		when(operatorStateStore.getSerializableListState(Matchers.any(String.class))).thenReturn(new TestingListState<Serializable>());
-		// mock 1.3 state
-		when(operatorStateStore.getUnionListState(Matchers.any(ListStateDescriptor.class))).thenReturn(restoredListState);
-
-		StateInitializationContext initializationContext = mock(StateInitializationContext.class);
-
-		when(initializationContext.getOperatorStateStore()).thenReturn(operatorStateStore);
-		when(initializationContext.isRestored()).thenReturn(true);
-
-		consumer.initializeState(initializationContext);
-
-		consumer.open(new Configuration());
-
+		// snapshot before the fetcher starts running
 		consumer.snapshotState(new StateSnapshotContextSynchronousImpl(17, 17));
 
 		// ensure that the list was cleared and refilled. while this is an implementation detail, we use it here
@@ -192,67 +177,74 @@ public class FlinkKafkaConsumerBaseTest {
 
 	@Test
 	public void testConfigureOnCheckpointsCommitMode() throws Exception {
-
-		DummyFlinkKafkaConsumer consumer = new DummyFlinkKafkaConsumer();
+		@SuppressWarnings("unchecked")
+		final DummyFlinkKafkaConsumer<String> consumer =
+			new DummyFlinkKafkaConsumer<>(mock(AbstractFetcher.class), mock(AbstractPartitionDiscoverer.class));
 		consumer.setIsAutoCommitEnabled(true); // this should be ignored
 
-		StreamingRuntimeContext context = mock(StreamingRuntimeContext.class);
-		when(context.getIndexOfThisSubtask()).thenReturn(0);
-		when(context.getNumberOfParallelSubtasks()).thenReturn(1);
-		when(context.isCheckpointingEnabled()).thenReturn(true); // enable checkpointing, auto commit should be ignored
-		consumer.setRuntimeContext(context);
+		setupConsumer(
+			consumer,
+			false,
+			null,
+			true, // enable checkpointing; auto commit should be ignored
+			0,
+			1);
 
-		consumer.open(new Configuration());
 		assertEquals(OffsetCommitMode.ON_CHECKPOINTS, consumer.getOffsetCommitMode());
 	}
 
 	@Test
 	public void testConfigureAutoCommitMode() throws Exception {
-
-		DummyFlinkKafkaConsumer consumer = new DummyFlinkKafkaConsumer();
+		@SuppressWarnings("unchecked")
+		final DummyFlinkKafkaConsumer<String> consumer =
+			new DummyFlinkKafkaConsumer<>(mock(AbstractFetcher.class), mock(AbstractPartitionDiscoverer.class));
 		consumer.setIsAutoCommitEnabled(true);
 
-		StreamingRuntimeContext context = mock(StreamingRuntimeContext.class);
-		when(context.getIndexOfThisSubtask()).thenReturn(0);
-		when(context.getNumberOfParallelSubtasks()).thenReturn(1);
-		when(context.isCheckpointingEnabled()).thenReturn(false); // disable checkpointing, auto commit should be respected
-		consumer.setRuntimeContext(context);
+		setupConsumer(
+			consumer,
+			false,
+			null,
+			false, // disable checkpointing; auto commit should be respected
+			0,
+			1);
 
-		consumer.open(new Configuration());
 		assertEquals(OffsetCommitMode.KAFKA_PERIODIC, consumer.getOffsetCommitMode());
 	}
 
 	@Test
 	public void testConfigureDisableOffsetCommitWithCheckpointing() throws Exception {
-
-		DummyFlinkKafkaConsumer consumer = new DummyFlinkKafkaConsumer();
+		@SuppressWarnings("unchecked")
+		final DummyFlinkKafkaConsumer<String> consumer =
+			new DummyFlinkKafkaConsumer<>(mock(AbstractFetcher.class), mock(AbstractPartitionDiscoverer.class));
 		consumer.setIsAutoCommitEnabled(true); // this should be ignored
-
-		StreamingRuntimeContext context = mock(StreamingRuntimeContext.class);
-		when(context.getIndexOfThisSubtask()).thenReturn(0);
-		when(context.getNumberOfParallelSubtasks()).thenReturn(1);
-		when(context.isCheckpointingEnabled()).thenReturn(true); // enable checkpointing, auto commit should be ignored
-		consumer.setRuntimeContext(context);
-
 		consumer.setCommitOffsetsOnCheckpoints(false); // disabling offset committing should override everything
 
-		consumer.open(new Configuration());
+		setupConsumer(
+			consumer,
+			false,
+			null,
+			true, // enable checkpointing; auto commit should be ignored
+			0,
+			1);
+
 		assertEquals(OffsetCommitMode.DISABLED, consumer.getOffsetCommitMode());
 	}
 
 	@Test
 	public void testConfigureDisableOffsetCommitWithoutCheckpointing() throws Exception {
-
-		DummyFlinkKafkaConsumer consumer = new DummyFlinkKafkaConsumer();
+		@SuppressWarnings("unchecked")
+		final DummyFlinkKafkaConsumer<String> consumer =
+			new DummyFlinkKafkaConsumer<>(mock(AbstractFetcher.class), mock(AbstractPartitionDiscoverer.class));
 		consumer.setIsAutoCommitEnabled(false);
 
-		StreamingRuntimeContext context = mock(StreamingRuntimeContext.class);
-		when(context.getIndexOfThisSubtask()).thenReturn(0);
-		when(context.getNumberOfParallelSubtasks()).thenReturn(1);
-		when(context.isCheckpointingEnabled()).thenReturn(false); // disable checkpointing, auto commit should be respected
-		consumer.setRuntimeContext(context);
+		setupConsumer(
+			consumer,
+			false,
+			null,
+			false, // disable checkpointing; auto commit should be respected
+			0,
+			1);
 
-		consumer.open(new Configuration());
 		assertEquals(OffsetCommitMode.DISABLED, consumer.getOffsetCommitMode());
 	}
 
@@ -278,36 +270,34 @@ public class FlinkKafkaConsumerBaseTest {
 
 		// --------------------------------------------------------------------
 
-		final AbstractFetcher<String, ?> fetcher = mock(AbstractFetcher.class);
+		final OneShotLatch runLatch = new OneShotLatch();
+		final OneShotLatch stopLatch = new OneShotLatch();
+		final AbstractFetcher<String, ?> fetcher = getRunnableMockFetcher(runLatch, stopLatch);
 		when(fetcher.snapshotCurrentState()).thenReturn(state1, state2, state3);
 
-		final LinkedMap pendingOffsetsToCommit = new LinkedMap();
+		final FlinkKafkaConsumerBase<String> consumer = new DummyFlinkKafkaConsumer<>(fetcher, mock(AbstractPartitionDiscoverer.class));
 
-		FlinkKafkaConsumerBase<String> consumer = getConsumer(fetcher, pendingOffsetsToCommit, true);
-		StreamingRuntimeContext mockRuntimeContext = mock(StreamingRuntimeContext.class);
-		when(mockRuntimeContext.isCheckpointingEnabled()).thenReturn(true); // enable checkpointing
-		when(mockRuntimeContext.getIndexOfThisSubtask()).thenReturn(0);
-		when(mockRuntimeContext.getNumberOfParallelSubtasks()).thenReturn(1);
-		consumer.setRuntimeContext(mockRuntimeContext);
+		final TestingListState<Serializable> listState = new TestingListState<>();
 
-		assertEquals(0, pendingOffsetsToCommit.size());
+		// setup and run the consumer; wait until the consumer reaches the main fetch loop before continuing test
+		setupConsumer(consumer, false, listState, true, 0, 1);
 
-		OperatorStateStore backend = mock(OperatorStateStore.class);
+		final CheckedThread runThread = new CheckedThread() {
+			@Override
+			public void go() throws Exception {
+				consumer.run(mock(SourceFunction.SourceContext.class));
+			}
 
-		TestingListState<Serializable> listState = new TestingListState<>();
-		// mock old 1.2 state (empty)
-		when(backend.getSerializableListState(Matchers.any(String.class))).thenReturn(new TestingListState<Serializable>());
-		// mock 1.3 state
-		when(backend.getUnionListState(Matchers.any(ListStateDescriptor.class))).thenReturn(listState);
+			@Override
+			public void sync() throws Exception {
+				stopLatch.trigger();
+				super.sync();
+			}
+		};
+		runThread.start();
+		runLatch.await();
 
-		StateInitializationContext initializationContext = mock(StateInitializationContext.class);
-
-		when(initializationContext.getOperatorStateStore()).thenReturn(backend);
-		when(initializationContext.isRestored()).thenReturn(false, true, true, true);
-
-		consumer.initializeState(initializationContext);
-
-		consumer.open(new Configuration());
+		assertEquals(0, consumer.getPendingOffsetsToCommit().size());
 
 		// checkpoint 1
 		consumer.snapshotState(new StateSnapshotContextSynchronousImpl(138, 138));
@@ -320,8 +310,8 @@ public class FlinkKafkaConsumerBaseTest {
 		}
 
 		assertEquals(state1, snapshot1);
-		assertEquals(1, pendingOffsetsToCommit.size());
-		assertEquals(state1, pendingOffsetsToCommit.get(138L));
+		assertEquals(1, consumer.getPendingOffsetsToCommit().size());
+		assertEquals(state1, consumer.getPendingOffsetsToCommit().get(138L));
 
 		// checkpoint 2
 		consumer.snapshotState(new StateSnapshotContextSynchronousImpl(140, 140));
@@ -334,13 +324,13 @@ public class FlinkKafkaConsumerBaseTest {
 		}
 
 		assertEquals(state2, snapshot2);
-		assertEquals(2, pendingOffsetsToCommit.size());
-		assertEquals(state2, pendingOffsetsToCommit.get(140L));
+		assertEquals(2, consumer.getPendingOffsetsToCommit().size());
+		assertEquals(state2, consumer.getPendingOffsetsToCommit().get(140L));
 
 		// ack checkpoint 1
 		consumer.notifyCheckpointComplete(138L);
-		assertEquals(1, pendingOffsetsToCommit.size());
-		assertTrue(pendingOffsetsToCommit.containsKey(140L));
+		assertEquals(1, consumer.getPendingOffsetsToCommit().size());
+		assertTrue(consumer.getPendingOffsetsToCommit().containsKey(140L));
 
 		// checkpoint 3
 		consumer.snapshotState(new StateSnapshotContextSynchronousImpl(141, 141));
@@ -353,37 +343,35 @@ public class FlinkKafkaConsumerBaseTest {
 		}
 
 		assertEquals(state3, snapshot3);
-		assertEquals(2, pendingOffsetsToCommit.size());
-		assertEquals(state3, pendingOffsetsToCommit.get(141L));
+		assertEquals(2, consumer.getPendingOffsetsToCommit().size());
+		assertEquals(state3, consumer.getPendingOffsetsToCommit().get(141L));
 
 		// ack checkpoint 3, subsumes number 2
 		consumer.notifyCheckpointComplete(141L);
-		assertEquals(0, pendingOffsetsToCommit.size());
+		assertEquals(0, consumer.getPendingOffsetsToCommit().size());
 
 		consumer.notifyCheckpointComplete(666); // invalid checkpoint
-		assertEquals(0, pendingOffsetsToCommit.size());
-
-		OperatorStateStore operatorStateStore = mock(OperatorStateStore.class);
-		listState = new TestingListState<>();
-		when(operatorStateStore.getListState(Matchers.any(ListStateDescriptor.class))).thenReturn(listState);
+		assertEquals(0, consumer.getPendingOffsetsToCommit().size());
 
 		// create 500 snapshots
 		for (int i = 100; i < 600; i++) {
 			consumer.snapshotState(new StateSnapshotContextSynchronousImpl(i, i));
 			listState.clear();
 		}
-		assertEquals(FlinkKafkaConsumerBase.MAX_NUM_PENDING_CHECKPOINTS, pendingOffsetsToCommit.size());
+		assertEquals(FlinkKafkaConsumerBase.MAX_NUM_PENDING_CHECKPOINTS, consumer.getPendingOffsetsToCommit().size());
 
 		// commit only the second last
 		consumer.notifyCheckpointComplete(598);
-		assertEquals(1, pendingOffsetsToCommit.size());
+		assertEquals(1, consumer.getPendingOffsetsToCommit().size());
 
 		// access invalid checkpoint
 		consumer.notifyCheckpointComplete(590);
 
 		// and the last
 		consumer.notifyCheckpointComplete(599);
-		assertEquals(0, pendingOffsetsToCommit.size());
+		assertEquals(0, consumer.getPendingOffsetsToCommit().size());
+
+		runThread.sync();
 	}
 
 	@Test
@@ -407,38 +395,35 @@ public class FlinkKafkaConsumerBaseTest {
 
 		// --------------------------------------------------------------------
 
-		final AbstractFetcher<String, ?> fetcher = mock(AbstractFetcher.class);
+		final OneShotLatch runLatch = new OneShotLatch();
+		final OneShotLatch stopLatch = new OneShotLatch();
+		final AbstractFetcher<String, ?> fetcher = getRunnableMockFetcher(runLatch, stopLatch);
 		when(fetcher.snapshotCurrentState()).thenReturn(state1, state2, state3);
 
-		final LinkedMap pendingOffsetsToCommit = new LinkedMap();
-
-		FlinkKafkaConsumerBase<String> consumer = getConsumer(fetcher, pendingOffsetsToCommit, true);
-		StreamingRuntimeContext mockRuntimeContext = mock(StreamingRuntimeContext.class);
-		when(mockRuntimeContext.isCheckpointingEnabled()).thenReturn(true); // enable checkpointing
-		when(mockRuntimeContext.getIndexOfThisSubtask()).thenReturn(0);
-		when(mockRuntimeContext.getNumberOfParallelSubtasks()).thenReturn(1);
-		consumer.setRuntimeContext(mockRuntimeContext);
-
+		final FlinkKafkaConsumerBase<String> consumer = new DummyFlinkKafkaConsumer<>(fetcher, mock(AbstractPartitionDiscoverer.class));
 		consumer.setCommitOffsetsOnCheckpoints(false); // disable offset committing
 
-		assertEquals(0, pendingOffsetsToCommit.size());
+		final TestingListState<Serializable> listState = new TestingListState<>();
 
-		OperatorStateStore backend = mock(OperatorStateStore.class);
+		// setup and run the consumer; wait until the consumer reaches the main fetch loop before continuing test
+		setupConsumer(consumer, false, listState, true, 0, 1);
 
-		TestingListState<Serializable> listState = new TestingListState<>();
-		// mock old 1.2 state (empty)
-		when(backend.getSerializableListState(Matchers.any(String.class))).thenReturn(new TestingListState<Serializable>());
-		// mock 1.3 state
-		when(backend.getUnionListState(Matchers.any(ListStateDescriptor.class))).thenReturn(listState);
+		final CheckedThread runThread = new CheckedThread() {
+			@Override
+			public void go() throws Exception {
+				consumer.run(mock(SourceFunction.SourceContext.class));
+			}
 
-		StateInitializationContext initializationContext = mock(StateInitializationContext.class);
+			@Override
+			public void sync() throws Exception {
+				stopLatch.trigger();
+				super.sync();
+			}
+		};
+		runThread.start();
+		runLatch.await();
 
-		when(initializationContext.getOperatorStateStore()).thenReturn(backend);
-		when(initializationContext.isRestored()).thenReturn(false, true, true, true);
-
-		consumer.initializeState(initializationContext);
-
-		consumer.open(new Configuration());
+		assertEquals(0, consumer.getPendingOffsetsToCommit().size());
 
 		// checkpoint 1
 		consumer.snapshotState(new StateSnapshotContextSynchronousImpl(138, 138));
@@ -451,7 +436,7 @@ public class FlinkKafkaConsumerBaseTest {
 		}
 
 		assertEquals(state1, snapshot1);
-		assertEquals(0, pendingOffsetsToCommit.size()); // pending offsets to commit should not be updated
+		assertEquals(0, consumer.getPendingOffsetsToCommit().size()); // pending offsets to commit should not be updated
 
 		// checkpoint 2
 		consumer.snapshotState(new StateSnapshotContextSynchronousImpl(140, 140));
@@ -464,7 +449,7 @@ public class FlinkKafkaConsumerBaseTest {
 		}
 
 		assertEquals(state2, snapshot2);
-		assertEquals(0, pendingOffsetsToCommit.size()); // pending offsets to commit should not be updated
+		assertEquals(0, consumer.getPendingOffsetsToCommit().size()); // pending offsets to commit should not be updated
 
 		// ack checkpoint 1
 		consumer.notifyCheckpointComplete(138L);
@@ -481,7 +466,7 @@ public class FlinkKafkaConsumerBaseTest {
 		}
 
 		assertEquals(state3, snapshot3);
-		assertEquals(0, pendingOffsetsToCommit.size()); // pending offsets to commit should not be updated
+		assertEquals(0, consumer.getPendingOffsetsToCommit().size()); // pending offsets to commit should not be updated
 
 		// ack checkpoint 3, subsumes number 2
 		consumer.notifyCheckpointComplete(141L);
@@ -490,16 +475,12 @@ public class FlinkKafkaConsumerBaseTest {
 		consumer.notifyCheckpointComplete(666); // invalid checkpoint
 		verify(fetcher, never()).commitInternalOffsetsToKafka(anyMap(), Matchers.any(KafkaCommitCallback.class)); // no offsets should be committed
 
-		OperatorStateStore operatorStateStore = mock(OperatorStateStore.class);
-		listState = new TestingListState<>();
-		when(operatorStateStore.getListState(Matchers.any(ListStateDescriptor.class))).thenReturn(listState);
-
 		// create 500 snapshots
 		for (int i = 100; i < 600; i++) {
 			consumer.snapshotState(new StateSnapshotContextSynchronousImpl(i, i));
 			listState.clear();
 		}
-		assertEquals(0, pendingOffsetsToCommit.size()); // pending offsets to commit should not be updated
+		assertEquals(0, consumer.getPendingOffsetsToCommit().size()); // pending offsets to commit should not be updated
 
 		// commit only the second last
 		consumer.notifyCheckpointComplete(598);
@@ -532,7 +513,7 @@ public class FlinkKafkaConsumerBaseTest {
 	 * of topics fetched from Kafka.
 	 */
 	@SuppressWarnings("unchecked")
-	void testRescaling(
+	private void testRescaling(
 		final int initialParallelism,
 		final int numPartitions,
 		final int restoredParallelism,
@@ -554,8 +535,14 @@ public class FlinkKafkaConsumerBaseTest {
 			new AbstractStreamOperatorTestHarness[initialParallelism];
 
 		for (int i = 0; i < initialParallelism; i++) {
-			consumers[i] = new DummyFlinkKafkaConsumer<>(
-				Collections.singletonList("test-topic"), mockFetchedPartitionsOnStartup);
+			TestPartitionDiscoverer partitionDiscoverer = new TestPartitionDiscoverer(
+				new KafkaTopicsDescriptor(Collections.singletonList("test-topic"), null),
+				i,
+				initialParallelism,
+				TestPartitionDiscoverer.createMockGetAllTopicsSequenceFromFixedReturn(Collections.singletonList("test-topic")),
+				TestPartitionDiscoverer.createMockGetAllPartitionsFromTopicsSequenceFromFixedReturn(mockFetchedPartitionsOnStartup));
+
+			consumers[i] = new DummyFlinkKafkaConsumer<>(mock(AbstractFetcher.class), partitionDiscoverer);
 			testHarnesses[i] = createTestHarness(consumers[i], initialParallelism, i);
 
 			// initializeState() is always called, null signals that we didn't restore
@@ -602,8 +589,14 @@ public class FlinkKafkaConsumerBaseTest {
 			new AbstractStreamOperatorTestHarness[restoredParallelism];
 
 		for (int i = 0; i < restoredParallelism; i++) {
-			restoredConsumers[i] = new DummyFlinkKafkaConsumer<>(
-				Collections.singletonList("test-topic"), mockFetchedPartitionsAfterRestore);
+			TestPartitionDiscoverer partitionDiscoverer = new TestPartitionDiscoverer(
+				new KafkaTopicsDescriptor(Collections.singletonList("test-topic"), null),
+				i,
+				restoredParallelism,
+				TestPartitionDiscoverer.createMockGetAllTopicsSequenceFromFixedReturn(Collections.singletonList("test-topic")),
+				TestPartitionDiscoverer.createMockGetAllPartitionsFromTopicsSequenceFromFixedReturn(mockFetchedPartitionsAfterRestore));
+
+			restoredConsumers[i] = new DummyFlinkKafkaConsumer<>(mock(AbstractFetcher.class), partitionDiscoverer);
 			restoredTestHarnesses[i] = createTestHarness(restoredConsumers[i], restoredParallelism, i);
 
 			// initializeState() is always called, null signals that we didn't restore
@@ -630,28 +623,6 @@ public class FlinkKafkaConsumerBaseTest {
 
 	// ------------------------------------------------------------------------
 
-	private static <T> FlinkKafkaConsumerBase<T> getConsumer(
-			AbstractFetcher<T, ?> fetcher, LinkedMap pendingOffsetsToCommit, boolean running) throws Exception {
-		FlinkKafkaConsumerBase<T> consumer = new DummyFlinkKafkaConsumer<>();
-		StreamingRuntimeContext mockRuntimeContext = mock(StreamingRuntimeContext.class);
-		Mockito.when(mockRuntimeContext.isCheckpointingEnabled()).thenReturn(true);
-		consumer.setRuntimeContext(mockRuntimeContext);
-
-		Field fetcherField = FlinkKafkaConsumerBase.class.getDeclaredField("kafkaFetcher");
-		fetcherField.setAccessible(true);
-		fetcherField.set(consumer, fetcher);
-
-		Field mapField = FlinkKafkaConsumerBase.class.getDeclaredField("pendingOffsetsToCommit");
-		mapField.setAccessible(true);
-		mapField.set(consumer, pendingOffsetsToCommit);
-
-		Field runningField = FlinkKafkaConsumerBase.class.getDeclaredField("running");
-		runningField.setAccessible(true);
-		runningField.set(consumer, running);
-
-		return consumer;
-	}
-
 	private static <T> AbstractStreamOperatorTestHarness<T> createTestHarness(
 		SourceFunction<T> source, int numSubtasks, int subtaskIndex) throws Exception {
 
@@ -672,20 +643,19 @@ public class FlinkKafkaConsumerBaseTest {
 
 		boolean isAutoCommitEnabled = false;
 
-		private List<String> fixedMockGetAllTopicsReturnSequence;
-		private List<KafkaTopicPartition> fixedMockGetAllPartitionsForTopicsReturnSequence;
-
-		public DummyFlinkKafkaConsumer() {
-			this(Collections.singletonList("dummy-topic"), Collections.singletonList(new KafkaTopicPartition("dummy-topic", 0)));
-		}
+		private AbstractFetcher<T, ?> testFetcher;
+		private AbstractPartitionDiscoverer testPartitionDiscoverer;
 
 		@SuppressWarnings("unchecked")
-		public DummyFlinkKafkaConsumer(
-				List<String> fixedMockGetAllTopicsReturnSequence,
-				List<KafkaTopicPartition> fixedMockGetAllPartitionsForTopicsReturnSequence) {
-			super(Arrays.asList("dummy-topic"), null, (KeyedDeserializationSchema < T >) mock(KeyedDeserializationSchema.class), 0);
-			this.fixedMockGetAllTopicsReturnSequence = Preconditions.checkNotNull(fixedMockGetAllTopicsReturnSequence);
-			this.fixedMockGetAllPartitionsForTopicsReturnSequence = Preconditions.checkNotNull(fixedMockGetAllPartitionsForTopicsReturnSequence);
+		DummyFlinkKafkaConsumer(AbstractFetcher<T, ?> testFetcher, AbstractPartitionDiscoverer testPartitionDiscoverer) {
+			super(
+					Collections.singletonList("dummy-topic"),
+					null,
+					(KeyedDeserializationSchema < T >) mock(KeyedDeserializationSchema.class),
+					PARTITION_DISCOVERY_DISABLED);
+
+			this.testFetcher = testFetcher;
+			this.testPartitionDiscoverer = testPartitionDiscoverer;
 		}
 
 		@Override
@@ -697,7 +667,7 @@ public class FlinkKafkaConsumerBaseTest {
 				SerializedValue<AssignerWithPunctuatedWatermarks<T>> watermarksPunctuated,
 				StreamingRuntimeContext runtimeContext,
 				OffsetCommitMode offsetCommitMode) throws Exception {
-			return mock(AbstractFetcher.class);
+			return this.testFetcher;
 		}
 
 		@Override
@@ -705,12 +675,7 @@ public class FlinkKafkaConsumerBaseTest {
 				KafkaTopicsDescriptor topicsDescriptor,
 				int indexOfThisSubtask,
 				int numParallelSubtasks) {
-			return new TestPartitionDiscoverer(
-				topicsDescriptor,
-				indexOfThisSubtask,
-				numParallelSubtasks,
-				TestPartitionDiscoverer.createMockGetAllTopicsSequenceFromFixedReturn(fixedMockGetAllTopicsReturnSequence),
-				TestPartitionDiscoverer.createMockGetAllPartitionsFromTopicsSequenceFromFixedReturn(fixedMockGetAllPartitionsForTopicsReturnSequence));
+			return this.testPartitionDiscoverer;
 		}
 
 		@Override
@@ -718,7 +683,7 @@ public class FlinkKafkaConsumerBaseTest {
 			return isAutoCommitEnabled;
 		}
 
-		public void setIsAutoCommitEnabled(boolean isAutoCommitEnabled) {
+		void setIsAutoCommitEnabled(boolean isAutoCommitEnabled) {
 			this.isAutoCommitEnabled = isAutoCommitEnabled;
 		}
 	}
@@ -748,8 +713,59 @@ public class FlinkKafkaConsumerBaseTest {
 			return list;
 		}
 
-		public boolean isClearCalled() {
+		boolean isClearCalled() {
 			return clearCalled;
 		}
+	}
+
+	/**
+	 * Returns a mock {@link AbstractFetcher}, with run / stop latches injected in
+	 * the {@link AbstractFetcher#runFetchLoop()} method.
+	 */
+	private static <T> AbstractFetcher<T, ?> getRunnableMockFetcher(
+			OneShotLatch runLatch,
+			OneShotLatch stopLatch) throws Exception {
+
+		@SuppressWarnings("unchecked")
+		final AbstractFetcher<T, ?> fetcher = mock(AbstractFetcher.class);
+
+		Mockito.doAnswer(invocationOnMock -> {
+			runLatch.trigger();
+			stopLatch.await();
+			return null;
+		}).when(fetcher).runFetchLoop();
+
+		return fetcher;
+	}
+
+	@SuppressWarnings("unchecked")
+	private static <T, S> void setupConsumer(
+			FlinkKafkaConsumerBase<T> consumer,
+			boolean isRestored,
+			ListState<S> restoredListState,
+			boolean isCheckpointingEnabled,
+			int subtaskIndex,
+			int totalNumSubtasks) throws Exception {
+
+		final StreamingRuntimeContext runtimeContext = Mockito.mock(StreamingRuntimeContext.class);
+		when(runtimeContext.isCheckpointingEnabled()).thenReturn(isCheckpointingEnabled);
+		when(runtimeContext.getIndexOfThisSubtask()).thenReturn(subtaskIndex);
+		when(runtimeContext.getNumberOfParallelSubtasks()).thenReturn(totalNumSubtasks);
+		when(runtimeContext.getMetricGroup()).thenReturn(mock(MetricGroup.class));
+
+		final OperatorStateStore operatorStateStore = mock(OperatorStateStore.class);
+		when(operatorStateStore.getUnionListState((ListStateDescriptor<S>) Matchers.any(ListStateDescriptor.class)))
+			.thenReturn(restoredListState);
+		// also mock the legacy 1.2 Kafka consumer state (return empty state)
+		when(operatorStateStore.getSerializableListState(Matchers.anyString())).thenReturn(new TestingListState<>());
+
+		final FunctionInitializationContext initializationContext = Mockito.mock(FunctionInitializationContext.class);
+		when(initializationContext.isRestored()).thenReturn(isRestored);
+		when(initializationContext.getOperatorStateStore()).thenReturn(operatorStateStore);
+
+		// run setup procedure in operator life cycle
+		consumer.setRuntimeContext(runtimeContext);
+		consumer.initializeState(initializationContext);
+		consumer.open(new Configuration());
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR is built upon the reworked `FlinkKafkaConsumerBaseTest` in #5188.
The broken `FlinkKafkaConsumerBaseTest` is properly fixed only when both #5188 and this PR is merged.

Prior to this PR, offset committing was coupled tightly with the `AbstractFetcher`, making unit tests for offset committing behaviours hard to compose concisely. For example, we had tests that required mocking the offset commit methods on `AbstractFetcher`, while ideally, it would be best that those methods are made final (thus, unable to be mocked) to prevent accidental overrides.

This PR decouples offset committing as a separate service behind a new `KafkaOffsetCommitter` interface. For now, the `AbstractFetcher` is reused as an implementation of this service, so that this PR does not introduce any more change other than introducing a new layer of abstraction.

Unit tests that verify offset committing behaviour now provide a dummy verifiable implementation of the `KafkaOffsetCommitter` (instead of using mocks on AbstractFetcher) and test against that.

## Brief change log

- Migrate `AbstractFetcher::commitInternalOffsetsToKafka` method to the newly introduced `KafkaOffsetCommitter` interface.
- Let `AbstractFetcher` implement `KafkaOffsetCommitter`
- In the `FlinkKafkaConsumerBase`, let "offset committing" and "record fetching" be logically separated to be handled by two services, i.e. namely a `KafkaOffsetCommitter` and a `AbstractFetcher`. Physically, the fetcher instance sits behind both service abstractions.
- In `FlinkKafkaConsumerBaseTest`, remove all mocks on `AbstractFetcher::commitInternalOffsetsToKafka`, and test against a `KafkaOffsetCommitter` instead.
- Additional hotfix 2906968 that fixes a stale comment referring to an old `AbstractFetcher` behaviour to avoid confusion.

## Verifying this change

This PR does not add any new functionality. Reworked test also do not affect test coverage.
`FlinkKafkaConsumerBaseTest` verifies all changes.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? n/a
