### PR TITLE
[FLINK-8401][Cassandra Connector]Refactor CassandraOutputFormat to allow subclass to customize the fai…

### DIFF
--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/batch/connectors/cassandra/CassandraOutputFormat.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/batch/connectors/cassandra/CassandraOutputFormat.java
@@ -67,6 +67,26 @@ public class CassandraOutputFormat<OUT extends Tuple> extends RichOutputFormat<O
 	}
 
 	/**
+	 * Callback that is invoked after a record is written to Cassandra successfully.
+	 *
+	 * <p>Subclass can override to provide its own logic.
+	 * @param ignored the result.
+	 */
+	protected void onWriteSuccess(ResultSet ignored) {
+	}
+
+	/**
+	 * Callback that is invoked when failing to write to Cassandra.
+	 * Current implementation will record the exception and fail the job upon next record.
+	 *
+	 * <p>Subclass can override to provide its own failure handling logic.
+	 * @param t the exception
+	 */
+	protected void onWriteFailure(Throwable t) {
+		exception = t;
+	}
+
+	/**
 	 * Opens a Session to Cassandra and initializes the prepared statement.
 	 *
 	 * @param taskNumber The number of the parallel instance.
@@ -80,11 +100,12 @@ public class CassandraOutputFormat<OUT extends Tuple> extends RichOutputFormat<O
 		this.callback = new FutureCallback<ResultSet>() {
 			@Override
 			public void onSuccess(ResultSet ignored) {
+				onWriteSuccess(ignored);
 			}
 
 			@Override
 			public void onFailure(Throwable t) {
-				exception = t;
+				onWriteFailure(t);
 			}
 		};
 	}


### PR DESCRIPTION
## What is the purpose of the change

Refactor CassandraOutputFormat to allow subclass to customize the failure handling logic.


## Brief change log
  - Added to protected methods for handling cassandra write result, these allow subclass to override them to customize.


## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: ( no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
