### PR TITLE
[FLINK-8301] Support Unicode in codegen for  SQL && TableAPI

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
@@ -692,7 +692,9 @@ abstract class CodeGenerator(
         generateNonNullLiteral(resultType, decimalField)
 
       case VARCHAR | CHAR =>
-        val escapedValue = StringEscapeUtils.ESCAPE_JAVA.translate(value.toString)
+        val escapedValue = StringEscapeUtils.escapeJava(
+          StringEscapeUtils.unescapeJava(value.toString)
+        )
         generateNonNullLiteral(resultType, "\"" + escapedValue + "\"")
 
       case SYMBOL =>

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/literals.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/literals.scala
@@ -27,9 +27,10 @@ import org.apache.calcite.util.{DateString, TimeString, TimestampString}
 import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, SqlTimeTypeInfo, TypeInformation}
 import org.apache.flink.table.calcite.FlinkTypeFactory
 import org.apache.flink.table.typeutils.{RowIntervalTypeInfo, TimeIntervalTypeInfo}
-
 import java.sql.{Date, Time, Timestamp}
 import java.util.{Calendar, TimeZone}
+
+import org.apache.commons.lang3.StringEscapeUtils
 
 object Literal {
   private[flink] val UTC = TimeZone.getTimeZone("UTC")
@@ -102,6 +103,11 @@ case class Literal(value: Any, resultType: TypeInformation[_]) extends LeafExpre
           TimeUnit.SECOND,
           SqlParserPos.ZERO)
         relBuilder.getRexBuilder.makeIntervalLiteral(interval, intervalQualifier)
+
+      case BasicTypeInfo.STRING_TYPE_INFO =>
+        relBuilder.getRexBuilder.makeLiteral(
+          StringEscapeUtils.escapeJava(value.asInstanceOf[String])
+        )
 
       case _ => relBuilder.literal(value)
     }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/utils/userDefinedScalarFunctions.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/utils/userDefinedScalarFunctions.scala
@@ -20,6 +20,7 @@ package org.apache.flink.table.expressions.utils
 
 import java.sql.{Date, Time, Timestamp}
 
+import org.apache.commons.lang3.StringUtils
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.table.api.Types
 import org.apache.flink.table.functions.{FunctionContext, ScalarFunction}
