### PR TITLE
[FLINK-8302][table]Add SHIFT_LEFT and SHIFT_RIGHT supported in SQL

### DIFF
--- a/docs/dev/table/sql.md
+++ b/docs/dev/table/sql.md
@@ -1575,6 +1575,50 @@ LOG(x numeric), LOG(base numeric, x numeric)
       <p>Returns the natural logarithm of a specified number of a specified base. If called with one parameter, this function returns the natural logarithm of <code>x</code>. If called with two parameters, this function returns the logarithm of <code>x</code> to the base <code>b</code>. <code>x</code> must be greater than 0. <code>b</code> must be greater than 1.</p>
     </td>
    </tr>
+   
+    <tr>
+     <td>
+       {% highlight text %}
+SHIFT_LEFT(input integer, n integer)
+{% endhighlight %}
+     </td>
+    <td>
+      <p>Returns the integer number after input shift left n bits, equals to input << n </p>
+    </td>
+   </tr>
+   
+    <tr>
+     <td>
+       {% highlight text %}
+SHIFT_LEFT(input long, n integer)
+{% endhighlight %}
+     </td>
+    <td>
+      <p>Returns the long number after input shift left n bits, equals to input << n </p>
+    </td>
+   </tr>
+   
+    <tr>
+     <td>
+       {% highlight text %}
+SHIFT_RIGHT(input integer, n integer)
+{% endhighlight %}
+     </td>
+    <td>
+      <p>Returns the integer number after input shift right n bits, equals to input >> n </p>
+    </td>
+   </tr>
+   
+    <tr>
+     <td>
+       {% highlight text %}
+SHIFT_RIGHT(input long, n integer)
+{% endhighlight %}
+     </td>
+    <td>
+      <p>Returns the long number after input shift right n bits, equals to input >> n </p>
+    </td>
+   </tr>
 
   </tbody>
 </table>

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/BuiltInMethods.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/BuiltInMethods.scala
@@ -96,9 +96,13 @@ object BuiltInMethods {
     Types.lookupMethod(
       classOf[ScalarFunctions], "concat_ws", classOf[String], classOf[Array[String]])
 
-  val SHIFT_LEFT_INT = Types.lookupMethod(classOf[ScalarFunctions], "shiftLeft", classOf[Int], classOf[Int])
-  val SHIFT_LEFT_LONG = Types.lookupMethod(classOf[ScalarFunctions], "shiftLeft", classOf[Long], classOf[Int])
-  val SHIFT_RIGHT_INT = Types.lookupMethod(classOf[ScalarFunctions], "shiftRight", classOf[Int], classOf[Int])
-  val SHIFT_RIGHT_LONG = Types.lookupMethod(classOf[ScalarFunctions], "shiftRight", classOf[Long], classOf[Int])
+  val SHIFT_LEFT_INT =
+    Types.lookupMethod(classOf[ScalarFunctions], "shiftLeft", classOf[Int], classOf[Int])
+  val SHIFT_LEFT_LONG =
+    Types.lookupMethod(classOf[ScalarFunctions], "shiftLeft", classOf[Long], classOf[Int])
+  val SHIFT_RIGHT_INT =
+    Types.lookupMethod(classOf[ScalarFunctions], "shiftRight", classOf[Int], classOf[Int])
+  val SHIFT_RIGHT_LONG =
+    Types.lookupMethod(classOf[ScalarFunctions], "shiftRight", classOf[Long], classOf[Int])
 
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/BuiltInMethods.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/BuiltInMethods.scala
@@ -96,4 +96,9 @@ object BuiltInMethods {
     Types.lookupMethod(
       classOf[ScalarFunctions], "concat_ws", classOf[String], classOf[Array[String]])
 
+  val SHIFT_LEFT_INT = Types.lookupMethod(classOf[ScalarFunctions], "shiftLeft", classOf[Int], classOf[Int])
+  val SHIFT_LEFT_LONG = Types.lookupMethod(classOf[ScalarFunctions], "shiftLeft", classOf[Long], classOf[Int])
+  val SHIFT_RIGHT_INT = Types.lookupMethod(classOf[ScalarFunctions], "shiftRight", classOf[Int], classOf[Int])
+  val SHIFT_RIGHT_LONG = Types.lookupMethod(classOf[ScalarFunctions], "shiftRight", classOf[Long], classOf[Int])
+
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/FunctionGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/FunctionGenerator.scala
@@ -414,6 +414,34 @@ object FunctionGenerator {
     DOUBLE_TYPE_INFO,
     BuiltInMethods.LOG_WITH_BASE)
 
+  addSqlFunctionMethod(
+    SHIFT_LEFT,
+    Seq(INT_TYPE_INFO, INT_TYPE_INFO),
+    INT_TYPE_INFO,
+    BuiltInMethods.SHIFT_LEFT_INT
+  )
+
+  addSqlFunctionMethod(
+    SHIFT_LEFT,
+    Seq(LONG_TYPE_INFO, INT_TYPE_INFO),
+    LONG_TYPE_INFO,
+    BuiltInMethods.SHIFT_LEFT_LONG
+  )
+
+  addSqlFunctionMethod(
+    SHIFT_RIGHT,
+    Seq(INT_TYPE_INFO, INT_TYPE_INFO),
+    INT_TYPE_INFO,
+    BuiltInMethods.SHIFT_RIGHT_INT
+  )
+
+  addSqlFunctionMethod(
+    SHIFT_RIGHT,
+    Seq(LONG_TYPE_INFO, INT_TYPE_INFO),
+    LONG_TYPE_INFO,
+    BuiltInMethods.SHIFT_RIGHT_LONG
+  )
+
   // ----------------------------------------------------------------------------------------------
   // Temporal functions
   // ----------------------------------------------------------------------------------------------

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/sql/ScalarSqlFunctions.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/sql/ScalarSqlFunctions.scala
@@ -58,4 +58,22 @@ object ScalarSqlFunctions {
       OperandTypes.family(SqlTypeFamily.NUMERIC, SqlTypeFamily.NUMERIC)),
     SqlFunctionCategory.NUMERIC)
 
+  val SHIFT_LEFT = new SqlFunction(
+    "SHIFT_LEFT",
+    SqlKind.OTHER_FUNCTION,
+    ReturnTypes.ARG0,
+    null,
+    OperandTypes.family(SqlTypeFamily.NUMERIC, SqlTypeFamily.NUMERIC),
+    SqlFunctionCategory.NUMERIC
+  )
+
+  val SHIFT_RIGHT = new SqlFunction(
+    "SHIFT_RIGHT",
+    SqlKind.OTHER_FUNCTION,
+    ReturnTypes.ARG0,
+    null,
+    OperandTypes.family(SqlTypeFamily.NUMERIC, SqlTypeFamily.NUMERIC),
+    SqlFunctionCategory.NUMERIC
+  )
+
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/functions/ScalarFunctions.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/functions/ScalarFunctions.scala
@@ -159,7 +159,8 @@ object ScalarFunctions {
     input match {
       case l: jl.Long => l << n
       case i: jl.Integer => i << n
-      case _ => throw new IllegalArgumentException(s"type of input in function 'shiftLeft(input, n)' must be Long or Integer")
+      case _ =>
+        throw new IllegalArgumentException(s"type of input in function 'shiftLeft(input, n)' must be Long or Integer")
     }
   }
 
@@ -171,7 +172,8 @@ object ScalarFunctions {
     input match {
       case l: jl.Long => l >> n
       case i: jl.Integer => i >> n
-      case _ => throw new IllegalArgumentException(s"type of input in function 'shiftRight(input, n)' must be Long or Integer")
+      case _ =>
+        throw new IllegalArgumentException(s"type of input in function 'shiftRight(input, n)' must be Long or Integer")
     }
   }
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/functions/ScalarFunctions.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/functions/ScalarFunctions.scala
@@ -20,6 +20,7 @@ package org.apache.flink.table.runtime.functions
 import scala.annotation.varargs
 import java.math.{BigDecimal => JBigDecimal}
 import java.lang.StringBuilder
+import java.{lang => jl}
 
 /**
   * Built-in scalar runtime functions.
@@ -109,4 +110,69 @@ object ScalarFunctions {
       Math.log(x) / Math.log(base)
     }
   }
+
+  /**
+    * Returns the Int number after the input number left shift n bits
+    * @param input Int type
+    * @param n
+    * @return input << n
+    */
+  def shiftLeft(input: Int, n: Int): Int = {
+    _shiftLeft(input, n).asInstanceOf[Int]
+  }
+
+  /**
+    * Returns the Long number after the input number left shift n bits
+    * @param input Long type
+    * @param n
+    * @return input << n
+    */
+  def shiftLeft(input: Long, n: Int): Long = {
+    _shiftLeft(input, n).asInstanceOf[Long]
+  }
+
+  /**
+    * Returns the Int number after the input number right shift n bits
+    * @param input Int type
+    * @param n
+    * @return input >> n
+    */
+  def shiftRight(input: Int, n: Int): Int = {
+    _shiftRight(input, n).asInstanceOf[Int]
+  }
+
+  /**
+    * Returns the Long number after the input number right shift n bits
+    * @param input Long type
+    * @param n
+    * @return input >> n
+    */
+  def shiftRight(input: Long, n: Int): Long = {
+    _shiftRight(input, n).asInstanceOf[Long]
+  }
+
+  /**
+    * Returns the number after the input number left shift n bits
+    * Input must be type 'Long' or type 'Int'
+    */
+  private def _shiftLeft(input: Any, n: Int): Any = {
+    input match {
+      case l: jl.Long => l << n
+      case i: jl.Integer => i << n
+      case _ => throw new IllegalArgumentException(s"type of input in function 'shiftLeft(input, n)' must be Long or Integer")
+    }
+  }
+
+  /**
+    * Returns the number after the input number right shift n bits
+    * Input must be type 'Long' or type 'Int'
+    */
+  private def _shiftRight(input: Any, n: Int): Any = {
+    input match {
+      case l: jl.Long => l >> n
+      case i: jl.Integer => i >> n
+      case _ => throw new IllegalArgumentException(s"type of input in function 'shiftRight(input, n)' must be Long or Integer")
+    }
+  }
+
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
@@ -413,6 +413,8 @@ class BasicOperatorTable extends ReflectiveSqlOperatorTable {
     ScalarSqlFunctions.CONCAT_WS,
     SqlStdOperatorTable.TIMESTAMP_ADD,
     ScalarSqlFunctions.LOG,
+    ScalarSqlFunctions.SHIFT_LEFT,
+    ScalarSqlFunctions.SHIFT_RIGHT,
 
     // EXTENSIONS
     BasicOperatorTable.TUMBLE,

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarFunctionsTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarFunctionsTest.scala
@@ -1216,6 +1216,69 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
     )
   }
 
