### PR TITLE
[FLINK-8299][flip6] Poll JobExecutionResult after job submission

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
@@ -124,7 +124,7 @@ public abstract class ClusterClient {
 	 * been run inside the user JAR. We pass the Client to every instance of the ContextEnvironment
 	 * which lets us access the execution result here.
 	 */
-	private JobExecutionResult lastJobExecutionResult;
+	protected JobExecutionResult lastJobExecutionResult;
 
 	/** Switch for blocking/detached job submission of the client. */
 	private boolean detachedJobSubmission = false;

--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
@@ -18,40 +18,50 @@
 
 package org.apache.flink.client.program.rest;
 
-import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobSubmissionResult;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.client.program.ProgramInvocationException;
+import org.apache.flink.client.program.rest.retry.ExponentialWaitStrategy;
+import org.apache.flink.client.program.rest.retry.WaitStrategy;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobClient;
 import org.apache.flink.runtime.blob.PermanentBlobKey;
 import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.runtime.client.JobSubmissionException;
+import org.apache.flink.runtime.client.SerializedJobExecutionResult;
 import org.apache.flink.runtime.clusterframework.messages.GetClusterStatusResponse;
 import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.runtime.messages.webmonitor.JobDetails;
 import org.apache.flink.runtime.messages.webmonitor.MultipleJobsDetails;
 import org.apache.flink.runtime.rest.RestClient;
 import org.apache.flink.runtime.rest.messages.BlobServerPortHeaders;
 import org.apache.flink.runtime.rest.messages.BlobServerPortResponseBody;
 import org.apache.flink.runtime.rest.messages.EmptyResponseBody;
+import org.apache.flink.runtime.rest.messages.JobMessageParameters;
 import org.apache.flink.runtime.rest.messages.JobTerminationHeaders;
 import org.apache.flink.runtime.rest.messages.JobTerminationMessageParameters;
 import org.apache.flink.runtime.rest.messages.JobsOverviewHeaders;
 import org.apache.flink.runtime.rest.messages.TerminationModeQueryParameter;
+import org.apache.flink.runtime.rest.messages.job.JobExecutionResultHeaders;
+import org.apache.flink.runtime.rest.messages.job.JobExecutionResultResponseBody;
 import org.apache.flink.runtime.rest.messages.job.JobSubmitHeaders;
 import org.apache.flink.runtime.rest.messages.job.JobSubmitRequestBody;
 import org.apache.flink.runtime.rest.messages.job.JobSubmitResponseBody;
 import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointMessageParameters;
 import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointTriggerHeaders;
 import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointTriggerResponseBody;
+import org.apache.flink.runtime.rest.messages.queue.QueueStatus;
 import org.apache.flink.runtime.util.ExecutorThreadFactory;
 import org.apache.flink.util.ExecutorUtils;
+import org.apache.flink.util.SerializedThrowable;
 
 import javax.annotation.Nullable;
 
+import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.URL;
 import java.util.ArrayList;
@@ -59,9 +69,14 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static java.util.Objects.requireNonNull;
+import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * A {@link ClusterClient} implementation that communicates via HTTP REST requests.
@@ -71,15 +86,18 @@ public class RestClusterClient extends ClusterClient {
 	private final RestClusterClientConfiguration restClusterClientConfiguration;
 	private final RestClient restClient;
 	private final ExecutorService executorService = Executors.newFixedThreadPool(4, new ExecutorThreadFactory("Flink-RestClusterClient-IO"));
+	private final WaitStrategy waitStrategy;
 
 	public RestClusterClient(Configuration config) throws Exception {
-		this(config, RestClusterClientConfiguration.fromConfiguration(config));
+		this(config, new ExponentialWaitStrategy(10, 2000));
 	}
 
-	public RestClusterClient(Configuration config, RestClusterClientConfiguration configuration) throws Exception {
-		super(config);
-		this.restClusterClientConfiguration = configuration;
-		this.restClient = new RestClient(configuration.getRestClientConfiguration(), executorService);
+	@VisibleForTesting
+	RestClusterClient(Configuration configuration, WaitStrategy waitStrategy) throws Exception {
+		super(configuration);
+		this.restClusterClientConfiguration = RestClusterClientConfiguration.fromConfiguration(configuration);
+		this.restClient = new RestClient(restClusterClientConfiguration.getRestClientConfiguration(), executorService);
+		this.waitStrategy = requireNonNull(waitStrategy);
 	}
 
 	@Override
@@ -104,11 +122,26 @@ public class RestClusterClient extends ClusterClient {
 		} catch (JobSubmissionException e) {
 			throw new ProgramInvocationException(e);
 		}
-		// don't return just a JobSubmissionResult here, the signature is lying
-		// The CliFrontend expects this to be a JobExecutionResult
 
-		// TOOD: do not exit this method until job is finished
-		return new JobExecutionResult(jobGraph.getJobID(), 1, Collections.emptyMap());
+		final JobResult jobExecutionResult = waitForJobExecutionResult(jobGraph.getJobID());
+
+		if (jobExecutionResult.getSerializedThrowable().isPresent()) {
+			final SerializedThrowable serializedThrowable = jobExecutionResult.getSerializedThrowable().get();
+			final Throwable throwable = serializedThrowable.deserializeError(classLoader);
+			throw new ProgramInvocationException(throwable);
+		}
+
+		try {
+			// don't return just a JobSubmissionResult here, the signature is lying
+			// The CliFrontend expects this to be a JobExecutionResult
+			this.lastJobExecutionResult = new SerializedJobExecutionResult(
+				jobExecutionResult.getJobId(),
+				jobExecutionResult.getNetRuntime(),
+				jobExecutionResult.getAccumulatorResults()).toJobExecutionResult(classLoader);
+			return lastJobExecutionResult;
+		} catch (IOException | ClassNotFoundException e) {
+			throw new ProgramInvocationException(e);
+		}
 	}
 
 	private void submitJob(JobGraph jobGraph) throws JobSubmissionException {
@@ -146,6 +179,39 @@ public class RestClusterClient extends ClusterClient {
 		} catch (Exception e) {
 			throw new JobSubmissionException(jobGraph.getJobID(), "Failed to submit JobGraph.", e);
 		}
+	}
+
+	private JobResult waitForJobExecutionResult(
+			final JobID jobId) throws ProgramInvocationException {
+
+		final JobMessageParameters messageParameters = new JobMessageParameters();
+		messageParameters.jobPathParameter.resolve(jobId);
+		JobExecutionResultResponseBody jobExecutionResultResponseBody;
+		try {
+			long attempt = 0;
+			do {
+				final CompletableFuture<JobExecutionResultResponseBody> responseFuture =
+					restClient.sendRequest(
+						restClusterClientConfiguration.getRestServerAddress(),
+						restClusterClientConfiguration.getRestServerPort(),
+						JobExecutionResultHeaders.getInstance(),
+						messageParameters);
+				jobExecutionResultResponseBody = responseFuture.get(timeout.toMillis(), TimeUnit.MILLISECONDS);
+				Thread.sleep(waitStrategy.sleepTime(attempt));
+				attempt++;
+			}
+			while (jobExecutionResultResponseBody.getStatus().getStatusId() != QueueStatus.StatusId.COMPLETED);
+		} catch (IOException | TimeoutException | ExecutionException e) {
+			throw new ProgramInvocationException(e);
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new ProgramInvocationException(e);
+		}
+
+		final JobResult jobExecutionResult = jobExecutionResultResponseBody.getJobExecutionResult();
+		checkState(jobExecutionResult != null, "jobExecutionResult must not be null");
+
+		return jobExecutionResult;
 	}
 
 	@Override

--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/retry/ExponentialWaitStrategy.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/retry/ExponentialWaitStrategy.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.program.rest.retry;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/**
+ * {@link WaitStrategy} with exponentially increasing sleep time.
+ */
+public class ExponentialWaitStrategy implements WaitStrategy {
+
+	private final long initialWait;
+
+	private final long maxWait;
+
+	public ExponentialWaitStrategy(final long initialWait, final long maxWait) {
+		checkArgument(initialWait > 0, "initialWait must be positive, was %s", initialWait);
+		checkArgument(maxWait > 0, "maxWait must be positive, was %s", maxWait);
+		this.initialWait = initialWait;
+		this.maxWait = maxWait;
+	}
+
+	@Override
+	public long sleepTime(final long attempt) {
+		final long exponentialSleepTime = initialWait * Math.round(Math.pow(2, attempt));
+		return exponentialSleepTime >= 0 && exponentialSleepTime < maxWait ? exponentialSleepTime : maxWait;
+	}
+
+}

--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/retry/ExponentialWaitStrategy.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/retry/ExponentialWaitStrategy.java
@@ -32,14 +32,15 @@ public class ExponentialWaitStrategy implements WaitStrategy {
 	public ExponentialWaitStrategy(final long initialWait, final long maxWait) {
 		checkArgument(initialWait > 0, "initialWait must be positive, was %s", initialWait);
 		checkArgument(maxWait > 0, "maxWait must be positive, was %s", maxWait);
+		checkArgument(initialWait <= maxWait, "initialWait must be lower than or equal to maxWait", maxWait);
 		this.initialWait = initialWait;
 		this.maxWait = maxWait;
 	}
 
 	@Override
 	public long sleepTime(final long attempt) {
+		checkArgument(attempt >= 0, "attempt must not be negative (%d)", attempt);
 		final long exponentialSleepTime = initialWait * Math.round(Math.pow(2, attempt));
 		return exponentialSleepTime >= 0 && exponentialSleepTime < maxWait ? exponentialSleepTime : maxWait;
 	}
-
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/retry/WaitStrategy.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/retry/WaitStrategy.java
@@ -16,25 +16,20 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.rest.messages;
-
-import java.util.Collection;
-import java.util.Collections;
+package org.apache.flink.client.program.rest.retry;
 
 /**
- * Message parameters which require a job path parameter.
+ * Operations that are polling for a result to arrive require a waiting time between consecutive
+ * polls. A {@code WaitStrategy} determines this waiting time.
  */
-public class JobMessageParameters extends MessageParameters {
+@FunctionalInterface
+public interface WaitStrategy {
 
-	public final JobIDPathParameter jobPathParameter = new JobIDPathParameter();
+	/**
+	 * Returns the time to wait until the next attempt. Attempts start at {@code 0}.
+	 * @param attempt The number of the last attempt.
+	 * @return Waiting time in ms.
+	 */
+	long sleepTime(long attempt);
 
-	@Override
-	public Collection<MessagePathParameter<?>> getPathParameters() {
-		return Collections.singleton(jobPathParameter);
-	}
-
-	@Override
-	public Collection<MessageQueryParameter<?>> getQueryParameters() {
-		return Collections.emptySet();
-	}
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/program/rest/retry/ExponentialWaitStrategyTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/rest/retry/ExponentialWaitStrategyTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.program.rest.retry;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for {@link ExponentialWaitStrategy}.
+ */
+public class ExponentialWaitStrategyTest {
+
+	@Test
+	public void testNegativeInitialWait() {
+		try {
+			new ExponentialWaitStrategy(0, 1);
+			fail("Expected exception not thrown.");
+		} catch (final IllegalArgumentException e) {
+			assertThat(e.getMessage(), containsString("initialWait must be positive"));
+		}
+	}
+
+	@Test
+	public void testNegativeMaxWait() {
+		try {
+			new ExponentialWaitStrategy(1, -1);
+			fail("Expected exception not thrown.");
+		} catch (final IllegalArgumentException e) {
+			assertThat(e.getMessage(), containsString("maxWait must be positive"));
+		}
+	}
+
+	@Test
+	public void testMaxSleepTime() {
+		final long sleepTime = new ExponentialWaitStrategy(1, 1).sleepTime(100);
+		assertThat(sleepTime, equalTo(1L));
+	}
+
+	@Test
+	public void testExponentialGrowth() {
+		final long sleepTime = new ExponentialWaitStrategy(1, 1000).sleepTime(2);
+		assertThat(sleepTime, equalTo(4L));
+	}
+
+}

--- a/flink-clients/src/test/java/org/apache/flink/client/program/rest/retry/ExponentialWaitStrategyTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/rest/retry/ExponentialWaitStrategyTest.java
@@ -51,6 +51,16 @@ public class ExponentialWaitStrategyTest {
 	}
 
 	@Test
+	public void testInitialWaitGreaterThanMaxWait() {
+		try {
+			new ExponentialWaitStrategy(2, 1);
+			fail("Expected exception not thrown.");
+		} catch (final IllegalArgumentException e) {
+			assertThat(e.getMessage(), containsString("initialWait must be lower than or equal to maxWait"));
+		}
+	}
+
+	@Test
 	public void testMaxSleepTime() {
 		final long sleepTime = new ExponentialWaitStrategy(1, 1).sleepTime(100);
 		assertThat(sleepTime, equalTo(1L));
@@ -58,8 +68,22 @@ public class ExponentialWaitStrategyTest {
 
 	@Test
 	public void testExponentialGrowth() {
-		final long sleepTime = new ExponentialWaitStrategy(1, 1000).sleepTime(2);
-		assertThat(sleepTime, equalTo(4L));
+		final ExponentialWaitStrategy exponentialWaitStrategy = new ExponentialWaitStrategy(1, 1000);
+		assertThat(exponentialWaitStrategy.sleepTime(3) / exponentialWaitStrategy.sleepTime(2), equalTo(2L));
+	}
+
+	@Test
+	public void testMaxAttempts() {
+		final long maxWait = 1000;
+		final ExponentialWaitStrategy exponentialWaitStrategy = new ExponentialWaitStrategy(1, maxWait);
+		assertThat(exponentialWaitStrategy.sleepTime(Long.MAX_VALUE), equalTo(maxWait));
+	}
+
+	@Test
+	public void test64Attempts() {
+		final long maxWait = 1000;
+		final ExponentialWaitStrategy exponentialWaitStrategy = new ExponentialWaitStrategy(1, maxWait);
+		assertThat(exponentialWaitStrategy.sleepTime(64), equalTo(maxWait));
 	}
 
 }


### PR DESCRIPTION
## What is the purpose of the change

*Poll JobExecutionResult after job submission. This is needed, for example, to enable `collect()` calls from the job in FLIP-6 mode. This PR is based on #5194.*

CC: @tillrohrmann 


## Brief change log

  - *Retrieve JobExecutionResult after job submission in `RestClusterClient`*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added unit tests for all new classes and changed classes.*
  - *Manually run job in examples/batch/WordCount.jar and verified that the results are correctly collected/printed.*
  
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
