### PR TITLE
[FLINK-8398] [kinesis, tests] Harden KinesisDataFetcherTest unit tests

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcherTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcherTest.java
@@ -37,6 +37,7 @@ import org.apache.flink.streaming.connectors.kinesis.testutils.TestableKinesisDa
 import com.amazonaws.services.kinesis.model.HashKeyRange;
 import com.amazonaws.services.kinesis.model.SequenceNumberRange;
 import com.amazonaws.services.kinesis.model.Shard;
+import org.apache.flink.util.TestLogger;
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -58,7 +59,7 @@ import static org.mockito.Mockito.when;
 /**
  * Tests for the {@link KinesisDataFetcher}.
  */
-public class KinesisDataFetcherTest {
+public class KinesisDataFetcherTest extends TestLogger {
 
 	@Test(expected = RuntimeException.class)
 	public void testIfNoShardsAreFoundShouldThrowException() throws Exception {
@@ -214,7 +215,8 @@ public class KinesisDataFetcherTest {
 			}
 		};
 		runFetcherThread.start();
-		Thread.sleep(1000); // sleep a while before closing
+
+		fetcher.waitUntilInitialDiscovery();
 		fetcher.shutdownFetcher();
 		runFetcherThread.sync();
 
@@ -303,7 +305,8 @@ public class KinesisDataFetcherTest {
 			}
 		};
 		runFetcherThread.start();
-		Thread.sleep(1000); // sleep a while before closing
+
+		fetcher.waitUntilInitialDiscovery();
 		fetcher.shutdownFetcher();
 		runFetcherThread.sync();
 
@@ -396,7 +399,8 @@ public class KinesisDataFetcherTest {
 			}
 		};
 		runFetcherThread.start();
-		Thread.sleep(1000); // sleep a while before closing
+
+		fetcher.waitUntilInitialDiscovery();
 		fetcher.shutdownFetcher();
 		runFetcherThread.sync();
 
@@ -492,7 +496,8 @@ public class KinesisDataFetcherTest {
 			}
 		};
 		runFetcherThread.start();
-		Thread.sleep(1000); // sleep a while before closing
+
+		fetcher.waitUntilInitialDiscovery();
 		fetcher.shutdownFetcher();
 		runFetcherThread.sync();
 

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumerTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumerTest.java
@@ -17,13 +17,16 @@
 
 package org.apache.flink.streaming.connectors.kinesis.internals;
 
+import org.apache.flink.api.common.serialization.SimpleStringSchema;
 import org.apache.flink.streaming.connectors.kinesis.model.KinesisStreamShardState;
 import org.apache.flink.streaming.connectors.kinesis.model.SentinelSequenceNumber;
 import org.apache.flink.streaming.connectors.kinesis.model.SequenceNumber;
 import org.apache.flink.streaming.connectors.kinesis.model.StreamShardHandle;
 import org.apache.flink.streaming.connectors.kinesis.proxy.KinesisProxyInterface;
+import org.apache.flink.streaming.connectors.kinesis.serialization.KinesisDeserializationSchemaWrapper;
 import org.apache.flink.streaming.connectors.kinesis.testutils.FakeKinesisBehavioursFactory;
 import org.apache.flink.streaming.connectors.kinesis.testutils.KinesisShardIdGenerator;
+import org.apache.flink.streaming.connectors.kinesis.testutils.TestSourceContext;
 import org.apache.flink.streaming.connectors.kinesis.testutils.TestableKinesisDataFetcher;
 
 import com.amazonaws.services.kinesis.model.HashKeyRange;
@@ -38,7 +41,7 @@ import java.util.LinkedList;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Tests for the {@link ShardConsumer}.
@@ -61,13 +64,17 @@ public class ShardConsumerTest {
 			new KinesisStreamShardState(KinesisDataFetcher.convertToStreamShardMetadata(fakeToBeConsumedShard),
 				fakeToBeConsumedShard, new SequenceNumber("fakeStartingState")));
 
