### PR TITLE
[FLINK-8431] [mesos] Allow to specify # GPUs for TaskManager in Mesos

### DIFF
--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -520,6 +520,8 @@ May be set to -1 to disable this feature.
 
 - `mesos.resourcemanager.tasks.cpus`: CPUs to assign to the Mesos workers (**DEFAULT**: 0.0)
 
+- `mesos.resourcemanager.tasks.gpus`: GPUs to assign to the Mesos workers (**DEFAULT**: 0.0)
+
 - `mesos.resourcemanager.tasks.container.type`: Type of the containerization used: "mesos" or "docker" (DEFAULT: mesos);
 
 - `mesos.resourcemanager.tasks.container.image.name`: Image name to use for the container (**NO DEFAULT**)

--- a/docs/ops/deployment/mesos.md
+++ b/docs/ops/deployment/mesos.md
@@ -258,6 +258,8 @@ May be set to -1 to disable this feature.
 
 `mesos.resourcemanager.tasks.cpus`: CPUs to assign to the Mesos workers (**DEFAULT**: 0.0)
 
+`mesos.resourcemanager.tasks.gpus`: GPUs to assign to the Mesos workers (**DEFAULT**: 0.0)
+
 `mesos.resourcemanager.tasks.container.type`: Type of the containerization used: "mesos" or "docker" (DEFAULT: mesos);
 
 `mesos.resourcemanager.tasks.container.image.name`: Image name to use for the container (**NO DEFAULT**)

--- a/flink-mesos/pom.xml
+++ b/flink-mesos/pom.xml
@@ -88,7 +88,7 @@ under the License.
 		<dependency>
 			<groupId>com.netflix.fenzo</groupId>
 			<artifactId>fenzo-core</artifactId>
-			<version>0.10.0</version>
+			<version>0.10.1</version>
 			<exclusions>
 				<!-- exclude mesos here to override -->
 				<exclusion>

--- a/flink-mesos/pom.xml
+++ b/flink-mesos/pom.xml
@@ -88,7 +88,7 @@ under the License.
 		<dependency>
 			<groupId>com.netflix.fenzo</groupId>
 			<artifactId>fenzo-core</artifactId>
-			<version>0.9.3</version>
+			<version>0.10.0</version>
 			<exclusions>
 				<!-- exclude mesos here to override -->
 				<exclusion>

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/Utils.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/Utils.java
@@ -110,6 +110,20 @@ public class Utils {
 	}
 
 	/**
+	 * Construct a gpu resource.
+	 */
+	public static Protos.Resource gpus(double amount) {
+		return gpus(UNRESERVED_ROLE, amount);
+	}
+
+	/**
+	 * Construct a gpu resource.
+	 */
+	public static Protos.Resource gpus(String role, double amount) {
+		return scalar("gpus", role, amount);
+	}
+
+	/**
 	 * Construct a mem resource.
 	 */
 	public static Protos.Resource mem(double amount) {

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosEntrypointUtils.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosEntrypointUtils.java
@@ -105,11 +105,12 @@ public class MesosEntrypointUtils {
 		log.info("TaskManagers will be created with {} task slots",
 			taskManagerParameters.containeredParameters().numSlots());
 		log.info("TaskManagers will be started with container size {} MB, JVM heap size {} MB, " +
-				"JVM direct memory limit {} MB, {} cpus",
+				"JVM direct memory limit {} MB, {} cpus, {} gpus",
 			taskManagerParameters.containeredParameters().taskManagerTotalMemoryMB(),
 			taskManagerParameters.containeredParameters().taskManagerHeapSizeMB(),
 			taskManagerParameters.containeredParameters().taskManagerDirectMemoryLimitMB(),
-			taskManagerParameters.cpus());
+			taskManagerParameters.cpus(),
+			taskManagerParameters.gpus());
 
 		return taskManagerParameters;
 	}

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorker.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorker.java
@@ -125,6 +125,10 @@ public class LaunchableMesosWorker implements LaunchableTask {
 			return params.cpus();
 		}
 
