### PR TITLE
[FLINK-8393] [flip6] Reconnect to last known JobMaster when connection is lost

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/registration/RegisteredRpcConnection.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/registration/RegisteredRpcConnection.java
@@ -27,6 +27,7 @@ import java.io.Serializable;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
@@ -46,6 +47,11 @@ import static org.apache.flink.util.Preconditions.checkState;
  */
 public abstract class RegisteredRpcConnection<F extends Serializable, G extends RpcGateway, S extends RegistrationResponse.Success> {
 
+	private static final AtomicReferenceFieldUpdater<RegisteredRpcConnection, RetryingRegistration> REGISTRATION_UPDATER = AtomicReferenceFieldUpdater.newUpdater(
+		RegisteredRpcConnection.class,
+		RetryingRegistration.class,
+		"pendingRegistration");
+
 	/** The logger for all log messages of this class. */
 	protected final Logger log;
 
@@ -59,7 +65,7 @@ public abstract class RegisteredRpcConnection<F extends Serializable, G extends 
 	private final Executor executor;
 
 	/** The Registration of this RPC connection. */
-	private RetryingRegistration<F, G, S> pendingRegistration;
+	private volatile RetryingRegistration<F, G, S> pendingRegistration;
 
 	/** The gateway to register, it's null until the registration is completed. */
 	private volatile G targetGateway;
@@ -85,27 +91,47 @@ public abstract class RegisteredRpcConnection<F extends Serializable, G extends 
 		checkState(!closed, "The RPC connection is already closed");
 		checkState(!isConnected() && pendingRegistration == null, "The RPC connection is already started");
 
-		pendingRegistration = checkNotNull(generateRegistration());
-		pendingRegistration.startRegistration();
+		final RetryingRegistration<F, G, S> newRegistration = createNewRegistration();
 
-		CompletableFuture<Tuple2<G, S>> future = pendingRegistration.getFuture();
+		if (REGISTRATION_UPDATER.compareAndSet(this, null, newRegistration)) {
+			newRegistration.startRegistration();
+		} else {
+			// concurrent start operation
+			newRegistration.cancel();
+		}
+	}
 
-		future.whenCompleteAsync(
-			(Tuple2<G, S> result, Throwable failure) -> {
-				if (failure != null) {
-					if (failure instanceof CancellationException) {
-						// we ignore cancellation exceptions because they originate from cancelling
-						// the RetryingRegistration
-						log.debug("Retrying registration towards {} was cancelled.", targetAddress);
-					} else {
-						// this future should only ever fail if there is a bug, not if the registration is declined
-						onRegistrationFailure(failure);
-					}
-				} else {
-					targetGateway = result.f0;
-					onRegistrationSuccess(result.f1);
-				}
-			}, executor);
+	public boolean tryReconnect() {
+		checkState(isConnected(), "Cannot reconnect to an unknown destination.");
+
+		if (closed) {
+			return false;
+		} else {
+			final RetryingRegistration<F, G, S> currentPendingRegistration = pendingRegistration;
+
+			if (currentPendingRegistration != null) {
+				currentPendingRegistration.cancel();
+			}
+
+			final RetryingRegistration<F, G, S> newRegistration = createNewRegistration();
+
+			if (REGISTRATION_UPDATER.compareAndSet(this, currentPendingRegistration, newRegistration)) {
+				newRegistration.startRegistration();
+			} else {
+				// concurrent modification
+				newRegistration.cancel();
+				return false;
+			}
+
+			// double check for concurrent close operations
+			if (closed) {
+				newRegistration.cancel();
+
+				return false;
+			} else {
+				return true;
+			}
+		}
 	}
 
 	/**
@@ -175,13 +201,42 @@ public abstract class RegisteredRpcConnection<F extends Serializable, G extends 
 		}
 
 		if (isClosed()) {
-			connectionInfo = connectionInfo + " is closed";
+			connectionInfo += " is closed";
 		} else if (isConnected()){
-			connectionInfo = connectionInfo + " is established";
+			connectionInfo += " is established";
 		} else {
-			connectionInfo = connectionInfo + " is connecting";
+			connectionInfo += " is connecting";
 		}
 
 		return connectionInfo;
+	}
+
+	// ------------------------------------------------------------------------
+	//  Internal methods
+	// ------------------------------------------------------------------------
+
+	private RetryingRegistration<F, G, S> createNewRegistration() {
+		RetryingRegistration<F, G, S> newRegistration = checkNotNull(generateRegistration());
+
+		CompletableFuture<Tuple2<G, S>> future = newRegistration.getFuture();
+
+		future.whenCompleteAsync(
+			(Tuple2<G, S> result, Throwable failure) -> {
+				if (failure != null) {
+					if (failure instanceof CancellationException) {
+						// we ignore cancellation exceptions because they originate from cancelling
+						// the RetryingRegistration
+						log.debug("Retrying registration towards {} was cancelled.", targetAddress);
+					} else {
+						// this future should only ever fail if there is a bug, not if the registration is declined
+						onRegistrationFailure(failure);
+					}
+				} else {
+					targetGateway = result.f0;
+					onRegistrationSuccess(result.f1);
+				}
+			}, executor);
+
+		return newRegistration;
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

Reconnect to the last known location of a lost `JobMaster` connection.

## Brief change log

- In case of a heartbeat timeout or a disconnect call, the `TaskExecutor` tries to reconnect to the last known `JobMaster` location

## Verifying this change

- Added `RegisteredRpcConnection#testReconnect`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
