### PR TITLE
[FLINK-8385] Fix exceptions in AbstractEventTimeWindowCheckpointingITCase

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/SharedStateRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/SharedStateRegistry.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
 
 /**
  * This registry manages state that is shared across (incremental) checkpoints, and is responsible
@@ -194,8 +195,17 @@ public class SharedStateRegistry implements AutoCloseable {
 		// We do the small optimization to not issue discards for placeholders, which are NOPs.
 		if (streamStateHandle != null && !isPlaceholder(streamStateHandle)) {
 			LOG.trace("Scheduled delete of state handle {}.", streamStateHandle);
-			asyncDisposalExecutor.execute(
-				new SharedStateRegistry.AsyncDisposalRunnable(streamStateHandle));
+			AsyncDisposalRunnable asyncDisposalRunnable = new AsyncDisposalRunnable(streamStateHandle);
+			try {
+				asyncDisposalExecutor.execute(asyncDisposalRunnable);
+			} catch (RejectedExecutionException ex) {
+				// TODO This is a temporary fix for a problem during ZooKeeperCompletedCheckpointStore#shutdown:
+				// Disposal is issued in another async thread and the shutdown proceeds to close the I/O Executor pool.
+				// This leads to RejectedExecutionException once the async deletes are triggered by ZK. We need to
+				// wait for all pending ZK deletes before closing the I/O Executor pool. We can simply call #run()
+				// because we are already in the async ZK thread that disposes the handles.
+				asyncDisposalRunnable.run();
+			}
 		}
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/OperatorSnapshotResult.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/OperatorSnapshotResult.java
@@ -88,9 +88,7 @@ public class OperatorSnapshotResult {
 		try {
 			StateUtil.discardStateFuture(getKeyedStateManagedFuture());
 		} catch (Exception e) {
-			exception = ExceptionUtils.firstOrSuppressed(
-				new Exception("Could not properly cancel managed keyed state future.", e),
-				exception);
+			exception = new Exception("Could not properly cancel managed keyed state future.", e);
 		}
 
 		try {


### PR DESCRIPTION
## What is the purpose of the change

This change fixes two types of exceptions that I found when running `AbstractEventTimeWindowCheckpointingITCase` in debug mode (see JIRA).

## Brief change log

  - *As a temporary fix for the first mentioned exception, we catch the `RejectedExecutionException` and execute the `Runnable` directly.*
  - *Suppress expected `CancellationException` or `ExecutionException` when closing snapshot future task.*

## Verifying this change

This change is already covered by `AbstractEventTimeWindowCheckpointingITCase`. You should no longer see the mentioned exceptions when running all concrete instances of the test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
