### PR TITLE
[hotfix] [docs] Fix Iterations documentation in datastream_api.md

### DIFF
--- a/docs/dev/datastream_api.md
+++ b/docs/dev/datastream_api.md
@@ -375,9 +375,6 @@ iteration.closeWith(iterationBody.filter(/* one part of the stream */));
 DataStream<Integer> output = iterationBody.filter(/* some other part of the stream */);
 {% endhighlight %}
 
-By default the partitioning of the feedback stream will be automatically set to be the same as the input of the
-iteration head. To override this the user can set an optional boolean flag in the `closeWith` method.
-
 For example, here is program that continuously subtracts 1 from a series of integers until they reach zero:
 
 {% highlight java %}
@@ -424,13 +421,9 @@ are forwarded downstream using filters.
 val iteratedStream = someDataStream.iterate(
   iteration => {
     val iterationBody = iteration.map(/* this is executed many times */)
-    (tail.filter(/* one part of the stream */), tail.filter(/* some other part of the stream */))
+    (iterationBody.filter(/* one part of the stream */), iterationBody.filter(/* some other part of the stream */))
 })
 {% endhighlight %}
-
-
-By default the partitioning of the feedback stream will be automatically set to be the same as the input of the
-iteration head. To override this the user can set an optional boolean flag in the `closeWith` method.
 
 For example, here is program that continuously subtracts 1 from a series of integers until they reach zero:
 


### PR DESCRIPTION
* Fix a scala example which is using a wrong variable
* Remove partitioning descriptions
  * partitioning parameters are already removed from
  IterativeStream#closeWith/DateStream#iterate
  * https://github.com/apache/flink/pull/988
  * https://github.com/apache/flink/pull/4655

I'm not sure that the second modification is proper.