### PR TITLE
[hotfix] Fix typos

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/CliFrontend.java
@@ -1164,7 +1164,7 @@ public class CliFrontend {
 
 	/**
 	 * Retrieves the loaded custom command-lines.
-	 * @return An unmodifiyable list of loaded custom command-lines.
+	 * @return An unmodifiable list of loaded custom command-lines.
 	 */
 	public static List<CustomCommandLine<?>> getCustomCommandLineList() {
 		return Collections.unmodifiableList(customCommandLines);

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkBase.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkBase.java
@@ -142,7 +142,7 @@ public abstract class ElasticsearchSinkBase<T> extends RichSinkFunction<T> imple
 	/** The user specified config map that we forward to Elasticsearch when we create the {@link Client}. */
 	private final Map<String, String> userConfig;
 
-	/** The function that is used to construct mulitple {@link ActionRequest ActionRequests} from each incoming element. */
+	/** The function that is used to construct multiple {@link ActionRequest ActionRequests} from each incoming element. */
 	private final ElasticsearchSinkFunction<T> elasticsearchSinkFunction;
 
 	/** User-provided handler for failed {@link ActionRequest ActionRequests}. */

--- a/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/testutils/SourceSinkDataTestKit.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/testutils/SourceSinkDataTestKit.java
@@ -67,7 +67,7 @@ public class SourceSinkDataTestKit {
 	}
 
 	/**
-	 * A {@link ElasticsearchSinkFunction} that indexes each element it receives to a sepecified Elasticsearch index.
+	 * A {@link ElasticsearchSinkFunction} that indexes each element it receives to a specified Elasticsearch index.
 	 */
 	public static class TestElasticsearchSinkFunction implements ElasticsearchSinkFunction<Tuple2<Integer, String>> {
 		private static final long serialVersionUID = 1L;

--- a/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011.java
@@ -170,7 +170,7 @@ public class FlinkKafkaProducer011<IN>
 	public static final String KEY_DISABLE_METRICS = "flink.disable-metrics";
 
 	/**
-	 * Descriptor of the transacionalIds list.
+	 * Descriptor of the transactional IDs list.
 	 */
 	private static final ListStateDescriptor<NextTransactionalIdHint> NEXT_TRANSACTIONAL_ID_HINT_DESCRIPTOR =
 		new ListStateDescriptor<>("next-transactional-id-hint", TypeInformation.of(NextTransactionalIdHint.class));

--- a/flink-connectors/flink-connector-kafka-0.11/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011ITCase.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011ITCase.java
@@ -101,7 +101,7 @@ public class FlinkKafkaProducer011ITCase extends KafkaTestBase {
 				assertIsCausedBy(FlinkKafka011ErrorCode.PRODUCERS_POOL_EMPTY, ex);
 			}
 
-			// Resume transactions before testHrness1 is being closed (in case of failures close() might not be called)
+			// Resume transactions before testHarness1 is being closed (in case of failures close() might not be called)
 			try (OneInputStreamOperatorTestHarness<Integer, Object> testHarness2 = createTestHarness(topic)) {
 				testHarness2.setup();
 				// restore from snapshot1, transactions with records 43 and 44 should be aborted

--- a/flink-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer08.java
+++ b/flink-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer08.java
@@ -75,7 +75,7 @@ public class FlinkKafkaProducer08<IN> extends FlinkKafkaProducerBase<IN>  {
 	 * @param topicId The topic to write data to
 	 * @param serializationSchema A (keyless) serializable serialization schema for turning user objects into a kafka-consumable byte[]
 	 * @param producerConfig Configuration properties for the KafkaProducer. 'bootstrap.servers.' is the only required argument.
-	 * @param customPartitioner A serializable partitioner for assining messages to Kafka partitions.
+	 * @param customPartitioner A serializable partitioner for assigning messages to Kafka partitions.
 	 */
 	public FlinkKafkaProducer08(String topicId, SerializationSchema<IN> serializationSchema, Properties producerConfig, FlinkKafkaPartitioner<IN> customPartitioner) {
 		this(topicId, new KeyedSerializationSchemaWrapper<>(serializationSchema), producerConfig, customPartitioner);
@@ -120,7 +120,7 @@ public class FlinkKafkaProducer08<IN> extends FlinkKafkaProducerBase<IN>  {
 	 * @param topicId The topic to write data to
 	 * @param serializationSchema A serializable serialization schema for turning user objects into a kafka-consumable byte[] supporting key/value messages
 	 * @param producerConfig Configuration properties for the KafkaProducer. 'bootstrap.servers.' is the only required argument.
-	 * @param customPartitioner A serializable partitioner for assining messages to Kafka partitions.
+	 * @param customPartitioner A serializable partitioner for assigning messages to Kafka partitions.
 	 */
 	public FlinkKafkaProducer08(String topicId, KeyedSerializationSchema<IN> serializationSchema, Properties producerConfig, FlinkKafkaPartitioner<IN> customPartitioner) {
 		super(topicId, serializationSchema, producerConfig, customPartitioner);
@@ -134,7 +134,7 @@ public class FlinkKafkaProducer08<IN> extends FlinkKafkaProducerBase<IN>  {
 	 * @param topicId The topic to write data to
 	 * @param serializationSchema A (keyless) serializable serialization schema for turning user objects into a kafka-consumable byte[]
 	 * @param producerConfig Configuration properties for the KafkaProducer. 'bootstrap.servers.' is the only required argument.
-	 * @param customPartitioner A serializable partitioner for assining messages to Kafka partitions.
+	 * @param customPartitioner A serializable partitioner for assigning messages to Kafka partitions.
 	 *
 	 * @deprecated This is a deprecated constructor that does not correctly handle partitioning when
 	 *             producing to multiple topics. Use
@@ -151,7 +151,7 @@ public class FlinkKafkaProducer08<IN> extends FlinkKafkaProducerBase<IN>  {
 	 * @param topicId The topic to write data to
 	 * @param serializationSchema A serializable serialization schema for turning user objects into a kafka-consumable byte[] supporting key/value messages
 	 * @param producerConfig Configuration properties for the KafkaProducer. 'bootstrap.servers.' is the only required argument.
-	 * @param customPartitioner A serializable partitioner for assining messages to Kafka partitions.
+	 * @param customPartitioner A serializable partitioner for assigning messages to Kafka partitions.
 	 *
 	 * @deprecated This is a deprecated constructor that does not correctly handle partitioning when
 	 *             producing to multiple topics. Use

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaAvroTableSource.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaAvroTableSource.java
@@ -156,7 +156,7 @@ public abstract class KafkaAvroTableSource extends KafkaTableSource implements D
 		private Map<String, String> fieldMapping;
 
 		/**
-		 * Sets the class of the Avro records that aree read from the Kafka topic.
+		 * Sets the class of the Avro records that are read from the Kafka topic.
 		 *
 		 * @param avroClass The class of the Avro records that are read from the Kafka topic.
 		 * @return The builder.

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSink.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSink.java
@@ -61,7 +61,7 @@ public abstract class KafkaTableSink implements AppendStreamTableSink<Row> {
 	}
 
 	/**
-	 * Returns the version-specifid Kafka producer.
+	 * Returns the version-specific Kafka producer.
 	 *
 	 * @param topic               Kafka topic to produce to.
 	 * @param properties          Properties for the Kafka producer.

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSource.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSource.java
@@ -307,7 +307,7 @@ public abstract class KafkaTableSource
 
 		/**
 		 * Configures a field of the table to be a processing time attribute.
-		 * The configured field must be present in the tabel schema and of type {@link Types#SQL_TIMESTAMP()}.
+		 * The configured field must be present in the table schema and of type {@link Types#SQL_TIMESTAMP()}.
 		 *
 		 * @param proctimeAttribute The name of the processing time attribute in the table schema.
 		 * @return The builder.
@@ -322,7 +322,7 @@ public abstract class KafkaTableSource
 
 		/**
 		 * Configures a field of the table to be a rowtime attribute.
-		 * The configured field must be present in the tabel schema and of type {@link Types#SQL_TIMESTAMP()}.
+		 * The configured field must be present in the table schema and of type {@link Types#SQL_TIMESTAMP()}.
 		 *
 		 * @param rowtimeAttribute The name of the rowtime attribute in the table schema.
 		 * @param timestampExtractor The {@link TimestampExtractor} to extract the rowtime attribute from the physical type.

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/config/OffsetCommitModes.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/config/OffsetCommitModes.java
@@ -29,7 +29,7 @@ public class OffsetCommitModes {
 	 * @param enableCommitOnCheckpoint whether or not committing on checkpoints is enabled.
 	 * @param enableCheckpointing whether or not checkpoint is enabled for the consumer.
 	 *
-	 * @return the offset commmit mode to use, based on the configuration values.
+	 * @return the offset commit mode to use, based on the configuration values.
 	 */
 	public static OffsetCommitMode fromConfiguration(
 			boolean enableAutoCommit,

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/ClosableBlockingQueue.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/ClosableBlockingQueue.java
@@ -70,7 +70,7 @@ public class ClosableBlockingQueue<E> {
 
 	/**
 	 * Creates a new empty queue, reserving space for at least the specified number
-	 * of elements. The queu can still grow, of more elements are added than the
+	 * of elements. The queue can still grow, of more elements are added than the
 	 * reserved space.
 	 *
 	 * @param initialSize The number of elements to reserve space for.

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerBaseTest.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerBaseTest.java
@@ -189,7 +189,7 @@ public class FlinkKafkaProducerBaseTest {
 	 * Test ensuring that if an async exception is caught for one of the flushed requests on checkpoint,
 	 * it should be rethrown; we set a timeout because the test will not finish if the logic is broken.
 	 *
-	 * <p>Note that this test does not test the snapshot method is blocked correctly when there are pending recorrds.
+	 * <p>Note that this test does not test the snapshot method is blocked correctly when there are pending records.
 	 * The test for that is covered in testAtLeastOnceProducer.
 	 */
 	@SuppressWarnings("unchecked")

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
@@ -406,7 +406,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBase {
 		final String consumeExtraRecordsJobName = "Consume Extra Records Job";
 		final String writeExtraRecordsJobName = "Write Extra Records Job";
 
-		// seriliazation / deserialization schemas for writing and consuming the extra records
+		// serialization / deserialization schemas for writing and consuming the extra records
 		final TypeInformation<Tuple2<Integer, Integer>> resultType =
 			TypeInformation.of(new TypeHint<Tuple2<Integer, Integer>>() {});
 

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxy.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxy.java
@@ -58,7 +58,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * <p>NOTE:
  * In the AWS KCL library, there is a similar implementation - {@link com.amazonaws.services.kinesis.clientlibrary.proxies.KinesisProxy}.
  * This implementation differs mainly in that we can make operations to arbitrary Kinesis streams, which is a needed
- * functionality for the Flink Kinesis Connecter since the consumer may simultaneously read from multiple Kinesis streams.
+ * functionality for the Flink Kinesis Connector since the consumer may simultaneously read from multiple Kinesis streams.
  */
 public class KinesisProxy implements KinesisProxyInterface {
 

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisProducerTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisProducerTest.java
@@ -167,7 +167,7 @@ public class FlinkKinesisProducerTest {
 	 * Test ensuring that if an async exception is caught for one of the flushed requests on checkpoint,
 	 * it should be rethrown; we set a timeout because the test will not finish if the logic is broken.
 	 *
-	 * <p>Note that this test does not test the snapshot method is blocked correctly when there are pending recorrds.
+	 * <p>Note that this test does not test the snapshot method is blocked correctly when there are pending records.
 	 * The test for that is covered in testAtLeastOnceProducer.
 	 */
 	@SuppressWarnings("ResultOfMethodCallIgnored")

--- a/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/common/RMQConnectionConfig.java
+++ b/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/common/RMQConnectionConfig.java
@@ -355,7 +355,7 @@ public class RMQConnectionConfig implements Serializable {
 		/**
 		 * Convenience method for setting the fields in an AMQP URI: host,
 		 * port, username, password and virtual host.  If any part of the
-		 * URI is ommited, the ConnectionFactory's corresponding variable
+		 * URI is omitted, the ConnectionFactory's corresponding variable
 		 * is left unchanged.
 		 * @param uri is the AMQP URI containing the data
 		 * @return the Builder

--- a/flink-connectors/flink-hadoop-compatibility/src/main/java/org/apache/flink/api/java/hadoop/mapred/HadoopInputFormatBase.java
+++ b/flink-connectors/flink-hadoop-compatibility/src/main/java/org/apache/flink/api/java/hadoop/mapred/HadoopInputFormatBase.java
@@ -53,7 +53,7 @@ import java.util.ArrayList;
  *
  * @param <K> Type of key
  * @param <V> Type of value
- * @param <T> The type iself
+ * @param <T> The type itself
  */
 @Internal
 public abstract class HadoopInputFormatBase<K, V, T> extends HadoopInputFormatCommonBase<T, HadoopInputSplit> {

--- a/flink-connectors/flink-hadoop-compatibility/src/test/java/org/apache/flink/test/hadoopcompatibility/mapred/HadoopIOFormatsITCase.java
+++ b/flink-connectors/flink-hadoop-compatibility/src/test/java/org/apache/flink/test/hadoopcompatibility/mapred/HadoopIOFormatsITCase.java
@@ -51,7 +51,7 @@ import java.util.Collection;
 import java.util.LinkedList;
 
 /**
- * Integraiton tests for Hadoop IO formats.
+ * Integration tests for Hadoop IO formats.
  */
 @RunWith(Parameterized.class)
 public class HadoopIOFormatsITCase extends JavaProgramTestBase {

--- a/flink-connectors/flink-hbase/src/main/java/org/apache/flink/addons/hbase/TableInputFormat.java
+++ b/flink-connectors/flink-hbase/src/main/java/org/apache/flink/addons/hbase/TableInputFormat.java
@@ -51,7 +51,7 @@ public abstract class TableInputFormat<T extends Tuple> extends AbstractTableInp
 	 * The output from HBase is always an instance of {@link Result}.
 	 * This method is to copy the data in the Result instance into the required {@link Tuple}
 	 * @param r The Result instance from HBase that needs to be converted
-	 * @return The approriate instance of {@link Tuple} that contains the needed information.
+	 * @return The appropriate instance of {@link Tuple} that contains the needed information.
 	 */
 	protected abstract T mapResultToTuple(Result r);
 

--- a/flink-connectors/flink-hbase/src/test/java/org/apache/flink/addons/hbase/HBaseConnectorITCase.java
+++ b/flink-connectors/flink-hbase/src/test/java/org/apache/flink/addons/hbase/HBaseConnectorITCase.java
@@ -312,7 +312,7 @@ public class HBaseConnectorITCase extends HBaseTestingClusterAutostarter {
 		}
 	}
 
-	// ######## TableInputFormate tests ############
+	// ######## TableInputFormat tests ############
 
 	class InputFormatForTestTable extends TableInputFormat<Tuple1<Integer>> {
 

--- a/flink-contrib/docker-flink/create-docker-swarm-service.sh
+++ b/flink-contrib/docker-flink/create-docker-swarm-service.sh
@@ -50,5 +50,5 @@ docker network create -d overlay ${OVERLAY_NETWORK_NAME}
 # Create the jobmanager service
 docker service create --name ${JOB_MANAGER_NAME} --env JOB_MANAGER_RPC_ADDRESS=${JOB_MANAGER_RPC_ADDRESS} -p ${SERVICE_PORT}:8081 --network ${OVERLAY_NETWORK_NAME} ${IMAGE_NAME} jobmanager
 
-# Create the taskmanger service (scale this out as needed)
+# Create the taskmanager service (scale this out as needed)
 docker service create --name ${TASK_MANAGER_NAME} --env JOB_MANAGER_RPC_ADDRESS=${JOB_MANAGER_RPC_ADDRESS} --network ${OVERLAY_NETWORK_NAME} ${IMAGE_NAME} taskmanager

--- a/flink-contrib/flink-connector-wikiedits/src/test/java/org/apache/flink/streaming/connectors/wikiedits/WikipediaEditsSourceTest.java
+++ b/flink-contrib/flink-connector-wikiedits/src/test/java/org/apache/flink/streaming/connectors/wikiedits/WikipediaEditsSourceTest.java
@@ -71,7 +71,7 @@ public class WikipediaEditsSourceTest {
 
 				// Execute the source in a different thread and collect events into the queue.
 				// We do this in a separate thread in order to not block the main test thread
-				// indefinitely in case that somethign bad happens (like not receiving any
+				// indefinitely in case that something bad happens (like not receiving any
 				// events)
 				executorService.execute(() -> {
 					try {

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
@@ -82,7 +82,7 @@ public class RocksDBStateBackend extends AbstractStateBackend {
 	/** The state backend that we use for creating checkpoint streams. */
 	private final AbstractStateBackend checkpointStreamBackend;
 
-	/** Operator identifier that is used to uniqueify the RocksDB storage path. */
+	/** Operator identifier that is used to uniquify the RocksDB storage path. */
 	private String operatorIdentifier;
 
 	/** JobID for uniquifying backup paths. */
@@ -202,7 +202,7 @@ public class RocksDBStateBackend extends AbstractStateBackend {
 	 * {@link AbstractStateBackend#createStreamFactory(JobID, String) checkpoint stream}.
 	 *
 	 * @param checkpointStreamBackend The backend to store the
-	 * @param enableIncrementalCheckpointing True if incremental checkponting is enabled
+	 * @param enableIncrementalCheckpointing True if incremental checkpointing is enabled
 	 */
 	public RocksDBStateBackend(AbstractStateBackend checkpointStreamBackend, boolean enableIncrementalCheckpointing) {
 		this.checkpointStreamBackend = requireNonNull(checkpointStreamBackend);

--- a/flink-contrib/flink-storm-examples/src/main/java/org/apache/flink/storm/exclamation/ExclamationWithBolt.java
+++ b/flink-contrib/flink-storm-examples/src/main/java/org/apache/flink/storm/exclamation/ExclamationWithBolt.java
@@ -36,7 +36,7 @@ import org.apache.storm.utils.Utils;
  * <p>The input is a plain text file with lines separated by newline characters.
  *
  * <p>Usage:
- * <code>ExclamationWithmBolt &lt;text path&gt; &lt;result path&gt; &lt;number of exclamation marks&gt;</code><br>
+ * <code>ExclamationWithBolt &lt;text path&gt; &lt;result path&gt; &lt;number of exclamation marks&gt;</code><br>
  * If no parameters are provided, the program is run with default data from {@link WordCountData} with x=2.
  *
  * <p>This example shows how to:

--- a/flink-contrib/flink-storm-examples/src/test/java/org/apache/flink/storm/exclamation/ExclamationWithSpoutITCase.java
+++ b/flink-contrib/flink-storm-examples/src/test/java/org/apache/flink/storm/exclamation/ExclamationWithSpoutITCase.java
@@ -23,7 +23,7 @@ import org.apache.flink.streaming.util.StreamingProgramTestBase;
 import org.apache.flink.test.testdata.WordCountData;
 
 /**
- * Test for the ExclamantionWithSpout example.
+ * Test for the ExclamationWithSpout example.
  */
 public class ExclamationWithSpoutITCase extends StreamingProgramTestBase {
 

--- a/flink-contrib/flink-storm-examples/src/test/java/org/apache/flink/storm/tests/StormFieldsGroupingITCase.java
+++ b/flink-contrib/flink-storm-examples/src/test/java/org/apache/flink/storm/tests/StormFieldsGroupingITCase.java
@@ -77,7 +77,7 @@ public class StormFieldsGroupingITCase extends StreamingProgramTestBase {
 		Collections.sort(expectedResults);
 		System.out.println(actualResults);
 		for (int i = 0; i < actualResults.size(); ++i) {
-			//compare against actual results with removed prefex (as it depends e.g. on the hash function used)
+			//compare against actual results with removed prefix (as it depends e.g. on the hash function used)
 			Assert.assertEquals(expectedResults.get(i), actualResults.get(i));
 		}
 	}

--- a/flink-contrib/flink-storm/src/main/java/org/apache/flink/storm/api/FlinkClient.java
+++ b/flink-contrib/flink-storm/src/main/java/org/apache/flink/storm/api/FlinkClient.java
@@ -156,7 +156,7 @@ public class FlinkClient {
 		return this;
 	}
 
-	// The following methods are derived from "backtype.storm.generated.Nimubs.Client"
+	// The following methods are derived from "backtype.storm.generated.Nimbus.Client"
 
 	/**
 	 * Parameter {@code uploadedJarLocation} is actually used to point to the local jar, because Flink does not support

--- a/flink-contrib/flink-storm/src/main/java/org/apache/flink/storm/wrappers/BoltWrapper.java
+++ b/flink-contrib/flink-storm/src/main/java/org/apache/flink/storm/wrappers/BoltWrapper.java
@@ -75,7 +75,7 @@ public class BoltWrapper<IN, OUT> extends AbstractStreamOperator<OUT> implements
 
 	/** The IDs of the input streams for this bolt per producer task ID. */
 	private final HashMap<Integer, String> inputStreamIds = new HashMap<Integer, String>();
-	/** The IDs of the producres for this bolt per producer task ID.. */
+	/** The IDs of the producers for this bolt per producer task ID.. */
 	private final HashMap<Integer, String> inputComponentIds = new HashMap<Integer, String>();
 	/** The schema (ie, ordered field names) of the input streams per producer taskID. */
 	private final HashMap<Integer, Fields> inputSchemas = new HashMap<Integer, Fields>();
@@ -131,8 +131,8 @@ public class BoltWrapper<IN, OUT> extends AbstractStreamOperator<OUT> implements
 	 *            Contains stream names if a single attribute output stream, should not be of type {@link Tuple1} but be
 	 *            of a raw type.
 	 * @throws IllegalArgumentException
-	 *             If {@code rawOuput} is {@code true} and the number of declared output attributes is not 1 or if
-	 *             {@code rawOuput} is {@code false} and the number of declared output attributes is not within range
+	 *             If {@code rawOutput} is {@code true} and the number of declared output attributes is not 1 or if
+	 *             {@code rawOutput} is {@code false} and the number of declared output attributes is not within range
 	 *             [1;25].
 	 */
 	public BoltWrapper(final IRichBolt bolt, final String[] rawOutputs)
@@ -153,8 +153,8 @@ public class BoltWrapper<IN, OUT> extends AbstractStreamOperator<OUT> implements
 	 *            Contains stream names if a single attribute output stream, should not be of type {@link Tuple1} but be
 	 *            of a raw type.
 	 * @throws IllegalArgumentException
-	 *             If {@code rawOuput} is {@code true} and the number of declared output attributes is not 1 or if
-	 *             {@code rawOuput} is {@code false} and the number of declared output attributes is not with range
+	 *             If {@code rawOutput} is {@code true} and the number of declared output attributes is not 1 or if
+	 *             {@code rawOutput} is {@code false} and the number of declared output attributes is not with range
 	 *             [1;25].
 	 */
 	public BoltWrapper(final IRichBolt bolt, final Collection<String> rawOutputs) throws IllegalArgumentException {
@@ -176,8 +176,8 @@ public class BoltWrapper<IN, OUT> extends AbstractStreamOperator<OUT> implements
 	 *            Contains stream names if a single attribute output stream, should not be of type {@link Tuple1} but be
 	 *            of a raw type.
 	 * @throws IllegalArgumentException
-	 *             If {@code rawOuput} is {@code true} and the number of declared output attributes is not 1 or if
-	 *             {@code rawOuput} is {@code false} and the number of declared output attributes is not with range
+	 *             If {@code rawOutput} is {@code true} and the number of declared output attributes is not 1 or if
+	 *             {@code rawOutput} is {@code false} and the number of declared output attributes is not with range
 	 *             [0;25].
 	 */
 	public BoltWrapper(
@@ -199,14 +199,14 @@ public class BoltWrapper<IN, OUT> extends AbstractStreamOperator<OUT> implements
 	 *            The Storm {@link IRichBolt bolt} to be used.
 	 * @param inputSchema
 	 *            The schema (ie, ordered field names) of the input stream. @throws IllegalArgumentException If
-	 *            {@code rawOuput} is {@code true} and the number of declared output attributes is not 1 or if
-	 *            {@code rawOuput} is {@code false} and the number of declared output attributes is not with range
+	 *            {@code rawOutput} is {@code true} and the number of declared output attributes is not 1 or if
+	 *            {@code rawOutput} is {@code false} and the number of declared output attributes is not with range
 	 * @param rawOutputs
 	 *            Contains stream names if a single attribute output stream, should not be of type {@link Tuple1} but be
 	 *            of a raw type.
 	 * @throws IllegalArgumentException
-	 *             If {@code rawOuput} is {@code true} and the number of declared output attributes is not 1 or if
-	 *             {@code rawOuput} is {@code false} and the number of declared output attributes is not with range
+	 *             If {@code rawOutput} is {@code true} and the number of declared output attributes is not 1 or if
+	 *             {@code rawOutput} is {@code false} and the number of declared output attributes is not with range
 	 *             [0;25].
 	 */
 	public BoltWrapper(final IRichBolt bolt, final Fields inputSchema,
@@ -229,8 +229,8 @@ public class BoltWrapper<IN, OUT> extends AbstractStreamOperator<OUT> implements
 	 *            Contains stream names if a single attribute output stream, should not be of type {@link Tuple1} but be
 	 *            of a raw type.
 	 * @throws IllegalArgumentException
-	 *             If {@code rawOuput} is {@code true} and the number of declared output attributes is not 1 or if
-	 *             {@code rawOuput} is {@code false} and the number of declared output attributes is not with range
+	 *             If {@code rawOutput} is {@code true} and the number of declared output attributes is not 1 or if
+	 *             {@code rawOutput} is {@code false} and the number of declared output attributes is not with range
 	 *             [0;25].
 	 */
 	public BoltWrapper(final IRichBolt bolt, final String name, final String inputStreamId,

--- a/flink-contrib/flink-storm/src/main/java/org/apache/flink/storm/wrappers/MergedInputsBoltWrapper.java
+++ b/flink-contrib/flink-storm/src/main/java/org/apache/flink/storm/wrappers/MergedInputsBoltWrapper.java
@@ -63,8 +63,8 @@ public final class MergedInputsBoltWrapper<IN, OUT> extends BoltWrapper<StormTup
 	 *            Contains stream names if a single attribute output stream, should not be of type {@link Tuple1} but be
 	 *            of a raw type.
 	 * @throws IllegalArgumentException
-	 *             If {@code rawOuput} is {@code true} and the number of declared output attributes is not 1 or if
-	 *             {@code rawOuput} is {@code false} and the number of declared output attributes is not within range
+	 *             If {@code rawOutput} is {@code true} and the number of declared output attributes is not 1 or if
+	 *             {@code rawOutput} is {@code false} and the number of declared output attributes is not within range
 	 *             [1;25].
 	 */
 	public MergedInputsBoltWrapper(final IRichBolt bolt, final String[] rawOutputs)
@@ -85,8 +85,8 @@ public final class MergedInputsBoltWrapper<IN, OUT> extends BoltWrapper<StormTup
 	 *            Contains stream names if a single attribute output stream, should not be of type {@link Tuple1} but be
 	 *            of a raw type.
 	 * @throws IllegalArgumentException
-	 *             If {@code rawOuput} is {@code true} and the number of declared output attributes is not 1 or if
-	 *             {@code rawOuput} is {@code false} and the number of declared output attributes is not with range
+	 *             If {@code rawOutput} is {@code true} and the number of declared output attributes is not 1 or if
+	 *             {@code rawOutput} is {@code false} and the number of declared output attributes is not with range
 	 *             [1;25].
 	 */
 	public MergedInputsBoltWrapper(final IRichBolt bolt, final Collection<String> rawOutputs)
@@ -109,8 +109,8 @@ public final class MergedInputsBoltWrapper<IN, OUT> extends BoltWrapper<StormTup
 	 *            Contains stream names if a single attribute output stream, should not be of type {@link Tuple1} but be
 	 *            of a raw type.
 	 * @throws IllegalArgumentException
-	 *             If {@code rawOuput} is {@code true} and the number of declared output attributes is not 1 or if
-	 *             {@code rawOuput} is {@code false} and the number of declared output attributes is not with range
+	 *             If {@code rawOutput} is {@code true} and the number of declared output attributes is not 1 or if
+	 *             {@code rawOutput} is {@code false} and the number of declared output attributes is not with range
 	 *             [0;25].
 	 */
 	public MergedInputsBoltWrapper(final IRichBolt bolt, final String name, final Collection<String> rawOutputs)

--- a/flink-contrib/flink-storm/src/main/java/org/apache/flink/storm/wrappers/SpoutWrapper.java
+++ b/flink-contrib/flink-storm/src/main/java/org/apache/flink/storm/wrappers/SpoutWrapper.java
@@ -115,8 +115,8 @@ public final class SpoutWrapper<OUT> extends RichParallelSourceFunction<OUT> imp
 	 *            Contains stream names if a single attribute output stream, should not be of type {@link Tuple1} but be
 	 *            of a raw type. (Can be {@code null}.)
 	 * @throws IllegalArgumentException
-	 *             If {@code rawOuput} is {@code true} and the number of declared output attributes is not 1 or if
-	 *             {@code rawOuput} is {@code false} and the number of declared output attributes is not with range
+	 *             If {@code rawOutput} is {@code true} and the number of declared output attributes is not 1 or if
+	 *             {@code rawOutput} is {@code false} and the number of declared output attributes is not with range
 	 *             [0;25].
 	 */
 	public SpoutWrapper(final IRichSpout spout, final String[] rawOutputs)
@@ -141,8 +141,8 @@ public final class SpoutWrapper<OUT> extends RichParallelSourceFunction<OUT> imp
 	 *            terminates if no tuple was emitted for the first time. If value is {@code null}, finite invocation is
 	 *            disabled.
 	 * @throws IllegalArgumentException
-	 *             If {@code rawOuput} is {@code true} and the number of declared output attributes is not 1 or if
-	 *             {@code rawOuput} is {@code false} and the number of declared output attributes is not with range
+	 *             If {@code rawOutput} is {@code true} and the number of declared output attributes is not 1 or if
+	 *             {@code rawOutput} is {@code false} and the number of declared output attributes is not with range
 	 *             [0;25].
 	 */
 	public SpoutWrapper(final IRichSpout spout, final String[] rawOutputs,
@@ -163,8 +163,8 @@ public final class SpoutWrapper<OUT> extends RichParallelSourceFunction<OUT> imp
 	 *            Contains stream names if a single attribute output stream, should not be of type {@link Tuple1} but be
 	 *            of a raw type. (Can be {@code null}.)
 	 * @throws IllegalArgumentException
-	 *             If {@code rawOuput} is {@code true} and the number of declared output attributes is not 1 or if
-	 *             {@code rawOuput} is {@code false} and the number of declared output attributes is not with range
+	 *             If {@code rawOutput} is {@code true} and the number of declared output attributes is not 1 or if
+	 *             {@code rawOutput} is {@code false} and the number of declared output attributes is not with range
 	 *             [0;25].
 	 */
 	public SpoutWrapper(final IRichSpout spout, final Collection<String> rawOutputs)
@@ -189,8 +189,8 @@ public final class SpoutWrapper<OUT> extends RichParallelSourceFunction<OUT> imp
 	 *            terminates if no tuple was emitted for the first time. If value is {@code null}, finite invocation is
 	 *            disabled.
 	 * @throws IllegalArgumentException
-	 *             If {@code rawOuput} is {@code true} and the number of declared output attributes is not 1 or if
-	 *             {@code rawOuput} is {@code false} and the number of declared output attributes is not with range
+	 *             If {@code rawOutput} is {@code true} and the number of declared output attributes is not 1 or if
+	 *             {@code rawOutput} is {@code false} and the number of declared output attributes is not with range
 	 *             [0;25].
 	 */
 	public SpoutWrapper(final IRichSpout spout, final Collection<String> rawOutputs,
@@ -217,8 +217,8 @@ public final class SpoutWrapper<OUT> extends RichParallelSourceFunction<OUT> imp
 	 *            terminates if no tuple was emitted for the first time. If value is {@code null}, finite invocation is
 	 *            disabled.
 	 * @throws IllegalArgumentException
-	 *             If {@code rawOuput} is {@code true} and the number of declared output attributes is not 1 or if
-	 *             {@code rawOuput} is {@code false} and the number of declared output attributes is not with range
+	 *             If {@code rawOutput} is {@code true} and the number of declared output attributes is not 1 or if
+	 *             {@code rawOutput} is {@code false} and the number of declared output attributes is not with range
 	 *             [0;25].
 	 */
 	public SpoutWrapper(final IRichSpout spout, final String name, final Collection<String> rawOutputs,

--- a/flink-contrib/flink-storm/src/main/java/org/apache/flink/storm/wrappers/WrapperSetupHelper.java
+++ b/flink-contrib/flink-storm/src/main/java/org/apache/flink/storm/wrappers/WrapperSetupHelper.java
@@ -62,8 +62,8 @@ class WrapperSetupHelper {
 	 *            {@link org.apache.flink.api.java.tuple.Tuple1 Tuple1} but be of a raw type. (Can be {@code null}.)
 	 * @return The number of attributes to be used for each stream.
 	 * @throws IllegalArgumentException
-	 *             If {@code rawOuput} is {@code true} and the number of declared output attributes is not 1 or if
-	 *             {@code rawOuput} is {@code false} and the number of declared output attributes is not with range
+	 *             If {@code rawOutput} is {@code true} and the number of declared output attributes is not 1 or if
+	 *             {@code rawOutput} is {@code false} and the number of declared output attributes is not with range
 	 *             [0;25].
 	 */
 	static HashMap<String, Integer> getNumberOfAttributes(final IComponent spoutOrBolt,

--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
@@ -205,7 +205,7 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 	}
 
 	/**
-	 * Sets the interval of the automatic watermark emission. Watermaks are used throughout
+	 * Sets the interval of the automatic watermark emission. Watermarks are used throughout
 	 * the streaming system to keep track of the progress of time. They are used, for example,
 	 * for time based windowing.
 	 *

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/DelimitedInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/DelimitedInputFormat.java
@@ -588,7 +588,7 @@ public abstract class DelimitedInputFormat<OT> extends FileInputFormat<OT> imple
 			int startPos = this.readPos - delimPos;
 			int count;
 
-			// Search for next occurence of delimiter in read buffer.
+			// Search for next occurrence of delimiter in read buffer.
 			while (this.readPos < this.limit && delimPos < this.delimiter.length) {
 				if ((this.readBuffer[this.readPos]) == this.delimiter[delimPos]) {
 					// Found the expected delimiter character. Continue looking for the next character of delimiter.

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/FileInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/FileInputFormat.java
@@ -256,7 +256,7 @@ public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputS
 		// paths) to compute the preview graph. The following is a workaround for
 		// this situation and we should fix this.
 
-		// comment (Stephan Ewen) this should be no longer relevant with the current Java/Scalal APIs.
+		// comment (Stephan Ewen) this should be no longer relevant with the current Java/Scala APIs.
 		if (filePath.isEmpty()) {
 			setFilePath(new Path());
 			return;

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/ListStateDescriptor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/ListStateDescriptor.java
@@ -31,7 +31,7 @@ import java.util.List;
  * is a list that can be appended and iterated over.
  * 
  * <p>Using {@code ListState} is typically more efficient than manually maintaining a list in a
- * {@link ValueState}, because the backing implementation can support efficient appends, rathern then
+ * {@link ValueState}, because the backing implementation can support efficient appends, rather than
  * replacing the full list on write.
  * 
  * <p>To create keyed list state (on a KeyedStream), use 

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/MapStateDescriptor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/MapStateDescriptor.java
@@ -54,7 +54,7 @@ public class MapStateDescriptor<UK, UV> extends StateDescriptor<MapState<UK, UV>
 	}
 
 	/**
-	 * Create a new {@code MapStateDescriptor} with the given name and the given type informations.
+	 * Create a new {@code MapStateDescriptor} with the given name and the given type information.
 	 *
 	 * @param name The name of the {@code MapStateDescriptor}.
 	 * @param keyTypeInfo The type information for the keys in the state.

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializerSerializationUtil.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializerSerializationUtil.java
@@ -76,7 +76,7 @@ public class TypeSerializerSerializationUtil {
 
 	/**
 	 * An {@link ObjectInputStream} that ignores serialVersionUID mismatches when deserializing objects of
-	 * anonymous classes or our Scala serializer classes and also replaces occurences of GenericData.Array
+	 * anonymous classes or our Scala serializer classes and also replaces occurrences of GenericData.Array
 	 * (from Avro) by a dummy class so that the KryoSerializer can still be deserialized without
 	 * Avro being on the classpath.
 	 *

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/CharComparator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/CharComparator.java
@@ -60,7 +60,7 @@ public final class CharComparator extends BasicTypeComparator<Character> {
 	@Override
 	public void putNormalizedKey(Character value, MemorySegment target, int offset, int numBytes) {
 		// note that the char is an unsigned data type in java and consequently needs
-		// no code that transforms the signed representation to an offsetted representation
+		// no code that transforms the signed representation to an offset representation
 		// that is equivalent to unsigned, when compared byte by byte
 		if (numBytes == 2) {
 			// default case, full normalized key

--- a/flink-core/src/main/java/org/apache/flink/api/java/functions/KeySelector.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/functions/KeySelector.java
@@ -25,7 +25,7 @@ import java.io.Serializable;
 
 /**
  * The {@link KeySelector} allows to use deterministic objects for operations such as
- * reduce, reduceGroup, join, coGoup, etc. If invoked multiple times on the same object,
+ * reduce, reduceGroup, join, coGroup, etc. If invoked multiple times on the same object,
  * the returned key must be the same.
  * 
  * The extractor takes an object and returns the deterministic key for that object.

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
@@ -481,7 +481,7 @@ public class TypeExtractor {
 				final int paramLen = exec.getParameterTypes().length;
 
 				final Method sam = TypeExtractionUtils.getSingleAbstractMethod(Partitioner.class);
-				// number of parameters the SAM of implemented interface has, the parameter indexing aplicates to this range
+				// number of parameters the SAM of implemented interface has; the parameter indexing applies to this range
 				final int baseParametersLen = sam.getParameterTypes().length;
 
 				final Type keyType = TypeExtractionUtils.extractTypeFromLambda(
@@ -581,7 +581,7 @@ public class TypeExtractor {
 
 				final Method sam = TypeExtractionUtils.getSingleAbstractMethod(baseClass);
 
-				// number of parameters the SAM of implemented interface has, the parameter indexing aplicates to this range
+				// number of parameters the SAM of implemented interface has; the parameter indexing applies to this range
 				final int baseParametersLen = sam.getParameterTypes().length;
 
 				// executable references "this" implicitly

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/KryoRegistrationSerializerConfigSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/KryoRegistrationSerializerConfigSnapshot.java
@@ -18,10 +18,6 @@
 
 package org.apache.flink.api.java.typeutils.runtime;
 
-import com.esotericsoftware.kryo.Kryo;
-import com.esotericsoftware.kryo.Serializer;
-import com.esotericsoftware.kryo.io.Input;
-import com.esotericsoftware.kryo.io.Output;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.GenericTypeSerializerConfigSnapshot;
@@ -31,6 +27,11 @@ import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.Preconditions;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -220,7 +221,7 @@ public abstract class KryoRegistrationSerializerConfigSnapshot<T> extends Generi
 	public static class DummyRegisteredClass implements Serializable {}
 
 	/**
-	 * Placeholder dummmy for a previously registered Kryo serializer that is no longer valid or in classpath on restore.
+	 * Placeholder dummy for a previously registered Kryo serializer that is no longer valid or in classpath on restore.
 	 */
 	public static class DummyKryoSerializerClass<RC> extends Serializer<RC> implements Serializable {
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoComparator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoComparator.java
@@ -86,7 +86,7 @@ public final class PojoComparator<T> extends CompositeTypeComparator<T> implemen
 					inverted = k.invertNormalizedKey();
 				}
 				else if (k.invertNormalizedKey() != inverted) {
-					// if a successor does not agree on the invertion direction, it cannot be part of the normalized key
+					// if a successor does not agree on the inversion direction, it cannot be part of the normalized key
 					break;
 				}
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializer.java
@@ -309,7 +309,7 @@ public class KryoSerializer<T> extends TypeSerializer<T> {
 	// --------------------------------------------------------------------------------------------
 
 	/**
-	 * Returns the Chill Kryo Serializer which is implictly added to the classpath via flink-runtime.
+	 * Returns the Chill Kryo Serializer which is implicitly added to the classpath via flink-runtime.
 	 * Falls back to the default Kryo serializer if it can't be found.
 	 * @return The Kryo serializer instance.
 	 */

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -484,7 +484,7 @@ public final class ConfigConstants {
 	public static final String YARN_TASK_MANAGER_ENV_PREFIX = "yarn.taskmanager.env.";
 
 	/**
-	 * Template for the YARN container start incovation.
+	 * Template for the YARN container start invocation.
 	 */
 	public static final String YARN_CONTAINER_START_COMMAND_TEMPLATE =
 		"yarn.container-start-command-template";
@@ -594,7 +594,7 @@ public final class ConfigConstants {
 	// ------------------------ Hadoop Configuration ------------------------
 
 	/**
-	 * Path to hdfs-defaul.xml file
+	 * Path to hdfs-default.xml file
 	 *
 	 * @deprecated Use environment variable HADOOP_CONF_DIR instead.
 	 */
@@ -980,7 +980,7 @@ public final class ConfigConstants {
 
 	// --------------------------- High Availability --------------------------
 
-	/** Defines high availabilty mode used for the cluster execution ("NONE", "ZOOKEEPER") */
+	/** Defines high availability mode used for the cluster execution ("NONE", "ZOOKEEPER") */
 	@PublicEvolving
 	public static final String HA_MODE = "high-availability";
 

--- a/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalDataInputStream.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalDataInputStream.java
@@ -75,7 +75,7 @@ public class LocalDataInputStream extends FSDataInputStream {
 
 	@Override
 	public void close() throws IOException {
-		// Accoring to javadoc, this also closes the channel
+		// According to javadoc, this also closes the channel
 		this.fis.close();
 	}
 

--- a/flink-core/src/main/java/org/apache/flink/types/CharValue.java
+++ b/flink-core/src/main/java/org/apache/flink/types/CharValue.java
@@ -124,7 +124,7 @@ public class CharValue implements NormalizableKey<CharValue>, ResettableValue<Ch
 	@Override
 	public void copyNormalizedKey(MemorySegment target, int offset, int len) {
 		// note that the char is an unsigned data type in java and consequently needs
-		// no code that transforms the signed representation to an offsetted representation
+		// no code that transforms the signed representation to an offset representation
 		// that is equivalent to unsigned, when compared byte by byte
 		if (len == 2) {
 			// default case, full normalized key

--- a/flink-core/src/main/java/org/apache/flink/types/IntValue.java
+++ b/flink-core/src/main/java/org/apache/flink/types/IntValue.java
@@ -123,7 +123,7 @@ public class IntValue implements NormalizableKey<IntValue>, ResettableValue<IntV
 
 	@Override
 	public void copyNormalizedKey(MemorySegment target, int offset, int len) {
-		// take out value and add the integer min value. This gets an offsetted
+		// take out value and add the integer min value. This gets an offset
 		// representation when interpreted as an unsigned integer (as is the case
 		// with normalized keys). write this value as big endian to ensure the
 		// most significant byte comes first.

--- a/flink-core/src/main/java/org/apache/flink/util/StringBasedID.java
+++ b/flink-core/src/main/java/org/apache/flink/util/StringBasedID.java
@@ -34,7 +34,7 @@ public class StringBasedID implements Serializable {
 	private final String keyString;
 
 	/**
-	 * Protected constructor to enfore that subclassing.
+	 * Protected constructor to enforce that subclassing.
 	 */
 	protected StringBasedID(String keyString) {
 		this.keyString = Preconditions.checkNotNull(keyString);

--- a/flink-core/src/test/java/org/apache/flink/configuration/MemorySizeTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/MemorySizeTest.java
@@ -161,7 +161,7 @@ public class MemorySizeTest {
 			fail("exception expected");
 		} catch (IllegalArgumentException ignored) {}
 
-		// brank
+		// blank
 		try {
 			MemorySize.parseBytes("     ");
 			fail("exception expected");
@@ -185,7 +185,7 @@ public class MemorySizeTest {
 			fail("exception expected");
 		} catch (IllegalArgumentException ignored) {}
 
-		// negavive number
+		// negative number
 		try {
 			MemorySize.parseBytes("-100 bytes");
 			fail("exception expected");

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/java/org/apache/hadoop/conf/Configuration.java
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/java/org/apache/hadoop/conf/Configuration.java
@@ -19,6 +19,43 @@
 package org.apache.hadoop.conf;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Charsets;
+import com.google.common.base.Preconditions;
+import org.apache.commons.collections.map.UnmodifiableMap;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.fs.CommonConfigurationKeys;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.io.WritableUtils;
+import org.apache.hadoop.net.NetUtils;
+import org.apache.hadoop.security.alias.CredentialProvider;
+import org.apache.hadoop.security.alias.CredentialProvider.CredentialEntry;
+import org.apache.hadoop.security.alias.CredentialProviderFactory;
+import org.apache.hadoop.util.ReflectionUtils;
+import org.apache.hadoop.util.StringInterner;
+import org.apache.hadoop.util.StringUtils;
+import org.codehaus.jackson.JsonFactory;
+import org.codehaus.jackson.JsonGenerator;
+import org.w3c.dom.DOMException;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.w3c.dom.Text;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
 
 import java.io.BufferedInputStream;
 import java.io.DataInput;
@@ -56,51 +93,12 @@ import java.util.StringTokenizer;
 import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
-
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.stream.StreamResult;
-
-import com.google.common.base.Charsets;
-import org.apache.commons.collections.map.UnmodifiableMap;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.apache.hadoop.classification.InterfaceAudience;
-import org.apache.hadoop.classification.InterfaceStability;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.CommonConfigurationKeys;
-import org.apache.hadoop.io.Writable;
-import org.apache.hadoop.io.WritableUtils;
-import org.apache.hadoop.net.NetUtils;
-import org.apache.hadoop.security.alias.CredentialProvider;
-import org.apache.hadoop.security.alias.CredentialProvider.CredentialEntry;
-import org.apache.hadoop.security.alias.CredentialProviderFactory;
-import org.apache.hadoop.util.ReflectionUtils;
-import org.apache.hadoop.util.StringInterner;
-import org.apache.hadoop.util.StringUtils;
-import org.codehaus.jackson.JsonFactory;
-import org.codehaus.jackson.JsonGenerator;
-import org.w3c.dom.DOMException;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-import org.w3c.dom.Text;
-import org.xml.sax.SAXException;
-
-import com.google.common.base.Preconditions;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 /** 
  * Provides access to configuration parameters.
@@ -1937,7 +1935,7 @@ public class Configuration implements Iterable<Map.Entry<String,String>>,
    * Get the value for a known password configuration element.
    * In order to enable the elimination of clear text passwords in config,
    * this method attempts to resolve the property name as an alias through
-   * the CredentialProvider API and conditionally fallsback to config.
+   * the CredentialProvider API and conditionally falls back to config.
    * @param name property name
    * @return password
    */

--- a/flink-java/src/test/java/org/apache/flink/api/java/io/CsvInputFormatTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/io/CsvInputFormatTest.java
@@ -808,7 +808,7 @@ public class CsvInputFormatTest {
 
 	}
 
-	// Test disabled becase we do not support double-quote escaped quotes right now.
+	// Test disabled because we do not support double-quote escaped quotes right now.
 	// @Test
 	public void testParserCorrectness() throws Exception {
 		// RFC 4180 Compliance Test content
@@ -875,13 +875,13 @@ public class CsvInputFormatTest {
 	@Test
 	public void testWindowsLineEndRemoval() {
 
-		//Check typical use case -- linux file is correct and it is set up to linuc(\n)
+		//Check typical use case -- linux file is correct and it is set up to linux (\n)
 		this.testRemovingTrailingCR("\n", "\n");
 
 		//Check typical windows case -- windows file endings and file has windows file endings set up
 		this.testRemovingTrailingCR("\r\n", "\r\n");
 
-		//Check problematic case windows file -- windows file endings(\r\n) but linux line endings (\n) set up
+		//Check problematic case windows file -- windows file endings (\r\n) but linux line endings (\n) set up
 		this.testRemovingTrailingCR("\r\n", "\n");
 
 		//Check problematic case linux file -- linux file endings (\n) but windows file endings set up (\r\n)

--- a/flink-java/src/test/java/org/apache/flink/api/java/operator/MaxByOperatorTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/operator/MaxByOperatorTest.java
@@ -69,7 +69,7 @@ public class MaxByOperatorTest {
 	private final List<CustomType> customTypeData = new ArrayList<CustomType>();
 
 	/**
-	 * This test validates that an InvalidProgrammException is thrown when maxBy
+	 * This test validates that an InvalidProgramException is thrown when maxBy
 	 * is used on a custom data type.
 	 */
 	@Test(expected = InvalidProgramException.class)
@@ -86,7 +86,7 @@ public class MaxByOperatorTest {
 
 	/**
 	 * This test validates that an index which is out of bounds throws an
-	 * IndexOutOfBOundsExcpetion.
+	 * IndexOutOfBoundsException.
 	 */
 	@Test(expected = IndexOutOfBoundsException.class)
 	public void testOutOfTupleBoundsDataset1() {
@@ -100,7 +100,7 @@ public class MaxByOperatorTest {
 
 	/**
 	 * This test validates that an index which is out of bounds throws an
-	 * IndexOutOfBOundsExcpetion.
+	 * IndexOutOfBoundsException.
 	 */
 	@Test(expected = IndexOutOfBoundsException.class)
 	public void testOutOfTupleBoundsDataset2() {
@@ -114,7 +114,7 @@ public class MaxByOperatorTest {
 
 	/**
 	 * This test validates that an index which is out of bounds throws an
-	 * IndexOutOfBOundsExcpetion.
+	 * IndexOutOfBoundsException.
 	 */
 	@Test(expected = IndexOutOfBoundsException.class)
 	public void testOutOfTupleBoundsDataset3() {
@@ -147,7 +147,7 @@ public class MaxByOperatorTest {
 	}
 
 	/**
-	 * This test validates that an InvalidProgrammException is thrown when maxBy
+	 * This test validates that an InvalidProgramException is thrown when maxBy
 	 * is used on a custom data type.
 	 */
 	@Test(expected = InvalidProgramException.class)
@@ -164,7 +164,7 @@ public class MaxByOperatorTest {
 
 	/**
 	 * This test validates that an index which is out of bounds throws an
-	 * IndexOutOfBOundsExcpetion.
+	 * IndexOutOfBoundsException.
 	 */
 	@Test(expected = IndexOutOfBoundsException.class)
 	public void testOutOfTupleBoundsGrouping1() {
@@ -178,7 +178,7 @@ public class MaxByOperatorTest {
 
 	/**
 	 * This test validates that an index which is out of bounds throws an
-	 * IndexOutOfBOundsExcpetion.
+	 * IndexOutOfBoundsException.
 	 */
 	@Test(expected = IndexOutOfBoundsException.class)
 	public void testOutOfTupleBoundsGrouping2() {
@@ -192,7 +192,7 @@ public class MaxByOperatorTest {
 
 	/**
 	 * This test validates that an index which is out of bounds throws an
-	 * IndexOutOfBOundsExcpetion.
+	 * IndexOutOfBoundsException.
 	 */
 	@Test(expected = IndexOutOfBoundsException.class)
 	public void testOutOfTupleBoundsGrouping3() {

--- a/flink-java/src/test/java/org/apache/flink/api/java/operator/MinByOperatorTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/operator/MinByOperatorTest.java
@@ -69,7 +69,7 @@ public class MinByOperatorTest {
 	private final List<CustomType> customTypeData = new ArrayList<CustomType>();
 
 	/**
-	 * This test validates that an InvalidProgrammException is thrown when minBy
+	 * This test validates that an InvalidProgramException is thrown when minBy
 	 * is used on a custom data type.
 	 */
 	@Test(expected = InvalidProgramException.class)
@@ -86,7 +86,7 @@ public class MinByOperatorTest {
 
 	/**
 	 * This test validates that an index which is out of bounds throws an
-	 * IndexOutOfBOundsExcpetion.
+	 * IndexOutOfBoundsException.
 	 */
 	@Test(expected = IndexOutOfBoundsException.class)
 	public void testOutOfTupleBoundsDataset1() {
@@ -100,7 +100,7 @@ public class MinByOperatorTest {
 
 	/**
 	 * This test validates that an index which is out of bounds throws an
-	 * IndexOutOfBOundsExcpetion.
+	 * IndexOutOfBoundsException.
 	 */
 	@Test(expected = IndexOutOfBoundsException.class)
 	public void testOutOfTupleBoundsDataset2() {
@@ -114,7 +114,7 @@ public class MinByOperatorTest {
 
 	/**
 	 * This test validates that an index which is out of bounds throws an
-	 * IndexOutOfBOundsExcpetion.
+	 * IndexOutOfBoundsException.
 	 */
 	@Test(expected = IndexOutOfBoundsException.class)
 	public void testOutOfTupleBoundsDataset3() {
@@ -147,7 +147,7 @@ public class MinByOperatorTest {
 	}
 
 	/**
-	 * This test validates that an InvalidProgrammException is thrown when minBy
+	 * This test validates that an InvalidProgramException is thrown when minBy
 	 * is used on a custom data type.
 	 */
 	@Test(expected = InvalidProgramException.class)
@@ -164,7 +164,7 @@ public class MinByOperatorTest {
 
 	/**
 	 * This test validates that an index which is out of bounds throws an
-	 * IndexOutOfBOundsExcpetion.
+	 * IndexOutOfBoundsException.
 	 */
 	@Test(expected = IndexOutOfBoundsException.class)
 	public void testOutOfTupleBoundsGrouping1() {
@@ -178,7 +178,7 @@ public class MinByOperatorTest {
 
 	/**
 	 * This test validates that an index which is out of bounds throws an
-	 * IndexOutOfBOundsExcpetion.
+	 * IndexOutOfBoundsException.
 	 */
 	@Test(expected = IndexOutOfBoundsException.class)
 	public void testOutOfTupleBoundsGrouping2() {
@@ -192,7 +192,7 @@ public class MinByOperatorTest {
 
 	/**
 	 * This test validates that an index which is out of bounds throws an
-	 * IndexOutOfBOundsExcpetion.
+	 * IndexOutOfBoundsException.
 	 */
 	@Test(expected = IndexOutOfBoundsException.class)
 	public void testOutOfTupleBoundsGrouping3() {

--- a/flink-java8/src/main/java/org/apache/flink/examples/java8/wordcount/WordCount.java
+++ b/flink-java8/src/main/java/org/apache/flink/examples/java8/wordcount/WordCount.java
@@ -62,7 +62,7 @@ public class WordCount {
 		DataSet<Tuple2<String, Integer>> counts =
 				// normalize and split each line
 				text.map(line -> line.toLowerCase().split("\\W+"))
-				// convert splitted line in pairs (2-tuples) containing: (word,1)
+				// convert split line in pairs (2-tuples) containing: (word,1)
 				.flatMap((String[] tokens, Collector<Tuple2<String, Integer>> out) -> {
 					// emit the pairs with non-zero-length words
 					Arrays.stream(tokens)

--- a/flink-java8/src/main/java/org/apache/flink/streaming/examples/java8/wordcount/WordCount.java
+++ b/flink-java8/src/main/java/org/apache/flink/streaming/examples/java8/wordcount/WordCount.java
@@ -62,7 +62,7 @@ public class WordCount {
 		DataStream<Tuple2<String, Integer>> counts =
 				// normalize and split each line
 				text.map(line -> line.toLowerCase().split("\\W+"))
-				// convert splitted line in pairs (2-tuples) containing: (word,1)
+				// convert split line in pairs (2-tuples) containing: (word,1)
 				.flatMap((String[] tokens, Collector<Tuple2<String, Integer>> out) -> {
 					// emit the pairs with non-zero-length words
 					Arrays.stream(tokens)

--- a/flink-java8/src/test/java/org/apache/flink/test/api/java/operators/lambdas/FilterITCase.java
+++ b/flink-java8/src/test/java/org/apache/flink/test/api/java/operators/lambdas/FilterITCase.java
@@ -28,7 +28,7 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * IT cases for lambda filter funtions.
+ * IT cases for lambda filter functions.
  */
 public class FilterITCase extends JavaProgramTestBase {
 

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/NFATest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/NFATest.java
@@ -133,7 +133,7 @@ public class NFATest extends TestLogger {
 
 	/**
 	 * Tests that elements whose timestamp difference is exactly the window length are not matched.
-	 * The reaon is that the right window side (later elements) is exclusive.
+	 * The reason is that the right window side (later elements) is exclusive.
 	 */
 	@Test
 	public void testWindowBorders() {

--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/random/RandomGenerableFactory.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/generator/random/RandomGenerableFactory.java
@@ -46,7 +46,7 @@ import java.util.List;
 public interface RandomGenerableFactory<T extends RandomGenerator> {
 
 	/**
-	 * The amount of work ({@code elementCount * cyclerPerElement}) is used to
+	 * The amount of work ({@code elementCount * cyclesPerElement}) is used to
 	 * generate a list of blocks of work of near-equal size.
 	 *
 	 * @param elementCount number of elements, as indexed in the {@code BlockInfo}

--- a/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/classification/SVM.scala
+++ b/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/classification/SVM.scala
@@ -35,7 +35,7 @@ import breeze.linalg.{DenseVector => BreezeDenseVector, Vector => BreezeVector}
 /** Implements a soft-margin SVM using the communication-efficient distributed dual coordinate
   * ascent algorithm (CoCoA) with hinge-loss function.
   *
-  * It can be used for binary classification problems, with the labels set as +1.0 to indiciate a
+  * It can be used for binary classification problems, with the labels set as +1.0 to indicate a
   * positive example and -1.0 to indicate a negative example.
   *
   * The algorithm solves the following minimization problem:

--- a/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/outlier/StochasticOutlierSelection.scala
+++ b/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/outlier/StochasticOutlierSelection.scala
@@ -154,7 +154,7 @@ object StochasticOutlierSelection extends WithParameters {
     new TransformDataSetOperation[StochasticOutlierSelection, LabeledVector, (Int, Double)] {
 
 
-      /** Overrides the method of the parent class and applies the sochastic outlier selection
+      /** Overrides the method of the parent class and applies the stochastic outlier selection
         * algorithm.
         *
         * @param instance Instance of the class
@@ -181,7 +181,7 @@ object StochasticOutlierSelection extends WithParameters {
   }
 
   /** [[TransformDataSetOperation]] applies the stochastic outlier selection algorithm on a
-    * [[Vector]] which will transform the high-dimensionaly input to a single Double output.
+    * [[Vector]] which will transform the high-dimensional input to a single Double output.
     *
     * @tparam T Type of the input and output data which has to be a subtype of [[Vector]]
     * @return [[TransformDataSetOperation]] a single double which represents the oulierness of

--- a/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/pipeline/Estimator.scala
+++ b/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/pipeline/Estimator.scala
@@ -117,7 +117,7 @@ object Estimator{
   }
 
   /** Fallback [[TransformDataSetOperation]] for [[Transformer]] which do not support the input or
-    * output type with which they are called. This is usualy the case if pipeline operators are
+    * output type with which they are called. This is usually the case if pipeline operators are
     * chained which have incompatible input/output types. In order to detect these failures, the
     * fallback [[TransformDataSetOperation]] throws a [[RuntimeException]] with the corresponding
     * input/output types. Consequently, a wrong pipeline will be detected at pre-flight phase of

--- a/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/pipeline/Predictor.scala
+++ b/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/pipeline/Predictor.scala
@@ -230,7 +230,7 @@ trait PredictOperation[Instance, Model, Testing, Prediction] extends Serializabl
   /** Calculates the prediction for a single element given the model of the [[Predictor]].
     *
     * @param value The unlabeled example on which we make the prediction
-    * @param model The model representation of the prediciton algorithm
+    * @param model The model representation of the prediction algorithm
     * @return A label for the provided example of type [[Prediction]]
     */
   def predict(value: Testing, model: Model):

--- a/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/pipeline/Transformer.scala
+++ b/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/pipeline/Transformer.scala
@@ -48,7 +48,7 @@ trait Transformer[Self <: Transformer[Self]]
   with Serializable {
   that: Self =>
 
-  /** Transform operation which transforms an input [[DataSet]] of type I into an ouptut [[DataSet]]
+  /** Transform operation which transforms an input [[DataSet]] of type I into an output [[DataSet]]
     * of type O. The actual transform operation is implemented within the
     * [[TransformDataSetOperation]].
     *
@@ -57,7 +57,7 @@ trait Transformer[Self <: Transformer[Self]]
     * @param transformOperation [[TransformDataSetOperation]] which encapsulates the algorithm's
     *                          logic
     * @tparam Input Input data type
-    * @tparam Output Ouptut data type
+    * @tparam Output Output data type
     * @return
     */
   def transform[Input, Output](
@@ -125,7 +125,7 @@ object Transformer{
   * @tparam Instance Type of the [[Transformer]] for which the [[TransformDataSetOperation]] is
   *                  defined
   * @tparam Input Input data type
-  * @tparam Output Ouptut data type
+  * @tparam Output Output data type
   */
 trait TransformDataSetOperation[Instance, Input, Output] extends Serializable{
   def transformDataSet(
@@ -148,10 +148,10 @@ trait TransformOperation[Instance, Model, Input, Output] extends Serializable{
   /** Retrieves the model of the [[Transformer]] for which this operation has been defined.
     *
     * @param instance
-    * @param transformParemters
+    * @param transformParameters
     * @return
     */
-  def getModel(instance: Instance, transformParemters: ParameterMap): DataSet[Model]
+  def getModel(instance: Instance, transformParameters: ParameterMap): DataSet[Model]
 
   /** Transforms a single element with respect to the model associated with the respective
     * [[Transformer]]

--- a/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/preprocessing/Splitter.scala
+++ b/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/preprocessing/Splitter.scala
@@ -140,7 +140,7 @@ object Splitter {
    * @param kFolds          The number of TrainTest DataSets to be returns. Each 'testing' will be
    *                        1/k of the dataset, randomly sampled, the training will be the remainder
    *                        of the dataset.  The DataSet is split into kFolds first, so that no
-   *                        observation will occurin in multiple folds.
+   *                        observation will occuring in multiple folds.
    * @param seed            Random number generator seed.
    * @return An array of TrainTestDataSets
    */

--- a/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/recommendation/ALS.scala
+++ b/flink-libraries/flink-ml/src/main/scala/org/apache/flink/ml/recommendation/ALS.scala
@@ -40,7 +40,7 @@ import scala.util.Random
 
 /** Alternating least squares algorithm to calculate a matrix factorization.
   *
-  * Given a matrix `R`, ALS calculates two matricess `U` and `V` such that `R ~~ U^TV`. The
+  * Given a matrix `R`, ALS calculates two matrices `U` and `V` such that `R ~~ U^TV`. The
   * unknown row dimension is given by the number of latent factors. Since matrix factorization
   * is often used in the context of recommendation, we'll call the first matrix the user and the
   * second matrix the item matrix. The `i`th column of the user matrix is `u_i` and the `i`th

--- a/flink-libraries/flink-table/src/main/resources/tableSourceConverter.properties
+++ b/flink-libraries/flink-table/src/main/resources/tableSourceConverter.properties
@@ -18,9 +18,9 @@
 
 ################################################################################
 # The config file is used to specify the packages of current module where
-# to find TableSourceConverter implementation class annotationed with TableType.
+# to find TableSourceConverter implementation class annotated with TableType.
 # If there are multiple packages to scan, put those packages together into a
-# string seperated with ',', for example, org.package1,org.package2.
+# string separated with ',', for example, org.package1,org.package2.
 # Please notice:
 # It's better to have a tableSourceConverter.properties in each connector Module
 # which offers converters instead of put all information into the

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/TableEnvironment.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/TableEnvironment.scala
@@ -301,7 +301,7 @@ abstract class TableEnvironment(val config: TableConfig) {
       throw new ExternalCatalogAlreadyExistException(name)
     }
     this.externalCatalogs.put(name, externalCatalog)
-    // create an external catalog calicte schema, register it on the root schema
+    // create an external catalog Calcite schema, register it on the root schema
     ExternalCatalogSchema.registerCatalog(rootSchema, name, externalCatalog)
   }
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/TableSchema.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/TableSchema.scala
@@ -40,9 +40,9 @@ class TableSchema(
   // check uniqueness of field names
   if (columnNames.toSet.size != columnTypes.length) {
     val duplicateFields = columnNames
-      // count occurences of field names
+      // count occurrences of field names
       .groupBy(identity).mapValues(_.length)
-      // filter for occurences > 1 and map to field name
+      // filter for occurrences > 1 and map to field name
       .filter(g => g._2 > 1).keys
 
     throw new TableException(

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/calcite/FlinkTypeSystem.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/calcite/FlinkTypeSystem.scala
@@ -26,11 +26,11 @@ import org.apache.calcite.sql.`type`.SqlTypeName
   */
 class FlinkTypeSystem extends RelDataTypeSystemImpl {
 
-  // we cannot use Int.MaxValue because of an overflow in Calcites type inference logic
+  // we cannot use Int.MaxValue because of an overflow in Calcite's type inference logic
   // half should be enough for all use cases
   override def getMaxNumericScale: Int = Int.MaxValue / 2
 
-  // we cannot use Int.MaxValue because of an overflow in Calcites type inference logic
+  // we cannot use Int.MaxValue because of an overflow in Calcite's type inference logic
   // half should be enough for all use cases
   override def getMaxNumericPrecision: Int = Int.MaxValue / 2
 
@@ -40,7 +40,7 @@ class FlinkTypeSystem extends RelDataTypeSystemImpl {
     case SqlTypeName.VARCHAR =>
       Int.MaxValue
 
-    // we currenty support only timestamps with milliseconds precision
+    // we currently support only timestamps with milliseconds precision
     case SqlTypeName.TIMESTAMP =>
       3
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
@@ -244,7 +244,7 @@ abstract class CodeGenerator(
     * @param returnType conversion target type. Inputs and output must have the same arity.
     * @param resultFieldNames result field names necessary for a mapping to POJO fields.
     * @param rowtimeExpression an expression to extract the value of a rowtime field from
-    *                          the input data. Required if the field indicies include a rowtime
+    *                          the input data. Required if the field indices include a rowtime
     *                          marker.
     * @return instance of GeneratedExpression
     */

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/ScalarFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/ScalarFunction.scala
@@ -61,7 +61,7 @@ abstract class ScalarFunction extends UserDefinedFunction {
   /**
     * Returns the result type of the evaluation method with a given signature.
     *
-    * This method needs to be overriden in case Flink's type extraction facilities are not
+    * This method needs to be overridden in case Flink's type extraction facilities are not
     * sufficient to extract the [[TypeInformation]] based on the return type of the evaluation
     * method. Flink's type extraction facilities can handle basic types or
     * simple POJOs but might be wrong for more complex, custom, or composite types.

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/TableFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/TableFunction.scala
@@ -111,7 +111,7 @@ abstract class TableFunction[T] extends UserDefinedFunction {
   /**
     * Returns the result type of the evaluation method with a given signature.
     *
-    * This method needs to be overriden in case Flink's type extraction facilities are not
+    * This method needs to be overridden in case Flink's type extraction facilities are not
     * sufficient to extract the [[TypeInformation]] based on the return type of the evaluation
     * method. Flink's type extraction facilities can handle basic types or
     * simple POJOs but might be wrong for more complex, custom, or composite types.

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/utils/AggSqlFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/utils/AggSqlFunction.scala
@@ -58,7 +58,7 @@ class AggSqlFunction(
     createReturnTypeInference(returnType, typeFactory),
     createOperandTypeInference(aggregateFunction, typeFactory),
     createOperandTypeChecker(aggregateFunction),
-    // Do not need to provide a calcite aggregateFunction here. Flink aggregateion function
+    // Do not need to provide a calcite aggregateFunction here. Flink aggregation function
     // will be generated when translating the calcite relnode to flink runtime execution plan
     null,
     false,

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/utils/UserDefinedFunctionUtils.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/utils/UserDefinedFunctionUtils.scala
@@ -632,7 +632,7 @@ object UserDefinedFunctionUtils {
   /**
     * Creates a [[LogicalTableFunctionCall]] by parsing a String expression.
     *
-    * @param tableEnv The table environmenent to lookup the function.
+    * @param tableEnv The table environment to lookup the function.
     * @param udtf a String expression of a TableFunctionCall, such as "split(c)"
     * @return A LogicalTableFunctionCall.
     */

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/CommonCorrelate.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/CommonCorrelate.scala
@@ -143,7 +143,7 @@ trait CommonCorrelate {
          |""".stripMargin
     } else {
 
-      // adjust indicies of InputRefs to adhere to schema expected by generator
+      // adjust indices of InputRefs to adhere to schema expected by generator
       val changeInputRefIndexShuttle = new RexShuttle {
         override def visitInputRef(inputRef: RexInputRef): RexNode = {
           new RexInputRef(inputSchema.arity + inputRef.getIndex, inputRef.getType)

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/dataset/DataSetJoin.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/dataset/DataSetJoin.scala
@@ -441,11 +441,11 @@ class DataSetJoin(
       s"join: (${joinSelectionToString(joinRowType)})"
   }
 
-  /** Returns an array of indicies with some indicies being a prefix. */
+  /** Returns an array of indices with some indices being a prefix. */
   private def getFullIndiciesWithPrefix(keys: Array[Int], numFields: Int): Array[Int] = {
-    // get indicies of all fields which are not keys
+    // get indices of all fields which are not keys
     val nonKeys = (0 until numFields).filter(!keys.contains(_))
-    // return all field indicies prefixed by keys
+    // return all field indices prefixed by keys
     keys ++ nonKeys
   }
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/retractionTraits.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/retractionTraits.scala
@@ -98,13 +98,14 @@ object AccMode extends Enumeration {
     * Changes are encoded as follows:
     * - insert: (true, NewRow)
     * - update: (true, NewRow) // the Row includes the full unique key to identify the row to update
-    * - delete: (false, OldRow) // the Row includes the full unique key to idenify the row to delete
+    * - delete: (false, OldRow) // the Row includes the full unique key to identify the row to
+    * delete
     *
     */
   val Acc = Value
 
   /**
-    * * An operator in [[AccRetract]] mode emits change messages as
+    * An operator in [[AccRetract]] mode emits change messages as
     * [[org.apache.flink.table.runtime.types.CRow]] which encode a pair of (Boolean, Row).
     *
     * Changes are encoded as follows:

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/schema/InlineTable.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/schema/InlineTable.scala
@@ -46,9 +46,9 @@ abstract class InlineTable[T](
   // check uniqueness of field names
   if (fieldNames.length != fieldNames.toSet.size) {
     val duplicateFields = fieldNames
-      // count occurences of field names
+      // count occurrences of field names
       .groupBy(identity).mapValues(_.length)
-      // filter for occurences > 1 and map to field name
+      // filter for occurrences > 1 and map to field name
       .filter(g => g._2 > 1).keys
 
     throw new TableException(

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/IncrementalAggregateTimeWindowFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/IncrementalAggregateTimeWindowFunction.scala
@@ -27,7 +27,7 @@ import org.apache.flink.table.runtime.types.CRow
 import org.apache.flink.util.Collector
 
 /**
-  * Computes the final aggregate value from incrementally computed aggreagtes.
+  * Computes the final aggregate value from incrementally computed aggregates.
   *
   * @param numGroupingKey the number of grouping keys
   * @param numAggregates the number of aggregates

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/IncrementalAggregateWindowFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/IncrementalAggregateWindowFunction.scala
@@ -27,7 +27,7 @@ import org.apache.flink.types.Row
 import org.apache.flink.util.Collector
 
 /**
-  * Computes the final aggregate value from incrementally computed aggreagtes.
+  * Computes the final aggregate value from incrementally computed aggregates.
   *
   * @param numGroupingKey The number of grouping keys.
   * @param numAggregates The number of aggregates.

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/RowTimeSortProcessFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/RowTimeSortProcessFunction.scala
@@ -30,7 +30,7 @@ import org.apache.flink.types.Row
 import org.apache.flink.util.{Collector, Preconditions}
 
 /**
- * ProcessFunction to sort on event-time and possibly addtional secondary sort attributes.
+ * ProcessFunction to sort on event-time and possibly additional secondary sort attributes.
  *
   * @param inputRowType The data type of the input data.
   * @param rowtimeIdx The index of the rowtime field.

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/RowTimeUnboundedOver.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/RowTimeUnboundedOver.scala
@@ -192,7 +192,7 @@ abstract class RowTimeUnboundedOver(
         val curTimestamp = sortedTimestamps.removeFirst()
         val curRowList = rowMapState.get(curTimestamp)
 
-        // process the same timestamp datas, the mechanism is different according ROWS or RANGE
+        // process the same timestamp data, the mechanism is different according ROWS or RANGE
         processElementsWithSameTimestamp(curRowList, lastAccumulator, out)
 
         rowMapState.remove(curTimestamp)
@@ -234,7 +234,7 @@ abstract class RowTimeUnboundedOver(
   }
 
   /**
-   * Process the same timestamp datas, the mechanism is different between
+   * Process the same timestamp data, the mechanism is different between
    * rows and range window.
    */
   def processElementsWithSameTimestamp(

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/join/WindowJoinUtil.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/join/WindowJoinUtil.scala
@@ -420,7 +420,7 @@ object WindowJoinUtil {
     * Generates a JoinFunction that applies additional join predicates and projects the result.
     *
     * @param  config          table env config
-    * @param  joinType        join type to determain whether input can be null
+    * @param  joinType        join type to determine whether input can be null
     * @param  leftType        left stream type
     * @param  rightType       right stream type
     * @param  returnType      return type

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sources/CsvTableSource.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sources/CsvTableSource.scala
@@ -153,7 +153,7 @@ class CsvTableSource private (
   override def projectFields(fields: Array[Int]): CsvTableSource = {
 
     val selectedFields = if (fields.isEmpty) Array(0) else fields
-//    val selectedFiels = fields
+//    val selectedFields = fields
 
     new CsvTableSource(
       path,

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sources/TableSourceUtil.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sources/TableSourceUtil.scala
@@ -243,7 +243,7 @@ object TableSourceUtil {
     * Returns the Calcite schema of a [[TableSource]].
     *
     * @param tableSource The [[TableSource]] for which the Calcite schema is generated.
-    * @param selectedFields The indicies of all selected fields. None, if all fields are selected.
+    * @param selectedFields The indices of all selected fields. None, if all fields are selected.
     * @param streaming Flag to determine whether the schema of a stream or batch table is created.
     * @param typeFactory The type factory to create the schema.
     * @return The Calcite schema for the selected fields of the given [[TableSource]].

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/RowTypeTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/RowTypeTest.scala
@@ -49,7 +49,7 @@ class RowTypeTest extends RowTypeTestBase {
         "Map('foo', 'bar'), row(1, true))",
       "ROW(DATE '1985-04-11', CAST(0.1 AS DECIMAL), ARRAY[1, 2, 3], " +
         "MAP['foo', 'bar'], row(1, true))",
-      "1985-04-11,0.1,[1, 2, 3],{foo=bar},1,true") // string faltten
+      "1985-04-11,0.1,[1, 2, 3],{foo=bar},1,true") // string flatten
 
     testAllApis(
       row(1 + 1, 2 * 3, Null(Types.STRING)),

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarOperatorsTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarOperatorsTest.scala
@@ -76,7 +76,7 @@ class ScalarOperatorsTest extends ScalarOperatorsTestBase {
 
   @Test
   def testArithmetic(): Unit = {
-    // math arthmetic
+    // math arithmetic
     testTableApi('f8 - 5, "f8 - 5", "0")
     testTableApi('f8 + 5, "f8 + 5", "10")
     testTableApi('f8 / 2, "f8 / 2", "2")

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosEntrypointUtils.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosEntrypointUtils.java
@@ -42,7 +42,7 @@ import scala.concurrent.duration.Duration;
 import scala.concurrent.duration.FiniteDuration;
 
 /**
- * Utils for Mesos entrpoints.
+ * Utils for Mesos entry points.
  */
 public class MesosEntrypointUtils {
 

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/services/AbstractMesosServices.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/services/AbstractMesosServices.java
@@ -27,7 +27,7 @@ import akka.actor.ActorSystem;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
- * An abrstact implementation of {@link MesosServices}.
+ * An abstract implementation of {@link MesosServices}.
  */
 public abstract class AbstractMesosServices implements MesosServices {
 

--- a/flink-metrics/flink-metrics-jmx/src/main/java/org/apache/flink/metrics/jmx/JMXReporter.java
+++ b/flink-metrics/flink-metrics-jmx/src/main/java/org/apache/flink/metrics/jmx/JMXReporter.java
@@ -85,7 +85,7 @@ public class JMXReporter implements MetricReporter {
 	/** The names under which the registered metrics have been added to the MBeanServer. */
 	private final Map<Metric, ObjectName> registeredMetrics;
 
-	/** The server to which JMX clients connect to. ALlows for better control over port usage. */
+	/** The server to which JMX clients connect to. Allows for better control over port usage. */
 	private JMXServer jmxServer;
 
 	public JMXReporter() {

--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/traversals/PlanFinalizer.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/traversals/PlanFinalizer.java
@@ -209,7 +209,7 @@ public class PlanFinalizer implements Visitor<PlanNode> {
 			}
 		}
 
-		// pass the visitor to the iteraton's step function
+		// pass the visitor to the iteration's step function
 		if (visitable instanceof IterationPlanNode) {
 			// push the iteration node onto the stack
 			final IterationPlanNode iterNode = (IterationPlanNode) visitable;

--- a/flink-optimizer/src/test/java/org/apache/flink/optimizer/UnionPropertyPropagationTest.java
+++ b/flink-optimizer/src/test/java/org/apache/flink/optimizer/UnionPropertyPropagationTest.java
@@ -136,7 +136,7 @@ public class UnionPropertyPropagationTest extends CompilerTestBase {
 				}
 				
 				/* Test on the union input connections
-				 * Must be NUM_INPUTS input connections, all FlatMapOperators with a own partitioning strategy(propably hash)
+				 * Must be NUM_INPUTS input connections, all FlatMapOperators with a own partitioning strategy (probably hash)
 				 */
 				if (visitable instanceof NAryUnionPlanNode) {
 					int numberInputs = 0;

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/RedirectHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/RedirectHandlerTest.java
@@ -59,7 +59,7 @@ public class RedirectHandlerTest extends TestLogger {
 	 * Tests the behaviour of the RedirectHandler under the following conditions.
 	 *
 	 * <p>1. No local address known --> service unavailable
-	 * 2. Local address knwon but no gateway resolved --> service unavailable
+	 * 2. Local address known but no gateway resolved --> service unavailable
 	 * 3. Remote leader gateway --> redirection
 	 * 4. Local leader gateway
 	 * @throws Exception

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/history/HistoryServerStaticFileServerHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/history/HistoryServerStaticFileServerHandlerTest.java
@@ -55,7 +55,7 @@ public class HistoryServerStaticFileServerHandlerTest {
 
 		int port = webUI.getServerPort();
 		try {
-			// verify that 404 message is returned when requesting a non-existant file
+			// verify that 404 message is returned when requesting a non-existent file
 			String notFound404 = HistoryServerTest.getFromHTTP("http://localhost:" + port + "/hello");
 			Assert.assertTrue(notFound404.contains("404 Not Found"));
 

--- a/flink-runtime-web/web-dashboard/vendor-local/d3-timeline.js
+++ b/flink-runtime-web/web-dashboard/vendor-local/d3-timeline.js
@@ -69,7 +69,7 @@
         .attr("clip-path", "url(#" + prefix + "-gclip" + ")")
 
       // check if the user wants relative time
-      // if so, substract the first timestamp from each subsequent timestamps
+      // if so, subtract the first timestamp from each subsequent timestamps
       if(timeIsRelative){
         g.each(function (d, i) {
           d.forEach(function (datum, index) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/akka/FlinkUntypedActor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/akka/FlinkUntypedActor.java
@@ -49,7 +49,7 @@ public abstract class FlinkUntypedActor extends UntypedActor {
 	 * processing time of the incoming message if the logging level is set to debug. After logging
 	 * the handleLeaderSessionID method is called.
 	 *
-	 * <p>Important: This method cannot be overriden. The actor specific message handling logic is
+	 * <p>Important: This method cannot be overridden. The actor specific message handling logic is
 	 * implemented by the method handleMessage.
 	 *
 	 * @param message Incoming message
@@ -124,7 +124,7 @@ public abstract class FlinkUntypedActor extends UntypedActor {
 	protected abstract void handleMessage(Object message) throws Exception;
 
 	/**
-	 * Returns the current leader session ID associcated with this actor.
+	 * Returns the current leader session ID associated with this actor.
 	 * @return
 	 */
 	protected abstract UUID getLeaderSessionID();
@@ -134,10 +134,10 @@ public abstract class FlinkUntypedActor extends UntypedActor {
 	 * a leader session ID (indicated by {@link RequiresLeaderSessionID}) in a
 	 * {@link LeaderSessionMessage} with the actor's leader session ID.
 	 *
-	 * <p>This method can be overriden to implement a different decoration behavior.
+	 * <p>This method can be overridden to implement a different decoration behavior.
 	 *
 	 * @param message Message to be decorated
-	 * @return The deocrated message
+	 * @return The decorated message
 	 */
 	protected Object decorateMessage(Object message) {
 		if (message instanceof RequiresLeaderSessionID) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/PermanentBlobCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/PermanentBlobCache.java
@@ -261,7 +261,7 @@ public class PermanentBlobCache extends AbstractBlobCache implements PermanentBl
 
 					/*
 					 * NOTE: normally it is not required to acquire the write lock to delete the job's
-					 *       storage directory since there should be noone accessing it with the ref
+					 *       storage directory since there should be no one accessing it with the ref
 					 *       counter being 0 - acquire it just in case, to always be on the safe side
 					 */
 						readWriteLock.writeLock().lock();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -946,7 +946,7 @@ public class CheckpointCoordinator {
 	 * Fails all pending checkpoints which have not been acknowledged by the given execution
 	 * attempt id.
 	 *
-	 * @param executionAttemptId for which to discard unaknowledged pending checkpoints
+	 * @param executionAttemptId for which to discard unacknowledged pending checkpoints
 	 * @param cause of the failure
 	 */
 	public void failUnacknowledgedPendingCheckpointsFor(ExecutionAttemptID executionAttemptId, Throwable cause) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpointStats.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpointStats.java
@@ -56,7 +56,7 @@ public class PendingCheckpointStats extends AbstractCheckpointStats {
 	/** Current buffered bytes during alignment over all collected subtasks. */
 	private volatile long currentAlignmentBuffered;
 
-	/** Stats of the latest acknowleged subtask. */
+	/** Stats of the latest acknowledged subtask. */
 	private volatile SubtaskStateStats latestAcknowledgedSubtask;
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobListeningContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobListeningContext.java
@@ -114,7 +114,7 @@ public final class JobListeningContext {
 	}
 
 	/**
-	 * @return The Job Client actor which communicats with the JobManager.
+	 * @return The Job Client actor which communicates with the JobManager.
 	 */
 	public ActorRef getJobClientActor() {
 		return jobClientActor;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/BootstrapTools.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/BootstrapTools.java
@@ -353,7 +353,7 @@ public class BootstrapTools {
 	/**
 	 * Generates the shell command to start a task manager.
 	 * @param flinkConfig The Flink configuration.
-	 * @param tmParams Paramaters for the task manager.
+	 * @param tmParams Parameters for the task manager.
 	 * @param configDirectory The configuration directory for the flink-conf.yaml
 	 * @param logDirectory The log directory.
 	 * @param hasLogback Uses logback?

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/FlinkResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/FlinkResourceManager.java
@@ -738,7 +738,7 @@ public abstract class FlinkResourceManager<WorkerType extends ResourceIDRetrieva
 	 * Starts the resource manager actors.
 	 * @param configuration The configuration for the resource manager
 	 * @param actorSystem The actor system to start the resource manager in
-	 * @param leaderRetriever The leader retriever service to intialize the resource manager
+	 * @param leaderRetriever The leader retriever service to initialize the resource manager
 	 * @param resourceManagerClass The class of the ResourceManager to be started
 	 * @return ActorRef of the resource manager
 	 */
@@ -757,7 +757,7 @@ public abstract class FlinkResourceManager<WorkerType extends ResourceIDRetrieva
 	 * Starts the resource manager actors.
 	 * @param configuration The configuration for the resource manager
 	 * @param actorSystem The actor system to start the resource manager in
-	 * @param leaderRetriever The leader retriever service to intialize the resource manager
+	 * @param leaderRetriever The leader retriever service to initialize the resource manager
 	 * @param resourceManagerClass The class of the ResourceManager to be started
 	 * @param resourceManagerActorName The name of the resource manager actor.
 	 * @return ActorRef of the resource manager

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/overlays/HadoopConfOverlay.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/overlays/HadoopConfOverlay.java
@@ -40,7 +40,7 @@ import java.io.IOException;
  * The following environment variables are set in the container:
  *  - HADOOP_CONF_DIR
  *
- * The folloowing Flink configuration entries are updated:
+ * The following Flink configuration entries are updated:
  *  - fs.hdfs.hadoopconf
  */
 public class HadoopConfOverlay implements ContainerOverlay {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/overlays/KeytabOverlay.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/overlays/KeytabOverlay.java
@@ -33,7 +33,7 @@ import java.io.IOException;
 /**
  * Overlays cluster-level Kerberos credentials (i.e. keytab) into a container.
  *
- * The folloowing Flink configuration entries are updated:
+ * The following Flink configuration entries are updated:
  *  - security.kerberos.login.keytab
  */
 public class KeytabOverlay extends AbstractContainerOverlay {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceProfile.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceProfile.java
@@ -76,7 +76,7 @@ public class ResourceProfile implements Serializable, Comparable<ResourceProfile
 	 * @param heapMemoryInMB The size of the heap memory, in megabytes.
 	 * @param directMemoryInMB The size of the direct memory, in megabytes.
 	 * @param nativeMemoryInMB The size of the native memory, in megabytes.
-	 * @param extendedResources The extendiable resources such as GPU and FPGA
+	 * @param extendedResources The extended resources such as GPU and FPGA
 	 */
 	public ResourceProfile(
 			double cpuCores,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/AccessExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/AccessExecutionGraph.java
@@ -50,7 +50,7 @@ public interface AccessExecutionGraph {
 	JobID getJobID();
 
 	/**
-	 * Returns the job name for thie execution graph.
+	 * Returns the job name for the execution graph.
 	 *
 	 * @return job name for this execution graph
 	 */
@@ -90,7 +90,7 @@ public interface AccessExecutionGraph {
 	/**
 	 * Returns an iterable containing all job vertices for this execution graph in the order they were created.
 	 *
-	 * @return iterable containing all job vertices for this execution graph in the order they were creater
+	 * @return iterable containing all job vertices for this execution graph in the order they were created
 	 */
 	Iterable<? extends AccessExecutionJobVertex> getVerticesTopologically();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -782,7 +782,7 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 	 * @param sampleId of the stack trace sample
 	 * @param numSamples the sample should contain
 	 * @param delayBetweenSamples to wait
-	 * @param maxStrackTraceDepth of the samples
+	 * @param maxStackTraceDepth of the samples
 	 * @param timeout until the request times out
 	 * @return Future stack trace sample response
 	 */
@@ -790,7 +790,7 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 			int sampleId,
 			int numSamples,
 			Time delayBetweenSamples,
-			int maxStrackTraceDepth,
+			int maxStackTraceDepth,
 			Time timeout) {
 
 		final LogicalSlot slot = assignedResource;
@@ -803,7 +803,7 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 				sampleId,
 				numSamples,
 				delayBetweenSamples,
-				maxStrackTraceDepth,
+				maxStackTraceDepth,
 				timeout);
 		} else {
 			return FutureUtils.completedExceptionally(new Exception("The execution has no slot assigned."));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -447,7 +447,7 @@ public class ExecutionVertex implements AccessExecutionVertex, Archiveable<Archi
 	 *     <li>Repeated executions of stateful tasks try to co-locate the execution with its state.
 	 * </ul>
 	 * 
-	 * @return The preferred excution locations for the execution attempt.
+	 * @return The preferred execution locations for the execution attempt.
 	 * 
 	 * @see #getPreferredLocationsBasedOnState()
 	 * @see #getPreferredLocationsBasedOnInputs() 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/FsNegativeRunningJobsRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/FsNegativeRunningJobsRegistry.java
@@ -31,7 +31,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * This {@link RunningJobsRegistry} tracks the status jobs via marker files,
- * marking running jobs viarunning marker files, marking finished jobs via finished marker files.
+ * marking running jobs via running marker files, marking finished jobs via finished marker files.
  * 
  * <p>The general contract is the following:
  * <ul>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartition.java
@@ -204,7 +204,7 @@ class SpillableSubpartition extends ResultSubpartition {
 			ResultSubpartitionView view = readView;
 
 			if (view != null && view.getClass() == SpillableSubpartitionView.class) {
-				// If there is a spilalble view, it's the responsibility of the
+				// If there is a spillable view, it's the responsibility of the
 				// view to release memory.
 				SpillableSubpartitionView spillableView = (SpillableSubpartitionView) view;
 				return spillableView.releaseMemory();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/iterative/task/AbstractIterativeTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/iterative/task/AbstractIterativeTask.java
@@ -97,7 +97,7 @@ public abstract class AbstractIterativeTask<S extends Function, OT> extends Batc
 		// check if the driver is resettable
 		if (this.driver instanceof ResettableDriver) {
 			final ResettableDriver<?, ?> resDriver = (ResettableDriver<?, ?>) this.driver;
-			// make sure that the according inputs are not reseted
+			// make sure that the according inputs are not reset
 			for (int i = 0; i < resDriver.getNumberOfInputs(); i++) {
 				if (resDriver.isInputResettable(i)) {
 					excludeFromReset(i);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobVertex.java
@@ -68,7 +68,7 @@ public class JobVertex implements java.io.Serializable {
 	/** Number of subtasks to split this task into at runtime.*/
 	private int parallelism = ExecutionConfig.PARALLELISM_DEFAULT;
 
-	/** Maximum number of subtasks to split this taks into a runtime. */
+	/** Maximum number of subtasks to split this task into a runtime. */
 	private int maxParallelism = -1;
 
 	/** The minimum resource of the vertex */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/SlotContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/SlotContext.java
@@ -32,7 +32,7 @@ public interface SlotContext {
 	 * Gets the id under which the slot has been allocated on the TaskManager. This id uniquely identifies the
 	 * physical slot.
 	 *
-	 * @return The id under whic teh slot has been allocated on the TaskManager
+	 * @return The id under which the slot has been allocated on the TaskManager
 	 */
 	AllocationID getAllocationId();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolGateway.java
@@ -108,7 +108,7 @@ public interface SlotPoolGateway extends AllocatedSlotActions, RpcGateway {
 	 * individually accepted or rejected by returning the collection of accepted
 	 * slot offers.
 	 *
-	 * @param taskManagerLocation from which the slot offeres originate
+	 * @param taskManagerLocation from which the slot offers originate
 	 * @param taskManagerGateway to talk to the slot offerer
 	 * @param offers slot offers which are offered to the {@link SlotPool}
 	 * @return A collection of accepted slot offers (future). The remaining slot offers are

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/BatchTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/BatchTask.java
@@ -131,7 +131,7 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable impleme
 	protected int[] iterativeInputs;
 	
 	/**
-	 * The indices of the iterative broadcast inputs. Empty, if non of the inputs is iteratve. 
+	 * The indices of the iterative broadcast inputs. Empty, if non of the inputs is iterative.
 	 */
 	protected int[] iterativeBroadcastInputs;
 	
@@ -184,13 +184,13 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable impleme
 
 	/**
 	 * Certain inputs may be excluded from resetting. For example, the initial partial solution
-	 * in an iteration head must not be reseted (it is read through the back channel), when all
-	 * others are reseted.
+	 * in an iteration head must not be reset (it is read through the back channel), when all
+	 * others are reset.
 	 */
 	private boolean[] excludeFromReset;
 
 	/**
-	 * Flag indicating for each input whether it is cached and can be reseted.
+	 * Flag indicating for each input whether it is cached and can be reset.
 	 */
 	private boolean[] inputIsCached;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/CoGroupDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/CoGroupDriver.java
@@ -122,14 +122,14 @@ public class CoGroupDriver<IT1, IT2, OT> implements Driver<CoGroupFunction<IT1, 
 		}
 
 		if (objectReuseEnabled) {
-			// create CoGropuTaskIterator according to provided local strategy.
+			// create CoGroupTaskIterator according to provided local strategy.
 			this.coGroupIterator = new ReusingSortMergeCoGroupIterator<IT1, IT2>(
 					in1, in2,
 					serializer1, groupComparator1,
 					serializer2, groupComparator2,
 					pairComparatorFactory.createComparator12(groupComparator1, groupComparator2));
 		} else {
-			// create CoGropuTaskIterator according to provided local strategy.
+			// create CoGroupTaskIterator according to provided local strategy.
 			this.coGroupIterator = new NonReusingSortMergeCoGroupIterator<IT1, IT2>(
 					in1, in2,
 					serializer1, groupComparator1,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/InPlaceMutableHashTable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/hash/InPlaceMutableHashTable.java
@@ -628,7 +628,7 @@ public class InPlaceMutableHashTable<T> extends AbstractMutableHashTable<T> {
 		}
 
 		/**
-		 * Overwrites a record at the sepcified position. The record is read from a DataInputView  (this will be the staging area).
+		 * Overwrites a record at the specified position. The record is read from a DataInputView  (this will be the staging area).
 		 * WARNING: The record must not be larger than the original record.
 		 * @param pointer Points to the position to overwrite.
 		 * @param input The DataInputView to read the record from

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/ClusterConfigurationInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/ClusterConfigurationInfo.java
@@ -24,7 +24,7 @@ import org.apache.flink.runtime.rest.handler.legacy.ClusterConfigHandler;
 import java.util.ArrayList;
 
 /**
- * Response of the {@link ClusterConfigHandler}, respresented as a list
+ * Response of the {@link ClusterConfigHandler}, represented as a list
  * of key-value pairs of the cluster {@link Configuration}.
  */
 public class ClusterConfigurationInfo extends ArrayList<ClusterConfigurationInfoEntry> implements ResponseBody {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
@@ -99,7 +99,7 @@ public abstract class AbstractKeyedStateBackend<K>
 	private final ExecutionConfig executionConfig;
 
 	/**
-	 * Decoratores the input and output streams to write key-groups compressed.
+	 * Decorates the input and output streams to write key-groups compressed.
 	 */
 	protected final StreamCompressionDecorator keyGroupCompressionDecorator;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackend.java
@@ -426,7 +426,7 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 		private final ArrayList<S> internalList;
 
 		/**
-		 * A serializer that allows to perfom deep copies of internalList
+		 * A serializer that allows to perform deep copies of internalList
 		 */
 		private final ArrayListSerializer<S> internalListCopySerializer;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/SharedStateRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/SharedStateRegistry.java
@@ -79,7 +79,7 @@ public class SharedStateRegistry implements AutoCloseable {
 	 *
 	 * @param state the shared state for which we register a reference.
 	 * @return the result of this registration request, consisting of the state handle that is
-	 * registered under the key by the end of the oepration and its current reference count.
+	 * registered under the key by the end of the operation and its current reference count.
 	 */
 	public Result registerReference(SharedStateRegistryKey registrationKey, StreamStateHandle state) {
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTable.java
@@ -179,7 +179,7 @@ public class TaskSlotTable implements TimeoutListener<AllocationID> {
 		boolean result = taskSlot.allocate(jobId, allocationId);
 
 		if (result) {
-			// update the alloction id to task slot map
+			// update the allocation id to task slot map
 			allocationIDTaskSlotMap.put(allocationId, taskSlot);
 
 			// register a timeout for this slot since it's in state allocated

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -1550,7 +1550,7 @@ public class Task implements Runnable, TaskActions {
 
 				// It is possible that the user code does not react to the task canceller.
 				// for that reason, we spawn this separate thread that repeatedly interrupts
-				// the user code until it exits. If the suer user code does not exit within
+				// the user code until it exits. If the user code does not exit within
 				// the timeout, we notify the job manager about a fatal error.
 				while (executer.isAlive()) {
 					long now = System.nanoTime();

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
@@ -588,7 +588,7 @@ object AkkaUtils {
    * @param tries maximum number of tries before the future fails
    * @param executionContext which shall execute the future
    * @param timeout of the future
-   * @return future which tries to receover by re-executing itself a given number of times
+   * @return future which tries to recover by re-executing itself a given number of times
    */
   def retry(target: ActorRef, message: Any, tries: Int)(implicit executionContext:
   ExecutionContext, timeout: FiniteDuration): Future[Any] = {

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/ArchiveMessages.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/messages/ArchiveMessages.scala
@@ -39,7 +39,7 @@ object ArchiveMessages {
   case object RequestJobCounts
 
   /**
-   * Reqeuest a specific ExecutionGraph by JobID. The response is [[RequestArchivedJob]]
+   * Request a specific ExecutionGraph by JobID. The response is [[RequestArchivedJob]]
    * @param jobID
    */
   case class RequestArchivedJob(jobID: JobID)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
@@ -1493,7 +1493,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 		assertTrue(pending.isDiscarded());
 		assertTrue(savepointFuture.isDone());
 
-		// the now the saveppoint should be completed but not added to the completed checkpoint store
+		// the now the savepoint should be completed but not added to the completed checkpoint store
 		assertEquals(0, coord.getNumberOfRetainedSuccessfulCheckpoints());
 		assertEquals(0, coord.getNumberOfPendingCheckpoints());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PendingCheckpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PendingCheckpointTest.java
@@ -249,7 +249,7 @@ public class PendingCheckpointTest {
 	@Test
 	public void testPendingCheckpointStatsCallbacks() throws Exception {
 		{
-			// Complete sucessfully
+			// Complete successfully
 			PendingCheckpointStats callback = mock(PendingCheckpointStats.class);
 			PendingCheckpoint pending = createPendingCheckpoint(CheckpointProperties.forStandardCheckpoint(), null);
 			pending.setStatsCallback(callback);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreITCase.java
@@ -270,7 +270,7 @@ public class ZooKeeperCompletedCheckpointStoreITCase extends CompletedCheckpoint
 
 		TestCompletedCheckpoint completedCheckpoint3 = createCheckpoint(3, sharedStateRegistry);
 
-		// this should release the last lock on completedCheckoint and thus discard it
+		// this should release the last lock on completedCheckpoint and thus discard it
 		zkCheckpointStore2.addCheckpoint(completedCheckpoint3);
 
 		// the checkpoint should be discarded eventually because there is no lock on it anymore

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/client/JobClientActorRecoveryITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/client/JobClientActorRecoveryITCase.java
@@ -67,7 +67,7 @@ public class JobClientActorRecoveryITCase extends TestLogger {
 	}
 
 	/**
-	 * Tests wether the JobClientActor can connect to a newly elected leading job manager to obtain
+	 * Tests whether the JobClientActor can connect to a newly elected leading job manager to obtain
 	 * the JobExecutionResult. The submitted job blocks for the first execution attempt. The
 	 * leading job manager will be killed so that the second job manager will be elected as the
 	 * leader. The newly elected leader has to retrieve the checkpointed job from ZooKeeper

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/GlobalModVersionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/GlobalModVersionTest.java
@@ -95,7 +95,7 @@ public class GlobalModVersionTest extends TestLogger {
 	}
 
 	/**
-	 * Tests that failures during a global faiover are not handed to the local
+	 * Tests that failures during a global failover are not handed to the local
 	 * failover strategy.
 	 */
 	@Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerTest.java
@@ -251,7 +251,7 @@ public class HeartbeatManagerTest extends TestLogger {
 	 */
 	@Test
 	public void testTargetUnmonitoring() throws InterruptedException, ExecutionException {
-		// this might be too aggresive for Travis, let's see...
+		// this might be too aggressive for Travis, let's see...
 		long heartbeatTimeout = 100L;
 		ResourceID resourceID = new ResourceID("foobar");
 		ResourceID targetID = new ResourceID("target");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/ChannelViewsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/ChannelViewsTest.java
@@ -262,7 +262,7 @@ public class ChannelViewsTest
 		final ChannelReaderInputView inView = new ChannelReaderInputView(reader, memory, true);
 		generator.reset();
 		
-		// read and re-generate all records and cmpare them
+		// read and re-generate all records and compare them
 		final Tuple2<Integer, String> readRec = new Tuple2<>();
 		for (int i = 0; i < NUM_PAIRS_SHORT; i++) {
 			generator.next(rec);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NetworkEnvironmentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NetworkEnvironmentTest.java
@@ -112,7 +112,7 @@ public class NetworkEnvironmentTest {
 	 * @param partitionType
 	 * 		the produced partition type
 	 * @param channels
-	 * 		the nummer of output channels
+	 * 		the number of output channels
 	 *
 	 * @return instance with minimal data set and some mocks so that it is useful for {@link
 	 * NetworkEnvironment#registerTask(Task)}
@@ -140,7 +140,7 @@ public class NetworkEnvironmentTest {
 	 * @param partitionType
 	 * 		the consumed partition type
 	 * @param channels
-	 * 		the nummer of input channels
+	 * 		the number of input channels
 	 *
 	 * @return mock with minimal functionality necessary by {@link NetworkEnvironment#registerTask(Task)}
 	 */

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/TaskEventDispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/TaskEventDispatcherTest.java
@@ -122,7 +122,7 @@ public class TaskEventDispatcherTest extends TestLogger {
 
 		ted.unregisterPartition(partitionId2);
 
-		// publis something for partitionId1 triggering all according listeners
+		// publish something for partitionId1 triggering all according listeners
 		assertTrue(ted.publish(partitionId1, event));
 		assertTrue("listener should have fired for AllWorkersDoneEvent", eventListener1a.fired);
 		assertTrue("listener should have fired for AllWorkersDoneEvent", eventListener2.fired);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerTest.java
@@ -906,7 +906,7 @@ public class JobManagerTest extends TestLogger {
 			msg = new TestingJobManagerMessages.WaitForAllVerticesToBeRunning(jobGraph.getJobID());
 			Await.result(jobManager.ask(msg, timeout), timeout);
 
-			// Notify when canelled
+			// Notify when cancelled
 			msg = new NotifyWhenJobStatus(jobGraph.getJobID(), JobStatus.CANCELED);
 			Future<Object> cancelled = jobManager.ask(msg, timeout);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/TaskMetricGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/TaskMetricGroupTest.java
@@ -147,7 +147,7 @@ public class TaskMetricGroupTest extends TestLogger {
 
 		taskMetricGroup.close();
 
-		// now alle registered metrics should have been unregistered
+		// now all registered metrics should have been unregistered
 		assertEquals(0, registry.getNumberRegisteredMetrics());
 
 		registry.shutdown();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/query/KvStateLocationRegistryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/query/KvStateLocationRegistryTest.java
@@ -44,7 +44,7 @@ import static org.mockito.Mockito.when;
 public class KvStateLocationRegistryTest {
 
 	/**
-	 * Simple test registering/unregistereing state and looking it up again.
+	 * Simple test registering/unregistering state and looking it up again.
 	 */
 	@Test
 	public void testRegisterAndLookup() throws Exception {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/query/KvStateLocationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/query/KvStateLocationTest.java
@@ -38,7 +38,7 @@ import static org.junit.Assert.assertEquals;
 public class KvStateLocationTest {
 
 	/**
-	 * Simple test registering/unregistereing state and looking it up again.
+	 * Simple test registering/unregistering state and looking it up again.
 	 */
 	@Test
 	public void testRegisterAndLookup() throws Exception {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerTest.java
@@ -999,7 +999,7 @@ public class SlotManagerTest extends TestLogger {
 				() -> slotManager.isTaskManagerIdle(taskManagerConnection.getInstanceID()),
 				mainThreadExecutor);
 
-			// check that the TaskManaer is not idle
+			// check that the TaskManager is not idle
 			assertFalse(idleFuture.get());
 
 			final SlotID slotId = slotIdArgumentCaptor.getValue();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/checkpoints/CheckpointStatsCacheTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/checkpoints/CheckpointStatsCacheTest.java
@@ -30,7 +30,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * Tests for the CheckpoitnStatsCache.
+ * Tests for the CheckpointStatsCache.
  */
 public class CheckpointStatsCacheTest {
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/SharedStateRegistryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/SharedStateRegistryTest.java
@@ -82,7 +82,7 @@ public class SharedStateRegistryTest {
 	}
 
 	/**
-	 * Validate that unregister an unexisted key will throw exception
+	 * Validate that unregister a nonexistent key will throw exception
 	 */
 	@Test(expected = IllegalStateException.class)
 	public void testUnregisterWithUnexistedKey() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
@@ -463,7 +463,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 	 *  - snapshot was taken without any Kryo registrations, specific serializers or default serializers for the state type
 	 *  - restored with the state type registered (no specific serializer)
 	 *
-	 * This test should not fail, because de- / serialization of the state should noth be performed with Kryo's default
+	 * This test should not fail, because de- / serialization of the state should not be performed with Kryo's default
 	 * {@link com.esotericsoftware.kryo.serializers.FieldSerializer}.
 	 */
 	@Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesTest.java
@@ -174,7 +174,7 @@ public class TaskManagerServicesTest extends TestLogger{
 	/**
 	 * Returns the value or the lower/upper bound in case the value is less/greater than the lower/upper bound, respectively.
 	 *
-	 * @param value value to inspec
+	 * @param value value to inspect
 	 * @param lower lower bound
 	 * @param upper upper bound
 	 *

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGateway.java
@@ -104,7 +104,7 @@ public class TestingTaskExecutorGateway implements TaskExecutorGateway {
 
 	@Override
 	public void disconnectJobManager(JobID jobId, Exception cause) {
-		// nooop
+		// noop
 	}
 
 	@Override

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingJobManagerMessages.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingJobManagerMessages.scala
@@ -121,7 +121,7 @@ object TestingJobManagerMessages {
     */
   case object NotifyWhenClientConnects
   /**
-    * Notifes of client connect
+    * Notifies of client connect
     */
   case object ClientConnected
   /**

--- a/flink-scala-shell/src/test/scala/org/apache/flink/api/scala/ScalaShellITCase.scala
+++ b/flink-scala-shell/src/test/scala/org/apache/flink/api/scala/ScalaShellITCase.scala
@@ -325,7 +325,7 @@ object ScalaShellITCase {
 
   @AfterClass
   def afterAll(): Unit = {
-    // The Scala interpreter somehow changes the class loader. Therfore, we have to reset it
+    // The Scala interpreter somehow changes the class loader. Therefore, we have to reset it
     Thread.currentThread().setContextClassLoader(classOf[ScalaShellITCase].getClassLoader)
 
     cluster.foreach(_.close)

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/codegen/TypeAnalyzer.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/codegen/TypeAnalyzer.scala
@@ -204,7 +204,7 @@ private[flink] trait TypeAnalyzer[C <: Context] { this: MacroContextHolder[C]
       }
 
       if (!hasZeroCtor) {
-        // We don't support POJOs without zero-paramter ctor
+        // We don't support POJOs without zero-parameter ctor
         return GenericClassDescriptor(id, tpe)
       }
 

--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/MaxByOperatorTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/MaxByOperatorTest.scala
@@ -40,7 +40,7 @@ class MaxByOperatorTest {
 
   /**
     * This test validates that an index which is out of bounds throws an
-    * IndexOutOfBOundsExcpetion.
+    * IndexOutOfBoundsException.
     */
   @Test(expected = classOf[IndexOutOfBoundsException])
   def testOutOfTupleBoundsDataset1() {
@@ -54,7 +54,7 @@ class MaxByOperatorTest {
 
   /**
     * This test validates that an index which is out of bounds throws an
-    * IndexOutOfBOundsExcpetion.
+    * IndexOutOfBoundsException.
     */
   @Test(expected = classOf[IndexOutOfBoundsException])
   def testOutOfTupleBoundsDataset2() {
@@ -67,7 +67,7 @@ class MaxByOperatorTest {
 
   /**
     * This test validates that an index which is out of bounds throws an
-    * IndexOutOfBOundsExcpetion.
+    * IndexOutOfBoundsException.
     */
   @Test(expected = classOf[IndexOutOfBoundsException])
   def testOutOfTupleBoundsDataset3() {
@@ -96,7 +96,7 @@ class MaxByOperatorTest {
   }
 
   /**
-    * This test validates that an InvalidProgrammException is thrown when maxBy
+    * This test validates that an InvalidProgramException is thrown when maxBy
     * is used on a custom data type.
     */
   @Test(expected = classOf[InvalidProgramException])
@@ -110,7 +110,7 @@ class MaxByOperatorTest {
   }
 
   /**
-    * This test validates that an InvalidProgrammException is thrown when maxBy
+    * This test validates that an InvalidProgramException is thrown when maxBy
     * is used on a custom data type.
     */
   @Test(expected = classOf[InvalidProgramException])
@@ -123,7 +123,7 @@ class MaxByOperatorTest {
   }
   /**
     * This test validates that an index which is out of bounds throws an
-    * IndexOutOfBOundsExcpetion.
+    * IndexOutOfBoundsException.
     */
   @Test(expected = classOf[IndexOutOfBoundsException])
   def testOutOfTupleBoundsGrouping1() {
@@ -135,7 +135,7 @@ class MaxByOperatorTest {
 
   /**
     * This test validates that an index which is out of bounds throws an
-    * IndexOutOfBOundsExcpetion.
+    * IndexOutOfBoundsException.
     */
   @Test(expected = classOf[IndexOutOfBoundsException])
   def testOutOfTupleBoundsGrouping2() {
@@ -147,7 +147,7 @@ class MaxByOperatorTest {
 
   /**
     * This test validates that an index which is out of bounds throws an
-    * IndexOutOfBOundsExcpetion.
+    * IndexOutOfBoundsException.
     */
   @Test(expected = classOf[IndexOutOfBoundsException])
   def testOutOfTupleBoundsGrouping3() {

--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/MinByOperatorTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/MinByOperatorTest.scala
@@ -39,7 +39,7 @@ class MinByOperatorTest {
 
   /**
     * This test validates that an index which is out of bounds throws an
-    * IndexOutOfBOundsExcpetion.
+    * IndexOutOfBoundsException.
     */
   @Test(expected = classOf[IndexOutOfBoundsException])
   def testOutOfTupleBoundsDataset1() {
@@ -53,7 +53,7 @@ class MinByOperatorTest {
 
   /**
     * This test validates that an index which is out of bounds throws an
-    * IndexOutOfBOundsExcpetion.
+    * IndexOutOfBoundsException.
     */
   @Test(expected = classOf[IndexOutOfBoundsException])
   def testOutOfTupleBoundsDataset2() {
@@ -66,7 +66,7 @@ class MinByOperatorTest {
 
   /**
     * This test validates that an index which is out of bounds throws an
-    * IndexOutOfBOundsExcpetion.
+    * IndexOutOfBoundsException.
     */
   @Test(expected = classOf[IndexOutOfBoundsException])
   def testOutOfTupleBoundsDataset3() {
@@ -78,7 +78,7 @@ class MinByOperatorTest {
   }
 
   /**
-    * This test validates that an InvalidProgrammException is thrown when minBy
+    * This test validates that an InvalidProgramException is thrown when minBy
     * is used on a custom data type.
     */
   @Test(expected = classOf[InvalidProgramException])
@@ -109,7 +109,7 @@ class MinByOperatorTest {
   }
 
   /**
-    * This test validates that an InvalidProgrammException is thrown when minBy
+    * This test validates that an InvalidProgramException is thrown when minBy
     * is used on a custom data type.
     */
   @Test(expected = classOf[InvalidProgramException])
@@ -123,7 +123,7 @@ class MinByOperatorTest {
 
   /**
     * This test validates that an index which is out of bounds throws an
-    * IndexOutOfBOundsExcpetion.
+    * IndexOutOfBoundsException.
     */
   @Test(expected = classOf[IndexOutOfBoundsException])
   def testOutOfTupleBoundsGrouping1() {
@@ -136,7 +136,7 @@ class MinByOperatorTest {
 
   /**
     * This test validates that an index which is out of bounds throws an
-    * IndexOutOfBOundsExcpetion.
+    * IndexOutOfBoundsException.
     */
   @Test(expected = classOf[IndexOutOfBoundsException])
   def testOutOfTupleBoundsGrouping2() {
@@ -149,7 +149,7 @@ class MinByOperatorTest {
 
   /**s
     * This test validates that an index which is out of bounds throws an
-    * IndexOutOfBOundsExcpetion.
+    * IndexOutOfBoundsException.
     */
   @Test(expected = classOf[IndexOutOfBoundsException])
   def testOutOfTupleBoundsGrouping3() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/CheckpointingMode.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/CheckpointingMode.java
@@ -28,7 +28,7 @@ import org.apache.flink.annotation.Public;
  * processing are repeated. For stateful operations and functions, the checkpointing mode defines
  * whether the system draws checkpoints such that a recovery behaves as if the operators/functions
  * see each record "exactly once" ({@link #EXACTLY_ONCE}), or whether the checkpoints are drawn
- * in a simpler fashion that typically encounteres some duplicates upon recovery
+ * in a simpler fashion that typically encounters some duplicates upon recovery
  * ({@link #AT_LEAST_ONCE})</p>
  */
 @Public

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/CoGroupedStreams.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/CoGroupedStreams.java
@@ -611,7 +611,7 @@ public class CoGroupedStreams<T1, T2> {
 
 	// ------------------------------------------------------------------------
 	//  Utility functions that implement the CoGroup logic based on the tagged
-	//  untion window reduce
+	//  union window reduce
 	// ------------------------------------------------------------------------
 
 	private static class Input1Tagger<T1, T2> implements MapFunction<T1, TaggedUnion<T1, T2>> {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -424,7 +424,7 @@ public abstract class StreamExecutionEnvironment {
 	 *
 	 * <p>Shorthand for {@code getCheckpointConfig().getCheckpointingMode()}.
 	 *
-	 * @return The checkpoin
+	 * @return The checkpoint mode
 	 */
 	public CheckpointingMode getCheckpointingMode() {
 		return checkpointCfg.getCheckpointingMode();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamConfig.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamConfig.java
@@ -499,7 +499,7 @@ public class StreamConfig implements Serializable {
 
 
 	// ------------------------------------------------------------------------
-	//  Miscellansous
+	//  Miscellaneous
 	// ------------------------------------------------------------------------
 
 	public void setChainStart() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -558,7 +558,7 @@ public class StreamGraphGenerator {
 	/**
 	 * Transforms a {@code TwoInputTransformation}.
 	 *
-	 * <p>This recusively transforms the inputs, creates a new {@code StreamNode} in the graph and
+	 * <p>This recursively transforms the inputs, creates a new {@code StreamNode} in the graph and
 	 * wired the inputs to this new node.
 	 */
 	private <IN1, IN2, OUT> Collection<Integer> transformTwoInputTransform(TwoInputTransformation<IN1, IN2, OUT> transform) {
@@ -617,7 +617,7 @@ public class StreamGraphGenerator {
 	 *
 	 * <p>If the user specifies a group name, this is taken as is. If nothing is specified and
 	 * the input operations all have the same group name then this name is taken. Otherwise the
-	 * default group is choosen.
+	 * default group is chosen.
 	 *
 	 * @param specifiedGroup The group specified by the user.
 	 * @param inputIds The IDs of the input operations.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/HeapInternalTimerService.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/HeapInternalTimerService.java
@@ -128,7 +128,7 @@ public class HeapInternalTimerService<K, N> implements InternalTimerService<N>, 
 	 * <ol>
 	 *     <li>Setting the {@code keySerialized} and {@code namespaceSerializer} for the timers it will contain.</li>
 	 *     <li>Setting the {@code triggerTarget} which contains the action to be performed when a timer fires.</li>
-	 *     <li>Re-registering timers that were retrieved after recoveting from a node failure, if any.</li>
+	 *     <li>Re-registering timers that were retrieved after recovering from a node failure, if any.</li>
 	 * </ol>
 	 * This method can be called multiple times, as long as it is called with the same serializers.
 	 */

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/queue/AsyncResult.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/queue/AsyncResult.java
@@ -40,7 +40,7 @@ public interface AsyncResult {
 	/**
 	 * True fi the async result is a collection of output elements; otherwise false.
 	 *
-	 * @return True if the async reuslt is a collection of output elements; otherwise false
+	 * @return True if the async result is a collection of output elements; otherwise false
 	 */
 	boolean isResultCollection();
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/queue/UnorderedStreamElementQueue.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/queue/UnorderedStreamElementQueue.java
@@ -219,7 +219,7 @@ public class UnorderedStreamElementQueue implements StreamElementQueue {
 
 	/**
 	 * Callback for onComplete events for the given stream element queue entry. Whenever a queue
-	 * entry is completed, it is checked whether this entry belogns to the first set. If this is the
+	 * entry is completed, it is checked whether this entry belongs to the first set. If this is the
 	 * case, then the element is added to the completed entries queue from where it can be consumed.
 	 * If the first set becomes empty, then the next set is polled from the uncompleted entries
 	 * queue. Completed entries from this new set are then added to the completed entries queue.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/CoFeedbackTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/CoFeedbackTransformation.java
@@ -61,7 +61,7 @@ public class CoFeedbackTransformation<F> extends StreamTransformation<F> {
 	/**
 	 * Creates a new {@code CoFeedbackTransformation} from the given input.
 	 *
-	 * @param parallelism The parallelism of the upstream {@code StreamTransformatino} and the
+	 * @param parallelism The parallelism of the upstream {@code StreamTransformation} and the
 	 *                    feedback edges.
 	 * @param feedbackType The type of the feedback edges
 	 * @param waitTime The wait time of the feedback operator. After the time expires

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/OneInputTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/OneInputTransformation.java
@@ -34,7 +34,7 @@ import java.util.List;
  * {@link org.apache.flink.streaming.api.operators.OneInputStreamOperator} to one input
  * {@link org.apache.flink.streaming.api.transformations.StreamTransformation}.
  *
- * @param <IN> The type of the elements in the nput {@code StreamTransformation}
+ * @param <IN> The type of the elements in the input {@code StreamTransformation}
  * @param <OUT> The type of the elements that result from this {@code OneInputTransformation}
  */
 @Internal

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/MergingWindowSet.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/MergingWindowSet.java
@@ -207,7 +207,7 @@ public class MergingWindowSet<W extends Window> {
 
 			// don't merge the new window itself, it never had any state associated with it
 			// i.e. if we are only merging one pre-existing window into itself
-			// without extending the pre-exising window
+			// without extending the pre-existing window
 			if (!(mergedWindows.contains(mergeResult) && mergedWindows.size() == 1)) {
 				mergeFunction.merge(mergeResult,
 						mergedWindows,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
@@ -628,7 +628,7 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 	/**
 	 * Returns the cleanup time for a window, which is
 	 * {@code window.maxTimestamp + allowedLateness}. In
-	 * case this leads to a value greated than {@link Long#MAX_VALUE}
+	 * case this leads to a value greater than {@link Long#MAX_VALUE}
 	 * then a cleanup time of {@link Long#MAX_VALUE} is
 	 * returned.
 	 *

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/typeutils/FieldAccessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/typeutils/FieldAccessor.java
@@ -47,7 +47,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  *
  * <p>Field expressions that specify nested fields (e.g. "f1.a.foo") result in nested field
  * accessors. These penetrate one layer, and then delegate the rest of the work to an
- * "innerAccesor". (see PojoFieldAccessor, RecursiveTupleFieldAccessor,
+ * "innerAccessor". (see PojoFieldAccessor, RecursiveTupleFieldAccessor,
  * RecursiveProductFieldAccessor)
  */
 @Internal

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/DataStreamTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/DataStreamTest.java
@@ -187,7 +187,7 @@ public class DataStreamTest {
 			assertTrue(edge.getPartitioner() instanceof ForwardPartitioner);
 		}
 
-		// verify self union with differnt partitioners
+		// verify self union with different partitioners
 		assertTrue(streamGraph.getStreamNode(selfUnionDifferentPartition.getId()).getInEdges().size() == 2);
 		boolean hasForward = false;
 		boolean hasBroadcast = false;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/MergingWindowSetTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/MergingWindowSetTest.java
@@ -208,7 +208,7 @@ public class MergingWindowSetTest {
 
 		TestingMergeFunction mergeFunction = new TestingMergeFunction();
 
-		// add several non-overlapping initial windoww
+		// add several non-overlapping initial windows
 
 		mergeFunction.reset();
 		assertEquals(new TimeWindow(0, 3), windowSet.addWindow(new TimeWindow(0, 3), mergeFunction));
@@ -333,7 +333,7 @@ public class MergingWindowSetTest {
 
 		TestingMergeFunction mergeFunction = new TestingMergeFunction();
 
-		// add several non-overlapping initial windoww
+		// add several non-overlapping initial windows
 
 		mergeFunction.reset();
 		assertEquals(new TimeWindow(1, 3), windowSet.addWindow(new TimeWindow(1, 3), mergeFunction));

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorContractTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorContractTest.java
@@ -1468,7 +1468,7 @@ public abstract class WindowOperatorContractTest extends TestLogger {
 			@Override
 			public TriggerResult answer(InvocationOnMock invocation) throws Exception {
 				Trigger.TriggerContext context = (Trigger.TriggerContext) invocation.getArguments()[3];
-				// don't intefere with cleanup timers
+				// don't interfere with cleanup timers
 				timeAdaptor.registerTimer(context, 0L);
 				context.getPartitionedState(valueStateDescriptor).update("hello");
 				return TriggerResult.CONTINUE;
@@ -1479,7 +1479,7 @@ public abstract class WindowOperatorContractTest extends TestLogger {
 			@Override
 			public TriggerResult answer(InvocationOnMock invocation) throws Exception {
 				Trigger.OnMergeContext context = (Trigger.OnMergeContext) invocation.getArguments()[1];
-				// don't intefere with cleanup timers
+				// don't interfere with cleanup timers
 				timeAdaptor.registerTimer(context, 0L);
 				context.getPartitionedState(valueStateDescriptor).update("hello");
 				return TriggerResult.CONTINUE;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorMigrationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorMigrationTest.java
@@ -191,7 +191,7 @@ public class WindowOperatorMigrationTest {
 
 		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new Tuple3ResultSortComparator());
 
-		// add an element that merges the two "key1" sessions, they should now have count 6, and therfore fire
+		// add an element that merges the two "key1" sessions, they should now have count 6, and therefore fire
 		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key1", 10), 4500));
 
 		expectedOutput.add(new StreamRecord<>(new Tuple3<>("key1-22", 10L, 10000L), 9999L));
@@ -300,7 +300,7 @@ public class WindowOperatorMigrationTest {
 
 		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new Tuple3ResultSortComparator());
 
-		// add an element that merges the two "key1" sessions, they should now have count 6, and therfore fire
+		// add an element that merges the two "key1" sessions, they should now have count 6, and therefore fire
 		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key1", 10), 4500));
 
 		expectedOutput.add(new StreamRecord<>(new Tuple3<>("key1-22", 10L, 10000L), 9999L));

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorTest.java
@@ -713,7 +713,7 @@ public class WindowOperatorTest extends TestLogger {
 
 		TestHarnessUtil.assertOutputEqualsSorted("Output was not correct.", expectedOutput, testHarness.getOutput(), new Tuple3ResultSortComparator());
 
-		// add an element that merges the two "key1" sessions, they should now have count 6, and therfore fire
+		// add an element that merges the two "key1" sessions, they should now have count 6, and therefore fire
 		testHarness.processElement(new StreamRecord<>(new Tuple2<>("key1", 10), 4500));
 
 		expectedOutput.add(new StreamRecord<>(new Tuple3<>("key1-22", 10L, 10000L), 9999L));

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
@@ -283,7 +283,7 @@ public class StreamTaskTerminationTest extends TestLogger {
 
 		@Override
 		public OperatorStateHandle call() throws Exception {
-			// notify that we have started the asynchronous checkpointint operation
+			// notify that we have started the asynchronous checkpointed operation
 			CHECKPOINTING_LATCH.trigger();
 			// wait until we have reached the StreamTask#cleanup --> This will already cancel this FutureTask
 			CLEANUP_LATCH.await();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -743,7 +743,7 @@ public class StreamTaskTest extends TestLogger {
 	}
 
 	/**
-	 * Tests that the StreamTask first closes alls its operators before setting its
+	 * Tests that the StreamTask first closes all of its operators before setting its
 	 * state to not running (isRunning == false)
 	 *
 	 * <p>See FLINK-7430.

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/CoGroupedStreams.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/CoGroupedStreams.scala
@@ -75,7 +75,7 @@ class CoGroupedStreams[T1, T2](input1: DataStream[T1], input2: DataStream[T2]) {
    * A co-group operation that has [[KeySelector]]s defined for the first input.
    *
    * You need to specify a [[KeySelector]] for the second input using [[equalTo()]]
-   * before you can proceeed with specifying a [[WindowAssigner]] using [[EqualTo.window()]].
+   * before you can proceed with specifying a [[WindowAssigner]] using [[EqualTo.window()]].
    *
    * @tparam KEY Type of the key. This must be the same for both inputs
    */

--- a/flink-tests/src/test/java/org/apache/flink/test/classloading/jar/CheckpointedStreamingProgram.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/classloading/jar/CheckpointedStreamingProgram.java
@@ -53,7 +53,7 @@ public class CheckpointedStreamingProgram {
 		env.execute("Checkpointed Streaming Program");
 	}
 
-	// with Checkpoining
+	// with Checkpointing
 	private static class SimpleStringGenerator implements SourceFunction<String>, ListCheckpointed<Integer> {
 		public boolean running = true;
 

--- a/flink-tests/src/test/java/org/apache/flink/test/classloading/jar/CustomKvStateProgram.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/classloading/jar/CustomKvStateProgram.java
@@ -37,7 +37,7 @@ import java.util.concurrent.ThreadLocalRandom;
 /**
  * A streaming program with a custom reducing KvState.
  *
- * <p>This is used to test proper usage of the user code class laoder when
+ * <p>This is used to test proper usage of the user code class loader when
  * disposing savepoints.
  */
 public class CustomKvStateProgram {

--- a/flink-tests/src/test/java/org/apache/flink/test/operators/JoinITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/operators/JoinITCase.java
@@ -460,7 +460,7 @@ public class JoinITCase extends MultipleProgramsTestBase {
 	@Test
 	public void testDefaultJoinOnTwoCustomTypeInputsWithInnerClassKeyExtractorsDisabledClosureCleaner() throws Exception {
 		/*
-		 * (Default) Join on two custom type inputs with key extractors, check if disableing closure cleaning works
+		 * (Default) Join on two custom type inputs with key extractors, check if disabling closure cleaning works
 		 */
 
 		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/leaderelection/ZooKeeperLeaderElectionITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/leaderelection/ZooKeeperLeaderElectionITCase.java
@@ -156,7 +156,7 @@ public class ZooKeeperLeaderElectionITCase extends TestLogger {
 		configuration.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, numSlotsPerTM);
 
 		// we "effectively" disable the automatic RecoverAllJobs message and sent it manually to make
-		// sure that all TMs have registered to the JM prior to issueing the RecoverAllJobs message
+		// sure that all TMs have registered to the JM prior to issuing the RecoverAllJobs message
 		configuration.setString(AkkaOptions.ASK_TIMEOUT, AkkaUtils.INF_TIMEOUT().toString());
 
 		Tasks.BlockingOnceReceiver$.MODULE$.blocking_$eq(true);

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/TimestampITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/TimestampITCase.java
@@ -301,7 +301,7 @@ public class TimestampITCase extends TestLogger {
 
 	/**
 	 * This tests whether timestamps are properly extracted in the timestamp
-	 * extractor and whether watermarks are also correctly forwared from this with the auto watermark
+	 * extractor and whether watermarks are also correctly forwarded from this with the auto watermark
 	 * interval.
 	 */
 	@Test
@@ -363,7 +363,7 @@ public class TimestampITCase extends TestLogger {
 	}
 
 	/**
-	 * This thests whether timestamps are properly extracted in the timestamp
+	 * This tests whether timestamps are properly extracted in the timestamp
 	 * extractor and whether watermark are correctly forwarded from the custom watermark emit
 	 * function.
 	 */

--- a/flink-tests/src/test/java/org/apache/flink/test/util/CoordVector.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/util/CoordVector.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 /**
  * Implements a feature vector as a multi-dimensional point. Coordinates of that point
  * (= the features) are stored as double values. The distance between two feature vectors is
- * the Euclidian distance between the points.
+ * the Euclidean distance between the points.
  */
 public final class CoordVector implements Value, Comparable<CoordVector> {
 	private static final long serialVersionUID = 1L;
@@ -82,14 +82,14 @@ public final class CoordVector implements Value, Comparable<CoordVector> {
 	}
 
 	/**
-	 * Computes the Euclidian distance between this coordinate vector and a
+	 * Computes the Euclidean distance between this coordinate vector and a
 	 * second coordinate vector.
 	 *
 	 * @param cv The coordinate vector to which the distance is computed.
-	 * @return The Euclidian distance to coordinate vector cv. If cv has a
+	 * @return The Euclidean distance to coordinate vector cv. If cv has a
 	 *         different length than this coordinate vector, -1 is returned.
 	 */
-	public double computeEuclidianDistance(CoordVector cv) {
+	public double computeEuclideanDistance(CoordVector cv) {
 		// check coordinate vector lengths
 		if (cv.coordinates.length != this.coordinates.length) {
 			return -1.0;

--- a/flink-tests/src/test/java/org/apache/flink/test/windowing/sessionwindows/ParallelSessionsEventGenerator.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/windowing/sessionwindows/ParallelSessionsEventGenerator.java
@@ -95,7 +95,7 @@ public class ParallelSessionsEventGenerator<K, E> {
 			final int index = i % subGeneratorLists.size();
 			EventGenerator<K, E> subGenerator = subGeneratorLists.get(index);
 
-			// check if the sub-generator can produce an event under the current gloabl watermark
+			// check if the sub-generator can produce an event under the current global watermark
 			if (subGenerator.canGenerateEventAtWatermark(globalWatermark)) {
 
 				E event = subGenerator.generateEvent(globalWatermark);

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/completeness/BatchScalaAPICompletenessTest.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/completeness/BatchScalaAPICompletenessTest.scala
@@ -78,7 +78,7 @@ class BatchScalaAPICompletenessTest extends ScalaAPICompletenessTestBase {
        """^org\.apache\.flink\.api.java.*project""",
 
        // I don't want to have withParameters in the API since I consider Configuration to be
-       // deprecated. But maybe thats just me ...
+       // deprecated. But maybe that's just me ...
        """^org\.apache\.flink\.api.java.*withParameters""",
 
        // These are only used internally. Should be internal API but Java doesn't have

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/operators/GroupingTest.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/operators/GroupingTest.scala
@@ -71,7 +71,7 @@ class GroupingTest {
     val env = ExecutionEnvironment.getExecutionEnvironment
     val tupleDs = env.fromCollection(emptyTupleData)
 
-    // should not work, fiels position out of range
+    // should not work, field position out of range
     tupleDs.groupBy(5)
   }
 

--- a/flink-yarn-tests/src/test/scala/org/apache/flink/yarn/TestingYarnTaskManager.scala
+++ b/flink-yarn-tests/src/test/scala/org/apache/flink/yarn/TestingYarnTaskManager.scala
@@ -36,7 +36,7 @@ import org.apache.flink.runtime.testingUtils.TestingTaskManagerLike
   * @param config Configuration object for the actor
   * @param resourceID The Yarn container id
   * @param connectionInfo Connection information of this actor
-  * @param memoryManager MemoryManager which is responsibel for Flink's managed memory allocation
+  * @param memoryManager MemoryManager which is responsible for Flink's managed memory allocation
   * @param ioManager IOManager responsible for I/O
   * @param network NetworkEnvironment for this actor
   * @param numberOfSlots Number of slots for this TaskManager

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
@@ -291,7 +291,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 				.getCommands().get(0));
 
 		// logback + log4j, with/out krb5, different JVM opts
-		// IMPORTANT: Beaware that we are using side effects here to modify the created YarnClusterDescriptor
+		// IMPORTANT: Be aware that we are using side effects here to modify the created YarnClusterDescriptor
 		cfg.setString(CoreOptions.FLINK_JM_JVM_OPTIONS, jmJvmOpts);
 		assertEquals(
 			java + " " + jvmmem +
@@ -322,7 +322,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 				.getCommands().get(0));
 
 		// now try some configurations with different yarn.container-start-command-template
-		// IMPORTANT: Beaware that we are using side effects here to modify the created YarnClusterDescriptor
+		// IMPORTANT: Be aware that we are using side effects here to modify the created YarnClusterDescriptor
 		cfg.setString(ConfigConstants.YARN_CONTAINER_START_COMMAND_TEMPLATE,
 			"%java% 1 %jvmmem% 2 %jvmopts% 3 %logging% 4 %class% 5 %args% 6 %redirects%");
 		assertEquals(
@@ -341,7 +341,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 
 		cfg.setString(ConfigConstants.YARN_CONTAINER_START_COMMAND_TEMPLATE,
 			"%java% %logging% %jvmopts% %jvmmem% %class% %args% %redirects%");
-		// IMPORTANT: Beaware that we are using side effects here to modify the created YarnClusterDescriptor
+		// IMPORTANT: Be aware that we are using side effects here to modify the created YarnClusterDescriptor
 		assertEquals(
 			java +
 				" " + logfile + " " + logback + " " + log4j +

--- a/tools/create_release_files.sh
+++ b/tools/create_release_files.sh
@@ -266,7 +266,7 @@ prepare
 
 make_source_release
 
-# build dist by input parameter of "--scala-vervion xxx --hadoop-version xxx"
+# build dist by input parameter of "--scala-version xxx --hadoop-version xxx"
 if [ "$SCALA_VERSION" == "none" ] && [ "$HADOOP_VERSION" == "none" ]; then
   make_binary_release "hadoop2" "" "2.11"
   make_binary_release "hadoop26" "-Dhadoop.version=2.6.5" "2.11"

--- a/tools/list_deps.py
+++ b/tools/list_deps.py
@@ -23,7 +23,7 @@ import sys
 
 # This lists all dependencies in the Maven Project root given as first
 # argument. If a dependency is included in several versions it is listed once
-# for every version. The resul output is sorted. So this can be used
+# for every version. The result output is sorted. So this can be used
 # to get a diff between the Maven dependencies of two versions of a project.
 
 path = sys.argv[1]

--- a/tools/merge_flink_pr.py
+++ b/tools/merge_flink_pr.py
@@ -46,7 +46,7 @@ except ImportError:
 
 # Location of your FLINK git development area
 FLINK_HOME = os.environ.get("FLINK_HOME", "/home/patrick/Documents/spark")
-# Remote name which points to the Gihub site
+# Remote name which points to the Github site
 PR_REMOTE_NAME = os.environ.get("PR_REMOTE_NAME", "apache-github")
 # Remote name which points to Apache git
 PUSH_REMOTE_NAME = os.environ.get("PUSH_REMOTE_NAME", "apache")


### PR DESCRIPTION
## What is the purpose of the change

Fix typos from the IntelliJ "Typos" inspection. I have tried to preserve British vs American English spellings. IntelliJ is adamant about reordering imports in two files.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)