### PR TITLE
[FLINK-8267] [Kinesis Connector] update Kinesis Producer example for setting Region key

### DIFF
--- a/docs/dev/connectors/kinesis.md
+++ b/docs/dev/connectors/kinesis.md
@@ -271,9 +271,9 @@ For the monitoring to work, the user accessing the stream needs access to the Cl
 {% highlight java %}
 Properties producerConfig = new Properties();
 // Required configs
-producerConfig.put(AWSConfigConstants.AWS_REGION, "us-east-1");
 producerConfig.put(AWSConfigConstants.AWS_ACCESS_KEY_ID, "aws_access_key_id");
 producerConfig.put(AWSConfigConstants.AWS_SECRET_ACCESS_KEY, "aws_secret_access_key");
+producerConfig.put("Region", "us-east-1");
 // Optional configs
 producerConfig.put("AggregationMaxCount", "4294967295");
 producerConfig.put("CollectionMaxCount", "1000");
@@ -297,9 +297,9 @@ simpleStringStream.addSink(kinesis);
 {% highlight scala %}
 val producerConfig = new Properties()
 // Required configs
-producerConfig.put(AWSConfigConstants.AWS_REGION, "us-east-1")
 producerConfig.put(AWSConfigConstants.AWS_ACCESS_KEY_ID, "aws_access_key_id")
 producerConfig.put(AWSConfigConstants.AWS_SECRET_ACCESS_KEY, "aws_secret_access_key")
+producerConfig.put("Region", "us-east-1")
 // Optional KPL configs
 producerConfig.put("AggregationMaxCount", "4294967295")
 producerConfig.put("CollectionMaxCount", "1000")
@@ -351,19 +351,19 @@ The following example shows how one might supply the `AWSConfigConstants.AWS_END
 <div data-lang="java" markdown="1">
 {% highlight java %}
 Properties producerConfig = new Properties();
-producerConfig.put(AWSConfigConstants.AWS_REGION, "us-east-1");
 producerConfig.put(AWSConfigConstants.AWS_ACCESS_KEY_ID, "aws_access_key_id");
 producerConfig.put(AWSConfigConstants.AWS_SECRET_ACCESS_KEY, "aws_secret_access_key");
 producerConfig.put(AWSConfigConstants.AWS_ENDPOINT, "http://localhost:4567");
+producerConfig.put("Region", "us-east-1");
 {% endhighlight %}
 </div>
 <div data-lang="scala" markdown="1">
 {% highlight scala %}
 val producerConfig = new Properties()
-producerConfig.put(AWSConfigConstants.AWS_REGION, "us-east-1")
 producerConfig.put(AWSConfigConstants.AWS_ACCESS_KEY_ID, "aws_access_key_id")
 producerConfig.put(AWSConfigConstants.AWS_SECRET_ACCESS_KEY, "aws_secret_access_key")
 producerConfig.put(AWSConfigConstants.AWS_ENDPOINT, "http://localhost:4567")
+producerConfig.put("Region", "us-east-1")
 {% endhighlight %}
 </div>
 </div>


### PR DESCRIPTION
## What is the purpose of the change

Update doc to guide users to use KPL's native keys to set regions. 

This originates from a bug that we forgot to set region keys explicitly for kinesis connector, which has been fixed. According to the previous discussion between @tzulitai and I, we want to remove AWSConfigConstants in 2.0 because it basically copies/translates config keys of KPL/KCL, which doesn't add much value. 

Guide users to use KPL's native keys to set regions can be the first step that facilitates the migration.

## Brief change log

- updated doc

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

## Documentation

  - Does this pull request introduce a new feature? (no)


cc @tzulitai 