### PR TITLE
[FLINK-7711] Port JarListHandler to WebMonitorEndpoint

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/RemoteExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/RemoteExecutor.java
@@ -23,7 +23,6 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.common.PlanExecutor;
 import org.apache.flink.client.program.ClusterClient;
-import org.apache.flink.client.program.JobWithJars;
 import org.apache.flink.client.program.StandaloneClusterClient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
@@ -32,6 +31,7 @@ import org.apache.flink.optimizer.Optimizer;
 import org.apache.flink.optimizer.costs.DefaultCostEstimator;
 import org.apache.flink.optimizer.plan.OptimizedPlan;
 import org.apache.flink.optimizer.plandump.PlanJSONDumpGenerator;
+import org.apache.flink.runtime.util.JobWithJars;
 
 import java.net.InetSocketAddress;
 import java.net.URL;

--- a/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
@@ -59,6 +59,7 @@ import org.apache.flink.runtime.messages.accumulators.RequestAccumulatorResults;
 import org.apache.flink.runtime.messages.webmonitor.JobDetails;
 import org.apache.flink.runtime.messages.webmonitor.MultipleJobsDetails;
 import org.apache.flink.runtime.messages.webmonitor.RequestJobDetails;
+import org.apache.flink.runtime.util.JobWithJars;
 import org.apache.flink.runtime.util.LeaderConnectionInfo;
 import org.apache.flink.runtime.util.LeaderRetrievalUtils;
 import org.apache.flink.util.FlinkException;

--- a/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironment.java
@@ -26,6 +26,7 @@ import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.optimizer.plan.OptimizedPlan;
 import org.apache.flink.optimizer.plandump.PlanJSONDumpGenerator;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
+import org.apache.flink.runtime.util.JobWithJars;
 
 import java.net.URL;
 import java.util.List;

--- a/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
@@ -25,6 +25,7 @@ import org.apache.flink.optimizer.Optimizer;
 import org.apache.flink.optimizer.dag.DataSinkNode;
 import org.apache.flink.optimizer.plandump.PlanJSONDumpGenerator;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
+import org.apache.flink.runtime.util.JobWithJars;
 import org.apache.flink.util.InstantiationUtil;
 
 import java.io.BufferedInputStream;

--- a/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
@@ -43,6 +43,7 @@ import org.apache.flink.runtime.akka.FlinkUntypedActor;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.jobmaster.JobMaster;
 import org.apache.flink.runtime.messages.JobManagerMessages;
+import org.apache.flink.runtime.util.JobWithJars;
 import org.apache.flink.util.NetUtils;
 import org.apache.flink.util.SerializedThrowable;
 import org.apache.flink.util.TestLogger;

--- a/flink-contrib/flink-storm/src/main/java/org/apache/flink/storm/api/FlinkClient.java
+++ b/flink-contrib/flink-storm/src/main/java/org/apache/flink/storm/api/FlinkClient.java
@@ -21,7 +21,6 @@ package org.apache.flink.storm.api;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.client.program.ClusterClient;
-import org.apache.flink.client.program.JobWithJars;
 import org.apache.flink.client.program.ProgramInvocationException;
 import org.apache.flink.client.program.StandaloneClusterClient;
 import org.apache.flink.configuration.AkkaOptions;
@@ -37,6 +36,7 @@ import org.apache.flink.runtime.jobmaster.JobMaster;
 import org.apache.flink.runtime.messages.JobManagerMessages;
 import org.apache.flink.runtime.messages.JobManagerMessages.RunningJobsStatus;
 import org.apache.flink.runtime.rpc.akka.AkkaRpcServiceUtils;
+import org.apache.flink.runtime.util.JobWithJars;
 import org.apache.flink.storm.util.StormConfig;
 import org.apache.flink.streaming.api.graph.StreamGraph;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/RestHandlerConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/RestHandlerConfiguration.java
