### PR TITLE
[FLINK-8316][table]The CsvTableSink and the CsvInputFormat are not in sync

### DIFF
--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/batch/table/TableSinkITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/batch/table/TableSinkITCase.scala
@@ -19,6 +19,7 @@
 package org.apache.flink.table.runtime.batch.table
 
 import java.io.File
+import java.lang.{Long => JLong, Integer => JInt}
 
 import org.apache.flink.api.scala.util.CollectionDataSets
 import org.apache.flink.api.scala.{ExecutionEnvironment, _}
@@ -31,6 +32,8 @@ import org.apache.flink.test.util.TestBaseUtils
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
+
+import scala.collection.mutable
 
 @RunWith(classOf[Parameterized])
 class TableSinkITCase(
@@ -51,7 +54,7 @@ class TableSinkITCase(
     val input = CollectionDataSets.get3TupleDataSet(env)
       .map(x => x).setParallelism(4) // increase DOP to 4
 
-    val results = input.toTable(tEnv, 'a, 'b, 'c)
+    input.toTable(tEnv, 'a, 'b, 'c)
       .where('a < 5 || 'a > 17)
       .select('c, 'b)
       .writeToSink(new CsvTableSink(path, fieldDelim = "|"))
@@ -61,6 +64,35 @@ class TableSinkITCase(
     val expected = Seq(
       "Hi|1", "Hello|2", "Hello world|2", "Hello world, how are you?|3",
       "Comment#12|6", "Comment#13|6", "Comment#14|6", "Comment#15|6").mkString("\n")
+
+    TestBaseUtils.compareResultsByLinesInMemory(expected, path)
+  }
+
+  @Test
+  def testBatchTableSinkWithNullFieldsAndTrailingDelim(): Unit = {
+
+    val tmpFile = File.createTempFile("flink-table-sink-test", ".tmp")
+    tmpFile.deleteOnExit()
+    val path = tmpFile.toURI.toString
+
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+    env.setParallelism(4)
+
+    val data = new mutable.MutableList[(JInt, String, JLong)]
+    data.+=((1, "a", null.asInstanceOf[JLong]))
+    data.+=((2, null.asInstanceOf[String], 22L))
+    data.+=((null.asInstanceOf[JInt], null.asInstanceOf[String], null.asInstanceOf[JLong]))
+    data.+=((4, "d", 44L))
+    val input = env.fromCollection(data)
+      .map(x => x).setParallelism(4) // increase DOP to 4
+
+    input.toTable(tEnv, 'a, 'b, 'c)
+      .writeToSink(new CsvTableSink(path, fieldDelim = "|", trailingDelim = true))
+
+    env.execute()
+
+    val expected = Seq("1|a||", "2||22|", "|||", "4|d|44|").mkString("\n")
 
     TestBaseUtils.compareResultsByLinesInMemory(expected, path)
   }


### PR DESCRIPTION
## What is the purpose of the change

This PR adds an extra parameter (`trailingDelim`) to `CsvTableSink` to enable appending a trailing field delimiter for each row.

## Brief change log

  - Adds an extra boolean parameter `trailingDelim` to `CsvTableSink`.
  - Adds a related test case to `org.apache.flink.table.runtime.batch.table.TableSinkITCase`.


## Verifying this change

This change can be verified by the added test case in `TableSinkITCase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (**yes**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
