### PR TITLE
[FLINK-8344][flip6] Add support for HA to RestClusterClient

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/cli/AbstractCustomCommandLine.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/AbstractCustomCommandLine.java
@@ -73,7 +73,7 @@ public abstract class AbstractCustomCommandLine<T> implements CustomCommandLine<
 	 * Override configuration settings by specified command line options.
 	 *
 	 * @param commandLine containing the overriding values
-	 * @return Effective configuration with the overriden configuration settings
+	 * @return Effective configuration with the overridden configuration settings
 	 */
 	protected Configuration applyCommandLineOptionsToConfiguration(CommandLine commandLine) throws FlinkException {
 		final Configuration resultingConfiguration = new Configuration(configuration);

--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
@@ -85,8 +85,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static java.util.Objects.requireNonNull;
-
 /**
  * A {@link ClusterClient} implementation that communicates via HTTP REST requests.
  */
@@ -97,6 +95,7 @@ public class RestClusterClient<T> extends ClusterClient<T> {
 	private final RestClient restClient;
 
 	private final ExecutorService executorService = Executors.newFixedThreadPool(4, new ExecutorThreadFactory("Flink-RestClusterClient-IO"));
+
 	private final WaitStrategy waitStrategy;
 
 	private final T clusterId;
@@ -113,7 +112,7 @@ public class RestClusterClient<T> extends ClusterClient<T> {
 		super(configuration);
 		this.restClusterClientConfiguration = RestClusterClientConfiguration.fromConfiguration(configuration);
 		this.restClient = new RestClient(restClusterClientConfiguration.getRestClientConfiguration(), executorService);
-		this.waitStrategy = requireNonNull(waitStrategy);
+		this.waitStrategy = Preconditions.checkNotNull(waitStrategy);
 		this.clusterId = Preconditions.checkNotNull(clusterId);
 	}
 

--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
@@ -34,18 +34,25 @@ import org.apache.flink.runtime.blob.PermanentBlobKey;
 import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.runtime.client.JobSubmissionException;
 import org.apache.flink.runtime.clusterframework.messages.GetClusterStatusResponse;
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.concurrent.ScheduledExecutorServiceAdapter;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmaster.JobResult;
-import org.apache.flink.runtime.messages.webmonitor.JobDetails;
-import org.apache.flink.runtime.messages.webmonitor.MultipleJobsDetails;
+import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
 import org.apache.flink.runtime.rest.RestClient;
 import org.apache.flink.runtime.rest.messages.BlobServerPortHeaders;
 import org.apache.flink.runtime.rest.messages.BlobServerPortResponseBody;
+import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
 import org.apache.flink.runtime.rest.messages.EmptyResponseBody;
 import org.apache.flink.runtime.rest.messages.JobMessageParameters;
 import org.apache.flink.runtime.rest.messages.JobTerminationHeaders;
 import org.apache.flink.runtime.rest.messages.JobTerminationMessageParameters;
 import org.apache.flink.runtime.rest.messages.JobsOverviewHeaders;
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+import org.apache.flink.runtime.rest.messages.MessageParameters;
+import org.apache.flink.runtime.rest.messages.RequestBody;
+import org.apache.flink.runtime.rest.messages.ResponseBody;
 import org.apache.flink.runtime.rest.messages.TerminationModeQueryParameter;
 import org.apache.flink.runtime.rest.messages.job.JobExecutionResultHeaders;
 import org.apache.flink.runtime.rest.messages.job.JobSubmitHeaders;
@@ -61,29 +68,42 @@ import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointTriggerReq
 import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointTriggerResponseBody;
 import org.apache.flink.runtime.rest.messages.queue.AsynchronouslyCreatedResource;
 import org.apache.flink.runtime.rest.messages.queue.QueueStatus;
+import org.apache.flink.runtime.rest.util.RestClientException;
 import org.apache.flink.runtime.util.ExecutorThreadFactory;
+import org.apache.flink.runtime.webmonitor.retriever.LeaderRetriever;
+import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.ExecutorUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.SerializedThrowable;
-import org.apache.flink.util.function.SupplierWithException;
+import org.apache.flink.util.function.CheckedSupplier;
+
+import org.apache.flink.shaded.netty4.io.netty.channel.ConnectTimeoutException;
+
+import akka.actor.AddressFromURIString;
 
 import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import scala.Option;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
 
 /**
  * A {@link ClusterClient} implementation that communicates via HTTP REST requests.
@@ -100,20 +120,48 @@ public class RestClusterClient<T> extends ClusterClient<T> {
 
 	private final T clusterId;
 
+	private final LeaderRetrievalService webMonitorRetrievalService;
+
+	private final LeaderRetrievalService dispatcherRetrievalService;
+
+	private final LeaderRetriever webMonitorLeaderRetriever = new LeaderRetriever();
+
+	private final LeaderRetriever dispatcherLeaderRetriever = new LeaderRetriever();
+
+	/** ExecutorService to run operations that can be retried on exceptions. */
+	private ScheduledExecutorService retryExecutorService;
+
 	public RestClusterClient(Configuration config, T clusterId) throws Exception {
 		this(
 			config,
+			null,
 			clusterId,
 			new ExponentialWaitStrategy(10L, 2000L));
 	}
 
 	@VisibleForTesting
-	RestClusterClient(Configuration configuration, T clusterId, WaitStrategy waitStrategy) throws Exception {
+	RestClusterClient(Configuration configuration, @Nullable RestClient restClient, T clusterId, WaitStrategy waitStrategy) throws Exception {
 		super(configuration);
 		this.restClusterClientConfiguration = RestClusterClientConfiguration.fromConfiguration(configuration);
-		this.restClient = new RestClient(restClusterClientConfiguration.getRestClientConfiguration(), executorService);
+
+		if (restClient != null) {
+			this.restClient = restClient;
+		} else {
+			this.restClient = new RestClient(restClusterClientConfiguration.getRestClientConfiguration(), executorService);
+		}
+
 		this.waitStrategy = Preconditions.checkNotNull(waitStrategy);
 		this.clusterId = Preconditions.checkNotNull(clusterId);
+
+		this.webMonitorRetrievalService = highAvailabilityServices.getWebMonitorLeaderRetriever();
+		this.dispatcherRetrievalService = highAvailabilityServices.getDispatcherLeaderRetriever();
+		this.retryExecutorService = Executors.newSingleThreadScheduledExecutor(new ExecutorThreadFactory("Flink-RestClusterClient-Retry"));
+		startLeaderRetrievers();
+	}
+
+	private void startLeaderRetrievers() throws Exception {
+		this.webMonitorRetrievalService.start(webMonitorLeaderRetriever);
+		this.dispatcherRetrievalService.start(dispatcherLeaderRetriever);
 	}
 
 	@Override
@@ -124,8 +172,23 @@ public class RestClusterClient<T> extends ClusterClient<T> {
 		} catch (Exception e) {
 			log.error("An error occurred during the client shutdown.", e);
 		}
+
+		ExecutorUtils.gracefulShutdown(restClusterClientConfiguration.getRetryDelay(), TimeUnit.MILLISECONDS, retryExecutorService);
+
 		this.restClient.shutdown(Time.seconds(5));
 		ExecutorUtils.gracefulShutdown(5, TimeUnit.SECONDS, this.executorService);
+
+		try {
+			webMonitorRetrievalService.stop();
+		} catch (Exception e) {
+			log.error("An error occurred during stopping the webMonitorRetrievalService", e);
+		}
+
+		try {
+			dispatcherRetrievalService.stop();
+		} catch (Exception e) {
+			log.error("An error occurred during stopping the dispatcherLeaderRetriever", e);
+		}
 	}
 
 	@Override
@@ -145,12 +208,12 @@ public class RestClusterClient<T> extends ClusterClient<T> {
 				() -> {
 					final JobMessageParameters messageParameters = new JobMessageParameters();
 					messageParameters.jobPathParameter.resolve(jobGraph.getJobID());
-					return restClient.sendRequest(
-						restClusterClientConfiguration.getRestServerAddress(),
-						restClusterClientConfiguration.getRestServerPort(),
+					return sendRetryableRequest(
 						JobExecutionResultHeaders.getInstance(),
-						messageParameters);
-				});
+						messageParameters,
+						EmptyRequestBody.getInstance(),
+						isConnectionProblemException().or(isHttpStatusUnsuccessfulException()));
+				}).get();
 		} catch (final Exception e) {
 			throw new ProgramInvocationException(e);
 		}
