### PR TITLE
[FLINK-8422] [core] Checkstyle for org.apache.flink.api.java.tuple

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple.java
@@ -27,21 +27,21 @@ import org.apache.flink.types.NullFieldException;
  * which may all be of different types. Because Tuples are strongly typed, each distinct
  * tuple length is represented by its own class. Tuples exists with up to 25 fields and
  * are described in the classes {@link Tuple1} to {@link Tuple25}.
- * <p>
- * The fields in the tuples may be accessed directly a public fields, or via position (zero indexed)
+ *
+ * <p>The fields in the tuples may be accessed directly a public fields, or via position (zero indexed)
  * {@link #getField(int)}.
- * <p>
- * Tuples are in principle serializable. However, they may contain non-serializable fields,
+ *
+ * <p>Tuples are in principle serializable. However, they may contain non-serializable fields,
  * in which case serialization will fail.
  */
 @Public
 public abstract class Tuple implements java.io.Serializable {
-	
+
 	private static final long serialVersionUID = 1L;
-	
+
 	public static final int MAX_ARITY = 25;
-	
-	
+
+
 	/**
 	 * Gets the field at the specified position.
 	 *
@@ -50,11 +50,11 @@ public abstract class Tuple implements java.io.Serializable {
 	 * @throws IndexOutOfBoundsException Thrown, if the position is negative, or equal to, or larger than the number of fields.
 	 */
 	public abstract <T> T getField(int pos);
-	
+
 	/**
 	 * Gets the field at the specified position, throws NullFieldException if the field is null. Used for comparing key fields.
-	 * 
-	 * @param pos The position of the field, zero indexed. 
+	 *
+	 * @param pos The position of the field, zero indexed.
 	 * @return The field at the specified position.
 	 * @throws IndexOutOfBoundsException Thrown, if the position is negative, or equal to, or larger than the number of fields.
 	 * @throws NullFieldException Thrown, if the field at pos is null.
@@ -91,11 +91,11 @@ public abstract class Tuple implements java.io.Serializable {
 	public abstract <T extends Tuple> T copy();
 
 	// --------------------------------------------------------------------------------------------
-	
+
 	/**
 	 * Gets the class corresponding to the tuple of the given arity (dimensions). For
 	 * example, {@code getTupleClass(3)} will return the {@code Tuple3.class}.
-	 * 
+	 *
 	 * @param arity The arity of the tuple class to get.
 	 * @return The tuple class with the given arity.
 	 */
@@ -106,12 +106,12 @@ public abstract class Tuple implements java.io.Serializable {
 		}
 		return (Class<? extends Tuple>) CLASSES[arity];
 	}
-	
-	// --------------------------------------------------------------------------------------------	
+
+	// --------------------------------------------------------------------------------------------
 	// The following lines are generated.
 	// --------------------------------------------------------------------------------------------
-	
-	// BEGIN_OF_TUPLE_DEPENDENT_CODE	
+
+	// BEGIN_OF_TUPLE_DEPENDENT_CODE
 	// GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 	private static final Class<?>[] CLASSES = new Class<?>[] {
 		Tuple0.class, Tuple1.class, Tuple2.class, Tuple3.class, Tuple4.class, Tuple5.class, Tuple6.class, Tuple7.class, Tuple8.class, Tuple9.class, Tuple10.class, Tuple11.class, Tuple12.class, Tuple13.class, Tuple14.class, Tuple15.class, Tuple16.class, Tuple17.class, Tuple18.class, Tuple19.class, Tuple20.class, Tuple21.class, Tuple22.class, Tuple23.class, Tuple24.class, Tuple25.class

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple0.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple0.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.flink.api.java.tuple;
 
 import org.apache.flink.annotation.Public;
@@ -23,21 +24,21 @@ import java.io.ObjectStreamException;
 
 /**
  * A tuple with 0 fields.
- * 
+ *
  * <p>The Tuple0 is a soft singleton, i.e., there is a "singleton" instance, but it does
  * not prevent creation of additional instances.</p>
- * 
+ *
  * @see Tuple
  */
 @Public
 public class Tuple0 extends Tuple {
 	private static final long serialVersionUID = 1L;
 
-	/** An immutable reusable Tuple0 instance */
+	// an immutable reusable Tuple0 instance
 	public static final Tuple0 INSTANCE = new Tuple0();
 
 	// ------------------------------------------------------------------------
-	
+
 	@Override
 	public int getArity() {
 		return 0;
@@ -68,8 +69,8 @@ public class Tuple0 extends Tuple {
 	// -------------------------------------------------------------------------------------------------
 
 	/**
-	 * Creates a string representation of the tuple in the form "()"
-	 * 
+	 * Creates a string representation of the tuple in the form "()".
+	 *
 	 * @return The string representation of the tuple.
 	 */
 	@Override
@@ -78,8 +79,8 @@ public class Tuple0 extends Tuple {
 	}
 
 	/**
-	 * Deep equality for tuples by calling equals() on the tuple members
-	 * 
+	 * Deep equality for tuples by calling equals() on the tuple members.
+	 *
 	 * @param o
 	 *            the object checked for equality
 	 * @return true if this is equal to o.

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple1.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple1.java
@@ -16,12 +16,10 @@
  * limitations under the License.
  */
 
-
 // --------------------------------------------------------------
 //  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
 //  GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 // --------------------------------------------------------------
-
 
 package org.apache.flink.api.java.tuple;
 
@@ -70,7 +68,9 @@ public class Tuple1<T0> extends Tuple {
 	}
 
 	@Override
-	public int getArity() { return 1; }
+	public int getArity() {
+		return 1;
+	}
 
 	@Override
 	@SuppressWarnings("unchecked")
@@ -119,17 +119,23 @@ public class Tuple1<T0> extends Tuple {
 	}
 
 	/**
-	 * Deep equality for tuples by calling equals() on the tuple members
+	 * Deep equality for tuples by calling equals() on the tuple members.
 	 * @param o the object checked for equality
 	 * @return true if this is equal to o.
 	 */
 	@Override
 	public boolean equals(Object o) {
-		if(this == o) { return true; }
-		if (!(o instanceof Tuple1)) { return false; }
+		if (this == o) {
+			return true;
+		}
+		if (!(o instanceof Tuple1)) {
+			return false;
+		}
 		@SuppressWarnings("rawtypes")
 		Tuple1 tuple = (Tuple1) o;
-		if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) { return false; }
+		if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) {
+			return false;
+		}
 		return true;
 	}
 
@@ -145,8 +151,8 @@ public class Tuple1<T0> extends Tuple {
 	*/
 	@Override
 	@SuppressWarnings("unchecked")
-	public Tuple1<T0> copy(){ 
-		return new Tuple1<T0>(this.f0);
+	public Tuple1<T0> copy() {
+		return new Tuple1<>(this.f0);
 	}
 
 	/**
@@ -158,6 +164,6 @@ public class Tuple1<T0> extends Tuple {
 	 * {@code new Tuple3<Integer, Double, String>(n, x, s)}
 	 */
 	public static <T0> Tuple1<T0> of(T0 value0) {
-		return new Tuple1<T0>(value0);
+		return new Tuple1<>(value0);
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple10.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple10.java
@@ -16,12 +16,10 @@
  * limitations under the License.
  */
 
-
 // --------------------------------------------------------------
 //  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
 //  GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 // --------------------------------------------------------------
-
 
 package org.apache.flink.api.java.tuple;
 
@@ -115,7 +113,9 @@ public class Tuple10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> extends Tuple {
 	}
 
 	@Override
-	public int getArity() { return 10; }
+	public int getArity() {
+		return 10;
+	}
 
 	@Override
 	@SuppressWarnings("unchecked")
@@ -227,26 +227,50 @@ public class Tuple10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> extends Tuple {
 	}
 
 	/**
-	 * Deep equality for tuples by calling equals() on the tuple members
+	 * Deep equality for tuples by calling equals() on the tuple members.
 	 * @param o the object checked for equality
 	 * @return true if this is equal to o.
 	 */
 	@Override
 	public boolean equals(Object o) {
-		if(this == o) { return true; }
-		if (!(o instanceof Tuple10)) { return false; }
+		if (this == o) {
+			return true;
+		}
+		if (!(o instanceof Tuple10)) {
+			return false;
+		}
 		@SuppressWarnings("rawtypes")
 		Tuple10 tuple = (Tuple10) o;
-		if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) { return false; }
-		if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) { return false; }
-		if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) { return false; }
-		if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) { return false; }
-		if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) { return false; }
-		if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) { return false; }
-		if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) { return false; }
-		if (f7 != null ? !f7.equals(tuple.f7) : tuple.f7 != null) { return false; }
-		if (f8 != null ? !f8.equals(tuple.f8) : tuple.f8 != null) { return false; }
-		if (f9 != null ? !f9.equals(tuple.f9) : tuple.f9 != null) { return false; }
+		if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) {
+			return false;
+		}
+		if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) {
+			return false;
+		}
+		if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) {
+			return false;
+		}
+		if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) {
+			return false;
+		}
+		if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) {
+			return false;
+		}
+		if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) {
+			return false;
+		}
+		if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) {
+			return false;
+		}
+		if (f7 != null ? !f7.equals(tuple.f7) : tuple.f7 != null) {
+			return false;
+		}
+		if (f8 != null ? !f8.equals(tuple.f8) : tuple.f8 != null) {
+			return false;
+		}
+		if (f9 != null ? !f9.equals(tuple.f9) : tuple.f9 != null) {
+			return false;
+		}
 		return true;
 	}
 
@@ -271,8 +295,8 @@ public class Tuple10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> extends Tuple {
 	*/
 	@Override
 	@SuppressWarnings("unchecked")
-	public Tuple10<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9> copy(){ 
-		return new Tuple10<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9>(this.f0,
+	public Tuple10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> copy() {
+		return new Tuple10<>(this.f0,
 			this.f1,
 			this.f2,
 			this.f3,
@@ -292,7 +316,16 @@ public class Tuple10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> extends Tuple {
 	 * instead of
 	 * {@code new Tuple3<Integer, Double, String>(n, x, s)}
 	 */
-	public static <T0,T1,T2,T3,T4,T5,T6,T7,T8,T9> Tuple10<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9> of(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9) {
-		return new Tuple10<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9>(value0, value1, value2, value3, value4, value5, value6, value7, value8, value9);
+	public static <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> Tuple10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> of(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9) {
+		return new Tuple10<>(value0,
+			value1,
+			value2,
+			value3,
+			value4,
+			value5,
+			value6,
+			value7,
+			value8,
+			value9);
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple11.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple11.java
@@ -16,12 +16,10 @@
  * limitations under the License.
  */
 
-
 // --------------------------------------------------------------
 //  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
 //  GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 // --------------------------------------------------------------
-
 
 package org.apache.flink.api.java.tuple;
 
@@ -120,7 +118,9 @@ public class Tuple11<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> extends Tuple 
 	}
 
 	@Override
-	public int getArity() { return 11; }
+	public int getArity() {
+		return 11;
+	}
 
 	@Override
 	@SuppressWarnings("unchecked")
@@ -239,27 +239,53 @@ public class Tuple11<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> extends Tuple 
 	}
 
 	/**
-	 * Deep equality for tuples by calling equals() on the tuple members
+	 * Deep equality for tuples by calling equals() on the tuple members.
 	 * @param o the object checked for equality
 	 * @return true if this is equal to o.
 	 */
 	@Override
 	public boolean equals(Object o) {
-		if(this == o) { return true; }
-		if (!(o instanceof Tuple11)) { return false; }
+		if (this == o) {
+			return true;
+		}
+		if (!(o instanceof Tuple11)) {
+			return false;
+		}
 		@SuppressWarnings("rawtypes")
 		Tuple11 tuple = (Tuple11) o;
-		if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) { return false; }
-		if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) { return false; }
-		if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) { return false; }
-		if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) { return false; }
-		if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) { return false; }
-		if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) { return false; }
-		if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) { return false; }
-		if (f7 != null ? !f7.equals(tuple.f7) : tuple.f7 != null) { return false; }
-		if (f8 != null ? !f8.equals(tuple.f8) : tuple.f8 != null) { return false; }
-		if (f9 != null ? !f9.equals(tuple.f9) : tuple.f9 != null) { return false; }
-		if (f10 != null ? !f10.equals(tuple.f10) : tuple.f10 != null) { return false; }
+		if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) {
+			return false;
+		}
+		if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) {
+			return false;
+		}
+		if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) {
+			return false;
+		}
+		if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) {
+			return false;
+		}
+		if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) {
+			return false;
+		}
+		if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) {
+			return false;
+		}
+		if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) {
+			return false;
+		}
+		if (f7 != null ? !f7.equals(tuple.f7) : tuple.f7 != null) {
+			return false;
+		}
+		if (f8 != null ? !f8.equals(tuple.f8) : tuple.f8 != null) {
+			return false;
+		}
+		if (f9 != null ? !f9.equals(tuple.f9) : tuple.f9 != null) {
+			return false;
+		}
+		if (f10 != null ? !f10.equals(tuple.f10) : tuple.f10 != null) {
+			return false;
+		}
 		return true;
 	}
 
@@ -285,8 +311,8 @@ public class Tuple11<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> extends Tuple 
 	*/
 	@Override
 	@SuppressWarnings("unchecked")
-	public Tuple11<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10> copy(){ 
-		return new Tuple11<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10>(this.f0,
+	public Tuple11<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> copy() {
+		return new Tuple11<>(this.f0,
 			this.f1,
 			this.f2,
 			this.f3,
@@ -307,7 +333,17 @@ public class Tuple11<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> extends Tuple 
 	 * instead of
 	 * {@code new Tuple3<Integer, Double, String>(n, x, s)}
 	 */
-	public static <T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10> Tuple11<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10> of(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10) {
-		return new Tuple11<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10>(value0, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10);
+	public static <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Tuple11<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> of(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10) {
+		return new Tuple11<>(value0,
+			value1,
+			value2,
+			value3,
+			value4,
+			value5,
+			value6,
+			value7,
+			value8,
+			value9,
+			value10);
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple12.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple12.java
@@ -16,12 +16,10 @@
  * limitations under the License.
  */
 
-
 // --------------------------------------------------------------
 //  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
 //  GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 // --------------------------------------------------------------
-
 
 package org.apache.flink.api.java.tuple;
 
@@ -125,7 +123,9 @@ public class Tuple12<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> extends T
 	}
 
 	@Override
-	public int getArity() { return 12; }
+	public int getArity() {
+		return 12;
+	}
 
 	@Override
 	@SuppressWarnings("unchecked")
@@ -251,28 +251,56 @@ public class Tuple12<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> extends T
 	}
 
 	/**
-	 * Deep equality for tuples by calling equals() on the tuple members
+	 * Deep equality for tuples by calling equals() on the tuple members.
 	 * @param o the object checked for equality
 	 * @return true if this is equal to o.
 	 */
 	@Override
 	public boolean equals(Object o) {
-		if(this == o) { return true; }
-		if (!(o instanceof Tuple12)) { return false; }
+		if (this == o) {
+			return true;
+		}
+		if (!(o instanceof Tuple12)) {
+			return false;
+		}
 		@SuppressWarnings("rawtypes")
 		Tuple12 tuple = (Tuple12) o;
-		if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) { return false; }
-		if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) { return false; }
-		if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) { return false; }
-		if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) { return false; }
-		if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) { return false; }
-		if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) { return false; }
-		if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) { return false; }
-		if (f7 != null ? !f7.equals(tuple.f7) : tuple.f7 != null) { return false; }
-		if (f8 != null ? !f8.equals(tuple.f8) : tuple.f8 != null) { return false; }
-		if (f9 != null ? !f9.equals(tuple.f9) : tuple.f9 != null) { return false; }
-		if (f10 != null ? !f10.equals(tuple.f10) : tuple.f10 != null) { return false; }
-		if (f11 != null ? !f11.equals(tuple.f11) : tuple.f11 != null) { return false; }
+		if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) {
+			return false;
+		}
+		if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) {
+			return false;
+		}
+		if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) {
+			return false;
+		}
+		if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) {
+			return false;
+		}
+		if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) {
+			return false;
+		}
+		if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) {
+			return false;
+		}
+		if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) {
+			return false;
+		}
+		if (f7 != null ? !f7.equals(tuple.f7) : tuple.f7 != null) {
+			return false;
+		}
+		if (f8 != null ? !f8.equals(tuple.f8) : tuple.f8 != null) {
+			return false;
+		}
+		if (f9 != null ? !f9.equals(tuple.f9) : tuple.f9 != null) {
+			return false;
+		}
+		if (f10 != null ? !f10.equals(tuple.f10) : tuple.f10 != null) {
+			return false;
+		}
+		if (f11 != null ? !f11.equals(tuple.f11) : tuple.f11 != null) {
+			return false;
+		}
 		return true;
 	}
 
@@ -299,8 +327,8 @@ public class Tuple12<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> extends T
 	*/
 	@Override
 	@SuppressWarnings("unchecked")
-	public Tuple12<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11> copy(){ 
-		return new Tuple12<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11>(this.f0,
+	public Tuple12<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> copy() {
+		return new Tuple12<>(this.f0,
 			this.f1,
 			this.f2,
 			this.f3,
@@ -322,7 +350,18 @@ public class Tuple12<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> extends T
 	 * instead of
 	 * {@code new Tuple3<Integer, Double, String>(n, x, s)}
 	 */
-	public static <T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11> Tuple12<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11> of(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11) {
-		return new Tuple12<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11>(value0, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11);
+	public static <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Tuple12<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> of(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11) {
+		return new Tuple12<>(value0,
+			value1,
+			value2,
+			value3,
+			value4,
+			value5,
+			value6,
+			value7,
+			value8,
+			value9,
+			value10,
+			value11);
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple13.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple13.java
@@ -16,12 +16,10 @@
  * limitations under the License.
  */
 
-
 // --------------------------------------------------------------
 //  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
 //  GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 // --------------------------------------------------------------
-
 
 package org.apache.flink.api.java.tuple;
 
@@ -130,7 +128,9 @@ public class Tuple13<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> exte
 	}
 
 	@Override
-	public int getArity() { return 13; }
+	public int getArity() {
+		return 13;
+	}
 
 	@Override
 	@SuppressWarnings("unchecked")
@@ -263,29 +263,59 @@ public class Tuple13<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> exte
 	}
 
 	/**
-	 * Deep equality for tuples by calling equals() on the tuple members
+	 * Deep equality for tuples by calling equals() on the tuple members.
 	 * @param o the object checked for equality
 	 * @return true if this is equal to o.
 	 */
 	@Override
 	public boolean equals(Object o) {
-		if(this == o) { return true; }
-		if (!(o instanceof Tuple13)) { return false; }
+		if (this == o) {
+			return true;
+		}
+		if (!(o instanceof Tuple13)) {
+			return false;
+		}
 		@SuppressWarnings("rawtypes")
 		Tuple13 tuple = (Tuple13) o;
-		if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) { return false; }
-		if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) { return false; }
-		if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) { return false; }
-		if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) { return false; }
-		if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) { return false; }
-		if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) { return false; }
-		if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) { return false; }
-		if (f7 != null ? !f7.equals(tuple.f7) : tuple.f7 != null) { return false; }
-		if (f8 != null ? !f8.equals(tuple.f8) : tuple.f8 != null) { return false; }
-		if (f9 != null ? !f9.equals(tuple.f9) : tuple.f9 != null) { return false; }
-		if (f10 != null ? !f10.equals(tuple.f10) : tuple.f10 != null) { return false; }
-		if (f11 != null ? !f11.equals(tuple.f11) : tuple.f11 != null) { return false; }
-		if (f12 != null ? !f12.equals(tuple.f12) : tuple.f12 != null) { return false; }
+		if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) {
+			return false;
+		}
+		if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) {
+			return false;
+		}
+		if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) {
+			return false;
+		}
+		if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) {
+			return false;
+		}
+		if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) {
+			return false;
+		}
+		if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) {
+			return false;
+		}
+		if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) {
+			return false;
+		}
+		if (f7 != null ? !f7.equals(tuple.f7) : tuple.f7 != null) {
+			return false;
+		}
+		if (f8 != null ? !f8.equals(tuple.f8) : tuple.f8 != null) {
+			return false;
+		}
+		if (f9 != null ? !f9.equals(tuple.f9) : tuple.f9 != null) {
+			return false;
+		}
+		if (f10 != null ? !f10.equals(tuple.f10) : tuple.f10 != null) {
+			return false;
+		}
+		if (f11 != null ? !f11.equals(tuple.f11) : tuple.f11 != null) {
+			return false;
+		}
+		if (f12 != null ? !f12.equals(tuple.f12) : tuple.f12 != null) {
+			return false;
+		}
 		return true;
 	}
 
