### PR TITLE
[FLINK-8455] [core] Make 'org.apache.hadoop.' a 'parent-first' classloading pattern

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
@@ -79,7 +79,7 @@ public class CoreOptions {
 	 */
 	public static final ConfigOption<String> ALWAYS_PARENT_FIRST_LOADER = ConfigOptions
 		.key("classloader.parent-first-patterns")
-		.defaultValue("java.;scala.;org.apache.flink.;javax.annotation;org.slf4j;org.apache.log4j;org.apache.logging.log4j;ch.qos.logback");
+		.defaultValue("java.;scala.;org.apache.flink.;org.apache.hadoop.;javax.annotation.;org.slf4j;org.apache.log4j;org.apache.logging.log4j;ch.qos.logback");
 
 	// ------------------------------------------------------------------------
 	//  process parameters

--- a/flink-core/src/test/java/org/apache/flink/configuration/ParentFirstPatternsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/ParentFirstPatternsTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.configuration;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashSet;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test that checks that all packages that need to be loaded 'parent-first' are also
+ * in the parent-first patterns.
+ */
+public class ParentFirstPatternsTest {
+
+	private static final HashSet<String> PARENT_FIRST_PACKAGES = new HashSet<>(
+			Arrays.asList(CoreOptions.ALWAYS_PARENT_FIRST_LOADER.defaultValue().split(";")));
+
+	/**
+	 * All java and Flink classes must be loaded parent first.
+	 */
+	@Test
+	public void testAllCorePatterns() {
+		assertTrue(PARENT_FIRST_PACKAGES.contains("java."));
+		assertTrue(PARENT_FIRST_PACKAGES.contains("org.apache.flink."));
+		assertTrue(PARENT_FIRST_PACKAGES.contains("javax.annotation."));
+	}
+
+	/**
+	 * To avoid multiple binding problems and warnings for logger frameworks, we load them
+	 * parent-first.
+	 */
+	@Test
+	public void testLoggersParentFirst() {
+		assertTrue(PARENT_FIRST_PACKAGES.contains("org.slf4j"));
+		assertTrue(PARENT_FIRST_PACKAGES.contains("org.apache.log4j"));
+		assertTrue(PARENT_FIRST_PACKAGES.contains("org.apache.logging.log4j"));
+		assertTrue(PARENT_FIRST_PACKAGES.contains("ch.qos.logback"));
+	}
+
+	/**
+	 * As long as Scala is not a pure user library, but is also used in the Flink runtime, we need
+	 * to load all Scala classes parent-first.
+	 */
+	@Test
+	public void testScalaParentFirst() {
+		assertTrue(PARENT_FIRST_PACKAGES.contains("scala."));
+	}
+
+	/**
+	 * As long as we have Hadoop classes leaking through some of Flink's APIs (example bucketing sink),
+	 * we need to make them parent first.
+	 */
+	@Test
+	public void testHadoopParentFirst() {
+		assertTrue(PARENT_FIRST_PACKAGES.contains("org.apache.hadoop."));
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

This change avoids duplication of Hadoop classes between the Flink runtime and the user code.
Hadoop (and transitively its dependencies) should be part of the application class loader.
The user code classloader is allowed to duplicate transitive dependencies, but not Hadoop's
classes directly.

This change addresses an issue that various users have reported (mainly using the BucketingSink) where they get ClassCastExceptions related to Hadoop classes.

In all cases, users had Hadoop dependencies bundled into their application jar files. To make the experience better, I suggest to let Hadoop always load its classes parent-first.

## Brief change log

  - Add `org.apache.hadoop.` to the parent-first patterns.
  - Add some tests for the parent-first patterns.

## Verifying this change

This change added self-contained tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
