### PR TITLE
[FLINK-8411] [State Backends] HeapListState#add(null) will wipe out entire list state

### DIFF
--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBListState.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBListState.java
@@ -108,6 +108,10 @@ public class RocksDBListState<K, N, V>
 
 	@Override
 	public void add(V value) throws IOException {
+		if (value == null) {
+			return;
+		}
+
 		try {
 			writeCurrentKeyWithGroupAndNamespace();
 			byte[] key = keySerializationStream.toByteArray();

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/AppendingState.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/AppendingState.java
@@ -63,6 +63,8 @@ public interface AppendingState<IN, OUT> extends State {
 	 * Updates the operator state accessible by {@link #get()} by adding the given value
 	 * to the list of values. The next time {@link #get()} is called (for the same state
 	 * partition) the returned state will represent the updated list.
+	 *
+	 * If `null` is passed in, the state value will remain unchanged
 	 * 
 	 * @param value The new value for the state.
 	 *            

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapListState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapListState.java
@@ -67,12 +67,11 @@ public class HeapListState<K, N, V>
 
 	@Override
 	public void add(V value) {
-		final N namespace = currentNamespace;
-
 		if (value == null) {
-			clear();
 			return;
 		}
+
+		final N namespace = currentNamespace;
 
 		final StateTable<K, N, ArrayList<V>> map = stateTable;
 		ArrayList<V> list = map.get(namespace);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
@@ -1330,6 +1330,10 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 			assertThat(state.get(), containsInAnyOrder(3L, 4L));
 			state.addAll(Arrays.asList(5L, 6L));
 			assertThat(state.get(), containsInAnyOrder(3L, 4L, 5L, 6L));
+			state.addAll(new ArrayList<>());
+			assertThat(state.get(), containsInAnyOrder(3L, 4L));
+			state.addAll(Arrays.asList(5L, 6L));
+			assertThat(state.get(), containsInAnyOrder(3L, 4L, 5L, 6L));
 
 			state.update(Arrays.asList(1L, 2L));
 			assertThat(state.get(), containsInAnyOrder(1L, 2L));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
@@ -1335,8 +1335,6 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 			state.addAll(Arrays.asList(5L, 6L));
 			assertThat(state.get(), containsInAnyOrder(3L, 4L, 5L, 6L));
 			state.addAll(new ArrayList<>());
-			assertThat(state.get(), containsInAnyOrder(3L, 4L));
-			state.addAll(Arrays.asList(5L, 6L));
 			assertThat(state.get(), containsInAnyOrder(3L, 4L, 5L, 6L));
 
 			state.add(null);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
@@ -1328,10 +1328,9 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 			assertThat(state.get(), containsInAnyOrder(3L, 4L));
 			state.addAll(new ArrayList<>());
 			assertThat(state.get(), containsInAnyOrder(3L, 4L));
-			state.addAll(new ArrayList<>());
-			assertThat(state.get(), containsInAnyOrder(3L, 4L));
 			state.addAll(Arrays.asList(5L, 6L));
 			assertThat(state.get(), containsInAnyOrder(3L, 4L, 5L, 6L));
+
 			state.update(Arrays.asList(1L, 2L));
 			assertThat(state.get(), containsInAnyOrder(1L, 2L));
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
@@ -1298,6 +1298,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 
 			keyedBackend.setCurrentKey("abc");
 			assertNull(state.get());
+			state.add(null);
+			assertNull(state.get());
 
 			keyedBackend.setCurrentKey("def");
 			assertNull(state.get());
@@ -1311,6 +1313,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 			state.update(Arrays.asList());
 			assertNull(state.get());
 			state.update(Arrays.asList(10L, 16L));
+			assertThat(state.get(), containsInAnyOrder(16L, 10L));
+			state.add(null);
 			assertThat(state.get(), containsInAnyOrder(16L, 10L));
 
 			keyedBackend.setCurrentKey("abc");
@@ -1335,6 +1339,8 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 			state.addAll(Arrays.asList(5L, 6L));
 			assertThat(state.get(), containsInAnyOrder(3L, 4L, 5L, 6L));
 
+			state.add(null);
+			assertThat(state.get(), containsInAnyOrder(3L, 4L, 5L, 6L));
 			state.update(Arrays.asList(1L, 2L));
 			assertThat(state.get(), containsInAnyOrder(1L, 2L));
 

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,2 @@
+git fetch upstream
+git rebase upstream/master

--- a/update.sh
+++ b/update.sh
@@ -1,2 +1,0 @@
-git fetch upstream
-git rebase upstream/master


### PR DESCRIPTION
## What is the purpose of the change

`HeapListState#add(null)` will result in the whole state being cleared or wiped out. There's never a unit test for `List#add(null)` in `StateBackendTestBase`

## Brief change log

- changed ListState impls such that `add(null)` will be explicitly ignored
- added unit tests to test `add(null)`
- updated javaDoc

## Verifying this change

This change is already covered by existing tests, such as `StateBackendTestBase`.

## Does this pull request potentially affect one of the following parts:

  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (JavaDocs)


Note! **This work depends on FLINK-7983 and its PR at https://github.com/apache/flink/pull/5281**

cc @StefanRRichter 