@@ -313,8 +343,8 @@ public class Tuple13<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> exte
 	*/
 	@Override
 	@SuppressWarnings("unchecked")
-	public Tuple13<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12> copy(){ 
-		return new Tuple13<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12>(this.f0,
+	public Tuple13<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> copy() {
+		return new Tuple13<>(this.f0,
 			this.f1,
 			this.f2,
 			this.f3,
@@ -337,7 +367,19 @@ public class Tuple13<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> exte
 	 * instead of
 	 * {@code new Tuple3<Integer, Double, String>(n, x, s)}
 	 */
-	public static <T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12> Tuple13<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12> of(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12) {
-		return new Tuple13<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12>(value0, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12);
+	public static <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Tuple13<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> of(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12) {
+		return new Tuple13<>(value0,
+			value1,
+			value2,
+			value3,
+			value4,
+			value5,
+			value6,
+			value7,
+			value8,
+			value9,
+			value10,
+			value11,
+			value12);
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple14.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple14.java
@@ -16,12 +16,10 @@
  * limitations under the License.
  */
 
-
 // --------------------------------------------------------------
 //  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
 //  GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 // --------------------------------------------------------------
-
 
 package org.apache.flink.api.java.tuple;
 
@@ -135,7 +133,9 @@ public class Tuple14<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>
 	}
 
 	@Override
-	public int getArity() { return 14; }
+	public int getArity() {
+		return 14;
+	}
 
 	@Override
 	@SuppressWarnings("unchecked")
@@ -275,30 +275,62 @@ public class Tuple14<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>
 	}
 
 	/**
-	 * Deep equality for tuples by calling equals() on the tuple members
+	 * Deep equality for tuples by calling equals() on the tuple members.
 	 * @param o the object checked for equality
 	 * @return true if this is equal to o.
 	 */
 	@Override
 	public boolean equals(Object o) {
-		if(this == o) { return true; }
-		if (!(o instanceof Tuple14)) { return false; }
+		if (this == o) {
+			return true;
+		}
+		if (!(o instanceof Tuple14)) {
+			return false;
+		}
 		@SuppressWarnings("rawtypes")
 		Tuple14 tuple = (Tuple14) o;
-		if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) { return false; }
-		if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) { return false; }
-		if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) { return false; }
-		if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) { return false; }
-		if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) { return false; }
-		if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) { return false; }
-		if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) { return false; }
-		if (f7 != null ? !f7.equals(tuple.f7) : tuple.f7 != null) { return false; }
-		if (f8 != null ? !f8.equals(tuple.f8) : tuple.f8 != null) { return false; }
-		if (f9 != null ? !f9.equals(tuple.f9) : tuple.f9 != null) { return false; }
-		if (f10 != null ? !f10.equals(tuple.f10) : tuple.f10 != null) { return false; }
-		if (f11 != null ? !f11.equals(tuple.f11) : tuple.f11 != null) { return false; }
-		if (f12 != null ? !f12.equals(tuple.f12) : tuple.f12 != null) { return false; }
-		if (f13 != null ? !f13.equals(tuple.f13) : tuple.f13 != null) { return false; }
+		if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) {
+			return false;
+		}
+		if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) {
+			return false;
+		}
+		if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) {
+			return false;
+		}
+		if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) {
+			return false;
+		}
+		if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) {
+			return false;
+		}
+		if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) {
+			return false;
+		}
+		if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) {
+			return false;
+		}
+		if (f7 != null ? !f7.equals(tuple.f7) : tuple.f7 != null) {
+			return false;
+		}
+		if (f8 != null ? !f8.equals(tuple.f8) : tuple.f8 != null) {
+			return false;
+		}
+		if (f9 != null ? !f9.equals(tuple.f9) : tuple.f9 != null) {
+			return false;
+		}
+		if (f10 != null ? !f10.equals(tuple.f10) : tuple.f10 != null) {
+			return false;
+		}
+		if (f11 != null ? !f11.equals(tuple.f11) : tuple.f11 != null) {
+			return false;
+		}
+		if (f12 != null ? !f12.equals(tuple.f12) : tuple.f12 != null) {
+			return false;
+		}
+		if (f13 != null ? !f13.equals(tuple.f13) : tuple.f13 != null) {
+			return false;
+		}
 		return true;
 	}
 
@@ -327,8 +359,8 @@ public class Tuple14<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>
 	*/
 	@Override
 	@SuppressWarnings("unchecked")
-	public Tuple14<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13> copy(){ 
-		return new Tuple14<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13>(this.f0,
+	public Tuple14<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> copy() {
+		return new Tuple14<>(this.f0,
 			this.f1,
 			this.f2,
 			this.f3,
@@ -352,7 +384,20 @@ public class Tuple14<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>
 	 * instead of
 	 * {@code new Tuple3<Integer, Double, String>(n, x, s)}
 	 */
-	public static <T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13> Tuple14<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13> of(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13) {
-		return new Tuple14<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13>(value0, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13);
+	public static <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Tuple14<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> of(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13) {
+		return new Tuple14<>(value0,
+			value1,
+			value2,
+			value3,
+			value4,
+			value5,
+			value6,
+			value7,
+			value8,
+			value9,
+			value10,
+			value11,
+			value12,
+			value13);
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple15.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple15.java
@@ -16,12 +16,10 @@
  * limitations under the License.
  */
 
-
 // --------------------------------------------------------------
 //  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
 //  GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 // --------------------------------------------------------------
-
 
 package org.apache.flink.api.java.tuple;
 
@@ -140,7 +138,9 @@ public class Tuple15<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 	}
 
 	@Override
-	public int getArity() { return 15; }
+	public int getArity() {
+		return 15;
+	}
 
 	@Override
 	@SuppressWarnings("unchecked")
@@ -287,31 +287,65 @@ public class Tuple15<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 	}
 
 	/**
-	 * Deep equality for tuples by calling equals() on the tuple members
+	 * Deep equality for tuples by calling equals() on the tuple members.
 	 * @param o the object checked for equality
 	 * @return true if this is equal to o.
 	 */
 	@Override
 	public boolean equals(Object o) {
-		if(this == o) { return true; }
-		if (!(o instanceof Tuple15)) { return false; }
+		if (this == o) {
+			return true;
+		}
+		if (!(o instanceof Tuple15)) {
+			return false;
+		}
 		@SuppressWarnings("rawtypes")
 		Tuple15 tuple = (Tuple15) o;
-		if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) { return false; }
-		if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) { return false; }
-		if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) { return false; }
-		if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) { return false; }
-		if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) { return false; }
-		if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) { return false; }
-		if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) { return false; }
-		if (f7 != null ? !f7.equals(tuple.f7) : tuple.f7 != null) { return false; }
-		if (f8 != null ? !f8.equals(tuple.f8) : tuple.f8 != null) { return false; }
-		if (f9 != null ? !f9.equals(tuple.f9) : tuple.f9 != null) { return false; }
-		if (f10 != null ? !f10.equals(tuple.f10) : tuple.f10 != null) { return false; }
-		if (f11 != null ? !f11.equals(tuple.f11) : tuple.f11 != null) { return false; }
-		if (f12 != null ? !f12.equals(tuple.f12) : tuple.f12 != null) { return false; }
-		if (f13 != null ? !f13.equals(tuple.f13) : tuple.f13 != null) { return false; }
-		if (f14 != null ? !f14.equals(tuple.f14) : tuple.f14 != null) { return false; }
+		if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) {
+			return false;
+		}
+		if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) {
+			return false;
+		}
+		if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) {
+			return false;
+		}
+		if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) {
+			return false;
+		}
+		if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) {
+			return false;
+		}
+		if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) {
+			return false;
+		}
+		if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) {
+			return false;
+		}
+		if (f7 != null ? !f7.equals(tuple.f7) : tuple.f7 != null) {
+			return false;
+		}
+		if (f8 != null ? !f8.equals(tuple.f8) : tuple.f8 != null) {
+			return false;
+		}
+		if (f9 != null ? !f9.equals(tuple.f9) : tuple.f9 != null) {
+			return false;
+		}
+		if (f10 != null ? !f10.equals(tuple.f10) : tuple.f10 != null) {
+			return false;
+		}
+		if (f11 != null ? !f11.equals(tuple.f11) : tuple.f11 != null) {
+			return false;
+		}
+		if (f12 != null ? !f12.equals(tuple.f12) : tuple.f12 != null) {
+			return false;
+		}
+		if (f13 != null ? !f13.equals(tuple.f13) : tuple.f13 != null) {
+			return false;
+		}
+		if (f14 != null ? !f14.equals(tuple.f14) : tuple.f14 != null) {
+			return false;
+		}
 		return true;
 	}
 
@@ -341,8 +375,8 @@ public class Tuple15<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 	*/
 	@Override
 	@SuppressWarnings("unchecked")
-	public Tuple15<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14> copy(){ 
-		return new Tuple15<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14>(this.f0,
+	public Tuple15<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> copy() {
+		return new Tuple15<>(this.f0,
 			this.f1,
 			this.f2,
 			this.f3,
@@ -367,7 +401,21 @@ public class Tuple15<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 	 * instead of
 	 * {@code new Tuple3<Integer, Double, String>(n, x, s)}
 	 */
-	public static <T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14> Tuple15<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14> of(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13, T14 value14) {
-		return new Tuple15<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14>(value0, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14);
+	public static <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Tuple15<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> of(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13, T14 value14) {
+		return new Tuple15<>(value0,
+			value1,
+			value2,
+			value3,
+			value4,
+			value5,
+			value6,
+			value7,
+			value8,
+			value9,
+			value10,
+			value11,
+			value12,
+			value13,
+			value14);
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple16.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple16.java
@@ -16,12 +16,10 @@
  * limitations under the License.
  */
 
-
 // --------------------------------------------------------------
 //  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
 //  GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 // --------------------------------------------------------------
-
 
 package org.apache.flink.api.java.tuple;
 
@@ -145,7 +143,9 @@ public class Tuple16<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 	}
 
 	@Override
-	public int getArity() { return 16; }
+	public int getArity() {
+		return 16;
+	}
 
 	@Override
 	@SuppressWarnings("unchecked")
@@ -299,32 +299,68 @@ public class Tuple16<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 	}
 
 	/**
-	 * Deep equality for tuples by calling equals() on the tuple members
+	 * Deep equality for tuples by calling equals() on the tuple members.
 	 * @param o the object checked for equality
 	 * @return true if this is equal to o.
 	 */
 	@Override
 	public boolean equals(Object o) {
-		if(this == o) { return true; }
-		if (!(o instanceof Tuple16)) { return false; }
+		if (this == o) {
+			return true;
+		}
+		if (!(o instanceof Tuple16)) {
+			return false;
+		}
 		@SuppressWarnings("rawtypes")
 		Tuple16 tuple = (Tuple16) o;
-		if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) { return false; }
-		if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) { return false; }
-		if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) { return false; }
-		if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) { return false; }
-		if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) { return false; }
-		if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) { return false; }
-		if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) { return false; }
-		if (f7 != null ? !f7.equals(tuple.f7) : tuple.f7 != null) { return false; }
-		if (f8 != null ? !f8.equals(tuple.f8) : tuple.f8 != null) { return false; }
-		if (f9 != null ? !f9.equals(tuple.f9) : tuple.f9 != null) { return false; }
-		if (f10 != null ? !f10.equals(tuple.f10) : tuple.f10 != null) { return false; }
-		if (f11 != null ? !f11.equals(tuple.f11) : tuple.f11 != null) { return false; }
-		if (f12 != null ? !f12.equals(tuple.f12) : tuple.f12 != null) { return false; }
-		if (f13 != null ? !f13.equals(tuple.f13) : tuple.f13 != null) { return false; }
-		if (f14 != null ? !f14.equals(tuple.f14) : tuple.f14 != null) { return false; }
-		if (f15 != null ? !f15.equals(tuple.f15) : tuple.f15 != null) { return false; }
+		if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) {
+			return false;
+		}
+		if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) {
+			return false;
+		}
+		if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) {
+			return false;
+		}
+		if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) {
+			return false;
+		}
+		if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) {
+			return false;
+		}
+		if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) {
+			return false;
+		}
+		if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) {
+			return false;
+		}
+		if (f7 != null ? !f7.equals(tuple.f7) : tuple.f7 != null) {
+			return false;
+		}
+		if (f8 != null ? !f8.equals(tuple.f8) : tuple.f8 != null) {
+			return false;
+		}
+		if (f9 != null ? !f9.equals(tuple.f9) : tuple.f9 != null) {
+			return false;
+		}
+		if (f10 != null ? !f10.equals(tuple.f10) : tuple.f10 != null) {
+			return false;
+		}
+		if (f11 != null ? !f11.equals(tuple.f11) : tuple.f11 != null) {
+			return false;
+		}
+		if (f12 != null ? !f12.equals(tuple.f12) : tuple.f12 != null) {
+			return false;
+		}
+		if (f13 != null ? !f13.equals(tuple.f13) : tuple.f13 != null) {
+			return false;
+		}
+		if (f14 != null ? !f14.equals(tuple.f14) : tuple.f14 != null) {
+			return false;
+		}
+		if (f15 != null ? !f15.equals(tuple.f15) : tuple.f15 != null) {
+			return false;
+		}
 		return true;
 	}
 
@@ -355,8 +391,8 @@ public class Tuple16<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 	*/
 	@Override
 	@SuppressWarnings("unchecked")
-	public Tuple16<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15> copy(){ 
-		return new Tuple16<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15>(this.f0,
+	public Tuple16<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> copy() {
+		return new Tuple16<>(this.f0,
 			this.f1,
 			this.f2,
 			this.f3,
@@ -382,7 +418,22 @@ public class Tuple16<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 	 * instead of
 	 * {@code new Tuple3<Integer, Double, String>(n, x, s)}
 	 */
-	public static <T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15> Tuple16<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15> of(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13, T14 value14, T15 value15) {
-		return new Tuple16<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15>(value0, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15);
+	public static <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Tuple16<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> of(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13, T14 value14, T15 value15) {
+		return new Tuple16<>(value0,
+			value1,
+			value2,
+			value3,
+			value4,
+			value5,
+			value6,
+			value7,
+			value8,
+			value9,
+			value10,
+			value11,
+			value12,
+			value13,
+			value14,
+			value15);
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple17.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple17.java
@@ -16,12 +16,10 @@
  * limitations under the License.
  */
 
-
 // --------------------------------------------------------------
 //  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
 //  GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 // --------------------------------------------------------------
-
 
 package org.apache.flink.api.java.tuple;
 
@@ -150,7 +148,9 @@ public class Tuple17<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 	}
 
 	@Override
-	public int getArity() { return 17; }
+	public int getArity() {
+		return 17;
+	}
 
 	@Override
 	@SuppressWarnings("unchecked")
@@ -311,33 +311,71 @@ public class Tuple17<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 	}
 
 	/**
-	 * Deep equality for tuples by calling equals() on the tuple members
+	 * Deep equality for tuples by calling equals() on the tuple members.
 	 * @param o the object checked for equality
 	 * @return true if this is equal to o.
 	 */
 	@Override
 	public boolean equals(Object o) {
-		if(this == o) { return true; }
-		if (!(o instanceof Tuple17)) { return false; }
+		if (this == o) {
+			return true;
+		}
+		if (!(o instanceof Tuple17)) {
+			return false;
+		}
 		@SuppressWarnings("rawtypes")
 		Tuple17 tuple = (Tuple17) o;
-		if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) { return false; }
-		if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) { return false; }
-		if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) { return false; }
-		if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) { return false; }
-		if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) { return false; }
-		if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) { return false; }
-		if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) { return false; }
-		if (f7 != null ? !f7.equals(tuple.f7) : tuple.f7 != null) { return false; }
-		if (f8 != null ? !f8.equals(tuple.f8) : tuple.f8 != null) { return false; }
-		if (f9 != null ? !f9.equals(tuple.f9) : tuple.f9 != null) { return false; }
-		if (f10 != null ? !f10.equals(tuple.f10) : tuple.f10 != null) { return false; }
-		if (f11 != null ? !f11.equals(tuple.f11) : tuple.f11 != null) { return false; }
-		if (f12 != null ? !f12.equals(tuple.f12) : tuple.f12 != null) { return false; }
-		if (f13 != null ? !f13.equals(tuple.f13) : tuple.f13 != null) { return false; }
-		if (f14 != null ? !f14.equals(tuple.f14) : tuple.f14 != null) { return false; }
-		if (f15 != null ? !f15.equals(tuple.f15) : tuple.f15 != null) { return false; }
-		if (f16 != null ? !f16.equals(tuple.f16) : tuple.f16 != null) { return false; }
+		if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) {
+			return false;
+		}
+		if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) {
+			return false;
+		}
+		if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) {
+			return false;
+		}
+		if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) {
+			return false;
+		}
+		if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) {
+			return false;
+		}
+		if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) {
+			return false;
+		}
+		if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) {
+			return false;
+		}
+		if (f7 != null ? !f7.equals(tuple.f7) : tuple.f7 != null) {
+			return false;
+		}
+		if (f8 != null ? !f8.equals(tuple.f8) : tuple.f8 != null) {
+			return false;
+		}
+		if (f9 != null ? !f9.equals(tuple.f9) : tuple.f9 != null) {
+			return false;
+		}
+		if (f10 != null ? !f10.equals(tuple.f10) : tuple.f10 != null) {
+			return false;
+		}
+		if (f11 != null ? !f11.equals(tuple.f11) : tuple.f11 != null) {
+			return false;
+		}
+		if (f12 != null ? !f12.equals(tuple.f12) : tuple.f12 != null) {
+			return false;
+		}
+		if (f13 != null ? !f13.equals(tuple.f13) : tuple.f13 != null) {
+			return false;
+		}
+		if (f14 != null ? !f14.equals(tuple.f14) : tuple.f14 != null) {
+			return false;
+		}
+		if (f15 != null ? !f15.equals(tuple.f15) : tuple.f15 != null) {
+			return false;
+		}
+		if (f16 != null ? !f16.equals(tuple.f16) : tuple.f16 != null) {
+			return false;
+		}
 		return true;
 	}
 
