### PR TITLE
[FLINK-8450] [flip6] Make JobMaster/DispatcherGateway#requestJob type safe

### DIFF
--- a/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSinkTest.java
+++ b/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSinkTest.java
@@ -34,6 +34,7 @@ import org.apache.flink.streaming.util.AbstractStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.util.NetUtils;
 import org.apache.flink.util.OperatingSystem;
+import org.apache.flink.util.TestLogger;
 
 import org.apache.avro.Schema;
 import org.apache.avro.file.DataFileConstants;
@@ -70,7 +71,7 @@ import java.util.Map;
 /**
  * Tests for the {@link BucketingSink}.
  */
-public class BucketingSinkTest {
+public class BucketingSinkTest extends TestLogger {
 	@ClassRule
 	public static TemporaryFolder tempFolder = new TemporaryFolder();
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/accumulators/AccumulatorHelper.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/accumulators/AccumulatorHelper.java
@@ -28,13 +28,16 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Helper functions for the interaction with {@link Accumulator}.
+ */
 @Internal
 public class AccumulatorHelper {
 
 	/**
 	 * Merge two collections of accumulators. The second will be merged into the
 	 * first.
-	 * 
+	 *
 	 * @param target
 	 *            The collection of accumulators that will be updated
 	 * @param toMerge
@@ -59,7 +62,7 @@ public class AccumulatorHelper {
 	}
 
 	/**
-	 * Workaround method for type safety
+	 * Workaround method for type safety.
 	 */
 	private static <V, R extends Serializable> void mergeSingle(Accumulator<?, ?> target,
 															Accumulator<?, ?> toMerge) {
@@ -74,14 +77,13 @@ public class AccumulatorHelper {
 
 	/**
 	 * Compare both classes and throw {@link UnsupportedOperationException} if
-	 * they differ
+	 * they differ.
 	 */
 	@SuppressWarnings("rawtypes")
-	public static void compareAccumulatorTypes(Object name,
-												Class<? extends Accumulator> first,
-												Class<? extends Accumulator> second)
-			throws UnsupportedOperationException
-	{
+	public static void compareAccumulatorTypes(
+			Object name,
+			Class<? extends Accumulator> first,
+			Class<? extends Accumulator> second) throws UnsupportedOperationException {
 		if (first == null || second == null) {
 			throw new NullPointerException();
 		}
@@ -102,7 +104,7 @@ public class AccumulatorHelper {
 
 	/**
 	 * Transform the Map with accumulators into a Map containing only the
-	 * results
+	 * results.
 	 */
 	public static Map<String, Object> toResultMap(Map<String, Accumulator<?, ?>> accumulators) {
 		Map<String, Object> resultMap = new HashMap<String, Object>();
@@ -134,7 +136,7 @@ public class AccumulatorHelper {
 	public static Map<String, Accumulator<?, ?>> copy(Map<String, Accumulator<?, ?>> accumulators) {
 		Map<String, Accumulator<?, ?>> result = new HashMap<String, Accumulator<?, ?>>();
 
-		for(Map.Entry<String, Accumulator<?, ?>> entry: accumulators.entrySet()){
+		for (Map.Entry<String, Accumulator<?, ?>> entry: accumulators.entrySet()){
 			result.put(entry.getKey(), entry.getValue().clone());
 		}
 
@@ -172,24 +174,4 @@ public class AccumulatorHelper {
 
 		return accumulators;
 	}
-
-	/**
-	 * Serializes the given accumulators.
-	 *
-	 * @param accumulators to serialize
-	 * @return Map of serialized accumulators
-	 * @throws IOException if an accumulator could not be serialized
-	 */
-	public static Map<String, SerializedValue<Object>> serializeAccumulators(Map<String, Accumulator<?, ?>> accumulators) throws IOException {
-		final Map<String, SerializedValue<Object>> serializedAccumulators = new HashMap<>(accumulators.size());
-
-		for (Map.Entry<String, Accumulator<?, ?>> stringAccumulatorEntry : accumulators.entrySet()) {
-			serializedAccumulators.put(
-				stringAccumulatorEntry.getKey(),
-				new SerializedValue<>(stringAccumulatorEntry.getValue()));
-		}
-
-		return serializedAccumulators;
-	}
-
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/accumulators/AccumulatorHelper.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/accumulators/AccumulatorHelper.java
@@ -173,4 +173,23 @@ public class AccumulatorHelper {
 		return accumulators;
 	}
 
+	/**
+	 * Serializes the given accumulators.
+	 *
+	 * @param accumulators to serialize
+	 * @return Map of serialized accumulators
+	 * @throws IOException if an accumulator could not be serialized
+	 */
+	public static Map<String, SerializedValue<Object>> serializeAccumulators(Map<String, Accumulator<?, ?>> accumulators) throws IOException {
+		final Map<String, SerializedValue<Object>> serializedAccumulators = new HashMap<>(accumulators.size());
+
+		for (Map.Entry<String, Accumulator<?, ?>> stringAccumulatorEntry : accumulators.entrySet()) {
+			serializedAccumulators.put(
+				stringAccumulatorEntry.getKey(),
+				new SerializedValue<>(stringAccumulatorEntry.getValue()));
+		}
+
+		return serializedAccumulators;
+	}
+
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/accumulators/FailedAccumulatorSerialization.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/accumulators/FailedAccumulatorSerialization.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.accumulators;
+
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.Preconditions;
+
+import java.io.Serializable;
+
+/**
+ * {@link Accumulator} implementation which indicates a serialization problem with the original
+ * accumulator. Accessing any of the {@link Accumulator} method will result in throwing the
+ * serialization exception.
+ *
+ * @param <V> type of the value
+ * @param <R> type of the accumulator result
+ */
+public class FailedAccumulatorSerialization<V, R extends Serializable> implements Accumulator<V, R> {
+	private static final long serialVersionUID = 6965908827065879760L;
+
+	private final Throwable throwable;
+
+	public FailedAccumulatorSerialization(Throwable throwable) {
+		this.throwable = Preconditions.checkNotNull(throwable);
+	}
+
+	public Throwable getThrowable() {
+		return throwable;
+	}
+
+	@Override
+	public void add(V value) {
+		ExceptionUtils.rethrow(throwable);
+	}
+
+	@Override
+	public R getLocalValue() {
+		ExceptionUtils.rethrow(throwable);
+		return null;
+	}
+
+	@Override
+	public void resetLocal() {
+		ExceptionUtils.rethrow(throwable);
+	}
+
+	@Override
+	public void merge(Accumulator<V, R> other) {
+		ExceptionUtils.rethrow(throwable);
+	}
+
+	@Override
+	public Accumulator<V, R> clone() {
+		ExceptionUtils.rethrow(throwable);
+		return null;
+	}
+}

--- a/flink-core/src/test/java/org/apache/flink/api/common/accumulators/FailedAccumulatorSerializationTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/accumulators/FailedAccumulatorSerializationTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.accumulators;
+
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.InstantiationUtil;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for the {@link FailedAccumulatorSerialization}.
+ */
+public class FailedAccumulatorSerializationTest extends TestLogger {
+
+	private static final IOException TEST_EXCEPTION = new IOException("Test exception");
+
+	/**
+	 * Tests that any method call will throw the contained throwable (wrapped in an
+	 * unchecked exception if it is checked).
+	 */
+	@Test
+	public void testMethodCallThrowsException() {
+		final FailedAccumulatorSerialization<Integer, Integer> accumulator = new FailedAccumulatorSerialization<>(TEST_EXCEPTION);
+
+		try {
+			accumulator.getLocalValue();
+		} catch (RuntimeException re) {
+			assertThat(ExceptionUtils.findThrowableWithMessage(re, TEST_EXCEPTION.getMessage()).isPresent(), is(true));
+		}
+
+		try {
+			accumulator.resetLocal();
+		} catch (RuntimeException re) {
+			assertThat(ExceptionUtils.findThrowableWithMessage(re, TEST_EXCEPTION.getMessage()).isPresent(), is(true));
+		}
+
+		try {
+			accumulator.add(1);
+		} catch (RuntimeException re) {
+			assertThat(ExceptionUtils.findThrowableWithMessage(re, TEST_EXCEPTION.getMessage()).isPresent(), is(true));
+		}
+
+		try {
+			accumulator.merge(new IntMinimum());
+		} catch (RuntimeException re) {
+			assertThat(ExceptionUtils.findThrowableWithMessage(re, TEST_EXCEPTION.getMessage()).isPresent(), is(true));
+		}
+	}
+
+	/**
+	 * Tests that the class can be serialized and deserialized using Java serialization.
+	 */
+	@Test
+	public void testSerialization() throws Exception {
+		final FailedAccumulatorSerialization<?, ?> accumulator = new FailedAccumulatorSerialization<>(TEST_EXCEPTION);
+
+		final byte[] serializedAccumulator = InstantiationUtil.serializeObject(accumulator);
+
+		final FailedAccumulatorSerialization<?, ?> deserializedAccumulator = InstantiationUtil.deserializeObject(serializedAccumulator, ClassLoader.getSystemClassLoader());
+
+		assertThat(deserializedAccumulator.getThrowable(), is(instanceOf(TEST_EXCEPTION.getClass())));
+		assertThat(deserializedAccumulator.getThrowable().getMessage(), is(equalTo(TEST_EXCEPTION.getMessage())));
+	}
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.client.JobSubmissionException;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.highavailability.RunningJobsRegistry;
@@ -485,6 +486,19 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 		fatalErrorHandler.onFatalError(throwable);
 	}
 
+	private void jobReachedGloballyTerminalState(AccessExecutionGraph accessExecutionGraph) {
+		final JobResult jobResult = JobResult.createFrom(accessExecutionGraph);
+
+		jobExecutionResultCache.put(jobResult);
+		final JobID jobId = accessExecutionGraph.getJobID();
+
+		try {
+			removeJob(jobId, true);
+		} catch (Exception e) {
+			log.warn("Could not properly remove job {} from the dispatcher.", jobId, e);
+		}
+	}
+
 	protected abstract JobManagerRunner createJobManagerRunner(
 		ResourceID resourceId,
 		JobGraph jobGraph,
@@ -607,31 +621,10 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 		}
 
 		@Override
-		public void jobFinished(JobResult result) {
-			log.info("Job {} finished.", jobId);
+		public void jobReachedGloballyTerminalState(ArchivedExecutionGraph executionGraph) {
+			log.info("Job {} reached globally terminal state {}.", jobId, executionGraph.getState());
 
-			runAsync(() -> {
-				jobExecutionResultCache.put(result);
-				try {
-					removeJob(jobId, true);
-				} catch (Exception e) {
-					log.warn("Could not properly remove job {} from the dispatcher.", jobId, e);
-				}
-			});
-		}
-
-		@Override
-		public void jobFailed(JobResult result) {
-			log.info("Job {} failed.", jobId);
-
-			runAsync(() -> {
-				jobExecutionResultCache.put(result);
-				try {
-					removeJob(jobId, true);
-				} catch (Exception e) {
-					log.warn("Could not properly remove job {} from the dispatcher.", jobId, e);
-				}
-			});
+			runAsync(() -> Dispatcher.this.jobReachedGloballyTerminalState(executionGraph));
 		}
 
 		@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -331,13 +331,13 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 	}
 
 	@Override
-	public CompletableFuture<AccessExecutionGraph> requestJob(JobID jobId, Time timeout) {
+	public CompletableFuture<ArchivedExecutionGraph> requestJob(JobID jobId, Time timeout) {
 		final JobManagerRunner jobManagerRunner = jobManagerRunners.get(jobId);
 
 		if (jobManagerRunner == null) {
 			return FutureUtils.completedExceptionally(new FlinkJobNotFoundException(jobId));
 		} else {
-			return jobManagerRunner.getJobManagerGateway().requestArchivedExecutionGraph(timeout);
+			return jobManagerRunner.getJobManagerGateway().requestJob(jobId, timeout);
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherGateway.java
@@ -20,8 +20,10 @@ package org.apache.flink.runtime.dispatcher;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.messages.FlinkJobNotFoundException;
 import org.apache.flink.runtime.rpc.FencedRpcGateway;
 import org.apache.flink.runtime.rpc.RpcTimeout;
 import org.apache.flink.runtime.webmonitor.RestfulGateway;
@@ -79,4 +81,18 @@ public interface DispatcherGateway extends FencedRpcGateway<DispatcherId>, Restf
 	 * @return A future integer of the blob server port
 	 */
 	CompletableFuture<Integer> getBlobServerPort(@RpcTimeout Time timeout);
+
+	/**
+	 * Requests the {@link ArchivedExecutionGraph} for the given jobId. If there is no such graph, then
+	 * the future is completed with a {@link FlinkJobNotFoundException}.
+	 *
+	 * <p>Note: We enforce that the returned future contains a {@link ArchivedExecutionGraph} unlike
+	 * the super interface.
+	 *
+	 * @param jobId identifying the job whose AccessExecutionGraph is requested
+	 * @param timeout for the asynchronous operation
+	 * @return Future containing the AccessExecutionGraph for the given jobId, otherwise {@link FlinkJobNotFoundException}
+	 */
+	@Override
+	CompletableFuture<ArchivedExecutionGraph> requestJob(JobID jobId, @RpcTimeout Time timeout);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/AccessExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/AccessExecutionGraph.java
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.flink.runtime.executiongraph;
 
 import org.apache.flink.api.common.ArchivedExecutionConfig;
@@ -28,7 +29,6 @@ import org.apache.flink.util.SerializedValue;
 
 import javax.annotation.Nullable;
 
-import java.io.IOException;
 import java.util.Map;
 
 /**
@@ -103,7 +103,7 @@ public interface AccessExecutionGraph {
 	Iterable<? extends AccessExecutionVertex> getAllExecutionVertices();
 
 	/**
-	 * Returns the timestamp for the given {@link JobStatus}
+	 * Returns the timestamp for the given {@link JobStatus}.
 	 *
 	 * @param status status for which the timestamp should be returned
 	 * @return timestamp for the given job status
@@ -154,9 +154,8 @@ public interface AccessExecutionGraph {
 	 * Returns a map containing the serialized values of user-defined accumulators.
 	 *
 	 * @return map containing serialized values of user-defined accumulators
-	 * @throws IOException indicates that the serialization has failed
 	 */
-	Map<String, SerializedValue<Object>> getAccumulatorsSerialized() throws IOException;
+	Map<String, SerializedValue<Object>> getAccumulatorsSerialized();
 
 	/**
 	 * Returns whether this execution graph was archived.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ErrorInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ErrorInfo.java
@@ -34,7 +34,6 @@ public class ErrorInfo implements Serializable {
 	private final SerializedThrowable exception;
 
 	private final long timestamp;
-
 	public ErrorInfo(Throwable exception, long timestamp) {
 		Preconditions.checkNotNull(exception);
 		Preconditions.checkArgument(timestamp > 0);
@@ -48,7 +47,7 @@ public class ErrorInfo implements Serializable {
 	 * Returns the serialized form of the original exception.
 	 */
 	public SerializedThrowable getException() {
-		return this.exception;
+		return exception;
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.executiongraph;
 
 import org.apache.flink.annotation.VisibleForTesting;
-import org.apache.flink.api.common.Archiveable;
 import org.apache.flink.api.common.ArchivedExecutionConfig;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
@@ -51,7 +50,6 @@ import org.apache.flink.runtime.executiongraph.failover.RestartAllStrategy;
 import org.apache.flink.runtime.executiongraph.restart.ExecutionGraphRestartCallback;
 import org.apache.flink.runtime.executiongraph.restart.RestartCallback;
 import org.apache.flink.runtime.executiongraph.restart.RestartStrategy;
-import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.JobStatus;
@@ -62,6 +60,7 @@ import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguratio
 import org.apache.flink.runtime.jobmanager.scheduler.CoLocationGroup;
 import org.apache.flink.runtime.jobmanager.scheduler.LocationPreferenceConstraint;
 import org.apache.flink.runtime.jobmanager.scheduler.NoResourceAvailableException;
+import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.query.KvStateLocationRegistry;
 import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.runtime.state.StateBackend;
@@ -148,7 +147,7 @@ import static org.apache.flink.util.Preconditions.checkState;
  * local failover (meaning there is a concurrent global failover), the failover strategy has to
  * yield before the global failover.
  */
-public class ExecutionGraph implements AccessExecutionGraph, Archiveable<ArchivedExecutionGraph> {
+public class ExecutionGraph implements AccessExecutionGraph {
 
 	/** In place updater for the execution graph's current state. Avoids having to use an
 	 * AtomicReference and thus makes the frequent read access a bit faster */
@@ -761,16 +760,21 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 	/**
 	 * Gets a serialized accumulator map.
 	 * @return The accumulator map with serialized accumulator values.
-	 * @throws IOException
 	 */
 	@Override
-	public Map<String, SerializedValue<Object>> getAccumulatorsSerialized() throws IOException {
+	public Map<String, SerializedValue<Object>> getAccumulatorsSerialized() {
 
 		Map<String, Accumulator<?, ?>> accumulatorMap = aggregateUserAccumulators();
 
 		Map<String, SerializedValue<Object>> result = new HashMap<>(accumulatorMap.size());
 		for (Map.Entry<String, Accumulator<?, ?>> entry : accumulatorMap.entrySet()) {
-			result.put(entry.getKey(), new SerializedValue<>(entry.getValue().getLocalValue()));
+
+			try {
+				final SerializedValue<Object> serializedValue = new SerializedValue<>(entry.getValue().getLocalValue());
+				result.put(entry.getKey(), serializedValue);
+			} catch (IOException ioe) {
+				LOG.info("Could not serialize accumulator " + entry.getKey() + '.', ioe);
+			}
 		}
 
 		return result;
@@ -1686,41 +1690,5 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 				}
 			}
 		}
-	}
-
-	@Override
-	public ArchivedExecutionGraph archive() {
-		Map<JobVertexID, ArchivedExecutionJobVertex> archivedTasks = new HashMap<>(verticesInCreationOrder.size());
-		List<ArchivedExecutionJobVertex> archivedVerticesInCreationOrder = new ArrayList<>(verticesInCreationOrder.size());
-
-		for (ExecutionJobVertex task : verticesInCreationOrder) {
-			ArchivedExecutionJobVertex archivedTask = task.archive();
-			archivedVerticesInCreationOrder.add(archivedTask);
-			archivedTasks.put(task.getJobVertexId(), archivedTask);
-		}
-
-		Map<String, SerializedValue<Object>> serializedUserAccumulators;
-		try {
-			serializedUserAccumulators = getAccumulatorsSerialized();
-		} catch (Exception e) {
-			LOG.warn("Error occurred while archiving user accumulators.", e);
-			serializedUserAccumulators = Collections.emptyMap();
-		}
-
-		return new ArchivedExecutionGraph(
-			getJobID(),
-			getJobName(),
-			archivedTasks,
-			archivedVerticesInCreationOrder,
-			stateTimestamps,
-			getState(),
-			failureInfo,
-			getJsonPlan(),
-			getAccumulatorResultsStringified(),
-			serializedUserAccumulators,
-			getArchivedExecutionConfig(),
-			isStoppable(),
-			getCheckpointCoordinatorConfiguration(),
-			getCheckpointStatsSnapshot());
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/OnCompletionActions.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/OnCompletionActions.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.runtime.jobmanager;
 
-import org.apache.flink.runtime.jobmaster.JobResult;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 
 /**
  * Interface for completion actions once a Flink job has reached
@@ -27,18 +27,11 @@ import org.apache.flink.runtime.jobmaster.JobResult;
 public interface OnCompletionActions {
 
 	/**
-	 * Job finished successfully.
+	 * Job reached a globally terminal state.
 	 *
-	 * @param result of the job execution
+	 * @param executionGraph serializable execution graph
 	 */
-	void jobFinished(JobResult result);
-
-	/**
-	 * Job failed with an exception.
-	 *
-	 * @param result The result of the job carrying the failure cause.
-	 */
-	void jobFailed(JobResult result);
+	void jobReachedGloballyTerminalState(ArchivedExecutionGraph executionGraph);
 
 	/**
 	 * Job was finished by another JobMaster.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerRunner.java
@@ -24,6 +24,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.execution.librarycache.BlobLibraryCacheManager;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.highavailability.RunningJobsRegistry;
@@ -251,30 +252,14 @@ public class JobManagerRunner implements LeaderContender, OnCompletionActions, F
 	 * Job completion notification triggered by JobManager.
 	 */
 	@Override
-	public void jobFinished(JobResult result) {
+	public void jobReachedGloballyTerminalState(ArchivedExecutionGraph executionGraph) {
 		try {
 			unregisterJobFromHighAvailability();
 			shutdownInternally();
 		}
 		finally {
 			if (toNotifyOnComplete != null) {
-				toNotifyOnComplete.jobFinished(result);
-			}
-		}
-	}
-
-	/**
-	 * Job completion notification triggered by JobManager.
-	 */
-	@Override
-	public void jobFailed(JobResult result) {
-		try {
-			unregisterJobFromHighAvailability();
-			shutdownInternally();
-		}
-		finally {
-			if (toNotifyOnComplete != null) {
-				toNotifyOnComplete.jobFailed(result);
+				toNotifyOnComplete.jobReachedGloballyTerminalState(executionGraph);
 			}
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -39,7 +39,6 @@ import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.execution.librarycache.BlobLibraryCacheManager;
-import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
@@ -784,11 +783,6 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 	}
 
 	@Override
-	public CompletableFuture<AccessExecutionGraph> requestArchivedExecutionGraph(Time timeout) {
-		return CompletableFuture.completedFuture(ArchivedExecutionGraph.createFrom(executionGraph));
-	}
-
-	@Override
 	public CompletableFuture<JobStatus> requestJobStatus(Time timeout) {
 		return CompletableFuture.completedFuture(executionGraph.getState());
 	}
@@ -803,9 +797,9 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 	}
 
 	@Override
-	public CompletableFuture<AccessExecutionGraph> requestJob(JobID jobId, Time timeout) {
+	public CompletableFuture<ArchivedExecutionGraph> requestJob(JobID jobId, Time timeout) {
 		if (jobGraph.getJobID().equals(jobId)) {
-			return requestArchivedExecutionGraph(timeout);
+			return CompletableFuture.completedFuture(ArchivedExecutionGraph.createFrom(executionGraph));
 		} else {
 			return FutureUtils.completedExceptionally(new FlinkJobNotFoundException(jobId));
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniClusterJobDispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniClusterJobDispatcher.java
@@ -25,6 +25,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobServer;
 import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.jobgraph.JobGraph;
@@ -361,12 +362,7 @@ public class MiniClusterJobDispatcher {
 		}
 
 		@Override
-		public void jobFinished(JobResult result) {
-			decrementCheckAndCleanup();
-		}
-
-		@Override
-		public void jobFailed(JobResult result) {
+		public void jobReachedGloballyTerminalState(ArchivedExecutionGraph executionGraph) {
 			decrementCheckAndCleanup();
 		}
 
@@ -414,16 +410,8 @@ public class MiniClusterJobDispatcher {
 		}
 
 		@Override
-		public void jobFinished(JobResult result) {
-			this.result = result;
-			jobMastersToWaitFor.countDown();
-		}
-
-		@Override
-		public void jobFailed(JobResult result) {
-			checkArgument(result.getSerializedThrowable().isPresent());
-
-			this.result = result;
+		public void jobReachedGloballyTerminalState(ArchivedExecutionGraph executionGraph) {
+			this.result = JobResult.createFrom(executionGraph);
 			jobMastersToWaitFor.countDown();
 		}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobExceptionsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobExceptionsHandler.java
@@ -71,7 +71,7 @@ public class JobExceptionsHandler extends AbstractExecutionGraphHandler<JobExcep
 		ErrorInfo rootException = executionGraph.getFailureInfo();
 		String rootExceptionMessage = null;
 		Long rootTimestamp = null;
-		if (rootException != null && !rootException.getExceptionAsString().equals(ExceptionUtils.STRINGIFIED_NULL_EXCEPTION)) {
+		if (rootException != null) {
 			rootExceptionMessage = rootException.getExceptionAsString();
 			rootTimestamp = rootException.getTimestamp();
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/ExecutionGraphCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/ExecutionGraphCache.java
@@ -122,7 +122,7 @@ public class ExecutionGraphCache implements Closeable {
 			}
 
 			if (successfulUpdate) {
-				final CompletableFuture<AccessExecutionGraph> executionGraphFuture = restfulGateway.requestJob(jobId, timeout);
+				final CompletableFuture<? extends AccessExecutionGraph> executionGraphFuture = restfulGateway.requestJob(jobId, timeout);
 
 				executionGraphFuture.whenComplete(
 					(AccessExecutionGraph executionGraph, Throwable throwable) -> {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/JobExceptionsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/JobExceptionsHandler.java
@@ -93,7 +93,7 @@ public class JobExceptionsHandler extends AbstractExecutionGraphRequestHandler {
 
 		// most important is the root failure cause
 		ErrorInfo rootException = graph.getFailureInfo();
-		if (rootException != null && !rootException.getExceptionAsString().equals(ExceptionUtils.STRINGIFIED_NULL_EXCEPTION)) {
+		if (rootException != null) {
 			gen.writeStringField("root-exception", rootException.getExceptionAsString());
 			gen.writeNumberField("timestamp", rootException.getTimestamp());
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/RestfulGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/RestfulGateway.java
@@ -54,14 +54,14 @@ public interface RestfulGateway extends RpcGateway {
 	CompletableFuture<String> requestRestAddress(@RpcTimeout  Time timeout);
 
 	/**
-	 * Requests the AccessExecutionGraph for the given jobId. If there is no such graph, then
+	 * Requests the {@link AccessExecutionGraph} for the given jobId. If there is no such graph, then
 	 * the future is completed with a {@link FlinkJobNotFoundException}.
 	 *
 	 * @param jobId identifying the job whose AccessExecutionGraph is requested
 	 * @param timeout for the asynchronous operation
 	 * @return Future containing the AccessExecutionGraph for the given jobId, otherwise {@link FlinkJobNotFoundException}
 	 */
-	CompletableFuture<AccessExecutionGraph> requestJob(JobID jobId, @RpcTimeout Time timeout);
+	CompletableFuture<? extends AccessExecutionGraph> requestJob(JobID jobId, @RpcTimeout Time timeout);
 
 	/**
 	 * Requests job details currently being executed on the Flink cluster.

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -1727,7 +1727,10 @@ class JobManager(
           }(context.dispatcher))
 
           try {
-            archive ! decorateMessage(ArchiveExecutionGraph(jobID, eg.archive()))
+            archive ! decorateMessage(
+              ArchiveExecutionGraph(
+                jobID,
+                ArchivedExecutionGraph.createFrom(eg)))
           } catch {
             case t: Throwable => log.warn(s"Could not archive the execution graph $eg.", t)
           }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
@@ -142,14 +142,14 @@ public class ArchivedExecutionGraphTest extends TestLogger {
 
 	@Test
 	public void testArchive() throws IOException, ClassNotFoundException {
-		ArchivedExecutionGraph archivedGraph = runtimeGraph.archive();
+		ArchivedExecutionGraph archivedGraph = ArchivedExecutionGraph.createFrom(runtimeGraph);
 
 		compareExecutionGraph(runtimeGraph, archivedGraph);
 	}
 
 	@Test
 	public void testSerialization() throws IOException, ClassNotFoundException {
-		ArchivedExecutionGraph archivedGraph = runtimeGraph.archive();
+		ArchivedExecutionGraph archivedGraph = ArchivedExecutionGraph.createFrom(runtimeGraph);
 
 		verifySerializability(archivedGraph);
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.execution.librarycache.BlobLibraryCacheManager;
 import org.apache.flink.runtime.execution.librarycache.FlinkUserCodeClassLoaders;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.heartbeat.TestingHeartbeatServices;
@@ -265,12 +266,7 @@ public class JobMasterTest extends TestLogger {
 	private static final class NoOpOnCompletionActions implements OnCompletionActions {
 
 		@Override
-		public void jobFinished(final JobResult result) {
-
-		}
-
-		@Override
-		public void jobFailed(final JobResult result) {
+		public void jobReachedGloballyTerminalState(ArchivedExecutionGraph executionGraph) {
 
 		}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/ExecutionGraphCacheTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/ExecutionGraphCacheTest.java
@@ -30,37 +30,48 @@ import org.apache.flink.runtime.executiongraph.ErrorInfo;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobmanager.JobManager;
-import org.apache.flink.runtime.jobmaster.JobManagerGateway;
 import org.apache.flink.runtime.messages.FlinkJobNotFoundException;
+import org.apache.flink.runtime.rest.handler.legacy.utils.ArchivedExecutionGraphBuilder;
+import org.apache.flink.runtime.webmonitor.RestfulGateway;
+import org.apache.flink.runtime.webmonitor.TestingRestfulGateway;
 import org.apache.flink.util.ExecutorUtils;
 import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.TestLogger;
 
+import org.hamcrest.Matchers;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * Tests for the {@link ExecutionGraphCache}.
  */
 public class ExecutionGraphCacheTest extends TestLogger {
+
+	private static ArchivedExecutionGraph expectedExecutionGraph;
+	private static final JobID expectedJobId = new JobID();
+
+	@BeforeClass
+	public static void setup() {
+		expectedExecutionGraph = new ArchivedExecutionGraphBuilder().build();
+	}
 
 	/**
 	 * Tests that we can cache AccessExecutionGraphs over multiple accesses.
@@ -69,23 +80,19 @@ public class ExecutionGraphCacheTest extends TestLogger {
 	public void testExecutionGraphCaching() throws Exception {
 		final Time timeout = Time.milliseconds(100L);
 		final Time timeToLive = Time.hours(1L);
-		final JobID jobId = new JobID();
-		final AccessExecutionGraph accessExecutionGraph = mock(AccessExecutionGraph.class);
 
-		final JobManagerGateway jobManagerGateway = mock(JobManagerGateway.class);
-		when(jobManagerGateway.requestJob(eq(jobId), any(Time.class))).thenReturn(CompletableFuture.completedFuture(accessExecutionGraph));
+		final CountingRestfulGateway restfulGateway = createCountingRestfulGateway(expectedJobId, CompletableFuture.completedFuture(expectedExecutionGraph));
 
 		try (ExecutionGraphCache executionGraphCache = new ExecutionGraphCache(timeout, timeToLive)) {
-			CompletableFuture<AccessExecutionGraph> accessExecutionGraphFuture = executionGraphCache.getExecutionGraph(jobId, jobManagerGateway);
+			CompletableFuture<AccessExecutionGraph> accessExecutionGraphFuture = executionGraphCache.getExecutionGraph(expectedJobId, restfulGateway);
 
-			assertEquals(accessExecutionGraph, accessExecutionGraphFuture.get());
+			assertEquals(expectedExecutionGraph, accessExecutionGraphFuture.get());
 
-			CompletableFuture<AccessExecutionGraph> accessExecutionGraphFuture2 = executionGraphCache.getExecutionGraph(jobId, jobManagerGateway);
+			CompletableFuture<AccessExecutionGraph> accessExecutionGraphFuture2 = executionGraphCache.getExecutionGraph(expectedJobId, restfulGateway);
 
-			assertEquals(accessExecutionGraph, accessExecutionGraphFuture2.get());
+			assertEquals(expectedExecutionGraph, accessExecutionGraphFuture2.get());
 
-			// verify that we only issued a single request to the gateway
-			verify(jobManagerGateway, times(1)).requestJob(eq(jobId), any(Time.class));
+			assertThat(restfulGateway.getNumRequestJobCalls(), Matchers.equalTo(1));
 		}
 	}
 
@@ -96,25 +103,25 @@ public class ExecutionGraphCacheTest extends TestLogger {
 	public void testExecutionGraphEntryInvalidation() throws Exception {
 		final Time timeout = Time.milliseconds(100L);
 		final Time timeToLive = Time.milliseconds(1L);
-		final JobID jobId = new JobID();
-		final AccessExecutionGraph accessExecutionGraph = mock(AccessExecutionGraph.class);
 
-		final JobManagerGateway jobManagerGateway = mock(JobManagerGateway.class);
-		when(jobManagerGateway.requestJob(eq(jobId), any(Time.class))).thenReturn(CompletableFuture.completedFuture(accessExecutionGraph));
+		final CountingRestfulGateway restfulGateway = createCountingRestfulGateway(
+			expectedJobId,
+			CompletableFuture.completedFuture(expectedExecutionGraph),
+			CompletableFuture.completedFuture(expectedExecutionGraph));
 
 		try (ExecutionGraphCache executionGraphCache = new ExecutionGraphCache(timeout, timeToLive)) {
-			CompletableFuture<AccessExecutionGraph> executionGraphFuture = executionGraphCache.getExecutionGraph(jobId, jobManagerGateway);
+			CompletableFuture<AccessExecutionGraph> executionGraphFuture = executionGraphCache.getExecutionGraph(expectedJobId, restfulGateway);
 
-			assertEquals(accessExecutionGraph, executionGraphFuture.get());
+			assertEquals(expectedExecutionGraph, executionGraphFuture.get());
 
 			// sleep for the TTL
-			Thread.sleep(timeToLive.toMilliseconds());
+			Thread.sleep(timeToLive.toMilliseconds() * 5L);
 
-			CompletableFuture<AccessExecutionGraph> executionGraphFuture2 = executionGraphCache.getExecutionGraph(jobId, jobManagerGateway);
+			CompletableFuture<AccessExecutionGraph> executionGraphFuture2 = executionGraphCache.getExecutionGraph(expectedJobId, restfulGateway);
 
-			assertEquals(accessExecutionGraph, executionGraphFuture2.get());
+			assertEquals(expectedExecutionGraph, executionGraphFuture2.get());
 
-			verify(jobManagerGateway, times(2)).requestJob(eq(jobId), any(Time.class));
+			assertThat(restfulGateway.getNumRequestJobCalls(), Matchers.equalTo(2));
 		}
 	}
 
@@ -127,18 +134,15 @@ public class ExecutionGraphCacheTest extends TestLogger {
 	public void testImmediateCacheInvalidationAfterFailure() throws Exception {
 		final Time timeout = Time.milliseconds(100L);
 		final Time timeToLive = Time.hours(1L);
-		final JobID jobId = new JobID();
 
-		final AccessExecutionGraph accessExecutionGraph = mock(AccessExecutionGraph.class);
-
-		final JobManagerGateway jobManagerGateway = mock(JobManagerGateway.class);
 		// let's first answer with a JobNotFoundException and then only with the correct result
-		when(jobManagerGateway.requestJob(eq(jobId), any(Time.class))).thenReturn(
-			FutureUtils.completedExceptionally(new FlinkJobNotFoundException(jobId)),
-			CompletableFuture.completedFuture(accessExecutionGraph));
+		final CountingRestfulGateway restfulGateway = createCountingRestfulGateway(
+			expectedJobId,
+			FutureUtils.completedExceptionally(new FlinkJobNotFoundException(expectedJobId)),
+			CompletableFuture.completedFuture(expectedExecutionGraph));
 
 		try (ExecutionGraphCache executionGraphCache = new ExecutionGraphCache(timeout, timeToLive)) {
-			CompletableFuture<AccessExecutionGraph> executionGraphFuture = executionGraphCache.getExecutionGraph(jobId, jobManagerGateway);
+			CompletableFuture<AccessExecutionGraph> executionGraphFuture = executionGraphCache.getExecutionGraph(expectedJobId, restfulGateway);
 
 			try {
 				executionGraphFuture.get();
@@ -148,9 +152,9 @@ public class ExecutionGraphCacheTest extends TestLogger {
 				assertTrue(ee.getCause() instanceof FlinkException);
 			}
 
-			CompletableFuture<AccessExecutionGraph> executionGraphFuture2 = executionGraphCache.getExecutionGraph(jobId, jobManagerGateway);
+			CompletableFuture<AccessExecutionGraph> executionGraphFuture2 = executionGraphCache.getExecutionGraph(expectedJobId, restfulGateway);
 
-			assertEquals(accessExecutionGraph, executionGraphFuture2.get());
+			assertEquals(expectedExecutionGraph, executionGraphFuture2.get());
 		}
 	}
 
@@ -162,27 +166,36 @@ public class ExecutionGraphCacheTest extends TestLogger {
 	public void testCacheEntryCleanup() throws Exception {
 		final Time timeout = Time.milliseconds(100L);
 		final Time timeToLive = Time.milliseconds(1L);
-		final JobID jobId1 = new JobID();
-		final JobID jobId2 = new JobID();
-		final AccessExecutionGraph accessExecutionGraph1 = mock(AccessExecutionGraph.class);
-		final AccessExecutionGraph accessExecutionGraph2 = mock(AccessExecutionGraph.class);
+		final JobID expectedJobId2 = new JobID();
+		final ArchivedExecutionGraph expectedExecutionGraph2 = new ArchivedExecutionGraphBuilder().build();
 
-		final JobManagerGateway jobManagerGateway = mock(JobManagerGateway.class);
-		when(jobManagerGateway.requestJob(eq(jobId1), any(Time.class))).thenReturn(CompletableFuture.completedFuture(accessExecutionGraph1));
-		when(jobManagerGateway.requestJob(eq(jobId2), any(Time.class))).thenReturn(CompletableFuture.completedFuture(accessExecutionGraph2));
+		final AtomicInteger requestJobCalls = new AtomicInteger(0);
+		final TestingRestfulGateway restfulGateway = TestingRestfulGateway.newBuilder()
+			.setRequestJobFunction(
+				jobId -> {
+					requestJobCalls.incrementAndGet();
+					if (jobId.equals(expectedJobId)) {
+						return CompletableFuture.completedFuture(expectedExecutionGraph);
+					} else if (jobId.equals(expectedJobId2)) {
+						return CompletableFuture.completedFuture(expectedExecutionGraph2);
+					} else {
+						throw new AssertionError("Invalid job id received.");
+					}
+				}
+			)
+			.build();
 
 		try (ExecutionGraphCache executionGraphCache = new ExecutionGraphCache(timeout, timeToLive)) {
 
-			CompletableFuture<AccessExecutionGraph> executionGraph1Future = executionGraphCache.getExecutionGraph(jobId1, jobManagerGateway);
+			CompletableFuture<AccessExecutionGraph> executionGraph1Future = executionGraphCache.getExecutionGraph(expectedJobId, restfulGateway);
 
-			CompletableFuture<AccessExecutionGraph> executionGraph2Future = executionGraphCache.getExecutionGraph(jobId2, jobManagerGateway);
+			CompletableFuture<AccessExecutionGraph> executionGraph2Future = executionGraphCache.getExecutionGraph(expectedJobId2, restfulGateway);
 
-			assertEquals(accessExecutionGraph1, executionGraph1Future.get());
+			assertEquals(expectedExecutionGraph, executionGraph1Future.get());
 
-			assertEquals(accessExecutionGraph2, executionGraph2Future.get());
+			assertEquals(expectedExecutionGraph2, executionGraph2Future.get());
 
-			verify(jobManagerGateway, times(1)).requestJob(eq(jobId1), any(Time.class));
-			verify(jobManagerGateway, times(1)).requestJob(eq(jobId2), any(Time.class));
+			assertThat(requestJobCalls.get(), Matchers.equalTo(2));
 
 			Thread.sleep(timeToLive.toMilliseconds());
 
@@ -199,12 +212,17 @@ public class ExecutionGraphCacheTest extends TestLogger {
 	public void testConcurrentAccess() throws Exception {
 		final Time timeout = Time.milliseconds(100L);
 		final Time timeToLive = Time.hours(1L);
-		final JobID jobId = new JobID();
 
-		final AccessExecutionGraph accessExecutionGraph = mock(AccessExecutionGraph.class);
-
-		final JobManagerGateway jobManagerGateway = mock(JobManagerGateway.class);
-		when(jobManagerGateway.requestJob(eq(jobId), any(Time.class))).thenReturn(CompletableFuture.completedFuture(accessExecutionGraph));
+		final AtomicInteger requestJobCalls = new AtomicInteger(0);
+		final TestingRestfulGateway restfulGateway = TestingRestfulGateway.newBuilder()
+			.setRequestJobFunction(
+				jobId -> {
+					requestJobCalls.incrementAndGet();
+					assertThat(jobId, Matchers.equalTo(expectedJobId));
+					return CompletableFuture.completedFuture(expectedExecutionGraph);
+				}
+			)
+			.build();
 
 		final int numConcurrentAccesses = 10;
 
@@ -216,7 +234,7 @@ public class ExecutionGraphCacheTest extends TestLogger {
 			for (int i = 0; i < numConcurrentAccesses; i++) {
 				CompletableFuture<AccessExecutionGraph> executionGraphFuture = CompletableFuture
 					.supplyAsync(
-						() -> executionGraphCache.getExecutionGraph(jobId, jobManagerGateway),
+						() -> executionGraphCache.getExecutionGraph(expectedJobId, restfulGateway),
 						executor)
 					.thenCompose(Function.identity());
 
@@ -228,10 +246,10 @@ public class ExecutionGraphCacheTest extends TestLogger {
 			Collection<AccessExecutionGraph> allExecutionGraphs = allExecutionGraphFutures.get();
 
 			for (AccessExecutionGraph executionGraph : allExecutionGraphs) {
-				assertEquals(accessExecutionGraph, executionGraph);
+				assertEquals(expectedExecutionGraph, executionGraph);
 			}
 
-			verify(jobManagerGateway, times(1)).requestJob(eq(jobId), any(Time.class));
+			assertThat(requestJobCalls.get(), Matchers.equalTo(1));
 		} finally {
 			ExecutorUtils.gracefulShutdown(5000L, TimeUnit.MILLISECONDS, executor);
 		}
@@ -248,27 +266,32 @@ public class ExecutionGraphCacheTest extends TestLogger {
 	public void testCacheInvalidationIfSuspended() throws Exception {
 		final Time timeout = Time.milliseconds(100L);
 		final Time timeToLive = Time.hours(1L);
-		final JobID jobId = new JobID();
+		final JobID expectedJobId = new JobID();
 
-		final AccessExecutionGraph accessExecutionGraph = mock(AccessExecutionGraph.class);
+		final ArchivedExecutionGraph suspendedExecutionGraph = new ArchivedExecutionGraphBuilder().setState(JobStatus.SUSPENDED).build();
+		final ConcurrentLinkedQueue<CompletableFuture<? extends AccessExecutionGraph>> requestJobAnswers = new ConcurrentLinkedQueue<>();
 
-		final AccessExecutionGraph suspendedExecutionGraph = mock(AccessExecutionGraph.class);
-		when(suspendedExecutionGraph.getState()).thenReturn(JobStatus.SUSPENDED);
+		requestJobAnswers.offer(CompletableFuture.completedFuture(suspendedExecutionGraph));
+		requestJobAnswers.offer(CompletableFuture.completedFuture(expectedExecutionGraph));
 
-		final JobManagerGateway jobManagerGateway = mock(JobManagerGateway.class);
-		// let's first answer with a suspended ExecutionGraph and then only with the correct result
-		when(jobManagerGateway.requestJob(eq(jobId), any(Time.class))).thenReturn(
-			CompletableFuture.completedFuture(suspendedExecutionGraph),
-			CompletableFuture.completedFuture(accessExecutionGraph));
+		final TestingRestfulGateway restfulGateway = TestingRestfulGateway.newBuilder()
+			.setRequestJobFunction(
+				jobId -> {
+					assertThat(jobId, Matchers.equalTo(expectedJobId));
+
+					return requestJobAnswers.poll();
+				}
+			)
+			.build();
 
 		try (ExecutionGraphCache executionGraphCache = new ExecutionGraphCache(timeout, timeToLive)) {
-			CompletableFuture<AccessExecutionGraph> executionGraphFuture = executionGraphCache.getExecutionGraph(jobId, jobManagerGateway);
+			CompletableFuture<AccessExecutionGraph> executionGraphFuture = executionGraphCache.getExecutionGraph(expectedJobId, restfulGateway);
 
 			assertEquals(suspendedExecutionGraph, executionGraphFuture.get());
 
-			CompletableFuture<AccessExecutionGraph> executionGraphFuture2 = executionGraphCache.getExecutionGraph(jobId, jobManagerGateway);
+			CompletableFuture<AccessExecutionGraph> executionGraphFuture2 = executionGraphCache.getExecutionGraph(expectedJobId, restfulGateway);
 
-			assertEquals(accessExecutionGraph, executionGraphFuture2.get());
+			assertEquals(expectedExecutionGraph, executionGraphFuture2.get());
 		}
 	}
 
@@ -283,35 +306,65 @@ public class ExecutionGraphCacheTest extends TestLogger {
 	public void testCacheInvalidationIfSwitchToSuspended() throws Exception {
 		final Time timeout = Time.milliseconds(100L);
 		final Time timeToLive = Time.hours(1L);
-		final JobID jobId = new JobID();
+		final JobID expectedJobId = new JobID();
 
-		final AccessExecutionGraph accessExecutionGraph = mock(AccessExecutionGraph.class);
+		final SuspendableAccessExecutionGraph toBeSuspendedExecutionGraph = new SuspendableAccessExecutionGraph(expectedJobId);
 
-		final SuspendableAccessExecutionGraph toBeSuspendedExecutionGraph = new SuspendableAccessExecutionGraph(jobId);
-
-		final JobManagerGateway jobManagerGateway = mock(JobManagerGateway.class);
-		// let's first answer with a JobNotFoundException and then only with the correct result
-		when(jobManagerGateway.requestJob(eq(jobId), any(Time.class))).thenReturn(
+		final CountingRestfulGateway restfulGateway = createCountingRestfulGateway(
+			expectedJobId,
 			CompletableFuture.completedFuture(toBeSuspendedExecutionGraph),
-			CompletableFuture.completedFuture(accessExecutionGraph));
+			CompletableFuture.completedFuture(expectedExecutionGraph));
 
 		try (ExecutionGraphCache executionGraphCache = new ExecutionGraphCache(timeout, timeToLive)) {
-			CompletableFuture<AccessExecutionGraph> executionGraphFuture = executionGraphCache.getExecutionGraph(jobId, jobManagerGateway);
+			CompletableFuture<AccessExecutionGraph> executionGraphFuture = executionGraphCache.getExecutionGraph(expectedJobId, restfulGateway);
 
 			assertEquals(toBeSuspendedExecutionGraph, executionGraphFuture.get());
 
 			toBeSuspendedExecutionGraph.setJobStatus(JobStatus.SUSPENDED);
 
 			// retrieve the same job from the cache again --> this should return it and invalidate the cache entry
-			CompletableFuture<AccessExecutionGraph> executionGraphFuture2 = executionGraphCache.getExecutionGraph(jobId, jobManagerGateway);
+			CompletableFuture<AccessExecutionGraph> executionGraphFuture2 = executionGraphCache.getExecutionGraph(expectedJobId, restfulGateway);
 
-			assertEquals(accessExecutionGraph, executionGraphFuture2.get());
+			assertEquals(expectedExecutionGraph, executionGraphFuture2.get());
 
-			CompletableFuture<AccessExecutionGraph> executionGraphFuture3 = executionGraphCache.getExecutionGraph(jobId, jobManagerGateway);
+			CompletableFuture<AccessExecutionGraph> executionGraphFuture3 = executionGraphCache.getExecutionGraph(expectedJobId, restfulGateway);
 
-			assertEquals(accessExecutionGraph, executionGraphFuture3.get());
+			assertEquals(expectedExecutionGraph, executionGraphFuture3.get());
 
-			verify(jobManagerGateway, times(2)).requestJob(eq(jobId), any(Time.class));
+			assertThat(restfulGateway.getNumRequestJobCalls(), Matchers.equalTo(2));
+		}
+	}
+
+	private CountingRestfulGateway createCountingRestfulGateway(JobID jobId, CompletableFuture<? extends AccessExecutionGraph>... accessExecutionGraphs) {
+		final ConcurrentLinkedQueue<CompletableFuture<? extends AccessExecutionGraph>> queue = new ConcurrentLinkedQueue<>(Arrays.asList(accessExecutionGraphs));
+		return new CountingRestfulGateway(
+			jobId,
+			ignored -> queue.poll());
+	}
+
+	/**
+	 * {@link RestfulGateway} implementation which counts the number of {@link #requestJob(JobID, Time)} calls.
+	 */
+	private static class CountingRestfulGateway extends TestingRestfulGateway {
+
+		private final JobID expectedJobId;
+
+		private int numRequestJobCalls = 0;
+
+		private CountingRestfulGateway(JobID expectedJobId, Function<JobID, CompletableFuture<? extends AccessExecutionGraph>> requestJobFunction) {
+			this.expectedJobId = Preconditions.checkNotNull(expectedJobId);
+			this.requestJobFunction = Preconditions.checkNotNull(requestJobFunction);
+		}
+
+		@Override
+		public CompletableFuture<? extends AccessExecutionGraph> requestJob(JobID jobId, Time timeout) {
+			assertThat(jobId, Matchers.equalTo(expectedJobId));
+			numRequestJobCalls++;
+			return super.requestJob(jobId, timeout);
+		}
+
+		public int getNumRequestJobCalls() {
+			return numRequestJobCalls;
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/JobExceptionsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/JobExceptionsHandlerTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
 import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.TestLogger;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ArrayNode;
@@ -42,7 +43,7 @@ import static org.mockito.Mockito.mock;
 /**
  * Tests for the JobExceptionsHandler.
  */
-public class JobExceptionsHandlerTest {
+public class JobExceptionsHandlerTest extends TestLogger {
 
 	@Test
 	public void testArchiver() throws Exception {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/utils/ArchivedExecutionGraphBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/utils/ArchivedExecutionGraphBuilder.java
@@ -117,9 +117,13 @@ public class ArchivedExecutionGraphBuilder {
 	}
 
 	public ArchivedExecutionGraph build() {
-		Preconditions.checkNotNull(tasks, "Tasks must not be null.");
 		JobID jobID = this.jobID != null ? this.jobID : new JobID();
 		String jobName = this.jobName != null ? this.jobName : "job_" + RANDOM.nextInt();
+
+		if (tasks == null) {
+			tasks = Collections.emptyMap();
+		}
+
 		return new ArchivedExecutionGraph(
 			jobID,
 			jobName,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/TestingRestfulGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/TestingRestfulGateway.java
@@ -1,0 +1,204 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.webmonitor;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
+import org.apache.flink.runtime.messages.webmonitor.ClusterOverview;
+import org.apache.flink.runtime.messages.webmonitor.MultipleJobsDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * Testing implementation of the {@link RestfulGateway}.
+ */
+public class TestingRestfulGateway implements RestfulGateway {
+
+	static final Function<JobID, CompletableFuture<? extends AccessExecutionGraph>> DEFAULT_REQUEST_JOB_FUNCTION = jobId -> FutureUtils.completedExceptionally(new UnsupportedOperationException());
+	static final Supplier<CompletableFuture<MultipleJobsDetails>> DEFAULT_REQUEST_MULTIPLE_JOB_DETAILS_SUPPLIER = () -> CompletableFuture.completedFuture(new MultipleJobsDetails(Collections.emptyList()));
+	static final Supplier<CompletableFuture<ClusterOverview>> DEFAULT_REQUEST_CLUSTER_OVERVIEW_SUPPLIER = () -> CompletableFuture.completedFuture(new ClusterOverview(0, 0, 0, 0, 0, 0, 0));
+	static final Supplier<CompletableFuture<Collection<String>>> DEFAULT_REQUEST_METRIC_QUERY_SERVICE_PATHS_SUPPLIER = () -> CompletableFuture.completedFuture(Collections.emptyList());
+	static final Supplier<CompletableFuture<Collection<Tuple2<ResourceID, String>>>> DEFAULT_REQUEST_TASK_MANAGER_METRIC_QUERY_SERVICE_PATHS_SUPPLIER = () -> CompletableFuture.completedFuture(Collections.emptyList());
+	static final String LOCALHOST = "localhost";
+
+	protected String address;
+
+	protected String hostname;
+
+	protected String restAddress;
+
+	protected Function<JobID, CompletableFuture<? extends AccessExecutionGraph>> requestJobFunction;
+
+	protected Supplier<CompletableFuture<MultipleJobsDetails>> requestMultipleJobDetailsSupplier;
+
+	protected Supplier<CompletableFuture<ClusterOverview>> requestClusterOverviewSupplier;
+
+	protected Supplier<CompletableFuture<Collection<String>>> requestMetricQueryServicePathsSupplier;
+
+	protected Supplier<CompletableFuture<Collection<Tuple2<ResourceID, String>>>> requestTaskManagerMetricQueryServicePathsSupplier;
+
+	public TestingRestfulGateway() {
+		this(
+			LOCALHOST,
+			LOCALHOST,
+			LOCALHOST,
+			DEFAULT_REQUEST_JOB_FUNCTION,
+			DEFAULT_REQUEST_MULTIPLE_JOB_DETAILS_SUPPLIER,
+			DEFAULT_REQUEST_CLUSTER_OVERVIEW_SUPPLIER,
+			DEFAULT_REQUEST_METRIC_QUERY_SERVICE_PATHS_SUPPLIER,
+			DEFAULT_REQUEST_TASK_MANAGER_METRIC_QUERY_SERVICE_PATHS_SUPPLIER);
+	}
+
+	public TestingRestfulGateway(
+			String address,
+			String hostname,
+			String restAddress,
+			Function<JobID, CompletableFuture<? extends AccessExecutionGraph>> requestJobFunction,
+			Supplier<CompletableFuture<MultipleJobsDetails>> requestMultipleJobDetailsSupplier,
+			Supplier<CompletableFuture<ClusterOverview>> requestClusterOverviewSupplier,
+			Supplier<CompletableFuture<Collection<String>>> requestMetricQueryServicePathsSupplier,
+			Supplier<CompletableFuture<Collection<Tuple2<ResourceID, String>>>> requestTaskManagerMetricQueryServicePathsSupplier) {
+		this.address = address;
+		this.hostname = hostname;
+		this.restAddress = restAddress;
+		this.requestJobFunction = requestJobFunction;
+		this.requestMultipleJobDetailsSupplier = requestMultipleJobDetailsSupplier;
+		this.requestClusterOverviewSupplier = requestClusterOverviewSupplier;
+		this.requestMetricQueryServicePathsSupplier = requestMetricQueryServicePathsSupplier;
+		this.requestTaskManagerMetricQueryServicePathsSupplier = requestTaskManagerMetricQueryServicePathsSupplier;
+	}
+
+	@Override
+	public CompletableFuture<String> requestRestAddress(Time timeout) {
+		return CompletableFuture.completedFuture(restAddress);
+	}
+
+	@Override
+	public CompletableFuture<? extends AccessExecutionGraph> requestJob(JobID jobId, Time timeout) {
+		return requestJobFunction.apply(jobId);
+	}
+
+	@Override
+	public CompletableFuture<MultipleJobsDetails> requestMultipleJobDetails(Time timeout) {
+		return requestMultipleJobDetailsSupplier.get();
+	}
+
+	@Override
+	public CompletableFuture<ClusterOverview> requestClusterOverview(Time timeout) {
+		return requestClusterOverviewSupplier.get();
+	}
+
+	@Override
+	public CompletableFuture<Collection<String>> requestMetricQueryServicePaths(Time timeout) {
+		return requestMetricQueryServicePathsSupplier.get();
+	}
+
+	@Override
+	public CompletableFuture<Collection<Tuple2<ResourceID, String>>> requestTaskManagerMetricQueryServicePaths(Time timeout) {
+		return requestTaskManagerMetricQueryServicePathsSupplier.get();
+	}
+
+	@Override
+	public String getAddress() {
+		return address;
+	}
+
+	@Override
+	public String getHostname() {
+		return hostname;
+	}
+
+	public static Builder newBuilder() {
+		return new Builder();
+	}
+
+	/**
+	 * Builder for the {@link TestingRestfulGateway}.
+	 */
+	public static final class Builder {
+		private String address = LOCALHOST;
+		private String hostname = LOCALHOST;
+		private String restAddress = LOCALHOST;
+		private Function<JobID, CompletableFuture<? extends AccessExecutionGraph>> requestJobFunction;
+		private Supplier<CompletableFuture<MultipleJobsDetails>> requestMultipleJobDetailsSupplier;
+		private Supplier<CompletableFuture<ClusterOverview>> requestClusterOverviewSupplier;
+		private Supplier<CompletableFuture<Collection<String>>> requestMetricQueryServicePathsSupplier;
+		private Supplier<CompletableFuture<Collection<Tuple2<ResourceID, String>>>> requestTaskManagerMetricQueryServicePathsSupplier;
+
+		public Builder() {
+			requestJobFunction = DEFAULT_REQUEST_JOB_FUNCTION;
+			requestMultipleJobDetailsSupplier = DEFAULT_REQUEST_MULTIPLE_JOB_DETAILS_SUPPLIER;
+			requestClusterOverviewSupplier = DEFAULT_REQUEST_CLUSTER_OVERVIEW_SUPPLIER;
+			requestMetricQueryServicePathsSupplier = DEFAULT_REQUEST_METRIC_QUERY_SERVICE_PATHS_SUPPLIER;
+			requestTaskManagerMetricQueryServicePathsSupplier = DEFAULT_REQUEST_TASK_MANAGER_METRIC_QUERY_SERVICE_PATHS_SUPPLIER;
+		}
+
+		public Builder setAddress(String address) {
+			this.address = address;
+			return this;
+		}
+
+		public Builder setHostname(String hostname) {
+			this.hostname = hostname;
+			return this;
+		}
+
+		public Builder setRestAddress(String restAddress) {
+			this.restAddress = restAddress;
+			return this;
+		}
+
+		public Builder setRequestJobFunction(Function<JobID, CompletableFuture<? extends AccessExecutionGraph>> requestJobFunction) {
+			this.requestJobFunction = requestJobFunction;
+			return this;
+		}
+
+		public Builder setRequestMultipleJobDetailsSupplier(Supplier<CompletableFuture<MultipleJobsDetails>> requestMultipleJobDetailsSupplier) {
+			this.requestMultipleJobDetailsSupplier = requestMultipleJobDetailsSupplier;
+			return this;
+		}
+
+		public Builder setRequestClusterOverviewSupplier(Supplier<CompletableFuture<ClusterOverview>> requestClusterOverviewSupplier) {
+			this.requestClusterOverviewSupplier = requestClusterOverviewSupplier;
+			return this;
+		}
+
+		public Builder setRequestMetricQueryServicePathsSupplier(Supplier<CompletableFuture<Collection<String>>> requestMetricQueryServicePathsSupplier) {
+			this.requestMetricQueryServicePathsSupplier = requestMetricQueryServicePathsSupplier;
+			return this;
+		}
+
+		public Builder setRequestTaskManagerMetricQueryServicePathsSupplier(Supplier<CompletableFuture<Collection<Tuple2<ResourceID, String>>>> requestTaskManagerMetricQueryServicePathsSupplier) {
+			this.requestTaskManagerMetricQueryServicePathsSupplier = requestTaskManagerMetricQueryServicePathsSupplier;
+			return this;
+		}
+
+		public TestingRestfulGateway build() {
+			return new TestingRestfulGateway(address, hostname, restAddress, requestJobFunction, requestMultipleJobDetailsSupplier, requestClusterOverviewSupplier, requestMetricQueryServicePathsSupplier, requestTaskManagerMetricQueryServicePathsSupplier);
+		}
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

Let JobMasterGateway#requestJob and DispatcherGateway#requestJob return a
CompletableFuture<SerializableExecutionGraph> instead of a
CompletableFuture<AccessExecutionGraph>. In order to support the old code
and the JobManagerGateway implementation we have to keep the return type
in RestfulGateway. Once the old code has been removed, we should change
this as well.

## Brief change log

- Change return type of `RestfulGateway#requestJob` to `CompletableFuture<? extends AccessExecutionGraph>`
- Change return type of `JobMasterGateway#requestJob` and `DispatcherGateway#requestJob` to `CompletableFuture<SerializableExecutionGraph>`
- Introduce `TestingRestfulGateway` as a testing utility
- Adapt `ExecutionGraphCacheTest` to use `TestingRestfulGateway` instead of Mockito mocks

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
