### PR TITLE
[FLINK-8392] [rpc] Let termination future be completed by AkkaRpcActor#postStop

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaBasedEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaBasedEndpoint.java
@@ -22,10 +22,8 @@ import org.apache.flink.runtime.rpc.RpcGateway;
 
 import akka.actor.ActorRef;
 
-import java.util.concurrent.CompletableFuture;
-
 /**
- * Interface for Akka based rpc gateways
+ * Interface for Akka based rpc gateways.
  */
 interface AkkaBasedEndpoint extends RpcGateway {
 
@@ -35,11 +33,4 @@ interface AkkaBasedEndpoint extends RpcGateway {
 	 * @return the {@link ActorRef} of the underlying RPC actor
 	 */
 	ActorRef getActorRef();
-
-	/**
-	 * Returns the internal termination future.
-	 *
-	 * @return Internal termination future
-	 */
-	CompletableFuture<Void> getInternalTerminationFuture();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaInvocationHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaInvocationHandler.java
@@ -18,23 +18,24 @@
 
 package org.apache.flink.runtime.rpc.akka;
 
-import akka.actor.ActorRef;
-import akka.pattern.Patterns;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.rpc.FencedRpcGateway;
 import org.apache.flink.runtime.rpc.MainThreadExecutable;
-import org.apache.flink.runtime.rpc.RpcServer;
 import org.apache.flink.runtime.rpc.RpcGateway;
+import org.apache.flink.runtime.rpc.RpcServer;
 import org.apache.flink.runtime.rpc.RpcTimeout;
 import org.apache.flink.runtime.rpc.StartStoppable;
+import org.apache.flink.runtime.rpc.akka.messages.Processing;
 import org.apache.flink.runtime.rpc.messages.CallAsync;
 import org.apache.flink.runtime.rpc.messages.LocalRpcInvocation;
-import org.apache.flink.runtime.rpc.akka.messages.Processing;
 import org.apache.flink.runtime.rpc.messages.RemoteRpcInvocation;
 import org.apache.flink.runtime.rpc.messages.RpcInvocation;
 import org.apache.flink.runtime.rpc.messages.RunAsync;
 import org.apache.flink.util.Preconditions;
+
+import akka.actor.ActorRef;
+import akka.pattern.Patterns;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,8 +50,8 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
 
-import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * Invocation handler to be used with an {@link AkkaRpcActor}. The invocation handler wraps the
@@ -85,18 +86,13 @@ class AkkaInvocationHandler implements InvocationHandler, AkkaBasedEndpoint, Rpc
 	@Nullable
 	private final CompletableFuture<Boolean> terminationFuture;
 
-	// null if gateway; otherwise non-null
-	@Nullable
-	private final CompletableFuture<Void> internalTerminationFuture;
-
 	AkkaInvocationHandler(
 			String address,
 			String hostname,
 			ActorRef rpcEndpoint,
 			Time timeout,
 			long maximumFramesize,
-			@Nullable CompletableFuture<Boolean> terminationFuture,
-			@Nullable CompletableFuture<Void> internalTerminationFuture) {
+			@Nullable CompletableFuture<Boolean> terminationFuture) {
 
 		this.address = Preconditions.checkNotNull(address);
 		this.hostname = Preconditions.checkNotNull(hostname);
@@ -105,7 +101,6 @@ class AkkaInvocationHandler implements InvocationHandler, AkkaBasedEndpoint, Rpc
 		this.timeout = Preconditions.checkNotNull(timeout);
 		this.maximumFramesize = maximumFramesize;
 		this.terminationFuture = terminationFuture;
-		this.internalTerminationFuture = internalTerminationFuture;
 	}
 
 	@Override
@@ -159,7 +154,7 @@ class AkkaInvocationHandler implements InvocationHandler, AkkaBasedEndpoint, Rpc
 
 	@Override
 	public <V> CompletableFuture<V> callAsync(Callable<V> callable, Time callTimeout) {
-		if(isLocal) {
+		if (isLocal) {
 			@SuppressWarnings("unchecked")
 			CompletableFuture<V> resultFuture = (CompletableFuture<V>) ask(new CallAsync(callable), callTimeout);
 
@@ -208,7 +203,7 @@ class AkkaInvocationHandler implements InvocationHandler, AkkaBasedEndpoint, Rpc
 			tell(rpcInvocation);
 
 			result = null;
-		} else if (Objects.equals(returnType,CompletableFuture.class)) {
+		} else if (Objects.equals(returnType, CompletableFuture.class)) {
 			// execute an asynchronous call
 			result = ask(rpcInvocation, futureTimeout);
 		} else {
@@ -298,7 +293,7 @@ class AkkaInvocationHandler implements InvocationHandler, AkkaBasedEndpoint, Rpc
 	}
 
 	/**
-	 * Checks whether any of the annotations is of type {@link RpcTimeout}
+	 * Checks whether any of the annotations is of type {@link RpcTimeout}.
 	 *
 	 * @param annotations Array of annotations
 	 * @return True if {@link RpcTimeout} was found; otherwise false
@@ -348,10 +343,5 @@ class AkkaInvocationHandler implements InvocationHandler, AkkaBasedEndpoint, Rpc
 	@Override
 	public CompletableFuture<Boolean> getTerminationFuture() {
 		return terminationFuture;
-	}
-
-	@Override
-	public CompletableFuture<Void> getInternalTerminationFuture() {
-		return internalTerminationFuture;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActor.java
@@ -53,14 +53,14 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /**
  * Akka rpc actor which receives {@link LocalRpcInvocation}, {@link RunAsync} and {@link CallAsync}
  * {@link Processing} messages.
- * <p>
- * The {@link LocalRpcInvocation} designates a rpc and is dispatched to the given {@link RpcEndpoint}
+ *
+ * <p>The {@link LocalRpcInvocation} designates a rpc and is dispatched to the given {@link RpcEndpoint}
  * instance.
- * <p>
- * The {@link RunAsync} and {@link CallAsync} messages contain executable code which is executed
+ *
+ * <p>The {@link RunAsync} and {@link CallAsync} messages contain executable code which is executed
  * in the context of the actor thread.
- * <p>
- * The {@link Processing} message controls the processing behaviour of the akka rpc actor. A
+ *
+ * <p>The {@link Processing} message controls the processing behaviour of the akka rpc actor. A
  * {@link Processing#START} starts processing incoming messages. A {@link Processing#STOP} message
  * stops processing messages. All messages which arrive when the processing is stopped, will be
  * discarded.
@@ -68,7 +68,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * @param <T> Type of the {@link RpcEndpoint}
  */
 class AkkaRpcActor<T extends RpcEndpoint & RpcGateway> extends UntypedActor {
-	
+
 	protected final Logger log = LoggerFactory.getLogger(getClass());
 
 	/** the endpoint to invoke the methods on. */
@@ -77,12 +77,12 @@ class AkkaRpcActor<T extends RpcEndpoint & RpcGateway> extends UntypedActor {
 	/** the helper that tracks whether calls come from the main thread. */
 	private final MainThreadValidatorUtil mainThreadValidator;
 
-	private final CompletableFuture<Void> internalTerminationFuture;
+	private final CompletableFuture<Boolean> terminationFuture;
 
-	AkkaRpcActor(final T rpcEndpoint, final CompletableFuture<Void> internalTerminationFuture) {
+	AkkaRpcActor(final T rpcEndpoint, final CompletableFuture<Boolean> terminationFuture) {
 		this.rpcEndpoint = checkNotNull(rpcEndpoint, "rpc endpoint");
 		this.mainThreadValidator = new MainThreadValidatorUtil(rpcEndpoint);
-		this.internalTerminationFuture = checkNotNull(internalTerminationFuture);
+		this.terminationFuture = checkNotNull(terminationFuture);
 	}
 
 	@Override
@@ -106,9 +106,9 @@ class AkkaRpcActor<T extends RpcEndpoint & RpcGateway> extends UntypedActor {
 			// Complete the termination future so that others know that we've stopped.
 
 			if (shutdownThrowable != null) {
-				internalTerminationFuture.completeExceptionally(shutdownThrowable);
+				terminationFuture.completeExceptionally(shutdownThrowable);
 			} else {
-				internalTerminationFuture.complete(null);
+				terminationFuture.complete(null);
 			}
 		} finally {
 			mainThreadValidator.exitMainThread();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/FencedAkkaInvocationHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/FencedAkkaInvocationHandler.java
@@ -61,9 +61,8 @@ public class FencedAkkaInvocationHandler<F extends Serializable> extends AkkaInv
 			Time timeout,
 			long maximumFramesize,
 			@Nullable CompletableFuture<Boolean> terminationFuture,
-			@Nullable CompletableFuture<Void> internalTerminationFuture,
 			Supplier<F> fencingTokenSupplier) {
-		super(address, hostname, rpcEndpoint, timeout, maximumFramesize, terminationFuture, internalTerminationFuture);
+		super(address, hostname, rpcEndpoint, timeout, maximumFramesize, terminationFuture);
 
 		this.fencingTokenSupplier = Preconditions.checkNotNull(fencingTokenSupplier);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/FencedAkkaRpcActor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/FencedAkkaRpcActor.java
@@ -19,9 +19,9 @@
 package org.apache.flink.runtime.rpc.akka;
 
 import org.apache.flink.runtime.rpc.FencedRpcEndpoint;
+import org.apache.flink.runtime.rpc.RpcGateway;
 import org.apache.flink.runtime.rpc.akka.exceptions.AkkaUnknownMessageException;
 import org.apache.flink.runtime.rpc.exceptions.FencingTokenException;
-import org.apache.flink.runtime.rpc.RpcGateway;
 import org.apache.flink.runtime.rpc.messages.FencedMessage;
 import org.apache.flink.runtime.rpc.messages.UnfencedMessage;
 
@@ -38,8 +38,8 @@ import java.util.concurrent.CompletableFuture;
  */
 public class FencedAkkaRpcActor<F extends Serializable, T extends FencedRpcEndpoint<F> & RpcGateway> extends AkkaRpcActor<T> {
 
-	public FencedAkkaRpcActor(T rpcEndpoint, CompletableFuture<Void> internalTerminationFuture) {
-		super(rpcEndpoint, internalTerminationFuture);
+	public FencedAkkaRpcActor(T rpcEndpoint, CompletableFuture<Boolean> terminationFuture) {
+		super(rpcEndpoint, terminationFuture);
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceTest.java
@@ -137,12 +137,9 @@ public class AkkaRpcServiceTest extends TestLogger {
 
 	/**
 	 * Tests that we can wait for the termination of the rpc service
-	 *
-	 * @throws ExecutionException
-	 * @throws InterruptedException
 	 */
 	@Test(timeout = 60000)
-	public void testTerminationFuture() throws ExecutionException, InterruptedException {
+	public void testTerminationFuture() throws Exception {
 		final ActorSystem actorSystem = AkkaUtils.createDefaultActorSystem();
 		final AkkaRpcService rpcService = new AkkaRpcService(actorSystem, Time.milliseconds(1000));
 
@@ -150,7 +147,7 @@ public class AkkaRpcServiceTest extends TestLogger {
 
 		assertFalse(terminationFuture.isDone());
 
-		CompletableFuture.runAsync(() -> rpcService.stopService(), actorSystem.dispatcher());
+		CompletableFuture.runAsync(rpcService::stopService, actorSystem.dispatcher());
 
 		terminationFuture.get();
 	}


### PR DESCRIPTION
## What is the purpose of the change

Revert the changes introduced by FLINK-7754. An RpcEndpoint's termination future is now
completed from the AkkaRpcActor#postStop method. This enables that we can wait in the `RpcEndpoint#postStop` method on the termination of logically nested `RpcEndpoint`.

## Verifying this change

- Covered by existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