@@ -369,8 +407,8 @@ public class Tuple17<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 	*/
 	@Override
 	@SuppressWarnings("unchecked")
-	public Tuple17<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16> copy(){ 
-		return new Tuple17<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16>(this.f0,
+	public Tuple17<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> copy() {
+		return new Tuple17<>(this.f0,
 			this.f1,
 			this.f2,
 			this.f3,
@@ -397,7 +435,23 @@ public class Tuple17<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 	 * instead of
 	 * {@code new Tuple3<Integer, Double, String>(n, x, s)}
 	 */
-	public static <T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16> Tuple17<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16> of(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13, T14 value14, T15 value15, T16 value16) {
-		return new Tuple17<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16>(value0, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15, value16);
+	public static <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> Tuple17<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> of(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13, T14 value14, T15 value15, T16 value16) {
+		return new Tuple17<>(value0,
+			value1,
+			value2,
+			value3,
+			value4,
+			value5,
+			value6,
+			value7,
+			value8,
+			value9,
+			value10,
+			value11,
+			value12,
+			value13,
+			value14,
+			value15,
+			value16);
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple18.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple18.java
@@ -16,12 +16,10 @@
  * limitations under the License.
  */
 
-
 // --------------------------------------------------------------
 //  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
 //  GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 // --------------------------------------------------------------
-
 
 package org.apache.flink.api.java.tuple;
 
@@ -155,7 +153,9 @@ public class Tuple18<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 	}
 
 	@Override
-	public int getArity() { return 18; }
+	public int getArity() {
+		return 18;
+	}
 
 	@Override
 	@SuppressWarnings("unchecked")
@@ -323,34 +323,74 @@ public class Tuple18<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 	}
 
 	/**
-	 * Deep equality for tuples by calling equals() on the tuple members
+	 * Deep equality for tuples by calling equals() on the tuple members.
 	 * @param o the object checked for equality
 	 * @return true if this is equal to o.
 	 */
 	@Override
 	public boolean equals(Object o) {
-		if(this == o) { return true; }
-		if (!(o instanceof Tuple18)) { return false; }
+		if (this == o) {
+			return true;
+		}
+		if (!(o instanceof Tuple18)) {
+			return false;
+		}
 		@SuppressWarnings("rawtypes")
 		Tuple18 tuple = (Tuple18) o;
-		if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) { return false; }
-		if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) { return false; }
-		if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) { return false; }
-		if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) { return false; }
-		if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) { return false; }
-		if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) { return false; }
-		if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) { return false; }
-		if (f7 != null ? !f7.equals(tuple.f7) : tuple.f7 != null) { return false; }
-		if (f8 != null ? !f8.equals(tuple.f8) : tuple.f8 != null) { return false; }
-		if (f9 != null ? !f9.equals(tuple.f9) : tuple.f9 != null) { return false; }
-		if (f10 != null ? !f10.equals(tuple.f10) : tuple.f10 != null) { return false; }
-		if (f11 != null ? !f11.equals(tuple.f11) : tuple.f11 != null) { return false; }
-		if (f12 != null ? !f12.equals(tuple.f12) : tuple.f12 != null) { return false; }
-		if (f13 != null ? !f13.equals(tuple.f13) : tuple.f13 != null) { return false; }
-		if (f14 != null ? !f14.equals(tuple.f14) : tuple.f14 != null) { return false; }
-		if (f15 != null ? !f15.equals(tuple.f15) : tuple.f15 != null) { return false; }
-		if (f16 != null ? !f16.equals(tuple.f16) : tuple.f16 != null) { return false; }
-		if (f17 != null ? !f17.equals(tuple.f17) : tuple.f17 != null) { return false; }
+		if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) {
+			return false;
+		}
+		if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) {
+			return false;
+		}
+		if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) {
+			return false;
+		}
+		if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) {
+			return false;
+		}
+		if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) {
+			return false;
+		}
+		if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) {
+			return false;
+		}
+		if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) {
+			return false;
+		}
+		if (f7 != null ? !f7.equals(tuple.f7) : tuple.f7 != null) {
+			return false;
+		}
+		if (f8 != null ? !f8.equals(tuple.f8) : tuple.f8 != null) {
+			return false;
+		}
+		if (f9 != null ? !f9.equals(tuple.f9) : tuple.f9 != null) {
+			return false;
+		}
+		if (f10 != null ? !f10.equals(tuple.f10) : tuple.f10 != null) {
+			return false;
+		}
+		if (f11 != null ? !f11.equals(tuple.f11) : tuple.f11 != null) {
+			return false;
+		}
+		if (f12 != null ? !f12.equals(tuple.f12) : tuple.f12 != null) {
+			return false;
+		}
+		if (f13 != null ? !f13.equals(tuple.f13) : tuple.f13 != null) {
+			return false;
+		}
+		if (f14 != null ? !f14.equals(tuple.f14) : tuple.f14 != null) {
+			return false;
+		}
+		if (f15 != null ? !f15.equals(tuple.f15) : tuple.f15 != null) {
+			return false;
+		}
+		if (f16 != null ? !f16.equals(tuple.f16) : tuple.f16 != null) {
+			return false;
+		}
+		if (f17 != null ? !f17.equals(tuple.f17) : tuple.f17 != null) {
+			return false;
+		}
 		return true;
 	}
 
@@ -383,8 +423,8 @@ public class Tuple18<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 	*/
 	@Override
 	@SuppressWarnings("unchecked")
-	public Tuple18<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17> copy(){ 
-		return new Tuple18<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17>(this.f0,
+	public Tuple18<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> copy() {
+		return new Tuple18<>(this.f0,
 			this.f1,
 			this.f2,
 			this.f3,
@@ -412,7 +452,24 @@ public class Tuple18<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 	 * instead of
 	 * {@code new Tuple3<Integer, Double, String>(n, x, s)}
 	 */
-	public static <T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17> Tuple18<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17> of(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13, T14 value14, T15 value15, T16 value16, T17 value17) {
-		return new Tuple18<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17>(value0, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15, value16, value17);
+	public static <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> Tuple18<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> of(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13, T14 value14, T15 value15, T16 value16, T17 value17) {
+		return new Tuple18<>(value0,
+			value1,
+			value2,
+			value3,
+			value4,
+			value5,
+			value6,
+			value7,
+			value8,
+			value9,
+			value10,
+			value11,
+			value12,
+			value13,
+			value14,
+			value15,
+			value16,
+			value17);
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple19.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple19.java
@@ -16,12 +16,10 @@
  * limitations under the License.
  */
 
-
 // --------------------------------------------------------------
 //  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
 //  GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 // --------------------------------------------------------------
-
 
 package org.apache.flink.api.java.tuple;
 
@@ -160,7 +158,9 @@ public class Tuple19<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 	}
 
 	@Override
-	public int getArity() { return 19; }
+	public int getArity() {
+		return 19;
+	}
 
 	@Override
 	@SuppressWarnings("unchecked")
@@ -335,35 +335,77 @@ public class Tuple19<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 	}
 
 	/**
-	 * Deep equality for tuples by calling equals() on the tuple members
+	 * Deep equality for tuples by calling equals() on the tuple members.
 	 * @param o the object checked for equality
 	 * @return true if this is equal to o.
 	 */
 	@Override
 	public boolean equals(Object o) {
-		if(this == o) { return true; }
-		if (!(o instanceof Tuple19)) { return false; }
+		if (this == o) {
+			return true;
+		}
+		if (!(o instanceof Tuple19)) {
+			return false;
+		}
 		@SuppressWarnings("rawtypes")
 		Tuple19 tuple = (Tuple19) o;
-		if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) { return false; }
-		if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) { return false; }
-		if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) { return false; }
-		if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) { return false; }
-		if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) { return false; }
-		if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) { return false; }
-		if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) { return false; }
-		if (f7 != null ? !f7.equals(tuple.f7) : tuple.f7 != null) { return false; }
-		if (f8 != null ? !f8.equals(tuple.f8) : tuple.f8 != null) { return false; }
-		if (f9 != null ? !f9.equals(tuple.f9) : tuple.f9 != null) { return false; }
-		if (f10 != null ? !f10.equals(tuple.f10) : tuple.f10 != null) { return false; }
-		if (f11 != null ? !f11.equals(tuple.f11) : tuple.f11 != null) { return false; }
-		if (f12 != null ? !f12.equals(tuple.f12) : tuple.f12 != null) { return false; }
-		if (f13 != null ? !f13.equals(tuple.f13) : tuple.f13 != null) { return false; }
-		if (f14 != null ? !f14.equals(tuple.f14) : tuple.f14 != null) { return false; }
-		if (f15 != null ? !f15.equals(tuple.f15) : tuple.f15 != null) { return false; }
-		if (f16 != null ? !f16.equals(tuple.f16) : tuple.f16 != null) { return false; }
-		if (f17 != null ? !f17.equals(tuple.f17) : tuple.f17 != null) { return false; }
-		if (f18 != null ? !f18.equals(tuple.f18) : tuple.f18 != null) { return false; }
+		if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) {
+			return false;
+		}
+		if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) {
+			return false;
+		}
+		if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) {
+			return false;
+		}
+		if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) {
+			return false;
+		}
+		if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) {
+			return false;
+		}
+		if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) {
+			return false;
+		}
+		if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) {
+			return false;
+		}
+		if (f7 != null ? !f7.equals(tuple.f7) : tuple.f7 != null) {
+			return false;
+		}
+		if (f8 != null ? !f8.equals(tuple.f8) : tuple.f8 != null) {
+			return false;
+		}
+		if (f9 != null ? !f9.equals(tuple.f9) : tuple.f9 != null) {
+			return false;
+		}
+		if (f10 != null ? !f10.equals(tuple.f10) : tuple.f10 != null) {
+			return false;
+		}
+		if (f11 != null ? !f11.equals(tuple.f11) : tuple.f11 != null) {
+			return false;
+		}
+		if (f12 != null ? !f12.equals(tuple.f12) : tuple.f12 != null) {
+			return false;
+		}
+		if (f13 != null ? !f13.equals(tuple.f13) : tuple.f13 != null) {
+			return false;
+		}
+		if (f14 != null ? !f14.equals(tuple.f14) : tuple.f14 != null) {
+			return false;
+		}
+		if (f15 != null ? !f15.equals(tuple.f15) : tuple.f15 != null) {
+			return false;
+		}
+		if (f16 != null ? !f16.equals(tuple.f16) : tuple.f16 != null) {
+			return false;
+		}
+		if (f17 != null ? !f17.equals(tuple.f17) : tuple.f17 != null) {
+			return false;
+		}
+		if (f18 != null ? !f18.equals(tuple.f18) : tuple.f18 != null) {
+			return false;
+		}
 		return true;
 	}
 
@@ -397,8 +439,8 @@ public class Tuple19<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 	*/
 	@Override
 	@SuppressWarnings("unchecked")
-	public Tuple19<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18> copy(){ 
-		return new Tuple19<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18>(this.f0,
+	public Tuple19<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> copy() {
+		return new Tuple19<>(this.f0,
 			this.f1,
 			this.f2,
 			this.f3,
@@ -427,7 +469,25 @@ public class Tuple19<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 	 * instead of
 	 * {@code new Tuple3<Integer, Double, String>(n, x, s)}
 	 */
-	public static <T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18> Tuple19<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18> of(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13, T14 value14, T15 value15, T16 value16, T17 value17, T18 value18) {
-		return new Tuple19<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18>(value0, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15, value16, value17, value18);
+	public static <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> Tuple19<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> of(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13, T14 value14, T15 value15, T16 value16, T17 value17, T18 value18) {
+		return new Tuple19<>(value0,
+			value1,
+			value2,
+			value3,
+			value4,
+			value5,
+			value6,
+			value7,
+			value8,
+			value9,
+			value10,
+			value11,
+			value12,
+			value13,
+			value14,
+			value15,
+			value16,
+			value17,
+			value18);
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple2.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple2.java
@@ -16,12 +16,10 @@
  * limitations under the License.
  */
 
-
 // --------------------------------------------------------------
 //  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
 //  GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 // --------------------------------------------------------------
-
 
 package org.apache.flink.api.java.tuple;
 
@@ -75,7 +73,9 @@ public class Tuple2<T0, T1> extends Tuple {
 	}
 
 	@Override
-	public int getArity() { return 2; }
+	public int getArity() {
+		return 2;
+	}
 
 	@Override
 	@SuppressWarnings("unchecked")
@@ -139,18 +139,26 @@ public class Tuple2<T0, T1> extends Tuple {
 	}
 
 	/**
-	 * Deep equality for tuples by calling equals() on the tuple members
+	 * Deep equality for tuples by calling equals() on the tuple members.
 	 * @param o the object checked for equality
 	 * @return true if this is equal to o.
 	 */
 	@Override
 	public boolean equals(Object o) {
-		if(this == o) { return true; }
-		if (!(o instanceof Tuple2)) { return false; }
+		if (this == o) {
+			return true;
+		}
+		if (!(o instanceof Tuple2)) {
+			return false;
+		}
 		@SuppressWarnings("rawtypes")
 		Tuple2 tuple = (Tuple2) o;
-		if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) { return false; }
-		if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) { return false; }
+		if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) {
+			return false;
+		}
+		if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) {
+			return false;
+		}
 		return true;
 	}
 
@@ -167,8 +175,8 @@ public class Tuple2<T0, T1> extends Tuple {
 	*/
 	@Override
 	@SuppressWarnings("unchecked")
-	public Tuple2<T0,T1> copy(){ 
-		return new Tuple2<T0,T1>(this.f0,
+	public Tuple2<T0, T1> copy() {
+		return new Tuple2<>(this.f0,
 			this.f1);
 	}
 
@@ -180,7 +188,8 @@ public class Tuple2<T0, T1> extends Tuple {
 	 * instead of
 	 * {@code new Tuple3<Integer, Double, String>(n, x, s)}
 	 */
-	public static <T0,T1> Tuple2<T0,T1> of(T0 value0, T1 value1) {
-		return new Tuple2<T0,T1>(value0, value1);
+	public static <T0, T1> Tuple2<T0, T1> of(T0 value0, T1 value1) {
+		return new Tuple2<>(value0,
+			value1);
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple20.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple20.java
@@ -16,12 +16,10 @@
  * limitations under the License.
  */
 
-
 // --------------------------------------------------------------
 //  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
 //  GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 // --------------------------------------------------------------
-
 
 package org.apache.flink.api.java.tuple;
 
@@ -165,7 +163,9 @@ public class Tuple20<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 	}
 
 	@Override
-	public int getArity() { return 20; }
+	public int getArity() {
+		return 20;
+	}
 
 	@Override
 	@SuppressWarnings("unchecked")
@@ -347,36 +347,80 @@ public class Tuple20<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 	}
 
 	/**
-	 * Deep equality for tuples by calling equals() on the tuple members
+	 * Deep equality for tuples by calling equals() on the tuple members.
 	 * @param o the object checked for equality
 	 * @return true if this is equal to o.
 	 */
 	@Override
 	public boolean equals(Object o) {
-		if(this == o) { return true; }
-		if (!(o instanceof Tuple20)) { return false; }
+		if (this == o) {
+			return true;
+		}
+		if (!(o instanceof Tuple20)) {
+			return false;
+		}
 		@SuppressWarnings("rawtypes")
 		Tuple20 tuple = (Tuple20) o;
-		if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) { return false; }
-		if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) { return false; }
-		if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) { return false; }
-		if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) { return false; }
-		if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) { return false; }
-		if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) { return false; }
-		if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) { return false; }
-		if (f7 != null ? !f7.equals(tuple.f7) : tuple.f7 != null) { return false; }
-		if (f8 != null ? !f8.equals(tuple.f8) : tuple.f8 != null) { return false; }
-		if (f9 != null ? !f9.equals(tuple.f9) : tuple.f9 != null) { return false; }
-		if (f10 != null ? !f10.equals(tuple.f10) : tuple.f10 != null) { return false; }
-		if (f11 != null ? !f11.equals(tuple.f11) : tuple.f11 != null) { return false; }
-		if (f12 != null ? !f12.equals(tuple.f12) : tuple.f12 != null) { return false; }
-		if (f13 != null ? !f13.equals(tuple.f13) : tuple.f13 != null) { return false; }
-		if (f14 != null ? !f14.equals(tuple.f14) : tuple.f14 != null) { return false; }
-		if (f15 != null ? !f15.equals(tuple.f15) : tuple.f15 != null) { return false; }
-		if (f16 != null ? !f16.equals(tuple.f16) : tuple.f16 != null) { return false; }
-		if (f17 != null ? !f17.equals(tuple.f17) : tuple.f17 != null) { return false; }
-		if (f18 != null ? !f18.equals(tuple.f18) : tuple.f18 != null) { return false; }
-		if (f19 != null ? !f19.equals(tuple.f19) : tuple.f19 != null) { return false; }
+		if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) {
+			return false;
+		}
+		if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) {
+			return false;
+		}
+		if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) {
+			return false;
+		}
+		if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) {
+			return false;
+		}
+		if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) {
+			return false;
+		}
+		if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) {
+			return false;
+		}
+		if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) {
+			return false;
+		}
+		if (f7 != null ? !f7.equals(tuple.f7) : tuple.f7 != null) {
+			return false;
+		}
+		if (f8 != null ? !f8.equals(tuple.f8) : tuple.f8 != null) {
+			return false;
+		}
+		if (f9 != null ? !f9.equals(tuple.f9) : tuple.f9 != null) {
+			return false;
+		}
+		if (f10 != null ? !f10.equals(tuple.f10) : tuple.f10 != null) {
+			return false;
+		}
+		if (f11 != null ? !f11.equals(tuple.f11) : tuple.f11 != null) {
+			return false;
+		}
+		if (f12 != null ? !f12.equals(tuple.f12) : tuple.f12 != null) {
+			return false;
+		}
+		if (f13 != null ? !f13.equals(tuple.f13) : tuple.f13 != null) {
+			return false;
+		}
+		if (f14 != null ? !f14.equals(tuple.f14) : tuple.f14 != null) {
+			return false;
+		}
+		if (f15 != null ? !f15.equals(tuple.f15) : tuple.f15 != null) {
+			return false;
+		}
+		if (f16 != null ? !f16.equals(tuple.f16) : tuple.f16 != null) {
+			return false;
+		}
+		if (f17 != null ? !f17.equals(tuple.f17) : tuple.f17 != null) {
+			return false;
+		}
+		if (f18 != null ? !f18.equals(tuple.f18) : tuple.f18 != null) {
+			return false;
+		}
+		if (f19 != null ? !f19.equals(tuple.f19) : tuple.f19 != null) {
+			return false;
+		}
 		return true;
 	}
 
