### PR TITLE
[FLINK-8322] support getting number of existing timers in TimerService

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/SimpleTimerService.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/SimpleTimerService.java
@@ -53,4 +53,14 @@ public class SimpleTimerService implements TimerService {
 	public void registerEventTimeTimer(long time) {
 		internalTimerService.registerEventTimeTimer(VoidNamespace.INSTANCE, time);
 	}
+
+	@Override
+	public int numProcessingTimeTimers() {
+		return internalTimerService.numProcessingTimeTimers(VoidNamespace.INSTANCE);
+	}
+
+	@Override
+	public int numEventTimeTimers() {
+		return internalTimerService.numEventTimeTimers(VoidNamespace.INSTANCE);
+	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/TimerService.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/TimerService.java
@@ -51,4 +51,16 @@ public interface TimerService {
 	 * will also be active when you receive the timer notification.
 	 */
 	void registerEventTimeTimer(long time);
+
+	/**
+	 *
+	 * @return
+	 */
+	int numProcessingTimeTimers();
+
+	/**
+	 *
+	 * @return
+	 */
+	int numEventTimeTimers();
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/TimerService.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/TimerService.java
@@ -26,10 +26,14 @@ import org.apache.flink.annotation.PublicEvolving;
 @PublicEvolving
 public interface TimerService {
 
-	/** Returns the current processing time. */
+	/**
+	 * Returns the current processing time.
+	 */
 	long currentProcessingTime();
 
-	/** Returns the current event-time watermark. */
+	/**
+	 * Returns the current event-time watermark.
+	 */
 	long currentWatermark();
 
 	/**
@@ -53,14 +57,12 @@ public interface TimerService {
 	void registerEventTimeTimer(long time);
 
 	/**
-	 *
-	 * @return
+	 * Returns the number of processing time timers.
 	 */
 	int numProcessingTimeTimers();
 
 	/**
-	 *
-	 * @return
+	 * Returns the number of event time timers.
 	 */
 	int numEventTimeTimers();
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/HeapInternalTimerService.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/HeapInternalTimerService.java
@@ -261,12 +261,10 @@ public class HeapInternalTimerService<K, N> implements InternalTimerService<N>, 
 		InternalTimer<K, N> timer;
 
 		while ((timer = processingTimeTimersQueue.peek()) != null && timer.getTimestamp() <= time) {
-
 			Set<InternalTimer<K, N>> timerSet = getProcessingTimeTimerSetForTimer(timer);
-
 			timerSet.remove(timer);
-			decrementProcessingTimeTimer(timer.getKey(), timer.getNamespace());
 			processingTimeTimersQueue.remove();
+			decrementProcessingTimeTimer(timer.getKey(), timer.getNamespace());
 
 			keyContext.setCurrentKey(timer.getKey());
 			triggerTarget.onProcessingTime(timer);
@@ -279,17 +277,17 @@ public class HeapInternalTimerService<K, N> implements InternalTimerService<N>, 
 		}
 	}
 
+	private int i = 0;
 	public void advanceWatermark(long time) throws Exception {
 		currentWatermark = time;
 
 		InternalTimer<K, N> timer;
 
 		while ((timer = eventTimeTimersQueue.peek()) != null && timer.getTimestamp() <= time) {
-
 			Set<InternalTimer<K, N>> timerSet = getEventTimeTimerSetForTimer(timer);
 			timerSet.remove(timer);
-			decrementEventTimeTimer(timer.getKey(), timer.getNamespace());
 			eventTimeTimersQueue.remove();
+			decrementEventTimeTimer(timer.getKey(), timer.getNamespace());
 
 			keyContext.setCurrentKey(timer.getKey());
 			triggerTarget.onEventTime(timer);
@@ -512,7 +510,7 @@ public class HeapInternalTimerService<K, N> implements InternalTimerService<N>, 
 
 	private void decrementTimeTimer(Table<K, N, Integer> table, K key, N namespace) {
 		if (table.contains(key, namespace)) {
-			if (table.get(key, namespace) != 1) {
+			if (table.get(key, namespace) > 1) {
 				table.put(key, namespace, table.get(key, namespace) - 1);
 			} else {
 				table.remove(key, namespace);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimerService.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimerService.java
@@ -58,4 +58,14 @@ public interface InternalTimerService<N> {
 	 * Deletes the timer for the given key and namespace.
 	 */
 	void deleteEventTimeTimer(N namespace, long time);
+
+	/**
+	 * Gets number of processing time timers for the given key and namespace.
+	 */
+	int numProcessingTimeTimers(N namespace);
+
+	/**
+	 * Gets number of event time timers for the given key and namespace.
+	 */
+	int numEventTimeTimers(N namespace);
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimerService.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimerService.java
@@ -60,12 +60,12 @@ public interface InternalTimerService<N> {
 	void deleteEventTimeTimer(N namespace, long time);
 
 	/**
-	 * Gets number of processing time timers for the given key and namespace.
+	 * Returns number of processing time timers for the given key and namespace.
 	 */
 	int numProcessingTimeTimers(N namespace);
 
 	/**
-	 * Gets number of event time timers for the given key and namespace.
+	 * Returns number of event time timers for the given key and namespace.
 	 */
 	int numEventTimeTimers(N namespace);
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/ProcessOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/ProcessOperator.java
@@ -123,6 +123,16 @@ public class ProcessOperator<IN, OUT>
 		}
 
 		@Override
+		public int numProcessingTimeTimers() {
+			throw new UnsupportedOperationException("Getting number of timers is only supported on a KeyedStream.");
+		}
+
+		@Override
+		public int numEventTimeTimers() {
+			throw new UnsupportedOperationException("Getting number of timers is only supported on a KeyedStream.");
+		}
+
+		@Override
 		public TimerService timerService() {
 			return this;
 		}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/co/CoProcessOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/co/CoProcessOperator.java
@@ -84,10 +84,7 @@ public class CoProcessOperator<IN1, IN2, OUT>
 		currentWatermark = mark.getTimestamp();
 	}
 
-	private class ContextImpl
-			extends CoProcessFunction<IN1, IN2, OUT>.Context
-			implements TimerService {
-
+	private class ContextImpl extends CoProcessFunction<IN1, IN2, OUT>.Context implements TimerService {
 		private final ProcessingTimeService timerService;
 
 		private StreamRecord<?> element;
@@ -120,12 +117,22 @@ public class CoProcessOperator<IN1, IN2, OUT>
 
 		@Override
 		public void registerProcessingTimeTimer(long time) {
-			throw new UnsupportedOperationException("Setting timers is only supported on a keyed streams.");
+			throw new UnsupportedOperationException("Setting timers is only supported on a KeyedStream.");
 		}
 
 		@Override
 		public void registerEventTimeTimer(long time) {
-			throw new UnsupportedOperationException("Setting timers is only supported on a keyed streams.");
+			throw new UnsupportedOperationException("Setting timers is only supported on a KeyedStream.");
+		}
+
+		@Override
+		public int numProcessingTimeTimers() {
+			throw new UnsupportedOperationException("Getting number of timers is only supported on a KeyedStream.");
+		}
+
+		@Override
+		public int numEventTimeTimers() {
+			throw new UnsupportedOperationException("Getting number of timers is only supported on a KeyedStream.");
 		}
 
 		@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/KeyedProcessOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/KeyedProcessOperatorTest.java
@@ -463,10 +463,10 @@ public class KeyedProcessOperatorTest extends TestLogger {
 			getRuntimeContext().getState(state).update(value);
 			if (timeDomain.equals(TimeDomain.EVENT_TIME)) {
 				ctx.timerService().registerEventTimeTimer(ctx.timerService().currentWatermark() + 5);
-				assertEquals(++ count, ctx.timerService().numEventTimeTimers());
+				assertEquals(++count, ctx.timerService().numEventTimeTimers());
 			} else {
 				ctx.timerService().registerProcessingTimeTimer(ctx.timerService().currentProcessingTime() + 5);
-				assertEquals(++ count, ctx.timerService().numProcessingTimeTimers());
+				assertEquals(++count, ctx.timerService().numProcessingTimeTimers());
 			}
 		}
 
@@ -479,9 +479,9 @@ public class KeyedProcessOperatorTest extends TestLogger {
 			out.collect("STATE:" + getRuntimeContext().getState(state).value());
 
 			if (timeDomain.equals(TimeDomain.EVENT_TIME)) {
-				assertEquals(-- count, ctx.timerService().numEventTimeTimers());
+				assertEquals(--count, ctx.timerService().numEventTimeTimers());
 			} else {
-				assertEquals(-- count, ctx.timerService().numProcessingTimeTimers());
+				assertEquals(--count, ctx.timerService().numProcessingTimeTimers());
 			}
 		}
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/co/KeyedCoProcessOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/co/KeyedCoProcessOperatorTest.java
@@ -284,7 +284,7 @@ public class KeyedCoProcessOperatorTest extends TestLogger {
 				new KeyedTwoInputStreamOperatorTestHarness<>(
 						operator,
 						new IntToStringKeySelector<>(),
-						new IdentityKeySelector<String>(),
+						new IdentityKeySelector<>(),
 						BasicTypeInfo.STRING_TYPE_INFO);
 
 		testHarness.setup();
@@ -362,6 +362,8 @@ public class KeyedCoProcessOperatorTest extends TestLogger {
 				long timestamp,
 				OnTimerContext ctx,
 				Collector<String> out) throws Exception {
+			assertEquals(0, ctx.timerService().numEventTimeTimers());
+			assertEquals(0, ctx.timerService().numProcessingTimeTimers());
 		}
 	}
 
@@ -369,16 +371,20 @@ public class KeyedCoProcessOperatorTest extends TestLogger {
 
 		private static final long serialVersionUID = 1L;
 
+		private static int numEventTimeTimers = 0;
+
 		@Override
 		public void processElement1(Integer value, Context ctx, Collector<String> out) throws Exception {
 			out.collect("INPUT1:" + value);
 			ctx.timerService().registerEventTimeTimer(5);
+			assertEquals(++numEventTimeTimers, ctx.timerService().numEventTimeTimers());
 		}
 
 		@Override
 		public void processElement2(String value, Context ctx, Collector<String> out) throws Exception {
 			out.collect("INPUT2:" + value);
 			ctx.timerService().registerEventTimeTimer(6);
+			assertEquals(++numEventTimeTimers, ctx.timerService().numEventTimeTimers());
 		}
 
 		@Override
@@ -389,12 +395,15 @@ public class KeyedCoProcessOperatorTest extends TestLogger {
 
 			assertEquals(TimeDomain.EVENT_TIME, ctx.timeDomain());
 			out.collect("" + 1777);
+			assertEquals(--numEventTimeTimers, ctx.timerService().numEventTimeTimers());
 		}
 	}
 
 	private static class EventTimeTriggeringStatefulProcessFunction extends CoProcessFunction<Integer, String, String> {
 
 		private static final long serialVersionUID = 1L;
+
+		private static int numEventTimeTimers = 0;
 
 		private final ValueStateDescriptor<String> state =
 				new ValueStateDescriptor<>("seen-element", StringSerializer.INSTANCE);
@@ -404,6 +413,7 @@ public class KeyedCoProcessOperatorTest extends TestLogger {
 			out.collect("INPUT1:" + value);
 			getRuntimeContext().getState(state).update("" + value);
 			ctx.timerService().registerEventTimeTimer(ctx.timerService().currentWatermark() + 5);
+			assertEquals(++numEventTimeTimers, ctx.timerService().numEventTimeTimers());
 		}
 
 		@Override
@@ -411,6 +421,7 @@ public class KeyedCoProcessOperatorTest extends TestLogger {
 			out.collect("INPUT2:" + value);
 			getRuntimeContext().getState(state).update(value);
 			ctx.timerService().registerEventTimeTimer(ctx.timerService().currentWatermark() + 5);
+			assertEquals(++numEventTimeTimers, ctx.timerService().numEventTimeTimers());
 		}
 
 		@Override
@@ -420,6 +431,8 @@ public class KeyedCoProcessOperatorTest extends TestLogger {
 				Collector<String> out) throws Exception {
 			assertEquals(TimeDomain.EVENT_TIME, ctx.timeDomain());
 			out.collect("STATE:" + getRuntimeContext().getState(state).value());
+			assertEquals(--numEventTimeTimers, ctx.timerService().numEventTimeTimers());
+			assertEquals(0, ctx.timerService().numProcessingTimeTimers());
 		}
 	}
 
@@ -427,16 +440,20 @@ public class KeyedCoProcessOperatorTest extends TestLogger {
 
 		private static final long serialVersionUID = 1L;
 
+		private static int numProcessingTimeTimers = 0;
+
 		@Override
 		public void processElement1(Integer value, Context ctx, Collector<String> out) throws Exception {
 			out.collect("INPUT1:" + value);
 			ctx.timerService().registerProcessingTimeTimer(5);
+			assertEquals(++numProcessingTimeTimers, ctx.timerService().numProcessingTimeTimers());
 		}
 
 		@Override
 		public void processElement2(String value, Context ctx, Collector<String> out) throws Exception {
 			out.collect("INPUT2:" + value);
 			ctx.timerService().registerProcessingTimeTimer(6);
+			assertEquals(++numProcessingTimeTimers, ctx.timerService().numProcessingTimeTimers());
 		}
 
 		@Override
@@ -447,6 +464,8 @@ public class KeyedCoProcessOperatorTest extends TestLogger {
 
 			assertEquals(TimeDomain.PROCESSING_TIME, ctx.timeDomain());
 			out.collect("" + 1777);
+			assertEquals(--numProcessingTimeTimers, ctx.timerService().numProcessingTimeTimers());
+			assertEquals(0, ctx.timerService().numEventTimeTimers());
 		}
 	}
 
@@ -469,12 +488,16 @@ public class KeyedCoProcessOperatorTest extends TestLogger {
 				long timestamp,
 				OnTimerContext ctx,
 				Collector<String> out) throws Exception {
+			assertEquals(0, ctx.timerService().numEventTimeTimers());
+			assertEquals(0, ctx.timerService().numProcessingTimeTimers());
 		}
 	}
 
 	private static class ProcessingTimeTriggeringStatefulProcessFunction extends CoProcessFunction<Integer, String, String> {
 
 		private static final long serialVersionUID = 1L;
+
+		private static int numProcessingTimeTimers = 0;
 
 		private final ValueStateDescriptor<String> state =
 				new ValueStateDescriptor<>("seen-element", StringSerializer.INSTANCE);
@@ -484,6 +507,7 @@ public class KeyedCoProcessOperatorTest extends TestLogger {
 			out.collect("INPUT1:" + value);
 			getRuntimeContext().getState(state).update("" + value);
 			ctx.timerService().registerProcessingTimeTimer(ctx.timerService().currentProcessingTime() + 5);
+			assertEquals(++numProcessingTimeTimers, ctx.timerService().numProcessingTimeTimers());
 		}
 
 		@Override
@@ -491,6 +515,7 @@ public class KeyedCoProcessOperatorTest extends TestLogger {
 			out.collect("INPUT2:" + value);
 			getRuntimeContext().getState(state).update(value);
 			ctx.timerService().registerProcessingTimeTimer(ctx.timerService().currentProcessingTime() + 5);
+			assertEquals(++numProcessingTimeTimers, ctx.timerService().numProcessingTimeTimers());
 		}
 
 		@Override
@@ -500,6 +525,7 @@ public class KeyedCoProcessOperatorTest extends TestLogger {
 				Collector<String> out) throws Exception {
 			assertEquals(TimeDomain.PROCESSING_TIME, ctx.timeDomain());
 			out.collect("STATE:" + getRuntimeContext().getState(state).value());
+			assertEquals(--numProcessingTimeTimers, ctx.timerService().numProcessingTimeTimers());
 		}
 	}
 
@@ -507,19 +533,19 @@ public class KeyedCoProcessOperatorTest extends TestLogger {
 
 		private static final long serialVersionUID = 1L;
 
-		int numProcessingTimeTimers = 0;
-		int numEventTimeTimers = 0;
+		private static int numProcessingTimeTimers = 0;
+		private static int numEventTimeTimers = 0;
 
 		@Override
 		public void processElement1(Integer value, Context ctx, Collector<String> out) throws Exception {
 			ctx.timerService().registerEventTimeTimer(6);
-			assertEquals(++ numEventTimeTimers, ctx.timerService().numEventTimeTimers());
+			assertEquals(++numEventTimeTimers, ctx.timerService().numEventTimeTimers());
 		}
 
 		@Override
 		public void processElement2(String value, Context ctx, Collector<String> out) throws Exception {
 			ctx.timerService().registerProcessingTimeTimer(5);
-			assertEquals(++ numProcessingTimeTimers, ctx.timerService().numProcessingTimeTimers());
+			assertEquals(++numProcessingTimeTimers, ctx.timerService().numProcessingTimeTimers());
 		}
 
 		@Override
@@ -529,10 +555,10 @@ public class KeyedCoProcessOperatorTest extends TestLogger {
 				Collector<String> out) throws Exception {
 			if (TimeDomain.EVENT_TIME.equals(ctx.timeDomain())) {
 				out.collect("EVENT:1777");
-				assertEquals(-- numEventTimeTimers, ctx.timerService().numEventTimeTimers());
+				assertEquals(--numEventTimeTimers, ctx.timerService().numEventTimeTimers());
 			} else {
 				out.collect("PROC:1777");
-				assertEquals(Math.max(0, -- numProcessingTimeTimers), ctx.timerService().numProcessingTimeTimers());
+				assertEquals(--numProcessingTimeTimers, ctx.timerService().numProcessingTimeTimers());
 			}
 		}
 	}

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,2 @@
+git fetch upstream
+git rebase upstream/master

--- a/update.sh
+++ b/update.sh
@@ -1,2 +1,0 @@
-git fetch upstream
-git rebase upstream/master


### PR DESCRIPTION
## What is the purpose of the change


There are pretty common use cases where users want to use timers as scheduled threads - e.g. add a timer to wake up x hours later and do something (reap old data usually) only if there's no existing timers, basically we only want at most 1 timer exists for the key all the time

## Brief change log

Discussed with Aljoscha that we should use extra data structures to keep track number of timers. I decided to use Guava's Table to store `<Key, Namespace, NumberOfTimers>`. 

## Verifying this change


This change added tests and can be verified as follows: `HeapInternalTimerServiceTest`, `KeyedProcessOperatorTest`, and `KeyedCoProcessOperatorTest`.

## Does this pull request potentially affect one of the following parts:

  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
