### PR TITLE
[FLINK-8324] [kafka] Expose another offsets metrics by using new metric API to specify user defined variables

### DIFF
--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -1290,6 +1290,18 @@ Thus, in order to infer the metric identifier:
        <td>Kafka offset commit failure count if Kafka commit is turned on and checkpointing is enabled.</td>
        <td>Counter</td>
     </tr>
+    <tr>
+      <th rowspan="1">Operator</th>
+      <td>currentOffsets</td>
+      <td>Kafka current offset.This metric has two user-scope variables: topic, partition, which can be used to specifiy particular metric by topic name and partition id</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <th rowspan="1">Operator</th>
+      <td>committedOffsets</td>
+      <td>Kafka successfully committed offset if Kafka commit is turned on and checkpointing is enabled. This metric has two user-scope variables: topic, partition, which can be used to specifiy particular metric by topic name and partition id</td>
+      <td>Gauge</td>
+    </tr>
   </tbody>
 </table>
 

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractFetcher.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractFetcher.java
@@ -570,6 +570,12 @@ public abstract class AbstractFetcher<T, KPH> {
 		for (KafkaTopicPartitionState<KPH> ktp : subscribedPartitionStates) {
 			currentOffsets.gauge(ktp.getTopic() + "-" + ktp.getPartition(), new OffsetGauge(ktp, OffsetGaugeType.CURRENT_OFFSET));
 			committedOffsets.gauge(ktp.getTopic() + "-" + ktp.getPartition(), new OffsetGauge(ktp, OffsetGaugeType.COMMITTED_OFFSET));
+
+			MetricGroup topicPartitionGroup = metricGroup
+				.addGroup("topic", ktp.getTopic())
+				.addGroup("partition", Integer.toString(ktp.getPartition()));
+			topicPartitionGroup.gauge("currentOffsets", new OffsetGauge(ktp, OffsetGaugeType.CURRENT_OFFSET));
+			topicPartitionGroup.gauge("committedOffsets", new OffsetGauge(ktp, OffsetGaugeType.COMMITTED_OFFSET));
 		}
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

Add two metrics for current offsets and committed offsets by using new metric API, which can define user scope variables.

## Brief change log

  - add two metrics for current offsets and committed offsets

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not documented