@@ -180,9 +243,7 @@ public class RestClusterClient<T> extends ClusterClient<T> {
 		log.info("Requesting blob server port.");
 		int blobServerPort;
 		try {
-			CompletableFuture<BlobServerPortResponseBody> portFuture = restClient.sendRequest(
-				restClusterClientConfiguration.getRestServerAddress(),
-				restClusterClientConfiguration.getRestServerPort(),
+			CompletableFuture<BlobServerPortResponseBody> portFuture = sendRequest(
 				BlobServerPortHeaders.getInstance());
 			blobServerPort = portFuture.get(timeout.toMillis(), TimeUnit.MILLISECONDS).port;
 		} catch (Exception e) {
@@ -191,7 +252,7 @@ public class RestClusterClient<T> extends ClusterClient<T> {
 
 		log.info("Uploading jar files.");
 		try {
-			InetSocketAddress address = new InetSocketAddress(restClusterClientConfiguration.getBlobServerAddress(), blobServerPort);
+			InetSocketAddress address = new InetSocketAddress(getDispatcherAddress().get(), blobServerPort);
 			List<PermanentBlobKey> keys = BlobClient.uploadJarFiles(address, this.flinkConfig, jobGraph.getJobID(), jobGraph.getUserJars());
 			for (PermanentBlobKey key : keys) {
 				jobGraph.addBlob(key);
@@ -202,9 +263,7 @@ public class RestClusterClient<T> extends ClusterClient<T> {
 
 		log.info("Submitting job graph.");
 		try {
-			CompletableFuture<JobSubmitResponseBody> responseFuture = restClient.sendRequest(
-				restClusterClientConfiguration.getRestServerAddress(),
-				restClusterClientConfiguration.getRestServerPort(),
+			CompletableFuture<JobSubmitResponseBody> responseFuture = sendRequest(
 				JobSubmitHeaders.getInstance(),
 				new JobSubmitRequestBody(jobGraph));
 			responseFuture.get(timeout.toMillis(), TimeUnit.MILLISECONDS);
@@ -218,9 +277,7 @@ public class RestClusterClient<T> extends ClusterClient<T> {
 		JobTerminationMessageParameters params = new JobTerminationMessageParameters();
 		params.jobPathParameter.resolve(jobID);
 		params.terminationModeQueryParameter.resolve(Collections.singletonList(TerminationModeQueryParameter.TerminationMode.STOP));
-		CompletableFuture<EmptyResponseBody> responseFuture = restClient.sendRequest(
-			restClusterClientConfiguration.getRestServerAddress(),
-			restClusterClientConfiguration.getRestServerPort(),
+		CompletableFuture<EmptyResponseBody> responseFuture = sendRequest(
 			JobTerminationHeaders.getInstance(),
 			params
 		);
@@ -232,9 +289,7 @@ public class RestClusterClient<T> extends ClusterClient<T> {
 		JobTerminationMessageParameters params = new JobTerminationMessageParameters();
 		params.jobPathParameter.resolve(jobID);
 		params.terminationModeQueryParameter.resolve(Collections.singletonList(TerminationModeQueryParameter.TerminationMode.CANCEL));
-		CompletableFuture<EmptyResponseBody> responseFuture = restClient.sendRequest(
-			restClusterClientConfiguration.getRestServerAddress(),
-			restClusterClientConfiguration.getRestServerPort(),
+		CompletableFuture<EmptyResponseBody> responseFuture = sendRequest(
 			JobTerminationHeaders.getInstance(),
 			params
 		);
@@ -257,25 +312,15 @@ public class RestClusterClient<T> extends ClusterClient<T> {
 
 		final CompletableFuture<SavepointTriggerResponseBody> responseFuture;
 
-		try {
-			responseFuture = restClient.sendRequest(
-				restClusterClientConfiguration.getRestServerAddress(),
-				restClusterClientConfiguration.getRestServerPort(),
-				savepointTriggerHeaders,
-				savepointTriggerMessageParameters,
-				new SavepointTriggerRequestBody(savepointDirectory));
-		} catch (IOException e) {
-			throw new FlinkException("Could not send trigger savepoint request to Flink cluster.", e);
-		}
+		responseFuture = sendRequest(
+			savepointTriggerHeaders,
+			savepointTriggerMessageParameters,
+			new SavepointTriggerRequestBody(savepointDirectory));
 
-		return responseFuture.thenApply(savepointTriggerResponseBody -> {
+		return responseFuture.thenCompose(savepointTriggerResponseBody -> {
 			final SavepointTriggerId savepointTriggerId = savepointTriggerResponseBody.getSavepointTriggerId();
-			final SavepointInfo savepointInfo;
-			try {
-				savepointInfo = waitForSavepointCompletion(jobId, savepointTriggerId);
-			} catch (Exception e) {
-				throw new CompletionException(e);
-			}
+			return waitForSavepointCompletion(jobId, savepointTriggerId);
+		}).thenApply(savepointInfo -> {
 			if (savepointInfo.getFailureCause() != null) {
 				throw new CompletionException(savepointInfo.getFailureCause());
 			}
@@ -283,41 +328,36 @@ public class RestClusterClient<T> extends ClusterClient<T> {
 		});
 	}
 
-	private SavepointInfo waitForSavepointCompletion(
+	private CompletableFuture<SavepointInfo> waitForSavepointCompletion(
 			final JobID jobId,
-			final SavepointTriggerId savepointTriggerId) throws Exception {
+			final SavepointTriggerId savepointTriggerId) {
 		return waitForResource(() -> {
 			final SavepointStatusHeaders savepointStatusHeaders = SavepointStatusHeaders.getInstance();
 			final SavepointStatusMessageParameters savepointStatusMessageParameters =
 				savepointStatusHeaders.getUnresolvedMessageParameters();
 			savepointStatusMessageParameters.jobIdPathParameter.resolve(jobId);
 			savepointStatusMessageParameters.savepointTriggerIdPathParameter.resolve(savepointTriggerId);
-			return restClient.sendRequest(
-				restClusterClientConfiguration.getRestServerAddress(),
-				restClusterClientConfiguration.getRestServerPort(),
+			return sendRetryableRequest(
 				savepointStatusHeaders,
-				savepointStatusMessageParameters
-			);
+				savepointStatusMessageParameters,
+				EmptyRequestBody.getInstance(),
+				isConnectionProblemException());
 		});
 	}
 
 	@Override
 	public CompletableFuture<Collection<JobStatusMessage>> listJobs() throws Exception {
-		JobsOverviewHeaders headers = JobsOverviewHeaders.getInstance();
-		CompletableFuture<MultipleJobsDetails> jobDetailsFuture = restClient.sendRequest(
-			restClusterClientConfiguration.getRestServerAddress(),
-			restClusterClientConfiguration.getRestServerPort(),
-			headers
-		);
-		return jobDetailsFuture
+		return sendRequest(JobsOverviewHeaders.getInstance())
 			.thenApply(
-				(MultipleJobsDetails multipleJobsDetails) -> {
-					final Collection<JobDetails> jobDetails = multipleJobsDetails.getJobs();
-					Collection<JobStatusMessage> flattenedDetails = new ArrayList<>(jobDetails.size());
-					jobDetails.forEach(detail -> flattenedDetails.add(new JobStatusMessage(detail.getJobId(), detail.getJobName(), detail.getStatus(), detail.getStartTime())));
-
-					return flattenedDetails;
-			});
+				(multipleJobsDetails) -> multipleJobsDetails
+					.getJobs()
+					.stream()
+					.map(detail -> new JobStatusMessage(
+						detail.getJobId(),
+						detail.getJobName(),
+						detail.getStatus(),
+						detail.getStartTime()))
+					.collect(Collectors.toList()));
 	}
 
 	@Override
@@ -325,21 +365,43 @@ public class RestClusterClient<T> extends ClusterClient<T> {
 		return clusterId;
 	}
 
-	private <R, A extends AsynchronouslyCreatedResource<R>> R waitForResource(
-			final SupplierWithException<CompletableFuture<A>, IOException> resourceFutureSupplier)
-				throws IOException, InterruptedException, ExecutionException, TimeoutException {
-		A asynchronouslyCreatedResource;
-		long attempt = 0;
-		while (true) {
-			final CompletableFuture<A> responseFuture = resourceFutureSupplier.get();
-			asynchronouslyCreatedResource = responseFuture.get(timeout.toMillis(), TimeUnit.MILLISECONDS);
-			if (asynchronouslyCreatedResource.queueStatus().getId() == QueueStatus.Id.COMPLETED) {
-				break;
+	/**
+	 * Polls a {@code AsynchronouslyCreatedResource} until its
+	 * {@link AsynchronouslyCreatedResource#queueStatus() QueueStatus} becomes
+	 * {@link QueueStatus.Id#COMPLETED COMPLETED}. This method returns a {@code CompletableFuture}
+	 * which completes with {@link AsynchronouslyCreatedResource#resource()}.
+	 *
+	 * @param resourceFutureSupplier The operation which polls for the
+	 *                               {@code AsynchronouslyCreatedResource}.
+	 * @param <R>                    The type of the resource.
+	 * @param <A>                    The type of the {@code AsynchronouslyCreatedResource}.
+	 * @return A {@code CompletableFuture} delivering the resource.
+	 */
+	private <R, A extends AsynchronouslyCreatedResource<R>> CompletableFuture<R> waitForResource(
+			final Supplier<CompletableFuture<A>> resourceFutureSupplier) {
+		return waitForResource(resourceFutureSupplier, new CompletableFuture<>(), 0);
+	}
+
+	private <R, A extends AsynchronouslyCreatedResource<R>> CompletableFuture<R> waitForResource(
+			final Supplier<CompletableFuture<A>> resourceFutureSupplier,
+			final CompletableFuture<R> resultFuture,
+			final long attempt) {
+
+		resourceFutureSupplier.get().whenComplete((asynchronouslyCreatedResource, throwable) -> {
+			if (throwable != null) {
+				resultFuture.completeExceptionally(throwable);
+			} else {
+				if (asynchronouslyCreatedResource.queueStatus().getId() == QueueStatus.Id.COMPLETED) {
+					resultFuture.complete(asynchronouslyCreatedResource.resource());
+				} else {
+					retryExecutorService.schedule(() -> {
+						waitForResource(resourceFutureSupplier, resultFuture, attempt + 1);
+					}, waitStrategy.sleepTime(attempt), TimeUnit.MILLISECONDS);
+				}
 			}
-			Thread.sleep(waitStrategy.sleepTime(attempt));
-			attempt++;
-		}
-		return asynchronouslyCreatedResource.resource();
+		});
+
+		return resultFuture;
 	}
 
 	// ======================================
@@ -358,7 +420,7 @@ public class RestClusterClient<T> extends ClusterClient<T> {
 
 	@Override
 	public String getWebInterfaceURL() {
-		return "http://" + restClusterClientConfiguration.getRestServerAddress() + ':' + restClusterClientConfiguration.getRestServerPort();
+		return getWebMonitorBaseUrl().toString();
 	}
 
 	@Override
@@ -375,4 +437,102 @@ public class RestClusterClient<T> extends ClusterClient<T> {
 	public int getMaxSlots() {
 		return 0;
 	}
+
+	//-------------------------------------------------------------------------
+	// RestClient Helper
+	//-------------------------------------------------------------------------
+
+	private <M extends MessageHeaders<EmptyRequestBody, P, U>, U extends MessageParameters, P extends ResponseBody> CompletableFuture<P>
+			sendRequest(M messageHeaders, U messageParameters) {
+		return sendRequest(messageHeaders, messageParameters, EmptyRequestBody.getInstance());
+	}
+
+	private <M extends MessageHeaders<R, P, EmptyMessageParameters>, R extends RequestBody, P extends ResponseBody> CompletableFuture<P>
+			sendRequest(M messageHeaders, R request) {
+		return sendRequest(messageHeaders, EmptyMessageParameters.getInstance(), request);
+	}
+
+	private <M extends MessageHeaders<EmptyRequestBody, P, EmptyMessageParameters>, P extends ResponseBody> CompletableFuture<P>
+			sendRequest(M messageHeaders) {
+		return sendRequest(messageHeaders, EmptyMessageParameters.getInstance(), EmptyRequestBody.getInstance());
+	}
+
+	private <M extends MessageHeaders<R, P, U>, U extends MessageParameters, R extends RequestBody, P extends ResponseBody> CompletableFuture<P>
+			sendRequest(M messageHeaders, U messageParameters, R request) {
+		return getWebMonitorBaseUrl().thenCompose(webMonitorBaseUrl -> {
+			try {
+				return restClient.sendRequest(webMonitorBaseUrl.getHost(), webMonitorBaseUrl.getPort(), messageHeaders, messageParameters, request);
+			} catch (IOException e) {
+				throw new CompletionException(e);
+			}
+		});
+	}
+
+	private <M extends MessageHeaders<R, P, U>, U extends MessageParameters, R extends RequestBody, P extends ResponseBody> CompletableFuture<P>
+			sendRetryableRequest(M messageHeaders, U messageParameters, R request, Predicate<Throwable> retryPredicate) {
+		return retry(() -> getWebMonitorBaseUrl().thenCompose(webMonitorBaseUrl -> {
+			try {
+				return restClient.sendRequest(webMonitorBaseUrl.getHost(), webMonitorBaseUrl.getPort(), messageHeaders, messageParameters, request);
+			} catch (IOException e) {
+				throw new CompletionException(e);
+			}
+		}), retryPredicate);
+	}
+
+	private <C> CompletableFuture<C> retry(
+			CheckedSupplier<CompletableFuture<C>> operation,
+			Predicate<Throwable> retryPredicate) {
+		return FutureUtils.retryWithDelay(
+			CheckedSupplier.unchecked(operation),
+			restClusterClientConfiguration.getRetryMaxAttempts(),
+			Time.milliseconds(restClusterClientConfiguration.getRetryDelay()),
+			retryPredicate,
+			new ScheduledExecutorServiceAdapter(retryExecutorService));
+	}
+
+	private static Predicate<Throwable> isConnectionProblemException() {
+		return (throwable) ->
+			ExceptionUtils.findThrowable(throwable, java.net.ConnectException.class).isPresent() ||
+				ExceptionUtils.findThrowable(throwable, java.net.SocketTimeoutException.class).isPresent() ||
+				ExceptionUtils.findThrowable(throwable, ConnectTimeoutException.class).isPresent() ||
+				ExceptionUtils.findThrowable(throwable, IOException.class).isPresent();
+	}
+
+	private static Predicate<Throwable> isHttpStatusUnsuccessfulException() {
+		return (throwable) -> ExceptionUtils.findThrowable(throwable, RestClientException.class)
+				.map(restClientException -> {
+					final int code = restClientException.getHttpResponseStatus().code();
+					return code < 200 || code > 299;
+				})
+				.orElse(false);
+	}
+
+	private CompletableFuture<URL> getWebMonitorBaseUrl() {
+		return FutureUtils.orTimeout(
+				webMonitorLeaderRetriever.getLeaderFuture(),
+				restClusterClientConfiguration.getAwaitLeaderTimeout(),
+				TimeUnit.MILLISECONDS)
+			.thenApplyAsync(leaderAddressSessionId -> {
+				final String url = leaderAddressSessionId.f0;
+				try {
+					return new URL(url);
+				} catch (MalformedURLException e) {
+					throw new IllegalArgumentException("Could not parse URL from " + url, e);
+				}
+			}, executorService);
+	}
+
+	private CompletableFuture<String> getDispatcherAddress() {
+		return FutureUtils.orTimeout(
+				dispatcherLeaderRetriever.getLeaderFuture(),
+				restClusterClientConfiguration.getAwaitLeaderTimeout(),
+				TimeUnit.MILLISECONDS)
+			.thenApplyAsync(leaderAddressSessionId -> {
+				final String address = leaderAddressSessionId.f0;
+				final Option<String> host = AddressFromURIString.parse(address).host();
+				checkArgument(host.isDefined(), "Could not parse host from %s", address);
+				return host.get();
+			}, executorService);
+	}
+
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClientConfiguration.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClientConfiguration.java
@@ -33,17 +33,17 @@ public final class RestClusterClientConfiguration {
 
 	private final RestClientConfiguration restClientConfiguration;
 
-	private final int awaitLeaderTimeout;
+	private final long awaitLeaderTimeout;
 
 	private final int retryMaxAttempts;
 
-	private final int retryDelay;
+	private final long retryDelay;
 
 	private RestClusterClientConfiguration(
 			final RestClientConfiguration endpointConfiguration,
-			final int awaitLeaderTimeout,
+			final long awaitLeaderTimeout,
 			final int retryMaxAttempts,
-			final int retryDelay) {
+			final long retryDelay) {
 		checkArgument(awaitLeaderTimeout >= 0, "awaitLeaderTimeout must be equal to or greater than 0");
 		checkArgument(retryMaxAttempts >= 0, "retryMaxAttempts must be equal to or greater than 0");
 		checkArgument(retryDelay >= 0, "retryDelay must be equal to or greater than 0");
@@ -61,7 +61,7 @@ public final class RestClusterClientConfiguration {
 	/**
 	 * @see RestOptions#AWAIT_LEADER_TIMEOUT
 	 */
-	public int getAwaitLeaderTimeout() {
+	public long getAwaitLeaderTimeout() {
 		return awaitLeaderTimeout;
 	}
 
@@ -75,16 +75,16 @@ public final class RestClusterClientConfiguration {
 	/**
 	 * @see RestOptions#RETRY_DELAY
 	 */
-	public int getRetryDelay() {
+	public long getRetryDelay() {
 		return retryDelay;
 	}
 
 	public static RestClusterClientConfiguration fromConfiguration(Configuration config) throws ConfigurationException {
 		RestClientConfiguration restClientConfiguration = RestClientConfiguration.fromConfiguration(config);
 
-		final int awaitLeaderTimeout = config.getInteger(RestOptions.AWAIT_LEADER_TIMEOUT);
+		final long awaitLeaderTimeout = config.getLong(RestOptions.AWAIT_LEADER_TIMEOUT);
 		final int retryMaxAttempts = config.getInteger(RestOptions.RETRY_MAX_ATTEMPTS);
-		final int retryDelay = config.getInteger(RestOptions.RETRY_DELAY);
+		final long retryDelay = config.getLong(RestOptions.RETRY_DELAY);
 
 		return new RestClusterClientConfiguration(restClientConfiguration, awaitLeaderTimeout, retryMaxAttempts, retryDelay);
 	}

--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClientConfiguration.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClientConfiguration.java
@@ -19,60 +19,73 @@
 package org.apache.flink.client.program.rest;
 
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.runtime.rest.RestClientConfiguration;
 import org.apache.flink.util.ConfigurationException;
 import org.apache.flink.util.Preconditions;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
 
 /**
  * A configuration object for {@link RestClusterClient}s.
  */
 public final class RestClusterClientConfiguration {
 
-	private final String blobServerAddress;
-
 	private final RestClientConfiguration restClientConfiguration;
 
-	private final String restServerAddress;
+	private final int awaitLeaderTimeout;
 
-	private final int restServerPort;
+	private final int retryMaxAttempts;
+
+	private final int retryDelay;
 
 	private RestClusterClientConfiguration(
-			String blobServerAddress,
-			RestClientConfiguration endpointConfiguration,
-			String restServerAddress,
-			int restServerPort) {
-		this.blobServerAddress = Preconditions.checkNotNull(blobServerAddress);
+			final RestClientConfiguration endpointConfiguration,
+			final int awaitLeaderTimeout,
+			final int retryMaxAttempts,
+			final int retryDelay) {
+		checkArgument(awaitLeaderTimeout >= 0, "awaitLeaderTimeout must be equal to or greater than 0");
+		checkArgument(retryMaxAttempts >= 0, "retryMaxAttempts must be equal to or greater than 0");
+		checkArgument(retryDelay >= 0, "retryDelay must be equal to or greater than 0");
+
 		this.restClientConfiguration = Preconditions.checkNotNull(endpointConfiguration);
-		this.restServerAddress = Preconditions.checkNotNull(restServerAddress);
-		this.restServerPort = restServerPort;
-	}
-
-	public String getBlobServerAddress() {
-		return blobServerAddress;
-	}
-
-	public String getRestServerAddress() {
-		return restServerAddress;
-	}
-
-	public int getRestServerPort() {
-		return restServerPort;
+		this.awaitLeaderTimeout = awaitLeaderTimeout;
+		this.retryMaxAttempts = retryMaxAttempts;
+		this.retryDelay = retryDelay;
 	}
 
 	public RestClientConfiguration getRestClientConfiguration() {
 		return restClientConfiguration;
 	}
 
+	/**
+	 * @see RestOptions#AWAIT_LEADER_TIMEOUT
+	 */
+	public int getAwaitLeaderTimeout() {
+		return awaitLeaderTimeout;
+	}
+
+	/**
+	 * @see RestOptions#RETRY_MAX_ATTEMPTS
+	 */
+	public int getRetryMaxAttempts() {
+		return retryMaxAttempts;
+	}
+
+	/**
+	 * @see RestOptions#RETRY_DELAY
+	 */
+	public int getRetryDelay() {
+		return retryDelay;
+	}
+
 	public static RestClusterClientConfiguration fromConfiguration(Configuration config) throws ConfigurationException {
-		String blobServerAddress = config.getString(JobManagerOptions.ADDRESS);
-
-		String serverAddress = config.getString(RestOptions.REST_ADDRESS);
-		int serverPort = config.getInteger(RestOptions.REST_PORT);
-
 		RestClientConfiguration restClientConfiguration = RestClientConfiguration.fromConfiguration(config);
 
-		return new RestClusterClientConfiguration(blobServerAddress, restClientConfiguration, serverAddress, serverPort);
+		final int awaitLeaderTimeout = config.getInteger(RestOptions.AWAIT_LEADER_TIMEOUT);
+		final int retryMaxAttempts = config.getInteger(RestOptions.RETRY_MAX_ATTEMPTS);
+		final int retryDelay = config.getInteger(RestOptions.RETRY_DELAY);
+
+		return new RestClusterClientConfiguration(restClientConfiguration, awaitLeaderTimeout, retryMaxAttempts, retryDelay);
 	}
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientConfigurationTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientConfigurationTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.program.rest;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.RestOptions;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link RestClusterClientConfiguration}.
+ */
+public class RestClusterClientConfigurationTest {
+
+	private RestClusterClientConfiguration restClusterClientConfiguration;
+
+	@Before
+	public void setUp() throws Exception {
+		final Configuration config = new Configuration();
+		config.setInteger(RestOptions.AWAIT_LEADER_TIMEOUT, 1);
+		config.setInteger(RestOptions.RETRY_MAX_ATTEMPTS, 2);
+		config.setInteger(RestOptions.RETRY_DELAY, 3);
+		restClusterClientConfiguration = RestClusterClientConfiguration.fromConfiguration(config);
+	}
+
+	@Test
+	public void testConfiguration() {
+		assertEquals(1, restClusterClientConfiguration.getAwaitLeaderTimeout());
+		assertEquals(2, restClusterClientConfiguration.getRetryMaxAttempts());
+		assertEquals(3, restClusterClientConfiguration.getRetryDelay());
+	}
+}

--- a/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientConfigurationTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientConfigurationTest.java
@@ -37,9 +37,9 @@ public class RestClusterClientConfigurationTest extends TestLogger {
 	@Before
 	public void setUp() throws Exception {
 		final Configuration config = new Configuration();
-		config.setInteger(RestOptions.AWAIT_LEADER_TIMEOUT, 1);
+		config.setLong(RestOptions.AWAIT_LEADER_TIMEOUT, 1);
 		config.setInteger(RestOptions.RETRY_MAX_ATTEMPTS, 2);
-		config.setInteger(RestOptions.RETRY_DELAY, 3);
+		config.setLong(RestOptions.RETRY_DELAY, 3);
 		restClusterClientConfiguration = RestClusterClientConfiguration.fromConfiguration(config);
 	}
 

--- a/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientConfigurationTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientConfigurationTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.client.program.rest;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.util.TestLogger;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -29,7 +30,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * Tests for {@link RestClusterClientConfiguration}.
  */
-public class RestClusterClientConfigurationTest {
+public class RestClusterClientConfigurationTest extends TestLogger {
 
 	private RestClusterClientConfiguration restClusterClientConfiguration;
 

--- a/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.client.program.rest;
 
+import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.tuple.Tuple2;
@@ -25,6 +26,7 @@ import org.apache.flink.client.deployment.StandaloneClusterId;
 import org.apache.flink.client.program.ProgramInvocationException;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.dispatcher.Dispatcher;
@@ -34,6 +36,8 @@ import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.runtime.messages.webmonitor.JobDetails;
 import org.apache.flink.runtime.messages.webmonitor.MultipleJobsDetails;
+import org.apache.flink.runtime.rest.RestClient;
+import org.apache.flink.runtime.rest.RestClientConfiguration;
 import org.apache.flink.runtime.rest.RestServerEndpoint;
 import org.apache.flink.runtime.rest.RestServerEndpointConfiguration;
 import org.apache.flink.runtime.rest.handler.AbstractRestHandler;
@@ -70,9 +74,12 @@ import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointTriggerMes
 import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointTriggerRequestBody;
 import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointTriggerResponseBody;
 import org.apache.flink.runtime.rest.messages.queue.QueueStatus;
+import org.apache.flink.runtime.rest.util.RestClientException;
 import org.apache.flink.runtime.rpc.RpcUtils;
+import org.apache.flink.runtime.util.ExecutorThreadFactory;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
 import org.apache.flink.testutils.category.Flip6;
+import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.SerializedThrowable;
 import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.TestLogger;
@@ -90,6 +97,7 @@ import org.mockito.MockitoAnnotations;
 
 import javax.annotation.Nonnull;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -99,12 +107,17 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
 
+import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkState;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
@@ -130,6 +143,10 @@ public class RestClusterClientTest extends TestLogger {
 
 	private RestClusterClient<StandaloneClusterId> restClusterClient;
 
+	private volatile FailHttpRequestPredicate failHttpRequest = FailHttpRequestPredicate.never();
+
+	private ExecutorService executor;
+
 	@Before
 	public void setUp() throws Exception {
 		MockitoAnnotations.initMocks(this);
@@ -137,15 +154,40 @@ public class RestClusterClientTest extends TestLogger {
 
 		final Configuration config = new Configuration();
 		config.setString(JobManagerOptions.ADDRESS, "localhost");
+		config.setInteger(RestOptions.RETRY_MAX_ATTEMPTS, 10);
+		config.setInteger(RestOptions.RETRY_DELAY, 0);
+
 		restServerEndpointConfiguration = RestServerEndpointConfiguration.fromConfiguration(config);
 		mockGatewayRetriever = () -> CompletableFuture.completedFuture(mockRestfulGateway);
-		restClusterClient = new RestClusterClient(config, StandaloneClusterId.getInstance(), (attempt) -> 0);
+
+		executor = Executors.newSingleThreadExecutor(new ExecutorThreadFactory(RestClusterClientTest.class.getSimpleName()));
+		final RestClient restClient = new RestClient(RestClientConfiguration.fromConfiguration(config), executor) {
+			@Override
+			public <M extends MessageHeaders<R, P, U>, U extends MessageParameters, R extends RequestBody, P extends ResponseBody> CompletableFuture<P>
+			sendRequest(
+					final String targetAddress,
+					final int targetPort,
+					final M messageHeaders,
+					final U messageParameters,
+					final R request) throws IOException {
+				if (failHttpRequest.test(messageHeaders, messageParameters, request)) {
+					return FutureUtils.completedExceptionally(new IOException("expected"));
+				} else {
+					return super.sendRequest(targetAddress, targetPort, messageHeaders, messageParameters, request);
+				}
+			}
+		};
+		restClusterClient = new RestClusterClient<>(config, restClient, StandaloneClusterId.getInstance(), (attempt) -> 0);
 	}
 
 	@After
 	public void tearDown() throws Exception {
 		if (restClusterClient != null) {
 			restClusterClient.shutdown();
+		}
+
+		if (executor != null) {
+			executor.shutdown();
 		}
 	}
 
@@ -158,11 +200,11 @@ public class RestClusterClientTest extends TestLogger {
 		TestJobSubmitHandler submitHandler = new TestJobSubmitHandler();
 		TestJobTerminationHandler terminationHandler = new TestJobTerminationHandler();
 		TestJobExecutionResultHandler testJobExecutionResultHandler =
-			new TestJobExecutionResultHandler(Collections.singletonList(
+			new TestJobExecutionResultHandler(
 				JobExecutionResultResponseBody.created(new JobResult.Builder()
 					.jobId(id)
 					.netRuntime(Long.MAX_VALUE)
-					.build())).iterator());
+					.build()));
 
 		try (TestRestServerEndpoint ignored = createRestServerEndpoint(
 			portHandler,
@@ -239,14 +281,17 @@ public class RestClusterClientTest extends TestLogger {
 	private class TestJobExecutionResultHandler
 		extends TestHandler<EmptyRequestBody, JobExecutionResultResponseBody, JobMessageParameters> {
 
-		private final Iterator<JobExecutionResultResponseBody> jobExecutionResults;
+		private final Iterator<Object> jobExecutionResults;
 
-		private JobExecutionResultResponseBody lastJobExecutionResult;
+		private Object lastJobExecutionResult;
 
 		private TestJobExecutionResultHandler(
-				final Iterator<JobExecutionResultResponseBody> jobExecutionResults) {
+				final Object... jobExecutionResults) {
 			super(JobExecutionResultHeaders.getInstance());
-			this.jobExecutionResults = jobExecutionResults;
+			checkArgument(Arrays.stream(jobExecutionResults)
+				.allMatch(object -> object instanceof JobExecutionResultResponseBody
+					|| object instanceof RestHandlerException));
+			this.jobExecutionResults = Arrays.asList(jobExecutionResults).iterator();
 		}
 
 		@Override
@@ -257,7 +302,13 @@ public class RestClusterClientTest extends TestLogger {
 				lastJobExecutionResult = jobExecutionResults.next();
 			}
 			checkState(lastJobExecutionResult != null);
-			return CompletableFuture.completedFuture(lastJobExecutionResult);
+			if (lastJobExecutionResult instanceof JobExecutionResultResponseBody) {
+				return CompletableFuture.completedFuture((JobExecutionResultResponseBody) lastJobExecutionResult);
+			} else if (lastJobExecutionResult instanceof RestHandlerException) {
+				return FutureUtils.completedExceptionally((RestHandlerException) lastJobExecutionResult);
+			} else {
+				throw new AssertionError();
+			}
 		}
 	}
 
@@ -267,7 +318,8 @@ public class RestClusterClientTest extends TestLogger {
 		final JobID jobId = jobGraph.getJobID();
 
 		final TestJobExecutionResultHandler testJobExecutionResultHandler =
-			new TestJobExecutionResultHandler(Arrays.asList(
+			new TestJobExecutionResultHandler(
+				new RestHandlerException("should trigger retry", HttpResponseStatus.NOT_FOUND),
 				JobExecutionResultResponseBody.inProgress(),
 				JobExecutionResultResponseBody.created(new JobResult.Builder()
 					.jobId(jobId)
@@ -278,17 +330,23 @@ public class RestClusterClientTest extends TestLogger {
 					.jobId(jobId)
 					.netRuntime(Long.MAX_VALUE)
 					.serializedThrowable(new SerializedThrowable(new RuntimeException("expected")))
-					.build())).iterator());
+					.build()));
+
+		// fail first HTTP polling attempt, which should not be a problem because of the retries
+		final AtomicBoolean firstPollFailed = new AtomicBoolean();
+		failHttpRequest = (messageHeaders, messageParameters, requestBody) ->
+			messageHeaders instanceof JobExecutionResultHeaders && !firstPollFailed.getAndSet(true);
 
 		try (TestRestServerEndpoint ignored = createRestServerEndpoint(
 			testJobExecutionResultHandler,
 			new TestBlobServerPortHandler(),
 			new TestJobSubmitHandler())) {
 
-			final org.apache.flink.api.common.JobExecutionResult jobExecutionResult =
-				(org.apache.flink.api.common.JobExecutionResult) restClusterClient.submitJob(
-					jobGraph,
-					ClassLoader.getSystemClassLoader());
+			JobExecutionResult jobExecutionResult;
+
+			jobExecutionResult = (JobExecutionResult) restClusterClient.submitJob(
+				jobGraph,
+				ClassLoader.getSystemClassLoader());
 			assertThat(jobExecutionResult.getJobID(), equalTo(jobId));
 			assertThat(jobExecutionResult.getNetRuntime(), equalTo(Long.MAX_VALUE));
 			assertThat(
@@ -314,9 +372,9 @@ public class RestClusterClientTest extends TestLogger {
 		final TestSavepointHandlers testSavepointHandlers = new TestSavepointHandlers();
 		final TestSavepointHandlers.TestSavepointTriggerHandler triggerHandler =
 			testSavepointHandlers.new TestSavepointTriggerHandler(
-				Arrays.asList(null, targetSavepointDirectory, null).iterator());
+				null, targetSavepointDirectory, null);
 		final TestSavepointHandlers.TestSavepointHandler savepointHandler =
-			testSavepointHandlers.new TestSavepointHandler(Arrays.asList(
+			testSavepointHandlers.new TestSavepointHandler(
 				new SavepointResponseBody(QueueStatus.completed(), new SavepointInfo(
 					testSavepointHandlers.testSavepointTriggerId,
 					savepointLocationDefaultDir,
@@ -328,7 +386,14 @@ public class RestClusterClientTest extends TestLogger {
 				new SavepointResponseBody(QueueStatus.completed(), new SavepointInfo(
 					testSavepointHandlers.testSavepointTriggerId,
 					null,
-					new SerializedThrowable(new RuntimeException("expected"))))).iterator());
+					new SerializedThrowable(new RuntimeException("expected")))),
+				new RestHandlerException("not found", HttpResponseStatus.NOT_FOUND));
+
+		// fail first HTTP polling attempt, which should not be a problem because of the retries
+		final AtomicBoolean firstPollFailed = new AtomicBoolean();
+		failHttpRequest = (messageHeaders, messageParameters, requestBody) ->
+			messageHeaders instanceof SavepointStatusHeaders && !firstPollFailed.getAndSet(true);
+
 		try (TestRestServerEndpoint ignored = createRestServerEndpoint(
 			triggerHandler,
 			savepointHandler)) {
@@ -358,6 +423,14 @@ public class RestClusterClientTest extends TestLogger {
 						.getMessage(), equalTo("expected"));
 				}
 			}
+
+			try {
+				restClusterClient.triggerSavepoint(new JobID(), null).get();
+			} catch (final ExecutionException e) {
+				assertTrue(
+					"RestClientException not in causal chain",
+					ExceptionUtils.findThrowable(e, RestClientException.class).isPresent());
+			}
 		}
 	}
 
@@ -369,9 +442,9 @@ public class RestClusterClientTest extends TestLogger {
 
 			private final Iterator<String> expectedTargetDirectories;
 
-			TestSavepointTriggerHandler(final Iterator<String> expectedTargetDirectories) {
+			TestSavepointTriggerHandler(final String... expectedTargetDirectories) {
 				super(SavepointTriggerHeaders.getInstance());
-				this.expectedTargetDirectories = expectedTargetDirectories;
+				this.expectedTargetDirectories = Arrays.asList(expectedTargetDirectories).iterator();
 			}
 
 			@Override
@@ -393,11 +466,14 @@ public class RestClusterClientTest extends TestLogger {
 		private class TestSavepointHandler
 				extends TestHandler<EmptyRequestBody, SavepointResponseBody, SavepointStatusMessageParameters> {
 
-			private final Iterator<SavepointResponseBody> expectedSavepointResponseBodies;
+			private final Iterator<Object> expectedSavepointResponseBodies;
 
-			TestSavepointHandler(final Iterator<SavepointResponseBody> expectedSavepointResponseBodies) {
+			TestSavepointHandler(final Object... expectedSavepointResponseBodies) {
 				super(SavepointStatusHeaders.getInstance());
-				this.expectedSavepointResponseBodies = expectedSavepointResponseBodies;
+				checkArgument(Arrays.stream(expectedSavepointResponseBodies)
+					.allMatch(response -> response instanceof SavepointResponseBody ||
+						response instanceof RestHandlerException));
+				this.expectedSavepointResponseBodies = Arrays.asList(expectedSavepointResponseBodies).iterator();
 			}
 
 			@Override
@@ -406,7 +482,14 @@ public class RestClusterClientTest extends TestLogger {
 					@Nonnull DispatcherGateway gateway) throws RestHandlerException {
 				final SavepointTriggerId savepointTriggerId = request.getPathParameter(SavepointTriggerIdPathParameter.class);
 				if (testSavepointTriggerId.equals(savepointTriggerId)) {
-					return CompletableFuture.completedFuture(expectedSavepointResponseBodies.next());
+					final Object response = expectedSavepointResponseBodies.next();
+					if (response instanceof SavepointResponseBody) {
+						return CompletableFuture.completedFuture((SavepointResponseBody) response);
+					} else if (response instanceof RestHandlerException) {
+						return FutureUtils.completedExceptionally((RestHandlerException) response);
+					} else {
+						throw new AssertionError();
+					}
 				} else {
 					return FutureUtils.completedExceptionally(
 						new RestHandlerException(
@@ -490,4 +573,15 @@ public class RestClusterClientTest extends TestLogger {
 			shutdown(Time.seconds(5));
 		}
 	}
+
+	@FunctionalInterface
+	private interface FailHttpRequestPredicate {
+
+		boolean test(MessageHeaders<?, ?, ?> messageHeaders, MessageParameters messageParameters, RequestBody requestBody);
+
+		static FailHttpRequestPredicate never() {
+			return ((messageHeaders, messageParameters, requestBody) -> false);
+		}
+	}
+
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
@@ -155,7 +155,7 @@ public class RestClusterClientTest extends TestLogger {
 		final Configuration config = new Configuration();
 		config.setString(JobManagerOptions.ADDRESS, "localhost");
 		config.setInteger(RestOptions.RETRY_MAX_ATTEMPTS, 10);
-		config.setInteger(RestOptions.RETRY_DELAY, 0);
+		config.setLong(RestOptions.RETRY_DELAY, 0);
 
 		restServerEndpointConfiguration = RestServerEndpointConfiguration.fromConfiguration(config);
 		mockGatewayRetriever = () -> CompletableFuture.completedFuture(mockRestfulGateway);

--- a/flink-core/src/main/java/org/apache/flink/configuration/RestOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/RestOptions.java
@@ -41,4 +41,34 @@ public class RestOptions {
 	public static final ConfigOption<Integer> REST_PORT =
 		key("rest.port")
 			.defaultValue(9067);
+
+	/**
+	 * The time in ms to wait for the leader address, e.g., Dispatcher or WebMonitorEndpoint.
+	 */
+	public static final ConfigOption<Integer> AWAIT_LEADER_TIMEOUT =
+		key("rest.await-leader-timeout")
+			.defaultValue(30_000);
+
+	/**
+	 * The number of attempts to retry a retryable operation.
+	 * @see #RETRY_DELAY
+	 */
+	public static final ConfigOption<Integer> RETRY_MAX_ATTEMPTS =
+		key("rest.retry.max-attempts")
+			.defaultValue(20);
+
+	/**
+	 * The time in ms to wait between retries.
+	 * @see #RETRY_MAX_ATTEMPTS
+	 */
+	public static final ConfigOption<Integer> RETRY_DELAY =
+		key("rest.retry.delay")
+			.defaultValue(3_000);
+
+	/**
+	 * The maximum time in ms to establish a TCP connection.
+	 */
+	public static final ConfigOption<Integer> CONNECTION_TIMEOUT =
+		key("rest.connection-timeout")
+			.defaultValue(15_000);
 }

--- a/flink-core/src/main/java/org/apache/flink/configuration/RestOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/RestOptions.java
@@ -33,42 +33,52 @@ public class RestOptions {
 	 */
 	public static final ConfigOption<String> REST_ADDRESS =
 		key("rest.address")
-			.defaultValue("localhost");
+			.defaultValue("localhost")
+			.withDescription("The address that the server binds itself to / the client connects to.");
 
 	/**
 	 * The port that the server listens on / the client connects to.
 	 */
 	public static final ConfigOption<Integer> REST_PORT =
 		key("rest.port")
-			.defaultValue(9067);
+			.defaultValue(9067)
+			.withDescription("The port that the server listens on / the client connects to.");
 
 	/**
-	 * The time in ms to wait for the leader address, e.g., Dispatcher or WebMonitorEndpoint.
+	 * The time in ms that the client waits for the leader address, e.g., Dispatcher or
+	 * WebMonitorEndpoint.
 	 */
-	public static final ConfigOption<Integer> AWAIT_LEADER_TIMEOUT =
+	public static final ConfigOption<Long> AWAIT_LEADER_TIMEOUT =
 		key("rest.await-leader-timeout")
-			.defaultValue(30_000);
+			.defaultValue(30_000L)
+			.withDescription("The time in ms that the client waits for the leader address, e.g., " +
+				"Dispatcher or WebMonitorEndpoint");
 
 	/**
-	 * The number of attempts to retry a retryable operation.
+	 * The number of retries the client will attempt if a retryable operations fails.
 	 * @see #RETRY_DELAY
 	 */
 	public static final ConfigOption<Integer> RETRY_MAX_ATTEMPTS =
 		key("rest.retry.max-attempts")
-			.defaultValue(20);
+			.defaultValue(20)
+			.withDescription("The number of retries the client will attempt if a retryable " +
+				"operations fails.");
 
 	/**
-	 * The time in ms to wait between retries.
+	 * The time in ms that the client waits between retries.
 	 * @see #RETRY_MAX_ATTEMPTS
 	 */
-	public static final ConfigOption<Integer> RETRY_DELAY =
+	public static final ConfigOption<Long> RETRY_DELAY =
 		key("rest.retry.delay")
-			.defaultValue(3_000);
+			.defaultValue(3_000L)
+			.withDescription(String.format("The time in ms that the client waits between retries " +
+				"(See also `%s`).", RETRY_MAX_ATTEMPTS.key()));
 
 	/**
-	 * The maximum time in ms to establish a TCP connection.
+	 * The maximum time in ms for the client to establish a TCP connection.
 	 */
-	public static final ConfigOption<Integer> CONNECTION_TIMEOUT =
+	public static final ConfigOption<Long> CONNECTION_TIMEOUT =
 		key("rest.connection-timeout")
-			.defaultValue(15_000);
+			.defaultValue(15_000L)
+			.withDescription("The maximum time in ms for the client to establish a TCP connection.");
 }

--- a/flink-core/src/main/java/org/apache/flink/util/ExceptionUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/ExceptionUtils.java
@@ -286,7 +286,7 @@ public final class ExceptionUtils {
 	 * @param searchType the type of exception to search for in the chain.
 	 * @return Optional throwable of the requested type if available, otherwise empty
 	 */
-	public static Optional<Throwable> findThrowable(Throwable throwable, Class<?> searchType) {
+	public static <T extends Throwable> Optional<T> findThrowable(Throwable throwable, Class<T> searchType) {
 		if (throwable == null || searchType == null) {
 			return Optional.empty();
 		}
@@ -294,7 +294,7 @@ public final class ExceptionUtils {
 		Throwable t = throwable;
 		while (t != null) {
 			if (searchType.isAssignableFrom(t.getClass())) {
-				return Optional.of(t);
+				return Optional.of(searchType.cast(t));
 			} else {
 				t = t.getCause();
 			}

--- a/flink-core/src/main/java/org/apache/flink/util/function/CheckedSupplier.java
+++ b/flink-core/src/main/java/org/apache/flink/util/function/CheckedSupplier.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.util.function;
+
+import java.util.function.Supplier;
+
+/**
+ * Similar to {@link java.util.function.Supplier} but can throw {@link Exception}.
+ */
+@FunctionalInterface
+public interface CheckedSupplier<R> extends SupplierWithException<R, Exception> {
+
+	static <R> Supplier<R> unchecked(CheckedSupplier<R> checkedSupplier) {
+		return () -> {
+			try {
+				return checkedSupplier.get();
+			} catch (Exception e) {
+				throw new RuntimeException(e);
+			}
+		};
+	}
+
+}

--- a/flink-core/src/test/java/org/apache/flink/util/ExceptionUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/ExceptionUtilsTest.java
@@ -61,4 +61,12 @@ public class ExceptionUtilsTest extends TestLogger {
 		// non-fatal error is not rethrown
 		ExceptionUtils.rethrowIfFatalError(new NoClassDefFoundError());
 	}
+
+	@Test
+	public void testFindThrowableByType() {
+		assertTrue(ExceptionUtils.findThrowable(
+			new RuntimeException(new IllegalStateException()),
+			IllegalStateException.class).isPresent());
+	}
+
 }

--- a/flink-docs/src/main/java/org/apache/flink/docs/rest/RestAPIDocGenerator.java
+++ b/flink-docs/src/main/java/org/apache/flink/docs/rest/RestAPIDocGenerator.java
@@ -23,6 +23,8 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.concurrent.Executors;
 import org.apache.flink.runtime.dispatcher.DispatcherGateway;
 import org.apache.flink.runtime.dispatcher.DispatcherRestEndpoint;
+import org.apache.flink.runtime.leaderelection.LeaderContender;
+import org.apache.flink.runtime.leaderelection.LeaderElectionService;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.rest.RestServerEndpoint;
 import org.apache.flink.runtime.rest.RestServerEndpointConfiguration;
@@ -33,6 +35,7 @@ import org.apache.flink.runtime.rest.messages.EmptyResponseBody;
 import org.apache.flink.runtime.rest.messages.MessageHeaders;
 import org.apache.flink.runtime.rest.messages.MessagePathParameter;
 import org.apache.flink.runtime.rest.messages.MessageQueryParameter;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
 import org.apache.flink.runtime.webmonitor.retriever.MetricQueryServiceRetriever;
 import org.apache.flink.util.ConfigurationException;
@@ -54,6 +57,7 @@ import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
@@ -285,12 +289,44 @@ public class RestAPIDocGenerator {
 		}
 
 		private DocumentingDispatcherRestEndpoint() {
-			super(restConfig, dispatcherGatewayRetriever, config, handlerConfig, resourceManagerGatewayRetriever, executor, metricQueryServiceRetriever);
+			super(restConfig, dispatcherGatewayRetriever, config, handlerConfig, resourceManagerGatewayRetriever, executor, metricQueryServiceRetriever, NoOpElectionService.INSTANCE, NoOpFatalErrorHandler.INSTANCE);
 		}
 
 		@Override
 		public List<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> initializeHandlers(CompletableFuture<String> restAddressFuture) {
 			return super.initializeHandlers(restAddressFuture);
+		}
+
+		private enum NoOpElectionService implements LeaderElectionService {
+			INSTANCE;
+			@Override
+			public void start(final LeaderContender contender) throws Exception {
+
+			}
+
+			@Override
+			public void stop() throws Exception {
+
+			}
+
+			@Override
+			public void confirmLeaderSessionID(final UUID leaderSessionID) {
+
+			}
+
+			@Override
+			public boolean hasLeadership() {
+				return false;
+			}
+		}
+
+		private enum NoOpFatalErrorHandler implements FatalErrorHandler {
+			INSTANCE;
+
+			@Override
+			public void onFatalError(final Throwable exception) {
+
+			}
 		}
 	}
 

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/RuntimeMonitorHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/RuntimeMonitorHandler.java
@@ -119,7 +119,7 @@ public class RuntimeMonitorHandler extends RedirectHandler<JobManagerGateway> im
 				if (throwable != null) {
 					LOG.debug("Error while handling request.", throwable);
 
-					Optional<Throwable> optNotFound = ExceptionUtils.findThrowable(throwable, NotFoundException.class);
+					Optional<NotFoundException> optNotFound = ExceptionUtils.findThrowable(throwable, NotFoundException.class);
 
 					if (optNotFound.isPresent()) {
 						// this should result in a 404 error code (not found)

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
@@ -37,6 +37,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import scala.concurrent.Future;
@@ -127,6 +128,7 @@ public class FutureUtils {
 	 * @param operation to retry
 	 * @param retries number of retries
 	 * @param retryDelay delay between retries
+	 * @param retryPredicate Predicate to test whether an exception is retryable
 	 * @param scheduledExecutor executor to be used for the retry operation
 	 * @param <T> type of the result
 	 * @return Future which retries the given operation a given amount of times and delays the retry in case of failures
@@ -135,6 +137,7 @@ public class FutureUtils {
 			final Supplier<CompletableFuture<T>> operation,
 			final int retries,
 			final Time retryDelay,
+			final Predicate<Throwable> retryPredicate,
 			final ScheduledExecutor scheduledExecutor) {
 
 		final CompletableFuture<T> resultFuture = new CompletableFuture<>();
@@ -144,9 +147,33 @@ public class FutureUtils {
 			operation,
 			retries,
 			retryDelay,
+			retryPredicate,
 			scheduledExecutor);
 
 		return resultFuture;
+	}
+
+	/**
+	 * Retry the given operation with the given delay in between failures.
+	 *
+	 * @param operation to retry
+	 * @param retries number of retries
+	 * @param retryDelay delay between retries
+	 * @param scheduledExecutor executor to be used for the retry operation
+	 * @param <T> type of the result
+	 * @return Future which retries the given operation a given amount of times and delays the retry in case of failures
+	 */
+	public static <T> CompletableFuture<T> retryWithDelay(
+			final Supplier<CompletableFuture<T>> operation,
+			final int retries,
+			final Time retryDelay,
+			final ScheduledExecutor scheduledExecutor) {
+		return retryWithDelay(
+			operation,
+			retries,
+			retryDelay,
+			(throwable) -> true,
+			scheduledExecutor);
 	}
 
 	private static <T> void retryOperationWithDelay(
@@ -154,6 +181,7 @@ public class FutureUtils {
 			final Supplier<CompletableFuture<T>> operation,
 			final int retries,
 			final Time retryDelay,
+			final Predicate<Throwable> retryPredicate,
 			final ScheduledExecutor scheduledExecutor) {
 
 		if (!resultFuture.isDone()) {
@@ -165,17 +193,21 @@ public class FutureUtils {
 						if (throwable instanceof CancellationException) {
 							resultFuture.completeExceptionally(new RetryException("Operation future was cancelled.", throwable));
 						} else {
-							if (retries > 0) {
+							if (retries > 0 && retryPredicate.test(throwable)) {
 								final ScheduledFuture<?> scheduledFuture = scheduledExecutor.schedule(
-									() -> retryOperationWithDelay(resultFuture, operation, retries - 1, retryDelay, scheduledExecutor),
+									() -> retryOperationWithDelay(resultFuture, operation, retries - 1, retryDelay, retryPredicate, scheduledExecutor),
 									retryDelay.toMilliseconds(),
 									TimeUnit.MILLISECONDS);
 
 								resultFuture.whenComplete(
 									(innerT, innerThrowable) -> scheduledFuture.cancel(false));
 							} else {
-								resultFuture.completeExceptionally(new RetryException("Could not complete the operation. Number of retries " +
-									"has been exhausted.", throwable));
+								final String errorMsg = retries == 0 ?
+									"Number of retries has been exhausted." :
+									"Exception is not retryable.";
+								resultFuture.completeExceptionally(new RetryException(
+									"Could not complete the operation. " + errorMsg,
+									throwable));
 							}
 						}
 					} else {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
@@ -459,13 +459,15 @@ public class FutureUtils {
 	 * @return The timeout enriched future
 	 */
 	public static <T> CompletableFuture<T> orTimeout(CompletableFuture<T> future, long timeout, TimeUnit timeUnit) {
-		final ScheduledFuture<?> timeoutFuture = Delayer.delay(new Timeout(future), timeout, timeUnit);
+		if (!future.isDone()) {
+			final ScheduledFuture<?> timeoutFuture = Delayer.delay(new Timeout(future), timeout, timeUnit);
 
-		future.whenComplete((T value, Throwable throwable) -> {
-			if (!timeoutFuture.isDone()) {
-				timeoutFuture.cancel(false);
-			}
-		});
+			future.whenComplete((T value, Throwable throwable) -> {
+				if (!timeoutFuture.isDone()) {
+					timeoutFuture.cancel(false);
+				}
+			});
+		}
 
 		return future;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherRestEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherRestEndpoint.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.dispatcher;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.leaderelection.LeaderElectionService;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.rest.RestServerEndpointConfiguration;
 import org.apache.flink.runtime.rest.handler.RestHandlerConfiguration;
@@ -29,6 +30,7 @@ import org.apache.flink.runtime.rest.handler.job.BlobServerPortHandler;
 import org.apache.flink.runtime.rest.handler.job.JobSubmitHandler;
 import org.apache.flink.runtime.rest.handler.job.JobTerminationHandler;
 import org.apache.flink.runtime.rest.messages.JobTerminationHeaders;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.webmonitor.WebMonitorEndpoint;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
 import org.apache.flink.runtime.webmonitor.retriever.MetricQueryServiceRetriever;
@@ -46,13 +48,15 @@ import java.util.concurrent.Executor;
 public class DispatcherRestEndpoint extends WebMonitorEndpoint<DispatcherGateway> {
 
 	public DispatcherRestEndpoint(
-			RestServerEndpointConfiguration endpointConfiguration,
-			GatewayRetriever<DispatcherGateway> leaderRetriever,
-			Configuration clusterConfiguration,
-			RestHandlerConfiguration restConfiguration,
-			GatewayRetriever<ResourceManagerGateway> resourceManagerRetriever,
-			Executor executor,
-			MetricQueryServiceRetriever metricQueryServiceRetriever) {
+		RestServerEndpointConfiguration endpointConfiguration,
+		GatewayRetriever<DispatcherGateway> leaderRetriever,
+		Configuration clusterConfiguration,
+		RestHandlerConfiguration restConfiguration,
+		GatewayRetriever<ResourceManagerGateway> resourceManagerRetriever,
+		Executor executor,
+		MetricQueryServiceRetriever metricQueryServiceRetriever,
+		LeaderElectionService leaderElectionService,
+		FatalErrorHandler fatalErrorHandler) {
 		super(
 			endpointConfiguration,
 			leaderRetriever,
@@ -60,7 +64,9 @@ public class DispatcherRestEndpoint extends WebMonitorEndpoint<DispatcherGateway
 			restConfiguration,
 			resourceManagerRetriever,
 			executor,
-			metricQueryServiceRetriever);
+			metricQueryServiceRetriever,
+			leaderElectionService,
+			fatalErrorHandler);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/JobClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/JobClusterEntrypoint.java
@@ -34,6 +34,7 @@ import org.apache.flink.runtime.jobmaster.JobMasterGateway;
 import org.apache.flink.runtime.jobmaster.JobMasterId;
 import org.apache.flink.runtime.jobmaster.JobMasterRestEndpoint;
 import org.apache.flink.runtime.jobmaster.JobResult;
+import org.apache.flink.runtime.leaderelection.LeaderElectionService;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.resourcemanager.ResourceManager;
@@ -119,7 +120,8 @@ public abstract class JobClusterEntrypoint extends ClusterEntrypoint {
 			jobMasterGatewayRetriever,
 			resourceManagerGatewayRetriever,
 			rpcService.getExecutor(),
-			new AkkaQueryServiceRetriever(actorSystem, timeout));
+			new AkkaQueryServiceRetriever(actorSystem, timeout),
+			highAvailabilityServices.getWebMonitorLeaderElectionService());
 
 		LOG.debug("Starting JobMaster REST endpoint.");
 		jobMasterRestEndpoint.start();
@@ -163,7 +165,8 @@ public abstract class JobClusterEntrypoint extends ClusterEntrypoint {
 			GatewayRetriever<JobMasterGateway> jobMasterGatewayRetriever,
 			GatewayRetriever<ResourceManagerGateway> resourceManagerGatewayRetriever,
 			Executor executor,
-			MetricQueryServiceRetriever metricQueryServiceRetriever) throws ConfigurationException {
+			MetricQueryServiceRetriever metricQueryServiceRetriever,
+			LeaderElectionService leaderElectionService) throws ConfigurationException {
 
 		final RestHandlerConfiguration restHandlerConfiguration = RestHandlerConfiguration.fromConfiguration(configuration);
 
@@ -174,7 +177,9 @@ public abstract class JobClusterEntrypoint extends ClusterEntrypoint {
 			restHandlerConfiguration,
 			resourceManagerGatewayRetriever,
 			executor,
-			metricQueryServiceRetriever);
+			metricQueryServiceRetriever,
+			leaderElectionService,
+			this);
 
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServices.java
@@ -98,6 +98,8 @@ public interface HighAvailabilityServices extends AutoCloseable {
 	 */
 	LeaderRetrievalService getJobManagerLeaderRetriever(JobID jobID, String defaultJobManagerAddress);
 
+	LeaderRetrievalService getWebMonitorLeaderRetriever();
+
 	/**
 	 * Gets the leader election service for the cluster's resource manager.
 	 *
@@ -119,6 +121,8 @@ public interface HighAvailabilityServices extends AutoCloseable {
 	 * @return Leader election service for the job manager leader election
 	 */
 	LeaderElectionService getJobManagerLeaderElectionService(JobID jobID);
+
+	LeaderElectionService getWebMonitorLeaderElectionService();
 
 	/**
 	 * Gets the checkpoint recovery factory for the job manager

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServicesUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServicesUtils.java
@@ -21,6 +21,8 @@ package org.apache.flink.runtime.highavailability;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.runtime.blob.BlobStoreService;
 import org.apache.flink.runtime.blob.BlobUtils;
 import org.apache.flink.runtime.dispatcher.Dispatcher;
@@ -95,10 +97,16 @@ public class HighAvailabilityServicesUtils {
 					addressResolution,
 					configuration);
 
+				final String address = configuration.getString(RestOptions.REST_ADDRESS);
+				final int port = configuration.getInteger(RestOptions.REST_PORT);
+				final boolean enableSSL = configuration.getBoolean(SecurityOptions.SSL_ENABLED);
+				final String protocol = enableSSL ? "https://" : "http://";
+
 				return new StandaloneHaServices(
 					resourceManagerRpcUrl,
 					dispatcherRpcUrl,
-					jobManagerRpcUrl);
+					jobManagerRpcUrl,
+					String.format("%s%s:%s", protocol, address, port));
 			case ZOOKEEPER:
 				BlobStoreService blobStoreService = BlobUtils.createBlobStoreFromConfig(configuration);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedHaServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedHaServices.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
 import org.apache.flink.util.Preconditions;
 
 import javax.annotation.concurrent.GuardedBy;
+
 import java.util.HashMap;
 import java.util.concurrent.Executor;
 
@@ -49,11 +50,14 @@ public class EmbeddedHaServices extends AbstractNonHaServices {
 
 	private final HashMap<JobID, EmbeddedLeaderService> jobManagerLeaderServices;
 
+	private final EmbeddedLeaderService webMonitorLeaderService;
+
 	public EmbeddedHaServices(Executor executor) {
 		this.executor = Preconditions.checkNotNull(executor);
 		this.resourceManagerLeaderService = new EmbeddedLeaderService(executor);
 		this.dispatcherLeaderService = new EmbeddedLeaderService(executor);
 		this.jobManagerLeaderServices = new HashMap<>();
+		this.webMonitorLeaderService = new EmbeddedLeaderService(executor);
 	}
 
 	// ------------------------------------------------------------------------
@@ -97,6 +101,11 @@ public class EmbeddedHaServices extends AbstractNonHaServices {
 	}
 
 	@Override
+	public LeaderRetrievalService getWebMonitorLeaderRetriever() {
+		return webMonitorLeaderService.createLeaderRetrievalService();
+	}
+
+	@Override
 	public LeaderElectionService getJobManagerLeaderElectionService(JobID jobID) {
 		checkNotNull(jobID);
 
@@ -105,6 +114,11 @@ public class EmbeddedHaServices extends AbstractNonHaServices {
 			EmbeddedLeaderService service = getOrCreateJobManagerService(jobID);
 			return service.createLeaderElectionService();
 		}
+	}
+
+	@Override
+	public LeaderElectionService getWebMonitorLeaderElectionService() {
+		return webMonitorLeaderService.createLeaderElectionService();
 	}
 
 	// ------------------------------------------------------------------------
@@ -136,6 +150,8 @@ public class EmbeddedHaServices extends AbstractNonHaServices {
 				jobManagerLeaderServices.clear();
 
 				resourceManagerLeaderService.shutdown();
+
+				webMonitorLeaderService.shutdown();
 			}
 
 			super.close();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/standalone/StandaloneHaServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/standalone/StandaloneHaServices.java
@@ -51,18 +51,23 @@ public class StandaloneHaServices extends AbstractNonHaServices {
 	/** The fix address of the JobManager */
 	private final String jobManagerAddress;
 
+	private final String webMonitorAddress;
+
 	/**
 	 * Creates a new services class for the fix pre-defined leaders.
-	 * 
+	 *
 	 * @param resourceManagerAddress    The fix address of the ResourceManager
+	 * @param webMonitorAddress
 	 */
 	public StandaloneHaServices(
-		String resourceManagerAddress,
-		String dispatcherAddress,
-		String jobManagerAddress) {
+			String resourceManagerAddress,
+			String dispatcherAddress,
+			String jobManagerAddress,
+			String webMonitorAddress) {
 		this.resourceManagerAddress = checkNotNull(resourceManagerAddress, "resourceManagerAddress");
 		this.dispatcherAddress = checkNotNull(dispatcherAddress, "dispatcherAddress");
 		this.jobManagerAddress = checkNotNull(jobManagerAddress, "jobManagerAddress");
+		this.webMonitorAddress = checkNotNull(webMonitorAddress, webMonitorAddress);
 	}
 
 	// ------------------------------------------------------------------------
@@ -132,4 +137,23 @@ public class StandaloneHaServices extends AbstractNonHaServices {
 			return new StandaloneLeaderElectionService();
 		}
 	}
+
+	@Override
+	public LeaderRetrievalService getWebMonitorLeaderRetriever() {
+		synchronized (lock) {
+			checkNotShutdown();
+
+			return new StandaloneLeaderRetrievalService(webMonitorAddress, DEFAULT_LEADER_ID);
+		}
+	}
+
+	@Override
+	public LeaderElectionService getWebMonitorLeaderElectionService() {
+		synchronized (lock) {
+			checkNotShutdown();
+
+			return new StandaloneLeaderElectionService();
+		}
+	}
+
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/zookeeper/ZooKeeperHaServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/zookeeper/ZooKeeperHaServices.java
@@ -18,8 +18,6 @@
 
 package org.apache.flink.runtime.highavailability.zookeeper;
 
-import org.apache.curator.framework.CuratorFramework;
-
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
@@ -34,6 +32,8 @@ import org.apache.flink.runtime.leaderelection.LeaderElectionService;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
 import org.apache.flink.runtime.util.ZooKeeperUtils;
 import org.apache.flink.util.ExceptionUtils;
+
+import org.apache.curator.framework.CuratorFramework;
 
 import java.io.IOException;
 import java.util.concurrent.Executor;
@@ -85,6 +85,8 @@ public class ZooKeeperHaServices implements HighAvailabilityServices {
 	private static final String DISPATCHER_LEADER_PATH = "/dispatcher_lock";
 
 	private static final String JOB_MANAGER_LEADER_PATH = "/job_manager_lock";
+
+	private static final String REST_SERVER_LEADER_PATH = "/rest_server_lock";
 
 	// ------------------------------------------------------------------------
 	
@@ -142,6 +144,11 @@ public class ZooKeeperHaServices implements HighAvailabilityServices {
 	}
 
 	@Override
+	public LeaderRetrievalService getWebMonitorLeaderRetriever() {
+		return ZooKeeperUtils.createLeaderRetrievalService(client, configuration, REST_SERVER_LEADER_PATH);
+	}
+
+	@Override
 	public LeaderElectionService getResourceManagerLeaderElectionService() {
 		return ZooKeeperUtils.createLeaderElectionService(client, configuration, RESOURCE_MANAGER_LEADER_PATH);
 	}
@@ -154,6 +161,11 @@ public class ZooKeeperHaServices implements HighAvailabilityServices {
 	@Override
 	public LeaderElectionService getJobManagerLeaderElectionService(JobID jobID) {
 		return ZooKeeperUtils.createLeaderElectionService(client, configuration, getPathForJobManager(jobID));
+	}
+
+	@Override
+	public LeaderElectionService getWebMonitorLeaderElectionService() {
+		return ZooKeeperUtils.createLeaderElectionService(client, configuration, REST_SERVER_LEADER_PATH);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterRestEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterRestEndpoint.java
@@ -19,9 +19,11 @@
 package org.apache.flink.runtime.jobmaster;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.leaderelection.LeaderElectionService;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.rest.RestServerEndpointConfiguration;
 import org.apache.flink.runtime.rest.handler.RestHandlerConfiguration;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.webmonitor.WebMonitorEndpoint;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
 import org.apache.flink.runtime.webmonitor.retriever.MetricQueryServiceRetriever;
@@ -34,13 +36,15 @@ import java.util.concurrent.Executor;
 public class JobMasterRestEndpoint extends WebMonitorEndpoint<JobMasterGateway> {
 
 	public JobMasterRestEndpoint(
-			RestServerEndpointConfiguration endpointConfiguration,
-			GatewayRetriever<JobMasterGateway> leaderRetriever,
-			Configuration clusterConfiguration,
-			RestHandlerConfiguration restConfiguration,
-			GatewayRetriever<ResourceManagerGateway> resourceManagerRetriever,
-			Executor executor,
-			MetricQueryServiceRetriever metricQueryServiceRetriever) {
-		super(endpointConfiguration, leaderRetriever, clusterConfiguration, restConfiguration, resourceManagerRetriever, executor, metricQueryServiceRetriever);
+		RestServerEndpointConfiguration endpointConfiguration,
+		GatewayRetriever<JobMasterGateway> leaderRetriever,
+		Configuration clusterConfiguration,
+		RestHandlerConfiguration restConfiguration,
+		GatewayRetriever<ResourceManagerGateway> resourceManagerRetriever,
+		Executor executor,
+		MetricQueryServiceRetriever metricQueryServiceRetriever,
+		LeaderElectionService leaderElectionService,
+		FatalErrorHandler fatalErrorHandler) {
+		super(endpointConfiguration, leaderRetriever, clusterConfiguration, restConfiguration, resourceManagerRetriever, executor, metricQueryServiceRetriever, leaderElectionService, fatalErrorHandler);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionService.java
@@ -413,4 +413,11 @@ public class ZooKeeperLeaderElectionService implements LeaderElectionService, Le
 	public void unhandledError(String message, Throwable e) {
 		leaderContender.handleError(new FlinkException("Unhandled error in ZooKeeperLeaderElectionService: " + message, e));
 	}
+
+	@Override
+	public String toString() {
+		return "ZooKeeperLeaderElectionService{" +
+			"leaderPath='" + leaderPath + '\'' +
+			'}';
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionService.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.leaderelection;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.Preconditions;
+
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.api.UnhandledErrorListener;
 import org.apache.curator.framework.recipes.cache.ChildData;
@@ -53,23 +54,23 @@ public class ZooKeeperLeaderElectionService implements LeaderElectionService, Le
 
 	private final Object lock = new Object();
 
-	/** Client to the ZooKeeper quorum */
+	/** Client to the ZooKeeper quorum. */
 	private final CuratorFramework client;
 
-	/** Curator recipe for leader election */
+	/** Curator recipe for leader election. */
 	private final LeaderLatch leaderLatch;
 
-	/** Curator recipe to watch a given ZooKeeper node for changes */
+	/** Curator recipe to watch a given ZooKeeper node for changes. */
 	private final NodeCache cache;
 
-	/** ZooKeeper path of the node which stores the current leader information */
+	/** ZooKeeper path of the node which stores the current leader information. */
 	private final String leaderPath;
 
 	private UUID issuedLeaderSessionID;
 
 	private volatile UUID confirmedLeaderSessionID;
 
-	/** The leader contender which applies for leadership */
+	/** The leader contender which applies for leadership. */
 	private volatile LeaderContender leaderContender;
 
 	private volatile boolean running;
@@ -164,7 +165,7 @@ public class ZooKeeperLeaderElectionService implements LeaderElectionService, Le
 
 		try {
 			leaderLatch.close();
-		} catch(Exception e) {
+		} catch (Exception e) {
 			exception = ExceptionUtils.firstOrSuppressed(e, exception);
 		}
 
@@ -184,7 +185,7 @@ public class ZooKeeperLeaderElectionService implements LeaderElectionService, Le
 
 		Preconditions.checkNotNull(leaderSessionID);
 
-		if(leaderLatch.hasLeadership()) {
+		if (leaderLatch.hasLeadership()) {
 			// check if this is an old confirmation call
 			synchronized (lock) {
 				if (running) {
@@ -340,14 +341,14 @@ public class ZooKeeperLeaderElectionService implements LeaderElectionService, Le
 
 			boolean dataWritten = false;
 
-			while(!dataWritten && leaderLatch.hasLeadership()) {
+			while (!dataWritten && leaderLatch.hasLeadership()) {
 				Stat stat = client.checkExists().forPath(leaderPath);
 
 				if (stat != null) {
 					long owner = stat.getEphemeralOwner();
 					long sessionID = client.getZookeeperClient().getZooKeeper().getSessionId();
 
-					if(owner == sessionID) {
+					if (owner == sessionID) {
 						try {
 							client.setData().forPath(leaderPath, baos.toByteArray());
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderretrieval/LeaderRetrievalListener.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderretrieval/LeaderRetrievalListener.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.leaderretrieval;
 
+import javax.annotation.Nullable;
+
 import java.util.UUID;
 
 /**
@@ -32,7 +34,7 @@ public interface LeaderRetrievalListener {
 	 * @param leaderAddress The address of the new leader
 	 * @param leaderSessionID The new leader session ID
 	 */
-	void notifyLeaderAddress(String leaderAddress, UUID leaderSessionID);
+	void notifyLeaderAddress(@Nullable String leaderAddress, @Nullable UUID leaderSessionID);
 
 	/**
 	 * This method is called by the {@link LeaderRetrievalService} in case of an exception. This

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
@@ -109,7 +109,7 @@ public class RestClient {
 
 		bootstrap = new Bootstrap();
 		bootstrap
-			.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, configuration.getConnectionTimeout())
+			.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, Math.toIntExact(configuration.getConnectionTimeout()))
 			.group(group)
 			.channel(NioSocketChannel.class)
 			.handler(initializer);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
@@ -21,8 +21,6 @@ package org.apache.flink.runtime.rest;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.runtime.rest.handler.PipelineErrorHandler;
-import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
-import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
 import org.apache.flink.runtime.rest.messages.ErrorResponseBody;
 import org.apache.flink.runtime.rest.messages.MessageHeaders;
 import org.apache.flink.runtime.rest.messages.MessageParameters;
@@ -45,6 +43,7 @@ import org.apache.flink.shaded.netty4.io.netty.channel.Channel;
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelFuture;
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelHandlerContext;
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelInitializer;
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelOption;
 import org.apache.flink.shaded.netty4.io.netty.channel.SimpleChannelInboundHandler;
 import org.apache.flink.shaded.netty4.io.netty.channel.nio.NioEventLoopGroup;
 import org.apache.flink.shaded.netty4.io.netty.channel.socket.SocketChannel;
@@ -110,6 +109,7 @@ public class RestClient {
 
 		bootstrap = new Bootstrap();
 		bootstrap
+			.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, configuration.getConnectionTimeout())
 			.group(group)
 			.channel(NioSocketChannel.class)
 			.handler(initializer);
@@ -139,18 +139,6 @@ public class RestClient {
 		} catch (Exception e) {
 			LOG.warn("Rest endpoint shutdown failed.", e);
 		}
-	}
-
-	public <M extends MessageHeaders<EmptyRequestBody, P, U>, U extends MessageParameters, P extends ResponseBody> CompletableFuture<P> sendRequest(String targetAddress, int targetPort, M messageHeaders, U messageParameters) throws IOException {
-		return sendRequest(targetAddress, targetPort, messageHeaders, messageParameters, EmptyRequestBody.getInstance());
-	}
-
-	public <M extends MessageHeaders<R, P, EmptyMessageParameters>, R extends RequestBody, P extends ResponseBody> CompletableFuture<P> sendRequest(String targetAddress, int targetPort, M messageHeaders, R request) throws IOException {
-		return sendRequest(targetAddress, targetPort, messageHeaders, EmptyMessageParameters.getInstance(), request);
-	}
-
-	public <M extends MessageHeaders<EmptyRequestBody, P, EmptyMessageParameters>, P extends ResponseBody> CompletableFuture<P> sendRequest(String targetAddress, int targetPort, M messageHeaders) throws IOException {
-		return sendRequest(targetAddress, targetPort, messageHeaders, EmptyMessageParameters.getInstance(), EmptyRequestBody.getInstance());
 	}
 
 	public <M extends MessageHeaders<R, P, U>, U extends MessageParameters, R extends RequestBody, P extends ResponseBody> CompletableFuture<P> sendRequest(String targetAddress, int targetPort, M messageHeaders, U messageParameters, R request) throws IOException {
@@ -261,6 +249,12 @@ public class RestClient {
 				}
 
 			}
+			ctx.close();
+		}
+
+		@Override
+		public void exceptionCaught(final ChannelHandlerContext ctx, final Throwable cause) throws Exception {
+			jsonFuture.completeExceptionally(cause);
 			ctx.close();
 		}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClientConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClientConfiguration.java
@@ -37,9 +37,9 @@ public final class RestClientConfiguration {
 	@Nullable
 	private final SSLEngine sslEngine;
 
-	private final int connectionTimeout;
+	private final long connectionTimeout;
 
-	private RestClientConfiguration(@Nullable SSLEngine sslEngine, final int connectionTimeout) {
+	private RestClientConfiguration(@Nullable SSLEngine sslEngine, final long connectionTimeout) {
 		this.sslEngine = sslEngine;
 		this.connectionTimeout = connectionTimeout;
 	}
@@ -57,7 +57,7 @@ public final class RestClientConfiguration {
 	/**
 	 * @see RestOptions#CONNECTION_TIMEOUT
 	 */
-	public int getConnectionTimeout() {
+	public long getConnectionTimeout() {
 		return connectionTimeout;
 	}
 
@@ -87,7 +87,7 @@ public final class RestClientConfiguration {
 			}
 		}
 
-		final int connectionTimeout = config.getInteger(RestOptions.CONNECTION_TIMEOUT);
+		final long connectionTimeout = config.getLong(RestOptions.CONNECTION_TIMEOUT);
 
 		return new RestClientConfiguration(sslEngine, connectionTimeout);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClientConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClientConfiguration.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.rest;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.runtime.net.SSLUtils;
 import org.apache.flink.util.ConfigurationException;
@@ -36,8 +37,11 @@ public final class RestClientConfiguration {
 	@Nullable
 	private final SSLEngine sslEngine;
 
-	private RestClientConfiguration(@Nullable SSLEngine sslEngine) {
+	private final int connectionTimeout;
+
+	private RestClientConfiguration(@Nullable SSLEngine sslEngine, final int connectionTimeout) {
 		this.sslEngine = sslEngine;
+		this.connectionTimeout = connectionTimeout;
 	}
 
 	/**
@@ -48,6 +52,13 @@ public final class RestClientConfiguration {
 
 	public SSLEngine getSslEngine() {
 		return sslEngine;
+	}
+
+	/**
+	 * @see RestOptions#CONNECTION_TIMEOUT
+	 */
+	public int getConnectionTimeout() {
+		return connectionTimeout;
 	}
 
 	/**
@@ -76,6 +87,8 @@ public final class RestClientConfiguration {
 			}
 		}
 
-		return new RestClientConfiguration(sslEngine);
+		final int connectionTimeout = config.getInteger(RestOptions.CONNECTION_TIMEOUT);
+
+		return new RestClientConfiguration(sslEngine, connectionTimeout);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
@@ -168,7 +168,7 @@ public abstract class RestServerEndpoint {
 			String address = bindAddress.getAddress().getHostAddress();
 			int port = bindAddress.getPort();
 
-			log.info("Rest endpoint listening at {}" + ':' + "{}", address, port);
+			log.info("Rest endpoint listening at {}:{}", address, port);
 
 			final String protocol;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
@@ -207,9 +207,7 @@ public abstract class RestServerEndpoint {
 	}
 
 	/**
-	 * Returns the address of the REST server endpoint. Since the address is only known
-	 * after the endpoint is started, it is returned as a future which is completed
-	 * with the REST address at start up.
+	 * Returns the address of the REST server endpoint.
 	 *
 	 * @return REST address of this endpoint
 	 */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
@@ -18,12 +18,6 @@
 
 package org.apache.flink.runtime.util;
 
-import org.apache.commons.lang3.StringUtils;
-import org.apache.curator.framework.CuratorFramework;
-import org.apache.curator.framework.CuratorFrameworkFactory;
-import org.apache.curator.framework.api.ACLProvider;
-import org.apache.curator.framework.imps.DefaultACLProvider;
-import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
@@ -41,6 +35,13 @@ import org.apache.flink.runtime.leaderretrieval.ZooKeeperLeaderRetrievalService;
 import org.apache.flink.runtime.zookeeper.RetrievableStateStorageHelper;
 import org.apache.flink.runtime.zookeeper.filesystem.FileSystemStateStorageHelper;
 import org.apache.flink.util.Preconditions;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.api.ACLProvider;
+import org.apache.curator.framework.imps.DefaultACLProvider;
+import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.data.ACL;
 import org.slf4j.Logger;
@@ -92,21 +93,20 @@ public class ZooKeeperUtils {
 
 		ZkClientACLMode aclMode = ZkClientACLMode.fromConfig(configuration);
 
-		if(disableSaslClient && aclMode == ZkClientACLMode.CREATOR) {
-			String errorMessage = "Cannot set ACL role to " + aclMode +"  since SASL authentication is " +
+		if (disableSaslClient && aclMode == ZkClientACLMode.CREATOR) {
+			String errorMessage = "Cannot set ACL role to " + aclMode + "  since SASL authentication is " +
 					"disabled through the " + SecurityOptions.ZOOKEEPER_SASL_DISABLE.key() + " property";
 			LOG.warn(errorMessage);
 			throw new IllegalConfigurationException(errorMessage);
 		}
 
-		if(aclMode == ZkClientACLMode.CREATOR) {
+		if (aclMode == ZkClientACLMode.CREATOR) {
 			LOG.info("Enforcing creator for ZK connections");
 			aclProvider = new SecureAclProvider();
 		} else {
 			LOG.info("Enforcing default ACL for ZK connections");
 			aclProvider = new DefaultACLProvider();
 		}
-
 
 		String rootWithNamespace = generateZookeeperPath(root, namespace);
 
@@ -181,8 +181,7 @@ public class ZooKeeperUtils {
 	public static ZooKeeperLeaderRetrievalService createLeaderRetrievalService(
 		final CuratorFramework client,
 		final Configuration configuration,
-		final String pathSuffix)
-	{
+		final String pathSuffix) {
 		String leaderPath = configuration.getString(
 			HighAvailabilityOptions.HA_ZOOKEEPER_LEADER_PATH) + pathSuffix;
 
@@ -212,10 +211,9 @@ public class ZooKeeperUtils {
 	 * @return {@link ZooKeeperLeaderElectionService} instance.
 	 */
 	public static ZooKeeperLeaderElectionService createLeaderElectionService(
-		final CuratorFramework client,
-		final Configuration configuration,
-		final String pathSuffix)
-	{
+			final CuratorFramework client,
+			final Configuration configuration,
+			final String pathSuffix) {
 		final String latchPath = configuration.getString(
 			HighAvailabilityOptions.HA_ZOOKEEPER_LATCH_PATH) + pathSuffix;
 		final String leaderPath = configuration.getString(
@@ -346,18 +344,14 @@ public class ZooKeeperUtils {
 		return root + namespace;
 	}
 
-
-	public static class SecureAclProvider implements ACLProvider
-	{
+	public static class SecureAclProvider implements ACLProvider {
 		@Override
-		public List<ACL> getDefaultAcl()
-		{
+		public List<ACL> getDefaultAcl() {
 			return ZooDefs.Ids.CREATOR_ALL_ACL;
 		}
 
 		@Override
-		public List<ACL> getAclForPath(String path)
-		{
+		public List<ACL> getAclForPath(String path) {
 			return ZooDefs.Ids.CREATOR_ALL_ACL;
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
@@ -22,6 +22,8 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.leaderelection.LeaderContender;
+import org.apache.flink.runtime.leaderelection.LeaderElectionService;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.rest.RestServerEndpoint;
 import org.apache.flink.runtime.rest.RestServerEndpointConfiguration;
@@ -89,6 +91,7 @@ import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointStatusHead
 import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointTriggerHeaders;
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerDetailsHeaders;
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagersHeaders;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
 import org.apache.flink.runtime.webmonitor.retriever.MetricQueryServiceRetriever;
 import org.apache.flink.util.FileUtils;
@@ -102,6 +105,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
@@ -110,7 +114,7 @@ import java.util.concurrent.Executor;
  *
  * @param <T> type of the leader gateway
  */
-public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndpoint {
+public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndpoint implements LeaderContender {
 
 	protected final GatewayRetriever<T> leaderRetriever;
 	private final Configuration clusterConfiguration;
@@ -123,6 +127,10 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
 
 	private final MetricFetcher<T> metricFetcher;
 
+	private final LeaderElectionService leaderElectionService;
+
+	private final FatalErrorHandler fatalErrorHandler;
+
 	public WebMonitorEndpoint(
 			RestServerEndpointConfiguration endpointConfiguration,
 			GatewayRetriever<T> leaderRetriever,
@@ -130,7 +138,9 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
 			RestHandlerConfiguration restConfiguration,
 			GatewayRetriever<ResourceManagerGateway> resourceManagerRetriever,
 			Executor executor,
-			MetricQueryServiceRetriever metricQueryServiceRetriever) {
+			MetricQueryServiceRetriever metricQueryServiceRetriever,
+			LeaderElectionService leaderElectionService,
+			FatalErrorHandler fatalErrorHandler) {
 		super(endpointConfiguration);
 		this.leaderRetriever = Preconditions.checkNotNull(leaderRetriever);
 		this.clusterConfiguration = Preconditions.checkNotNull(clusterConfiguration);
@@ -150,6 +160,9 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
 			metricQueryServiceRetriever,
 			executor,
 			restConfiguration.getTimeout());
+
+		this.leaderElectionService = Preconditions.checkNotNull(leaderElectionService);
+		this.fatalErrorHandler = Preconditions.checkNotNull(fatalErrorHandler);
 	}
 
 	@Override
@@ -455,6 +468,12 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
 	}
 
 	@Override
+	public void start() throws Exception {
+		super.start();
+		leaderElectionService.start(this);
+	}
+
+	@Override
 	public void shutdown(Time timeout) {
 		super.shutdown(timeout);
 
@@ -468,5 +487,37 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
 		} catch (Throwable t) {
 			log.warn("Error while deleting cache directory {}", tmpDir, t);
 		}
+
+		try {
+			leaderElectionService.stop();
+		} catch (Exception e) {
+			log.warn("Error while stopping leaderElectionService", e);
+		}
 	}
+
+	//-------------------------------------------------------------------------
+	// LeaderContender
+	//-------------------------------------------------------------------------
+
+	@Override
+	public void grantLeadership(final UUID leaderSessionID) {
+		log.info("{} was granted leadership with leaderSessionID={}", getRestAddress(), leaderSessionID);
+		leaderElectionService.confirmLeaderSessionID(leaderSessionID);
+	}
+
+	@Override
+	public void revokeLeadership() {
+		log.info("{} lost leadership", getRestAddress());
+	}
+
+	@Override
+	public String getAddress() {
+		return getRestAddress();
+	}
+
+	@Override
+	public void handleError(final Exception exception) {
+		fatalErrorHandler.onFatalError(exception);
+	}
+
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/retriever/LeaderRetriever.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/retriever/LeaderRetriever.java
@@ -52,10 +52,8 @@ public class LeaderRetriever implements LeaderRetrievalListener {
 	public Optional<Tuple2<String, UUID>> getLeaderNow() throws Exception {
 		CompletableFuture<Tuple2<String, UUID>> leaderFuture = this.atomicLeaderFuture.get();
 		if (leaderFuture != null) {
-			CompletableFuture<Tuple2<String, UUID>> currentLeaderFuture = leaderFuture;
-
-			if (currentLeaderFuture.isDone()) {
-				return Optional.of(currentLeaderFuture.get());
+			if (leaderFuture.isDone()) {
+				return Optional.of(leaderFuture.get());
 			} else {
 				return Optional.empty();
 			}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/TestingHighAvailabilityServices.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/TestingHighAvailabilityServices.java
@@ -40,6 +40,8 @@ public class TestingHighAvailabilityServices implements HighAvailabilityServices
 
 	private volatile LeaderRetrievalService dispatcherLeaderRetriever;
 
+	private volatile LeaderRetrievalService webMonitorEndpointLeaderRetriever;
+
 	private ConcurrentHashMap<JobID, LeaderRetrievalService> jobMasterLeaderRetrievers = new ConcurrentHashMap<>();
 
 	private ConcurrentHashMap<JobID, LeaderElectionService> jobManagerLeaderElectionServices = new ConcurrentHashMap<>();
@@ -47,6 +49,8 @@ public class TestingHighAvailabilityServices implements HighAvailabilityServices
 	private volatile LeaderElectionService resourceManagerLeaderElectionService;
 
 	private volatile LeaderElectionService dispatcherLeaderElectionService;
+
+	private volatile LeaderElectionService webMonitorEndpointLeaderElectionService;
 
 	private volatile CheckpointRecoveryFactory checkpointRecoveryFactory;
 
@@ -66,6 +70,10 @@ public class TestingHighAvailabilityServices implements HighAvailabilityServices
 		this.dispatcherLeaderRetriever = dispatcherLeaderRetriever;
 	}
 
+	public void setWebMonitorEndpointLeaderRetriever(final LeaderRetrievalService webMonitorEndpointLeaderRetriever) {
+		this.webMonitorEndpointLeaderRetriever = webMonitorEndpointLeaderRetriever;
+	}
+
 	public void setJobMasterLeaderRetriever(JobID jobID, LeaderRetrievalService jobMasterLeaderRetriever) {
 		this.jobMasterLeaderRetrievers.put(jobID, jobMasterLeaderRetriever);
 	}
@@ -80,6 +88,10 @@ public class TestingHighAvailabilityServices implements HighAvailabilityServices
 
 	public void setDispatcherLeaderElectionService(LeaderElectionService leaderElectionService) {
 		this.dispatcherLeaderElectionService = leaderElectionService;
+	}
+
+	public void setWebMonitorEndpointLeaderElectionService(final LeaderElectionService webMonitorEndpointLeaderElectionService) {
+		this.webMonitorEndpointLeaderElectionService = webMonitorEndpointLeaderElectionService;
 	}
 
 	public void setCheckpointRecoveryFactory(CheckpointRecoveryFactory checkpointRecoveryFactory) {
@@ -130,6 +142,11 @@ public class TestingHighAvailabilityServices implements HighAvailabilityServices
 	}
 
 	@Override
+	public LeaderRetrievalService getWebMonitorLeaderRetriever() {
+		return webMonitorEndpointLeaderRetriever;
+	}
+
+	@Override
 	public LeaderElectionService getResourceManagerLeaderElectionService() {
 		LeaderElectionService service = resourceManagerLeaderElectionService;
 
@@ -160,6 +177,11 @@ public class TestingHighAvailabilityServices implements HighAvailabilityServices
 		} else {
 			throw new IllegalStateException("JobMasterLeaderElectionService has not been set");
 		}
+	}
+
+	@Override
+	public LeaderElectionService getWebMonitorLeaderElectionService() {
+		return webMonitorEndpointLeaderElectionService;
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/TestingManualHighAvailabilityServices.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/TestingManualHighAvailabilityServices.java
@@ -47,10 +47,13 @@ public class TestingManualHighAvailabilityServices implements HighAvailabilitySe
 
 	private final ManualLeaderService dispatcherLeaderService;
 
+	private final ManualLeaderService webMonitorEndpointLeaderService;
+
 	public TestingManualHighAvailabilityServices() {
 		jobManagerLeaderServices = new HashMap<>(4);
 		resourceManagerLeaderService = new ManualLeaderService();
 		dispatcherLeaderService = new ManualLeaderService();
+		webMonitorEndpointLeaderService = new ManualLeaderService();
 	}
 
 	@Override
@@ -76,6 +79,11 @@ public class TestingManualHighAvailabilityServices implements HighAvailabilitySe
 	}
 
 	@Override
+	public LeaderRetrievalService getWebMonitorLeaderRetriever() {
+		return webMonitorEndpointLeaderService.createLeaderRetrievalService();
+	}
+
+	@Override
 	public LeaderElectionService getResourceManagerLeaderElectionService() {
 		return resourceManagerLeaderService.createLeaderElectionService();
 	}
@@ -90,6 +98,11 @@ public class TestingManualHighAvailabilityServices implements HighAvailabilitySe
 		ManualLeaderService leaderService = getOrCreateJobManagerLeaderService(jobID);
 
 		return leaderService.createLeaderElectionService();
+	}
+
+	@Override
+	public LeaderElectionService getWebMonitorLeaderElectionService() {
+		return webMonitorEndpointLeaderService.createLeaderElectionService();
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/nonha/standalone/StandaloneHaServicesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/nonha/standalone/StandaloneHaServicesTest.java
@@ -41,6 +41,7 @@ public class StandaloneHaServicesTest extends TestLogger {
 	private final String jobManagerAddress = "jobManager";
 	private final String dispatcherAddress = "dispatcher";
 	private final String resourceManagerAddress = "resourceManager";
+	private final String webMonitorAddress = "webMonitor";
 
 	private StandaloneHaServices standaloneHaServices;
 
@@ -50,7 +51,8 @@ public class StandaloneHaServicesTest extends TestLogger {
 		standaloneHaServices = new StandaloneHaServices(
 			resourceManagerAddress,
 			dispatcherAddress,
-			jobManagerAddress);
+			jobManagerAddress,
+			webMonitorAddress);
 	}
 
 	@After

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestClientTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestClientTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.runtime.concurrent.Executors;
+import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.EmptyResponseBody;
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+import org.apache.flink.util.ExceptionUtils;
+
+import org.apache.flink.shaded.netty4.io.netty.channel.ConnectTimeoutException;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+import org.junit.Test;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for {@link RestClient}.
+ */
+public class RestClientTest {
+
+	@Test
+	public void testConnectionTimeout() throws Exception {
+		final Configuration config = new Configuration();
+		config.setInteger(RestOptions.CONNECTION_TIMEOUT, 1);
+		final RestClient restClient = new RestClient(RestClientConfiguration.fromConfiguration(config), Executors.directExecutor());
+		final String unroutableIp = "10.255.255.1";
+		try {
+			restClient.sendRequest(
+				unroutableIp,
+				80,
+				new TestMessageHeaders(),
+				EmptyMessageParameters.getInstance(),
+				EmptyRequestBody.getInstance())
+				.get(60, TimeUnit.SECONDS);
+		} catch (final ExecutionException e) {
+			final Throwable throwable = ExceptionUtils.stripExecutionException(e);
+			assertThat(throwable, instanceOf(ConnectTimeoutException.class));
+			assertThat(throwable.getMessage(), containsString(unroutableIp));
+		}
+	}
+
+	private static class TestMessageHeaders implements MessageHeaders<EmptyRequestBody, EmptyResponseBody, EmptyMessageParameters> {
+
+		@Override
+		public Class<EmptyRequestBody> getRequestClass() {
+			return EmptyRequestBody.class;
+		}
+
+		@Override
+		public Class<EmptyResponseBody> getResponseClass() {
+			return EmptyResponseBody.class;
+		}
+
+		@Override
+		public HttpResponseStatus getResponseStatusCode() {
+			return HttpResponseStatus.OK;
+		}
+
+		@Override
+		public EmptyMessageParameters getUnresolvedMessageParameters() {
+			return EmptyMessageParameters.getInstance();
+		}
+
+		@Override
+		public HttpMethodWrapper getHttpMethod() {
+			return HttpMethodWrapper.GET;
+		}
+
+		@Override
+		public String getTargetRestEndpointURL() {
+			return "/";
+		}
+
+	}
+
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestClientTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestClientTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
 import org.apache.flink.runtime.rest.messages.EmptyResponseBody;
 import org.apache.flink.runtime.rest.messages.MessageHeaders;
 import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.TestLogger;
 
 import org.apache.flink.shaded.netty4.io.netty.channel.ConnectTimeoutException;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
@@ -42,7 +43,7 @@ import static org.junit.Assert.assertThat;
 /**
  * Tests for {@link RestClient}.
  */
-public class RestClientTest {
+public class RestClientTest extends TestLogger {
 
 	@Test
 	public void testConnectionTimeout() throws Exception {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestClientTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestClientTest.java
@@ -48,7 +48,7 @@ public class RestClientTest extends TestLogger {
 	@Test
 	public void testConnectionTimeout() throws Exception {
 		final Configuration config = new Configuration();
-		config.setInteger(RestOptions.CONNECTION_TIMEOUT, 1);
+		config.setLong(RestOptions.CONNECTION_TIMEOUT, 1);
 		final RestClient restClient = new RestClient(RestClientConfiguration.fromConfiguration(config), Executors.directExecutor());
 		final String unroutableIp = "10.255.255.1";
 		try {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -522,6 +522,7 @@ public class TaskExecutorTest extends TestLogger {
 		final ResourceID resourceManagerResourceId = new ResourceID(resourceManagerAddress);
 		final String dispatcherAddress = "localhost";
 		final String jobManagerAddress = "localhost";
+		final String webMonitorAddress = "localhost";
 
 		// register a mock resource manager gateway
 		ResourceManagerGateway rmGateway = mock(ResourceManagerGateway.class);
@@ -540,8 +541,9 @@ public class TaskExecutorTest extends TestLogger {
 
 		StandaloneHaServices haServices = new StandaloneHaServices(
 			resourceManagerAddress,
-				dispatcherAddress,
-			jobManagerAddress);
+			dispatcherAddress,
+			jobManagerAddress,
+			webMonitorAddress);
 
 		final TaskSlotTable taskSlotTable = mock(TaskSlotTable.class);
 		final SlotReport slotReport = new SlotReport();

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/highavailability/YarnIntraNonHaMasterServices.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/highavailability/YarnIntraNonHaMasterServices.java
@@ -177,6 +177,17 @@ public class YarnIntraNonHaMasterServices extends AbstractYarnNonHaServices {
 	}
 
 	@Override
+	public LeaderElectionService getWebMonitorLeaderElectionService() {
+		enter();
+		try {
+			throw new UnsupportedOperationException();
+		}
+		finally {
+			exit();
+		}
+	}
+
+	@Override
 	public LeaderRetrievalService getJobManagerLeaderRetriever(JobID jobID) {
 		enter();
 		try {
@@ -192,6 +203,17 @@ public class YarnIntraNonHaMasterServices extends AbstractYarnNonHaServices {
 		enter();
 		try {
 			throw new UnsupportedOperationException("needs refactoring to accept default address");
+		}
+		finally {
+			exit();
+		}
+	}
+
+	@Override
+	public LeaderRetrievalService getWebMonitorLeaderRetriever() {
+		enter();
+		try {
+			throw new UnsupportedOperationException();
 		}
 		finally {
 			exit();

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/highavailability/YarnPreConfiguredMasterNonHaServices.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/highavailability/YarnPreConfiguredMasterNonHaServices.java
@@ -199,6 +199,17 @@ public class YarnPreConfiguredMasterNonHaServices extends AbstractYarnNonHaServi
 	}
 
 	@Override
+	public LeaderElectionService getWebMonitorLeaderElectionService() {
+		enter();
+		try {
+			throw new UnsupportedOperationException();
+		}
+		finally {
+			exit();
+		}
+	}
+
+	@Override
 	public LeaderRetrievalService getJobManagerLeaderRetriever(JobID jobID) {
 		enter();
 		try {
@@ -215,6 +226,17 @@ public class YarnPreConfiguredMasterNonHaServices extends AbstractYarnNonHaServi
 		try {
 			return new StandaloneLeaderRetrievalService(defaultJobManagerAddress, DEFAULT_LEADER_ID);
 		} finally {
+			exit();
+		}
+	}
+
+	@Override
+	public LeaderRetrievalService getWebMonitorLeaderRetriever() {
+		enter();
+		try {
+			throw new UnsupportedOperationException();
+		}
+		finally {
 			exit();
 		}
 	}


### PR DESCRIPTION
## What is the purpose of the change

*Retrieve leading WebMonitor in RestClusterClient. This enables the client to work in a HA setup.*

## Brief change log
  - *Make WebMonitorEndpoint instances participate in leader election.*
  - *Use leading instance's base url to issue HTTP request from RestClusterClient.*
  - *Make polling of JobExecutionResults and savepoints fault tolerant.*
  - *Make polling of JobExecutionResults and savepoints non-blocking.*


## Verifying this change
This change added tests and can be verified as follows:

  - *Added unit tests to `RestClusterClientTest`*
  - *Manually deployed batch WordCount job, restarted the Dispatcher, and verified that the JobExecutionResult is retrieved correctly (with temporary fix for FLINK-8488):*
    1. `bin/flink run -p1 -flip6 examples/batch/WordCount.jar --input /large/file`
    1. `bin/jobmanager.sh stop flip6 && bin/jobmanager.sh start flip6`
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
