### PR TITLE
[FLINK-8233][flip6] Add JobExecutionResultHandler

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/SerializedThrowable.java
+++ b/flink-core/src/main/java/org/apache/flink/util/SerializedThrowable.java
@@ -25,6 +25,8 @@ import java.lang.ref.WeakReference;
 import java.util.HashSet;
 import java.util.Set;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * Utility class for dealing with user-defined Throwable types that are serialized (for
  * example during RPC/Actor communication), but cannot be resolved with the default
@@ -47,12 +49,11 @@ public class SerializedThrowable extends Exception implements Serializable {
 	/** The original stack trace, to be printed */
 	private final String fullStringifiedStackTrace;
 
-	/** The original exception, not transported via serialization, 
+	/** The original exception, not transported via serialization,
 	 * because the class may not be part of the system class loader.
 	 * In addition, we make sure our cached references to not prevent
 	 * unloading the exception class. */
 	private transient WeakReference<Throwable> cachedException;
-
 
 	/**
 	 * Create a new SerializedThrowable.
@@ -61,6 +62,18 @@ public class SerializedThrowable extends Exception implements Serializable {
 	 */
 	public SerializedThrowable(Throwable exception) {
 		this(exception, new HashSet<Throwable>());
+	}
+
+	/**
+	 * Creates a new SerializedThrowable from a serialized exception provided as a byte array.
+	 */
+	public SerializedThrowable(
+			final byte[] serializedException,
+			final String originalErrorClassName,
+			final String fullStringifiedStackTrace) {
+		this.serializedException = requireNonNull(serializedException);
+		this.originalErrorClassName = requireNonNull(originalErrorClassName);
+		this.fullStringifiedStackTrace = requireNonNull(fullStringifiedStackTrace);
 	}
 
 	private SerializedThrowable(Throwable exception, Set<Throwable> alreadySeen) {
@@ -134,6 +147,14 @@ public class SerializedThrowable extends Exception implements Serializable {
 
 	public String getOriginalErrorClassName() {
 		return originalErrorClassName;
+	}
+
+	public byte[] getSerializedException() {
+		return serializedException;
+	}
+
+	public String getFullStringifiedStackTrace() {
+		return fullStringifiedStackTrace;
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -721,7 +721,7 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 	 * Merges all accumulator results from the tasks previously executed in the Executions.
 	 * @return The accumulator map
 	 */
-	public Map<String, Accumulator<?,?>> aggregateUserAccumulators() {
+	public Map<String, Accumulator<?, ?>> aggregateUserAccumulators() {
 
 		Map<String, Accumulator<?, ?>> userAccumulators = new HashMap<>();
 
@@ -738,7 +738,7 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 	/**
 	 * Gets the accumulator results.
 	 */
-	public Map<String, Object> getAccumulators() throws IOException {
+	public Map<String, Object> getAccumulators() {
 
 		Map<String, Accumulator<?, ?>> accumulatorMap = aggregateUserAccumulators();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobExecutionResultHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobExecutionResultHandler.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.job;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.messages.FlinkJobNotFoundException;
+import org.apache.flink.runtime.messages.JobExecutionResultGoneException;
+import org.apache.flink.runtime.rest.handler.AbstractRestHandler;
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.RestHandlerException;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.JobIDPathParameter;
+import org.apache.flink.runtime.rest.messages.JobMessageParameters;
+import org.apache.flink.runtime.rest.messages.job.JobExecutionResultHeaders;
+import org.apache.flink.runtime.rest.messages.job.JobExecutionResultResponseBody;
+import org.apache.flink.runtime.webmonitor.RestfulGateway;
+import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+import org.apache.flink.util.ExceptionUtils;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+import javax.annotation.Nonnull;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+/**
+ * Returns the {@link org.apache.flink.api.common.JobExecutionResult} for a given {@link JobID}.
+ */
+public class JobExecutionResultHandler
+	extends AbstractRestHandler<RestfulGateway, EmptyRequestBody, JobExecutionResultResponseBody, JobMessageParameters> {
+
+	public JobExecutionResultHandler(
+			final CompletableFuture<String> localRestAddress,
+			final GatewayRetriever<? extends RestfulGateway> leaderRetriever,
+			final Time timeout,
+			final Map<String, String> responseHeaders) {
+		super(
+			localRestAddress,
+			leaderRetriever,
+			timeout,
+			responseHeaders,
+			JobExecutionResultHeaders.getInstance());
+	}
+
+	@Override
+	protected CompletableFuture<JobExecutionResultResponseBody> handleRequest(
+			@Nonnull final HandlerRequest<EmptyRequestBody, JobMessageParameters> request,
+			@Nonnull final RestfulGateway gateway) throws RestHandlerException {
+
+		final JobID jobId = request.getPathParameter(JobIDPathParameter.class);
+		return gateway.isJobExecutionResultPresent(jobId, timeout).thenCompose(present -> {
+				if (!present) {
+					return CompletableFuture.completedFuture(
+						JobExecutionResultResponseBody.inProgress());
+				} else {
+					return gateway.getJobExecutionResult(jobId, timeout)
+						.thenApply(JobExecutionResultResponseBody::created);
+				}
+			}
+		).exceptionally(throwable -> {
+			throw propagateException(throwable);
+		});
+	}
+
+	private static CompletionException propagateException(final Throwable throwable) {
+		final Throwable cause = ExceptionUtils.stripCompletionException(throwable);
+
+		if (cause instanceof JobExecutionResultGoneException
+			|| cause instanceof FlinkJobNotFoundException) {
+			throw new CompletionException(new RestHandlerException(
+				throwable.getMessage(),
+				HttpResponseStatus.NOT_FOUND,
+				throwable));
+		} else {
+			throw new CompletionException(throwable);
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobExecutionResultHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobExecutionResultHeaders.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.job;
+
+import org.apache.flink.runtime.rest.HttpMethodWrapper;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.JobIDPathParameter;
+import org.apache.flink.runtime.rest.messages.JobMessageParameters;
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+/**
+ * {@link MessageHeaders} for {@link JobExecutionResultHeaders}.
+ */
+public class JobExecutionResultHeaders
+	implements MessageHeaders<EmptyRequestBody, JobExecutionResultResponseBody, JobMessageParameters> {
+
+	private static final JobExecutionResultHeaders INSTANCE = new JobExecutionResultHeaders();
+
+	@Override
+	public Class<EmptyRequestBody> getRequestClass() {
+		return EmptyRequestBody.class;
+	}
+
+	@Override
+	public Class<JobExecutionResultResponseBody> getResponseClass() {
+		return JobExecutionResultResponseBody.class;
+	}
+
+	@Override
+	public HttpResponseStatus getResponseStatusCode() {
+		return HttpResponseStatus.OK;
+	}
+
+	@Override
+	public JobMessageParameters getUnresolvedMessageParameters() {
+		return new JobMessageParameters();
+	}
+
+	@Override
+	public HttpMethodWrapper getHttpMethod() {
+		return HttpMethodWrapper.GET;
+	}
+
+	@Override
+	public String getTargetRestEndpointURL() {
+		return "/jobs/:" + JobIDPathParameter.KEY + "/execution-result";
+	}
+
+	public static JobExecutionResultHeaders getInstance() {
+		return INSTANCE;
+	}
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobExecutionResultResponseBody.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobExecutionResultResponseBody.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.rest.messages.json.JobResultSerializer;
 import org.apache.flink.runtime.rest.messages.queue.QueueStatus;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -38,6 +39,7 @@ import static java.util.Objects.requireNonNull;
  *
  * @see org.apache.flink.runtime.rest.handler.job.JobExecutionResultHandler
  */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class JobExecutionResultResponseBody implements ResponseBody {
 
 	@JsonProperty(value = "status", required = true)

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobExecutionResultResponseBody.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobExecutionResultResponseBody.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.job;
+
+import org.apache.flink.runtime.jobmaster.JobResult;
+import org.apache.flink.runtime.rest.messages.ResponseBody;
+import org.apache.flink.runtime.rest.messages.json.JobResultDeserializer;
+import org.apache.flink.runtime.rest.messages.json.JobResultSerializer;
+import org.apache.flink.runtime.rest.messages.queue.QueueStatus;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+import javax.annotation.Nullable;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * {@link ResponseBody} that carries a {@link QueueStatus} and a {@link JobResult}.
+ *
+ * @see org.apache.flink.runtime.rest.handler.job.JobExecutionResultHandler
+ */
+public class JobExecutionResultResponseBody implements ResponseBody {
+
+	@JsonProperty(value = "status", required = true)
+	private final QueueStatus status;
+
+	@JsonProperty(value = "job-execution-result")
+	@JsonSerialize(using = JobResultSerializer.class)
+	@JsonDeserialize(using = JobResultDeserializer.class)
+	@Nullable
+	private final JobResult jobExecutionResult;
+
+	@JsonCreator
+	public JobExecutionResultResponseBody(
+			@JsonProperty(value = "status", required = true) final QueueStatus status,
+			@JsonProperty(value = "job-execution-result")
+			@JsonDeserialize(using = JobResultDeserializer.class)
+			@Nullable final JobResult jobExecutionResult) {
+		this.status = requireNonNull(status);
+		this.jobExecutionResult = jobExecutionResult;
+	}
+
+	public static JobExecutionResultResponseBody inProgress() {
+		return new JobExecutionResultResponseBody(QueueStatus.inProgress(), null);
+	}
+
+	public static JobExecutionResultResponseBody created(
+			final JobResult jobExecutionResult) {
+		return new JobExecutionResultResponseBody(QueueStatus.completed(), jobExecutionResult);
+	}
+
+	public QueueStatus getStatus() {
+		return status;
+	}
+
+	@Nullable
+	public JobResult getJobExecutionResult() {
+		return jobExecutionResult;
+	}
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/json/JobResultDeserializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/json/JobResultDeserializer.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.json;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.jobmaster.JobResult;
+import org.apache.flink.util.SerializedThrowable;
+import org.apache.flink.util.SerializedValue;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonParser;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonToken;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.type.TypeReference;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.DeserializationContext;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JavaType;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.type.TypeFactory;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * JSON deserializer for {@link JobResult}.
+ *
+ * @see JobResultSerializer
+ */
+public class JobResultDeserializer extends StdDeserializer<JobResult> {
+
+	private static final long serialVersionUID = 1L;
+
+	private final JobIDDeserializer jobIdDeserializer = new JobIDDeserializer();
+
+	private final SerializedThrowableDeserializer serializedThrowableDeserializer =
+		new SerializedThrowableDeserializer();
+
+	private final SerializedValueDeserializer serializedValueDeserializer;
+
+	public JobResultDeserializer() {
+		super(JobResult.class);
+		final JavaType objectSerializedValueType = TypeFactory.defaultInstance()
+			.constructType(new TypeReference<SerializedValue<Object>>() {
+			});
+		serializedValueDeserializer = new SerializedValueDeserializer(objectSerializedValueType);
+	}
+
+	@Override
+	public JobResult deserialize(final JsonParser p, final DeserializationContext ctxt) throws IOException {
+		JobID jobId = null;
+		long netRuntime = -1;
+		SerializedThrowable serializedThrowable = null;
+		Map<String, SerializedValue<Object>> accumulatorResults = null;
+
+		while (true) {
+			final JsonToken jsonToken = p.nextToken();
+			assertNotEndOfInput(p, jsonToken);
+			if (jsonToken == JsonToken.END_OBJECT) {
+				break;
+			}
+
+			final String fieldName = p.getValueAsString();
+			switch (fieldName) {
+				case JobResultSerializer.FIELD_NAME_JOB_ID:
+					assertNextToken(p, JsonToken.VALUE_STRING);
+					jobId = jobIdDeserializer.deserialize(p, ctxt);
+					break;
+				case JobResultSerializer.FIELD_NAME_NET_RUNTIME:
+					assertNextToken(p, JsonToken.VALUE_NUMBER_INT);
+					netRuntime = p.getLongValue();
+					break;
+				case JobResultSerializer.FIELD_NAME_ACCUMULATOR_RESULTS:
+					assertNextToken(p, JsonToken.START_OBJECT);
+					accumulatorResults = parseAccumulatorResults(p, ctxt);
+					break;
+				case JobResultSerializer.FIELD_NAME_FAILURE_CAUSE:
+					assertNextToken(p, JsonToken.START_OBJECT);
+					serializedThrowable = serializedThrowableDeserializer.deserialize(p, ctxt);
+					break;
+				default:
+					throw new IllegalStateException();
+			}
+		}
+
+		return new JobResult.Builder()
+			.jobId(jobId)
+			.netRuntime(netRuntime)
+			.accumulatorResults(accumulatorResults)
+			.serializedThrowable(serializedThrowable)
+			.build();
+	}
+
+	@SuppressWarnings("unchecked")
+	private Map<String, SerializedValue<Object>> parseAccumulatorResults(
+			final JsonParser p,
+			final DeserializationContext ctxt) throws IOException {
+
+		final Map<String, SerializedValue<Object>> accumulatorResults = new HashMap<>();
+		while (true) {
+			final JsonToken jsonToken = p.nextToken();
+			assertNotEndOfInput(p, jsonToken);
+			if (jsonToken == JsonToken.END_OBJECT) {
+				break;
+			}
+			final String accumulatorName = p.getValueAsString();
+			p.nextValue();
+			accumulatorResults.put(
+				accumulatorName,
+				(SerializedValue<Object>) serializedValueDeserializer.deserialize(p, ctxt));
+		}
+		return accumulatorResults;
+	}
+
+	/**
+	 * Asserts that the provided JsonToken is not null, i.e., not at the end of the input.
+	 */
+	private static void assertNotEndOfInput(
+			final JsonParser p,
+			@Nullable final JsonToken jsonToken) {
+		checkState(jsonToken != null, "Unexpected end of input at %s", p.getCurrentLocation());
+	}
+
+	/**
+	 * Advances the token and asserts that it matches the required {@link JsonToken}.
+	 */
+	private static void assertNextToken(
+			final JsonParser p,
+			final JsonToken requiredJsonToken) throws IOException {
+		final JsonToken nextToken = p.nextToken();
+		checkState(nextToken == requiredJsonToken, "Expected token %s (was %s) at %s",
+			requiredJsonToken,
+			nextToken,
+			p.getCurrentLocation());
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/json/JobResultSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/json/JobResultSerializer.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.json;
+
+import org.apache.flink.runtime.jobmaster.JobResult;
+import org.apache.flink.util.SerializedThrowable;
+import org.apache.flink.util.SerializedValue;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.type.TypeReference;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JavaType;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.SerializerProvider;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.type.TypeFactory;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * JSON serializer for {@link JobResult}.
+ *
+ * @see JobResultDeserializer
+ */
+public class JobResultSerializer extends StdSerializer<JobResult> {
+
+	private static final long serialVersionUID = 1L;
+
+	static final String FIELD_NAME_JOB_ID = "id";
+
+	static final String FIELD_NAME_NET_RUNTIME = "net-runtime";
+
+	static final String FIELD_NAME_ACCUMULATOR_RESULTS = "accumulator-results";
+
+	static final String FIELD_NAME_FAILURE_CAUSE = "failure-cause";
+
+	private final JobIDSerializer jobIdSerializer = new JobIDSerializer();
+
+	private final SerializedValueSerializer serializedValueSerializer;
+
+	private final SerializedThrowableSerializer serializedThrowableSerializer = new SerializedThrowableSerializer();
+
+	public JobResultSerializer() {
+		super(JobResult.class);
+
+		final JavaType objectSerializedValueType = TypeFactory.defaultInstance()
+			.constructType(new TypeReference<SerializedValue<Object>>() {
+			});
+		serializedValueSerializer = new SerializedValueSerializer(objectSerializedValueType);
+	}
+
+	@Override
+	public void serialize(
+			final JobResult result,
+			final JsonGenerator gen,
+			final SerializerProvider provider) throws IOException {
+
+		gen.writeStartObject();
+
+		gen.writeFieldName(FIELD_NAME_JOB_ID);
+		jobIdSerializer.serialize(result.getJobId(), gen, provider);
+
+		gen.writeFieldName(FIELD_NAME_ACCUMULATOR_RESULTS);
+		gen.writeStartObject();
+		final Map<String, SerializedValue<Object>> accumulatorResults = result.getAccumulatorResults();
+		for (final Map.Entry<String, SerializedValue<Object>> nameValue : accumulatorResults.entrySet()) {
+			final String name = nameValue.getKey();
+			final SerializedValue<Object> value = nameValue.getValue();
+
+			gen.writeFieldName(name);
+			serializedValueSerializer.serialize(value, gen, provider);
+		}
+		gen.writeEndObject();
+
+		gen.writeNumberField(FIELD_NAME_NET_RUNTIME, result.getNetRuntime());
+
+		if (result.getSerializedThrowable().isPresent()) {
+			gen.writeFieldName(FIELD_NAME_FAILURE_CAUSE);
+
+			final SerializedThrowable serializedThrowable = result.getSerializedThrowable().get();
+			serializedThrowableSerializer.serialize(serializedThrowable, gen, provider);
+		}
+
+		gen.writeEndObject();
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/json/SerializedThrowableDeserializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/json/SerializedThrowableDeserializer.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.json;
+
+import org.apache.flink.util.SerializedThrowable;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonParser;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.DeserializationContext;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+import java.io.IOException;
+
+import static org.apache.flink.runtime.rest.messages.json.SerializedThrowableSerializer.FIELD_NAME_CLASS;
+import static org.apache.flink.runtime.rest.messages.json.SerializedThrowableSerializer.FIELD_NAME_SERIALIZED_EXCEPTION;
+import static org.apache.flink.runtime.rest.messages.json.SerializedThrowableSerializer.FIELD_NAME_STACK_TRACE;
+
+/**
+ * JSON deserializer for {@link SerializedThrowable}.
+ */
+public class SerializedThrowableDeserializer extends StdDeserializer<SerializedThrowable> {
+
+	private static final long serialVersionUID = 1L;
+
+	public SerializedThrowableDeserializer() {
+		super(SerializedThrowable.class);
+	}
+
+	@Override
+	public SerializedThrowable deserialize(
+			final JsonParser p,
+			final DeserializationContext ctxt) throws IOException {
+		final JsonNode root = p.readValueAsTree();
+
+		final String exceptionClassName = root.get(FIELD_NAME_CLASS).asText();
+		final String stackTrace = root.get(FIELD_NAME_STACK_TRACE).asText();
+		final byte[] serializedException = root.get(FIELD_NAME_SERIALIZED_EXCEPTION).binaryValue();
+		return new SerializedThrowable(serializedException, exceptionClassName, stackTrace);
+	}
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/json/SerializedThrowableSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/json/SerializedThrowableSerializer.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.json;
+
+import org.apache.flink.util.SerializedThrowable;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.SerializerProvider;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import java.io.IOException;
+
+/**
+ * JSON serializer for {@link SerializedThrowable}.
+ */
+public class SerializedThrowableSerializer extends StdSerializer<SerializedThrowable> {
+
+	private static final long serialVersionUID = 1L;
+
+	static final String FIELD_NAME_SERIALIZED_EXCEPTION = "serialized-exception";
+
+	static final String FIELD_NAME_CLASS = "class";
+
+	static final String FIELD_NAME_STACK_TRACE = "stack-trace";
+
+	public SerializedThrowableSerializer() {
+		super(SerializedThrowable.class);
+	}
+
+	@Override
+	public void serialize(final SerializedThrowable value, final JsonGenerator gen, final SerializerProvider provider) throws IOException {
+		gen.writeStartObject();
+		gen.writeStringField(FIELD_NAME_CLASS, value.getOriginalErrorClassName());
+		gen.writeStringField(FIELD_NAME_STACK_TRACE, value.getFullStringifiedStackTrace());
+		gen.writeBinaryField(FIELD_NAME_SERIALIZED_EXCEPTION, value.getSerializedException());
+		gen.writeEndObject();
+	}
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/json/SerializedValueDeserializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/json/SerializedValueDeserializer.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.json;
+
+import org.apache.flink.util.SerializedValue;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonParser;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.DeserializationContext;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JavaType;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+import java.io.IOException;
+
+/**
+ * JSON deserializer for {@link SerializedValue}.
+ */
+public class SerializedValueDeserializer extends StdDeserializer<SerializedValue<?>> {
+
+	private static final long serialVersionUID = 1L;
+
+	public SerializedValueDeserializer(final JavaType valueType) {
+		super(valueType);
+	}
+
+	@Override
+	public SerializedValue<?> deserialize(final JsonParser p, final DeserializationContext ctxt) throws IOException {
+		return SerializedValue.fromBytes(p.getBinaryValue());
+	}
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/json/SerializedValueSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/json/SerializedValueSerializer.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.json;
+
+import org.apache.flink.util.SerializedValue;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JavaType;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.SerializerProvider;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import java.io.IOException;
+
+/**
+ * JSON serializer for {@link SerializedValue}.
+ *
+ * <p>{@link SerializedValue}'s byte array will be base64 encoded.
+ */
+public class SerializedValueSerializer extends StdSerializer<SerializedValue<?>> {
+
+	private static final long serialVersionUID = 1L;
+
+	public SerializedValueSerializer(final JavaType javaType) {
+		super(javaType);
+	}
+
+	@Override
+	public void serialize(
+			final SerializedValue<?> value,
+			final JsonGenerator gen,
+			final SerializerProvider provider) throws IOException {
+		gen.writeBinary(value.getByteArray());
+	}
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/queue/QueueStatus.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/queue/QueueStatus.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.queue;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Response type for temporary queue resources, i.e., resources that are asynchronously created.
+ *
+ * @see org.apache.flink.runtime.rest.handler.job.JobExecutionResultHandler
+ */
+public class QueueStatus {
+
+	private static final String FIELD_NAME_STATUS = "id";
+
+	@JsonProperty(value = FIELD_NAME_STATUS, required = true)
+	private final StatusId statusId;
+
+	@JsonCreator
+	public QueueStatus(
+		@JsonProperty(value = FIELD_NAME_STATUS, required = true) final StatusId statusId) {
+		this.statusId = requireNonNull(statusId, "statusId must not be null");
+	}
+
+	public static QueueStatus inProgress() {
+		return new QueueStatus(StatusId.IN_PROGRESS);
+	}
+
+	public static QueueStatus completed() {
+		return new QueueStatus(StatusId.COMPLETED);
+	}
+
+	public StatusId getStatusId() {
+		return statusId;
+	}
+
+	/**
+	 * Defines queue statuses.
+	 */
+	public enum StatusId {
+		IN_PROGRESS,
+		COMPLETED
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/util/RestMapperUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/util/RestMapperUtils.java
@@ -33,8 +33,7 @@ public class RestMapperUtils {
 		objectMapper.enable(
 			DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES,
 			DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES,
-			DeserializationFeature.FAIL_ON_READING_DUP_TREE_KEY,
-			DeserializationFeature.FAIL_ON_MISSING_CREATOR_PROPERTIES);
+			DeserializationFeature.FAIL_ON_READING_DUP_TREE_KEY);
 		objectMapper.disable(
 			SerializationFeature.FAIL_ON_EMPTY_BEANS);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
@@ -33,6 +33,7 @@ import org.apache.flink.runtime.rest.handler.job.JobAccumulatorsHandler;
 import org.apache.flink.runtime.rest.handler.job.JobConfigHandler;
 import org.apache.flink.runtime.rest.handler.job.JobDetailsHandler;
 import org.apache.flink.runtime.rest.handler.job.JobExceptionsHandler;
+import org.apache.flink.runtime.rest.handler.job.JobExecutionResultHandler;
 import org.apache.flink.runtime.rest.handler.job.JobIdsHandler;
 import org.apache.flink.runtime.rest.handler.job.JobPlanHandler;
 import org.apache.flink.runtime.rest.handler.job.JobVertexAccumulatorsHandler;
@@ -70,6 +71,7 @@ import org.apache.flink.runtime.rest.messages.checkpoints.CheckpointStatisticDet
 import org.apache.flink.runtime.rest.messages.checkpoints.CheckpointingStatisticsHeaders;
 import org.apache.flink.runtime.rest.messages.checkpoints.TaskCheckpointStatisticsHeaders;
 import org.apache.flink.runtime.rest.messages.job.JobDetailsHeaders;
+import org.apache.flink.runtime.rest.messages.job.JobExecutionResultHeaders;
 import org.apache.flink.runtime.rest.messages.job.metrics.JobManagerMetricsHeaders;
 import org.apache.flink.runtime.rest.messages.job.metrics.JobMetricsHeaders;
 import org.apache.flink.runtime.rest.messages.job.metrics.JobVertexMetricsHeaders;
@@ -338,6 +340,12 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
 			responseHeaders,
 			metricFetcher);
 
+		final JobExecutionResultHandler jobExecutionResultHandler = new JobExecutionResultHandler(
+			restAddressFuture,
+			leaderRetriever,
+			timeout,
+			responseHeaders);
+
 		final File tmpDir = restConfiguration.getTmpDir();
 
 		Optional<StaticFileServerHandler<T>> optWebContent;
@@ -376,6 +384,7 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
 		handlers.add(Tuple2.of(SubtaskMetricsHeaders.getInstance(), subtaskMetricsHandler));
 		handlers.add(Tuple2.of(TaskManagerMetricsHeaders.getInstance(), taskManagerMetricsHandler));
 		handlers.add(Tuple2.of(JobManagerMetricsHeaders.getInstance(), jobManagerMetricsHandler));
+		handlers.add(Tuple2.of(JobExecutionResultHeaders.getInstance(), jobExecutionResultHandler));
 
 		// This handler MUST be added last, as it otherwise masks all subsequent GET handlers
 		optWebContent.ifPresent(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobExecutionResultHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobExecutionResultHandlerTest.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.job;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.jobmaster.JobResult;
+import org.apache.flink.runtime.messages.FlinkJobNotFoundException;
+import org.apache.flink.runtime.messages.JobExecutionResultGoneException;
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.RestHandlerException;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.JobMessageParameters;
+import org.apache.flink.runtime.rest.messages.job.JobExecutionResultResponseBody;
+import org.apache.flink.runtime.rest.messages.queue.QueueStatus;
+import org.apache.flink.runtime.webmonitor.RestfulGateway;
+import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.TestLogger;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link JobExecutionResultHandler}.
+ */
+public class JobExecutionResultHandlerTest extends TestLogger {
+
+	private static final JobID TEST_JOB_ID = new JobID();
+
+	private JobExecutionResultHandler jobExecutionResultHandler;
+
+	@Mock
+	private RestfulGateway mockRestfulGateway;
+
+	private HandlerRequest<EmptyRequestBody, JobMessageParameters> testRequest;
+
+	@Before
+	public void setUp() throws Exception {
+		MockitoAnnotations.initMocks(this);
+
+		jobExecutionResultHandler = new JobExecutionResultHandler(
+			CompletableFuture.completedFuture("localhost:12345"),
+			new GatewayRetriever<RestfulGateway>() {
+				@Override
+				public CompletableFuture<RestfulGateway> getFuture() {
+					return CompletableFuture.completedFuture(mockRestfulGateway);
+				}
+			},
+			Time.seconds(10),
+			Collections.emptyMap());
+
+		testRequest = new HandlerRequest<>(
+			EmptyRequestBody.getInstance(),
+			new JobMessageParameters(),
+			Collections.singletonMap("jobid", TEST_JOB_ID.toString()),
+			Collections.emptyMap());
+	}
+
+	@Test
+	public void testResultInProgress() throws Exception {
+		when(mockRestfulGateway.isJobExecutionResultPresent(any(JobID.class), any(Time.class)))
+			.thenReturn(CompletableFuture.completedFuture(false));
+
+		final JobExecutionResultResponseBody responseBody = jobExecutionResultHandler.handleRequest(
+			testRequest,
+			mockRestfulGateway).get();
+
+		assertThat(
+			responseBody.getStatus().getStatusId(),
+			equalTo(QueueStatus.StatusId.IN_PROGRESS));
+	}
+
+	@Test
+	public void testCompletedResult() throws Exception {
+		when(mockRestfulGateway.isJobExecutionResultPresent(any(JobID.class), any(Time.class)))
+			.thenReturn(CompletableFuture.completedFuture(true));
+
+		when(mockRestfulGateway.getJobExecutionResult(any(JobID.class), any(Time.class)))
+			.thenReturn(CompletableFuture.completedFuture(new JobResult.Builder()
+				.jobId(TEST_JOB_ID)
+				.netRuntime(Long.MAX_VALUE)
+				.build()));
+
+		final JobExecutionResultResponseBody responseBody = jobExecutionResultHandler.handleRequest(
+			testRequest,
+			mockRestfulGateway).get();
+
+		assertThat(
+			responseBody.getStatus().getStatusId(),
+			equalTo(QueueStatus.StatusId.COMPLETED));
+		assertThat(responseBody.getJobExecutionResult(), not(nullValue()));
+	}
+
+	@Test
+	public void testPropagateFlinkJobNotFoundExceptionAsRestHandlerException() throws Exception {
+		assertPropagateAsRestHandlerException(
+			new CompletionException(new FlinkJobNotFoundException(new JobID())));
+	}
+
+	@Test
+	public void testPropagateJobExecutionResultGoneExceptionAsRestHandlerException() throws Exception {
+		assertPropagateAsRestHandlerException(
+			new CompletionException(new JobExecutionResultGoneException(new JobID())));
+	}
+
+	private void assertPropagateAsRestHandlerException(final Exception exception) throws Exception {
+		when(mockRestfulGateway.isJobExecutionResultPresent(any(JobID.class), any(Time.class)))
+			.thenReturn(FutureUtils.completedExceptionally(
+				exception));
+
+		try {
+			jobExecutionResultHandler.handleRequest(
+				testRequest,
+				mockRestfulGateway).get();
+			fail("Expected exception not thrown");
+		} catch (final ExecutionException e) {
+			final Throwable cause = ExceptionUtils.stripCompletionException(e.getCause());
+			assertThat(cause, instanceOf(RestHandlerException.class));
+			assertThat(
+				((RestHandlerException) cause).getHttpResponseStatus(),
+				equalTo(HttpResponseStatus.NOT_FOUND));
+		}
+	}
+
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/JobExecutionResultResponseBodyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/JobExecutionResultResponseBodyTest.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.job;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.jobmaster.JobResult;
+import org.apache.flink.runtime.rest.messages.RestResponseMarshallingTestBase;
+import org.apache.flink.util.SerializedThrowable;
+import org.apache.flink.util.SerializedValue;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Test for {@link JobExecutionResultResponseBody}.
+ */
+@RunWith(Parameterized.class)
+public class JobExecutionResultResponseBodyTest
+	extends RestResponseMarshallingTestBase<JobExecutionResultResponseBody> {
+
+	private static final JobID TEST_JOB_ID = new JobID();
+
+	private static final long TEST_NET_RUNTIME = Long.MAX_VALUE;
+
+	private static final byte[] TEST_ACCUMULATOR_VALUE = {1, 2, 3, 4, 5};
+
+	private static final String TEST_ACCUMULATOR_NAME = "test";
+
+	private static final Map<String, SerializedValue<Object>> TEST_ACCUMULATORS = Collections.singletonMap(
+		TEST_ACCUMULATOR_NAME,
+		SerializedValue.fromBytes(TEST_ACCUMULATOR_VALUE));
+
+	@Parameterized.Parameters
+	public static Collection<Object[]> data() throws IOException {
+		return Arrays.asList(new Object[][] {
+			{JobExecutionResultResponseBody.created(new JobResult.Builder()
+				.jobId(TEST_JOB_ID)
+				.netRuntime(TEST_NET_RUNTIME)
+				.accumulatorResults(TEST_ACCUMULATORS)
+				.serializedThrowable(new SerializedThrowable(new RuntimeException("expected")))
+				.build())},
+			{JobExecutionResultResponseBody.created(new JobResult.Builder()
+				.jobId(TEST_JOB_ID)
+				.netRuntime(TEST_NET_RUNTIME)
+				.accumulatorResults(TEST_ACCUMULATORS)
+				.build())},
+			{JobExecutionResultResponseBody.inProgress()}
+		});
+	}
+
+	private final JobExecutionResultResponseBody jobExecutionResultResponseBody;
+
+	public JobExecutionResultResponseBodyTest(
+			final JobExecutionResultResponseBody jobExecutionResultResponseBody) {
+		this.jobExecutionResultResponseBody = jobExecutionResultResponseBody;
+	}
+
+	@Override
+	protected Class<JobExecutionResultResponseBody> getTestResponseClass() {
+		return JobExecutionResultResponseBody.class;
+	}
+
+	@Override
+	protected JobExecutionResultResponseBody getTestResponseInstance() throws Exception {
+		return jobExecutionResultResponseBody;
+	}
+
+	@Override
+	protected void assertOriginalEqualsToUnmarshalled(
+			final JobExecutionResultResponseBody expected,
+			final JobExecutionResultResponseBody actual) {
+
+		assertThat(actual.getStatus(), equalTo(actual.getStatus()));
+
+		final JobResult expectedJobExecutionResult = expected.getJobExecutionResult();
+		final JobResult actualJobExecutionResult = actual.getJobExecutionResult();
+
+		if (expectedJobExecutionResult != null) {
+			assertNotNull(actualJobExecutionResult);
+
+			assertThat(actualJobExecutionResult.getJobId(), equalTo(expectedJobExecutionResult.getJobId()));
+			assertThat(actualJobExecutionResult.getNetRuntime(), equalTo(expectedJobExecutionResult.getNetRuntime()));
+			assertThat(actualJobExecutionResult.getAccumulatorResults(), equalTo(expectedJobExecutionResult.getAccumulatorResults()));
+
+			final Optional<SerializedThrowable> expectedFailureCauseOptional = expectedJobExecutionResult.getSerializedThrowable();
+			expectedFailureCauseOptional.ifPresent(expectedFailureCause -> {
+				final SerializedThrowable actualFailureCause = actualJobExecutionResult.getSerializedThrowable()
+					.orElseThrow(() -> new AssertionError("actualFailureCause is not available"));
+				assertThat(actualFailureCause.getFullStringifiedStackTrace(), equalTo(expectedFailureCause.getFullStringifiedStackTrace()));
+				assertThat(actualFailureCause.getOriginalErrorClassName(), equalTo(expectedFailureCause.getOriginalErrorClassName()));
+				assertArrayEquals(expectedFailureCause.getSerializedException(), actualFailureCause.getSerializedException());
+			});
+
+			if (expectedJobExecutionResult.getAccumulatorResults() != null) {
+				assertNotNull(actualJobExecutionResult.getAccumulatorResults());
+				assertArrayEquals(
+					actualJobExecutionResult.getAccumulatorResults().get(TEST_ACCUMULATOR_NAME).getByteArray(),
+					expectedJobExecutionResult.getAccumulatorResults().get(TEST_ACCUMULATOR_NAME).getByteArray());
+			}
+		}
+
+	}
+
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/json/JobResultDeserializerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/json/JobResultDeserializerTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.json;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.jobmaster.JobResult;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonMappingException;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.module.SimpleModule;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for {@link JobResultDeserializer}.
+ */
+public class JobResultDeserializerTest {
+
+	private ObjectMapper objectMapper;
+
+	@Before
+	public void setUp() {
+		final SimpleModule simpleModule = new SimpleModule();
+		simpleModule.addDeserializer(JobResult.class, new JobResultDeserializer());
+
+		objectMapper = new ObjectMapper();
+		objectMapper.registerModule(simpleModule);
+	}
+
+	@Test
+	public void testDeserialization() throws Exception {
+		final JobResult jobResult = objectMapper.readValue("{\n" +
+			"\t\"id\": \"1bb5e8c7df49938733b7c6a73678de6a\",\n" +
+			"\t\"accumulator-results\": {},\n" +
+			"\t\"net-runtime\": 0,\n" +
+			"\t\"unknownfield\": \"foobar\"\n" +
+			"}", JobResult.class);
+
+		assertThat(jobResult.getJobId(), equalTo(JobID.fromHexString("1bb5e8c7df49938733b7c6a73678de6a")));
+		assertThat(jobResult.getNetRuntime(), equalTo(0L));
+		assertThat(jobResult.getAccumulatorResults().size(), equalTo(0));
+		assertThat(jobResult.getSerializedThrowable().isPresent(), equalTo(false));
+	}
+
+	@Test
+	public void testInvalidType() throws Exception {
+		try {
+			objectMapper.readValue("{\n" +
+				"\t\"id\": \"1bb5e8c7df49938733b7c6a73678de6a\",\n" +
+				"\t\"net-runtime\": \"invalid\"\n" +
+				"}", JobResult.class);
+		} catch (final JsonMappingException e) {
+			assertThat(e.getMessage(), containsString("Expected token VALUE_NUMBER_INT (was VALUE_STRING)"));
+		}
+	}
+
+	@Test
+	public void testIncompleteJobResult() throws Exception {
+		try {
+			objectMapper.readValue("{\n" +
+				"\t\"id\": \"1bb5e8c7df49938733b7c6a73678de6a\"\n" +
+				"}", JobResult.class);
+		} catch (final JsonMappingException e) {
+			assertThat(e.getMessage(), containsString("Could not deserialize JobResult"));
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/json/JobResultDeserializerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/json/JobResultDeserializerTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.rest.messages.json;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.jobmaster.JobResult;
+import org.apache.flink.util.TestLogger;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonMappingException;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
@@ -35,7 +36,7 @@ import static org.junit.Assert.assertThat;
 /**
  * Tests for {@link JobResultDeserializer}.
  */
-public class JobResultDeserializerTest {
+public class JobResultDeserializerTest extends TestLogger {
 
 	private ObjectMapper objectMapper;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/json/SerializedValueSerializerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/json/SerializedValueSerializerTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.json;
+
+import org.apache.flink.util.SerializedValue;
+import org.apache.flink.util.TestLogger;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.type.TypeReference;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JavaType;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.module.SimpleModule;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.Serializable;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link SerializedValueSerializer} and {@link SerializedValueDeserializer}.
+ */
+public class SerializedValueSerializerTest extends TestLogger {
+
+	private ObjectMapper objectMapper;
+
+	@Before
+	public void setUp() {
+		objectMapper = new ObjectMapper();
+		final SimpleModule simpleModule = new SimpleModule();
+		final JavaType serializedValueWildcardType = objectMapper
+			.getTypeFactory()
+			.constructType(new TypeReference<SerializedValue<?>>() {
+			});
+		simpleModule.addSerializer(new SerializedValueSerializer(serializedValueWildcardType));
+		simpleModule.addDeserializer(
+			SerializedValue.class,
+			new SerializedValueDeserializer(serializedValueWildcardType));
+		objectMapper.registerModule(simpleModule);
+	}
+
+	@Test
+	public void testSerializationDeserialization() throws Exception {
+		final String json = objectMapper.writeValueAsString(new SerializedValue<>(new TestClass()));
+
+		final SerializedValue<TestClass> serializedValue =
+			objectMapper.readValue(json, new TypeReference<SerializedValue<TestClass>>() {
+			});
+		final TestClass deserializedValue =
+			serializedValue.deserializeValue(ClassLoader.getSystemClassLoader());
+
+		assertEquals("baz", deserializedValue.foo);
+		assertEquals(1, deserializedValue.bar);
+	}
+
+	private static class TestClass implements Serializable {
+
+		private static final long serialVersionUID = 1L;
+
+		private String foo = "baz";
+
+		private int bar = 1;
+
+	}
+
+}


### PR DESCRIPTION
## What is the purpose of the change

*Allow retrieval of the JobExecutionResult cached in Dispatcher via HTTP. This will be needed so that accumulator results can be transmitted to the client.*

This PR is based on #5184.

## Brief change log

  - *Add `JobExecutionResultHandler` to enable retrieval of `JobExecutionResult`.*
  - *Add serializer and deserializer for `JobExecutionResult`*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added unit tests for all new and changed classes.*
  - *Manually ran the WordCount example job and fetched the `JobExecutionResult` with `curl`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)

CC: @tillrohrmann 
