### PR TITLE
[FLINK-8268][tests] Improve tests stability

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/TaskTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/TaskTestBase.java
@@ -23,7 +23,6 @@ import org.apache.flink.api.common.io.DelimitedInputFormat;
 import org.apache.flink.api.common.io.FileOutputFormat;
 import org.apache.flink.api.common.operators.util.UserCodeClassWrapper;
 import org.apache.flink.api.common.operators.util.UserCodeObjectWrapper;
-import org.apache.flink.runtime.testutils.recordutils.RecordSerializerFactory;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.FileSystem.WriteMode;
 import org.apache.flink.core.fs.Path;
@@ -33,12 +32,13 @@ import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.operators.Driver;
 import org.apache.flink.runtime.operators.shipping.ShipStrategyType;
 import org.apache.flink.runtime.operators.util.TaskConfig;
+import org.apache.flink.runtime.testutils.recordutils.RecordSerializerFactory;
 import org.apache.flink.types.Record;
 import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.MutableObjectIterator;
 import org.apache.flink.util.TestLogger;
+
 import org.junit.After;
-import org.junit.Assert;
 
 import java.util.List;
 
@@ -145,19 +145,7 @@ public abstract class TaskTestBase extends TestLogger {
 	}
 
 	@After
-	public void shutdownIOManager() throws Exception {
-		this.mockEnv.getIOManager().shutdown();
-		Assert.assertTrue("IO Manager has not properly shut down.", this.mockEnv.getIOManager().isProperlyShutDown());
-	}
-
-	@After
-	public void shutdownMemoryManager() throws Exception {
-		if (this.memorySize > 0) {
-			MemoryManager memMan = getMemoryManager();
-			if (memMan != null) {
-				Assert.assertTrue("Memory Manager managed memory was not completely freed.", memMan.verifyEmpty());
-				memMan.shutdown();
-			}
-		}
+	public void shutdown() {
+		mockEnv.close();
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/ContentDump.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/ContentDump.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.util;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * Utility class to simulate in memory file like writes, flushes and closing.
+ */
+public class ContentDump {
+	private boolean writable = true;
+	private Map<String, List<String>> filesContent = new HashMap<>();
+
+	public Set<String> listFiles() {
+		return new HashSet<>(filesContent.keySet());
+	}
+
+	public void setWritable(boolean writable) {
+		this.writable = writable;
+	}
+
+	/**
+	 * Creates an empty file.
+	 */
+	public ContentWriter createWriter(String name) {
+		checkArgument(!filesContent.containsKey(name), "File [%s] already exists", name);
+		filesContent.put(name, new ArrayList<>());
+		return new ContentWriter(name, this);
+	}
+
+	public static void move(String name, ContentDump source, ContentDump target) {
+		Collection<String> content = source.read(name);
+		try (ContentWriter contentWriter = target.createWriter(name)) {
+			contentWriter.write(content).flush();
+		}
+		source.delete(name);
+	}
+
+	public void delete(String name) {
+		filesContent.remove(name);
+	}
+
+	public Collection<String> read(String name) {
+		List<String> content = filesContent.get(name);
+		checkState(content != null, "Unknown file [%s]", name);
+		List<String> result = new ArrayList<>(content);
+		return result;
+	}
+
+	private void putContent(String name, List<String> values) {
+		List<String> content = filesContent.get(name);
+		checkState(content != null, "Unknown file [%s]", name);
+		if (!writable) {
+			throw new NotWritableException(name);
+		}
+		content.addAll(values);
+	}
+
+	/**
+	 * {@link ContentWriter} represents an abstraction that allows to putContent to the {@link ContentDump}.
+	 */
+	public static class ContentWriter implements AutoCloseable {
+		private final ContentDump contentDump;
+		private final String name;
+		private final List<String> buffer = new ArrayList<>();
+		private boolean closed = false;
+
+		private ContentWriter(String name, ContentDump contentDump) {
+			this.name = checkNotNull(name);
+			this.contentDump = checkNotNull(contentDump);
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public ContentWriter write(String value) {
+			checkState(!closed);
+			buffer.add(value);
+			return this;
+		}
+
+		public ContentWriter write(Collection<String> values) {
+			values.forEach(this::write);
+			return this;
+		}
+
+		public ContentWriter flush() {
+			contentDump.putContent(name, buffer);
+			return this;
+		}
+
+		public void close() {
+			buffer.clear();
+			closed = true;
+		}
+	}
+
+	/**
+	 * Exception thrown for an attempt to write into read-only {@link ContentDump}.
+	 */
+	public class NotWritableException extends RuntimeException {
+		public NotWritableException(String name) {
+			super(String.format("File [%s] is not writable", name));
+		}
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/SourceFunctionUtil.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/SourceFunctionUtil.java
@@ -18,7 +18,6 @@
 package org.apache.flink.streaming.util;
 
 import org.apache.flink.api.common.ExecutionConfig;
-import org.apache.flink.api.common.accumulators.Accumulator;
 import org.apache.flink.api.common.functions.RichFunction;
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.configuration.Configuration;
@@ -42,22 +41,32 @@ import static org.mockito.Mockito.when;
 public class SourceFunctionUtil {
 
 	public static <T extends Serializable> List<T> runSourceFunction(SourceFunction<T> sourceFunction) throws Exception {
-		final List<T> outputs = new ArrayList<T>();
-
 		if (sourceFunction instanceof RichFunction) {
+			return runRichSourceFunction(sourceFunction);
+		}
+		else {
+			return runNonRichSourceFunction(sourceFunction);
+		}
+	}
 
+	private static <T extends Serializable> List<T> runRichSourceFunction(SourceFunction<T> sourceFunction) throws Exception {
+		try (MockEnvironment environment = new MockEnvironment("MockTask", 3 * 1024 * 1024, new MockInputSplitProvider(), 1024)) {
 			AbstractStreamOperator<?> operator = mock(AbstractStreamOperator.class);
 			when(operator.getExecutionConfig()).thenReturn(new ExecutionConfig());
 
-			RuntimeContext runtimeContext =  new StreamingRuntimeContext(
-					operator,
-					new MockEnvironment("MockTask", 3 * 1024 * 1024, new MockInputSplitProvider(), 1024),
-					new HashMap<String, Accumulator<?, ?>>());
-
+			RuntimeContext runtimeContext = new StreamingRuntimeContext(
+				operator,
+				environment,
+				new HashMap<>());
 			((RichFunction) sourceFunction).setRuntimeContext(runtimeContext);
-
 			((RichFunction) sourceFunction).open(new Configuration());
+
+			return runNonRichSourceFunction(sourceFunction);
 		}
+	}
+
+	private static <T extends Serializable> List<T> runNonRichSourceFunction(SourceFunction<T> sourceFunction) {
+		final List<T> outputs = new ArrayList<>();
 		try {
 			SourceFunction.SourceContext<T> ctx = new CollectingSourceContext<T>(new Object(), outputs);
 			sourceFunction.run(ctx);


### PR DESCRIPTION
This is a walk-around an error reported in the issue: https://issues.apache.org/jira/browse/FLINK-8268 . Instead of writing files to disk, this PR creates a simple in memory "file like" abstraction.

Second commit is to further improve stability by cleaning up the resources from `MockEnvironment`.

## Verifying this change

This is change in tests.