### PR TITLE
[FLINK-8453] [flip6] Add ArchivedExecutionGraphStore to Dispatcher

### DIFF
--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -242,6 +242,10 @@ Default value is `1 minute`.
 - `restart-strategy.failure-rate.delay`: Delay between restart attempts, used if the default restart strategy is set to "failure-rate".
 Default value is the `akka.ask.timeout`.
 
+- `jobstore.cache-size`: The job store cache size in bytes which is used to keep completed jobs in memory (DEFAULT: `52428800` (`50` MB)).
+
+- `jobstore.expiration-time`: The time in seconds after which a completed job expires and is purged from the job store (DEFAULT: `3600`).
+
 ## Full Reference
 
 ### HDFS

--- a/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSinkTest.java
+++ b/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSinkTest.java
@@ -34,6 +34,7 @@ import org.apache.flink.streaming.util.AbstractStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.util.NetUtils;
 import org.apache.flink.util.OperatingSystem;
+import org.apache.flink.util.TestLogger;
 
 import org.apache.avro.Schema;
 import org.apache.avro.file.DataFileConstants;
@@ -70,7 +71,7 @@ import java.util.Map;
 /**
  * Tests for the {@link BucketingSink}.
  */
-public class BucketingSinkTest {
+public class BucketingSinkTest extends TestLogger {
 	@ClassRule
 	public static TemporaryFolder tempFolder = new TemporaryFolder();
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/accumulators/AccumulatorHelper.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/accumulators/AccumulatorHelper.java
@@ -28,13 +28,16 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Helper functions for the interaction with {@link Accumulator}.
+ */
 @Internal
 public class AccumulatorHelper {
 
 	/**
 	 * Merge two collections of accumulators. The second will be merged into the
 	 * first.
-	 * 
+	 *
 	 * @param target
 	 *            The collection of accumulators that will be updated
 	 * @param toMerge
@@ -59,7 +62,7 @@ public class AccumulatorHelper {
 	}
 
 	/**
-	 * Workaround method for type safety
+	 * Workaround method for type safety.
 	 */
 	private static <V, R extends Serializable> void mergeSingle(Accumulator<?, ?> target,
 															Accumulator<?, ?> toMerge) {
@@ -74,14 +77,13 @@ public class AccumulatorHelper {
 
 	/**
 	 * Compare both classes and throw {@link UnsupportedOperationException} if
-	 * they differ
+	 * they differ.
 	 */
 	@SuppressWarnings("rawtypes")
-	public static void compareAccumulatorTypes(Object name,
-												Class<? extends Accumulator> first,
-												Class<? extends Accumulator> second)
-			throws UnsupportedOperationException
-	{
+	public static void compareAccumulatorTypes(
+			Object name,
+			Class<? extends Accumulator> first,
+			Class<? extends Accumulator> second) throws UnsupportedOperationException {
 		if (first == null || second == null) {
 			throw new NullPointerException();
 		}
@@ -102,7 +104,7 @@ public class AccumulatorHelper {
 
 	/**
 	 * Transform the Map with accumulators into a Map containing only the
-	 * results
+	 * results.
 	 */
 	public static Map<String, Object> toResultMap(Map<String, Accumulator<?, ?>> accumulators) {
 		Map<String, Object> resultMap = new HashMap<String, Object>();
@@ -134,7 +136,7 @@ public class AccumulatorHelper {
 	public static Map<String, Accumulator<?, ?>> copy(Map<String, Accumulator<?, ?>> accumulators) {
 		Map<String, Accumulator<?, ?>> result = new HashMap<String, Accumulator<?, ?>>();
 
-		for(Map.Entry<String, Accumulator<?, ?>> entry: accumulators.entrySet()){
+		for (Map.Entry<String, Accumulator<?, ?>> entry: accumulators.entrySet()){
 			result.put(entry.getKey(), entry.getValue().clone());
 		}
 
@@ -172,24 +174,4 @@ public class AccumulatorHelper {
 
 		return accumulators;
 	}
-
-	/**
-	 * Serializes the given accumulators.
-	 *
-	 * @param accumulators to serialize
-	 * @return Map of serialized accumulators
-	 * @throws IOException if an accumulator could not be serialized
-	 */
-	public static Map<String, SerializedValue<Object>> serializeAccumulators(Map<String, Accumulator<?, ?>> accumulators) throws IOException {
-		final Map<String, SerializedValue<Object>> serializedAccumulators = new HashMap<>(accumulators.size());
-
-		for (Map.Entry<String, Accumulator<?, ?>> stringAccumulatorEntry : accumulators.entrySet()) {
-			serializedAccumulators.put(
-				stringAccumulatorEntry.getKey(),
-				new SerializedValue<>(stringAccumulatorEntry.getValue()));
-		}
-
-		return serializedAccumulators;
-	}
-
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/accumulators/AccumulatorHelper.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/accumulators/AccumulatorHelper.java
@@ -173,4 +173,23 @@ public class AccumulatorHelper {
 		return accumulators;
 	}
 
+	/**
+	 * Serializes the given accumulators.
+	 *
+	 * @param accumulators to serialize
+	 * @return Map of serialized accumulators
+	 * @throws IOException if an accumulator could not be serialized
+	 */
+	public static Map<String, SerializedValue<Object>> serializeAccumulators(Map<String, Accumulator<?, ?>> accumulators) throws IOException {
+		final Map<String, SerializedValue<Object>> serializedAccumulators = new HashMap<>(accumulators.size());
+
+		for (Map.Entry<String, Accumulator<?, ?>> stringAccumulatorEntry : accumulators.entrySet()) {
+			serializedAccumulators.put(
+				stringAccumulatorEntry.getKey(),
+				new SerializedValue<>(stringAccumulatorEntry.getValue()));
+		}
+
+		return serializedAccumulators;
+	}
+
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/accumulators/FailedAccumulatorSerialization.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/accumulators/FailedAccumulatorSerialization.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.accumulators;
+
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.Preconditions;
+
+import java.io.Serializable;
+
+/**
+ * {@link Accumulator} implementation which indicates a serialization problem with the original
+ * accumulator. Accessing any of the {@link Accumulator} method will result in throwing the
+ * serialization exception.
+ *
+ * @param <V> type of the value
+ * @param <R> type of the accumulator result
+ */
+public class FailedAccumulatorSerialization<V, R extends Serializable> implements Accumulator<V, R> {
+	private static final long serialVersionUID = 6965908827065879760L;
+
+	private final Throwable throwable;
+
+	public FailedAccumulatorSerialization(Throwable throwable) {
+		this.throwable = Preconditions.checkNotNull(throwable);
+	}
+
+	public Throwable getThrowable() {
+		return throwable;
+	}
+
+	@Override
+	public void add(V value) {
+		ExceptionUtils.rethrow(throwable);
+	}
+
+	@Override
+	public R getLocalValue() {
+		ExceptionUtils.rethrow(throwable);
+		return null;
+	}
+
+	@Override
+	public void resetLocal() {
+		ExceptionUtils.rethrow(throwable);
+	}
+
+	@Override
+	public void merge(Accumulator<V, R> other) {
+		ExceptionUtils.rethrow(throwable);
+	}
+
+	@Override
+	public Accumulator<V, R> clone() {
+		ExceptionUtils.rethrow(throwable);
+		return null;
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
@@ -96,6 +96,23 @@ public class JobManagerOptions {
 		key("jobmanager.archive.fs.dir")
 			.noDefaultValue();
 
+	/**
+	 * The job store cache size in bytes which is used to keep completed
+	 * jobs in memory.
+	 */
+	public static final ConfigOption<Long> JOB_STORE_CACHE_SIZE =
+		key("jobstore.cache-size")
+		.defaultValue(50L * 1024L * 1024L)
+		.withDescription("The job store cache size in bytes which is used to keep completed jobs in memory.");
+
+	/**
+	 * The time in seconds after which a completed job expires and is purged from the job store.
+	 */
+	public static final ConfigOption<Long> JOB_STORE_EXPIRATION_TIME =
+		key("jobstore.expiration-time")
+		.defaultValue(60L * 60L)
+		.withDescription("The time in seconds after which a completed job expires and is purged from the job store.");
+
 	// ---------------------------------------------------------------------------------------------
 
 	private JobManagerOptions() {

--- a/flink-core/src/test/java/org/apache/flink/api/common/accumulators/FailedAccumulatorSerializationTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/accumulators/FailedAccumulatorSerializationTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.accumulators;
+
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.InstantiationUtil;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for the {@link FailedAccumulatorSerialization}.
+ */
+public class FailedAccumulatorSerializationTest extends TestLogger {
+
+	private static final IOException TEST_EXCEPTION = new IOException("Test exception");
+
+	/**
+	 * Tests that any method call will throw the contained throwable (wrapped in an
+	 * unchecked exception if it is checked).
+	 */
+	@Test
+	public void testMethodCallThrowsException() {
+		final FailedAccumulatorSerialization<Integer, Integer> accumulator = new FailedAccumulatorSerialization<>(TEST_EXCEPTION);
+
+		try {
+			accumulator.getLocalValue();
+		} catch (RuntimeException re) {
+			assertThat(ExceptionUtils.findThrowableWithMessage(re, TEST_EXCEPTION.getMessage()).isPresent(), is(true));
+		}
+
+		try {
+			accumulator.resetLocal();
+		} catch (RuntimeException re) {
+			assertThat(ExceptionUtils.findThrowableWithMessage(re, TEST_EXCEPTION.getMessage()).isPresent(), is(true));
+		}
+
+		try {
+			accumulator.add(1);
+		} catch (RuntimeException re) {
+			assertThat(ExceptionUtils.findThrowableWithMessage(re, TEST_EXCEPTION.getMessage()).isPresent(), is(true));
+		}
+
+		try {
+			accumulator.merge(new IntMinimum());
+		} catch (RuntimeException re) {
+			assertThat(ExceptionUtils.findThrowableWithMessage(re, TEST_EXCEPTION.getMessage()).isPresent(), is(true));
+		}
+	}
+
+	/**
+	 * Tests that the class can be serialized and deserialized using Java serialization.
+	 */
+	@Test
+	public void testSerialization() throws Exception {
+		final FailedAccumulatorSerialization<?, ?> accumulator = new FailedAccumulatorSerialization<>(TEST_EXCEPTION);
+
+		final byte[] serializedAccumulator = InstantiationUtil.serializeObject(accumulator);
+
+		final FailedAccumulatorSerialization<?, ?> deserializedAccumulator = InstantiationUtil.deserializeObject(serializedAccumulator, ClassLoader.getSystemClassLoader());
+
+		assertThat(deserializedAccumulator.getThrowable(), is(instanceOf(TEST_EXCEPTION.getClass())));
+		assertThat(deserializedAccumulator.getThrowable().getMessage(), is(equalTo(TEST_EXCEPTION.getMessage())));
+	}
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobUtils.java
@@ -306,7 +306,7 @@ public class BlobUtils {
 	/**
 	 * Adds a shutdown hook to the JVM and returns the Thread, which has been registered.
 	 */
-	static Thread addShutdownHook(final Closeable service, final Logger logger) {
+	public static Thread addShutdownHook(final Closeable service, final Logger logger) {
 		checkNotNull(service);
 		checkNotNull(logger);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/ArchivedExecutionGraphStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/ArchivedExecutionGraphStore.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
+import org.apache.flink.runtime.messages.webmonitor.JobDetails;
+import org.apache.flink.runtime.messages.webmonitor.JobsOverview;
+
+import javax.annotation.Nullable;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Collection;
+
+/**
+ * Interface for a {@link ArchivedExecutionGraph} store.
+ */
+public interface ArchivedExecutionGraphStore extends Closeable {
+
+	/**
+	 * Returns the current number of stored {@link ArchivedExecutionGraph}.
+	 *
+	 * @return Current number of stored {@link ArchivedExecutionGraph}
+	 */
+	int size();
+
+	/**
+	 * Get the {@link ArchivedExecutionGraph} for the given job id. Null if it isn't stored.
+	 *
+	 * @param jobId identifying the serializable execution graph to retrieve
+	 * @return The stored serializable execution graph or null
+	 */
+	@Nullable
+	ArchivedExecutionGraph get(JobID jobId);
+
+	/**
+	 * Store the given {@link ArchivedExecutionGraph} in the store.
+	 *
+	 * @param archivedExecutionGraph to store
+	 * @throws IOException if the serializable execution graph could not be stored in the store
+	 */
+	void put(ArchivedExecutionGraph archivedExecutionGraph) throws IOException;
+
+	/**
+	 * Return the {@link JobsOverview} for all stored/past jobs.
+	 *
+	 * @return Jobs overview for all stored/past jobs
+	 */
+	JobsOverview getStoredJobsOverview();
+
+	/**
+	 * Return the collection of {@link JobDetails} of all currently stored jobs.
+	 *
+	 * @return Collection of job details of all currently stored jobs
+	 */
+	Collection<JobDetails> getAvailableJobDetails();
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -511,7 +511,10 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 	}
 
 	private void jobReachedGloballyTerminalState(ArchivedExecutionGraph archivedExecutionGraph) {
-		Preconditions.checkArgument(archivedExecutionGraph.getState().isGloballyTerminalState(), "");
+		Preconditions.checkArgument(
+			archivedExecutionGraph.getState().isGloballyTerminalState(),
+			"Job " + archivedExecutionGraph.getJobID() + " is in state " +
+				archivedExecutionGraph.getState() + " which is not globally terminal.");
 		final JobResult jobResult = JobResult.createFrom(archivedExecutionGraph);
 
 		jobExecutionResultCache.put(jobResult);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.client.JobSubmissionException;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.highavailability.RunningJobsRegistry;
@@ -485,6 +486,19 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 		fatalErrorHandler.onFatalError(throwable);
 	}
 
+	private void jobReachedGloballyTerminalState(AccessExecutionGraph accessExecutionGraph) {
+		final JobResult jobResult = JobResult.createFrom(accessExecutionGraph);
+
+		jobExecutionResultCache.put(jobResult);
+		final JobID jobId = accessExecutionGraph.getJobID();
+
+		try {
+			removeJob(jobId, true);
+		} catch (Exception e) {
+			log.warn("Could not properly remove job {} from the dispatcher.", jobId, e);
+		}
+	}
+
 	protected abstract JobManagerRunner createJobManagerRunner(
 		ResourceID resourceId,
 		JobGraph jobGraph,
@@ -607,31 +621,10 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 		}
 
 		@Override
-		public void jobFinished(JobResult result) {
-			log.info("Job {} finished.", jobId);
+		public void jobReachedGloballyTerminalState(ArchivedExecutionGraph executionGraph) {
+			log.info("Job {} reached globally terminal state {}.", jobId, executionGraph.getState());
 
-			runAsync(() -> {
-				jobExecutionResultCache.put(result);
-				try {
-					removeJob(jobId, true);
-				} catch (Exception e) {
-					log.warn("Could not properly remove job {} from the dispatcher.", jobId, e);
-				}
-			});
-		}
-
-		@Override
-		public void jobFailed(JobResult result) {
-			log.info("Job {} failed.", jobId);
-
-			runAsync(() -> {
-				jobExecutionResultCache.put(result);
-				try {
-					removeJob(jobId, true);
-				} catch (Exception e) {
-					log.warn("Could not properly remove job {} from the dispatcher.", jobId, e);
-				}
-			});
+			runAsync(() -> Dispatcher.this.jobReachedGloballyTerminalState(executionGraph));
 		}
 
 		@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -331,13 +331,13 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 	}
 
 	@Override
-	public CompletableFuture<AccessExecutionGraph> requestJob(JobID jobId, Time timeout) {
+	public CompletableFuture<ArchivedExecutionGraph> requestJob(JobID jobId, Time timeout) {
 		final JobManagerRunner jobManagerRunner = jobManagerRunners.get(jobId);
 
 		if (jobManagerRunner == null) {
 			return FutureUtils.completedExceptionally(new FlinkJobNotFoundException(jobId));
 		} else {
-			return jobManagerRunner.getJobManagerGateway().requestArchivedExecutionGraph(timeout);
+			return jobManagerRunner.getJobManagerGateway().requestJob(jobId, timeout);
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -27,7 +27,6 @@ import org.apache.flink.runtime.blob.BlobServer;
 import org.apache.flink.runtime.client.JobSubmissionException;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.concurrent.FutureUtils;
-import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
@@ -47,6 +46,7 @@ import org.apache.flink.runtime.messages.FlinkJobNotFoundException;
 import org.apache.flink.runtime.messages.JobExecutionResultGoneException;
 import org.apache.flink.runtime.messages.webmonitor.ClusterOverview;
 import org.apache.flink.runtime.messages.webmonitor.JobDetails;
+import org.apache.flink.runtime.messages.webmonitor.JobsOverview;
 import org.apache.flink.runtime.messages.webmonitor.MultipleJobsDetails;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
@@ -102,6 +102,8 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 
 	private final JobExecutionResultCache jobExecutionResultCache = new JobExecutionResultCache();
 
+	private final ArchivedExecutionGraphStore archivedExecutionGraphStore;
+
 	@Nullable
 	protected final String restAddress;
 
@@ -114,6 +116,7 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 			BlobServer blobServer,
 			HeartbeatServices heartbeatServices,
 			MetricRegistry metricRegistry,
+			ArchivedExecutionGraphStore archivedExecutionGraphStore,
 			FatalErrorHandler fatalErrorHandler,
 			@Nullable String restAddress) throws Exception {
 		super(rpcService, endpointId);
@@ -136,6 +139,8 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 		leaderElectionService = highAvailabilityServices.getDispatcherLeaderElectionService();
 
 		this.restAddress = restAddress;
+
+		this.archivedExecutionGraphStore = Preconditions.checkNotNull(archivedExecutionGraphStore);
 	}
 
 	//------------------------------------------------------
@@ -307,10 +312,15 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 
 		CompletableFuture<Collection<JobStatus>> allJobsFuture = FutureUtils.combineAll(jobStatus);
 
+		final JobsOverview completedJobsOverview = archivedExecutionGraphStore.getStoredJobsOverview();
+
 		return allJobsFuture.thenCombine(
 			taskManagerOverviewFuture,
-			(Collection<JobStatus> allJobsStatus, ResourceOverview resourceOverview) ->
-				ClusterOverview.create(resourceOverview, allJobsStatus));
+			(Collection<JobStatus> runningJobsStatus, ResourceOverview resourceOverview) -> {
+				final JobsOverview allJobsOverview = JobsOverview.create(runningJobsStatus).combine(completedJobsOverview);
+				return new ClusterOverview(resourceOverview, allJobsOverview);
+			});
+
 	}
 
 	@Override
@@ -325,9 +335,16 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 
 		CompletableFuture<Collection<JobDetails>> combinedJobDetails = FutureUtils.combineAll(individualJobDetails);
 
+		final Collection<JobDetails> completedJobDetails = archivedExecutionGraphStore.getAvailableJobDetails();
+
 		return combinedJobDetails.thenApply(
-			(Collection<JobDetails> jobDetails) ->
-				new MultipleJobsDetails(jobDetails));
+			(Collection<JobDetails> runningJobDetails) -> {
+				final Collection<JobDetails> allJobDetails = new ArrayList<>(completedJobDetails.size() + runningJobDetails.size());
+				allJobDetails.addAll(runningJobDetails);
+				allJobDetails.addAll(completedJobDetails);
+				return new MultipleJobsDetails(allJobDetails);
+			});
+
 	}
 
 	@Override
@@ -335,7 +352,14 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 		final JobManagerRunner jobManagerRunner = jobManagerRunners.get(jobId);
 
 		if (jobManagerRunner == null) {
-			return FutureUtils.completedExceptionally(new FlinkJobNotFoundException(jobId));
+			final ArchivedExecutionGraph serializableExecutionGraph = archivedExecutionGraphStore.get(jobId);
+
+			// check whether it is a completed job
+			if (serializableExecutionGraph == null) {
+				return FutureUtils.completedExceptionally(new FlinkJobNotFoundException(jobId));
+			} else {
+				return CompletableFuture.completedFuture(serializableExecutionGraph);
+			}
 		} else {
 			return jobManagerRunner.getJobManagerGateway().requestJob(jobId, timeout);
 		}
@@ -486,11 +510,22 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 		fatalErrorHandler.onFatalError(throwable);
 	}
 
-	private void jobReachedGloballyTerminalState(AccessExecutionGraph accessExecutionGraph) {
-		final JobResult jobResult = JobResult.createFrom(accessExecutionGraph);
+	private void jobReachedGloballyTerminalState(ArchivedExecutionGraph archivedExecutionGraph) {
+		Preconditions.checkArgument(archivedExecutionGraph.getState().isGloballyTerminalState(), "");
+		final JobResult jobResult = JobResult.createFrom(archivedExecutionGraph);
 
 		jobExecutionResultCache.put(jobResult);
-		final JobID jobId = accessExecutionGraph.getJobID();
+		final JobID jobId = archivedExecutionGraph.getJobID();
+
+		try {
+			archivedExecutionGraphStore.put(archivedExecutionGraph);
+		} catch (IOException e) {
+			log.info(
+				"Could not store completed job {}({}).",
+				archivedExecutionGraph.getJobName(),
+				archivedExecutionGraph.getJobID(),
+				e);
+		}
 
 		try {
 			removeJob(jobId, true);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherGateway.java
@@ -20,8 +20,10 @@ package org.apache.flink.runtime.dispatcher;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.messages.FlinkJobNotFoundException;
 import org.apache.flink.runtime.rpc.FencedRpcGateway;
 import org.apache.flink.runtime.rpc.RpcTimeout;
 import org.apache.flink.runtime.webmonitor.RestfulGateway;
@@ -79,4 +81,18 @@ public interface DispatcherGateway extends FencedRpcGateway<DispatcherId>, Restf
 	 * @return A future integer of the blob server port
 	 */
 	CompletableFuture<Integer> getBlobServerPort(@RpcTimeout Time timeout);
+
+	/**
+	 * Requests the {@link ArchivedExecutionGraph} for the given jobId. If there is no such graph, then
+	 * the future is completed with a {@link FlinkJobNotFoundException}.
+	 *
+	 * <p>Note: We enforce that the returned future contains a {@link ArchivedExecutionGraph} unlike
+	 * the super interface.
+	 *
+	 * @param jobId identifying the job whose AccessExecutionGraph is requested
+	 * @param timeout for the asynchronous operation
+	 * @return Future containing the AccessExecutionGraph for the given jobId, otherwise {@link FlinkJobNotFoundException}
+	 */
+	@Override
+	CompletableFuture<ArchivedExecutionGraph> requestJob(JobID jobId, @RpcTimeout Time timeout);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/FileArchivedExecutionGraphStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/FileArchivedExecutionGraphStore.java
@@ -32,6 +32,7 @@ import org.apache.flink.util.FileUtils;
 import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.Preconditions;
 
+import org.apache.flink.shaded.guava18.com.google.common.base.Ticker;
 import org.apache.flink.shaded.guava18.com.google.common.cache.Cache;
 import org.apache.flink.shaded.guava18.com.google.common.cache.CacheBuilder;
 import org.apache.flink.shaded.guava18.com.google.common.cache.CacheLoader;
@@ -83,7 +84,8 @@ public class FileArchivedExecutionGraphStore implements ArchivedExecutionGraphSt
 			File rootDir,
 			Time expirationTime,
 			long maximumCacheSizeBytes,
-			ScheduledExecutor scheduledExecutor) throws IOException {
+			ScheduledExecutor scheduledExecutor,
+			Ticker ticker) throws IOException {
 
 		final File storageDirectory = initExecutionGraphStorageDirectory(rootDir);
 
@@ -102,6 +104,7 @@ public class FileArchivedExecutionGraphStore implements ArchivedExecutionGraphSt
 			.expireAfterWrite(expirationTime.toMilliseconds(), TimeUnit.MILLISECONDS)
 			.removalListener(
 				(RemovalListener<JobID, JobDetails>) notification -> deleteExecutionGraphFile(notification.getKey()))
+			.ticker(ticker)
 			.build();
 
 		this.archivedExecutionGraphCache = CacheBuilder.newBuilder()

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/FileArchivedExecutionGraphStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/FileArchivedExecutionGraphStore.java
@@ -1,0 +1,298 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.blob.BlobUtils;
+import org.apache.flink.runtime.concurrent.ScheduledExecutor;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
+import org.apache.flink.runtime.jobgraph.JobStatus;
+import org.apache.flink.runtime.messages.webmonitor.JobDetails;
+import org.apache.flink.runtime.messages.webmonitor.JobsOverview;
+import org.apache.flink.runtime.webmonitor.WebMonitorUtils;
+import org.apache.flink.util.FileUtils;
+import org.apache.flink.util.InstantiationUtil;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.flink.shaded.guava18.com.google.common.cache.Cache;
+import org.apache.flink.shaded.guava18.com.google.common.cache.CacheBuilder;
+import org.apache.flink.shaded.guava18.com.google.common.cache.CacheLoader;
+import org.apache.flink.shaded.guava18.com.google.common.cache.LoadingCache;
+import org.apache.flink.shaded.guava18.com.google.common.cache.RemovalListener;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Store for {@link ArchivedExecutionGraph}. The store writes the archived execution graph to disk
+ * and keeps the most recently used execution graphs in a memory cache for faster serving. Moreover,
+ * the stored execution graphs are periodically cleaned up.
+ */
+public class FileArchivedExecutionGraphStore implements ArchivedExecutionGraphStore {
+
+	private static final Logger LOG = LoggerFactory.getLogger(FileArchivedExecutionGraphStore.class);
+
+	private final File storageDir;
+
+	private final Cache<JobID, JobDetails> jobDetailsCache;
+
+	private final LoadingCache<JobID, ArchivedExecutionGraph> archivedExecutionGraphCache;
+
+	private final ScheduledFuture<?> cleanupFuture;
+
+	private final Thread shutdownHook;
+
+	private int numFinishedJobs;
+
+	private int numFailedJobs;
+
+	private int numCanceledJobs;
+
+	public FileArchivedExecutionGraphStore(
+			File rootDir,
+			Time expirationTime,
+			long maximumCacheSizeBytes,
+			ScheduledExecutor scheduledExecutor) throws IOException {
+
+		final File storageDirectory = initExecutionGraphStorageDirectory(rootDir);
+
+		LOG.info(
+			"Initializing {}: Storage directory {}, expiration time {}, maximum cache size {} bytes.",
+			FileArchivedExecutionGraphStore.class.getSimpleName(),
+			storageDirectory,
+			expirationTime.toMilliseconds(),
+			maximumCacheSizeBytes);
+
+		this.storageDir = Preconditions.checkNotNull(storageDirectory);
+		Preconditions.checkArgument(
+			storageDirectory.exists() && storageDirectory.isDirectory(),
+			"The storage directory must exist and be a directory.");
+		this.jobDetailsCache = CacheBuilder.newBuilder()
+			.expireAfterWrite(expirationTime.toMilliseconds(), TimeUnit.MILLISECONDS)
+			.removalListener(
+				(RemovalListener<JobID, JobDetails>) notification -> deleteExecutionGraphFile(notification.getKey()))
+			.build();
+
+		this.archivedExecutionGraphCache = CacheBuilder.newBuilder()
+			.maximumWeight(maximumCacheSizeBytes)
+			.weigher(this::calculateSize)
+			.build(new CacheLoader<JobID, ArchivedExecutionGraph>() {
+				@Override
+				public ArchivedExecutionGraph load(JobID jobId) throws Exception {
+					return loadExecutionGraph(jobId);
+				}});
+
+		this.cleanupFuture = scheduledExecutor.scheduleWithFixedDelay(
+			jobDetailsCache::cleanUp,
+			expirationTime.toMilliseconds(),
+			expirationTime.toMilliseconds(),
+			TimeUnit.MILLISECONDS);
+
+		this.shutdownHook = BlobUtils.addShutdownHook(this, LOG);
+
+		this.numFinishedJobs = 0;
+		this.numFailedJobs = 0;
+		this.numCanceledJobs = 0;
+	}
+
+	@Override
+	public int size() {
+		return Math.toIntExact(jobDetailsCache.size());
+	}
+
+	@Override
+	@Nullable
+	public ArchivedExecutionGraph get(JobID jobId) {
+		try {
+			return archivedExecutionGraphCache.get(jobId);
+		} catch (ExecutionException e) {
+			LOG.debug("Could not load archived execution graph for job id {}.", jobId, e);
+			return null;
+		}
+	}
+
+	@Override
+	public void put(ArchivedExecutionGraph archivedExecutionGraph) throws IOException {
+		final JobStatus jobStatus = archivedExecutionGraph.getState();
+		final JobID jobId = archivedExecutionGraph.getJobID();
+		final String jobName = archivedExecutionGraph.getJobName();
+
+		Preconditions.checkArgument(
+			jobStatus.isGloballyTerminalState(),
+			"The job " + jobName + '(' + jobId +
+				") is not in a globally terminal state. Instead it is in state " + jobStatus + '.');
+
+		switch (jobStatus) {
+			case FINISHED:
+				numFinishedJobs++;
+				break;
+			case CANCELED:
+				numCanceledJobs++;
+				break;
+			case FAILED:
+				numFailedJobs++;
+				break;
+			default:
+				throw new IllegalStateException("The job " + jobName + '(' +
+					jobId + ") should have been in a globally terminal state. " +
+					"Instead it was in state " + jobStatus + '.');
+		}
+
+		// write the ArchivedExecutionGraph to disk
+		storeArchivedExecutionGraph(archivedExecutionGraph);
+
+		final JobDetails detailsForJob = WebMonitorUtils.createDetailsForJob(archivedExecutionGraph);
+
+		jobDetailsCache.put(jobId, detailsForJob);
+		archivedExecutionGraphCache.put(jobId, archivedExecutionGraph);
+	}
+
+	@Override
+	public JobsOverview getStoredJobsOverview() {
+		return new JobsOverview(0, numFinishedJobs, numCanceledJobs, numFailedJobs);
+	}
+
+	@Override
+	public Collection<JobDetails> getAvailableJobDetails() {
+		return jobDetailsCache.asMap().values();
+	}
+
+	@Override
+	public void close() throws IOException {
+		cleanupFuture.cancel(false);
+
+		jobDetailsCache.invalidateAll();
+
+		// clean up the storage directory
+		FileUtils.deleteFileOrDirectory(storageDir);
+
+		// Remove shutdown hook to prevent resource leaks, unless this is invoked by the
+		// shutdown hook itself
+		if (shutdownHook != null && shutdownHook != Thread.currentThread()) {
+			try {
+				Runtime.getRuntime().removeShutdownHook(shutdownHook);
+			}
+			catch (IllegalStateException e) {
+				// race, JVM is in shutdown already, we can safely ignore this
+			}
+			catch (Throwable t) {
+				LOG.warn("Exception while unregistering FileArchivedExecutionGraphStore's cleanup shutdown hook.", t);
+			}
+		}
+	}
+
+	// --------------------------------------------------------------
+	// Internal methods
+	// --------------------------------------------------------------
+
+	private int calculateSize(JobID jobId, ArchivedExecutionGraph serializableExecutionGraph) {
+		final File archivedExecutionGraphFile = getExecutionGraphFile(jobId);
+
+		if (archivedExecutionGraphFile.exists()) {
+			return Math.toIntExact(archivedExecutionGraphFile.length());
+		} else {
+			LOG.debug("Could not find archived execution graph file for {}. Estimating the size instead.", jobId);
+			return serializableExecutionGraph.getAllVertices().size() * 1000 +
+				serializableExecutionGraph.getAccumulatorsSerialized().size() * 1000;
+		}
+	}
+
+	private ArchivedExecutionGraph loadExecutionGraph(JobID jobId) throws IOException, ClassNotFoundException {
+		final File archivedExecutionGraphFile = getExecutionGraphFile(jobId);
+
+		if (archivedExecutionGraphFile.exists()) {
+			try (FileInputStream fileInputStream = new FileInputStream(archivedExecutionGraphFile)) {
+				return InstantiationUtil.deserializeObject(fileInputStream, getClass().getClassLoader());
+			}
+		} else {
+			throw new FileNotFoundException("Could not find file for archived execution graph " + jobId +
+				". This indicates that the file either has been deleted or never written.");
+		}
+	}
+
+	private void storeArchivedExecutionGraph(ArchivedExecutionGraph archivedExecutionGraph) throws IOException {
+		final File archivedExecutionGraphFile = getExecutionGraphFile(archivedExecutionGraph.getJobID());
+
+		try (FileOutputStream fileOutputStream = new FileOutputStream(archivedExecutionGraphFile)) {
+			InstantiationUtil.serializeObject(fileOutputStream, archivedExecutionGraph);
+		}
+	}
+
+	private File getExecutionGraphFile(JobID jobId) {
+		return new File(storageDir, jobId.toString());
+	}
+
+	private void deleteExecutionGraphFile(JobID jobId) {
+		Preconditions.checkNotNull(jobId);
+
+		final File archivedExecutionGraphFile = getExecutionGraphFile(jobId);
+
+		try {
+			FileUtils.deleteFileOrDirectory(archivedExecutionGraphFile);
+		} catch (IOException e) {
+			LOG.debug("Could not delete file {}.", archivedExecutionGraphFile, e);
+		}
+
+		archivedExecutionGraphCache.invalidate(jobId);
+		jobDetailsCache.invalidate(jobId);
+	}
+
+	private static File initExecutionGraphStorageDirectory(File tmpDir) throws IOException {
+		final int maxAttempts = 10;
+
+		for (int attempt = 0; attempt < maxAttempts; attempt++) {
+			final File storageDirectory = new File(tmpDir, "executionGraphStore-" + UUID.randomUUID());
+
+			if (storageDirectory.mkdir()) {
+				return storageDirectory;
+			}
+		}
+
+		throw new IOException("Could not create executionGraphStorage directory in " + tmpDir + '.');
+	}
+
+	// --------------------------------------------------------------
+	// Testing methods
+	// --------------------------------------------------------------
+
+	@VisibleForTesting
+	File getStorageDir() {
+		return storageDir;
+	}
+
+	@VisibleForTesting
+	LoadingCache<JobID, ArchivedExecutionGraph> getArchivedExecutionGraphCache() {
+		return archivedExecutionGraphCache;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/StandaloneDispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/StandaloneDispatcher.java
@@ -50,6 +50,7 @@ public class StandaloneDispatcher extends Dispatcher {
 			BlobServer blobServer,
 			HeartbeatServices heartbeatServices,
 			MetricRegistry metricRegistry,
+			ArchivedExecutionGraphStore archivedExecutionGraphStore,
 			FatalErrorHandler fatalErrorHandler,
 			@Nullable String restAddress) throws Exception {
 		super(
@@ -61,6 +62,7 @@ public class StandaloneDispatcher extends Dispatcher {
 			blobServer,
 			heartbeatServices,
 			metricRegistry,
+			archivedExecutionGraphStore,
 			fatalErrorHandler,
 			restAddress);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/SessionClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/SessionClusterEntrypoint.java
@@ -20,13 +20,18 @@ package org.apache.flink.runtime.entrypoint;
 
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ConfigurationUtils;
+import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.WebOptions;
 import org.apache.flink.runtime.blob.BlobServer;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.concurrent.ScheduledExecutor;
+import org.apache.flink.runtime.dispatcher.ArchivedExecutionGraphStore;
 import org.apache.flink.runtime.dispatcher.Dispatcher;
 import org.apache.flink.runtime.dispatcher.DispatcherGateway;
 import org.apache.flink.runtime.dispatcher.DispatcherId;
 import org.apache.flink.runtime.dispatcher.DispatcherRestEndpoint;
+import org.apache.flink.runtime.dispatcher.FileArchivedExecutionGraphStore;
 import org.apache.flink.runtime.dispatcher.StandaloneDispatcher;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
@@ -51,6 +56,8 @@ import akka.actor.ActorSystem;
 
 import javax.annotation.Nullable;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.concurrent.Executor;
 
 /**
@@ -68,6 +75,8 @@ public abstract class SessionClusterEntrypoint extends ClusterEntrypoint {
 
 	private DispatcherRestEndpoint dispatcherRestEndpoint;
 
+	private ArchivedExecutionGraphStore archivedExecutionGraphStore;
+
 	public SessionClusterEntrypoint(Configuration configuration) {
 		super(configuration);
 	}
@@ -80,6 +89,8 @@ public abstract class SessionClusterEntrypoint extends ClusterEntrypoint {
 			BlobServer blobServer,
 			HeartbeatServices heartbeatServices,
 			MetricRegistry metricRegistry) throws Exception {
+
+		archivedExecutionGraphStore = createSerializableExecutionGraphStore(configuration, rpcService.getScheduledExecutor());
 
 		dispatcherLeaderRetrievalService = highAvailabilityServices.getDispatcherLeaderRetriever();
 
@@ -131,6 +142,7 @@ public abstract class SessionClusterEntrypoint extends ClusterEntrypoint {
 			blobServer,
 			heartbeatServices,
 			metricRegistry,
+			archivedExecutionGraphStore,
 			this,
 			dispatcherRestEndpoint.getRestAddress());
 
@@ -141,6 +153,21 @@ public abstract class SessionClusterEntrypoint extends ClusterEntrypoint {
 		LOG.debug("Starting Dispatcher.");
 		dispatcher.start();
 		dispatcherLeaderRetrievalService.start(dispatcherGatewayRetriever);
+	}
+
+	private ArchivedExecutionGraphStore createSerializableExecutionGraphStore(
+			Configuration configuration,
+			ScheduledExecutor scheduledExecutor) throws IOException {
+		final File tmpDir = new File(ConfigurationUtils.parseTempDirectories(configuration)[0]);
+
+		final Time expirationTime =  Time.seconds(configuration.getLong(JobManagerOptions.JOB_STORE_EXPIRATION_TIME));
+		final long maximumCacheSizeBytes = configuration.getLong(JobManagerOptions.JOB_STORE_CACHE_SIZE);
+
+		return new FileArchivedExecutionGraphStore(
+			tmpDir,
+			expirationTime,
+			maximumCacheSizeBytes,
+			scheduledExecutor);
 	}
 
 	@Override
@@ -183,6 +210,14 @@ public abstract class SessionClusterEntrypoint extends ClusterEntrypoint {
 			}
 		}
 
+		if (archivedExecutionGraphStore != null) {
+			try {
+				archivedExecutionGraphStore.close();
+			} catch (Throwable t) {
+				exception = ExceptionUtils.firstOrSuppressed(t, exception);
+			}
+		}
+
 		if (exception != null) {
 			throw new FlinkException("Could not properly shut down the session cluster entry point.", exception);
 		}
@@ -215,6 +250,7 @@ public abstract class SessionClusterEntrypoint extends ClusterEntrypoint {
 		BlobServer blobServer,
 		HeartbeatServices heartbeatServices,
 		MetricRegistry metricRegistry,
+		ArchivedExecutionGraphStore archivedExecutionGraphStore,
 		FatalErrorHandler fatalErrorHandler,
 		@Nullable String restAddress) throws Exception {
 
@@ -228,6 +264,7 @@ public abstract class SessionClusterEntrypoint extends ClusterEntrypoint {
 			blobServer,
 			heartbeatServices,
 			metricRegistry,
+			archivedExecutionGraphStore,
 			fatalErrorHandler,
 			restAddress);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/SessionClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/SessionClusterEntrypoint.java
@@ -52,6 +52,8 @@ import org.apache.flink.runtime.webmonitor.retriever.impl.RpcGatewayRetriever;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 
+import org.apache.flink.shaded.guava18.com.google.common.base.Ticker;
+
 import akka.actor.ActorSystem;
 
 import javax.annotation.Nullable;
@@ -167,7 +169,8 @@ public abstract class SessionClusterEntrypoint extends ClusterEntrypoint {
 			tmpDir,
 			expirationTime,
 			maximumCacheSizeBytes,
-			scheduledExecutor);
+			scheduledExecutor,
+			Ticker.systemTicker());
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/AccessExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/AccessExecutionGraph.java
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.flink.runtime.executiongraph;
 
 import org.apache.flink.api.common.ArchivedExecutionConfig;
@@ -28,7 +29,6 @@ import org.apache.flink.util.SerializedValue;
 
 import javax.annotation.Nullable;
 
-import java.io.IOException;
 import java.util.Map;
 
 /**
@@ -103,7 +103,7 @@ public interface AccessExecutionGraph {
 	Iterable<? extends AccessExecutionVertex> getAllExecutionVertices();
 
 	/**
-	 * Returns the timestamp for the given {@link JobStatus}
+	 * Returns the timestamp for the given {@link JobStatus}.
 	 *
 	 * @param status status for which the timestamp should be returned
 	 * @return timestamp for the given job status
@@ -154,9 +154,8 @@ public interface AccessExecutionGraph {
 	 * Returns a map containing the serialized values of user-defined accumulators.
 	 *
 	 * @return map containing serialized values of user-defined accumulators
-	 * @throws IOException indicates that the serialization has failed
 	 */
-	Map<String, SerializedValue<Object>> getAccumulatorsSerialized() throws IOException;
+	Map<String, SerializedValue<Object>> getAccumulatorsSerialized();
 
 	/**
 	 * Returns whether this execution graph was archived.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ErrorInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ErrorInfo.java
@@ -34,7 +34,6 @@ public class ErrorInfo implements Serializable {
 	private final SerializedThrowable exception;
 
 	private final long timestamp;
-
 	public ErrorInfo(Throwable exception, long timestamp) {
 		Preconditions.checkNotNull(exception);
 		Preconditions.checkArgument(timestamp > 0);
@@ -48,7 +47,7 @@ public class ErrorInfo implements Serializable {
 	 * Returns the serialized form of the original exception.
 	 */
 	public SerializedThrowable getException() {
-		return this.exception;
+		return exception;
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.executiongraph;
 
 import org.apache.flink.annotation.VisibleForTesting;
-import org.apache.flink.api.common.Archiveable;
 import org.apache.flink.api.common.ArchivedExecutionConfig;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
@@ -51,7 +50,6 @@ import org.apache.flink.runtime.executiongraph.failover.RestartAllStrategy;
 import org.apache.flink.runtime.executiongraph.restart.ExecutionGraphRestartCallback;
 import org.apache.flink.runtime.executiongraph.restart.RestartCallback;
 import org.apache.flink.runtime.executiongraph.restart.RestartStrategy;
-import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.JobStatus;
@@ -62,6 +60,7 @@ import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguratio
 import org.apache.flink.runtime.jobmanager.scheduler.CoLocationGroup;
 import org.apache.flink.runtime.jobmanager.scheduler.LocationPreferenceConstraint;
 import org.apache.flink.runtime.jobmanager.scheduler.NoResourceAvailableException;
+import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.query.KvStateLocationRegistry;
 import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.runtime.state.StateBackend;
@@ -148,7 +147,7 @@ import static org.apache.flink.util.Preconditions.checkState;
  * local failover (meaning there is a concurrent global failover), the failover strategy has to
  * yield before the global failover.
  */
-public class ExecutionGraph implements AccessExecutionGraph, Archiveable<ArchivedExecutionGraph> {
+public class ExecutionGraph implements AccessExecutionGraph {
 
 	/** In place updater for the execution graph's current state. Avoids having to use an
 	 * AtomicReference and thus makes the frequent read access a bit faster */
@@ -761,16 +760,21 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 	/**
 	 * Gets a serialized accumulator map.
 	 * @return The accumulator map with serialized accumulator values.
-	 * @throws IOException
 	 */
 	@Override
-	public Map<String, SerializedValue<Object>> getAccumulatorsSerialized() throws IOException {
+	public Map<String, SerializedValue<Object>> getAccumulatorsSerialized() {
 
 		Map<String, Accumulator<?, ?>> accumulatorMap = aggregateUserAccumulators();
 
 		Map<String, SerializedValue<Object>> result = new HashMap<>(accumulatorMap.size());
 		for (Map.Entry<String, Accumulator<?, ?>> entry : accumulatorMap.entrySet()) {
-			result.put(entry.getKey(), new SerializedValue<>(entry.getValue().getLocalValue()));
+
+			try {
+				final SerializedValue<Object> serializedValue = new SerializedValue<>(entry.getValue().getLocalValue());
+				result.put(entry.getKey(), serializedValue);
+			} catch (IOException ioe) {
+				LOG.info("Could not serialize accumulator " + entry.getKey() + '.', ioe);
+			}
 		}
 
 		return result;
@@ -1686,41 +1690,5 @@ public class ExecutionGraph implements AccessExecutionGraph, Archiveable<Archive
 				}
 			}
 		}
-	}
-
-	@Override
-	public ArchivedExecutionGraph archive() {
-		Map<JobVertexID, ArchivedExecutionJobVertex> archivedTasks = new HashMap<>(verticesInCreationOrder.size());
-		List<ArchivedExecutionJobVertex> archivedVerticesInCreationOrder = new ArrayList<>(verticesInCreationOrder.size());
-
-		for (ExecutionJobVertex task : verticesInCreationOrder) {
-			ArchivedExecutionJobVertex archivedTask = task.archive();
-			archivedVerticesInCreationOrder.add(archivedTask);
-			archivedTasks.put(task.getJobVertexId(), archivedTask);
-		}
-
-		Map<String, SerializedValue<Object>> serializedUserAccumulators;
-		try {
-			serializedUserAccumulators = getAccumulatorsSerialized();
-		} catch (Exception e) {
-			LOG.warn("Error occurred while archiving user accumulators.", e);
-			serializedUserAccumulators = Collections.emptyMap();
-		}
-
-		return new ArchivedExecutionGraph(
-			getJobID(),
-			getJobName(),
-			archivedTasks,
-			archivedVerticesInCreationOrder,
-			stateTimestamps,
-			getState(),
-			failureInfo,
-			getJsonPlan(),
-			getAccumulatorResultsStringified(),
-			serializedUserAccumulators,
-			getArchivedExecutionConfig(),
-			isStoppable(),
-			getCheckpointCoordinatorConfiguration(),
-			getCheckpointStatsSnapshot());
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/OnCompletionActions.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/OnCompletionActions.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.runtime.jobmanager;
 
-import org.apache.flink.runtime.jobmaster.JobResult;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 
 /**
  * Interface for completion actions once a Flink job has reached
@@ -27,18 +27,11 @@ import org.apache.flink.runtime.jobmaster.JobResult;
 public interface OnCompletionActions {
 
 	/**
-	 * Job finished successfully.
+	 * Job reached a globally terminal state.
 	 *
-	 * @param result of the job execution
+	 * @param executionGraph serializable execution graph
 	 */
-	void jobFinished(JobResult result);
-
-	/**
-	 * Job failed with an exception.
-	 *
-	 * @param result The result of the job carrying the failure cause.
-	 */
-	void jobFailed(JobResult result);
+	void jobReachedGloballyTerminalState(ArchivedExecutionGraph executionGraph);
 
 	/**
 	 * Job was finished by another JobMaster.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerRunner.java
@@ -24,6 +24,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.execution.librarycache.BlobLibraryCacheManager;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.highavailability.RunningJobsRegistry;
@@ -251,30 +252,14 @@ public class JobManagerRunner implements LeaderContender, OnCompletionActions, F
 	 * Job completion notification triggered by JobManager.
 	 */
 	@Override
-	public void jobFinished(JobResult result) {
+	public void jobReachedGloballyTerminalState(ArchivedExecutionGraph executionGraph) {
 		try {
 			unregisterJobFromHighAvailability();
 			shutdownInternally();
 		}
 		finally {
 			if (toNotifyOnComplete != null) {
-				toNotifyOnComplete.jobFinished(result);
-			}
-		}
-	}
-
-	/**
-	 * Job completion notification triggered by JobManager.
-	 */
-	@Override
-	public void jobFailed(JobResult result) {
-		try {
-			unregisterJobFromHighAvailability();
-			shutdownInternally();
-		}
-		finally {
-			if (toNotifyOnComplete != null) {
-				toNotifyOnComplete.jobFailed(result);
+				toNotifyOnComplete.jobReachedGloballyTerminalState(executionGraph);
 			}
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -72,6 +72,7 @@ import org.apache.flink.runtime.messages.checkpoint.AcknowledgeCheckpoint;
 import org.apache.flink.runtime.messages.checkpoint.DeclineCheckpoint;
 import org.apache.flink.runtime.messages.webmonitor.ClusterOverview;
 import org.apache.flink.runtime.messages.webmonitor.JobDetails;
+import org.apache.flink.runtime.messages.webmonitor.JobsOverview;
 import org.apache.flink.runtime.messages.webmonitor.MultipleJobsDetails;
 import org.apache.flink.runtime.metrics.groups.JobManagerMetricGroup;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
@@ -824,7 +825,9 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 		Collection<JobStatus> jobStatuses = Collections.singleton(executionGraph.getState());
 
 		return resourceOverviewFuture.thenApply(
-			(ResourceOverview resourceOverview) -> ClusterOverview.create(resourceOverview, jobStatuses));
+			(ResourceOverview resourceOverview) -> new ClusterOverview(
+				resourceOverview,
+				JobsOverview.create(jobStatuses)));
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -39,7 +39,6 @@ import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.execution.librarycache.BlobLibraryCacheManager;
-import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
@@ -784,11 +783,6 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 	}
 
 	@Override
-	public CompletableFuture<AccessExecutionGraph> requestArchivedExecutionGraph(Time timeout) {
-		return CompletableFuture.completedFuture(ArchivedExecutionGraph.createFrom(executionGraph));
-	}
-
-	@Override
 	public CompletableFuture<JobStatus> requestJobStatus(Time timeout) {
 		return CompletableFuture.completedFuture(executionGraph.getState());
 	}
@@ -803,9 +797,9 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 	}
 
 	@Override
-	public CompletableFuture<AccessExecutionGraph> requestJob(JobID jobId, Time timeout) {
+	public CompletableFuture<ArchivedExecutionGraph> requestJob(JobID jobId, Time timeout) {
 		if (jobGraph.getJobID().equals(jobId)) {
-			return requestArchivedExecutionGraph(timeout);
+			return CompletableFuture.completedFuture(ArchivedExecutionGraph.createFrom(executionGraph));
 		} else {
 			return FutureUtils.completedExceptionally(new FlinkJobNotFoundException(jobId));
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/messages/webmonitor/ClusterOverview.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/messages/webmonitor/ClusterOverview.java
@@ -18,14 +18,10 @@
 
 package org.apache.flink.runtime.messages.webmonitor;
 
-import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.resourcemanager.ResourceOverview;
-import org.apache.flink.util.Preconditions;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
-
-import java.util.Collection;
 
 /**
  * Response to the {@link RequestStatusOverview} message, carrying a description
@@ -71,6 +67,17 @@ public class ClusterOverview extends JobsOverview {
 		this.numTaskManagersConnected = numTaskManagersConnected;
 		this.numSlotsTotal = numSlotsTotal;
 		this.numSlotsAvailable = numSlotsAvailable;
+	}
+
+	public ClusterOverview(ResourceOverview resourceOverview, JobsOverview jobsOverview) {
+		this(
+			resourceOverview.getNumberTaskManagers(),
+			resourceOverview.getNumberRegisteredSlots(),
+			resourceOverview.getNumberFreeSlots(),
+			jobsOverview.getNumJobsRunningOrPending(),
+			jobsOverview.getNumJobsFinished(),
+			jobsOverview.getNumJobsCancelled(),
+			jobsOverview.getNumJobsFailed());
 	}
 
 	public int getNumTaskManagersConnected() {
@@ -127,41 +134,5 @@ public class ClusterOverview extends JobsOverview {
 				", numJobsCancelled=" + getNumJobsCancelled() +
 				", numJobsFailed=" + getNumJobsFailed() +
 				'}';
-	}
-
-	public static ClusterOverview create(ResourceOverview resourceOverview, Collection<JobStatus> allJobsStatus) {
-		Preconditions.checkNotNull(resourceOverview);
-		Preconditions.checkNotNull(allJobsStatus);
-
-		int numberRunningOrPendingJobs = 0;
-		int numberFinishedJobs = 0;
-		int numberCancelledJobs = 0;
-		int numberFailedJobs = 0;
-
-		for (JobStatus status : allJobsStatus) {
-			switch (status) {
-				case FINISHED:
-					numberFinishedJobs++;
-					break;
-				case FAILED:
-					numberFailedJobs++;
-					break;
-				case CANCELED:
-					numberCancelledJobs++;
-					break;
-				default:
-					numberRunningOrPendingJobs++;
-					break;
-			}
-		}
-
-		return new ClusterOverview(
-			resourceOverview.getNumberTaskManagers(),
-			resourceOverview.getNumberRegisteredSlots(),
-			resourceOverview.getNumberFreeSlots(),
-			numberRunningOrPendingJobs,
-			numberFinishedJobs,
-			numberCancelledJobs,
-			numberFailedJobs);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/messages/webmonitor/JobsOverview.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/messages/webmonitor/JobsOverview.java
@@ -18,8 +18,13 @@
 
 package org.apache.flink.runtime.messages.webmonitor;
 
+import org.apache.flink.runtime.jobgraph.JobStatus;
+import org.apache.flink.util.Preconditions;
+
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Collection;
 
 /**
  * An overview of how many jobs are in which status.
@@ -51,7 +56,7 @@ public class JobsOverview implements InfoMessage {
 			@JsonProperty(FIELD_NAME_JOBS_FINISHED) int numJobsFinished,
 			@JsonProperty(FIELD_NAME_JOBS_CANCELLED) int numJobsCancelled,
 			@JsonProperty(FIELD_NAME_JOBS_FAILED) int numJobsFailed) {
-		
+
 		this.numJobsRunningOrPending = numJobsRunningOrPending;
 		this.numJobsFinished = numJobsFinished;
 		this.numJobsCancelled = numJobsCancelled;
@@ -80,9 +85,9 @@ public class JobsOverview implements InfoMessage {
 	public int getNumJobsFailed() {
 		return numJobsFailed;
 	}
-	
+
 	// ------------------------------------------------------------------------
-	
+
 	@Override
 	public boolean equals(Object obj) {
 		if (this == obj) {
@@ -117,5 +122,43 @@ public class JobsOverview implements InfoMessage {
 				", numJobsCancelled=" + numJobsCancelled +
 				", numJobsFailed=" + numJobsFailed +
 				'}';
+	}
+
+	/**
+	 * Combines the given jobs overview with this.
+	 *
+	 * @param jobsOverview to combine with this
+	 * @return Combined jobs overview
+	 */
+	public JobsOverview combine(JobsOverview jobsOverview) {
+		return new JobsOverview(this, jobsOverview);
+	}
+
+	public static JobsOverview create(Collection<JobStatus> allJobsStatus) {
+		Preconditions.checkNotNull(allJobsStatus);
+
+		int numberRunningOrPendingJobs = 0;
+		int numberFinishedJobs = 0;
+		int numberCancelledJobs = 0;
+		int numberFailedJobs = 0;
+
+		for (JobStatus status : allJobsStatus) {
+			switch (status) {
+				case FINISHED:
+					numberFinishedJobs++;
+					break;
+				case FAILED:
+					numberFailedJobs++;
+					break;
+				case CANCELED:
+					numberCancelledJobs++;
+					break;
+				default:
+					numberRunningOrPendingJobs++;
+					break;
+			}
+		}
+
+		return new JobsOverview(numberRunningOrPendingJobs, numberFinishedJobs, numberCancelledJobs, numberFailedJobs);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniClusterJobDispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniClusterJobDispatcher.java
@@ -25,6 +25,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobServer;
 import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.jobgraph.JobGraph;
@@ -361,12 +362,7 @@ public class MiniClusterJobDispatcher {
 		}
 
 		@Override
-		public void jobFinished(JobResult result) {
-			decrementCheckAndCleanup();
-		}
-
-		@Override
-		public void jobFailed(JobResult result) {
+		public void jobReachedGloballyTerminalState(ArchivedExecutionGraph executionGraph) {
 			decrementCheckAndCleanup();
 		}
 
@@ -414,16 +410,8 @@ public class MiniClusterJobDispatcher {
 		}
 
 		@Override
-		public void jobFinished(JobResult result) {
-			this.result = result;
-			jobMastersToWaitFor.countDown();
-		}
-
-		@Override
-		public void jobFailed(JobResult result) {
-			checkArgument(result.getSerializedThrowable().isPresent());
-
-			this.result = result;
+		public void jobReachedGloballyTerminalState(ArchivedExecutionGraph executionGraph) {
+			this.result = JobResult.createFrom(executionGraph);
 			jobMastersToWaitFor.countDown();
 		}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobExceptionsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobExceptionsHandler.java
@@ -71,7 +71,7 @@ public class JobExceptionsHandler extends AbstractExecutionGraphHandler<JobExcep
 		ErrorInfo rootException = executionGraph.getFailureInfo();
 		String rootExceptionMessage = null;
 		Long rootTimestamp = null;
-		if (rootException != null && !rootException.getExceptionAsString().equals(ExceptionUtils.STRINGIFIED_NULL_EXCEPTION)) {
+		if (rootException != null) {
 			rootExceptionMessage = rootException.getExceptionAsString();
 			rootTimestamp = rootException.getTimestamp();
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/ExecutionGraphCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/ExecutionGraphCache.java
@@ -122,7 +122,7 @@ public class ExecutionGraphCache implements Closeable {
 			}
 
 			if (successfulUpdate) {
-				final CompletableFuture<AccessExecutionGraph> executionGraphFuture = restfulGateway.requestJob(jobId, timeout);
+				final CompletableFuture<? extends AccessExecutionGraph> executionGraphFuture = restfulGateway.requestJob(jobId, timeout);
 
 				executionGraphFuture.whenComplete(
 					(AccessExecutionGraph executionGraph, Throwable throwable) -> {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/JobExceptionsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/JobExceptionsHandler.java
@@ -93,7 +93,7 @@ public class JobExceptionsHandler extends AbstractExecutionGraphRequestHandler {
 
 		// most important is the root failure cause
 		ErrorInfo rootException = graph.getFailureInfo();
-		if (rootException != null && !rootException.getExceptionAsString().equals(ExceptionUtils.STRINGIFIED_NULL_EXCEPTION)) {
+		if (rootException != null) {
 			gen.writeStringField("root-exception", rootException.getExceptionAsString());
 			gen.writeNumberField("timestamp", rootException.getTimestamp());
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/RestfulGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/RestfulGateway.java
@@ -54,14 +54,14 @@ public interface RestfulGateway extends RpcGateway {
 	CompletableFuture<String> requestRestAddress(@RpcTimeout  Time timeout);
 
 	/**
-	 * Requests the AccessExecutionGraph for the given jobId. If there is no such graph, then
+	 * Requests the {@link AccessExecutionGraph} for the given jobId. If there is no such graph, then
 	 * the future is completed with a {@link FlinkJobNotFoundException}.
 	 *
 	 * @param jobId identifying the job whose AccessExecutionGraph is requested
 	 * @param timeout for the asynchronous operation
 	 * @return Future containing the AccessExecutionGraph for the given jobId, otherwise {@link FlinkJobNotFoundException}
 	 */
-	CompletableFuture<AccessExecutionGraph> requestJob(JobID jobId, @RpcTimeout Time timeout);
+	CompletableFuture<? extends AccessExecutionGraph> requestJob(JobID jobId, @RpcTimeout Time timeout);
 
 	/**
 	 * Requests job details currently being executed on the Flink cluster.

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -1727,7 +1727,10 @@ class JobManager(
           }(context.dispatcher))
 
           try {
-            archive ! decorateMessage(ArchiveExecutionGraph(jobID, eg.archive()))
+            archive ! decorateMessage(
+              ArchiveExecutionGraph(
+                jobID,
+                ArchivedExecutionGraph.createFrom(eg)))
           } catch {
             case t: Throwable => log.warn(s"Could not archive the execution graph $eg.", t)
           }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/ManuallyTriggeredScheduledExecutor.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/ManuallyTriggeredScheduledExecutor.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.concurrent;
+
+import org.apache.flink.core.testutils.ManuallyTriggeredDirectExecutor;
+import org.apache.flink.util.Preconditions;
+
+import java.util.Iterator;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Delayed;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Simple {@link ScheduledExecutor} implementation for testing purposes.
+ */
+public class ManuallyTriggeredScheduledExecutor extends ManuallyTriggeredDirectExecutor implements ScheduledExecutor {
+
+	private final ConcurrentLinkedQueue<ScheduledTask<?>> scheduledTasks = new ConcurrentLinkedQueue<>();
+
+	@Override
+	public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+		return insertRunnable(command, false);
+	}
+
+	@Override
+	public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+		final ScheduledTask<V> scheduledTask = new ScheduledTask<>(callable, false);
+
+		scheduledTasks.offer(scheduledTask);
+
+		return scheduledTask;
+	}
+
+	@Override
+	public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
+		return insertRunnable(command, true);
+	}
+
+	@Override
+	public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit) {
+		return insertRunnable(command, true);
+	}
+
+	/**
+	 * Triggers all registered tasks.
+	 */
+	public void triggerScheduledTasks() {
+		final Iterator<ScheduledTask<?>> iterator = scheduledTasks.iterator();
+
+		while (iterator.hasNext()) {
+			final ScheduledTask<?> scheduledTask = iterator.next();
+
+			scheduledTask.execute();
+
+			if (!scheduledTask.isPeriodic) {
+				iterator.remove();
+			}
+		}
+	}
+
+	private ScheduledFuture<?> insertRunnable(Runnable command, boolean isPeriodic) {
+		final ScheduledTask<?> scheduledTask = new ScheduledTask<>(
+			() -> {
+				command.run();
+				return null;
+			},
+			isPeriodic);
+
+		scheduledTasks.offer(scheduledTask);
+
+		return scheduledTask;
+	}
+
+	private static final class ScheduledTask<T> implements ScheduledFuture<T> {
+
+		private final Callable<T> callable;
+
+		private final boolean isPeriodic;
+
+		private final CompletableFuture<T> result;
+
+		private ScheduledTask(Callable<T> callable, boolean isPeriodic) {
+			this.callable = Preconditions.checkNotNull(callable);
+			this.isPeriodic = isPeriodic;
+
+			this.result = new CompletableFuture<>();
+		}
+
+		public boolean isPeriodic() {
+			return isPeriodic;
+		}
+
+		public void execute() {
+			if (!result.isDone()) {
+				if (!isPeriodic) {
+					try {
+						result.complete(callable.call());
+					} catch (Exception e) {
+						result.completeExceptionally(e);
+					}
+				} else {
+					try {
+						callable.call();
+					} catch (Exception e) {
+						result.completeExceptionally(e);
+					}
+				}
+			}
+		}
+
+		@Override
+		public long getDelay(TimeUnit unit) {
+			return 0;
+		}
+
+		@Override
+		public int compareTo(Delayed o) {
+			return 0;
+		}
+
+		@Override
+		public boolean cancel(boolean mayInterruptIfRunning) {
+			return result.cancel(mayInterruptIfRunning);
+		}
+
+		@Override
+		public boolean isCancelled() {
+			return result.isCancelled();
+		}
+
+		@Override
+		public boolean isDone() {
+			return result.isDone();
+		}
+
+		@Override
+		public T get() throws InterruptedException, ExecutionException {
+			return result.get();
+		}
+
+		@Override
+		public T get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+			return result.get(timeout, unit);
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/ManuallyTriggeredScheduledExecutor.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/ManuallyTriggeredScheduledExecutor.java
@@ -107,10 +107,6 @@ public class ManuallyTriggeredScheduledExecutor extends ManuallyTriggeredDirectE
 			this.result = new CompletableFuture<>();
 		}
 
-		public boolean isPeriodic() {
-			return isPeriodic;
-		}
-
 		public void execute() {
 			if (!result.isDone()) {
 				if (!isPeriodic) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -173,6 +173,7 @@ public class DispatcherTest extends TestLogger {
 			new BlobServer(blobServerConfig, new VoidBlobStore()),
 			heartbeatServices,
 			NoOpMetricRegistry.INSTANCE,
+			new MemoryArchivedExecutionGraphStore(),
 			fatalErrorHandler,
 			TEST_JOB_ID);
 
@@ -344,6 +345,7 @@ public class DispatcherTest extends TestLogger {
 				BlobServer blobServer,
 				HeartbeatServices heartbeatServices,
 				MetricRegistry metricRegistry,
+				ArchivedExecutionGraphStore archivedExecutionGraphStore,
 				FatalErrorHandler fatalErrorHandler,
 				JobID expectedJobId) throws Exception {
 			super(
@@ -355,6 +357,7 @@ public class DispatcherTest extends TestLogger {
 				blobServer,
 				heartbeatServices,
 				metricRegistry,
+				archivedExecutionGraphStore,
 				fatalErrorHandler,
 				null);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/FileArchivedExecutionGraphStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/FileArchivedExecutionGraphStoreTest.java
@@ -1,0 +1,319 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.concurrent.ManuallyTriggeredScheduledExecutor;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
+import org.apache.flink.runtime.jobgraph.JobStatus;
+import org.apache.flink.runtime.messages.webmonitor.JobDetails;
+import org.apache.flink.runtime.messages.webmonitor.JobsOverview;
+import org.apache.flink.runtime.rest.handler.legacy.utils.ArchivedExecutionGraphBuilder;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.apache.flink.runtime.webmonitor.WebMonitorUtils;
+import org.apache.flink.testutils.category.Flip6;
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.TestLogger;
+
+import org.apache.flink.shaded.guava18.com.google.common.cache.LoadingCache;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matchers;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.Random;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for the {@link FileArchivedExecutionGraphStore}.
+ */
+@Category(Flip6.class)
+public class FileArchivedExecutionGraphStoreTest extends TestLogger {
+
+	private static final List<JobStatus> GLOBALLY_TERMINAL_JOB_STATUS = new ArrayList<>(3);
+
+	private static final Random RANDOM = new Random();
+
+	@ClassRule
+	public static TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	@BeforeClass
+	public static void setup() {
+		GLOBALLY_TERMINAL_JOB_STATUS.add(JobStatus.FINISHED);
+		GLOBALLY_TERMINAL_JOB_STATUS.add(JobStatus.FAILED);
+		GLOBALLY_TERMINAL_JOB_STATUS.add(JobStatus.CANCELED);
+	}
+
+	/**
+	 * Tests that we can put {@link ArchivedExecutionGraph} into the
+	 * {@link FileArchivedExecutionGraphStore} and that the graph is persisted.
+	 */
+	@Test
+	public void testPut() throws IOException {
+		final ArchivedExecutionGraph dummyExecutionGraph = new ArchivedExecutionGraphBuilder().setState(JobStatus.FINISHED).build();
+		final File rootDir = temporaryFolder.newFolder();
+
+		try (final FileArchivedExecutionGraphStore executionGraphStore = createDefaultExecutionGraphStore(rootDir)) {
+
+			final File storageDirectory = executionGraphStore.getStorageDir();
+
+			// check that the storage directory is empty
+			assertThat(storageDirectory.listFiles().length, Matchers.equalTo(0));
+
+			executionGraphStore.put(dummyExecutionGraph);
+
+			// check that we have persisted the given execution graph
+			assertThat(storageDirectory.listFiles().length, Matchers.equalTo(1));
+
+			assertThat(executionGraphStore.get(dummyExecutionGraph.getJobID()), new PartialArchivedExecutionGraphMatcher(dummyExecutionGraph));
+		}
+	}
+
+	/**
+	 * Tests that null is returned if we request an unknown JobID.
+	 */
+	@Test
+	public void testUnknownGet() throws IOException {
+		final File rootDir = temporaryFolder.newFolder();
+
+		try (final FileArchivedExecutionGraphStore executionGraphStore = createDefaultExecutionGraphStore(rootDir)) {
+			assertThat(executionGraphStore.get(new JobID()), Matchers.nullValue());
+		}
+	}
+
+	/**
+	 * Tests that we obtain the correct jobs overview.
+	 */
+	@Test
+	public void testStoredJobsOverview() throws IOException {
+		final int numberExecutionGraphs = 10;
+		final Collection<ArchivedExecutionGraph> executionGraphs = generateTerminalExecutionGraphs(numberExecutionGraphs);
+
+		final List<JobStatus> jobStatuses = executionGraphs.stream().map(ArchivedExecutionGraph::getState).collect(Collectors.toList());
+
+		final JobsOverview expectedJobsOverview = JobsOverview.create(jobStatuses);
+
+		final File rootDir = temporaryFolder.newFolder();
+
+		try (final FileArchivedExecutionGraphStore executionGraphStore = createDefaultExecutionGraphStore(rootDir)) {
+			for (ArchivedExecutionGraph executionGraph : executionGraphs) {
+				executionGraphStore.put(executionGraph);
+			}
+
+			assertThat(executionGraphStore.getStoredJobsOverview(), Matchers.equalTo(expectedJobsOverview));
+		}
+	}
+
+	/**
+	 * Tests that we obtain the correct collection of available job details.
+	 */
+	@Test
+	public void testAvailableJobDetails() throws IOException {
+		final int numberExecutionGraphs = 10;
+		final Collection<ArchivedExecutionGraph> executionGraphs = generateTerminalExecutionGraphs(numberExecutionGraphs);
+
+		final Collection<JobDetails> jobDetails = executionGraphs.stream().map(WebMonitorUtils::createDetailsForJob).collect(Collectors.toList());
+
+		final File rootDir = temporaryFolder.newFolder();
+
+		try (final FileArchivedExecutionGraphStore executionGraphStore = createDefaultExecutionGraphStore(rootDir)) {
+			for (ArchivedExecutionGraph executionGraph : executionGraphs) {
+				executionGraphStore.put(executionGraph);
+			}
+
+			assertThat(executionGraphStore.getAvailableJobDetails(), Matchers.containsInAnyOrder(jobDetails.toArray()));
+		}
+	}
+
+	/**
+	 * Tests that an expired execution graph is removed from the execution graph store.
+	 */
+	@Test
+	public void testExecutionGraphExpiration() throws Exception {
+		final File rootDir = temporaryFolder.newFolder();
+
+		final Time expirationTime = Time.milliseconds(1L);
+
+		final ManuallyTriggeredScheduledExecutor scheduledExecutor = new ManuallyTriggeredScheduledExecutor();
+
+		try (final FileArchivedExecutionGraphStore executionGraphStore = new FileArchivedExecutionGraphStore(
+			rootDir,
+			expirationTime,
+			10000L,
+			scheduledExecutor)) {
+
+			final ArchivedExecutionGraph executionGraph = new ArchivedExecutionGraphBuilder().setState(JobStatus.FINISHED).build();
+
+			executionGraphStore.put(executionGraph);
+
+			// there should one execution graph
+			assertThat(executionGraphStore.size(), Matchers.equalTo(1));
+
+			Thread.sleep(expirationTime.toMilliseconds());
+
+			// this should trigger the cleanup after expiration
+			scheduledExecutor.triggerScheduledTasks();
+
+			assertThat(executionGraphStore.size(), Matchers.equalTo(0));
+
+			assertThat(executionGraphStore.get(executionGraph.getJobID()), Matchers.nullValue());
+
+			final File storageDirectory = executionGraphStore.getStorageDir();
+
+			// check that the persisted file has been deleted
+			assertThat(storageDirectory.listFiles().length, Matchers.equalTo(0));
+		}
+	}
+
+	/**
+	 * Tests that all persisted files are cleaned up after closing the store.
+	 */
+	@Test
+	public void testCloseCleansUp() throws IOException {
+		final File rootDir = temporaryFolder.newFolder();
+
+		assertThat(rootDir.listFiles().length, Matchers.equalTo(0));
+
+		try (final FileArchivedExecutionGraphStore executionGraphStore = createDefaultExecutionGraphStore(rootDir)) {
+
+			assertThat(rootDir.listFiles().length, Matchers.equalTo(1));
+
+			final File storageDirectory = executionGraphStore.getStorageDir();
+
+			assertThat(storageDirectory.listFiles().length, Matchers.equalTo(0));
+
+			executionGraphStore.put(new ArchivedExecutionGraphBuilder().setState(JobStatus.FINISHED).build());
+
+			assertThat(storageDirectory.listFiles().length, Matchers.equalTo(1));
+		}
+
+		assertThat(rootDir.listFiles().length, Matchers.equalTo(0));
+	}
+
+	/**
+	 * Tests that evicted {@link ArchivedExecutionGraph} are loaded from disk again.
+	 */
+	@Test
+	public void testCacheLoading() throws IOException {
+		final File rootDir = temporaryFolder.newFolder();
+
+		try (final FileArchivedExecutionGraphStore executionGraphStore = new FileArchivedExecutionGraphStore(
+			rootDir,
+			Time.hours(1L),
+			100L << 10,
+			TestingUtils.defaultScheduledExecutor())) {
+
+			final LoadingCache<JobID, ArchivedExecutionGraph> executionGraphCache = executionGraphStore.getArchivedExecutionGraphCache();
+
+			Collection<ArchivedExecutionGraph> executionGraphs = new ArrayList<>(64);
+
+			boolean continueInserting = true;
+
+			// insert execution graphs until the first one got evicted
+			while (continueInserting) {
+				// has roughly a size of 1.4 KB
+				final ArchivedExecutionGraph executionGraph = new ArchivedExecutionGraphBuilder().setState(JobStatus.FINISHED).build();
+
+				executionGraphStore.put(executionGraph);
+
+				executionGraphs.add(executionGraph);
+
+				continueInserting = executionGraphCache.size() == executionGraphs.size();
+			}
+
+			final File storageDirectory = executionGraphStore.getStorageDir();
+
+			assertThat(storageDirectory.listFiles().length, Matchers.equalTo(executionGraphs.size()));
+
+			for (ArchivedExecutionGraph executionGraph : executionGraphs) {
+				assertThat(executionGraphStore.get(executionGraph.getJobID()), new PartialArchivedExecutionGraphMatcher(executionGraph));
+			}
+		}
+	}
+
+	private Collection<ArchivedExecutionGraph> generateTerminalExecutionGraphs(int number) throws IOException {
+		final Collection<ArchivedExecutionGraph> executionGraphs = new ArrayList<>(number);
+
+		for (int i = 0; i < number; i++) {
+			final JobStatus state = GLOBALLY_TERMINAL_JOB_STATUS.get(RANDOM.nextInt(GLOBALLY_TERMINAL_JOB_STATUS.size()));
+			executionGraphs.add(
+				new ArchivedExecutionGraphBuilder()
+					.setState(state)
+					.build());
+		}
+
+		return executionGraphs;
+	}
+
+	private FileArchivedExecutionGraphStore createDefaultExecutionGraphStore(File storageDirectory) throws IOException {
+		return new FileArchivedExecutionGraphStore(
+			storageDirectory,
+			Time.hours(1L),
+			10000L,
+			TestingUtils.defaultScheduledExecutor());
+	}
+
+	private static final class PartialArchivedExecutionGraphMatcher extends BaseMatcher<ArchivedExecutionGraph> {
+
+		private final ArchivedExecutionGraph archivedExecutionGraph;
+
+		private PartialArchivedExecutionGraphMatcher(ArchivedExecutionGraph expectedArchivedExecutionGraph) {
+			this.archivedExecutionGraph = Preconditions.checkNotNull(expectedArchivedExecutionGraph);
+		}
+
+		@Override
+		public boolean matches(Object o) {
+			if (archivedExecutionGraph == o) {
+				return true;
+			}
+			if (o == null || archivedExecutionGraph.getClass() != o.getClass()) {
+				return false;
+			}
+			ArchivedExecutionGraph that = (ArchivedExecutionGraph) o;
+			return archivedExecutionGraph.isStoppable() == that.isStoppable() &&
+				Objects.equals(archivedExecutionGraph.getJobID(), that.getJobID()) &&
+				Objects.equals(archivedExecutionGraph.getJobName(), that.getJobName()) &&
+				archivedExecutionGraph.getState() == that.getState() &&
+				Objects.equals(archivedExecutionGraph.getJsonPlan(), that.getJsonPlan()) &&
+				Objects.equals(archivedExecutionGraph.getAccumulatorsSerialized(), that.getAccumulatorsSerialized()) &&
+				Objects.equals(archivedExecutionGraph.getCheckpointCoordinatorConfiguration(), that.getCheckpointCoordinatorConfiguration()) &&
+				archivedExecutionGraph.getAllVertices().size() == that.getAllVertices().size();
+		}
+
+		@Override
+		public void describeTo(Description description) {
+			description.appendText("Matches against " + ArchivedExecutionGraph.class.getSimpleName() + ": " +
+				archivedExecutionGraph);
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/MemoryArchivedExecutionGraphStore.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/MemoryArchivedExecutionGraphStore.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
+import org.apache.flink.runtime.jobgraph.JobStatus;
+import org.apache.flink.runtime.messages.webmonitor.JobDetails;
+import org.apache.flink.runtime.messages.webmonitor.JobsOverview;
+import org.apache.flink.runtime.webmonitor.WebMonitorUtils;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * {@link ArchivedExecutionGraphStore} implementation which stores the {@link ArchivedExecutionGraph}
+ * in memory.
+ */
+public class MemoryArchivedExecutionGraphStore implements ArchivedExecutionGraphStore {
+
+	private final Map<JobID, ArchivedExecutionGraph> serializableExecutionGraphs = new HashMap<>(4);
+
+	@Override
+	public int size() {
+		return serializableExecutionGraphs.size();
+	}
+
+	@Nullable
+	@Override
+	public ArchivedExecutionGraph get(JobID jobId) {
+		return serializableExecutionGraphs.get(jobId);
+	}
+
+	@Override
+	public void put(ArchivedExecutionGraph serializableExecutionGraph) throws IOException {
+		serializableExecutionGraphs.put(serializableExecutionGraph.getJobID(), serializableExecutionGraph);
+	}
+
+	@Override
+	public JobsOverview getStoredJobsOverview() {
+		Collection<JobStatus> allJobStatus = serializableExecutionGraphs.values().stream()
+			.map(ArchivedExecutionGraph::getState)
+			.collect(Collectors.toList());
+
+		return JobsOverview.create(allJobStatus);
+	}
+
+	@Override
+	public Collection<JobDetails> getAvailableJobDetails() {
+		return serializableExecutionGraphs.values().stream()
+			.map(WebMonitorUtils::createDetailsForJob)
+			.collect(Collectors.toList());
+	}
+
+	@Override
+	public void close() throws IOException {
+		serializableExecutionGraphs.clear();
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
@@ -142,14 +142,14 @@ public class ArchivedExecutionGraphTest extends TestLogger {
 
 	@Test
 	public void testArchive() throws IOException, ClassNotFoundException {
-		ArchivedExecutionGraph archivedGraph = runtimeGraph.archive();
+		ArchivedExecutionGraph archivedGraph = ArchivedExecutionGraph.createFrom(runtimeGraph);
 
 		compareExecutionGraph(runtimeGraph, archivedGraph);
 	}
 
 	@Test
 	public void testSerialization() throws IOException, ClassNotFoundException {
-		ArchivedExecutionGraph archivedGraph = runtimeGraph.archive();
+		ArchivedExecutionGraph archivedGraph = ArchivedExecutionGraph.createFrom(runtimeGraph);
 
 		verifySerializability(archivedGraph);
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.execution.librarycache.BlobLibraryCacheManager;
 import org.apache.flink.runtime.execution.librarycache.FlinkUserCodeClassLoaders;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.heartbeat.TestingHeartbeatServices;
@@ -265,12 +266,7 @@ public class JobMasterTest extends TestLogger {
 	private static final class NoOpOnCompletionActions implements OnCompletionActions {
 
 		@Override
-		public void jobFinished(final JobResult result) {
-
-		}
-
-		@Override
-		public void jobFailed(final JobResult result) {
+		public void jobReachedGloballyTerminalState(ArchivedExecutionGraph executionGraph) {
 
 		}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/ExecutionGraphCacheTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/ExecutionGraphCacheTest.java
@@ -30,37 +30,48 @@ import org.apache.flink.runtime.executiongraph.ErrorInfo;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobmanager.JobManager;
-import org.apache.flink.runtime.jobmaster.JobManagerGateway;
 import org.apache.flink.runtime.messages.FlinkJobNotFoundException;
+import org.apache.flink.runtime.rest.handler.legacy.utils.ArchivedExecutionGraphBuilder;
+import org.apache.flink.runtime.webmonitor.RestfulGateway;
+import org.apache.flink.runtime.webmonitor.TestingRestfulGateway;
 import org.apache.flink.util.ExecutorUtils;
 import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.TestLogger;
 
+import org.hamcrest.Matchers;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * Tests for the {@link ExecutionGraphCache}.
  */
 public class ExecutionGraphCacheTest extends TestLogger {
+
+	private static ArchivedExecutionGraph expectedExecutionGraph;
+	private static final JobID expectedJobId = new JobID();
+
+	@BeforeClass
+	public static void setup() {
+		expectedExecutionGraph = new ArchivedExecutionGraphBuilder().build();
+	}
 
 	/**
 	 * Tests that we can cache AccessExecutionGraphs over multiple accesses.
@@ -69,23 +80,19 @@ public class ExecutionGraphCacheTest extends TestLogger {
 	public void testExecutionGraphCaching() throws Exception {
 		final Time timeout = Time.milliseconds(100L);
 		final Time timeToLive = Time.hours(1L);
-		final JobID jobId = new JobID();
-		final AccessExecutionGraph accessExecutionGraph = mock(AccessExecutionGraph.class);
 
-		final JobManagerGateway jobManagerGateway = mock(JobManagerGateway.class);
-		when(jobManagerGateway.requestJob(eq(jobId), any(Time.class))).thenReturn(CompletableFuture.completedFuture(accessExecutionGraph));
+		final CountingRestfulGateway restfulGateway = createCountingRestfulGateway(expectedJobId, CompletableFuture.completedFuture(expectedExecutionGraph));
 
 		try (ExecutionGraphCache executionGraphCache = new ExecutionGraphCache(timeout, timeToLive)) {
-			CompletableFuture<AccessExecutionGraph> accessExecutionGraphFuture = executionGraphCache.getExecutionGraph(jobId, jobManagerGateway);
+			CompletableFuture<AccessExecutionGraph> accessExecutionGraphFuture = executionGraphCache.getExecutionGraph(expectedJobId, restfulGateway);
 
-			assertEquals(accessExecutionGraph, accessExecutionGraphFuture.get());
+			assertEquals(expectedExecutionGraph, accessExecutionGraphFuture.get());
 
-			CompletableFuture<AccessExecutionGraph> accessExecutionGraphFuture2 = executionGraphCache.getExecutionGraph(jobId, jobManagerGateway);
+			CompletableFuture<AccessExecutionGraph> accessExecutionGraphFuture2 = executionGraphCache.getExecutionGraph(expectedJobId, restfulGateway);
 
-			assertEquals(accessExecutionGraph, accessExecutionGraphFuture2.get());
+			assertEquals(expectedExecutionGraph, accessExecutionGraphFuture2.get());
 
-			// verify that we only issued a single request to the gateway
-			verify(jobManagerGateway, times(1)).requestJob(eq(jobId), any(Time.class));
+			assertThat(restfulGateway.getNumRequestJobCalls(), Matchers.equalTo(1));
 		}
 	}
 
@@ -96,25 +103,25 @@ public class ExecutionGraphCacheTest extends TestLogger {
 	public void testExecutionGraphEntryInvalidation() throws Exception {
 		final Time timeout = Time.milliseconds(100L);
 		final Time timeToLive = Time.milliseconds(1L);
-		final JobID jobId = new JobID();
-		final AccessExecutionGraph accessExecutionGraph = mock(AccessExecutionGraph.class);
 
-		final JobManagerGateway jobManagerGateway = mock(JobManagerGateway.class);
-		when(jobManagerGateway.requestJob(eq(jobId), any(Time.class))).thenReturn(CompletableFuture.completedFuture(accessExecutionGraph));
+		final CountingRestfulGateway restfulGateway = createCountingRestfulGateway(
+			expectedJobId,
+			CompletableFuture.completedFuture(expectedExecutionGraph),
+			CompletableFuture.completedFuture(expectedExecutionGraph));
 
 		try (ExecutionGraphCache executionGraphCache = new ExecutionGraphCache(timeout, timeToLive)) {
-			CompletableFuture<AccessExecutionGraph> executionGraphFuture = executionGraphCache.getExecutionGraph(jobId, jobManagerGateway);
+			CompletableFuture<AccessExecutionGraph> executionGraphFuture = executionGraphCache.getExecutionGraph(expectedJobId, restfulGateway);
 
-			assertEquals(accessExecutionGraph, executionGraphFuture.get());
+			assertEquals(expectedExecutionGraph, executionGraphFuture.get());
 
 			// sleep for the TTL
-			Thread.sleep(timeToLive.toMilliseconds());
+			Thread.sleep(timeToLive.toMilliseconds() * 5L);
 
-			CompletableFuture<AccessExecutionGraph> executionGraphFuture2 = executionGraphCache.getExecutionGraph(jobId, jobManagerGateway);
+			CompletableFuture<AccessExecutionGraph> executionGraphFuture2 = executionGraphCache.getExecutionGraph(expectedJobId, restfulGateway);
 
-			assertEquals(accessExecutionGraph, executionGraphFuture2.get());
+			assertEquals(expectedExecutionGraph, executionGraphFuture2.get());
 
-			verify(jobManagerGateway, times(2)).requestJob(eq(jobId), any(Time.class));
+			assertThat(restfulGateway.getNumRequestJobCalls(), Matchers.equalTo(2));
 		}
 	}
 
@@ -127,18 +134,15 @@ public class ExecutionGraphCacheTest extends TestLogger {
 	public void testImmediateCacheInvalidationAfterFailure() throws Exception {
 		final Time timeout = Time.milliseconds(100L);
 		final Time timeToLive = Time.hours(1L);
-		final JobID jobId = new JobID();
 
-		final AccessExecutionGraph accessExecutionGraph = mock(AccessExecutionGraph.class);
-
-		final JobManagerGateway jobManagerGateway = mock(JobManagerGateway.class);
 		// let's first answer with a JobNotFoundException and then only with the correct result
-		when(jobManagerGateway.requestJob(eq(jobId), any(Time.class))).thenReturn(
-			FutureUtils.completedExceptionally(new FlinkJobNotFoundException(jobId)),
-			CompletableFuture.completedFuture(accessExecutionGraph));
+		final CountingRestfulGateway restfulGateway = createCountingRestfulGateway(
+			expectedJobId,
+			FutureUtils.completedExceptionally(new FlinkJobNotFoundException(expectedJobId)),
+			CompletableFuture.completedFuture(expectedExecutionGraph));
 
 		try (ExecutionGraphCache executionGraphCache = new ExecutionGraphCache(timeout, timeToLive)) {
-			CompletableFuture<AccessExecutionGraph> executionGraphFuture = executionGraphCache.getExecutionGraph(jobId, jobManagerGateway);
+			CompletableFuture<AccessExecutionGraph> executionGraphFuture = executionGraphCache.getExecutionGraph(expectedJobId, restfulGateway);
 
 			try {
 				executionGraphFuture.get();
@@ -148,9 +152,9 @@ public class ExecutionGraphCacheTest extends TestLogger {
 				assertTrue(ee.getCause() instanceof FlinkException);
 			}
 
-			CompletableFuture<AccessExecutionGraph> executionGraphFuture2 = executionGraphCache.getExecutionGraph(jobId, jobManagerGateway);
+			CompletableFuture<AccessExecutionGraph> executionGraphFuture2 = executionGraphCache.getExecutionGraph(expectedJobId, restfulGateway);
 
-			assertEquals(accessExecutionGraph, executionGraphFuture2.get());
+			assertEquals(expectedExecutionGraph, executionGraphFuture2.get());
 		}
 	}
 
@@ -162,27 +166,36 @@ public class ExecutionGraphCacheTest extends TestLogger {
 	public void testCacheEntryCleanup() throws Exception {
 		final Time timeout = Time.milliseconds(100L);
 		final Time timeToLive = Time.milliseconds(1L);
-		final JobID jobId1 = new JobID();
-		final JobID jobId2 = new JobID();
-		final AccessExecutionGraph accessExecutionGraph1 = mock(AccessExecutionGraph.class);
-		final AccessExecutionGraph accessExecutionGraph2 = mock(AccessExecutionGraph.class);
+		final JobID expectedJobId2 = new JobID();
+		final ArchivedExecutionGraph expectedExecutionGraph2 = new ArchivedExecutionGraphBuilder().build();
 
-		final JobManagerGateway jobManagerGateway = mock(JobManagerGateway.class);
-		when(jobManagerGateway.requestJob(eq(jobId1), any(Time.class))).thenReturn(CompletableFuture.completedFuture(accessExecutionGraph1));
-		when(jobManagerGateway.requestJob(eq(jobId2), any(Time.class))).thenReturn(CompletableFuture.completedFuture(accessExecutionGraph2));
+		final AtomicInteger requestJobCalls = new AtomicInteger(0);
+		final TestingRestfulGateway restfulGateway = TestingRestfulGateway.newBuilder()
+			.setRequestJobFunction(
+				jobId -> {
+					requestJobCalls.incrementAndGet();
+					if (jobId.equals(expectedJobId)) {
+						return CompletableFuture.completedFuture(expectedExecutionGraph);
+					} else if (jobId.equals(expectedJobId2)) {
+						return CompletableFuture.completedFuture(expectedExecutionGraph2);
+					} else {
+						throw new AssertionError("Invalid job id received.");
+					}
+				}
+			)
+			.build();
 
 		try (ExecutionGraphCache executionGraphCache = new ExecutionGraphCache(timeout, timeToLive)) {
 
-			CompletableFuture<AccessExecutionGraph> executionGraph1Future = executionGraphCache.getExecutionGraph(jobId1, jobManagerGateway);
+			CompletableFuture<AccessExecutionGraph> executionGraph1Future = executionGraphCache.getExecutionGraph(expectedJobId, restfulGateway);
 
-			CompletableFuture<AccessExecutionGraph> executionGraph2Future = executionGraphCache.getExecutionGraph(jobId2, jobManagerGateway);
+			CompletableFuture<AccessExecutionGraph> executionGraph2Future = executionGraphCache.getExecutionGraph(expectedJobId2, restfulGateway);
 
-			assertEquals(accessExecutionGraph1, executionGraph1Future.get());
+			assertEquals(expectedExecutionGraph, executionGraph1Future.get());
 
-			assertEquals(accessExecutionGraph2, executionGraph2Future.get());
+			assertEquals(expectedExecutionGraph2, executionGraph2Future.get());
 
-			verify(jobManagerGateway, times(1)).requestJob(eq(jobId1), any(Time.class));
-			verify(jobManagerGateway, times(1)).requestJob(eq(jobId2), any(Time.class));
+			assertThat(requestJobCalls.get(), Matchers.equalTo(2));
 
 			Thread.sleep(timeToLive.toMilliseconds());
 
@@ -199,12 +212,17 @@ public class ExecutionGraphCacheTest extends TestLogger {
 	public void testConcurrentAccess() throws Exception {
 		final Time timeout = Time.milliseconds(100L);
 		final Time timeToLive = Time.hours(1L);
-		final JobID jobId = new JobID();
 
-		final AccessExecutionGraph accessExecutionGraph = mock(AccessExecutionGraph.class);
-
-		final JobManagerGateway jobManagerGateway = mock(JobManagerGateway.class);
-		when(jobManagerGateway.requestJob(eq(jobId), any(Time.class))).thenReturn(CompletableFuture.completedFuture(accessExecutionGraph));
+		final AtomicInteger requestJobCalls = new AtomicInteger(0);
+		final TestingRestfulGateway restfulGateway = TestingRestfulGateway.newBuilder()
+			.setRequestJobFunction(
+				jobId -> {
+					requestJobCalls.incrementAndGet();
+					assertThat(jobId, Matchers.equalTo(expectedJobId));
+					return CompletableFuture.completedFuture(expectedExecutionGraph);
+				}
+			)
+			.build();
 
 		final int numConcurrentAccesses = 10;
 
@@ -216,7 +234,7 @@ public class ExecutionGraphCacheTest extends TestLogger {
 			for (int i = 0; i < numConcurrentAccesses; i++) {
 				CompletableFuture<AccessExecutionGraph> executionGraphFuture = CompletableFuture
 					.supplyAsync(
-						() -> executionGraphCache.getExecutionGraph(jobId, jobManagerGateway),
+						() -> executionGraphCache.getExecutionGraph(expectedJobId, restfulGateway),
 						executor)
 					.thenCompose(Function.identity());
 
@@ -228,10 +246,10 @@ public class ExecutionGraphCacheTest extends TestLogger {
 			Collection<AccessExecutionGraph> allExecutionGraphs = allExecutionGraphFutures.get();
 
 			for (AccessExecutionGraph executionGraph : allExecutionGraphs) {
-				assertEquals(accessExecutionGraph, executionGraph);
+				assertEquals(expectedExecutionGraph, executionGraph);
 			}
 
-			verify(jobManagerGateway, times(1)).requestJob(eq(jobId), any(Time.class));
+			assertThat(requestJobCalls.get(), Matchers.equalTo(1));
 		} finally {
 			ExecutorUtils.gracefulShutdown(5000L, TimeUnit.MILLISECONDS, executor);
 		}
@@ -248,27 +266,32 @@ public class ExecutionGraphCacheTest extends TestLogger {
 	public void testCacheInvalidationIfSuspended() throws Exception {
 		final Time timeout = Time.milliseconds(100L);
 		final Time timeToLive = Time.hours(1L);
-		final JobID jobId = new JobID();
+		final JobID expectedJobId = new JobID();
 
-		final AccessExecutionGraph accessExecutionGraph = mock(AccessExecutionGraph.class);
+		final ArchivedExecutionGraph suspendedExecutionGraph = new ArchivedExecutionGraphBuilder().setState(JobStatus.SUSPENDED).build();
+		final ConcurrentLinkedQueue<CompletableFuture<? extends AccessExecutionGraph>> requestJobAnswers = new ConcurrentLinkedQueue<>();
 
-		final AccessExecutionGraph suspendedExecutionGraph = mock(AccessExecutionGraph.class);
-		when(suspendedExecutionGraph.getState()).thenReturn(JobStatus.SUSPENDED);
+		requestJobAnswers.offer(CompletableFuture.completedFuture(suspendedExecutionGraph));
+		requestJobAnswers.offer(CompletableFuture.completedFuture(expectedExecutionGraph));
 
-		final JobManagerGateway jobManagerGateway = mock(JobManagerGateway.class);
-		// let's first answer with a suspended ExecutionGraph and then only with the correct result
-		when(jobManagerGateway.requestJob(eq(jobId), any(Time.class))).thenReturn(
-			CompletableFuture.completedFuture(suspendedExecutionGraph),
-			CompletableFuture.completedFuture(accessExecutionGraph));
+		final TestingRestfulGateway restfulGateway = TestingRestfulGateway.newBuilder()
+			.setRequestJobFunction(
+				jobId -> {
+					assertThat(jobId, Matchers.equalTo(expectedJobId));
+
+					return requestJobAnswers.poll();
+				}
+			)
+			.build();
 
 		try (ExecutionGraphCache executionGraphCache = new ExecutionGraphCache(timeout, timeToLive)) {
-			CompletableFuture<AccessExecutionGraph> executionGraphFuture = executionGraphCache.getExecutionGraph(jobId, jobManagerGateway);
+			CompletableFuture<AccessExecutionGraph> executionGraphFuture = executionGraphCache.getExecutionGraph(expectedJobId, restfulGateway);
 
 			assertEquals(suspendedExecutionGraph, executionGraphFuture.get());
 
-			CompletableFuture<AccessExecutionGraph> executionGraphFuture2 = executionGraphCache.getExecutionGraph(jobId, jobManagerGateway);
+			CompletableFuture<AccessExecutionGraph> executionGraphFuture2 = executionGraphCache.getExecutionGraph(expectedJobId, restfulGateway);
 
-			assertEquals(accessExecutionGraph, executionGraphFuture2.get());
+			assertEquals(expectedExecutionGraph, executionGraphFuture2.get());
 		}
 	}
 
@@ -283,35 +306,65 @@ public class ExecutionGraphCacheTest extends TestLogger {
 	public void testCacheInvalidationIfSwitchToSuspended() throws Exception {
 		final Time timeout = Time.milliseconds(100L);
 		final Time timeToLive = Time.hours(1L);
-		final JobID jobId = new JobID();
+		final JobID expectedJobId = new JobID();
 
-		final AccessExecutionGraph accessExecutionGraph = mock(AccessExecutionGraph.class);
+		final SuspendableAccessExecutionGraph toBeSuspendedExecutionGraph = new SuspendableAccessExecutionGraph(expectedJobId);
 
-		final SuspendableAccessExecutionGraph toBeSuspendedExecutionGraph = new SuspendableAccessExecutionGraph(jobId);
-
-		final JobManagerGateway jobManagerGateway = mock(JobManagerGateway.class);
-		// let's first answer with a JobNotFoundException and then only with the correct result
-		when(jobManagerGateway.requestJob(eq(jobId), any(Time.class))).thenReturn(
+		final CountingRestfulGateway restfulGateway = createCountingRestfulGateway(
+			expectedJobId,
 			CompletableFuture.completedFuture(toBeSuspendedExecutionGraph),
-			CompletableFuture.completedFuture(accessExecutionGraph));
+			CompletableFuture.completedFuture(expectedExecutionGraph));
 
 		try (ExecutionGraphCache executionGraphCache = new ExecutionGraphCache(timeout, timeToLive)) {
-			CompletableFuture<AccessExecutionGraph> executionGraphFuture = executionGraphCache.getExecutionGraph(jobId, jobManagerGateway);
+			CompletableFuture<AccessExecutionGraph> executionGraphFuture = executionGraphCache.getExecutionGraph(expectedJobId, restfulGateway);
 
 			assertEquals(toBeSuspendedExecutionGraph, executionGraphFuture.get());
 
 			toBeSuspendedExecutionGraph.setJobStatus(JobStatus.SUSPENDED);
 
 			// retrieve the same job from the cache again --> this should return it and invalidate the cache entry
-			CompletableFuture<AccessExecutionGraph> executionGraphFuture2 = executionGraphCache.getExecutionGraph(jobId, jobManagerGateway);
+			CompletableFuture<AccessExecutionGraph> executionGraphFuture2 = executionGraphCache.getExecutionGraph(expectedJobId, restfulGateway);
 
-			assertEquals(accessExecutionGraph, executionGraphFuture2.get());
+			assertEquals(expectedExecutionGraph, executionGraphFuture2.get());
 
-			CompletableFuture<AccessExecutionGraph> executionGraphFuture3 = executionGraphCache.getExecutionGraph(jobId, jobManagerGateway);
+			CompletableFuture<AccessExecutionGraph> executionGraphFuture3 = executionGraphCache.getExecutionGraph(expectedJobId, restfulGateway);
 
-			assertEquals(accessExecutionGraph, executionGraphFuture3.get());
+			assertEquals(expectedExecutionGraph, executionGraphFuture3.get());
 
-			verify(jobManagerGateway, times(2)).requestJob(eq(jobId), any(Time.class));
+			assertThat(restfulGateway.getNumRequestJobCalls(), Matchers.equalTo(2));
+		}
+	}
+
+	private CountingRestfulGateway createCountingRestfulGateway(JobID jobId, CompletableFuture<? extends AccessExecutionGraph>... accessExecutionGraphs) {
+		final ConcurrentLinkedQueue<CompletableFuture<? extends AccessExecutionGraph>> queue = new ConcurrentLinkedQueue<>(Arrays.asList(accessExecutionGraphs));
+		return new CountingRestfulGateway(
+			jobId,
+			ignored -> queue.poll());
+	}
+
+	/**
+	 * {@link RestfulGateway} implementation which counts the number of {@link #requestJob(JobID, Time)} calls.
+	 */
+	private static class CountingRestfulGateway extends TestingRestfulGateway {
+
+		private final JobID expectedJobId;
+
+		private int numRequestJobCalls = 0;
+
+		private CountingRestfulGateway(JobID expectedJobId, Function<JobID, CompletableFuture<? extends AccessExecutionGraph>> requestJobFunction) {
+			this.expectedJobId = Preconditions.checkNotNull(expectedJobId);
+			this.requestJobFunction = Preconditions.checkNotNull(requestJobFunction);
+		}
+
+		@Override
+		public CompletableFuture<? extends AccessExecutionGraph> requestJob(JobID jobId, Time timeout) {
+			assertThat(jobId, Matchers.equalTo(expectedJobId));
+			numRequestJobCalls++;
+			return super.requestJob(jobId, timeout);
+		}
+
+		public int getNumRequestJobCalls() {
+			return numRequestJobCalls;
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/JobExceptionsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/JobExceptionsHandlerTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
 import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.TestLogger;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ArrayNode;
@@ -42,7 +43,7 @@ import static org.mockito.Mockito.mock;
 /**
  * Tests for the JobExceptionsHandler.
  */
-public class JobExceptionsHandlerTest {
+public class JobExceptionsHandlerTest extends TestLogger {
 
 	@Test
 	public void testArchiver() throws Exception {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/utils/ArchivedExecutionGraphBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/utils/ArchivedExecutionGraphBuilder.java
@@ -117,9 +117,13 @@ public class ArchivedExecutionGraphBuilder {
 	}
 
 	public ArchivedExecutionGraph build() {
-		Preconditions.checkNotNull(tasks, "Tasks must not be null.");
 		JobID jobID = this.jobID != null ? this.jobID : new JobID();
 		String jobName = this.jobName != null ? this.jobName : "job_" + RANDOM.nextInt();
+
+		if (tasks == null) {
+			tasks = Collections.emptyMap();
+		}
+
 		return new ArchivedExecutionGraph(
 			jobID,
 			jobName,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/TestingRestfulGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/TestingRestfulGateway.java
@@ -1,0 +1,204 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.webmonitor;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
+import org.apache.flink.runtime.messages.webmonitor.ClusterOverview;
+import org.apache.flink.runtime.messages.webmonitor.MultipleJobsDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * Testing implementation of the {@link RestfulGateway}.
+ */
+public class TestingRestfulGateway implements RestfulGateway {
+
+	static final Function<JobID, CompletableFuture<? extends AccessExecutionGraph>> DEFAULT_REQUEST_JOB_FUNCTION = jobId -> FutureUtils.completedExceptionally(new UnsupportedOperationException());
+	static final Supplier<CompletableFuture<MultipleJobsDetails>> DEFAULT_REQUEST_MULTIPLE_JOB_DETAILS_SUPPLIER = () -> CompletableFuture.completedFuture(new MultipleJobsDetails(Collections.emptyList()));
+	static final Supplier<CompletableFuture<ClusterOverview>> DEFAULT_REQUEST_CLUSTER_OVERVIEW_SUPPLIER = () -> CompletableFuture.completedFuture(new ClusterOverview(0, 0, 0, 0, 0, 0, 0));
+	static final Supplier<CompletableFuture<Collection<String>>> DEFAULT_REQUEST_METRIC_QUERY_SERVICE_PATHS_SUPPLIER = () -> CompletableFuture.completedFuture(Collections.emptyList());
+	static final Supplier<CompletableFuture<Collection<Tuple2<ResourceID, String>>>> DEFAULT_REQUEST_TASK_MANAGER_METRIC_QUERY_SERVICE_PATHS_SUPPLIER = () -> CompletableFuture.completedFuture(Collections.emptyList());
+	static final String LOCALHOST = "localhost";
+
+	protected String address;
+
+	protected String hostname;
+
+	protected String restAddress;
+
+	protected Function<JobID, CompletableFuture<? extends AccessExecutionGraph>> requestJobFunction;
+
+	protected Supplier<CompletableFuture<MultipleJobsDetails>> requestMultipleJobDetailsSupplier;
+
+	protected Supplier<CompletableFuture<ClusterOverview>> requestClusterOverviewSupplier;
+
+	protected Supplier<CompletableFuture<Collection<String>>> requestMetricQueryServicePathsSupplier;
+
+	protected Supplier<CompletableFuture<Collection<Tuple2<ResourceID, String>>>> requestTaskManagerMetricQueryServicePathsSupplier;
+
+	public TestingRestfulGateway() {
+		this(
+			LOCALHOST,
+			LOCALHOST,
+			LOCALHOST,
+			DEFAULT_REQUEST_JOB_FUNCTION,
+			DEFAULT_REQUEST_MULTIPLE_JOB_DETAILS_SUPPLIER,
+			DEFAULT_REQUEST_CLUSTER_OVERVIEW_SUPPLIER,
+			DEFAULT_REQUEST_METRIC_QUERY_SERVICE_PATHS_SUPPLIER,
+			DEFAULT_REQUEST_TASK_MANAGER_METRIC_QUERY_SERVICE_PATHS_SUPPLIER);
+	}
+
+	public TestingRestfulGateway(
+			String address,
+			String hostname,
+			String restAddress,
+			Function<JobID, CompletableFuture<? extends AccessExecutionGraph>> requestJobFunction,
+			Supplier<CompletableFuture<MultipleJobsDetails>> requestMultipleJobDetailsSupplier,
+			Supplier<CompletableFuture<ClusterOverview>> requestClusterOverviewSupplier,
+			Supplier<CompletableFuture<Collection<String>>> requestMetricQueryServicePathsSupplier,
+			Supplier<CompletableFuture<Collection<Tuple2<ResourceID, String>>>> requestTaskManagerMetricQueryServicePathsSupplier) {
+		this.address = address;
+		this.hostname = hostname;
+		this.restAddress = restAddress;
+		this.requestJobFunction = requestJobFunction;
+		this.requestMultipleJobDetailsSupplier = requestMultipleJobDetailsSupplier;
+		this.requestClusterOverviewSupplier = requestClusterOverviewSupplier;
+		this.requestMetricQueryServicePathsSupplier = requestMetricQueryServicePathsSupplier;
+		this.requestTaskManagerMetricQueryServicePathsSupplier = requestTaskManagerMetricQueryServicePathsSupplier;
+	}
+
+	@Override
+	public CompletableFuture<String> requestRestAddress(Time timeout) {
+		return CompletableFuture.completedFuture(restAddress);
+	}
+
+	@Override
+	public CompletableFuture<? extends AccessExecutionGraph> requestJob(JobID jobId, Time timeout) {
+		return requestJobFunction.apply(jobId);
+	}
+
+	@Override
+	public CompletableFuture<MultipleJobsDetails> requestMultipleJobDetails(Time timeout) {
+		return requestMultipleJobDetailsSupplier.get();
+	}
+
+	@Override
+	public CompletableFuture<ClusterOverview> requestClusterOverview(Time timeout) {
+		return requestClusterOverviewSupplier.get();
+	}
+
+	@Override
+	public CompletableFuture<Collection<String>> requestMetricQueryServicePaths(Time timeout) {
+		return requestMetricQueryServicePathsSupplier.get();
+	}
+
+	@Override
+	public CompletableFuture<Collection<Tuple2<ResourceID, String>>> requestTaskManagerMetricQueryServicePaths(Time timeout) {
+		return requestTaskManagerMetricQueryServicePathsSupplier.get();
+	}
+
+	@Override
+	public String getAddress() {
+		return address;
+	}
+
+	@Override
+	public String getHostname() {
+		return hostname;
+	}
+
+	public static Builder newBuilder() {
+		return new Builder();
+	}
+
+	/**
+	 * Builder for the {@link TestingRestfulGateway}.
+	 */
+	public static final class Builder {
+		private String address = LOCALHOST;
+		private String hostname = LOCALHOST;
+		private String restAddress = LOCALHOST;
+		private Function<JobID, CompletableFuture<? extends AccessExecutionGraph>> requestJobFunction;
+		private Supplier<CompletableFuture<MultipleJobsDetails>> requestMultipleJobDetailsSupplier;
+		private Supplier<CompletableFuture<ClusterOverview>> requestClusterOverviewSupplier;
+		private Supplier<CompletableFuture<Collection<String>>> requestMetricQueryServicePathsSupplier;
+		private Supplier<CompletableFuture<Collection<Tuple2<ResourceID, String>>>> requestTaskManagerMetricQueryServicePathsSupplier;
+
+		public Builder() {
+			requestJobFunction = DEFAULT_REQUEST_JOB_FUNCTION;
+			requestMultipleJobDetailsSupplier = DEFAULT_REQUEST_MULTIPLE_JOB_DETAILS_SUPPLIER;
+			requestClusterOverviewSupplier = DEFAULT_REQUEST_CLUSTER_OVERVIEW_SUPPLIER;
+			requestMetricQueryServicePathsSupplier = DEFAULT_REQUEST_METRIC_QUERY_SERVICE_PATHS_SUPPLIER;
+			requestTaskManagerMetricQueryServicePathsSupplier = DEFAULT_REQUEST_TASK_MANAGER_METRIC_QUERY_SERVICE_PATHS_SUPPLIER;
+		}
+
+		public Builder setAddress(String address) {
+			this.address = address;
+			return this;
+		}
+
+		public Builder setHostname(String hostname) {
+			this.hostname = hostname;
+			return this;
+		}
+
+		public Builder setRestAddress(String restAddress) {
+			this.restAddress = restAddress;
+			return this;
+		}
+
+		public Builder setRequestJobFunction(Function<JobID, CompletableFuture<? extends AccessExecutionGraph>> requestJobFunction) {
+			this.requestJobFunction = requestJobFunction;
+			return this;
+		}
+
+		public Builder setRequestMultipleJobDetailsSupplier(Supplier<CompletableFuture<MultipleJobsDetails>> requestMultipleJobDetailsSupplier) {
+			this.requestMultipleJobDetailsSupplier = requestMultipleJobDetailsSupplier;
+			return this;
+		}
+
+		public Builder setRequestClusterOverviewSupplier(Supplier<CompletableFuture<ClusterOverview>> requestClusterOverviewSupplier) {
+			this.requestClusterOverviewSupplier = requestClusterOverviewSupplier;
+			return this;
+		}
+
+		public Builder setRequestMetricQueryServicePathsSupplier(Supplier<CompletableFuture<Collection<String>>> requestMetricQueryServicePathsSupplier) {
+			this.requestMetricQueryServicePathsSupplier = requestMetricQueryServicePathsSupplier;
+			return this;
+		}
+
+		public Builder setRequestTaskManagerMetricQueryServicePathsSupplier(Supplier<CompletableFuture<Collection<Tuple2<ResourceID, String>>>> requestTaskManagerMetricQueryServicePathsSupplier) {
+			this.requestTaskManagerMetricQueryServicePathsSupplier = requestTaskManagerMetricQueryServicePathsSupplier;
+			return this;
+		}
+
+		public TestingRestfulGateway build() {
+			return new TestingRestfulGateway(address, hostname, restAddress, requestJobFunction, requestMultipleJobDetailsSupplier, requestClusterOverviewSupplier, requestMetricQueryServicePathsSupplier, requestTaskManagerMetricQueryServicePathsSupplier);
+		}
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

The ArchivedExecutionGraphStore is responsible for storing completed jobs
for historic job requests (e.g. from the web ui or from the client). The store
is populated by the Dispatcher once a job has terminated.

The FileArchivedExecutionGraphStore implementation persists all
ArchivedExecutionGraphs on disk in order to avoid OOM problems. It only keeps
some of the stored graphs in memory until it reaches a configurable size. Once
coming close to this size, it will evict the elements and only reload them if
requested again. Additionally, the FileArchivedExecutionGraphStore defines
an expiration time after which the execution graphs will be removed from disk.
This prevents excessive use of disk resources.

This PR is based on #5309.

## Brief change log

- Introduce `ArchivedExecutionGraphStore` and `FileArchivedExecutionGraphStore`
- Add `FileArchivedExecutionGraphStore` to `Dispatcher`
- Store `ArchivedExecutionGraphs` in corresponding `FileArchivedExecutionGraphStore`
- Adapt `Dispatcher` to serve requests for historic jobs

## Verifying this change

- Added `FileArchivedExecutionGraphStoreTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

cc @GJL 