### PR TITLE
[hotfix][docs] Put HADOOP_CONF_DIR in <code> tag

### DIFF
--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -245,7 +245,7 @@ Default value is the `akka.ask.timeout`.
 ### HDFS
 
 <div class="alert alert-warning">
-  <strong>Note:</strong> These keys are deprecated and it is recommended to configure the Hadoop path with the environment variable *HADOOP_CONF_DIR* instead.
+  <strong>Note:</strong> These keys are deprecated and it is recommended to configure the Hadoop path with the environment variable <code>HADOOP_CONF_DIR</code> instead.
 </div>
 
 These parameters configure the default HDFS used by Flink. Setups that do not specify a HDFS configuration have to specify the full path to HDFS files (`hdfs://address:port/path/to/files`) Files will also be written with default HDFS parameters (block size, replication factor).


### PR DESCRIPTION
See title.

`*HADOOP_CONF_DIR*` -> `<code>HADOOP_CONF_DIR</code>`

The asterisks are currently rendered because markdown is not supported in html tags.