### PR TITLE
[FLINK-8332] [flip6] Move savepoint dispose into ClusterClient

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/CliFrontend.java
@@ -671,7 +671,7 @@ public class CliFrontend {
 				if (cleanedArgs.length >= 1) {
 					String jobIdString = cleanedArgs[0];
 					try {
-						jobId = new JobID(StringUtils.hexStringToByte(jobIdString));
+						jobId = JobID.fromHexString(jobIdString);
 					} catch (Exception e) {
 						return handleArgException(new IllegalArgumentException(
 							"Error: The value for the Job ID is not a valid ID."));
@@ -739,7 +739,7 @@ public class CliFrontend {
 
 		logAndSysout("Disposing savepoint '" + savepointPath + "'.");
 
-		CompletableFuture<Acknowledge> disposeFuture = null;
+		final CompletableFuture<Acknowledge> disposeFuture;
 		try {
 			disposeFuture = clusterClient.disposeSavepoint(savepointPath, FutureUtils.toTime(clientTimeout));
 		} catch (Exception e) {

--- a/flink-clients/src/main/java/org/apache/flink/client/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/CliFrontend.java
@@ -57,9 +57,9 @@ import org.apache.flink.optimizer.plan.StreamingPlan;
 import org.apache.flink.optimizer.plandump.PlanJSONDumpGenerator;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.client.JobStatusMessage;
-import org.apache.flink.runtime.instance.ActorGateway;
+import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.jobgraph.JobStatus;
-import org.apache.flink.runtime.messages.JobManagerMessages;
+import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.security.SecurityConfiguration;
 import org.apache.flink.runtime.security.SecurityUtils;
 import org.apache.flink.runtime.util.EnvironmentInformation;
@@ -91,13 +91,9 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 
-import scala.concurrent.Await;
-import scala.concurrent.Future;
 import scala.concurrent.duration.FiniteDuration;
-
-import static org.apache.flink.runtime.messages.JobManagerMessages.DisposeSavepoint;
-import static org.apache.flink.runtime.messages.JobManagerMessages.DisposeSavepointFailure;
 
 /**
  * Implementation of a simple command line frontend for executing programs.
@@ -659,39 +655,53 @@ public class CliFrontend {
 			return 0;
 		}
 
-		if (options.isDispose()) {
-			// Discard
-			return disposeSavepoint(options);
-		} else {
-			// Trigger
-			String[] cleanedArgs = options.getArgs();
-			JobID jobId;
+		CustomCommandLine<?> customCommandLine = getActiveCustomCommandLine(options.getCommandLine());
 
-			if (cleanedArgs.length >= 1) {
-				String jobIdString = cleanedArgs[0];
-				try {
-					jobId = new JobID(StringUtils.hexStringToByte(jobIdString));
-				} catch (Exception e) {
-					return handleArgException(new IllegalArgumentException(
-							"Error: The value for the Job ID is not a valid ID."));
-				}
+		ClusterClient clusterClient = customCommandLine.retrieveCluster(options.getCommandLine(), config, configurationDirectory);
+
+		try {
+			if (options.isDispose()) {
+				// Discard
+				return disposeSavepoint(clusterClient, options.getSavepointPath());
 			} else {
-				return handleArgException(new IllegalArgumentException(
+				// Trigger
+				String[] cleanedArgs = options.getArgs();
+				JobID jobId;
+
+				if (cleanedArgs.length >= 1) {
+					String jobIdString = cleanedArgs[0];
+					try {
+						jobId = new JobID(StringUtils.hexStringToByte(jobIdString));
+					} catch (Exception e) {
+						return handleArgException(new IllegalArgumentException(
+							"Error: The value for the Job ID is not a valid ID."));
+					}
+				} else {
+					return handleArgException(new IllegalArgumentException(
 						"Error: The value for the Job ID is not a valid ID. " +
-								"Specify a Job ID to trigger a savepoint."));
-			}
+							"Specify a Job ID to trigger a savepoint."));
+				}
 
-			String savepointDirectory = null;
-			if (cleanedArgs.length >= 2) {
-				savepointDirectory = cleanedArgs[1];
-			}
+				String savepointDirectory = null;
+				if (cleanedArgs.length >= 2) {
+					savepointDirectory = cleanedArgs[1];
+				}
 
-			// Print superfluous arguments
-			if (cleanedArgs.length >= 3) {
-				logAndSysout("Provided more arguments than required. Ignoring not needed arguments.");
-			}
+				// Print superfluous arguments
+				if (cleanedArgs.length >= 3) {
+					logAndSysout("Provided more arguments than required. Ignoring not needed arguments.");
+				}
 
-			return triggerSavepoint(options, jobId, savepointDirectory);
+				return triggerSavepoint(clusterClient, jobId, savepointDirectory);
+			}
+		} catch (Exception e) {
+			return handleError(e);
+		} finally {
+			try {
+				clusterClient.shutdown();
+			} catch (Exception e) {
+				LOG.info("Could not shutdown the cluster client.", e);
+			}
 		}
 	}
 
@@ -699,88 +709,53 @@ public class CliFrontend {
 	 * Sends a {@link org.apache.flink.runtime.messages.JobManagerMessages.TriggerSavepoint}
 	 * message to the job manager.
 	 */
-	private int triggerSavepoint(SavepointOptions options, JobID jobId, String savepointDirectory) {
+	private int triggerSavepoint(ClusterClient clusterClient, JobID jobId, String savepointDirectory) throws Exception {
+		logAndSysout("Triggering savepoint for job " + jobId + ".");
+		CompletableFuture<String> savepointPathFuture = clusterClient.triggerSavepoint(jobId, savepointDirectory);
+
+		String savepointPath;
 		try {
-			CustomCommandLine<?> activeCommandLine = getActiveCustomCommandLine(options.getCommandLine());
-			ClusterClient client = activeCommandLine.retrieveCluster(options.getCommandLine(), config, configurationDirectory);
-			try {
-				logAndSysout("Triggering savepoint for job " + jobId + ".");
-				CompletableFuture<String> savepointPathFuture = client.triggerSavepoint(jobId, savepointDirectory);
-
-				String savepointPath;
-				try {
-					logAndSysout("Waiting for response...");
-					savepointPath = savepointPathFuture.get();
-				}
-				catch (ExecutionException ee) {
-					Throwable cause = ExceptionUtils.stripExecutionException(ee);
-					throw new FlinkException("Triggering a savepoint for the job " + jobId + " failed.", cause);
-				}
-
-				logAndSysout("Savepoint completed. Path: " + savepointPath);
-				logAndSysout("You can resume your program from this savepoint with the run command.");
-
-				return 0;
-			}
-			finally {
-				client.shutdown();
-			}
+			logAndSysout("Waiting for response...");
+			savepointPath = savepointPathFuture.get();
 		}
-		catch (Throwable t) {
-			return handleError(t);
+		catch (ExecutionException ee) {
+			Throwable cause = ExceptionUtils.stripExecutionException(ee);
+			throw new FlinkException("Triggering a savepoint for the job " + jobId + " failed.", cause);
 		}
+
+		logAndSysout("Savepoint completed. Path: " + savepointPath);
+		logAndSysout("You can resume your program from this savepoint with the run command.");
+
+		return 0;
 	}
 
 	/**
 	 * Sends a {@link org.apache.flink.runtime.messages.JobManagerMessages.DisposeSavepoint}
 	 * message to the job manager.
 	 */
-	private int disposeSavepoint(SavepointOptions options) {
+	private int disposeSavepoint(ClusterClient clusterClient, String savepointPath) {
+		Preconditions.checkNotNull(savepointPath, "Missing required argument: savepoint path. " +
+			"Usage: bin/flink savepoint -d <savepoint-path>");
+
+		logAndSysout("Disposing savepoint '" + savepointPath + "'.");
+
+		CompletableFuture<Acknowledge> disposeFuture = null;
 		try {
-			String savepointPath = options.getSavepointPath();
-			if (savepointPath == null) {
-				throw new IllegalArgumentException("Missing required argument: savepoint path. " +
-						"Usage: bin/flink savepoint -d <savepoint-path>");
-			}
-
-			ActorGateway jobManager = getJobManagerGateway(options);
-
-			logAndSysout("Disposing savepoint '" + savepointPath + "'.");
-
-			Object msg = new DisposeSavepoint(savepointPath);
-			Future<Object> response = jobManager.ask(msg, clientTimeout);
-
-			Object result;
-			try {
-				logAndSysout("Waiting for response...");
-				result = Await.result(response, clientTimeout);
-			} catch (Exception e) {
-				throw new Exception("Disposing the savepoint with path" + savepointPath + " failed.", e);
-			}
-
-			if (result.getClass() == JobManagerMessages.getDisposeSavepointSuccess().getClass()) {
-				logAndSysout("Savepoint '" + savepointPath + "' disposed.");
-				return 0;
-			} else if (result instanceof DisposeSavepointFailure) {
-				DisposeSavepointFailure failure = (DisposeSavepointFailure) result;
-
-				if (failure.cause() instanceof ClassNotFoundException) {
-					throw new ClassNotFoundException("Savepoint disposal failed, because of a " +
-							"missing class. This is most likely caused by a custom state " +
-							"instance, which cannot be disposed without the user code class " +
-							"loader. Please provide the program jar with which you have created " +
-							"the savepoint via -j <JAR> for disposal.",
-							failure.cause().getCause());
-				} else {
-					throw failure.cause();
-				}
-			} else {
-				throw new IllegalStateException("Unknown JobManager response of type " +
-						result.getClass());
-			}
-		} catch (Throwable t) {
-			return handleError(t);
+			disposeFuture = clusterClient.disposeSavepoint(savepointPath, FutureUtils.toTime(clientTimeout));
+		} catch (Exception e) {
+			return handleError(new FlinkException("Could not dispose savepoint", e));
 		}
+
+		logAndSysout("Waiting for response...");
+
+		try {
+			disposeFuture.get(clientTimeout.toMillis(), TimeUnit.MILLISECONDS);
+		} catch (Exception e) {
+			return handleError(e);
+		}
+
+		logAndSysout("Savepoint '" + savepointPath + "' disposed.");
+		return 0;
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -880,19 +855,6 @@ public class CliFrontend {
 			LOG.error("Couldn't retrieve {} cluster.", customCLI.getId(), e);
 			throw new IllegalConfigurationException("Couldn't retrieve client for cluster", e);
 		}
-	}
-
-	/**
-	 * Retrieves the {@link ActorGateway} for the JobManager. The ClusterClient is retrieved
-	 * from the provided {@link CommandLineOptions}.
-	 *
-	 * @param options CommandLineOptions specifying the JobManager URL
-	 * @return Gateway to the JobManager
-	 * @throws Exception
-	 */
-	protected ActorGateway getJobManagerGateway(CommandLineOptions options) throws Exception {
-		logAndSysout("Retrieving JobManager.");
-		return retrieveClient(options).getJobManagerGateway();
 	}
 
 	/**

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterDescriptor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterDescriptor.java
@@ -24,7 +24,7 @@ import org.apache.flink.runtime.jobgraph.JobGraph;
 /**
  * A descriptor to deploy a cluster (e.g. Yarn or Mesos) and return a Client for Cluster communication.
  */
-public interface ClusterDescriptor<ClientType extends ClusterClient> {
+public interface ClusterDescriptor<ClientType extends ClusterClient> extends AutoCloseable {
 
 	/**
 	 * Returns a String containing details about the cluster (NodeManagers, available memory, ...).

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/Flip6StandaloneClusterDescriptor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/Flip6StandaloneClusterDescriptor.java
@@ -60,4 +60,9 @@ public class Flip6StandaloneClusterDescriptor implements ClusterDescriptor<RestC
 	public RestClusterClient deployJobCluster(ClusterSpecification clusterSpecification, JobGraph jobGraph) {
 		throw new UnsupportedOperationException("Can't deploy a standalone FLIP-6 per-job cluster.");
 	}
+
+	@Override
+	public void close() throws Exception {
+		// nothing to do
+	}
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/StandaloneClusterDescriptor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/StandaloneClusterDescriptor.java
@@ -59,4 +59,9 @@ public class StandaloneClusterDescriptor implements ClusterDescriptor<Standalone
 	public StandaloneClusterClient deployJobCluster(ClusterSpecification clusterSpecification, JobGraph jobGraph) {
 		throw new UnsupportedOperationException("Can't deploy a standalone per-job cluster.");
 	}
+
+	@Override
+	public void close() throws Exception {
+		// nothing to do
+	}
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/CliFrontendSavepointTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/CliFrontendSavepointTest.java
@@ -190,12 +190,8 @@ public class CliFrontendSavepointTest extends TestLogger {
 
 		String savepointPath = "expectedSavepointPath";
 
-		final CompletableFuture<Acknowledge> disposeCallFuture = new CompletableFuture<>();
-
-		ClusterClient clusterClient = new DisposeSavepointClusterClient((String path, Time timeout) -> {
-			disposeCallFuture.complete(Acknowledge.get());
-			return CompletableFuture.completedFuture(Acknowledge.get());
-		});
+		ClusterClient clusterClient = new DisposeSavepointClusterClient(
+			(String path, Time timeout) -> CompletableFuture.completedFuture(Acknowledge.get()));
 
 		try {
 
@@ -203,8 +199,6 @@ public class CliFrontendSavepointTest extends TestLogger {
 
 			String[] parameters = { "-d", savepointPath };
 			frontend.savepoint(parameters);
-
-			disposeCallFuture.get();
 
 			String outMsg = buffer.toString();
 			assertTrue(outMsg.contains(savepointPath));

--- a/flink-clients/src/test/java/org/apache/flink/client/CliFrontendSavepointTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/CliFrontendSavepointTest.java
@@ -84,8 +84,9 @@ public class CliFrontendSavepointTest extends TestLogger {
 			MockedCliFrontend frontend = new MockedCliFrontend(clusterClient);
 
 			String[] parameters = { jobId.toString() };
-			frontend.savepoint(parameters);
+			int returnCode = frontend.savepoint(parameters);
 
+			assertEquals(0, returnCode);
 			verify(clusterClient, times(1))
 				.triggerSavepoint(eq(jobId), isNull(String.class));
 
@@ -138,6 +139,7 @@ public class CliFrontendSavepointTest extends TestLogger {
 			String[] parameters = { "invalid job id" };
 			int returnCode = frontend.savepoint(parameters);
 
+			assertTrue(buffer.toString().contains("not a valid ID"));
 			assertNotEquals(0, returnCode);
 		}
 		finally {
@@ -163,8 +165,9 @@ public class CliFrontendSavepointTest extends TestLogger {
 			MockedCliFrontend frontend = new MockedCliFrontend(clusterClient);
 
 			String[] parameters = { jobId.toString(), savepointDirectory };
-			frontend.savepoint(parameters);
+			int returnCode = frontend.savepoint(parameters);
 
+			assertEquals(0, returnCode);
 			verify(clusterClient, times(1))
 				.triggerSavepoint(eq(jobId), eq(savepointDirectory));
 

--- a/flink-clients/src/test/java/org/apache/flink/client/CliFrontendSavepointTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/CliFrontendSavepointTest.java
@@ -19,32 +19,29 @@
 package org.apache.flink.client;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.client.cli.CommandLineOptions;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.client.program.StandaloneClusterClient;
 import org.apache.flink.client.util.MockedCliFrontend;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.concurrent.FutureUtils;
-import org.apache.flink.runtime.instance.ActorGateway;
-import org.apache.flink.runtime.messages.JobManagerMessages;
+import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
+import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.TestLogger;
 
-import akka.dispatch.Futures;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.mockito.Mockito;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.PrintStream;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.BiFunction;
 import java.util.zip.ZipOutputStream;
 
-import scala.concurrent.Future;
-import scala.concurrent.Promise;
-import scala.concurrent.duration.FiniteDuration;
-
-import static org.apache.flink.runtime.messages.JobManagerMessages.DisposeSavepoint;
-import static org.apache.flink.runtime.messages.JobManagerMessages.DisposeSavepointFailure;
-import static org.apache.flink.runtime.messages.JobManagerMessages.getDisposeSavepointSuccess;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
@@ -60,7 +57,7 @@ import static org.mockito.Mockito.when;
 /**
  * Tests for the SAVEPOINT command.
  */
-public class CliFrontendSavepointTest {
+public class CliFrontendSavepointTest extends TestLogger {
 
 	private static PrintStream stdOut;
 	private static PrintStream stdErr;
@@ -77,23 +74,25 @@ public class CliFrontendSavepointTest {
 	public void testTriggerSavepointSuccess() throws Exception {
 		replaceStdOutAndStdErr();
 
+		JobID jobId = new JobID();
+
+		String savepointPath = "expectedSavepointPath";
+
+		final ClusterClient clusterClient = createClusterClient(savepointPath);
+
 		try {
-			JobID jobId = new JobID();
-
-			String savepointPath = "expectedSavepointPath";
-
-			MockedCliFrontend frontend = new SavepointTestCliFrontend(savepointPath);
+			MockedCliFrontend frontend = new MockedCliFrontend(clusterClient);
 
 			String[] parameters = { jobId.toString() };
-			int returnCode = frontend.savepoint(parameters);
+			frontend.savepoint(parameters);
 
-			assertEquals(0, returnCode);
-			verify(frontend.client, times(1))
+			verify(clusterClient, times(1))
 				.triggerSavepoint(eq(jobId), isNull(String.class));
 
 			assertTrue(buffer.toString().contains(savepointPath));
 		}
 		finally {
+			clusterClient.shutdown();
 			restoreStdOutAndStdErr();
 		}
 	}
@@ -102,23 +101,27 @@ public class CliFrontendSavepointTest {
 	public void testTriggerSavepointFailure() throws Exception {
 		replaceStdOutAndStdErr();
 
+		JobID jobId = new JobID();
+
+		String expectedTestException = "expectedTestException";
+		Exception testException = new Exception(expectedTestException);
+
+		final ClusterClient clusterClient = createFailingClusterClient(testException);
+
 		try {
-			JobID jobId = new JobID();
-
-			Exception testException = new Exception("expectedTestException");
-
-			MockedCliFrontend frontend = new SavepointTestCliFrontend(testException);
+			MockedCliFrontend frontend = new MockedCliFrontend(clusterClient);
 
 			String[] parameters = { jobId.toString() };
+
 			int returnCode = frontend.savepoint(parameters);
 
 			assertNotEquals(0, returnCode);
-			verify(frontend.client, times(1))
-				.triggerSavepoint(eq(jobId), isNull(String.class));
 
-			assertTrue(buffer.toString().contains("expectedTestException"));
+			assertTrue(buffer.toString().contains(expectedTestException));
 		}
 		finally {
+
+			clusterClient.shutdown();
 			restoreStdOutAndStdErr();
 		}
 	}
@@ -128,13 +131,14 @@ public class CliFrontendSavepointTest {
 		replaceStdOutAndStdErr();
 
 		try {
-			CliFrontend frontend = new CliFrontend(CliFrontendTestUtils.getConfigDir());
+			CliFrontend frontend = new MockedCliFrontend(new StandaloneClusterClient(
+				new Configuration(),
+				new TestingHighAvailabilityServices()));
 
 			String[] parameters = { "invalid job id" };
 			int returnCode = frontend.savepoint(parameters);
 
-			assertTrue(returnCode != 0);
-			assertTrue(buffer.toString().contains("not a valid ID"));
+			assertNotEquals(0, returnCode);
 		}
 		finally {
 			restoreStdOutAndStdErr();
@@ -149,23 +153,26 @@ public class CliFrontendSavepointTest {
 	public void testTriggerSavepointCustomTarget() throws Exception {
 		replaceStdOutAndStdErr();
 
+		JobID jobId = new JobID();
+
+		String savepointDirectory = "customTargetDirectory";
+
+		final ClusterClient clusterClient = createClusterClient(savepointDirectory);
+
 		try {
-			JobID jobId = new JobID();
-
-			String savepointDirectory = "customTargetDirectory";
-
-			MockedCliFrontend frontend = new SavepointTestCliFrontend(savepointDirectory);
+			MockedCliFrontend frontend = new MockedCliFrontend(clusterClient);
 
 			String[] parameters = { jobId.toString(), savepointDirectory };
-			int returnCode = frontend.savepoint(parameters);
+			frontend.savepoint(parameters);
 
-			assertEquals(0, returnCode);
-			verify(frontend.client, times(1))
+			verify(clusterClient, times(1))
 				.triggerSavepoint(eq(jobId), eq(savepointDirectory));
 
 			assertTrue(buffer.toString().contains(savepointDirectory));
 		}
 		finally {
+			clusterClient.shutdown();
+
 			restoreStdOutAndStdErr();
 		}
 	}
@@ -178,65 +185,30 @@ public class CliFrontendSavepointTest {
 	public void testDisposeSavepointSuccess() throws Exception {
 		replaceStdOutAndStdErr();
 
+		String savepointPath = "expectedSavepointPath";
+
+		final CompletableFuture<Acknowledge> disposeCallFuture = new CompletableFuture<>();
+
+		ClusterClient clusterClient = new DisposeSavepointClusterClient((String path, Time timeout) -> {
+			disposeCallFuture.complete(Acknowledge.get());
+			return CompletableFuture.completedFuture(Acknowledge.get());
+		});
+
 		try {
-			String savepointPath = "expectedSavepointPath";
-			ActorGateway jobManager = mock(ActorGateway.class);
 
-			Promise<Object> triggerResponse = new scala.concurrent.impl.Promise.DefaultPromise<>();
-
-			when(jobManager.ask(
-					Mockito.eq(new DisposeSavepoint(savepointPath)),
-					any(FiniteDuration.class))).thenReturn(triggerResponse.future());
-
-			triggerResponse.success(getDisposeSavepointSuccess());
-
-			CliFrontend frontend = new MockCliFrontend(
-					CliFrontendTestUtils.getConfigDir(), jobManager);
+			CliFrontend frontend = new MockedCliFrontend(clusterClient);
 
 			String[] parameters = { "-d", savepointPath };
-			int returnCode = frontend.savepoint(parameters);
+			frontend.savepoint(parameters);
 
-			assertEquals(0, returnCode);
-			verify(jobManager, times(1)).ask(
-					Mockito.eq(new DisposeSavepoint(savepointPath)),
-					any(FiniteDuration.class));
+			disposeCallFuture.get();
 
 			String outMsg = buffer.toString();
 			assertTrue(outMsg.contains(savepointPath));
 			assertTrue(outMsg.contains("disposed"));
 		}
 		finally {
-			restoreStdOutAndStdErr();
-		}
-	}
-
-	/**
-	 * Tests that a disposal failure due a  ClassNotFoundException triggers a
-	 * note about the JAR option.
-	 */
-	@Test
-	public void testDisposeClassNotFoundException() throws Exception {
-		replaceStdOutAndStdErr();
-
-		try {
-			Future<Object> classNotFoundFailure = Futures
-					.<Object>successful(new DisposeSavepointFailure(new ClassNotFoundException("Test exception")));
-
-			ActorGateway jobManager = mock(ActorGateway.class);
-			when(jobManager.ask(any(DisposeSavepoint.class), any(FiniteDuration.class)))
-					.thenReturn(classNotFoundFailure);
-
-			CliFrontend frontend = new MockCliFrontend(CliFrontendTestUtils.getConfigDir(), jobManager);
-
-			String[] parameters = { "-d", "any-path" };
-
-			int returnCode = frontend.savepoint(parameters);
-			assertTrue(returnCode != 0);
-
-			String out = buffer.toString();
-			assertTrue(out.contains("Please provide the program jar with which you have created " +
-					"the savepoint via -j <JAR> for disposal"));
-		} finally {
+			clusterClient.shutdown();
 			restoreStdOutAndStdErr();
 		}
 	}
@@ -248,23 +220,32 @@ public class CliFrontendSavepointTest {
 	public void testDisposeWithJar() throws Exception {
 		replaceStdOutAndStdErr();
 
-		try {
-			ActorGateway jobManager = mock(ActorGateway.class);
-			when(jobManager.ask(any(DisposeSavepoint.class), any(FiniteDuration.class)))
-					.thenReturn(Futures.successful(JobManagerMessages.getDisposeSavepointSuccess()));
+		final CompletableFuture<String> disposeSavepointFuture = new CompletableFuture<>();
 
-			CliFrontend frontend = new MockCliFrontend(CliFrontendTestUtils.getConfigDir(), jobManager);
+		final ClusterClient clusterClient = new DisposeSavepointClusterClient(
+			(String savepointPath, Time timeout) -> {
+				disposeSavepointFuture.complete(savepointPath);
+				return CompletableFuture.completedFuture(Acknowledge.get());
+			});
+
+		try {
+			CliFrontend frontend = new MockedCliFrontend(clusterClient);
 
 			// Fake JAR file
 			File f = tmp.newFile();
 			ZipOutputStream out = new ZipOutputStream(new FileOutputStream(f));
 			out.close();
 
-			String[] parameters = { "-d", "any-path", "-j", f.getAbsolutePath() };
+			final String disposePath = "any-path";
+			String[] parameters = { "-d", disposePath, "-j", f.getAbsolutePath() };
 
-			int returnCode = frontend.savepoint(parameters);
-			assertEquals(0, returnCode);
+			frontend.savepoint(parameters);
+
+			final String actualSavepointPath = disposeSavepointFuture.get();
+
+			assertEquals(disposePath, actualSavepointPath);
 		} finally {
+			clusterClient.shutdown();
 			restoreStdOutAndStdErr();
 		}
 	}
@@ -273,92 +254,44 @@ public class CliFrontendSavepointTest {
 	public void testDisposeSavepointFailure() throws Exception {
 		replaceStdOutAndStdErr();
 
-		try {
-			String savepointPath = "expectedSavepointPath";
-			ActorGateway jobManager = mock(ActorGateway.class);
+		String savepointPath = "expectedSavepointPath";
 
-			Promise<Object> triggerResponse = new scala.concurrent.impl.Promise.DefaultPromise<>();
+		Exception testException = new Exception("expectedTestException");
 
-			when(jobManager.ask(
-					Mockito.eq(new DisposeSavepoint(savepointPath)),
-					any(FiniteDuration.class)))
-					.thenReturn(triggerResponse.future());
-
-			Exception testException = new Exception("expectedTestException");
-
-			triggerResponse.success(new DisposeSavepointFailure(testException));
-
-			CliFrontend frontend = new MockCliFrontend(
-					CliFrontendTestUtils.getConfigDir(), jobManager);
-
-			String[] parameters = { "-d", savepointPath };
-			int returnCode = frontend.savepoint(parameters);
-
-			assertTrue(returnCode != 0);
-			verify(jobManager, times(1)).ask(
-					Mockito.eq(new DisposeSavepoint(savepointPath)),
-					any(FiniteDuration.class));
-
-			assertTrue(buffer.toString().contains("expectedTestException"));
-		}
-		finally {
-			restoreStdOutAndStdErr();
-		}
-	}
-
-	@Test
-	public void testDisposeSavepointFailureUnknownResponse() throws Exception {
-		replaceStdOutAndStdErr();
+		ClusterClient clusterClient = new DisposeSavepointClusterClient((String path, Time timeout) -> FutureUtils.completedExceptionally(testException));
 
 		try {
-			String savepointPath = "expectedSavepointPath";
-			ActorGateway jobManager = mock(ActorGateway.class);
-
-			Promise<Object> triggerResponse = new scala.concurrent.impl.Promise.DefaultPromise<>();
-
-			when(jobManager.ask(
-					Mockito.eq(new DisposeSavepoint(savepointPath)),
-					any(FiniteDuration.class)))
-					.thenReturn(triggerResponse.future());
-
-			triggerResponse.success("UNKNOWN RESPONSE");
-
-			CliFrontend frontend = new MockCliFrontend(
-					CliFrontendTestUtils.getConfigDir(), jobManager);
+			CliFrontend frontend = new MockedCliFrontend(clusterClient);
 
 			String[] parameters = { "-d", savepointPath };
+
 			int returnCode = frontend.savepoint(parameters);
 
-			assertTrue(returnCode != 0);
-			verify(jobManager, times(1)).ask(
-					Mockito.eq(new DisposeSavepoint(savepointPath)),
-					any(FiniteDuration.class));
+			assertNotEquals(0, returnCode);
 
-			String errMsg = buffer.toString();
-			assertTrue(errMsg.contains("IllegalStateException"));
-			assertTrue(errMsg.contains("Unknown JobManager response"));
+			assertTrue(buffer.toString().contains(testException.getMessage()));
 		}
 		finally {
+			clusterClient.shutdown();
 			restoreStdOutAndStdErr();
 		}
-
-		replaceStdOutAndStdErr();
 	}
 
 	// ------------------------------------------------------------------------
 
-	private static class MockCliFrontend extends CliFrontend {
+	private static final class DisposeSavepointClusterClient extends StandaloneClusterClient {
 
-		private final ActorGateway mockJobManager;
+		final BiFunction<String, Time, CompletableFuture<Acknowledge>> disposeSavepointFunction;
 
-		public MockCliFrontend(String configDir, ActorGateway mockJobManager) throws Exception {
-			super(configDir);
-			this.mockJobManager = mockJobManager;
+		public DisposeSavepointClusterClient(BiFunction<String, Time, CompletableFuture<Acknowledge>> disposeSavepointFunction) throws Exception {
+			super(new Configuration(), new TestingHighAvailabilityServices());
+
+			this.disposeSavepointFunction = Preconditions.checkNotNull(disposeSavepointFunction);
 		}
 
 		@Override
-		protected ActorGateway getJobManagerGateway(CommandLineOptions options) throws Exception {
-			return mockJobManager;
+		public CompletableFuture<Acknowledge> disposeSavepoint(String savepointPath, Time timeout) {
+			return disposeSavepointFunction.apply(savepointPath, timeout);
 		}
 	}
 
@@ -376,16 +309,21 @@ public class CliFrontendSavepointTest {
 		System.setErr(stdErr);
 	}
 
-	private static final class SavepointTestCliFrontend extends MockedCliFrontend {
+	private static ClusterClient createClusterClient(String expectedResponse) throws Exception {
+		final ClusterClient clusterClient = mock(ClusterClient.class);
 
-		SavepointTestCliFrontend(String expectedResponse) throws Exception {
-			when(client.triggerSavepoint(any(JobID.class), anyString()))
-				.thenReturn(CompletableFuture.completedFuture(expectedResponse));
-		}
+		when(clusterClient.triggerSavepoint(any(JobID.class), anyString()))
+			.thenReturn(CompletableFuture.completedFuture(expectedResponse));
 
-		SavepointTestCliFrontend(Exception expectedException) throws Exception {
-			when(client.triggerSavepoint(any(JobID.class), anyString()))
-				.thenReturn(FutureUtils.completedExceptionally(expectedException));
-		}
+		return clusterClient;
+	}
+
+	private static ClusterClient createFailingClusterClient(Exception expectedException) throws Exception {
+		final ClusterClient clusterClient = mock(ClusterClient.class);
+
+		when(clusterClient.triggerSavepoint(any(JobID.class), anyString()))
+			.thenReturn(FutureUtils.completedExceptionally(expectedException));
+
+		return clusterClient;
 	}
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/util/MockedCliFrontend.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/util/MockedCliFrontend.java
@@ -39,6 +39,11 @@ import static org.powermock.api.mockito.PowerMockito.when;
 public class MockedCliFrontend extends CliFrontend {
 	public final ClusterClient client;
 
+	public MockedCliFrontend(ClusterClient clusterClient) throws Exception {
+		super(CliFrontendTestUtils.getConfigDir());
+		this.client = clusterClient;
+	}
+
 	protected MockedCliFrontend() throws Exception {
 		super(CliFrontendTestUtils.getConfigDir());
 		this.client = mock(ClusterClient.class);

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/CliFrontendYarnAddressConfigurationTest.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/CliFrontendYarnAddressConfigurationTest.java
@@ -379,7 +379,7 @@ public class CliFrontendYarnAddressConfigurationTest extends TestLogger {
 				}
 
 				@Override
-				protected YarnClient getYarnClient() {
+				public YarnClient getYarnClient() {
 					return new TestYarnClient();
 				}
 

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/FlinkYarnSessionCliTest.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/FlinkYarnSessionCliTest.java
@@ -174,7 +174,10 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 
 		private static class JarAgnosticClusterDescriptor extends YarnClusterDescriptor {
 			public JarAgnosticClusterDescriptor(Configuration flinkConfiguration, String configurationDirectory) {
-				super(flinkConfiguration, configurationDirectory);
+				super(
+					flinkConfiguration,
+					configurationDirectory,
+					YarnClient.createYarnClient());
 			}
 
 			@Override
@@ -202,7 +205,6 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 			super(descriptor,
 				numberTaskManagers,
 				slotsPerTaskManager,
-				Mockito.mock(YarnClient.class),
 				Mockito.mock(ApplicationReport.class),
 				config,
 				false);

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/TestingYarnClusterDescriptor.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/TestingYarnClusterDescriptor.java
@@ -23,6 +23,8 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.util.Preconditions;
 
+import org.apache.hadoop.yarn.client.api.YarnClient;
+
 import java.io.File;
 import java.io.FilenameFilter;
 import java.util.ArrayList;
@@ -36,7 +38,10 @@ import java.util.List;
 public class TestingYarnClusterDescriptor extends AbstractYarnClusterDescriptor {
 
 	public TestingYarnClusterDescriptor(Configuration configuration, String configurationDirectory) {
-		super(configuration, configurationDirectory);
+		super(
+			configuration,
+			configurationDirectory,
+			YarnClient.createYarnClient());
 		List<File> filesToShip = new ArrayList<>();
 
 		File testingJar = YarnTestBase.findFile("..", new TestJarFinder("flink-yarn-tests"));

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
@@ -656,7 +656,7 @@ public abstract class YarnTestBase extends TestLogger {
 			throw new RuntimeException("Runner failed", runner.getRunnerError());
 		}
 		Assert.assertTrue("During the timeout period of " + startTimeoutSeconds + " seconds the " +
-				"expected string did not show up", expectedStringSeen);
+				"expected string \"" + terminateAfterString + "\" did not show up.", expectedStringSeen);
 
 		LOG.info("Test was successful");
 	}

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
@@ -308,7 +308,7 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 	 * Gets a Hadoop Yarn client.
 	 * @return Returns a YarnClient which has to be shutdown manually
 	 */
-	protected YarnClient getYarnClient() {
+	public YarnClient getYarnClient() {
 		YarnClient yarnClient = YarnClient.createYarnClient();
 		yarnClient.init(conf);
 		yarnClient.start();

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.client.deployment.ClusterDescriptor;
 import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.IllegalConfigurationException;
@@ -35,7 +36,6 @@ import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.yarn.configuration.YarnConfigOptions;
 
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsAction;
@@ -108,14 +108,9 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 	private static final int MIN_JM_MEMORY = 768; // the minimum memory should be higher than the min heap cutoff
 	private static final int MIN_TM_MEMORY = 768;
 
-	private Configuration conf = new YarnConfiguration();
+	private final YarnConfiguration yarnConfiguration;
 
-	/**
-	 * If the user has specified a different number of slots, we store them here
-	 * Files (usually in a distributed file system) used for the YARN session of Flink.
-	 * Contains configuration files and jar files.
-	 */
-	private Path sessionFilesDir;
+	private final YarnClient yarnClient;
 
 	private String yarnQueue;
 
@@ -128,7 +123,7 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 	/** Lazily initialized list of files to ship. */
 	protected List<File> shipFiles = new LinkedList<>();
 
-	private final org.apache.flink.configuration.Configuration flinkConfiguration;
+	private final Configuration flinkConfiguration;
 
 	private boolean detached;
 
@@ -143,16 +138,24 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 	private YarnConfigOptions.UserJarInclusion userJarInclusion;
 
 	public AbstractYarnClusterDescriptor(
-		org.apache.flink.configuration.Configuration flinkConfiguration,
-		String configurationDirectory) {
+			Configuration flinkConfiguration,
+			String configurationDirectory,
+			YarnClient yarnClient) {
+
+		yarnConfiguration = new YarnConfiguration();
+
 		// for unit tests only
 		if (System.getenv("IN_TESTS") != null) {
 			try {
-				conf.addResource(new File(System.getenv("YARN_CONF_DIR") + "/yarn-site.xml").toURI().toURL());
+				yarnConfiguration.addResource(new File(System.getenv("YARN_CONF_DIR") + "/yarn-site.xml").toURI().toURL());
 			} catch (Throwable t) {
 				throw new RuntimeException("Error", t);
 			}
 		}
+
+		this.yarnClient = Preconditions.checkNotNull(yarnClient);
+		yarnClient.init(yarnConfiguration);
+		yarnClient.start();
 
 		this.flinkConfiguration = Preconditions.checkNotNull(flinkConfiguration);
 		userJarInclusion = getUserJarInclusionMode(flinkConfiguration);
@@ -160,14 +163,23 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 		this.configurationDirectory = Preconditions.checkNotNull(configurationDirectory);
 	}
 
+	public YarnClient getYarnClient() {
+		return yarnClient;
+	}
+
 	/**
-	 * The class to bootstrap the application master of the Yarn cluster (runs main method).
+	 * The class to start the application master with. This class runs the main
+	 * method in case of session cluster.
 	 */
 	protected abstract String getYarnSessionClusterEntrypoint();
 
+	/**
+	 * The class to start the application master with. This class runs the main
+	 * method in case of the job cluster.
+	 */
 	protected abstract String getYarnJobClusterEntrypoint();
 
-	public org.apache.flink.configuration.Configuration getFlinkConfiguration() {
+	public Configuration getFlinkConfiguration() {
 		return flinkConfiguration;
 	}
 
@@ -257,7 +269,7 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 		// Check if we don't exceed YARN's maximum virtual cores.
 		// The number of cores can be configured in the config.
 		// If not configured, it is set to the number of task slots
-		int numYarnVcores = conf.getInt(YarnConfiguration.NM_VCORES, YarnConfiguration.DEFAULT_NM_VCORES);
+		int numYarnVcores = yarnConfiguration.getInt(YarnConfiguration.NM_VCORES, YarnConfiguration.DEFAULT_NM_VCORES);
 		int configuredVcores = flinkConfiguration.getInteger(YarnConfigOptions.VCORES, clusterSpecification.getSlotsPerTaskManager());
 		// don't configure more than the maximum configured number of vcores
 		if (configuredVcores > numYarnVcores) {
@@ -304,21 +316,22 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 		this.zookeeperNamespace = zookeeperNamespace;
 	}
 
-	/**
-	 * Gets a Hadoop Yarn client.
-	 * @return Returns a YarnClient which has to be shutdown manually
-	 */
-	public YarnClient getYarnClient() {
-		YarnClient yarnClient = YarnClient.createYarnClient();
-		yarnClient.init(conf);
-		yarnClient.start();
-		return yarnClient;
+	// -------------------------------------------------------------
+	// Lifecycle management
+	// -------------------------------------------------------------
+
+	@Override
+	public void close() {
+		yarnClient.stop();
 	}
+
+	// -------------------------------------------------------------
+	// ClusterClient overrides
+	// -------------------------------------------------------------
 
 	@Override
 	public YarnClusterClient retrieve(String applicationID) {
 
-		YarnClient yarnClient = null;
 		try {
 			// check if required Hadoop environment variables are set. If not, warn user
 			if (System.getenv("HADOOP_CONF_DIR") == null &&
@@ -329,7 +342,6 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 			}
 
 			final ApplicationId yarnAppId = ConverterUtils.toApplicationId(applicationID);
-			yarnClient = getYarnClient();
 			final ApplicationReport appReport = yarnClient.getApplicationReport(yarnAppId);
 
 			if (appReport.getFinalApplicationStatus() != FinalApplicationStatus.UNDEFINED) {
@@ -349,14 +361,10 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 				this,
 				-1, // we don't know the number of task managers of a started Flink cluster
 				-1, // we don't know how many slots each task manager has for a started Flink cluster
-				yarnClient,
 				appReport,
 				flinkConfiguration,
 				false);
 		} catch (Exception e) {
-			if (null != yarnClient) {
-				yarnClient.stop();
-			}
 			throw new RuntimeException("Couldn't retrieve Yarn cluster", e);
 		}
 	}
@@ -414,8 +422,6 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 
 		isReadyForDeployment(clusterSpecification);
 
-		final YarnClient yarnClient = getYarnClient();
-
 		// ------------------ Check if the specified queue exists --------------------
 
 		checkYarnQueues(yarnClient);
@@ -442,7 +448,7 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 			throw new YarnDeploymentException("Could not retrieve information about free cluster resources.", e);
 		}
 
-		final int yarnMinAllocationMB = conf.getInt("yarn.scheduler.minimum-allocation-mb", 0);
+		final int yarnMinAllocationMB = yarnConfiguration.getInt("yarn.scheduler.minimum-allocation-mb", 0);
 
 		final ClusterSpecification validClusterSpecification;
 		try {
@@ -477,7 +483,6 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 			this,
 			clusterSpecification.getNumberTaskManagers(),
 			clusterSpecification.getSlotsPerTaskManager(),
-			yarnClient,
 			report,
 			flinkConfiguration,
 			true);
@@ -627,7 +632,7 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 		// initialize file system
 		// Copy the application master jar to the filesystem
 		// Create a local resource to point to the destination jar path
-		final FileSystem fs = FileSystem.get(conf);
+		final FileSystem fs = FileSystem.get(yarnConfiguration);
 		final Path homeDir = fs.getHomeDirectory();
 
 		// hard coded check for the GoogleHDFS client because its not overriding the getScheme() method.
@@ -881,7 +886,7 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 		if (UserGroupInformation.isSecurityEnabled()) {
 			// set HDFS delegation tokens when security is enabled
 			LOG.info("Adding delegation token to the AM container..");
-			Utils.setTokensFor(amContainer, paths, conf);
+			Utils.setTokensFor(amContainer, paths, yarnConfiguration);
 		}
 
 		amContainer.setLocalResources(localResources);
@@ -926,7 +931,7 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 		}
 
 		// set classpath from YARN configuration
-		Utils.setupYarnClassPath(conf, appMasterEnv);
+		Utils.setupYarnClassPath(yarnConfiguration, appMasterEnv);
 
 		amContainer.setEnvironment(appMasterEnv);
 
@@ -1196,7 +1201,6 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 			ByteArrayOutputStream baos = new ByteArrayOutputStream();
 			PrintStream ps = new PrintStream(baos);
 
-			YarnClient yarnClient = getYarnClient();
 			YarnClusterMetrics metrics = yarnClient.getYarnClusterMetrics();
 
 			ps.append("NodeManagers in the ClusterClient " + metrics.getNumNodeManagers());
@@ -1223,7 +1227,6 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 				ps.println("Queue: " + q.getQueueName() + ", Current Capacity: " + q.getCurrentCapacity() + " Max Capacity: " +
 					q.getMaximumCapacity() + " Applications: " + q.getApplications().size());
 			}
-			yarnClient.stop();
 			return baos.toString();
 		} catch (Exception e) {
 			throw new RuntimeException("Couldn't get cluster description", e);
@@ -1411,7 +1414,7 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 			failSessionDuringDeployment(yarnClient, yarnApplication);
 			LOG.info("Deleting files in {}.", yarnFilesDir);
 			try {
-				FileSystem fs = FileSystem.get(conf);
+				FileSystem fs = FileSystem.get(yarnConfiguration);
 
 				if (!fs.delete(yarnFilesDir, true)) {
 					throw new IOException("Deleting files in " + yarnFilesDir + " was unsuccessful");
@@ -1419,7 +1422,7 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 
 				fs.close();
 			} catch (IOException e) {
-				LOG.error("Failed to delete Flink Jar and conf files in HDFS", e);
+				LOG.error("Failed to delete Flink Jar and configuration files in HDFS", e);
 			}
 		}
 	}
@@ -1525,7 +1528,6 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 			AbstractYarnClusterDescriptor descriptor,
 			int numberTaskManagers,
 			int slotsPerTaskManager,
-			YarnClient yarnClient,
 			ApplicationReport report,
 			org.apache.flink.configuration.Configuration flinkConfiguration,
 			boolean perJobCluster) throws Exception {
@@ -1533,7 +1535,6 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 			descriptor,
 			numberTaskManagers,
 			slotsPerTaskManager,
-			yarnClient,
 			report,
 			flinkConfiguration,
 			perJobCluster);

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
@@ -147,7 +147,7 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 		// for unit tests only
 		if (System.getenv("IN_TESTS") != null) {
 			try {
-				yarnConfiguration.addResource(new File(System.getenv("YARN_CONF_DIR") + "/yarn-site.xml").toURI().toURL());
+				yarnConfiguration.addResource(new File(System.getenv("YARN_CONF_DIR"), "yarn-site.xml").toURI().toURL());
 			} catch (Throwable t) {
 				throw new RuntimeException("Error", t);
 			}

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -22,13 +22,18 @@ import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 
+import org.apache.hadoop.yarn.client.api.YarnClient;
+
 /**
  * Default implementation of {@link AbstractYarnClusterDescriptor} which starts an {@link YarnApplicationMasterRunner}.
  */
 public class YarnClusterDescriptor extends AbstractYarnClusterDescriptor {
 
-	public YarnClusterDescriptor(Configuration flinkConfiguration, String configurationDirectory) {
-		super(flinkConfiguration, configurationDirectory);
+	public YarnClusterDescriptor(
+			Configuration flinkConfiguration,
+			String configurationDirectory,
+			YarnClient yarnClient) {
+		super(flinkConfiguration, configurationDirectory, yarnClient);
 	}
 
 	@Override

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptorV2.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptorV2.java
@@ -22,14 +22,19 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.yarn.entrypoint.YarnJobClusterEntrypoint;
 import org.apache.flink.yarn.entrypoint.YarnSessionClusterEntrypoint;
 
+import org.apache.hadoop.yarn.client.api.YarnClient;
+
 /**
  * Implementation of {@link org.apache.flink.yarn.AbstractYarnClusterDescriptor} which is used to start the
  * new application master for a job under flip-6.
  */
 public class YarnClusterDescriptorV2 extends AbstractYarnClusterDescriptor {
 
-	public YarnClusterDescriptorV2(Configuration flinkConfiguration, String configurationDirectory) {
-		super(flinkConfiguration, configurationDirectory);
+	public YarnClusterDescriptorV2(
+			Configuration flinkConfiguration,
+			String configurationDirectory,
+			YarnClient yarnCLient) {
+		super(flinkConfiguration, configurationDirectory, yarnCLient);
 	}
 
 	@Override

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
@@ -31,8 +31,10 @@ import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.messages.GetClusterStatusResponse;
+import org.apache.flink.runtime.concurrent.ScheduledExecutorServiceAdapter;
 import org.apache.flink.runtime.security.SecurityConfiguration;
 import org.apache.flink.runtime.security.SecurityUtils;
+import org.apache.flink.util.ExecutorUtils;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.yarn.AbstractYarnClusterDescriptor;
 import org.apache.flink.yarn.YarnClusterClient;
@@ -71,6 +73,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 import static org.apache.flink.client.cli.CliFrontendParser.ADDRESS_OPTION;
 import static org.apache.flink.configuration.HighAvailabilityOptions.HA_CLUSTER_ID;
@@ -86,7 +90,7 @@ public class FlinkYarnSessionCli implements CustomCommandLine<YarnClusterClient>
 	public static final String CONFIG_FILE_LOGBACK_NAME = "logback.xml";
 	public static final String CONFIG_FILE_LOG4J_NAME = "log4j.properties";
 
-	private static final int CLIENT_POLLING_INTERVALL = 3;
+	private static final long CLIENT_POLLING_INTERVAL_MS = 3000L;
 
 	/** The id for the CommandLine interface. */
 	private static final String ID = "yarn-cluster";
@@ -98,6 +102,10 @@ public class FlinkYarnSessionCli implements CustomCommandLine<YarnClusterClient>
 	private static final String YARN_PROPERTIES_DYNAMIC_PROPERTIES_STRING = "dynamicPropertiesString";
 
 	private static final String YARN_DYNAMIC_PROPERTIES_SEPARATOR = "@@"; // this has to be a regex for String.split()
+
+	private static final String YARN_SESSION_HELP = "Available commands:\n" +
+		"help - show these commands\n" +
+		"stop - stop the YARN session";
 
 	//------------------------------------ Command Line argument options -------------------------
 	// the prefix transformation is used by the CliFrontend static constructor.
@@ -419,104 +427,6 @@ public class FlinkYarnSessionCli implements CustomCommandLine<YarnClusterClient>
 		formatter.printHelp(" ", options);
 	}
 
-	private static void writeYarnProperties(Properties properties, File propertiesFile) {
-		try (final OutputStream out = new FileOutputStream(propertiesFile)) {
-			properties.store(out, "Generated YARN properties file");
-		} catch (IOException e) {
-			throw new RuntimeException("Error writing the properties file", e);
-		}
-		propertiesFile.setReadable(true, false); // readable for all.
-	}
-
-	public static void runInteractiveCli(YarnClusterClient yarnCluster, boolean readConsoleInput) {
-		final String help = "Available commands:\n" +
-				"help - show these commands\n" +
-				"stop - stop the YARN session";
-		int numTaskmanagers = 0;
-		try {
-			BufferedReader in = new BufferedReader(new InputStreamReader(System.in));
-			label:
-			while (true) {
-				// ------------------ check if there are updates by the cluster -----------
-
-				try {
-					GetClusterStatusResponse status = yarnCluster.getClusterStatus();
-					LOG.debug("Received status message: {}", status);
-
-					if (status != null && numTaskmanagers != status.numRegisteredTaskManagers()) {
-						System.err.println("Number of connected TaskManagers changed to " +
-							status.numRegisteredTaskManagers() + ". " +
-							"Slots available: " + status.totalNumberOfSlots());
-						numTaskmanagers = status.numRegisteredTaskManagers();
-					}
-				} catch (Exception e) {
-					LOG.warn("Could not retrieve the current cluster status. Skipping current retrieval attempt ...", e);
-				}
-
-				List<String> messages = yarnCluster.getNewMessages();
-				if (messages != null && messages.size() > 0) {
-					System.err.println("New messages from the YARN cluster: ");
-					for (String msg : messages) {
-						System.err.println(msg);
-					}
-				}
-
-				if (yarnCluster.getApplicationStatus() != ApplicationStatus.SUCCEEDED) {
-					System.err.println("The YARN cluster has failed");
-					yarnCluster.shutdown();
-				}
-
-				// wait until CLIENT_POLLING_INTERVAL is over or the user entered something.
-				long startTime = System.currentTimeMillis();
-				while ((System.currentTimeMillis() - startTime) < CLIENT_POLLING_INTERVALL * 1000
-						&& (!readConsoleInput || !in.ready())) {
-					Thread.sleep(200);
-				}
-				//------------- handle interactive command by user. ----------------------
-
-				if (readConsoleInput && in.ready()) {
-					String command = in.readLine();
-					switch (command) {
-						case "quit":
-						case "stop":
-							yarnCluster.shutdownCluster();
-							break label;
-
-						case "help":
-							System.err.println(help);
-							break;
-						default:
-							System.err.println("Unknown command '" + command + "'. Showing help: \n" + help);
-							break;
-					}
-				}
-
-				if (yarnCluster.hasBeenShutdown()) {
-					LOG.info("Stopping interactive command line interface, YARN cluster has been stopped.");
-					break;
-				}
-			}
-		} catch (Exception e) {
-			LOG.warn("Exception while running the interactive command line interface", e);
-		}
-	}
-
-	public static void main(final String[] args) throws Exception {
-		final FlinkYarnSessionCli cli = new FlinkYarnSessionCli("", ""); // no prefix for the YARN session
-
-		final String configurationDirectory = CliFrontend.getConfigurationDirectoryFromEnv();
-
-		final Configuration flinkConfiguration = GlobalConfiguration.loadConfiguration();
-		SecurityUtils.install(new SecurityConfiguration(flinkConfiguration));
-		int retCode = SecurityUtils.getInstalledContext().runSecured(new Callable<Integer>() {
-			@Override
-			public Integer call() {
-				return cli.run(args, flinkConfiguration, configurationDirectory);
-			}
-		});
-		System.exit(retCode);
-	}
-
 	@Override
 	public boolean isActive(CommandLine commandLine, Configuration configuration) {
 		String jobManagerOption = commandLine.getOptionValue(ADDRESS_OPTION.getOpt(), null);
@@ -660,7 +570,25 @@ public class FlinkYarnSessionCli implements CustomCommandLine<YarnClusterClient>
 					"yarn application -kill " + applicationId.getOpt());
 				yarnCluster.disconnect();
 			} else {
-				runInteractiveCli(yarnCluster, true);
+				ScheduledThreadPoolExecutor scheduledExecutorService = new ScheduledThreadPoolExecutor(1);
+
+				try (YarnApplicationStatusMonitor yarnApplicationStatusMonitor = new YarnApplicationStatusMonitor(
+						yarnDescriptor.getYarnClient(),
+						yarnCluster.getApplicationId(),
+						new ScheduledExecutorServiceAdapter(scheduledExecutorService))) {
+					runInteractiveCli(
+						yarnCluster,
+						yarnApplicationStatusMonitor,
+						true);
+				} catch (Exception e) {
+					LOG.info("Could not properly close the Yarn application status monitor.", e);
+				} finally {
+					// shut down the scheduled executor service
+					ExecutorUtils.gracefulShutdown(
+						1000L,
+						TimeUnit.MILLISECONDS,
+						scheduledExecutorService);
+				}
 			}
 		} else {
 
@@ -717,7 +645,26 @@ public class FlinkYarnSessionCli implements CustomCommandLine<YarnClusterClient>
 				yarnCluster.waitForClusterToBeReady();
 				yarnCluster.disconnect();
 			} else {
-				runInteractiveCli(yarnCluster, acceptInteractiveInput);
+
+				ScheduledThreadPoolExecutor scheduledExecutorService = new ScheduledThreadPoolExecutor(1);
+
+				try (YarnApplicationStatusMonitor yarnApplicationStatusMonitor = new YarnApplicationStatusMonitor(
+						yarnDescriptor.getYarnClient(),
+						yarnCluster.getApplicationId(),
+						new ScheduledExecutorServiceAdapter(scheduledExecutorService))){
+					runInteractiveCli(
+						yarnCluster,
+						yarnApplicationStatusMonitor,
+						acceptInteractiveInput);
+				} catch (Exception e) {
+					LOG.info("Could not properly close the Yarn application status monitor.", e);
+				} finally {
+					// shut down the scheduled executor service
+					ExecutorUtils.gracefulShutdown(
+						1000L,
+						TimeUnit.MILLISECONDS,
+						scheduledExecutorService);
+				}
 			}
 		}
 		return 0;
@@ -741,6 +688,142 @@ public class FlinkYarnSessionCli implements CustomCommandLine<YarnClusterClient>
 	private void logAndSysout(String message) {
 		LOG.info(message);
 		System.out.println(message);
+	}
+
+	public static void main(final String[] args) throws Exception {
+		final FlinkYarnSessionCli cli = new FlinkYarnSessionCli("", ""); // no prefix for the YARN session
+
+		final String configurationDirectory = CliFrontend.getConfigurationDirectoryFromEnv();
+
+		final Configuration flinkConfiguration = GlobalConfiguration.loadConfiguration();
+		SecurityUtils.install(new SecurityConfiguration(flinkConfiguration));
+		int retCode = SecurityUtils.getInstalledContext().runSecured(new Callable<Integer>() {
+			@Override
+			public Integer call() {
+				return cli.run(args, flinkConfiguration, configurationDirectory);
+			}
+		});
+		System.exit(retCode);
+	}
+
+	private static void runInteractiveCli(
+		YarnClusterClient clusterClient,
+		YarnApplicationStatusMonitor yarnApplicationStatusMonitor,
+		boolean readConsoleInput) {
+		try (BufferedReader in = new BufferedReader(new InputStreamReader(System.in))) {
+			boolean continueRepl = true;
+			int numTaskmanagers = 0;
+			long unknownStatusSince = System.currentTimeMillis();
+
+			while (continueRepl) {
+
+				final ApplicationStatus applicationStatus = yarnApplicationStatusMonitor.getApplicationStatusNow();
+
+				switch (applicationStatus) {
+					case FAILED:
+					case CANCELED:
+						System.err.println("The Flink Yarn cluster has failed.");
+						continueRepl = false;
+						break;
+					case UNKNOWN:
+						if (unknownStatusSince < 0L) {
+							unknownStatusSince = System.currentTimeMillis();
+						}
+
+						if ((System.currentTimeMillis() - unknownStatusSince) > CLIENT_POLLING_INTERVAL_MS) {
+							System.err.println("The Flink Yarn cluster is in an unknown state. Please check the Yarn cluster.");
+							continueRepl = false;
+						} else {
+							continueRepl = repStep(in, readConsoleInput);
+						}
+						break;
+					case SUCCEEDED:
+						if (unknownStatusSince > 0L) {
+							unknownStatusSince = -1L;
+						}
+
+						// ------------------ check if there are updates by the cluster -----------
+						try {
+							final GetClusterStatusResponse status = clusterClient.getClusterStatus();
+
+							if (status != null && numTaskmanagers != status.numRegisteredTaskManagers()) {
+								System.err.println("Number of connected TaskManagers changed to " +
+									status.numRegisteredTaskManagers() + ". " +
+									"Slots available: " + status.totalNumberOfSlots());
+								numTaskmanagers = status.numRegisteredTaskManagers();
+							}
+						} catch (Exception e) {
+							LOG.warn("Could not retrieve the current cluster status. Skipping current retrieval attempt ...", e);
+						}
+
+						printClusterMessages(clusterClient);
+
+						continueRepl = repStep(in, readConsoleInput);
+				}
+			}
+		} catch (Exception e) {
+			LOG.warn("Exception while running the interactive command line interface.", e);
+		}
+	}
+
+	private static void printClusterMessages(YarnClusterClient clusterClient) {
+		final List<String> messages = clusterClient.getNewMessages();
+		if (messages != null && messages.size() > 0) {
+			System.err.println("New messages from the YARN cluster: ");
+			for (String msg : messages) {
+				System.err.println(msg);
+			}
+		}
+	}
+
+	/**
+	 * Read-Evaluate-Print step for the REPL.
+	 *
+	 * @param in to read from
+	 * @param readConsoleInput true if console input has to be read
+	 * @return true if the REPL shall be continued, otherwise false
+	 * @throws IOException
+	 * @throws InterruptedException
+	 */
+	private static boolean repStep(
+		BufferedReader in,
+		boolean readConsoleInput) throws IOException, InterruptedException {
+
+		// wait until CLIENT_POLLING_INTERVAL is over or the user entered something.
+		long startTime = System.currentTimeMillis();
+		while ((System.currentTimeMillis() - startTime) < CLIENT_POLLING_INTERVAL_MS
+			&& (!readConsoleInput || !in.ready())) {
+			Thread.sleep(200L);
+		}
+		//------------- handle interactive command by user. ----------------------
+
+		if (readConsoleInput && in.ready()) {
+			String command = in.readLine();
+			switch (command) {
+				case "quit":
+				case "stop":
+					return false;
+
+				case "help":
+					System.err.println(YARN_SESSION_HELP);
+					break;
+				default:
+					System.err.println("Unknown command '" + command + "'. Showing help:");
+					System.err.println(YARN_SESSION_HELP);
+					break;
+			}
+		}
+
+		return true;
+	}
+
+	private static void writeYarnProperties(Properties properties, File propertiesFile) {
+		try (final OutputStream out = new FileOutputStream(propertiesFile)) {
+			properties.store(out, "Generated YARN properties file");
+		} catch (IOException e) {
+			throw new RuntimeException("Error writing the properties file", e);
+		}
+		propertiesFile.setReadable(true, false); // readable for all.
 	}
 
 	public static Map<String, String> getDynamicProperties(String dynamicPropertiesEncoded) {

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
@@ -50,6 +50,7 @@ import org.apache.commons.cli.Options;
 import org.apache.commons.cli.PosixParser;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.yarn.client.api.YarnClient;
 import org.apache.hadoop.yarn.util.ConverterUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -862,10 +863,11 @@ public class FlinkYarnSessionCli implements CustomCommandLine<YarnClusterClient>
 	}
 
 	protected AbstractYarnClusterDescriptor getClusterDescriptor(Configuration configuration, String configurationDirectory, boolean flip6) {
+		final YarnClient yarnClient = YarnClient.createYarnClient();
 		if (flip6) {
-			return new YarnClusterDescriptorV2(configuration, configurationDirectory);
+			return new YarnClusterDescriptorV2(configuration, configurationDirectory, yarnClient);
 		} else {
-			return new YarnClusterDescriptor(configuration, configurationDirectory);
+			return new YarnClusterDescriptor(configuration, configurationDirectory, yarnClient);
 		}
 	}
 }

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
@@ -728,7 +728,7 @@ public class FlinkYarnSessionCli implements CustomCommandLine<YarnClusterClient>
 							isLastStatusUnknown = true;
 						}
 
-						if ((System.nanoTime() - unknownStatusSince) > CLIENT_POLLING_INTERVAL_MS) {
+						if ((System.nanoTime() - unknownStatusSince) > 5L * CLIENT_POLLING_INTERVAL_MS * 1_000_000L) {
 							System.err.println("The Flink Yarn cluster is in an unknown state. Please check the Yarn cluster.");
 							continueRepl = false;
 						} else {

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/YarnApplicationStatusMonitor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/YarnApplicationStatusMonitor.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.yarn.cli;
+
+import org.apache.flink.runtime.clusterframework.ApplicationStatus;
+import org.apache.flink.runtime.concurrent.ScheduledExecutor;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.hadoop.service.Service;
+import org.apache.hadoop.yarn.api.records.ApplicationId;
+import org.apache.hadoop.yarn.api.records.ApplicationReport;
+import org.apache.hadoop.yarn.api.records.YarnApplicationState;
+import org.apache.hadoop.yarn.client.api.YarnClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Utility class which monitors the specified yarn application status periodically.
+ */
+public class YarnApplicationStatusMonitor implements AutoCloseable {
+
+	private static final Logger LOG = LoggerFactory.getLogger(YarnApplicationStatusMonitor.class);
+
+	private static final long UPDATE_INTERVAL = 1000L;
+
+	private final YarnClient yarnClient;
+
+	private final ApplicationId yarnApplicationId;
+
+	private final ScheduledFuture<?> applicationStatusUpdateFuture;
+
+	private volatile ApplicationStatus applicationStatus;
+
+	public YarnApplicationStatusMonitor(
+			YarnClient yarnClient,
+			ApplicationId yarnApplicationId,
+			ScheduledExecutor scheduledExecutor) {
+		this.yarnClient = Preconditions.checkNotNull(yarnClient);
+		this.yarnApplicationId = Preconditions.checkNotNull(yarnApplicationId);
+
+		applicationStatusUpdateFuture = scheduledExecutor.scheduleWithFixedDelay(
+			this::updateApplicationStatus,
+			UPDATE_INTERVAL,
+			UPDATE_INTERVAL,
+			TimeUnit.MILLISECONDS);
+
+		applicationStatus = ApplicationStatus.UNKNOWN;
+	}
+
+	public ApplicationStatus getApplicationStatusNow() {
+		return applicationStatus;
+	}
+
+	@Override
+	public void close() throws Exception {
+		applicationStatusUpdateFuture.cancel(false);
+	}
+
+	private void updateApplicationStatus() {
+		if (yarnClient.isInState(Service.STATE.STARTED)) {
+			final ApplicationReport applicationReport;
+
+			try {
+				applicationReport = yarnClient.getApplicationReport(yarnApplicationId);
+			} catch (Exception e) {
+				LOG.info("Could not retrieve the Yarn application report for {}.", yarnApplicationId);
+				return;
+			}
+
+			YarnApplicationState yarnApplicationState = applicationReport.getYarnApplicationState();
+
+			if (yarnApplicationState == YarnApplicationState.FAILED || yarnApplicationState == YarnApplicationState.KILLED) {
+				applicationStatus = ApplicationStatus.FAILED;
+			} else {
+				applicationStatus = ApplicationStatus.SUCCEEDED;
+			}
+		} else {
+			LOG.info("Yarn client is no longer in state STARTED. Stopping the Yarn application status monitor.");
+			applicationStatusUpdateFuture.cancel(false);
+		}
+	}
+}

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/YarnApplicationStatusMonitor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/YarnApplicationStatusMonitor.java
@@ -71,7 +71,7 @@ public class YarnApplicationStatusMonitor implements AutoCloseable {
 	}
 
 	@Override
-	public void close() throws Exception {
+	public void close() {
 		applicationStatusUpdateFuture.cancel(false);
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

Move the savepoint disposal logic from the CliFrontend into the ClusterClient. This gives
a better separation of concerns and allows the CliFrontend to be used with different
ClusterClient implementations.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