-		TestableKinesisDataFetcher fetcher =
-			new TestableKinesisDataFetcher(
+		TestSourceContext<String> sourceContext = new TestSourceContext<>();
+
+		TestableKinesisDataFetcher<String> fetcher =
+			new TestableKinesisDataFetcher<>(
 				Collections.singletonList("fakeStream"),
+				sourceContext,
 				new Properties(),
+				new KinesisDeserializationSchemaWrapper<>(new SimpleStringSchema()),
 				10,
 				2,
-				new AtomicReference<Throwable>(),
+				new AtomicReference<>(),
 				subscribedShardsStateUnderTest,
 				KinesisDataFetcher.createInitialSubscribedStreamsToLastDiscoveredShardsState(Collections.singletonList("fakeStream")),
 				Mockito.mock(KinesisProxyInterface.class));
@@ -79,9 +86,10 @@ public class ShardConsumerTest {
 			subscribedShardsStateUnderTest.get(0).getLastProcessedSequenceNum(),
 			FakeKinesisBehavioursFactory.totalNumOfRecordsAfterNumOfGetRecordsCalls(1000, 9)).run();
 
-		assertTrue(fetcher.getNumOfElementsCollected() == 1000);
-		assertTrue(subscribedShardsStateUnderTest.get(0).getLastProcessedSequenceNum().equals(
-			SentinelSequenceNumber.SENTINEL_SHARD_ENDING_SEQUENCE_NUM.get()));
+		assertEquals(1000, sourceContext.getCollectedOutputs().size());
+		assertEquals(
+			SentinelSequenceNumber.SENTINEL_SHARD_ENDING_SEQUENCE_NUM.get(),
+			subscribedShardsStateUnderTest.get(0).getLastProcessedSequenceNum());
 	}
 
 	@Test
@@ -100,13 +108,17 @@ public class ShardConsumerTest {
 			new KinesisStreamShardState(KinesisDataFetcher.convertToStreamShardMetadata(fakeToBeConsumedShard),
 				fakeToBeConsumedShard, new SequenceNumber("fakeStartingState")));
 
-		TestableKinesisDataFetcher fetcher =
-			new TestableKinesisDataFetcher(
+		TestSourceContext<String> sourceContext = new TestSourceContext<>();
+
+		TestableKinesisDataFetcher<String> fetcher =
+			new TestableKinesisDataFetcher<>(
 				Collections.singletonList("fakeStream"),
+				sourceContext,
 				new Properties(),
+				new KinesisDeserializationSchemaWrapper<>(new SimpleStringSchema()),
 				10,
 				2,
-				new AtomicReference<Throwable>(),
+				new AtomicReference<>(),
 				subscribedShardsStateUnderTest,
 				KinesisDataFetcher.createInitialSubscribedStreamsToLastDiscoveredShardsState(Collections.singletonList("fakeStream")),
 				Mockito.mock(KinesisProxyInterface.class));
@@ -120,9 +132,10 @@ public class ShardConsumerTest {
 			// and the 7th getRecords() call will encounter an unexpected expired shard iterator
 			FakeKinesisBehavioursFactory.totalNumOfRecordsAfterNumOfGetRecordsCallsWithUnexpectedExpiredIterator(1000, 9, 7)).run();
 
-		assertTrue(fetcher.getNumOfElementsCollected() == 1000);
-		assertTrue(subscribedShardsStateUnderTest.get(0).getLastProcessedSequenceNum().equals(
-			SentinelSequenceNumber.SENTINEL_SHARD_ENDING_SEQUENCE_NUM.get()));
+		assertEquals(1000, sourceContext.getCollectedOutputs().size());
+		assertEquals(
+			SentinelSequenceNumber.SENTINEL_SHARD_ENDING_SEQUENCE_NUM.get(),
+			subscribedShardsStateUnderTest.get(0).getLastProcessedSequenceNum());
 	}
 
 }

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/TestSourceContext.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/TestSourceContext.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kinesis.testutils;
+
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+/**
+ * A testable {@link SourceFunction.SourceContext}.
+ */
+public class TestSourceContext<T> implements SourceFunction.SourceContext<T> {
+
+	private final Object checkpointLock = new Object();
+
+	private ConcurrentLinkedQueue<StreamRecord<T>> collectedOutputs = new ConcurrentLinkedQueue<>();
+
+	@Override
+	public void collect(T element) {
+		this.collectedOutputs.add(new StreamRecord<>(element));
+	}
+
+	@Override
+	public void collectWithTimestamp(T element, long timestamp) {
+		this.collectedOutputs.add(new StreamRecord<>(element, timestamp));
+	}
+
+	@Override
+	public void emitWatermark(Watermark mark) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void markAsTemporarilyIdle() {}
+
+	@Override
+	public Object getCheckpointLock() {
+		return checkpointLock;
+	}
+
+	@Override
+	public void close() {}
+
+	public ConcurrentLinkedQueue<StreamRecord<T>> getCollectedOutputs() {
+		return collectedOutputs;
+	}
+}

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/TestableKinesisDataFetcher.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/TestableKinesisDataFetcher.java
@@ -22,6 +22,7 @@ import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.connectors.kinesis.internals.KinesisDataFetcher;
 import org.apache.flink.streaming.connectors.kinesis.model.KinesisStreamShardState;
