### PR TITLE
[FLINK-8082][build] Bump flink version for japicmp plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1416,7 +1416,7 @@ under the License.
 							<dependency>
 								<groupId>org.apache.flink</groupId>
 								<artifactId>${project.artifactId}</artifactId>
-								<version>1.1.4</version>
+								<version>1.4.0</version>
 								<type>${project.packaging}</type>
 							</dependency>
 						</oldVersion>


### PR DESCRIPTION
## What is the purpose of the change

This PR modifies the `japicmp` configuration to check API compatibility against 1.4.

## Verifying this change

Check travis run.