@@ -287,4 +288,16 @@ object Func19 extends ScalarFunction {
   override def getResultType(signature: Array[Class[_]]): TypeInformation[_] =
     Types.ROW(Types.INT, Types.BOOLEAN, Types.ROW(Types.INT, Types.INT, Types.INT))
 
+}
+
+class SplitUDF(deterministic: Boolean) extends ScalarFunction {
+  def eval(x: String, sep: String, index: Int): String = {
+    val splits = StringUtils.splitByWholeSeparator(x, sep)
+    if (splits.length > index) {
+      splits(index)
+    } else {
+      null
+    }
+  }
+  override def isDeterministic: Boolean = deterministic
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/batch/sql/CalcITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/batch/sql/CalcITCase.scala
@@ -25,6 +25,7 @@ import org.apache.flink.api.scala._
 import org.apache.flink.api.scala.util.CollectionDataSets
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.api.{TableEnvironment, ValidationException}
+import org.apache.flink.table.expressions.utils.SplitUDF
 import org.apache.flink.table.functions.ScalarFunction
 import org.apache.flink.table.runtime.batch.table.OldHashCode
 import org.apache.flink.table.runtime.utils.TableProgramsTestBase.TableConfigMode
@@ -350,6 +351,42 @@ class CalcITCase(
 
     val expected = "97\n98\n99"
     val results = result.toDataSet[Row].collect()
+    TestBaseUtils.compareResultAsText(results.asJava, expected)
+  }
+
+  @Test
+  def testUdfWithUnicodeParameter(): Unit = {
+    val data = List(
+      ("a\u0001b", "c\"d", "e\\\"\u0004f"),
+      ("x\u0001y", "y\"z", "z\\\"\u0004z")
+    )
+
+    val env = ExecutionEnvironment.getExecutionEnvironment
+
+    val tEnv = TableEnvironment.getTableEnvironment(env)
+
+    val splitUDF0 = new SplitUDF(deterministic = true)
+    val splitUDF1 = new SplitUDF(deterministic = false)
+
+    tEnv.registerFunction("splitUDF0", splitUDF0)
+    tEnv.registerFunction("splitUDF1", splitUDF1)
+
+    // user have to specify '\' with '\\' in SQL
+    val sqlQuery = "SELECT " +
+      "splitUDF0(a, '\u0001', 0) as a0, " +
+      "splitUDF1(a, '\u0001', 0) as a1, " +
+      "splitUDF0(b, '\"', 1) as b0, " +
+      "splitUDF1(b, '\"', 1) as b1, " +
+      "splitUDF0(c, '\\\\\"\u0004', 0) as c0, " +
+      "splitUDF1(c, '\\\\\"\u0004', 0) as c1 from T1"
+
+    val t1 = env.fromCollection(data).toTable(tEnv, 'a, 'b, 'c)
+
+    tEnv.registerTable("T1", t1)
+
+    val results = tEnv.sql(sqlQuery).toDataSet[Row].collect()
+
+    val expected = List("a,a,d,d,e,e", "x,x,z,z,z,z").mkString("\n")
     TestBaseUtils.compareResultAsText(results.asJava, expected)
   }
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/CalcITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/CalcITCase.scala
@@ -24,7 +24,7 @@ import org.apache.flink.streaming.util.StreamingMultipleProgramsTestBase
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.api.TableEnvironment
 import org.apache.flink.table.expressions.Literal
-import org.apache.flink.table.expressions.utils.{Func13, RichFunc1, RichFunc2}
+import org.apache.flink.table.expressions.utils.{Func13, RichFunc1, RichFunc2, SplitUDF}
 import org.apache.flink.table.runtime.utils.{StreamITCase, StreamTestData}
 import org.apache.flink.table.runtime.utils.UserDefinedFunctionTestUtils
 import org.apache.flink.types.Row
@@ -350,6 +350,34 @@ class CalcITCase extends StreamingMultipleProgramsTestBase {
       "{7=Comment#1}",
       "{8=Comment#2}",
       "{9=Comment#3}")
+    assertEquals(expected.sorted, StreamITCase.testResults.sorted)
+  }
+
+  @Test
+  def testUDFWithUnicodeParameter(): Unit = {
+    val data = List(
+      ("a\u0001b", "c\"d", "e\\\"\u0004f"),
+      ("x\u0001y", "y\"z", "z\\\"\u0004z")
+    )
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env)
+    StreamITCase.testResults = mutable.MutableList()
+    val splitUDF0 = new SplitUDF(deterministic = true)
+    val splitUDF1 = new SplitUDF(deterministic = false)
+    val ds = env.fromCollection(data).toTable(tEnv, 'a, 'b, 'c)
+      .select(splitUDF0('a, "\u0001", 0) as 'a0,
+              splitUDF1('a, "\u0001", 0) as 'a1,
+              splitUDF0('b, "\"", 1) as 'b0,
+              splitUDF1('b, "\"", 1) as 'b1,
+              splitUDF0('c, "\\\"\u0004", 0) as 'c0,
+              splitUDF1('c, "\\\"\u0004", 0) as 'c1
+      )
+    val results = ds.toAppendStream[Row]
+    results.addSink(new StreamITCase.StringSink[Row])
+    env.execute()
+    val expected = mutable.MutableList(
+      "a,a,d,d,e,e", "x,x,z,z,z,z"
+    )
     assertEquals(expected.sorted, StreamITCase.testResults.sorted)
   }
 }


### PR DESCRIPTION




## What is the purpose of the change

*support unicode literal in sql and handles code generation correctly


## Brief change log

  - *SQL && TableAPI has different literals if using unicode. After sql parse, the literal is "\\u0001" with length = 6 but TableAPI get "\u0001" with length = 1
  - *before generating code, unescape first to make \uxxxx in one character , and escape to generate a valid Java String.
  - *the literal '\uxxxx' from TableAPI has already been an one character String, it needs escaping before code generation
 - *so in SQL path, a literal needs unescape and escape, in TableAPI path a literal needs escape first and join the same path with SQL.


## Verifying this change

This change added tests and can be verified as follows:

  - *Added test for both SQL && TableAPI with unicode parameter*
     no

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): 
    no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: 
    no
  - The serializers: 
    no
  - The runtime per-record code paths (performance sensitive): 
    no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: 
    no
  - The S3 file system connector: 
    no

## Documentation

  - Does this pull request introduce a new feature? no