+import org.apache.flink.streaming.connectors.kinesis.model.StreamShardHandle;
 import org.apache.flink.streaming.connectors.kinesis.proxy.KinesisProxyInterface;
 import org.apache.flink.streaming.connectors.kinesis.serialization.KinesisDeserializationSchema;
 
@@ -44,6 +45,8 @@ import static org.mockito.Mockito.when;
 public class TestableKinesisDataFetcher<T> extends KinesisDataFetcher<T> {
 
 	private OneShotLatch runWaiter;
+	private OneShotLatch initialDiscoveryWaiter;
+
 	private volatile boolean running;
 
 	public TestableKinesisDataFetcher(
@@ -70,6 +73,8 @@ public class TestableKinesisDataFetcher<T> extends KinesisDataFetcher<T> {
 			fakeKinesis);
 
 		this.runWaiter = new OneShotLatch();
+		this.initialDiscoveryWaiter = new OneShotLatch();
+
 		this.running = true;
 	}
 
@@ -95,6 +100,16 @@ public class TestableKinesisDataFetcher<T> extends KinesisDataFetcher<T> {
 	public void awaitTermination() throws InterruptedException {
 		this.running = false;
 		super.awaitTermination();
+	}
+
+	@Override
+	public List<StreamShardHandle> discoverNewShardsToSubscribe() throws InterruptedException {
+		initialDiscoveryWaiter.trigger();
+		return super.discoverNewShardsToSubscribe();
+	}
+
+	public void waitUntilInitialDiscovery() throws InterruptedException {
+		initialDiscoveryWaiter.await();
 	}
 
 	private static RuntimeContext getMockedRuntimeContext(final int fakeTotalCountOfSubtasks, final int fakeIndexOfThisSubtask) {

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/TestableKinesisDataFetcher.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/TestableKinesisDataFetcher.java
@@ -18,76 +18,59 @@
 package org.apache.flink.streaming.connectors.kinesis.testutils;
 
 import org.apache.flink.api.common.functions.RuntimeContext;
-import org.apache.flink.api.common.serialization.SimpleStringSchema;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.connectors.kinesis.internals.KinesisDataFetcher;
 import org.apache.flink.streaming.connectors.kinesis.model.KinesisStreamShardState;
-import org.apache.flink.streaming.connectors.kinesis.model.SequenceNumber;
 import org.apache.flink.streaming.connectors.kinesis.proxy.KinesisProxyInterface;
 import org.apache.flink.streaming.connectors.kinesis.serialization.KinesisDeserializationSchema;
-import org.apache.flink.streaming.connectors.kinesis.serialization.KinesisDeserializationSchemaWrapper;
 
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Extension of the {@link KinesisDataFetcher} for testing.
  */
-public class TestableKinesisDataFetcher extends KinesisDataFetcher<String> {
-
-	private static final Object fakeCheckpointLock = new Object();
-
-	private long numElementsCollected;
+public class TestableKinesisDataFetcher<T> extends KinesisDataFetcher<T> {
 
 	private OneShotLatch runWaiter;
+	private volatile boolean running;
 
 	public TestableKinesisDataFetcher(
 			List<String> fakeStreams,
+			SourceFunction.SourceContext<T> sourceContext,
 			Properties fakeConfiguration,
+			KinesisDeserializationSchema<T> deserializationSchema,
 			int fakeTotalCountOfSubtasks,
 			int fakeIndexOfThisSubtask,
 			AtomicReference<Throwable> thrownErrorUnderTest,
 			LinkedList<KinesisStreamShardState> subscribedShardsStateUnderTest,
 			HashMap<String, String> subscribedStreamsToLastDiscoveredShardIdsStateUnderTest,
 			KinesisProxyInterface fakeKinesis) {
-		super(fakeStreams,
-			getMockedSourceContext(),
-			fakeCheckpointLock,
+		super(
+			fakeStreams,
+			sourceContext,
+			sourceContext.getCheckpointLock(),
 			getMockedRuntimeContext(fakeTotalCountOfSubtasks, fakeIndexOfThisSubtask),
 			fakeConfiguration,
-			new KinesisDeserializationSchemaWrapper<>(new SimpleStringSchema()),
+			deserializationSchema,
 			thrownErrorUnderTest,
 			subscribedShardsStateUnderTest,
 			subscribedStreamsToLastDiscoveredShardIdsStateUnderTest,
 			fakeKinesis);
 
-		this.numElementsCollected = 0;
 		this.runWaiter = new OneShotLatch();
-	}
-
-	public long getNumOfElementsCollected() {
-		return numElementsCollected;
-	}
-
-	@Override
-	protected KinesisDeserializationSchema<String> getClonedDeserializationSchema() {
-		return new KinesisDeserializationSchemaWrapper<>(new SimpleStringSchema());
-	}
-
-	@Override
-	protected void emitRecordAndUpdateState(String record, long recordTimestamp, int shardStateIndex, SequenceNumber lastSequenceNumber) {
-		synchronized (fakeCheckpointLock) {
-			this.numElementsCollected++;
-			updateState(shardStateIndex, lastSequenceNumber);
-		}
+		this.running = true;
 	}
 
 	@Override
@@ -100,41 +83,30 @@ public class TestableKinesisDataFetcher extends KinesisDataFetcher<String> {
 		runWaiter.await();
 	}
 
-	@SuppressWarnings("unchecked")
-	private static SourceFunction.SourceContext<String> getMockedSourceContext() {
-		return Mockito.mock(SourceFunction.SourceContext.class);
+	@Override
+	protected ExecutorService createShardConsumersThreadPool(String subtaskName) {
+		// this is just a dummy fetcher, so no need to create a thread pool for shard consumers
+		ExecutorService mockExecutor = mock(ExecutorService.class);
+		when(mockExecutor.isTerminated()).thenAnswer((InvocationOnMock invocation) -> !running);
+		return mockExecutor;
+	}
+
+	@Override
+	public void awaitTermination() throws InterruptedException {
+		this.running = false;
+		super.awaitTermination();
 	}
 
 	private static RuntimeContext getMockedRuntimeContext(final int fakeTotalCountOfSubtasks, final int fakeIndexOfThisSubtask) {
-		RuntimeContext mockedRuntimeContext = Mockito.mock(RuntimeContext.class);
+		RuntimeContext mockedRuntimeContext = mock(RuntimeContext.class);
 
-		Mockito.when(mockedRuntimeContext.getNumberOfParallelSubtasks()).thenAnswer(new Answer<Integer>() {
-			@Override
-			public Integer answer(InvocationOnMock invocationOnMock) throws Throwable {
-				return fakeTotalCountOfSubtasks;
-			}
-		});
-
-		Mockito.when(mockedRuntimeContext.getIndexOfThisSubtask()).thenAnswer(new Answer<Integer>() {
-			@Override
-			public Integer answer(InvocationOnMock invocationOnMock) throws Throwable {
-				return fakeIndexOfThisSubtask;
-			}
-		});
-
-		Mockito.when(mockedRuntimeContext.getTaskName()).thenAnswer(new Answer<String>() {
-			@Override
-			public String answer(InvocationOnMock invocationOnMock) throws Throwable {
-				return "Fake Task";
-			}
-		});
-
-		Mockito.when(mockedRuntimeContext.getTaskNameWithSubtasks()).thenAnswer(new Answer<String>() {
-			@Override
-			public String answer(InvocationOnMock invocationOnMock) throws Throwable {
-				return "Fake Task (" + fakeIndexOfThisSubtask + "/" + fakeTotalCountOfSubtasks + ")";
-			}
-		});
+		Mockito.when(mockedRuntimeContext.getNumberOfParallelSubtasks()).thenReturn(fakeTotalCountOfSubtasks);
+		Mockito.when(mockedRuntimeContext.getIndexOfThisSubtask()).thenReturn(fakeIndexOfThisSubtask);
+		Mockito.when(mockedRuntimeContext.getTaskName()).thenReturn("Fake Task");
+		Mockito.when(mockedRuntimeContext.getTaskNameWithSubtasks()).thenReturn(
+				"Fake Task (" + fakeIndexOfThisSubtask + "/" + fakeTotalCountOfSubtasks + ")");
+		Mockito.when(mockedRuntimeContext.getUserCodeClassLoader()).thenReturn(
+				Thread.currentThread().getContextClassLoader());
 
 		return mockedRuntimeContext;
 	}


### PR DESCRIPTION
## What is the purpose of the change

Prior to this PR, many of the `KinesisDataFetcherTest` unit tests relied on thread sleeps to wait until a certain operation occurs to allow the test to pass. This test behaviour is very flaky, and should be replaced with `OneShotLatch`.

## Brief change log

- 94b4591: Several minor cleanups of confusing implementations / code smells in the `KinesisDataFetcherTest` and related test classes. The commit message explains what exactly was changed.
- 547d19f: Remove thread sleeps in unit tests, and replace them with `OneShotLatch`.


## Verifying this change

No test coverage should have been affected by this change.
The existing tests in `KinesisDataFetcherTest` verifies this.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)

  