### PR TITLE
[FLINK-8037] Fix integer multiplication or shift implicitly cast to long

### DIFF
--- a/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/RollingSinkITCase.java
+++ b/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/RollingSinkITCase.java
@@ -927,7 +927,7 @@ public class RollingSinkITCase extends TestLogger {
 					// with 5 elements in each time window
 					latch1.await();
 					latch2.await();
-					ModifyableClock.setCurrentTime(i * 1000);
+					ModifyableClock.setCurrentTime(i * 1000L);
 				}
 				ctx.collect(Tuple2.of(i, "message #" + i));
 			}

--- a/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011.java
@@ -807,7 +807,7 @@ public class FlinkKafkaProducer011<IN>
 			// case we adjust nextFreeTransactionalId by the range of transactionalIds that could be used for this
 			// scaling up.
 			if (getRuntimeContext().getNumberOfParallelSubtasks() > nextTransactionalIdHint.lastParallelism) {
-				nextFreeTransactionalId += getRuntimeContext().getNumberOfParallelSubtasks() * kafkaProducersPoolSize;
+				nextFreeTransactionalId += (long) getRuntimeContext().getNumberOfParallelSubtasks() * kafkaProducersPoolSize;
 			}
 
 			nextTransactionalIdHintState.add(new NextTransactionalIdHint(

--- a/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/TransactionalIdsGenerator.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/TransactionalIdsGenerator.java
@@ -71,7 +71,7 @@ public class TransactionalIdsGenerator {
 	public Set<String> generateIdsToUse(long nextFreeTransactionalId) {
 		Set<String> transactionalIds = new HashSet<>();
 		for (int i = 0; i < poolSize; i++) {
-			long transactionalId = nextFreeTransactionalId + subtaskIndex * poolSize + i;
+			long transactionalId = nextFreeTransactionalId + (long) subtaskIndex * poolSize + i;
 			transactionalIds.add(generateTransactionalId(transactionalId));
 		}
 		return transactionalIds;
@@ -85,7 +85,7 @@ public class TransactionalIdsGenerator {
 	public Set<String> generateIdsToAbort() {
 		Set<String> idsToAbort = new HashSet<>();
 		for (int i = 0; i < safeScaleDownFactor; i++) {
-			idsToAbort.addAll(generateIdsToUse(i * poolSize * totalNumberOfSubtasks));
+			idsToAbort.addAll(generateIdsToUse((long) i * poolSize * totalNumberOfSubtasks));
 		}
 		return idsToAbort;
 	}

--- a/flink-connectors/flink-connector-kafka-0.11/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011ITCase.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011ITCase.java
@@ -510,8 +510,8 @@ public class FlinkKafkaProducer011ITCase extends KafkaTestBase {
 			testHarness.open();
 
 			for (int i = 0; i < FlinkKafkaProducer011.DEFAULT_KAFKA_PRODUCERS_POOL_SIZE * 2; i++) {
-				testHarness.processElement(i, i * 2);
-				testHarness.snapshot(i, i * 2 + 1);
+				testHarness.processElement(i, i * 2L);
+				testHarness.snapshot(i, i * 2L + 1);
 			}
 		}
 		catch (Exception ex) {

--- a/flink-contrib/flink-storm/src/main/java/org/apache/flink/storm/api/FlinkClient.java
+++ b/flink-contrib/flink-storm/src/main/java/org/apache/flink/storm/api/FlinkClient.java
@@ -234,7 +234,7 @@ public class FlinkClient {
 
 		if (options != null) {
 			try {
-				Thread.sleep(1000 * options.get_wait_secs());
+				Thread.sleep(1000L * options.get_wait_secs());
 			} catch (final InterruptedException e) {
 				throw new RuntimeException(e);
 			}

--- a/flink-core/src/main/java/org/apache/flink/util/AbstractID.java
+++ b/flink-core/src/main/java/org/apache/flink/util/AbstractID.java
@@ -186,7 +186,7 @@ public class AbstractID implements Comparable<AbstractID>, java.io.Serializable 
 		long l = 0;
 
 		for (int i = 0; i < SIZE_OF_LONG; ++i) {
-			l |= (ba[offset + SIZE_OF_LONG - 1 - i] & 0xffL) << ((long) i << 3);
+			l |= (ba[offset + SIZE_OF_LONG - 1 - i] & 0xffL) << (i << 3);
 		}
 
 		return l;

--- a/flink-core/src/main/java/org/apache/flink/util/AbstractID.java
+++ b/flink-core/src/main/java/org/apache/flink/util/AbstractID.java
@@ -186,7 +186,7 @@ public class AbstractID implements Comparable<AbstractID>, java.io.Serializable 
 		long l = 0;
 
 		for (int i = 0; i < SIZE_OF_LONG; ++i) {
-			l |= (ba[offset + SIZE_OF_LONG - 1 - i] & 0xffL) << (i << 3);
+			l |= (ba[offset + SIZE_OF_LONG - 1 - i] & 0xffL) << ((long) i << 3);
 		}
 
 		return l;

--- a/flink-java/src/test/java/org/apache/flink/api/common/operators/CollectionExecutionWithBroadcastVariableTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/common/operators/CollectionExecutionWithBroadcastVariableTest.java
@@ -86,7 +86,7 @@ public class CollectionExecutionWithBroadcastVariableTest {
 
 			env.execute();
 
-			assertEquals(TEST_DATA.length * TEST_DATA.length, result.size());
+			assertEquals((long) TEST_DATA.length * TEST_DATA.length, result.size());
 			for (String s : result) {
 				assertTrue(s.indexOf(SUFFIX) == 2);
 			}

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/dataset/ChecksumHashCodeTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/asm/dataset/ChecksumHashCodeTest.java
@@ -51,13 +51,14 @@ public class ChecksumHashCodeTest {
 	public void testList() throws Exception {
 		List<Long> list = Arrays.asList(ArrayUtils.toObject(
 			new long[]{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 }));
+		long listSize = list.size();
 
 		DataSet<Long> dataset = env.fromCollection(list);
 
 		Checksum checksum = new ChecksumHashCode<Long>().run(dataset).execute();
 
-		assertEquals(list.size(), checksum.getCount());
-		assertEquals(list.size() * (list.size() - 1) / 2, checksum.getChecksum());
+		assertEquals(listSize, checksum.getCount());
+		assertEquals(listSize * (listSize - 1) / 2, checksum.getChecksum());
 	}
 
 	@Test

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/CirculantGraphTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/CirculantGraphTest.java
@@ -49,7 +49,7 @@ public class CirculantGraphTest extends GraphGeneratorTestBase {
 
 	@Test
 	public void testGraphMetrics() throws Exception {
-		int vertexCount = 10;
+		long vertexCount = 10;
 		int offset = 4;
 		int length = 2;
 

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/CompleteGraphTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/CompleteGraphTest.java
@@ -47,7 +47,7 @@ public class CompleteGraphTest extends GraphGeneratorTestBase {
 
 	@Test
 	public void testGraphMetrics() throws Exception {
-		int vertexCount = 10;
+		long vertexCount = 10;
 
 		Graph<LongValue, NullValue, NullValue> graph = new CompleteGraph(env, vertexCount)
 			.generate();

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/CycleGraphTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/CycleGraphTest.java
@@ -46,7 +46,7 @@ public class CycleGraphTest extends GraphGeneratorTestBase {
 
 	@Test
 	public void testGraphMetrics() throws Exception {
-		int vertexCount = 100;
+		long vertexCount = 100;
 
 		Graph<LongValue, NullValue, NullValue> graph = new CycleGraph(env, vertexCount)
 			.generate();

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/EchoGraphTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/EchoGraphTest.java
@@ -90,7 +90,7 @@ public class EchoGraphTest extends GraphGeneratorTestBase {
 
 	@Test
 	public void testGraphMetrics() throws Exception {
-		int vertexCount = 10;
+		long vertexCount = 10;
 		int vertexDegree = 3;
 
 		Graph<LongValue, NullValue, NullValue> graph = new EchoGraph(env, vertexCount, vertexDegree)

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/PathGraphTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/PathGraphTest.java
@@ -46,7 +46,7 @@ public class PathGraphTest extends GraphGeneratorTestBase {
 
 	@Test
 	public void testGraphMetrics() throws Exception {
-		int vertexCount = 100;
+		long vertexCount = 100;
 
 		Graph<LongValue, NullValue, NullValue> graph = new PathGraph(env, vertexCount)
 			.generate();

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/SingletonEdgeGraphTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/SingletonEdgeGraphTest.java
@@ -47,7 +47,7 @@ public class SingletonEdgeGraphTest extends GraphGeneratorTestBase {
 
 	@Test
 	public void testGraphMetrics() throws Exception {
-		int vertexPairCount = 10;
+		long vertexPairCount = 10;
 
 		Graph<LongValue, NullValue, NullValue> graph = new SingletonEdgeGraph(env, vertexPairCount)
 			.generate();

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/StarGraphTest.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/StarGraphTest.java
@@ -48,7 +48,7 @@ public class StarGraphTest extends GraphGeneratorTestBase {
 
 	@Test
 	public void testGraphMetrics() throws Exception {
-		int vertexCount = 100;
+		long vertexCount = 100;
 
 		Graph<LongValue, NullValue, NullValue> graph = new StarGraph(env, vertexCount)
 			.generate();

--- a/flink-libraries/flink-table/src/test/java/org/apache/flink/table/runtime/utils/JavaUserDefinedAggFunctions.java
+++ b/flink-libraries/flink-table/src/test/java/org/apache/flink/table/runtime/utils/JavaUserDefinedAggFunctions.java
@@ -100,7 +100,7 @@ public class JavaUserDefinedAggFunctions {
 
 		//Overloaded accumulate method
 		public void accumulate(WeightedAvgAccum accumulator, int iValue, int iWeight) {
-			accumulator.sum += iValue * iWeight;
+			accumulator.sum += (long) iValue * iWeight;
 			accumulator.count += iWeight;
 		}
 	}
@@ -146,7 +146,7 @@ public class JavaUserDefinedAggFunctions {
 
 		//Overloaded retract method
 		public void retract(WeightedAvgAccum accumulator, int iValue, int iWeight) {
-			accumulator.sum -= iValue * iWeight;
+			accumulator.sum -= (long) iValue * iWeight;
 			accumulator.count -= iWeight;
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/iomanager/ChannelWriterOutputView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/iomanager/ChannelWriterOutputView.java
@@ -190,7 +190,7 @@ public final class ChannelWriterOutputView extends AbstractPagedOutputView {
 	 */
 	public long getBytesMemoryUsed()
 	{
-		return (this.blockCount - 1) * getSegmentSize() + getCurrentPositionInSegment();
+		return (long) (this.blockCount - 1) * getSegmentSize() + getCurrentPositionInSegment();
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
@@ -568,7 +568,7 @@ public class MemoryManager {
 	 * @return The number of pages corresponding to the memory fraction.
 	 */
 	public long computeMemorySize(double fraction) {
-		return pageSize * computeNumberOfPages(fraction);
+		return (long) pageSize * computeNumberOfPages(fraction);
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/InPlaceMutableHashTable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/InPlaceMutableHashTable.java
@@ -199,7 +199,7 @@ public class InPlaceMutableHashTable<T> extends AbstractMutableHashTable<T> {
 	 * @return The hash table's total capacity.
 	 */
 	public long getCapacity() {
-		return numAllMemorySegments * segmentSize;
+		return (long) numAllMemorySegments * segmentSize;
 	}
 
 	/**
@@ -208,7 +208,7 @@ public class InPlaceMutableHashTable<T> extends AbstractMutableHashTable<T> {
 	 * @return The number of bytes occupied.
 	 */
 	public long getOccupancy() {
-		return numAllMemorySegments * segmentSize - freeMemorySegments.size() * segmentSize;
+		return (long) numAllMemorySegments * segmentSize - (long) freeMemorySegments.size() * segmentSize;
 	}
 
 	private void open(int numBucketSegments) {
@@ -562,7 +562,7 @@ public class InPlaceMutableHashTable<T> extends AbstractMutableHashTable<T> {
 		}
 
 		public long getTotalSize() {
-			return segments.size() * segmentSize;
+			return (long) segments.size() * segmentSize;
 		}
 
 		// ----------------------- Output -----------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/util/BloomFilter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/util/BloomFilter.java
@@ -51,7 +51,7 @@ public class BloomFilter {
 	public BloomFilter(int expectedEntries, int byteSize) {
 		checkArgument(expectedEntries > 0, "expectedEntries should be > 0");
 		this.expectedEntries = expectedEntries;
-		this.numHashFunctions = optimalNumOfHashFunctions(expectedEntries, byteSize << 3);
+		this.numHashFunctions = optimalNumOfHashFunctions(expectedEntries, (long) byteSize << 3);
 		this.bitSet = new BitSet(byteSize);
 	}
 	

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/PointwisePatternTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/PointwisePatternTest.java
@@ -140,8 +140,8 @@ public class PointwisePatternTest {
 			ExecutionEdge[] inEdges = ev.getInputEdges(0);
 			assertEquals(2, inEdges.length);
 			
-			assertEquals(ev.getParallelSubtaskIndex() * 2, inEdges[0].getSource().getPartitionNumber());
-			assertEquals(ev.getParallelSubtaskIndex() * 2 + 1, inEdges[1].getSource().getPartitionNumber());
+			assertEquals(ev.getParallelSubtaskIndex() * 2L, inEdges[0].getSource().getPartitionNumber());
+			assertEquals(ev.getParallelSubtaskIndex() * 2L + 1, inEdges[1].getSource().getPartitionNumber());
 		}
 	}
 	
@@ -188,9 +188,9 @@ public class PointwisePatternTest {
 			ExecutionEdge[] inEdges = ev.getInputEdges(0);
 			assertEquals(3, inEdges.length);
 			
-			assertEquals(ev.getParallelSubtaskIndex() * 3, inEdges[0].getSource().getPartitionNumber());
-			assertEquals(ev.getParallelSubtaskIndex() * 3 + 1, inEdges[1].getSource().getPartitionNumber());
-			assertEquals(ev.getParallelSubtaskIndex() * 3 + 2, inEdges[2].getSource().getPartitionNumber());
+			assertEquals(ev.getParallelSubtaskIndex() * 3L, inEdges[0].getSource().getPartitionNumber());
+			assertEquals(ev.getParallelSubtaskIndex() * 3L + 1, inEdges[1].getSource().getPartitionNumber());
+			assertEquals(ev.getParallelSubtaskIndex() * 3L + 2, inEdges[2].getSource().getPartitionNumber());
 		}
 	}
 	

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NetworkEnvironmentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NetworkEnvironmentTest.java
@@ -153,7 +153,7 @@ public class NetworkEnvironmentTest {
 			public Void answer(final InvocationOnMock invocation) throws Throwable {
 				BufferPool bp = invocation.getArgumentAt(0, BufferPool.class);
 				if (partitionType == ResultPartitionType.PIPELINED_BOUNDED) {
-					assertEquals(channels * 2 + 8, bp.getMaxNumberOfMemorySegments());
+					assertEquals(channels * 2L + 8, bp.getMaxNumberOfMemorySegments());
 				} else if (partitionType == ResultPartitionType.PIPELINED_CREDIT_BASED) {
 					assertEquals(8, bp.getMaxNumberOfMemorySegments());
 				} else {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyBufferPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyBufferPoolTest.java
@@ -95,7 +95,7 @@ public class NettyBufferPoolTest {
 			// Allocate a little more (one more chunk required)
 			nettyBufferPool.directBuffer(128);
 			long allocated = nettyBufferPool.getNumberOfAllocatedBytes().get();
-			assertEquals(2 * chunkSize, allocated);
+			assertEquals(2L * chunkSize, allocated);
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
@@ -365,10 +365,10 @@ public class SingleInputGateTest {
 			assertEquals(initialBackoff, ch.getCurrentBackoff());
 
 			assertTrue(ch.increaseBackoff());
-			assertEquals(initialBackoff * 2, ch.getCurrentBackoff());
+			assertEquals(initialBackoff * 2L, ch.getCurrentBackoff());
 
 			assertTrue(ch.increaseBackoff());
-			assertEquals(initialBackoff * 2 * 2, ch.getCurrentBackoff());
+			assertEquals(initialBackoff * 2L * 2L, ch.getCurrentBackoff());
 
 			assertTrue(ch.increaseBackoff());
 			assertEquals(maxBackoff, ch.getCurrentBackoff());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/SchedulerSlotSharingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/SchedulerSlotSharingTest.java
@@ -982,7 +982,7 @@ public class SchedulerSlotSharingTest extends SchedulerTestBase {
 				}
 				
 				assertEquals(4, testingSlotProvider.getNumberOfAvailableSlots());
-				assertEquals(13 * (run + 1), testingSlotProvider.getNumberOfUnconstrainedAssignments());
+				assertEquals(13L * (run + 1), testingSlotProvider.getNumberOfUnconstrainedAssignments());
 			}
 		}
 		catch (Exception e) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/TaskCancelThread.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/TaskCancelThread.java
@@ -49,7 +49,7 @@ public class TaskCancelThread extends Thread {
 	@Override
 	public void run() {
 		try {
-			Thread.sleep(this.cancelTimeout*1000);
+			Thread.sleep(this.cancelTimeout*1000L);
 		}
 		catch (InterruptedException e) {
 			Assert.fail("CancelThread interruped while waiting for cancel timeout");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/TaskCancelThread.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/TaskCancelThread.java
@@ -49,7 +49,7 @@ public class TaskCancelThread extends Thread {
 	@Override
 	public void run() {
 		try {
-			Thread.sleep(this.cancelTimeout*1000L);
+			Thread.sleep(this.cancelTimeout * 1000L);
 		}
 		catch (InterruptedException e) {
 			Assert.fail("CancelThread interruped while waiting for cancel timeout");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/backpressure/StackTraceSampleCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/backpressure/StackTraceSampleCoordinatorTest.java
@@ -221,7 +221,7 @@ public class StackTraceSampleCoordinatorTest extends TestLogger {
 				vertices, 1, Time.milliseconds(100L), 0);
 
 			// Wait for the timeout
-			Thread.sleep(timeout * 2);
+			Thread.sleep(timeout * 2L);
 
 			boolean success = false;
 			for (int i = 0; i < 10; i++) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStateOutputStreamTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStateOutputStreamTest.java
@@ -110,7 +110,7 @@ public class FsCheckpointStateOutputStreamTest {
 
 		byte[] data = "testme!".getBytes(ConfigConstants.DEFAULT_CHARSET);
 
-		for (int i = 0; i < 7; ++i) {
+		for (long i = 0; i < 7; ++i) {
 			Assert.assertEquals(i * (1 + data.length), stream.getPos());
 			stream.write(0x42);
 			stream.write(data);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerRegistrationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerRegistrationTest.java
@@ -453,7 +453,7 @@ public class TaskManagerRegistrationTest extends TestLogger {
 
 				int exp = Math.min(maxExponent, exponent);
 
-				long difference = timeout.toMillis() - (initialRegistrationPause * (1 << exp));
+				long difference = timeout.toMillis() - (initialRegistrationPause * (1L << exp));
 
 				int numberRegisterTaskManagerMessages = exp;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerRegistrationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerRegistrationTest.java
@@ -453,7 +453,7 @@ public class TaskManagerRegistrationTest extends TestLogger {
 
 				int exp = Math.min(maxExponent, exponent);
 
-				long difference = timeout.toMillis() - (initialRegistrationPause * (1L << exp));
+				long difference = timeout.toMillis() - (initialRegistrationPause * (1 << exp));
 
 				int numberRegisterTaskManagerMessages = exp;
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StateInitializationContextImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StateInitializationContextImplTest.java
@@ -147,7 +147,7 @@ public class StateInitializationContextImplTest {
 				DataInputView div = new DataInputViewStreamWrapper(is);
 
 				int val = div.readInt();
-				Assert.assertEquals(i * NUM_HANDLES + s, val);
+				Assert.assertEquals((long) i * NUM_HANDLES + s, val);
 			}
 
 			++s;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/ContinuousFileProcessingRescalingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/ContinuousFileProcessingRescalingTest.java
@@ -274,7 +274,7 @@ public class ContinuousFileProcessingRescalingTest {
 		public FileInputSplit[] createInputSplits(int minNumSplits) throws IOException {
 			FileInputSplit[] splits = new FileInputSplit[minNumSplits];
 			for (int i = 0; i < minNumSplits; i++) {
-				splits[i] = new FileInputSplit(i, getFilePath(), i * linesPerSplit + 1, linesPerSplit, null);
+				splits[i] = new FileInputSplit(i, getFilePath(), (long) i * linesPerSplit + 1, linesPerSplit, null);
 			}
 			return splits;
 		}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/KeyMapPutIfAbsentTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/KeyMapPutIfAbsentTest.java
@@ -52,11 +52,11 @@ public class KeyMapPutIfAbsentTest {
 			assertEquals(1 << 21, map.getCurrentTableCapacity());
 
 			for (int i = 0; i < numElements; i++) {
-				assertEquals(2 * i + 1, map.get(i).intValue());
+				assertEquals(2L * i + 1, map.get(i).intValue());
 			}
 
 			for (int i = numElements - 1; i >= 0; i--) {
-				assertEquals(2 * i + 1, map.get(i).intValue());
+				assertEquals(2L * i + 1, map.get(i).intValue());
 			}
 
 			assertEquals(numElements, map.size());
@@ -88,11 +88,11 @@ public class KeyMapPutIfAbsentTest {
 			for (int i = 0; i < numElements; i += 3) {
 				factory.set(2 * i);
 				Integer put = map.putIfAbsent(i, factory);
-				assertEquals(2 * i + 1, put.intValue());
+				assertEquals(2L * i + 1, put.intValue());
 			}
 
 			for (int i = 0; i < numElements; i++) {
-				assertEquals(2 * i + 1, map.get(i).intValue());
+				assertEquals(2L * i + 1, map.get(i).intValue());
 			}
 
 			assertEquals(numElements, map.size());

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/KeyMapPutTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/KeyMapPutTest.java
@@ -55,11 +55,11 @@ public class KeyMapPutTest {
 			assertEquals(1 << 21, map.getCurrentTableCapacity());
 
 			for (int i = 0; i < numElements; i++) {
-				assertEquals(2 * i + 1, map.get(i).intValue());
+				assertEquals(2L * i + 1, map.get(i).intValue());
 			}
 
 			for (int i = numElements - 1; i >= 0; i--) {
-				assertEquals(2 * i + 1, map.get(i).intValue());
+				assertEquals(2L * i + 1, map.get(i).intValue());
 			}
 
 			BitSet bitset = new BitSet();
@@ -67,7 +67,7 @@ public class KeyMapPutTest {
 			for (KeyMap.Entry<Integer, Integer> entry : map) {
 				numContained++;
 
-				assertEquals(entry.getKey() * 2 + 1, entry.getValue().intValue());
+				assertEquals(entry.getKey() * 2L + 1, entry.getValue().intValue());
 				assertFalse(bitset.get(entry.getKey()));
 				bitset.set(entry.getKey());
 			}
@@ -100,7 +100,7 @@ public class KeyMapPutTest {
 			for (int i = 0; i < numElements; i += 3) {
 				Integer put = map.put(i, 2 * i);
 				assertNotNull(put);
-				assertEquals(2 * i + 1, put.intValue());
+				assertEquals(2L * i + 1, put.intValue());
 			}
 
 			for (int i = 0; i < numElements; i++) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/KeyMapTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/KeyMapTest.java
@@ -105,7 +105,7 @@ public class KeyMapTest {
 				assertEquals(Integer.highestOneBit(Integer.MAX_VALUE), map.getCurrentTableCapacity());
 				assertEquals(30, map.getLog2TableCapacity());
 				assertEquals(0, map.getShift());
-				assertEquals(maxCap / 4 * 3, map.getRehashThreshold());
+				assertEquals(maxCap / 4L * 3, map.getRehashThreshold());
 			}
 			catch (OutOfMemoryError e) {
 				// this may indeed happen in small test setups. we tolerate this in this test

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/NetworkStackThroughputITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/NetworkStackThroughputITCase.java
@@ -86,7 +86,7 @@ public class NetworkStackThroughputITCase extends TestLogger {
 				// Determine the amount of data to send per subtask
 				int dataVolumeGb = getTaskConfiguration().getInteger(NetworkStackThroughputITCase.DATA_VOLUME_GB_CONFIG_KEY, 1);
 
-				long dataMbPerSubtask = (dataVolumeGb * 1024) / getCurrentNumberOfSubtasks();
+				long dataMbPerSubtask = (dataVolumeGb * 1024L) / getCurrentNumberOfSubtasks();
 				long numRecordsToEmit = (dataMbPerSubtask * 1024 * 1024) / SpeedTestRecord.RECORD_SIZE;
 
 				LOG.info(String.format("%d/%d: Producing %d records (each record: %d bytes, total: %.2f GB)",
@@ -272,7 +272,7 @@ public class NetworkStackThroughputITCase extends TestLogger {
 				parallelism),
 			false);
 
-		long dataVolumeMbit = dataVolumeGb * 8192;
+		long dataVolumeMbit = dataVolumeGb * 8192L;
 		long runtimeSecs = jer.getNetRuntime(TimeUnit.SECONDS);
 
 		int mbitPerSecond = (int) (((double) dataVolumeMbit) / runtimeSecs);

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/IterateITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/IterateITCase.java
@@ -383,7 +383,7 @@ public class IterateITCase extends AbstractTestBase {
 				DataStream<Boolean> source = env.fromCollection(Collections.nCopies(parallelism * 2, false))
 						.map(noOpBoolMap).name("ParallelizeMap");
 
-				IterativeStream<Boolean> iteration = source.iterate(3000 * timeoutScale);
+				IterativeStream<Boolean> iteration = source.iterate(3000L * timeoutScale);
 
 				DataStream<Boolean> increment = iteration.flatMap(new IterationHead()).map(noOpBoolMap);
 
@@ -427,7 +427,7 @@ public class IterateITCase extends AbstractTestBase {
 
 				ConnectedIterativeStreams<Integer, String> coIt = env.fromElements(0, 0)
 						.map(noOpIntMap).name("ParallelizeMap")
-						.iterate(2000 * timeoutScale)
+						.iterate(2000L * timeoutScale)
 						.withFeedbackType("String");
 
 				try {
@@ -533,7 +533,7 @@ public class IterateITCase extends AbstractTestBase {
 				DataStream<Integer> source = env.fromElements(1, 2, 3)
 						.map(noOpIntMap).name("ParallelizeMap");
 
-				IterativeStream<Integer> it = source.keyBy(key).iterate(3000 * timeoutScale);
+				IterativeStream<Integer> it = source.keyBy(key).iterate(3000L * timeoutScale);
 
 				DataStream<Integer> head = it.flatMap(new RichFlatMapFunction<Integer, Integer>() {
 
@@ -591,7 +591,7 @@ public class IterateITCase extends AbstractTestBase {
 				DataStream<Boolean> source = env.fromCollection(Collections.nCopies(parallelism * 2, false))
 						.map(noOpBoolMap).name("ParallelizeMap");
 
-				IterativeStream<Boolean> iteration = source.iterate(3000 * timeoutScale);
+				IterativeStream<Boolean> iteration = source.iterate(3000L * timeoutScale);
 
 				iteration.closeWith(iteration.flatMap(new IterationHead())).addSink(new ReceiveCheckNoOpSink<Boolean>());
 


### PR DESCRIPTION
## What is the purpose of the change

Fixes potential overflow flagged by the IntelliJ inspection "Integer multiplication or shift implicitly cast to long".

## Brief change log

- mark integer literal as long
- cast multiplied integer to long

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no)**
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)