### PR TITLE
[hotfix] [REST] Fix WebMonitorEndpoint that missing parameters while initializing handlers

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/SubtaskExecutionAttemptAccumulatorsHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/SubtaskExecutionAttemptAccumulatorsHeaders.java
@@ -31,7 +31,7 @@ import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseSt
 /**
  * Message headers for the {@link SubtaskExecutionAttemptAccumulatorsHandler}.
  */
-public class SubtaskExecutionAttemptAccumulatorsHeaders implements MessageHeaders<EmptyRequestBody, SubtaskExecutionAttemptDetailsInfo, SubtaskAttemptMessageParameters> {
+public class SubtaskExecutionAttemptAccumulatorsHeaders implements MessageHeaders<EmptyRequestBody, SubtaskExecutionAttemptAccumulatorsInfo, SubtaskAttemptMessageParameters> {
 
 	private static final SubtaskExecutionAttemptAccumulatorsHeaders INSTANCE = new SubtaskExecutionAttemptAccumulatorsHeaders();
 
@@ -58,8 +58,8 @@ public class SubtaskExecutionAttemptAccumulatorsHeaders implements MessageHeader
 	}
 
 	@Override
-	public Class<SubtaskExecutionAttemptDetailsInfo> getResponseClass() {
-		return SubtaskExecutionAttemptDetailsInfo.class;
+	public Class<SubtaskExecutionAttemptAccumulatorsInfo> getResponseClass() {
+		return SubtaskExecutionAttemptAccumulatorsInfo.class;
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
@@ -376,7 +376,7 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
 			leaderRetriever,
 			timeout,
 			responseHeaders,
-			null,
+			SubtaskExecutionAttemptDetailsHeaders.getInstance(),
 			executionGraphCache,
 			executor,
 			metricFetcher);
@@ -386,7 +386,7 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
 			leaderRetriever,
 			timeout,
 			responseHeaders,
-			null,
+			SubtaskExecutionAttemptAccumulatorsHeaders.getInstance(),
 			executionGraphCache,
 			executor
 		);
@@ -396,7 +396,7 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
 			leaderRetriever,
 			timeout,
 			responseHeaders,
-			null,
+			SubtaskCurrentAttemptDetailsHeaders.getInstance(),
 			executionGraphCache,
 			executor,
 			metricFetcher


### PR DESCRIPTION
## What is the purpose of the change

* Fix bugs in my recent PRs about migrating subtask REST handlers

## Brief change log

* Some `MessageHeaders` are missing while initializing handlers in `WebMonitorEndpoint`
* There is wrong parameter type in `SubtaskExecutionAttemptAccumulatorsHeaders`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
