### PR TITLE
[FLINK-8372] Fix NPEs when stopping worker nodes and adding tasks.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTable.java
@@ -448,7 +448,7 @@ public class TaskSlotTable implements TimeoutListener<AllocationID> {
 				throw new SlotNotActiveException(task.getJobID(), task.getAllocationId());
 			}
 		} else {
-			throw new SlotNotFoundException(taskSlot.getAllocationId());
+			throw new SlotNotFoundException(task.getAllocationId());
 		}
 	}
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
@@ -276,7 +276,7 @@ public class YarnResourceManager extends ResourceManager<YarnWorkerNode> impleme
 			resourceManagerClient.releaseAssignedContainer(container.getId());
 			workerNodeMap.remove(workerNode.getResourceID());
 		} else {
-			log.error("Can not find container with resource ID {}.", workerNode.getResourceID());
+			log.error("Error while calling YARN Node Manager to stop container. Given container is null!");
 		}
 		return true;
 	}


### PR DESCRIPTION
## What is the purpose of the change

Fix potential `NullPointerExceptions` when stopping worker nodes and adding tasks.
[lgtm.com](https://lgtm.com) detected these two NPEs for `apache/flink` which can be viewed [here](https://lgtm.com/projects/g/apache/flink/alerts/?mode=tree&severity=error&rule=3960073)

## Brief change log

- The first commit fixes `YarnResourceManager.stopWorker()`, which, when given a null reference, will attempt to obtain and print the resource id, which in turn will fail. I opted to change the commit message as well in order to accommodate for the missing id.
- The second commit fixes `TaskSlotTable.addTask()`, which, when given a null reference will throw a `SlotNotFoundException`. However, since it attempts to get an allocation id from that null reference, that exception will be shadowed by an NPE.

## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no / don't know)
  - The runtime per-record code paths (performance sensitive): (no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no / don't know)
  - The S3 file system connector: (no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
