### PR TITLE
[FLINK-8400] [table] Use the lexicographic smallest attribute as the common group id when extract unique key

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/util/UpdatingPlanChecker.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/util/UpdatingPlanChecker.scala
@@ -39,8 +39,13 @@ object UpdatingPlanChecker {
 
   /** Extracts the unique keys of the table produced by the plan. */
   def getUniqueKeyFields(plan: RelNode): Option[Array[String]] = {
+    getUniqueKeyGroups(plan).map(_.map(_._1).toArray)
+  }
+
+  /** Extracts the unique keys and groups of the table produced by the plan. */
+  def getUniqueKeyGroups(plan: RelNode): Option[Seq[(String, String)]] = {
     val keyExtractor = new UniqueKeyExtractor
-    keyExtractor.visit(plan).map(_.map(_._1).toArray)
+    keyExtractor.visit(plan)
   }
 
   private class AppendOnlyValidator extends RelVisitor {
@@ -101,7 +106,7 @@ object UpdatingPlanChecker {
               .filter(io => inputKeys.get.map(e => e._1).contains(io._1))
 
             val inputKeysMap = inputKeys.get.toMap
-            val inOutGroups = inputKeysAndOutput
+            val inOutGroups = inputKeysAndOutput.sorted.reverse
               .map(e => (inputKeysMap(e._1), e._2))
               .toMap
 


### PR DESCRIPTION

## What is the purpose of the change

`UniqueKeyExtractor` will return a tuple, the first element is the name of a key field, the second is a group name that is shared by all equivalent key fields. The group names are used to identify same keys, for example: select('pk as pk1, 'pk as pk2), both pk1 and pk2 belong to the same group, i.e., pk1. Here we use the lexicographic smallest attribute as the common group id.

Currently, when extract unique keys from `DataStreamCalc`, the generated group id is not the lexicographic smallest attribute. This pr will fix this bug.


## Brief change log

  - Use lexicographic smallest attribute as group id when extract unique key for `DataStreamCalc`
  - Add test to check whether group id is the lexicographic smallest attribute.


## Verifying this change

This change added tests and can be verified as follows:

  - Add test to check whether group id is the lexicographic smallest attribute


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
