### PR TITLE
[FLINK-8326] [checkpoints] CheckpointCoordinatorTest#testRestoreLatestCheckpointedStateScaleOut() didn't use the correct parameter to trigger test function

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
@@ -2199,7 +2199,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 
 	@Test
 	public void testRestoreLatestCheckpointedStateScaleOut() throws Exception {
-		testRestoreLatestCheckpointedStateWithChangingParallelism(false);
+		testRestoreLatestCheckpointedStateWithChangingParallelism(true);
 	}
 
 	@Test


### PR DESCRIPTION
## What is the purpose of the change

Correct the wrong parameter in unit test.

## Brief change log

 - change the parameter from `false` to `true` in `CheckpointCoordinatorTest#testRestoreLatestCheckpointedStateWithChangingParallelism(boolean scaleOut)` which was called in `CheckpointCoordinatorTest#testRestoreLatestCheckpointedStateScaleOut()`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not documented
