### PR TITLE
[FLINK-8383][mesos] Disable test-jar shading

### DIFF
--- a/flink-mesos/pom.xml
+++ b/flink-mesos/pom.xml
@@ -262,6 +262,7 @@ under the License.
 							<goal>shade</goal>
 						</goals>
 						<configuration>
+							<shadeTestJar>false</shadeTestJar>
 							<artifactSet>
 								<includes combine.children="append">
 									<include>com.google.protobuf:protobuf-java</include>


### PR DESCRIPTION
## What is the purpose of the change

This PR disables the shading of the flink-mesos test jar, which resolves the build-failure we currently see on master.

Note that this is just a bandaid; I don't know why this fails in the first place.

## Verifying this change

Check travis build.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
