### PR TITLE
[FLINK-8433] [doc] Remove ununsed CheckpointedRestoring interface

### DIFF
--- a/docs/dev/stream/state/state.md
+++ b/docs/dev/stream/state/state.md
@@ -331,8 +331,7 @@ the basic even-split redistribution list state:
 {% highlight java %}
 public class BufferingSink
         implements SinkFunction<Tuple2<String, Integer>>,
-                   CheckpointedFunction,
-                   CheckpointedRestoring<ArrayList<Tuple2<String, Integer>>> {
+                   CheckpointedFunction {
 
     private final int threshold;
 
@@ -378,12 +377,6 @@ public class BufferingSink
                 bufferedElements.add(element);
             }
         }
-    }
-
-    @Override
-    public void restoreState(ArrayList<Tuple2<String, Integer>> state) throws Exception {
-        // this is from the CheckpointedRestoring interface.
-        this.bufferedElements.addAll(state);
     }
 }
 {% endhighlight %}


### PR DESCRIPTION
## What is the purpose of the change

*Update the document, as the ```CheckpointedRestoring``` interface introduced in the doc is unused since flink 1.4.*


## Brief change log

  - *Update the ```state.md``` file.*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: ( no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (docs / JavaDocs)
