### PR TITLE
[FLINK-8345] Add iterator of keyed state on broadcast side of connected streams.

### DIFF
--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBaseTest.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBaseTest.java
@@ -19,9 +19,11 @@
 package org.apache.flink.streaming.connectors.kafka;
 
 import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.state.BroadcastState;
 import org.apache.flink.api.common.state.KeyedStateStore;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.state.MapStateDescriptor;
 import org.apache.flink.api.common.state.OperatorStateStore;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
@@ -894,12 +896,22 @@ public class FlinkKafkaConsumerBaseTest {
 		}
 
 		@Override
+		public <K, V> BroadcastState<K, V> getBroadcastState(MapStateDescriptor<K, V> stateDescriptor) throws Exception {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
 		public <S> ListState<S> getListState(ListStateDescriptor<S> stateDescriptor) throws Exception {
 			throw new UnsupportedOperationException();
 		}
 
 		@Override
 		public Set<String> getRegisteredStateNames() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public Set<String> getRegisteredBroadcastStateNames() {
 			throw new UnsupportedOperationException();
 		}
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/BroadcastState.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/BroadcastState.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.state;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * A type of state that can be created to store the state of a {@code BroadcastStream}. This state assumes that
+ * <b>the same elements are sent to all instances of an operator.</b>
+ *
+ * <p><b>CAUTION:</b> the user has to guarantee that all task instances store the same elements in this type of state.
+ *
+ * <p> Each operator instance individually maintains and stores elements in the broadcast state. The fact that the
+ * incoming stream is a broadcast one guarantees that all instances see all the elements. Upon recovery
+ * or re-scaling, the same state is given to each of the instances. To avoid hotspots, each task reads its previous
+ * partition, and if there are more tasks (scale up), then the new instances read from the old instances in a round
+ * robin fashion. This is why each instance has to guarantee that it stores the same elements as the rest. If not,
+ * upon recovery or rescaling you may have unpredictable redistribution of the partitions, thus unpredictable results.
+ *
+ * @param <K> The key type of the elements in the {@link BroadcastState}.
+ * @param <V> The value type of the elements in the {@link BroadcastState}.
+ */
+@PublicEvolving
+public interface BroadcastState<K, V> extends ReadOnlyBroadcastState<K, V> {
+
+	/**
+	 * Associates a new value with the given key.
+	 *
+	 * @param key The key of the mapping
+	 * @param value The new value of the mapping
+	 *
+	 * @throws Exception Thrown if the system cannot access the state.
+	 */
+	void put(K key, V value) throws Exception;
+
+	/**
+	 * Copies all of the mappings from the given map into the state.
+	 *
+	 * @param map The mappings to be stored in this state
+	 *
+	 * @throws Exception Thrown if the system cannot access the state.
+	 */
+	void putAll(Map<K, V> map) throws Exception;
+
+	/**
+	 * Deletes the mapping of the given key.
+	 *
+	 * @param key The key of the mapping
+	 *
+	 * @throws Exception Thrown if the system cannot access the state.
+	 */
+	void remove(K key) throws Exception;
+
+	/**
+	 * Iterates over all the mappings in the state.
+	 *
+	 * @return An iterator over all the mappings in the state
+	 *
+	 * @throws Exception Thrown if the system cannot access the state.
+	 */
+	Iterator<Map.Entry<K, V>> iterator() throws Exception;
+
+	/**
+	 * Returns all the mappings in the state
+	 *
+	 * @return An iterable view of all the key-value pairs in the state.
+	 *
+	 * @throws Exception Thrown if the system cannot access the state.
+	 */
+	Iterable<Map.Entry<K, V>> entries() throws Exception;
+}

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/ReadOnlyBroadcastState.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/ReadOnlyBroadcastState.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.state;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import java.util.Map;
+
+/**
+ * A read-only view of the {@link BroadcastState}.
+ *
+ * <p>Although read-only, the user code should not modify the value
+ * returned by the {@link #get(Object)} or the entries of the immutable
+ * iterator returned by the {@link #immutableEntries()}, as this can lead to
+ * inconsistent states. The reason for this is that we do not create extra
+ * copies of the elements for performance reasons.
+ *
+ * @param <K> The key type of the elements in the {@link ReadOnlyBroadcastState}.
+ * @param <V> The value type of the elements in the {@link ReadOnlyBroadcastState}.
+ */
+@PublicEvolving
+public interface ReadOnlyBroadcastState<K, V> extends State {
+
+	/**
+	 * Returns the current value associated with the given key.
+	 *
+	 * <p>The user code must not modify the value returned, as
+	 * this can lead to inconsistent states.
+	 *
+	 * @param key The key of the mapping
+	 * @return The value of the mapping with the given key
+	 *
+	 * @throws Exception Thrown if the system cannot access the state.
+	 */
+	V get(K key) throws Exception;
+
+	/**
+	 * Returns whether there exists the given mapping.
+	 *
+	 * @param key The key of the mapping
+	 * @return True if there exists a mapping whose key equals to the given key
+	 *
+	 * @throws Exception Thrown if the system cannot access the state.
+	 */
+	boolean contains(K key) throws Exception;
+
+	/**
+	 * Returns an immutable {@link Iterable} over the entries in the state.
+	 *
+	 * <p>The user code must not modify the entries of the returned immutable
+	 * iterator, as this can lead to inconsistent states.
+	 */
+	Iterable<Map.Entry<K, V>> immutableEntries() throws Exception;
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorStateRepartitioner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorStateRepartitioner.java
@@ -31,12 +31,12 @@ public interface OperatorStateRepartitioner {
 	/**
 	 * @param previousParallelSubtaskStates List of state handles to the parallel subtask states of an operator, as they
 	 *                                      have been checkpointed.
-	 * @param parallelism                   The parallelism that we consider for the state redistribution. Determines the size of the
+	 * @param newParallelism                The parallelism that we consider for the state redistribution. Determines the size of the
 	 *                                      returned list.
 	 * @return List with one entry per parallel subtask. Each subtask receives now one collection of states that build
 	 * of the new total state for this subtask.
 	 */
 	List<Collection<OperatorStateHandle>> repartitionState(
 			List<OperatorStateHandle> previousParallelSubtaskStates,
-			int parallelism);
+			int newParallelism);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/RoundRobinOperatorStateRepartitioner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/RoundRobinOperatorStateRepartitioner.java
@@ -42,10 +42,10 @@ public class RoundRobinOperatorStateRepartitioner implements OperatorStateRepart
 	@Override
 	public List<Collection<OperatorStateHandle>> repartitionState(
 			List<OperatorStateHandle> previousParallelSubtaskStates,
-			int parallelism) {
+			int newParallelism) {
 
 		Preconditions.checkNotNull(previousParallelSubtaskStates);
-		Preconditions.checkArgument(parallelism > 0);
+		Preconditions.checkArgument(newParallelism > 0);
 
 		// Reorganize: group by (State Name -> StreamStateHandle + Offsets)
 		GroupByStateNameResults nameToStateByMode = groupByStateName(previousParallelSubtaskStates);
@@ -55,11 +55,11 @@ public class RoundRobinOperatorStateRepartitioner implements OperatorStateRepart
 		}
 
 		// Assemble result from all merge maps
-		List<Collection<OperatorStateHandle>> result = new ArrayList<>(parallelism);
+		List<Collection<OperatorStateHandle>> result = new ArrayList<>(newParallelism);
 
 		// Do the actual repartitioning for all named states
 		List<Map<StreamStateHandle, OperatorStateHandle>> mergeMapList =
-				repartition(nameToStateByMode, parallelism);
+				repartition(nameToStateByMode, newParallelism);
 
 		for (int i = 0; i < mergeMapList.size(); ++i) {
 			result.add(i, new ArrayList<>(mergeMapList.get(i).values()));
@@ -72,8 +72,7 @@ public class RoundRobinOperatorStateRepartitioner implements OperatorStateRepart
 	 * Group by the different named states.
 	 */
 	@SuppressWarnings("unchecked, rawtype")
-	private GroupByStateNameResults groupByStateName(
-			List<OperatorStateHandle> previousParallelSubtaskStates) {
+	private GroupByStateNameResults groupByStateName(List<OperatorStateHandle> previousParallelSubtaskStates) {
 
 		//Reorganize: group by (State Name -> StreamStateHandle + StateMetaInfo)
 		EnumMap<OperatorStateHandle.Mode,
@@ -81,10 +80,7 @@ public class RoundRobinOperatorStateRepartitioner implements OperatorStateRepart
 				new EnumMap<>(OperatorStateHandle.Mode.class);
 
 		for (OperatorStateHandle.Mode mode : OperatorStateHandle.Mode.values()) {
-			Map<String, List<Tuple2<StreamStateHandle, OperatorStateHandle.StateMetaInfo>>> map = new HashMap<>();
-			nameToStateByMode.put(
-					mode,
-					new HashMap<String, List<Tuple2<StreamStateHandle, OperatorStateHandle.StateMetaInfo>>>());
+			nameToStateByMode.put(mode, new HashMap<>());
 		}
 
 		for (OperatorStateHandle psh : previousParallelSubtaskStates) {
@@ -120,14 +116,14 @@ public class RoundRobinOperatorStateRepartitioner implements OperatorStateRepart
 	 */
 	private List<Map<StreamStateHandle, OperatorStateHandle>> repartition(
 			GroupByStateNameResults nameToStateByMode,
-			int parallelism) {
+			int newParallelism) {
 
 		// We will use this to merge w.r.t. StreamStateHandles for each parallel subtask inside the maps
-		List<Map<StreamStateHandle, OperatorStateHandle>> mergeMapList = new ArrayList<>(parallelism);
+		List<Map<StreamStateHandle, OperatorStateHandle>> mergeMapList = new ArrayList<>(newParallelism);
 
 		// Initialize
-		for (int i = 0; i < parallelism; ++i) {
-			mergeMapList.add(new HashMap<StreamStateHandle, OperatorStateHandle>());
+		for (int i = 0; i < newParallelism; ++i) {
+			mergeMapList.add(new HashMap<>());
 		}
 
 		// Start with the state handles we distribute round robin by splitting by offsets
@@ -150,15 +146,15 @@ public class RoundRobinOperatorStateRepartitioner implements OperatorStateRepart
 			// Repartition the state across the parallel operator instances
 			int lstIdx = 0;
 			int offsetIdx = 0;
-			int baseFraction = totalPartitions / parallelism;
-			int remainder = totalPartitions % parallelism;
+			int baseFraction = totalPartitions / newParallelism;
+			int remainder = totalPartitions % newParallelism;
 
 			int newStartParallelOp = startParallelOp;
 
-			for (int i = 0; i < parallelism; ++i) {
+			for (int i = 0; i < newParallelism; ++i) {
 
 				// Preparation: calculate the actual index considering wrap around
-				int parallelOpIdx = (i + startParallelOp) % parallelism;
+				int parallelOpIdx = (i + startParallelOp) % newParallelism;
 
 				// Now calculate the number of partitions we will assign to the parallel instance in this round ...
 				int numberOfPartitionsToAssign = baseFraction;
@@ -209,10 +205,7 @@ public class RoundRobinOperatorStateRepartitioner implements OperatorStateRepart
 					Map<StreamStateHandle, OperatorStateHandle> mergeMap = mergeMapList.get(parallelOpIdx);
 					OperatorStateHandle operatorStateHandle = mergeMap.get(handleWithOffsets.f0);
 					if (operatorStateHandle == null) {
-						operatorStateHandle = new OperatorStateHandle(
-								new HashMap<String, OperatorStateHandle.StateMetaInfo>(),
-								handleWithOffsets.f0);
-
+						operatorStateHandle = new OperatorStateHandle(new HashMap<>(), handleWithOffsets.f0);
 						mergeMap.put(handleWithOffsets.f0, operatorStateHandle);
 					}
 					operatorStateHandle.getStateNameToPartitionOffsets().put(
@@ -226,28 +219,49 @@ public class RoundRobinOperatorStateRepartitioner implements OperatorStateRepart
 
 		// Now we also add the state handles marked for broadcast to all parallel instances
 		Map<String, List<Tuple2<StreamStateHandle, OperatorStateHandle.StateMetaInfo>>> broadcastNameToState =
-				nameToStateByMode.getByMode(OperatorStateHandle.Mode.BROADCAST);
+				nameToStateByMode.getByMode(OperatorStateHandle.Mode.UNION);
 
-		for (int i = 0; i < parallelism; ++i) {
+		for (int i = 0; i < newParallelism; ++i) {
 
 			Map<StreamStateHandle, OperatorStateHandle> mergeMap = mergeMapList.get(i);
 
 			for (Map.Entry<String, List<Tuple2<StreamStateHandle, OperatorStateHandle.StateMetaInfo>>> e :
 					broadcastNameToState.entrySet()) {
 
-				List<Tuple2<StreamStateHandle, OperatorStateHandle.StateMetaInfo>> current = e.getValue();
-
-				for (Tuple2<StreamStateHandle, OperatorStateHandle.StateMetaInfo> handleWithMetaInfo : current) {
+				for (Tuple2<StreamStateHandle, OperatorStateHandle.StateMetaInfo> handleWithMetaInfo : e.getValue()) {
 					OperatorStateHandle operatorStateHandle = mergeMap.get(handleWithMetaInfo.f0);
 					if (operatorStateHandle == null) {
-						operatorStateHandle = new OperatorStateHandle(
-								new HashMap<String, OperatorStateHandle.StateMetaInfo>(),
-								handleWithMetaInfo.f0);
-
+						operatorStateHandle = new OperatorStateHandle(new HashMap<>(), handleWithMetaInfo.f0);
 						mergeMap.put(handleWithMetaInfo.f0, operatorStateHandle);
 					}
 					operatorStateHandle.getStateNameToPartitionOffsets().put(e.getKey(), handleWithMetaInfo.f1);
 				}
+			}
+		}
+
+		// Now we also add the state handles marked for uniform broadcast to all parallel instances
+		Map<String, List<Tuple2<StreamStateHandle, OperatorStateHandle.StateMetaInfo>>> uniformBroadcastNameToState =
+				nameToStateByMode.getByMode(OperatorStateHandle.Mode.BROADCAST);
+
+		for (int i = 0; i < newParallelism; ++i) {
+
+			final Map<StreamStateHandle, OperatorStateHandle> mergeMap = mergeMapList.get(i);
+
+			// for each name, pick the i-th entry
+			for (Map.Entry<String, List<Tuple2<StreamStateHandle, OperatorStateHandle.StateMetaInfo>>> e :
+					uniformBroadcastNameToState.entrySet()) {
+
+				int oldParallelism = e.getValue().size();
+				
+				Tuple2<StreamStateHandle, OperatorStateHandle.StateMetaInfo> handleWithMetaInfo =
+							e.getValue().get(i % oldParallelism);
+
+				OperatorStateHandle operatorStateHandle = mergeMap.get(handleWithMetaInfo.f0);
+				if (operatorStateHandle == null) {
+					operatorStateHandle = new OperatorStateHandle(new HashMap<>(), handleWithMetaInfo.f0);
+					mergeMap.put(handleWithMetaInfo.f0, operatorStateHandle);
+				}
+				operatorStateHandle.getStateNameToPartitionOffsets().put(e.getKey(), handleWithMetaInfo.f1);
 			}
 		}
 		return mergeMapList;
@@ -257,7 +271,7 @@ public class RoundRobinOperatorStateRepartitioner implements OperatorStateRepart
 		private final EnumMap<OperatorStateHandle.Mode,
 				Map<String, List<Tuple2<StreamStateHandle, OperatorStateHandle.StateMetaInfo>>>> byMode;
 
-		public GroupByStateNameResults(
+		GroupByStateNameResults(
 				EnumMap<OperatorStateHandle.Mode,
 						Map<String, List<Tuple2<StreamStateHandle, OperatorStateHandle.StateMetaInfo>>>> byMode) {
 			this.byMode = Preconditions.checkNotNull(byMode);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StateAssignmentOperation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StateAssignmentOperation.java
@@ -618,11 +618,10 @@ public class StateAssignmentOperation {
 					Map<String, OperatorStateHandle.StateMetaInfo> partitionOffsets =
 						operatorStateHandle.getStateNameToPartitionOffsets();
 
-
 					for (OperatorStateHandle.StateMetaInfo metaInfo : partitionOffsets.values()) {
 
 						// if we find any broadcast state, we cannot take the shortcut and need to go through repartitioning
-						if (OperatorStateHandle.Mode.BROADCAST.equals(metaInfo.getDistributionMode())) {
+						if (OperatorStateHandle.Mode.UNION.equals(metaInfo.getDistributionMode())) {
 							return opStateRepartitioner.repartitionState(
 								chainOpParallelStates,
 								newParallelism);
@@ -639,7 +638,7 @@ public class StateAssignmentOperation {
 	/**
 	 * Determine the subset of {@link KeyGroupsStateHandle KeyGroupsStateHandles} with correct
 	 * key group index for the given subtask {@link KeyGroupRange}.
-	 * <p>
+	 *
 	 * <p>This is publicly visible to be used in tests.
 	 */
 	public static List<KeyedStateHandle> getKeyedStateHandles(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
@@ -98,9 +98,7 @@ public abstract class AbstractKeyedStateBackend<K>
 
 	private final ExecutionConfig executionConfig;
 
-	/**
-	 * Decorates the input and output streams to write key-groups compressed.
-	 */
+	/** Decorates the input and output streams to write key-groups compressed. */
 	protected final StreamCompressionDecorator keyGroupCompressionDecorator;
 
 	public AbstractKeyedStateBackend(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/BackendWritableBroadcastState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/BackendWritableBroadcastState.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.api.common.state.BroadcastState;
+import org.apache.flink.core.fs.FSDataOutputStream;
+
+import java.io.IOException;
+
+/**
+ * An interface with methods related to the interplay between the {@link BroadcastState Broadcast State} and
+ * the {@link OperatorStateBackend}.
+ *
+ * @param <K> The key type of the elements in the {@link BroadcastState Broadcast State}.
+ * @param <V> The value type of the elements in the {@link BroadcastState Broadcast State}.
+ */
+public interface BackendWritableBroadcastState<K, V> extends BroadcastState<K, V> {
+
+	BackendWritableBroadcastState<K, V> deepCopy();
+
+	long write(FSDataOutputStream out) throws IOException;
+
+	void setStateMetaInfo(RegisteredBroadcastBackendStateMetaInfo<K, V> stateMetaInfo);
+
+	RegisteredBroadcastBackendStateMetaInfo<K, V> getStateMetaInfo();
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackend.java
@@ -22,6 +22,8 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.state.BroadcastState;
 import org.apache.flink.api.common.typeutils.CompatibilityResult;
 import org.apache.flink.api.common.typeutils.CompatibilityUtil;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -69,7 +71,12 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 	/**
 	 * Map for all registered operator states. Maps state name -> state
 	 */
-	private final Map<String, PartitionableListState<?>> registeredStates;
+	private final Map<String, PartitionableListState<?>> registeredOperatorStates;
+
+	/**
+	 * Map for all registered operator broadcast states. Maps state name -> state
+	 */
+	private final Map<String, BackendWritableBroadcastState<?, ?>> registeredBroadcastStates;
 
 	/**
 	 * CloseableRegistry to participate in the tasks lifecycle.
@@ -102,12 +109,17 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 	 * <p>TODO this map can be removed when eager-state registration is in place.
 	 * TODO we currently need this cached to check state migration strategies when new serializers are registered.
 	 */
-	private final Map<String, RegisteredOperatorBackendStateMetaInfo.Snapshot<?>> restoredStateMetaInfos;
+	private final Map<String, RegisteredOperatorBackendStateMetaInfo.Snapshot<?>> restoredOperatorStateMetaInfos;
+
+	/**
+	 * Map of state names to their corresponding restored broadcast state meta info.
+	 */
+	private final Map<String, RegisteredBroadcastBackendStateMetaInfo.Snapshot<?, ?>> restoredBroadcastStateMetaInfos;
 
 	/**
 	 * Cache of already accessed states.
 	 *
-	 * <p>In contrast to {@link #registeredStates} and {@link #restoredStateMetaInfos} which may be repopulated
+	 * <p>In contrast to {@link #registeredOperatorStates} and {@link #restoredOperatorStateMetaInfos} which may be repopulated
 	 * with restored state, this map is always empty at the beginning.
 	 *
 	 * <p>TODO this map should be moved to a base class once we have proper hierarchy for the operator state backends.
@@ -115,6 +127,8 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 	 * @see <a href="https://issues.apache.org/jira/browse/FLINK-6849">FLINK-6849</a>
 	 */
 	private final HashMap<String, PartitionableListState<?>> accessedStatesByName;
+
+	private final Map<String, BackendWritableBroadcastState<?, ?>> accessedBroadcastStatesByName;
 
 	public DefaultOperatorStateBackend(
 		ClassLoader userClassLoader,
@@ -125,10 +139,13 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 		this.userClassloader = Preconditions.checkNotNull(userClassLoader);
 		this.executionConfig = executionConfig;
 		this.javaSerializer = new JavaSerializer<>();
-		this.registeredStates = new HashMap<>();
+		this.registeredOperatorStates = new HashMap<>();
+		this.registeredBroadcastStates = new HashMap<>();
 		this.asynchronousSnapshots = asynchronousSnapshots;
 		this.accessedStatesByName = new HashMap<>();
-		this.restoredStateMetaInfos = new HashMap<>();
+		this.accessedBroadcastStatesByName = new HashMap<>();
+		this.restoredOperatorStateMetaInfos = new HashMap<>();
+		this.restoredBroadcastStateMetaInfos = new HashMap<>();
 	}
 
 	public ExecutionConfig getExecutionConfig() {
@@ -137,7 +154,12 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 
 	@Override
 	public Set<String> getRegisteredStateNames() {
-		return registeredStates.keySet();
+		return registeredOperatorStates.keySet();
+	}
+
+	@Override
+	public Set<String> getRegisteredBroadcastStateNames() {
+		return registeredBroadcastStates.keySet();
 	}
 
 	@Override
@@ -148,12 +170,94 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 	@Override
 	public void dispose() {
 		IOUtils.closeQuietly(closeStreamOnCancelRegistry);
-		registeredStates.clear();
+		registeredOperatorStates.clear();
+		registeredBroadcastStates.clear();
 	}
 
 	// -------------------------------------------------------------------------------------------
 	//  State access methods
 	// -------------------------------------------------------------------------------------------
+
+	@Override
+	public <K, V> BroadcastState<K, V> getBroadcastState(final MapStateDescriptor<K, V> stateDescriptor) throws StateMigrationException {
+
+		Preconditions.checkNotNull(stateDescriptor);
+		String name = Preconditions.checkNotNull(stateDescriptor.getName());
+
+		@SuppressWarnings("unchecked")
+		BackendWritableBroadcastState<K, V> previous = (BackendWritableBroadcastState<K, V>) accessedBroadcastStatesByName.get(name);
+		if (previous != null) {
+			checkStateNameAndMode(
+					previous.getStateMetaInfo().getName(),
+					name,
+					previous.getStateMetaInfo().getAssignmentMode(),
+					OperatorStateHandle.Mode.BROADCAST);
+			return previous;
+		}
+
+		stateDescriptor.initializeSerializerUnlessSet(getExecutionConfig());
+		TypeSerializer<K> broadcastStateKeySerializer = Preconditions.checkNotNull(stateDescriptor.getKeySerializer());
+		TypeSerializer<V> broadcastStateValueSerializer = Preconditions.checkNotNull(stateDescriptor.getValueSerializer());
+
+		BackendWritableBroadcastState<K, V> broadcastState = (BackendWritableBroadcastState<K, V>) registeredBroadcastStates.get(name);
+
+		if (broadcastState == null) {
+			broadcastState = new HeapBroadcastState<>(
+					new RegisteredBroadcastBackendStateMetaInfo<>(
+							name,
+							OperatorStateHandle.Mode.BROADCAST,
+							broadcastStateKeySerializer,
+							broadcastStateValueSerializer));
+			registeredBroadcastStates.put(name, broadcastState);
+		} else {
+			// has restored state; check compatibility of new state access
+
+			checkStateNameAndMode(
+					broadcastState.getStateMetaInfo().getName(),
+					name,
+					broadcastState.getStateMetaInfo().getAssignmentMode(),
+					OperatorStateHandle.Mode.BROADCAST);
+
+			@SuppressWarnings("unchecked")
+			RegisteredBroadcastBackendStateMetaInfo.Snapshot<K, V> restoredMetaInfo =
+					(RegisteredBroadcastBackendStateMetaInfo.Snapshot<K, V>) restoredBroadcastStateMetaInfos.get(name);
+
+			// check compatibility to determine if state migration is required
+			CompatibilityResult<K> keyCompatibility = CompatibilityUtil.resolveCompatibilityResult(
+					restoredMetaInfo.getKeySerializer(),
+					UnloadableDummyTypeSerializer.class,
+					restoredMetaInfo.getKeySerializerConfigSnapshot(),
+					broadcastStateKeySerializer);
+
+			CompatibilityResult<V> valueCompatibility = CompatibilityUtil.resolveCompatibilityResult(
+					restoredMetaInfo.getValueSerializer(),
+					UnloadableDummyTypeSerializer.class,
+					restoredMetaInfo.getValueSerializerConfigSnapshot(),
+					broadcastStateValueSerializer);
+
+			if (!keyCompatibility.isRequiresMigration() && !valueCompatibility.isRequiresMigration()) {
+				// new serializer is compatible; use it to replace the old serializer
+				broadcastState.setStateMetaInfo(
+						new RegisteredBroadcastBackendStateMetaInfo<>(
+								name,
+								OperatorStateHandle.Mode.BROADCAST,
+								broadcastStateKeySerializer,
+								broadcastStateValueSerializer));
+			} else {
+				// TODO state migration currently isn't possible.
+
+				// NOTE: for heap backends, it is actually fine to proceed here without failing the restore,
+				// since the state has already been deserialized to objects and we can just continue with
+				// the new serializer; we're deliberately failing here for now to have equal functionality with
+				// the RocksDB backend to avoid confusion for users.
+
+				throw new StateMigrationException("State migration isn't supported, yet.");
+			}
+		}
+
+		accessedBroadcastStatesByName.put(name, broadcastState);
+		return broadcastState;
+	}
 
 	@Override
 	public <S> ListState<S> getListState(ListStateDescriptor<S> stateDescriptor) throws Exception {
@@ -162,7 +266,7 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 
 	@Override
 	public <S> ListState<S> getUnionListState(ListStateDescriptor<S> stateDescriptor) throws Exception {
-		return getListState(stateDescriptor, OperatorStateHandle.Mode.BROADCAST);
+		return getListState(stateDescriptor, OperatorStateHandle.Mode.UNION);
 	}
 
 	// -------------------------------------------------------------------------------------------
@@ -203,23 +307,39 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 
 		final long syncStartTime = System.currentTimeMillis();
 
-		if (registeredStates.isEmpty()) {
+		if (registeredOperatorStates.isEmpty() && registeredBroadcastStates.isEmpty()) {
 			return DoneFuture.nullValue();
 		}
 
-		final Map<String, PartitionableListState<?>> registeredStatesDeepCopies =
-				new HashMap<>(registeredStates.size());
+		final Map<String, PartitionableListState<?>> registeredOperatorStatesDeepCopies =
+				new HashMap<>(registeredOperatorStates.size());
+		final Map<String, BackendWritableBroadcastState<?, ?>> registeredBroadcastStatesDeepCopies =
+				new HashMap<>(registeredBroadcastStates.size());
 
-		// eagerly create deep copies of the list states in the sync phase, so that we can use them in the async writing
 		ClassLoader snapshotClassLoader = Thread.currentThread().getContextClassLoader();
 		Thread.currentThread().setContextClassLoader(userClassloader);
 		try {
-			for (Map.Entry<String, PartitionableListState<?>> entry : this.registeredStates.entrySet()) {
-				PartitionableListState<?> listState = entry.getValue();
-				if (null != listState) {
-					listState = listState.deepCopy();
+			// eagerly create deep copies of the list and the broadcast states (if any)
+			// in the synchronous phase, so that we can use them in the async writing.
+
+			if (!registeredOperatorStates.isEmpty()) {
+				for (Map.Entry<String, PartitionableListState<?>> entry : registeredOperatorStates.entrySet()) {
+					PartitionableListState<?> listState = entry.getValue();
+					if (null != listState) {
+						listState = listState.deepCopy();
+					}
+					registeredOperatorStatesDeepCopies.put(entry.getKey(), listState);
 				}
-				registeredStatesDeepCopies.put(entry.getKey(), listState);
+			}
+
+			if (!registeredBroadcastStates.isEmpty()) {
+				for (Map.Entry<String, BackendWritableBroadcastState<?, ?>> entry : registeredBroadcastStates.entrySet()) {
+					BackendWritableBroadcastState<?, ?> broadcastState = entry.getValue();
+					if (null != broadcastState) {
+						broadcastState = broadcastState.deepCopy();
+					}
+					registeredBroadcastStatesDeepCopies.put(entry.getKey(), broadcastState);
+				}
 			}
 		} finally {
 			Thread.currentThread().setContextClassLoader(snapshotClassLoader);
@@ -263,25 +383,38 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 
 					CheckpointStreamFactory.CheckpointStateOutputStream localOut = this.out;
 
-					final Map<String, OperatorStateHandle.StateMetaInfo> writtenStatesMetaData =
-						new HashMap<>(registeredStatesDeepCopies.size());
+					// get the registered operator state infos ...
+					List<RegisteredOperatorBackendStateMetaInfo.Snapshot<?>> operatorMetaInfoSnapshots =
+						new ArrayList<>(registeredOperatorStatesDeepCopies.size());
 
-					List<RegisteredOperatorBackendStateMetaInfo.Snapshot<?>> metaInfoSnapshots =
-						new ArrayList<>(registeredStatesDeepCopies.size());
-
-					for (Map.Entry<String, PartitionableListState<?>> entry : registeredStatesDeepCopies.entrySet()) {
-						metaInfoSnapshots.add(entry.getValue().getStateMetaInfo().snapshot());
+					for (Map.Entry<String, PartitionableListState<?>> entry : registeredOperatorStatesDeepCopies.entrySet()) {
+						operatorMetaInfoSnapshots.add(entry.getValue().getStateMetaInfo().snapshot());
 					}
 
+					// ... get the registered broadcast operator state infos ...
+					List<RegisteredBroadcastBackendStateMetaInfo.Snapshot<?, ?>> broadcastMetaInfoSnapshots =
+							new ArrayList<>(registeredBroadcastStatesDeepCopies.size());
+
+					for (Map.Entry<String, BackendWritableBroadcastState<?, ?>> entry : registeredBroadcastStatesDeepCopies.entrySet()) {
+						broadcastMetaInfoSnapshots.add(entry.getValue().getStateMetaInfo().snapshot());
+					}
+
+					// ... write them all in the checkpoint stream ...
 					DataOutputView dov = new DataOutputViewStreamWrapper(localOut);
 
 					OperatorBackendSerializationProxy backendSerializationProxy =
-						new OperatorBackendSerializationProxy(metaInfoSnapshots);
+						new OperatorBackendSerializationProxy(operatorMetaInfoSnapshots, broadcastMetaInfoSnapshots);
 
 					backendSerializationProxy.write(dov);
 
+					// ... and then go for the states ...
+
+					// we put BOTH normal and broadcast state metadata here
+					final Map<String, OperatorStateHandle.StateMetaInfo> writtenStatesMetaData =
+							new HashMap<>(registeredOperatorStatesDeepCopies.size() + registeredBroadcastStatesDeepCopies.size());
+
 					for (Map.Entry<String, PartitionableListState<?>> entry :
-						registeredStatesDeepCopies.entrySet()) {
+							registeredOperatorStatesDeepCopies.entrySet()) {
 
 						PartitionableListState<?> value = entry.getValue();
 						long[] partitionOffsets = value.write(localOut);
@@ -291,6 +424,19 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 							new OperatorStateHandle.StateMetaInfo(partitionOffsets, mode));
 					}
 
+					// ... and the broadcast states themselves ...
+					for (Map.Entry<String, BackendWritableBroadcastState<?, ?>> entry :
+							registeredBroadcastStatesDeepCopies.entrySet()) {
+
+						BackendWritableBroadcastState<?, ?> value = entry.getValue();
+						long[] partitionOffsets = {value.write(localOut)};
+						OperatorStateHandle.Mode mode = value.getStateMetaInfo().getAssignmentMode();
+						writtenStatesMetaData.put(
+								entry.getKey(),
+								new OperatorStateHandle.StateMetaInfo(partitionOffsets, mode));
+					}
+
+					// ... and, finally, create the state handle.
 					OperatorStateHandle retValue = null;
 
 					if (closeStreamOnCancelRegistry.unregisterCloseable(out)) {
@@ -348,11 +494,11 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 
 				backendSerializationProxy.read(new DataInputViewStreamWrapper(in));
 
-				List<RegisteredOperatorBackendStateMetaInfo.Snapshot<?>> restoredMetaInfoSnapshots =
-						backendSerializationProxy.getStateMetaInfoSnapshots();
+				List<RegisteredOperatorBackendStateMetaInfo.Snapshot<?>> restoredOperatorMetaInfoSnapshots =
+						backendSerializationProxy.getOperatorStateMetaInfoSnapshots();
 
 				// Recreate all PartitionableListStates from the meta info
-				for (RegisteredOperatorBackendStateMetaInfo.Snapshot<?> restoredMetaInfo : restoredMetaInfoSnapshots) {
+				for (RegisteredOperatorBackendStateMetaInfo.Snapshot<?> restoredMetaInfo : restoredOperatorMetaInfoSnapshots) {
 
 					if (restoredMetaInfo.getPartitionStateSerializer() == null ||
 							restoredMetaInfo.getPartitionStateSerializer() instanceof UnloadableDummyTypeSerializer) {
@@ -368,9 +514,9 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 							" not be loaded. This is a temporary restriction that will be fixed in future versions.");
 					}
 
-					restoredStateMetaInfos.put(restoredMetaInfo.getName(), restoredMetaInfo);
+					restoredOperatorStateMetaInfos.put(restoredMetaInfo.getName(), restoredMetaInfo);
 
-					PartitionableListState<?> listState = registeredStates.get(restoredMetaInfo.getName());
+					PartitionableListState<?> listState = registeredOperatorStates.get(restoredMetaInfo.getName());
 
 					if (null == listState) {
 						listState = new PartitionableListState<>(
@@ -379,22 +525,66 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 										restoredMetaInfo.getPartitionStateSerializer(),
 										restoredMetaInfo.getAssignmentMode()));
 
-						registeredStates.put(listState.getStateMetaInfo().getName(), listState);
+						registeredOperatorStates.put(listState.getStateMetaInfo().getName(), listState);
 					} else {
 						// TODO with eager state registration in place, check here for serializer migration strategies
 					}
 				}
 
-				// Restore all the state in PartitionableListStates
+				// ... and then get back the broadcast state.
+				List<RegisteredBroadcastBackendStateMetaInfo.Snapshot<?, ?>> restoredBroadcastMetaInfoSnapshots =
+						backendSerializationProxy.getBroadcastStateMetaInfoSnapshots();
+
+				for (RegisteredBroadcastBackendStateMetaInfo.Snapshot<? ,?> restoredMetaInfo : restoredBroadcastMetaInfoSnapshots) {
+
+					if (restoredMetaInfo.getKeySerializer() == null || restoredMetaInfo.getValueSerializer() == null ||
+							restoredMetaInfo.getKeySerializer() instanceof UnloadableDummyTypeSerializer ||
+							restoredMetaInfo.getValueSerializer() instanceof UnloadableDummyTypeSerializer) {
+
+						// must fail now if the previous serializer cannot be restored because there is no serializer
+						// capable of reading previous state
+						// TODO when eager state registration is in place, we can try to get a convert deserializer
+						// TODO from the newly registered serializer instead of simply failing here
+
+						throw new IOException("Unable to restore broadcast state [" + restoredMetaInfo.getName() + "]." +
+								" The previous key and value serializers of the state must be present; the serializers could" +
+								" have been removed from the classpath, or their implementations have changed and could" +
+								" not be loaded. This is a temporary restriction that will be fixed in future versions.");
+					}
+
+					restoredBroadcastStateMetaInfos.put(restoredMetaInfo.getName(), restoredMetaInfo);
+
+					BackendWritableBroadcastState<? ,?> broadcastState = registeredBroadcastStates.get(restoredMetaInfo.getName());
+
+					if (broadcastState == null) {
+						broadcastState = new HeapBroadcastState<>(
+								new RegisteredBroadcastBackendStateMetaInfo<>(
+										restoredMetaInfo.getName(),
+										restoredMetaInfo.getAssignmentMode(),
+										restoredMetaInfo.getKeySerializer(),
+										restoredMetaInfo.getValueSerializer()));
+
+						registeredBroadcastStates.put(broadcastState.getStateMetaInfo().getName(), broadcastState);
+					} else {
+						// TODO with eager state registration in place, check here for serializer migration strategies
+					}
+				}
+
+				// Restore all the states
 				for (Map.Entry<String, OperatorStateHandle.StateMetaInfo> nameToOffsets :
 						stateHandle.getStateNameToPartitionOffsets().entrySet()) {
 
-					PartitionableListState<?> stateListForName = registeredStates.get(nameToOffsets.getKey());
+					final String stateName = nameToOffsets.getKey();
 
-					Preconditions.checkState(null != stateListForName, "Found state without " +
-							"corresponding meta info: " + nameToOffsets.getKey());
-
-					deserializeStateValues(stateListForName, in, nameToOffsets.getValue());
+					PartitionableListState<?> listStateForName = registeredOperatorStates.get(stateName);
+					if (listStateForName == null) {
+						BackendWritableBroadcastState<?, ?> broadcastStateForName = registeredBroadcastStates.get(stateName);
+						Preconditions.checkState(broadcastStateForName != null, "Found state without " +
+								"corresponding meta info: " + stateName);
+						deserializeBroadcastStateValues(broadcastStateForName, in, nameToOffsets.getValue());
+					} else {
+						deserializeOperatorStateValues(listStateForName, in, nameToOffsets.getValue());
+					}
 				}
 
 			} finally {
@@ -428,7 +618,7 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 		 */
 		private final ArrayListSerializer<S> internalListCopySerializer;
 
-		public PartitionableListState(RegisteredOperatorBackendStateMetaInfo<S> stateMetaInfo) {
+		PartitionableListState(RegisteredOperatorBackendStateMetaInfo<S> stateMetaInfo) {
 			this(stateMetaInfo, new ArrayList<S>());
 		}
 
@@ -513,7 +703,7 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 
 	private <S> ListState<S> getListState(
 			ListStateDescriptor<S> stateDescriptor,
-			OperatorStateHandle.Mode mode) throws IOException, StateMigrationException {
+			OperatorStateHandle.Mode mode) throws StateMigrationException {
 
 		Preconditions.checkNotNull(stateDescriptor);
 		String name = Preconditions.checkNotNull(stateDescriptor.getName());
@@ -521,7 +711,11 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 		@SuppressWarnings("unchecked")
 		PartitionableListState<S> previous = (PartitionableListState<S>) accessedStatesByName.get(name);
 		if (previous != null) {
-			checkStateNameAndMode(previous.getStateMetaInfo(), name, mode);
+			checkStateNameAndMode(
+					previous.getStateMetaInfo().getName(),
+					name,
+					previous.getStateMetaInfo().getAssignmentMode(),
+					mode);
 			return previous;
 		}
 
@@ -533,7 +727,7 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 		TypeSerializer<S> partitionStateSerializer = Preconditions.checkNotNull(stateDescriptor.getElementSerializer());
 
 		@SuppressWarnings("unchecked")
-		PartitionableListState<S> partitionableListState = (PartitionableListState<S>) registeredStates.get(name);
+		PartitionableListState<S> partitionableListState = (PartitionableListState<S>) registeredOperatorStates.get(name);
 
 		if (null == partitionableListState) {
 			// no restored state for the state name; simply create new state holder
@@ -544,15 +738,19 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 					partitionStateSerializer,
 					mode));
 
-			registeredStates.put(name, partitionableListState);
+			registeredOperatorStates.put(name, partitionableListState);
 		} else {
 			// has restored state; check compatibility of new state access
 
-			checkStateNameAndMode(partitionableListState.getStateMetaInfo(), name, mode);
+			checkStateNameAndMode(
+					partitionableListState.getStateMetaInfo().getName(),
+					name,
+					partitionableListState.getStateMetaInfo().getAssignmentMode(),
+					mode);
 
 			@SuppressWarnings("unchecked")
 			RegisteredOperatorBackendStateMetaInfo.Snapshot<S> restoredMetaInfo =
-				(RegisteredOperatorBackendStateMetaInfo.Snapshot<S>) restoredStateMetaInfos.get(name);
+				(RegisteredOperatorBackendStateMetaInfo.Snapshot<S>) restoredOperatorStateMetaInfos.get(name);
 
 			// check compatibility to determine if state migration is required
 			CompatibilityResult<S> stateCompatibility = CompatibilityUtil.resolveCompatibilityResult(
@@ -581,7 +779,7 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 		return partitionableListState;
 	}
 
-	private static <S> void deserializeStateValues(
+	private static <S> void deserializeOperatorStateValues(
 		PartitionableListState<S> stateListForName,
 		FSDataInputStream in,
 		OperatorStateHandle.StateMetaInfo metaInfo) throws IOException {
@@ -599,21 +797,45 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 		}
 	}
 
+	private static <K, V> void deserializeBroadcastStateValues(
+			final BackendWritableBroadcastState<K, V> broadcastStateForName,
+			final FSDataInputStream in,
+			final OperatorStateHandle.StateMetaInfo metaInfo) throws Exception {
+
+		if (metaInfo != null) {
+			long[] offsets = metaInfo.getOffsets();
+			if (offsets != null) {
+
+				TypeSerializer<K> keySerializer = broadcastStateForName.getStateMetaInfo().getKeySerializer();
+				TypeSerializer<V> valueSerializer = broadcastStateForName.getStateMetaInfo().getValueSerializer();
+
+				in.seek(offsets[0]);
+
+				DataInputView div = new DataInputViewStreamWrapper(in);
+				int size = div.readInt();
+				for (int i = 0; i < size; i++) {
+					broadcastStateForName.put(keySerializer.deserialize(div), valueSerializer.deserialize(div));
+				}
+			}
+		}
+	}
+
 	private static void checkStateNameAndMode(
-			RegisteredOperatorBackendStateMetaInfo previousMetaInfo,
+			String actualName,
 			String expectedName,
+			OperatorStateHandle.Mode actualMode,
 			OperatorStateHandle.Mode expectedMode) {
 
 		Preconditions.checkState(
-			previousMetaInfo.getName().equals(expectedName),
+			actualName.equals(expectedName),
 			"Incompatible state names. " +
-				"Was [" + previousMetaInfo.getName() + "], " +
+				"Was [" + actualName + "], " +
 				"registered with [" + expectedName + "].");
 
 		Preconditions.checkState(
-			previousMetaInfo.getAssignmentMode().equals(expectedMode),
+				actualMode.equals(expectedMode),
 			"Incompatible state assignment modes. " +
-				"Was [" + previousMetaInfo.getAssignmentMode() + "], " +
+				"Was [" + actualMode + "], " +
 				"registered with [" + expectedMode + "].");
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackend.java
@@ -280,8 +280,6 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 
 					backendSerializationProxy.write(dov);
 
-					dov.writeInt(registeredStatesDeepCopies.size());
-
 					for (Map.Entry<String, PartitionableListState<?>> entry :
 						registeredStatesDeepCopies.entrySet()) {
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/HeapBroadcastState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/HeapBroadcastState.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.api.common.state.BroadcastState;
+import org.apache.flink.api.common.typeutils.base.MapSerializer;
+import org.apache.flink.core.fs.FSDataOutputStream;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.util.Preconditions;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * A {@link BroadcastState Broadcast State} backed a heap-based {@link Map}.
+ *
+ * @param <K> The key type of the elements in the {@link BroadcastState Broadcast State}.
+ * @param <V> The value type of the elements in the {@link BroadcastState Broadcast State}.
+ */
+public class HeapBroadcastState<K, V> implements BackendWritableBroadcastState<K, V> {
+
+	/**
+	 * Meta information of the state, including state name, assignment mode, and serializer.
+	 */
+	private RegisteredBroadcastBackendStateMetaInfo<K, V> stateMetaInfo;
+
+	/**
+	 * The internal map the holds the elements of the state.
+	 */
+	private final Map<K, V> backingMap;
+
+	/**
+	 * A serializer that allows to perform deep copies of internal map state.
+	 */
+	private final MapSerializer<K, V> internalMapCopySerializer;
+
+	HeapBroadcastState(RegisteredBroadcastBackendStateMetaInfo<K, V> stateMetaInfo) {
+		this(stateMetaInfo, new HashMap<>());
+	}
+
+	private HeapBroadcastState(final RegisteredBroadcastBackendStateMetaInfo<K, V> stateMetaInfo, final Map<K, V> internalMap) {
+
+		this.stateMetaInfo = Preconditions.checkNotNull(stateMetaInfo);
+		this.backingMap = Preconditions.checkNotNull(internalMap);
+		this.internalMapCopySerializer = new MapSerializer<>(stateMetaInfo.getKeySerializer(), stateMetaInfo.getValueSerializer());
+	}
+
+	private HeapBroadcastState(HeapBroadcastState<K, V> toCopy) {
+		this(toCopy.stateMetaInfo, toCopy.internalMapCopySerializer.copy(toCopy.backingMap));
+	}
+
+	@Override
+	public void setStateMetaInfo(RegisteredBroadcastBackendStateMetaInfo<K, V> stateMetaInfo) {
+		this.stateMetaInfo = stateMetaInfo;
+	}
+
+	@Override
+	public RegisteredBroadcastBackendStateMetaInfo<K, V> getStateMetaInfo() {
+		return stateMetaInfo;
+	}
+
+	@Override
+	public HeapBroadcastState<K, V> deepCopy() {
+		return new HeapBroadcastState<>(this);
+	}
+
+	@Override
+	public void clear() {
+		backingMap.clear();
+	}
+
+	@Override
+	public String toString() {
+		return "HeapBroadcastState{" +
+				"stateMetaInfo=" + stateMetaInfo +
+				", backingMap=" + backingMap +
+				", internalMapCopySerializer=" + internalMapCopySerializer +
+				'}';
+	}
+
+	@Override
+	public long write(FSDataOutputStream out) throws IOException {
+		long partitionOffset = out.getPos();
+
+		DataOutputView dov = new DataOutputViewStreamWrapper(out);
+		dov.writeInt(backingMap.size());
+		for (Map.Entry<K, V> entry: backingMap.entrySet()) {
+			getStateMetaInfo().getKeySerializer().serialize(entry.getKey(), dov);
+			getStateMetaInfo().getValueSerializer().serialize(entry.getValue(), dov);
+		}
+
+		return partitionOffset;
+	}
+
+	@Override
+	public V get(K key) {
+		return backingMap.get(key);
+	}
+
+	@Override
+	public void put(K key, V value) {
+		backingMap.put(key, value);
+	}
+
+	@Override
+	public void putAll(Map<K, V> map) {
+		backingMap.putAll(map);
+	}
+
+	@Override
+	public void remove(K key) {
+		backingMap.remove(key);
+	}
+
+	@Override
+	public boolean contains(K key) {
+		return backingMap.containsKey(key);
+	}
+
+	@Override
+	public Iterator<Map.Entry<K, V>> iterator() {
+		return backingMap.entrySet().iterator();
+	}
+
+	@Override
+	public Iterable<Map.Entry<K, V>> entries() {
+		return backingMap.entrySet();
+	}
+
+	@Override
+	public Iterable<Map.Entry<K, V>> immutableEntries() {
+		return Collections.unmodifiableSet(backingMap.entrySet());
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateBackend.java
@@ -39,6 +39,24 @@ public interface KeyedStateBackend<K> extends InternalKeyContext<K> {
 	void setCurrentKey(K newKey);
 
 	/**
+	 * Applies the provided {@link KeyedStateFunction} to the state with the provided
+	 * {@link StateDescriptor} of all the currently active keys.
+	 *
+	 * @param namespace the namespace of the state.
+	 * @param namespaceSerializer the serializer for the namespace.
+	 * @param stateDescriptor the descriptor of the state to which the function is going to be applied.
+	 * @param function the function to be applied to the keyed state.
+	 *
+	 * @param <N> The type of the namespace.
+	 * @param <S> The type of the state.
+	 */
+	<N, S extends State, T> void applyToAllKeys(
+			final N namespace,
+			final TypeSerializer<N> namespaceSerializer,
+			final StateDescriptor<S, T> stateDescriptor,
+			final KeyedStateFunction<K, S> function) throws Exception;
+
+	/**
 	 * @return A stream of all keys for the given state and namespace. Modifications to the state during iterating
 	 * 		   over it keys are not supported.
 	 * @param state State variable for which existing keys will be returned.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateFunction.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateFunction.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.api.common.state.State;
+
+/**
+ * A function to be applied to all keyed states.
+ *
+ * <p>This functionality is only available through the
+ * {@code BroadcastConnectedStream.process(final KeyedBroadcastProcessFunction function)}.
+ */
+public abstract class KeyedStateFunction<K, S extends State> {
+
+	/**
+	 * The actual method to be applied on each of the states.
+	 *
+	 * @param key a safe copy of the key (see {@link KeyedStateBackend#getCurrentKeySafe()})
+	 *               whose state is being processed.
+	 * @param state the state associated with the aforementioned key.
+	 */
+	public abstract void process(K key, S state) throws Exception;
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/OperatorBackendSerializationProxy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/OperatorBackendSerializationProxy.java
@@ -33,9 +33,10 @@ import java.util.List;
  */
 public class OperatorBackendSerializationProxy extends VersionedIOReadableWritable {
 
-	public static final int VERSION = 2;
+	public static final int VERSION = 3;
 
-	private List<RegisteredOperatorBackendStateMetaInfo.Snapshot<?>> stateMetaInfoSnapshots;
+	private List<RegisteredOperatorBackendStateMetaInfo.Snapshot<?>> operatorStateMetaInfoSnapshots;
+	private List<RegisteredBroadcastBackendStateMetaInfo.Snapshot<?, ?>> broadcastStateMetaInfoSnapshots;
 	private ClassLoader userCodeClassLoader;
 
 	public OperatorBackendSerializationProxy(ClassLoader userCodeClassLoader) {
@@ -43,10 +44,15 @@ public class OperatorBackendSerializationProxy extends VersionedIOReadableWritab
 	}
 
 	public OperatorBackendSerializationProxy(
-			List<RegisteredOperatorBackendStateMetaInfo.Snapshot<?>> stateMetaInfoSnapshots) {
+			List<RegisteredOperatorBackendStateMetaInfo.Snapshot<?>> operatorStateMetaInfoSnapshots,
+			List<RegisteredBroadcastBackendStateMetaInfo.Snapshot<?, ?>> broadcastStateMetaInfoSnapshots) {
 
-		this.stateMetaInfoSnapshots = Preconditions.checkNotNull(stateMetaInfoSnapshots);
-		Preconditions.checkArgument(stateMetaInfoSnapshots.size() <= Short.MAX_VALUE);
+		this.operatorStateMetaInfoSnapshots = Preconditions.checkNotNull(operatorStateMetaInfoSnapshots);
+		this.broadcastStateMetaInfoSnapshots = Preconditions.checkNotNull(broadcastStateMetaInfoSnapshots);
+		Preconditions.checkArgument(
+				operatorStateMetaInfoSnapshots.size() <= Short.MAX_VALUE &&
+						broadcastStateMetaInfoSnapshots.size() <= Short.MAX_VALUE
+		);
 	}
 
 	@Override
@@ -56,19 +62,26 @@ public class OperatorBackendSerializationProxy extends VersionedIOReadableWritab
 
 	@Override
 	public int[] getCompatibleVersions() {
-		// we are compatible with version 2 (Flink 1.3.x) and version 1 (Flink 1.2.x)
-		return new int[] {VERSION, 1};
+		// we are compatible with version 3 (Flink 1.5.x), 2 (Flink 1.4.x, Flink 1.3.x) and version 1 (Flink 1.2.x)
+		return new int[] {VERSION, 2, 1};
 	}
 
 	@Override
 	public void write(DataOutputView out) throws IOException {
 		super.write(out);
 
-		out.writeShort(stateMetaInfoSnapshots.size());
-		for (RegisteredOperatorBackendStateMetaInfo.Snapshot<?> kvState : stateMetaInfoSnapshots) {
+		out.writeShort(operatorStateMetaInfoSnapshots.size());
+		for (RegisteredOperatorBackendStateMetaInfo.Snapshot<?> state : operatorStateMetaInfoSnapshots) {
 			OperatorBackendStateMetaInfoSnapshotReaderWriters
-				.getWriterForVersion(VERSION, kvState)
-				.writeStateMetaInfo(out);
+					.getOperatorStateWriterForVersion(VERSION, state)
+					.writeOperatorStateMetaInfo(out);
+		}
+
+		out.writeShort(broadcastStateMetaInfoSnapshots.size());
+		for (RegisteredBroadcastBackendStateMetaInfo.Snapshot<?, ?> state : broadcastStateMetaInfoSnapshots) {
+			OperatorBackendStateMetaInfoSnapshotReaderWriters
+					.getBroadcastStateWriterForVersion(VERSION, state)
+					.writeBroadcastStateMetaInfo(out);
 		}
 	}
 
@@ -76,17 +89,35 @@ public class OperatorBackendSerializationProxy extends VersionedIOReadableWritab
 	public void read(DataInputView in) throws IOException {
 		super.read(in);
 
-		int numKvStates = in.readShort();
-		stateMetaInfoSnapshots = new ArrayList<>(numKvStates);
-		for (int i = 0; i < numKvStates; i++) {
-			stateMetaInfoSnapshots.add(
-				OperatorBackendStateMetaInfoSnapshotReaderWriters
-					.getReaderForVersion(getReadVersion(), userCodeClassLoader)
-					.readStateMetaInfo(in));
+		int numOperatorStates = in.readShort();
+		operatorStateMetaInfoSnapshots = new ArrayList<>(numOperatorStates);
+		for (int i = 0; i < numOperatorStates; i++) {
+			operatorStateMetaInfoSnapshots.add(
+					OperatorBackendStateMetaInfoSnapshotReaderWriters
+							.getOperatorStateReaderForVersion(getReadVersion(), userCodeClassLoader)
+							.readOperatorStateMetaInfo(in));
+		}
+
+		if (getReadVersion() >= 3) {
+			// broadcast states did not exist prior to version 3
+			int numBroadcastStates = in.readShort();
+			broadcastStateMetaInfoSnapshots = new ArrayList<>(numBroadcastStates);
+			for (int i = 0; i < numBroadcastStates; i++) {
+				broadcastStateMetaInfoSnapshots.add(
+						OperatorBackendStateMetaInfoSnapshotReaderWriters
+								.getBroadcastStateReaderForVersion(getReadVersion(), userCodeClassLoader)
+								.readBroadcastStateMetaInfo(in));
+			}
+		} else {
+			broadcastStateMetaInfoSnapshots = new ArrayList<>();
 		}
 	}
 
-	public List<RegisteredOperatorBackendStateMetaInfo.Snapshot<?>> getStateMetaInfoSnapshots() {
-		return stateMetaInfoSnapshots;
+	public List<RegisteredOperatorBackendStateMetaInfo.Snapshot<?>> getOperatorStateMetaInfoSnapshots() {
+		return operatorStateMetaInfoSnapshots;
+	}
+
+	public List<RegisteredBroadcastBackendStateMetaInfo.Snapshot<?, ?>> getBroadcastStateMetaInfoSnapshots() {
+		return broadcastStateMetaInfoSnapshots;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/OperatorStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/OperatorStateHandle.java
@@ -36,8 +36,9 @@ public class OperatorStateHandle implements StreamStateHandle {
 	 * The modes that determine how an {@link OperatorStateHandle} is assigned to tasks during restore.
 	 */
 	public enum Mode {
-		SPLIT_DISTRIBUTE, // The operator state partitions in the state handle are split and distributed to one task each.
-		BROADCAST // The operator state partitions are broadcast to all task.
+		SPLIT_DISTRIBUTE,	// The operator state partitions in the state handle are split and distributed to one task each.
+		UNION,				// The operator state partitions are UNION-ed upon restoring and sent to all tasks.
+		BROADCAST			// The operator states are identical, as the state is produced from a broadcast stream.
 	}
 
 	private static final long serialVersionUID = 35876522969227335L;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredBroadcastBackendStateMetaInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredBroadcastBackendStateMetaInfo.java
@@ -1,0 +1,230 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
+import org.apache.flink.util.Preconditions;
+
+import java.util.Objects;
+
+public class RegisteredBroadcastBackendStateMetaInfo<K, V> {
+
+	/** The name of the state, as registered by the user. */
+	private final String name;
+
+	/** The mode how elements in this state are assigned to tasks during restore. */
+	private final OperatorStateHandle.Mode assignmentMode;
+
+	/** The type serializer for the keys in the map state. */
+	private final TypeSerializer<K> keySerializer;
+
+	/** The type serializer for the values in the map state. */
+	private final TypeSerializer<V> valueSerializer;
+
+	public RegisteredBroadcastBackendStateMetaInfo(
+			final String name,
+			final OperatorStateHandle.Mode assignmentMode,
+			final TypeSerializer<K> keySerializer,
+			final TypeSerializer<V> valueSerializer) {
+
+		Preconditions.checkArgument(assignmentMode != null && assignmentMode == OperatorStateHandle.Mode.BROADCAST);
+
+		this.name = Preconditions.checkNotNull(name);
+		this.assignmentMode = assignmentMode;
+		this.keySerializer = Preconditions.checkNotNull(keySerializer);
+		this.valueSerializer = Preconditions.checkNotNull(valueSerializer);
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public TypeSerializer<K> getKeySerializer() {
+		return keySerializer;
+	}
+
+	public TypeSerializer<V> getValueSerializer() {
+		return valueSerializer;
+	}
+
+	public OperatorStateHandle.Mode getAssignmentMode() {
+		return assignmentMode;
+	}
+
+	public RegisteredBroadcastBackendStateMetaInfo.Snapshot<K, V> snapshot() {
+		return new RegisteredBroadcastBackendStateMetaInfo.Snapshot<>(
+				name,
+				assignmentMode,
+				keySerializer.duplicate(),
+				valueSerializer.duplicate(),
+				keySerializer.snapshotConfiguration(),
+				valueSerializer.snapshotConfiguration());
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (obj == this) {
+			return true;
+		}
+
+		if (!(obj instanceof RegisteredBroadcastBackendStateMetaInfo)) {
+			return false;
+		}
+
+		final RegisteredBroadcastBackendStateMetaInfo other =
+				(RegisteredBroadcastBackendStateMetaInfo) obj;
+
+		return Objects.equals(name, other.getName())
+				&& Objects.equals(assignmentMode, other.getAssignmentMode())
+				&& Objects.equals(keySerializer, other.getKeySerializer())
+				&& Objects.equals(valueSerializer, other.getValueSerializer());
+	}
+
+	@Override
+	public int hashCode() {
+		int result = name.hashCode();
+		result = 31 * result + assignmentMode.hashCode();
+		result = 31 * result + keySerializer.hashCode();
+		result = 31 * result + valueSerializer.hashCode();
+		return result;
+	}
+
+	@Override
+	public String toString() {
+		return "RegisteredBroadcastBackendStateMetaInfo{" +
+				"name='" + name + '\'' +
+				", keySerializer=" + keySerializer +
+				", valueSerializer=" + valueSerializer +
+				", assignmentMode=" + assignmentMode +
+				'}';
+	}
+
+	/**
+	 * A consistent snapshot of a {@link RegisteredOperatorBackendStateMetaInfo}.
+	 */
+	public static class Snapshot<K, V> {
+
+		private String name;
+		private OperatorStateHandle.Mode assignmentMode;
+		private TypeSerializer<K> keySerializer;
+		private TypeSerializer<V> valueSerializer;
+		private TypeSerializerConfigSnapshot keySerializerConfigSnapshot;
+		private TypeSerializerConfigSnapshot valueSerializerConfigSnapshot;
+
+		/** Empty constructor used when restoring the state meta info snapshot. */
+		Snapshot() {}
+
+		private Snapshot(
+				final String name,
+				final OperatorStateHandle.Mode assignmentMode,
+				final TypeSerializer<K> keySerializer,
+				final TypeSerializer<V> valueSerializer,
+				final TypeSerializerConfigSnapshot keySerializerConfigSnapshot,
+				final TypeSerializerConfigSnapshot valueSerializerConfigSnapshot) {
+
+			this.name = Preconditions.checkNotNull(name);
+			this.assignmentMode = Preconditions.checkNotNull(assignmentMode);
+			this.keySerializer = Preconditions.checkNotNull(keySerializer);
+			this.valueSerializer = Preconditions.checkNotNull(valueSerializer);
+			this.keySerializerConfigSnapshot = Preconditions.checkNotNull(keySerializerConfigSnapshot);
+			this.valueSerializerConfigSnapshot = Preconditions.checkNotNull(valueSerializerConfigSnapshot);
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		void setName(String name) {
+			this.name = name;
+		}
+
+		public OperatorStateHandle.Mode getAssignmentMode() {
+			return assignmentMode;
+		}
+
+		void setAssignmentMode(OperatorStateHandle.Mode mode) {
+			this.assignmentMode = mode;
+		}
+
+		public TypeSerializer<K> getKeySerializer() {
+			return keySerializer;
+		}
+
+		void setKeySerializer(TypeSerializer<K> serializer) {
+			this.keySerializer = serializer;
+		}
+
+		public TypeSerializer<V> getValueSerializer() {
+			return valueSerializer;
+		}
+
+		void setValueSerializer(TypeSerializer<V> serializer) {
+			this.valueSerializer = serializer;
+		}
+
+		public TypeSerializerConfigSnapshot getKeySerializerConfigSnapshot() {
+			return keySerializerConfigSnapshot;
+		}
+
+		void setKeySerializerConfigSnapshot(TypeSerializerConfigSnapshot configSnapshot) {
+			this.keySerializerConfigSnapshot = configSnapshot;
+		}
+
+		public TypeSerializerConfigSnapshot getValueSerializerConfigSnapshot() {
+			return valueSerializerConfigSnapshot;
+		}
+
+		void setValueSerializerConfigSnapshot(TypeSerializerConfigSnapshot configSnapshot) {
+			this.valueSerializerConfigSnapshot = configSnapshot;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (obj == this) {
+				return true;
+			}
+
+			if (!(obj instanceof RegisteredBroadcastBackendStateMetaInfo.Snapshot)) {
+				return false;
+			}
+
+			RegisteredBroadcastBackendStateMetaInfo.Snapshot snapshot =
+					(RegisteredBroadcastBackendStateMetaInfo.Snapshot) obj;
+
+			return name.equals(snapshot.getName())
+					&& assignmentMode.ordinal() == snapshot.getAssignmentMode().ordinal()
+					&& Objects.equals(keySerializer, snapshot.getKeySerializer())
+					&& Objects.equals(valueSerializer, snapshot.getValueSerializer())
+					&& keySerializerConfigSnapshot.equals(snapshot.getKeySerializerConfigSnapshot())
+					&& valueSerializerConfigSnapshot.equals(snapshot.getValueSerializerConfigSnapshot());
+		}
+
+		@Override
+		public int hashCode() {
+			int result = name.hashCode();
+			result = 31 * result + assignmentMode.hashCode();
+			result = 31 * result + ((keySerializer != null) ? keySerializer.hashCode() : 0);
+			result = 31 * result + ((valueSerializer != null) ? valueSerializer.hashCode() : 0);
+			result = 31 * result + keySerializerConfigSnapshot.hashCode();
+			result = 31 * result + valueSerializerConfigSnapshot.hashCode();
+			return result;
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/savepoint/CheckpointTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/savepoint/CheckpointTestUtils.java
@@ -97,7 +97,7 @@ public class CheckpointTestUtils {
 				Map<String, StateMetaInfo> offsetsMap = new HashMap<>();
 				offsetsMap.put("A", new OperatorStateHandle.StateMetaInfo(new long[]{0, 10, 20}, OperatorStateHandle.Mode.SPLIT_DISTRIBUTE));
 				offsetsMap.put("B", new OperatorStateHandle.StateMetaInfo(new long[]{30, 40, 50}, OperatorStateHandle.Mode.SPLIT_DISTRIBUTE));
-				offsetsMap.put("C", new OperatorStateHandle.StateMetaInfo(new long[]{60, 70, 80}, OperatorStateHandle.Mode.BROADCAST));
+				offsetsMap.put("C", new OperatorStateHandle.StateMetaInfo(new long[]{60, 70, 80}, OperatorStateHandle.Mode.UNION));
 
 				if (hasOperatorStateBackend) {
 					operatorStateHandleBackend = new OperatorStateHandle(offsetsMap, operatorStateBackend);
@@ -179,7 +179,7 @@ public class CheckpointTestUtils {
 					Map<String, StateMetaInfo> offsetsMap = new HashMap<>();
 					offsetsMap.put("A", new OperatorStateHandle.StateMetaInfo(new long[]{0, 10, 20}, OperatorStateHandle.Mode.SPLIT_DISTRIBUTE));
 					offsetsMap.put("B", new OperatorStateHandle.StateMetaInfo(new long[]{30, 40, 50}, OperatorStateHandle.Mode.SPLIT_DISTRIBUTE));
-					offsetsMap.put("C", new OperatorStateHandle.StateMetaInfo(new long[]{60, 70, 80}, OperatorStateHandle.Mode.BROADCAST));
+					offsetsMap.put("C", new OperatorStateHandle.StateMetaInfo(new long[]{60, 70, 80}, OperatorStateHandle.Mode.UNION));
 
 					if (chainIdx != noOperatorStateBackendAtIndex) {
 						OperatorStateHandle operatorStateHandleBackend =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/OperatorStateBackendTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/OperatorStateBackendTest.java
@@ -18,8 +18,11 @@
 package org.apache.flink.runtime.state;
 
 import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.state.BroadcastState;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeutils.CompatibilityResult;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
@@ -49,7 +52,9 @@ import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -85,6 +90,7 @@ public class OperatorStateBackendTest {
 
 		assertNotNull(operatorStateBackend);
 		assertTrue(operatorStateBackend.getRegisteredStateNames().isEmpty());
+		assertTrue(operatorStateBackend.getRegisteredBroadcastStateNames().isEmpty());
 	}
 
 	@Test
@@ -233,6 +239,20 @@ public class OperatorStateBackendTest {
 
 		listState.add(42);
 
+		AtomicInteger keyCopyCounter = new AtomicInteger(0);
+		AtomicInteger valueCopyCounter = new AtomicInteger(0);
+
+		TypeSerializer<Integer> keySerializer = new VerifyingIntSerializer(env.getUserClassLoader(), keyCopyCounter);
+		TypeSerializer<Integer> valueSerializer = new VerifyingIntSerializer(env.getUserClassLoader(), valueCopyCounter);
+
+		MapStateDescriptor<Integer, Integer> broadcastStateDesc = new MapStateDescriptor<>(
+				"test-broadcast", keySerializer, valueSerializer);
+
+		BroadcastState<Integer, Integer> broadcastState = operatorStateBackend.getBroadcastState(broadcastStateDesc);
+		broadcastState.put(1, 2);
+		broadcastState.put(3, 4);
+		broadcastState.put(5, 6);
+
 		CheckpointStreamFactory streamFactory = new MemCheckpointStreamFactory(4096);
 		RunnableFuture<OperatorStateHandle> runnableFuture =
 			operatorStateBackend.snapshot(1, 1, streamFactory, CheckpointOptions.forCheckpointWithDefaultLocation());
@@ -240,6 +260,8 @@ public class OperatorStateBackendTest {
 
 		// make sure that the copy method has been called
 		assertTrue(copyCounter.get() > 0);
+		assertTrue(keyCopyCounter.get() > 0);
+		assertTrue(valueCopyCounter.get() > 0);
 	}
 
 	/**
@@ -361,16 +383,101 @@ public class OperatorStateBackendTest {
 	}
 
 	@Test
+	public void testSnapshotBroadcastStateWithEmptyOperatorState() throws Exception {
+		final AbstractStateBackend abstractStateBackend = new MemoryStateBackend(4096);
+
+		final OperatorStateBackend operatorStateBackend =
+				abstractStateBackend.createOperatorStateBackend(createMockEnvironment(), "testOperator");
+
+		final MapStateDescriptor<Integer, Integer> broadcastStateDesc = new MapStateDescriptor<>(
+				"test-broadcast", BasicTypeInfo.INT_TYPE_INFO, BasicTypeInfo.INT_TYPE_INFO);
+
+		final Map<Integer, Integer> expected = new HashMap<>(3);
+		expected.put(1, 2);
+		expected.put(3, 4);
+		expected.put(5, 6);
+
+		final BroadcastState<Integer, Integer> broadcastState = operatorStateBackend.getBroadcastState(broadcastStateDesc);
+		broadcastState.putAll(expected);
+
+		final CheckpointStreamFactory streamFactory = new MemCheckpointStreamFactory(4096);
+		OperatorStateHandle stateHandle = null;
+
+		try {
+			RunnableFuture<OperatorStateHandle> snapshot =
+					operatorStateBackend.snapshot(0L, 0L, streamFactory, CheckpointOptions.forCheckpointWithDefaultLocation());
+
+			stateHandle = FutureUtil.runIfNotDoneAndGet(snapshot);
+			assertNotNull(stateHandle);
+
+			final Map<Integer, Integer> retrieved = new HashMap<>();
+
+			operatorStateBackend.restore(Collections.singleton(stateHandle));
+			BroadcastState<Integer, Integer> retrievedState = operatorStateBackend.getBroadcastState(broadcastStateDesc);
+			for (Map.Entry<Integer, Integer> e: retrievedState.entries()) {
+				retrieved.put(e.getKey(), e.getValue());
+			}
+			assertEquals(expected, retrieved);
+
+			// remove an element from both expected and stored state.
+			broadcastState.remove(1);
+			expected.remove(1);
+
+			snapshot = operatorStateBackend.snapshot(1L, 1L, streamFactory, CheckpointOptions.forCheckpointWithDefaultLocation());
+			stateHandle = FutureUtil.runIfNotDoneAndGet(snapshot);
+
+			retrieved.clear();
+			operatorStateBackend.restore(Collections.singleton(stateHandle));
+			retrievedState = operatorStateBackend.getBroadcastState(broadcastStateDesc);
+			for (Map.Entry<Integer, Integer> e: retrievedState.immutableEntries()) {
+				retrieved.put(e.getKey(), e.getValue());
+			}
+			assertEquals(expected, retrieved);
+
+			// remove all elements from both expected and stored state.
+			broadcastState.clear();
+			expected.clear();
+
+			snapshot = operatorStateBackend.snapshot(2L, 2L, streamFactory, CheckpointOptions.forCheckpointWithDefaultLocation());
+			stateHandle = FutureUtil.runIfNotDoneAndGet(snapshot);
+
+			retrieved.clear();
+			operatorStateBackend.restore(Collections.singleton(stateHandle));
+			retrievedState = operatorStateBackend.getBroadcastState(broadcastStateDesc);
+			for (Map.Entry<Integer, Integer> e: retrievedState.immutableEntries()) {
+				retrieved.put(e.getKey(), e.getValue());
+			}
+			assertTrue(expected.isEmpty());
+			assertEquals(expected, retrieved);
+		} finally {
+			operatorStateBackend.close();
+			operatorStateBackend.dispose();
+			if (stateHandle != null) {
+				stateHandle.discardState();
+			}
+		}
+	}
+
+	@Test
 	public void testSnapshotRestoreSync() throws Exception {
-		AbstractStateBackend abstractStateBackend = new MemoryStateBackend(4096);
+		AbstractStateBackend abstractStateBackend = new MemoryStateBackend(2 * 4096);
 
 		OperatorStateBackend operatorStateBackend = abstractStateBackend.createOperatorStateBackend(createMockEnvironment(), "test-op-name");
 		ListStateDescriptor<Serializable> stateDescriptor1 = new ListStateDescriptor<>("test1", new JavaSerializer<>());
 		ListStateDescriptor<Serializable> stateDescriptor2 = new ListStateDescriptor<>("test2", new JavaSerializer<>());
 		ListStateDescriptor<Serializable> stateDescriptor3 = new ListStateDescriptor<>("test3", new JavaSerializer<>());
+
+		MapStateDescriptor<Serializable, Serializable> broadcastStateDescriptor1 = new MapStateDescriptor<>("test4", new JavaSerializer<>(), new JavaSerializer<>());
+		MapStateDescriptor<Serializable, Serializable> broadcastStateDescriptor2 = new MapStateDescriptor<>("test5", new JavaSerializer<>(), new JavaSerializer<>());
+		MapStateDescriptor<Serializable, Serializable> broadcastStateDescriptor3 = new MapStateDescriptor<>("test6", new JavaSerializer<>(), new JavaSerializer<>());
+
 		ListState<Serializable> listState1 = operatorStateBackend.getListState(stateDescriptor1);
 		ListState<Serializable> listState2 = operatorStateBackend.getListState(stateDescriptor2);
 		ListState<Serializable> listState3 = operatorStateBackend.getUnionListState(stateDescriptor3);
+
+		BroadcastState<Serializable, Serializable> broadcastState1 = operatorStateBackend.getBroadcastState(broadcastStateDescriptor1);
+		BroadcastState<Serializable, Serializable> broadcastState2 = operatorStateBackend.getBroadcastState(broadcastStateDescriptor2);
+		BroadcastState<Serializable, Serializable> broadcastState3 = operatorStateBackend.getBroadcastState(broadcastStateDescriptor3);
 
 		listState1.add(42);
 		listState1.add(4711);
@@ -384,7 +491,12 @@ public class OperatorStateBackendTest {
 		listState3.add(19);
 		listState3.add(20);
 
-		CheckpointStreamFactory streamFactory = new MemCheckpointStreamFactory(4096);
+		broadcastState1.put(1, 2);
+		broadcastState1.put(2, 5);
+
+		broadcastState2.put(2, 5);
+
+		CheckpointStreamFactory streamFactory = new MemCheckpointStreamFactory(2 * 4096);
 		RunnableFuture<OperatorStateHandle> runnableFuture =
 				operatorStateBackend.snapshot(1, 1, streamFactory, CheckpointOptions.forCheckpointWithDefaultLocation());
 		OperatorStateHandle stateHandle = FutureUtil.runIfNotDoneAndGet(runnableFuture);
@@ -401,12 +513,18 @@ public class OperatorStateBackendTest {
 			operatorStateBackend.restore(Collections.singletonList(stateHandle));
 
 			assertEquals(3, operatorStateBackend.getRegisteredStateNames().size());
+			assertEquals(3, operatorStateBackend.getRegisteredBroadcastStateNames().size());
 
 			listState1 = operatorStateBackend.getListState(stateDescriptor1);
 			listState2 = operatorStateBackend.getListState(stateDescriptor2);
 			listState3 = operatorStateBackend.getUnionListState(stateDescriptor3);
 
+			broadcastState1 = operatorStateBackend.getBroadcastState(broadcastStateDescriptor1);
+			broadcastState2 = operatorStateBackend.getBroadcastState(broadcastStateDescriptor2);
+			broadcastState3 = operatorStateBackend.getBroadcastState(broadcastStateDescriptor3);
+
 			assertEquals(3, operatorStateBackend.getRegisteredStateNames().size());
+			assertEquals(3, operatorStateBackend.getRegisteredBroadcastStateNames().size());
 
 			Iterator<Serializable> it = listState1.get().iterator();
 			assertEquals(42, it.next());
@@ -426,6 +544,27 @@ public class OperatorStateBackendTest {
 			assertEquals(20, it.next());
 			assertFalse(it.hasNext());
 
+			Iterator<Map.Entry<Serializable, Serializable>> bIt = broadcastState1.iterator();
+			assertTrue(bIt.hasNext());
+			Map.Entry<Serializable, Serializable> entry = bIt.next();
+			assertEquals(1, entry.getKey());
+			assertEquals(2, entry.getValue());
+			assertTrue(bIt.hasNext());
+			entry = bIt.next();
+			assertEquals(2, entry.getKey());
+			assertEquals(5, entry.getValue());
+			assertFalse(bIt.hasNext());
+
+			bIt = broadcastState2.iterator();
+			assertTrue(bIt.hasNext());
+			entry = bIt.next();
+			assertEquals(2, entry.getKey());
+			assertEquals(5, entry.getValue());
+			assertFalse(bIt.hasNext());
+
+			bIt = broadcastState3.iterator();
+			assertFalse(bIt.hasNext());
+
 			operatorStateBackend.close();
 			operatorStateBackend.dispose();
 		} finally {
@@ -444,9 +583,21 @@ public class OperatorStateBackendTest {
 				new ListStateDescriptor<>("test2", new JavaSerializer<MutableType>());
 		ListStateDescriptor<MutableType> stateDescriptor3 =
 				new ListStateDescriptor<>("test3", new JavaSerializer<MutableType>());
+
+		MapStateDescriptor<MutableType, MutableType> broadcastStateDescriptor1 =
+				new MapStateDescriptor<>("test4", new JavaSerializer<MutableType>(), new JavaSerializer<MutableType>());
+		MapStateDescriptor<MutableType, MutableType> broadcastStateDescriptor2 =
+				new MapStateDescriptor<>("test5", new JavaSerializer<MutableType>(), new JavaSerializer<MutableType>());
+		MapStateDescriptor<MutableType, MutableType> broadcastStateDescriptor3 =
+				new MapStateDescriptor<>("test6", new JavaSerializer<MutableType>(), new JavaSerializer<MutableType>());
+
 		ListState<MutableType> listState1 = operatorStateBackend.getListState(stateDescriptor1);
 		ListState<MutableType> listState2 = operatorStateBackend.getListState(stateDescriptor2);
 		ListState<MutableType> listState3 = operatorStateBackend.getUnionListState(stateDescriptor3);
+
+		BroadcastState<MutableType, MutableType> broadcastState1 = operatorStateBackend.getBroadcastState(broadcastStateDescriptor1);
+		BroadcastState<MutableType, MutableType> broadcastState2 = operatorStateBackend.getBroadcastState(broadcastStateDescriptor2);
+		BroadcastState<MutableType, MutableType> broadcastState3 = operatorStateBackend.getBroadcastState(broadcastStateDescriptor3);
 
 		listState1.add(MutableType.of(42));
 		listState1.add(MutableType.of(4711));
@@ -459,6 +610,11 @@ public class OperatorStateBackendTest {
 		listState3.add(MutableType.of(18));
 		listState3.add(MutableType.of(19));
 		listState3.add(MutableType.of(20));
+
+		broadcastState1.put(MutableType.of(1), MutableType.of(2));
+		broadcastState1.put(MutableType.of(2), MutableType.of(5));
+
+		broadcastState2.put(MutableType.of(2), MutableType.of(5));
 
 		BlockerCheckpointStreamFactory streamFactory = new BlockerCheckpointStreamFactory(1024 * 1024);
 
@@ -482,6 +638,8 @@ public class OperatorStateBackendTest {
 
 		listState1.add(MutableType.of(77));
 
+		broadcastState1.put(MutableType.of(32), MutableType.of(97));
+
 		int n = 0;
 
 		for (MutableType mutableType : listState2.get()) {
@@ -493,6 +651,7 @@ public class OperatorStateBackendTest {
 		}
 
 		listState3.clear();
+		broadcastState2.clear();
 
 		operatorStateBackend.getListState(
 				new ListStateDescriptor<>("test4", new JavaSerializer<MutableType>()));
@@ -514,12 +673,18 @@ public class OperatorStateBackendTest {
 			operatorStateBackend.restore(Collections.singletonList(stateHandle));
 
 			assertEquals(3, operatorStateBackend.getRegisteredStateNames().size());
+			assertEquals(3, operatorStateBackend.getRegisteredBroadcastStateNames().size());
 
 			listState1 = operatorStateBackend.getListState(stateDescriptor1);
 			listState2 = operatorStateBackend.getListState(stateDescriptor2);
 			listState3 = operatorStateBackend.getUnionListState(stateDescriptor3);
 
+			broadcastState1 = operatorStateBackend.getBroadcastState(broadcastStateDescriptor1);
+			broadcastState2 = operatorStateBackend.getBroadcastState(broadcastStateDescriptor2);
+			broadcastState3 = operatorStateBackend.getBroadcastState(broadcastStateDescriptor3);
+
 			assertEquals(3, operatorStateBackend.getRegisteredStateNames().size());
+			assertEquals(3, operatorStateBackend.getRegisteredBroadcastStateNames().size());
 
 			Iterator<MutableType> it = listState1.get().iterator();
 			assertEquals(42, it.next().value);
@@ -538,6 +703,27 @@ public class OperatorStateBackendTest {
 			assertEquals(19, it.next().value);
 			assertEquals(20, it.next().value);
 			assertFalse(it.hasNext());
+
+			Iterator<Map.Entry<MutableType, MutableType>> bIt = broadcastState1.iterator();
+			assertTrue(bIt.hasNext());
+			Map.Entry<MutableType, MutableType> entry = bIt.next();
+			assertEquals(1, entry.getKey().value);
+			assertEquals(2, entry.getValue().value);
+			assertTrue(bIt.hasNext());
+			entry = bIt.next();
+			assertEquals(2, entry.getKey().value);
+			assertEquals(5, entry.getValue().value);
+			assertFalse(bIt.hasNext());
+
+			bIt = broadcastState2.iterator();
+			assertTrue(bIt.hasNext());
+			entry = bIt.next();
+			assertEquals(2, entry.getKey().value);
+			assertEquals(5, entry.getValue().value);
+			assertFalse(bIt.hasNext());
+
+			bIt = broadcastState3.iterator();
+			assertFalse(bIt.hasNext());
 
 			operatorStateBackend.close();
 			operatorStateBackend.dispose();
@@ -558,9 +744,15 @@ public class OperatorStateBackendTest {
 
 		ListState<MutableType> listState1 = operatorStateBackend.getOperatorState(stateDescriptor1);
 
-
 		listState1.add(MutableType.of(42));
 		listState1.add(MutableType.of(4711));
+
+		MapStateDescriptor<MutableType, MutableType> broadcastStateDescriptor1 =
+				new MapStateDescriptor<>("test4", new JavaSerializer<MutableType>(), new JavaSerializer<MutableType>());
+
+		BroadcastState<MutableType, MutableType> broadcastState1 = operatorStateBackend.getBroadcastState(broadcastStateDescriptor1);
+		broadcastState1.put(MutableType.of(1), MutableType.of(2));
+		broadcastState1.put(MutableType.of(2), MutableType.of(5));
 
 		BlockerCheckpointStreamFactory streamFactory = new BlockerCheckpointStreamFactory(1024 * 1024);
 
@@ -601,7 +793,6 @@ public class OperatorStateBackendTest {
 				new ListStateDescriptor<>("test1", new JavaSerializer<MutableType>());
 
 		ListState<MutableType> listState1 = operatorStateBackend.getOperatorState(stateDescriptor1);
-
 
 		listState1.add(MutableType.of(42));
 		listState1.add(MutableType.of(4711));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/OperatorStateHandleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/OperatorStateHandleTest.java
@@ -28,10 +28,11 @@ public class OperatorStateHandleTest {
 
 		// Ensure the order / ordinal of all values of enum 'mode' are fixed, as this is used for serialization
 		Assert.assertEquals(0, OperatorStateHandle.Mode.SPLIT_DISTRIBUTE.ordinal());
-		Assert.assertEquals(1, OperatorStateHandle.Mode.BROADCAST.ordinal());
+		Assert.assertEquals(1, OperatorStateHandle.Mode.UNION.ordinal());
+		Assert.assertEquals(2, OperatorStateHandle.Mode.BROADCAST.ordinal());
 
 		// Ensure all enum values are registered and fixed forever by this test
-		Assert.assertEquals(2, OperatorStateHandle.Mode.values().length);
+		Assert.assertEquals(3, OperatorStateHandle.Mode.values().length);
 
 		// Byte is used to encode enum value on serialization
 		Assert.assertTrue(OperatorStateHandle.Mode.values().length <= Byte.MAX_VALUE);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/BroadcastConnectedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/BroadcastConnectedStream.java
@@ -1,0 +1,255 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.datastream;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.Utils;
+import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.co.BroadcastProcessFunction;
+import org.apache.flink.streaming.api.functions.co.KeyedBroadcastProcessFunction;
+import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+import org.apache.flink.streaming.api.operators.co.CoBroadcastWithKeyedOperator;
+import org.apache.flink.streaming.api.operators.co.CoBroadcastWithNonKeyedOperator;
+import org.apache.flink.streaming.api.transformations.TwoInputTransformation;
+import org.apache.flink.util.Preconditions;
+
+import java.util.Collections;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A BroadcastConnectedStream represents the result of connecting a keyed or non-keyed stream,
+ * with a {@link BroadcastStream} with {@link org.apache.flink.api.common.state.BroadcastState
+ * BroadcastState}. As in the case of {@link ConnectedStreams} these streams are useful for cases
+ * where operations on one stream directly affect the operations on the other stream, usually via
+ * shared state between the streams.
+ *
+ * <p>An example for the use of such connected streams would be to apply rules that change over time
+ * onto another, possibly keyed stream. The stream with the broadcast state has the rules, and will
+ * store them in the broadcast state, while the other stream will contain the elements to apply the
+ * rules to. By broadcasting the rules, these will be available in all parallel instances, and
+ * can be applied to all partitions of the other stream.
+ *
+ * @param <IN1> The input type of the non-broadcast side.
+ * @param <IN2> The input type of the broadcast side.
+ * @param <K> The key type of the elements in the {@link org.apache.flink.api.common.state.BroadcastState BroadcastState}.
+ * @param <V> The value type of the elements in the {@link org.apache.flink.api.common.state.BroadcastState BroadcastState}.
+ */
+@PublicEvolving
+public class BroadcastConnectedStream<IN1, IN2, K, V> {
+
+	private final StreamExecutionEnvironment environment;
+	private final DataStream<IN1> inputStream1;
+	private final BroadcastStream<IN2, K, V> inputStream2;
+	private final MapStateDescriptor<K, V> broadcastStateDescriptor;
+
+	protected BroadcastConnectedStream(
+			final StreamExecutionEnvironment env,
+			final DataStream<IN1> input1,
+			final BroadcastStream<IN2, K, V> input2,
+			final MapStateDescriptor<K, V> broadcastStateDescriptor) {
+		this.environment = requireNonNull(env);
+		this.inputStream1 = requireNonNull(input1);
+		this.inputStream2 = requireNonNull(input2);
+		this.broadcastStateDescriptor = requireNonNull(broadcastStateDescriptor);
+	}
+
+	public StreamExecutionEnvironment getExecutionEnvironment() {
+		return environment;
+	}
+
+	/**
+	 * Returns the non-broadcast {@link DataStream}.
+	 *
+	 * @return The stream which, by convention, is not broadcasted.
+	 */
+	public DataStream<IN1> getFirstInput() {
+		return inputStream1;
+	}
+
+	/**
+	 * Returns the {@link BroadcastStream}.
+	 *
+	 * @return The stream which, by convention, is the broadcast one.
+	 */
+	public BroadcastStream<IN2, K, V> getSecondInput() {
+		return inputStream2;
+	}
+
+	/**
+	 * Gets the type of the first input.
+	 *
+	 * @return The type of the first input
+	 */
+	public TypeInformation<IN1> getType1() {
+		return inputStream1.getType();
+	}
+
+	/**
+	 * Gets the type of the second input.
+	 *
+	 * @return The type of the second input
+	 */
+	public TypeInformation<IN2> getType2() {
+		return inputStream2.getType();
+	}
+
+	/**
+	 * Assumes as inputs a {@link BroadcastStream} and a {@link KeyedStream} and applies the given
+	 * {@link KeyedBroadcastProcessFunction} on them, thereby creating a transformed output stream.
+	 *
+	 * @param function The {@link KeyedBroadcastProcessFunction} that is called for each element in the stream.
+	 * @param <OUT> The type of the output elements.
+	 * @return The transformed {@link DataStream}.
+	 */
+	@PublicEvolving
+	public <OUT> SingleOutputStreamOperator<OUT> process(final KeyedBroadcastProcessFunction<IN1, IN2, OUT> function) {
+
+		TypeInformation<OUT> outTypeInfo = TypeExtractor.getBinaryOperatorReturnType(
+				function,
+				KeyedBroadcastProcessFunction.class,
+				0,
+				1,
+				2,
+				TypeExtractor.NO_INDEX,
+				TypeExtractor.NO_INDEX,
+				TypeExtractor.NO_INDEX,
+				getType1(),
+				getType2(),
+				Utils.getCallLocationName(),
+				true);
+
+		return process(function, outTypeInfo);
+	}
+
+	/**
+	 * Assumes as inputs a {@link BroadcastStream} and a {@link KeyedStream} and applies the given
+	 * {@link KeyedBroadcastProcessFunction} on them, thereby creating a transformed output stream.
+	 *
+	 * @param function The {@link KeyedBroadcastProcessFunction} that is called for each element in the stream.
+	 * @param outTypeInfo The type of the output elements.
+	 * @param <OUT> The type of the output elements.
+	 * @return The transformed {@link DataStream}.
+	 */
+	@PublicEvolving
+	public <OUT> SingleOutputStreamOperator<OUT> process(
+			final KeyedBroadcastProcessFunction<IN1, IN2, OUT> function,
+			final TypeInformation<OUT> outTypeInfo) {
+
+		Preconditions.checkNotNull(function);
+		Preconditions.checkArgument(inputStream1 instanceof KeyedStream,
+				"A KeyedBroadcastProcessFunction can only be used with a keyed stream as the second input.");
+
+		TwoInputStreamOperator<IN1, IN2, OUT> operator =
+				new CoBroadcastWithKeyedOperator<>(function, Collections.singletonList(broadcastStateDescriptor));
+		return transform("Co-Process-Broadcast-Keyed", outTypeInfo, operator);
+	}
+
+	/**
+	 * Assumes as inputs a {@link BroadcastStream} and a non-keyed {@link DataStream} and applies the given
+	 * {@link BroadcastProcessFunction} on them, thereby creating a transformed output stream.
+	 *
+	 * @param function The {@link BroadcastProcessFunction} that is called for each element in the stream.
+	 * @param <OUT> The type of the output elements.
+	 * @return The transformed {@link DataStream}.
+	 */
+	@PublicEvolving
+	public <OUT> SingleOutputStreamOperator<OUT> process(final BroadcastProcessFunction<IN1, IN2, OUT> function) {
+
+		TypeInformation<OUT> outTypeInfo = TypeExtractor.getBinaryOperatorReturnType(
+				function,
+				BroadcastProcessFunction.class,
+				0,
+				1,
+				2,
+				TypeExtractor.NO_INDEX,
+				TypeExtractor.NO_INDEX,
+				TypeExtractor.NO_INDEX,
+				getType1(),
+				getType2(),
+				Utils.getCallLocationName(),
+				true);
+
+		return process(function, outTypeInfo);
+	}
+
+	/**
+	 * Assumes as inputs a {@link BroadcastStream} and a non-keyed {@link DataStream} and applies the given
+	 * {@link BroadcastProcessFunction} on them, thereby creating a transformed output stream.
+	 *
+	 * @param function The {@link BroadcastProcessFunction} that is called for each element in the stream.
+	 * @param outTypeInfo The type of the output elements.
+	 * @param <OUT> The type of the output elements.
+	 * @return The transformed {@link DataStream}.
+	 */
+	@PublicEvolving
+	public <OUT> SingleOutputStreamOperator<OUT> process(
+			final BroadcastProcessFunction<IN1, IN2, OUT> function,
+			final TypeInformation<OUT> outTypeInfo) {
+
+		Preconditions.checkNotNull(function);
+		Preconditions.checkArgument(!(inputStream1 instanceof KeyedStream),
+				"A BroadcastProcessFunction can only be used with a non-keyed stream as the second input.");
+
+		TwoInputStreamOperator<IN1, IN2, OUT> operator =
+				new CoBroadcastWithNonKeyedOperator<>(function, Collections.singletonList(broadcastStateDescriptor));
+		return transform("Co-Process-Broadcast", outTypeInfo, operator);
+	}
+
+	@Internal
+	private <OUT> SingleOutputStreamOperator<OUT> transform(
+			final String functionName,
+			final TypeInformation<OUT> outTypeInfo,
+			final TwoInputStreamOperator<IN1, IN2, OUT> operator) {
+
+		// read the output type of the input Transforms to coax out errors about MissingTypeInfo
+		inputStream1.getType();
+		inputStream2.getType();
+
+		TwoInputTransformation<IN1, IN2, OUT> transform = new TwoInputTransformation<>(
+				inputStream1.getTransformation(),
+				inputStream2.getTransformation(),
+				functionName,
+				operator,
+				outTypeInfo,
+				environment.getParallelism());
+
+		if (inputStream1 instanceof KeyedStream) {
+			KeyedStream<IN1, ?> keyedInput1 = (KeyedStream<IN1, ?>) inputStream1;
+			TypeInformation<?> keyType1 = keyedInput1.getKeyType();
+			transform.setStateKeySelectors(keyedInput1.getKeySelector(), null);
+			transform.setStateKeyType(keyType1);
+		}
+
+		@SuppressWarnings({ "unchecked", "rawtypes" })
+		SingleOutputStreamOperator<OUT> returnStream = new SingleOutputStreamOperator(environment, transform);
+
+		getExecutionEnvironment().addOperator(transform);
+
+		return returnStream;
+	}
+
+	protected <F> F clean(F f) {
+		return getExecutionEnvironment().clean(f);
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/BroadcastConnectedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/BroadcastConnectedStream.java
@@ -119,18 +119,19 @@ public class BroadcastConnectedStream<IN1, IN2, K, V> {
 	 * {@link KeyedBroadcastProcessFunction} on them, thereby creating a transformed output stream.
 	 *
 	 * @param function The {@link KeyedBroadcastProcessFunction} that is called for each element in the stream.
+	 * @param <KS> The type of the keys in the keyed stream.
 	 * @param <OUT> The type of the output elements.
 	 * @return The transformed {@link DataStream}.
 	 */
 	@PublicEvolving
-	public <OUT> SingleOutputStreamOperator<OUT> process(final KeyedBroadcastProcessFunction<IN1, IN2, OUT> function) {
+	public <KS, OUT> SingleOutputStreamOperator<OUT> process(final KeyedBroadcastProcessFunction<KS, IN1, IN2, OUT> function) {
 
 		TypeInformation<OUT> outTypeInfo = TypeExtractor.getBinaryOperatorReturnType(
 				function,
 				KeyedBroadcastProcessFunction.class,
-				0,
 				1,
 				2,
+				3,
 				TypeExtractor.NO_INDEX,
 				TypeExtractor.NO_INDEX,
 				TypeExtractor.NO_INDEX,
@@ -148,12 +149,13 @@ public class BroadcastConnectedStream<IN1, IN2, K, V> {
 	 *
 	 * @param function The {@link KeyedBroadcastProcessFunction} that is called for each element in the stream.
 	 * @param outTypeInfo The type of the output elements.
+	 * @param <KS> The type of the keys in the keyed stream.
 	 * @param <OUT> The type of the output elements.
 	 * @return The transformed {@link DataStream}.
 	 */
 	@PublicEvolving
-	public <OUT> SingleOutputStreamOperator<OUT> process(
-			final KeyedBroadcastProcessFunction<IN1, IN2, OUT> function,
+	public <KS, OUT> SingleOutputStreamOperator<OUT> process(
+			final KeyedBroadcastProcessFunction<KS, IN1, IN2, OUT> function,
 			final TypeInformation<OUT> outTypeInfo) {
 
 		Preconditions.checkNotNull(function);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/BroadcastStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/BroadcastStream.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.datastream;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.transformations.StreamTransformation;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A {@code BroadcastStream} is a stream with {@link org.apache.flink.api.common.state.BroadcastState BroadcastState}.
+ * This can be created by any stream using the {@link DataStream#broadcast(MapStateDescriptor)} method and
+ * implicitly creates a state where the user can store elements of the created {@code BroadcastStream}.
+ * (see {@link BroadcastConnectedStream}).
+ *
+ * <p>Note that no further operation can be applied to these streams. The only available option is to connect them
+ * with a keyed or non-keyed stream, using the {@link KeyedStream#connect(BroadcastStream)} and the
+ * {@link DataStream#connect(BroadcastStream)} respectively. Applying these methods will result it a
+ * {@link BroadcastConnectedStream} for further processing.
+ *
+ * @param <T> The type of input/output elements.
+ * @param <K> The key type of the elements in the {@link org.apache.flink.api.common.state.BroadcastState BroadcastState}.
+ * @param <V> The value type of the elements in the {@link org.apache.flink.api.common.state.BroadcastState BroadcastState}.
+ */
+@PublicEvolving
+public class BroadcastStream<T, K, V> {
+
+	private final StreamExecutionEnvironment environment;
+
+	private final DataStream<T> inputStream;
+
+	/**
+	 * The {@link org.apache.flink.api.common.state.StateDescriptor state descriptor} of the
+	 * {@link org.apache.flink.api.common.state.BroadcastState broadcast state}. This state
+	 * has a {@code key-value} format.
+	 */
+	private final MapStateDescriptor<K, V> broadcastStateDescriptor;
+
+	protected BroadcastStream(
+			final StreamExecutionEnvironment env,
+			final DataStream<T> input,
+			final MapStateDescriptor<K, V> broadcastStateDescriptor) {
+
+		this.environment = requireNonNull(env);
+		this.inputStream = requireNonNull(input);
+		this.broadcastStateDescriptor = requireNonNull(broadcastStateDescriptor);
+	}
+
+	public TypeInformation<T> getType() {
+		return inputStream.getType();
+	}
+
+	public <F> F clean(F f) {
+		return environment.clean(f);
+	}
+
+	public StreamTransformation<T> getTransformation() {
+		return inputStream.getTransformation();
+	}
+
+	public MapStateDescriptor<K, V> getBroadcastStateDescriptor() {
+		return broadcastStateDescriptor;
+	}
+
+	public StreamExecutionEnvironment getEnvironment() {
+		return environment;
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/BroadcastStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/BroadcastStream.java
@@ -24,12 +24,15 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.transformations.StreamTransformation;
 
+import java.util.Arrays;
+import java.util.List;
+
 import static java.util.Objects.requireNonNull;
 
 /**
- * A {@code BroadcastStream} is a stream with {@link org.apache.flink.api.common.state.BroadcastState BroadcastState}.
- * This can be created by any stream using the {@link DataStream#broadcast(MapStateDescriptor)} method and
- * implicitly creates a state where the user can store elements of the created {@code BroadcastStream}.
+ * A {@code BroadcastStream} is a stream with {@link org.apache.flink.api.common.state.BroadcastState broadcast state(s)}.
+ * This can be created by any stream using the {@link DataStream#broadcast(MapStateDescriptor[])} method and
+ * implicitly creates states where the user can store elements of the created {@code BroadcastStream}.
  * (see {@link BroadcastConnectedStream}).
  *
  * <p>Note that no further operation can be applied to these streams. The only available option is to connect them
@@ -38,31 +41,29 @@ import static java.util.Objects.requireNonNull;
  * {@link BroadcastConnectedStream} for further processing.
  *
  * @param <T> The type of input/output elements.
- * @param <K> The key type of the elements in the {@link org.apache.flink.api.common.state.BroadcastState BroadcastState}.
- * @param <V> The value type of the elements in the {@link org.apache.flink.api.common.state.BroadcastState BroadcastState}.
  */
 @PublicEvolving
-public class BroadcastStream<T, K, V> {
+public class BroadcastStream<T> {
 
 	private final StreamExecutionEnvironment environment;
 
 	private final DataStream<T> inputStream;
 
 	/**
-	 * The {@link org.apache.flink.api.common.state.StateDescriptor state descriptor} of the
-	 * {@link org.apache.flink.api.common.state.BroadcastState broadcast state}. This state
-	 * has a {@code key-value} format.
+	 * The {@link org.apache.flink.api.common.state.StateDescriptor state descriptors} of the
+	 * registered {@link org.apache.flink.api.common.state.BroadcastState broadcast states}. These
+	 * states have {@code key-value} format.
 	 */
-	private final MapStateDescriptor<K, V> broadcastStateDescriptor;
+	private final List<MapStateDescriptor<?, ?>> broadcastStateDescriptors;
 
 	protected BroadcastStream(
 			final StreamExecutionEnvironment env,
 			final DataStream<T> input,
-			final MapStateDescriptor<K, V> broadcastStateDescriptor) {
+			final MapStateDescriptor<?, ?>... broadcastStateDescriptors) {
 
 		this.environment = requireNonNull(env);
 		this.inputStream = requireNonNull(input);
-		this.broadcastStateDescriptor = requireNonNull(broadcastStateDescriptor);
+		this.broadcastStateDescriptors = Arrays.asList(requireNonNull(broadcastStateDescriptors));
 	}
 
 	public TypeInformation<T> getType() {
@@ -77,8 +78,8 @@ public class BroadcastStream<T, K, V> {
 		return inputStream.getTransformation();
 	}
 
-	public MapStateDescriptor<K, V> getBroadcastStateDescriptor() {
-		return broadcastStateDescriptor;
+	public List<MapStateDescriptor<?, ?>> getBroadcastStateDescriptor() {
+		return broadcastStateDescriptors;
 	}
 
 	public StreamExecutionEnvironment getEnvironment() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
@@ -257,7 +257,7 @@ public class DataStream<T> {
 	 * Creates a new {@link BroadcastConnectedStream} by connecting the current
 	 * {@link DataStream} or {@link KeyedStream} with a {@link BroadcastStream}.
 	 *
-	 * <p>The latter can be created using the {@link #broadcast(MapStateDescriptor)} method.
+	 * <p>The latter can be created using the {@link #broadcast(MapStateDescriptor[])} method.
 	 *
 	 * <p>The resulting stream can be further processed using the {@code BroadcastConnectedStream.process(MyFunction)}
 	 * method, where {@code MyFunction} can be either a
@@ -269,7 +269,7 @@ public class DataStream<T> {
 	 * @return The {@link BroadcastConnectedStream}.
 	 */
 	@PublicEvolving
-	public <R, K, V> BroadcastConnectedStream<T, R, K, V> connect(BroadcastStream<R, K, V> broadcastStream) {
+	public <R> BroadcastConnectedStream<T, R> connect(BroadcastStream<R> broadcastStream) {
 		return new BroadcastConnectedStream<>(
 				environment,
 				this,
@@ -402,14 +402,15 @@ public class DataStream<T> {
 	 * it implicitly creates a {@link org.apache.flink.api.common.state.BroadcastState broadcast state}
 	 * which can be used to store the element of the stream.
 	 *
+	 * @param broadcastStateDescriptors the descriptors of the broadcast states to create.
 	 * @return A {@link BroadcastStream} which can be used in the {@link #connect(BroadcastStream)} to
 	 * create a {@link BroadcastConnectedStream} for further processing of the elements.
 	 */
 	@PublicEvolving
-	public <K, V> BroadcastStream<T, K, V> broadcast(final MapStateDescriptor<K, V> broadcastStateDescriptor) {
-		Preconditions.checkNotNull(broadcastStateDescriptor);
+	public BroadcastStream<T> broadcast(final MapStateDescriptor<?, ?>... broadcastStateDescriptors) {
+		Preconditions.checkNotNull(broadcastStateDescriptors);
 		final DataStream<T> broadcastStream = setConnectionType(new BroadcastPartitioner<>());
-		return new BroadcastStream<>(environment, broadcastStream, broadcastStateDescriptor);
+		return new BroadcastStream<>(environment, broadcastStream, broadcastStateDescriptors);
 	}
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/co/BaseBroadcastProcessFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/co/BaseBroadcastProcessFunction.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.functions.co;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.functions.AbstractRichFunction;
+import org.apache.flink.api.common.state.BroadcastState;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.state.ReadOnlyBroadcastState;
+import org.apache.flink.util.OutputTag;
+
+/**
+ * The base class containing the functionality available to all broadcast process function.
+ * These include the {@link BroadcastProcessFunction} and the {@link KeyedBroadcastProcessFunction}.
+ */
+@PublicEvolving
+public abstract class BaseBroadcastProcessFunction extends AbstractRichFunction {
+
+	private static final long serialVersionUID = -131631008887478610L;
+
+	/**
+	 * The base context available to all methods in a broadcast process function. This
+	 * include {@link BroadcastProcessFunction BroadcastProcessFunctions} and
+	 * {@link KeyedBroadcastProcessFunction KeyedBroadcastProcessFunctions}.
+	 */
+	abstract class BaseContext {
+
+		/**
+		 * Timestamp of the element currently being processed or timestamp of a firing timer.
+		 *
+		 * <p>This might be {@code null}, for example if the time characteristic of your program
+		 * is set to {@link org.apache.flink.streaming.api.TimeCharacteristic#ProcessingTime}.
+		 */
+		public abstract Long timestamp();
+
+		/**
+		 * Emits a record to the side output identified by the {@link OutputTag}.
+		 *
+		 * @param outputTag the {@code OutputTag} that identifies the side output to emit to.
+		 * @param value The record to emit.
+		 */
+		public abstract <X> void output(OutputTag<X> outputTag, X value);
+
+		/** Returns the current processing time. */
+		public abstract long currentProcessingTime();
+
+		/** Returns the current event-time watermark. */
+		public abstract long currentWatermark();
+	}
+
+	/**
+	 * A base {@link BaseContext context} available to the broadcasted stream side of
+	 * a {@link org.apache.flink.streaming.api.datastream.BroadcastConnectedStream BroadcastConnectedStream}.
+	 *
+	 * <p>Apart from the basic functionality of a {@link BaseContext context},
+	 * this also allows to get and update the elements stored in the
+	 * {@link BroadcastState broadcast state}.
+	 * In other words, it gives read/write access to the broadcast state.
+	 */
+	public abstract class Context extends BaseContext {
+
+		/**
+		 * Fetches the {@link BroadcastState} with the specified name.
+		 *
+		 * @param stateDescriptor the {@link MapStateDescriptor} of the state to be fetched.
+		 * @return The required {@link BroadcastState broadcast state}.
+		 */
+		public abstract <K, V> BroadcastState<K, V> getBroadcastState(MapStateDescriptor<K, V> stateDescriptor);
+	}
+
+	/**
+	 * A {@link BaseContext context} available to the non-broadcasted stream side of
+	 * a {@link org.apache.flink.streaming.api.datastream.BroadcastConnectedStream BroadcastConnectedStream}.
+	 *
+	 * <p>Apart from the basic functionality of a {@link BaseContext context},
+	 * this also allows to get a <b>read-only</b> {@link Iterable} over the elements stored in the
+	 * broadcast state.
+	 */
+	public abstract class ReadOnlyContext extends BaseContext {
+
+		/**
+		 * Fetches a read-only view of the broadcast state with the specified name.
+		 *
+		 * @param stateDescriptor the {@link MapStateDescriptor} of the state to be fetched.
+		 * @return The required read-only view of the broadcast state.
+		 */
+		public abstract <K, V> ReadOnlyBroadcastState<K, V> getBroadcastState(MapStateDescriptor<K, V> stateDescriptor);
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/co/BroadcastProcessFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/co/BroadcastProcessFunction.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.functions.co;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.util.Collector;
+
+/**
+ * A function to be applied to a
+ * {@link org.apache.flink.streaming.api.datastream.BroadcastConnectedStream BroadcastConnectedStream} that
+ * connects {@link org.apache.flink.streaming.api.datastream.BroadcastStream BroadcastStream}, i.e. a stream
+ * with broadcast state, with a <b>non-keyed</b> {@link org.apache.flink.streaming.api.datastream.DataStream DataStream}.
+ *
+ * <p>The stream with the broadcast state can be created using the
+ * {@link org.apache.flink.streaming.api.datastream.DataStream#broadcast(MapStateDescriptor)
+ * stream.broadcast(MapStateDescriptor)} method.
+ *
+ * <p>The user has to implement two methods:
+ * <ol>
+ *     <li>the {@link #processBroadcastElement(Object, Context, Collector)} which will be applied to
+ *     each element in the broadcast side
+ *     <li> and the {@link #processElement(Object, ReadOnlyContext, Collector)} which will be applied to the
+ *     non-broadcasted/keyed side.
+ * </ol>
+ *
+ * <p>The {@code processElementOnBroadcastSide()} takes as argument (among others) a context that allows it to
+ * read/write to the broadcast state, while the {@code processElement()} has read-only access to the broadcast state.
+ *
+ * @param <IN1> The input type of the non-broadcast side.
+ * @param <IN2> The input type of the broadcast side.
+ * @param <OUT> The output type of the operator.
+ */
+@PublicEvolving
+public abstract class BroadcastProcessFunction<IN1, IN2, OUT> extends BaseBroadcastProcessFunction {
+
+	private static final long serialVersionUID = 8352559162119034453L;
+
+	/**
+	 * This method is called for each element in the (non-broadcast)
+	 * {@link org.apache.flink.streaming.api.datastream.DataStream data stream}.
+	 *
+	 * <p>This function can output zero or more elements using the {@link Collector} parameter,
+	 * query the current processing/event time, and also query and update the local keyed state.
+	 * Finally, it has <b>read-only</b> access to the broadcast state.
+	 * The context is only valid during the invocation of this method, do not store it.
+	 *
+	 * @param value The stream element.
+	 * @param ctx A {@link ReadOnlyContext} that allows querying the timestamp of the element,
+	 *            querying the current processing/event time and updating the broadcast state.
+	 *            The context is only valid during the invocation of this method, do not store it.
+	 * @param out The collector to emit resulting elements to
+	 * @throws Exception The function may throw exceptions which cause the streaming program
+	 *                   to fail and go into recovery.
+	 */
+	public abstract void processElement(IN1 value, ReadOnlyContext ctx, Collector<OUT> out) throws Exception;
+
+	/**
+	 * This method is called for each element in the
+	 * {@link org.apache.flink.streaming.api.datastream.BroadcastStream broadcast stream}.
+	 *
+	 * <p>This function can output zero or more elements using the {@link Collector} parameter,
+	 * query the current processing/event time, and also query and update the internal
+	 * {@link org.apache.flink.api.common.state.BroadcastState broadcast state}. These can be done
+	 * through the provided {@link Context}.
+	 * The context is only valid during the invocation of this method, do not store it.
+	 *
+	 * @param value The stream element.
+	 * @param ctx A {@link Context} that allows querying the timestamp of the element,
+	 *            querying the current processing/event time and updating the broadcast state.
+	 *            The context is only valid during the invocation of this method, do not store it.
+	 * @param out The collector to emit resulting elements to
+	 * @throws Exception The function may throw exceptions which cause the streaming program
+	 *                   to fail and go into recovery.
+	 */
+	public abstract void processBroadcastElement(IN2 value, Context ctx, Collector<OUT> out) throws Exception;
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/co/BroadcastProcessFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/co/BroadcastProcessFunction.java
@@ -29,7 +29,7 @@ import org.apache.flink.util.Collector;
  * with broadcast state, with a <b>non-keyed</b> {@link org.apache.flink.streaming.api.datastream.DataStream DataStream}.
  *
  * <p>The stream with the broadcast state can be created using the
- * {@link org.apache.flink.streaming.api.datastream.DataStream#broadcast(MapStateDescriptor)
+ * {@link org.apache.flink.streaming.api.datastream.DataStream#broadcast(MapStateDescriptor[])}
  * stream.broadcast(MapStateDescriptor)} method.
  *
  * <p>The user has to implement two methods:

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/co/KeyedBroadcastProcessFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/co/KeyedBroadcastProcessFunction.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.functions.co;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.streaming.api.TimeDomain;
+import org.apache.flink.streaming.api.TimerService;
+import org.apache.flink.util.Collector;
+
+/**
+ * A function to be applied to a
+ * {@link org.apache.flink.streaming.api.datastream.BroadcastConnectedStream BroadcastConnectedStream} that
+ * connects {@link org.apache.flink.streaming.api.datastream.BroadcastStream BroadcastStream}, i.e. a stream
+ * with broadcast state, with a {@link org.apache.flink.streaming.api.datastream.KeyedStream KeyedStream}.
+ *
+ * <p>The stream with the broadcast state can be created using the
+ * {@link org.apache.flink.streaming.api.datastream.KeyedStream#broadcast(MapStateDescriptor)
+ * keyedStream.broadcast(MapStateDescriptor)} method.
+ *
+ * <p>The user has to implement two methods:
+ * <ol>
+ *     <li>the {@link #processBroadcastElement(Object, Context, Collector)} which will be applied to
+ *     each element in the broadcast side
+ *     <li> and the {@link #processElement(Object, KeyedReadOnlyContext, Collector)} which will be applied to the
+ *     non-broadcasted/keyed side.
+ * </ol>
+ *
+ * <p>The {@code processElementOnBroadcastSide()} takes as an argument (among others) a context that allows it to
+ * read/write to the broadcast state and also apply a transformation to all (local) keyed states, while the
+ * {@code processElement()} has read-only access to the broadcast state, but can read/write to the keyed state and
+ * register timers.
+ *
+ * @param <IN1> The input type of the keyed (non-broadcast) side.
+ * @param <IN2> The input type of the broadcast side.
+ * @param <OUT> The output type of the operator.
+ */
+@PublicEvolving
+public abstract class KeyedBroadcastProcessFunction<IN1, IN2, OUT> extends BaseBroadcastProcessFunction {
+
+	private static final long serialVersionUID = -2584726797564976453L;
+
+	/**
+	 * This method is called for each element in the (non-broadcast)
+	 * {@link org.apache.flink.streaming.api.datastream.KeyedStream keyed stream}.
+	 *
+	 * <p>It can output zero or more elements using the {@link Collector} parameter,
+	 * query the current processing/event time, and also query and update the local keyed state.
+	 * In addition, it can get a {@link TimerService} for registering timers and querying the time.
+	 * Finally, it has <b>read-only</b> access to the broadcast state.
+	 * The context is only valid during the invocation of this method, do not store it.
+	 *
+	 * @param value The stream element.
+	 * @param ctx A {@link KeyedReadOnlyContext} that allows querying the timestamp of the element,
+	 *            querying the current processing/event time and iterating the broadcast state
+	 *            with <b>read-only</b> access.
+	 *            The context is only valid during the invocation of this method, do not store it.
+	 * @param out The collector to emit resulting elements to
+	 * @throws Exception The function may throw exceptions which cause the streaming program
+	 *                   to fail and go into recovery.
+	 */
+	public abstract void processElement(final IN1 value, final KeyedReadOnlyContext ctx, final Collector<OUT> out) throws Exception;
+
+	/**
+	 * This method is called for each element in the
+	 * {@link org.apache.flink.streaming.api.datastream.BroadcastStream broadcast stream}.
+	 *
+	 * <p>It can output zero or more elements using the {@link Collector} parameter,
+	 * query the current processing/event time, and also query and update the internal
+	 * {@link org.apache.flink.api.common.state.BroadcastState broadcast state}. These can
+	 * be done through the provided {@link Context}.
+	 * The context is only valid during the invocation of this method, do not store it.
+	 *
+	 * @param value The stream element.
+	 * @param ctx A {@link Context} that allows querying the timestamp of the element,
+	 *            querying the current processing/event time and updating the broadcast state.
+	 *            The context is only valid during the invocation of this method, do not store it.
+	 * @param out The collector to emit resulting elements to
+	 * @throws Exception The function may throw exceptions which cause the streaming program
+	 *                   to fail and go into recovery.
+	 */
+	public abstract void processBroadcastElement(final IN2 value, final Context ctx, final Collector<OUT> out) throws Exception;
+
+	/**
+	 * Called when a timer set using {@link TimerService} fires.
+	 *
+	 * @param timestamp The timestamp of the firing timer.
+	 * @param ctx An {@link OnTimerContext} that allows querying the timestamp of the firing timer,
+	 *            querying the current processing/event time, iterating the broadcast state
+	 *            with <b>read-only</b> access, querying the {@link TimeDomain} of the firing timer
+	 *            and getting a {@link TimerService} for registering timers and querying the time.
+	 *            The context is only valid during the invocation of this method, do not store it.
+	 * @param out The collector for returning result values.
+	 *
+	 * @throws Exception This method may throw exceptions. Throwing an exception will cause the operation
+	 *                   to fail and may trigger recovery.
+	 */
+	public void onTimer(final long timestamp, final OnTimerContext ctx, final Collector<OUT> out) throws Exception {
+		// the default implementation does nothing.
+	}
+
+	/**
+	 * A {@link BaseBroadcastProcessFunction.Context context} available to the keyed stream side of
+	 * a {@link org.apache.flink.streaming.api.datastream.BroadcastConnectedStream} (if any).
+	 *
+	 * <p>Apart from the basic functionality of a {@link BaseBroadcastProcessFunction.Context context},
+	 * this also allows to get a <b>read-only</b> {@link Iterable} over the elements stored in the
+	 * broadcast state and a {@link TimerService} for querying time and registering timers.
+	 */
+	public abstract class KeyedReadOnlyContext extends ReadOnlyContext {
+
+		/**
+		 * A {@link TimerService} for querying time and registering timers.
+		 */
+		public abstract TimerService timerService();
+	}
+
+	/**
+	 * Information available in an invocation of {@link #onTimer(long, OnTimerContext, Collector)}.
+	 */
+	public abstract class OnTimerContext extends KeyedReadOnlyContext {
+
+		/**
+		 * The {@link TimeDomain} of the firing timer, i.e. if it is
+		 * event or processing time timer.
+		 */
+		public abstract TimeDomain timeDomain();
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/co/KeyedBroadcastProcessFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/co/KeyedBroadcastProcessFunction.java
@@ -34,7 +34,7 @@ import org.apache.flink.util.Collector;
  * with broadcast state, with a {@link org.apache.flink.streaming.api.datastream.KeyedStream KeyedStream}.
  *
  * <p>The stream with the broadcast state can be created using the
- * {@link org.apache.flink.streaming.api.datastream.KeyedStream#broadcast(MapStateDescriptor)
+ * {@link org.apache.flink.streaming.api.datastream.KeyedStream#broadcast(MapStateDescriptor[])}
  * keyedStream.broadcast(MapStateDescriptor)} method.
  *
  * <p>The user has to implement two methods:

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -586,7 +586,7 @@ public class StreamGraphGenerator {
 				transform.getOutputType(),
 				transform.getName());
 
-		if (transform.getStateKeySelector1() != null) {
+		if (transform.getStateKeySelector1() != null || transform.getStateKeySelector2() != null) {
 			TypeSerializer<?> keySerializer = transform.getStateKeyType().createSerializer(env.getConfig());
 			streamGraph.setTwoInputStateKey(transform.getId(), transform.getStateKeySelector1(), transform.getStateKeySelector2(), keySerializer);
 		}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/co/CoBroadcastWithKeyedOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/co/CoBroadcastWithKeyedOperator.java
@@ -1,0 +1,324 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.co;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.state.BroadcastState;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.state.ReadOnlyBroadcastState;
+import org.apache.flink.runtime.state.VoidNamespace;
+import org.apache.flink.runtime.state.VoidNamespaceSerializer;
+import org.apache.flink.streaming.api.SimpleTimerService;
+import org.apache.flink.streaming.api.TimeDomain;
+import org.apache.flink.streaming.api.TimerService;
+import org.apache.flink.streaming.api.functions.co.BaseBroadcastProcessFunction;
+import org.apache.flink.streaming.api.functions.co.KeyedBroadcastProcessFunction;
+import org.apache.flink.streaming.api.operators.AbstractUdfStreamOperator;
+import org.apache.flink.streaming.api.operators.InternalTimer;
+import org.apache.flink.streaming.api.operators.InternalTimerService;
+import org.apache.flink.streaming.api.operators.TimestampedCollector;
+import org.apache.flink.streaming.api.operators.Triggerable;
+import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.util.OutputTag;
+import org.apache.flink.util.Preconditions;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * A {@link TwoInputStreamOperator} for executing {@link KeyedBroadcastProcessFunction KeyedBroadcastProcessFunctions}.
+ *
+ * @param <KS> The key type of the input keyed stream.
+ * @param <IN1> The input type of the keyed (non-broadcast) side.
+ * @param <IN2> The input type of the broadcast side.
+ * @param <OUT> The output type of the operator.
+ */
+@Internal
+public class CoBroadcastWithKeyedOperator<KS, IN1, IN2, OUT>
+		extends AbstractUdfStreamOperator<OUT, KeyedBroadcastProcessFunction<IN1, IN2, OUT>>
+		implements TwoInputStreamOperator<IN1, IN2, OUT>, Triggerable<KS, VoidNamespace> {
+
+	private static final long serialVersionUID = 5926499536290284870L;
+
+	private final List<MapStateDescriptor<?, ?>> broadcastStateDescriptors;
+
+	private transient TimestampedCollector<OUT> collector;
+
+	private transient Map<MapStateDescriptor<?, ?>, BroadcastState<?, ?>> broadcastStates;
+
+	private transient ReadWriteContextImpl rwContext;
+
+	private transient ReadOnlyContextImpl rContext;
+
+	private transient OnTimerContextImpl onTimerContext;
+
+	public CoBroadcastWithKeyedOperator(
+			final KeyedBroadcastProcessFunction<IN1, IN2, OUT> function,
+			final List<MapStateDescriptor<?, ?>> broadcastStateDescriptors) {
+		super(function);
+		this.broadcastStateDescriptors = Preconditions.checkNotNull(broadcastStateDescriptors);
+	}
+
+	@Override
+	public void open() throws Exception {
+		super.open();
+
+		InternalTimerService<VoidNamespace> internalTimerService =
+				getInternalTimerService("user-timers", VoidNamespaceSerializer.INSTANCE, this);
+
+		TimerService timerService = new SimpleTimerService(internalTimerService);
+
+		collector = new TimestampedCollector<>(output);
+
+		this.broadcastStates = new HashMap<>(broadcastStateDescriptors.size());
+		for (MapStateDescriptor<?, ?> descriptor: broadcastStateDescriptors) {
+			broadcastStates.put(descriptor, getOperatorStateBackend().getBroadcastState(descriptor));
+		}
+
+		rwContext = new ReadWriteContextImpl(userFunction, broadcastStates, timerService);
+		rContext = new ReadOnlyContextImpl(userFunction, broadcastStates, timerService);
+		onTimerContext = new OnTimerContextImpl(userFunction, broadcastStates, timerService);
+	}
+
+	@Override
+	public void processElement1(StreamRecord<IN1> element) throws Exception {
+		collector.setTimestamp(element);
+		rContext.setElement(element);
+		userFunction.processElement(element.getValue(), rContext, collector);
+		rContext.setElement(null);
+	}
+
+	@Override
+	public void processElement2(StreamRecord<IN2> element) throws Exception {
+		collector.setTimestamp(element);
+		rwContext.setElement(element);
+		userFunction.processBroadcastElement(element.getValue(), rwContext, collector);
+		rwContext.setElement(null);
+	}
+
+	@Override
+	public void onEventTime(InternalTimer<KS, VoidNamespace> timer) throws Exception {
+		collector.setAbsoluteTimestamp(timer.getTimestamp());
+		onTimerContext.timeDomain = TimeDomain.EVENT_TIME;
+		onTimerContext.timer = timer;
+		userFunction.onTimer(timer.getTimestamp(), onTimerContext, collector);
+		onTimerContext.timeDomain = null;
+		onTimerContext.timer = null;
+	}
+
+	@Override
+	public void onProcessingTime(InternalTimer<KS, VoidNamespace> timer) throws Exception {
+		collector.eraseTimestamp();
+		onTimerContext.timeDomain = TimeDomain.PROCESSING_TIME;
+		onTimerContext.timer = timer;
+		userFunction.onTimer(timer.getTimestamp(), onTimerContext, collector);
+		onTimerContext.timeDomain = null;
+		onTimerContext.timer = null;
+	}
+
+	private class ReadWriteContextImpl extends BaseBroadcastProcessFunction.Context {
+
+		private final Map<MapStateDescriptor<?, ?>, BroadcastState<?, ?>> states;
+
+		private final TimerService timerService;
+
+		private StreamRecord<IN2> element;
+
+		ReadWriteContextImpl (
+				final KeyedBroadcastProcessFunction<IN1, IN2, OUT> function,
+				final Map<MapStateDescriptor<?, ?>, BroadcastState<?, ?>> broadcastStates,
+				final TimerService timerService) {
+
+			function.super();
+			this.states = Preconditions.checkNotNull(broadcastStates);
+			this.timerService = Preconditions.checkNotNull(timerService);
+		}
+
+		void setElement(StreamRecord<IN2> e) {
+			this.element = e;
+		}
+
+		@Override
+		public Long timestamp() {
+			checkState(element != null);
+			return element.getTimestamp();
+		}
+
+		@Override
+		public <K, V> BroadcastState<K, V> getBroadcastState(MapStateDescriptor<K, V> stateDescriptor) {
+			Preconditions.checkNotNull(stateDescriptor);
+			BroadcastState<K, V> state = (BroadcastState<K, V>) states.get(stateDescriptor);
+			if (state == null) {
+				throw new IllegalArgumentException("The requested state does not exist. " +
+						"Check for typos in your state descriptor, or specify the state descriptor " +
+						"in the datastream.broadcast(...) call if you forgot to register it.");
+			}
+			return state;
+		}
+
+		@Override
+		public <X> void output(OutputTag<X> outputTag, X value) {
+			checkArgument(outputTag != null, "OutputTag must not be null.");
+			output.collect(outputTag, new StreamRecord<>(value, element.getTimestamp()));
+		}
+
+		@Override
+		public long currentProcessingTime() {
+			return timerService.currentProcessingTime();
+		}
+
+		@Override
+		public long currentWatermark() {
+			return timerService.currentWatermark();
+		}
+	}
+
+	private class ReadOnlyContextImpl extends KeyedBroadcastProcessFunction<IN1, IN2, OUT>.KeyedReadOnlyContext {
+
+		private final Map<MapStateDescriptor<?, ?>, BroadcastState<?, ?>> states;
+
+		private final TimerService timerService;
+
+		private StreamRecord<IN1> element;
+
+		ReadOnlyContextImpl(
+				final KeyedBroadcastProcessFunction<IN1, IN2, OUT> function,
+				final Map<MapStateDescriptor<?, ?>, BroadcastState<?, ?>> broadcastStates,
+				final TimerService timerService) {
+
+			function.super();
+			this.states = Preconditions.checkNotNull(broadcastStates);
+			this.timerService = Preconditions.checkNotNull(timerService);
+		}
+
+		void setElement(StreamRecord<IN1> e) {
+			this.element = e;
+		}
+
+		@Override
+		public Long timestamp() {
+			checkState(element != null);
+			return element.hasTimestamp() ? element.getTimestamp() : null;
+		}
+
+		@Override
+		public TimerService timerService() {
+			return timerService;
+		}
+
+		@Override
+		public long currentProcessingTime() {
+			return timerService.currentProcessingTime();
+		}
+
+		@Override
+		public long currentWatermark() {
+			return timerService.currentWatermark();
+		}
+
+		@Override
+		public <X> void output(OutputTag<X> outputTag, X value) {
+			checkArgument(outputTag != null, "OutputTag must not be null.");
+			output.collect(outputTag, new StreamRecord<>(value, element.getTimestamp()));
+		}
+
+		@Override
+		public  <K, V> ReadOnlyBroadcastState<K, V> getBroadcastState(MapStateDescriptor<K, V> stateDescriptor) {
+			Preconditions.checkNotNull(stateDescriptor);
+			ReadOnlyBroadcastState<K, V> state = (ReadOnlyBroadcastState<K, V>) states.get(stateDescriptor);
+			if (state == null) {
+				throw new IllegalArgumentException("The requested state does not exist. " +
+						"Check for typos in your state descriptor, or specify the state descriptor " +
+						"in the datastream.broadcast(...) call if you forgot to register it.");
+			}
+			return state;
+		}
+	}
+
+	private class OnTimerContextImpl extends KeyedBroadcastProcessFunction<IN1, IN2, OUT>.OnTimerContext {
+
+		private final Map<MapStateDescriptor<?, ?>, BroadcastState<?, ?>> states;
+
+		private final TimerService timerService;
+
+		private TimeDomain timeDomain;
+
+		private InternalTimer<KS, VoidNamespace> timer;
+
+		OnTimerContextImpl(
+				final KeyedBroadcastProcessFunction<IN1, IN2, OUT> function,
+				final Map<MapStateDescriptor<?, ?>, BroadcastState<?, ?>> broadcastStates,
+				final TimerService timerService) {
+
+			function.super();
+			this.states = Preconditions.checkNotNull(broadcastStates);
+			this.timerService = Preconditions.checkNotNull(timerService);
+		}
+
+		@Override
+		public Long timestamp() {
+			checkState(timer != null);
+			return timer.getTimestamp();
+		}
+
+		@Override
+		public TimeDomain timeDomain() {
+			checkState(timeDomain != null);
+			return timeDomain;
+		}
+
+		@Override
+		public TimerService timerService() {
+			return timerService;
+		}
+
+		@Override
+		public long currentProcessingTime() {
+			return timerService.currentProcessingTime();
+		}
+
+		@Override
+		public long currentWatermark() {
+			return timerService.currentWatermark();
+		}
+
+		@Override
+		public <X> void output(OutputTag<X> outputTag, X value) {
+			checkArgument(outputTag != null, "OutputTag must not be null.");
+			output.collect(outputTag, new StreamRecord<>(value, timer.getTimestamp()));
+		}
+
+		@Override
+		public <K, V> ReadOnlyBroadcastState<K, V> getBroadcastState(MapStateDescriptor<K, V> stateDescriptor) {
+			Preconditions.checkNotNull(stateDescriptor);
+			ReadOnlyBroadcastState<K, V> state = (ReadOnlyBroadcastState<K, V>) states.get(stateDescriptor);
+			if (state == null) {
+				throw new IllegalArgumentException("The requested state does not exist. " +
+						"Check for typos in your state descriptor, or specify the state descriptor " +
+						"in the datastream.broadcast(...) call if you forgot to register it.");
+			}
+			return state;
+		}
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/co/CoBroadcastWithNonKeyedOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/co/CoBroadcastWithNonKeyedOperator.java
@@ -1,0 +1,228 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.co;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.state.BroadcastState;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.state.ReadOnlyBroadcastState;
+import org.apache.flink.streaming.api.functions.co.BaseBroadcastProcessFunction;
+import org.apache.flink.streaming.api.functions.co.BroadcastProcessFunction;
+import org.apache.flink.streaming.api.operators.AbstractUdfStreamOperator;
+import org.apache.flink.streaming.api.operators.InternalTimerService;
+import org.apache.flink.streaming.api.operators.TimestampedCollector;
+import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
+import org.apache.flink.util.OutputTag;
+import org.apache.flink.util.Preconditions;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * A {@link TwoInputStreamOperator} for executing {@link BroadcastProcessFunction BroadcastProcessFunctions}.
+ *
+ * @param <IN1> The input type of the keyed (non-broadcast) side.
+ * @param <IN2> The input type of the broadcast side.
+ * @param <OUT> The output type of the operator.
+ */
+@Internal
+public class CoBroadcastWithNonKeyedOperator<IN1, IN2, OUT>
+		extends AbstractUdfStreamOperator<OUT, BroadcastProcessFunction<IN1, IN2, OUT>>
+		implements TwoInputStreamOperator<IN1, IN2, OUT> {
+
+	private static final long serialVersionUID = -1869740381935471752L;
+
+	/** We listen to this ourselves because we don't have an {@link InternalTimerService}. */
+	private long currentWatermark = Long.MIN_VALUE;
+
+	private final List<MapStateDescriptor<?, ?>> broadcastStateDescriptors;
+
+	private transient TimestampedCollector<OUT> collector;
+
+	private transient Map<MapStateDescriptor<?, ?>, BroadcastState<?, ?>> broadcastStates;
+
+	private transient ReadWriteContextImpl rwContext;
+
+	private transient ReadOnlyContextImpl rContext;
+
+	public CoBroadcastWithNonKeyedOperator(
+			final BroadcastProcessFunction<IN1, IN2, OUT> function,
+			final List<MapStateDescriptor<?, ?>> broadcastStateDescriptors) {
+		super(function);
+		this.broadcastStateDescriptors = Preconditions.checkNotNull(broadcastStateDescriptors);
+	}
+
+	@Override
+	public void open() throws Exception {
+		super.open();
+
+		collector = new TimestampedCollector<>(output);
+
+		this.broadcastStates = new HashMap<>(broadcastStateDescriptors.size());
+		for (MapStateDescriptor<?, ?> descriptor: broadcastStateDescriptors) {
+			broadcastStates.put(descriptor, getOperatorStateBackend().getBroadcastState(descriptor));
+		}
+
+		rwContext = new ReadWriteContextImpl(userFunction, broadcastStates, getProcessingTimeService());
+		rContext = new ReadOnlyContextImpl(userFunction, broadcastStates, getProcessingTimeService());
+	}
+
+	@Override
+	public void processElement1(StreamRecord<IN1> element) throws Exception {
+		collector.setTimestamp(element);
+		rContext.setElement(element);
+		userFunction.processElement(element.getValue(), rContext, collector);
+		rContext.setElement(null);
+	}
+
+	@Override
+	public void processElement2(StreamRecord<IN2> element) throws Exception {
+		collector.setTimestamp(element);
+		rwContext.setElement(element);
+		userFunction.processBroadcastElement(element.getValue(), rwContext, collector);
+		rwContext.setElement(null);
+	}
+
+	@Override
+	public void processWatermark(Watermark mark) throws Exception {
+		super.processWatermark(mark);
+		currentWatermark = mark.getTimestamp();
+	}
+
+	private class ReadWriteContextImpl extends BaseBroadcastProcessFunction.Context {
+
+		private final Map<MapStateDescriptor<?, ?>, BroadcastState<?, ?>> states;
+
+		private final ProcessingTimeService timerService;
+
+		private StreamRecord<IN2> element;
+
+		ReadWriteContextImpl(
+				final BroadcastProcessFunction<IN1, IN2, OUT> function,
+				final Map<MapStateDescriptor<?, ?>, BroadcastState<?, ?>> broadcastStates,
+				final ProcessingTimeService timerService) {
+
+			function.super();
+			this.states = Preconditions.checkNotNull(broadcastStates);
+			this.timerService = Preconditions.checkNotNull(timerService);
+		}
+
+		void setElement(StreamRecord<IN2> e) {
+			this.element = e;
+		}
+
+		@Override
+		public Long timestamp() {
+			checkState(element != null);
+			return element.getTimestamp();
+		}
+
+		@Override
+		public <K, V> BroadcastState<K, V> getBroadcastState(MapStateDescriptor<K, V> stateDescriptor) {
+			Preconditions.checkNotNull(stateDescriptor);
+			BroadcastState<K, V> state = (BroadcastState<K, V>) states.get(stateDescriptor);
+			if (state == null) {
+				throw new IllegalArgumentException("The requested state does not exist. " +
+						"Check for typos in your state descriptor, or specify the state descriptor " +
+						"in the datastream.broadcast(...) call if you forgot to register it.");
+			}
+			return state;
+		}
+
+		@Override
+		public <X> void output(OutputTag<X> outputTag, X value) {
+			checkArgument(outputTag != null, "OutputTag must not be null.");
+			output.collect(outputTag, new StreamRecord<>(value, element.getTimestamp()));
+		}
+
+		@Override
+		public long currentProcessingTime() {
+			return timerService.getCurrentProcessingTime();
+		}
+
+		@Override
+		public long currentWatermark() {
+			return currentWatermark;
+		}
+	}
+
+	private class ReadOnlyContextImpl extends BroadcastProcessFunction<IN1, IN2, OUT>.ReadOnlyContext {
+
+		private final Map<MapStateDescriptor<?, ?>, BroadcastState<?, ?>> states;
+
+		private final ProcessingTimeService timerService;
+
+		private StreamRecord<IN1> element;
+
+		ReadOnlyContextImpl(
+				final BroadcastProcessFunction<IN1, IN2, OUT> function,
+				final Map<MapStateDescriptor<?, ?>, BroadcastState<?, ?>> broadcastStates,
+				final ProcessingTimeService timerService) {
+
+			function.super();
+			this.states = Preconditions.checkNotNull(broadcastStates);
+			this.timerService = Preconditions.checkNotNull(timerService);
+		}
+
+		void setElement(StreamRecord<IN1> e) {
+			this.element = e;
+		}
+
+		@Override
+		public Long timestamp() {
+			checkState(element != null);
+			return element.hasTimestamp() ? element.getTimestamp() : null;
+		}
+
+		@Override
+		public <X> void output(OutputTag<X> outputTag, X value) {
+			checkArgument(outputTag != null, "OutputTag must not be null.");
+			output.collect(outputTag, new StreamRecord<>(value, element.getTimestamp()));
+		}
+
+		@Override
+		public long currentProcessingTime() {
+			return timerService.getCurrentProcessingTime();
+		}
+
+		@Override
+		public long currentWatermark() {
+			return currentWatermark;
+		}
+
+		@Override
+		public <K, V> ReadOnlyBroadcastState<K, V> getBroadcastState(MapStateDescriptor<K, V> stateDescriptor) {
+			Preconditions.checkNotNull(stateDescriptor);
+			ReadOnlyBroadcastState<K, V> state = (ReadOnlyBroadcastState<K, V>) states.get(stateDescriptor);
+			if (state == null) {
+				throw new IllegalArgumentException("The requested state does not exist. " +
+						"Check for typos in your state descriptor, or specify the state descriptor " +
+						"in the datastream.broadcast(...) call if you forgot to register it.");
+			}
+			return state;
+		}
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/TwoInputTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/TwoInputTransformation.java
@@ -31,8 +31,8 @@ import java.util.List;
 
 /**
  * This Transformation represents the application of a
- * {@link org.apache.flink.streaming.api.operators.TwoInputStreamOperator} to two input
- * {@code StreamTransformations}. The result is again only one stream.
+ * {@link TwoInputStreamOperator} to two input {@code StreamTransformations}.
+ * The result is again only one stream.
  *
  * @param <IN1> The type of the elements in the first input {@code StreamTransformation}
  * @param <IN2> The type of the elements in the second input {@code StreamTransformation}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/DataStreamTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/DataStreamTest.java
@@ -38,6 +38,7 @@ import org.apache.flink.api.java.typeutils.ObjectArrayTypeInfo;
 import org.apache.flink.api.java.typeutils.TupleTypeInfo;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.streaming.api.collector.selector.OutputSelector;
+import org.apache.flink.streaming.api.datastream.BroadcastConnectedStream;
 import org.apache.flink.streaming.api.datastream.BroadcastStream;
 import org.apache.flink.streaming.api.datastream.ConnectedStreams;
 import org.apache.flink.streaming.api.datastream.DataStream;
@@ -87,9 +88,7 @@ import org.junit.rules.ExpectedException;
 import javax.annotation.Nullable;
 
 import java.lang.reflect.Method;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -102,6 +101,9 @@ import static org.junit.Assert.fail;
  */
 @SuppressWarnings("serial")
 public class DataStreamTest extends TestLogger {
+
+	@Rule
+	public ExpectedException expectedException = ExpectedException.none();
 
 	/**
 	 * Tests union functionality. This ensures that self-unions and unions of streams
@@ -763,99 +765,10 @@ public class DataStreamTest extends TestLogger {
 		assertTrue(getOperatorForDataStream(processed) instanceof ProcessOperator);
 	}
 
-	@Test
-	public void testConnectWithBroadcastTranslation() throws Exception {
-
-		final Map<Long, String> expected = new HashMap<>();
-		expected.put(0L, "test:0");
-		expected.put(1L, "test:1");
-		expected.put(2L, "test:2");
-		expected.put(3L, "test:3");
-		expected.put(4L, "test:4");
-		expected.put(5L, "test:5");
-
-		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
-
-		final DataStream<Long> srcOne = env.generateSequence(0L, 5L)
-				.assignTimestampsAndWatermarks(new CustomWmEmitter<Long>() {
-
-					@Override
-					public long extractTimestamp(Long element, long previousElementTimestamp) {
-						return element;
-					}
-				}).keyBy((KeySelector<Long, Long>) value -> value);
-
-		final DataStream<String> srcTwo = env.fromCollection(expected.values())
-				.assignTimestampsAndWatermarks(new CustomWmEmitter<String>() {
-					@Override
-					public long extractTimestamp(String element, long previousElementTimestamp) {
-						return Long.parseLong(element.split(":")[1]);
-					}
-				});
-
-		final BroadcastStream<String> broadcast = srcTwo.broadcast(TestBroadcastProcessFunction.DESCRIPTOR);
-
-		// the timestamp should be high enough to trigger the timer after all the elements arrive.
-		final DataStream<String> output = srcOne.connect(broadcast).process(
-				new TestBroadcastProcessFunction(100000L, expected));
-
-		output.addSink(new DiscardingSink<>());
-		env.execute();
-	}
-
-	private abstract static class CustomWmEmitter<T> implements AssignerWithPunctuatedWatermarks<T> {
-
-		@Nullable
-		@Override
-		public Watermark checkAndGetNextWatermark(T lastElement, long extractedTimestamp) {
-			return new Watermark(extractedTimestamp);
-		}
-	}
-
-	private static class TestBroadcastProcessFunction extends KeyedBroadcastProcessFunction<Long, Long, String, String> {
-
-		private final Map<Long, String> expectedState;
-
-		private final long timerTimestamp;
-
-		static final MapStateDescriptor<Long, String> DESCRIPTOR = new MapStateDescriptor<>(
-				"broadcast-state", BasicTypeInfo.LONG_TYPE_INFO, BasicTypeInfo.STRING_TYPE_INFO
-		);
-
-		TestBroadcastProcessFunction(
-				final long timerTS,
-				final Map<Long, String> expectedBroadcastState
-		) {
-			expectedState = expectedBroadcastState;
-			timerTimestamp = timerTS;
-		}
-
-		@Override
-		public void processElement(Long value, KeyedReadOnlyContext ctx, Collector<String> out) throws Exception {
-			ctx.timerService().registerEventTimeTimer(timerTimestamp);
-		}
-
-		@Override
-		public void processBroadcastElement(String value, KeyedContext ctx, Collector<String> out) throws Exception {
-			long key = Long.parseLong(value.split(":")[1]);
-			ctx.getBroadcastState(DESCRIPTOR).put(key, value);
-		}
-
-		@Override
-		public void onTimer(long timestamp, OnTimerContext ctx, Collector<String> out) throws Exception {
-			Map<Long, String> map = new HashMap<>();
-			for (Map.Entry<Long, String> entry : ctx.getBroadcastState(DESCRIPTOR).immutableEntries()) {
-				map.put(entry.getKey(), entry.getValue());
-			}
-			Assert.assertEquals(expectedState, map);
-		}
-	}
-
 	/**
 	 * Tests that with a {@link KeyedStream} we have to provide a {@link KeyedBroadcastProcessFunction}.
 	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testFailedTranslationOnKeyed() {
 
 		final MapStateDescriptor<Long, String> descriptor = new MapStateDescriptor<>(
@@ -881,8 +794,11 @@ public class DataStreamTest extends TestLogger {
 				});
 
 		BroadcastStream<String> broadcast = srcTwo.broadcast(descriptor);
-		srcOne.connect(broadcast)
-				.process(new BroadcastProcessFunction<Long, String, String>() {
+		BroadcastConnectedStream<Long, String> bcStream = srcOne.connect(broadcast);
+
+		expectedException.expect(IllegalArgumentException.class);
+		bcStream.process(
+				new BroadcastProcessFunction<Long, String, String>() {
 					@Override
 					public void processBroadcastElement(String value, Context ctx, Collector<String> out) throws Exception {
 						// do nothing
@@ -898,7 +814,7 @@ public class DataStreamTest extends TestLogger {
 	/**
 	 * Tests that with a non-keyed stream we have to provide a {@link BroadcastProcessFunction}.
 	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testFailedTranslationOnNonKeyed() {
 
 		final MapStateDescriptor<Long, String> descriptor = new MapStateDescriptor<>(
@@ -924,9 +840,11 @@ public class DataStreamTest extends TestLogger {
 				});
 
 		BroadcastStream<String> broadcast = srcTwo.broadcast(descriptor);
-		srcOne.connect(broadcast)
-				.process(new KeyedBroadcastProcessFunction<String, Long, String, String>() {
+		BroadcastConnectedStream<Long, String> bcStream = srcOne.connect(broadcast);
 
+		expectedException.expect(IllegalArgumentException.class);
+		bcStream.process(
+				new KeyedBroadcastProcessFunction<String, Long, String, String>() {
 					@Override
 					public void processBroadcastElement(String value, KeyedContext ctx, Collector<String> out) throws Exception {
 						// do nothing
@@ -937,6 +855,15 @@ public class DataStreamTest extends TestLogger {
 						// do nothing
 					}
 				});
+	}
+
+	private abstract static class CustomWmEmitter<T> implements AssignerWithPunctuatedWatermarks<T> {
+
+		@Nullable
+		@Override
+		public Watermark checkAndGetNextWatermark(T lastElement, long extractedTimestamp) {
+			return new Watermark(extractedTimestamp);
+		}
 	}
 
 	@Test
@@ -1130,9 +1057,6 @@ public class DataStreamTest extends TestLogger {
 	/////////////////////////////////////////////////////////////
 	// KeyBy testing
 	/////////////////////////////////////////////////////////////
-
-	@Rule
-	public ExpectedException expectedException = ExpectedException.none();
 
 	@Test
 	public void testPrimitiveArrayKeyRejection() {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/DataStreamTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/DataStreamTest.java
@@ -794,7 +794,7 @@ public class DataStreamTest extends TestLogger {
 					}
 				});
 
-		final BroadcastStream<String, Long, String> broadcast = srcTwo.broadcast(TestBroadcastProcessFunction.DESCRIPTOR);
+		final BroadcastStream<String> broadcast = srcTwo.broadcast(TestBroadcastProcessFunction.DESCRIPTOR);
 
 		// the timestamp should be high enough to trigger the timer after all the elements arrive.
 		final DataStream<String> output = srcOne.connect(broadcast).process(
@@ -880,7 +880,7 @@ public class DataStreamTest extends TestLogger {
 					}
 				});
 
-		BroadcastStream<String, Long, String> broadcast = srcTwo.broadcast(descriptor);
+		BroadcastStream<String> broadcast = srcTwo.broadcast(descriptor);
 		srcOne.connect(broadcast)
 				.process(new BroadcastProcessFunction<Long, String, String>() {
 					@Override
@@ -923,7 +923,7 @@ public class DataStreamTest extends TestLogger {
 					}
 				});
 
-		BroadcastStream<String, Long, String> broadcast = srcTwo.broadcast(descriptor);
+		BroadcastStream<String> broadcast = srcTwo.broadcast(descriptor);
 		srcOne.connect(broadcast)
 				.process(new KeyedBroadcastProcessFunction<String, Long, String, String>() {
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/DataStreamTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/DataStreamTest.java
@@ -813,7 +813,7 @@ public class DataStreamTest extends TestLogger {
 		}
 	}
 
-	private static class TestBroadcastProcessFunction extends KeyedBroadcastProcessFunction<Long, String, String> {
+	private static class TestBroadcastProcessFunction extends KeyedBroadcastProcessFunction<Long, Long, String, String> {
 
 		private final Map<Long, String> expectedState;
 
@@ -837,7 +837,7 @@ public class DataStreamTest extends TestLogger {
 		}
 
 		@Override
-		public void processBroadcastElement(String value, Context ctx, Collector<String> out) throws Exception {
+		public void processBroadcastElement(String value, KeyedContext ctx, Collector<String> out) throws Exception {
 			long key = Long.parseLong(value.split(":")[1]);
 			ctx.getBroadcastState(DESCRIPTOR).put(key, value);
 		}
@@ -925,10 +925,10 @@ public class DataStreamTest extends TestLogger {
 
 		BroadcastStream<String, Long, String> broadcast = srcTwo.broadcast(descriptor);
 		srcOne.connect(broadcast)
-				.process(new KeyedBroadcastProcessFunction<Long, String, String>() {
+				.process(new KeyedBroadcastProcessFunction<String, Long, String, String>() {
 
 					@Override
-					public void processBroadcastElement(String value, Context ctx, Collector<String> out) throws Exception {
+					public void processBroadcastElement(String value, KeyedContext ctx, Collector<String> out) throws Exception {
 						// do nothing
 					}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/co/CoBroadcastWithKeyedOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/co/CoBroadcastWithKeyedOperatorTest.java
@@ -1,0 +1,655 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.co;
+
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.streaming.api.functions.co.KeyedBroadcastProcessFunction;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.tasks.OperatorStateHandles;
+import org.apache.flink.streaming.util.AbstractStreamOperatorTestHarness;
+import org.apache.flink.streaming.util.KeyedTwoInputStreamOperatorTestHarness;
+import org.apache.flink.streaming.util.TestHarnessUtil;
+import org.apache.flink.streaming.util.TwoInputStreamOperatorTestHarness;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.OutputTag;
+import org.apache.flink.util.Preconditions;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.function.Function;
+
+/**
+ * Tests for the {@link CoBroadcastWithKeyedOperator}.
+ */
+public class CoBroadcastWithKeyedOperatorTest {
+
+	private static final MapStateDescriptor<String, Integer> STATE_DESCRIPTOR =
+			new MapStateDescriptor<>(
+					"broadcast-state",
+					BasicTypeInfo.STRING_TYPE_INFO,
+					BasicTypeInfo.INT_TYPE_INFO
+			);
+
+	@Test
+	public void testFunctionWithTimer() throws Exception {
+
+		try (
+				TwoInputStreamOperatorTestHarness<String, Integer, String> testHarness = getInitializedTestHarness(
+						BasicTypeInfo.STRING_TYPE_INFO,
+						new IdentityKeySelector<>(),
+						new FunctionWithTimerOnKeyed(41L))
+		) {
+			testHarness.processWatermark1(new Watermark(10L));
+			testHarness.processWatermark2(new Watermark(10L));
+			testHarness.processElement2(new StreamRecord<>(5, 12L));
+
+			testHarness.processWatermark1(new Watermark(40L));
+			testHarness.processWatermark2(new Watermark(40L));
+			testHarness.processElement1(new StreamRecord<>("6", 13L));
+			testHarness.processElement1(new StreamRecord<>("6", 15L));
+
+			testHarness.processWatermark1(new Watermark(50L));
+			testHarness.processWatermark2(new Watermark(50L));
+
+			Queue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+
+			expectedOutput.add(new Watermark(10L));
+			expectedOutput.add(new StreamRecord<>("BR:5 WM:10 TS:12", 12L));
+			expectedOutput.add(new Watermark(40L));
+			expectedOutput.add(new StreamRecord<>("NON-BR:6 WM:40 TS:13", 13L));
+			expectedOutput.add(new StreamRecord<>("NON-BR:6 WM:40 TS:15", 15L));
+			expectedOutput.add(new StreamRecord<>("TIMER:41", 41L));
+			expectedOutput.add(new Watermark(50L));
+
+			TestHarnessUtil.assertOutputEquals("Output was not correct.", expectedOutput, testHarness.getOutput());
+		}
+	}
+
+	/**
+	 * {@link KeyedBroadcastProcessFunction} that registers a timer and emits
+	 * for every element the watermark and the timestamp of the element.
+	 */
+	private static class FunctionWithTimerOnKeyed extends KeyedBroadcastProcessFunction<String, Integer, String> {
+
+		private static final long serialVersionUID = 7496674620398203933L;
+
+		private final long timerTS;
+
+		FunctionWithTimerOnKeyed(long timerTS) {
+			this.timerTS = timerTS;
+		}
+
+		@Override
+		public void processBroadcastElement(Integer value, Context ctx, Collector<String> out) throws Exception {
+			out.collect("BR:" + value + " WM:" + ctx.currentWatermark() + " TS:" + ctx.timestamp());
+		}
+
+		@Override
+		public void processElement(String value, KeyedReadOnlyContext ctx, Collector<String> out) throws Exception {
+			ctx.timerService().registerEventTimeTimer(timerTS);
+			out.collect("NON-BR:" + value + " WM:" + ctx.currentWatermark() + " TS:" + ctx.timestamp());
+		}
+
+		@Override
+		public void onTimer(long timestamp, OnTimerContext ctx, Collector<String> out) throws Exception {
+			out.collect("TIMER:" + timestamp);
+		}
+	}
+
+	@Test
+	public void testSideOutput() throws Exception {
+		try (
+				TwoInputStreamOperatorTestHarness<String, Integer, String> testHarness = getInitializedTestHarness(
+						BasicTypeInfo.STRING_TYPE_INFO,
+						new IdentityKeySelector<>(),
+						new FunctionWithSideOutput())
+		) {
+
+			testHarness.processWatermark1(new Watermark(10L));
+			testHarness.processWatermark2(new Watermark(10L));
+			testHarness.processElement2(new StreamRecord<>(5, 12L));
+
+			testHarness.processWatermark1(new Watermark(40L));
+			testHarness.processWatermark2(new Watermark(40L));
+			testHarness.processElement1(new StreamRecord<>("6", 13L));
+			testHarness.processElement1(new StreamRecord<>("6", 15L));
+
+			testHarness.processWatermark1(new Watermark(50L));
+			testHarness.processWatermark2(new Watermark(50L));
+
+			Queue<StreamRecord<String>> expectedBr = new ConcurrentLinkedQueue<>();
+			expectedBr.add(new StreamRecord<>("BR:5 WM:10 TS:12", 12L));
+
+			Queue<StreamRecord<String>> expectedNonBr = new ConcurrentLinkedQueue<>();
+			expectedNonBr.add(new StreamRecord<>("NON-BR:6 WM:40 TS:13", 13L));
+			expectedNonBr.add(new StreamRecord<>("NON-BR:6 WM:40 TS:15", 15L));
+
+			TestHarnessUtil.assertOutputEquals(
+					"Wrong Side Output",
+					expectedBr,
+					testHarness.getSideOutput(FunctionWithSideOutput.BROADCAST_TAG));
+
+			TestHarnessUtil.assertOutputEquals(
+					"Wrong Side Output",
+					expectedNonBr,
+					testHarness.getSideOutput(FunctionWithSideOutput.NON_BROADCAST_TAG));
+		}
+	}
+
+	/**
+	 * {@link KeyedBroadcastProcessFunction} that emits elements on side outputs.
+	 */
+	private static class FunctionWithSideOutput extends KeyedBroadcastProcessFunction<String, Integer, String> {
+
+		private static final long serialVersionUID = 7496674620398203933L;
+
+		static final OutputTag<String> BROADCAST_TAG = new OutputTag<String>("br-out") {
+			private static final long serialVersionUID = -6899484480421899631L;
+		};
+
+		static final OutputTag<String> NON_BROADCAST_TAG = new OutputTag<String>("non-br-out") {
+			private static final long serialVersionUID = 3837387110613831791L;
+		};
+
+		@Override
+		public void processBroadcastElement(Integer value, Context ctx, Collector<String> out) throws Exception {
+			ctx.output(BROADCAST_TAG, "BR:" + value + " WM:" + ctx.currentWatermark() + " TS:" + ctx.timestamp());
+		}
+
+		@Override
+		public void processElement(String value, KeyedReadOnlyContext ctx, Collector<String> out) throws Exception {
+			ctx.output(NON_BROADCAST_TAG, "NON-BR:" + value + " WM:" + ctx.currentWatermark() + " TS:" + ctx.timestamp());
+		}
+	}
+
+	@Test
+	public void testFunctionWithBroadcastState() throws Exception {
+
+		final Map<String, Integer> expectedBroadcastState = new HashMap<>();
+		expectedBroadcastState.put("5.key", 5);
+		expectedBroadcastState.put("34.key", 34);
+		expectedBroadcastState.put("53.key", 53);
+		expectedBroadcastState.put("12.key", 12);
+		expectedBroadcastState.put("98.key", 98);
+
+		try (
+				TwoInputStreamOperatorTestHarness<String, Integer, String> testHarness = getInitializedTestHarness(
+						BasicTypeInfo.STRING_TYPE_INFO,
+						new IdentityKeySelector<>(),
+						new FunctionWithBroadcastState("key", expectedBroadcastState, 41L))
+		) {
+			testHarness.processWatermark1(new Watermark(10L));
+			testHarness.processWatermark2(new Watermark(10L));
+
+			testHarness.processElement2(new StreamRecord<>(5, 10L));
+			testHarness.processElement2(new StreamRecord<>(34, 12L));
+			testHarness.processElement2(new StreamRecord<>(53, 15L));
+			testHarness.processElement2(new StreamRecord<>(12, 16L));
+			testHarness.processElement2(new StreamRecord<>(98, 19L));
+
+			testHarness.processElement1(new StreamRecord<>("trigger", 13L));
+
+			testHarness.processElement2(new StreamRecord<>(51, 21L));
+
+			testHarness.processWatermark1(new Watermark(50L));
+			testHarness.processWatermark2(new Watermark(50L));
+
+			Queue<Object> output = testHarness.getOutput();
+			Assert.assertEquals(3L, output.size());
+
+			Object firstRawWm = output.poll();
+			Assert.assertTrue(firstRawWm instanceof Watermark);
+			Watermark firstWm = (Watermark) firstRawWm;
+			Assert.assertEquals(10L, firstWm.getTimestamp());
+
+			Object rawOutputElem = output.poll();
+			Assert.assertTrue(rawOutputElem instanceof StreamRecord);
+			StreamRecord<?> outputRec = (StreamRecord<?>) rawOutputElem;
+			Assert.assertTrue(outputRec.getValue() instanceof String);
+			String outputElem = (String) outputRec.getValue();
+
+			expectedBroadcastState.put("51.key", 51);
+			List<Map.Entry<String, Integer>> expectedEntries = new ArrayList<>();
+			expectedEntries.addAll(expectedBroadcastState.entrySet());
+			String expected = "TS:41 " + mapToString(expectedEntries);
+			Assert.assertEquals(expected, outputElem);
+
+			Object secondRawWm = output.poll();
+			Assert.assertTrue(secondRawWm instanceof Watermark);
+			Watermark secondWm = (Watermark) secondRawWm;
+			Assert.assertEquals(50L, secondWm.getTimestamp());
+		}
+	}
+
+	private static class FunctionWithBroadcastState extends KeyedBroadcastProcessFunction<String, Integer, String> {
+
+		private static final long serialVersionUID = 7496674620398203933L;
+
+		private final String keyPostfix;
+		private final Map<String, Integer> expectedBroadcastState;
+		private final long timerTs;
+
+		FunctionWithBroadcastState(
+				final String keyPostfix,
+				final Map<String, Integer> expectedBroadcastState,
+				final long timerTs
+		) {
+			this.keyPostfix = Preconditions.checkNotNull(keyPostfix);
+			this.expectedBroadcastState = Preconditions.checkNotNull(expectedBroadcastState);
+			this.timerTs = timerTs;
+		}
+
+		@Override
+		public void processBroadcastElement(Integer value, Context ctx, Collector<String> out) throws Exception {
+			// put an element in the broadcast state
+			final String key = value + "." + keyPostfix;
+			ctx.getBroadcastState(STATE_DESCRIPTOR).put(key, value);
+		}
+
+		@Override
+		public void processElement(String value, KeyedReadOnlyContext ctx, Collector<String> out) throws Exception {
+			Iterable<Map.Entry<String, Integer>> broadcastStateIt = ctx.getBroadcastState(STATE_DESCRIPTOR).immutableEntries();
+			Iterator<Map.Entry<String, Integer>> iter = broadcastStateIt.iterator();
+
+			for (int i = 0; i < expectedBroadcastState.size(); i++) {
+				Assert.assertTrue(iter.hasNext());
+
+				Map.Entry<String, Integer> entry = iter.next();
+				Assert.assertTrue(expectedBroadcastState.containsKey(entry.getKey()));
+				Assert.assertEquals(expectedBroadcastState.get(entry.getKey()), entry.getValue());
+			}
+
+			Assert.assertFalse(iter.hasNext());
+
+			ctx.timerService().registerEventTimeTimer(timerTs);
+		}
+
+		@Override
+		public void onTimer(long timestamp, OnTimerContext ctx, Collector<String> out) throws Exception {
+			final Iterator<Map.Entry<String, Integer>> iter = ctx.getBroadcastState(STATE_DESCRIPTOR).immutableEntries().iterator();
+
+			final List<Map.Entry<String, Integer>> map = new ArrayList<>();
+			while (iter.hasNext()) {
+				map.add(iter.next());
+			}
+			final String mapToStr = mapToString(map);
+			out.collect("TS:" + timestamp + " " + mapToStr);
+		}
+	}
+
+	@Test
+	public void testScaleUp() throws Exception {
+		final Set<String> keysToRegister = new HashSet<>();
+		keysToRegister.add("test1");
+		keysToRegister.add("test2");
+		keysToRegister.add("test3");
+
+		final OperatorStateHandles mergedSnapshot;
+
+		try (
+				TwoInputStreamOperatorTestHarness<String, Integer, String> testHarness1 = getInitializedTestHarness(
+						BasicTypeInfo.STRING_TYPE_INFO,
+						new IdentityKeySelector<>(),
+						new TestFunctionWithOutput(keysToRegister),
+						10,
+						2,
+						0);
+
+				TwoInputStreamOperatorTestHarness<String, Integer, String> testHarness2 = getInitializedTestHarness(
+						BasicTypeInfo.STRING_TYPE_INFO,
+						new IdentityKeySelector<>(),
+						new TestFunctionWithOutput(keysToRegister),
+						10,
+						2,
+						1)
+
+		) {
+
+			// make sure all operators have the same state
+			testHarness1.processElement2(new StreamRecord<>(3));
+			testHarness2.processElement2(new StreamRecord<>(3));
+
+			mergedSnapshot = AbstractStreamOperatorTestHarness.repackageState(
+					testHarness1.snapshot(0L, 0L),
+					testHarness2.snapshot(0L, 0L)
+			);
+		}
+
+		final Set<String> expected = new HashSet<>(3);
+		expected.add("test1=3");
+		expected.add("test2=3");
+		expected.add("test3=3");
+
+		try (
+				TwoInputStreamOperatorTestHarness<String, Integer, String> testHarness1 = getInitializedTestHarness(
+						BasicTypeInfo.STRING_TYPE_INFO,
+						new IdentityKeySelector<>(),
+						new TestFunctionWithOutput(keysToRegister),
+						10,
+						3,
+						0,
+						mergedSnapshot);
+
+				TwoInputStreamOperatorTestHarness<String, Integer, String> testHarness2 = getInitializedTestHarness(
+						BasicTypeInfo.STRING_TYPE_INFO,
+						new IdentityKeySelector<>(),
+						new TestFunctionWithOutput(keysToRegister),
+						10,
+						3,
+						1,
+						mergedSnapshot);
+
+				TwoInputStreamOperatorTestHarness<String, Integer, String> testHarness3 = getInitializedTestHarness(
+						BasicTypeInfo.STRING_TYPE_INFO,
+						new IdentityKeySelector<>(),
+						new TestFunctionWithOutput(keysToRegister),
+						10,
+						3,
+						2,
+						mergedSnapshot)
+		) {
+			testHarness1.processElement1(new StreamRecord<>("trigger"));
+			testHarness2.processElement1(new StreamRecord<>("trigger"));
+			testHarness3.processElement1(new StreamRecord<>("trigger"));
+
+			Queue<?> output1 = testHarness1.getOutput();
+			Queue<?> output2 = testHarness2.getOutput();
+			Queue<?> output3 = testHarness3.getOutput();
+
+			Assert.assertEquals(expected.size(), output1.size());
+			for (Object o: output1) {
+				StreamRecord<String> rec = (StreamRecord<String>) o;
+				Assert.assertTrue(expected.contains(rec.getValue()));
+			}
+
+			Assert.assertEquals(expected.size(), output2.size());
+			for (Object o: output2) {
+				StreamRecord<String> rec = (StreamRecord<String>) o;
+				Assert.assertTrue(expected.contains(rec.getValue()));
+			}
+
+			Assert.assertEquals(expected.size(), output3.size());
+			for (Object o: output3) {
+				StreamRecord<String> rec = (StreamRecord<String>) o;
+				Assert.assertTrue(expected.contains(rec.getValue()));
+			}
+		}
+	}
+
+	@Test
+	public void testScaleDown() throws Exception {
+		final Set<String> keysToRegister = new HashSet<>();
+		keysToRegister.add("test1");
+		keysToRegister.add("test2");
+		keysToRegister.add("test3");
+
+		final OperatorStateHandles mergedSnapshot;
+
+		try (
+				TwoInputStreamOperatorTestHarness<String, Integer, String> testHarness1 = getInitializedTestHarness(
+						BasicTypeInfo.STRING_TYPE_INFO,
+						new IdentityKeySelector<>(),
+						new TestFunctionWithOutput(keysToRegister),
+						10,
+						3,
+						0);
+
+				TwoInputStreamOperatorTestHarness<String, Integer, String> testHarness2 = getInitializedTestHarness(
+						BasicTypeInfo.STRING_TYPE_INFO,
+						new IdentityKeySelector<>(),
+						new TestFunctionWithOutput(keysToRegister),
+						10,
+						3,
+						1);
+
+				TwoInputStreamOperatorTestHarness<String, Integer, String> testHarness3 = getInitializedTestHarness(
+						BasicTypeInfo.STRING_TYPE_INFO,
+						new IdentityKeySelector<>(),
+						new TestFunctionWithOutput(keysToRegister),
+						10,
+						3,
+						2)
+		) {
+
+			// make sure all operators have the same state
+			testHarness1.processElement2(new StreamRecord<>(3));
+			testHarness2.processElement2(new StreamRecord<>(3));
+			testHarness3.processElement2(new StreamRecord<>(3));
+
+			mergedSnapshot = AbstractStreamOperatorTestHarness.repackageState(
+					testHarness1.snapshot(0L, 0L),
+					testHarness2.snapshot(0L, 0L),
+					testHarness3.snapshot(0L, 0L)
+			);
+		}
+
+		final Set<String> expected = new HashSet<>(3);
+		expected.add("test1=3");
+		expected.add("test2=3");
+		expected.add("test3=3");
+
+		try (
+				TwoInputStreamOperatorTestHarness<String, Integer, String> testHarness1 = getInitializedTestHarness(
+						BasicTypeInfo.STRING_TYPE_INFO,
+						new IdentityKeySelector<>(),
+						new TestFunctionWithOutput(keysToRegister),
+						10,
+						2,
+						0,
+						mergedSnapshot);
+
+				TwoInputStreamOperatorTestHarness<String, Integer, String> testHarness2 = getInitializedTestHarness(
+						BasicTypeInfo.STRING_TYPE_INFO,
+						new IdentityKeySelector<>(),
+						new TestFunctionWithOutput(keysToRegister),
+						10,
+						2,
+						1,
+						mergedSnapshot)
+		) {
+
+			testHarness1.processElement1(new StreamRecord<>("trigger"));
+			testHarness2.processElement1(new StreamRecord<>("trigger"));
+
+			Queue<?> output1 = testHarness1.getOutput();
+			Queue<?> output2 = testHarness2.getOutput();
+
+			Assert.assertEquals(expected.size(), output1.size());
+			for (Object o: output1) {
+				StreamRecord<String> rec = (StreamRecord<String>) o;
+				Assert.assertTrue(expected.contains(rec.getValue()));
+			}
+
+			Assert.assertEquals(expected.size(), output2.size());
+			for (Object o: output2) {
+				StreamRecord<String> rec = (StreamRecord<String>) o;
+				Assert.assertTrue(expected.contains(rec.getValue()));
+			}
+		}
+	}
+
+	private static class TestFunctionWithOutput extends KeyedBroadcastProcessFunction<String, Integer, String> {
+
+		private static final long serialVersionUID = 7496674620398203933L;
+
+		private final Set<String> keysToRegister;
+
+		TestFunctionWithOutput(Set<String> keysToRegister) {
+			this.keysToRegister = Preconditions.checkNotNull(keysToRegister);
+		}
+
+		@Override
+		public void processBroadcastElement(Integer value, Context ctx, Collector<String> out) throws Exception {
+			// put an element in the broadcast state
+			for (String k : keysToRegister) {
+				ctx.getBroadcastState(STATE_DESCRIPTOR).put(k, value);
+			}
+		}
+
+		@Override
+		public void processElement(String value, KeyedReadOnlyContext ctx, Collector<String> out) throws Exception {
+			for (Map.Entry<String, Integer> entry : ctx.getBroadcastState(STATE_DESCRIPTOR).immutableEntries()) {
+				out.collect(entry.toString());
+			}
+		}
+	}
+
+	@Test
+	public void testNoKeyedStateOnBroadcastSide() throws Exception {
+
+		boolean exceptionThrown = false;
+
+		try (
+				TwoInputStreamOperatorTestHarness<String, Integer, String> testHarness = getInitializedTestHarness(
+						BasicTypeInfo.STRING_TYPE_INFO,
+						new IdentityKeySelector<>(),
+						new KeyedBroadcastProcessFunction<String, Integer, String>() {
+
+							private static final long serialVersionUID = -1725365436500098384L;
+
+							private final ValueStateDescriptor<String> valueState = new ValueStateDescriptor<>("any", BasicTypeInfo.STRING_TYPE_INFO);
+
+							@Override
+							public void processBroadcastElement(Integer value, Context ctx, Collector<String> out) throws Exception {
+								getRuntimeContext().getState(valueState).value(); // this should fail
+							}
+
+							@Override
+							public void processElement(String value, KeyedReadOnlyContext ctx, Collector<String> out) throws Exception {
+								// do nothing
+							}
+						})
+		) {
+			testHarness.processWatermark1(new Watermark(10L));
+			testHarness.processWatermark2(new Watermark(10L));
+			testHarness.processElement2(new StreamRecord<>(5, 12L));
+		} catch (NullPointerException e) {
+			Assert.assertEquals("No key set. This method should not be called outside of a keyed context.", e.getMessage());
+			exceptionThrown = true;
+		}
+
+		if (!exceptionThrown) {
+			Assert.fail("No exception thrown");
+		}
+	}
+
+	private static class IdentityKeySelector<T> implements KeySelector<T, T> {
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public T getKey(T value) throws Exception {
+			return value;
+		}
+	}
+
+	private static <KEY, IN1, IN2, K, V, OUT> TwoInputStreamOperatorTestHarness<IN1, IN2, OUT> getInitializedTestHarness(
+			final TypeInformation<KEY> keyTypeInfo,
+			final KeySelector<IN1, KEY> keyKeySelector,
+			final KeyedBroadcastProcessFunction<IN1, IN2, OUT> function) throws Exception {
+
+		return getInitializedTestHarness(
+				keyTypeInfo,
+				keyKeySelector,
+				function,
+				1,
+				1,
+				0);
+	}
+
+	private static <KEY, IN1, IN2, K, V, OUT> TwoInputStreamOperatorTestHarness<IN1, IN2, OUT> getInitializedTestHarness(
+			final TypeInformation<KEY> keyTypeInfo,
+			final KeySelector<IN1, KEY> keyKeySelector,
+			final KeyedBroadcastProcessFunction<IN1, IN2, OUT> function,
+			final int maxParallelism,
+			final int numTasks,
+			final int taskIdx) throws Exception {
+
+		return getInitializedTestHarness(
+				keyTypeInfo,
+				keyKeySelector,
+				function,
+				maxParallelism,
+				numTasks,
+				taskIdx,
+				null);
+	}
+
+	private static <KEY, IN1, IN2, K, V, OUT> TwoInputStreamOperatorTestHarness<IN1, IN2, OUT> getInitializedTestHarness(
+			final TypeInformation<KEY> keyTypeInfo,
+			final KeySelector<IN1, KEY> keyKeySelector,
+			final KeyedBroadcastProcessFunction<IN1, IN2, OUT> function,
+			final int maxParallelism,
+			final int numTasks,
+			final int taskIdx,
+			final OperatorStateHandles initState) throws Exception {
+
+		final TwoInputStreamOperatorTestHarness<IN1, IN2, OUT>  testHarness =
+				new KeyedTwoInputStreamOperatorTestHarness<>(
+						new CoBroadcastWithKeyedOperator<>(
+								Preconditions.checkNotNull(function),
+								Collections.singletonList(STATE_DESCRIPTOR)),
+						keyKeySelector,
+						null,
+						keyTypeInfo,
+						maxParallelism,
+						numTasks,
+						taskIdx
+				);
+
+		testHarness.setup();
+		testHarness.initializeState(initState);
+		testHarness.open();
+
+		return testHarness;
+	}
+
+	private static String mapToString(List<Map.Entry<String, Integer>> entries) {
+		entries.sort(
+				Comparator.comparing(
+						(Function<Map.Entry<String, Integer>, String>) Map.Entry::getKey
+				).thenComparingInt(Map.Entry::getValue)
+		);
+
+		final StringBuilder builder = new StringBuilder();
+		for (Map.Entry<String, Integer> entry : entries) {
+			builder.append(' ')
+					.append(entry.getKey())
+					.append('=')
+					.append(entry.getValue());
+		}
+		return builder.toString();
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/co/CoBroadcastWithNonKeyedOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/co/CoBroadcastWithNonKeyedOperatorTest.java
@@ -1,0 +1,497 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.co;
+
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.streaming.api.functions.co.BroadcastProcessFunction;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.tasks.OperatorStateHandles;
+import org.apache.flink.streaming.util.AbstractStreamOperatorTestHarness;
+import org.apache.flink.streaming.util.TestHarnessUtil;
+import org.apache.flink.streaming.util.TwoInputStreamOperatorTestHarness;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.OutputTag;
+import org.apache.flink.util.Preconditions;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+/**
+ * Tests for the {@link CoBroadcastWithNonKeyedOperator}.
+ */
+public class CoBroadcastWithNonKeyedOperatorTest {
+
+	private static final MapStateDescriptor<String, Integer> STATE_DESCRIPTOR =
+			new MapStateDescriptor<>(
+					"broadcast-state",
+					BasicTypeInfo.STRING_TYPE_INFO,
+					BasicTypeInfo.INT_TYPE_INFO
+			);
+
+	@Test
+	public void testBroadcastState() throws Exception {
+
+		final Set<String> keysToRegister = new HashSet<>();
+		keysToRegister.add("test1");
+		keysToRegister.add("test2");
+		keysToRegister.add("test3");
+
+		try (
+				TwoInputStreamOperatorTestHarness<String, Integer, String> testHarness = getInitializedTestHarness(
+						new TestFunction(keysToRegister))
+		) {
+			testHarness.processWatermark1(new Watermark(10L));
+			testHarness.processWatermark2(new Watermark(10L));
+			testHarness.processElement2(new StreamRecord<>(5, 12L));
+
+			testHarness.processWatermark1(new Watermark(40L));
+			testHarness.processWatermark2(new Watermark(40L));
+			testHarness.processElement1(new StreamRecord<>("6", 13L));
+			testHarness.processElement1(new StreamRecord<>("6", 15L));
+
+			testHarness.processWatermark1(new Watermark(50L));
+			testHarness.processWatermark2(new Watermark(50L));
+
+			Queue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+
+			expectedOutput.add(new Watermark(10L));
+			expectedOutput.add(new StreamRecord<>("5WM:10 TS:12", 12L));
+			expectedOutput.add(new Watermark(40L));
+			expectedOutput.add(new StreamRecord<>("6WM:40 TS:13", 13L));
+			expectedOutput.add(new StreamRecord<>("6WM:40 TS:15", 15L));
+			expectedOutput.add(new Watermark(50L));
+
+			TestHarnessUtil.assertOutputEquals("Output was not correct.", expectedOutput, testHarness.getOutput());
+		}
+	}
+
+	private static class TestFunction extends BroadcastProcessFunction<String, Integer, String> {
+
+		private static final long serialVersionUID = 7496674620398203933L;
+
+		private final Set<String> keysToRegister;
+
+		TestFunction(Set<String> keysToRegister) {
+			this.keysToRegister = Preconditions.checkNotNull(keysToRegister);
+		}
+
+		@Override
+		public void processBroadcastElement(Integer value, Context ctx, Collector<String> out) throws Exception {
+			// put an element in the broadcast state
+			for (String k : keysToRegister) {
+				ctx.getBroadcastState(STATE_DESCRIPTOR).put(k, value);
+			}
+			out.collect(value + "WM:" + ctx.currentWatermark() + " TS:" + ctx.timestamp());
+		}
+
+		@Override
+		public void processElement(String value, ReadOnlyContext ctx, Collector<String> out) throws Exception {
+			Set<String> retrievedKeySet = new HashSet<>();
+			for (Map.Entry<String, Integer> entry : ctx.getBroadcastState(STATE_DESCRIPTOR).immutableEntries()) {
+				retrievedKeySet.add(entry.getKey());
+			}
+
+			Assert.assertEquals(keysToRegister, retrievedKeySet);
+
+			out.collect(value + "WM:" + ctx.currentWatermark() + " TS:" + ctx.timestamp());
+		}
+	}
+
+	@Test
+	public void testSideOutput() throws Exception {
+		try (
+				TwoInputStreamOperatorTestHarness<String, Integer, String> testHarness = getInitializedTestHarness(
+						new FunctionWithSideOutput())
+		) {
+
+			testHarness.processWatermark1(new Watermark(10L));
+			testHarness.processWatermark2(new Watermark(10L));
+			testHarness.processElement2(new StreamRecord<>(5, 12L));
+
+			testHarness.processWatermark1(new Watermark(40L));
+			testHarness.processWatermark2(new Watermark(40L));
+			testHarness.processElement1(new StreamRecord<>("6", 13L));
+			testHarness.processElement1(new StreamRecord<>("6", 15L));
+
+			testHarness.processWatermark1(new Watermark(50L));
+			testHarness.processWatermark2(new Watermark(50L));
+
+			ConcurrentLinkedQueue<StreamRecord<String>> expectedBr = new ConcurrentLinkedQueue<>();
+			expectedBr.add(new StreamRecord<>("BR:5 WM:10 TS:12", 12L));
+
+			ConcurrentLinkedQueue<StreamRecord<String>> expectedNonBr = new ConcurrentLinkedQueue<>();
+			expectedNonBr.add(new StreamRecord<>("NON-BR:6 WM:40 TS:13", 13L));
+			expectedNonBr.add(new StreamRecord<>("NON-BR:6 WM:40 TS:15", 15L));
+
+			ConcurrentLinkedQueue<StreamRecord<String>> brSideOutput = testHarness.getSideOutput(FunctionWithSideOutput.BROADCAST_TAG);
+			ConcurrentLinkedQueue<StreamRecord<String>> nonBrSideOutput = testHarness.getSideOutput(FunctionWithSideOutput.NON_BROADCAST_TAG);
+
+			TestHarnessUtil.assertOutputEquals("Wrong Side Output", expectedBr, brSideOutput);
+			TestHarnessUtil.assertOutputEquals("Wrong Side Output", expectedNonBr, nonBrSideOutput);
+		}
+	}
+
+	/**
+	 * {@link BroadcastProcessFunction} that emits elements on side outputs.
+	 */
+	private static class FunctionWithSideOutput extends BroadcastProcessFunction<String, Integer, String> {
+
+		private static final long serialVersionUID = 7496674620398203933L;
+
+		static final OutputTag<String> BROADCAST_TAG = new OutputTag<String>("br-out") {
+			private static final long serialVersionUID = 8037335313997479800L;
+		};
+
+		static final OutputTag<String> NON_BROADCAST_TAG = new OutputTag<String>("non-br-out") {
+			private static final long serialVersionUID = -1092362442658548175L;
+		};
+
+		@Override
+		public void processBroadcastElement(Integer value, Context ctx, Collector<String> out) throws Exception {
+			ctx.output(BROADCAST_TAG, "BR:" + value + " WM:" + ctx.currentWatermark() + " TS:" + ctx.timestamp());
+		}
+
+		@Override
+		public void processElement(String value, ReadOnlyContext ctx, Collector<String> out) throws Exception {
+			ctx.output(NON_BROADCAST_TAG, "NON-BR:" + value + " WM:" + ctx.currentWatermark() + " TS:" + ctx.timestamp());
+		}
+	}
+
+	@Test
+	public void testScaleUp() throws Exception {
+		final Set<String> keysToRegister = new HashSet<>();
+		keysToRegister.add("test1");
+		keysToRegister.add("test2");
+		keysToRegister.add("test3");
+
+		final OperatorStateHandles mergedSnapshot;
+
+		try (
+				TwoInputStreamOperatorTestHarness<String, Integer, String> testHarness1 = getInitializedTestHarness(
+						new TestFunctionWithOutput(keysToRegister),
+						10,
+						2,
+						0);
+
+				TwoInputStreamOperatorTestHarness<String, Integer, String> testHarness2 = getInitializedTestHarness(
+						new TestFunctionWithOutput(keysToRegister),
+						10,
+						2,
+						1)
+		) {
+			// make sure all operators have the same state
+			testHarness1.processElement2(new StreamRecord<>(3));
+			testHarness2.processElement2(new StreamRecord<>(3));
+
+			mergedSnapshot = AbstractStreamOperatorTestHarness.repackageState(
+					testHarness1.snapshot(0L, 0L),
+					testHarness2.snapshot(0L, 0L)
+			);
+		}
+
+		final Set<String> expected = new HashSet<>(3);
+		expected.add("test1=3");
+		expected.add("test2=3");
+		expected.add("test3=3");
+
+		try (
+				TwoInputStreamOperatorTestHarness<String, Integer, String> testHarness1 = getInitializedTestHarness(
+						new TestFunctionWithOutput(keysToRegister),
+						10,
+						3,
+						0,
+						mergedSnapshot);
+
+				TwoInputStreamOperatorTestHarness<String, Integer, String> testHarness2 = getInitializedTestHarness(
+						new TestFunctionWithOutput(keysToRegister),
+						10,
+						3,
+						1,
+						mergedSnapshot);
+
+				TwoInputStreamOperatorTestHarness<String, Integer, String> testHarness3 = getInitializedTestHarness(
+						new TestFunctionWithOutput(keysToRegister),
+						10,
+						3,
+						2,
+						mergedSnapshot)
+		) {
+			testHarness1.processElement1(new StreamRecord<>("trigger"));
+			testHarness2.processElement1(new StreamRecord<>("trigger"));
+			testHarness3.processElement1(new StreamRecord<>("trigger"));
+
+			Queue<?> output1 = testHarness1.getOutput();
+			Queue<?> output2 = testHarness2.getOutput();
+			Queue<?> output3 = testHarness3.getOutput();
+
+			Assert.assertEquals(expected.size(), output1.size());
+			for (Object o: output1) {
+				StreamRecord<String> rec = (StreamRecord<String>) o;
+				Assert.assertTrue(expected.contains(rec.getValue()));
+			}
+
+			Assert.assertEquals(expected.size(), output2.size());
+			for (Object o: output2) {
+				StreamRecord<String> rec = (StreamRecord<String>) o;
+				Assert.assertTrue(expected.contains(rec.getValue()));
+			}
+
+			Assert.assertEquals(expected.size(), output3.size());
+			for (Object o: output3) {
+				StreamRecord<String> rec = (StreamRecord<String>) o;
+				Assert.assertTrue(expected.contains(rec.getValue()));
+			}
+		}
+	}
+
+	@Test
+	public void testScaleDown() throws Exception {
+		final Set<String> keysToRegister = new HashSet<>();
+		keysToRegister.add("test1");
+		keysToRegister.add("test2");
+		keysToRegister.add("test3");
+
+		final OperatorStateHandles mergedSnapshot;
+
+		try (
+				TwoInputStreamOperatorTestHarness<String, Integer, String> testHarness1 = getInitializedTestHarness(
+						new TestFunctionWithOutput(keysToRegister),
+						10,
+						3,
+						0);
+
+				TwoInputStreamOperatorTestHarness<String, Integer, String> testHarness2 = getInitializedTestHarness(
+						new TestFunctionWithOutput(keysToRegister),
+						10,
+						3,
+						1);
+
+				TwoInputStreamOperatorTestHarness<String, Integer, String> testHarness3 = getInitializedTestHarness(
+						new TestFunctionWithOutput(keysToRegister),
+						10,
+						3,
+						2)
+		) {
+
+			// make sure all operators have the same state
+			testHarness1.processElement2(new StreamRecord<>(3));
+			testHarness2.processElement2(new StreamRecord<>(3));
+			testHarness3.processElement2(new StreamRecord<>(3));
+
+			mergedSnapshot = AbstractStreamOperatorTestHarness.repackageState(
+					testHarness1.snapshot(0L, 0L),
+					testHarness2.snapshot(0L, 0L),
+					testHarness3.snapshot(0L, 0L)
+			);
+		}
+
+		final Set<String> expected = new HashSet<>(3);
+		expected.add("test1=3");
+		expected.add("test2=3");
+		expected.add("test3=3");
+
+		try (
+				TwoInputStreamOperatorTestHarness<String, Integer, String> testHarness1 = getInitializedTestHarness(
+						new TestFunctionWithOutput(keysToRegister),
+						10,
+						2,
+						0,
+						mergedSnapshot);
+
+				TwoInputStreamOperatorTestHarness<String, Integer, String> testHarness2 = getInitializedTestHarness(
+						new TestFunctionWithOutput(keysToRegister),
+						10,
+						2,
+						1,
+						mergedSnapshot)
+		) {
+			testHarness1.processElement1(new StreamRecord<>("trigger"));
+			testHarness2.processElement1(new StreamRecord<>("trigger"));
+
+			Queue<?> output1 = testHarness1.getOutput();
+			Queue<?> output2 = testHarness2.getOutput();
+
+			Assert.assertEquals(expected.size(), output1.size());
+			for (Object o: output1) {
+				StreamRecord<String> rec = (StreamRecord<String>) o;
+				Assert.assertTrue(expected.contains(rec.getValue()));
+			}
+
+			Assert.assertEquals(expected.size(), output2.size());
+			for (Object o: output2) {
+				StreamRecord<String> rec = (StreamRecord<String>) o;
+				Assert.assertTrue(expected.contains(rec.getValue()));
+			}
+		}
+	}
+
+	private static class TestFunctionWithOutput extends BroadcastProcessFunction<String, Integer, String> {
+
+		private static final long serialVersionUID = 7496674620398203933L;
+
+		private final Set<String> keysToRegister;
+
+		TestFunctionWithOutput(Set<String> keysToRegister) {
+			this.keysToRegister = Preconditions.checkNotNull(keysToRegister);
+		}
+
+		@Override
+		public void processBroadcastElement(Integer value, Context ctx, Collector<String> out) throws Exception {
+			// put an element in the broadcast state
+			for (String k : keysToRegister) {
+				ctx.getBroadcastState(STATE_DESCRIPTOR).put(k, value);
+			}
+		}
+
+		@Override
+		public void processElement(String value, ReadOnlyContext ctx, Collector<String> out) throws Exception {
+			for (Map.Entry<String, Integer> entry : ctx.getBroadcastState(STATE_DESCRIPTOR).immutableEntries()) {
+				out.collect(entry.toString());
+			}
+		}
+	}
+
+	@Test
+	public void testNoKeyedStateOnBroadcastSide() throws Exception {
+
+		boolean exceptionThrown = false;
+
+		try (
+				TwoInputStreamOperatorTestHarness<String, Integer, String> testHarness =
+						getInitializedTestHarness(
+								new BroadcastProcessFunction<String, Integer, String>() {
+									private static final long serialVersionUID = -1725365436500098384L;
+
+									private final ValueStateDescriptor<String> valueState = new ValueStateDescriptor<>("any", BasicTypeInfo.STRING_TYPE_INFO);
+
+									@Override
+									public void processBroadcastElement(Integer value, Context ctx, Collector<String> out) throws Exception {
+										getRuntimeContext().getState(valueState).value(); // this should fail
+									}
+
+									@Override
+									public void processElement(String value, ReadOnlyContext ctx, Collector<String> out) throws Exception {
+										// do nothing
+									}
+								})
+		) {
+			testHarness.processWatermark1(new Watermark(10L));
+			testHarness.processWatermark2(new Watermark(10L));
+			testHarness.processElement2(new StreamRecord<>(5, 12L));
+		} catch (NullPointerException e) {
+			Assert.assertEquals("Keyed state can only be used on a 'keyed stream', i.e., after a 'keyBy()' operation.", e.getMessage());
+			exceptionThrown = true;
+		}
+
+		if (!exceptionThrown) {
+			Assert.fail("No exception thrown");
+		}
+	}
+
+	@Test
+	public void testNoKeyedStateOnNonBroadcastSide() throws Exception {
+
+		boolean exceptionThrown = false;
+
+		try (
+				TwoInputStreamOperatorTestHarness<String, Integer, String> testHarness =
+						getInitializedTestHarness(
+								new BroadcastProcessFunction<String, Integer, String>() {
+									private static final long serialVersionUID = -1725365436500098384L;
+
+									private final ValueStateDescriptor<String> valueState = new ValueStateDescriptor<>("any", BasicTypeInfo.STRING_TYPE_INFO);
+
+									@Override
+									public void processBroadcastElement(Integer value, Context ctx, Collector<String> out) throws Exception {
+										// do nothing
+									}
+
+									@Override
+									public void processElement(String value, ReadOnlyContext ctx, Collector<String> out) throws Exception {
+										getRuntimeContext().getState(valueState).value(); // this should fail
+									}
+								})
+		) {
+			testHarness.processWatermark1(new Watermark(10L));
+			testHarness.processWatermark2(new Watermark(10L));
+			testHarness.processElement1(new StreamRecord<>("5", 12L));
+		} catch (NullPointerException e) {
+			Assert.assertEquals("Keyed state can only be used on a 'keyed stream', i.e., after a 'keyBy()' operation.", e.getMessage());
+			exceptionThrown = true;
+		}
+
+		if (!exceptionThrown) {
+			Assert.fail("No exception thrown");
+		}
+	}
+
+	private static <IN1, IN2, OUT> TwoInputStreamOperatorTestHarness<IN1, IN2, OUT> getInitializedTestHarness(
+			final BroadcastProcessFunction<IN1, IN2, OUT> function) throws Exception {
+
+		return getInitializedTestHarness(
+				function,
+				1,
+				1,
+				0);
+	}
+
+	private static <IN1, IN2, OUT> TwoInputStreamOperatorTestHarness<IN1, IN2, OUT> getInitializedTestHarness(
+			final BroadcastProcessFunction<IN1, IN2, OUT> function,
+			final int maxParallelism,
+			final int numTasks,
+			final int taskIdx) throws Exception {
+
+		return getInitializedTestHarness(
+				function,
+				maxParallelism,
+				numTasks,
+				taskIdx,
+				null);
+	}
+
+	private static <IN1, IN2, OUT> TwoInputStreamOperatorTestHarness<IN1, IN2, OUT> getInitializedTestHarness(
+			final BroadcastProcessFunction<IN1, IN2, OUT> function,
+			final int maxParallelism,
+			final int numTasks,
+			final int taskIdx,
+			final OperatorStateHandles initState) throws Exception {
+
+		TwoInputStreamOperatorTestHarness<IN1, IN2, OUT> testHarness = new TwoInputStreamOperatorTestHarness<>(
+				new CoBroadcastWithNonKeyedOperator<>(
+						Preconditions.checkNotNull(function),
+						Collections.singletonList(STATE_DESCRIPTOR)),
+				maxParallelism, numTasks, taskIdx
+		);
+		testHarness.setup();
+		testHarness.initializeState(initState);
+		testHarness.open();
+
+		return testHarness;
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/TwoInputStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/TwoInputStreamOperatorTestHarness.java
@@ -29,7 +29,7 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
  * and watermarks into the operator. {@link java.util.Deque}s containing the emitted elements
  * and watermarks can be retrieved. you are free to modify these.
  */
-public class TwoInputStreamOperatorTestHarness<IN1, IN2, OUT>extends AbstractStreamOperatorTestHarness<OUT> {
+public class TwoInputStreamOperatorTestHarness<IN1, IN2, OUT> extends AbstractStreamOperatorTestHarness<OUT> {
 
 	private final TwoInputStreamOperator<IN1, IN2, OUT> twoInputOperator;
 

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/BroadcastStateITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/BroadcastStateITCase.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.streaming.runtime;
+
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.streaming.api.TimeCharacteristic;
+import org.apache.flink.streaming.api.datastream.BroadcastStream;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.AssignerWithPunctuatedWatermarks;
+import org.apache.flink.streaming.api.functions.co.KeyedBroadcastProcessFunction;
+import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.util.Collector;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.annotation.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * ITCase for the {@link org.apache.flink.api.common.state.BroadcastState}.
+ */
+public class BroadcastStateITCase {
+
+	@Test
+	public void testConnectWithBroadcastTranslation() throws Exception {
+
+		final Map<Long, String> expected = new HashMap<>();
+		expected.put(0L, "test:0");
+		expected.put(1L, "test:1");
+		expected.put(2L, "test:2");
+		expected.put(3L, "test:3");
+		expected.put(4L, "test:4");
+		expected.put(5L, "test:5");
+
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+
+		final DataStream<Long> srcOne = env.generateSequence(0L, 5L)
+				.assignTimestampsAndWatermarks(new CustomWmEmitter<Long>() {
+
+					private static final long serialVersionUID = -8500904795760316195L;
+
+					@Override
+					public long extractTimestamp(Long element, long previousElementTimestamp) {
+						return element;
+					}
+				}).keyBy((KeySelector<Long, Long>) value -> value);
+
+		final DataStream<String> srcTwo = env.fromCollection(expected.values())
+				.assignTimestampsAndWatermarks(new CustomWmEmitter<String>() {
+
+					private static final long serialVersionUID = -2148318224248467213L;
+
+					@Override
+					public long extractTimestamp(String element, long previousElementTimestamp) {
+						return Long.parseLong(element.split(":")[1]);
+					}
+				});
+
+		final BroadcastStream<String> broadcast = srcTwo.broadcast(TestBroadcastProcessFunction.DESCRIPTOR);
+
+		// the timestamp should be high enough to trigger the timer after all the elements arrive.
+		final DataStream<String> output = srcOne.connect(broadcast).process(
+				new TestBroadcastProcessFunction(100000L, expected));
+
+		output
+				.addSink(new TestSink(expected.size()))
+				.setParallelism(1);
+		env.execute();
+	}
+
+	private static class TestSink extends RichSinkFunction<String> {
+
+		private static final long serialVersionUID = 7252508825104554749L;
+
+		private final int expectedOutputCounter;
+
+		private int outputCounter;
+
+		TestSink(int expectedOutputCounter) {
+			this.expectedOutputCounter = expectedOutputCounter;
+			this.outputCounter = 0;
+		}
+
+		@Override
+		public void invoke(String value, Context context) throws Exception {
+			outputCounter++;
+		}
+
+		@Override
+		public void close() throws Exception {
+			super.close();
+
+			// make sure that all the timers fired
+			Assert.assertEquals(expectedOutputCounter, outputCounter);
+		}
+	}
+
+	private abstract static class CustomWmEmitter<T> implements AssignerWithPunctuatedWatermarks<T> {
+
+		private static final long serialVersionUID = -5187335197674841233L;
+
+		@Nullable
+		@Override
+		public Watermark checkAndGetNextWatermark(T lastElement, long extractedTimestamp) {
+			return new Watermark(extractedTimestamp);
+		}
+	}
+
+	/**
+	 * A {@link KeyedBroadcastProcessFunction} which on the broadcast side puts elements in the broadcast state
+	 * while on the non-broadcast side, it sets a timer to fire at some point in the future. Finally, when the onTimer
+	 * method is called (i.e. when the timer fires), we verify that the result is the expected one.
+	 */
+	private static class TestBroadcastProcessFunction extends KeyedBroadcastProcessFunction<Long, Long, String, String> {
+
+		private static final long serialVersionUID = 7616910653561100842L;
+
+		private final Map<Long, String> expectedState;
+
+		private final long timerTimestamp;
+
+		static final MapStateDescriptor<Long, String> DESCRIPTOR = new MapStateDescriptor<>(
+				"broadcast-state", BasicTypeInfo.LONG_TYPE_INFO, BasicTypeInfo.STRING_TYPE_INFO
+		);
+
+		TestBroadcastProcessFunction(
+				final long timerTS,
+				final Map<Long, String> expectedBroadcastState
+		) {
+			expectedState = expectedBroadcastState;
+			timerTimestamp = timerTS;
+		}
+
+		@Override
+		public void processElement(Long value, KeyedReadOnlyContext ctx, Collector<String> out) throws Exception {
+			ctx.timerService().registerEventTimeTimer(timerTimestamp);
+		}
+
+		@Override
+		public void processBroadcastElement(String value, KeyedContext ctx, Collector<String> out) throws Exception {
+			long key = Long.parseLong(value.split(":")[1]);
+			ctx.getBroadcastState(DESCRIPTOR).put(key, value);
+		}
+
+		@Override
+		public void onTimer(long timestamp, OnTimerContext ctx, Collector<String> out) throws Exception {
+			Assert.assertEquals(timerTimestamp, timestamp);
+
+			Map<Long, String> map = new HashMap<>();
+			for (Map.Entry<Long, String> entry : ctx.getBroadcastState(DESCRIPTOR).immutableEntries()) {
+				map.put(entry.getKey(), entry.getValue());
+			}
+
+			Assert.assertEquals(expectedState, map);
+
+			out.collect(Long.toString(timestamp));
+		}
+	}
+}


### PR DESCRIPTION
R @aljoscha 

## What is the purpose of the change

This PR adds support for broadcast state and exposes it through the `DataStream API`. The user can now create a `BroadcastStream`, i.e. a stream whose elements are broadcasted to all downstream tasks, connect it with a keyed or non-keyed datastream, and from the broadcast side, he can read/write to the broadcast state, while on the non-broadcasted he can only read the broadcast state.

## Brief change log

At the state backend level, the `OperatorStateStore` has now a new method `getBroadcastState()` which returns a handle to the broadcast state.

At the API level, there are some new commands added to the `Datastream API` and a new type of `ProcessFunction` which operates on connected streams with broadcast state.

## Verifying this change

There are tests added.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: yes (a new type of state)
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? not documented