@@ -411,8 +455,8 @@ public class Tuple20<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 	*/
 	@Override
 	@SuppressWarnings("unchecked")
-	public Tuple20<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19> copy(){ 
-		return new Tuple20<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19>(this.f0,
+	public Tuple20<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> copy() {
+		return new Tuple20<>(this.f0,
 			this.f1,
 			this.f2,
 			this.f3,
@@ -442,7 +486,26 @@ public class Tuple20<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 	 * instead of
 	 * {@code new Tuple3<Integer, Double, String>(n, x, s)}
 	 */
-	public static <T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19> Tuple20<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19> of(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13, T14 value14, T15 value15, T16 value16, T17 value17, T18 value18, T19 value19) {
-		return new Tuple20<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19>(value0, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15, value16, value17, value18, value19);
+	public static <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> Tuple20<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> of(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13, T14 value14, T15 value15, T16 value16, T17 value17, T18 value18, T19 value19) {
+		return new Tuple20<>(value0,
+			value1,
+			value2,
+			value3,
+			value4,
+			value5,
+			value6,
+			value7,
+			value8,
+			value9,
+			value10,
+			value11,
+			value12,
+			value13,
+			value14,
+			value15,
+			value16,
+			value17,
+			value18,
+			value19);
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple21.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple21.java
@@ -16,12 +16,10 @@
  * limitations under the License.
  */
 
-
 // --------------------------------------------------------------
 //  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
 //  GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 // --------------------------------------------------------------
-
 
 package org.apache.flink.api.java.tuple;
 
@@ -170,7 +168,9 @@ public class Tuple21<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 	}
 
 	@Override
-	public int getArity() { return 21; }
+	public int getArity() {
+		return 21;
+	}
 
 	@Override
 	@SuppressWarnings("unchecked")
@@ -359,37 +359,83 @@ public class Tuple21<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 	}
 
 	/**
-	 * Deep equality for tuples by calling equals() on the tuple members
+	 * Deep equality for tuples by calling equals() on the tuple members.
 	 * @param o the object checked for equality
 	 * @return true if this is equal to o.
 	 */
 	@Override
 	public boolean equals(Object o) {
-		if(this == o) { return true; }
-		if (!(o instanceof Tuple21)) { return false; }
+		if (this == o) {
+			return true;
+		}
+		if (!(o instanceof Tuple21)) {
+			return false;
+		}
 		@SuppressWarnings("rawtypes")
 		Tuple21 tuple = (Tuple21) o;
-		if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) { return false; }
-		if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) { return false; }
-		if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) { return false; }
-		if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) { return false; }
-		if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) { return false; }
-		if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) { return false; }
-		if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) { return false; }
-		if (f7 != null ? !f7.equals(tuple.f7) : tuple.f7 != null) { return false; }
-		if (f8 != null ? !f8.equals(tuple.f8) : tuple.f8 != null) { return false; }
-		if (f9 != null ? !f9.equals(tuple.f9) : tuple.f9 != null) { return false; }
-		if (f10 != null ? !f10.equals(tuple.f10) : tuple.f10 != null) { return false; }
-		if (f11 != null ? !f11.equals(tuple.f11) : tuple.f11 != null) { return false; }
-		if (f12 != null ? !f12.equals(tuple.f12) : tuple.f12 != null) { return false; }
-		if (f13 != null ? !f13.equals(tuple.f13) : tuple.f13 != null) { return false; }
-		if (f14 != null ? !f14.equals(tuple.f14) : tuple.f14 != null) { return false; }
-		if (f15 != null ? !f15.equals(tuple.f15) : tuple.f15 != null) { return false; }
-		if (f16 != null ? !f16.equals(tuple.f16) : tuple.f16 != null) { return false; }
-		if (f17 != null ? !f17.equals(tuple.f17) : tuple.f17 != null) { return false; }
-		if (f18 != null ? !f18.equals(tuple.f18) : tuple.f18 != null) { return false; }
-		if (f19 != null ? !f19.equals(tuple.f19) : tuple.f19 != null) { return false; }
-		if (f20 != null ? !f20.equals(tuple.f20) : tuple.f20 != null) { return false; }
+		if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) {
+			return false;
+		}
+		if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) {
+			return false;
+		}
+		if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) {
+			return false;
+		}
+		if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) {
+			return false;
+		}
+		if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) {
+			return false;
+		}
+		if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) {
+			return false;
+		}
+		if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) {
+			return false;
+		}
+		if (f7 != null ? !f7.equals(tuple.f7) : tuple.f7 != null) {
+			return false;
+		}
+		if (f8 != null ? !f8.equals(tuple.f8) : tuple.f8 != null) {
+			return false;
+		}
+		if (f9 != null ? !f9.equals(tuple.f9) : tuple.f9 != null) {
+			return false;
+		}
+		if (f10 != null ? !f10.equals(tuple.f10) : tuple.f10 != null) {
+			return false;
+		}
+		if (f11 != null ? !f11.equals(tuple.f11) : tuple.f11 != null) {
+			return false;
+		}
+		if (f12 != null ? !f12.equals(tuple.f12) : tuple.f12 != null) {
+			return false;
+		}
+		if (f13 != null ? !f13.equals(tuple.f13) : tuple.f13 != null) {
+			return false;
+		}
+		if (f14 != null ? !f14.equals(tuple.f14) : tuple.f14 != null) {
+			return false;
+		}
+		if (f15 != null ? !f15.equals(tuple.f15) : tuple.f15 != null) {
+			return false;
+		}
+		if (f16 != null ? !f16.equals(tuple.f16) : tuple.f16 != null) {
+			return false;
+		}
+		if (f17 != null ? !f17.equals(tuple.f17) : tuple.f17 != null) {
+			return false;
+		}
+		if (f18 != null ? !f18.equals(tuple.f18) : tuple.f18 != null) {
+			return false;
+		}
+		if (f19 != null ? !f19.equals(tuple.f19) : tuple.f19 != null) {
+			return false;
+		}
+		if (f20 != null ? !f20.equals(tuple.f20) : tuple.f20 != null) {
+			return false;
+		}
 		return true;
 	}
 
@@ -425,8 +471,8 @@ public class Tuple21<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 	*/
 	@Override
 	@SuppressWarnings("unchecked")
-	public Tuple21<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20> copy(){ 
-		return new Tuple21<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20>(this.f0,
+	public Tuple21<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> copy() {
+		return new Tuple21<>(this.f0,
 			this.f1,
 			this.f2,
 			this.f3,
@@ -457,7 +503,27 @@ public class Tuple21<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 	 * instead of
 	 * {@code new Tuple3<Integer, Double, String>(n, x, s)}
 	 */
-	public static <T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20> Tuple21<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20> of(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13, T14 value14, T15 value15, T16 value16, T17 value17, T18 value18, T19 value19, T20 value20) {
-		return new Tuple21<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20>(value0, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15, value16, value17, value18, value19, value20);
+	public static <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> Tuple21<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> of(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13, T14 value14, T15 value15, T16 value16, T17 value17, T18 value18, T19 value19, T20 value20) {
+		return new Tuple21<>(value0,
+			value1,
+			value2,
+			value3,
+			value4,
+			value5,
+			value6,
+			value7,
+			value8,
+			value9,
+			value10,
+			value11,
+			value12,
+			value13,
+			value14,
+			value15,
+			value16,
+			value17,
+			value18,
+			value19,
+			value20);
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple22.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple22.java
@@ -16,12 +16,10 @@
  * limitations under the License.
  */
 
-
 // --------------------------------------------------------------
 //  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
 //  GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 // --------------------------------------------------------------
-
 
 package org.apache.flink.api.java.tuple;
 
@@ -175,7 +173,9 @@ public class Tuple22<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 	}
 
 	@Override
-	public int getArity() { return 22; }
+	public int getArity() {
+		return 22;
+	}
 
 	@Override
 	@SuppressWarnings("unchecked")
@@ -371,38 +371,86 @@ public class Tuple22<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 	}
 
 	/**
-	 * Deep equality for tuples by calling equals() on the tuple members
+	 * Deep equality for tuples by calling equals() on the tuple members.
 	 * @param o the object checked for equality
 	 * @return true if this is equal to o.
 	 */
 	@Override
 	public boolean equals(Object o) {
-		if(this == o) { return true; }
-		if (!(o instanceof Tuple22)) { return false; }
+		if (this == o) {
+			return true;
+		}
+		if (!(o instanceof Tuple22)) {
+			return false;
+		}
 		@SuppressWarnings("rawtypes")
 		Tuple22 tuple = (Tuple22) o;
-		if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) { return false; }
-		if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) { return false; }
-		if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) { return false; }
-		if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) { return false; }
-		if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) { return false; }
-		if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) { return false; }
-		if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) { return false; }
-		if (f7 != null ? !f7.equals(tuple.f7) : tuple.f7 != null) { return false; }
-		if (f8 != null ? !f8.equals(tuple.f8) : tuple.f8 != null) { return false; }
-		if (f9 != null ? !f9.equals(tuple.f9) : tuple.f9 != null) { return false; }
-		if (f10 != null ? !f10.equals(tuple.f10) : tuple.f10 != null) { return false; }
-		if (f11 != null ? !f11.equals(tuple.f11) : tuple.f11 != null) { return false; }
-		if (f12 != null ? !f12.equals(tuple.f12) : tuple.f12 != null) { return false; }
-		if (f13 != null ? !f13.equals(tuple.f13) : tuple.f13 != null) { return false; }
-		if (f14 != null ? !f14.equals(tuple.f14) : tuple.f14 != null) { return false; }
-		if (f15 != null ? !f15.equals(tuple.f15) : tuple.f15 != null) { return false; }
-		if (f16 != null ? !f16.equals(tuple.f16) : tuple.f16 != null) { return false; }
-		if (f17 != null ? !f17.equals(tuple.f17) : tuple.f17 != null) { return false; }
-		if (f18 != null ? !f18.equals(tuple.f18) : tuple.f18 != null) { return false; }
-		if (f19 != null ? !f19.equals(tuple.f19) : tuple.f19 != null) { return false; }
-		if (f20 != null ? !f20.equals(tuple.f20) : tuple.f20 != null) { return false; }
-		if (f21 != null ? !f21.equals(tuple.f21) : tuple.f21 != null) { return false; }
+		if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) {
+			return false;
+		}
+		if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) {
+			return false;
+		}
+		if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) {
+			return false;
+		}
+		if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) {
+			return false;
+		}
+		if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) {
+			return false;
+		}
+		if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) {
+			return false;
+		}
+		if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) {
+			return false;
+		}
+		if (f7 != null ? !f7.equals(tuple.f7) : tuple.f7 != null) {
+			return false;
+		}
+		if (f8 != null ? !f8.equals(tuple.f8) : tuple.f8 != null) {
+			return false;
+		}
+		if (f9 != null ? !f9.equals(tuple.f9) : tuple.f9 != null) {
+			return false;
+		}
+		if (f10 != null ? !f10.equals(tuple.f10) : tuple.f10 != null) {
+			return false;
+		}
+		if (f11 != null ? !f11.equals(tuple.f11) : tuple.f11 != null) {
+			return false;
+		}
+		if (f12 != null ? !f12.equals(tuple.f12) : tuple.f12 != null) {
+			return false;
+		}
+		if (f13 != null ? !f13.equals(tuple.f13) : tuple.f13 != null) {
+			return false;
+		}
+		if (f14 != null ? !f14.equals(tuple.f14) : tuple.f14 != null) {
+			return false;
+		}
+		if (f15 != null ? !f15.equals(tuple.f15) : tuple.f15 != null) {
+			return false;
+		}
+		if (f16 != null ? !f16.equals(tuple.f16) : tuple.f16 != null) {
+			return false;
+		}
+		if (f17 != null ? !f17.equals(tuple.f17) : tuple.f17 != null) {
+			return false;
+		}
+		if (f18 != null ? !f18.equals(tuple.f18) : tuple.f18 != null) {
+			return false;
+		}
+		if (f19 != null ? !f19.equals(tuple.f19) : tuple.f19 != null) {
+			return false;
+		}
+		if (f20 != null ? !f20.equals(tuple.f20) : tuple.f20 != null) {
+			return false;
+		}
+		if (f21 != null ? !f21.equals(tuple.f21) : tuple.f21 != null) {
+			return false;
+		}
 		return true;
 	}
 
@@ -439,8 +487,8 @@ public class Tuple22<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 	*/
 	@Override
 	@SuppressWarnings("unchecked")
-	public Tuple22<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21> copy(){ 
-		return new Tuple22<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21>(this.f0,
+	public Tuple22<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> copy() {
+		return new Tuple22<>(this.f0,
 			this.f1,
 			this.f2,
 			this.f3,
@@ -472,7 +520,28 @@ public class Tuple22<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 	 * instead of
 	 * {@code new Tuple3<Integer, Double, String>(n, x, s)}
 	 */
-	public static <T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21> Tuple22<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21> of(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13, T14 value14, T15 value15, T16 value16, T17 value17, T18 value18, T19 value19, T20 value20, T21 value21) {
-		return new Tuple22<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21>(value0, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15, value16, value17, value18, value19, value20, value21);
+	public static <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> Tuple22<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> of(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13, T14 value14, T15 value15, T16 value16, T17 value17, T18 value18, T19 value19, T20 value20, T21 value21) {
+		return new Tuple22<>(value0,
+			value1,
+			value2,
+			value3,
+			value4,
+			value5,
+			value6,
+			value7,
+			value8,
+			value9,
+			value10,
+			value11,
+			value12,
+			value13,
+			value14,
+			value15,
+			value16,
+			value17,
+			value18,
+			value19,
+			value20,
+			value21);
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple23.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple23.java
@@ -16,12 +16,10 @@
  * limitations under the License.
  */
 
-
 // --------------------------------------------------------------
 //  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
 //  GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 // --------------------------------------------------------------
-
 
 package org.apache.flink.api.java.tuple;
 
@@ -180,7 +178,9 @@ public class Tuple23<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 	}
 
 	@Override
-	public int getArity() { return 23; }
+	public int getArity() {
+		return 23;
+	}
 
 	@Override
 	@SuppressWarnings("unchecked")
@@ -383,39 +383,89 @@ public class Tuple23<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 	}
 
 	/**
-	 * Deep equality for tuples by calling equals() on the tuple members
+	 * Deep equality for tuples by calling equals() on the tuple members.
 	 * @param o the object checked for equality
 	 * @return true if this is equal to o.
 	 */
 	@Override
 	public boolean equals(Object o) {
-		if(this == o) { return true; }
-		if (!(o instanceof Tuple23)) { return false; }
+		if (this == o) {
+			return true;
+		}
+		if (!(o instanceof Tuple23)) {
+			return false;
+		}
 		@SuppressWarnings("rawtypes")
 		Tuple23 tuple = (Tuple23) o;
-		if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) { return false; }
-		if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) { return false; }
-		if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) { return false; }
-		if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) { return false; }
-		if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) { return false; }
-		if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) { return false; }
-		if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) { return false; }
-		if (f7 != null ? !f7.equals(tuple.f7) : tuple.f7 != null) { return false; }
-		if (f8 != null ? !f8.equals(tuple.f8) : tuple.f8 != null) { return false; }
-		if (f9 != null ? !f9.equals(tuple.f9) : tuple.f9 != null) { return false; }
-		if (f10 != null ? !f10.equals(tuple.f10) : tuple.f10 != null) { return false; }
-		if (f11 != null ? !f11.equals(tuple.f11) : tuple.f11 != null) { return false; }
-		if (f12 != null ? !f12.equals(tuple.f12) : tuple.f12 != null) { return false; }
-		if (f13 != null ? !f13.equals(tuple.f13) : tuple.f13 != null) { return false; }
-		if (f14 != null ? !f14.equals(tuple.f14) : tuple.f14 != null) { return false; }
-		if (f15 != null ? !f15.equals(tuple.f15) : tuple.f15 != null) { return false; }
-		if (f16 != null ? !f16.equals(tuple.f16) : tuple.f16 != null) { return false; }
-		if (f17 != null ? !f17.equals(tuple.f17) : tuple.f17 != null) { return false; }
-		if (f18 != null ? !f18.equals(tuple.f18) : tuple.f18 != null) { return false; }
-		if (f19 != null ? !f19.equals(tuple.f19) : tuple.f19 != null) { return false; }
-		if (f20 != null ? !f20.equals(tuple.f20) : tuple.f20 != null) { return false; }
-		if (f21 != null ? !f21.equals(tuple.f21) : tuple.f21 != null) { return false; }
-		if (f22 != null ? !f22.equals(tuple.f22) : tuple.f22 != null) { return false; }
+		if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) {
+			return false;
+		}
+		if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) {
+			return false;
+		}
+		if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) {
+			return false;
+		}
+		if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) {
+			return false;
+		}
+		if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) {
+			return false;
+		}
+		if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) {
+			return false;
+		}
+		if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) {
+			return false;
+		}
+		if (f7 != null ? !f7.equals(tuple.f7) : tuple.f7 != null) {
+			return false;
+		}
+		if (f8 != null ? !f8.equals(tuple.f8) : tuple.f8 != null) {
+			return false;
+		}
+		if (f9 != null ? !f9.equals(tuple.f9) : tuple.f9 != null) {
+			return false;
+		}
+		if (f10 != null ? !f10.equals(tuple.f10) : tuple.f10 != null) {
+			return false;
+		}
+		if (f11 != null ? !f11.equals(tuple.f11) : tuple.f11 != null) {
+			return false;
+		}
+		if (f12 != null ? !f12.equals(tuple.f12) : tuple.f12 != null) {
+			return false;
+		}
+		if (f13 != null ? !f13.equals(tuple.f13) : tuple.f13 != null) {
+			return false;
+		}
+		if (f14 != null ? !f14.equals(tuple.f14) : tuple.f14 != null) {
+			return false;
+		}
+		if (f15 != null ? !f15.equals(tuple.f15) : tuple.f15 != null) {
+			return false;
+		}
+		if (f16 != null ? !f16.equals(tuple.f16) : tuple.f16 != null) {
+			return false;
+		}
+		if (f17 != null ? !f17.equals(tuple.f17) : tuple.f17 != null) {
+			return false;
+		}
+		if (f18 != null ? !f18.equals(tuple.f18) : tuple.f18 != null) {
+			return false;
+		}
+		if (f19 != null ? !f19.equals(tuple.f19) : tuple.f19 != null) {
+			return false;
+		}
+		if (f20 != null ? !f20.equals(tuple.f20) : tuple.f20 != null) {
+			return false;
+		}
+		if (f21 != null ? !f21.equals(tuple.f21) : tuple.f21 != null) {
+			return false;
+		}
+		if (f22 != null ? !f22.equals(tuple.f22) : tuple.f22 != null) {
+			return false;
+		}
 		return true;
 	}
 
@@ -453,8 +503,8 @@ public class Tuple23<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 	*/
 	@Override
 	@SuppressWarnings("unchecked")
