### PR TITLE
[FLINK-8388][docs] Fix baseUrl for master branch

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -44,7 +44,7 @@ github_url: "https://github.com/apache/flink"
 download_url: "http://flink.apache.org/downloads.html"
 
 # please use a protocol relative URL here
-baseurl: //ci.apache.org/projects/flink/flink-docs-release-1.4
+baseurl: //ci.apache.org/projects/flink/flink-docs-master
 
 # Flag whether this is a stable version or not. Used for the quickstart page.
 is_stable: false
@@ -53,6 +53,7 @@ is_stable: false
 show_outdated_warning: false
 
 previous_docs:
+  1.4: http://ci.apache.org/projects/flink/flink-docs-release-1.4
   1.3: http://ci.apache.org/projects/flink/flink-docs-release-1.3
   1.2: http://ci.apache.org/projects/flink/flink-docs-release-1.2
   1.1: http://ci.apache.org/projects/flink/flink-docs-release-1.1


### PR DESCRIPTION
## What is the purpose of the change

This PR modifies the documentation configuration to always point to the snapshot version of the docs.

I don't know why it ever pointed to a specific version as this should only be done on release branches.
