### PR TITLE
[FLINK-8458] Add the switch for keeping both the old mode and the new credit-based mode

### DIFF
--- a/docs/_includes/generated/netty_configuration.html
+++ b/docs/_includes/generated/netty_configuration.html
@@ -55,7 +55,7 @@
         <tr>
             <td><h5>taskmanager.network.memory.floating-buffers-per-gate</h5></td>
             <td style="word-wrap: break-word;">8</td>
-            <td>Number of extra network buffers to use for each outgoing/incoming gate (result partition/input gate). In credit-based flow control mode, this indicates how many floating credits are shared among all the input channels. The floating buffers are distributed based on backlog (real-time output buffers in the subpartition) feedback, and can help relieve back-pressure caused by unbalanced data distribution among the subpartitions</td>
+            <td>Number of extra network buffers to use for each outgoing/incoming gate (result partition/input gate). In credit-based flow control mode, this indicates how many floating credits are shared among all the input channels. The floating buffers are distributed based on backlog (real-time output buffers in the subpartition) feedback, and can help relieve back-pressure caused by unbalanced data distribution among the subpartitions. This value should be increased in case of higher round trip times between nodes and/or larger number of machines in the cluster</td>
         </tr>
     </tbody>
 </table>

--- a/docs/_includes/generated/netty_configuration.html
+++ b/docs/_includes/generated/netty_configuration.html
@@ -42,5 +42,20 @@
             <td style="word-wrap: break-word;">"nio"</td>
             <td>The Netty transport type, either "nio" or "epoll"</td>
         </tr>
+        <tr>
+            <td><h5>taskmanager.network.credit-based-flow-control.enabled</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean flag to enable/disable network credit-based flow control</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.network.memory.buffers-per-channel</h5></td>
+            <td style="word-wrap: break-word;">2</td>
+            <td>Number of network buffers to use for each outgoing/incoming channel (subpartition/input channel). In credit-based flow control mode, this indicates how many credits are exclusive in each input channel. It should be configured at least 2 for good performance. 1 buffer is for receiving in-flight data in the subpartition and 1 buffer is for parallel serialization</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.network.memory.floating-buffers-per-gate</h5></td>
+            <td style="word-wrap: break-word;">8</td>
+            <td>Number of extra network buffers to use for each outgoing/incoming gate (result partition/input gate). In credit-based flow control mode, this indicates how many floating credits are shared among all the input channels. The floating buffers are distributed based on backlog (real-time output buffers in the subpartition) feedback, and can help relieve back-pressure caused by unbalanced data distribution among the subpartitions</td>
+        </tr>
     </tbody>
 </table>

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -269,7 +269,10 @@ public class TaskManagerOptions {
 	public static final ConfigOption<Integer> NETWORK_BUFFERS_PER_CHANNEL =
 			key("taskmanager.network.memory.buffers-per-channel")
 			.defaultValue(2)
-			.withDescription("Number of network buffers to use for each outgoing/incoming channel (subpartition/input channel).");
+			.withDescription("Number of network buffers to use for each outgoing/incoming channel (subpartition/input channel)." +
+				"In credit-based flow control mode, this indicates how many credits are exclusive in each input channel. It should be" +
+				" configured at least 2 for good performance. 1 buffer is for receiving in-flight data in the subpartition and 1 buffer is" +
+				" for parallel serialization.");
 
 	/**
 	 * Number of extra network buffers to use for each outgoing/incoming gate (result partition/input gate).
@@ -277,7 +280,10 @@ public class TaskManagerOptions {
 	public static final ConfigOption<Integer> NETWORK_EXTRA_BUFFERS_PER_GATE =
 			key("taskmanager.network.memory.floating-buffers-per-gate")
 			.defaultValue(8)
-			.withDescription("Number of extra network buffers to use for each outgoing/incoming gate (result partition/input gate).");
+			.withDescription("Number of extra network buffers to use for each outgoing/incoming gate (result partition/input gate)." +
+				" In credit-based flow control mode, this indicates how many floating credits are shared among all the input channels." +
+				" The floating buffers are distributed based on backlog (real-time output buffers in the subpartition) feedback, and can" +
+				" help relieve back-pressure caused by unbalanced data distribution among the subpartitions.");
 
 	/**
 	 * Minimum backoff for partition requests of input channels.
@@ -307,7 +313,7 @@ public class TaskManagerOptions {
 			.withDescription("Boolean flag to enable/disable more detailed metrics about inbound/outbound network queue lengths.");
 
 	/**
-	 * Config parameter defining whether to enable credit-based flow control or not.
+	 * Boolean flag to enable/disable network credit-based flow control.
 	 *
 	 * @deprecated Will be removed for Flink 1.6 when the old code will be dropped in favour of
 	 * credit-based flow control.
@@ -315,7 +321,8 @@ public class TaskManagerOptions {
 	@Deprecated
 	public static final ConfigOption<Boolean> NETWORK_CREDIT_BASED_FLOW_CONTROL_ENABLED =
 			key("taskmanager.network.credit-based-flow-control.enabled")
-			.defaultValue(true);
+			.defaultValue(true)
+			.withDescription("Boolean flag to enable/disable network credit-based flow control.");
 
 	/**
 	 * Config parameter defining whether to spill data for channels with barrier or not in exactly-once

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -283,7 +283,9 @@ public class TaskManagerOptions {
 			.withDescription("Number of extra network buffers to use for each outgoing/incoming gate (result partition/input gate)." +
 				" In credit-based flow control mode, this indicates how many floating credits are shared among all the input channels." +
 				" The floating buffers are distributed based on backlog (real-time output buffers in the subpartition) feedback, and can" +
-				" help relieve back-pressure caused by unbalanced data distribution among the subpartitions.");
+				" help relieve back-pressure caused by unbalanced data distribution among the subpartitions. This value should be" +
+				" increased in case of higher round trip times between nodes and/or larger number of machines in the cluster.");
+
 
 	/**
 	 * Minimum backoff for partition requests of input channels.


### PR DESCRIPTION
## What is the purpose of the change

*After the whole feature of credit-based flow control is done, we should add a config parameter to switch on/off the new credit-based mode. To do so, we can roll back to the old network mode for any expected risks.*

*The parameter is defined as taskmanager.network.credit-based-flow-control.enabled and the default value is true. This switch may be removed after next release.*

## Brief change log

  - *Abstract the `NetworkClientHandler` interface for different implementations in two modes*
  - *Abstract the `NetworkSequenceViewReader` interface for different implementations in two modes*
  - *Define the `taskmanager.network.credit-based-flow-control.enabled` in `TaskManagerOptions`*

## Verifying this change

This change is already covered by existing tests*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