-	public Tuple23<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21,T22> copy(){ 
-		return new Tuple23<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21,T22>(this.f0,
+	public Tuple23<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> copy() {
+		return new Tuple23<>(this.f0,
 			this.f1,
 			this.f2,
 			this.f3,
@@ -487,7 +537,29 @@ public class Tuple23<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 	 * instead of
 	 * {@code new Tuple3<Integer, Double, String>(n, x, s)}
 	 */
-	public static <T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21,T22> Tuple23<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21,T22> of(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13, T14 value14, T15 value15, T16 value16, T17 value17, T18 value18, T19 value19, T20 value20, T21 value21, T22 value22) {
-		return new Tuple23<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21,T22>(value0, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15, value16, value17, value18, value19, value20, value21, value22);
+	public static <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> Tuple23<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> of(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13, T14 value14, T15 value15, T16 value16, T17 value17, T18 value18, T19 value19, T20 value20, T21 value21, T22 value22) {
+		return new Tuple23<>(value0,
+			value1,
+			value2,
+			value3,
+			value4,
+			value5,
+			value6,
+			value7,
+			value8,
+			value9,
+			value10,
+			value11,
+			value12,
+			value13,
+			value14,
+			value15,
+			value16,
+			value17,
+			value18,
+			value19,
+			value20,
+			value21,
+			value22);
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple24.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple24.java
@@ -16,12 +16,10 @@
  * limitations under the License.
  */
 
-
 // --------------------------------------------------------------
 //  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
 //  GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 // --------------------------------------------------------------
-
 
 package org.apache.flink.api.java.tuple;
 
@@ -185,7 +183,9 @@ public class Tuple24<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 	}
 
 	@Override
-	public int getArity() { return 24; }
+	public int getArity() {
+		return 24;
+	}
 
 	@Override
 	@SuppressWarnings("unchecked")
@@ -395,40 +395,92 @@ public class Tuple24<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 	}
 
 	/**
-	 * Deep equality for tuples by calling equals() on the tuple members
+	 * Deep equality for tuples by calling equals() on the tuple members.
 	 * @param o the object checked for equality
 	 * @return true if this is equal to o.
 	 */
 	@Override
 	public boolean equals(Object o) {
-		if(this == o) { return true; }
-		if (!(o instanceof Tuple24)) { return false; }
+		if (this == o) {
+			return true;
+		}
+		if (!(o instanceof Tuple24)) {
+			return false;
+		}
 		@SuppressWarnings("rawtypes")
 		Tuple24 tuple = (Tuple24) o;
-		if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) { return false; }
-		if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) { return false; }
-		if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) { return false; }
-		if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) { return false; }
-		if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) { return false; }
-		if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) { return false; }
-		if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) { return false; }
-		if (f7 != null ? !f7.equals(tuple.f7) : tuple.f7 != null) { return false; }
-		if (f8 != null ? !f8.equals(tuple.f8) : tuple.f8 != null) { return false; }
-		if (f9 != null ? !f9.equals(tuple.f9) : tuple.f9 != null) { return false; }
-		if (f10 != null ? !f10.equals(tuple.f10) : tuple.f10 != null) { return false; }
-		if (f11 != null ? !f11.equals(tuple.f11) : tuple.f11 != null) { return false; }
-		if (f12 != null ? !f12.equals(tuple.f12) : tuple.f12 != null) { return false; }
-		if (f13 != null ? !f13.equals(tuple.f13) : tuple.f13 != null) { return false; }
-		if (f14 != null ? !f14.equals(tuple.f14) : tuple.f14 != null) { return false; }
-		if (f15 != null ? !f15.equals(tuple.f15) : tuple.f15 != null) { return false; }
-		if (f16 != null ? !f16.equals(tuple.f16) : tuple.f16 != null) { return false; }
-		if (f17 != null ? !f17.equals(tuple.f17) : tuple.f17 != null) { return false; }
-		if (f18 != null ? !f18.equals(tuple.f18) : tuple.f18 != null) { return false; }
-		if (f19 != null ? !f19.equals(tuple.f19) : tuple.f19 != null) { return false; }
-		if (f20 != null ? !f20.equals(tuple.f20) : tuple.f20 != null) { return false; }
-		if (f21 != null ? !f21.equals(tuple.f21) : tuple.f21 != null) { return false; }
-		if (f22 != null ? !f22.equals(tuple.f22) : tuple.f22 != null) { return false; }
-		if (f23 != null ? !f23.equals(tuple.f23) : tuple.f23 != null) { return false; }
+		if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) {
+			return false;
+		}
+		if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) {
+			return false;
+		}
+		if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) {
+			return false;
+		}
+		if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) {
+			return false;
+		}
+		if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) {
+			return false;
+		}
+		if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) {
+			return false;
+		}
+		if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) {
+			return false;
+		}
+		if (f7 != null ? !f7.equals(tuple.f7) : tuple.f7 != null) {
+			return false;
+		}
+		if (f8 != null ? !f8.equals(tuple.f8) : tuple.f8 != null) {
+			return false;
+		}
+		if (f9 != null ? !f9.equals(tuple.f9) : tuple.f9 != null) {
+			return false;
+		}
+		if (f10 != null ? !f10.equals(tuple.f10) : tuple.f10 != null) {
+			return false;
+		}
+		if (f11 != null ? !f11.equals(tuple.f11) : tuple.f11 != null) {
+			return false;
+		}
+		if (f12 != null ? !f12.equals(tuple.f12) : tuple.f12 != null) {
+			return false;
+		}
+		if (f13 != null ? !f13.equals(tuple.f13) : tuple.f13 != null) {
+			return false;
+		}
+		if (f14 != null ? !f14.equals(tuple.f14) : tuple.f14 != null) {
+			return false;
+		}
+		if (f15 != null ? !f15.equals(tuple.f15) : tuple.f15 != null) {
+			return false;
+		}
+		if (f16 != null ? !f16.equals(tuple.f16) : tuple.f16 != null) {
+			return false;
+		}
+		if (f17 != null ? !f17.equals(tuple.f17) : tuple.f17 != null) {
+			return false;
+		}
+		if (f18 != null ? !f18.equals(tuple.f18) : tuple.f18 != null) {
+			return false;
+		}
+		if (f19 != null ? !f19.equals(tuple.f19) : tuple.f19 != null) {
+			return false;
+		}
+		if (f20 != null ? !f20.equals(tuple.f20) : tuple.f20 != null) {
+			return false;
+		}
+		if (f21 != null ? !f21.equals(tuple.f21) : tuple.f21 != null) {
+			return false;
+		}
+		if (f22 != null ? !f22.equals(tuple.f22) : tuple.f22 != null) {
+			return false;
+		}
+		if (f23 != null ? !f23.equals(tuple.f23) : tuple.f23 != null) {
+			return false;
+		}
 		return true;
 	}
 
@@ -467,8 +519,8 @@ public class Tuple24<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 	*/
 	@Override
 	@SuppressWarnings("unchecked")
-	public Tuple24<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21,T22,T23> copy(){ 
-		return new Tuple24<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21,T22,T23>(this.f0,
+	public Tuple24<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> copy() {
+		return new Tuple24<>(this.f0,
 			this.f1,
 			this.f2,
 			this.f3,
@@ -502,7 +554,30 @@ public class Tuple24<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 	 * instead of
 	 * {@code new Tuple3<Integer, Double, String>(n, x, s)}
 	 */
-	public static <T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21,T22,T23> Tuple24<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21,T22,T23> of(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13, T14 value14, T15 value15, T16 value16, T17 value17, T18 value18, T19 value19, T20 value20, T21 value21, T22 value22, T23 value23) {
-		return new Tuple24<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21,T22,T23>(value0, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15, value16, value17, value18, value19, value20, value21, value22, value23);
+	public static <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> Tuple24<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> of(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13, T14 value14, T15 value15, T16 value16, T17 value17, T18 value18, T19 value19, T20 value20, T21 value21, T22 value22, T23 value23) {
+		return new Tuple24<>(value0,
+			value1,
+			value2,
+			value3,
+			value4,
+			value5,
+			value6,
+			value7,
+			value8,
+			value9,
+			value10,
+			value11,
+			value12,
+			value13,
+			value14,
+			value15,
+			value16,
+			value17,
+			value18,
+			value19,
+			value20,
+			value21,
+			value22,
+			value23);
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple25.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple25.java
@@ -16,12 +16,10 @@
  * limitations under the License.
  */
 
-
 // --------------------------------------------------------------
 //  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
 //  GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 // --------------------------------------------------------------
-
 
 package org.apache.flink.api.java.tuple;
 
@@ -190,7 +188,9 @@ public class Tuple25<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 	}
 
 	@Override
-	public int getArity() { return 25; }
+	public int getArity() {
+		return 25;
+	}
 
 	@Override
 	@SuppressWarnings("unchecked")
@@ -407,41 +407,95 @@ public class Tuple25<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 	}
 
 	/**
-	 * Deep equality for tuples by calling equals() on the tuple members
+	 * Deep equality for tuples by calling equals() on the tuple members.
 	 * @param o the object checked for equality
 	 * @return true if this is equal to o.
 	 */
 	@Override
 	public boolean equals(Object o) {
-		if(this == o) { return true; }
-		if (!(o instanceof Tuple25)) { return false; }
+		if (this == o) {
+			return true;
+		}
+		if (!(o instanceof Tuple25)) {
+			return false;
+		}
 		@SuppressWarnings("rawtypes")
 		Tuple25 tuple = (Tuple25) o;
-		if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) { return false; }
-		if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) { return false; }
-		if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) { return false; }
-		if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) { return false; }
-		if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) { return false; }
-		if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) { return false; }
-		if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) { return false; }
-		if (f7 != null ? !f7.equals(tuple.f7) : tuple.f7 != null) { return false; }
-		if (f8 != null ? !f8.equals(tuple.f8) : tuple.f8 != null) { return false; }
-		if (f9 != null ? !f9.equals(tuple.f9) : tuple.f9 != null) { return false; }
-		if (f10 != null ? !f10.equals(tuple.f10) : tuple.f10 != null) { return false; }
-		if (f11 != null ? !f11.equals(tuple.f11) : tuple.f11 != null) { return false; }
-		if (f12 != null ? !f12.equals(tuple.f12) : tuple.f12 != null) { return false; }
-		if (f13 != null ? !f13.equals(tuple.f13) : tuple.f13 != null) { return false; }
-		if (f14 != null ? !f14.equals(tuple.f14) : tuple.f14 != null) { return false; }
-		if (f15 != null ? !f15.equals(tuple.f15) : tuple.f15 != null) { return false; }
-		if (f16 != null ? !f16.equals(tuple.f16) : tuple.f16 != null) { return false; }
-		if (f17 != null ? !f17.equals(tuple.f17) : tuple.f17 != null) { return false; }
-		if (f18 != null ? !f18.equals(tuple.f18) : tuple.f18 != null) { return false; }
-		if (f19 != null ? !f19.equals(tuple.f19) : tuple.f19 != null) { return false; }
-		if (f20 != null ? !f20.equals(tuple.f20) : tuple.f20 != null) { return false; }
-		if (f21 != null ? !f21.equals(tuple.f21) : tuple.f21 != null) { return false; }
-		if (f22 != null ? !f22.equals(tuple.f22) : tuple.f22 != null) { return false; }
-		if (f23 != null ? !f23.equals(tuple.f23) : tuple.f23 != null) { return false; }
-		if (f24 != null ? !f24.equals(tuple.f24) : tuple.f24 != null) { return false; }
+		if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) {
+			return false;
+		}
+		if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) {
+			return false;
+		}
+		if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) {
+			return false;
+		}
+		if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) {
+			return false;
+		}
+		if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) {
+			return false;
+		}
+		if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) {
+			return false;
+		}
+		if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) {
+			return false;
+		}
+		if (f7 != null ? !f7.equals(tuple.f7) : tuple.f7 != null) {
+			return false;
+		}
+		if (f8 != null ? !f8.equals(tuple.f8) : tuple.f8 != null) {
+			return false;
+		}
+		if (f9 != null ? !f9.equals(tuple.f9) : tuple.f9 != null) {
+			return false;
+		}
+		if (f10 != null ? !f10.equals(tuple.f10) : tuple.f10 != null) {
+			return false;
+		}
+		if (f11 != null ? !f11.equals(tuple.f11) : tuple.f11 != null) {
+			return false;
+		}
+		if (f12 != null ? !f12.equals(tuple.f12) : tuple.f12 != null) {
+			return false;
+		}
+		if (f13 != null ? !f13.equals(tuple.f13) : tuple.f13 != null) {
+			return false;
+		}
+		if (f14 != null ? !f14.equals(tuple.f14) : tuple.f14 != null) {
+			return false;
+		}
+		if (f15 != null ? !f15.equals(tuple.f15) : tuple.f15 != null) {
+			return false;
+		}
+		if (f16 != null ? !f16.equals(tuple.f16) : tuple.f16 != null) {
+			return false;
+		}
+		if (f17 != null ? !f17.equals(tuple.f17) : tuple.f17 != null) {
+			return false;
+		}
+		if (f18 != null ? !f18.equals(tuple.f18) : tuple.f18 != null) {
+			return false;
+		}
+		if (f19 != null ? !f19.equals(tuple.f19) : tuple.f19 != null) {
+			return false;
+		}
+		if (f20 != null ? !f20.equals(tuple.f20) : tuple.f20 != null) {
+			return false;
+		}
+		if (f21 != null ? !f21.equals(tuple.f21) : tuple.f21 != null) {
+			return false;
+		}
+		if (f22 != null ? !f22.equals(tuple.f22) : tuple.f22 != null) {
+			return false;
+		}
+		if (f23 != null ? !f23.equals(tuple.f23) : tuple.f23 != null) {
+			return false;
+		}
+		if (f24 != null ? !f24.equals(tuple.f24) : tuple.f24 != null) {
+			return false;
+		}
 		return true;
 	}
 
@@ -481,8 +535,8 @@ public class Tuple25<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 	*/
 	@Override
 	@SuppressWarnings("unchecked")
-	public Tuple25<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21,T22,T23,T24> copy(){ 
-		return new Tuple25<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21,T22,T23,T24>(this.f0,
+	public Tuple25<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> copy() {
+		return new Tuple25<>(this.f0,
 			this.f1,
 			this.f2,
 			this.f3,
@@ -517,7 +571,31 @@ public class Tuple25<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 	 * instead of
 	 * {@code new Tuple3<Integer, Double, String>(n, x, s)}
 	 */
-	public static <T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21,T22,T23,T24> Tuple25<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21,T22,T23,T24> of(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13, T14 value14, T15 value15, T16 value16, T17 value17, T18 value18, T19 value19, T20 value20, T21 value21, T22 value22, T23 value23, T24 value24) {
-		return new Tuple25<T0,T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,T17,T18,T19,T20,T21,T22,T23,T24>(value0, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15, value16, value17, value18, value19, value20, value21, value22, value23, value24);
+	public static <T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> Tuple25<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> of(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8, T9 value9, T10 value10, T11 value11, T12 value12, T13 value13, T14 value14, T15 value15, T16 value16, T17 value17, T18 value18, T19 value19, T20 value20, T21 value21, T22 value22, T23 value23, T24 value24) {
+		return new Tuple25<>(value0,
+			value1,
+			value2,
+			value3,
+			value4,
+			value5,
+			value6,
+			value7,
+			value8,
+			value9,
+			value10,
+			value11,
+			value12,
+			value13,
+			value14,
+			value15,
+			value16,
+			value17,
+			value18,
+			value19,
+			value20,
+			value21,
+			value22,
+			value23,
+			value24);
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple3.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple3.java
@@ -16,12 +16,10 @@
  * limitations under the License.
  */
 
-
 // --------------------------------------------------------------
 //  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
 //  GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 // --------------------------------------------------------------
-
 
 package org.apache.flink.api.java.tuple;
 
@@ -80,7 +78,9 @@ public class Tuple3<T0, T1, T2> extends Tuple {
 	}
 
 	@Override
-	public int getArity() { return 3; }
+	public int getArity() {
+		return 3;
+	}
 
 	@Override
 	@SuppressWarnings("unchecked")
@@ -143,19 +143,29 @@ public class Tuple3<T0, T1, T2> extends Tuple {
 	}
 
 	/**
-	 * Deep equality for tuples by calling equals() on the tuple members
+	 * Deep equality for tuples by calling equals() on the tuple members.
 	 * @param o the object checked for equality
 	 * @return true if this is equal to o.
 	 */
 	@Override
 	public boolean equals(Object o) {
-		if(this == o) { return true; }
-		if (!(o instanceof Tuple3)) { return false; }
+		if (this == o) {
+			return true;
+		}
+		if (!(o instanceof Tuple3)) {
+			return false;
+		}
 		@SuppressWarnings("rawtypes")
 		Tuple3 tuple = (Tuple3) o;
-		if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) { return false; }
-		if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) { return false; }
-		if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) { return false; }
+		if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) {
+			return false;
+		}
+		if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) {
+			return false;
+		}
+		if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) {
+			return false;
+		}
 		return true;
 	}
 
@@ -173,8 +183,8 @@ public class Tuple3<T0, T1, T2> extends Tuple {
 	*/
 	@Override
 	@SuppressWarnings("unchecked")
-	public Tuple3<T0,T1,T2> copy(){ 
-		return new Tuple3<T0,T1,T2>(this.f0,
+	public Tuple3<T0, T1, T2> copy() {
+		return new Tuple3<>(this.f0,
 			this.f1,
 			this.f2);
 	}
@@ -187,7 +197,9 @@ public class Tuple3<T0, T1, T2> extends Tuple {
 	 * instead of
 	 * {@code new Tuple3<Integer, Double, String>(n, x, s)}
 	 */
-	public static <T0,T1,T2> Tuple3<T0,T1,T2> of(T0 value0, T1 value1, T2 value2) {
-		return new Tuple3<T0,T1,T2>(value0, value1, value2);
+	public static <T0, T1, T2> Tuple3<T0, T1, T2> of(T0 value0, T1 value1, T2 value2) {
+		return new Tuple3<>(value0,
+			value1,
+			value2);
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple4.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple4.java
@@ -16,12 +16,10 @@
  * limitations under the License.
  */
 
-
 // --------------------------------------------------------------
 //  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
 //  GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 // --------------------------------------------------------------
-
 
 package org.apache.flink.api.java.tuple;
 
@@ -85,7 +83,9 @@ public class Tuple4<T0, T1, T2, T3> extends Tuple {
 	}
 
 	@Override
-	public int getArity() { return 4; }
+	public int getArity() {
+		return 4;
+	}
 
 	@Override
 	@SuppressWarnings("unchecked")
@@ -155,20 +155,32 @@ public class Tuple4<T0, T1, T2, T3> extends Tuple {
 	}
 
 	/**
-	 * Deep equality for tuples by calling equals() on the tuple members
+	 * Deep equality for tuples by calling equals() on the tuple members.
 	 * @param o the object checked for equality
 	 * @return true if this is equal to o.
 	 */
 	@Override
 	public boolean equals(Object o) {
-		if(this == o) { return true; }
-		if (!(o instanceof Tuple4)) { return false; }
+		if (this == o) {
+			return true;
+		}
+		if (!(o instanceof Tuple4)) {
+			return false;
+		}
 		@SuppressWarnings("rawtypes")
 		Tuple4 tuple = (Tuple4) o;
-		if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) { return false; }
-		if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) { return false; }
-		if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) { return false; }
-		if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) { return false; }
+		if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) {
+			return false;
+		}
+		if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) {
+			return false;
+		}
+		if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) {
+			return false;
+		}
+		if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) {
+			return false;
+		}
 		return true;
 	}
 
