### PR TITLE
[FLINK-8371][network] always recycle Buffers when releasing SpillableSubpartition

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/iomanager/BlockChannelWriterWithCallback.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/iomanager/BlockChannelWriterWithCallback.java
@@ -26,7 +26,7 @@ public interface BlockChannelWriterWithCallback<T> extends FileIOChannel {
 	 * Writes the given block. The request may be executed synchronously, or asynchronously, depending
 	 * on the implementation.
 	 *
-	 * @param block The segment to be written.
+	 * @param block The segment to be written (transferring ownership to this writer).
 	 * @throws IOException Thrown, when the writer encounters an I/O error.
 	 */
 	void writeBlock(T block) throws IOException;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
@@ -67,6 +67,7 @@ class PipelinedSubpartition extends ResultSubpartition {
 
 		synchronized (buffers) {
 			if (isFinished || isReleased) {
+				buffer.recycle();
 				return false;
 			}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
@@ -128,7 +128,6 @@ class PipelinedSubpartition extends ResultSubpartition {
 				buffer.recycle();
 			}
 
-			// Get the view...
 			view = readView;
 			readView = null;
 
@@ -138,7 +137,6 @@ class PipelinedSubpartition extends ResultSubpartition {
 
 		LOG.debug("Released {}.", this);
 
-		// Release all resources of the view
 		if (view != null) {
 			view.releaseAllResources();
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartition.java
@@ -70,6 +70,18 @@ public abstract class ResultSubpartition {
 		return parent.getFailureCause();
 	}
 
+	/**
+	 * Adds the given buffer.
+	 *
+	 * <p>The request may be executed synchronously, or asynchronously, depending on the
+	 * implementation.
+	 *
+	 * @param buffer
+	 * 		the buffer to add (transferring ownership to this writer)
+	 *
+	 * @throws IOException
+	 * 		thrown in case of errors while adding the buffer
+	 */
 	abstract public boolean add(Buffer buffer) throws IOException;
 
 	abstract public void finish() throws IOException;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartition.java
@@ -138,6 +138,7 @@ class SpillableSubpartition extends ResultSubpartition {
 
 	@Override
 	public void release() throws IOException {
+		// view reference accessible outside the lock, but assigned inside the locked scope
 		final ResultSubpartitionView view;
 
 		synchronized (buffers) {
@@ -145,16 +146,18 @@ class SpillableSubpartition extends ResultSubpartition {
 				return;
 			}
 
+			// Release all available buffers
+			for (Buffer buffer : buffers) {
+				buffer.recycle();
+			}
+			buffers.clear();
+
 			view = readView;
 
 			// No consumer yet, we are responsible to clean everything up. If
 			// one is available, the view is responsible is to clean up (see
 			// below).
 			if (view == null) {
-				for (Buffer buffer : buffers) {
-					buffer.recycle();
-				}
-				buffers.clear();
 
 				// TODO This can block until all buffers are written out to
 				// disk if a spill is in-progress before deleting the file.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartition.java
@@ -95,13 +95,12 @@ class SpillableSubpartition extends ResultSubpartition {
 				return false;
 			}
 
-			// The number of buffers are needed later when creating
-			// the read views. If you ever remove this line here,
-			// make sure to still count the number of buffers.
-			updateStatistics(buffer);
-
 			if (spillWriter == null) {
 				buffers.add(buffer);
+				// The number of buffers are needed later when creating
+				// the read views. If you ever remove this line here,
+				// make sure to still count the number of buffers.
+				updateStatistics(buffer);
 
 				return true;
 			}
@@ -109,6 +108,10 @@ class SpillableSubpartition extends ResultSubpartition {
 
 		// Didn't return early => go to disk
 		spillWriter.writeBlock(buffer);
+		synchronized (buffers) {
+			// See the note above, but only do this if the buffer was correctly added!
+			updateStatistics(buffer);
+		}
 
 		return true;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartitionView.java
@@ -108,11 +108,7 @@ class SpillableSubpartitionView implements ResultSubpartitionView {
 				for (int i = 0; i < numBuffers; i++) {
 					Buffer buffer = buffers.remove();
 					spilledBytes += buffer.getSize();
-					try {
-						spillWriter.writeBlock(buffer);
-					} finally {
-						buffer.recycle();
-					}
+					spillWriter.writeBlock(buffer);
 				}
 
 				spilledView = new SpilledSubpartitionView(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartitionView.java
@@ -165,6 +165,13 @@ class SpillableSubpartitionView implements ResultSubpartitionView {
 			if (spilled != null) {
 				spilled.releaseAllResources();
 			}
+			// we are never giving this buffer out in getNextBuffer(), so we need to clean it up
+			synchronized (buffers) {
+				if (nextBuffer != null) {
+					nextBuffer.recycle();
+					nextBuffer = null;
+				}
+			}
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/iomanager/AsynchronousBufferFileWriterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/iomanager/AsynchronousBufferFileWriterTest.java
@@ -18,13 +18,17 @@
 
 package org.apache.flink.runtime.io.disk.iomanager;
 
+import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
 import org.apache.flink.runtime.io.network.util.TestNotificationListener;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 import java.util.concurrent.Callable;
@@ -39,7 +43,12 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
+/**
+ * Tests for {@link AsynchronousBufferFileWriter}.
+ */
 public class AsynchronousBufferFileWriterTest {
+	@Rule
+	public ExpectedException exception = ExpectedException.none();
 
 	private static final IOManager ioManager = new IOManagerAsync();
 
@@ -64,6 +73,27 @@ public class AsynchronousBufferFileWriterTest {
 
 		handleRequest();
 		assertEquals("Didn't decrement number of outstanding requests.", 0, writer.getNumberOfOutstandingRequests());
+	}
+
+	@Test
+	public void testAddWithFailingWriter() throws Exception {
+		AsynchronousBufferFileWriter writer =
+			new AsynchronousBufferFileWriter(ioManager.createChannel(), new RequestQueue<>());
+		writer.close();
+
+		exception.expect(IOException.class);
+
+		Buffer buffer = new Buffer(MemorySegmentFactory.allocateUnpooledSegment(4096),
+			FreeingBufferRecycler.INSTANCE);
+		try {
+			writer.writeBlock(buffer);
+		} finally {
+			if (!buffer.isRecycled()) {
+				buffer.recycle();
+				Assert.fail("buffer not recycled");
+			}
+			assertEquals("Shouln't increment number of outstanding requests.", 0, writer.getNumberOfOutstandingRequests());
+		}
 	}
 
 	@Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/iomanager/IOManagerAsyncWithNoOpBufferFileWriter.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/iomanager/IOManagerAsyncWithNoOpBufferFileWriter.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.disk.iomanager;
+
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+
+import java.io.IOException;
+
+/**
+ * An {@link IOManagerAsync} that creates {@link BufferFileWriter} instances which do nothing in their {@link BufferFileWriter#writeBlock(Object)} method.
+ *
+ * <p>Beware: the passed {@link Buffer} instances must be cleaned up manually!
+ */
+public class IOManagerAsyncWithNoOpBufferFileWriter extends IOManagerAsync {
+	@Override
+	public BufferFileWriter createBufferFileWriter(FileIOChannel.ID channelID)
+			throws IOException {
+		return new NoOpAsynchronousBufferFileWriter(channelID, getWriteRequestQueue(channelID));
+	}
+
+	/**
+	 * {@link BufferFileWriter} subclass with a no-op in {@link #writeBlock(Buffer)}.
+	 */
+	private static class NoOpAsynchronousBufferFileWriter extends AsynchronousBufferFileWriter {
+
+		private NoOpAsynchronousBufferFileWriter(
+				ID channelID,
+				RequestQueue<WriteRequest> requestQueue) throws IOException {
+			super(channelID, requestQueue);
+		}
+
+		@Override
+		public void writeBlock(Buffer buffer) throws IOException {
+			// do nothing
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionTest.java
@@ -35,6 +35,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import static org.apache.flink.runtime.io.network.util.TestBufferFactory.BUFFER_SIZE;
 import static org.apache.flink.runtime.io.network.util.TestBufferFactory.createBuffer;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -102,6 +103,8 @@ public class PipelinedSubpartitionTest extends SubpartitionTestBase {
 
 		// Add data to the queue...
 		subpartition.add(createBuffer());
+		assertEquals(1, subpartition.getTotalNumberOfBuffers());
+		assertEquals(BUFFER_SIZE, subpartition.getTotalNumberOfBytes());
 
 		// ...should have resulted in a notification
 		verify(listener, times(1)).notifyBuffersAvailable(eq(1L));
@@ -112,6 +115,8 @@ public class PipelinedSubpartitionTest extends SubpartitionTestBase {
 
 		// Add data to the queue...
 		subpartition.add(createBuffer());
+		assertEquals(2, subpartition.getTotalNumberOfBuffers());
+		assertEquals(2 * BUFFER_SIZE, subpartition.getTotalNumberOfBytes());
 		verify(listener, times(2)).notifyBuffersAvailable(eq(1L));
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionTest.java
@@ -19,16 +19,20 @@
 package org.apache.flink.runtime.io.network.partition;
 
 import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.runtime.event.AbstractEvent;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferProvider;
+import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
 import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
 import org.apache.flink.runtime.io.network.util.TestConsumerCallback;
 import org.apache.flink.runtime.io.network.util.TestPooledBufferProvider;
 import org.apache.flink.runtime.io.network.util.TestProducerSource;
 import org.apache.flink.runtime.io.network.util.TestSubpartitionConsumer;
 import org.apache.flink.runtime.io.network.util.TestSubpartitionProducer;
+
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.concurrent.ExecutorService;
@@ -237,5 +241,73 @@ public class PipelinedSubpartitionTest extends SubpartitionTestBase {
 		// Wait for producer and consumer to finish
 		producerResult.get();
 		consumerResult.get();
+	}
+
+
+	/**
+	 * Tests cleanup of {@link PipelinedSubpartition#release()} with no read view attached.
+	 */
+	@Test
+	public void testCleanupReleasedPartitionNoView() throws Exception {
+		testCleanupReleasedPartition(false);
+	}
+
+	/**
+	 * Tests cleanup of {@link PipelinedSubpartition#release()} with a read view attached.
+	 */
+	@Test
+	public void testCleanupReleasedPartitionWithView() throws Exception {
+		testCleanupReleasedPartition(true);
+	}
+
+	/**
+	 * Tests cleanup of {@link PipelinedSubpartition#release()}.
+	 *
+	 * @param createView
+	 * 		whether the partition should have a view attached to it (<tt>true</tt>) or not (<tt>false</tt>)
+	 */
+	private void testCleanupReleasedPartition(boolean createView) throws Exception {
+		PipelinedSubpartition partition = createSubpartition();
+
+		Buffer buffer1 = new Buffer(MemorySegmentFactory.allocateUnpooledSegment(4096),
+			FreeingBufferRecycler.INSTANCE);
+		Buffer buffer2 = new Buffer(MemorySegmentFactory.allocateUnpooledSegment(4096),
+			FreeingBufferRecycler.INSTANCE);
+		boolean buffer1Recycled;
+		boolean buffer2Recycled;
+		try {
+			partition.add(buffer1);
+			partition.add(buffer2);
+			// create the read view first
+			ResultSubpartitionView view = null;
+			if (createView) {
+				view = partition.createReadView(numBuffers -> {});
+			}
+
+			partition.release();
+
+			assertTrue(partition.isReleased());
+			if (createView) {
+				assertTrue(view.isReleased());
+			}
+			assertTrue(buffer1.isRecycled());
+		} finally {
+			buffer1Recycled = buffer1.isRecycled();
+			if (!buffer1Recycled) {
+				buffer1.recycle();
+			}
+			buffer2Recycled = buffer2.isRecycled();
+			if (!buffer2Recycled) {
+				buffer2.recycle();
+			}
+		}
+		if (!buffer1Recycled) {
+			Assert.fail("buffer 1 not recycled");
+		}
+		if (!buffer2Recycled) {
+			Assert.fail("buffer 2 not recycled");
+		}
+		assertEquals(2, partition.getTotalNumberOfBuffers());
+		assertEquals(2 * 4096, partition.getTotalNumberOfBytes());
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartitionTest.java
@@ -541,6 +541,105 @@ public class SpillableSubpartitionTest extends SubpartitionTestBase {
 		}
 	}
 
+	/**
+	 * Tests cleanup of {@link SpillableSubpartition#release()} with a spillable partition and no
+	 * read view attached.
+	 */
+	@Test
+	public void testCleanupReleasedSpillablePartitionNoView() throws Exception {
+		testCleanupReleasedPartition(false, false);
+	}
+
+	/**
+	 * Tests cleanup of {@link SpillableSubpartition#release()} with a spillable partition and a
+	 * read view attached - [FLINK-8371].
+	 */
+	@Test
+	public void testCleanupReleasedSpillablePartitionWithView() throws Exception {
+		testCleanupReleasedPartition(false, true);
+	}
+
+	/**
+	 * Tests cleanup of {@link SpillableSubpartition#release()} with a spilled partition and no
+	 * read view attached.
+	 */
+	@Test
+	public void testCleanupReleasedSpilledPartitionNoView() throws Exception {
+		testCleanupReleasedPartition(true, false);
+	}
+
+	/**
+	 * Tests cleanup of {@link SpillableSubpartition#release()} with a spilled partition and a
+	 * read view attached.
+	 */
+	@Test
+	public void testCleanupReleasedSpilledPartitionWithView() throws Exception {
+		testCleanupReleasedPartition(true, true);
+	}
+
+	/**
+	 * Tests cleanup of {@link SpillableSubpartition#release()}.
+	 *
+	 * @param spilled
+	 * 		whether the partition should be spilled to disk (<tt>true</tt>) or not (<tt>false</tt>,
+	 * 		spillable)
+	 * @param createView
+	 * 		whether the partition should have a view attached to it (<tt>true</tt>) or not (<tt>false</tt>)
+	 */
+	private void testCleanupReleasedPartition(boolean spilled, boolean createView) throws Exception {
+		SpillableSubpartition partition = createSubpartition();
+
+		Buffer buffer1 = new Buffer(MemorySegmentFactory.allocateUnpooledSegment(4096),
+			FreeingBufferRecycler.INSTANCE);
+		Buffer buffer2 = new Buffer(MemorySegmentFactory.allocateUnpooledSegment(4096),
+			FreeingBufferRecycler.INSTANCE);
+		boolean buffer1Recycled;
+		boolean buffer2Recycled;
+		try {
+			partition.add(buffer1);
+			partition.add(buffer2);
+			// create the read view before spilling
+			// (tests both code paths since this view may then contain the spilled view)
+			ResultSubpartitionView view = null;
+			if (createView) {
+				partition.finish();
+				view = partition.createReadView(numBuffers -> {});
+			}
+			if (spilled) {
+				// note: in case we create a view, one buffer will already reside in the view and
+				//       one EndOfPartitionEvent will be added instead (so overall the number of
+				//       buffers to spill is the same
+				assertEquals(2, partition.releaseMemory());
+			}
+
+			partition.release();
+
+			assertTrue(partition.isReleased());
+			if (createView) {
+				assertTrue(view.isReleased());
+			}
+			assertTrue(buffer1.isRecycled());
+		} finally {
+			buffer1Recycled = buffer1.isRecycled();
+			if (!buffer1Recycled) {
+				buffer1.recycle();
+			}
+			buffer2Recycled = buffer2.isRecycled();
+			if (!buffer2Recycled) {
+				buffer2.recycle();
+			}
+		}
+		if (!buffer1Recycled) {
+			Assert.fail("buffer 1 not recycled");
+		}
+		if (!buffer2Recycled) {
+			Assert.fail("buffer 2 not recycled");
+		}
+		// note: in case we create a view, there will be an additional EndOfPartitionEvent
+		assertEquals(createView ? 3 : 2, partition.getTotalNumberOfBuffers());
+		assertEquals((createView ? 4 : 0) + 2 * 4096, partition.getTotalNumberOfBytes());
+	}
+
 	private static class AwaitableBufferAvailablityListener implements BufferAvailabilityListener {
 
 		private long numNotifiedBuffers;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SpilledSubpartitionViewTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SpilledSubpartitionViewTest.java
@@ -44,6 +44,10 @@ import java.util.concurrent.TimeoutException;
 
 import static org.mockito.Mockito.mock;
 
+/**
+ * Tests for {@link SpillableSubpartitionView}, in addition to indirect tests via {@link
+ * SpillableSubpartitionTest}.
+ */
 public class SpilledSubpartitionViewTest {
 
 	private static final IOManager IO_MANAGER = new IOManagerAsync();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SubpartitionTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SubpartitionTestBase.java
@@ -21,8 +21,10 @@ package org.apache.flink.runtime.io.network.partition;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.util.TestBufferFactory;
 import org.apache.flink.util.TestLogger;
+
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -46,8 +48,12 @@ public abstract class SubpartitionTestBase extends TestLogger {
 
 		try {
 			subpartition.finish();
+			assertEquals(1, subpartition.getTotalNumberOfBuffers());
+			assertEquals(4, subpartition.getTotalNumberOfBytes());
 
 			assertFalse(subpartition.add(mock(Buffer.class)));
+			assertEquals(1, subpartition.getTotalNumberOfBuffers());
+			assertEquals(4, subpartition.getTotalNumberOfBytes());
 		} finally {
 			if (subpartition != null) {
 				subpartition.release();
@@ -61,8 +67,12 @@ public abstract class SubpartitionTestBase extends TestLogger {
 
 		try {
 			subpartition.release();
+			assertEquals(0, subpartition.getTotalNumberOfBuffers());
+			assertEquals(0, subpartition.getTotalNumberOfBytes());
 
 			assertFalse(subpartition.add(mock(Buffer.class)));
+			assertEquals(0, subpartition.getTotalNumberOfBuffers());
+			assertEquals(0, subpartition.getTotalNumberOfBytes());
 		} finally {
 			if (subpartition != null) {
 				subpartition.release();


### PR DESCRIPTION
## What is the purpose of the change

This is a rebase of #5261 for the release-1.4 branch. Please refer to the original PR for details.

Please also note that this PR includes #5275.
  