### PR TITLE
[FLINK-8399] [runtime] use independent configurations for the different timeouts in slot manager

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
@@ -59,6 +59,27 @@ public class ResourceManagerOptions {
 		.withDeprecatedKeys("yarn.heap-cutoff-min");
 
 	/**
+	 * The timeout for requesting slot to a task manager, in milliseconds.
+	 */
+	public static final ConfigOption<Integer> TASK_MANAGER_REQUEST_TIMEOUT = ConfigOptions
+			.key("slotmanager.taskmanager.request-timeout")
+			.defaultValue(30000);
+
+	/**
+	 * The timeout for a slot request to be discarded, in milliseconds.
+	 */
+	public static final ConfigOption<Integer> SLOT_REQUEST_TIMEOUT = ConfigOptions
+			.key("slotmanager.slot.request-timeout")
+			.defaultValue(600000);
+
+	/**
+	 * The timeout for an idle task manager to be released, in milliseconds.
+	 */
+	public static final ConfigOption<Integer> TASK_MANAGER_TIMEOUT = ConfigOptions
+			.key("slotmanager.taskmanager.timeout")
+			.defaultValue(30000);
+
+	/**
 	 * Prefix for passing custom environment variables to Flink's master process.
 	 * For example for passing LD_LIBRARY_PATH as an env variable to the AppMaster, set:
 	 * containerized.master.env.LD_LIBRARY_PATH: "/usr/lib/native"

--- a/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
@@ -61,23 +61,26 @@ public class ResourceManagerOptions {
 	/**
 	 * The timeout for requesting slot to a task manager, in milliseconds.
 	 */
-	public static final ConfigOption<Integer> TASK_MANAGER_REQUEST_TIMEOUT = ConfigOptions
-			.key("slotmanager.taskmanager.request-timeout")
-			.defaultValue(30000);
+	public static final ConfigOption<Long> TASK_MANAGER_REQUEST_TIMEOUT = ConfigOptions
+		.key("slotmanager.rpc-timeout")
+		.defaultValue(30000L)
+		.withDescription("The timeout for rpc request with task manager.");
 
 	/**
 	 * The timeout for a slot request to be discarded, in milliseconds.
 	 */
-	public static final ConfigOption<Integer> SLOT_REQUEST_TIMEOUT = ConfigOptions
-			.key("slotmanager.slot.request-timeout")
-			.defaultValue(600000);
+	public static final ConfigOption<Long> SLOT_REQUEST_TIMEOUT = ConfigOptions
+		.key("slotmanager.request-timeout")
+		.defaultValue(600000L)
+		.withDescription("The timeout for a slot request to be discarded.");
 
 	/**
 	 * The timeout for an idle task manager to be released, in milliseconds.
 	 */
-	public static final ConfigOption<Integer> TASK_MANAGER_TIMEOUT = ConfigOptions
-			.key("slotmanager.taskmanager.timeout")
-			.defaultValue(30000);
+	public static final ConfigOption<Long> TASK_MANAGER_TIMEOUT = ConfigOptions
+		.key("slotmanager.taskmanager-timeout")
+		.defaultValue(30000L)
+		.withDescription("The timeout for an idle task manager to be released.");
 
 	/**
 	 * Prefix for passing custom environment variables to Flink's master process.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfiguration.java
@@ -19,11 +19,10 @@
 package org.apache.flink.runtime.resourcemanager.slotmanager;
 
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.configuration.AkkaOptions;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ResourceManagerOptions;
 import org.apache.flink.util.ConfigurationException;
 import org.apache.flink.util.Preconditions;
-import scala.concurrent.duration.Duration;
 
 public class SlotManagerConfiguration {
 
@@ -53,16 +52,13 @@ public class SlotManagerConfiguration {
 	}
 
 	public static SlotManagerConfiguration fromConfiguration(Configuration configuration) throws ConfigurationException {
-		final String strTimeout = configuration.getString(AkkaOptions.ASK_TIMEOUT);
-		final Time timeout;
+		final Time taskManagerRequestTimeout = Time.milliseconds(
+				configuration.getInteger(ResourceManagerOptions.TASK_MANAGER_REQUEST_TIMEOUT));
+		final Time slotRequestTimeout = Time.milliseconds(
+				configuration.getInteger(ResourceManagerOptions.SLOT_REQUEST_TIMEOUT));
+		final Time taskManagerTimeout = Time.milliseconds(
+				configuration.getInteger(ResourceManagerOptions.TASK_MANAGER_TIMEOUT));
 
-		try {
-			timeout = Time.milliseconds(Duration.apply(strTimeout).toMillis());
-		} catch (NumberFormatException e) {
-			throw new ConfigurationException("Could not parse the resource manager's timeout " +
-				"value " + AkkaOptions.ASK_TIMEOUT + '.', e);
-		}
-
-		return new SlotManagerConfiguration(timeout, timeout, timeout);
+		return new SlotManagerConfiguration(taskManagerRequestTimeout, slotRequestTimeout, taskManagerTimeout);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfiguration.java
@@ -53,11 +53,11 @@ public class SlotManagerConfiguration {
 
 	public static SlotManagerConfiguration fromConfiguration(Configuration configuration) throws ConfigurationException {
 		final Time taskManagerRequestTimeout = Time.milliseconds(
-				configuration.getInteger(ResourceManagerOptions.TASK_MANAGER_REQUEST_TIMEOUT));
+				configuration.getLong(ResourceManagerOptions.TASK_MANAGER_REQUEST_TIMEOUT));
 		final Time slotRequestTimeout = Time.milliseconds(
-				configuration.getInteger(ResourceManagerOptions.SLOT_REQUEST_TIMEOUT));
+				configuration.getLong(ResourceManagerOptions.SLOT_REQUEST_TIMEOUT));
 		final Time taskManagerTimeout = Time.milliseconds(
-				configuration.getInteger(ResourceManagerOptions.TASK_MANAGER_TIMEOUT));
+				configuration.getLong(ResourceManagerOptions.TASK_MANAGER_TIMEOUT));
 
 		return new SlotManagerConfiguration(taskManagerRequestTimeout, slotRequestTimeout, taskManagerTimeout);
 	}


### PR DESCRIPTION

## What is the purpose of the change

*This pull request separate the timeouts for slot request to task manager, slot request to be discarded and task manager to be released in slot manager to three different configurations.*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