@@ -187,8 +199,8 @@ public class Tuple4<T0, T1, T2, T3> extends Tuple {
 	*/
 	@Override
 	@SuppressWarnings("unchecked")
-	public Tuple4<T0,T1,T2,T3> copy(){ 
-		return new Tuple4<T0,T1,T2,T3>(this.f0,
+	public Tuple4<T0, T1, T2, T3> copy() {
+		return new Tuple4<>(this.f0,
 			this.f1,
 			this.f2,
 			this.f3);
@@ -202,7 +214,10 @@ public class Tuple4<T0, T1, T2, T3> extends Tuple {
 	 * instead of
 	 * {@code new Tuple3<Integer, Double, String>(n, x, s)}
 	 */
-	public static <T0,T1,T2,T3> Tuple4<T0,T1,T2,T3> of(T0 value0, T1 value1, T2 value2, T3 value3) {
-		return new Tuple4<T0,T1,T2,T3>(value0, value1, value2, value3);
+	public static <T0, T1, T2, T3> Tuple4<T0, T1, T2, T3> of(T0 value0, T1 value1, T2 value2, T3 value3) {
+		return new Tuple4<>(value0,
+			value1,
+			value2,
+			value3);
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple5.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple5.java
@@ -16,12 +16,10 @@
  * limitations under the License.
  */
 
-
 // --------------------------------------------------------------
 //  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
 //  GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 // --------------------------------------------------------------
-
 
 package org.apache.flink.api.java.tuple;
 
@@ -90,7 +88,9 @@ public class Tuple5<T0, T1, T2, T3, T4> extends Tuple {
 	}
 
 	@Override
-	public int getArity() { return 5; }
+	public int getArity() {
+		return 5;
+	}
 
 	@Override
 	@SuppressWarnings("unchecked")
@@ -167,21 +167,35 @@ public class Tuple5<T0, T1, T2, T3, T4> extends Tuple {
 	}
 
 	/**
-	 * Deep equality for tuples by calling equals() on the tuple members
+	 * Deep equality for tuples by calling equals() on the tuple members.
 	 * @param o the object checked for equality
 	 * @return true if this is equal to o.
 	 */
 	@Override
 	public boolean equals(Object o) {
-		if(this == o) { return true; }
-		if (!(o instanceof Tuple5)) { return false; }
+		if (this == o) {
+			return true;
+		}
+		if (!(o instanceof Tuple5)) {
+			return false;
+		}
 		@SuppressWarnings("rawtypes")
 		Tuple5 tuple = (Tuple5) o;
-		if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) { return false; }
-		if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) { return false; }
-		if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) { return false; }
-		if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) { return false; }
-		if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) { return false; }
+		if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) {
+			return false;
+		}
+		if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) {
+			return false;
+		}
+		if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) {
+			return false;
+		}
+		if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) {
+			return false;
+		}
+		if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) {
+			return false;
+		}
 		return true;
 	}
 
@@ -201,8 +215,8 @@ public class Tuple5<T0, T1, T2, T3, T4> extends Tuple {
 	*/
 	@Override
 	@SuppressWarnings("unchecked")
-	public Tuple5<T0,T1,T2,T3,T4> copy(){ 
-		return new Tuple5<T0,T1,T2,T3,T4>(this.f0,
+	public Tuple5<T0, T1, T2, T3, T4> copy() {
+		return new Tuple5<>(this.f0,
 			this.f1,
 			this.f2,
 			this.f3,
@@ -217,7 +231,11 @@ public class Tuple5<T0, T1, T2, T3, T4> extends Tuple {
 	 * instead of
 	 * {@code new Tuple3<Integer, Double, String>(n, x, s)}
 	 */
-	public static <T0,T1,T2,T3,T4> Tuple5<T0,T1,T2,T3,T4> of(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4) {
-		return new Tuple5<T0,T1,T2,T3,T4>(value0, value1, value2, value3, value4);
+	public static <T0, T1, T2, T3, T4> Tuple5<T0, T1, T2, T3, T4> of(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4) {
+		return new Tuple5<>(value0,
+			value1,
+			value2,
+			value3,
+			value4);
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple6.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple6.java
@@ -16,12 +16,10 @@
  * limitations under the License.
  */
 
-
 // --------------------------------------------------------------
 //  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
 //  GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 // --------------------------------------------------------------
-
 
 package org.apache.flink.api.java.tuple;
 
@@ -95,7 +93,9 @@ public class Tuple6<T0, T1, T2, T3, T4, T5> extends Tuple {
 	}
 
 	@Override
-	public int getArity() { return 6; }
+	public int getArity() {
+		return 6;
+	}
 
 	@Override
 	@SuppressWarnings("unchecked")
@@ -179,22 +179,38 @@ public class Tuple6<T0, T1, T2, T3, T4, T5> extends Tuple {
 	}
 
 	/**
-	 * Deep equality for tuples by calling equals() on the tuple members
+	 * Deep equality for tuples by calling equals() on the tuple members.
 	 * @param o the object checked for equality
 	 * @return true if this is equal to o.
 	 */
 	@Override
 	public boolean equals(Object o) {
-		if(this == o) { return true; }
-		if (!(o instanceof Tuple6)) { return false; }
+		if (this == o) {
+			return true;
+		}
+		if (!(o instanceof Tuple6)) {
+			return false;
+		}
 		@SuppressWarnings("rawtypes")
 		Tuple6 tuple = (Tuple6) o;
-		if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) { return false; }
-		if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) { return false; }
-		if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) { return false; }
-		if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) { return false; }
-		if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) { return false; }
-		if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) { return false; }
+		if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) {
+			return false;
+		}
+		if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) {
+			return false;
+		}
+		if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) {
+			return false;
+		}
+		if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) {
+			return false;
+		}
+		if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) {
+			return false;
+		}
+		if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) {
+			return false;
+		}
 		return true;
 	}
 
@@ -215,8 +231,8 @@ public class Tuple6<T0, T1, T2, T3, T4, T5> extends Tuple {
 	*/
 	@Override
 	@SuppressWarnings("unchecked")
-	public Tuple6<T0,T1,T2,T3,T4,T5> copy(){ 
-		return new Tuple6<T0,T1,T2,T3,T4,T5>(this.f0,
+	public Tuple6<T0, T1, T2, T3, T4, T5> copy() {
+		return new Tuple6<>(this.f0,
 			this.f1,
 			this.f2,
 			this.f3,
@@ -232,7 +248,12 @@ public class Tuple6<T0, T1, T2, T3, T4, T5> extends Tuple {
 	 * instead of
 	 * {@code new Tuple3<Integer, Double, String>(n, x, s)}
 	 */
-	public static <T0,T1,T2,T3,T4,T5> Tuple6<T0,T1,T2,T3,T4,T5> of(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5) {
-		return new Tuple6<T0,T1,T2,T3,T4,T5>(value0, value1, value2, value3, value4, value5);
+	public static <T0, T1, T2, T3, T4, T5> Tuple6<T0, T1, T2, T3, T4, T5> of(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5) {
+		return new Tuple6<>(value0,
+			value1,
+			value2,
+			value3,
+			value4,
+			value5);
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple7.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple7.java
@@ -16,12 +16,10 @@
  * limitations under the License.
  */
 
-
 // --------------------------------------------------------------
 //  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
 //  GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 // --------------------------------------------------------------
-
 
 package org.apache.flink.api.java.tuple;
 
@@ -100,7 +98,9 @@ public class Tuple7<T0, T1, T2, T3, T4, T5, T6> extends Tuple {
 	}
 
 	@Override
-	public int getArity() { return 7; }
+	public int getArity() {
+		return 7;
+	}
 
 	@Override
 	@SuppressWarnings("unchecked")
@@ -191,23 +191,41 @@ public class Tuple7<T0, T1, T2, T3, T4, T5, T6> extends Tuple {
 	}
 
 	/**
-	 * Deep equality for tuples by calling equals() on the tuple members
+	 * Deep equality for tuples by calling equals() on the tuple members.
 	 * @param o the object checked for equality
 	 * @return true if this is equal to o.
 	 */
 	@Override
 	public boolean equals(Object o) {
-		if(this == o) { return true; }
-		if (!(o instanceof Tuple7)) { return false; }
+		if (this == o) {
+			return true;
+		}
+		if (!(o instanceof Tuple7)) {
+			return false;
+		}
 		@SuppressWarnings("rawtypes")
 		Tuple7 tuple = (Tuple7) o;
-		if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) { return false; }
-		if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) { return false; }
-		if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) { return false; }
-		if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) { return false; }
-		if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) { return false; }
-		if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) { return false; }
-		if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) { return false; }
+		if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) {
+			return false;
+		}
+		if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) {
+			return false;
+		}
+		if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) {
+			return false;
+		}
+		if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) {
+			return false;
+		}
+		if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) {
+			return false;
+		}
+		if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) {
+			return false;
+		}
+		if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) {
+			return false;
+		}
 		return true;
 	}
 
@@ -229,8 +247,8 @@ public class Tuple7<T0, T1, T2, T3, T4, T5, T6> extends Tuple {
 	*/
 	@Override
 	@SuppressWarnings("unchecked")
-	public Tuple7<T0,T1,T2,T3,T4,T5,T6> copy(){ 
-		return new Tuple7<T0,T1,T2,T3,T4,T5,T6>(this.f0,
+	public Tuple7<T0, T1, T2, T3, T4, T5, T6> copy() {
+		return new Tuple7<>(this.f0,
 			this.f1,
 			this.f2,
 			this.f3,
@@ -247,7 +265,13 @@ public class Tuple7<T0, T1, T2, T3, T4, T5, T6> extends Tuple {
 	 * instead of
 	 * {@code new Tuple3<Integer, Double, String>(n, x, s)}
 	 */
-	public static <T0,T1,T2,T3,T4,T5,T6> Tuple7<T0,T1,T2,T3,T4,T5,T6> of(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6) {
-		return new Tuple7<T0,T1,T2,T3,T4,T5,T6>(value0, value1, value2, value3, value4, value5, value6);
+	public static <T0, T1, T2, T3, T4, T5, T6> Tuple7<T0, T1, T2, T3, T4, T5, T6> of(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6) {
+		return new Tuple7<>(value0,
+			value1,
+			value2,
+			value3,
+			value4,
+			value5,
+			value6);
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple8.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple8.java
@@ -16,12 +16,10 @@
  * limitations under the License.
  */
 
-
 // --------------------------------------------------------------
 //  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
 //  GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 // --------------------------------------------------------------
-
 
 package org.apache.flink.api.java.tuple;
 
@@ -105,7 +103,9 @@ public class Tuple8<T0, T1, T2, T3, T4, T5, T6, T7> extends Tuple {
 	}
 
 	@Override
-	public int getArity() { return 8; }
+	public int getArity() {
+		return 8;
+	}
 
 	@Override
 	@SuppressWarnings("unchecked")
@@ -203,24 +203,44 @@ public class Tuple8<T0, T1, T2, T3, T4, T5, T6, T7> extends Tuple {
 	}
 
 	/**
-	 * Deep equality for tuples by calling equals() on the tuple members
+	 * Deep equality for tuples by calling equals() on the tuple members.
 	 * @param o the object checked for equality
 	 * @return true if this is equal to o.
 	 */
 	@Override
 	public boolean equals(Object o) {
-		if(this == o) { return true; }
-		if (!(o instanceof Tuple8)) { return false; }
+		if (this == o) {
+			return true;
+		}
+		if (!(o instanceof Tuple8)) {
+			return false;
+		}
 		@SuppressWarnings("rawtypes")
 		Tuple8 tuple = (Tuple8) o;
-		if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) { return false; }
-		if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) { return false; }
-		if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) { return false; }
-		if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) { return false; }
-		if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) { return false; }
-		if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) { return false; }
-		if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) { return false; }
-		if (f7 != null ? !f7.equals(tuple.f7) : tuple.f7 != null) { return false; }
+		if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) {
+			return false;
+		}
+		if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) {
+			return false;
+		}
+		if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) {
+			return false;
+		}
+		if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) {
+			return false;
+		}
+		if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) {
+			return false;
+		}
+		if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) {
+			return false;
+		}
+		if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) {
+			return false;
+		}
+		if (f7 != null ? !f7.equals(tuple.f7) : tuple.f7 != null) {
+			return false;
+		}
 		return true;
 	}
 
