### PR TITLE
[FLINK-7777][build] Bump japicmp to 0.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -766,22 +766,6 @@ under the License.
 			<id>aggregate-scaladoc</id>
 		</profile>
 
-		<profile>
-			<!--japicmp 0.7 does not support deactivation from the command
-				line, so we have to use a workaround with profiles instead.
-				This can be removed when upgrading japicmp to 0.10+.
-				-->
-			<id>skip-japicmp</id>
-			<activation>
-				<property>
-					<name>japicmp.skip</name>
-					<value>true</value>
-				</property>
-			</activation>
-			<properties>
-				<japicmp.skip>true</japicmp.skip>
-			</properties>
-		</profile>
 
 		<profile>
 			<!-- used for SNAPSHOT and regular releases -->
@@ -1435,7 +1419,7 @@ under the License.
 				<plugin>
 					<groupId>com.github.siom79.japicmp</groupId>
 					<artifactId>japicmp-maven-plugin</artifactId>
-					<version>0.7.0</version>
+					<version>0.11.0</version>
 					<configuration>
 						<oldVersion>
 							<dependency>
@@ -1480,7 +1464,6 @@ under the License.
 							<!-- Don't break build on newly added maven modules -->
 							<ignoreNonResolvableArtifacts>true</ignoreNonResolvableArtifacts>
 						</parameter>
-						<skip>${japicmp.skip}</skip>
 						<dependencies>
 							<dependency>
 								<groupId>org.apache.flink</groupId>


### PR DESCRIPTION
## What is the purpose of the change

Currently, flink used japicmp-maven-plugin version is 0.7.0, I observed some warning messages
, detail: https://issues.apache.org/jira/browse/FLINK-7777

japicmp fixed in version 0.7.1 : _Excluded xerces vom maven-reporting dependency in order to prevent warnings from SAXParserImpl. _

The current stable version is 0.11.0, and  it can be built under JDK 9, we should consider upgrading to this version.


## Brief change log

- *Bump japicmp-maven-plugin version from 0.7.0 to 0.11.0.*
- *Remove unnecessary profile `skip-japicmp` in root POM xml*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
