### PR TITLE
[hotfix][docs] Mention maven dependency for RocksDB state backend

### DIFF
--- a/docs/ops/state/state_backends.md
+++ b/docs/ops/state/state_backends.md
@@ -94,6 +94,17 @@ The FsStateBackend is encouraged for:
 
 ### The RocksDBStateBackend
 
+<div class="alert alert-warning">
+  <strong>Note:</strong> The RocksDBStateBackend is not part of the default Flink distribution. To use the state backend, you need to add the following Maven dependency to your project:
+  {% highlight xml %}
+<dependency>
+  <groupId>org.apache.flink</groupId>
+  <artifactId>flink-statebackend-rocksdb{{ site.scala_version_suffix }}</artifactId>
+  <version>{{site.version}}</version>
+</dependency>
+  {% endhighlight %}
+</div>
+
 The *RocksDBStateBackend* is configured with a file system URL (type, address, path), such as "hdfs://namenode:40010/flink/checkpoints" or "file:///data/flink/checkpoints".
 
 The RocksDBStateBackend holds in-flight data in a [RocksDB](http://rocksdb.org) database


### PR DESCRIPTION
This hotfix adds a note to the RocksDB state backend page, mentioning that it requires a maven dependency to be added to the users' project.