+		public double getGPUs() {
+			return params.gpus();
+		}
+
 		@Override
 		public double getMemory() {
 			return params.containeredParameters().taskManagerTotalMemoryMB();
@@ -143,6 +147,11 @@ public class LaunchableMesosWorker implements LaunchableTask {
 		@Override
 		public int getPorts() {
 			return TM_PORT_KEYS.length;
+		}
+
+		@Override
+		public Map<String, Double> getScalarRequests() {
+			return Collections.singletonMap("gpus", params.gpus());
 		}
 
 		@Override
@@ -174,8 +183,9 @@ public class LaunchableMesosWorker implements LaunchableTask {
 		public String toString() {
 			return "Request{" +
 				"cpus=" + getCPUs() +
-				"memory=" + getMemory() +
-				'}';
+				", memory=" + getMemory() +
+				", gpus=" + getGPUs() +
+				"}";
 		}
 	}
 
@@ -204,6 +214,7 @@ public class LaunchableMesosWorker implements LaunchableTask {
 		// take needed resources from the overall allocation, under the assumption of adequate resources
 		Set<String> roles = mesosConfiguration.roles();
 		taskInfo.addAllResources(allocation.takeScalar("cpus", taskRequest.getCPUs(), roles));
+		taskInfo.addAllResources(allocation.takeScalar("gpus", taskRequest.getGPUs(), roles));
 		taskInfo.addAllResources(allocation.takeScalar("mem", taskRequest.getMemory(), roles));
 
 		final Protos.CommandInfo.Builder cmd = taskInfo.getCommandBuilder();

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManager.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManager.java
@@ -661,6 +661,7 @@ public class MesosResourceManager extends ResourceManager<RegisteredMesosWorkerN
 		// create the specific TM parameters from the resource profile and some defaults
 		MesosTaskManagerParameters params = new MesosTaskManagerParameters(
 			resourceProfile.getCpuCores() < 1.0 ? taskManagerParameters.cpus() : resourceProfile.getCpuCores(),
+			taskManagerParameters.gpus(),
 			taskManagerParameters.containerType(),
 			taskManagerParameters.containerImageName(),
 			new ContaineredTaskManagerParameters(

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
@@ -62,6 +62,10 @@ public class MesosTaskManagerParameters {
 		key("mesos.resourcemanager.tasks.cpus")
 		.defaultValue(0.0);
 
+	public static final ConfigOption<Double> MESOS_RM_TASKS_GPUS =
+		key("mesos.resourcemanager.tasks.gpus")
+		.defaultValue(0.0);
+
 	public static final ConfigOption<String> MESOS_RM_CONTAINER_TYPE =
 		key("mesos.resourcemanager.tasks.container.type")
 		.defaultValue("mesos");
@@ -101,6 +105,8 @@ public class MesosTaskManagerParameters {
 
 	private final double cpus;
 
+	private final double gpus;
+
 	private final ContainerType containerType;
 
 	private final Option<String> containerImageName;
@@ -119,6 +125,7 @@ public class MesosTaskManagerParameters {
 
 	public MesosTaskManagerParameters(
 			double cpus,
+			double gpus,
 			ContainerType containerType,
 			Option<String> containerImageName,
 			ContaineredTaskManagerParameters containeredParameters,
@@ -129,6 +136,7 @@ public class MesosTaskManagerParameters {
 			Option<String> taskManagerHostname) {
 
 		this.cpus = cpus;
+		this.gpus = gpus;
 		this.containerType = Preconditions.checkNotNull(containerType);
 		this.containerImageName = Preconditions.checkNotNull(containerImageName);
 		this.containeredParameters = Preconditions.checkNotNull(containeredParameters);
@@ -144,6 +152,13 @@ public class MesosTaskManagerParameters {
 	 */
 	public double cpus() {
 		return cpus;
+	}
+
+	/**
+	 * Get the GPU units to use for the TaskManager Process.
+	 */
+	public double gpus() {
+		return gpus;
 	}
 
 	/**
@@ -208,6 +223,7 @@ public class MesosTaskManagerParameters {
 	public String toString() {
 		return "MesosTaskManagerParameters{" +
 			"cpus=" + cpus +
+			", gpus=" + gpus +
 			", containerType=" + containerType +
 			", containerImageName=" + containerImageName +
 			", containeredParameters=" + containeredParameters +
@@ -236,6 +252,16 @@ public class MesosTaskManagerParameters {
 		double cpus = flinkConfig.getDouble(MESOS_RM_TASKS_CPUS);
 		if (cpus <= 0.0) {
 			cpus = Math.max(containeredParameters.numSlots(), 1.0);
+		}
+
+		double gpus = flinkConfig.getDouble(MESOS_RM_TASKS_GPUS, 0.0);
+		if (gpus < 0) {
+			throw new IllegalConfigurationException(MESOS_RM_TASKS_GPUS.key() +
+				" cannot be negative");
+		}
+		if (gpus % 1 != 0) {
+			throw new IllegalConfigurationException(MESOS_RM_TASKS_GPUS.key() +
+				" must be whole numbers");
 		}
 
 		// parse the containerization parameters
@@ -271,6 +297,7 @@ public class MesosTaskManagerParameters {
 
 		return new MesosTaskManagerParameters(
 			cpus,
+			gpus,
 			containerType,
 			Option.apply(imageName),
 			containeredParameters,

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
@@ -254,14 +254,10 @@ public class MesosTaskManagerParameters {
 			cpus = Math.max(containeredParameters.numSlots(), 1.0);
 		}
 
-		double gpus = flinkConfig.getDouble(MESOS_RM_TASKS_GPUS, 0.0);
+		double gpus = Math.floor(flinkConfig.getDouble(MESOS_RM_TASKS_GPUS, 0.0));
 		if (gpus < 0) {
 			throw new IllegalConfigurationException(MESOS_RM_TASKS_GPUS.key() +
 				" cannot be negative");
-		}
-		if (gpus % 1 != 0) {
-			throw new IllegalConfigurationException(MESOS_RM_TASKS_GPUS.key() +
-				" must be whole numbers");
 		}
 
 		// parse the containerization parameters

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/util/MesosConfiguration.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/util/MesosConfiguration.java
@@ -146,6 +146,8 @@ public class MesosConfiguration {
 		log.info("    Name: {}", info.hasName() ? info.getName() : "(none)");
 		log.info("    Failover Timeout (secs): {}", info.getFailoverTimeout());
 		log.info("    Role: {}", info.hasRole() ? info.getRole() : "(none)");
+		log.info("    Capabilities: {}",
+			info.getCapabilitiesList().size() > 0 ? info.getCapabilitiesList() : "(none)");
 		log.info("    Principal: {}", info.hasPrincipal() ? info.getPrincipal() : "(none)");
 		log.info("    Host: {}", info.hasHostname() ? info.getHostname() : "(none)");
 		if (env.containsKey("LIBPROCESS_IP")) {

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosFlinkResourceManagerTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosFlinkResourceManagerTest.java
@@ -245,7 +245,7 @@ public class MesosFlinkResourceManagerTest extends TestLogger {
 			ContaineredTaskManagerParameters containeredParams =
 				new ContaineredTaskManagerParameters(1024, 768, 256, 4, new HashMap<String, String>());
 			MesosTaskManagerParameters tmParams = new MesosTaskManagerParameters(
-				1.0,
+				1.0, 1.0,
 				MesosTaskManagerParameters.ContainerType.MESOS,
 				Option.<String>empty(),
 				containeredParams,

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
@@ -262,7 +262,7 @@ public class MesosResourceManagerTest extends TestLogger {
 			ContaineredTaskManagerParameters containeredParams =
 				new ContaineredTaskManagerParameters(1024, 768, 256, 4, new HashMap<String, String>());
 			MesosTaskManagerParameters tmParams = new MesosTaskManagerParameters(
-				1.0, MesosTaskManagerParameters.ContainerType.MESOS, Option.<String>empty(), containeredParams,
+				1.0, 1.0, MesosTaskManagerParameters.ContainerType.MESOS, Option.<String>empty(), containeredParams,
 				Collections.<Protos.Volume>emptyList(), Collections.<ConstraintEvaluator>emptyList(), "", Option.<String>empty(),
 				Option.<String>empty());
 

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParametersTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParametersTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.mesos.runtime.clusterframework;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.util.TestLogger;
 
 import com.netflix.fenzo.ConstraintEvaluator;
@@ -132,6 +133,28 @@ public class MesosTaskManagerParametersTest extends TestLogger {
 
 		MesosTaskManagerParameters mesosTaskManagerParameters = MesosTaskManagerParameters.create(withHardHostAttrConstraintConfiguration(",:,"));
 		assertThat(mesosTaskManagerParameters.constraints().size(), is(0));
+	}
+
+	@Test(expected = IllegalConfigurationException.class)
+	public void testNegativeNumberOfGPUs() throws Exception {
+		MesosTaskManagerParameters.create(withGPUConfiguration(-1.0));
+	}
+
+	@Test(expected = IllegalConfigurationException.class)
+	public void testNotWholeNumberOfGPUs() throws Exception {
+		MesosTaskManagerParameters.create(withGPUConfiguration(1.5));
+	}
+
+	@Test
+	public void testWholeNumberOfGPUs() {
+		MesosTaskManagerParameters params = MesosTaskManagerParameters.create(withGPUConfiguration(1.0));
+		assertEquals(Double.doubleToLongBits(1.0), Double.doubleToLongBits(params.gpus()));
+	}
+
+	private static Configuration withGPUConfiguration(double gpus) {
+		Configuration config = new Configuration();
+		config.setDouble(MesosTaskManagerParameters.MESOS_RM_TASKS_GPUS, gpus);
+		return config;
 	}
 
 	private static Configuration withHardHostAttrConstraintConfiguration(final String configuration) {

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParametersTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParametersTest.java
@@ -140,14 +140,9 @@ public class MesosTaskManagerParametersTest extends TestLogger {
 		MesosTaskManagerParameters.create(withGPUConfiguration(-1.0));
 	}
 
-	@Test(expected = IllegalConfigurationException.class)
-	public void testNotWholeNumberOfGPUs() throws Exception {
-		MesosTaskManagerParameters.create(withGPUConfiguration(1.5));
-	}
-
 	@Test
 	public void testWholeNumberOfGPUs() {
-		MesosTaskManagerParameters params = MesosTaskManagerParameters.create(withGPUConfiguration(1.0));
+		MesosTaskManagerParameters params = MesosTaskManagerParameters.create(withGPUConfiguration(1.1));
 		assertEquals(Double.doubleToLongBits(1.0), Double.doubleToLongBits(params.gpus()));
 	}
 

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/scheduler/OfferTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/scheduler/OfferTest.java
@@ -33,6 +33,7 @@ import java.util.stream.Collectors;
 import static org.apache.flink.mesos.Utils.UNRESERVED_ROLE;
 import static org.apache.flink.mesos.Utils.cpus;
 import static org.apache.flink.mesos.Utils.disk;
+import static org.apache.flink.mesos.Utils.gpus;
 import static org.apache.flink.mesos.Utils.mem;
 import static org.apache.flink.mesos.Utils.network;
 import static org.apache.flink.mesos.Utils.ports;
@@ -97,6 +98,12 @@ public class OfferTest extends TestLogger {
 	public void testCpuCores() {
 		Offer offer = new Offer(offer(resources(cpus(1.0)), attrs()));
 		Assert.assertEquals(1.0, offer.cpuCores(), EPSILON);
+	}
+
+	@Test
+	public void testGPUs() {
+		Offer offer = new Offer(offer(resources(gpus(1.0)), attrs()));
+		Assert.assertEquals(1.0, offer.gpus(), EPSILON);
 	}
 
 	@Test

--- a/flink-mesos/src/test/scala/org/apache/flink/mesos/scheduler/LaunchCoordinatorTest.scala
+++ b/flink-mesos/src/test/scala/org/apache/flink/mesos/scheduler/LaunchCoordinatorTest.scala
@@ -80,6 +80,7 @@ class LaunchCoordinatorTest
         override def getNetworkMbps: Double = 0.0
         override def getDisk: Double = 0.0
         override def getPorts: Int = 1
+        override def getScalarRequests = Collections.singletonMap("gpus", 1.0)
         override def getCustomNamedResources: java.util.Map[String, NamedResourceSetRequest] =
           Collections.emptyMap[String, NamedResourceSetRequest]
         override def getSoftConstraints: java.util.List[_ <: VMTaskFitnessCalculator] = null


### PR DESCRIPTION
## What is the purpose of the change

This PR introduces a new configuration property named "mesos.resourcemanager.tasks.gpus"  to allow users to specify # of GPUs for each TaskManager process in Mesos. The configuration property is necessary because TaskManagers that do not specify to use GPUs cannot see GPUs at all when Mesos agents are configured to isolate GPUs as shown in [1].

[1] http://mesos.apache.org/documentation/latest/gpu-support/#agent-flags

## Brief change log

* Modify MesosTaskManagerParameters instead of ContaineredTaskManagerParameters to confine this problem to Mesos
* Augment data types: (1) offers from Mesos and (2) task requests of Mesos frameworks 
* Add GPU_RESOURCES to the list of framework capabilities if "mesos.resourcemanager.tasks.gpus" > 0. Otherwise, LaunchCoordinator gets no offers from Mesos masters that are configured to prevent Mesos frameworks without GPU_RESOURCES from being given resources offers of GPU-equipped agents.

## Verifying this change

I tested it by launching a standalone Flink cluster using ./bin/mesos-appmaster.sh. I tested the following scenarios with Mesos configured with --filter_gpu_resources.

* When mesos.resourcemanager.tasks.gpus is not specified or is set to 0.0
LaunchCoordinator isn't given any offer because MesosFlinkResourceManager does not enable GPU_RESOURCES capability when mesos.resourcemanager.tasks.gpus is not specified or it is set to 0.
* When mesos.resourcemanager.tasks.gpus is smaller than or equal to the available GPUs on a node 
Given offers, LaunchCoordinator aggregates offers of different roles from the same node and puts aggregated offers to Fenzo for scheduling resources over nodes. When notified of the success of scheduling from Fenzo, LaunchCoordinator allocates resources of different roles to tasks and then populate Protos.TaskInfo using the allocated resources which is then wired to the Mesos master.
* When mesos.resourcemanager.tasks.gpus is bigger than the available GPUs on a node 
Given offers, LaunchCoordinator aggregates offers of different roles from the same node and puts aggregated offers to Fenzo. However, Fenzo notifies LaunchCoordinator of the failure of scheduling with the following messages:
    AssignmentFailure {resource=Other, asking=3.0, used=0.0, available=2.0, message=gpus}.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes, it includes an upgrade (Fenzo)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: yes (JobManager and TaskManager on Mesos)
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