@@ -243,8 +263,8 @@ public class Tuple8<T0, T1, T2, T3, T4, T5, T6, T7> extends Tuple {
 	*/
 	@Override
 	@SuppressWarnings("unchecked")
-	public Tuple8<T0,T1,T2,T3,T4,T5,T6,T7> copy(){ 
-		return new Tuple8<T0,T1,T2,T3,T4,T5,T6,T7>(this.f0,
+	public Tuple8<T0, T1, T2, T3, T4, T5, T6, T7> copy() {
+		return new Tuple8<>(this.f0,
 			this.f1,
 			this.f2,
 			this.f3,
@@ -262,7 +282,14 @@ public class Tuple8<T0, T1, T2, T3, T4, T5, T6, T7> extends Tuple {
 	 * instead of
 	 * {@code new Tuple3<Integer, Double, String>(n, x, s)}
 	 */
-	public static <T0,T1,T2,T3,T4,T5,T6,T7> Tuple8<T0,T1,T2,T3,T4,T5,T6,T7> of(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7) {
-		return new Tuple8<T0,T1,T2,T3,T4,T5,T6,T7>(value0, value1, value2, value3, value4, value5, value6, value7);
+	public static <T0, T1, T2, T3, T4, T5, T6, T7> Tuple8<T0, T1, T2, T3, T4, T5, T6, T7> of(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7) {
+		return new Tuple8<>(value0,
+			value1,
+			value2,
+			value3,
+			value4,
+			value5,
+			value6,
+			value7);
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple9.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple9.java
@@ -16,12 +16,10 @@
  * limitations under the License.
  */
 
-
 // --------------------------------------------------------------
 //  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
 //  GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 // --------------------------------------------------------------
-
 
 package org.apache.flink.api.java.tuple;
 
@@ -110,7 +108,9 @@ public class Tuple9<T0, T1, T2, T3, T4, T5, T6, T7, T8> extends Tuple {
 	}
 
 	@Override
-	public int getArity() { return 9; }
+	public int getArity() {
+		return 9;
+	}
 
 	@Override
 	@SuppressWarnings("unchecked")
@@ -215,25 +215,47 @@ public class Tuple9<T0, T1, T2, T3, T4, T5, T6, T7, T8> extends Tuple {
 	}
 
 	/**
-	 * Deep equality for tuples by calling equals() on the tuple members
+	 * Deep equality for tuples by calling equals() on the tuple members.
 	 * @param o the object checked for equality
 	 * @return true if this is equal to o.
 	 */
 	@Override
 	public boolean equals(Object o) {
-		if(this == o) { return true; }
-		if (!(o instanceof Tuple9)) { return false; }
+		if (this == o) {
+			return true;
+		}
+		if (!(o instanceof Tuple9)) {
+			return false;
+		}
 		@SuppressWarnings("rawtypes")
 		Tuple9 tuple = (Tuple9) o;
-		if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) { return false; }
-		if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) { return false; }
-		if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) { return false; }
-		if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) { return false; }
-		if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) { return false; }
-		if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) { return false; }
-		if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) { return false; }
-		if (f7 != null ? !f7.equals(tuple.f7) : tuple.f7 != null) { return false; }
-		if (f8 != null ? !f8.equals(tuple.f8) : tuple.f8 != null) { return false; }
+		if (f0 != null ? !f0.equals(tuple.f0) : tuple.f0 != null) {
+			return false;
+		}
+		if (f1 != null ? !f1.equals(tuple.f1) : tuple.f1 != null) {
+			return false;
+		}
+		if (f2 != null ? !f2.equals(tuple.f2) : tuple.f2 != null) {
+			return false;
+		}
+		if (f3 != null ? !f3.equals(tuple.f3) : tuple.f3 != null) {
+			return false;
+		}
+		if (f4 != null ? !f4.equals(tuple.f4) : tuple.f4 != null) {
+			return false;
+		}
+		if (f5 != null ? !f5.equals(tuple.f5) : tuple.f5 != null) {
+			return false;
+		}
+		if (f6 != null ? !f6.equals(tuple.f6) : tuple.f6 != null) {
+			return false;
+		}
+		if (f7 != null ? !f7.equals(tuple.f7) : tuple.f7 != null) {
+			return false;
+		}
+		if (f8 != null ? !f8.equals(tuple.f8) : tuple.f8 != null) {
+			return false;
+		}
 		return true;
 	}
 
@@ -257,8 +279,8 @@ public class Tuple9<T0, T1, T2, T3, T4, T5, T6, T7, T8> extends Tuple {
 	*/
 	@Override
 	@SuppressWarnings("unchecked")
-	public Tuple9<T0,T1,T2,T3,T4,T5,T6,T7,T8> copy(){ 
-		return new Tuple9<T0,T1,T2,T3,T4,T5,T6,T7,T8>(this.f0,
+	public Tuple9<T0, T1, T2, T3, T4, T5, T6, T7, T8> copy() {
+		return new Tuple9<>(this.f0,
 			this.f1,
 			this.f2,
 			this.f3,
@@ -277,7 +299,15 @@ public class Tuple9<T0, T1, T2, T3, T4, T5, T6, T7, T8> extends Tuple {
 	 * instead of
 	 * {@code new Tuple3<Integer, Double, String>(n, x, s)}
 	 */
-	public static <T0,T1,T2,T3,T4,T5,T6,T7,T8> Tuple9<T0,T1,T2,T3,T4,T5,T6,T7,T8> of(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8) {
-		return new Tuple9<T0,T1,T2,T3,T4,T5,T6,T7,T8>(value0, value1, value2, value3, value4, value5, value6, value7, value8);
+	public static <T0, T1, T2, T3, T4, T5, T6, T7, T8> Tuple9<T0, T1, T2, T3, T4, T5, T6, T7, T8> of(T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8) {
+		return new Tuple9<>(value0,
+			value1,
+			value2,
+			value3,
+			value4,
+			value5,
+			value6,
+			value7,
+			value8);
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple0Builder.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple0Builder.java
@@ -16,21 +16,22 @@
  * limitations under the License.
  */
 
-
 // --------------------------------------------------------------
 //  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
 //  GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 // --------------------------------------------------------------
 
-
 package org.apache.flink.api.java.tuple.builder;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import org.apache.flink.annotation.Public;
 import org.apache.flink.api.java.tuple.Tuple0;
 
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A builder class for {@link Tuple0}.
+ */
 @Public
 public class Tuple0Builder {
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple10Builder.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple10Builder.java
@@ -16,21 +16,33 @@
  * limitations under the License.
  */
 
-
 // --------------------------------------------------------------
 //  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
 //  GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 // --------------------------------------------------------------
 
-
 package org.apache.flink.api.java.tuple.builder;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import org.apache.flink.annotation.Public;
 import org.apache.flink.api.java.tuple.Tuple10;
 
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A builder class for {@link Tuple10}.
+ *
+ * @param <T0> The type of field 0
+ * @param <T1> The type of field 1
+ * @param <T2> The type of field 2
+ * @param <T3> The type of field 3
+ * @param <T4> The type of field 4
+ * @param <T5> The type of field 5
+ * @param <T6> The type of field 6
+ * @param <T7> The type of field 7
+ * @param <T8> The type of field 8
+ * @param <T9> The type of field 9
+ */
 @Public
 public class Tuple10Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> {
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple11Builder.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple11Builder.java
@@ -16,21 +16,34 @@
  * limitations under the License.
  */
 
-
 // --------------------------------------------------------------
 //  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
 //  GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 // --------------------------------------------------------------
 
-
 package org.apache.flink.api.java.tuple.builder;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import org.apache.flink.annotation.Public;
 import org.apache.flink.api.java.tuple.Tuple11;
 
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A builder class for {@link Tuple11}.
+ *
+ * @param <T0> The type of field 0
+ * @param <T1> The type of field 1
+ * @param <T2> The type of field 2
+ * @param <T3> The type of field 3
+ * @param <T4> The type of field 4
+ * @param <T5> The type of field 5
+ * @param <T6> The type of field 6
+ * @param <T7> The type of field 7
+ * @param <T8> The type of field 8
+ * @param <T9> The type of field 9
+ * @param <T10> The type of field 10
+ */
 @Public
 public class Tuple11Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> {
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple12Builder.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple12Builder.java
@@ -16,21 +16,35 @@
  * limitations under the License.
  */
 
-
 // --------------------------------------------------------------
 //  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
 //  GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 // --------------------------------------------------------------
 
-
 package org.apache.flink.api.java.tuple.builder;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import org.apache.flink.annotation.Public;
 import org.apache.flink.api.java.tuple.Tuple12;
 
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A builder class for {@link Tuple12}.
+ *
+ * @param <T0> The type of field 0
+ * @param <T1> The type of field 1
+ * @param <T2> The type of field 2
+ * @param <T3> The type of field 3
+ * @param <T4> The type of field 4
+ * @param <T5> The type of field 5
+ * @param <T6> The type of field 6
+ * @param <T7> The type of field 7
+ * @param <T8> The type of field 8
+ * @param <T9> The type of field 9
+ * @param <T10> The type of field 10
+ * @param <T11> The type of field 11
+ */
 @Public
 public class Tuple12Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> {
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple13Builder.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple13Builder.java
@@ -16,21 +16,36 @@
  * limitations under the License.
  */
 
-
 // --------------------------------------------------------------
 //  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
 //  GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 // --------------------------------------------------------------
 
-
 package org.apache.flink.api.java.tuple.builder;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import org.apache.flink.annotation.Public;
 import org.apache.flink.api.java.tuple.Tuple13;
 
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A builder class for {@link Tuple13}.
+ *
+ * @param <T0> The type of field 0
+ * @param <T1> The type of field 1
+ * @param <T2> The type of field 2
+ * @param <T3> The type of field 3
+ * @param <T4> The type of field 4
+ * @param <T5> The type of field 5
+ * @param <T6> The type of field 6
+ * @param <T7> The type of field 7
+ * @param <T8> The type of field 8
+ * @param <T9> The type of field 9
+ * @param <T10> The type of field 10
+ * @param <T11> The type of field 11
+ * @param <T12> The type of field 12
+ */
 @Public
 public class Tuple13Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> {
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple14Builder.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple14Builder.java
@@ -16,21 +16,37 @@
  * limitations under the License.
  */
 
-
 // --------------------------------------------------------------
 //  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
 //  GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 // --------------------------------------------------------------
 
-
 package org.apache.flink.api.java.tuple.builder;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import org.apache.flink.annotation.Public;
 import org.apache.flink.api.java.tuple.Tuple14;
 
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A builder class for {@link Tuple14}.
+ *
+ * @param <T0> The type of field 0
+ * @param <T1> The type of field 1
+ * @param <T2> The type of field 2
+ * @param <T3> The type of field 3
+ * @param <T4> The type of field 4
+ * @param <T5> The type of field 5
+ * @param <T6> The type of field 6
+ * @param <T7> The type of field 7
+ * @param <T8> The type of field 8
+ * @param <T9> The type of field 9
+ * @param <T10> The type of field 10
+ * @param <T11> The type of field 11
+ * @param <T12> The type of field 12
+ * @param <T13> The type of field 13
+ */
 @Public
 public class Tuple14Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> {
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple15Builder.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple15Builder.java
@@ -16,21 +16,38 @@
  * limitations under the License.
  */
 
-
 // --------------------------------------------------------------
 //  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
 //  GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 // --------------------------------------------------------------
 
-
 package org.apache.flink.api.java.tuple.builder;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import org.apache.flink.annotation.Public;
 import org.apache.flink.api.java.tuple.Tuple15;
 
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A builder class for {@link Tuple15}.
+ *
+ * @param <T0> The type of field 0
+ * @param <T1> The type of field 1
+ * @param <T2> The type of field 2
+ * @param <T3> The type of field 3
+ * @param <T4> The type of field 4
+ * @param <T5> The type of field 5
+ * @param <T6> The type of field 6
+ * @param <T7> The type of field 7
+ * @param <T8> The type of field 8
+ * @param <T9> The type of field 9
+ * @param <T10> The type of field 10
+ * @param <T11> The type of field 11
+ * @param <T12> The type of field 12
+ * @param <T13> The type of field 13
+ * @param <T14> The type of field 14
+ */
 @Public
 public class Tuple15Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> {
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple16Builder.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple16Builder.java
@@ -16,21 +16,39 @@
  * limitations under the License.
  */
 
-
 // --------------------------------------------------------------
 //  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
 //  GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 // --------------------------------------------------------------
 
-
 package org.apache.flink.api.java.tuple.builder;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import org.apache.flink.annotation.Public;
 import org.apache.flink.api.java.tuple.Tuple16;
 
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A builder class for {@link Tuple16}.
+ *
+ * @param <T0> The type of field 0
+ * @param <T1> The type of field 1
+ * @param <T2> The type of field 2
+ * @param <T3> The type of field 3
+ * @param <T4> The type of field 4
+ * @param <T5> The type of field 5
+ * @param <T6> The type of field 6
+ * @param <T7> The type of field 7
+ * @param <T8> The type of field 8
+ * @param <T9> The type of field 9
+ * @param <T10> The type of field 10
+ * @param <T11> The type of field 11
+ * @param <T12> The type of field 12
+ * @param <T13> The type of field 13
+ * @param <T14> The type of field 14
+ * @param <T15> The type of field 15
+ */
 @Public
 public class Tuple16Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> {
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple17Builder.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple17Builder.java
@@ -16,21 +16,40 @@
  * limitations under the License.
  */
 
-
 // --------------------------------------------------------------
 //  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
 //  GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 // --------------------------------------------------------------
 
-
 package org.apache.flink.api.java.tuple.builder;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import org.apache.flink.annotation.Public;
 import org.apache.flink.api.java.tuple.Tuple17;
 
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A builder class for {@link Tuple17}.
+ *
+ * @param <T0> The type of field 0
+ * @param <T1> The type of field 1
+ * @param <T2> The type of field 2
+ * @param <T3> The type of field 3
+ * @param <T4> The type of field 4
+ * @param <T5> The type of field 5
+ * @param <T6> The type of field 6
+ * @param <T7> The type of field 7
+ * @param <T8> The type of field 8
+ * @param <T9> The type of field 9
+ * @param <T10> The type of field 10
+ * @param <T11> The type of field 11
+ * @param <T12> The type of field 12
+ * @param <T13> The type of field 13
+ * @param <T14> The type of field 14
+ * @param <T15> The type of field 15
+ * @param <T16> The type of field 16
+ */
 @Public
 public class Tuple17Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> {
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple18Builder.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple18Builder.java
@@ -16,21 +16,41 @@
  * limitations under the License.
  */
 
-
 // --------------------------------------------------------------
 //  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
 //  GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 // --------------------------------------------------------------
 
-
 package org.apache.flink.api.java.tuple.builder;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import org.apache.flink.annotation.Public;
 import org.apache.flink.api.java.tuple.Tuple18;
 
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A builder class for {@link Tuple18}.
+ *
+ * @param <T0> The type of field 0
+ * @param <T1> The type of field 1
+ * @param <T2> The type of field 2
+ * @param <T3> The type of field 3
+ * @param <T4> The type of field 4
+ * @param <T5> The type of field 5
+ * @param <T6> The type of field 6
+ * @param <T7> The type of field 7
+ * @param <T8> The type of field 8
+ * @param <T9> The type of field 9
+ * @param <T10> The type of field 10
+ * @param <T11> The type of field 11
+ * @param <T12> The type of field 12
+ * @param <T13> The type of field 13
+ * @param <T14> The type of field 14
+ * @param <T15> The type of field 15
+ * @param <T16> The type of field 16
+ * @param <T17> The type of field 17
+ */
 @Public
 public class Tuple18Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> {
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple19Builder.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple19Builder.java
@@ -16,21 +16,42 @@
  * limitations under the License.
  */
 
-
 // --------------------------------------------------------------
 //  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
 //  GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 // --------------------------------------------------------------
 
-
 package org.apache.flink.api.java.tuple.builder;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import org.apache.flink.annotation.Public;
 import org.apache.flink.api.java.tuple.Tuple19;
 
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A builder class for {@link Tuple19}.
+ *
+ * @param <T0> The type of field 0
+ * @param <T1> The type of field 1
+ * @param <T2> The type of field 2
+ * @param <T3> The type of field 3
+ * @param <T4> The type of field 4
+ * @param <T5> The type of field 5
+ * @param <T6> The type of field 6
+ * @param <T7> The type of field 7
+ * @param <T8> The type of field 8
+ * @param <T9> The type of field 9
+ * @param <T10> The type of field 10
+ * @param <T11> The type of field 11
+ * @param <T12> The type of field 12
+ * @param <T13> The type of field 13
+ * @param <T14> The type of field 14
+ * @param <T15> The type of field 15
+ * @param <T16> The type of field 16
+ * @param <T17> The type of field 17
+ * @param <T18> The type of field 18
+ */
 @Public
 public class Tuple19Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> {
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple1Builder.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple1Builder.java
@@ -16,21 +16,24 @@
  * limitations under the License.
  */
 
-
 // --------------------------------------------------------------
 //  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
 //  GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 // --------------------------------------------------------------
 
-
 package org.apache.flink.api.java.tuple.builder;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import org.apache.flink.annotation.Public;
 import org.apache.flink.api.java.tuple.Tuple1;
 
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A builder class for {@link Tuple1}.
+ *
+ * @param <T0> The type of field 0
+ */
 @Public
 public class Tuple1Builder<T0> {
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple20Builder.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple20Builder.java
@@ -16,21 +16,43 @@
  * limitations under the License.
  */
 
-
 // --------------------------------------------------------------
 //  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
 //  GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 // --------------------------------------------------------------
 
-
 package org.apache.flink.api.java.tuple.builder;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import org.apache.flink.annotation.Public;
 import org.apache.flink.api.java.tuple.Tuple20;
 
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A builder class for {@link Tuple20}.
+ *
+ * @param <T0> The type of field 0
+ * @param <T1> The type of field 1
+ * @param <T2> The type of field 2
+ * @param <T3> The type of field 3
+ * @param <T4> The type of field 4
+ * @param <T5> The type of field 5
+ * @param <T6> The type of field 6
+ * @param <T7> The type of field 7
+ * @param <T8> The type of field 8
+ * @param <T9> The type of field 9
+ * @param <T10> The type of field 10
+ * @param <T11> The type of field 11
+ * @param <T12> The type of field 12
+ * @param <T13> The type of field 13
+ * @param <T14> The type of field 14
+ * @param <T15> The type of field 15
+ * @param <T16> The type of field 16
+ * @param <T17> The type of field 17
+ * @param <T18> The type of field 18
+ * @param <T19> The type of field 19
+ */
 @Public
 public class Tuple20Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> {
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple21Builder.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple21Builder.java
@@ -16,21 +16,44 @@
  * limitations under the License.
  */
 
-
 // --------------------------------------------------------------
 //  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
 //  GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 // --------------------------------------------------------------
 
-
 package org.apache.flink.api.java.tuple.builder;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import org.apache.flink.annotation.Public;
 import org.apache.flink.api.java.tuple.Tuple21;
 
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A builder class for {@link Tuple21}.
+ *
+ * @param <T0> The type of field 0
+ * @param <T1> The type of field 1
+ * @param <T2> The type of field 2
+ * @param <T3> The type of field 3
+ * @param <T4> The type of field 4
+ * @param <T5> The type of field 5
+ * @param <T6> The type of field 6
+ * @param <T7> The type of field 7
+ * @param <T8> The type of field 8
+ * @param <T9> The type of field 9
+ * @param <T10> The type of field 10
+ * @param <T11> The type of field 11
+ * @param <T12> The type of field 12
+ * @param <T13> The type of field 13
+ * @param <T14> The type of field 14
+ * @param <T15> The type of field 15
+ * @param <T16> The type of field 16
+ * @param <T17> The type of field 17
+ * @param <T18> The type of field 18
+ * @param <T19> The type of field 19
+ * @param <T20> The type of field 20
+ */
 @Public
 public class Tuple21Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> {
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple22Builder.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple22Builder.java
@@ -16,21 +16,45 @@
  * limitations under the License.
  */
 
-
 // --------------------------------------------------------------
 //  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
 //  GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 // --------------------------------------------------------------
 
-
 package org.apache.flink.api.java.tuple.builder;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import org.apache.flink.annotation.Public;
 import org.apache.flink.api.java.tuple.Tuple22;
 
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A builder class for {@link Tuple22}.
+ *
+ * @param <T0> The type of field 0
+ * @param <T1> The type of field 1
+ * @param <T2> The type of field 2
+ * @param <T3> The type of field 3
+ * @param <T4> The type of field 4
+ * @param <T5> The type of field 5
+ * @param <T6> The type of field 6
+ * @param <T7> The type of field 7
+ * @param <T8> The type of field 8
+ * @param <T9> The type of field 9
+ * @param <T10> The type of field 10
+ * @param <T11> The type of field 11
+ * @param <T12> The type of field 12
+ * @param <T13> The type of field 13
+ * @param <T14> The type of field 14
+ * @param <T15> The type of field 15
+ * @param <T16> The type of field 16
+ * @param <T17> The type of field 17
+ * @param <T18> The type of field 18
+ * @param <T19> The type of field 19
+ * @param <T20> The type of field 20
+ * @param <T21> The type of field 21
+ */
 @Public
 public class Tuple22Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> {
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple23Builder.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple23Builder.java
@@ -16,21 +16,46 @@
  * limitations under the License.
  */
 
-
 // --------------------------------------------------------------
 //  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
 //  GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 // --------------------------------------------------------------
 
-
 package org.apache.flink.api.java.tuple.builder;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import org.apache.flink.annotation.Public;
 import org.apache.flink.api.java.tuple.Tuple23;
 
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A builder class for {@link Tuple23}.
+ *
+ * @param <T0> The type of field 0
+ * @param <T1> The type of field 1
+ * @param <T2> The type of field 2
+ * @param <T3> The type of field 3
+ * @param <T4> The type of field 4
+ * @param <T5> The type of field 5
+ * @param <T6> The type of field 6
+ * @param <T7> The type of field 7
+ * @param <T8> The type of field 8
+ * @param <T9> The type of field 9
+ * @param <T10> The type of field 10
+ * @param <T11> The type of field 11
+ * @param <T12> The type of field 12
+ * @param <T13> The type of field 13
+ * @param <T14> The type of field 14
+ * @param <T15> The type of field 15
+ * @param <T16> The type of field 16
+ * @param <T17> The type of field 17
+ * @param <T18> The type of field 18
+ * @param <T19> The type of field 19
+ * @param <T20> The type of field 20
+ * @param <T21> The type of field 21
+ * @param <T22> The type of field 22
+ */
 @Public
 public class Tuple23Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> {
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple24Builder.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple24Builder.java
@@ -16,21 +16,47 @@
  * limitations under the License.
  */
 
-
 // --------------------------------------------------------------
 //  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
 //  GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 // --------------------------------------------------------------
 
-
 package org.apache.flink.api.java.tuple.builder;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import org.apache.flink.annotation.Public;
 import org.apache.flink.api.java.tuple.Tuple24;
 
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A builder class for {@link Tuple24}.
+ *
+ * @param <T0> The type of field 0
+ * @param <T1> The type of field 1
+ * @param <T2> The type of field 2
+ * @param <T3> The type of field 3
+ * @param <T4> The type of field 4
+ * @param <T5> The type of field 5
+ * @param <T6> The type of field 6
+ * @param <T7> The type of field 7
+ * @param <T8> The type of field 8
+ * @param <T9> The type of field 9
+ * @param <T10> The type of field 10
+ * @param <T11> The type of field 11
+ * @param <T12> The type of field 12
+ * @param <T13> The type of field 13
+ * @param <T14> The type of field 14
+ * @param <T15> The type of field 15
+ * @param <T16> The type of field 16
+ * @param <T17> The type of field 17
+ * @param <T18> The type of field 18
+ * @param <T19> The type of field 19
+ * @param <T20> The type of field 20
+ * @param <T21> The type of field 21
+ * @param <T22> The type of field 22
+ * @param <T23> The type of field 23
+ */
 @Public
 public class Tuple24Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23> {
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple25Builder.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple25Builder.java
@@ -16,21 +16,48 @@
  * limitations under the License.
  */
 
-
 // --------------------------------------------------------------
 //  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
 //  GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 // --------------------------------------------------------------
 
-
 package org.apache.flink.api.java.tuple.builder;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import org.apache.flink.annotation.Public;
 import org.apache.flink.api.java.tuple.Tuple25;
 
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A builder class for {@link Tuple25}.
+ *
+ * @param <T0> The type of field 0
+ * @param <T1> The type of field 1
+ * @param <T2> The type of field 2
+ * @param <T3> The type of field 3
+ * @param <T4> The type of field 4
+ * @param <T5> The type of field 5
+ * @param <T6> The type of field 6
+ * @param <T7> The type of field 7
+ * @param <T8> The type of field 8
+ * @param <T9> The type of field 9
+ * @param <T10> The type of field 10
+ * @param <T11> The type of field 11
+ * @param <T12> The type of field 12
+ * @param <T13> The type of field 13
+ * @param <T14> The type of field 14
+ * @param <T15> The type of field 15
+ * @param <T16> The type of field 16
+ * @param <T17> The type of field 17
+ * @param <T18> The type of field 18
+ * @param <T19> The type of field 19
+ * @param <T20> The type of field 20
+ * @param <T21> The type of field 21
+ * @param <T22> The type of field 22
+ * @param <T23> The type of field 23
+ * @param <T24> The type of field 24
+ */
 @Public
 public class Tuple25Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24> {
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple2Builder.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple2Builder.java
@@ -16,21 +16,25 @@
  * limitations under the License.
  */
 
-
 // --------------------------------------------------------------
 //  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
 //  GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 // --------------------------------------------------------------
 
-
 package org.apache.flink.api.java.tuple.builder;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import org.apache.flink.annotation.Public;
 import org.apache.flink.api.java.tuple.Tuple2;
 
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A builder class for {@link Tuple2}.
+ *
+ * @param <T0> The type of field 0
+ * @param <T1> The type of field 1
+ */
 @Public
 public class Tuple2Builder<T0, T1> {
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple3Builder.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple3Builder.java
@@ -16,21 +16,26 @@
  * limitations under the License.
  */
 
-
 // --------------------------------------------------------------
 //  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
 //  GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 // --------------------------------------------------------------
 
-
 package org.apache.flink.api.java.tuple.builder;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import org.apache.flink.annotation.Public;
 import org.apache.flink.api.java.tuple.Tuple3;
 
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A builder class for {@link Tuple3}.
+ *
+ * @param <T0> The type of field 0
+ * @param <T1> The type of field 1
+ * @param <T2> The type of field 2
+ */
 @Public
 public class Tuple3Builder<T0, T1, T2> {
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple4Builder.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple4Builder.java
@@ -16,21 +16,27 @@
  * limitations under the License.
  */
 
-
 // --------------------------------------------------------------
 //  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
 //  GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 // --------------------------------------------------------------
 
-
 package org.apache.flink.api.java.tuple.builder;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import org.apache.flink.annotation.Public;
 import org.apache.flink.api.java.tuple.Tuple4;
 
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A builder class for {@link Tuple4}.
+ *
+ * @param <T0> The type of field 0
+ * @param <T1> The type of field 1
+ * @param <T2> The type of field 2
+ * @param <T3> The type of field 3
+ */
 @Public
 public class Tuple4Builder<T0, T1, T2, T3> {
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple5Builder.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple5Builder.java
@@ -16,21 +16,28 @@
  * limitations under the License.
  */
 
-
 // --------------------------------------------------------------
 //  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
 //  GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 // --------------------------------------------------------------
 
-
 package org.apache.flink.api.java.tuple.builder;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import org.apache.flink.annotation.Public;
 import org.apache.flink.api.java.tuple.Tuple5;
 
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A builder class for {@link Tuple5}.
+ *
+ * @param <T0> The type of field 0
+ * @param <T1> The type of field 1
+ * @param <T2> The type of field 2
+ * @param <T3> The type of field 3
+ * @param <T4> The type of field 4
+ */
 @Public
 public class Tuple5Builder<T0, T1, T2, T3, T4> {
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple6Builder.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple6Builder.java
@@ -16,21 +16,29 @@
  * limitations under the License.
  */
 
-
 // --------------------------------------------------------------
 //  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
 //  GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 // --------------------------------------------------------------
 
-
 package org.apache.flink.api.java.tuple.builder;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import org.apache.flink.annotation.Public;
 import org.apache.flink.api.java.tuple.Tuple6;
 
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A builder class for {@link Tuple6}.
+ *
+ * @param <T0> The type of field 0
+ * @param <T1> The type of field 1
+ * @param <T2> The type of field 2
+ * @param <T3> The type of field 3
+ * @param <T4> The type of field 4
+ * @param <T5> The type of field 5
+ */
 @Public
 public class Tuple6Builder<T0, T1, T2, T3, T4, T5> {
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple7Builder.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple7Builder.java
@@ -16,21 +16,30 @@
  * limitations under the License.
  */
 
-
 // --------------------------------------------------------------
 //  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
 //  GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 // --------------------------------------------------------------
 
-
 package org.apache.flink.api.java.tuple.builder;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import org.apache.flink.annotation.Public;
 import org.apache.flink.api.java.tuple.Tuple7;
 
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A builder class for {@link Tuple7}.
+ *
+ * @param <T0> The type of field 0
+ * @param <T1> The type of field 1
+ * @param <T2> The type of field 2
+ * @param <T3> The type of field 3
+ * @param <T4> The type of field 4
+ * @param <T5> The type of field 5
+ * @param <T6> The type of field 6
+ */
 @Public
 public class Tuple7Builder<T0, T1, T2, T3, T4, T5, T6> {
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple8Builder.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple8Builder.java
@@ -16,21 +16,31 @@
  * limitations under the License.
  */
 
-
 // --------------------------------------------------------------
 //  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
 //  GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 // --------------------------------------------------------------
 
-
 package org.apache.flink.api.java.tuple.builder;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import org.apache.flink.annotation.Public;
 import org.apache.flink.api.java.tuple.Tuple8;
 
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A builder class for {@link Tuple8}.
+ *
+ * @param <T0> The type of field 0
+ * @param <T1> The type of field 1
+ * @param <T2> The type of field 2
+ * @param <T3> The type of field 3
+ * @param <T4> The type of field 4
+ * @param <T5> The type of field 5
+ * @param <T6> The type of field 6
+ * @param <T7> The type of field 7
+ */
 @Public
 public class Tuple8Builder<T0, T1, T2, T3, T4, T5, T6, T7> {
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple9Builder.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/builder/Tuple9Builder.java
@@ -16,21 +16,32 @@
  * limitations under the License.
  */
 
-
 // --------------------------------------------------------------
 //  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!
 //  GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 // --------------------------------------------------------------
 
-
 package org.apache.flink.api.java.tuple.builder;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import org.apache.flink.annotation.Public;
 import org.apache.flink.api.java.tuple.Tuple9;
 
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A builder class for {@link Tuple9}.
+ *
+ * @param <T0> The type of field 0
+ * @param <T1> The type of field 1
+ * @param <T2> The type of field 2
+ * @param <T3> The type of field 3
+ * @param <T4> The type of field 4
+ * @param <T5> The type of field 5
+ * @param <T6> The type of field 6
+ * @param <T7> The type of field 7
+ * @param <T8> The type of field 8
+ */
 @Public
 public class Tuple9Builder<T0, T1, T2, T3, T4, T5, T6, T7, T8> {
 

--- a/flink-core/src/test/java/org/apache/flink/api/java/tuple/Tuple2Test.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/tuple/Tuple2Test.java
@@ -19,9 +19,13 @@
 package org.apache.flink.api.java.tuple;
 
 import org.apache.flink.types.NullFieldException;
+
 import org.junit.Assert;
 import org.junit.Test;
 
+/**
+ * Tests for {@link Tuple2}.
+ */
 public class Tuple2Test {
 
 	@Test
@@ -33,7 +37,7 @@ public class Tuple2Test {
 
 		Assert.assertEquals(swapped.f1, toSwap.f0);
 	}
-	
+
 	@Test(expected = NullFieldException.class)
 	public void testGetFieldNotNull() {
 		Tuple2<String, Integer> tuple = new Tuple2<>("Test case", null);

--- a/flink-core/src/test/java/org/apache/flink/api/java/tuple/TupleGenerator.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/tuple/TupleGenerator.java
@@ -58,14 +58,13 @@ class TupleGenerator {
 
 	private static final int LAST = 25;
 
-	
 	public static void main(String[] args) throws Exception {
-		System.err.println("Current directory "+System.getProperty("user.dir"));
+		System.err.println("Current directory " + System.getProperty("user.dir"));
 		String rootDir = ROOT_DIRECTORY;
-		if(args.length > 0) {
+		if (args.length > 0) {
 			rootDir = args[0] + "/" + ROOT_DIRECTORY;
 		}
-		System.err.println("Using root directory: "+rootDir);
+		System.err.println("Using root directory: " + rootDir);
 		File root = new File(rootDir);
 
 		createTupleClasses(root);
@@ -87,13 +86,13 @@ class TupleGenerator {
 
 	private static void insertCodeIntoFile(String code, File file) throws IOException {
 		String fileContent = FileUtils.readFileUtf8(file);
-		
+
 		try (Scanner s = new Scanner(fileContent)) {
 			StringBuilder sb = new StringBuilder();
 			String line;
-	
+
 			boolean indicatorFound = false;
-	
+
 			// add file beginning
 			while (s.hasNextLine() && (line = s.nextLine()) != null) {
 				sb.append(line).append("\n");
@@ -102,19 +101,19 @@ class TupleGenerator {
 					break;
 				}
 			}
-	
-			if(!indicatorFound) {
+
+			if (!indicatorFound) {
 				System.out.println("No indicator found in '" + file + "'. Will skip code generation.");
 				s.close();
 				return;
 			}
-	
+
 			// add generator signature
 			sb.append("\t// GENERATED FROM ").append(TupleGenerator.class.getName()).append(".\n");
-	
+
 			// add tuple dependent code
 			sb.append(code).append("\n");
-	
+
 			// skip generated code
 			while (s.hasNextLine() && (line = s.nextLine()) != null) {
 				if (line.contains(END_INDICATOR)) {
@@ -122,7 +121,7 @@ class TupleGenerator {
 					break;
 				}
 			}
-	
+
 			// add file ending
 			while (s.hasNextLine() && (line = s.nextLine()) != null) {
 				sb.append(line).append("\n");
@@ -131,7 +130,6 @@ class TupleGenerator {
 		}
 	}
 
-	
 	private static void modifyTupleType(File root) throws IOException {
 		// generate code
 		StringBuilder sb = new StringBuilder();
@@ -244,10 +242,11 @@ class TupleGenerator {
 		w.println("\t}");
 		w.println();
 
-
 		// arity accessor
 		w.println("\t@Override");
-		w.println("\tpublic int getArity() { return " + numFields + "; }");
+		w.println("\tpublic int getArity() {");
+		w.println("\t\treturn " + numFields + ";");
+		w.println("\t}");
 		w.println();
 
 		// accessor getter method
@@ -332,20 +331,26 @@ class TupleGenerator {
 
 		w.println();
 		w.println("\t/**");
-		w.println("\t * Deep equality for tuples by calling equals() on the tuple members");
+		w.println("\t * Deep equality for tuples by calling equals() on the tuple members.");
 		w.println("\t * @param o the object checked for equality");
 		w.println("\t * @return true if this is equal to o.");
 		w.println("\t */");
 		w.println("\t@Override");
 		w.println("\tpublic boolean equals(Object o) {");
-		w.println("\t\tif(this == o) { return true; }");
-		w.println("\t\tif (!(o instanceof " + className + ")) { return false; }");
+		w.println("\t\tif (this == o) {");
+		w.println("\t\t\treturn true;");
+		w.println("\t\t}");
+		w.println("\t\tif (!(o instanceof " + className + ")) {");
+		w.println("\t\t\treturn false;");
+		w.println("\t\t}");
 		w.println("\t\t@SuppressWarnings(\"rawtypes\")");
 		w.println("\t\t" + className + " tuple = (" + className + ") o;");
 		for (int i = 0; i < numFields; i++) {
 			String field = "f" + i;
-			w.println("\t\tif (" + field + " != null ? !" + field +".equals(tuple." +
-					field + ") : tuple." + field + " != null) { return false; }");
+			w.println("\t\tif (" + field + " != null ? !" + field + ".equals(tuple." +
+					field + ") : tuple." + field + " != null) {");
+			w.println("\t\t\treturn false;");
+			w.println("\t\t}");
 		}
 		w.println("\t\treturn true;");
 		w.println("\t}");
@@ -361,15 +366,13 @@ class TupleGenerator {
 		w.println("\t\treturn result;");
 		w.println("\t}");
 
-
-		String tupleTypes = "<";
+		String tupleTypes = "";
 		for (int i = 0; i < numFields; i++) {
 			tupleTypes += "T" + i;
 			if (i < numFields - 1) {
-				tupleTypes += ",";
+				tupleTypes += ", ";
 			}
 		}
-		tupleTypes += ">";
 
 		w.println();
 		w.println("\t/**");
@@ -378,9 +381,9 @@ class TupleGenerator {
 		w.println("\t*/");
 		w.println("\t@Override");
 		w.println("\t@SuppressWarnings(\"unchecked\")");
-		w.println("\tpublic " + className + tupleTypes + " copy(){ ");
+		w.println("\tpublic " + className + "<" + tupleTypes + "> copy() {");
 
-		w.print("\t\treturn new " + className + tupleTypes + "(this.f0");
+		w.print("\t\treturn new " + className + "<>(this.f0");
 		if (numFields > 1) {
 			w.println(",");
 		}
@@ -403,12 +406,16 @@ class TupleGenerator {
 		w.println("\t * instead of");
 		w.println("\t * {@code new Tuple3<Integer, Double, String>(n, x, s)}");
 		w.println("\t */");
-		w.println("\tpublic static " + tupleTypes + " " + className + tupleTypes + " of" + paramList + " {");
-		w.print("\t\treturn new " + className + tupleTypes + "(");
-		for(int i = 0; i < numFields; i++) {
-			w.print("value" + i);
-			if(i < numFields - 1) {
-				w.print(", ");
+		w.println("\tpublic static <" + tupleTypes + "> " + className + "<" + tupleTypes + "> of" + paramList + " {");
+
+		w.print("\t\treturn new " + className + "<>(value0");
+		if (numFields > 1) {
+			w.println(",");
+		}
+		for (int i = 1; i < numFields; i++) {
+			w.print("\t\t\tvalue" + i);
+			if (i < numFields - 1) {
+				w.println(",");
 			}
 		}
 		w.println(");");
@@ -419,7 +426,7 @@ class TupleGenerator {
 	}
 
 	private static void createTupleBuilderClasses(File root) throws FileNotFoundException {
-		File dir = getPackage(root, PACKAGE+"."+BUILDER_SUFFIX);
+		File dir = getPackage(root, PACKAGE + "." + BUILDER_SUFFIX);
 
 		for (int i = FIRST; i <= LAST; i++) {
 			File tupleFile = new File(dir, "Tuple" + i + "Builder.java");
@@ -450,12 +457,21 @@ class TupleGenerator {
 		// package and imports
 		w.println("package " + PACKAGE + "." + BUILDER_SUFFIX + ';');
 		w.println();
-		w.println("import java.util.ArrayList;");
-		w.println("import java.util.List;");
-		w.println();
 		w.println("import org.apache.flink.annotation.Public;");
 		w.println("import " + PACKAGE + ".Tuple" + numFields + ";");
 		w.println();
+		w.println("import java.util.ArrayList;");
+		w.println("import java.util.List;");
+		w.println();
+
+		// class javadoc
+		w.println("/**");
+		w.println(" * A builder class for {@link Tuple" + numFields + "}.");
+		w.println(" *");
+		for (int i = 0; i < numFields; i++) {
+			w.println(" * @param <" + GEN_TYPE_PREFIX + i + "> The type of field " + i);
+		}
+		w.println(" */");
 
 		// class declaration
 		w.println("@Public");
@@ -505,7 +521,7 @@ class TupleGenerator {
 		w.println("}");
 	}
 
-	private static String HEADER =
+	private static final String HEADER =
 		"/*\n"
 		+ " * Licensed to the Apache Software Foundation (ASF) under one\n"
 		+ " * or more contributor license agreements.  See the NOTICE file\n"
@@ -525,9 +541,8 @@ class TupleGenerator {
 		+ " */" +
 		"\n" +
 		"\n" +
-		"\n" +
 		"// --------------------------------------------------------------\n" +
 		"//  THIS IS A GENERATED SOURCE FILE. DO NOT EDIT!\n" +
 		"//  GENERATED FROM " + TupleGenerator.class.getName() + ".\n" +
-		"// --------------------------------------------------------------\n\n\n";
+		"// --------------------------------------------------------------\n\n";
 }

--- a/tools/maven/suppressions-core.xml
+++ b/tools/maven/suppressions-core.xml
@@ -28,10 +28,6 @@ under the License.
 		checks="NewlineAtEndOfFile|RegexpSingleline|TodoComment|RedundantImport|ImportOrder|RedundantModifier|JavadocMethod|JavadocParagraph|JavadocType|JavadocStyle|PackageName|TypeNameCheck|ConstantNameCheck|StaticVariableNameCheck|MemberNameCheck|MethodNameCheck|ParameterName|LocalFinalVariableName|LocalVariableName|LeftCurly|UpperEll|FallThrough|reliefPattern|SimplifyBooleanExpression|EmptyStatement|ModifierOrder|EmptyLineSeparator|WhitespaceAround|WhitespaceAfter|NoWhitespaceAfter|NoWhitespaceBefore|OperatorWrap|ParenPad"/>
 
 	<suppress
-		files="(.*)api[/\\]java[/\\]tuple[/\\](.*)"
-		checks="NewlineAtEndOfFile|RegexpSingleline|TodoComment|RedundantImport|ImportOrder|RedundantModifier|JavadocMethod|JavadocParagraph|JavadocType|JavadocStyle|PackageName|TypeNameCheck|ConstantNameCheck|StaticVariableNameCheck|MemberNameCheck|MethodNameCheck|ParameterName|LocalFinalVariableName|LocalVariableName|LeftCurly|UpperEll|FallThrough|reliefPattern|SimplifyBooleanExpression|EmptyStatement|ModifierOrder|EmptyLineSeparator|WhitespaceAround|WhitespaceAfter|NoWhitespaceAfter|NoWhitespaceBefore|OperatorWrap|ParenPad"/>
-
-	<suppress
 		files="(.*)api[/\\]java[/\\]typeutils[/\\]runtime[/\\](.*)"
 		checks="NewlineAtEndOfFile|RegexpSingleline|TodoComment|RedundantImport|ImportOrder|RedundantModifier|JavadocMethod|JavadocParagraph|JavadocType|JavadocStyle|PackageName|TypeNameCheck|ConstantNameCheck|StaticVariableNameCheck|MemberNameCheck|MethodNameCheck|ParameterName|LocalFinalVariableName|LocalVariableName|LeftCurly|UpperEll|FallThrough|reliefPattern|SimplifyBooleanExpression|EmptyStatement|ModifierOrder|EmptyLineSeparator|WhitespaceAround|WhitespaceAfter|NoWhitespaceAfter|NoWhitespaceBefore|OperatorWrap|ParenPad"/>
 	<!--Only additional checks for test sources. Those checks were present in the "pre-strict" checkstyle but were not applied to test sources. We do not want to suppress them for sources directory-->


### PR DESCRIPTION
## What is the purpose of the change

Update TupleGenerator for Flink's checkstyle and rebuild Tuple and TupleBuilder classes.

## Brief change log

`TupleGenerator` has been updated to write Flink-checkstyle compliant code.

The following non-generated files were manually updated: `Tuple`, `Tuple0`, `Tuple0Builder`, `Tuple2Test`

`org.apache.flink.api.java.tuple` was removed from the checkstyle suppressions for `flink-core`.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage. Re-running `TupleGenerator` should replicate the newly updated files.