@@ -45,12 +45,18 @@ public class RestHandlerConfiguration {
 
 	private final Map<String, String> responseHeaders;
 
+	private final boolean submitEnable;
+
+	private final File uploadDir;
+
 	public RestHandlerConfiguration(
 			long refreshInterval,
 			int maxCheckpointStatisticCacheEntries,
 			Time timeout,
 			File tmpDir,
-			Map<String, String> responseHeaders) {
+			Map<String, String> responseHeaders,
+			boolean submitEnable,
+			File uploadDir) {
 		Preconditions.checkArgument(refreshInterval > 0L, "The refresh interval (ms) should be larger than 0.");
 		this.refreshInterval = refreshInterval;
 
@@ -60,6 +66,9 @@ public class RestHandlerConfiguration {
 		this.tmpDir = Preconditions.checkNotNull(tmpDir);
 
 		this.responseHeaders = Preconditions.checkNotNull(responseHeaders);
+
+		this.submitEnable = submitEnable;
+		this.uploadDir = uploadDir;
 	}
 
 	public long getRefreshInterval() {
@@ -82,6 +91,14 @@ public class RestHandlerConfiguration {
 		return Collections.unmodifiableMap(responseHeaders);
 	}
 
+	public boolean isSubmitEnable() {
+		return submitEnable;
+	}
+
+	public File getUploadDir() {
+		return uploadDir;
+	}
+
 	public static RestHandlerConfiguration fromConfiguration(Configuration configuration) {
 		final long refreshInterval = configuration.getLong(WebOptions.REFRESH_INTERVAL);
 
@@ -96,11 +113,17 @@ public class RestHandlerConfiguration {
 			HttpHeaders.Names.ACCESS_CONTROL_ALLOW_ORIGIN,
 			configuration.getString(WebOptions.ACCESS_CONTROL_ALLOW_ORIGIN));
 
+		final boolean submitEnable = configuration.getBoolean(WebOptions.SUBMIT_ENABLE);
+		File uploadBaseDir = new File(configuration.getString(WebOptions.UPLOAD_DIR, configuration.getString(WebOptions.TMP_DIR)));
+		final File uploadDir = submitEnable ? (configuration.contains(WebOptions.UPLOAD_DIR) ? uploadBaseDir : new File(uploadBaseDir, "flink-web-" + UUID.randomUUID())) : null;
+
 		return new RestHandlerConfiguration(
 			refreshInterval,
 			maxCheckpointStatisticCacheEntries,
 			timeout,
 			tmpDir,
-			responseHeaders);
+			responseHeaders,
+			submitEnable,
+			uploadDir);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/jar/JarListHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/jar/JarListHandler.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.jar;
+
+import org.apache.flink.api.common.Program;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.rest.handler.AbstractRestHandler;
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.RestHandlerException;
+import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.JarListInfo;
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+import org.apache.flink.runtime.util.JarWithProgramUtils;
+import org.apache.flink.runtime.webmonitor.RestfulGateway;
+import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+import org.apache.flink.util.FlinkException;
+
+import javax.annotation.Nonnull;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
+
+/**
+ * Handle request for listing uploaded jars.
+ */
+public class JarListHandler extends AbstractRestHandler<RestfulGateway, EmptyRequestBody, JarListInfo, EmptyMessageParameters> {
+
+	private final File jarDir;
+
+	public JarListHandler(
+			CompletableFuture<String> localRestAddress,
+			GatewayRetriever<? extends RestfulGateway> leaderRetriever,
+			Time timeout,
+			Map<String, String> responseHeaders,
+			MessageHeaders<EmptyRequestBody, JarListInfo, EmptyMessageParameters> messageHeaders,
+			File jarDir) {
+		super(localRestAddress, leaderRetriever, timeout, responseHeaders, messageHeaders);
+
+		this.jarDir = jarDir;
+	}
+
+	@Override
+	protected CompletableFuture<JarListInfo> handleRequest(@Nonnull HandlerRequest<EmptyRequestBody, EmptyMessageParameters> request, @Nonnull RestfulGateway gateway) throws RestHandlerException {
+		String localAddress;
+		try {
+			localAddress = localAddressFuture.get();
+		} catch (Exception e) {
+			return FutureUtils.completedExceptionally(e);
+		}
+
+		CompletableFuture<JarListInfo> jarListFuture = new CompletableFuture<>();
+		return jarListFuture.thenApply(jarListInfo -> {
+			try {
+				List<JarListInfo.JarFileInfo> jarFileList = new ArrayList<>();
+				File[] list = jarDir.listFiles(new FilenameFilter() {
+					@Override
+					public boolean accept(File dir, String name) {
+						return name.endsWith(".jar");
+					}
+				});
+				// last modified ascending order
+				Arrays.sort(list, (f1, f2) -> Long.compare(f2.lastModified(), f1.lastModified()));
+
+				for (File f : list) {
+					// separate the uuid and the name parts.
+					String id = f.getName();
+
+					int startIndex = id.indexOf("_");
+					if (startIndex < 0) {
+						continue;
+					}
+					String name = id.substring(startIndex + 1);
+					if (name.length() < 5 || !name.endsWith(".jar")) {
+						continue;
+					}
+
+					List<JarListInfo.JarEntryInfo> jarEntryList = new ArrayList<>();
+					String[] classes = new String[0];
+					try {
+						JarFile jar = new JarFile(f);
+						Manifest manifest = jar.getManifest();
+						String assemblerClass = null;
+
+						if (manifest != null) {
+							assemblerClass = manifest.getMainAttributes().getValue(JarWithProgramUtils.MANIFEST_ATTRIBUTE_ASSEMBLER_CLASS);
+							if (assemblerClass == null) {
+								assemblerClass = manifest.getMainAttributes().getValue(JarWithProgramUtils.MANIFEST_ATTRIBUTE_MAIN_CLASS);
+							}
+						}
+						if (assemblerClass != null) {
+							classes = assemblerClass.split(",");
+						}
+					} catch (IOException ignored) {
+						// we simply show no entries here
+					}
+
+					// show every entry class that can be loaded later on.
+					for (String clazz : classes) {
+						clazz = clazz.trim();
+
+						Class<?> mainClass = null;
+						Program program = null;
+						try {
+							mainClass = JarWithProgramUtils.getMainClass(f, clazz, getClass().getClassLoader());
+							program = JarWithProgramUtils.createProgram(mainClass);
+						} catch (Exception e) {
+							// ignore jar files which throw an error upon creating a PackagedProgram
+						}
+						if (mainClass != null && program != null) {
+							JarListInfo.JarEntryInfo jarEntryInfo = new JarListInfo.JarEntryInfo(clazz, JarWithProgramUtils.getDescription(mainClass, program));
+							jarEntryList.add(jarEntryInfo);
+						}
+					}
+
+					jarFileList.add(new JarListInfo.JarFileInfo(id, name, f.lastModified(), jarEntryList));
+				}
+
+				return new JarListInfo(localAddress, jarFileList);
+			} catch (Exception e) {
+				throw new CompletionException(new FlinkException("Failed to fetch jar list.", e));
+			}
+		});
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JarListHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JarListHeaders.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages;
+
+import org.apache.flink.runtime.rest.HttpMethodWrapper;
+import org.apache.flink.runtime.rest.handler.jar.JarListHandler;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+/**
+ * Message headers for the {@link JarListHandler}.
+ */
+public class JarListHeaders implements MessageHeaders<EmptyRequestBody, JarListInfo, EmptyMessageParameters> {
+	private static final JarListHeaders INSTANCE = new JarListHeaders();
+
+	public static final String URL = "/jars";
+
+	@Override
+	public Class<EmptyRequestBody> getRequestClass() {
+		return EmptyRequestBody.class;
+	}
+
+	@Override
+	public Class<JarListInfo> getResponseClass() {
+		return JarListInfo.class;
+	}
+
+	@Override
+	public HttpResponseStatus getResponseStatusCode() {
+		return HttpResponseStatus.OK;
+	}
+
+	@Override
+	public EmptyMessageParameters getUnresolvedMessageParameters() {
+		return EmptyMessageParameters.getInstance();
+	}
+
+	@Override
+	public HttpMethodWrapper getHttpMethod() {
+		return HttpMethodWrapper.GET;
+	}
+
+	@Override
+	public String getTargetRestEndpointURL() {
+		return URL;
+	}
+
+	public static MessageHeaders<EmptyRequestBody, JarListInfo, EmptyMessageParameters> getInstance() {
+		return INSTANCE;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JarListInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JarListInfo.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages;
+
+import org.apache.flink.runtime.rest.handler.jar.JarListHandler;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Objects;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Response type of the {@link JarListHandler}.
+ */
+public class JarListInfo implements ResponseBody {
+	public static final String JAR_LIST_FIELD_ADDRESS = "address";
+	public static final String JAR_LIST_FIELD_FILES = "files";
+
+	@JsonProperty(JAR_LIST_FIELD_ADDRESS)
+	private String address;
+
+	@JsonProperty(JAR_LIST_FIELD_FILES)
+	private List<JarFileInfo> jarFileList;
+
+	@JsonCreator
+	public JarListInfo(
+			@JsonProperty(JAR_LIST_FIELD_ADDRESS) String address,
+			@JsonProperty(JAR_LIST_FIELD_FILES) List<JarFileInfo> jarFileList) {
+		this.address = checkNotNull(address);
+		this.jarFileList = checkNotNull(jarFileList);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(address, jarFileList);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+
+		if (null == o || this.getClass() != o.getClass()) {
+			return false;
+		}
+
+		JarListInfo that = (JarListInfo) o;
+		return Objects.equals(address, that.address) &&
+			Objects.equals(jarFileList, that.jarFileList);
+	}
+
+	//---------------------------------------------------------------------------------
+	// Static helper classes
+	//---------------------------------------------------------------------------------
+
+	/**
+	 * Nested class to encapsulate the jar file info.
+	 */
+	public static class JarFileInfo {
+		public static final String JAR_FILE_FIELD_ID = "id";
+		public static final String JAR_FILE_FIELD_NAME = "name";
+		public static final String JAR_FILE_FIELD_UPLOADED = "uploaded";
+		public static final String JAR_FILE_FIELD_ENTRY = "entry";
+
+		@JsonProperty(JAR_FILE_FIELD_ID)
+		private String id;
+
+		@JsonProperty(JAR_FILE_FIELD_NAME)
+		private String name;
+
+		@JsonProperty(JAR_FILE_FIELD_UPLOADED)
+		private long uploaded;
+
+		@JsonProperty(JAR_FILE_FIELD_ENTRY)
+		private List<JarEntryInfo> jarEntryList;
+
+		@JsonCreator
+		public JarFileInfo(
+				@JsonProperty(JAR_FILE_FIELD_ID) String id,
+				@JsonProperty(JAR_FILE_FIELD_NAME) String name,
+				@JsonProperty(JAR_FILE_FIELD_UPLOADED) long uploaded,
+				@JsonProperty(JAR_FILE_FIELD_ENTRY) List<JarEntryInfo> jarEntryList) {
+			this.id = checkNotNull(id);
+			this.name = checkNotNull(name);
+			this.uploaded = uploaded;
+			this.jarEntryList = checkNotNull(jarEntryList);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(id, name, uploaded, jarEntryList);
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+
+			if (null == o || this.getClass() != o.getClass()) {
+				return false;
+			}
+
+			JarFileInfo that = (JarFileInfo) o;
+			return Objects.equals(id, that.id) &&
+				Objects.equals(name, that.name) &&
+				uploaded == that.uploaded &&
+				Objects.equals(jarEntryList, that.jarEntryList);
+		}
+	}
+
+	/**
+	 * Nested class to encapsulate the jar entry info.
+	 */
+	public static class JarEntryInfo {
+		public static final String JAR_ENTRY_FIELD_NAME = "name";
+		public static final String JAR_ENTRY_FIELD_DESC = "description";
+
+		@JsonProperty(JAR_ENTRY_FIELD_NAME)
+		private String name;
+
+		@JsonProperty(JAR_ENTRY_FIELD_DESC)
+		private String description;
+
+		@JsonCreator
+		public JarEntryInfo(
+				@JsonProperty(JAR_ENTRY_FIELD_NAME) String name,
+				@JsonProperty(JAR_ENTRY_FIELD_DESC) String description) {
+			this.name = checkNotNull(name);
+			this.description = checkNotNull(description);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(name, description);
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+
+			if (null == o || this.getClass() != o.getClass()) {
+				return false;
+			}
+
+			JarEntryInfo that = (JarEntryInfo) o;
+			return Objects.equals(name, that.name) &&
+				Objects.equals(description, that.description);
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/JarWithProgramUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/JarWithProgramUtils.java
@@ -1,0 +1,416 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.util;
+
+import org.apache.flink.api.common.Program;
+import org.apache.flink.api.common.ProgramDescription;
+import org.apache.flink.util.InstantiationUtil;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Random;
+import java.util.jar.Attributes;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
+
+/**
+ * Jar file validation tool class for {@link Program}.
+ */
+public class JarWithProgramUtils {
+	/**
+	 * Property name of the entry in JAR manifest file that describes the Flink specific entry point.
+	 */
+	public static final String MANIFEST_ATTRIBUTE_ASSEMBLER_CLASS = "program-class";
+
+	/**
+	 * Property name of the entry in JAR manifest file that describes the class with the main method.
+	 */
+	public static final String MANIFEST_ATTRIBUTE_MAIN_CLASS = "Main-Class";
+
+	/**
+	 * Get main class from jar file.
+	 *
+	 * @param jarFile The given jar file.
+	 * @param entryPointClassName The given class name.
+	 * @param parent The given parent classloader.
+	 * @return The result class.
+	 * @throws Exception Any exception thrown by this method signals get main class fail.
+	 */
+	public static Class<?> getMainClass(File jarFile, String entryPointClassName, ClassLoader parent) throws Exception {
+		if (jarFile == null) {
+			throw new IllegalArgumentException("The jar file must not be null.");
+		}
+
+		URL jarFileUrl;
+		try {
+			jarFileUrl = jarFile.getAbsoluteFile().toURI().toURL();
+		} catch (MalformedURLException e1) {
+			throw new IllegalArgumentException("The jar file path is invalid.");
+		}
+
+		checkJarFile(jarFileUrl);
+
+		// if no entryPointClassName name was given, we try and look one up through the manifest
+		if (entryPointClassName == null) {
+			entryPointClassName = getEntryPointClassNameFromJar(jarFileUrl);
+		}
+
+		// now that we have an entry point, we can extract the nested jar files (if any)
+		List<File> extractedTempLibraries = extractContainedLibraries(jarFileUrl);
+		List<URL> classpaths = new ArrayList<>();
+		ClassLoader userCodeClassLoader = JobWithJars.buildUserCodeClassLoader(getAllLibraries(jarFileUrl, extractedTempLibraries), classpaths, parent);
+
+		// load the entry point class
+		return loadMainClass(entryPointClassName, userCodeClassLoader);
+	}
+
+	/**
+	 * Create instance of {@link Program} from sprcific main class.
+	 *
+	 * @param mainClass The given main class.
+	 * @return The result instance of Program
+	 * @throws Exception Any exception thrown by this method signals create Program fail.
+	 */
+	public static Program createProgram(Class<?> mainClass) throws Exception {
+		// if the entry point is a program, instantiate the class and get the plan
+		if (Program.class.isAssignableFrom(mainClass)) {
+			try {
+				return InstantiationUtil.instantiate(mainClass.asSubclass(Program.class), Program.class);
+			} catch (Exception e) {
+				// validate that the class has a main method at least.
+				// the main method possibly instantiates the program properly
+				if (!hasMainMethod(mainClass)) {
+					throw new Exception("The given program class implements the " +
+						Program.class.getName() + " interface, but cannot be instantiated. " +
+						"It also declares no main(String[]) method as alternative entry point", e);
+				}
+			} catch (Throwable t) {
+				throw new Exception("Error while trying to instantiate program class.", t);
+			}
+		} else if (hasMainMethod(mainClass)) {
+			return null;
+		} else {
+			throw new Exception("The given program class neither has a main(String[]) method, nor does it implement the " +
+				Program.class.getName() + " interface.");
+		}
+
+		return null;
+	}
+
+	public static void checkJarFile(URL jarfile) throws Exception {
+		try {
+			JobWithJars.checkJarFile(jarfile);
+		}
+		catch (IOException e) {
+			throw new Exception(e.getMessage());
+		}
+		catch (Throwable t) {
+			throw new Exception("Cannot access jar file" + (t.getMessage() == null ? "." : ": " + t.getMessage()), t);
+		}
+	}
+
+	/**
+	 * Get entry point class name from the specific jar file.
+	 *
+	 * @param jarFile The given jar file.
+	 * @return The result class name.
+	 * @throws Exception Any exception thrown by this method signals get class name fail.
+	 */
+	public static String getEntryPointClassNameFromJar(URL jarFile) throws Exception {
+		JarFile jar;
+		Manifest manifest;
+		String className;
+
+		// Open jar file
+		try {
+			jar = new JarFile(new File(jarFile.toURI()));
+		} catch (URISyntaxException use) {
+			throw new Exception("Invalid file path '" + jarFile.getPath() + "'", use);
+		} catch (IOException ioex) {
+			throw new Exception("Error while opening jar file '" + jarFile.getPath() + "'. "
+				+ ioex.getMessage(), ioex);
+		}
+
+		// jar file must be closed at the end
+		try {
+			// Read from jar manifest
+			try {
+				manifest = jar.getManifest();
+			} catch (IOException ioex) {
+				throw new Exception("The Manifest in the jar file could not be accessed '"
+					+ jarFile.getPath() + "'. " + ioex.getMessage(), ioex);
+			}
+
+			if (manifest == null) {
+				throw new Exception("No manifest found in jar file '" + jarFile.getPath() + "'. The manifest is need to point to the program's main class.");
+			}
+
+			Attributes attributes = manifest.getMainAttributes();
+
+			// check for a "program-class" entry first
+			className = attributes.getValue(MANIFEST_ATTRIBUTE_ASSEMBLER_CLASS);
+			if (className != null) {
+				return className;
+			}
+
+			// check for a main class
+			className = attributes.getValue(MANIFEST_ATTRIBUTE_MAIN_CLASS);
+			if (className != null) {
+				return className;
+			} else {
+				throw new Exception("Neither a '" + MANIFEST_ATTRIBUTE_MAIN_CLASS + "', nor a '" +
+					MANIFEST_ATTRIBUTE_ASSEMBLER_CLASS + "' entry was found in the jar file.");
+			}
+		}
+		finally {
+			try {
+				jar.close();
+			} catch (Throwable t) {
+				throw new Exception("Could not close the JAR file: " + t.getMessage(), t);
+			}
+		}
+	}
+
+	/**
+	 * Takes all JAR files that are contained in this program's JAR file and extracts them
+	 * to the system's temp directory.
+	 *
+	 * @return The file names of the extracted temporary files.
+	 * @throws Exception Thrown, if the extraction process failed.
+	 */
+	public static List<File> extractContainedLibraries(URL jarFile) throws Exception {
+
+		Random rnd = new Random();
+
+		JarFile jar = null;
+		try {
+			jar = new JarFile(new File(jarFile.toURI()));
+			final List<JarEntry> containedJarFileEntries = new ArrayList<JarEntry>();
+
+			Enumeration<JarEntry> entries = jar.entries();
+			while (entries.hasMoreElements()) {
+				JarEntry entry = entries.nextElement();
+				String name = entry.getName();
+
+				if (name.length() > 8 && name.startsWith("lib/") && name.endsWith(".jar")) {
+					containedJarFileEntries.add(entry);
+				}
+			}
+
+			if (containedJarFileEntries.isEmpty()) {
+				return Collections.emptyList();
+			}
+			else {
+				// go over all contained jar files
+				final List<File> extractedTempLibraries = new ArrayList<File>(containedJarFileEntries.size());
+				final byte[] buffer = new byte[4096];
+
+				boolean incomplete = true;
+
+				try {
+					for (int i = 0; i < containedJarFileEntries.size(); i++) {
+						final JarEntry entry = containedJarFileEntries.get(i);
+						String name = entry.getName();
+						name = name.replace(File.separatorChar, '_');
+
+						File tempFile;
+						try {
+							tempFile = File.createTempFile(rnd.nextInt(Integer.MAX_VALUE) + "_", name);
+							tempFile.deleteOnExit();
+						}
+						catch (IOException e) {
+							throw new Exception(
+								"An I/O error occurred while creating temporary file to extract nested library '" +
+									entry.getName() + "'.", e);
+						}
+
+						extractedTempLibraries.add(tempFile);
+
+						// copy the temp file contents to a temporary File
+						OutputStream out = null;
+						InputStream in = null;
+						try {
+
+							out = new FileOutputStream(tempFile);
+							in = new BufferedInputStream(jar.getInputStream(entry));
+
+							int numRead = 0;
+							while ((numRead = in.read(buffer)) != -1) {
+								out.write(buffer, 0, numRead);
+							}
+						}
+						catch (IOException e) {
+							throw new Exception("An I/O error occurred while extracting nested library '"
+								+ entry.getName() + "' to temporary file '" + tempFile.getAbsolutePath() + "'.");
+						}
+						finally {
+							if (out != null) {
+								out.close();
+							}
+							if (in != null) {
+								in.close();
+							}
+						}
+					}
+
+					incomplete = false;
+				}
+				finally {
+					if (incomplete) {
+						deleteExtractedLibraries(extractedTempLibraries);
+					}
+				}
+
+				return extractedTempLibraries;
+			}
+		}
+		catch (Throwable t) {
+			throw new Exception("Unknown I/O error while extracting contained jar files.", t);
+		}
+		finally {
+			if (jar != null) {
+				try {
+					jar.close();
+				} catch (Throwable t) {}
+			}
+		}
+	}
+
+	public static void deleteExtractedLibraries(List<File> tempLibraries) {
+		for (File f : tempLibraries) {
+			f.delete();
+		}
+	}
+
+	/**
+	 * Returns all provided libraries needed to run the program.
+	 */
+	public static List<URL> getAllLibraries(URL jarFile, List<File> extractedTempLibraries) {
+		List<URL> libs = new ArrayList<URL>(extractedTempLibraries.size() + 1);
+
+		if (jarFile != null) {
+			libs.add(jarFile);
+		}
+		for (File tmpLib : extractedTempLibraries) {
+			try {
+				libs.add(tmpLib.getAbsoluteFile().toURI().toURL());
+			}
+			catch (MalformedURLException e) {
+				throw new RuntimeException("URL is invalid. This should not happen.", e);
+			}
+		}
+
+		return libs;
+	}
+
+	public static Class<?> loadMainClass(String className, ClassLoader cl) throws Exception {
+		ClassLoader contextCl = null;
+		try {
+			contextCl = Thread.currentThread().getContextClassLoader();
+			Thread.currentThread().setContextClassLoader(cl);
+			return Class.forName(className, false, cl);
+		}
+		catch (ClassNotFoundException e) {
+			throw new Exception("The program's entry point class '" + className
+				+ "' was not found in the jar file.", e);
+		}
+		catch (ExceptionInInitializerError e) {
+			throw new Exception("The program's entry point class '" + className
+				+ "' threw an error during initialization.", e);
+		}
+		catch (LinkageError e) {
+			throw new Exception("The program's entry point class '" + className
+				+ "' could not be loaded due to a linkage failure.", e);
+		}
+		catch (Throwable t) {
+			throw new Exception("The program's entry point class '" + className
+				+ "' caused an exception during initialization: " + t.getMessage(), t);
+		} finally {
+			if (contextCl != null) {
+				Thread.currentThread().setContextClassLoader(contextCl);
+			}
+		}
+	}
+
+	public static boolean hasMainMethod(Class<?> entryClass) {
+		Method mainMethod;
+		try {
+			mainMethod = entryClass.getMethod("main", String[].class);
+		} catch (NoSuchMethodException e) {
+			return false;
+		}
+		catch (Throwable t) {
+			throw new RuntimeException("Could not look up the main(String[]) method from the class " +
+				entryClass.getName() + ": " + t.getMessage(), t);
+		}
+
+		return Modifier.isStatic(mainMethod.getModifiers()) && Modifier.isPublic(mainMethod.getModifiers());
+	}
+
+	/**
+	 * Returns the description provided by the Program class. This
+	 * may contain a description of the plan itself and its arguments.
+	 *
+	 * @return The description of the PactProgram's input parameters.
+	 * @throws Exception
+	 *         This invocation is thrown if the Program can't be properly loaded. Causes
+	 *         may be a missing / wrong class or manifest files.
+	 */
+	public static String getDescription(Class<?> mainClass, Program program) throws Exception {
+		if (ProgramDescription.class.isAssignableFrom(mainClass)) {
+
+			ProgramDescription descr;
+			if (program != null) {
+				descr = (ProgramDescription) program;
+			} else {
+				try {
+					descr =  InstantiationUtil.instantiate(
+						mainClass.asSubclass(ProgramDescription.class), ProgramDescription.class);
+				} catch (Throwable t) {
+					return null;
+				}
+			}
+
+			try {
+				return descr.getDescription();
+			}
+			catch (Throwable t) {
+				throw new Exception("Error while getting the program description" +
+					(t.getMessage() == null ? "." : ": " + t.getMessage()), t);
+			}
+
+		} else {
+			return null;
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/JobWithJars.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/JobWithJars.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.client.program;
+package org.apache.flink.runtime.util;
 
 import org.apache.flink.api.common.Plan;
 import org.apache.flink.runtime.execution.librarycache.FlinkUserCodeClassLoaders;
@@ -69,7 +69,7 @@ public class JobWithJars {
 		this.classpaths = Collections.<URL>emptyList();
 	}
 
-	JobWithJars(Plan plan, List<URL> jarFiles, List<URL> classpaths, ClassLoader userCodeClassLoader) {
+	public JobWithJars(Plan plan, List<URL> jarFiles, List<URL> classpaths, ClassLoader userCodeClassLoader) {
 		this.plan = plan;
 		this.jarFiles = jarFiles;
 		this.classpaths = classpaths;
@@ -98,7 +98,7 @@ public class JobWithJars {
 	}
 
 	/**
-	 * Gets the {@link java.lang.ClassLoader} that must be used to load user code classes.
+	 * Gets the {@link ClassLoader} that must be used to load user code classes.
 	 *
 	 * @return The user code ClassLoader.
 	 */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.rest.handler.RestHandlerSpecification;
 import org.apache.flink.runtime.rest.handler.cluster.ClusterConfigHandler;
 import org.apache.flink.runtime.rest.handler.cluster.ClusterOverviewHandler;
 import org.apache.flink.runtime.rest.handler.cluster.DashboardConfigHandler;
+import org.apache.flink.runtime.rest.handler.jar.JarListHandler;
 import org.apache.flink.runtime.rest.handler.job.JobAccumulatorsHandler;
 import org.apache.flink.runtime.rest.handler.job.JobConfigHandler;
 import org.apache.flink.runtime.rest.handler.job.JobDetailsHandler;
@@ -57,6 +58,7 @@ import org.apache.flink.runtime.rest.handler.taskmanager.TaskManagersHandler;
 import org.apache.flink.runtime.rest.messages.ClusterConfigurationInfoHeaders;
 import org.apache.flink.runtime.rest.messages.ClusterOverviewHeaders;
 import org.apache.flink.runtime.rest.messages.DashboardConfigurationHeaders;
+import org.apache.flink.runtime.rest.messages.JarListHeaders;
 import org.apache.flink.runtime.rest.messages.JobAccumulatorsHeaders;
 import org.apache.flink.runtime.rest.messages.JobConfigHeaders;
 import org.apache.flink.runtime.rest.messages.JobExceptionsHeaders;
@@ -338,6 +340,14 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
 			responseHeaders,
 			metricFetcher);
 
+		final JarListHandler jarListHandler = new JarListHandler(
+			restAddressFuture,
+			leaderRetriever,
+			timeout,
+			responseHeaders,
+			JarListHeaders.getInstance(),
+			restConfiguration.getUploadDir());
+
 		final File tmpDir = restConfiguration.getTmpDir();
 
 		Optional<StaticFileServerHandler<T>> optWebContent;
@@ -376,6 +386,7 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
 		handlers.add(Tuple2.of(SubtaskMetricsHeaders.getInstance(), subtaskMetricsHandler));
 		handlers.add(Tuple2.of(TaskManagerMetricsHeaders.getInstance(), taskManagerMetricsHandler));
 		handlers.add(Tuple2.of(JobManagerMetricsHeaders.getInstance(), jobManagerMetricsHandler));
+		handlers.add(Tuple2.of(JarListHeaders.getInstance(), jarListHandler));
 
 		// This handler MUST be added last, as it otherwise masks all subsequent GET handlers
 		optWebContent.ifPresent(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/JarListInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/JarListInfoTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Tests that the {@link JarListInfo} can be marshalled and unmarshalled.
+ */
+public class JarListInfoTest extends RestResponseMarshallingTestBase<JarListInfo> {
+	@Override
+	protected Class<JarListInfo> getTestResponseClass() {
+		return JarListInfo.class;
+	}
+
+	@Override
+	protected JarListInfo getTestResponseInstance() throws Exception {
+		List<JarListInfo.JarEntryInfo> jarEntryList1 = new ArrayList<>();
+		jarEntryList1.add(new JarListInfo.JarEntryInfo("name1", "desc1"));
+		jarEntryList1.add(new JarListInfo.JarEntryInfo("name2", "desc2"));
+
+		List<JarListInfo.JarEntryInfo> jarEntryList2 = new ArrayList<>();
+		jarEntryList2.add(new JarListInfo.JarEntryInfo("name3", "desc3"));
+		jarEntryList2.add(new JarListInfo.JarEntryInfo("name4", "desc4"));
+
+		List<JarListInfo.JarFileInfo> jarFileList = new ArrayList<>();
+		jarFileList.add(new JarListInfo.JarFileInfo("fileId1", "fileName1", System.currentTimeMillis(), jarEntryList1));
+		jarFileList.add(new JarListInfo.JarFileInfo("fileId2", "fileName2", System.currentTimeMillis(), jarEntryList2));
+
+		return new JarListInfo("local", jarFileList);
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/RemoteStreamEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/RemoteStreamEnvironment.java
@@ -22,11 +22,11 @@ import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.client.program.ClusterClient;
-import org.apache.flink.client.program.JobWithJars;
 import org.apache.flink.client.program.ProgramInvocationException;
 import org.apache.flink.client.program.StandaloneClusterClient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.runtime.util.JobWithJars;
 import org.apache.flink.streaming.api.graph.StreamGraph;
 
 import org.slf4j.Logger;


### PR DESCRIPTION
## What is the purpose of the change

Port JarListHandler to WebMonitorEndpoint

## Brief change log

  - *Create JarWithProgramUtils from PackageProgram to check jar file*
  - *Create new JarListHandler and JarListInfo*
  - *Add uploadDir to RestHandlerConfiguration*


## Verifying this change

This change added tests and can be verified as follows:

  - *Added test case JarListInfoTest*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
