### PR TITLE
[FLINK-8265] [Mesos] Missing jackson dependency for flink-mesos

### DIFF
--- a/flink-mesos/pom.xml
+++ b/flink-mesos/pom.xml
@@ -267,6 +267,9 @@ under the License.
 									<include>com.google.protobuf:protobuf-java</include>
 									<include>org.apache.mesos:mesos</include>
 									<include>com.netflix.fenzo:fenzo-core</include>
+									<include>com.fasterxml.jackson.core:jackson-core</include>
+									<include>com.fasterxml.jackson.core:jackson-annotations</include>
+									<include>com.fasterxml.jackson.core:jackson-databind</include>
 								</includes>
 							</artifactSet>
 							<relocations combine.children="append">


### PR DESCRIPTION
## What is the purpose of the change
Fix for missing dependency in Mesos deployments.

## Brief change log
- updated `pom.xml` of `flink-mesos` to include `com.fasterxml.jackson.core:*` as a shaded and relocated dependency.

## Verifying this change
- verify that `flink-dist_2.11-1.4-SNAPSHOT.jar` includes classes in `org/apache/flink/mesos/shaded/com/fasterxml/jackson/`.
- This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive):  no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
