### PR TITLE
[FLINK-8317][flip6] Implement Triggering of Savepoints

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
@@ -225,7 +225,7 @@ public class RestClusterClient<T> extends ClusterClient<T> {
 			Thread.sleep(waitStrategy.sleepTime(attempt));
 			attempt++;
 		}
-		while (asynchronouslyCreatedResource.queueStatus().getStatusId() != QueueStatus.StatusId.COMPLETED);
+		while (asynchronouslyCreatedResource.queueStatus().getId() != QueueStatus.Id.COMPLETED);
 		return asynchronouslyCreatedResource.resource();
 	}
 

--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
@@ -331,13 +331,15 @@ public class RestClusterClient<T> extends ClusterClient<T> {
 				throws IOException, InterruptedException, ExecutionException, TimeoutException {
 		A asynchronouslyCreatedResource;
 		long attempt = 0;
-		do {
+		while (true) {
 			final CompletableFuture<A> responseFuture = resourceFutureSupplier.get();
 			asynchronouslyCreatedResource = responseFuture.get(timeout.toMillis(), TimeUnit.MILLISECONDS);
+			if (asynchronouslyCreatedResource.queueStatus().getId() == QueueStatus.Id.COMPLETED) {
+				break;
+			}
 			Thread.sleep(waitStrategy.sleepTime(attempt));
 			attempt++;
 		}
-		while (asynchronouslyCreatedResource.queueStatus().getId() != QueueStatus.Id.COMPLETED);
 		return asynchronouslyCreatedResource.resource();
 	}
 

--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
@@ -214,21 +214,6 @@ public class RestClusterClient<T> extends ClusterClient<T> {
 		}
 	}
 
-	private <R, T extends AsynchronouslyCreatedResource<R>> R waitForResource(
-			final SupplierWithException<CompletableFuture<T>, IOException> resourceFutureSupplier)
-				throws IOException, InterruptedException, ExecutionException, TimeoutException {
-		T asynchronouslyCreatedResource;
-		long attempt = 0;
-		do {
-			final CompletableFuture<T> responseFuture = resourceFutureSupplier.get();
-			asynchronouslyCreatedResource = responseFuture.get(timeout.toMillis(), TimeUnit.MILLISECONDS);
-			Thread.sleep(waitStrategy.sleepTime(attempt));
-			attempt++;
-		}
-		while (asynchronouslyCreatedResource.queueStatus().getId() != QueueStatus.Id.COMPLETED);
-		return asynchronouslyCreatedResource.resource();
-	}
-
 	@Override
 	public void stop(JobID jobID) throws Exception {
 		JobTerminationMessageParameters params = new JobTerminationMessageParameters();
@@ -339,6 +324,21 @@ public class RestClusterClient<T> extends ClusterClient<T> {
 	@Override
 	public T getClusterId() {
 		return clusterId;
+	}
+
+	private <R, A extends AsynchronouslyCreatedResource<R>> R waitForResource(
+			final SupplierWithException<CompletableFuture<A>, IOException> resourceFutureSupplier)
+				throws IOException, InterruptedException, ExecutionException, TimeoutException {
+		A asynchronouslyCreatedResource;
+		long attempt = 0;
+		do {
+			final CompletableFuture<A> responseFuture = resourceFutureSupplier.get();
+			asynchronouslyCreatedResource = responseFuture.get(timeout.toMillis(), TimeUnit.MILLISECONDS);
+			Thread.sleep(waitStrategy.sleepTime(attempt));
+			attempt++;
+		}
+		while (asynchronouslyCreatedResource.queueStatus().getId() != QueueStatus.Id.COMPLETED);
+		return asynchronouslyCreatedResource.resource();
 	}
 
 	// ======================================

--- a/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.client.program.ProgramInvocationException;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.runtime.client.JobStatusMessage;
+import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.dispatcher.Dispatcher;
 import org.apache.flink.runtime.dispatcher.DispatcherGateway;
 import org.apache.flink.runtime.jobgraph.JobGraph;
@@ -52,16 +53,23 @@ import org.apache.flink.runtime.rest.messages.MessageHeaders;
 import org.apache.flink.runtime.rest.messages.MessageParameters;
 import org.apache.flink.runtime.rest.messages.RequestBody;
 import org.apache.flink.runtime.rest.messages.ResponseBody;
+import org.apache.flink.runtime.rest.messages.SavepointTriggerIdPathParameter;
 import org.apache.flink.runtime.rest.messages.TerminationModeQueryParameter;
 import org.apache.flink.runtime.rest.messages.job.JobExecutionResultHeaders;
 import org.apache.flink.runtime.rest.messages.job.JobExecutionResultResponseBody;
 import org.apache.flink.runtime.rest.messages.job.JobSubmitHeaders;
 import org.apache.flink.runtime.rest.messages.job.JobSubmitRequestBody;
 import org.apache.flink.runtime.rest.messages.job.JobSubmitResponseBody;
-import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointMessageParameters;
-import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointTargetDirectoryParameter;
+import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointInfo;
+import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointResponseBody;
+import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointStatusHeaders;
+import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointStatusMessageParameters;
 import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointTriggerHeaders;
+import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointTriggerId;
+import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointTriggerMessageParameters;
+import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointTriggerRequestBody;
 import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointTriggerResponseBody;
+import org.apache.flink.runtime.rest.messages.queue.QueueStatus;
 import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
 import org.apache.flink.testutils.category.Flip6;
@@ -70,6 +78,7 @@ import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.TestLogger;
 
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelInboundHandler;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -87,11 +96,14 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 
 import static org.apache.flink.util.Preconditions.checkState;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
@@ -295,44 +307,108 @@ public class RestClusterClientTest extends TestLogger {
 
 	@Test
 	public void testTriggerSavepoint() throws Exception {
-		String targetSavepointDirectory = "/alternate";
-		TestSavepointTriggerHandler triggerHandler = new TestSavepointTriggerHandler(targetSavepointDirectory);
-		try (TestRestServerEndpoint ignored = createRestServerEndpoint(triggerHandler)) {
+		final String targetSavepointDirectory = "/tmp";
+		final TestSavepointHandlers testSavepointHandlers = new TestSavepointHandlers();
+		final TestSavepointHandlers.TestSavepointTriggerHandler triggerHandler =
+			testSavepointHandlers.new TestSavepointTriggerHandler(
+				Arrays.asList(null, targetSavepointDirectory, null).iterator());
+		final TestSavepointHandlers.TestSavepointHandler savepointHandler =
+			testSavepointHandlers.new TestSavepointHandler(Arrays.asList(
+				new SavepointResponseBody(QueueStatus.completed(), new SavepointInfo(
+					testSavepointHandlers.testSavepointTriggerId,
+					"/other/savepoint-0d2fb9-8d5e0106041a",
+					null)),
+				new SavepointResponseBody(QueueStatus.completed(), new SavepointInfo(
+					testSavepointHandlers.testSavepointTriggerId,
+					"/tmp/savepoint-0d2fb9-8d5e0106041a",
+					null)),
+				new SavepointResponseBody(QueueStatus.completed(), new SavepointInfo(
+					testSavepointHandlers.testSavepointTriggerId,
+					null,
+					new SerializedThrowable(new RuntimeException("expected"))))).iterator());
+		try (TestRestServerEndpoint ignored = createRestServerEndpoint(
+			triggerHandler,
+			savepointHandler)) {
+
 			JobID id = new JobID();
 			{
 				CompletableFuture<String> savepointPathFuture = restClusterClient.triggerSavepoint(id, null);
 				String savepointPath = savepointPathFuture.get();
-				Assert.assertEquals("/universe", savepointPath);
+				assertEquals("/other/savepoint-0d2fb9-8d5e0106041a", savepointPath);
 			}
 
 			{
 				CompletableFuture<String> savepointPathFuture = restClusterClient.triggerSavepoint(id, targetSavepointDirectory);
 				String savepointPath = savepointPathFuture.get();
-				Assert.assertEquals(targetSavepointDirectory + "/universe", savepointPath);
+				assertEquals("/tmp/savepoint-0d2fb9-8d5e0106041a", savepointPath);
+			}
+
+			{
+				try {
+					restClusterClient.triggerSavepoint(id, null).get();
+					fail("Expected exception not thrown.");
+				} catch (ExecutionException e) {
+					final Throwable cause = e.getCause();
+					assertThat(cause, instanceOf(SerializedThrowable.class));
+					assertThat(((SerializedThrowable) cause)
+						.deserializeError(ClassLoader.getSystemClassLoader())
+						.getMessage(), equalTo("expected"));
+				}
 			}
 		}
 	}
 
-	private class TestSavepointTriggerHandler extends TestHandler<EmptyRequestBody, SavepointTriggerResponseBody, SavepointMessageParameters> {
+	private class TestSavepointHandlers {
 
-		private final String expectedSavepointDirectory;
+		private final SavepointTriggerId testSavepointTriggerId = new SavepointTriggerId();
 
-		TestSavepointTriggerHandler(String expectedSavepointDirectory) {
-			super(SavepointTriggerHeaders.getInstance());
-			this.expectedSavepointDirectory = expectedSavepointDirectory;
+		private class TestSavepointTriggerHandler extends TestHandler<SavepointTriggerRequestBody, SavepointTriggerResponseBody, SavepointTriggerMessageParameters> {
+
+			private final Iterator<String> expectedTargetDirectories;
+
+			TestSavepointTriggerHandler(final Iterator<String> expectedTargetDirectories) {
+				super(SavepointTriggerHeaders.getInstance());
+				this.expectedTargetDirectories = expectedTargetDirectories;
+			}
+
+			@Override
+			protected CompletableFuture<SavepointTriggerResponseBody> handleRequest(
+					@Nonnull HandlerRequest<SavepointTriggerRequestBody, SavepointTriggerMessageParameters> request,
+					@Nonnull DispatcherGateway gateway) throws RestHandlerException {
+				final String targetDirectory = request.getRequestBody().getTargetDirectory();
+				if (Objects.equals(expectedTargetDirectories.next(), targetDirectory)) {
+					return CompletableFuture.completedFuture(
+						new SavepointTriggerResponseBody(testSavepointTriggerId));
+				} else {
+					// return new random savepoint trigger id so that test can fail
+					return CompletableFuture.completedFuture(
+						new SavepointTriggerResponseBody(new SavepointTriggerId()));
+				}
+			}
 		}
 
-		@Override
-		protected CompletableFuture<SavepointTriggerResponseBody> handleRequest(@Nonnull HandlerRequest<EmptyRequestBody, SavepointMessageParameters> request, @Nonnull DispatcherGateway gateway) throws RestHandlerException {
-			List<String> targetDirectories = request.getQueryParameter(SavepointTargetDirectoryParameter.class);
-			if (targetDirectories.isEmpty()) {
-				return CompletableFuture.completedFuture(new SavepointTriggerResponseBody("growing", "/universe", "big-bang"));
-			} else {
-				String targetDir = targetDirectories.get(0);
-				if (targetDir.equals(expectedSavepointDirectory)) {
-					return CompletableFuture.completedFuture(new SavepointTriggerResponseBody("growing", targetDir + "/universe", "big-bang"));
+		private class TestSavepointHandler
+				extends TestHandler<EmptyRequestBody, SavepointResponseBody, SavepointStatusMessageParameters> {
+
+			private final Iterator<SavepointResponseBody> expectedSavepointResponseBodies;
+
+			TestSavepointHandler(final Iterator<SavepointResponseBody> expectedSavepointResponseBodies) {
+				super(SavepointStatusHeaders.getInstance());
+				this.expectedSavepointResponseBodies = expectedSavepointResponseBodies;
+			}
+
+			@Override
+			protected CompletableFuture<SavepointResponseBody> handleRequest(
+					@Nonnull HandlerRequest<EmptyRequestBody, SavepointStatusMessageParameters> request,
+					@Nonnull DispatcherGateway gateway) throws RestHandlerException {
+				final SavepointTriggerId savepointTriggerId = request.getPathParameter(SavepointTriggerIdPathParameter.class);
+				if (testSavepointTriggerId.equals(savepointTriggerId)) {
+					return CompletableFuture.completedFuture(expectedSavepointResponseBodies.next());
 				} else {
-					return CompletableFuture.completedFuture(new SavepointTriggerResponseBody("growing", "savepoint directory (" + targetDir + ") did not match expected (" + expectedSavepointDirectory + ')', "big-bang"));
+					return FutureUtils.completedExceptionally(
+						new RestHandlerException(
+							"Unexpected savepoint trigger id: " + savepointTriggerId,
+							HttpResponseStatus.BAD_REQUEST));
 				}
 			}
 		}

--- a/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
@@ -308,6 +308,9 @@ public class RestClusterClientTest extends TestLogger {
 	@Test
 	public void testTriggerSavepoint() throws Exception {
 		final String targetSavepointDirectory = "/tmp";
+		final String savepointLocationDefaultDir = "/other/savepoint-0d2fb9-8d5e0106041a";
+		final String savepointLocationRequestedDir = targetSavepointDirectory + "/savepoint-0d2fb9-8d5e0106041a";
+
 		final TestSavepointHandlers testSavepointHandlers = new TestSavepointHandlers();
 		final TestSavepointHandlers.TestSavepointTriggerHandler triggerHandler =
 			testSavepointHandlers.new TestSavepointTriggerHandler(
@@ -316,11 +319,11 @@ public class RestClusterClientTest extends TestLogger {
 			testSavepointHandlers.new TestSavepointHandler(Arrays.asList(
 				new SavepointResponseBody(QueueStatus.completed(), new SavepointInfo(
 					testSavepointHandlers.testSavepointTriggerId,
-					"/other/savepoint-0d2fb9-8d5e0106041a",
+					savepointLocationDefaultDir,
 					null)),
 				new SavepointResponseBody(QueueStatus.completed(), new SavepointInfo(
 					testSavepointHandlers.testSavepointTriggerId,
-					"/tmp/savepoint-0d2fb9-8d5e0106041a",
+					savepointLocationRequestedDir,
 					null)),
 				new SavepointResponseBody(QueueStatus.completed(), new SavepointInfo(
 					testSavepointHandlers.testSavepointTriggerId,
@@ -334,13 +337,13 @@ public class RestClusterClientTest extends TestLogger {
 			{
 				CompletableFuture<String> savepointPathFuture = restClusterClient.triggerSavepoint(id, null);
 				String savepointPath = savepointPathFuture.get();
-				assertEquals("/other/savepoint-0d2fb9-8d5e0106041a", savepointPath);
+				assertEquals(savepointLocationDefaultDir, savepointPath);
 			}
 
 			{
 				CompletableFuture<String> savepointPathFuture = restClusterClient.triggerSavepoint(id, targetSavepointDirectory);
 				String savepointPath = savepointPathFuture.get();
-				assertEquals("/tmp/savepoint-0d2fb9-8d5e0106041a", savepointPath);
+				assertEquals(savepointLocationRequestedDir, savepointPath);
 			}
 
 			{

--- a/flink-clients/src/test/java/org/apache/flink/client/program/rest/retry/ExponentialWaitStrategyTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/rest/retry/ExponentialWaitStrategyTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.client.program.rest.retry;
 
+import org.apache.flink.util.TestLogger;
+
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.containsString;
@@ -28,7 +30,7 @@ import static org.junit.Assert.fail;
 /**
  * Tests for {@link ExponentialWaitStrategy}.
  */
-public class ExponentialWaitStrategyTest {
+public class ExponentialWaitStrategyTest extends TestLogger {
 
 	@Test
 	public void testNegativeInitialWait() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobServer;
+import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
 import org.apache.flink.runtime.client.JobSubmissionException;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.concurrent.FutureUtils;
@@ -389,6 +390,20 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 			return FutureUtils.completedExceptionally(new FlinkJobNotFoundException(jobId));
 		}
 		return CompletableFuture.completedFuture(jobExecutionResultPresent);
+	}
+
+	@Override
+	public CompletableFuture<CompletedCheckpoint> triggerSavepoint(
+			final JobID jobId,
+			final String targetDirectory,
+			final Time timeout) {
+		if (jobManagerRunners.containsKey(jobId)) {
+			return jobManagerRunners.get(jobId)
+				.getJobManagerGateway()
+				.triggerSavepoint(jobId, targetDirectory, timeout);
+		} else {
+			return FutureUtils.completedExceptionally(new FlinkJobNotFoundException(jobId));
+		}
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -24,7 +24,6 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobServer;
-import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
 import org.apache.flink.runtime.client.JobSubmissionException;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.concurrent.FutureUtils;
@@ -393,7 +392,7 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 	}
 
 	@Override
-	public CompletableFuture<CompletedCheckpoint> triggerSavepoint(
+	public CompletableFuture<String> triggerSavepoint(
 			final JobID jobId,
 			final String targetDirectory,
 			final Time timeout) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -854,7 +854,7 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 	}
 
 	@Override
-	public CompletableFuture<CompletedCheckpoint> triggerSavepoint(
+	public CompletableFuture<String> triggerSavepoint(
 			final JobID jobId,
 			final String targetDirectory,
 			final Time timeout) {
@@ -865,7 +865,8 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 			jobId);
 		try {
 			return executionGraph.getCheckpointCoordinator()
-				.triggerSavepoint(System.currentTimeMillis(), targetDirectory);
+				.triggerSavepoint(System.currentTimeMillis(), targetDirectory)
+				.thenApply(CompletedCheckpoint::getExternalPointer);
 		} catch (Exception e) {
 			return FutureUtils.completedExceptionally(e);
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointHandlers.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointHandlers.java
@@ -1,0 +1,337 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.job.savepoints;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.rest.NotFoundException;
+import org.apache.flink.runtime.rest.handler.AbstractRestHandler;
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.RestHandlerException;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.JobIDPathParameter;
+import org.apache.flink.runtime.rest.messages.SavepointTriggerIdPathParameter;
+import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointInfo;
+import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointResponseBody;
+import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointStatusHeaders;
+import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointStatusMessageParameters;
+import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointTriggerHeaders;
+import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointTriggerId;
+import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointTriggerMessageParameters;
+import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointTriggerRequestBody;
+import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointTriggerResponseBody;
+import org.apache.flink.runtime.rest.messages.queue.QueueStatus;
+import org.apache.flink.runtime.rpc.RpcUtils;
+import org.apache.flink.runtime.webmonitor.RestfulGateway;
+import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+import org.apache.flink.types.Either;
+import org.apache.flink.util.SerializedThrowable;
+
+import org.apache.flink.shaded.guava18.com.google.common.cache.Cache;
+import org.apache.flink.shaded.guava18.com.google.common.cache.CacheBuilder;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * HTTP handlers for asynchronous triggering of savepoints.
+ *
+ * <p>Drawing savepoints is a potentially long-running operation. To avoid blocking HTTP
+ * connections, savepoints must be drawn in two steps. First, an HTTP request is issued to trigger
+ * the savepoint asynchronously. The request will be assigned a {@link SavepointTriggerId},
+ * which is returned in the response body. Next, the returned id should be used to poll the status
+ * of the savepoint until it is finished.
+ *
+ * <p>A savepoint is triggered by sending an HTTP {@code POST} request to
+ * {@code /jobs/:jobid/savepoints}. The HTTP request may contain a JSON body to specify the target
+ * directory of the savepoint, e.g.,
+ * <pre>
+ * { "target-directory": "/tmp" }
+ * </pre>
+ * If the body is omitted, or the field {@code target-property} is {@code null}, the default
+ * savepoint directory as specified by {@link CoreOptions#SAVEPOINT_DIRECTORY} will be used.
+ * As written above, the response will contain a request id, e.g.,
+ * <pre>
+ * { "request-id": "7d273f5a62eb4730b9dea8e833733c1e" }
+ * </pre>
+ *
+ * <p>To poll for the status of an ongoing savepoint, an HTTP {@code GET} request is issued to
+ * {@code /jobs/:jobid/savepoints/:savepointtriggerid}. If the specified savepoint is still ongoing,
+ * the response will be
+ * <pre>
+ * {
+ *     "status": {
+ *         "id": "IN_PROGRESS"
+ *     }
+ * }
+ * </pre>
+ * If the specified savepoint has completed, the status id will transition to {@code COMPLETED}, and
+ * the response will additionally contain information about the savepoint, such as the location:
+ * <pre>
+ * {
+ *     "status": {
+ *         "id": "COMPLETED"
+ *     },
+ *     "savepoint": {
+ *         "request-id": "7d273f5a62eb4730b9dea8e833733c1e",
+ *         "location": "/tmp/savepoint-d9813b-8a68e674325b"
+ *     }
+ * }
+ * </pre>
+ */
+public class SavepointHandlers {
+
+	private final CompletedCheckpointCache completedCheckpointCache = new CompletedCheckpointCache();
+
+	@Nullable
+	private String defaultSavepointDir;
+
+	public SavepointHandlers(@Nullable final String defaultSavepointDir) {
+		this.defaultSavepointDir = defaultSavepointDir;
+	}
+
+	/**
+	 * HTTP handler to trigger savepoints.
+	 */
+	public class SavepointTriggerHandler
+			extends AbstractRestHandler<RestfulGateway, SavepointTriggerRequestBody, SavepointTriggerResponseBody, SavepointTriggerMessageParameters> {
+
+		public SavepointTriggerHandler(
+				final CompletableFuture<String> localRestAddress,
+				final GatewayRetriever<? extends RestfulGateway> leaderRetriever,
+				final Time timeout,
+				final Map<String, String> responseHeaders) {
+			super(localRestAddress, leaderRetriever, timeout, responseHeaders, SavepointTriggerHeaders.getInstance());
+		}
+
+		@Override
+		protected CompletableFuture<SavepointTriggerResponseBody> handleRequest(
+				@Nonnull final HandlerRequest<SavepointTriggerRequestBody, SavepointTriggerMessageParameters> request,
+				@Nonnull final RestfulGateway gateway) throws RestHandlerException {
+
+			final JobID jobId = request.getPathParameter(JobIDPathParameter.class);
+			final String requestedTargetDirectory = request.getRequestBody().getTargetDirectory();
+
+			if (requestedTargetDirectory == null && defaultSavepointDir == null) {
+				return FutureUtils.completedExceptionally(
+					new RestHandlerException(
+						String.format("Config key [%s] is not set. Property [%s] must be provided.",
+							CoreOptions.SAVEPOINT_DIRECTORY.key(),
+							SavepointTriggerRequestBody.FIELD_NAME_TARGET_DIRECTORY),
+						HttpResponseStatus.BAD_REQUEST));
+			}
+
+			final String targetDirectory = requestedTargetDirectory != null ? requestedTargetDirectory : defaultSavepointDir;
+			final CompletableFuture<CompletedCheckpoint> completedCheckpointCompletableFuture =
+				gateway.triggerSavepoint(jobId, targetDirectory, RpcUtils.INF_TIMEOUT);
+			final SavepointTriggerId savepointTriggerId = new SavepointTriggerId();
+			completedCheckpointCache.registerOngoingCheckpoint(
+				SavepointKey.of(savepointTriggerId, jobId),
+				completedCheckpointCompletableFuture);
+			return CompletableFuture.completedFuture(
+				new SavepointTriggerResponseBody(savepointTriggerId));
+		}
+	}
+
+	/**
+	 * HTTP handler to query for the status of the savepoint.
+	 */
+	public class SavepointStatusHandler
+			extends AbstractRestHandler<RestfulGateway, EmptyRequestBody, SavepointResponseBody, SavepointStatusMessageParameters> {
+
+		public SavepointStatusHandler(
+				final CompletableFuture<String> localRestAddress,
+				final GatewayRetriever<? extends RestfulGateway> leaderRetriever,
+				final Time timeout,
+				final Map<String, String> responseHeaders) {
+			super(localRestAddress, leaderRetriever, timeout, responseHeaders, SavepointStatusHeaders.getInstance());
+		}
+
+		@Override
+		protected CompletableFuture<SavepointResponseBody> handleRequest(
+				@Nonnull final HandlerRequest<EmptyRequestBody, SavepointStatusMessageParameters> request,
+				@Nonnull final RestfulGateway gateway) throws RestHandlerException {
+
+			final JobID jobId = request.getPathParameter(JobIDPathParameter.class);
+			final SavepointTriggerId savepointTriggerId = request.getPathParameter(
+				SavepointTriggerIdPathParameter.class);
+			final Either<Throwable, CompletedCheckpoint> completedCheckpointOrError;
+			try {
+				completedCheckpointOrError = completedCheckpointCache.get(SavepointKey.of(
+					savepointTriggerId, jobId));
+			} catch (UnknownSavepointTriggerId e) {
+				return FutureUtils.completedExceptionally(
+					new NotFoundException("Savepoint not found. Savepoint trigger id: " +
+						savepointTriggerId + ", job id: " + jobId));
+			}
+
+			if (completedCheckpointOrError != null) {
+				if (completedCheckpointOrError.isLeft()) {
+					return CompletableFuture.completedFuture(new SavepointResponseBody(
+						QueueStatus.completed(),
+						new SavepointInfo(savepointTriggerId, null, new SerializedThrowable(
+							completedCheckpointOrError.left()))));
+				} else {
+					final CompletedCheckpoint completedCheckpoint = completedCheckpointOrError.right();
+					final String externalPointer = completedCheckpoint.getExternalPointer();
+					return CompletableFuture.completedFuture(new SavepointResponseBody(
+						QueueStatus.completed(),
+						new SavepointInfo(savepointTriggerId, externalPointer, null)));
+				}
+			} else {
+				return CompletableFuture.completedFuture(SavepointResponseBody.inProgress());
+			}
+		}
+	}
+
+	/**
+	 * Cache to manage ongoing checkpoints.
+	 *
+	 * <p>The cache allows to register an ongoing checkpoint in the form of a
+	 * {@code CompletableFuture<CompletedCheckpoint>}. Completed checkpoints will be removed from
+	 * the cache automatically after a fixed timeout.
+	 */
+	@ThreadSafe
+	static class CompletedCheckpointCache {
+
+		private static final long COMPLETED_CHECKPOINTS_CACHE_DURATION_SECONDS = 300;
+
+		/**
+		 * Stores SavepointKeys of ongoing checkpoints.
+		 * If the checkpoint completes, it will be moved to {@link #completedCheckpoints}.
+		 */
+		private final Set<SavepointKey> registeredSavepointTriggers = ConcurrentHashMap.newKeySet();
+
+		/** Caches completed checkpoints. */
+		private final Cache<SavepointKey, Either<Throwable, CompletedCheckpoint>> completedCheckpoints =
+			CacheBuilder.newBuilder()
+				.expireAfterWrite(COMPLETED_CHECKPOINTS_CACHE_DURATION_SECONDS, TimeUnit.SECONDS)
+				.build();
+
+		/**
+		 * Registers an ongoing checkpoint with the cache.
+		 */
+		void registerOngoingCheckpoint(
+				final SavepointKey savepointTriggerId,
+				final CompletableFuture<CompletedCheckpoint> checkpointFuture) {
+			registeredSavepointTriggers.add(savepointTriggerId);
+			checkpointFuture.whenComplete((completedCheckpoint, error) -> {
+				if (error == null) {
+					completedCheckpoints.put(savepointTriggerId, Either.Right(completedCheckpoint));
+				} else {
+					completedCheckpoints.put(savepointTriggerId, Either.Left(error));
+				}
+				registeredSavepointTriggers.remove(savepointTriggerId);
+			});
+		}
+
+		/**
+		 * Returns the CompletedCheckpoint or a Throwable if the CompletableFuture finished,
+		 * otherwise {@code null}.
+		 *
+		 * @throws UnknownSavepointTriggerId If the savepoint is not found, and there is no ongoing
+		 *                                   checkpoint under the provided key.
+		 */
+		@Nullable
+		Either<Throwable, CompletedCheckpoint> get(
+				final SavepointKey savepointTriggerId) throws UnknownSavepointTriggerId {
+			Either<Throwable, CompletedCheckpoint> completedCheckpointOrError = null;
+			if (!registeredSavepointTriggers.contains(savepointTriggerId)
+				&& (completedCheckpointOrError = completedCheckpoints.getIfPresent(savepointTriggerId)) == null) {
+				throw new UnknownSavepointTriggerId();
+			}
+			return completedCheckpointOrError;
+		}
+	}
+
+	/**
+	 * A pair of {@link JobID} and {@link SavepointTriggerId} used as a key to a hash based
+	 * collection.
+	 *
+	 * @see CompletedCheckpointCache
+	 */
+	@Immutable
+	static class SavepointKey {
+
+		private final SavepointTriggerId savepointTriggerId;
+
+		private final JobID jobId;
+
+		private SavepointKey(final SavepointTriggerId savepointTriggerId, final JobID jobId) {
+			this.savepointTriggerId = requireNonNull(savepointTriggerId);
+			this.jobId = requireNonNull(jobId);
+		}
+
+		private static SavepointKey of(final SavepointTriggerId savepointTriggerId, final JobID jobId) {
+			return new SavepointKey(savepointTriggerId, jobId);
+		}
+
+		@Override
+		public boolean equals(final Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+
+			final SavepointKey that = (SavepointKey) o;
+
+			if (!savepointTriggerId.equals(that.savepointTriggerId)) {
+				return false;
+			}
+			return jobId.equals(that.jobId);
+		}
+
+		@Override
+		public int hashCode() {
+			int result = savepointTriggerId.hashCode();
+			result = 31 * result + jobId.hashCode();
+			return result;
+		}
+	}
+
+	/**
+	 * Exception that indicates that there is no ongoing or completed checkpoint for a given
+	 * {@link JobID} and {@link SavepointTriggerId} pair.
+	 */
+	static class UnknownSavepointTriggerId extends Exception {
+		private static final long serialVersionUID = 1L;
+	}
+
+	@VisibleForTesting
+	void setDefaultSavepointDir(@Nullable final String defaultSavepointDir) {
+		this.defaultSavepointDir = defaultSavepointDir;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointHandlers.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointHandlers.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.rest.handler.job.savepoints;
 
-import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.CoreOptions;
@@ -115,7 +114,7 @@ public class SavepointHandlers {
 	private final CompletedSavepointCache completedSavepointCache = new CompletedSavepointCache();
 
 	@Nullable
-	private String defaultSavepointDir;
+	private final String defaultSavepointDir;
 
 	public SavepointHandlers(@Nullable final String defaultSavepointDir) {
 		this.defaultSavepointDir = defaultSavepointDir;
@@ -333,10 +332,5 @@ public class SavepointHandlers {
 		UnknownSavepointKeyException(final SavepointKey savepointKey) {
 			super("No ongoing savepoints for " + savepointKey);
 		}
-	}
-
-	@VisibleForTesting
-	void setDefaultSavepointDir(@Nullable final String defaultSavepointDir) {
-		this.defaultSavepointDir = defaultSavepointDir;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/SavepointTriggerIdPathParameter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/SavepointTriggerIdPathParameter.java
@@ -16,21 +16,28 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.rest;
+package org.apache.flink.runtime.rest.messages;
 
-import org.apache.flink.runtime.rest.handler.RestHandlerException;
-
-import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointTriggerId;
 
 /**
- * A special exception that indicates that an element was not found and that the
- * request should be answered with a {@code 404} return code.
+ * Path parameter identifying savepoint trigger requests.
  */
-public class NotFoundException extends RestHandlerException {
+public class SavepointTriggerIdPathParameter extends MessagePathParameter<SavepointTriggerId> {
 
-	private static final long serialVersionUID = -4036006746423754639L;
+	public static final String KEY = "savepointtriggerid";
 
-	public NotFoundException(String message) {
-		super(message, HttpResponseStatus.NOT_FOUND);
+	public SavepointTriggerIdPathParameter() {
+		super(KEY);
+	}
+
+	@Override
+	protected SavepointTriggerId convertFromString(String value) {
+		return SavepointTriggerId.fromHexString(value);
+	}
+
+	@Override
+	protected String convertToString(SavepointTriggerId value) {
+		return value.toString();
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobExecutionResultResponseBody.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobExecutionResultResponseBody.java
@@ -22,6 +22,7 @@ import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.runtime.rest.messages.ResponseBody;
 import org.apache.flink.runtime.rest.messages.json.JobResultDeserializer;
 import org.apache.flink.runtime.rest.messages.json.JobResultSerializer;
+import org.apache.flink.runtime.rest.messages.queue.AsynchronouslyCreatedResource;
 import org.apache.flink.runtime.rest.messages.queue.QueueStatus;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
@@ -40,7 +41,8 @@ import static java.util.Objects.requireNonNull;
  * @see org.apache.flink.runtime.rest.handler.job.JobExecutionResultHandler
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class JobExecutionResultResponseBody implements ResponseBody {
+public class JobExecutionResultResponseBody
+		implements ResponseBody, AsynchronouslyCreatedResource<JobResult> {
 
 	@JsonProperty(value = "status", required = true)
 	private final QueueStatus status;
@@ -79,4 +81,13 @@ public class JobExecutionResultResponseBody implements ResponseBody {
 		return jobExecutionResult;
 	}
 
+	@Override
+	public QueueStatus queueStatus() {
+		return status;
+	}
+
+	@Override
+	public JobResult resource() {
+		return jobExecutionResult;
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointInfo.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.job.savepoints;
+
+import org.apache.flink.runtime.rest.messages.json.SerializedThrowableDeserializer;
+import org.apache.flink.runtime.rest.messages.json.SerializedThrowableSerializer;
+import org.apache.flink.util.SerializedThrowable;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+import javax.annotation.Nullable;
+
+import static java.util.Objects.requireNonNull;
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/**
+ * Represents information about a finished savepoint.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class SavepointInfo {
+
+	private static final String FIELD_NAME_REQUEST_ID = "request-id";
+
+	private static final String FIELD_NAME_LOCATION = "location";
+
+	private static final String FIELD_NAME_FAILURE_CAUSE = "failure-cause";
+
+	@JsonProperty(FIELD_NAME_REQUEST_ID)
+	private final SavepointTriggerId requestId;
+
+	@JsonProperty(FIELD_NAME_LOCATION)
+	@Nullable
+	private final String location;
+
+	@JsonProperty(FIELD_NAME_FAILURE_CAUSE)
+	@JsonSerialize(using = SerializedThrowableSerializer.class)
+	@JsonDeserialize(using = SerializedThrowableDeserializer.class)
+	@Nullable
+	private final SerializedThrowable failureCause;
+
+	@JsonCreator
+	public SavepointInfo(
+			@JsonProperty(FIELD_NAME_REQUEST_ID) final SavepointTriggerId requestId,
+			@JsonProperty(FIELD_NAME_LOCATION) @Nullable final String location,
+			@JsonProperty(FIELD_NAME_FAILURE_CAUSE)
+			@JsonDeserialize(using = SerializedThrowableDeserializer.class)
+			@Nullable final SerializedThrowable failureCause) {
+		checkArgument(
+			location != null ^ failureCause != null,
+			"Either location or failureCause must be set");
+
+		this.requestId = requireNonNull(requestId);
+		this.location = location;
+		this.failureCause = failureCause;
+	}
+
+	public SavepointTriggerId getRequestId() {
+		return requestId;
+	}
+
+	@Nullable
+	public String getLocation() {
+		return location;
+	}
+
+	@Nullable
+	public SerializedThrowable getFailureCause() {
+		return failureCause;
+	}
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointResponseBody.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointResponseBody.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.job.savepoints;
+
+import org.apache.flink.runtime.rest.messages.queue.AsynchronouslyCreatedResource;
+import org.apache.flink.runtime.rest.messages.queue.QueueStatus;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.Nullable;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Status of the savepoint and savepoint information if available.
+ */
+public class SavepointResponseBody implements AsynchronouslyCreatedResource<SavepointInfo> {
+
+	private static final String FIELD_NAME_STATUS = "status";
+
+	private static final String FIELD_NAME_SAVEPOINT = "savepoint";
+
+	@JsonProperty(FIELD_NAME_STATUS)
+	private final QueueStatus status;
+
+	@JsonProperty(FIELD_NAME_SAVEPOINT)
+	@Nullable
+	private final SavepointInfo savepoint;
+
+	@JsonCreator
+	public SavepointResponseBody(
+			@JsonProperty(FIELD_NAME_STATUS) QueueStatus status,
+			@Nullable @JsonProperty(FIELD_NAME_SAVEPOINT) SavepointInfo savepoint) {
+		this.status = requireNonNull(status);
+		this.savepoint = savepoint;
+	}
+
+	public static SavepointResponseBody inProgress() {
+		return new SavepointResponseBody(QueueStatus.inProgress(), null);
+	}
+
+	public static SavepointResponseBody completed(final SavepointInfo savepoint) {
+		requireNonNull(savepoint);
+		return new SavepointResponseBody(QueueStatus.inProgress(), savepoint);
+	}
+
+	public QueueStatus getStatus() {
+		return status;
+	}
+
+	@Nullable
+	public SavepointInfo getSavepoint() {
+		return savepoint;
+	}
+
+	//-------------------------------------------------------------------------
+	// AsynchronouslyCreatedResource
+	//-------------------------------------------------------------------------
+
+	@JsonIgnore
+	@Override
+	public QueueStatus queueStatus() {
+		return status;
+	}
+
+	@JsonIgnore
+	@Override
+	public SavepointInfo resource() {
+		return savepoint;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointStatusHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointStatusHeaders.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.rest.messages.job.savepoints;
 
 import org.apache.flink.runtime.rest.HttpMethodWrapper;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
 import org.apache.flink.runtime.rest.messages.MessageHeaders;
 
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
@@ -26,54 +27,45 @@ import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseSt
 /**
  * These headers define the protocol for triggering a savepoint.
  */
-public class SavepointTriggerHeaders
-		implements MessageHeaders<SavepointTriggerRequestBody, SavepointTriggerResponseBody, SavepointTriggerMessageParameters> {
+public class SavepointStatusHeaders
+		implements MessageHeaders<EmptyRequestBody, SavepointResponseBody, SavepointStatusMessageParameters> {
 
-	private static final SavepointTriggerHeaders INSTANCE = new SavepointTriggerHeaders();
+	private static final SavepointStatusHeaders INSTANCE = new SavepointStatusHeaders();
 
-	private SavepointTriggerHeaders() {
+	private SavepointStatusHeaders() {
 	}
 
 	@Override
-	public Class<SavepointTriggerRequestBody> getRequestClass() {
-		return SavepointTriggerRequestBody.class;
+	public Class<EmptyRequestBody> getRequestClass() {
+		return EmptyRequestBody.class;
 	}
 
 	@Override
-	public Class<SavepointTriggerResponseBody> getResponseClass() {
-		return SavepointTriggerResponseBody.class;
+	public Class<SavepointResponseBody> getResponseClass() {
+		return SavepointResponseBody.class;
 	}
 
 	@Override
 	public HttpResponseStatus getResponseStatusCode() {
-		return HttpResponseStatus.ACCEPTED;
+		return HttpResponseStatus.OK;
 	}
 
 	@Override
-	public SavepointTriggerMessageParameters getUnresolvedMessageParameters() {
-		return new SavepointTriggerMessageParameters();
+	public SavepointStatusMessageParameters getUnresolvedMessageParameters() {
+		return new SavepointStatusMessageParameters();
 	}
 
 	@Override
 	public HttpMethodWrapper getHttpMethod() {
-		return HttpMethodWrapper.POST;
+		return HttpMethodWrapper.GET;
 	}
 
 	@Override
 	public String getTargetRestEndpointURL() {
-		/*
-		Note: this is different to the existing implementation for which the targetDirectory is a path parameter
-		Having it as a path parameter has several downsides as it
-			- is optional (which we only allow for query parameters)
-			- causes parsing issues, since the path is not reliably treated as a single parameter
-			- does not denote a hierarchy which path parameters are supposed to do
-			- interacts badly with the POST spec, as it would require the progress url to also contain the targetDirectory
-		 */
-
-		return "/jobs/:jobid/savepoints";
+		return "/jobs/:jobid/savepoints/:savepointtriggerid";
 	}
 
-	public static SavepointTriggerHeaders getInstance() {
+	public static SavepointStatusHeaders getInstance() {
 		return INSTANCE;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointStatusMessageParameters.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointStatusMessageParameters.java
@@ -18,24 +18,33 @@
 
 package org.apache.flink.runtime.rest.messages.job.savepoints;
 
+import org.apache.flink.runtime.rest.messages.JobIDPathParameter;
+import org.apache.flink.runtime.rest.messages.MessageParameters;
+import org.apache.flink.runtime.rest.messages.MessagePathParameter;
 import org.apache.flink.runtime.rest.messages.MessageQueryParameter;
+import org.apache.flink.runtime.rest.messages.SavepointTriggerIdPathParameter;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 
 /**
- * The parameter denoting the directory where to which a savepoint should be written to.
+ * The parameters for triggering a savepoint.
  */
-public class SavepointTargetDirectoryParameter extends MessageQueryParameter<String> {
+public class SavepointStatusMessageParameters extends MessageParameters {
 
-	SavepointTargetDirectoryParameter() {
-		super("targetDirectory", MessageParameterRequisiteness.OPTIONAL);
+	public final JobIDPathParameter jobIdPathParameter = new JobIDPathParameter();
+
+	public final SavepointTriggerIdPathParameter savepointTriggerIdPathParameter = new SavepointTriggerIdPathParameter();
+
+	@Override
+	public Collection<MessagePathParameter<?>> getPathParameters() {
+		return Collections.unmodifiableCollection(
+			Arrays.asList(jobIdPathParameter, savepointTriggerIdPathParameter));
 	}
 
 	@Override
-	public String convertValueFromString(String value) {
-		return value;
-	}
-
-	@Override
-	public String convertStringToValue(String value) {
-		return value;
+	public Collection<MessageQueryParameter<?>> getQueryParameters() {
+		return Collections.emptyList();
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointTriggerId.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointTriggerId.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.job.savepoints;
+
+import org.apache.flink.util.AbstractID;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonParser;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.DeserializationContext;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.SerializerProvider;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import javax.xml.bind.DatatypeConverter;
+
+import java.io.IOException;
+
+/**
+ * Identifies a savepoint trigger request.
+ */
+@JsonSerialize(using = SavepointTriggerId.SavepointTriggerIdSerializer.class)
+@JsonDeserialize(using = SavepointTriggerId.SavepointTriggerIdDeserializer.class)
+public class SavepointTriggerId extends AbstractID {
+
+	private static final long serialVersionUID = 1L;
+
+	public SavepointTriggerId() {
+	}
+
+	private SavepointTriggerId(final byte[] bytes) {
+		super(bytes);
+	}
+
+	public static SavepointTriggerId fromHexString(String hexString) {
+		return new SavepointTriggerId(DatatypeConverter.parseHexBinary(hexString));
+	}
+
+	/**
+	 * JSON serializer for {@link SavepointTriggerId}.
+	 */
+	public static class SavepointTriggerIdSerializer extends StdSerializer<SavepointTriggerId> {
+
+		private static final long serialVersionUID = 1L;
+
+		protected SavepointTriggerIdSerializer() {
+			super(SavepointTriggerId.class);
+		}
+
+		@Override
+		public void serialize(
+				final SavepointTriggerId value,
+				final JsonGenerator gen,
+				final SerializerProvider provider) throws IOException {
+			gen.writeString(value.toString());
+		}
+	}
+
+	/**
+	 * JSON deserializer for {@link SavepointTriggerId}.
+	 */
+	public static class SavepointTriggerIdDeserializer extends StdDeserializer<SavepointTriggerId> {
+
+		private static final long serialVersionUID = 1L;
+
+		protected SavepointTriggerIdDeserializer() {
+			super(SavepointTriggerId.class);
+		}
+
+		@Override
+		public SavepointTriggerId deserialize(
+				final JsonParser p,
+				final DeserializationContext ctxt) throws IOException {
+			return SavepointTriggerId.fromHexString(p.getValueAsString());
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointTriggerMessageParameters.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointTriggerMessageParameters.java
@@ -18,30 +18,28 @@
 
 package org.apache.flink.runtime.rest.messages.job.savepoints;
 
-import org.apache.flink.runtime.rest.messages.RestResponseMarshallingTestBase;
+import org.apache.flink.runtime.rest.messages.JobIDPathParameter;
+import org.apache.flink.runtime.rest.messages.MessageParameters;
+import org.apache.flink.runtime.rest.messages.MessagePathParameter;
+import org.apache.flink.runtime.rest.messages.MessageQueryParameter;
 
-import static org.junit.Assert.assertEquals;
+import java.util.Collection;
+import java.util.Collections;
 
 /**
- * Tests for {@link SavepointTriggerResponseBody}.
+ * The parameters for triggering a savepoint.
  */
-public class SavepointTriggerResponseBodyTest
-		extends RestResponseMarshallingTestBase<SavepointTriggerResponseBody> {
+public class SavepointTriggerMessageParameters extends MessageParameters {
+
+	public JobIDPathParameter jobID = new JobIDPathParameter();
 
 	@Override
-	protected Class<SavepointTriggerResponseBody> getTestResponseClass() {
-		return SavepointTriggerResponseBody.class;
+	public Collection<MessagePathParameter<?>> getPathParameters() {
+		return Collections.singleton(jobID);
 	}
 
 	@Override
-	protected SavepointTriggerResponseBody getTestResponseInstance() {
-		return new SavepointTriggerResponseBody(new SavepointTriggerId());
-	}
-
-	@Override
-	protected void assertOriginalEqualsToUnmarshalled(
-			final SavepointTriggerResponseBody expected,
-			final SavepointTriggerResponseBody actual) {
-		assertEquals(expected.getSavepointTriggerId(), actual.getSavepointTriggerId());
+	public Collection<MessageQueryParameter<?>> getQueryParameters() {
+		return Collections.emptyList();
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointTriggerRequestBody.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointTriggerRequestBody.java
@@ -18,29 +18,33 @@
 
 package org.apache.flink.runtime.rest.messages.job.savepoints;
 
-import org.apache.flink.runtime.rest.messages.JobIDPathParameter;
-import org.apache.flink.runtime.rest.messages.MessageParameters;
-import org.apache.flink.runtime.rest.messages.MessagePathParameter;
-import org.apache.flink.runtime.rest.messages.MessageQueryParameter;
+import org.apache.flink.runtime.rest.messages.RequestBody;
 
-import java.util.Collection;
-import java.util.Collections;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.Nullable;
 
 /**
- * The parameters for triggering a savepoint.
+ * {@link RequestBody} to trigger savepoints.
  */
-public class SavepointMessageParameters extends MessageParameters {
+public class SavepointTriggerRequestBody implements RequestBody {
 
-	public JobIDPathParameter jobID = new JobIDPathParameter();
-	public SavepointTargetDirectoryParameter targetDirectory = new SavepointTargetDirectoryParameter();
+	public static final String FIELD_NAME_TARGET_DIRECTORY = "target-directory";
 
-	@Override
-	public Collection<MessagePathParameter<?>> getPathParameters() {
-		return Collections.singleton(jobID);
+	@JsonProperty(FIELD_NAME_TARGET_DIRECTORY)
+	@Nullable
+	private final String targetDirectory;
+
+	@JsonCreator
+	public SavepointTriggerRequestBody(
+			@Nullable @JsonProperty(FIELD_NAME_TARGET_DIRECTORY) final String targetDirectory) {
+		this.targetDirectory = targetDirectory;
 	}
 
-	@Override
-	public Collection<MessageQueryParameter<?>> getQueryParameters() {
-		return Collections.singleton(targetDirectory);
+	@Nullable
+	public String getTargetDirectory() {
+		return targetDirectory;
 	}
+
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointTriggerResponseBody.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointTriggerResponseBody.java
@@ -19,64 +19,30 @@
 package org.apache.flink.runtime.rest.messages.job.savepoints;
 
 import org.apache.flink.runtime.rest.messages.ResponseBody;
-import org.apache.flink.util.Preconditions;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * Response to the triggering of a savepoint.
  */
 public class SavepointTriggerResponseBody implements ResponseBody {
 
-	private static final String FIELD_NAME_STATUS = "status";
-
-	private static final String FIELD_NAME_LOCATION = "location";
-
 	private static final String FIELD_NAME_REQUEST_ID = "request-id";
 
-	@JsonProperty(FIELD_NAME_STATUS)
-	public final String status;
-
-	@JsonProperty(FIELD_NAME_LOCATION)
-	public final String location;
-
 	@JsonProperty(FIELD_NAME_REQUEST_ID)
-	public final String requestId;
+	private final SavepointTriggerId savepointTriggerId;
 
 	@JsonCreator
 	public SavepointTriggerResponseBody(
-			@JsonProperty(FIELD_NAME_STATUS) String status,
-			@JsonProperty(FIELD_NAME_LOCATION) String location,
-			@JsonProperty(FIELD_NAME_REQUEST_ID) String requestId) {
-		this.status = status;
-		this.location = Preconditions.checkNotNull(location);
-		this.requestId = requestId;
+		@JsonProperty(FIELD_NAME_REQUEST_ID) final SavepointTriggerId savepointTriggerId) {
+		this.savepointTriggerId = requireNonNull(savepointTriggerId);
 	}
 
-	public String getStatus() {
-		return status;
+	public SavepointTriggerId getSavepointTriggerId() {
+		return savepointTriggerId;
 	}
 
-	public String getLocation() {
-		return location;
-	}
-
-	public String getRequestId() {
-		return requestId;
-	}
-
-	@Override
-	public int hashCode() {
-		return 79 * location.hashCode();
-	}
-
-	@Override
-	public boolean equals(Object object) {
-		if (object instanceof SavepointTriggerResponseBody) {
-			SavepointTriggerResponseBody other = (SavepointTriggerResponseBody) object;
-			return this.location.equals(other.location);
-		}
-		return false;
-	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/queue/AsynchronouslyCreatedResource.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/queue/AsynchronouslyCreatedResource.java
@@ -16,21 +16,27 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.rest;
+package org.apache.flink.runtime.rest.messages.queue;
 
-import org.apache.flink.runtime.rest.handler.RestHandlerException;
+import org.apache.flink.runtime.rest.messages.ResponseBody;
 
-import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+import javax.annotation.Nullable;
 
 /**
- * A special exception that indicates that an element was not found and that the
- * request should be answered with a {@code 404} return code.
+ * Interface for REST resources that are created asynchronously.
+ * @param <T> The type of the resource.
  */
-public class NotFoundException extends RestHandlerException {
+public interface AsynchronouslyCreatedResource<T> extends ResponseBody {
 
-	private static final long serialVersionUID = -4036006746423754639L;
+	/**
+	 * Retuns the status of the resource creation.
+	 */
+	QueueStatus queueStatus();
 
-	public NotFoundException(String message) {
-		super(message, HttpResponseStatus.NOT_FOUND);
-	}
+	/**
+	 * Returns the resource if it is available, {@code null} otherwise.
+	 */
+	@Nullable
+	T resource();
+
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/queue/QueueStatus.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/queue/QueueStatus.java
@@ -30,33 +30,33 @@ import static java.util.Objects.requireNonNull;
  */
 public class QueueStatus {
 
-	private static final String FIELD_NAME_STATUS = "id";
+	private static final String FIELD_NAME_ID = "id";
 
-	@JsonProperty(value = FIELD_NAME_STATUS, required = true)
-	private final StatusId statusId;
+	@JsonProperty(value = FIELD_NAME_ID, required = true)
+	private final Id id;
 
 	@JsonCreator
 	public QueueStatus(
-		@JsonProperty(value = FIELD_NAME_STATUS, required = true) final StatusId statusId) {
-		this.statusId = requireNonNull(statusId, "statusId must not be null");
+		@JsonProperty(value = FIELD_NAME_ID, required = true) final Id id) {
+		this.id = requireNonNull(id, "statusId must not be null");
 	}
 
 	public static QueueStatus inProgress() {
-		return new QueueStatus(StatusId.IN_PROGRESS);
+		return new QueueStatus(Id.IN_PROGRESS);
 	}
 
 	public static QueueStatus completed() {
-		return new QueueStatus(StatusId.COMPLETED);
+		return new QueueStatus(Id.COMPLETED);
 	}
 
-	public StatusId getStatusId() {
-		return statusId;
+	public Id getId() {
+		return id;
 	}
 
 	/**
 	 * Defines queue statuses.
 	 */
-	public enum StatusId {
+	public enum Id {
 		IN_PROGRESS,
 		COMPLETED
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcUtils.java
@@ -27,11 +27,16 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 /**
- * Utility functions for Flink's RPC implementation
+ * Utility functions for Flink's RPC implementation.
  */
 public class RpcUtils {
 
-	public static final Time INF_TIMEOUT = Time.milliseconds(Long.MAX_VALUE);
+	/**
+	 * <b>HACK:</b> Set to 21474835 seconds, Akka's maximum delay (Akka 2.4.20). The value cannot be
+	 * higher or an {@link IllegalArgumentException} will be thrown during an RPC. Check the private
+	 * method {@code checkMaxDelay()} in {@link akka.actor.LightArrayRevolverScheduler}.
+	 */
+	public static final Time INF_TIMEOUT = Time.milliseconds(TimeUnit.SECONDS.toMillis(21474835));
 
 	/**
 	 * Extracts all {@link RpcGateway} interfaces implemented by the given clazz.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcUtils.java
@@ -36,7 +36,7 @@ public class RpcUtils {
 	 * higher or an {@link IllegalArgumentException} will be thrown during an RPC. Check the private
 	 * method {@code checkMaxDelay()} in {@link akka.actor.LightArrayRevolverScheduler}.
 	 */
-	public static final Time INF_TIMEOUT = Time.milliseconds(TimeUnit.SECONDS.toMillis(21474835));
+	public static final Time INF_TIMEOUT = Time.seconds(21474835);
 
 	/**
 	 * Extracts all {@link RpcGateway} interfaces implemented by the given clazz.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/RestfulGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/RestfulGateway.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.webmonitor;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.jobmaster.JobResult;
@@ -135,6 +136,23 @@ public interface RestfulGateway extends RpcGateway {
 	 */
 	default CompletableFuture<Boolean> isJobExecutionResultPresent(
 			JobID jobId, @RpcTimeout Time timeout) {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Triggers a savepoint with the given savepoint directory as a target.
+	 *
+	 * @param targetDirectory Target directory for the savepoint.
+	 * @param timeout for the asynchronous operation
+	 * @return A future to the completed checkpoint
+	 * @throws IllegalStateException If no savepoint directory has been
+	 *                               specified and no default savepoint directory has been
+	 *                               configured
+	 */
+	default CompletableFuture<CompletedCheckpoint> triggerSavepoint(
+			JobID jobId,
+			String targetDirectory,
+			@RpcTimeout Time timeout) {
 		throw new UnsupportedOperationException();
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/RestfulGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/RestfulGateway.java
@@ -142,14 +142,13 @@ public interface RestfulGateway extends RpcGateway {
 	/**
 	 * Triggers a savepoint with the given savepoint directory as a target.
 	 *
+	 * @param jobId           ID of the job for which the savepoint should be triggered.
 	 * @param targetDirectory Target directory for the savepoint.
-	 * @param timeout for the asynchronous operation
-	 * @return A future to the completed checkpoint
-	 * @throws IllegalStateException If no savepoint directory has been
-	 *                               specified and no default savepoint directory has been
-	 *                               configured
+	 * @param timeout         Timeout for the asynchronous operation
+	 * @return A future to the {@link CompletedCheckpoint#getExternalPointer() external pointer} of
+	 * the savepoint.
 	 */
-	default CompletableFuture<CompletedCheckpoint> triggerSavepoint(
+	default CompletableFuture<String> triggerSavepoint(
 			JobID jobId,
 			String targetDirectory,
 			@RpcTimeout Time timeout) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobExecutionResultHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobExecutionResultHandlerTest.java
@@ -102,8 +102,8 @@ public class JobExecutionResultHandlerTest extends TestLogger {
 			mockRestfulGateway).get();
 
 		assertThat(
-			responseBody.getStatus().getStatusId(),
-			equalTo(QueueStatus.StatusId.IN_PROGRESS));
+			responseBody.getStatus().getId(),
+			equalTo(QueueStatus.Id.IN_PROGRESS));
 	}
 
 	@Test
@@ -122,8 +122,8 @@ public class JobExecutionResultHandlerTest extends TestLogger {
 			mockRestfulGateway).get();
 
 		assertThat(
-			responseBody.getStatus().getStatusId(),
-			equalTo(QueueStatus.StatusId.COMPLETED));
+			responseBody.getStatus().getId(),
+			equalTo(QueueStatus.Id.COMPLETED));
 		assertThat(responseBody.getJobExecutionResult(), not(nullValue()));
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointHandlersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointHandlersTest.java
@@ -39,6 +39,7 @@ import org.apache.flink.runtime.rest.messages.queue.QueueStatus;
 import org.apache.flink.runtime.state.filesystem.FileStateHandle;
 import org.apache.flink.runtime.webmonitor.RestfulGateway;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+import org.apache.flink.util.TestLogger;
 
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
 
@@ -69,7 +70,7 @@ import static org.mockito.Mockito.when;
 /**
  * Test for {@link SavepointHandlers}.
  */
-public class SavepointHandlersTest {
+public class SavepointHandlersTest extends TestLogger {
 
 	private static final CompletableFuture<String> LOCAL_REST_ADDRESS =
 		CompletableFuture.completedFuture("localhost:12345");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointHandlersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointHandlersTest.java
@@ -98,12 +98,8 @@ public class SavepointHandlersTest extends TestLogger {
 	public void setUp() throws Exception {
 		MockitoAnnotations.initMocks(this);
 
-		final GatewayRetriever<RestfulGateway> leaderRetriever = new GatewayRetriever<RestfulGateway>() {
-			@Override
-			public CompletableFuture<RestfulGateway> getFuture() {
-				return CompletableFuture.completedFuture(mockRestfulGateway);
-			}
-		};
+		final GatewayRetriever<RestfulGateway> leaderRetriever =
+			() -> CompletableFuture.completedFuture(mockRestfulGateway);
 
 		savepointHandlers = new SavepointHandlers(null);
 		savepointTriggerHandler = savepointHandlers.new SavepointTriggerHandler(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointHandlersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointHandlersTest.java
@@ -207,6 +207,7 @@ public class SavepointHandlersTest {
 			savepointTriggerHandler.handleRequest(
 				triggerSavepointRequestWithDefaultDirectory(),
 				mockRestfulGateway).get();
+			fail("Expected exception not thrown.");
 		} catch (ExecutionException e) {
 			final Throwable cause = e.getCause();
 			assertThat(cause, instanceOf(RestHandlerException.class));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointHandlersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointHandlersTest.java
@@ -147,8 +147,8 @@ public class SavepointHandlersTest {
 			mockRestfulGateway).get();
 
 		assertThat(
-			savepointResponseBody.getStatus().getStatusId(),
-			equalTo(QueueStatus.StatusId.IN_PROGRESS));
+			savepointResponseBody.getStatus().getId(),
+			equalTo(QueueStatus.Id.IN_PROGRESS));
 
 		checkpointCompletableFuture.complete(completedCheckpoint);
 		savepointResponseBody = savepointStatusHandler.handleRequest(
@@ -156,8 +156,8 @@ public class SavepointHandlersTest {
 			mockRestfulGateway).get();
 
 		assertThat(
-			savepointResponseBody.getStatus().getStatusId(),
-			equalTo(QueueStatus.StatusId.COMPLETED));
+			savepointResponseBody.getStatus().getId(),
+			equalTo(QueueStatus.Id.COMPLETED));
 		assertThat(savepointResponseBody.getSavepoint(), notNullValue());
 		assertThat(
 			savepointResponseBody.getSavepoint().getLocation(),
@@ -232,7 +232,7 @@ public class SavepointHandlersTest {
 			savepointStatusRequest(savepointTriggerId),
 			mockRestfulGateway).get();
 
-		assertThat(savepointResponseBody.getStatus().getStatusId(), equalTo(QueueStatus.StatusId.COMPLETED));
+		assertThat(savepointResponseBody.getStatus().getId(), equalTo(QueueStatus.Id.COMPLETED));
 		assertThat(savepointResponseBody.getSavepoint(), notNullValue());
 		assertThat(savepointResponseBody.getSavepoint().getFailureCause(), notNullValue());
 		final Throwable savepointError = savepointResponseBody.getSavepoint()

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointHandlersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointHandlersTest.java
@@ -1,0 +1,276 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.job.savepoints;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.checkpoint.CheckpointProperties;
+import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.HandlerRequestException;
+import org.apache.flink.runtime.rest.handler.RestHandlerException;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.JobIDPathParameter;
+import org.apache.flink.runtime.rest.messages.SavepointTriggerIdPathParameter;
+import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointResponseBody;
+import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointStatusMessageParameters;
+import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointTriggerId;
+import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointTriggerMessageParameters;
+import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointTriggerRequestBody;
+import org.apache.flink.runtime.rest.messages.queue.QueueStatus;
+import org.apache.flink.runtime.state.filesystem.FileStateHandle;
+import org.apache.flink.runtime.webmonitor.RestfulGateway;
+import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test for {@link SavepointHandlers}.
+ */
+public class SavepointHandlersTest {
+
+	private static final CompletableFuture<String> LOCAL_REST_ADDRESS =
+		CompletableFuture.completedFuture("localhost:12345");
+
+	private static final Time TIMEOUT = Time.seconds(10);
+
+	private static final JobID JOB_ID = new JobID();
+
+	private static final String COMPLETED_CHECKPOINT_EXTERNAL_POINTER = "/tmp/savepoint-0d2fb9-8d5e0106041a";
+
+	private static final String DEFAULT_REQUESTED_SAVEPOINT_TARGET_DIRECTORY = "/tmp";
+
+	@Mock
+	private RestfulGateway mockRestfulGateway;
+
+	private SavepointHandlers savepointHandlers;
+
+	private SavepointHandlers.SavepointTriggerHandler savepointTriggerHandler;
+
+	private SavepointHandlers.SavepointStatusHandler savepointStatusHandler;
+
+	private CompletedCheckpoint completedCheckpoint;
+
+	@Before
+	public void setUp() throws Exception {
+		MockitoAnnotations.initMocks(this);
+
+		final GatewayRetriever<RestfulGateway> leaderRetriever = new GatewayRetriever<RestfulGateway>() {
+			@Override
+			public CompletableFuture<RestfulGateway> getFuture() {
+				return CompletableFuture.completedFuture(mockRestfulGateway);
+			}
+		};
+
+		savepointHandlers = new SavepointHandlers(null);
+		savepointTriggerHandler = savepointHandlers.new SavepointTriggerHandler(
+			LOCAL_REST_ADDRESS,
+			leaderRetriever,
+			TIMEOUT,
+			Collections.emptyMap());
+
+		savepointStatusHandler = savepointHandlers.new SavepointStatusHandler(
+			LOCAL_REST_ADDRESS,
+			leaderRetriever,
+			TIMEOUT,
+			Collections.emptyMap());
+
+		completedCheckpoint = new CompletedCheckpoint(
+			new JobID(),
+			0,
+			0,
+			0,
+			Collections.emptyMap(),
+			null,
+			CheckpointProperties.forStandardSavepoint(),
+			new FileStateHandle(new Path("/tmp"), 0),
+			COMPLETED_CHECKPOINT_EXTERNAL_POINTER
+		);
+	}
+
+	@Test
+	public void testSavepointCompletedSuccessfully() throws Exception {
+		final CompletableFuture<CompletedCheckpoint> checkpointCompletableFuture =
+			new CompletableFuture<>();
+		when(mockRestfulGateway.triggerSavepoint(any(JobID.class), anyString(), any(Time.class)))
+			.thenReturn(checkpointCompletableFuture);
+
+		final SavepointTriggerId savepointTriggerId = savepointTriggerHandler.handleRequest(
+			triggerSavepointRequest(),
+			mockRestfulGateway).get().getSavepointTriggerId();
+
+		SavepointResponseBody savepointResponseBody;
+		savepointResponseBody = savepointStatusHandler.handleRequest(
+			savepointStatusRequest(savepointTriggerId),
+			mockRestfulGateway).get();
+
+		assertThat(
+			savepointResponseBody.getStatus().getStatusId(),
+			equalTo(QueueStatus.StatusId.IN_PROGRESS));
+
+		checkpointCompletableFuture.complete(completedCheckpoint);
+		savepointResponseBody = savepointStatusHandler.handleRequest(
+			savepointStatusRequest(savepointTriggerId),
+			mockRestfulGateway).get();
+
+		assertThat(
+			savepointResponseBody.getStatus().getStatusId(),
+			equalTo(QueueStatus.StatusId.COMPLETED));
+		assertThat(savepointResponseBody.getSavepoint(), notNullValue());
+		assertThat(
+			savepointResponseBody.getSavepoint().getLocation(),
+			equalTo(COMPLETED_CHECKPOINT_EXTERNAL_POINTER));
+	}
+
+	@Test
+	public void testTriggerSavepointWithDefaultDirectory() throws Exception {
+		final ArgumentCaptor<String> targetDirectoryCaptor = ArgumentCaptor.forClass(String.class);
+		when(mockRestfulGateway.triggerSavepoint(any(JobID.class), targetDirectoryCaptor.capture(), any(Time.class)))
+			.thenReturn(CompletableFuture.completedFuture(completedCheckpoint));
+		final String defaultSavepointDir = "/other/dir";
+		savepointHandlers.setDefaultSavepointDir(defaultSavepointDir);
+
+		savepointTriggerHandler.handleRequest(
+			triggerSavepointRequestWithDefaultDirectory(),
+			mockRestfulGateway).get();
+
+		final List<String> targetDirectories = targetDirectoryCaptor.getAllValues();
+		assertThat(targetDirectories, hasItem(equalTo(defaultSavepointDir)));
+	}
+
+	@Test
+	public void testGetSavepointStatusWithUnknownSavepointTriggerId() throws Exception {
+		final SavepointTriggerId unknownSavepointTriggerId = new SavepointTriggerId();
+
+		try {
+			savepointStatusHandler.handleRequest(
+				savepointStatusRequest(unknownSavepointTriggerId),
+				mockRestfulGateway).get();
+			fail("Expected exception not thrown.");
+		} catch (ExecutionException e) {
+			final Throwable cause = e.getCause();
+			assertThat(cause, instanceOf(RestHandlerException.class));
+			final RestHandlerException restHandlerException = (RestHandlerException) cause;
+			assertThat(restHandlerException.getMessage(), containsString("Savepoint not found"));
+			assertThat(restHandlerException.getHttpResponseStatus(), equalTo(HttpResponseStatus.NOT_FOUND));
+		}
+	}
+
+	@Test
+	public void testTriggerSavepointNoDirectory() throws Exception {
+		when(mockRestfulGateway.triggerSavepoint(any(JobID.class), anyString(), any(Time.class)))
+			.thenReturn(CompletableFuture.completedFuture(completedCheckpoint));
+
+		try {
+			savepointTriggerHandler.handleRequest(
+				triggerSavepointRequestWithDefaultDirectory(),
+				mockRestfulGateway).get();
+		} catch (ExecutionException e) {
+			final Throwable cause = e.getCause();
+			assertThat(cause, instanceOf(RestHandlerException.class));
+			final RestHandlerException restHandlerException = (RestHandlerException) cause;
+			assertThat(
+				restHandlerException.getMessage(),
+				equalTo("Config key [state.savepoints.dir] is not set. " +
+					"Property [target-directory] must be provided."));
+			assertThat(restHandlerException.getHttpResponseStatus(), equalTo(HttpResponseStatus.BAD_REQUEST));
+		}
+	}
+
+	@Test
+	public void testSavepointCompletedWithException() throws Exception {
+		when(mockRestfulGateway.triggerSavepoint(any(JobID.class), anyString(), any(Time.class)))
+			.thenReturn(FutureUtils.completedExceptionally(new RuntimeException("expected")));
+
+		final SavepointTriggerId savepointTriggerId = savepointTriggerHandler.handleRequest(
+			triggerSavepointRequest(),
+			mockRestfulGateway).get().getSavepointTriggerId();
+
+		final SavepointResponseBody savepointResponseBody = savepointStatusHandler.handleRequest(
+			savepointStatusRequest(savepointTriggerId),
+			mockRestfulGateway).get();
+
+		assertThat(savepointResponseBody.getStatus().getStatusId(), equalTo(QueueStatus.StatusId.COMPLETED));
+		assertThat(savepointResponseBody.getSavepoint(), notNullValue());
+		assertThat(savepointResponseBody.getSavepoint().getFailureCause(), notNullValue());
+		final Throwable savepointError = savepointResponseBody.getSavepoint()
+			.getFailureCause()
+			.deserializeError(ClassLoader.getSystemClassLoader());
+		assertThat(savepointError.getMessage(), equalTo("expected"));
+		assertThat(savepointError, instanceOf(RuntimeException.class));
+	}
+
+	private static HandlerRequest<SavepointTriggerRequestBody, SavepointTriggerMessageParameters> triggerSavepointRequest() throws HandlerRequestException {
+		return triggerSavepointRequest(DEFAULT_REQUESTED_SAVEPOINT_TARGET_DIRECTORY);
+	}
+
+	private static HandlerRequest<SavepointTriggerRequestBody, SavepointTriggerMessageParameters> triggerSavepointRequestWithDefaultDirectory() throws HandlerRequestException {
+		return triggerSavepointRequest(null);
+	}
+
+	private static HandlerRequest<SavepointTriggerRequestBody, SavepointTriggerMessageParameters> triggerSavepointRequest(
+			final String targetDirectory
+	) throws HandlerRequestException {
+		return new HandlerRequest<>(
+			new SavepointTriggerRequestBody(targetDirectory),
+			new SavepointTriggerMessageParameters(),
+			Collections.singletonMap(JobIDPathParameter.KEY, JOB_ID.toString()),
+			Collections.emptyMap());
+	}
+
+	private static HandlerRequest<EmptyRequestBody, SavepointStatusMessageParameters> savepointStatusRequest(
+			final SavepointTriggerId savepointTriggerId) throws HandlerRequestException {
+			final Map<String, String> pathParameters = new HashMap<>();
+		pathParameters.put(JobIDPathParameter.KEY, JOB_ID.toString());
+		pathParameters.put(SavepointTriggerIdPathParameter.KEY, savepointTriggerId.toString());
+
+		return new HandlerRequest<>(
+			EmptyRequestBody.getInstance(),
+			new SavepointStatusMessageParameters(),
+			pathParameters,
+			Collections.emptyMap());
+	}
+
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointHandlersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointHandlersTest.java
@@ -82,20 +82,19 @@ public class SavepointHandlersTest extends TestLogger {
 	@Mock
 	private RestfulGateway mockRestfulGateway;
 
-	private SavepointHandlers savepointHandlers;
-
 	private SavepointHandlers.SavepointTriggerHandler savepointTriggerHandler;
 
 	private SavepointHandlers.SavepointStatusHandler savepointStatusHandler;
+
+	private GatewayRetriever<RestfulGateway> leaderRetriever;
 
 	@Before
 	public void setUp() throws Exception {
 		MockitoAnnotations.initMocks(this);
 
-		final GatewayRetriever<RestfulGateway> leaderRetriever =
-			() -> CompletableFuture.completedFuture(mockRestfulGateway);
+		leaderRetriever = () -> CompletableFuture.completedFuture(mockRestfulGateway);
 
-		savepointHandlers = new SavepointHandlers(null);
+		final SavepointHandlers savepointHandlers = new SavepointHandlers(null);
 		savepointTriggerHandler = savepointHandlers.new SavepointTriggerHandler(
 			LOCAL_REST_ADDRESS,
 			leaderRetriever,
@@ -149,7 +148,12 @@ public class SavepointHandlersTest extends TestLogger {
 		when(mockRestfulGateway.triggerSavepoint(any(JobID.class), targetDirectoryCaptor.capture(), any(Time.class)))
 			.thenReturn(CompletableFuture.completedFuture(COMPLETED_SAVEPOINT_EXTERNAL_POINTER));
 		final String defaultSavepointDir = "/other/dir";
-		savepointHandlers.setDefaultSavepointDir(defaultSavepointDir);
+		final SavepointHandlers savepointHandlers = new SavepointHandlers(defaultSavepointDir);
+		final SavepointHandlers.SavepointTriggerHandler savepointTriggerHandler = savepointHandlers.new SavepointTriggerHandler(
+			LOCAL_REST_ADDRESS,
+			leaderRetriever,
+			TIMEOUT,
+			Collections.emptyMap());
 
 		savepointTriggerHandler.handleRequest(
 			triggerSavepointRequestWithDefaultDirectory(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/RestRequestMarshallingTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/RestRequestMarshallingTestBase.java
@@ -59,7 +59,17 @@ public abstract class RestRequestMarshallingTestBase<R extends RequestBody> exte
 		final String marshalled = objectMapper.writeValueAsString(expected);
 
 		final R unmarshalled = objectMapper.readValue(marshalled, getTestRequestClass());
-		Assert.assertEquals(expected, unmarshalled);
+		assertOriginalEqualsToUnmarshalled(expected, unmarshalled);
+	}
+
+	/**
+	 * Asserts that two objects are equal. If they are not, an {@link AssertionError} is thrown.
+	 *
+	 * @param expected expected value
+	 * @param actual   the value to check against expected
+	 */
+	protected void assertOriginalEqualsToUnmarshalled(R expected, R actual) {
+		Assert.assertEquals(expected, actual);
 	}
 
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointInfoTest.java
@@ -18,30 +18,35 @@
 
 package org.apache.flink.runtime.rest.messages.job.savepoints;
 
-import org.apache.flink.runtime.rest.messages.RestResponseMarshallingTestBase;
+import org.apache.flink.util.SerializedThrowable;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+import static org.junit.Assert.fail;
 
 /**
- * Tests for {@link SavepointTriggerResponseBody}.
+ * Tests for {@link SavepointInfo}.
  */
-public class SavepointTriggerResponseBodyTest
-		extends RestResponseMarshallingTestBase<SavepointTriggerResponseBody> {
+public class SavepointInfoTest {
 
-	@Override
-	protected Class<SavepointTriggerResponseBody> getTestResponseClass() {
-		return SavepointTriggerResponseBody.class;
+	@Test
+	public void testNullRequestId() {
+		try {
+			new SavepointInfo(null, "/tmp", null);
+			fail("Expected exception not thrown");
+		} catch (NullPointerException e) {
+		}
 	}
 
-	@Override
-	protected SavepointTriggerResponseBody getTestResponseInstance() {
-		return new SavepointTriggerResponseBody(new SavepointTriggerId());
-	}
-
-	@Override
-	protected void assertOriginalEqualsToUnmarshalled(
-			final SavepointTriggerResponseBody expected,
-			final SavepointTriggerResponseBody actual) {
-		assertEquals(expected.getSavepointTriggerId(), actual.getSavepointTriggerId());
+	@Test
+	public void testSetBothLocationAndFailureCause()  {
+		try {
+			new SavepointInfo(
+				new SavepointTriggerId(),
+				"/tmp",
+				new SerializedThrowable(new RuntimeException()));
+			fail("Expected exception not thrown");
+		} catch (IllegalArgumentException e) {
+		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointInfoTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.rest.messages.job.savepoints;
 
 import org.apache.flink.util.SerializedThrowable;
+import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
 
@@ -27,7 +28,7 @@ import static org.junit.Assert.fail;
 /**
  * Tests for {@link SavepointInfo}.
  */
-public class SavepointInfoTest {
+public class SavepointInfoTest extends TestLogger {
 
 	@Test
 	public void testNullRequestId() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointResponseBodyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointResponseBodyTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.job.savepoints;
+
+import org.apache.flink.runtime.rest.messages.RestResponseMarshallingTestBase;
+import org.apache.flink.util.SerializedThrowable;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Tests for {@link SavepointResponseBody}.
+ */
+@RunWith(Parameterized.class)
+public class SavepointResponseBodyTest extends RestResponseMarshallingTestBase<SavepointResponseBody> {
+
+	@Parameterized.Parameters
+	public static Collection<Object[]> data() {
+		return Arrays.asList(new Object[][]{
+			{SavepointResponseBody.inProgress()},
+			{SavepointResponseBody.completed(new SavepointInfo(
+				new SavepointTriggerId(),
+				"/tmp",
+				null))},
+			{SavepointResponseBody.completed(new SavepointInfo(
+				new SavepointTriggerId(),
+				null,
+				new SerializedThrowable(new RuntimeException("expected"))))}
+		});
+	}
+
+	private final SavepointResponseBody savepointResponseBody;
+
+	public SavepointResponseBodyTest(final SavepointResponseBody savepointResponseBody) {
+		this.savepointResponseBody = savepointResponseBody;
+	}
+
+	@Override
+	protected Class<SavepointResponseBody> getTestResponseClass() {
+		return SavepointResponseBody.class;
+	}
+
+	@Override
+	protected SavepointResponseBody getTestResponseInstance() throws Exception {
+		return savepointResponseBody;
+	}
+
+	@Override
+	protected void assertOriginalEqualsToUnmarshalled(
+			final SavepointResponseBody expected,
+			final SavepointResponseBody actual) {
+		assertEquals(expected.getStatus().getStatusId(), actual.getStatus().getStatusId());
+		if (expected.getSavepoint() != null) {
+			assertNotNull(actual.getSavepoint());
+			assertEquals(expected.getSavepoint().getRequestId(), actual.getSavepoint().getRequestId());
+			assertEquals(expected.getSavepoint().getLocation(), actual.getSavepoint().getLocation());
+			if (expected.getSavepoint().getFailureCause() != null) {
+				assertNotNull(actual.getSavepoint().getFailureCause());
+				assertEquals(expected.getSavepoint()
+						.getFailureCause()
+						.deserializeError(ClassLoader.getSystemClassLoader())
+						.getMessage(),
+					actual.getSavepoint()
+						.getFailureCause()
+						.deserializeError(ClassLoader.getSystemClassLoader())
+						.getMessage());
+			}
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointResponseBodyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointResponseBodyTest.java
@@ -71,7 +71,7 @@ public class SavepointResponseBodyTest extends RestResponseMarshallingTestBase<S
 	protected void assertOriginalEqualsToUnmarshalled(
 			final SavepointResponseBody expected,
 			final SavepointResponseBody actual) {
-		assertEquals(expected.getStatus().getStatusId(), actual.getStatus().getStatusId());
+		assertEquals(expected.getStatus().getId(), actual.getStatus().getId());
 		if (expected.getSavepoint() != null) {
 			assertNotNull(actual.getSavepoint());
 			assertEquals(expected.getSavepoint().getRequestId(), actual.getSavepoint().getRequestId());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointTriggerRequestBodyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointTriggerRequestBodyTest.java
@@ -18,30 +18,30 @@
 
 package org.apache.flink.runtime.rest.messages.job.savepoints;
 
-import org.apache.flink.runtime.rest.messages.RestResponseMarshallingTestBase;
+import org.apache.flink.runtime.rest.messages.RestRequestMarshallingTestBase;
 
 import static org.junit.Assert.assertEquals;
 
 /**
- * Tests for {@link SavepointTriggerResponseBody}.
+ * Tests for {@link SavepointTriggerRequestBody}.
  */
-public class SavepointTriggerResponseBodyTest
-		extends RestResponseMarshallingTestBase<SavepointTriggerResponseBody> {
+public class SavepointTriggerRequestBodyTest
+		extends RestRequestMarshallingTestBase<SavepointTriggerRequestBody> {
 
 	@Override
-	protected Class<SavepointTriggerResponseBody> getTestResponseClass() {
-		return SavepointTriggerResponseBody.class;
+	protected Class<SavepointTriggerRequestBody> getTestRequestClass() {
+		return SavepointTriggerRequestBody.class;
 	}
 
 	@Override
-	protected SavepointTriggerResponseBody getTestResponseInstance() {
-		return new SavepointTriggerResponseBody(new SavepointTriggerId());
+	protected SavepointTriggerRequestBody getTestRequestInstance() throws Exception {
+		return new SavepointTriggerRequestBody("/tmp");
 	}
 
 	@Override
 	protected void assertOriginalEqualsToUnmarshalled(
-			final SavepointTriggerResponseBody expected,
-			final SavepointTriggerResponseBody actual) {
-		assertEquals(expected.getSavepointTriggerId(), actual.getSavepointTriggerId());
+			final SavepointTriggerRequestBody expected,
+			final SavepointTriggerRequestBody actual) {
+		assertEquals(expected.getTargetDirectory(), actual.getTargetDirectory());
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/watermark/Watermark.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/watermark/Watermark.java
@@ -22,7 +22,7 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
 
 /**
- * A Watermark tells operators that receive it that no elements with a timestamp older or equal
+ * A Watermark tells operators that no elements with a timestamp older or equal
  * to the watermark timestamp should arrive at the operator. Watermarks are emitted at the
  * sources and propagate through the operators of the topology. Operators must themselves emit
  * watermarks to downstream operators using


### PR DESCRIPTION
## What is the purpose of the change

*Implement triggering of savepoints through HTTP and through command line in FLIP-6 mode. This PR is based on #5207.*

CC: @tillrohrmann 

## Brief change log

- *Allow triggering of savepoints through RestfulGateway.*
- *Implement REST handlers to trigger and query the status of savepoints.*
- *Implement savepoint command in RestClusterClient.*


## Verifying this change

This change added tests and can be verified as follows:

  - *Added unit tests for REST handlesr, and `RestClusterClient`*
  - *Manually deployed the `SocketWindowWordCount` job and triggered a savepoint using Flink's command line client and `curl`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
