### PR TITLE
[FLINK-8348] [flip6] Print help for DefaultCLI

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/RemoteExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/RemoteExecutor.java
@@ -58,7 +58,7 @@ public class RemoteExecutor extends PlanExecutor {
 
 	private final Configuration clientConfiguration;
 
-	private ClusterClient client;
+	private ClusterClient<?> client;
 
 	private int defaultParallelism = 1;
 

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/AbstractCustomCommandLine.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/AbstractCustomCommandLine.java
@@ -38,7 +38,7 @@ import static org.apache.flink.client.cli.CliFrontend.setJobManagerAddressInConf
  * a ZooKeeper namespace.
  *
  */
-public abstract class AbstractCustomCommandLine implements CustomCommandLine {
+public abstract class AbstractCustomCommandLine<T> implements CustomCommandLine<T> {
 
 	protected final Option zookeeperNamespaceOption = new Option("z", "zookeeperNamespace", true,
 		"Namespace to create the Zookeeper sub-paths for high availability mode");

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/AbstractCustomCommandLine.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/AbstractCustomCommandLine.java
@@ -19,7 +19,6 @@
 package org.apache.flink.client.cli;
 
 import org.apache.flink.client.ClientUtils;
-import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.UnmodifiableConfiguration;
@@ -38,9 +37,8 @@ import static org.apache.flink.client.cli.CliFrontend.setJobManagerAddressInConf
  * Base class for {@link CustomCommandLine} implementations which specify a JobManager address and
  * a ZooKeeper namespace.
  *
- * @param <C> type of the ClusterClient which is returned
  */
-public abstract class AbstractCustomCommandLine<C extends ClusterClient> implements CustomCommandLine<C> {
+public abstract class AbstractCustomCommandLine implements CustomCommandLine {
 
 	protected final Option zookeeperNamespaceOption = new Option("z", "zookeeperNamespace", true,
 		"Namespace to create the Zookeeper sub-paths for high availability mode");

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/AbstractCustomCommandLine.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/AbstractCustomCommandLine.java
@@ -22,6 +22,9 @@ import org.apache.flink.client.ClientUtils;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
+import org.apache.flink.configuration.UnmodifiableConfiguration;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.Preconditions;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
@@ -47,6 +50,16 @@ public abstract class AbstractCustomCommandLine<C extends ClusterClient> impleme
 		"Address of the JobManager (master) to which to connect. " +
 			"Use this flag to connect to a different JobManager than the one specified in the configuration.");
 
+	protected final Configuration configuration;
+
+	protected AbstractCustomCommandLine(Configuration configuration) {
+		this.configuration = new UnmodifiableConfiguration(Preconditions.checkNotNull(configuration));
+	}
+
+	public Configuration getConfiguration() {
+		return configuration;
+	}
+
 	@Override
 	public void addRunOptions(Options baseOptions) {
 		// nothing to add here
@@ -61,11 +74,10 @@ public abstract class AbstractCustomCommandLine<C extends ClusterClient> impleme
 	/**
 	 * Override configuration settings by specified command line options.
 	 *
-	 * @param configuration to use as the base configuration
 	 * @param commandLine containing the overriding values
 	 * @return Effective configuration with the overriden configuration settings
 	 */
-	protected Configuration applyCommandLineOptionsToConfiguration(Configuration configuration, CommandLine commandLine) {
+	protected Configuration applyCommandLineOptionsToConfiguration(CommandLine commandLine) throws FlinkException {
 		final Configuration resultingConfiguration = new Configuration(configuration);
 
 		if (commandLine.hasOption(addressOption.getOpt())) {

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -106,7 +106,7 @@ public class CliFrontend {
 
 	private final Configuration configuration;
 
-	private final List<CustomCommandLine<?>> customCommandLines;
+	private final List<CustomCommandLine> customCommandLines;
 
 	private final Options customCommandLineOptions;
 
@@ -116,7 +116,7 @@ public class CliFrontend {
 
 	public CliFrontend(
 			Configuration configuration,
-			List<CustomCommandLine<?>> customCommandLines) throws Exception {
+			List<CustomCommandLine> customCommandLines) throws Exception {
 		this.configuration = Preconditions.checkNotNull(configuration);
 		this.customCommandLines = Preconditions.checkNotNull(customCommandLines);
 
@@ -129,7 +129,7 @@ public class CliFrontend {
 
 		this.customCommandLineOptions = new Options();
 
-		for (CustomCommandLine<?> customCommandLine : customCommandLines) {
+		for (CustomCommandLine customCommandLine : customCommandLines) {
 			customCommandLine.addGeneralOptions(customCommandLineOptions);
 			customCommandLine.addRunOptions(customCommandLineOptions);
 		}
@@ -196,9 +196,9 @@ public class CliFrontend {
 			throw new CliArgsException("Could not build the program from JAR file.", e);
 		}
 
-		final CustomCommandLine<?> customCommandLine = getActiveCustomCommandLine(commandLine);
+		final CustomCommandLine customCommandLine = getActiveCustomCommandLine(commandLine);
 
-		final ClusterDescriptor<?> clusterDescriptor = customCommandLine.createClusterDescriptor(commandLine);
+		final ClusterDescriptor clusterDescriptor = customCommandLine.createClusterDescriptor(commandLine);
 
 		try {
 			final String clusterId = customCommandLine.getClusterId(commandLine);
@@ -351,8 +351,8 @@ public class CliFrontend {
 			scheduled = true;
 		}
 
-		final CustomCommandLine<?> activeCommandLine = getActiveCustomCommandLine(commandLine);
-		final ClusterDescriptor<?> clusterDescriptor = activeCommandLine.createClusterDescriptor(commandLine);
+		final CustomCommandLine activeCommandLine = getActiveCustomCommandLine(commandLine);
+		final ClusterDescriptor clusterDescriptor = activeCommandLine.createClusterDescriptor(commandLine);
 
 		final String clusterId = activeCommandLine.getClusterId(commandLine);
 
@@ -473,9 +473,9 @@ public class CliFrontend {
 			throw new CliArgsException("Missing JobID");
 		}
 
-		final CustomCommandLine<?> activeCommandLine = getActiveCustomCommandLine(commandLine);
+		final CustomCommandLine activeCommandLine = getActiveCustomCommandLine(commandLine);
 
-		final ClusterDescriptor<?> clusterDescriptor = activeCommandLine.createClusterDescriptor(commandLine);
+		final ClusterDescriptor clusterDescriptor = activeCommandLine.createClusterDescriptor(commandLine);
 
 		final String clusterId = activeCommandLine.getClusterId(commandLine);
 
@@ -553,9 +553,9 @@ public class CliFrontend {
 			throw new CliArgsException("Missing JobID in the command line arguments.");
 		}
 
-		final CustomCommandLine<?> activeCommandLine = getActiveCustomCommandLine(commandLine);
+		final CustomCommandLine activeCommandLine = getActiveCustomCommandLine(commandLine);
 
-		final ClusterDescriptor<?> clusterDescriptor = activeCommandLine.createClusterDescriptor(commandLine);
+		final ClusterDescriptor clusterDescriptor = activeCommandLine.createClusterDescriptor(commandLine);
 
 		final String clusterId = activeCommandLine.getClusterId(commandLine);
 
@@ -617,9 +617,9 @@ public class CliFrontend {
 			return;
 		}
 
-		CustomCommandLine<?> customCommandLine = getActiveCustomCommandLine(commandLine);
+		CustomCommandLine customCommandLine = getActiveCustomCommandLine(commandLine);
 
-		final ClusterDescriptor<?> clusterDescriptor = customCommandLine.createClusterDescriptor(commandLine);
+		final ClusterDescriptor clusterDescriptor = customCommandLine.createClusterDescriptor(commandLine);
 
 		final String clusterId = customCommandLine.getClusterId(commandLine);
 
@@ -972,7 +972,7 @@ public class CliFrontend {
 		final Configuration configuration = GlobalConfiguration.loadConfiguration(configurationDirectory);
 
 		// 3. load the custom command lines
-		final List<CustomCommandLine<?>> customCommandLines = loadCustomCommandLines(
+		final List<CustomCommandLine> customCommandLines = loadCustomCommandLines(
 			configuration,
 			configurationDirectory);
 
@@ -1039,8 +1039,8 @@ public class CliFrontend {
 		config.setInteger(JobManagerOptions.PORT, address.getPort());
 	}
 
-	public static List<CustomCommandLine<?>> loadCustomCommandLines(Configuration configuration, String configurationDirectory) {
-		List<CustomCommandLine<?>> customCommandLines = new ArrayList<>(2);
+	public static List<CustomCommandLine> loadCustomCommandLines(Configuration configuration, String configurationDirectory) {
+		List<CustomCommandLine> customCommandLines = new ArrayList<>(2);
 
 		//	Command line interface of the YARN session, with a special initialization here
 		//	to prefix all options with y/yarn.
@@ -1087,7 +1087,7 @@ public class CliFrontend {
 	 * @param className The fully-qualified class name to load.
 	 * @param params The constructor parameters
 	 */
-	private static CustomCommandLine<?> loadCustomCommandLine(String className, Object... params) throws IllegalAccessException, InvocationTargetException, InstantiationException, ClassNotFoundException, NoSuchMethodException {
+	private static CustomCommandLine loadCustomCommandLine(String className, Object... params) throws IllegalAccessException, InvocationTargetException, InstantiationException, ClassNotFoundException, NoSuchMethodException {
 
 		Class<? extends CustomCommandLine> customCliClass =
 			Class.forName(className).asSubclass(CustomCommandLine.class);

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -232,6 +232,15 @@ public class CliFrontend {
 
 				executeProgram(program, client, userParallelism);
 			} finally {
+				if (clusterId == null && !client.isDetached()) {
+					// terminate the cluster only if we have started it before and if it's not detached
+					try {
+						clusterDescriptor.terminateCluster(client.getClusterIdentifier());
+					} catch (FlinkException e) {
+						LOG.info("Could not properly terminate the Flink cluster.", e);
+					}
+				}
+
 				try {
 					client.shutdown();
 				} catch (Exception e) {

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
@@ -236,7 +236,7 @@ public class CliFrontendParser {
 	/**
 	 * Prints the help for the client.
 	 */
-	public static void printHelp(Collection<CustomCommandLine> customCommandLines) {
+	public static void printHelp(Collection<CustomCommandLine<?>> customCommandLines) {
 		System.out.println("./flink <ACTION> [OPTIONS] [ARGUMENTS]");
 		System.out.println();
 		System.out.println("The following actions are available:");
@@ -251,7 +251,7 @@ public class CliFrontendParser {
 		System.out.println();
 	}
 
-	public static void printHelpForRun(Collection<CustomCommandLine> customCommandLines) {
+	public static void printHelpForRun(Collection<CustomCommandLine<?>> customCommandLines) {
 		HelpFormatter formatter = new HelpFormatter();
 		formatter.setLeftPadding(5);
 		formatter.setWidth(80);
@@ -279,7 +279,7 @@ public class CliFrontendParser {
 		System.out.println();
 	}
 
-	public static void printHelpForList(Collection<CustomCommandLine> customCommandLines) {
+	public static void printHelpForList(Collection<CustomCommandLine<?>> customCommandLines) {
 		HelpFormatter formatter = new HelpFormatter();
 		formatter.setLeftPadding(5);
 		formatter.setWidth(80);
@@ -294,7 +294,7 @@ public class CliFrontendParser {
 		System.out.println();
 	}
 
-	public static void printHelpForStop(Collection<CustomCommandLine> customCommandLines) {
+	public static void printHelpForStop(Collection<CustomCommandLine<?>> customCommandLines) {
 		HelpFormatter formatter = new HelpFormatter();
 		formatter.setLeftPadding(5);
 		formatter.setWidth(80);
@@ -309,7 +309,7 @@ public class CliFrontendParser {
 		System.out.println();
 	}
 
-	public static void printHelpForCancel(Collection<CustomCommandLine> customCommandLines) {
+	public static void printHelpForCancel(Collection<CustomCommandLine<?>> customCommandLines) {
 		HelpFormatter formatter = new HelpFormatter();
 		formatter.setLeftPadding(5);
 		formatter.setWidth(80);
@@ -324,7 +324,7 @@ public class CliFrontendParser {
 		System.out.println();
 	}
 
-	public static void printHelpForSavepoint(Collection<CustomCommandLine> customCommandLines) {
+	public static void printHelpForSavepoint(Collection<CustomCommandLine<?>> customCommandLines) {
 		HelpFormatter formatter = new HelpFormatter();
 		formatter.setLeftPadding(5);
 		formatter.setWidth(80);
@@ -345,7 +345,7 @@ public class CliFrontendParser {
 	 * @param runOptions True if the run options should be printed, False to print only general options
 	 */
 	private static void printCustomCliOptions(
-			Collection<CustomCommandLine> customCommandLines,
+			Collection<CustomCommandLine<?>> customCommandLines,
 			HelpFormatter formatter,
 			boolean runOptions) {
 		// prints options from all available command-line classes

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
@@ -236,7 +236,7 @@ public class CliFrontendParser {
 	/**
 	 * Prints the help for the client.
 	 */
-	public static void printHelp(Collection<CustomCommandLine<?>> customCommandLines) {
+	public static void printHelp(Collection<CustomCommandLine> customCommandLines) {
 		System.out.println("./flink <ACTION> [OPTIONS] [ARGUMENTS]");
 		System.out.println();
 		System.out.println("The following actions are available:");
@@ -251,7 +251,7 @@ public class CliFrontendParser {
 		System.out.println();
 	}
 
-	public static void printHelpForRun(Collection<CustomCommandLine<?>> customCommandLines) {
+	public static void printHelpForRun(Collection<CustomCommandLine> customCommandLines) {
 		HelpFormatter formatter = new HelpFormatter();
 		formatter.setLeftPadding(5);
 		formatter.setWidth(80);
@@ -279,7 +279,7 @@ public class CliFrontendParser {
 		System.out.println();
 	}
 
-	public static void printHelpForList(Collection<CustomCommandLine<?>> customCommandLines) {
+	public static void printHelpForList(Collection<CustomCommandLine> customCommandLines) {
 		HelpFormatter formatter = new HelpFormatter();
 		formatter.setLeftPadding(5);
 		formatter.setWidth(80);
@@ -294,7 +294,7 @@ public class CliFrontendParser {
 		System.out.println();
 	}
 
-	public static void printHelpForStop(Collection<CustomCommandLine<?>> customCommandLines) {
+	public static void printHelpForStop(Collection<CustomCommandLine> customCommandLines) {
 		HelpFormatter formatter = new HelpFormatter();
 		formatter.setLeftPadding(5);
 		formatter.setWidth(80);
@@ -309,7 +309,7 @@ public class CliFrontendParser {
 		System.out.println();
 	}
 
-	public static void printHelpForCancel(Collection<CustomCommandLine<?>> customCommandLines) {
+	public static void printHelpForCancel(Collection<CustomCommandLine> customCommandLines) {
 		HelpFormatter formatter = new HelpFormatter();
 		formatter.setLeftPadding(5);
 		formatter.setWidth(80);
@@ -324,7 +324,7 @@ public class CliFrontendParser {
 		System.out.println();
 	}
 
-	public static void printHelpForSavepoint(Collection<CustomCommandLine<?>> customCommandLines) {
+	public static void printHelpForSavepoint(Collection<CustomCommandLine> customCommandLines) {
 		HelpFormatter formatter = new HelpFormatter();
 		formatter.setLeftPadding(5);
 		formatter.setWidth(80);
@@ -345,7 +345,7 @@ public class CliFrontendParser {
 	 * @param runOptions True if the run options should be printed, False to print only general options
 	 */
 	private static void printCustomCliOptions(
-			Collection<CustomCommandLine<?>> customCommandLines,
+			Collection<CustomCommandLine> customCommandLines,
 			HelpFormatter formatter,
 			boolean runOptions) {
 		// prints options from all available command-line classes

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
@@ -350,16 +350,14 @@ public class CliFrontendParser {
 			boolean runOptions) {
 		// prints options from all available command-line classes
 		for (CustomCommandLine cli: customCommandLines) {
-			if (cli.getId() != null) {
-				formatter.setSyntaxPrefix("  Options for " + cli.getId() + " mode:");
-				Options customOpts = new Options();
-				cli.addGeneralOptions(customOpts);
-				if (runOptions) {
-					cli.addRunOptions(customOpts);
-				}
-				formatter.printHelp(" ", customOpts);
-				System.out.println();
+			formatter.setSyntaxPrefix("  Options for " + cli.getId() + " mode:");
+			Options customOpts = new Options();
+			cli.addGeneralOptions(customOpts);
+			if (runOptions) {
+				cli.addRunOptions(customOpts);
 			}
+			formatter.printHelp(" ", customOpts);
+			System.out.println();
 		}
 	}
 

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CommandLineOptions.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CommandLineOptions.java
@@ -20,7 +20,6 @@ package org.apache.flink.client.cli;
 
 import org.apache.commons.cli.CommandLine;
 
-import static org.apache.flink.client.cli.CliFrontendParser.ADDRESS_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.HELP_OPTION;
 
 /**
@@ -29,28 +28,13 @@ import static org.apache.flink.client.cli.CliFrontendParser.HELP_OPTION;
  */
 public abstract class CommandLineOptions {
 
-	private final CommandLine commandLine;
-
-	private final String jobManagerAddress;
-
 	private final boolean printHelp;
 
 	protected CommandLineOptions(CommandLine line) {
-		this.commandLine = line;
 		this.printHelp = line.hasOption(HELP_OPTION.getOpt());
-		this.jobManagerAddress = line.hasOption(ADDRESS_OPTION.getOpt()) ?
-				line.getOptionValue(ADDRESS_OPTION.getOpt()) : null;
-	}
-
-	public CommandLine getCommandLine() {
-		return commandLine;
 	}
 
 	public boolean isPrintHelp() {
 		return printHelp;
-	}
-
-	public String getJobManagerAddress() {
-		return jobManagerAddress;
 	}
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CustomCommandLine.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CustomCommandLine.java
@@ -20,7 +20,6 @@ package org.apache.flink.client.cli;
 
 import org.apache.flink.client.deployment.ClusterDescriptor;
 import org.apache.flink.client.deployment.ClusterSpecification;
-import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.util.FlinkException;
 
 import org.apache.commons.cli.CommandLine;
@@ -31,7 +30,7 @@ import javax.annotation.Nullable;
 /**
  * Custom command-line interface to load hooks for the command-line interface.
  */
-public interface CustomCommandLine<ClusterType extends ClusterClient> {
+public interface CustomCommandLine {
 
 	/**
 	 * Signals whether the custom command-line wants to execute or not.
@@ -67,7 +66,7 @@ public interface CustomCommandLine<ClusterType extends ClusterClient> {
 	 * @return ClusterDescriptor
 	 * @throws FlinkException if the ClusterDescriptor could not be created
 	 */
-	ClusterDescriptor<ClusterType> createClusterDescriptor(CommandLine commandLine) throws FlinkException;
+	ClusterDescriptor createClusterDescriptor(CommandLine commandLine) throws FlinkException;
 
 	/**
 	 * Returns the cluster id if a cluster id was specified on the command line, otherwise it

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CustomCommandLine.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CustomCommandLine.java
@@ -21,7 +21,7 @@ package org.apache.flink.client.cli;
 import org.apache.flink.client.deployment.ClusterDescriptor;
 import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.client.program.ClusterClient;
-import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.FlinkException;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
@@ -36,10 +36,9 @@ public interface CustomCommandLine<ClusterType extends ClusterClient> {
 	/**
 	 * Signals whether the custom command-line wants to execute or not.
 	 * @param commandLine The command-line options
-	 * @param configuration The Flink configuration
 	 * @return True if the command-line wants to run, False otherwise
 	 */
-	boolean isActive(CommandLine commandLine, Configuration configuration);
+	boolean isActive(CommandLine commandLine);
 
 	/**
 	 * Gets the unique identifier of this CustomCommandLine.
@@ -55,6 +54,7 @@ public interface CustomCommandLine<ClusterType extends ClusterClient> {
 
 	/**
 	 * Adds custom options to the existing general options.
+	 *
 	 * @param baseOptions The existing options.
 	 */
 	void addGeneralOptions(Options baseOptions);
@@ -63,15 +63,11 @@ public interface CustomCommandLine<ClusterType extends ClusterClient> {
 	 * Create a {@link ClusterDescriptor} from the given configuration, configuration directory
 	 * and the command line.
 	 *
-	 * @param configuration to create the ClusterDescriptor with
-	 * @param configurationDirectory where the configuration was loaded from
 	 * @param commandLine containing command line options relevant for the ClusterDescriptor
 	 * @return ClusterDescriptor
+	 * @throws FlinkException if the ClusterDescriptor could not be created
 	 */
-	ClusterDescriptor<ClusterType> createClusterDescriptor(
-		Configuration configuration,
-		String configurationDirectory,
-		CommandLine commandLine);
+	ClusterDescriptor<ClusterType> createClusterDescriptor(CommandLine commandLine) throws FlinkException;
 
 	/**
 	 * Returns the cluster id if a cluster id was specified on the command line, otherwise it
@@ -80,24 +76,21 @@ public interface CustomCommandLine<ClusterType extends ClusterClient> {
 	 * <p>A cluster id identifies a running cluster, e.g. the Yarn application id for a Flink
 	 * cluster running on Yarn.
 	 *
-	 * @param configuration to be used for the cluster id retrieval
 	 * @param commandLine containing command line options relevant for the cluster id retrieval
 	 * @return Cluster id identifying the cluster to deploy jobs to or null
 	 */
 	@Nullable
-	String getClusterId(Configuration configuration, CommandLine commandLine);
+	String getClusterId(CommandLine commandLine);
 
 	/**
 	 * Returns the {@link ClusterSpecification} specified by the configuration and the command
 	 * line options. This specification can be used to deploy a new Flink cluster.
 	 *
-	 * @param configuration to be used for the ClusterSpecification values
 	 * @param commandLine containing command line options relevant for the ClusterSpecification
 	 * @return ClusterSpecification for a new Flink cluster
+	 * @throws FlinkException if the ClusterSpecification could not be created
 	 */
-	ClusterSpecification getClusterSpecification(
-		Configuration configuration,
-		CommandLine commandLine);
+	ClusterSpecification getClusterSpecification(CommandLine commandLine) throws FlinkException;
 
 	default CommandLine parseCommandLineOptions(String[] args, boolean stopAtNonOptions) throws CliArgsException {
 		final Options options = new Options();

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CustomCommandLine.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CustomCommandLine.java
@@ -30,7 +30,7 @@ import javax.annotation.Nullable;
 /**
  * Custom command-line interface to load hooks for the command-line interface.
  */
-public interface CustomCommandLine {
+public interface CustomCommandLine<T> {
 
 	/**
 	 * Signals whether the custom command-line wants to execute or not.
@@ -66,7 +66,7 @@ public interface CustomCommandLine {
 	 * @return ClusterDescriptor
 	 * @throws FlinkException if the ClusterDescriptor could not be created
 	 */
-	ClusterDescriptor createClusterDescriptor(CommandLine commandLine) throws FlinkException;
+	ClusterDescriptor<T> createClusterDescriptor(CommandLine commandLine) throws FlinkException;
 
 	/**
 	 * Returns the cluster id if a cluster id was specified on the command line, otherwise it
@@ -79,7 +79,7 @@ public interface CustomCommandLine {
 	 * @return Cluster id identifying the cluster to deploy jobs to or null
 	 */
 	@Nullable
-	String getClusterId(CommandLine commandLine);
+	T getClusterId(CommandLine commandLine);
 
 	/**
 	 * Returns the {@link ClusterSpecification} specified by the configuration and the command

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/DefaultCLI.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/DefaultCLI.java
@@ -18,9 +18,9 @@
 
 package org.apache.flink.client.cli;
 
-import org.apache.flink.client.deployment.ClusterDescriptor;
 import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.client.deployment.StandaloneClusterDescriptor;
+import org.apache.flink.client.deployment.StandaloneClusterId;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.FlinkException;
 
@@ -31,7 +31,7 @@ import javax.annotation.Nullable;
 /**
  * The default CLI which is used for interaction with standalone clusters.
  */
-public class DefaultCLI extends AbstractCustomCommandLine {
+public class DefaultCLI extends AbstractCustomCommandLine<StandaloneClusterId> {
 
 	public DefaultCLI(Configuration configuration) {
 		super(configuration);
@@ -49,7 +49,7 @@ public class DefaultCLI extends AbstractCustomCommandLine {
 	}
 
 	@Override
-	public ClusterDescriptor createClusterDescriptor(
+	public StandaloneClusterDescriptor createClusterDescriptor(
 			CommandLine commandLine) throws FlinkException {
 		final Configuration effectiveConfiguration = applyCommandLineOptionsToConfiguration(commandLine);
 
@@ -58,8 +58,8 @@ public class DefaultCLI extends AbstractCustomCommandLine {
 
 	@Override
 	@Nullable
-	public String getClusterId(CommandLine commandLine) {
-		return "standalone";
+	public StandaloneClusterId getClusterId(CommandLine commandLine) {
+		return StandaloneClusterId.getInstance();
 	}
 
 	@Override

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/DefaultCLI.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/DefaultCLI.java
@@ -23,6 +23,7 @@ import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.client.deployment.StandaloneClusterDescriptor;
 import org.apache.flink.client.program.StandaloneClusterClient;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.FlinkException;
 
 import org.apache.commons.cli.CommandLine;
 
@@ -33,8 +34,12 @@ import javax.annotation.Nullable;
  */
 public class DefaultCLI extends AbstractCustomCommandLine<StandaloneClusterClient> {
 
+	public DefaultCLI(Configuration configuration) {
+		super(configuration);
+	}
+
 	@Override
-	public boolean isActive(CommandLine commandLine, Configuration configuration) {
+	public boolean isActive(CommandLine commandLine) {
 		// always active because we can try to read a JobManager address from the config
 		return true;
 	}
@@ -46,22 +51,20 @@ public class DefaultCLI extends AbstractCustomCommandLine<StandaloneClusterClien
 
 	@Override
 	public ClusterDescriptor<StandaloneClusterClient> createClusterDescriptor(
-			Configuration configuration,
-			String configurationDirectory,
-			CommandLine commandLine) {
-		final Configuration effectiveConfiguration = applyCommandLineOptionsToConfiguration(configuration, commandLine);
+			CommandLine commandLine) throws FlinkException {
+		final Configuration effectiveConfiguration = applyCommandLineOptionsToConfiguration(commandLine);
 
 		return new StandaloneClusterDescriptor(effectiveConfiguration);
 	}
 
 	@Override
 	@Nullable
-	public String getClusterId(Configuration configuration, CommandLine commandLine) {
+	public String getClusterId(CommandLine commandLine) {
 		return "standalone";
 	}
 
 	@Override
-	public ClusterSpecification getClusterSpecification(Configuration configuration, CommandLine commandLine) {
+	public ClusterSpecification getClusterSpecification(CommandLine commandLine) {
 		return new ClusterSpecification.ClusterSpecificationBuilder().createClusterSpecification();
 	}
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/DefaultCLI.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/DefaultCLI.java
@@ -21,7 +21,6 @@ package org.apache.flink.client.cli;
 import org.apache.flink.client.deployment.ClusterDescriptor;
 import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.client.deployment.StandaloneClusterDescriptor;
-import org.apache.flink.client.program.StandaloneClusterClient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.FlinkException;
 
@@ -32,7 +31,7 @@ import javax.annotation.Nullable;
 /**
  * The default CLI which is used for interaction with standalone clusters.
  */
-public class DefaultCLI extends AbstractCustomCommandLine<StandaloneClusterClient> {
+public class DefaultCLI extends AbstractCustomCommandLine {
 
 	public DefaultCLI(Configuration configuration) {
 		super(configuration);
@@ -50,7 +49,7 @@ public class DefaultCLI extends AbstractCustomCommandLine<StandaloneClusterClien
 	}
 
 	@Override
-	public ClusterDescriptor<StandaloneClusterClient> createClusterDescriptor(
+	public ClusterDescriptor createClusterDescriptor(
 			CommandLine commandLine) throws FlinkException {
 		final Configuration effectiveConfiguration = applyCommandLineOptionsToConfiguration(commandLine);
 

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/DefaultCLI.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/DefaultCLI.java
@@ -45,7 +45,7 @@ public class DefaultCLI extends AbstractCustomCommandLine<StandaloneClusterId> {
 
 	@Override
 	public String getId() {
-		return null;
+		return "Default CLI";
 	}
 
 	@Override

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/Flip6DefaultCLI.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/Flip6DefaultCLI.java
@@ -18,9 +18,9 @@
 
 package org.apache.flink.client.cli;
 
-import org.apache.flink.client.deployment.ClusterDescriptor;
 import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.client.deployment.Flip6StandaloneClusterDescriptor;
+import org.apache.flink.client.deployment.StandaloneClusterId;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.FlinkException;
 
@@ -33,7 +33,7 @@ import javax.annotation.Nullable;
 /**
  * The default CLI which is used for interaction with standalone clusters.
  */
-public class Flip6DefaultCLI extends AbstractCustomCommandLine {
+public class Flip6DefaultCLI extends AbstractCustomCommandLine<StandaloneClusterId> {
 
 	public static final Option FLIP_6 = new Option("flip6", "Switches the client to Flip-6 mode.");
 
@@ -62,7 +62,7 @@ public class Flip6DefaultCLI extends AbstractCustomCommandLine {
 	}
 
 	@Override
-	public ClusterDescriptor createClusterDescriptor(
+	public Flip6StandaloneClusterDescriptor createClusterDescriptor(
 			CommandLine commandLine) throws FlinkException {
 		final Configuration effectiveConfiguration = applyCommandLineOptionsToConfiguration(commandLine);
 
@@ -71,8 +71,8 @@ public class Flip6DefaultCLI extends AbstractCustomCommandLine {
 
 	@Override
 	@Nullable
-	public String getClusterId(CommandLine commandLine) {
-		return "flip6Standalone";
+	public StandaloneClusterId getClusterId(CommandLine commandLine) {
+		return StandaloneClusterId.getInstance();
 	}
 
 	@Override

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/Flip6DefaultCLI.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/Flip6DefaultCLI.java
@@ -23,6 +23,7 @@ import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.client.deployment.Flip6StandaloneClusterDescriptor;
 import org.apache.flink.client.program.rest.RestClusterClient;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.FlinkException;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
@@ -41,8 +42,12 @@ public class Flip6DefaultCLI extends AbstractCustomCommandLine<RestClusterClient
 		FLIP_6.setRequired(false);
 	}
 
+	public Flip6DefaultCLI(Configuration configuration) {
+		super(configuration);
+	}
+
 	@Override
-	public boolean isActive(CommandLine commandLine, Configuration configuration) {
+	public boolean isActive(CommandLine commandLine) {
 		return commandLine.hasOption(FLIP_6.getOpt());
 	}
 
@@ -59,22 +64,20 @@ public class Flip6DefaultCLI extends AbstractCustomCommandLine<RestClusterClient
 
 	@Override
 	public ClusterDescriptor<RestClusterClient> createClusterDescriptor(
-			Configuration configuration,
-			String configurationDirectory,
-			CommandLine commandLine) {
-		final Configuration effectiveConfiguration = applyCommandLineOptionsToConfiguration(configuration, commandLine);
+			CommandLine commandLine) throws FlinkException {
+		final Configuration effectiveConfiguration = applyCommandLineOptionsToConfiguration(commandLine);
 
 		return new Flip6StandaloneClusterDescriptor(effectiveConfiguration);
 	}
 
 	@Override
 	@Nullable
-	public String getClusterId(Configuration configuration, CommandLine commandLine) {
+	public String getClusterId(CommandLine commandLine) {
 		return "flip6Standalone";
 	}
 
 	@Override
-	public ClusterSpecification getClusterSpecification(Configuration configuration, CommandLine commandLine) {
+	public ClusterSpecification getClusterSpecification(CommandLine commandLine) {
 		return new ClusterSpecification.ClusterSpecificationBuilder().createClusterSpecification();
 	}
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/Flip6DefaultCLI.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/Flip6DefaultCLI.java
@@ -21,7 +21,6 @@ package org.apache.flink.client.cli;
 import org.apache.flink.client.deployment.ClusterDescriptor;
 import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.client.deployment.Flip6StandaloneClusterDescriptor;
-import org.apache.flink.client.program.rest.RestClusterClient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.FlinkException;
 
@@ -34,7 +33,7 @@ import javax.annotation.Nullable;
 /**
  * The default CLI which is used for interaction with standalone clusters.
  */
-public class Flip6DefaultCLI extends AbstractCustomCommandLine<RestClusterClient> {
+public class Flip6DefaultCLI extends AbstractCustomCommandLine {
 
 	public static final Option FLIP_6 = new Option("flip6", "Switches the client to Flip-6 mode.");
 
@@ -63,7 +62,7 @@ public class Flip6DefaultCLI extends AbstractCustomCommandLine<RestClusterClient
 	}
 
 	@Override
-	public ClusterDescriptor<RestClusterClient> createClusterDescriptor(
+	public ClusterDescriptor createClusterDescriptor(
 			CommandLine commandLine) throws FlinkException {
 		final Configuration effectiveConfiguration = applyCommandLineOptionsToConfiguration(commandLine);
 

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterDescriptor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterDescriptor.java
@@ -24,7 +24,7 @@ import org.apache.flink.runtime.jobgraph.JobGraph;
 /**
  * A descriptor to deploy a cluster (e.g. Yarn or Mesos) and return a Client for Cluster communication.
  */
-public interface ClusterDescriptor<ClientType extends ClusterClient> extends AutoCloseable {
+public interface ClusterDescriptor extends AutoCloseable {
 
 	/**
 	 * Returns a String containing details about the cluster (NodeManagers, available memory, ...).
@@ -38,7 +38,7 @@ public interface ClusterDescriptor<ClientType extends ClusterClient> extends Aut
 	 * @return Client for the cluster
 	 * @throws UnsupportedOperationException if this cluster descriptor doesn't support the operation
 	 */
-	ClientType retrieve(String applicationID) throws UnsupportedOperationException;
+	ClusterClient retrieve(String applicationID) throws UnsupportedOperationException;
 
 	/**
 	 * Triggers deployment of a cluster.
@@ -46,7 +46,7 @@ public interface ClusterDescriptor<ClientType extends ClusterClient> extends Aut
 	 * @return Client for the cluster
 	 * @throws UnsupportedOperationException if this cluster descriptor doesn't support the operation
 	 */
-	ClientType deploySessionCluster(ClusterSpecification clusterSpecification) throws UnsupportedOperationException;
+	ClusterClient deploySessionCluster(ClusterSpecification clusterSpecification) throws UnsupportedOperationException;
 
 	/**
 	 * Deploys a per-job cluster with the given job on the cluster.
@@ -56,7 +56,7 @@ public interface ClusterDescriptor<ClientType extends ClusterClient> extends Aut
 	 * @return Cluster client to talk to the Flink cluster
 	 * @throws ClusterDeploymentException if the cluster could not be deployed
 	 */
-	ClientType deployJobCluster(
+	ClusterClient deployJobCluster(
 		final ClusterSpecification clusterSpecification,
 		final JobGraph jobGraph);
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterDescriptor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterDescriptor.java
@@ -20,6 +20,7 @@ package org.apache.flink.client.deployment;
 
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.util.FlinkException;
 
 /**
  * A descriptor to deploy a cluster (e.g. Yarn or Mesos) and return a Client for Cluster communication.
@@ -59,4 +60,12 @@ public interface ClusterDescriptor extends AutoCloseable {
 	ClusterClient deployJobCluster(
 		final ClusterSpecification clusterSpecification,
 		final JobGraph jobGraph);
+
+	/**
+	 * Terminates the cluster with the given cluster id.
+	 *
+	 * @param clusterId identifying the cluster to shut down
+	 * @throws FlinkException if the cluster could not be terminated
+	 */
+	void terminateCluster(String clusterId) throws FlinkException;
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterDescriptor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterDescriptor.java
@@ -24,8 +24,10 @@ import org.apache.flink.util.FlinkException;
 
 /**
  * A descriptor to deploy a cluster (e.g. Yarn or Mesos) and return a Client for Cluster communication.
+ *
+ * @param <T> Type of the cluster id
  */
-public interface ClusterDescriptor extends AutoCloseable {
+public interface ClusterDescriptor<T> extends AutoCloseable {
 
 	/**
 	 * Returns a String containing details about the cluster (NodeManagers, available memory, ...).
@@ -35,19 +37,19 @@ public interface ClusterDescriptor extends AutoCloseable {
 
 	/**
 	 * Retrieves an existing Flink Cluster.
-	 * @param applicationID The unique application identifier of the running cluster
+	 * @param clusterId The unique identifier of the running cluster
 	 * @return Client for the cluster
-	 * @throws UnsupportedOperationException if this cluster descriptor doesn't support the operation
+	 * @throws ClusterRetrieveException if the cluster client could not be retrieved
 	 */
-	ClusterClient retrieve(String applicationID) throws UnsupportedOperationException;
+	ClusterClient<T> retrieve(T clusterId) throws ClusterRetrieveException;
 
 	/**
 	 * Triggers deployment of a cluster.
 	 * @param clusterSpecification Cluster specification defining the cluster to deploy
 	 * @return Client for the cluster
-	 * @throws UnsupportedOperationException if this cluster descriptor doesn't support the operation
+	 * @throws ClusterDeploymentException if the cluster could not be deployed
 	 */
-	ClusterClient deploySessionCluster(ClusterSpecification clusterSpecification) throws UnsupportedOperationException;
+	ClusterClient<T> deploySessionCluster(ClusterSpecification clusterSpecification) throws ClusterDeploymentException;
 
 	/**
 	 * Deploys a per-job cluster with the given job on the cluster.
@@ -57,9 +59,9 @@ public interface ClusterDescriptor extends AutoCloseable {
 	 * @return Cluster client to talk to the Flink cluster
 	 * @throws ClusterDeploymentException if the cluster could not be deployed
 	 */
-	ClusterClient deployJobCluster(
+	ClusterClient<T> deployJobCluster(
 		final ClusterSpecification clusterSpecification,
-		final JobGraph jobGraph);
+		final JobGraph jobGraph) throws ClusterDeploymentException;
 
 	/**
 	 * Terminates the cluster with the given cluster id.
@@ -67,5 +69,5 @@ public interface ClusterDescriptor extends AutoCloseable {
 	 * @param clusterId identifying the cluster to shut down
 	 * @throws FlinkException if the cluster could not be terminated
 	 */
-	void terminateCluster(String clusterId) throws FlinkException;
+	void terminateCluster(T clusterId) throws FlinkException;
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterRetrieveException.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterRetrieveException.java
@@ -16,19 +16,26 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.rpc;
+package org.apache.flink.client.deployment;
 
-import java.util.concurrent.CompletableFuture;
+import org.apache.flink.util.FlinkException;
 
 /**
- * Interface for self gateways.
+ * Exception which indicates that a cluster could not be retrieved.
  */
-public interface RpcServer extends StartStoppable, MainThreadExecutable, RpcGateway {
+public class ClusterRetrieveException extends FlinkException {
 
-	/**
-	 * Return a future which is completed when the rpc endpoint has been terminated.
-	 *
-	 * @return Future indicating when the rpc endpoint has been terminated
-	 */
-	CompletableFuture<Boolean> getTerminationFuture();
+	private static final long serialVersionUID = 7718062507419172318L;
+
+	public ClusterRetrieveException(String message) {
+		super(message);
+	}
+
+	public ClusterRetrieveException(Throwable cause) {
+		super(cause);
+	}
+
+	public ClusterRetrieveException(String message, Throwable cause) {
+		super(message, cause);
+	}
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/Flip6StandaloneClusterDescriptor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/Flip6StandaloneClusterDescriptor.java
@@ -28,7 +28,7 @@ import org.apache.flink.util.Preconditions;
 /**
  * A deployment descriptor for an existing cluster.
  */
-public class Flip6StandaloneClusterDescriptor implements ClusterDescriptor {
+public class Flip6StandaloneClusterDescriptor implements ClusterDescriptor<StandaloneClusterId> {
 
 	private final Configuration config;
 
@@ -44,27 +44,27 @@ public class Flip6StandaloneClusterDescriptor implements ClusterDescriptor {
 	}
 
 	@Override
-	public RestClusterClient retrieve(String applicationID) {
+	public RestClusterClient<StandaloneClusterId> retrieve(StandaloneClusterId standaloneClusterId) throws ClusterRetrieveException {
 		try {
-			return new RestClusterClient(config);
+			return new RestClusterClient<>(config, standaloneClusterId);
 		} catch (Exception e) {
-			throw new RuntimeException("Couldn't retrieve FLIP-6 standalone cluster", e);
+			throw new ClusterRetrieveException("Couldn't retrieve FLIP-6 standalone cluster", e);
 		}
 	}
 
 	@Override
-	public RestClusterClient deploySessionCluster(ClusterSpecification clusterSpecification) throws UnsupportedOperationException {
+	public RestClusterClient<StandaloneClusterId> deploySessionCluster(ClusterSpecification clusterSpecification) {
 		throw new UnsupportedOperationException("Can't deploy a FLIP-6 standalone cluster.");
 	}
 
 	@Override
-	public RestClusterClient deployJobCluster(ClusterSpecification clusterSpecification, JobGraph jobGraph) {
+	public RestClusterClient<StandaloneClusterId> deployJobCluster(ClusterSpecification clusterSpecification, JobGraph jobGraph) {
 		throw new UnsupportedOperationException("Can't deploy a standalone FLIP-6 per-job cluster.");
 	}
 
 	@Override
-	public void terminateCluster(String clusterId) throws FlinkException {
-		throw new UnsupportedOperationException("Cannot terminate a standalone Flip-6 cluster.");
+	public void terminateCluster(StandaloneClusterId clusterId) throws FlinkException {
+		throw new UnsupportedOperationException("Cannot terminate a Flip-6 standalone cluster.");
 	}
 
 	@Override

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/Flip6StandaloneClusterDescriptor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/Flip6StandaloneClusterDescriptor.java
@@ -27,7 +27,7 @@ import org.apache.flink.util.Preconditions;
 /**
  * A deployment descriptor for an existing cluster.
  */
-public class Flip6StandaloneClusterDescriptor implements ClusterDescriptor<RestClusterClient> {
+public class Flip6StandaloneClusterDescriptor implements ClusterDescriptor {
 
 	private final Configuration config;
 

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/Flip6StandaloneClusterDescriptor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/Flip6StandaloneClusterDescriptor.java
@@ -22,6 +22,7 @@ import org.apache.flink.client.program.rest.RestClusterClient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.Preconditions;
 
 /**
@@ -59,6 +60,11 @@ public class Flip6StandaloneClusterDescriptor implements ClusterDescriptor {
 	@Override
 	public RestClusterClient deployJobCluster(ClusterSpecification clusterSpecification, JobGraph jobGraph) {
 		throw new UnsupportedOperationException("Can't deploy a standalone FLIP-6 per-job cluster.");
+	}
+
+	@Override
+	public void terminateCluster(String clusterId) throws FlinkException {
+		throw new UnsupportedOperationException("Cannot terminate a standalone Flip-6 cluster.");
 	}
 
 	@Override

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/StandaloneClusterDescriptor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/StandaloneClusterDescriptor.java
@@ -27,7 +27,7 @@ import org.apache.flink.util.FlinkException;
 /**
  * A deployment descriptor for an existing cluster.
  */
-public class StandaloneClusterDescriptor implements ClusterDescriptor {
+public class StandaloneClusterDescriptor implements ClusterDescriptor<StandaloneClusterId> {
 
 	private final Configuration config;
 
@@ -43,16 +43,16 @@ public class StandaloneClusterDescriptor implements ClusterDescriptor {
 	}
 
 	@Override
-	public StandaloneClusterClient retrieve(String applicationID) {
+	public StandaloneClusterClient retrieve(StandaloneClusterId standaloneClusterId) throws ClusterRetrieveException {
 		try {
 			return new StandaloneClusterClient(config);
 		} catch (Exception e) {
-			throw new RuntimeException("Couldn't retrieve standalone cluster", e);
+			throw new ClusterRetrieveException("Couldn't retrieve standalone cluster", e);
 		}
 	}
 
 	@Override
-	public StandaloneClusterClient deploySessionCluster(ClusterSpecification clusterSpecification) throws UnsupportedOperationException {
+	public StandaloneClusterClient deploySessionCluster(ClusterSpecification clusterSpecification) {
 		throw new UnsupportedOperationException("Can't deploy a standalone cluster.");
 	}
 
@@ -62,8 +62,8 @@ public class StandaloneClusterDescriptor implements ClusterDescriptor {
 	}
 
 	@Override
-	public void terminateCluster(String clusterId) throws FlinkException {
-		throw new UnsupportedOperationException("Cannot terminate a standalone cluster.");
+	public void terminateCluster(StandaloneClusterId clusterId) throws FlinkException {
+		throw new UnsupportedOperationException("Cannot terminate standalone clusters.");
 	}
 
 	@Override

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/StandaloneClusterDescriptor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/StandaloneClusterDescriptor.java
@@ -22,6 +22,7 @@ import org.apache.flink.client.program.StandaloneClusterClient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.util.FlinkException;
 
 /**
  * A deployment descriptor for an existing cluster.
@@ -58,6 +59,11 @@ public class StandaloneClusterDescriptor implements ClusterDescriptor {
 	@Override
 	public StandaloneClusterClient deployJobCluster(ClusterSpecification clusterSpecification, JobGraph jobGraph) {
 		throw new UnsupportedOperationException("Can't deploy a standalone per-job cluster.");
+	}
+
+	@Override
+	public void terminateCluster(String clusterId) throws FlinkException {
+		throw new UnsupportedOperationException("Cannot terminate a standalone cluster.");
 	}
 
 	@Override

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/StandaloneClusterDescriptor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/StandaloneClusterDescriptor.java
@@ -26,7 +26,7 @@ import org.apache.flink.runtime.jobgraph.JobGraph;
 /**
  * A deployment descriptor for an existing cluster.
  */
-public class StandaloneClusterDescriptor implements ClusterDescriptor<StandaloneClusterClient> {
+public class StandaloneClusterDescriptor implements ClusterDescriptor {
 
 	private final Configuration config;
 

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/StandaloneClusterId.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/StandaloneClusterId.java
@@ -16,19 +16,17 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.rpc;
-
-import java.util.concurrent.CompletableFuture;
+package org.apache.flink.client.deployment;
 
 /**
- * Interface for self gateways.
+ * Identifier for standalone clusters.
  */
-public interface RpcServer extends StartStoppable, MainThreadExecutable, RpcGateway {
+public class StandaloneClusterId {
+	private static final StandaloneClusterId INSTANCE = new StandaloneClusterId();
 
-	/**
-	 * Return a future which is completed when the rpc endpoint has been terminated.
-	 *
-	 * @return Future indicating when the rpc endpoint has been terminated
-	 */
-	CompletableFuture<Boolean> getTerminationFuture();
+	private StandaloneClusterId() {}
+
+	public static StandaloneClusterId getInstance() {
+		return INSTANCE;
+	}
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
@@ -262,11 +262,7 @@ public abstract class ClusterClient {
 	 */
 	public void shutdown() throws Exception {
 		synchronized (this) {
-			try {
-				finalizeCluster();
-			} finally {
-				actorSystemLoader.shutdown();
-			}
+			actorSystemLoader.shutdown();
 
 			if (highAvailabilityServices != null) {
 				highAvailabilityServices.close();
@@ -938,17 +934,12 @@ public abstract class ClusterClient {
 	 * May return new messages from the cluster.
 	 * Messages can be for example about failed containers or container launch requests.
 	 */
-	protected abstract List<String> getNewMessages();
+	public abstract List<String> getNewMessages();
 
 	/**
 	 * Returns a string representation of the cluster.
 	 */
 	public abstract String getClusterIdentifier();
-
-	/**
-	 * Request the cluster to shut down or disconnect.
-	 */
-	protected abstract void finalizeCluster();
 
 	/**
 	 * Set the mode of this client (detached or blocking job execution).

--- a/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
@@ -93,8 +93,10 @@ import scala.concurrent.duration.FiniteDuration;
 
 /**
  * Encapsulates the functionality necessary to submit a program to a remote cluster.
+ *
+ * @param <T> type of the cluster id
  */
-public abstract class ClusterClient {
+public abstract class ClusterClient<T> {
 
 	protected final Logger log = LoggerFactory.getLogger(getClass());
 
@@ -937,9 +939,11 @@ public abstract class ClusterClient {
 	public abstract List<String> getNewMessages();
 
 	/**
-	 * Returns a string representation of the cluster.
+	 * Returns the cluster id identifying the cluster to which the client is connected.
+	 *
+	 * @return cluster id of the connected cluster
 	 */
-	public abstract String getClusterIdentifier();
+	public abstract T getClusterId();
 
 	/**
 	 * Set the mode of this client (detached or blocking job execution).

--- a/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironment.java
@@ -35,7 +35,7 @@ import java.util.List;
  */
 public class ContextEnvironment extends ExecutionEnvironment {
 
-	protected final ClusterClient client;
+	protected final ClusterClient<?> client;
 
 	protected final List<URL> jarFilesToAttach;
 
@@ -45,7 +45,7 @@ public class ContextEnvironment extends ExecutionEnvironment {
 
 	protected final SavepointRestoreSettings savepointSettings;
 
-	public ContextEnvironment(ClusterClient remoteConnection, List<URL> jarFiles, List<URL> classpaths,
+	public ContextEnvironment(ClusterClient<?> remoteConnection, List<URL> jarFiles, List<URL> classpaths,
 				ClassLoader userCodeClassLoader, SavepointRestoreSettings savepointSettings) {
 		this.client = remoteConnection;
 		this.jarFilesToAttach = jarFiles;
@@ -84,7 +84,7 @@ public class ContextEnvironment extends ExecutionEnvironment {
 				+ ") : " + getIdString();
 	}
 
-	public ClusterClient getClient() {
+	public ClusterClient<?> getClient() {
 		return this.client;
 	}
 

--- a/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironmentFactory.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironmentFactory.java
@@ -33,7 +33,7 @@ import java.util.List;
  */
 public class ContextEnvironmentFactory implements ExecutionEnvironmentFactory {
 
-	private final ClusterClient client;
+	private final ClusterClient<?> client;
 
 	private final List<URL> jarFilesToAttach;
 
@@ -49,7 +49,7 @@ public class ContextEnvironmentFactory implements ExecutionEnvironmentFactory {
 
 	private SavepointRestoreSettings savepointSettings;
 
-	public ContextEnvironmentFactory(ClusterClient client, List<URL> jarFilesToAttach,
+	public ContextEnvironmentFactory(ClusterClient<?> client, List<URL> jarFilesToAttach,
 			List<URL> classpathsToAttach, ClassLoader userCodeClassLoader, int defaultParallelism,
 			boolean isDetached, SavepointRestoreSettings savepointSettings) {
 		this.client = client;

--- a/flink-clients/src/main/java/org/apache/flink/client/program/DetachedEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/DetachedEnvironment.java
@@ -44,7 +44,7 @@ public class DetachedEnvironment extends ContextEnvironment {
 	private static final Logger LOG = LoggerFactory.getLogger(DetachedEnvironment.class);
 
 	public DetachedEnvironment(
-			ClusterClient remoteConnection,
+			ClusterClient<?> remoteConnection,
 			List<URL> jarFiles,
 			List<URL> classpaths,
 			ClassLoader userCodeClassLoader,

--- a/flink-clients/src/main/java/org/apache/flink/client/program/StandaloneClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/StandaloneClusterClient.java
@@ -19,6 +19,7 @@
 package org.apache.flink.client.program;
 
 import org.apache.flink.api.common.JobSubmissionResult;
+import org.apache.flink.client.deployment.StandaloneClusterId;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.WebOptions;
 import org.apache.flink.runtime.clusterframework.messages.GetClusterStatus;
@@ -38,7 +39,7 @@ import scala.concurrent.Future;
  * Cluster client for communication with an standalone (on-premise) cluster or an existing cluster that has been
  * brought up independently of a specific job.
  */
-public class StandaloneClusterClient extends ClusterClient {
+public class StandaloneClusterClient extends ClusterClient<StandaloneClusterId> {
 
 	public StandaloneClusterClient(Configuration config) throws Exception {
 		super(config);
@@ -81,9 +82,8 @@ public class StandaloneClusterClient extends ClusterClient {
 	}
 
 	@Override
-	public String getClusterIdentifier() {
-		// Avoid blocking here by getting the address from the config without resolving the address
-		return "Standalone cluster with JobManager at " + this.getJobManagerAddress();
+	public StandaloneClusterId getClusterId() {
+		return StandaloneClusterId.getInstance();
 	}
 
 	@Override

--- a/flink-clients/src/main/java/org/apache/flink/client/program/StandaloneClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/StandaloneClusterClient.java
@@ -105,8 +105,4 @@ public class StandaloneClusterClient extends ClusterClient {
 			return super.run(jobGraph, classLoader);
 		}
 	}
-
-	@Override
-	protected void finalizeCluster() {}
-
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
@@ -59,6 +59,7 @@ import org.apache.flink.runtime.rest.messages.queue.QueueStatus;
 import org.apache.flink.runtime.util.ExecutorThreadFactory;
 import org.apache.flink.util.ExecutorUtils;
 import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.SerializedThrowable;
 
 import javax.annotation.Nullable;
@@ -83,23 +84,31 @@ import static org.apache.flink.util.Preconditions.checkState;
 /**
  * A {@link ClusterClient} implementation that communicates via HTTP REST requests.
  */
-public class RestClusterClient extends ClusterClient {
+public class RestClusterClient<T> extends ClusterClient<T> {
 
 	private final RestClusterClientConfiguration restClusterClientConfiguration;
+
 	private final RestClient restClient;
+
 	private final ExecutorService executorService = Executors.newFixedThreadPool(4, new ExecutorThreadFactory("Flink-RestClusterClient-IO"));
 	private final WaitStrategy waitStrategy;
 
-	public RestClusterClient(Configuration config) throws Exception {
-		this(config, new ExponentialWaitStrategy(10, 2000));
+	private final T clusterId;
+
+	public RestClusterClient(Configuration config, T clusterId) throws Exception {
+		this(
+			config,
+			clusterId,
+			new ExponentialWaitStrategy(10L, 2000L));
 	}
 
 	@VisibleForTesting
-	RestClusterClient(Configuration configuration, WaitStrategy waitStrategy) throws Exception {
+	RestClusterClient(Configuration configuration, T clusterId, WaitStrategy waitStrategy) throws Exception {
 		super(configuration);
 		this.restClusterClientConfiguration = RestClusterClientConfiguration.fromConfiguration(configuration);
 		this.restClient = new RestClient(restClusterClientConfiguration.getRestClientConfiguration(), executorService);
 		this.waitStrategy = requireNonNull(waitStrategy);
+		this.clusterId = Preconditions.checkNotNull(clusterId);
 	}
 
 	@Override
@@ -295,14 +304,14 @@ public class RestClusterClient extends ClusterClient {
 			});
 	}
 
+	@Override
+	public T getClusterId() {
+		return clusterId;
+	}
+
 	// ======================================
 	// Legacy stuff we actually implement
 	// ======================================
-
-	@Override
-	public String getClusterIdentifier() {
-		return "Flip-6 Standalone cluster with dispatcher at " + restClusterClientConfiguration.getRestServerAddress() + '.';
-	}
 
 	@Override
 	public boolean hasUserJarsInClassPath(List<URL> userJarFiles) {

--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
@@ -329,12 +329,7 @@ public class RestClusterClient extends ClusterClient {
 	}
 
 	@Override
-	protected List<String> getNewMessages() {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	protected void finalizeCluster() {
+	public List<String> getNewMessages() {
 		throw new UnsupportedOperationException();
 	}
 

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendCancelTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendCancelTest.java
@@ -52,7 +52,7 @@ public class CliFrontendCancelTest extends TestLogger {
 		JobID jid = new JobID();
 
 		String[] parameters = { jid.toString() };
-		final ClusterClient clusterClient = createClusterClient();
+		final ClusterClient<String> clusterClient = createClusterClient();
 		MockedCliFrontend testFrontend = new MockedCliFrontend(clusterClient);
 
 		testFrontend.cancel(parameters);
@@ -90,7 +90,7 @@ public class CliFrontendCancelTest extends TestLogger {
 			JobID jid = new JobID();
 
 			String[] parameters = { "-s", jid.toString() };
-			final ClusterClient clusterClient = createClusterClient();
+			final ClusterClient<String> clusterClient = createClusterClient();
 			MockedCliFrontend testFrontend = new MockedCliFrontend(clusterClient);
 			testFrontend.cancel(parameters);
 
@@ -103,7 +103,7 @@ public class CliFrontendCancelTest extends TestLogger {
 			JobID jid = new JobID();
 
 			String[] parameters = { "-s", "targetDirectory", jid.toString() };
-			final ClusterClient clusterClient = createClusterClient();
+			final ClusterClient<String> clusterClient = createClusterClient();
 			MockedCliFrontend testFrontend = new MockedCliFrontend(clusterClient);
 			testFrontend.cancel(parameters);
 
@@ -134,8 +134,8 @@ public class CliFrontendCancelTest extends TestLogger {
 		testFrontend.cancel(parameters);
 	}
 
-	private static ClusterClient createClusterClient() throws Exception {
-		final ClusterClient clusterClient = mock(ClusterClient.class);
+	private static ClusterClient<String> createClusterClient() throws Exception {
+		final ClusterClient<String> clusterClient = mock(ClusterClient.class);
 
 		return clusterClient;
 	}

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendCancelTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendCancelTest.java
@@ -63,20 +63,20 @@ public class CliFrontendCancelTest extends TestLogger {
 	@Test(expected = CliArgsException.class)
 	public void testMissingJobId() throws Exception {
 		String[] parameters = {};
+		Configuration configuration = new Configuration();
 		CliFrontend testFrontend = new CliFrontend(
-			new Configuration(),
-			Collections.singletonList(new DefaultCLI()),
-			CliFrontendTestUtils.getConfigDir());
+			configuration,
+			Collections.singletonList(new DefaultCLI(configuration)));
 		testFrontend.cancel(parameters);
 	}
 
 	@Test(expected = CliArgsException.class)
 	public void testUnrecognizedOption() throws Exception {
 		String[] parameters = {"-v", "-l"};
+		Configuration configuration = new Configuration();
 		CliFrontend testFrontend = new CliFrontend(
-			new Configuration(),
-			Collections.singletonList(new DefaultCLI()),
-			CliFrontendTestUtils.getConfigDir());
+			configuration,
+			Collections.singletonList(new DefaultCLI(configuration)));
 		testFrontend.cancel(parameters);
 	}
 
@@ -116,10 +116,10 @@ public class CliFrontendCancelTest extends TestLogger {
 	public void testCancelWithSavepointWithoutJobId() throws Exception {
 		// Cancel with savepoint (with target directory), but no job ID
 		String[] parameters = { "-s", "targetDirectory" };
+		Configuration configuration = new Configuration();
 		CliFrontend testFrontend = new CliFrontend(
-			new Configuration(),
-			Collections.singletonList(new DefaultCLI()),
-			CliFrontendTestUtils.getConfigDir());
+			configuration,
+			Collections.singletonList(new DefaultCLI(configuration)));
 		testFrontend.cancel(parameters);
 	}
 
@@ -127,10 +127,10 @@ public class CliFrontendCancelTest extends TestLogger {
 	public void testCancelWithSavepointWithoutParameters() throws Exception {
 		// Cancel with savepoint (no target directory) and no job ID
 		String[] parameters = { "-s" };
+		Configuration configuration = new Configuration();
 		CliFrontend testFrontend = new CliFrontend(
-			new Configuration(),
-			Collections.singletonList(new DefaultCLI()),
-			CliFrontendTestUtils.getConfigDir());
+			configuration,
+			Collections.singletonList(new DefaultCLI(configuration)));
 		testFrontend.cancel(parameters);
 	}
 

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendInfoTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendInfoTest.java
@@ -42,20 +42,20 @@ public class CliFrontendInfoTest extends TestLogger {
 	@Test(expected = CliArgsException.class)
 	public void testMissingOption() throws Exception {
 		String[] parameters = {};
+		Configuration configuration = new Configuration();
 		CliFrontend testFrontend = new CliFrontend(
-			new Configuration(),
-			Collections.singletonList(new DefaultCLI()),
-			CliFrontendTestUtils.getConfigDir());
+			configuration,
+			Collections.singletonList(new DefaultCLI(configuration)));
 		testFrontend.cancel(parameters);
 	}
 
 	@Test(expected = CliArgsException.class)
 	public void testUnrecognizedOption() throws Exception {
 		String[] parameters = {"-v", "-l"};
+		Configuration configuration = new Configuration();
 		CliFrontend testFrontend = new CliFrontend(
-			new Configuration(),
-			Collections.singletonList(new DefaultCLI()),
-			CliFrontendTestUtils.getConfigDir());
+			configuration,
+			Collections.singletonList(new DefaultCLI(configuration)));
 		testFrontend.cancel(parameters);
 	}
 
@@ -65,10 +65,10 @@ public class CliFrontendInfoTest extends TestLogger {
 		try {
 
 			String[] parameters = new String[]{CliFrontendTestUtils.getTestJarPath(), "-f", "true"};
+			Configuration configuration = new Configuration();
 			CliFrontend testFrontend = new CliFrontend(
-				new Configuration(),
-				Collections.singletonList(new DefaultCLI()),
-				CliFrontendTestUtils.getConfigDir());
+				configuration,
+				Collections.singletonList(new DefaultCLI(configuration)));
 			testFrontend.info(parameters);
 			assertTrue(buffer.toString().contains("\"parallelism\": \"1\""));
 		}
@@ -82,10 +82,10 @@ public class CliFrontendInfoTest extends TestLogger {
 		replaceStdOut();
 		try {
 			String[] parameters = {"-p", "17", CliFrontendTestUtils.getTestJarPath()};
+			Configuration configuration = new Configuration();
 			CliFrontend testFrontend = new CliFrontend(
-				new Configuration(),
-				Collections.singletonList(new DefaultCLI()),
-				CliFrontendTestUtils.getConfigDir());
+				configuration,
+				Collections.singletonList(new DefaultCLI(configuration)));
 			testFrontend.info(parameters);
 			assertTrue(buffer.toString().contains("\"parallelism\": \"17\""));
 		}

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendListTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendListTest.java
@@ -49,7 +49,7 @@ public class CliFrontendListTest extends TestLogger {
 		// test list properly
 		{
 			String[] parameters = {"-r", "-s"};
-			ClusterClient clusterClient = createClusterClient();
+			ClusterClient<String> clusterClient = createClusterClient();
 			MockedCliFrontend testFrontend = new MockedCliFrontend(clusterClient);
 			testFrontend.list(parameters);
 			Mockito.verify(clusterClient, times(1))
@@ -67,8 +67,8 @@ public class CliFrontendListTest extends TestLogger {
 		testFrontend.list(parameters);
 	}
 
-	private static ClusterClient createClusterClient() throws Exception {
-		final ClusterClient clusterClient = mock(ClusterClient.class);
+	private static ClusterClient<String> createClusterClient() throws Exception {
+		final ClusterClient<String> clusterClient = mock(ClusterClient.class);
 
 		when(clusterClient.listJobs()).thenReturn(CompletableFuture.completedFuture(Collections.emptyList()));
 

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendListTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendListTest.java
@@ -60,10 +60,10 @@ public class CliFrontendListTest extends TestLogger {
 	@Test(expected = CliArgsException.class)
 	public void testUnrecognizedOption() throws Exception {
 		String[] parameters = {"-v", "-k"};
+		Configuration configuration = new Configuration();
 		CliFrontend testFrontend = new CliFrontend(
-			new Configuration(),
-			Collections.singletonList(new DefaultCLI()),
-			CliFrontendTestUtils.getConfigDir());
+			configuration,
+			Collections.singletonList(new DefaultCLI(configuration)));
 		testFrontend.list(parameters);
 	}
 

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendPackageProgramTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendPackageProgramTest.java
@@ -22,7 +22,6 @@ import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.client.program.PackagedProgram;
 import org.apache.flink.client.program.ProgramInvocationException;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.optimizer.CompilerException;
 import org.apache.flink.optimizer.DataStatistics;
 import org.apache.flink.optimizer.Optimizer;
 import org.apache.flink.optimizer.costs.DefaultCostEstimator;
@@ -64,189 +63,145 @@ public class CliFrontendPackageProgramTest extends TestLogger {
 
 	@Before
 	public void setup() throws Exception {
+		final Configuration configuration = new Configuration();
 		frontend = new CliFrontend(
-			new Configuration(),
-			Collections.singletonList(new DefaultCLI()),
-			CliFrontendTestUtils.getConfigDir());
+			configuration,
+			Collections.singletonList(new DefaultCLI(configuration)));
 	}
 
 	@Test
-	public void testNonExistingJarFile() {
-		try {
-			ProgramOptions options = mock(ProgramOptions.class);
-			when(options.getJarFilePath()).thenReturn("/some/none/existing/path");
+	public void testNonExistingJarFile() throws Exception {
+		ProgramOptions options = mock(ProgramOptions.class);
+		when(options.getJarFilePath()).thenReturn("/some/none/existing/path");
 
-			try {
-				frontend.buildProgram(options);
-				fail("should throw an exception");
-			}
-			catch (FileNotFoundException e) {
-				// that's what we want
-			}
+		try {
+			frontend.buildProgram(options);
+			fail("should throw an exception");
 		}
-		catch (Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
+		catch (FileNotFoundException e) {
+			// that's what we want
 		}
 	}
 
 	@Test
-	public void testFileNotJarFile() {
-		try {
-			ProgramOptions options = mock(ProgramOptions.class);
-			when(options.getJarFilePath()).thenReturn(getNonJarFilePath());
+	public void testFileNotJarFile() throws Exception {
+		ProgramOptions options = mock(ProgramOptions.class);
+		when(options.getJarFilePath()).thenReturn(getNonJarFilePath());
 
-			try {
-				frontend.buildProgram(options);
-				fail("should throw an exception");
-			}
-			catch (ProgramInvocationException e) {
-				// that's what we want
-			}
+		try {
+			frontend.buildProgram(options);
+			fail("should throw an exception");
 		}
-		catch (Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
+		catch (ProgramInvocationException e) {
+			// that's what we want
 		}
 	}
 
 	@Test
-	public void testVariantWithExplicitJarAndArgumentsOption() {
-		try {
-			String[] arguments = {
-					"--classpath", "file:///tmp/foo",
-					"--classpath", "file:///tmp/bar",
-					"-j", getTestJarPath(),
-					"-a", "--debug", "true", "arg1", "arg2" };
-			URL[] classpath = new URL[] { new URL("file:///tmp/foo"), new URL("file:///tmp/bar") };
-			String[] reducedArguments = new String[] {"--debug", "true", "arg1", "arg2"};
+	public void testVariantWithExplicitJarAndArgumentsOption() throws Exception {
+		String[] arguments = {
+				"--classpath", "file:///tmp/foo",
+				"--classpath", "file:///tmp/bar",
+				"-j", getTestJarPath(),
+				"-a", "--debug", "true", "arg1", "arg2" };
+		URL[] classpath = new URL[] { new URL("file:///tmp/foo"), new URL("file:///tmp/bar") };
+		String[] reducedArguments = new String[] {"--debug", "true", "arg1", "arg2"};
 
-			RunOptions options = CliFrontendParser.parseRunCommand(arguments);
-			assertEquals(getTestJarPath(), options.getJarFilePath());
-			assertArrayEquals(classpath, options.getClasspaths().toArray());
-			assertArrayEquals(reducedArguments, options.getProgramArgs());
+		RunOptions options = CliFrontendParser.parseRunCommand(arguments);
+		assertEquals(getTestJarPath(), options.getJarFilePath());
+		assertArrayEquals(classpath, options.getClasspaths().toArray());
+		assertArrayEquals(reducedArguments, options.getProgramArgs());
 
-			PackagedProgram prog = frontend.buildProgram(options);
+		PackagedProgram prog = frontend.buildProgram(options);
 
-			Assert.assertArrayEquals(reducedArguments, prog.getArguments());
-			Assert.assertEquals(TEST_JAR_MAIN_CLASS, prog.getMainClassName());
-		}
-		catch (Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
-		}
+		Assert.assertArrayEquals(reducedArguments, prog.getArguments());
+		Assert.assertEquals(TEST_JAR_MAIN_CLASS, prog.getMainClassName());
 	}
 
 	@Test
-	public void testVariantWithExplicitJarAndNoArgumentsOption() {
-		try {
-			String[] arguments = {
-					"--classpath", "file:///tmp/foo",
-					"--classpath", "file:///tmp/bar",
-					"-j", getTestJarPath(),
-					"--debug", "true", "arg1", "arg2" };
-			URL[] classpath = new URL[] { new URL("file:///tmp/foo"), new URL("file:///tmp/bar") };
-			String[] reducedArguments = new String[] {"--debug", "true", "arg1", "arg2"};
+	public void testVariantWithExplicitJarAndNoArgumentsOption() throws Exception {
+		String[] arguments = {
+				"--classpath", "file:///tmp/foo",
+				"--classpath", "file:///tmp/bar",
+				"-j", getTestJarPath(),
+				"--debug", "true", "arg1", "arg2" };
+		URL[] classpath = new URL[] { new URL("file:///tmp/foo"), new URL("file:///tmp/bar") };
+		String[] reducedArguments = new String[] {"--debug", "true", "arg1", "arg2"};
 
-			RunOptions options = CliFrontendParser.parseRunCommand(arguments);
-			assertEquals(getTestJarPath(), options.getJarFilePath());
-			assertArrayEquals(classpath, options.getClasspaths().toArray());
-			assertArrayEquals(reducedArguments, options.getProgramArgs());
+		RunOptions options = CliFrontendParser.parseRunCommand(arguments);
+		assertEquals(getTestJarPath(), options.getJarFilePath());
+		assertArrayEquals(classpath, options.getClasspaths().toArray());
+		assertArrayEquals(reducedArguments, options.getProgramArgs());
 
-			PackagedProgram prog = frontend.buildProgram(options);
+		PackagedProgram prog = frontend.buildProgram(options);
 
-			Assert.assertArrayEquals(reducedArguments, prog.getArguments());
-			Assert.assertEquals(TEST_JAR_MAIN_CLASS, prog.getMainClassName());
-		}
-		catch (Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
-		}
+		Assert.assertArrayEquals(reducedArguments, prog.getArguments());
+		Assert.assertEquals(TEST_JAR_MAIN_CLASS, prog.getMainClassName());
 	}
 
 	@Test
-	public void testValidVariantWithNoJarAndNoArgumentsOption() {
-		try {
-			String[] arguments = {
-					"--classpath", "file:///tmp/foo",
-					"--classpath", "file:///tmp/bar",
-					getTestJarPath(),
-					"--debug", "true", "arg1", "arg2" };
-			URL[] classpath = new URL[] { new URL("file:///tmp/foo"), new URL("file:///tmp/bar") };
-			String[] reducedArguments = {"--debug", "true", "arg1", "arg2"};
+	public void testValidVariantWithNoJarAndNoArgumentsOption() throws Exception {
+		String[] arguments = {
+				"--classpath", "file:///tmp/foo",
+				"--classpath", "file:///tmp/bar",
+				getTestJarPath(),
+				"--debug", "true", "arg1", "arg2" };
+		URL[] classpath = new URL[] { new URL("file:///tmp/foo"), new URL("file:///tmp/bar") };
+		String[] reducedArguments = {"--debug", "true", "arg1", "arg2"};
 
-			RunOptions options = CliFrontendParser.parseRunCommand(arguments);
-			assertEquals(getTestJarPath(), options.getJarFilePath());
-			assertArrayEquals(classpath, options.getClasspaths().toArray());
-			assertArrayEquals(reducedArguments, options.getProgramArgs());
+		RunOptions options = CliFrontendParser.parseRunCommand(arguments);
+		assertEquals(getTestJarPath(), options.getJarFilePath());
+		assertArrayEquals(classpath, options.getClasspaths().toArray());
+		assertArrayEquals(reducedArguments, options.getProgramArgs());
 
-			PackagedProgram prog = frontend.buildProgram(options);
+		PackagedProgram prog = frontend.buildProgram(options);
 
-			Assert.assertArrayEquals(reducedArguments, prog.getArguments());
-			Assert.assertEquals(TEST_JAR_MAIN_CLASS, prog.getMainClassName());
-		}
-		catch (Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
-		}
+		Assert.assertArrayEquals(reducedArguments, prog.getArguments());
+		Assert.assertEquals(TEST_JAR_MAIN_CLASS, prog.getMainClassName());
 	}
 
 	@Test(expected = CliArgsException.class)
 	public void testNoJarNoArgumentsAtAll() throws Exception {
 		frontend.run(new String[0]);
-
-		fail("Should have failed.");
 	}
 
 	@Test
-	public void testNonExistingFileWithArguments() {
+	public void testNonExistingFileWithArguments() throws Exception {
+		String[] arguments = {
+				"--classpath", "file:///tmp/foo",
+				"--classpath", "file:///tmp/bar",
+				"/some/none/existing/path",
+				"--debug", "true", "arg1", "arg2"  };
+		URL[] classpath = new URL[] { new URL("file:///tmp/foo"), new URL("file:///tmp/bar") };
+		String[] reducedArguments = {"--debug", "true", "arg1", "arg2"};
+
+		RunOptions options = CliFrontendParser.parseRunCommand(arguments);
+		assertEquals(arguments[4], options.getJarFilePath());
+		assertArrayEquals(classpath, options.getClasspaths().toArray());
+		assertArrayEquals(reducedArguments, options.getProgramArgs());
+
 		try {
-			String[] arguments = {
-					"--classpath", "file:///tmp/foo",
-					"--classpath", "file:///tmp/bar",
-					"/some/none/existing/path",
-					"--debug", "true", "arg1", "arg2"  };
-			URL[] classpath = new URL[] { new URL("file:///tmp/foo"), new URL("file:///tmp/bar") };
-			String[] reducedArguments = {"--debug", "true", "arg1", "arg2"};
-
-			RunOptions options = CliFrontendParser.parseRunCommand(arguments);
-			assertEquals(arguments[4], options.getJarFilePath());
-			assertArrayEquals(classpath, options.getClasspaths().toArray());
-			assertArrayEquals(reducedArguments, options.getProgramArgs());
-
-			try {
-				frontend.buildProgram(options);
-				fail("Should fail with an exception");
-			}
-			catch (FileNotFoundException e) {
-				// that's what we want
-			}
+			frontend.buildProgram(options);
+			fail("Should fail with an exception");
 		}
-		catch (Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
+		catch (FileNotFoundException e) {
+			// that's what we want
 		}
 	}
 
 	@Test
-	public void testNonExistingFileWithoutArguments() {
+	public void testNonExistingFileWithoutArguments() throws Exception {
+		String[] arguments = {"/some/none/existing/path"};
+
+		RunOptions options = CliFrontendParser.parseRunCommand(arguments);
+		assertEquals(arguments[0], options.getJarFilePath());
+		assertArrayEquals(new String[0], options.getProgramArgs());
+
 		try {
-			String[] arguments = {"/some/none/existing/path"};
-
-			RunOptions options = CliFrontendParser.parseRunCommand(arguments);
-			assertEquals(arguments[0], options.getJarFilePath());
-			assertArrayEquals(new String[0], options.getProgramArgs());
-
-			try {
-				frontend.buildProgram(options);
-			}
-			catch (FileNotFoundException e) {
-				// that's what we want
-			}
+			frontend.buildProgram(options);
 		}
-		catch (Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
+		catch (FileNotFoundException e) {
+			// that's what we want
 		}
 	}
 
@@ -284,7 +239,7 @@ public class CliFrontendPackageProgramTest extends TestLogger {
 	 * </ul>
 	 */
 	@Test
-	public void testPlanWithExternalClass() throws CompilerException, ProgramInvocationException {
+	public void testPlanWithExternalClass() throws Exception {
 		final boolean[] callme = { false }; // create a final object reference, to be able to change its val later
 
 		try {
@@ -333,10 +288,6 @@ public class CliFrontendPackageProgramTest extends TestLogger {
 				fail("Program didn't throw ClassNotFoundException");
 			}
 			assertTrue("Classloader was not called", callme[0]);
-		}
-		catch (Exception e) {
-			e.printStackTrace();
-			fail("Program failed with the wrong exception: " + e.getClass().getName());
 		}
 	}
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendRunTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendRunTest.java
@@ -46,31 +46,32 @@ public class CliFrontendRunTest {
 
 	@Test
 	public void testRun() throws Exception {
+		final Configuration configuration = GlobalConfiguration.loadConfiguration(CliFrontendTestUtils.getConfigDir());
 		// test without parallelism
 		{
 			String[] parameters = {"-v", getTestJarPath()};
-			RunTestingCliFrontend testFrontend = new RunTestingCliFrontend(1, true, false);
+			RunTestingCliFrontend testFrontend = new RunTestingCliFrontend(configuration, 1, true, false);
 			testFrontend.run(parameters);
 		}
 
 		// test configure parallelism
 		{
 			String[] parameters = {"-v", "-p", "42",  getTestJarPath()};
-			RunTestingCliFrontend testFrontend = new RunTestingCliFrontend(42, true, false);
+			RunTestingCliFrontend testFrontend = new RunTestingCliFrontend(configuration, 42, true, false);
 			testFrontend.run(parameters);
 		}
 
 		// test configure sysout logging
 		{
 			String[] parameters = {"-p", "2", "-q", getTestJarPath()};
-			RunTestingCliFrontend testFrontend = new RunTestingCliFrontend(2, false, false);
+			RunTestingCliFrontend testFrontend = new RunTestingCliFrontend(configuration, 2, false, false);
 			testFrontend.run(parameters);
 		}
 
 		// test detached mode
 		{
 			String[] parameters = {"-p", "2", "-d", getTestJarPath()};
-			RunTestingCliFrontend testFrontend = new RunTestingCliFrontend(2, true, true);
+			RunTestingCliFrontend testFrontend = new RunTestingCliFrontend(configuration, 2, true, true);
 			testFrontend.run(parameters);
 		}
 
@@ -111,10 +112,10 @@ public class CliFrontendRunTest {
 	public void testUnrecognizedOption() throws Exception {
 		// test unrecognized option
 		String[] parameters = {"-v", "-l", "-a", "some", "program", "arguments"};
+		Configuration configuration = new Configuration();
 		CliFrontend testFrontend = new CliFrontend(
-			new Configuration(),
-			Collections.singletonList(new DefaultCLI()),
-			CliFrontendTestUtils.getConfigDir());
+			configuration,
+			Collections.singletonList(new DefaultCLI(configuration)));
 		testFrontend.run(parameters);
 	}
 
@@ -122,10 +123,10 @@ public class CliFrontendRunTest {
 	public void testInvalidParallelismOption() throws Exception {
 		// test configure parallelism with non integer value
 		String[] parameters = {"-v", "-p", "text",  getTestJarPath()};
+		Configuration configuration = new Configuration();
 		CliFrontend testFrontend = new CliFrontend(
-			new Configuration(),
-			Collections.singletonList(new DefaultCLI()),
-			CliFrontendTestUtils.getConfigDir());
+			configuration,
+			Collections.singletonList(new DefaultCLI(configuration)));
 		testFrontend.run(parameters);
 	}
 
@@ -133,10 +134,10 @@ public class CliFrontendRunTest {
 	public void testParallelismWithOverflow() throws Exception {
 		// test configure parallelism with overflow integer value
 		String[] parameters = {"-v", "-p", "475871387138",  getTestJarPath()};
+		Configuration configuration = new Configuration();
 		CliFrontend testFrontend = new CliFrontend(
-			new Configuration(),
-			Collections.singletonList(new DefaultCLI()),
-			CliFrontendTestUtils.getConfigDir());
+			configuration,
+			Collections.singletonList(new DefaultCLI(configuration)));
 		testFrontend.run(parameters);
 	}
 
@@ -148,11 +149,10 @@ public class CliFrontendRunTest {
 		private final boolean sysoutLogging;
 		private final boolean isDetached;
 
-		public RunTestingCliFrontend(int expectedParallelism, boolean logging, boolean isDetached) throws Exception {
+		public RunTestingCliFrontend(Configuration configuration, int expectedParallelism, boolean logging, boolean isDetached) throws Exception {
 			super(
-				GlobalConfiguration.loadConfiguration(CliFrontendTestUtils.getConfigDir()),
-				Collections.singletonList(new DefaultCLI()),
-				CliFrontendTestUtils.getConfigDir());
+				configuration,
+				Collections.singletonList(new DefaultCLI(configuration)));
 			this.expectedParallelism = expectedParallelism;
 			this.sysoutLogging = logging;
 			this.isDetached = isDetached;

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendSavepointTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendSavepointTest.java
@@ -82,7 +82,7 @@ public class CliFrontendSavepointTest extends TestLogger {
 
 		String savepointPath = "expectedSavepointPath";
 
-		final ClusterClient clusterClient = createClusterClient(savepointPath);
+		final ClusterClient<String> clusterClient = createClusterClient(savepointPath);
 
 		try {
 			MockedCliFrontend frontend = new MockedCliFrontend(clusterClient);
@@ -110,7 +110,7 @@ public class CliFrontendSavepointTest extends TestLogger {
 		String expectedTestException = "expectedTestException";
 		Exception testException = new Exception(expectedTestException);
 
-		final ClusterClient clusterClient = createFailingClusterClient(testException);
+		final ClusterClient<String> clusterClient = createFailingClusterClient(testException);
 
 		try {
 			MockedCliFrontend frontend = new MockedCliFrontend(clusterClient);
@@ -165,7 +165,7 @@ public class CliFrontendSavepointTest extends TestLogger {
 
 		String savepointDirectory = "customTargetDirectory";
 
-		final ClusterClient clusterClient = createClusterClient(savepointDirectory);
+		final ClusterClient<String> clusterClient = createClusterClient(savepointDirectory);
 
 		try {
 			MockedCliFrontend frontend = new MockedCliFrontend(clusterClient);
@@ -224,7 +224,7 @@ public class CliFrontendSavepointTest extends TestLogger {
 
 		final CompletableFuture<String> disposeSavepointFuture = new CompletableFuture<>();
 
-		final ClusterClient clusterClient = new DisposeSavepointClusterClient(
+		final DisposeSavepointClusterClient clusterClient = new DisposeSavepointClusterClient(
 			(String savepointPath, Time timeout) -> {
 				disposeSavepointFuture.complete(savepointPath);
 				return CompletableFuture.completedFuture(Acknowledge.get());
@@ -260,7 +260,7 @@ public class CliFrontendSavepointTest extends TestLogger {
 
 		Exception testException = new Exception("expectedTestException");
 
-		ClusterClient clusterClient = new DisposeSavepointClusterClient((String path, Time timeout) -> FutureUtils.completedExceptionally(testException));
+		DisposeSavepointClusterClient clusterClient = new DisposeSavepointClusterClient((String path, Time timeout) -> FutureUtils.completedExceptionally(testException));
 
 		try {
 			CliFrontend frontend = new MockedCliFrontend(clusterClient);
@@ -313,8 +313,8 @@ public class CliFrontendSavepointTest extends TestLogger {
 		System.setErr(stdErr);
 	}
 
-	private static ClusterClient createClusterClient(String expectedResponse) throws Exception {
-		final ClusterClient clusterClient = mock(ClusterClient.class);
+	private static ClusterClient<String> createClusterClient(String expectedResponse) throws Exception {
+		final ClusterClient<String> clusterClient = mock(ClusterClient.class);
 
 		when(clusterClient.triggerSavepoint(any(JobID.class), anyString()))
 			.thenReturn(CompletableFuture.completedFuture(expectedResponse));
@@ -322,8 +322,8 @@ public class CliFrontendSavepointTest extends TestLogger {
 		return clusterClient;
 	}
 
-	private static ClusterClient createFailingClusterClient(Exception expectedException) throws Exception {
-		final ClusterClient clusterClient = mock(ClusterClient.class);
+	private static ClusterClient<String> createFailingClusterClient(Exception expectedException) throws Exception {
+		final ClusterClient<String> clusterClient = mock(ClusterClient.class);
 
 		when(clusterClient.triggerSavepoint(any(JobID.class), anyString()))
 			.thenReturn(FutureUtils.completedExceptionally(expectedException));

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendStopTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendStopTest.java
@@ -69,10 +69,10 @@ public class CliFrontendStopTest extends TestLogger {
 	public void testUnrecognizedOption() throws Exception {
 		// test unrecognized option
 		String[] parameters = { "-v", "-l" };
+		Configuration configuration = new Configuration();
 		CliFrontend testFrontend = new CliFrontend(
-			new Configuration(),
-			Collections.singletonList(new DefaultCLI()),
-			CliFrontendTestUtils.getConfigDir());
+			configuration,
+			Collections.singletonList(new DefaultCLI(configuration)));
 		testFrontend.stop(parameters);
 	}
 
@@ -80,10 +80,10 @@ public class CliFrontendStopTest extends TestLogger {
 	public void testMissingJobId() throws Exception {
 		// test missing job id
 		String[] parameters = {};
+		Configuration configuration = new Configuration();
 		CliFrontend testFrontend = new CliFrontend(
-			new Configuration(),
-			Collections.singletonList(new DefaultCLI()),
-			CliFrontendTestUtils.getConfigDir());
+			configuration,
+			Collections.singletonList(new DefaultCLI(configuration)));
 		testFrontend.stop(parameters);
 	}
 

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendStopTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendStopTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.client.cli.util.MockedCliFrontend;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
 
@@ -29,9 +30,12 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import javax.annotation.Nullable;
+
 import java.util.Collections;
 
 import static org.apache.flink.client.cli.CliFrontendTestUtils.pipeSystemOutToNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
@@ -51,18 +55,16 @@ public class CliFrontendStopTest extends TestLogger {
 	@Test
 	public void testStop() throws Exception {
 		// test stop properly
-		{
-			JobID jid = new JobID();
-			String jidString = jid.toString();
+		JobID jid = new JobID();
+		String jidString = jid.toString();
 
-			String[] parameters = { jidString };
-			final ClusterClient clusterClient = createClusterClient(false);
-			MockedCliFrontend testFrontend = new MockedCliFrontend(clusterClient);
+		String[] parameters = { jidString };
+		final ClusterClient<String> clusterClient = createClusterClient(null);
+		MockedCliFrontend testFrontend = new MockedCliFrontend(clusterClient);
 
-			testFrontend.stop(parameters);
+		testFrontend.stop(parameters);
 
-			Mockito.verify(clusterClient, times(1)).stop(any(JobID.class));
-		}
+		Mockito.verify(clusterClient, times(1)).stop(any(JobID.class));
 	}
 
 	@Test(expected = CliArgsException.class)
@@ -87,32 +89,30 @@ public class CliFrontendStopTest extends TestLogger {
 		testFrontend.stop(parameters);
 	}
 
-	@Test(expected = TestException.class)
+	@Test
 	public void testUnknownJobId() throws Exception {
 		// test unknown job Id
 		JobID jid = new JobID();
 
 		String[] parameters = { jid.toString() };
-		final ClusterClient clusterClient = createClusterClient(true);
+		String expectedMessage = "Test exception";
+		FlinkException testException = new FlinkException(expectedMessage);
+		final ClusterClient<String> clusterClient = createClusterClient(testException);
 		MockedCliFrontend testFrontend = new MockedCliFrontend(clusterClient);
 
-		testFrontend.stop(parameters);
-		fail("Should have failed.");
-	}
-
-	private static final class TestException extends FlinkException {
-		private static final long serialVersionUID = -2650760898729937583L;
-
-		TestException(String message) {
-			super(message);
+		try {
+			testFrontend.stop(parameters);
+			fail("Should have failed.");
+		} catch (FlinkException e) {
+			assertTrue(ExceptionUtils.findThrowableWithMessage(e, expectedMessage).isPresent());
 		}
 	}
 
-	private static ClusterClient createClusterClient(boolean reject) throws Exception {
-		final ClusterClient clusterClient = mock(ClusterClient.class);
+	private static ClusterClient<String> createClusterClient(@Nullable Exception exception) throws Exception {
+		final ClusterClient<String> clusterClient = mock(ClusterClient.class);
 
-		if (reject) {
-				doThrow(new TestException("Test Exception")).when(clusterClient).stop(any(JobID.class));
+		if (exception != null) {
+			doThrow(exception).when(clusterClient).stop(any(JobID.class));
 		}
 
 		return clusterClient;

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/DefaultCLITest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/DefaultCLITest.java
@@ -46,30 +46,25 @@ public class DefaultCLITest extends TestLogger {
 	 */
 	@Test
 	public void testConfigurationPassing() throws Exception {
-		final DefaultCLI defaultCLI = new DefaultCLI();
-
-		final String configurationDirectory = temporaryFolder.newFolder().getAbsolutePath();
-		final String[] args = {};
-
-		CommandLine commandLine = defaultCLI.parseCommandLineOptions(args, false);
+		final Configuration configuration = new Configuration();
 
 		final String localhost = "localhost";
 		final int port = 1234;
-		final Configuration configuration = new Configuration();
 
 		configuration.setString(JobManagerOptions.ADDRESS, localhost);
 		configuration.setInteger(JobManagerOptions.PORT, port);
 
+		final DefaultCLI defaultCLI = new DefaultCLI(configuration);
+
+		final String[] args = {};
+
+		CommandLine commandLine = defaultCLI.parseCommandLineOptions(args, false);
+
 		final InetSocketAddress expectedAddress = new InetSocketAddress(localhost, port);
 
-		final ClusterDescriptor<?> clusterDescriptor = defaultCLI.createClusterDescriptor(
-			configuration,
-			configurationDirectory,
-			commandLine);
+		final ClusterDescriptor<?> clusterDescriptor = defaultCLI.createClusterDescriptor(commandLine);
 
-		final ClusterClient clusterClient = clusterDescriptor.retrieve(defaultCLI.getClusterId(
-			configuration,
-			commandLine));
+		final ClusterClient clusterClient = clusterDescriptor.retrieve(defaultCLI.getClusterId(commandLine));
 
 		Assert.assertEquals(expectedAddress, clusterClient.getJobManagerAddress());
 	}
@@ -79,15 +74,6 @@ public class DefaultCLITest extends TestLogger {
 	 */
 	@Test
 	public void testManualConfigurationOverride() throws Exception {
-		final DefaultCLI defaultCLI = new DefaultCLI();
-
-		final String manualHostname = "123.123.123.123";
-		final int manualPort = 4321;
-		final String configurationDirectory = temporaryFolder.newFolder().getAbsolutePath();
-		final String[] args = {"-m", manualHostname + ':' + manualPort};
-
-		CommandLine commandLine = defaultCLI.parseCommandLineOptions(args, false);
-
 		final String localhost = "localhost";
 		final int port = 1234;
 		final Configuration configuration = new Configuration();
@@ -95,14 +81,17 @@ public class DefaultCLITest extends TestLogger {
 		configuration.setString(JobManagerOptions.ADDRESS, localhost);
 		configuration.setInteger(JobManagerOptions.PORT, port);
 
-		final ClusterDescriptor<?> clusterDescriptor = defaultCLI.createClusterDescriptor(
-			configuration,
-			configurationDirectory,
-			commandLine);
+		final DefaultCLI defaultCLI = new DefaultCLI(configuration);
 
-		final ClusterClient clusterClient = clusterDescriptor.retrieve(defaultCLI.getClusterId(
-			configuration,
-			commandLine));
+		final String manualHostname = "123.123.123.123";
+		final int manualPort = 4321;
+		final String[] args = {"-m", manualHostname + ':' + manualPort};
+
+		CommandLine commandLine = defaultCLI.parseCommandLineOptions(args, false);
+
+		final ClusterDescriptor<?> clusterDescriptor = defaultCLI.createClusterDescriptor(commandLine);
+
+		final ClusterClient clusterClient = clusterDescriptor.retrieve(defaultCLI.getClusterId(commandLine));
 
 		final InetSocketAddress expectedAddress = new InetSocketAddress(manualHostname, manualPort);
 

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/DefaultCLITest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/DefaultCLITest.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.client.cli;
 
-import org.apache.flink.client.deployment.ClusterDescriptor;
+import org.apache.flink.client.deployment.StandaloneClusterDescriptor;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
@@ -62,9 +62,9 @@ public class DefaultCLITest extends TestLogger {
 
 		final InetSocketAddress expectedAddress = new InetSocketAddress(localhost, port);
 
-		final ClusterDescriptor clusterDescriptor = defaultCLI.createClusterDescriptor(commandLine);
+		final StandaloneClusterDescriptor clusterDescriptor = defaultCLI.createClusterDescriptor(commandLine);
 
-		final ClusterClient clusterClient = clusterDescriptor.retrieve(defaultCLI.getClusterId(commandLine));
+		final ClusterClient<?> clusterClient = clusterDescriptor.retrieve(defaultCLI.getClusterId(commandLine));
 
 		Assert.assertEquals(expectedAddress, clusterClient.getJobManagerAddress());
 	}
@@ -89,9 +89,9 @@ public class DefaultCLITest extends TestLogger {
 
 		CommandLine commandLine = defaultCLI.parseCommandLineOptions(args, false);
 
-		final ClusterDescriptor clusterDescriptor = defaultCLI.createClusterDescriptor(commandLine);
+		final StandaloneClusterDescriptor clusterDescriptor = defaultCLI.createClusterDescriptor(commandLine);
 
-		final ClusterClient clusterClient = clusterDescriptor.retrieve(defaultCLI.getClusterId(commandLine));
+		final ClusterClient<?> clusterClient = clusterDescriptor.retrieve(defaultCLI.getClusterId(commandLine));
 
 		final InetSocketAddress expectedAddress = new InetSocketAddress(manualHostname, manualPort);
 

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/DefaultCLITest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/DefaultCLITest.java
@@ -62,7 +62,7 @@ public class DefaultCLITest extends TestLogger {
 
 		final InetSocketAddress expectedAddress = new InetSocketAddress(localhost, port);
 
-		final ClusterDescriptor<?> clusterDescriptor = defaultCLI.createClusterDescriptor(commandLine);
+		final ClusterDescriptor clusterDescriptor = defaultCLI.createClusterDescriptor(commandLine);
 
 		final ClusterClient clusterClient = clusterDescriptor.retrieve(defaultCLI.getClusterId(commandLine));
 
@@ -89,7 +89,7 @@ public class DefaultCLITest extends TestLogger {
 
 		CommandLine commandLine = defaultCLI.parseCommandLineOptions(args, false);
 
-		final ClusterDescriptor<?> clusterDescriptor = defaultCLI.createClusterDescriptor(commandLine);
+		final ClusterDescriptor clusterDescriptor = defaultCLI.createClusterDescriptor(commandLine);
 
 		final ClusterClient clusterClient = clusterDescriptor.retrieve(defaultCLI.getClusterId(commandLine));
 

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/Flip6DefaultCLITest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/Flip6DefaultCLITest.java
@@ -37,7 +37,7 @@ public class Flip6DefaultCLITest extends TestLogger {
 	@Test
 	public void testFlip6Switch() throws CliArgsException {
 		final String[] args = {"-flip6"};
-		final Flip6DefaultCLI flip6DefaultCLI = new Flip6DefaultCLI();
+		final Flip6DefaultCLI flip6DefaultCLI = new Flip6DefaultCLI(new Configuration());
 
 		final Options options = new Options();
 		flip6DefaultCLI.addGeneralOptions(options);
@@ -46,6 +46,6 @@ public class Flip6DefaultCLITest extends TestLogger {
 		final CommandLine commandLine = CliFrontendParser.parse(options, args, false);
 
 		Assert.assertTrue(commandLine.hasOption(Flip6DefaultCLI.FLIP_6.getOpt()));
-		Assert.assertTrue(flip6DefaultCLI.isActive(commandLine, new Configuration()));
+		Assert.assertTrue(flip6DefaultCLI.isActive(commandLine));
 	}
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/util/DummyClusterDescriptor.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/util/DummyClusterDescriptor.java
@@ -22,6 +22,7 @@ import org.apache.flink.client.deployment.ClusterDescriptor;
 import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.Preconditions;
 
 /**
@@ -53,6 +54,11 @@ public class DummyClusterDescriptor implements ClusterDescriptor {
 	@Override
 	public ClusterClient deployJobCluster(ClusterSpecification clusterSpecification, JobGraph jobGraph) {
 		return clusterClient;
+	}
+
+	@Override
+	public void terminateCluster(String clusterId) throws FlinkException {
+		throw new UnsupportedOperationException("DummyClusterDescriptor does not support cluster termination.");
 	}
 
 	@Override

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/util/DummyClusterDescriptor.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/util/DummyClusterDescriptor.java
@@ -26,14 +26,12 @@ import org.apache.flink.util.Preconditions;
 
 /**
  * Dummy {@link ClusterDescriptor} implementation for testing purposes.
- *
- * @param <C> type of the returned {@link ClusterClient}
  */
-public class DummyClusterDescriptor<C extends ClusterClient> implements ClusterDescriptor<C> {
+public class DummyClusterDescriptor implements ClusterDescriptor {
 
-	private final C clusterClient;
+	private final ClusterClient clusterClient;
 
-	public DummyClusterDescriptor(C clusterClient) {
+	public DummyClusterDescriptor(ClusterClient clusterClient) {
 		this.clusterClient = Preconditions.checkNotNull(clusterClient);
 	}
 
@@ -43,17 +41,17 @@ public class DummyClusterDescriptor<C extends ClusterClient> implements ClusterD
 	}
 
 	@Override
-	public C retrieve(String applicationID) throws UnsupportedOperationException {
+	public ClusterClient retrieve(String applicationID) throws UnsupportedOperationException {
 		return clusterClient;
 	}
 
 	@Override
-	public C deploySessionCluster(ClusterSpecification clusterSpecification) throws UnsupportedOperationException {
+	public ClusterClient deploySessionCluster(ClusterSpecification clusterSpecification) throws UnsupportedOperationException {
 		return clusterClient;
 	}
 
 	@Override
-	public C deployJobCluster(ClusterSpecification clusterSpecification, JobGraph jobGraph) {
+	public ClusterClient deployJobCluster(ClusterSpecification clusterSpecification, JobGraph jobGraph) {
 		return clusterClient;
 	}
 

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/util/DummyClusterDescriptor.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/util/DummyClusterDescriptor.java
@@ -28,11 +28,11 @@ import org.apache.flink.util.Preconditions;
 /**
  * Dummy {@link ClusterDescriptor} implementation for testing purposes.
  */
-public class DummyClusterDescriptor implements ClusterDescriptor {
+public class DummyClusterDescriptor<T> implements ClusterDescriptor<T> {
 
-	private final ClusterClient clusterClient;
+	private final ClusterClient<T> clusterClient;
 
-	public DummyClusterDescriptor(ClusterClient clusterClient) {
+	public DummyClusterDescriptor(ClusterClient<T> clusterClient) {
 		this.clusterClient = Preconditions.checkNotNull(clusterClient);
 	}
 
@@ -42,23 +42,23 @@ public class DummyClusterDescriptor implements ClusterDescriptor {
 	}
 
 	@Override
-	public ClusterClient retrieve(String applicationID) throws UnsupportedOperationException {
+	public ClusterClient<T> retrieve(T clusterId) {
 		return clusterClient;
 	}
 
 	@Override
-	public ClusterClient deploySessionCluster(ClusterSpecification clusterSpecification) throws UnsupportedOperationException {
+	public ClusterClient<T> deploySessionCluster(ClusterSpecification clusterSpecification) {
 		return clusterClient;
 	}
 
 	@Override
-	public ClusterClient deployJobCluster(ClusterSpecification clusterSpecification, JobGraph jobGraph) {
+	public ClusterClient<T> deployJobCluster(ClusterSpecification clusterSpecification, JobGraph jobGraph) {
 		return clusterClient;
 	}
 
 	@Override
-	public void terminateCluster(String clusterId) throws FlinkException {
-		throw new UnsupportedOperationException("DummyClusterDescriptor does not support cluster termination.");
+	public void terminateCluster(T clusterId) throws FlinkException {
+		throw new UnsupportedOperationException("Cannot terminate a dummy cluster.");
 	}
 
 	@Override

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/util/DummyCustomCommandLine.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/util/DummyCustomCommandLine.java
@@ -22,7 +22,6 @@ import org.apache.flink.client.cli.CustomCommandLine;
 import org.apache.flink.client.deployment.ClusterDescriptor;
 import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.client.program.ClusterClient;
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.Preconditions;
 
 import org.apache.commons.cli.CommandLine;
@@ -43,7 +42,7 @@ public class DummyCustomCommandLine<T extends ClusterClient> implements CustomCo
 	}
 
 	@Override
-	public boolean isActive(CommandLine commandLine, Configuration configuration) {
+	public boolean isActive(CommandLine commandLine) {
 		return true;
 	}
 
@@ -63,21 +62,18 @@ public class DummyCustomCommandLine<T extends ClusterClient> implements CustomCo
 	}
 
 	@Override
-	public ClusterDescriptor<T> createClusterDescriptor(
-			Configuration configuration,
-			String configurationDirectory,
-			CommandLine commandLine) {
+	public ClusterDescriptor<T> createClusterDescriptor(CommandLine commandLine) {
 		return new DummyClusterDescriptor<>(clusterClient);
 	}
 
 	@Override
 	@Nullable
-	public String getClusterId(Configuration configuration, CommandLine commandLine) {
+	public String getClusterId(CommandLine commandLine) {
 		return "dummy";
 	}
 
 	@Override
-	public ClusterSpecification getClusterSpecification(Configuration configuration, CommandLine commandLine) {
+	public ClusterSpecification getClusterSpecification(CommandLine commandLine) {
 		return new ClusterSpecification.ClusterSpecificationBuilder().createClusterSpecification();
 	}
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/util/DummyCustomCommandLine.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/util/DummyCustomCommandLine.java
@@ -32,10 +32,10 @@ import javax.annotation.Nullable;
 /**
  * Dummy implementation of the {@link CustomCommandLine} for testing purposes.
  */
-public class DummyCustomCommandLine implements CustomCommandLine {
-	private final ClusterClient clusterClient;
+public class DummyCustomCommandLine<T> implements CustomCommandLine {
+	private final ClusterClient<T> clusterClient;
 
-	public DummyCustomCommandLine(ClusterClient clusterClient) {
+	public DummyCustomCommandLine(ClusterClient<T> clusterClient) {
 		this.clusterClient = Preconditions.checkNotNull(clusterClient);
 	}
 
@@ -60,8 +60,8 @@ public class DummyCustomCommandLine implements CustomCommandLine {
 	}
 
 	@Override
-	public ClusterDescriptor createClusterDescriptor(CommandLine commandLine) {
-		return new DummyClusterDescriptor(clusterClient);
+	public ClusterDescriptor<T> createClusterDescriptor(CommandLine commandLine) {
+		return new DummyClusterDescriptor<>(clusterClient);
 	}
 
 	@Override

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/util/DummyCustomCommandLine.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/util/DummyCustomCommandLine.java
@@ -31,13 +31,11 @@ import javax.annotation.Nullable;
 
 /**
  * Dummy implementation of the {@link CustomCommandLine} for testing purposes.
- *
- * @param <T> type of the returned cluster client
  */
-public class DummyCustomCommandLine<T extends ClusterClient> implements CustomCommandLine<T> {
-	private final T clusterClient;
+public class DummyCustomCommandLine implements CustomCommandLine {
+	private final ClusterClient clusterClient;
 
-	public DummyCustomCommandLine(T clusterClient) {
+	public DummyCustomCommandLine(ClusterClient clusterClient) {
 		this.clusterClient = Preconditions.checkNotNull(clusterClient);
 	}
 
@@ -62,8 +60,8 @@ public class DummyCustomCommandLine<T extends ClusterClient> implements CustomCo
 	}
 
 	@Override
-	public ClusterDescriptor<T> createClusterDescriptor(CommandLine commandLine) {
-		return new DummyClusterDescriptor<>(clusterClient);
+	public ClusterDescriptor createClusterDescriptor(CommandLine commandLine) {
+		return new DummyClusterDescriptor(clusterClient);
 	}
 
 	@Override

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/util/MockedCliFrontend.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/util/MockedCliFrontend.java
@@ -19,7 +19,6 @@
 package org.apache.flink.client.cli.util;
 
 import org.apache.flink.client.cli.CliFrontend;
-import org.apache.flink.client.cli.CliFrontendTestUtils;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.Configuration;
 
@@ -35,7 +34,6 @@ public class MockedCliFrontend extends CliFrontend {
 	public MockedCliFrontend(ClusterClient clusterClient) throws Exception {
 		super(
 			new Configuration(),
-			Collections.singletonList(new DummyCustomCommandLine<>(clusterClient)),
-			CliFrontendTestUtils.getConfigDir());
+			Collections.singletonList(new DummyCustomCommandLine<>(clusterClient)));
 	}
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/util/MockedCliFrontend.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/util/MockedCliFrontend.java
@@ -34,6 +34,6 @@ public class MockedCliFrontend extends CliFrontend {
 	public MockedCliFrontend(ClusterClient clusterClient) throws Exception {
 		super(
 			new Configuration(),
-			Collections.singletonList(new DummyCustomCommandLine<>(clusterClient)));
+			Collections.singletonList(new DummyCustomCommandLine(clusterClient)));
 	}
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/program/ClientConnectionTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/ClientConnectionTest.java
@@ -101,7 +101,7 @@ public class ClientConnectionTest extends TestLogger {
 		config.setString(JobManagerOptions.ADDRESS, unreachableEndpoint.getHostName());
 		config.setInteger(JobManagerOptions.PORT, unreachableEndpoint.getPort());
 
-		ClusterClient client = new StandaloneClusterClient(config);
+		StandaloneClusterClient client = new StandaloneClusterClient(config);
 
 		try {
 			// we have to query the cluster status to start the connection attempts
@@ -140,7 +140,7 @@ public class ClientConnectionTest extends TestLogger {
 
 			highAvailabilityServices.setJobMasterLeaderRetriever(HighAvailabilityServices.DEFAULT_JOB_ID, testingLeaderRetrievalService);
 
-			ClusterClient client = new StandaloneClusterClient(configuration, highAvailabilityServices);
+			StandaloneClusterClient client = new StandaloneClusterClient(configuration, highAvailabilityServices);
 
 			ActorGateway gateway = client.getJobManagerGateway();
 

--- a/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
@@ -131,7 +131,7 @@ public class ClientTest extends TestLogger {
 		jobManagerSystem.actorOf(
 			Props.create(SuccessReturningActor.class),
 			JobMaster.JOB_MANAGER_NAME);
-		ClusterClient out = new StandaloneClusterClient(config);
+		StandaloneClusterClient out = new StandaloneClusterClient(config);
 		out.setDetached(true);
 
 		try {
@@ -204,7 +204,7 @@ public class ClientTest extends TestLogger {
 			Props.create(SuccessReturningActor.class),
 			JobMaster.JOB_MANAGER_NAME);
 
-		ClusterClient out = new StandaloneClusterClient(config);
+		StandaloneClusterClient out = new StandaloneClusterClient(config);
 		out.setDetached(true);
 		JobSubmissionResult result = out.run(program.getPlanWithJars(), 1);
 
@@ -222,7 +222,7 @@ public class ClientTest extends TestLogger {
 				Props.create(FailureReturningActor.class),
 				JobMaster.JOB_MANAGER_NAME);
 
-		ClusterClient out = new StandaloneClusterClient(config);
+		StandaloneClusterClient out = new StandaloneClusterClient(config);
 		out.setDetached(true);
 
 		try {
@@ -259,7 +259,7 @@ public class ClientTest extends TestLogger {
 			}).when(packagedProgramMock).invokeInteractiveModeForExecution();
 
 			try {
-				ClusterClient client = new StandaloneClusterClient(config);
+				StandaloneClusterClient client = new StandaloneClusterClient(config);
 				client.setDetached(true);
 				client.run(packagedProgramMock, 1);
 				fail("Creating the local execution environment should not be possible");

--- a/flink-clients/src/test/java/org/apache/flink/client/program/ClusterClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/ClusterClientTest.java
@@ -188,6 +188,8 @@ public class ClusterClientTest extends TestLogger {
 			fail("Dispose operation should have failed.");
 		} catch (ExecutionException e) {
 			assertTrue(ExceptionUtils.findThrowable(e, FlinkRuntimeException.class).isPresent());
+		} finally {
+			clusterClient.shutdown();
 		}
 	}
 
@@ -214,6 +216,8 @@ public class ClusterClientTest extends TestLogger {
 				"instance, which cannot be disposed without the user code class " +
 				"loader. Please provide the program jar with which you have created " +
 				"the savepoint via -j <JAR> for disposal.").isPresent());
+		} finally {
+			clusterClient.shutdown();
 		}
 	}
 

--- a/flink-clients/src/test/java/org/apache/flink/client/program/ClusterClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/ClusterClientTest.java
@@ -71,7 +71,7 @@ public class ClusterClientTest extends TestLogger {
 		Configuration config = new Configuration();
 		HighAvailabilityServices highAvailabilityServices = mock(HighAvailabilityServices.class);
 
-		ClusterClient clusterClient = new StandaloneClusterClient(config, highAvailabilityServices);
+		StandaloneClusterClient clusterClient = new StandaloneClusterClient(config, highAvailabilityServices);
 
 		clusterClient.shutdown();
 
@@ -87,7 +87,7 @@ public class ClusterClientTest extends TestLogger {
 
 		JobID jobID = new JobID();
 		TestStopActorGateway gateway = new TestStopActorGateway(jobID);
-		ClusterClient clusterClient = new TestClusterClient(config, gateway);
+		TestClusterClient clusterClient = new TestClusterClient(config, gateway);
 		try {
 			clusterClient.stop(jobID);
 			Assert.assertTrue(gateway.messageArrived);
@@ -103,7 +103,7 @@ public class ClusterClientTest extends TestLogger {
 
 		JobID jobID = new JobID();
 		TestCancelActorGateway gateway = new TestCancelActorGateway(jobID);
-		ClusterClient clusterClient = new TestClusterClient(config, gateway);
+		TestClusterClient clusterClient = new TestClusterClient(config, gateway);
 		try {
 			clusterClient.cancel(jobID);
 			Assert.assertTrue(gateway.messageArrived);
@@ -121,7 +121,7 @@ public class ClusterClientTest extends TestLogger {
 		String savepointDirectory = "/test/directory";
 		String savepointPath = "/test/path";
 		TestCancelWithSavepointActorGateway gateway = new TestCancelWithSavepointActorGateway(jobID, savepointDirectory, savepointPath);
-		ClusterClient clusterClient = new TestClusterClient(config, gateway);
+		TestClusterClient clusterClient = new TestClusterClient(config, gateway);
 		try {
 			String path = clusterClient.cancelWithSavepoint(jobID, savepointDirectory);
 			Assert.assertTrue(gateway.messageArrived);
@@ -140,7 +140,7 @@ public class ClusterClientTest extends TestLogger {
 		String savepointDirectory = "/test/directory";
 		String savepointPath = "/test/path";
 		TestSavepointActorGateway gateway = new TestSavepointActorGateway(jobID, savepointDirectory, savepointPath);
-		ClusterClient clusterClient = new TestClusterClient(config, gateway);
+		TestClusterClient clusterClient = new TestClusterClient(config, gateway);
 		try {
 			CompletableFuture<String> pathFuture = clusterClient.triggerSavepoint(jobID, savepointDirectory);
 			Assert.assertTrue(gateway.messageArrived);
@@ -156,7 +156,7 @@ public class ClusterClientTest extends TestLogger {
 		config.setString(JobManagerOptions.ADDRESS, "localhost");
 
 		TestListActorGateway gateway = new TestListActorGateway();
-		ClusterClient clusterClient = new TestClusterClient(config, gateway);
+		TestClusterClient clusterClient = new TestClusterClient(config, gateway);
 		try {
 			CompletableFuture<Collection<JobStatusMessage>> jobDetailsFuture = clusterClient.listJobs();
 			Collection<JobStatusMessage> jobDetails = jobDetailsFuture.get();
@@ -179,7 +179,7 @@ public class ClusterClientTest extends TestLogger {
 
 		final ActorGateway jobManagerGateway = new TestDisposeWithWrongResponseActorGateway();
 
-		final ClusterClient clusterClient = new TestClusterClient(configuration, jobManagerGateway);
+		final TestClusterClient clusterClient = new TestClusterClient(configuration, jobManagerGateway);
 
 		CompletableFuture<Acknowledge> acknowledgeCompletableFuture = clusterClient.disposeSavepoint(savepointPath, timeout);
 
@@ -201,7 +201,7 @@ public class ClusterClientTest extends TestLogger {
 
 		final ActorGateway jobManagerGateway = new TestDisposeWithClassNotFoundExceptionActorGateway();
 
-		final ClusterClient clusterClient = new TestClusterClient(configuration, jobManagerGateway);
+		final TestClusterClient clusterClient = new TestClusterClient(configuration, jobManagerGateway);
 
 		CompletableFuture<Acknowledge> acknowledgeCompletableFuture = clusterClient.disposeSavepoint(savepointPath, timeout);
 

--- a/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.client.program.rest;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.client.deployment.StandaloneClusterId;
 import org.apache.flink.client.program.ProgramInvocationException;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
@@ -115,7 +116,7 @@ public class RestClusterClientTest extends TestLogger {
 
 	private RestServerEndpointConfiguration restServerEndpointConfiguration;
 
-	private RestClusterClient restClusterClient;
+	private RestClusterClient<StandaloneClusterId> restClusterClient;
 
 	@Before
 	public void setUp() throws Exception {
@@ -126,7 +127,7 @@ public class RestClusterClientTest extends TestLogger {
 		config.setString(JobManagerOptions.ADDRESS, "localhost");
 		restServerEndpointConfiguration = RestServerEndpointConfiguration.fromConfiguration(config);
 		mockGatewayRetriever = () -> CompletableFuture.completedFuture(mockRestfulGateway);
-		restClusterClient = new RestClusterClient(config, (attempt) -> 0);
+		restClusterClient = new RestClusterClient(config, StandaloneClusterId.getInstance(), (attempt) -> 0);
 	}
 
 	@After

--- a/flink-contrib/flink-storm/src/main/java/org/apache/flink/storm/api/FlinkClient.java
+++ b/flink-contrib/flink-storm/src/main/java/org/apache/flink/storm/api/FlinkClient.java
@@ -20,7 +20,6 @@ package org.apache.flink.storm.api;
 
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.client.program.JobWithJars;
 import org.apache.flink.client.program.ProgramInvocationException;
 import org.apache.flink.client.program.StandaloneClusterClient;
@@ -205,7 +204,7 @@ public class FlinkClient {
 		configuration.setString(JobManagerOptions.ADDRESS, jobManagerHost);
 		configuration.setInteger(JobManagerOptions.PORT, jobManagerPort);
 
-		final ClusterClient client;
+		final StandaloneClusterClient client;
 		try {
 			client = new StandaloneClusterClient(configuration);
 		} catch (final Exception e) {
@@ -245,7 +244,7 @@ public class FlinkClient {
 		configuration.setString(JobManagerOptions.ADDRESS, this.jobManagerHost);
 		configuration.setInteger(JobManagerOptions.PORT, this.jobManagerPort);
 
-		final ClusterClient client;
+		final StandaloneClusterClient client;
 		try {
 			client = new StandaloneClusterClient(configuration);
 		} catch (final Exception e) {

--- a/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkShell.scala
+++ b/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkShell.scala
@@ -20,7 +20,7 @@ package org.apache.flink.api.scala
 
 import java.io._
 
-import org.apache.flink.client.cli.{CliFrontend, CliFrontendParser}
+import org.apache.flink.client.cli.{CliFrontend, CliFrontendParser, RunOptions}
 import org.apache.flink.client.program.ClusterClient
 import org.apache.flink.configuration.{Configuration, GlobalConfiguration, JobManagerOptions}
 import org.apache.flink.runtime.minicluster.StandaloneMiniCluster
@@ -253,16 +253,19 @@ object FlinkShell {
     yarnConfig.queue.foreach((queue) => args ++= Seq("-yqu", queue.toString))
     yarnConfig.slots.foreach((slots) => args ++= Seq("-ys", slots.toString))
 
-    val options = CliFrontendParser.parseRunCommand(args.toArray)
+    val commandLine = CliFrontendParser.parse(
+      CliFrontendParser.getRunCommandOptions,
+      args.toArray,
+      true)
+
     val frontend = new CliFrontend(
       configuration,
       CliFrontend.loadCustomCommandLines(configuration, configurationDirectory))
-    val config = frontend.getConfiguration
-    val customCLI = frontend.getActiveCustomCommandLine(options.getCommandLine)
+    val customCLI = frontend.getActiveCustomCommandLine(commandLine)
 
-    val clusterDescriptor = customCLI.createClusterDescriptor(options.getCommandLine)
+    val clusterDescriptor = customCLI.createClusterDescriptor(commandLine)
 
-    val clusterSpecification = customCLI.getClusterSpecification(options.getCommandLine)
+    val clusterSpecification = customCLI.getClusterSpecification(commandLine)
 
     val cluster = clusterDescriptor.deploySessionCluster(clusterSpecification)
 
@@ -281,16 +284,19 @@ object FlinkShell {
       "-m", "yarn-cluster"
     )
 
-    val options = CliFrontendParser.parseRunCommand(args.toArray)
+    val commandLine = CliFrontendParser.parse(
+      CliFrontendParser.getRunCommandOptions,
+      args.toArray,
+      true)
+
     val frontend = new CliFrontend(
       configuration,
       CliFrontend.loadCustomCommandLines(configuration, configurationDirectory))
-    val config = frontend.getConfiguration
-    val customCLI = frontend.getActiveCustomCommandLine(options.getCommandLine)
+    val customCLI = frontend.getActiveCustomCommandLine(commandLine)
 
-    val clusterDescriptor = customCLI.createClusterDescriptor(options.getCommandLine)
+    val clusterDescriptor = customCLI.createClusterDescriptor(commandLine)
 
-    val clusterId = customCLI.getClusterId(options.getCommandLine)
+    val clusterId = customCLI.getClusterId(commandLine)
 
     val cluster = clusterDescriptor.retrieve(clusterId)
 

--- a/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkShell.scala
+++ b/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkShell.scala
@@ -256,22 +256,15 @@ object FlinkShell {
     val options = CliFrontendParser.parseRunCommand(args.toArray)
     val frontend = new CliFrontend(
       configuration,
-      CliFrontend.loadCustomCommandLines(),
-      configurationDirectory)
+      CliFrontend.loadCustomCommandLines(configuration, configurationDirectory))
     val config = frontend.getConfiguration
     val customCLI = frontend.getActiveCustomCommandLine(options.getCommandLine)
 
-    val clusterDescriptor = customCLI.createClusterDescriptor(
-      config,
-      frontend.getConfigurationDirectory,
-      options.getCommandLine)
+    val clusterDescriptor = customCLI.createClusterDescriptor(options.getCommandLine)
 
-    val clusterSpecification = customCLI.getClusterSpecification(
-      config,
-      options.getCommandLine)
+    val clusterSpecification = customCLI.getClusterSpecification(options.getCommandLine)
 
-    val cluster = clusterDescriptor.deploySessionCluster(
-      clusterSpecification)
+    val cluster = clusterDescriptor.deploySessionCluster(clusterSpecification)
 
     val address = cluster.getJobManagerAddress.getAddress.getHostAddress
     val port = cluster.getJobManagerAddress.getPort
@@ -291,19 +284,13 @@ object FlinkShell {
     val options = CliFrontendParser.parseRunCommand(args.toArray)
     val frontend = new CliFrontend(
       configuration,
-      CliFrontend.loadCustomCommandLines(),
-      configurationDirectory)
+      CliFrontend.loadCustomCommandLines(configuration, configurationDirectory))
     val config = frontend.getConfiguration
     val customCLI = frontend.getActiveCustomCommandLine(options.getCommandLine)
 
-    val clusterDescriptor = customCLI.createClusterDescriptor(
-      configuration,
-      configurationDirectory,
-      options.getCommandLine)
+    val clusterDescriptor = customCLI.createClusterDescriptor(options.getCommandLine)
 
-    val clusterId = customCLI.getClusterId(
-      configuration,
-      options.getCommandLine)
+    val clusterId = customCLI.getClusterId(options.getCommandLine)
 
     val cluster = clusterDescriptor.retrieve(clusterId)
 

--- a/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkShell.scala
+++ b/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkShell.scala
@@ -21,6 +21,7 @@ package org.apache.flink.api.scala
 import java.io._
 
 import org.apache.flink.client.cli.{CliFrontend, CliFrontendParser, RunOptions}
+import org.apache.flink.client.deployment.{ClusterDescriptor, StandaloneClusterId}
 import org.apache.flink.client.program.ClusterClient
 import org.apache.flink.configuration.{Configuration, GlobalConfiguration, JobManagerOptions}
 import org.apache.flink.runtime.minicluster.StandaloneMiniCluster
@@ -138,7 +139,7 @@ object FlinkShell {
   def fetchConnectionInfo(
     configuration: Configuration,
     config: Config
-  ): (String, Int, Option[Either[StandaloneMiniCluster, ClusterClient]]) = {
+  ): (String, Int, Option[Either[StandaloneMiniCluster, ClusterClient[_]]]) = {
     config.executionMode match {
       case ExecutionMode.LOCAL => // Local mode
         val config = GlobalConfiguration.loadConfiguration()
@@ -294,7 +295,9 @@ object FlinkShell {
       CliFrontend.loadCustomCommandLines(configuration, configurationDirectory))
     val customCLI = frontend.getActiveCustomCommandLine(commandLine)
 
-    val clusterDescriptor = customCLI.createClusterDescriptor(commandLine)
+    val clusterDescriptor = customCLI
+      .createClusterDescriptor(commandLine)
+      .asInstanceOf[ClusterDescriptor[Any]]
 
     val clusterId = customCLI.getClusterId(commandLine)
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/RemoteStreamEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/RemoteStreamEnvironment.java
@@ -21,7 +21,6 @@ import org.apache.flink.annotation.Public;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.java.ExecutionEnvironment;
-import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.client.program.JobWithJars;
 import org.apache.flink.client.program.ProgramInvocationException;
 import org.apache.flink.client.program.StandaloneClusterClient;
@@ -199,7 +198,7 @@ public class RemoteStreamEnvironment extends StreamExecutionEnvironment {
 		configuration.setString(JobManagerOptions.ADDRESS, host);
 		configuration.setInteger(JobManagerOptions.PORT, port);
 
-		ClusterClient client;
+		StandaloneClusterClient client;
 		try {
 			client = new StandaloneClusterClient(configuration);
 			client.setPrintStatusDuringExecution(getConfig().isSysoutLoggingEnabled());

--- a/flink-tests/src/test/java/org/apache/flink/test/example/client/JobRetrievalITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/example/client/JobRetrievalITCase.java
@@ -20,6 +20,7 @@
 package org.apache.flink.test.example.client;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.client.deployment.StandaloneClusterId;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.client.program.StandaloneClusterClient;
 import org.apache.flink.configuration.Configuration;
@@ -78,7 +79,7 @@ public class JobRetrievalITCase extends TestLogger {
 
 		final JobGraph jobGraph = new JobGraph(jobID, "testjob", imalock);
 
-		final ClusterClient client = new StandaloneClusterClient(cluster.configuration(), cluster.highAvailabilityServices());
+		final ClusterClient<StandaloneClusterId> client = new StandaloneClusterClient(cluster.configuration(), cluster.highAvailabilityServices());
 
 		// acquire the lock to make sure that the job cannot complete until the job client
 		// has been attached in resumingThread
@@ -123,7 +124,7 @@ public class JobRetrievalITCase extends TestLogger {
 	@Test
 	public void testNonExistingJobRetrieval() throws Exception {
 		final JobID jobID = new JobID();
-		ClusterClient client = new StandaloneClusterClient(cluster.configuration());
+		ClusterClient<StandaloneClusterId> client = new StandaloneClusterClient(cluster.configuration());
 
 		try {
 			client.retrieveJob(jobID);

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNHighAvailabilityITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNHighAvailabilityITCase.java
@@ -41,6 +41,7 @@ import akka.actor.PoisonPill;
 import akka.testkit.JavaTestKit;
 import org.apache.curator.test.TestingServer;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -125,7 +126,7 @@ public class YARNHighAvailabilityITCase extends YarnTestBase {
 			"@@" + FsStateBackendFactory.CHECKPOINT_DIRECTORY_URI_CONF_KEY + "=" + fsStateHandlePath + "/checkpoints" +
 			"@@" + HighAvailabilityOptions.HA_STORAGE_PATH.key() + "=" + fsStateHandlePath + "/recovery");
 
-		ClusterClient yarnCluster = null;
+		ClusterClient<ApplicationId> yarnCluster = null;
 
 		final FiniteDuration timeout = new FiniteDuration(2, TimeUnit.MINUTES);
 
@@ -140,8 +141,6 @@ public class YARNHighAvailabilityITCase extends YarnTestBase {
 
 		try {
 			yarnCluster = flinkYarnClient.deploySessionCluster(clusterSpecification);
-
-			final ClusterClient finalYarnCluster = yarnCluster;
 
 			highAvailabilityServices = HighAvailabilityServicesUtils.createHighAvailabilityServices(
 				yarnCluster.getFlinkConfiguration(),

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionCapacitySchedulerITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionCapacitySchedulerITCase.java
@@ -365,7 +365,7 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
 	@Test
 	public void testNonexistingQueueWARNmessage() {
 		LOG.info("Starting testNonexistingQueueWARNmessage()");
-		addTestAppender(YarnClusterDescriptor.class, Level.WARN);
+		addTestAppender(AbstractYarnClusterDescriptor.class, Level.WARN);
 		runWithArgs(new String[]{"-j", flinkUberjar.getAbsolutePath(),
 				"-t", flinkLibFolder.getAbsolutePath(),
 				"-n", "1",

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionCapacitySchedulerITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionCapacitySchedulerITCase.java
@@ -577,10 +577,10 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
 
 			// load the configuration
 			LOG.info("testDetachedPerJobYarnClusterInternal: Trying to load configuration file");
-			GlobalConfiguration.loadConfiguration(configDirectory.getAbsolutePath());
+			Configuration configuration = GlobalConfiguration.loadConfiguration(configDirectory.getAbsolutePath());
 
 			try {
-				File yarnPropertiesFile = FlinkYarnSessionCli.getYarnPropertiesLocation(GlobalConfiguration.loadConfiguration());
+				File yarnPropertiesFile = FlinkYarnSessionCli.getYarnPropertiesLocation(configuration.getValue(YarnConfigOptions.PROPERTIES_FILE_LOCATION));
 				if (yarnPropertiesFile.exists()) {
 					LOG.info("testDetachedPerJobYarnClusterInternal: Cleaning up temporary Yarn address reference: {}", yarnPropertiesFile.getAbsolutePath());
 					yarnPropertiesFile.delete();

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionCapacitySchedulerITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionCapacitySchedulerITCase.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.taskexecutor.TaskManagerServices;
 import org.apache.flink.runtime.webmonitor.WebMonitorUtils;
 import org.apache.flink.test.testdata.WordCountData;
 import org.apache.flink.test.util.TestBaseUtils;
+import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.yarn.cli.FlinkYarnSessionCli;
 import org.apache.flink.yarn.configuration.YarnConfigOptions;
 
@@ -74,6 +75,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static junit.framework.TestCase.assertTrue;
 import static org.apache.flink.yarn.UtilsTest.addTestAppender;
 import static org.apache.flink.yarn.UtilsTest.checkForLogString;
 
@@ -98,7 +100,7 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
 	 * Test regular operation, including command line parameter parsing.
 	 */
 	@Test
-	public void testClientStartup() {
+	public void testClientStartup() throws IOException {
 		LOG.info("Starting testClientStartup()");
 		runWithArgs(new String[]{"-j", flinkUberjar.getAbsolutePath(), "-t", flinkLibFolder.getAbsolutePath(),
 						"-n", "1",
@@ -116,7 +118,7 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
 	 * The parallelism is requested at the YARN client (-ys).
 	 */
 	@Test
-	public void perJobYarnCluster() {
+	public void perJobYarnCluster() throws IOException {
 		LOG.info("Starting perJobYarnCluster()");
 		addTestAppender(JobClient.class, Level.INFO);
 		File exampleJarLocation = new File("target/programs/BatchWordCount.jar");
@@ -145,7 +147,7 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
 	 * memory remains.
 	 */
 	@Test
-	public void perJobYarnClusterOffHeap() {
+	public void perJobYarnClusterOffHeap() throws IOException {
 		LOG.info("Starting perJobYarnCluster()");
 		addTestAppender(JobClient.class, Level.INFO);
 		File exampleJarLocation = new File("target/programs/BatchWordCount.jar");
@@ -363,15 +365,19 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
 	 * target queue. With an error message, we can help users identifying the issue)
 	 */
 	@Test
-	public void testNonexistingQueueWARNmessage() {
+	public void testNonexistingQueueWARNmessage() throws IOException {
 		LOG.info("Starting testNonexistingQueueWARNmessage()");
 		addTestAppender(AbstractYarnClusterDescriptor.class, Level.WARN);
-		runWithArgs(new String[]{"-j", flinkUberjar.getAbsolutePath(),
+		try {
+			runWithArgs(new String[]{"-j", flinkUberjar.getAbsolutePath(),
 				"-t", flinkLibFolder.getAbsolutePath(),
 				"-n", "1",
 				"-jm", "768",
 				"-tm", "1024",
 				"-qu", "doesntExist"}, "to unknown queue: doesntExist", null, RunTypes.YARN_SESSION, 1);
+		} catch (Exception e) {
+			assertTrue(ExceptionUtils.findThrowableWithMessage(e, "to unknown queue: doesntExist").isPresent());
+		}
 		checkForLogString("The specified queue 'doesntExist' does not exist. Available queues");
 		LOG.info("Finished testNonexistingQueueWARNmessage()");
 	}
@@ -380,7 +386,7 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
 	 * Test per-job yarn cluster with the parallelism set at the CliFrontend instead of the YARN client.
 	 */
 	@Test
-	public void perJobYarnClusterWithParallelism() {
+	public void perJobYarnClusterWithParallelism() throws IOException {
 		LOG.info("Starting perJobYarnClusterWithParallelism()");
 		// write log messages to stdout as well, so that the runWithArgs() method
 		// is catching the log output
@@ -407,7 +413,7 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
 	 * Test a fire-and-forget job submission to a YARN cluster.
 	 */
 	@Test(timeout = 60000)
-	public void testDetachedPerJobYarnCluster() {
+	public void testDetachedPerJobYarnCluster() throws IOException {
 		LOG.info("Starting testDetachedPerJobYarnCluster()");
 
 		File exampleJarLocation = new File("target/programs/BatchWordCount.jar");
@@ -423,7 +429,7 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
 	 * Test a fire-and-forget job submission to a YARN cluster.
 	 */
 	@Test(timeout = 60000)
-	public void testDetachedPerJobYarnClusterWithStreamingJob() {
+	public void testDetachedPerJobYarnClusterWithStreamingJob() throws IOException {
 		LOG.info("Starting testDetachedPerJobYarnClusterWithStreamingJob()");
 
 		File exampleJarLocation = new File("target/programs/StreamingWordCount.jar");
@@ -435,7 +441,7 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
 		LOG.info("Finished testDetachedPerJobYarnClusterWithStreamingJob()");
 	}
 
-	private void testDetachedPerJobYarnClusterInternal(String job) {
+	private void testDetachedPerJobYarnClusterInternal(String job) throws IOException {
 		YarnClient yc = YarnClient.createYarnClient();
 		yc.init(YARN_CONFIGURATION);
 		yc.start();

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
@@ -246,7 +246,7 @@ public class YARNSessionFIFOITCase extends YarnTestBase {
 				.setSlotsPerTaskManager(1)
 				.createClusterSpecification();
 			// deploy
-			ClusterClient yarnCluster = null;
+			ClusterClient<ApplicationId> yarnCluster = null;
 			try {
 				yarnCluster = clusterDescriptor.deploySessionCluster(clusterSpecification);
 			} catch (Exception e) {

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
@@ -45,6 +45,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
@@ -80,7 +81,7 @@ public class YARNSessionFIFOITCase extends YarnTestBase {
 	 * Test regular operation, including command line parameter parsing.
 	 */
 	@Test(timeout = 60000) // timeout after a minute.
-	public void testDetachedMode() throws InterruptedException {
+	public void testDetachedMode() throws InterruptedException, IOException {
 		LOG.info("Starting testDetachedMode()");
 		addTestAppender(FlinkYarnSessionCli.class, Level.INFO);
 		Runner runner =
@@ -158,7 +159,7 @@ public class YARNSessionFIFOITCase extends YarnTestBase {
 	 * <p>This test validates through 666*2 cores in the "cluster".
 	 */
 	@Test
-	public void testQueryCluster() {
+	public void testQueryCluster() throws IOException {
 		LOG.info("Starting testQueryCluster()");
 		runWithArgs(new String[] {"-q"}, "Summary: totalMemory 8192 totalCores 1332", null, RunTypes.YARN_SESSION, 0); // we have 666*2 cores.
 		LOG.info("Finished testQueryCluster()");
@@ -178,7 +179,7 @@ public class YARNSessionFIFOITCase extends YarnTestBase {
 	 */
 	@Ignore("The test is too resource consuming (8.5 GB of memory)")
 	@Test
-	public void testResourceComputation() {
+	public void testResourceComputation() throws IOException {
 		addTestAppender(AbstractYarnClusterDescriptor.class, Level.WARN);
 		LOG.info("Starting testResourceComputation()");
 		runWithArgs(new String[]{"-j", flinkUberjar.getAbsolutePath(), "-t", flinkLibFolder.getAbsolutePath(),
@@ -206,7 +207,7 @@ public class YARNSessionFIFOITCase extends YarnTestBase {
 	 */
 	@Ignore("The test is too resource consuming (8 GB of memory)")
 	@Test
-	public void testfullAlloc() {
+	public void testfullAlloc() throws IOException {
 		addTestAppender(AbstractYarnClusterDescriptor.class, Level.WARN);
 		LOG.info("Starting testfullAlloc()");
 		runWithArgs(new String[]{"-j", flinkUberjar.getAbsolutePath(), "-t", flinkLibFolder.getAbsolutePath(),

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
@@ -179,7 +179,7 @@ public class YARNSessionFIFOITCase extends YarnTestBase {
 	@Ignore("The test is too resource consuming (8.5 GB of memory)")
 	@Test
 	public void testResourceComputation() {
-		addTestAppender(YarnClusterDescriptor.class, Level.WARN);
+		addTestAppender(AbstractYarnClusterDescriptor.class, Level.WARN);
 		LOG.info("Starting testResourceComputation()");
 		runWithArgs(new String[]{"-j", flinkUberjar.getAbsolutePath(), "-t", flinkLibFolder.getAbsolutePath(),
 				"-n", "5",
@@ -207,7 +207,7 @@ public class YARNSessionFIFOITCase extends YarnTestBase {
 	@Ignore("The test is too resource consuming (8 GB of memory)")
 	@Test
 	public void testfullAlloc() {
-		addTestAppender(YarnClusterDescriptor.class, Level.WARN);
+		addTestAppender(AbstractYarnClusterDescriptor.class, Level.WARN);
 		LOG.info("Starting testfullAlloc()");
 		runWithArgs(new String[]{"-j", flinkUberjar.getAbsolutePath(), "-t", flinkLibFolder.getAbsolutePath(),
 				"-n", "2",

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
@@ -25,6 +25,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.runtime.clusterframework.messages.GetClusterStatusResponse;
 import org.apache.flink.yarn.cli.FlinkYarnSessionCli;
+import org.apache.flink.yarn.configuration.YarnConfigOptions;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
@@ -134,10 +135,10 @@ public class YARNSessionFIFOITCase extends YarnTestBase {
 
 			// load the configuration
 			LOG.info("testDetachedPerJobYarnClusterInternal: Trying to load configuration file");
-			GlobalConfiguration.loadConfiguration(configDirectory.getAbsolutePath());
+			Configuration configuration = GlobalConfiguration.loadConfiguration(configDirectory.getAbsolutePath());
 
 			try {
-				File yarnPropertiesFile = FlinkYarnSessionCli.getYarnPropertiesLocation(GlobalConfiguration.loadConfiguration());
+				File yarnPropertiesFile = FlinkYarnSessionCli.getYarnPropertiesLocation(configuration.getString(YarnConfigOptions.PROPERTIES_FILE_LOCATION));
 				if (yarnPropertiesFile.exists()) {
 					LOG.info("testDetachedPerJobYarnClusterInternal: Cleaning up temporary Yarn address reference: {}", yarnPropertiesFile.getAbsolutePath());
 					yarnPropertiesFile.delete();

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
@@ -693,6 +693,8 @@ public abstract class YarnTestBase extends TestLogger {
 				switch (type) {
 					case YARN_SESSION:
 						yCli = new FlinkYarnSessionCli(
+							configuration,
+							configurationDirectory,
 							"",
 							"",
 							false);
@@ -702,8 +704,7 @@ public abstract class YarnTestBase extends TestLogger {
 						try {
 							CliFrontend cli = new CliFrontend(
 								configuration,
-								CliFrontend.loadCustomCommandLines(),
-								configurationDirectory);
+								CliFrontend.loadCustomCommandLines(configuration, configurationDirectory));
 							returnValue = cli.parseParameters(args);
 						} catch (Exception e) {
 							throw new RuntimeException("Failed to execute the following args with CliFrontend: "

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
@@ -61,6 +61,9 @@ import java.io.FileNotFoundException;
 import java.io.FileWriter;
 import java.io.FilenameFilter;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.util.ArrayList;
@@ -86,6 +89,7 @@ public abstract class YarnTestBase extends TestLogger {
 
 	protected static final PrintStream ORIGINAL_STDOUT = System.out;
 	protected static final PrintStream ORIGINAL_STDERR = System.err;
+	private static final InputStream ORIGINAL_STDIN = System.in;
 
 	protected static final String TEST_CLUSTER_NAME_KEY = "flink-yarn-minicluster-name";
 
@@ -510,13 +514,18 @@ public abstract class YarnTestBase extends TestLogger {
 	/**
 	 * This method returns once the "startedAfterString" has been seen.
 	 */
-	protected Runner startWithArgs(String[] args, String startedAfterString, RunTypes type) {
+	protected Runner startWithArgs(String[] args, String startedAfterString, RunTypes type) throws IOException {
 		LOG.info("Running with args {}", Arrays.toString(args));
 
 		outContent = new ByteArrayOutputStream();
 		errContent = new ByteArrayOutputStream();
+		PipedOutputStream out = new PipedOutputStream();
+		PipedInputStream in = new PipedInputStream(out);
+		PrintStream stdinPrintStream = new PrintStream(out);
+
 		System.setOut(new PrintStream(outContent));
 		System.setErr(new PrintStream(errContent));
+		System.setIn(in);
 
 		final int startTimeoutSeconds = 60;
 
@@ -525,7 +534,8 @@ public abstract class YarnTestBase extends TestLogger {
 			flinkConfiguration,
 			CliFrontend.getConfigurationDirectoryFromEnv(),
 			type,
-			0);
+			0,
+			stdinPrintStream);
 		runner.setName("Frontend (CLI/YARN Client) runner thread (startWithArgs()).");
 		runner.start();
 
@@ -539,7 +549,7 @@ public abstract class YarnTestBase extends TestLogger {
 			}
 			// check if thread died
 			if (!runner.isAlive()) {
-				sendOutput();
+				resetStreamsAndSendOutput();
 				if (runner.getRunnerError() != null) {
 					throw new RuntimeException("Runner failed with exception.", runner.getRunnerError());
 				}
@@ -547,13 +557,13 @@ public abstract class YarnTestBase extends TestLogger {
 			}
 		}
 
-		sendOutput();
+		resetStreamsAndSendOutput();
 		Assert.fail("During the timeout period of " + startTimeoutSeconds + " seconds the " +
 				"expected string did not show up");
 		return null;
 	}
 
-	protected void runWithArgs(String[] args, String terminateAfterString, String[] failOnStrings, RunTypes type, int returnCode) {
+	protected void runWithArgs(String[] args, String terminateAfterString, String[] failOnStrings, RunTypes type, int returnCode) throws IOException {
 		runWithArgs(args, terminateAfterString, failOnStrings, type, returnCode, false);
 	}
 
@@ -566,13 +576,17 @@ public abstract class YarnTestBase extends TestLogger {
 	 * @param expectedReturnValue Expected return code from the runner.
 	 * @param checkLogForTerminateString  If true, the runner checks also the log4j logger for the terminate string
 	 */
-	protected void runWithArgs(String[] args, String terminateAfterString, String[] failOnPatterns, RunTypes type, int expectedReturnValue, boolean checkLogForTerminateString) {
+	protected void runWithArgs(String[] args, String terminateAfterString, String[] failOnPatterns, RunTypes type, int expectedReturnValue, boolean checkLogForTerminateString) throws IOException {
 		LOG.info("Running with args {}", Arrays.toString(args));
 
 		outContent = new ByteArrayOutputStream();
 		errContent = new ByteArrayOutputStream();
+		PipedOutputStream out = new PipedOutputStream();
+		PipedInputStream in = new PipedInputStream(out);
+		PrintStream stdinPrintStream = new PrintStream(out);
 		System.setOut(new PrintStream(outContent));
 		System.setErr(new PrintStream(errContent));
+		System.setIn(in);
 
 		// we wait for at most three minutes
 		final int startTimeoutSeconds = 180;
@@ -583,11 +597,13 @@ public abstract class YarnTestBase extends TestLogger {
 			flinkConfiguration,
 			CliFrontend.getConfigurationDirectoryFromEnv(),
 			type,
-			expectedReturnValue);
+			expectedReturnValue,
+			stdinPrintStream);
 		runner.start();
 
 		boolean expectedStringSeen = false;
 		boolean testPassedFromLog4j = false;
+		long shutdownTimeout = 30000L;
 		do {
 			sleep(1000);
 			String outContentString = outContent.toString();
@@ -597,9 +613,15 @@ public abstract class YarnTestBase extends TestLogger {
 					Pattern pattern = Pattern.compile(failOnString);
 					if (pattern.matcher(outContentString).find() || pattern.matcher(errContentString).find()) {
 						LOG.warn("Failing test. Output contained illegal string '" + failOnString + "'");
-						sendOutput();
+						resetStreamsAndSendOutput();
 						// stopping runner.
 						runner.sendStop();
+						// wait for the thread to stop
+						try {
+							runner.join(shutdownTimeout);
+						} catch (InterruptedException e) {
+							LOG.warn("Interrupted while stopping runner", e);
+						}
 						Assert.fail("Output contained illegal string '" + failOnString + "'");
 					}
 				}
@@ -622,7 +644,7 @@ public abstract class YarnTestBase extends TestLogger {
 				runner.sendStop();
 				// wait for the thread to stop
 				try {
-					runner.join(30000);
+					runner.join(shutdownTimeout);
 				}
 				catch (InterruptedException e) {
 					LOG.warn("Interrupted while stopping runner", e);
@@ -639,7 +661,7 @@ public abstract class YarnTestBase extends TestLogger {
 		}
 		while (runner.getRunnerError() == null && !expectedStringSeen && System.currentTimeMillis() < deadline);
 
-		sendOutput();
+		resetStreamsAndSendOutput();
 
 		if (runner.getRunnerError() != null) {
 			// this lets the test fail.
@@ -651,9 +673,10 @@ public abstract class YarnTestBase extends TestLogger {
 		LOG.info("Test was successful");
 	}
 
-	protected static void sendOutput() {
+	protected static void resetStreamsAndSendOutput() {
 		System.setOut(ORIGINAL_STDOUT);
 		System.setErr(ORIGINAL_STDERR);
+		System.setIn(ORIGINAL_STDIN);
 
 		LOG.info("Sending stdout content through logger: \n\n{}\n\n", outContent.toString());
 		LOG.info("Sending stderr content through logger: \n\n{}\n\n", errContent.toString());
@@ -668,6 +691,8 @@ public abstract class YarnTestBase extends TestLogger {
 		private final String configurationDirectory;
 		private final int expectedReturnValue;
 
+		private final PrintStream stdinPrintStream;
+
 		private RunTypes type;
 		private FlinkYarnSessionCli yCli;
 		private Throwable runnerError;
@@ -677,13 +702,15 @@ public abstract class YarnTestBase extends TestLogger {
 				org.apache.flink.configuration.Configuration configuration,
 				String configurationDirectory,
 				RunTypes type,
-				int expectedReturnValue) {
+				int expectedReturnValue,
+				PrintStream stdinPrintStream) {
 
 			this.args = args;
 			this.configuration = Preconditions.checkNotNull(configuration);
 			this.configurationDirectory = Preconditions.checkNotNull(configurationDirectory);
 			this.type = type;
 			this.expectedReturnValue = expectedReturnValue;
+			this.stdinPrintStream = Preconditions.checkNotNull(stdinPrintStream);
 		}
 
 		@Override
@@ -697,8 +724,8 @@ public abstract class YarnTestBase extends TestLogger {
 							configurationDirectory,
 							"",
 							"",
-							false);
-						returnValue = yCli.run(args, configuration, configurationDirectory);
+							true);
+						returnValue = yCli.run(args);
 						break;
 					case CLI_FRONTEND:
 						try {
@@ -727,9 +754,7 @@ public abstract class YarnTestBase extends TestLogger {
 
 		/** Stops the Yarn session. */
 		public void sendStop() {
-			if (yCli != null) {
-				yCli.stop();
-			}
+			stdinPrintStream.println("stop");
 		}
 
 		public Throwable getRunnerError() {

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
@@ -99,8 +99,8 @@ import static org.apache.flink.yarn.cli.FlinkYarnSessionCli.getDynamicProperties
 /**
  * The descriptor with deployment information for spawning or resuming a {@link YarnClusterClient}.
  */
-public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor<YarnClusterClient> {
-	private static final Logger LOG = LoggerFactory.getLogger(YarnClusterDescriptor.class);
+public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor {
+	private static final Logger LOG = LoggerFactory.getLogger(AbstractYarnClusterDescriptor.class);
 
 	/**
 	 * Minimum memory requirements, checked by the Client.

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterClient.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterClient.java
@@ -34,6 +34,7 @@ import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.yarn.cli.FlinkYarnSessionCli;
+import org.apache.flink.yarn.configuration.YarnConfigOptions;
 
 import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
@@ -330,7 +331,7 @@ public class YarnClusterClient extends ClusterClient {
 		}
 
 		try {
-			File propertiesFile = FlinkYarnSessionCli.getYarnPropertiesLocation(flinkConfig);
+			File propertiesFile = FlinkYarnSessionCli.getYarnPropertiesLocation(flinkConfig.getValue(YarnConfigOptions.PROPERTIES_FILE_LOCATION));
 			if (propertiesFile.isFile()) {
 				if (propertiesFile.delete()) {
 					LOG.info("Deleted Yarn properties file at {}", propertiesFile.getAbsoluteFile().toString());

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterClient.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterClient.java
@@ -24,7 +24,6 @@ import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.client.program.ProgramInvocationException;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
-import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.messages.GetClusterStatus;
 import org.apache.flink.runtime.clusterframework.messages.GetClusterStatusResponse;
 import org.apache.flink.runtime.clusterframework.messages.InfoMessage;
@@ -33,8 +32,6 @@ import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.Preconditions;
-import org.apache.flink.yarn.cli.FlinkYarnSessionCli;
-import org.apache.flink.yarn.configuration.YarnConfigOptions;
 
 import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
@@ -43,17 +40,15 @@ import akka.pattern.Patterns;
 import akka.util.Timeout;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.ApplicationReport;
-import org.apache.hadoop.yarn.api.records.YarnApplicationState;
 import org.apache.hadoop.yarn.exceptions.YarnException;
+import org.apache.hadoop.yarn.util.ConverterUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import scala.Option;
 import scala.concurrent.Await;
@@ -67,8 +62,6 @@ public class YarnClusterClient extends ClusterClient {
 
 	private static final Logger LOG = LoggerFactory.getLogger(YarnClusterClient.class);
 
-	private Thread clientShutdownHook = new ClientShutdownHook();
-
 	//---------- Class internal fields -------------------
 
 	private final AbstractYarnClusterDescriptor clusterDescriptor;
@@ -79,8 +72,6 @@ public class YarnClusterClient extends ClusterClient {
 	private final ApplicationReport appReport;
 	private final ApplicationId appId;
 	private final String trackingURL;
-
-	private boolean isConnected = true;
 
 	/** Indicator whether this cluster has just been created. */
 	private final boolean newlyCreatedCluster;
@@ -120,32 +111,6 @@ public class YarnClusterClient extends ClusterClient {
 			flinkConfig,
 			actorSystemLoader,
 			highAvailabilityServices);
-
-		Runtime.getRuntime().addShutdownHook(clientShutdownHook);
-	}
-
-	/**
-	 * Disconnect from the Yarn cluster.
-	 */
-	public void disconnect() {
-
-		if (hasBeenShutDown.getAndSet(true)) {
-			return;
-		}
-
-		if (!isConnected) {
-			throw new IllegalStateException("Can not disconnect from an unconnected cluster.");
-		}
-
-		LOG.info("Disconnecting YarnClusterClient from ApplicationMaster");
-
-		try {
-			Runtime.getRuntime().removeShutdownHook(clientShutdownHook);
-		} catch (IllegalStateException e) {
-			// we are already in the shutdown hook
-		}
-
-		isConnected = false;
 	}
 
 	// -------------------------- Interaction with the cluster ------------------------
@@ -207,7 +172,7 @@ public class YarnClusterClient extends ClusterClient {
 
 	@Override
 	public String getClusterIdentifier() {
-		return "Yarn cluster with application id " + appReport.getApplicationId();
+		return ConverterUtils.toString(appReport.getApplicationId());
 	}
 
 	/**
@@ -215,13 +180,6 @@ public class YarnClusterClient extends ClusterClient {
 	 */
 	@Override
 	public GetClusterStatusResponse getClusterStatus() {
-		if (!isConnected) {
-			throw new IllegalStateException("The cluster is not connected to the cluster.");
-		}
-		if (hasBeenShutdown()) {
-			throw new IllegalStateException("The cluster has already been shutdown.");
-		}
-
 		try {
 			final Future<Object> clusterStatusOption =
 				getJobManagerGateway().ask(
@@ -236,15 +194,7 @@ public class YarnClusterClient extends ClusterClient {
 	@Override
 	public List<String> getNewMessages() {
 
-		if (hasBeenShutdown()) {
-			throw new RuntimeException("The YarnClusterClient has already been stopped");
-		}
-
-		if (!isConnected) {
-			throw new IllegalStateException("The cluster has been connected to the ApplicationMaster.");
-		}
-
-		List<String> ret = new ArrayList<String>();
+		List<String> ret = new ArrayList<>();
 		// get messages from ApplicationClient (locally)
 		while (true) {
 			Object result;
@@ -281,105 +231,6 @@ public class YarnClusterClient extends ClusterClient {
 			}
 		}
 		return ret;
-	}
-
-	// -------------------------- Shutdown handling ------------------------
-
-	private AtomicBoolean hasBeenShutDown = new AtomicBoolean(false);
-
-	/**
-	 * Shuts down or disconnects from the YARN cluster.
-	 */
-	@Override
-	public void finalizeCluster() {
-		if (isDetached() || !newlyCreatedCluster) {
-			disconnect();
-		} else {
-			shutdownCluster();
-		}
-	}
-
-	/**
-	 * Shuts down the Yarn application.
-	 */
-	public void shutdownCluster() {
-
-		if (hasBeenShutDown.getAndSet(true)) {
-			return;
-		}
-
-		if (!isConnected) {
-			throw new IllegalStateException("The cluster has been not been connected to the ApplicationMaster.");
-		}
-
-		try {
-			Runtime.getRuntime().removeShutdownHook(clientShutdownHook);
-		} catch (IllegalStateException e) {
-			// we are already in the shutdown hook
-		}
-
-		LOG.info("Sending shutdown request to the Application Master");
-		try {
-			Future<Object> response =
-				Patterns.ask(applicationClient.get(),
-					new YarnMessages.LocalStopYarnSession(ApplicationStatus.CANCELED,
-						"Flink YARN Client requested shutdown"),
-					new Timeout(akkaDuration));
-			Await.ready(response, akkaDuration);
-		} catch (Exception e) {
-			LOG.warn("Error while stopping YARN cluster.", e);
-		}
-
-		try {
-			File propertiesFile = FlinkYarnSessionCli.getYarnPropertiesLocation(flinkConfig.getValue(YarnConfigOptions.PROPERTIES_FILE_LOCATION));
-			if (propertiesFile.isFile()) {
-				if (propertiesFile.delete()) {
-					LOG.info("Deleted Yarn properties file at {}", propertiesFile.getAbsoluteFile().toString());
-				} else {
-					LOG.warn("Couldn't delete Yarn properties file at {}", propertiesFile.getAbsoluteFile().toString());
-				}
-			}
-		} catch (Exception e) {
-			LOG.warn("Exception while deleting the JobManager address file", e);
-		}
-
-		try {
-			ApplicationReport appReport = clusterDescriptor.getYarnClient().getApplicationReport(appId);
-
-			LOG.info("Application " + appId + " finished with state " + appReport
-				.getYarnApplicationState() + " and final state " + appReport
-				.getFinalApplicationStatus() + " at " + appReport.getFinishTime());
-
-			if (appReport.getYarnApplicationState() == YarnApplicationState.FAILED || appReport.getYarnApplicationState()
-				== YarnApplicationState.KILLED) {
-				LOG.warn("Application failed. Diagnostics " + appReport.getDiagnostics());
-				LOG.warn("If log aggregation is activated in the Hadoop cluster, we recommend to retrieve "
-					+ "the full application log using this command:"
-					+ System.lineSeparator()
-					+ "\tyarn logs -applicationId " + appReport.getApplicationId()
-					+ System.lineSeparator()
-					+ "(It sometimes takes a few seconds until the logs are aggregated)");
-			}
-		} catch (Exception e) {
-			LOG.warn("Couldn't get final report", e);
-		}
-	}
-
-	public boolean hasBeenShutdown() {
-		return hasBeenShutDown.get();
-	}
-
-	private class ClientShutdownHook extends Thread {
-		@Override
-		public void run() {
-			LOG.info("Shutting down YarnClusterClient from the client shutdown hook");
-
-			try {
-				shutdown();
-			} catch (Throwable t) {
-				LOG.warn("Could not properly shut down the yarn cluster client.", t);
-			}
-		}
 	}
 
 	@Override

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterClient.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterClient.java
@@ -41,7 +41,6 @@ import akka.util.Timeout;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.ApplicationReport;
 import org.apache.hadoop.yarn.exceptions.YarnException;
-import org.apache.hadoop.yarn.util.ConverterUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,7 +57,7 @@ import scala.concurrent.duration.FiniteDuration;
 /**
  * Java representation of a running Flink cluster within YARN.
  */
-public class YarnClusterClient extends ClusterClient {
+public class YarnClusterClient extends ClusterClient<ApplicationId> {
 
 	private static final Logger LOG = LoggerFactory.getLogger(YarnClusterClient.class);
 
@@ -170,11 +169,6 @@ public class YarnClusterClient extends ClusterClient {
 		}
 	}
 
-	@Override
-	public String getClusterIdentifier() {
-		return ConverterUtils.toString(appReport.getApplicationId());
-	}
-
 	/**
 	 * This method is only available if the cluster hasn't been started in detached mode.
 	 */
@@ -231,6 +225,11 @@ public class YarnClusterClient extends ClusterClient {
 			}
 		}
 		return ret;
+	}
+
+	@Override
+	public ApplicationId getClusterId() {
+		return appId;
 	}
 
 	@Override

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
@@ -127,6 +127,7 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine {
 	private final Option detached;
 	private final Option zookeeperNamespace;
 	private final Option flip6;
+	private final Option help;
 
 	/**
 	 * @deprecated Streaming mode has been deprecated without replacement. Set the
@@ -198,6 +199,7 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine {
 		name = new Option(shortPrefix + "nm", longPrefix + "name", true, "Set a custom name for the application on YARN");
 		zookeeperNamespace = new Option(shortPrefix + "z", longPrefix + "zookeeperNamespace", true, "Namespace to create the Zookeeper sub-paths for high availability mode");
 		flip6 = new Option(shortPrefix + "f6", longPrefix + "flip6", false, "Specify this option to start a Flip-6 Yarn session cluster.");
+		help = new Option(shortPrefix + "h", longPrefix + "help", false, "Help for the Yarn session CLI.");
 
 		allOptions = new Options();
 		allOptions.addOption(flinkJar);
@@ -215,6 +217,7 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine {
 		allOptions.addOption(applicationId);
 		allOptions.addOption(zookeeperNamespace);
 		allOptions.addOption(flip6);
+		allOptions.addOption(help);
 
 		// try loading a potential yarn properties file
 		this.yarnPropertiesFileLocation = configuration.getString(YarnConfigOptions.PROPERTIES_FILE_LOCATION);
@@ -563,6 +566,11 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine {
 		//	Command Line Options
 		//
 		final CommandLine cmd = parseCommandLineOptions(args, true);
+
+		if (cmd.hasOption(help.getOpt())) {
+			printUsage();
+			return 0;
+		}
 
 		final AbstractYarnClusterDescriptor yarnClusterDescriptor = createClusterDescriptor(cmd);
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
@@ -19,9 +19,11 @@
 package org.apache.flink.yarn.cli;
 
 import org.apache.flink.client.cli.AbstractCustomCommandLine;
+import org.apache.flink.client.cli.CliArgsException;
 import org.apache.flink.client.cli.CliFrontend;
 import org.apache.flink.client.cli.CliFrontendParser;
 import org.apache.flink.client.deployment.ClusterSpecification;
+import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.GlobalConfiguration;
@@ -36,20 +38,21 @@ import org.apache.flink.util.ExecutorUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.yarn.AbstractYarnClusterDescriptor;
-import org.apache.flink.yarn.YarnClusterClient;
 import org.apache.flink.yarn.YarnClusterDescriptor;
 import org.apache.flink.yarn.YarnClusterDescriptorV2;
 import org.apache.flink.yarn.configuration.YarnConfigOptions;
 
 import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
-import org.apache.commons.cli.PosixParser;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.yarn.api.records.ApplicationId;
+import org.apache.hadoop.yarn.api.records.ApplicationReport;
+import org.apache.hadoop.yarn.api.records.YarnApplicationState;
 import org.apache.hadoop.yarn.client.api.YarnClient;
+import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.util.ConverterUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -73,8 +76,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 import static org.apache.flink.configuration.HighAvailabilityOptions.HA_CLUSTER_ID;
 
@@ -96,7 +101,7 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine {
 
 	// YARN-session related constants
 	private static final String YARN_PROPERTIES_FILE = ".yarn-properties-";
-	static final String YARN_APPLICATION_ID_KEY = "applicationID";
+	private static final String YARN_APPLICATION_ID_KEY = "applicationID";
 	private static final String YARN_PROPERTIES_PARALLELISM = "parallelism";
 	private static final String YARN_PROPERTIES_DYNAMIC_PROPERTIES_STRING = "dynamicPropertiesString";
 
@@ -148,8 +153,9 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine {
 
 	private final String yarnApplicationIdFromYarnProperties;
 
+	private final String yarnPropertiesFileLocation;
+
 	//------------------------------------ Internal fields -------------------------
-	private YarnClusterClient yarnCluster;
 	private boolean detachedMode = false;
 
 	public FlinkYarnSessionCli(
@@ -181,7 +187,12 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine {
 		tmMemory = new Option(shortPrefix + "tm", longPrefix + "taskManagerMemory", true, "Memory per TaskManager Container [in MB]");
 		container = new Option(shortPrefix + "n", longPrefix + "container", true, "Number of YARN container to allocate (=Number of Task Managers)");
 		slots = new Option(shortPrefix + "s", longPrefix + "slots", true, "Number of slots per TaskManager");
-		dynamicproperties = new Option(shortPrefix + "D", true, "Dynamic properties");
+		dynamicproperties = Option.builder(shortPrefix + "D")
+			.argName("property=value")
+			.numberOfArgs(2)
+			.valueSeparator()
+			.desc("use value for given property")
+			.build();
 		detached = new Option(shortPrefix + "d", longPrefix + "detached", false, "Start detached");
 		streaming = new Option(shortPrefix + "st", longPrefix + "streaming", false, "Start Flink in streaming mode");
 		name = new Option(shortPrefix + "nm", longPrefix + "name", true, "Set a custom name for the application on YARN");
@@ -206,7 +217,8 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine {
 		allOptions.addOption(flip6);
 
 		// try loading a potential yarn properties file
-		final File yarnPropertiesLocation = getYarnPropertiesLocation(configuration.getString(YarnConfigOptions.PROPERTIES_FILE_LOCATION));
+		this.yarnPropertiesFileLocation = configuration.getString(YarnConfigOptions.PROPERTIES_FILE_LOCATION);
+		final File yarnPropertiesLocation = getYarnPropertiesLocation(yarnPropertiesFileLocation);
 
 		yarnPropertiesFile = new Properties();
 
@@ -216,7 +228,8 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine {
 			try (InputStream is = new FileInputStream(yarnPropertiesLocation)) {
 				yarnPropertiesFile.load(is);
 			} catch (IOException ioe) {
-				throw new FlinkException("Could not read the Yarn properties file " + yarnPropertiesLocation + '.');
+				throw new FlinkException("Could not read the Yarn properties file " + yarnPropertiesLocation +
+					". Please delete the file at " + yarnPropertiesLocation.getAbsolutePath() + '.', ioe);
 			}
 
 			yarnApplicationIdFromYarnProperties = yarnPropertiesFile.getProperty(YARN_APPLICATION_ID_KEY);
@@ -305,10 +318,21 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine {
 			yarnClusterDescriptor.setQueue(cmd.getOptionValue(queue.getOpt()));
 		}
 
-		String[] dynamicProperties = null;
-		if (cmd.hasOption(dynamicproperties.getOpt())) {
-			dynamicProperties = cmd.getOptionValues(dynamicproperties.getOpt());
-		}
+		final Properties properties = cmd.getOptionProperties(dynamicproperties.getOpt());
+
+		String[] dynamicProperties = properties.stringPropertyNames().stream()
+			.flatMap(
+				(String key) -> {
+					final String value = properties.getProperty(key);
+
+					if (value != null) {
+						return Stream.of(key + dynamicproperties.getValueSeparator() + value);
+					} else {
+						return Stream.empty();
+					}
+				})
+			.toArray(String[]::new);
+
 		String dynamicPropertiesEncoded = StringUtils.join(dynamicProperties, YARN_DYNAMIC_PROPERTIES_SEPARATOR);
 
 		yarnClusterDescriptor.setDynamicPropertiesEncoded(dynamicPropertiesEncoded);
@@ -534,184 +558,168 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine {
 		return effectiveConfiguration;
 	}
 
-	public int run(
-			String[] args,
-			Configuration configuration,
-			String configurationDirectory) {
+	public int run(String[] args) throws CliArgsException, FlinkException {
 		//
 		//	Command Line Options
 		//
-		Options options = new Options();
-		addGeneralOptions(options);
-		addRunOptions(options);
+		final CommandLine cmd = parseCommandLineOptions(args, true);
 
-		CommandLineParser parser = new PosixParser();
-		CommandLine cmd;
+		final AbstractYarnClusterDescriptor yarnClusterDescriptor = createClusterDescriptor(cmd);
+
 		try {
-			cmd = parser.parse(options, args);
-		} catch (Exception e) {
-			System.out.println(e.getMessage());
-			printUsage();
-			return 1;
-		}
-
-		// Query cluster for metrics
-		if (cmd.hasOption(query.getOpt())) {
-			AbstractYarnClusterDescriptor yarnDescriptor = getClusterDescriptor(
-				configuration,
-				configurationDirectory,
-				cmd.hasOption(flip6.getOpt()));
-			String description;
-			try {
-				description = yarnDescriptor.getClusterDescription();
-			} catch (Exception e) {
-				System.err.println("Error while querying the YARN cluster for available resources: " + e.getMessage());
-				e.printStackTrace(System.err);
-				return 1;
-			}
-			System.out.println(description);
-			return 0;
-		} else if (cmd.hasOption(applicationId.getOpt())) {
-
-			AbstractYarnClusterDescriptor yarnDescriptor = getClusterDescriptor(
-				configuration,
-				configurationDirectory,
-				cmd.hasOption(flip6.getOpt()));
-
-			//configure ZK namespace depending on the value passed
-			String zkNamespace = cmd.hasOption(zookeeperNamespace.getOpt()) ?
-									cmd.getOptionValue(zookeeperNamespace.getOpt())
-									: yarnDescriptor.getFlinkConfiguration()
-									.getString(HA_CLUSTER_ID, cmd.getOptionValue(applicationId.getOpt()));
-			LOG.info("Going to use the ZK namespace: {}", zkNamespace);
-			yarnDescriptor.getFlinkConfiguration().setString(HA_CLUSTER_ID, zkNamespace);
-
-			try {
-				yarnCluster = yarnDescriptor.retrieve(cmd.getOptionValue(applicationId.getOpt()));
-			} catch (Exception e) {
-				throw new RuntimeException("Could not retrieve existing Yarn application", e);
-			}
-
-			if (detachedMode) {
-				LOG.info("The Flink YARN client has been started in detached mode. In order to stop " +
-					"Flink on YARN, use the following command or a YARN web interface to stop it:\n" +
-					"yarn application -kill " + applicationId.getOpt());
-				yarnCluster.disconnect();
+			// Query cluster for metrics
+			if (cmd.hasOption(query.getOpt())) {
+				final String description = yarnClusterDescriptor.getClusterDescription();
+				System.out.println(description);
+				return 0;
 			} else {
-				ScheduledThreadPoolExecutor scheduledExecutorService = new ScheduledThreadPoolExecutor(1);
+				final ClusterClient clusterClient;
+				final ApplicationId yarnApplicationId;
 
-				try (YarnApplicationStatusMonitor yarnApplicationStatusMonitor = new YarnApplicationStatusMonitor(
-						yarnDescriptor.getYarnClient(),
-						yarnCluster.getApplicationId(),
-						new ScheduledExecutorServiceAdapter(scheduledExecutorService))) {
-					runInteractiveCli(
-						yarnCluster,
-						yarnApplicationStatusMonitor,
-						true);
-				} finally {
-					// shut down the scheduled executor service
-					ExecutorUtils.gracefulShutdown(
-						1000L,
-						TimeUnit.MILLISECONDS,
-						scheduledExecutorService);
+				if (cmd.hasOption(applicationId.getOpt())) {
+					yarnApplicationId = ConverterUtils.toApplicationId(cmd.getOptionValue(applicationId.getOpt()));
+
+					clusterClient = yarnClusterDescriptor.retrieve(cmd.getOptionValue(applicationId.getOpt()));
+				} else {
+					final ClusterSpecification clusterSpecification = getClusterSpecification(cmd);
+
+					clusterClient = yarnClusterDescriptor.deploySessionCluster(clusterSpecification);
+
+					//------------------ ClusterClient deployed, handle connection details
+					yarnApplicationId = ConverterUtils.toApplicationId(clusterClient.getClusterIdentifier());
+
+					String jobManagerAddress =
+						clusterClient.getJobManagerAddress().getAddress().getHostName() +
+							':' + clusterClient.getJobManagerAddress().getPort();
+
+					System.out.println("Flink JobManager is now running on " + jobManagerAddress);
+					System.out.println("JobManager Web Interface: " + clusterClient.getWebInterfaceURL());
+
+					writeYarnPropertiesFile(
+						yarnApplicationId,
+						clusterSpecification.getNumberTaskManagers() * clusterSpecification.getSlotsPerTaskManager(),
+						yarnClusterDescriptor.getDynamicPropertiesEncoded());
 				}
-			}
-		} else {
-
-			try (AbstractYarnClusterDescriptor yarnDescriptor = createClusterDescriptor(cmd)){
-				final ClusterSpecification clusterSpecification;
-
-				try {
-					clusterSpecification = getClusterSpecification(cmd);
-				} catch (FlinkException e) {
-					System.err.println("Error while creating the cluster specification: " + e.getMessage());
-					e.printStackTrace();
-					return 1;
-				}
-
-				try {
-					yarnCluster = yarnDescriptor.deploySessionCluster(clusterSpecification);
-				} catch (Exception e) {
-					System.err.println("Error while deploying YARN cluster: " + e.getMessage());
-					e.printStackTrace(System.err);
-					return 1;
-				}
-				//------------------ ClusterClient deployed, handle connection details
-				String jobManagerAddress =
-					yarnCluster.getJobManagerAddress().getAddress().getHostName() +
-						":" + yarnCluster.getJobManagerAddress().getPort();
-
-				System.out.println("Flink JobManager is now running on " + jobManagerAddress);
-				System.out.println("JobManager Web Interface: " + yarnCluster.getWebInterfaceURL());
-
-				// file that we write into the conf/ dir containing the jobManager address and the dop.
-				File yarnPropertiesFile = getYarnPropertiesLocation(configuration.getValue(YarnConfigOptions.PROPERTIES_FILE_LOCATION));
-
-				Properties yarnProps = new Properties();
-				yarnProps.setProperty(YARN_APPLICATION_ID_KEY, yarnCluster.getApplicationId().toString());
-				if (clusterSpecification.getSlotsPerTaskManager() != -1) {
-					String parallelism =
-						Integer.toString(clusterSpecification.getSlotsPerTaskManager() * clusterSpecification.getNumberTaskManagers());
-					yarnProps.setProperty(YARN_PROPERTIES_PARALLELISM, parallelism);
-				}
-				// add dynamic properties
-				if (yarnDescriptor.getDynamicPropertiesEncoded() != null) {
-					yarnProps.setProperty(YARN_PROPERTIES_DYNAMIC_PROPERTIES_STRING,
-						yarnDescriptor.getDynamicPropertiesEncoded());
-				}
-				writeYarnProperties(yarnProps, yarnPropertiesFile);
-
-				//------------------ ClusterClient running, let user control it ------------
 
 				if (detachedMode) {
-					// print info and quit:
 					LOG.info("The Flink YARN client has been started in detached mode. In order to stop " +
 						"Flink on YARN, use the following command or a YARN web interface to stop it:\n" +
-						"yarn application -kill " + yarnCluster.getApplicationId());
-					yarnCluster.waitForClusterToBeReady();
-					yarnCluster.disconnect();
+						"yarn application -kill " + applicationId.getOpt());
 				} else {
+					ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
 
-					ScheduledThreadPoolExecutor scheduledExecutorService = new ScheduledThreadPoolExecutor(1);
+					final YarnApplicationStatusMonitor yarnApplicationStatusMonitor = new YarnApplicationStatusMonitor(
+						yarnClusterDescriptor.getYarnClient(),
+						yarnApplicationId,
+						new ScheduledExecutorServiceAdapter(scheduledExecutorService));
 
-					try (YarnApplicationStatusMonitor yarnApplicationStatusMonitor = new YarnApplicationStatusMonitor(
-						yarnDescriptor.getYarnClient(),
-						yarnCluster.getApplicationId(),
-						new ScheduledExecutorServiceAdapter(scheduledExecutorService))) {
+					try {
 						runInteractiveCli(
-							yarnCluster,
+							clusterClient,
 							yarnApplicationStatusMonitor,
 							acceptInteractiveInput);
 					} finally {
+						try {
+							yarnApplicationStatusMonitor.close();
+						} catch (Exception e) {
+							LOG.info("Could not properly close the Yarn application status monitor.", e);
+						}
+
+						try {
+							clusterClient.shutdown();
+						} catch (Exception e) {
+							LOG.info("Could not properly shutdown cluster client.", e);
+						}
+
+						try {
+							yarnClusterDescriptor.terminateCluster(yarnApplicationId);
+						} catch (FlinkException e) {
+							LOG.info("Could not properly terminate the Flink cluster.", e);
+						}
+
 						// shut down the scheduled executor service
 						ExecutorUtils.gracefulShutdown(
 							1000L,
 							TimeUnit.MILLISECONDS,
 							scheduledExecutorService);
+
+						deleteYarnPropertiesFile();
+
+						try {
+							final ApplicationReport applicationReport = yarnClusterDescriptor
+								.getYarnClient()
+								.getApplicationReport(yarnApplicationId);
+
+							logFinalApplicationReport(applicationReport);
+						} catch (YarnException | IOException e) {
+							LOG.info("Could not log the final application report.", e);
+						}
 					}
 				}
-			} catch (FlinkException e) {
-				System.err.println("Error while deploying a Flink cluster: " + e.getMessage());
-				e.printStackTrace();
-				return 1;
+			}
+		} finally {
+			try {
+				yarnClusterDescriptor.close();
+			} catch (Exception e) {
+				LOG.info("Could not properly close the yarn cluster descriptor.", e);
 			}
 		}
+
 		return 0;
 	}
 
-	/**
-	 * Utility method for tests.
-	 */
-	public void stop() {
-		if (yarnCluster != null) {
-			LOG.info("Command line interface is shutting down the yarnCluster");
+	private void logFinalApplicationReport(ApplicationReport appReport) {
+		LOG.info("Application " + appReport.getApplicationId() + " finished with state " + appReport
+			.getYarnApplicationState() + " and final state " + appReport
+			.getFinalApplicationStatus() + " at " + appReport.getFinishTime());
 
-			try {
-				yarnCluster.shutdown();
-			} catch (Throwable t) {
-				LOG.warn("Could not properly shutdown the yarn cluster.", t);
-			}
+		if (appReport.getYarnApplicationState() == YarnApplicationState.FAILED || appReport.getYarnApplicationState()
+			== YarnApplicationState.KILLED) {
+			LOG.warn("Application failed. Diagnostics " + appReport.getDiagnostics());
+			LOG.warn("If log aggregation is activated in the Hadoop cluster, we recommend to retrieve "
+				+ "the full application log using this command:"
+				+ System.lineSeparator()
+				+ "\tyarn logs -applicationId " + appReport.getApplicationId()
+				+ System.lineSeparator()
+				+ "(It sometimes takes a few seconds until the logs are aggregated)");
 		}
+	}
+
+	private void deleteYarnPropertiesFile() {
+		// try to clean up the old yarn properties file
+		try {
+			File propertiesFile = getYarnPropertiesLocation(yarnPropertiesFileLocation);
+			if (propertiesFile.isFile()) {
+				if (propertiesFile.delete()) {
+					LOG.info("Deleted Yarn properties file at {}", propertiesFile.getAbsoluteFile());
+				} else {
+					LOG.warn("Couldn't delete Yarn properties file at {}", propertiesFile.getAbsoluteFile());
+				}
+			}
+		} catch (Exception e) {
+			LOG.warn("Exception while deleting the JobManager address file", e);
+		}
+	}
+
+	private void writeYarnPropertiesFile(
+			ApplicationId yarnApplicationId,
+			int parallelism,
+			@Nullable String dynamicProperties) {
+		// file that we write into the conf/ dir containing the jobManager address and the dop.
+		final File yarnPropertiesFile = getYarnPropertiesLocation(yarnPropertiesFileLocation);
+
+		Properties yarnProps = new Properties();
+		yarnProps.setProperty(YARN_APPLICATION_ID_KEY, yarnApplicationId.toString());
+		if (parallelism > 0) {
+			yarnProps.setProperty(YARN_PROPERTIES_PARALLELISM, Integer.toString(parallelism));
+		}
+
+		// add dynamic properties
+		if (dynamicProperties != null) {
+			yarnProps.setProperty(YARN_PROPERTIES_DYNAMIC_PROPERTIES_STRING, dynamicProperties);
+		}
+
+		writeYarnProperties(yarnProps, yarnPropertiesFile);
 	}
 
 	private void logAndSysout(String message) {
@@ -719,28 +727,64 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine {
 		System.out.println(message);
 	}
 
-	public static void main(final String[] args) throws Exception {
+	public static Map<String, String> getDynamicProperties(String dynamicPropertiesEncoded) {
+		if (dynamicPropertiesEncoded != null && dynamicPropertiesEncoded.length() > 0) {
+			Map<String, String> properties = new HashMap<>();
+
+			String[] propertyLines = dynamicPropertiesEncoded.split(YARN_DYNAMIC_PROPERTIES_SEPARATOR);
+			for (String propLine : propertyLines) {
+				if (propLine == null) {
+					continue;
+				}
+
+				int firstEquals = propLine.indexOf("=");
+
+				if (firstEquals >= 0) {
+					String key = propLine.substring(0, firstEquals).trim();
+					String value = propLine.substring(firstEquals + 1, propLine.length()).trim();
+
+					if (!key.isEmpty()) {
+						properties.put(key, value);
+					}
+				}
+			}
+			return properties;
+		}
+		else {
+			return Collections.emptyMap();
+		}
+	}
+
+	public static void main(final String[] args) {
 		final String configurationDirectory = CliFrontend.getConfigurationDirectoryFromEnv();
 
 		final Configuration flinkConfiguration = GlobalConfiguration.loadConfiguration();
 
-		final FlinkYarnSessionCli cli = new FlinkYarnSessionCli(
-			flinkConfiguration,
-			configurationDirectory,
-			"",
-			""); // no prefix for the YARN session
+		int retCode;
 
-		SecurityUtils.install(new SecurityConfiguration(flinkConfiguration));
+		try {
+			final FlinkYarnSessionCli cli = new FlinkYarnSessionCli(
+				flinkConfiguration,
+				configurationDirectory,
+				"",
+				""); // no prefix for the YARN session
 
-		final int retCode = SecurityUtils.getInstalledContext().runSecured(() -> cli.run(args, flinkConfiguration, configurationDirectory));
+			SecurityUtils.install(new SecurityConfiguration(flinkConfiguration));
+
+			retCode = SecurityUtils.getInstalledContext().runSecured(() -> cli.run(args));
+		} catch (CliArgsException e) {
+			retCode = handleCliArgsException(e);
+		} catch (Exception e) {
+			retCode = handleError(e);
+		}
 
 		System.exit(retCode);
 	}
 
 	private static void runInteractiveCli(
-		YarnClusterClient clusterClient,
-		YarnApplicationStatusMonitor yarnApplicationStatusMonitor,
-		boolean readConsoleInput) {
+			ClusterClient clusterClient,
+			YarnApplicationStatusMonitor yarnApplicationStatusMonitor,
+			boolean readConsoleInput) {
 		try (BufferedReader in = new BufferedReader(new InputStreamReader(System.in))) {
 			boolean continueRepl = true;
 			int numTaskmanagers = 0;
@@ -799,7 +843,7 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine {
 		}
 	}
 
-	private static void printClusterMessages(YarnClusterClient clusterClient) {
+	private static void printClusterMessages(ClusterClient clusterClient) {
 		final List<String> messages = clusterClient.getNewMessages();
 		if (!messages.isEmpty()) {
 			System.err.println("New messages from the YARN cluster: ");
@@ -819,8 +863,8 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine {
 	 * @throws InterruptedException
 	 */
 	private static boolean repStep(
-		BufferedReader in,
-		boolean readConsoleInput) throws IOException, InterruptedException {
+			BufferedReader in,
+			boolean readConsoleInput) throws IOException, InterruptedException {
 
 		// wait until CLIENT_POLLING_INTERVAL is over or the user entered something.
 		long startTime = System.currentTimeMillis();
@@ -859,32 +903,25 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine {
 		propertiesFile.setReadable(true, false); // readable for all.
 	}
 
-	public static Map<String, String> getDynamicProperties(String dynamicPropertiesEncoded) {
-		if (dynamicPropertiesEncoded != null && dynamicPropertiesEncoded.length() > 0) {
-			Map<String, String> properties = new HashMap<>();
+	private static int handleCliArgsException(CliArgsException e) {
+		LOG.error("Could not parse the command line arguments.", e);
 
-			String[] propertyLines = dynamicPropertiesEncoded.split(YARN_DYNAMIC_PROPERTIES_SEPARATOR);
-			for (String propLine : propertyLines) {
-				if (propLine == null) {
-					continue;
-				}
+		System.out.println(e.getMessage());
+		System.out.println();
+		System.out.println("Use the help option (-h or --help) to get help on the command.");
+		return 1;
+	}
 
-				int firstEquals = propLine.indexOf("=");
+	private static int handleError(Exception e) {
+		LOG.error("Error while running the Flink Yarn session.", e);
 
-				if (firstEquals >= 0) {
-					String key = propLine.substring(0, firstEquals).trim();
-					String value = propLine.substring(firstEquals + 1, propLine.length()).trim();
+		System.err.println();
+		System.err.println("------------------------------------------------------------");
+		System.err.println(" The program finished with the following exception:");
+		System.err.println();
 
-					if (!key.isEmpty()) {
-						properties.put(key, value);
-					}
-				}
-			}
-			return properties;
-		}
-		else {
-			return Collections.emptyMap();
-		}
+		e.printStackTrace();
+		return 1;
 	}
 
 	public static File getYarnPropertiesLocation(@Nullable String yarnPropertiesFileLocation) {
@@ -902,7 +939,7 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine {
 		return new File(propertiesFileLocation, YARN_PROPERTIES_FILE + currentUser);
 	}
 
-	protected AbstractYarnClusterDescriptor getClusterDescriptor(Configuration configuration, String configurationDirectory, boolean flip6) {
+	private static AbstractYarnClusterDescriptor getClusterDescriptor(Configuration configuration, String configurationDirectory, boolean flip6) {
 		final YarnClient yarnClient = YarnClient.createYarnClient();
 		if (flip6) {
 			return new YarnClusterDescriptorV2(configuration, configurationDirectory, yarnClient);

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
@@ -81,7 +81,7 @@ import static org.apache.flink.configuration.HighAvailabilityOptions.HA_CLUSTER_
 /**
  * Class handling the command line interface to the YARN session.
  */
-public class FlinkYarnSessionCli extends AbstractCustomCommandLine<YarnClusterClient> {
+public class FlinkYarnSessionCli extends AbstractCustomCommandLine {
 	private static final Logger LOG = LoggerFactory.getLogger(FlinkYarnSessionCli.class);
 
 	//------------------------------------ Constants   -------------------------

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
@@ -25,7 +25,6 @@ import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.GlobalConfiguration;
-import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
@@ -34,6 +33,8 @@ import org.apache.flink.runtime.concurrent.ScheduledExecutorServiceAdapter;
 import org.apache.flink.runtime.security.SecurityConfiguration;
 import org.apache.flink.runtime.security.SecurityUtils;
 import org.apache.flink.util.ExecutorUtils;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.Preconditions;
 import org.apache.flink.yarn.AbstractYarnClusterDescriptor;
 import org.apache.flink.yarn.YarnClusterClient;
 import org.apache.flink.yarn.YarnClusterDescriptor;
@@ -53,6 +54,8 @@ import org.apache.hadoop.yarn.util.ConverterUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -70,7 +73,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
@@ -140,16 +142,35 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<YarnClusterCl
 
 	private final boolean acceptInteractiveInput;
 
+	private final String configurationDirectory;
+
+	private final Properties yarnPropertiesFile;
+
+	private final String yarnApplicationIdFromYarnProperties;
+
 	//------------------------------------ Internal fields -------------------------
 	private YarnClusterClient yarnCluster;
 	private boolean detachedMode = false;
 
-	public FlinkYarnSessionCli(String shortPrefix, String longPrefix) {
-		this(shortPrefix, longPrefix, true);
+	public FlinkYarnSessionCli(
+			Configuration configuration,
+			String configurationDirectory,
+			String shortPrefix,
+			String longPrefix) throws FlinkException {
+		this(configuration, configurationDirectory, shortPrefix, longPrefix, true);
 	}
 
-	public FlinkYarnSessionCli(String shortPrefix, String longPrefix, boolean acceptInteractiveInput) {
+	public FlinkYarnSessionCli(
+			Configuration configuration,
+			String configurationDirectory,
+			String shortPrefix,
+			String longPrefix,
+			boolean acceptInteractiveInput) throws FlinkException {
+		super(configuration);
+		this.configurationDirectory = Preconditions.checkNotNull(configurationDirectory);
 		this.acceptInteractiveInput = acceptInteractiveInput;
+
+		// Create the command line options
 
 		query = new Option(shortPrefix + "q", longPrefix + "query", false, "Display available YARN resources (memory, cores)");
 		applicationId = new Option(shortPrefix + "id", longPrefix + "applicationId", true, "Attach to running YARN session");
@@ -183,93 +204,43 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<YarnClusterCl
 		allOptions.addOption(applicationId);
 		allOptions.addOption(zookeeperNamespace);
 		allOptions.addOption(flip6);
-	}
 
-	/**
-	 * Tries to load a Flink Yarn properties file and returns the Yarn application id if successful.
-	 * @param cmdLine The command-line parameters
-	 * @param flinkConfiguration The flink configuration
-	 * @return Yarn application id or null if none could be retrieved
-	 */
-	private String loadYarnPropertiesFile(CommandLine cmdLine, Configuration flinkConfiguration) {
+		// try loading a potential yarn properties file
+		final File yarnPropertiesLocation = getYarnPropertiesLocation(configuration.getString(YarnConfigOptions.PROPERTIES_FILE_LOCATION));
 
-		String jobManagerOption = cmdLine.getOptionValue(addressOption.getOpt(), null);
-		if (jobManagerOption != null) {
-			// don't resume from properties file if a JobManager has been specified
-			return null;
-		}
+		yarnPropertiesFile = new Properties();
 
-		for (Option option : cmdLine.getOptions()) {
-			if (allOptions.hasOption(option.getOpt())) {
-				if (!option.getOpt().equals(detached.getOpt())) {
-					// don't resume from properties file if yarn options have been specified
-					return null;
-				}
+		if (yarnPropertiesLocation.exists()) {
+			LOG.info("Found Yarn properties file under {}.", yarnPropertiesLocation.getAbsolutePath());
+
+			try (InputStream is = new FileInputStream(yarnPropertiesLocation)) {
+				yarnPropertiesFile.load(is);
+			} catch (IOException ioe) {
+				throw new FlinkException("Could not read the Yarn properties file " + yarnPropertiesLocation + '.');
 			}
-		}
 
-		// load the YARN properties
-		File propertiesFile = getYarnPropertiesLocation(flinkConfiguration);
-		if (!propertiesFile.exists()) {
-			return null;
-		}
+			yarnApplicationIdFromYarnProperties = yarnPropertiesFile.getProperty(YARN_APPLICATION_ID_KEY);
 
-		logAndSysout("Found YARN properties file " + propertiesFile.getAbsolutePath());
-
-		Properties yarnProperties = new Properties();
-		try {
-			try (InputStream is = new FileInputStream(propertiesFile)) {
-				yarnProperties.load(is);
+			if (yarnApplicationIdFromYarnProperties == null) {
+				throw new FlinkException("Yarn properties file found but doesn't contain a " +
+					"Yarn application id. Please delete the file at " + yarnPropertiesLocation.getAbsolutePath());
 			}
-		}
-		catch (IOException e) {
-			throw new RuntimeException("Cannot read the YARN properties file", e);
-		}
 
-		// get the Yarn application id from the properties file
-		String applicationID = yarnProperties.getProperty(YARN_APPLICATION_ID_KEY);
-		if (applicationID == null) {
-			throw new IllegalConfigurationException("Yarn properties file found but doesn't contain a " +
-				"Yarn application id. Please delete the file at " + propertiesFile.getAbsolutePath());
-		}
-
-		try {
-			// try converting id to ApplicationId
-			ConverterUtils.toApplicationId(applicationID);
-		}
-		catch (Exception e) {
-			throw new RuntimeException("YARN properties contains an invalid entry for " +
-				"application id: " + applicationID, e);
-		}
-
-		logAndSysout("Using Yarn application id from YARN properties " + applicationID);
-
-		// configure the default parallelism from YARN
-		String propParallelism = yarnProperties.getProperty(YARN_PROPERTIES_PARALLELISM);
-		if (propParallelism != null) { // maybe the property is not set
 			try {
-				int parallelism = Integer.parseInt(propParallelism);
-				flinkConfiguration.setInteger(ConfigConstants.DEFAULT_PARALLELISM_KEY, parallelism);
-
-				logAndSysout("YARN properties set default parallelism to " + parallelism);
+				// try converting id to ApplicationId
+				ConverterUtils.toApplicationId(yarnApplicationIdFromYarnProperties);
 			}
-			catch (NumberFormatException e) {
-				throw new RuntimeException("Error while parsing the YARN properties: " +
-					"Property " + YARN_PROPERTIES_PARALLELISM + " is not an integer.");
+			catch (Exception e) {
+				throw new FlinkException("YARN properties contains an invalid entry for " +
+					"application id: " + yarnApplicationIdFromYarnProperties + ". Please delete the file at " +
+					yarnPropertiesLocation.getAbsolutePath(), e);
 			}
+		} else {
+			yarnApplicationIdFromYarnProperties = null;
 		}
-
-		// handle the YARN client's dynamic properties
-		String dynamicPropertiesEncoded = yarnProperties.getProperty(YARN_PROPERTIES_DYNAMIC_PROPERTIES_STRING);
-		Map<String, String> dynamicProperties = getDynamicProperties(dynamicPropertiesEncoded);
-		for (Map.Entry<String, String> dynamicProperty : dynamicProperties.entrySet()) {
-			flinkConfiguration.setString(dynamicProperty.getKey(), dynamicProperty.getValue());
-		}
-
-		return applicationID;
 	}
 
-	public AbstractYarnClusterDescriptor createDescriptor(
+	private AbstractYarnClusterDescriptor createDescriptor(
 		Configuration configuration,
 		String configurationDirectory,
 		String defaultApplicationName,
@@ -364,7 +335,7 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<YarnClusterCl
 		return yarnClusterDescriptor;
 	}
 
-	public ClusterSpecification createClusterSpecification(Configuration configuration, CommandLine cmd) {
+	private ClusterSpecification createClusterSpecification(Configuration configuration, CommandLine cmd) {
 		if (!cmd.hasOption(container.getOpt())) { // number of containers is required option!
 			LOG.error("Missing required argument {}", container.getOpt());
 			printUsage();
@@ -374,27 +345,12 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<YarnClusterCl
 		int numberTaskManagers = Integer.valueOf(cmd.getOptionValue(container.getOpt()));
 
 		// JobManager Memory
-		final int jobManagerMemoryMB;
-		if (cmd.hasOption(jmMemory.getOpt())) {
-			jobManagerMemoryMB = Integer.valueOf(cmd.getOptionValue(this.jmMemory.getOpt()));
-		} else {
-			jobManagerMemoryMB = configuration.getInteger(JobManagerOptions.JOB_MANAGER_HEAP_MEMORY);
-		}
+		final int jobManagerMemoryMB = configuration.getInteger(JobManagerOptions.JOB_MANAGER_HEAP_MEMORY);
 
 		// Task Managers memory
-		final int taskManagerMemoryMB;
-		if (cmd.hasOption(tmMemory.getOpt())) {
-			taskManagerMemoryMB = Integer.valueOf(cmd.getOptionValue(this.tmMemory.getOpt()));
-		} else {
-			taskManagerMemoryMB = configuration.getInteger(TaskManagerOptions.TASK_MANAGER_HEAP_MEMORY);
-		}
+		final int taskManagerMemoryMB = configuration.getInteger(TaskManagerOptions.TASK_MANAGER_HEAP_MEMORY);
 
-		int slotsPerTaskManager;
-		if (cmd.hasOption(slots.getOpt())) {
-			slotsPerTaskManager = Integer.valueOf(cmd.getOptionValue(this.slots.getOpt()));
-		} else {
-			slotsPerTaskManager = configuration.getInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, 1);
-		}
+		int slotsPerTaskManager = configuration.getInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, 1);
 
 		// convenience
 		int userParallelism = Integer.valueOf(cmd.getOptionValue(CliFrontendParser.PARALLELISM_OPTION.getOpt(), "-1"));
@@ -435,11 +391,11 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<YarnClusterCl
 	}
 
 	@Override
-	public boolean isActive(CommandLine commandLine, Configuration configuration) {
+	public boolean isActive(CommandLine commandLine) {
 		String jobManagerOption = commandLine.getOptionValue(addressOption.getOpt(), null);
 		boolean yarnJobManager = ID.equals(jobManagerOption);
 		boolean yarnAppId = commandLine.hasOption(applicationId.getOpt());
-		return yarnJobManager || yarnAppId || loadYarnPropertiesFile(commandLine, configuration) != null;
+		return yarnJobManager || yarnAppId || (isYarnPropertiesFileMode(commandLine) && yarnApplicationIdFromYarnProperties != null);
 	}
 
 	@Override
@@ -463,11 +419,8 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<YarnClusterCl
 	}
 
 	@Override
-	public AbstractYarnClusterDescriptor createClusterDescriptor(
-			Configuration configuration,
-			String configurationDirectory,
-			CommandLine commandLine) {
-		final Configuration effectiveConfiguration = applyCommandLineOptionsToConfiguration(configuration, commandLine);
+	public AbstractYarnClusterDescriptor createClusterDescriptor(CommandLine commandLine) throws FlinkException {
+		final Configuration effectiveConfiguration = applyCommandLineOptionsToConfiguration(commandLine);
 
 		return createDescriptor(
 			effectiveConfiguration,
@@ -477,17 +430,26 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<YarnClusterCl
 	}
 
 	@Override
-	public String getClusterId(Configuration configuration, CommandLine commandLine) {
-		return commandLine.hasOption(applicationId.getOpt()) ? commandLine.getOptionValue(applicationId.getOpt()) : loadYarnPropertiesFile(commandLine, configuration);
+	@Nullable
+	public String getClusterId(CommandLine commandLine) {
+		if (commandLine.hasOption(applicationId.getOpt())) {
+			return commandLine.getOptionValue(applicationId.getOpt());
+		} else if (isYarnPropertiesFileMode(commandLine)) {
+			return yarnApplicationIdFromYarnProperties;
+		} else {
+			return null;
+		}
 	}
 
 	@Override
-	public ClusterSpecification getClusterSpecification(Configuration configuration, CommandLine commandLine) {
-		return createClusterSpecification(configuration, commandLine);
+	public ClusterSpecification getClusterSpecification(CommandLine commandLine) throws FlinkException {
+		final Configuration effectiveConfiguration = applyCommandLineOptionsToConfiguration(commandLine);
+
+		return createClusterSpecification(effectiveConfiguration, commandLine);
 	}
 
 	@Override
-	protected Configuration applyCommandLineOptionsToConfiguration(Configuration configuration, CommandLine commandLine) {
+	protected Configuration applyCommandLineOptionsToConfiguration(CommandLine commandLine) throws FlinkException {
 		// we ignore the addressOption because it can only contain "yarn-cluster"
 		final Configuration effectiveConfiguration = new Configuration(configuration);
 
@@ -496,7 +458,7 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<YarnClusterCl
 			effectiveConfiguration.setString(HA_CLUSTER_ID, zkNamespace);
 		}
 
-		final String applicationId = getClusterId(configuration, commandLine);
+		final String applicationId = getClusterId(commandLine);
 
 		if (applicationId != null) {
 			final String zooKeeperNamespace;
@@ -507,6 +469,66 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<YarnClusterCl
 			}
 
 			effectiveConfiguration.setString(HA_CLUSTER_ID, zooKeeperNamespace);
+		}
+
+		if (commandLine.hasOption(jmMemory.getOpt())) {
+			effectiveConfiguration.setInteger(JobManagerOptions.JOB_MANAGER_HEAP_MEMORY, Integer.parseInt(commandLine.getOptionValue(jmMemory.getOpt())));
+		}
+
+		if (commandLine.hasOption(tmMemory.getOpt())) {
+			effectiveConfiguration.setInteger(TaskManagerOptions.TASK_MANAGER_HEAP_MEMORY, Integer.parseInt(commandLine.getOptionValue(tmMemory.getOpt())));
+		}
+
+		if (commandLine.hasOption(slots.getOpt())) {
+			effectiveConfiguration.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, Integer.parseInt(commandLine.getOptionValue(slots.getOpt())));
+		}
+
+		if (isYarnPropertiesFileMode(commandLine)) {
+			return applyYarnProperties(effectiveConfiguration);
+		} else {
+			return effectiveConfiguration;
+		}
+	}
+
+	private boolean isYarnPropertiesFileMode(CommandLine commandLine) {
+		boolean canApplyYarnProperties = !commandLine.hasOption(addressOption.getOpt());
+
+		for (Option option : commandLine.getOptions()) {
+			if (allOptions.hasOption(option.getOpt())) {
+				if (!option.getOpt().equals(detached.getOpt())) {
+					// don't resume from properties file if yarn options have been specified
+					canApplyYarnProperties = false;
+					break;
+				}
+			}
+		}
+
+		return canApplyYarnProperties;
+	}
+
+	private Configuration applyYarnProperties(Configuration configuration) throws FlinkException {
+		final Configuration effectiveConfiguration = new Configuration(configuration);
+
+		// configure the default parallelism from YARN
+		String propParallelism = yarnPropertiesFile.getProperty(YARN_PROPERTIES_PARALLELISM);
+		if (propParallelism != null) { // maybe the property is not set
+			try {
+				int parallelism = Integer.parseInt(propParallelism);
+				effectiveConfiguration.setInteger(ConfigConstants.DEFAULT_PARALLELISM_KEY, parallelism);
+
+				logAndSysout("YARN properties set default parallelism to " + parallelism);
+			}
+			catch (NumberFormatException e) {
+				throw new FlinkException("Error while parsing the YARN properties: " +
+					"Property " + YARN_PROPERTIES_PARALLELISM + " is not an integer.", e);
+			}
+		}
+
+		// handle the YARN client's dynamic properties
+		String dynamicPropertiesEncoded = yarnPropertiesFile.getProperty(YARN_PROPERTIES_DYNAMIC_PROPERTIES_STRING);
+		Map<String, String> dynamicProperties = getDynamicProperties(dynamicPropertiesEncoded);
+		for (Map.Entry<String, String> dynamicProperty : dynamicProperties.entrySet()) {
+			effectiveConfiguration.setString(dynamicProperty.getKey(), dynamicProperty.getValue());
 		}
 
 		return effectiveConfiguration;
@@ -596,77 +618,82 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<YarnClusterCl
 			}
 		} else {
 
-			AbstractYarnClusterDescriptor yarnDescriptor;
-			try {
-				yarnDescriptor = createDescriptor(configuration, configurationDirectory, null, cmd);
-			} catch (Exception e) {
-				System.err.println("Error while starting the YARN Client: " + e.getMessage());
-				e.printStackTrace(System.err);
-				return 1;
-			}
+			try (AbstractYarnClusterDescriptor yarnDescriptor = createClusterDescriptor(cmd)){
+				final ClusterSpecification clusterSpecification;
 
-			final ClusterSpecification clusterSpecification = createClusterSpecification(yarnDescriptor.getFlinkConfiguration(), cmd);
+				try {
+					clusterSpecification = getClusterSpecification(cmd);
+				} catch (FlinkException e) {
+					System.err.println("Error while creating the cluster specification: " + e.getMessage());
+					e.printStackTrace();
+					return 1;
+				}
 
-			try {
-				yarnCluster = yarnDescriptor.deploySessionCluster(clusterSpecification);
-			} catch (Exception e) {
-				System.err.println("Error while deploying YARN cluster: " + e.getMessage());
-				e.printStackTrace(System.err);
-				return 1;
-			}
-			//------------------ ClusterClient deployed, handle connection details
-			String jobManagerAddress =
-				yarnCluster.getJobManagerAddress().getAddress().getHostName() +
-					":" + yarnCluster.getJobManagerAddress().getPort();
+				try {
+					yarnCluster = yarnDescriptor.deploySessionCluster(clusterSpecification);
+				} catch (Exception e) {
+					System.err.println("Error while deploying YARN cluster: " + e.getMessage());
+					e.printStackTrace(System.err);
+					return 1;
+				}
+				//------------------ ClusterClient deployed, handle connection details
+				String jobManagerAddress =
+					yarnCluster.getJobManagerAddress().getAddress().getHostName() +
+						":" + yarnCluster.getJobManagerAddress().getPort();
 
-			System.out.println("Flink JobManager is now running on " + jobManagerAddress);
-			System.out.println("JobManager Web Interface: " + yarnCluster.getWebInterfaceURL());
+				System.out.println("Flink JobManager is now running on " + jobManagerAddress);
+				System.out.println("JobManager Web Interface: " + yarnCluster.getWebInterfaceURL());
 
-			// file that we write into the conf/ dir containing the jobManager address and the dop.
-			File yarnPropertiesFile = getYarnPropertiesLocation(yarnCluster.getFlinkConfiguration());
+				// file that we write into the conf/ dir containing the jobManager address and the dop.
+				File yarnPropertiesFile = getYarnPropertiesLocation(configuration.getValue(YarnConfigOptions.PROPERTIES_FILE_LOCATION));
 
-			Properties yarnProps = new Properties();
-			yarnProps.setProperty(YARN_APPLICATION_ID_KEY, yarnCluster.getApplicationId().toString());
-			if (clusterSpecification.getSlotsPerTaskManager() != -1) {
-				String parallelism =
+				Properties yarnProps = new Properties();
+				yarnProps.setProperty(YARN_APPLICATION_ID_KEY, yarnCluster.getApplicationId().toString());
+				if (clusterSpecification.getSlotsPerTaskManager() != -1) {
+					String parallelism =
 						Integer.toString(clusterSpecification.getSlotsPerTaskManager() * clusterSpecification.getNumberTaskManagers());
-				yarnProps.setProperty(YARN_PROPERTIES_PARALLELISM, parallelism);
-			}
-			// add dynamic properties
-			if (yarnDescriptor.getDynamicPropertiesEncoded() != null) {
-				yarnProps.setProperty(YARN_PROPERTIES_DYNAMIC_PROPERTIES_STRING,
+					yarnProps.setProperty(YARN_PROPERTIES_PARALLELISM, parallelism);
+				}
+				// add dynamic properties
+				if (yarnDescriptor.getDynamicPropertiesEncoded() != null) {
+					yarnProps.setProperty(YARN_PROPERTIES_DYNAMIC_PROPERTIES_STRING,
 						yarnDescriptor.getDynamicPropertiesEncoded());
-			}
-			writeYarnProperties(yarnProps, yarnPropertiesFile);
+				}
+				writeYarnProperties(yarnProps, yarnPropertiesFile);
 
-			//------------------ ClusterClient running, let user control it ------------
+				//------------------ ClusterClient running, let user control it ------------
 
-			if (detachedMode) {
-				// print info and quit:
-				LOG.info("The Flink YARN client has been started in detached mode. In order to stop " +
+				if (detachedMode) {
+					// print info and quit:
+					LOG.info("The Flink YARN client has been started in detached mode. In order to stop " +
 						"Flink on YARN, use the following command or a YARN web interface to stop it:\n" +
 						"yarn application -kill " + yarnCluster.getApplicationId());
-				yarnCluster.waitForClusterToBeReady();
-				yarnCluster.disconnect();
-			} else {
+					yarnCluster.waitForClusterToBeReady();
+					yarnCluster.disconnect();
+				} else {
 
-				ScheduledThreadPoolExecutor scheduledExecutorService = new ScheduledThreadPoolExecutor(1);
+					ScheduledThreadPoolExecutor scheduledExecutorService = new ScheduledThreadPoolExecutor(1);
 
-				try (YarnApplicationStatusMonitor yarnApplicationStatusMonitor = new YarnApplicationStatusMonitor(
+					try (YarnApplicationStatusMonitor yarnApplicationStatusMonitor = new YarnApplicationStatusMonitor(
 						yarnDescriptor.getYarnClient(),
 						yarnCluster.getApplicationId(),
-						new ScheduledExecutorServiceAdapter(scheduledExecutorService))){
-					runInteractiveCli(
-						yarnCluster,
-						yarnApplicationStatusMonitor,
-						acceptInteractiveInput);
-				} finally {
-					// shut down the scheduled executor service
-					ExecutorUtils.gracefulShutdown(
-						1000L,
-						TimeUnit.MILLISECONDS,
-						scheduledExecutorService);
+						new ScheduledExecutorServiceAdapter(scheduledExecutorService))) {
+						runInteractiveCli(
+							yarnCluster,
+							yarnApplicationStatusMonitor,
+							acceptInteractiveInput);
+					} finally {
+						// shut down the scheduled executor service
+						ExecutorUtils.gracefulShutdown(
+							1000L,
+							TimeUnit.MILLISECONDS,
+							scheduledExecutorService);
+					}
 				}
+			} catch (FlinkException e) {
+				System.err.println("Error while deploying a Flink cluster: " + e.getMessage());
+				e.printStackTrace();
+				return 1;
 			}
 		}
 		return 0;
@@ -693,18 +720,20 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<YarnClusterCl
 	}
 
 	public static void main(final String[] args) throws Exception {
-		final FlinkYarnSessionCli cli = new FlinkYarnSessionCli("", ""); // no prefix for the YARN session
-
 		final String configurationDirectory = CliFrontend.getConfigurationDirectoryFromEnv();
 
 		final Configuration flinkConfiguration = GlobalConfiguration.loadConfiguration();
+
+		final FlinkYarnSessionCli cli = new FlinkYarnSessionCli(
+			flinkConfiguration,
+			configurationDirectory,
+			"",
+			""); // no prefix for the YARN session
+
 		SecurityUtils.install(new SecurityConfiguration(flinkConfiguration));
-		int retCode = SecurityUtils.getInstalledContext().runSecured(new Callable<Integer>() {
-			@Override
-			public Integer call() {
-				return cli.run(args, flinkConfiguration, configurationDirectory);
-			}
-		});
+
+		final int retCode = SecurityUtils.getInstalledContext().runSecured(() -> cli.run(args, flinkConfiguration, configurationDirectory));
+
 		System.exit(retCode);
 	}
 
@@ -858,11 +887,17 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<YarnClusterCl
 		}
 	}
 
-	public static File getYarnPropertiesLocation(Configuration conf) {
-		String defaultPropertiesFileLocation = System.getProperty("java.io.tmpdir");
+	public static File getYarnPropertiesLocation(@Nullable String yarnPropertiesFileLocation) {
+
+		final String propertiesFileLocation;
+
+		if (yarnPropertiesFileLocation != null) {
+			propertiesFileLocation = yarnPropertiesFileLocation;
+		} else {
+			propertiesFileLocation = System.getProperty("java.io.tmpdir");
+		}
+
 		String currentUser = System.getProperty("user.name");
-		String propertiesFileLocation =
-			conf.getString(YarnConfigOptions.PROPERTIES_FILE_LOCATION, defaultPropertiesFileLocation);
 
 		return new File(propertiesFileLocation, YARN_PROPERTIES_FILE + currentUser);
 	}

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/YarnApplicationStatusMonitor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/YarnApplicationStatusMonitor.java
@@ -59,7 +59,7 @@ public class YarnApplicationStatusMonitor implements AutoCloseable {
 
 		applicationStatusUpdateFuture = scheduledExecutor.scheduleWithFixedDelay(
 			this::updateApplicationStatus,
-			UPDATE_INTERVAL,
+			0L,
 			UPDATE_INTERVAL,
 			TimeUnit.MILLISECONDS);
 
@@ -83,6 +83,7 @@ public class YarnApplicationStatusMonitor implements AutoCloseable {
 				applicationReport = yarnClient.getApplicationReport(yarnApplicationId);
 			} catch (Exception e) {
 				LOG.info("Could not retrieve the Yarn application report for {}.", yarnApplicationId);
+				applicationStatus = ApplicationStatus.UNKNOWN;
 				return;
 			}
 

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/AbstractYarnClusterTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/AbstractYarnClusterTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.yarn;
 
+import org.apache.flink.client.deployment.ClusterRetrieveException;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.TestLogger;
@@ -49,10 +50,9 @@ public class AbstractYarnClusterTest extends TestLogger {
 	/**
 	 * Tests that the cluster retrieval of a finished YARN application fails.
 	 */
-	@Test(expected = RuntimeException.class)
-	public void testClusterClientRetrievalOfFinishedYarnApplication() throws IOException {
+	@Test(expected = ClusterRetrieveException.class)
+	public void testClusterClientRetrievalOfFinishedYarnApplication() throws Exception {
 		final ApplicationId applicationId = ApplicationId.newInstance(System.currentTimeMillis(), 42);
-		final String clusterId = applicationId.toString();
 		final ApplicationReport applicationReport = createApplicationReport(
 			applicationId,
 			YarnApplicationState.FINISHED,
@@ -65,30 +65,7 @@ public class AbstractYarnClusterTest extends TestLogger {
 			temporaryFolder.newFolder().getAbsolutePath(),
 			yarnClient);
 
-		clusterDescriptor.retrieve(clusterId);
-	}
-
-	/**
-	 * Tests that the cluster retrieval fails if an invalid application id is provided.
-	 */
-	@Test(expected = RuntimeException.class)
-	public void testClusterClientRetrievalFromInvalidApplicationId() throws IOException {
-		final ApplicationId applicationId = ApplicationId.newInstance(System.currentTimeMillis(), 42);
-		final String clusterId = "foobar";
-
-		final ApplicationReport applicationReport = createApplicationReport(
-			applicationId,
-			YarnApplicationState.RUNNING,
-			FinalApplicationStatus.UNDEFINED);
-
-		final YarnClient yarnClient = new TestingYarnClient(Collections.singletonMap(applicationId, applicationReport));
-
-		final TestingAbstractYarnClusterDescriptor clusterDescriptor = new TestingAbstractYarnClusterDescriptor(
-			new Configuration(),
-			temporaryFolder.newFolder().getAbsolutePath(),
-			yarnClient);
-
-		clusterDescriptor.retrieve(clusterId);
+		clusterDescriptor.retrieve(applicationId);
 	}
 
 	private ApplicationReport createApplicationReport(

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/FlinkYarnSessionCliTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/FlinkYarnSessionCliTest.java
@@ -179,9 +179,9 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 
 		final CommandLine commandLine = flinkYarnSessionCli.parseCommandLineOptions(new String[] {}, true);
 
-		final String clusterId = flinkYarnSessionCli.getClusterId(commandLine);
+		final ApplicationId clusterId = flinkYarnSessionCli.getClusterId(commandLine);
 
-		assertEquals(TEST_YARN_APPLICATION_ID.toString(), clusterId);
+		assertEquals(TEST_YARN_APPLICATION_ID, clusterId);
 	}
 
 	/**
@@ -214,9 +214,9 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 
 		final CommandLine commandLine = flinkYarnSessionCli.parseCommandLineOptions(new String[] {"-yid", TEST_YARN_APPLICATION_ID.toString()}, true);
 
-		final String clusterId = flinkYarnSessionCli.getClusterId(commandLine);
+		final ApplicationId clusterId = flinkYarnSessionCli.getClusterId(commandLine);
 
-		assertEquals(TEST_YARN_APPLICATION_ID.toString(), clusterId);
+		assertEquals(TEST_YARN_APPLICATION_ID, clusterId);
 	}
 
 	@Test
@@ -272,8 +272,8 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 			"y",
 			"yarn");
 		final CommandLine commandLine = flinkYarnSessionCli.parseCommandLineOptions(new String[] {"-yid", TEST_YARN_APPLICATION_ID_2.toString() }, true);
-		final String clusterId = flinkYarnSessionCli.getClusterId(commandLine);
-		assertEquals(TEST_YARN_APPLICATION_ID_2.toString(), clusterId);
+		final ApplicationId clusterId = flinkYarnSessionCli.getClusterId(commandLine);
+		assertEquals(TEST_YARN_APPLICATION_ID_2, clusterId);
 	}
 
 	///////////

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.yarn;
 
+import org.apache.flink.client.deployment.ClusterDeploymentException;
 import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
@@ -66,7 +67,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 	}
 
 	@Test
-	public void testFailIfTaskSlotsHigherThanMaxVcores() {
+	public void testFailIfTaskSlotsHigherThanMaxVcores() throws ClusterDeploymentException {
 
 		final YarnClient yarnClient = YarnClient.createYarnClient();
 
@@ -88,7 +89,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 			clusterDescriptor.deploySessionCluster(clusterSpecification);
 
 			fail("The deploy call should have failed.");
-		} catch (RuntimeException e) {
+		} catch (ClusterDeploymentException e) {
 			// we expect the cause to be an IllegalConfigurationException
 			if (!(e.getCause() instanceof IllegalConfigurationException)) {
 				throw e;
@@ -99,7 +100,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 	}
 
 	@Test
-	public void testConfigOverwrite() {
+	public void testConfigOverwrite() throws ClusterDeploymentException {
 		Configuration configuration = new Configuration();
 		// overwrite vcores in config
 		configuration.setInteger(YarnConfigOptions.VCORES, Integer.MAX_VALUE);
@@ -125,7 +126,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 			clusterDescriptor.deploySessionCluster(clusterSpecification);
 
 			fail("The deploy call should have failed.");
-		} catch (RuntimeException e) {
+		} catch (ClusterDeploymentException e) {
 			// we expect the cause to be an IllegalConfigurationException
 			if (!(e.getCause() instanceof IllegalConfigurationException)) {
 				throw e;


### PR DESCRIPTION
## What is the purpose of the change

Print help for the `DefaultCLI`.

This PR is based on #5232.

## Verifying this change

- Trivial change

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