+  @Test
+  def testShiftLeft(): Unit = {
+    testSqlApi(
+      "SHIFT_LEFT(1,1)",
+      "2"
+    )
+
+    testSqlApi(
+      "SHIFT_LEFT(21,1)",
+      "42"
+    )
+
+    testSqlApi(
+      "SHIFT_LEFT(21,1)",
+      "42"
+    )
+
+    testSqlApi(
+      "SHIFT_LEFT(2147483647,-2147483648)",
+      "2147483647"
+    )
+
+    testSqlApi(
+      "SHIFT_LEFT(-2147483648,2147483647)",
+      "0"
+    )
+
+    testSqlApi(
+      "SHIFT_LEFT(9223372036854775807,-2147483648)",
+      "9223372036854775807"
+    )
+  }
+
+  @Test
+  def testShiftRight(): Unit = {
+    testSqlApi(
+      "SHIFT_RIGHT(1,1)",
+      "0"
+    )
+
+    testSqlApi(
+      "SHIFT_RIGHT(21,1)",
+      "10"
+    )
+
+    testSqlApi(
+      "SHIFT_RIGHT(2147483647,-2147483648)",
+      "2147483647"
+    )
+
+    testSqlApi(
+      "SHIFT_RIGHT(-2147483648,2147483647)",
+      "-1"
+    )
+
+    testSqlApi(
+      "SHIFT_RIGHT(123456789,-2147483648)",
+      "123456789"
+    )
+  }
+
+
+
   // ----------------------------------------------------------------------------------------------
   // Temporal functions
   // ----------------------------------------------------------------------------------------------


### PR DESCRIPTION
In this PR, SHIFT_LEFT and SHIFT_RIGHT are added.

General

The pull request references the related JIRA issue, [FLINK-8302]Support shift_left and shift_right in TableAPI
The pull request addresses only one issue
Each commit in the PR has a meaningful commit message (including the JIRA id)
Tests & Build

Functionality added by the pull request is covered by tests
Documentation

Does this pull request introduce a new feature? (yes )
If yes, how is the feature documented? (docs / JavaDocs)