### PR TITLE
 [FLINK-8389] [flip6] Release all slots upon closing of JobManager connection

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/OnCompletionActions.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/OnCompletionActions.java
@@ -20,11 +20,28 @@ package org.apache.flink.runtime.jobmanager;
 
 import org.apache.flink.api.common.JobExecutionResult;
 
+/**
+ * Interface for completion actions once a Flink job has reached
+ * a terminal state.
+ */
 public interface OnCompletionActions {
 
+	/**
+	 * Job finished successfully.
+	 *
+	 * @param result of the job execution
+	 */
 	void jobFinished(JobExecutionResult result);
 
+	/**
+	 * Job failed with the given exception.
+	 *
+	 * @param cause of the job failure
+	 */
 	void jobFailed(Throwable cause);
 
+	/**
+	 * Job was finished by another JobMaster.
+	 */
 	void jobFinishedByOther();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/slots/ActorTaskManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/slots/ActorTaskManagerGateway.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.blob.TransientBlobKey;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.messages.StopCluster;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
@@ -216,6 +217,11 @@ public class ActorTaskManagerGateway implements TaskManagerGateway {
 	@Override
 	public CompletableFuture<TransientBlobKey> requestTaskManagerStdout(Time timeout) {
 		return requestTaskManagerLog((TaskManagerMessages.RequestTaskManagerLog) TaskManagerMessages.getRequestTaskManagerStdout(), timeout);
+	}
+
+	@Override
+	public CompletableFuture<Acknowledge> freeSlot(AllocationID allocationId, Throwable cause, Time timeout) {
+		throw new UnsupportedOperationException("The old TaskManager does not support freeing slots");
 	}
 
 	private CompletableFuture<TransientBlobKey> requestTaskManagerLog(TaskManagerMessages.RequestTaskManagerLog request, Time timeout) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/slots/TaskManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/slots/TaskManagerGateway.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.blob.TransientBlobKey;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.PartitionInfo;
@@ -30,6 +31,7 @@ import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.messages.StackTrace;
 import org.apache.flink.runtime.messages.StackTraceSampleResponse;
+import org.apache.flink.runtime.rpc.RpcTimeout;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -186,4 +188,17 @@ public interface TaskManagerGateway {
 	 * @return Future blob key under which the task manager stdout file has been stored
 	 */
 	CompletableFuture<TransientBlobKey> requestTaskManagerStdout(final Time timeout);
+
+	/**
+	 * Frees the slot with the given allocation ID.
+	 *
+	 * @param allocationId identifying the slot to free
+	 * @param cause of the freeing operation
+	 * @param timeout for the operation
+	 * @return Future acknowledge which is returned once the slot has been freed
+	 */
+	CompletableFuture<Acknowledge> freeSlot(
+		final AllocationID allocationId,
+		final Throwable cause,
+		@RpcTimeout final Time timeout);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
@@ -131,8 +131,9 @@ public interface JobMasterGateway extends CheckpointCoordinatorGateway, FencedRp
 	 *
 	 * @param resourceID identifying the TaskManager to disconnect
 	 * @param cause for the disconnection of the TaskManager
+	 * @return Future acknowledge once the JobMaster has been disconnected from the TaskManager
 	 */
-	void disconnectTaskManager(ResourceID resourceID, Exception cause);
+	CompletableFuture<Acknowledge> disconnectTaskManager(ResourceID resourceID, Exception cause);
 
 	/**
 	 * Disconnects the resource manager from the job manager because of the given cause.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/RpcTaskManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/RpcTaskManagerGateway.java
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.flink.runtime.jobmaster;
 
 import org.apache.flink.api.common.JobID;
@@ -37,7 +38,7 @@ import org.apache.flink.util.Preconditions;
 import java.util.concurrent.CompletableFuture;
 
 /**
- * Implementation of the {@link TaskManagerGateway} for Flink's RPC system
+ * Implementation of the {@link TaskManagerGateway} for Flink's RPC system.
  */
 public class RpcTaskManagerGateway implements TaskManagerGateway {
 
@@ -112,14 +113,16 @@ public class RpcTaskManagerGateway implements TaskManagerGateway {
 
 	@Override
 	public void notifyCheckpointComplete(ExecutionAttemptID executionAttemptID, JobID jobId, long checkpointId, long timestamp) {
-//		taskExecutorGateway.notifyCheckpointComplete(executionAttemptID, jobId, checkpointId, timestamp);
-		throw new UnsupportedOperationException("Operation is not yet supported.");
+		taskExecutorGateway.confirmCheckpoint(executionAttemptID, checkpointId, timestamp);
 	}
 
 	@Override
 	public void triggerCheckpoint(ExecutionAttemptID executionAttemptID, JobID jobId, long checkpointId, long timestamp, CheckpointOptions checkpointOptions) {
-//		taskExecutorGateway.triggerCheckpoint(executionAttemptID, jobId, checkpointId, timestamp);
-		throw new UnsupportedOperationException("Operation is not yet supported.");
+		taskExecutorGateway.triggerCheckpoint(
+			executionAttemptID,
+			checkpointId,
+			timestamp,
+			checkpointOptions);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/RpcTaskManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/RpcTaskManagerGateway.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.blob.TransientBlobKey;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.PartitionInfo;
@@ -131,5 +132,13 @@ public class RpcTaskManagerGateway implements TaskManagerGateway {
 	public CompletableFuture<TransientBlobKey> requestTaskManagerStdout(Time timeout) {
 //		return taskExecutorGateway.requestTaskManagerStdout(timeout);
 		throw new UnsupportedOperationException("Operation is not yet supported.");
+	}
+
+	@Override
+	public CompletableFuture<Acknowledge> freeSlot(AllocationID allocationId, Throwable cause, Time timeout) {
+		return taskExecutorGateway.freeSlot(
+			allocationId,
+			cause,
+			timeout);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DualKeyMap.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DualKeyMap.java
@@ -24,6 +24,7 @@ import java.util.AbstractCollection;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Set;
 
 /**
  * Map which stores values under two different indices.
@@ -123,6 +124,14 @@ public class DualKeyMap<A, B, V> {
 		}
 
 		return vs;
+	}
+
+	public Set<A> keySetA() {
+		return aMap.keySet();
+	}
+
+	public Set<B> keySetB() {
+		return bMap.keySet();
 	}
 
 	public void clear() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolGateway.java
@@ -84,10 +84,10 @@ public interface SlotPoolGateway extends AllocatedSlotActions, RpcGateway {
 	/**
 	 * Releases a TaskExecutor with the given {@link ResourceID} from the {@link SlotPool}.
 	 *
-	 * @param resourceID identifying the TaskExecutor which shall be released from the SlotPool
+	 * @param resourceId identifying the TaskExecutor which shall be released from the SlotPool
 	 * @return Future acknowledge which is completed after the TaskExecutor has been released
 	 */
-	CompletableFuture<Acknowledge> releaseTaskManager(ResourceID resourceID);
+	CompletableFuture<Acknowledge> releaseTaskManager(final ResourceID resourceId);
 
 	/**
 	 * Offers a slot to the {@link SlotPool}. The slot offer can be accepted or

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/JobExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/JobExecutor.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.minicluster;
+
+import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.runtime.client.JobExecutionException;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+
+/**
+ * Interface for {@link JobGraph} executors.
+ */
+public interface JobExecutor {
+
+	/**
+	 * Run the given job and block until its execution result can be returned.
+	 *
+	 * @param jobGraph to execute
+	 * @return Execution result of the executed job
+	 * @throws JobExecutionException if the job failed to execute
+	 */
+	JobExecutionResult executeJobBlocking(final JobGraph jobGraph) throws JobExecutionException, InterruptedException;
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -58,7 +58,7 @@ import static org.apache.flink.util.ExceptionUtils.firstOrSuppressed;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
 
-public class MiniCluster {
+public class MiniCluster implements JobExecutor {
 
 	private static final Logger LOG = LoggerFactory.getLogger(MiniCluster.class);
 
@@ -448,7 +448,8 @@ public class MiniCluster {
 	 * @throws JobExecutionException Thrown if anything went amiss during initial job launch,
 	 *         or if the job terminally failed.
 	 */
-	public JobExecutionResult runJobBlocking(JobGraph job) throws JobExecutionException, InterruptedException {
+	@Override
+	public JobExecutionResult executeJobBlocking(JobGraph job) throws JobExecutionException, InterruptedException {
 		checkNotNull(job, "job is null");
 
 		MiniClusterJobDispatcher dispatcher;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaBasedEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaBasedEndpoint.java
@@ -22,10 +22,8 @@ import org.apache.flink.runtime.rpc.RpcGateway;
 
 import akka.actor.ActorRef;
 
-import java.util.concurrent.CompletableFuture;
-
 /**
- * Interface for Akka based rpc gateways
+ * Interface for Akka based rpc gateways.
  */
 interface AkkaBasedEndpoint extends RpcGateway {
 
@@ -35,11 +33,4 @@ interface AkkaBasedEndpoint extends RpcGateway {
 	 * @return the {@link ActorRef} of the underlying RPC actor
 	 */
 	ActorRef getActorRef();
-
-	/**
-	 * Returns the internal termination future.
-	 *
-	 * @return Internal termination future
-	 */
-	CompletableFuture<Void> getInternalTerminationFuture();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaInvocationHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaInvocationHandler.java
@@ -18,23 +18,24 @@
 
 package org.apache.flink.runtime.rpc.akka;
 
-import akka.actor.ActorRef;
-import akka.pattern.Patterns;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.rpc.FencedRpcGateway;
 import org.apache.flink.runtime.rpc.MainThreadExecutable;
-import org.apache.flink.runtime.rpc.RpcServer;
 import org.apache.flink.runtime.rpc.RpcGateway;
+import org.apache.flink.runtime.rpc.RpcServer;
 import org.apache.flink.runtime.rpc.RpcTimeout;
 import org.apache.flink.runtime.rpc.StartStoppable;
+import org.apache.flink.runtime.rpc.akka.messages.Processing;
 import org.apache.flink.runtime.rpc.messages.CallAsync;
 import org.apache.flink.runtime.rpc.messages.LocalRpcInvocation;
-import org.apache.flink.runtime.rpc.akka.messages.Processing;
 import org.apache.flink.runtime.rpc.messages.RemoteRpcInvocation;
 import org.apache.flink.runtime.rpc.messages.RpcInvocation;
 import org.apache.flink.runtime.rpc.messages.RunAsync;
 import org.apache.flink.util.Preconditions;
+
+import akka.actor.ActorRef;
+import akka.pattern.Patterns;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,8 +50,8 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
 
-import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * Invocation handler to be used with an {@link AkkaRpcActor}. The invocation handler wraps the
@@ -85,18 +86,13 @@ class AkkaInvocationHandler implements InvocationHandler, AkkaBasedEndpoint, Rpc
 	@Nullable
 	private final CompletableFuture<Boolean> terminationFuture;
 
-	// null if gateway; otherwise non-null
-	@Nullable
-	private final CompletableFuture<Void> internalTerminationFuture;
-
 	AkkaInvocationHandler(
 			String address,
 			String hostname,
 			ActorRef rpcEndpoint,
 			Time timeout,
 			long maximumFramesize,
-			@Nullable CompletableFuture<Boolean> terminationFuture,
-			@Nullable CompletableFuture<Void> internalTerminationFuture) {
+			@Nullable CompletableFuture<Boolean> terminationFuture) {
 
 		this.address = Preconditions.checkNotNull(address);
 		this.hostname = Preconditions.checkNotNull(hostname);
@@ -105,7 +101,6 @@ class AkkaInvocationHandler implements InvocationHandler, AkkaBasedEndpoint, Rpc
 		this.timeout = Preconditions.checkNotNull(timeout);
 		this.maximumFramesize = maximumFramesize;
 		this.terminationFuture = terminationFuture;
-		this.internalTerminationFuture = internalTerminationFuture;
 	}
 
 	@Override
@@ -159,7 +154,7 @@ class AkkaInvocationHandler implements InvocationHandler, AkkaBasedEndpoint, Rpc
 
 	@Override
 	public <V> CompletableFuture<V> callAsync(Callable<V> callable, Time callTimeout) {
-		if(isLocal) {
+		if (isLocal) {
 			@SuppressWarnings("unchecked")
 			CompletableFuture<V> resultFuture = (CompletableFuture<V>) ask(new CallAsync(callable), callTimeout);
 
@@ -208,7 +203,7 @@ class AkkaInvocationHandler implements InvocationHandler, AkkaBasedEndpoint, Rpc
 			tell(rpcInvocation);
 
 			result = null;
-		} else if (Objects.equals(returnType,CompletableFuture.class)) {
+		} else if (Objects.equals(returnType, CompletableFuture.class)) {
 			// execute an asynchronous call
 			result = ask(rpcInvocation, futureTimeout);
 		} else {
@@ -298,7 +293,7 @@ class AkkaInvocationHandler implements InvocationHandler, AkkaBasedEndpoint, Rpc
 	}
 
 	/**
-	 * Checks whether any of the annotations is of type {@link RpcTimeout}
+	 * Checks whether any of the annotations is of type {@link RpcTimeout}.
 	 *
 	 * @param annotations Array of annotations
 	 * @return True if {@link RpcTimeout} was found; otherwise false
@@ -348,10 +343,5 @@ class AkkaInvocationHandler implements InvocationHandler, AkkaBasedEndpoint, Rpc
 	@Override
 	public CompletableFuture<Boolean> getTerminationFuture() {
 		return terminationFuture;
-	}
-
-	@Override
-	public CompletableFuture<Void> getInternalTerminationFuture() {
-		return internalTerminationFuture;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActor.java
@@ -53,14 +53,14 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /**
  * Akka rpc actor which receives {@link LocalRpcInvocation}, {@link RunAsync} and {@link CallAsync}
  * {@link Processing} messages.
- * <p>
- * The {@link LocalRpcInvocation} designates a rpc and is dispatched to the given {@link RpcEndpoint}
+ *
+ * <p>The {@link LocalRpcInvocation} designates a rpc and is dispatched to the given {@link RpcEndpoint}
  * instance.
- * <p>
- * The {@link RunAsync} and {@link CallAsync} messages contain executable code which is executed
+ *
+ * <p>The {@link RunAsync} and {@link CallAsync} messages contain executable code which is executed
  * in the context of the actor thread.
- * <p>
- * The {@link Processing} message controls the processing behaviour of the akka rpc actor. A
+ *
+ * <p>The {@link Processing} message controls the processing behaviour of the akka rpc actor. A
  * {@link Processing#START} starts processing incoming messages. A {@link Processing#STOP} message
  * stops processing messages. All messages which arrive when the processing is stopped, will be
  * discarded.
@@ -68,7 +68,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * @param <T> Type of the {@link RpcEndpoint}
  */
 class AkkaRpcActor<T extends RpcEndpoint & RpcGateway> extends UntypedActor {
-	
+
 	protected final Logger log = LoggerFactory.getLogger(getClass());
 
 	/** the endpoint to invoke the methods on. */
@@ -77,12 +77,12 @@ class AkkaRpcActor<T extends RpcEndpoint & RpcGateway> extends UntypedActor {
 	/** the helper that tracks whether calls come from the main thread. */
 	private final MainThreadValidatorUtil mainThreadValidator;
 
-	private final CompletableFuture<Void> internalTerminationFuture;
+	private final CompletableFuture<Boolean> terminationFuture;
 
-	AkkaRpcActor(final T rpcEndpoint, final CompletableFuture<Void> internalTerminationFuture) {
+	AkkaRpcActor(final T rpcEndpoint, final CompletableFuture<Boolean> terminationFuture) {
 		this.rpcEndpoint = checkNotNull(rpcEndpoint, "rpc endpoint");
 		this.mainThreadValidator = new MainThreadValidatorUtil(rpcEndpoint);
-		this.internalTerminationFuture = checkNotNull(internalTerminationFuture);
+		this.terminationFuture = checkNotNull(terminationFuture);
 	}
 
 	@Override
@@ -106,9 +106,9 @@ class AkkaRpcActor<T extends RpcEndpoint & RpcGateway> extends UntypedActor {
 			// Complete the termination future so that others know that we've stopped.
 
 			if (shutdownThrowable != null) {
-				internalTerminationFuture.completeExceptionally(shutdownThrowable);
+				terminationFuture.completeExceptionally(shutdownThrowable);
 			} else {
-				internalTerminationFuture.complete(null);
+				terminationFuture.complete(null);
 			}
 		} finally {
 			mainThreadValidator.exitMainThread();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/FencedAkkaInvocationHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/FencedAkkaInvocationHandler.java
@@ -61,9 +61,8 @@ public class FencedAkkaInvocationHandler<F extends Serializable> extends AkkaInv
 			Time timeout,
 			long maximumFramesize,
 			@Nullable CompletableFuture<Boolean> terminationFuture,
-			@Nullable CompletableFuture<Void> internalTerminationFuture,
 			Supplier<F> fencingTokenSupplier) {
-		super(address, hostname, rpcEndpoint, timeout, maximumFramesize, terminationFuture, internalTerminationFuture);
+		super(address, hostname, rpcEndpoint, timeout, maximumFramesize, terminationFuture);
 
 		this.fencingTokenSupplier = Preconditions.checkNotNull(fencingTokenSupplier);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/FencedAkkaRpcActor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/FencedAkkaRpcActor.java
@@ -19,9 +19,9 @@
 package org.apache.flink.runtime.rpc.akka;
 
 import org.apache.flink.runtime.rpc.FencedRpcEndpoint;
+import org.apache.flink.runtime.rpc.RpcGateway;
 import org.apache.flink.runtime.rpc.akka.exceptions.AkkaUnknownMessageException;
 import org.apache.flink.runtime.rpc.exceptions.FencingTokenException;
-import org.apache.flink.runtime.rpc.RpcGateway;
 import org.apache.flink.runtime.rpc.messages.FencedMessage;
 import org.apache.flink.runtime.rpc.messages.UnfencedMessage;
 
@@ -38,8 +38,8 @@ import java.util.concurrent.CompletableFuture;
  */
 public class FencedAkkaRpcActor<F extends Serializable, T extends FencedRpcEndpoint<F> & RpcGateway> extends AkkaRpcActor<T> {
 
-	public FencedAkkaRpcActor(T rpcEndpoint, CompletableFuture<Void> internalTerminationFuture) {
-		super(rpcEndpoint, internalTerminationFuture);
+	public FencedAkkaRpcActor(T rpcEndpoint, CompletableFuture<Boolean> terminationFuture) {
+		super(rpcEndpoint, terminationFuture);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/JobLeaderService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/JobLeaderService.java
@@ -356,8 +356,7 @@ public class JobLeaderService {
 	 * Retrying registration for the job manager <--> task manager connection.
 	 */
 	private static final class JobManagerRetryingRegistration
-			extends RetryingRegistration<JobMasterId, JobMasterGateway, JMTMRegistrationSuccess>
-	{
+			extends RetryingRegistration<JobMasterId, JobMasterGateway, JMTMRegistrationSuccess> {
 
 		private final String taskManagerRpcAddress;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -113,34 +113,34 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 
 	public static final String TASK_MANAGER_NAME = "taskmanager";
 
-	/** The connection information of this task manager */
+	/** The connection information of this task manager. */
 	private final TaskManagerLocation taskManagerLocation;
 
-	/** Max blob port which is accepted */
+	/** Max blob port which is accepted. */
 	public static final int MAX_BLOB_PORT = 65536;
 
-	/** The access to the leader election and retrieval services */
+	/** The access to the leader election and retrieval services. */
 	private final HighAvailabilityServices haServices;
 
-	/** The task manager configuration */
+	/** The task manager configuration. */
 	private final TaskManagerConfiguration taskManagerConfiguration;
 
-	/** The I/O manager component in the task manager */
+	/** The I/O manager component in the task manager. */
 	private final IOManager ioManager;
 
-	/** The memory manager component in the task manager */
+	/** The memory manager component in the task manager. */
 	private final MemoryManager memoryManager;
 
-	/** The network component in the task manager */
+	/** The network component in the task manager. */
 	private final NetworkEnvironment networkEnvironment;
 
-	/** The heartbeat manager for job manager in the task manager */
+	/** The heartbeat manager for job manager in the task manager. */
 	private final HeartbeatManager<Void, Void> jobManagerHeartbeatManager;
 
-	/** The heartbeat manager for resource manager in the task manager */
+	/** The heartbeat manager for resource manager in the task manager. */
 	private final HeartbeatManager<Void, SlotReport> resourceManagerHeartbeatManager;
 
-	/** The fatal error handler to use in case of a fatal error */
+	/** The fatal error handler to use in case of a fatal error. */
 	private final FatalErrorHandler fatalErrorHandler;
 
 	private final TaskManagerMetricGroup taskManagerMetricGroup;
@@ -673,6 +673,13 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 		return CompletableFuture.completedFuture(Acknowledge.get());
 	}
 
+	@Override
+	public CompletableFuture<Acknowledge> freeSlot(AllocationID allocationId, Throwable cause, Time timeout) {
+		freeSlotInternal(allocationId, cause);
+
+		return CompletableFuture.completedFuture(Acknowledge.get());
+	}
+
 	// ----------------------------------------------------------------------
 	// Disconnection RPCs
 	// ----------------------------------------------------------------------
@@ -820,7 +827,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 
 								// We encountered an exception. Free the slots and return them to the RM.
 								for (SlotOffer reservedSlot: reservedSlots) {
-									freeSlot(reservedSlot.getAllocationId(), throwable);
+									freeSlotInternal(reservedSlot.getAllocationId(), throwable);
 								}
 							}
 						} else {
@@ -834,7 +841,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 								final Exception e = new Exception("The slot was rejected by the JobManager.");
 
 								for (SlotOffer rejectedSlot : reservedSlots) {
-									freeSlot(rejectedSlot.getAllocationId(), e);
+									freeSlotInternal(rejectedSlot.getAllocationId(), e);
 								}
 							} else {
 								// discard the response since there is a new leader for the job
@@ -898,20 +905,24 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 		// 1. fail tasks running under this JobID
 		Iterator<Task> tasks = taskSlotTable.getTasks(jobId);
 
+		final FlinkException failureCause = new FlinkException("JobManager responsible for " + jobId +
+			" lost the leadership.", cause);
+
 		while (tasks.hasNext()) {
-			tasks.next().failExternally(new Exception("JobManager responsible for " + jobId +
-				" lost the leadership."));
+			tasks.next().failExternally(failureCause);
 		}
 
 		// 2. Move the active slots to state allocated (possible to time out again)
 		Iterator<AllocationID> activeSlots = taskSlotTable.getActiveSlots(jobId);
+
+		final FlinkException freeingCause = new FlinkException("Slot could not be marked inactive.");
 
 		while (activeSlots.hasNext()) {
 			AllocationID activeSlot = activeSlots.next();
 
 			try {
 				if (!taskSlotTable.markSlotInactive(activeSlot, taskManagerConfiguration.getTimeout())) {
-					freeSlot(activeSlot, new Exception("Slot could not be marked inactive."));
+					freeSlotInternal(activeSlot, freeingCause);
 				}
 			} catch (SlotNotFoundException e) {
 				log.debug("Could not mark the slot {} inactive.", jobId, e);
@@ -1017,8 +1028,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 
 	private void updateTaskExecutionState(
 			final JobMasterGateway jobMasterGateway,
-			final TaskExecutionState taskExecutionState)
-	{
+			final TaskExecutionState taskExecutionState) {
 		final ExecutionAttemptID executionAttemptID = taskExecutionState.getID();
 
 		CompletableFuture<Acknowledge> futureAcknowledge = jobMasterGateway.updateTaskExecutionState(taskExecutionState);
@@ -1065,7 +1075,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 		}
 	}
 
-	private void freeSlot(AllocationID allocationId, Throwable cause) {
+	private void freeSlotInternal(AllocationID allocationId, Throwable cause) {
 		Preconditions.checkNotNull(allocationId);
 
 		try {
@@ -1085,8 +1095,8 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 		}
 	}
 
-	private void freeSlot(AllocationID allocationId) {
-		freeSlot(allocationId, new Exception("The slot " + allocationId + " is beeing freed."));
+	private void freeSlotInternal(AllocationID allocationId) {
+		freeSlotInternal(allocationId, new Exception("The slot " + allocationId + " is being freed."));
 	}
 
 	private void timeoutSlot(AllocationID allocationId, UUID ticket) {
@@ -1094,7 +1104,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 		Preconditions.checkNotNull(ticket);
 
 		if (taskSlotTable.isValidTimeout(allocationId, ticket)) {
-			freeSlot(allocationId, new Exception("The slot " + allocationId + " has timed out."));
+			freeSlotInternal(allocationId, new Exception("The slot " + allocationId + " has timed out."));
 		} else {
 			log.debug("Received an invalid timeout for allocation id {} with ticket {}.", allocationId, ticket);
 		}
@@ -1196,14 +1206,10 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 		public void jobManagerLostLeadership(final JobID jobId, final JobMasterId jobMasterId) {
 			log.info("JobManager for job {} with leader id {} lost leadership.", jobId, jobMasterId);
 
-			runAsync(new Runnable() {
-				@Override
-				public void run() {
-					closeJobManagerConnection(
-						jobId,
-						new Exception("Job leader for job id " + jobId + " lost leadership."));
-				}
-			});
+			runAsync(() ->
+				closeJobManagerConnection(
+					jobId,
+					new Exception("Job leader for job id " + jobId + " lost leadership.")));
 		}
 
 		@Override
@@ -1219,12 +1225,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 			final ResourceID resourceManagerId = success.getResourceManagerId();
 
 			runAsync(
-				new Runnable() {
-					@Override
-					public void run() {
-						establishResourceManagerConnection(resourceManagerId);
-					}
-				}
+				() -> establishResourceManagerConnection(resourceManagerId)
 			);
 		}
 
@@ -1243,12 +1244,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 
 		@Override
 		public void notifyFinalState(final ExecutionAttemptID executionAttemptID) {
-			runAsync(new Runnable() {
-				@Override
-				public void run() {
-					unregisterTaskAndNotifyFinalState(jobMasterGateway, executionAttemptID);
-				}
-			});
+			runAsync(() -> unregisterTaskAndNotifyFinalState(jobMasterGateway, executionAttemptID));
 		}
 
 		@Override
@@ -1263,12 +1259,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 
 		@Override
 		public void failTask(final ExecutionAttemptID executionAttemptID, final Throwable cause) {
-			runAsync(new Runnable() {
-				@Override
-				public void run() {
-					TaskExecutor.this.failTask(executionAttemptID, cause);
-				}
-			});
+			runAsync(() -> TaskExecutor.this.failTask(executionAttemptID, cause));
 		}
 
 		@Override
@@ -1281,22 +1272,12 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 
 		@Override
 		public void freeSlot(final AllocationID allocationId) {
-			runAsync(new Runnable() {
-				@Override
-				public void run() {
-					TaskExecutor.this.freeSlot(allocationId);
-				}
-			});
+			runAsync(() -> TaskExecutor.this.freeSlotInternal(allocationId));
 		}
 
 		@Override
 		public void timeoutSlot(final AllocationID allocationId, final UUID ticket) {
-			runAsync(new Runnable() {
-				@Override
-				public void run() {
-					TaskExecutor.this.timeoutSlot(allocationId, ticket);
-				}
-			});
+			runAsync(() -> TaskExecutor.this.timeoutSlot(allocationId, ticket));
 		}
 	}
 
@@ -1304,19 +1285,16 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 
 		@Override
 		public void notifyHeartbeatTimeout(final ResourceID resourceID) {
-			runAsync(new Runnable() {
-				@Override
-				public void run() {
-					log.info("The heartbeat of JobManager with id {} timed out.", resourceID);
+			runAsync(() -> {
+				log.info("The heartbeat of JobManager with id {} timed out.", resourceID);
 
-					if (jobManagerConnections.containsKey(resourceID)) {
-						JobManagerConnection jobManagerConnection = jobManagerConnections.get(resourceID);
+				if (jobManagerConnections.containsKey(resourceID)) {
+					JobManagerConnection jobManagerConnection = jobManagerConnections.get(resourceID);
 
-						if (jobManagerConnection != null) {
-							closeJobManagerConnection(
-								jobManagerConnection.getJobID(),
-								new TimeoutException("The heartbeat of JobManager with id " + resourceID + " timed out."));
-						}
+					if (jobManagerConnection != null) {
+						closeJobManagerConnection(
+							jobManagerConnection.getJobID(),
+							new TimeoutException("The heartbeat of JobManager with id " + resourceID + " timed out."));
 					}
 				}
 			});
@@ -1337,15 +1315,12 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 
 		@Override
 		public void notifyHeartbeatTimeout(final ResourceID resourceId) {
-			runAsync(new Runnable() {
-				@Override
-				public void run() {
-					log.info("The heartbeat of ResourceManager with id {} timed out.", resourceId);
+			runAsync(() -> {
+				log.info("The heartbeat of ResourceManager with id {} timed out.", resourceId);
 
-					closeResourceManagerConnection(
-						new TimeoutException(
-							"The heartbeat of ResourceManager with id " + resourceId + " timed out."));
-				}
+				closeResourceManagerConnection(
+					new TimeoutException(
+						"The heartbeat of ResourceManager with id " + resourceId + " timed out."));
 			});
 		}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
@@ -37,12 +37,12 @@ import org.apache.flink.runtime.taskmanager.Task;
 import java.util.concurrent.CompletableFuture;
 
 /**
- * {@link TaskExecutor} RPC gateway interface
+ * {@link TaskExecutor} RPC gateway interface.
  */
 public interface TaskExecutorGateway extends RpcGateway {
 
 	/**
-	 * Requests a slot from the TaskManager
+	 * Requests a slot from the TaskManager.
 	 *
 	 * @param slotId slot id for the request
 	 * @param jobId for which to request a slot

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
@@ -162,4 +162,17 @@ public interface TaskExecutorGateway extends RpcGateway {
 	 * @param cause for the disconnection from the ResourceManager
 	 */
 	void disconnectResourceManager(Exception cause);
+
+	/**
+	 * Frees the slot with the given allocation ID.
+	 *
+	 * @param allocationId identifying the slot to free
+	 * @param cause of the freeing operation
+	 * @param timeout for the operation
+	 * @return Future acknowledge which is returned once the slot has been freed
+	 */
+	CompletableFuture<Acknowledge> freeSlot(
+		final AllocationID allocationId,
+		final Throwable cause,
+		@RpcTimeout final Time timeout);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlot.java
@@ -38,34 +38,34 @@ import java.util.Map;
  *     <li>Allocated - The slot has been allocated for a job.</li>
  *     <li>Active - The slot is in active use by a job manager which is the leader of the allocating job.</li>
  * </ul>
- * <p>
- * A task slot can only be allocated if it is in state free. An allocated task slot can transition
+ *
+ * <p>A task slot can only be allocated if it is in state free. An allocated task slot can transition
  * to state active.
- *<p>
- * An active slot allows to add tasks from the respective job and with the correct allocation id.
+ *
+ * <p>An active slot allows to add tasks from the respective job and with the correct allocation id.
  * An active slot can be marked as inactive which sets the state back to allocated.
- * <p>
- * An allocated or active slot can only be freed if it is empty. If it is not empty, then it's state
+ *
+ * <p>An allocated or active slot can only be freed if it is empty. If it is not empty, then it's state
  * can be set to releasing indicating that it can be freed once it becomes empty.
  */
 public class TaskSlot {
 
-	/** Index of the task slot */
+	/** Index of the task slot. */
 	private final int index;
 
-	/** Resource characteristics for this slot */
+	/** Resource characteristics for this slot. */
 	private final ResourceProfile resourceProfile;
 
-	/** Tasks running in this slot */
+	/** Tasks running in this slot. */
 	private final Map<ExecutionAttemptID, Task> tasks;
 
-	/** State of this slot */
+	/** State of this slot. */
 	private TaskSlotState state;
 
-	/** Job id to which the slot has been allocated; null if not allocated */
+	/** Job id to which the slot has been allocated; null if not allocated. */
 	private JobID jobId;
 
-	/** Allocation id of this slot; null if not allocated */
+	/** Allocation id of this slot; null if not allocated. */
 	private AllocationID allocationId;
 
 	TaskSlot(final int index, final ResourceProfile resourceProfile) {
@@ -151,7 +151,7 @@ public class TaskSlot {
 	 * task with the same execution attempt id added to the task slot. In this case, the method
 	 * returns true. Otherwise the task slot is left unchanged and false is returned.
 	 *
-	 * In case that the task slot state is not active an {@link IllegalStateException} is thrown.
+	 * <p>In case that the task slot state is not active an {@link IllegalStateException} is thrown.
 	 * In case that the task's job id and allocation id don't match with the job id and allocation
 	 * id for which the task slot has been allocated, an {@link IllegalArgumentException} is thrown.
 	 *
@@ -199,7 +199,7 @@ public class TaskSlot {
 	 * or is already allocated/active for the given job and allocation id, then the method returns
 	 * true. Otherwise it returns false.
 	 *
-	 * A slot can only be allocated if it's current state is free.
+	 * <p>A slot can only be allocated if it's current state is free.
 	 *
 	 * @param newJobId to allocate the slot for
 	 * @param newAllocationId to identify the slot allocation
@@ -230,7 +230,7 @@ public class TaskSlot {
 	/**
 	 * Mark this slot as active. A slot can only be marked active if it's in state allocated.
 	 *
-	 * The method returns true if the slot was set to active. Otherwise it returns false.
+	 * <p>The method returns true if the slot was set to active. Otherwise it returns false.
 	 *
 	 * @return True if the new state of the slot is active; otherwise false
 	 */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotTable.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.taskexecutor.SlotReport;
 import org.apache.flink.runtime.taskexecutor.SlotStatus;
 import org.apache.flink.runtime.taskmanager.Task;
 import org.apache.flink.util.Preconditions;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,35 +48,35 @@ import java.util.UUID;
 /**
  * Container for multiple {@link TaskSlot} instances. Additionally, it maintains multiple indices
  * for faster access to tasks and sets of allocated slots.
- * <p>
- * The task slot table automatically registers timeouts for allocated slots which cannot be assigned
+ *
+ * <p>The task slot table automatically registers timeouts for allocated slots which cannot be assigned
  * to a job manager.
- * <p>
- * Before the task slot table can be used, it must be started via the {@link #start} method.
+ *
+ * <p>Before the task slot table can be used, it must be started via the {@link #start} method.
  */
 public class TaskSlotTable implements TimeoutListener<AllocationID> {
 
 	private static final Logger LOG = LoggerFactory.getLogger(TaskSlotTable.class);
 
-	/** Timer service used to time out allocated slots */
+	/** Timer service used to time out allocated slots. */
 	private final TimerService<AllocationID> timerService;
 
-	/** The list of all task slots */
+	/** The list of all task slots. */
 	private final List<TaskSlot> taskSlots;
 
-	/** Mapping from allocation id to task slot */
+	/** Mapping from allocation id to task slot. */
 	private final Map<AllocationID, TaskSlot> allocationIDTaskSlotMap;
 
-	/** Mapping from execution attempt id to task and task slot */
+	/** Mapping from execution attempt id to task and task slot. */
 	private final Map<ExecutionAttemptID, TaskSlotMapping> taskSlotMappings;
 
-	/** Mapping from job id to allocated slots for a job */
+	/** Mapping from job id to allocated slots for a job. */
 	private final Map<JobID, Set<AllocationID>> slotsPerJob;
 
-	/** Interface for slot actions, such as freeing them or timing them out */
+	/** Interface for slot actions, such as freeing them or timing them out. */
 	private SlotActions slotActions;
 
-	/** Whether the table has been started */
+	/** Whether the table has been started. */
 	private boolean started;
 
 	public TaskSlotTable(
@@ -555,7 +556,6 @@ public class TaskSlotTable implements TimeoutListener<AllocationID> {
 		private final Task task;
 		private final TaskSlot taskSlot;
 
-
 		private TaskSlotMapping(Task task, TaskSlot taskSlot) {
 			this.task = Preconditions.checkNotNull(task);
 			this.taskSlot = Preconditions.checkNotNull(taskSlot);
@@ -675,7 +675,7 @@ public class TaskSlotTable implements TimeoutListener<AllocationID> {
 	}
 
 	/**
-	 * Iterator over all {@link Task} for a given job
+	 * Iterator over all {@link Task} for a given job.
 	 */
 	private final class TaskIterator implements Iterator<Task> {
 		private final Iterator<TaskSlot> taskSlotIterator;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TimerService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/slot/TimerService.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.taskexecutor.slot;
 
 import org.apache.flink.util.Preconditions;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,16 +40,16 @@ public class TimerService<K> {
 
 	private static final Logger LOG = LoggerFactory.getLogger(TimerService.class);
 
-	/** Executor service for the scheduled timeouts */
+	/** Executor service for the scheduled timeouts. */
 	private final ScheduledExecutorService scheduledExecutorService;
 
 	/** Timeout for the shutdown of the service. */
 	private final long shutdownTimeout;
 
-	/** Map of currently active timeouts */
+	/** Map of currently active timeouts. */
 	private final Map<K, Timeout<K>> timeouts;
 
-	/** Listener which is notified about occurring timeouts */
+	/** Listener which is notified about occurring timeouts. */
 	private TimeoutListener<K> timeoutListener;
 
 	public TimerService(
@@ -79,7 +80,7 @@ public class TimerService<K> {
 		scheduledExecutorService.shutdown();
 
 		try {
-			if(!scheduledExecutorService.awaitTermination(shutdownTimeout, TimeUnit.MILLISECONDS)) {
+			if (!scheduledExecutorService.awaitTermination(shutdownTimeout, TimeUnit.MILLISECONDS)) {
 				LOG.debug("The scheduled executor service did not properly terminate. Shutting " +
 					"it down now.");
 				scheduledExecutorService.shutdownNow();

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/minicluster/FlinkMiniCluster.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/minicluster/FlinkMiniCluster.scala
@@ -64,7 +64,8 @@ abstract class FlinkMiniCluster(
     val userConfiguration: Configuration,
     val highAvailabilityServices: HighAvailabilityServices,
     val useSingleActorSystem: Boolean)
-  extends LeaderRetrievalListener {
+  extends LeaderRetrievalListener
+  with JobExecutor {
 
   protected val LOG = LoggerFactory.getLogger(classOf[FlinkMiniCluster])
 
@@ -700,5 +701,16 @@ abstract class FlinkMiniCluster(
     }
 
     FlinkUserCodeClassLoaders.parentFirst(urls, parentClassLoader)
+  }
+
+  /**
+    * Run the given job and block until its execution result can be returned.
+    *
+    * @param jobGraph to execute
+    * @return Execution result of the executed job
+    * @throws JobExecutionException if the job failed to execute
+    */
+  override def executeJobBlocking(jobGraph: JobGraph) = {
+    submitJobAndWait(jobGraph, false)
   }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
@@ -599,8 +599,8 @@ public class ExecutionGraphRestartTest extends TestLogger {
 
 		WaitForTasks waitForTasks = new WaitForTasks(parallelism);
 		WaitForTasks waitForTasksCancelled = new WaitForTasks(parallelism);
-		taskManagerGateway.setCondition(waitForTasks);
-		taskManagerGateway.setCancelCondition(waitForTasksCancelled);
+		taskManagerGateway.setSubmitConsumer(waitForTasks);
+		taskManagerGateway.setCancelConsumer(waitForTasksCancelled);
 
 		eg.setScheduleMode(ScheduleMode.EAGER);
 		eg.scheduleForExecution();
@@ -649,7 +649,7 @@ public class ExecutionGraphRestartTest extends TestLogger {
 		waitUntilJobStatus(eg, JobStatus.FAILING, 1000);
 
 		WaitForTasks waitForTasksAfterRestart = new WaitForTasks(parallelism);
-		taskManagerGateway.setCondition(waitForTasksAfterRestart);
+		taskManagerGateway.setSubmitConsumer(waitForTasksAfterRestart);
 
 		waitForTasksCancelled.getFuture().get(1000L, TimeUnit.MILLISECONDS);
 
@@ -685,7 +685,7 @@ public class ExecutionGraphRestartTest extends TestLogger {
 		final ExecutionGraph eg = createSimpleTestGraph(jid, slots, restartStrategy, vertex);
 
 		WaitForTasks waitForTasks = new WaitForTasks(parallelism);
-		taskManagerGateway.setCondition(waitForTasks);
+		taskManagerGateway.setSubmitConsumer(waitForTasks);
 
 		eg.setScheduleMode(ScheduleMode.EAGER);
 		eg.scheduleForExecution();
@@ -699,7 +699,7 @@ public class ExecutionGraphRestartTest extends TestLogger {
 		assertEquals(JobStatus.FAILING, eg.getState());
 
 		WaitForTasks waitForTasksRestart = new WaitForTasks(parallelism);
-		taskManagerGateway.setCondition(waitForTasksRestart);
+		taskManagerGateway.setSubmitConsumer(waitForTasksRestart);
 
 		completeCancellingForAllVertices(eg);
 		waitUntilJobStatus(eg, JobStatus.RESTARTING, 1000);
@@ -750,7 +750,7 @@ public class ExecutionGraphRestartTest extends TestLogger {
 			new JobID(), scheduler, new FixedDelayRestartStrategy(Integer.MAX_VALUE, 0), executor, source, sink);
 
 		WaitForTasks waitForTasks = new WaitForTasks(parallelism * 2);
-		taskManagerGateway.setCondition(waitForTasks);
+		taskManagerGateway.setSubmitConsumer(waitForTasks);
 
 		eg.setScheduleMode(ScheduleMode.EAGER);
 		eg.scheduleForExecution();
@@ -766,7 +766,7 @@ public class ExecutionGraphRestartTest extends TestLogger {
 		assertEquals(JobStatus.FAILING, eg.getState());
 
 		WaitForTasks waitForTasksAfterRestart = new WaitForTasks(parallelism * 2);
-		taskManagerGateway.setCondition(waitForTasksAfterRestart);
+		taskManagerGateway.setSubmitConsumer(waitForTasksAfterRestart);
 
 		completeCancellingForAllVertices(eg);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/DummyScheduledUnit.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/DummyScheduledUnit.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmanager.scheduler;
+
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+
+/**
+ * Dummy implementation of {@link ScheduledUnit} for testing purposes.
+ */
+public class DummyScheduledUnit extends ScheduledUnit {
+	public DummyScheduledUnit() {
+		super(
+			null,
+			new JobVertexID(),
+			null,
+			null);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DualKeyMapTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DualKeyMapTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.util.TestLogger;
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.Random;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Tests for the {@link DualKeyMap}.
+ */
+public class DualKeyMapTest extends TestLogger {
+
+	@Test
+	public void testKeySets() {
+		final Random random = new Random();
+		final int capacity = 10;
+		final Set<Tuple2<Integer, Integer>> keys = new HashSet<>(capacity);
+
+		for (int i = 0; i < capacity; i++) {
+			int keyA = random.nextInt();
+			int keyB = random.nextInt();
+			keys.add(Tuple2.of(keyA, keyB));
+		}
+
+		final DualKeyMap<Integer, Integer, String> dualKeyMap = new DualKeyMap<>(capacity);
+
+		for (Tuple2<Integer, Integer> key : keys) {
+			dualKeyMap.put(key.f0, key.f1, "foobar");
+		}
+
+		assertThat(dualKeyMap.keySetA(), Matchers.equalTo(keys.stream().map(t -> t.f0).collect(Collectors.toSet())));
+		assertThat(dualKeyMap.keySetB(), Matchers.equalTo(keys.stream().map(t -> t.f1).collect(Collectors.toSet())));
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/minicluster/MiniClusterITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/minicluster/MiniClusterITCase.java
@@ -99,7 +99,7 @@ public class MiniClusterITCase extends TestLogger {
 
 	private static void executeJob(MiniCluster miniCluster) throws Exception {
 		JobGraph job = getSimpleJob();
-		miniCluster.runJobBlocking(job);
+		miniCluster.executeJobBlocking(job);
 	}
 
 	private static JobGraph getSimpleJob() throws IOException {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceTest.java
@@ -137,12 +137,9 @@ public class AkkaRpcServiceTest extends TestLogger {
 
 	/**
 	 * Tests that we can wait for the termination of the rpc service
-	 *
-	 * @throws ExecutionException
-	 * @throws InterruptedException
 	 */
 	@Test(timeout = 60000)
-	public void testTerminationFuture() throws ExecutionException, InterruptedException {
+	public void testTerminationFuture() throws Exception {
 		final ActorSystem actorSystem = AkkaUtils.createDefaultActorSystem();
 		final AkkaRpcService rpcService = new AkkaRpcService(actorSystem, Time.milliseconds(1000));
 
@@ -150,7 +147,7 @@ public class AkkaRpcServiceTest extends TestLogger {
 
 		assertFalse(terminationFuture.isDone());
 
-		CompletableFuture.runAsync(() -> rpcService.stopService(), actorSystem.dispatcher());
+		CompletableFuture.runAsync(rpcService::stopService, actorSystem.dispatcher());
 
 		terminationFuture.get();
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGateway.java
@@ -113,6 +113,11 @@ public class TestingTaskExecutorGateway implements TaskExecutorGateway {
 	}
 
 	@Override
+	public CompletableFuture<Acknowledge> freeSlot(AllocationID allocationId, Throwable cause, Time timeout) {
+		return CompletableFuture.completedFuture(Acknowledge.get());
+	}
+
+	@Override
 	public String getAddress() {
 		return address;
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/Flip6LocalStreamEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/Flip6LocalStreamEnvironment.java
@@ -107,7 +107,7 @@ public class Flip6LocalStreamEnvironment extends StreamExecutionEnvironment {
 
 		try {
 			miniCluster.start();
-			return miniCluster.runJobBlocking(jobGraph);
+			return miniCluster.executeJobBlocking(jobGraph);
 		}
 		finally {
 			transformations.clear();

--- a/flink-streaming-scala/src/test/resources/log4j-test.properties
+++ b/flink-streaming-scala/src/test/resources/log4j-test.properties
@@ -1,0 +1,38 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+log4j.rootLogger=OFF, console
+
+# -----------------------------------------------------------------------------
+# Console (use 'console')
+# -----------------------------------------------------------------------------
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{HH:mm:ss,SSS} %-5p %-60c %x - %m%n
+
+# -----------------------------------------------------------------------------
+# File (use 'file')
+# -----------------------------------------------------------------------------
+log4j.appender.file=org.apache.log4j.FileAppender
+log4j.appender.file.file=${log.dir}/${mvn.forkNumber}.log
+log4j.appender.file.append=false
+log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.layout.ConversionPattern=%d{HH:mm:ss,SSS} %-5p %-60c %x - %m%n
+
+# suppress the irrelevant (wrong) warnings from the netty channel handler
+log4j.logger.org.jboss.netty.channel.DefaultChannelPipeline=ERROR, console

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/streaming/util/TestStreamEnvironment.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/streaming/util/TestStreamEnvironment.java
@@ -21,6 +21,7 @@ package org.apache.flink.streaming.util;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.minicluster.JobExecutor;
 import org.apache.flink.runtime.minicluster.LocalFlinkMiniCluster;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironmentFactory;
@@ -37,20 +38,20 @@ import java.util.Collections;
  */
 public class TestStreamEnvironment extends StreamExecutionEnvironment {
 
-	/** The mini cluster in which this environment executes its jobs. */
-	private final LocalFlinkMiniCluster miniCluster;
+	/** The job executor to use to execute environment's jobs. */
+	private final JobExecutor jobExecutor;
 
 	private final Collection<Path> jarFiles;
 
 	private final Collection<URL> classPaths;
 
 	public TestStreamEnvironment(
-			LocalFlinkMiniCluster miniCluster,
+			JobExecutor jobExecutor,
 			int parallelism,
 			Collection<Path> jarFiles,
 			Collection<URL> classPaths) {
 
-		this.miniCluster = Preconditions.checkNotNull(miniCluster);
+		this.jobExecutor = Preconditions.checkNotNull(jobExecutor);
 		this.jarFiles = Preconditions.checkNotNull(jarFiles);
 		this.classPaths = Preconditions.checkNotNull(classPaths);
 
@@ -58,9 +59,9 @@ public class TestStreamEnvironment extends StreamExecutionEnvironment {
 	}
 
 	public TestStreamEnvironment(
-			LocalFlinkMiniCluster miniCluster,
+			JobExecutor jobExecutor,
 			int parallelism) {
-		this(miniCluster, parallelism, Collections.<Path>emptyList(), Collections.<URL>emptyList());
+		this(jobExecutor, parallelism, Collections.emptyList(), Collections.emptyList());
 	}
 
 	@Override
@@ -75,7 +76,7 @@ public class TestStreamEnvironment extends StreamExecutionEnvironment {
 
 		jobGraph.setClasspaths(new ArrayList<>(classPaths));
 
-		return miniCluster.submitJobAndWait(jobGraph, false);
+		return jobExecutor.executeJobBlocking(jobGraph);
 	}
 
 	// ------------------------------------------------------------------------
@@ -85,13 +86,13 @@ public class TestStreamEnvironment extends StreamExecutionEnvironment {
 	 * the given cluster with the given default parallelism and the specified jar files and class
 	 * paths.
 	 *
-	 * @param cluster The test cluster to run the test program on.
+	 * @param jobExecutor The executor to execute the jobs on
 	 * @param parallelism The default parallelism for the test programs.
 	 * @param jarFiles Additional jar files to execute the job with
 	 * @param classpaths Additional class paths to execute the job with
 	 */
 	public static void setAsContext(
-			final LocalFlinkMiniCluster cluster,
+			final JobExecutor jobExecutor,
 			final int parallelism,
 			final Collection<Path> jarFiles,
 			final Collection<URL> classpaths) {
@@ -100,7 +101,7 @@ public class TestStreamEnvironment extends StreamExecutionEnvironment {
 			@Override
 			public StreamExecutionEnvironment createExecutionEnvironment() {
 				return new TestStreamEnvironment(
-					cluster,
+					jobExecutor,
 					parallelism,
 					jarFiles,
 					classpaths);
@@ -114,15 +115,15 @@ public class TestStreamEnvironment extends StreamExecutionEnvironment {
 	 * Sets the streaming context environment to a TestStreamEnvironment that runs its programs on
 	 * the given cluster with the given default parallelism.
 	 *
-	 * @param cluster The test cluster to run the test program on.
+	 * @param jobExecutor The executor to execute the jobs on
 	 * @param parallelism The default parallelism for the test programs.
 	 */
-	public static void setAsContext(final LocalFlinkMiniCluster cluster, final int parallelism) {
+	public static void setAsContext(final JobExecutor jobExecutor, final int parallelism) {
 		setAsContext(
-			cluster,
+			jobExecutor,
 			parallelism,
-			Collections.<Path>emptyList(),
-			Collections.<URL>emptyList());
+			Collections.emptyList(),
+			Collections.emptyList());
 	}
 
 	/**

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestEnvironment.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestEnvironment.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.ExecutionEnvironmentFactory;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.optimizer.DataStatistics;
 import org.apache.flink.optimizer.Optimizer;
@@ -30,6 +31,7 @@ import org.apache.flink.optimizer.plan.OptimizedPlan;
 import org.apache.flink.optimizer.plandump.PlanJSONDumpGenerator;
 import org.apache.flink.optimizer.plantranslate.JobGraphGenerator;
 import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.minicluster.JobExecutor;
 import org.apache.flink.runtime.minicluster.LocalFlinkMiniCluster;
 import org.apache.flink.util.Preconditions;
 
@@ -44,7 +46,7 @@ import java.util.Collections;
  */
 public class TestEnvironment extends ExecutionEnvironment {
 
-	private final LocalFlinkMiniCluster miniCluster;
+	private final JobExecutor jobExecutor;
 
 	private final Collection<Path> jarFiles;
 
@@ -53,12 +55,12 @@ public class TestEnvironment extends ExecutionEnvironment {
 	private TestEnvironment lastEnv;
 
 	public TestEnvironment(
-			LocalFlinkMiniCluster miniCluster,
+			JobExecutor jobExecutor,
 			int parallelism,
 			boolean isObjectReuseEnabled,
 			Collection<Path> jarFiles,
 			Collection<URL> classPaths) {
-		this.miniCluster = Preconditions.checkNotNull(miniCluster);
+		this.jobExecutor = Preconditions.checkNotNull(jobExecutor);
 		this.jarFiles = Preconditions.checkNotNull(jarFiles);
 		this.classPaths = Preconditions.checkNotNull(classPaths);
 
@@ -77,15 +79,15 @@ public class TestEnvironment extends ExecutionEnvironment {
 	}
 
 	public TestEnvironment(
-			LocalFlinkMiniCluster executor,
+			JobExecutor executor,
 			int parallelism,
 			boolean isObjectReuseEnabled) {
 		this(
 			executor,
 			parallelism,
 			isObjectReuseEnabled,
-			Collections.<Path>emptyList(),
-			Collections.<URL>emptyList());
+			Collections.emptyList(),
+			Collections.emptyList());
 	}
 
 	@Override
@@ -115,7 +117,7 @@ public class TestEnvironment extends ExecutionEnvironment {
 
 		jobGraph.setClasspaths(new ArrayList<>(classPaths));
 
-		this.lastJobExecutionResult = miniCluster.submitJobAndWait(jobGraph, false);
+		this.lastJobExecutionResult = jobExecutor.executeJobBlocking(jobGraph);
 		return this.lastJobExecutionResult;
 	}
 
@@ -130,7 +132,7 @@ public class TestEnvironment extends ExecutionEnvironment {
 	private OptimizedPlan compileProgram(String jobName) {
 		Plan p = createProgramPlan(jobName);
 
-		Optimizer pc = new Optimizer(new DataStatistics(), this.miniCluster.configuration());
+		Optimizer pc = new Optimizer(new DataStatistics(), new Configuration());
 		return pc.compile(p);
 	}
 
@@ -138,7 +140,7 @@ public class TestEnvironment extends ExecutionEnvironment {
 		ExecutionEnvironmentFactory factory = new ExecutionEnvironmentFactory() {
 			@Override
 			public ExecutionEnvironment createExecutionEnvironment() {
-				lastEnv = new TestEnvironment(miniCluster, getParallelism(), getConfig().isObjectReuseEnabled());
+				lastEnv = new TestEnvironment(jobExecutor, getParallelism(), getConfig().isObjectReuseEnabled());
 				return lastEnv;
 			}
 		};
@@ -153,13 +155,13 @@ public class TestEnvironment extends ExecutionEnvironment {
 	 * environment executes the given jobs on a Flink mini cluster with the given default
 	 * parallelism and the additional jar files and class paths.
 	 *
-	 * @param miniCluster The mini cluster on which to execute the jobs
+	 * @param jobExecutor The executor to run the jobs on
 	 * @param parallelism The default parallelism
 	 * @param jarFiles Additional jar files to execute the job with
 	 * @param classPaths Additional class paths to execute the job with
 	 */
 	public static void setAsContext(
-		final LocalFlinkMiniCluster miniCluster,
+		final JobExecutor jobExecutor,
 		final int parallelism,
 		final Collection<Path> jarFiles,
 		final Collection<URL> classPaths) {
@@ -168,7 +170,7 @@ public class TestEnvironment extends ExecutionEnvironment {
 			@Override
 			public ExecutionEnvironment createExecutionEnvironment() {
 				return new TestEnvironment(
-					miniCluster,
+					jobExecutor,
 					parallelism,
 					false,
 					jarFiles,
@@ -185,15 +187,15 @@ public class TestEnvironment extends ExecutionEnvironment {
 	 * environment executes the given jobs on a Flink mini cluster with the given default
 	 * parallelism and the additional jar files and class paths.
 	 *
-	 * @param miniCluster The mini cluster on which to execute the jobs
+	 * @param jobExecutor The executor to run the jobs on
 	 * @param parallelism The default parallelism
 	 */
-	public static void setAsContext(final LocalFlinkMiniCluster miniCluster, final int parallelism) {
+	public static void setAsContext(final JobExecutor jobExecutor, final int parallelism) {
 		setAsContext(
-			miniCluster,
+			jobExecutor,
 			parallelism,
-			Collections.<Path>emptyList(),
-			Collections.<URL>emptyList());
+			Collections.emptyList(),
+			Collections.emptyList());
 	}
 
 	public static void unsetAsContext() {


### PR DESCRIPTION
## What is the purpose of the change

Release the slots assigned to a `JobMaster` once it disconnects from the `TaskExecutor`.

## Brief change log

- Upon receiving a disconnect call from the `JobMaster`, the `TaskExecutor` tries to free all slots

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
