### PR TITLE
[hotfix] [build] Always include Kafka 0.11 connector

### DIFF
--- a/flink-connectors/pom.xml
+++ b/flink-connectors/pom.xml
@@ -45,6 +45,7 @@ under the License.
 		<module>flink-connector-kafka-0.8</module>
 		<module>flink-connector-kafka-0.9</module>
 		<module>flink-connector-kafka-0.10</module>
+		<module>flink-connector-kafka-0.11</module>
 		<module>flink-connector-elasticsearch-base</module>
 		<module>flink-connector-elasticsearch</module>
 		<module>flink-connector-elasticsearch2</module>
@@ -75,18 +76,6 @@ under the License.
 
 	<!-- See main pom.xml for explanation of profiles -->
 	<profiles>
-		<!-- Kafka 0.11 does not support scala 2.10-->
-		<profile>
-			<id>scala-2.11</id>
-			<activation>
-				<property>
-					<name>!scala-2.10</name>
-				</property>
-			</activation>
-			<modules>
-				<module>flink-connector-kafka-0.11</module>
-			</modules>
-		</profile>
 		<!--
 			We include the kinesis module only optionally because it contains a dependency
 			licenced under the "Amazon Software License".

--- a/tools/travis_mvn_watchdog.sh
+++ b/tools/travis_mvn_watchdog.sh
@@ -91,6 +91,7 @@ flink-connectors/flink-connector-filesystem,\
 flink-connectors/flink-connector-kafka-0.8,\
 flink-connectors/flink-connector-kafka-0.9,\
 flink-connectors/flink-connector-kafka-0.10,\
+flink-connectors/flink-connector-kafka-0.11,\
 flink-connectors/flink-connector-kafka-base,\
 flink-connectors/flink-connector-nifi,\
 flink-connectors/flink-connector-rabbitmq,\
@@ -98,10 +99,6 @@ flink-connectors/flink-connector-twitter"
 
 MODULES_TESTS="\
 flink-tests"
-
-if [[ $PROFILE != *"scala-2.10"* ]]; then
-	MODULES_CONNECTORS="$MODULES_CONNECTORS,flink-connectors/flink-connector-kafka-0.11"
-fi
 
 if [[ $PROFILE == *"include-kinesis"* ]]; then
 	case $TEST in


### PR DESCRIPTION
Now that Flink only supports builds for Scala 2.11+ we can unconditionally enable the Kafka 0.11 connector.