### PR TITLE
[FLINK-6926] [table] Add support for SHA-224, SHA-384, SHA-512

### DIFF
--- a/docs/dev/table/sql.md
+++ b/docs/dev/table/sql.md
@@ -2414,6 +2414,17 @@ SHA1(string)
     <tr>
       <td>
         {% highlight text %}
+SHA224(string)
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Returns the SHA-224 hash of the string argument as a string of 56 hexadecimal digits; null if <i>string</i> is null.</p>
+      </td>
+    </tr>    
+    
+    <tr>
+      <td>
+        {% highlight text %}
 SHA256(string)
 {% endhighlight %}
       </td>
@@ -2421,6 +2432,28 @@ SHA256(string)
         <p>Returns the SHA-256 hash of the string argument as a string of 64 hexadecimal digits; null if <i>string</i> is null.</p>
       </td>
     </tr>
+    
+    <tr>
+      <td>
+        {% highlight text %}
+SHA384(string)
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Returns the SHA-384 hash of the string argument as a string of 96 hexadecimal digits; null if <i>string</i> is null.</p>
+      </td>
+    </tr>  
+
+    <tr>
+      <td>
+        {% highlight text %}
+SHA512(string)
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Returns the SHA-512 hash of the string argument as a string of 128 hexadecimal digits; null if <i>string</i> is null.</p>
+      </td>
+    </tr>          
   </tbody>
 </table>
 

--- a/docs/dev/table/sql.md
+++ b/docs/dev/table/sql.md
@@ -2396,7 +2396,7 @@ MD5(string)
 {% endhighlight %}
       </td>
       <td>
-        <p>Returns the MD5 hash of the string argument as a string of 32 hexadecimal digits; null if <i>string</i> is null.</p>
+        <p>Returns the MD5 hash of the <i>string</i> argument as a string of 32 hexadecimal digits; null if <i>string</i> is null.</p>
       </td>
     </tr>
 
@@ -2407,7 +2407,7 @@ SHA1(string)
 {% endhighlight %}
       </td>
       <td>
-        <p>Returns the SHA-1 hash of the string argument as a string of 40 hexadecimal digits; null if <i>string</i> is null.</p>
+        <p>Returns the SHA-1 hash of the <i>string</i> argument as a string of 40 hexadecimal digits; null if <i>string</i> is null.</p>
       </td>
     </tr>
     
@@ -2418,7 +2418,7 @@ SHA224(string)
 {% endhighlight %}
       </td>
       <td>
-        <p>Returns the SHA-224 hash of the string argument as a string of 56 hexadecimal digits; null if <i>string</i> is null.</p>
+        <p>Returns the SHA-224 hash of the <i>string</i> argument as a string of 56 hexadecimal digits; null if <i>string</i> is null.</p>
       </td>
     </tr>    
     
@@ -2429,7 +2429,7 @@ SHA256(string)
 {% endhighlight %}
       </td>
       <td>
-        <p>Returns the SHA-256 hash of the string argument as a string of 64 hexadecimal digits; null if <i>string</i> is null.</p>
+        <p>Returns the SHA-256 hash of the <i>string</i> argument as a string of 64 hexadecimal digits; null if <i>string</i> is null.</p>
       </td>
     </tr>
     
@@ -2440,7 +2440,7 @@ SHA384(string)
 {% endhighlight %}
       </td>
       <td>
-        <p>Returns the SHA-384 hash of the string argument as a string of 96 hexadecimal digits; null if <i>string</i> is null.</p>
+        <p>Returns the SHA-384 hash of the <i>string</i> argument as a string of 96 hexadecimal digits; null if <i>string</i> is null.</p>
       </td>
     </tr>  
 
@@ -2451,9 +2451,25 @@ SHA512(string)
 {% endhighlight %}
       </td>
       <td>
-        <p>Returns the SHA-512 hash of the string argument as a string of 128 hexadecimal digits; null if <i>string</i> is null.</p>
+        <p>Returns the SHA-512 hash of the <i>string</i> argument as a string of 128 hexadecimal digits; null if <i>string</i> is null.</p>
       </td>
-    </tr>          
+    </tr>
+
+    <tr>
+      <td>
+        {% highlight text %}
+SHA2(string, hashLength)
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Returns the SHA-2 hash of the <i>string</i> argument as a string of 128 hexadecimal digits; null if <i>string</i> is null.</p>
+
+        <p>Returns the SHA-2 family of hash functions (SHA-224, SHA-256, SHA-384, and SHA-512).
+           <i>string</i> is the string to be hashed. <i>hashLength</i> is the bit length of the result (One of 224, 256, 384, 512).
+           Returns <i>null</i> if <i>string</i> or <i>hashLength</i> is <i>null</i>
+        </p>
+      </td>
+    </tr>
   </tbody>
 </table>
 

--- a/docs/dev/table/tableApi.md
+++ b/docs/dev/table/tableApi.md
@@ -3034,7 +3034,18 @@ STRING.sha1()
       </td>
     </tr>
 
-        <tr>
+    <tr>
+      <td>
+        {% highlight java %}
+STRING.sha224()
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Returns the SHA-224 hash of the string argument as a string of 56 hexadecimal digits; null if <i>string</i> is null.</p>
+      </td>
+    </tr>
+
+    <tr>
       <td>
         {% highlight java %}
 STRING.sha256()
@@ -3042,6 +3053,28 @@ STRING.sha256()
       </td>
       <td>
         <p>Returns the SHA-256 hash of the string argument as a string of 64 hexadecimal digits; null if <i>string</i> is null.</p>
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        {% highlight java %}
+STRING.sha384()
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Returns the SHA-384 hash of the string argument as a string of 96 hexadecimal digits; null if <i>string</i> is null.</p>
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        {% highlight java %}
+STRING.sha512()
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Returns the SHA-512 hash of the string argument as a string of 128 hexadecimal digits; null if <i>string</i> is null.</p>
       </td>
     </tr>
 
@@ -4456,7 +4489,18 @@ STRING.sha1()
       </td>
     </tr>
 
-        <tr>
+    <tr>
+      <td>
+        {% highlight scala %}
+STRING.sha224()
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Returns the SHA-224 hash of the string argument as a string of 56 hexadecimal digits; null if <i>string</i> is null.</p>
+      </td>
+    </tr>
+
+    <tr>
       <td>
         {% highlight scala %}
 STRING.sha256()
@@ -4466,7 +4510,28 @@ STRING.sha256()
         <p>Returns the SHA-256 hash of the string argument as a string of 64 hexadecimal digits; null if <i>string</i> is null.</p>
       </td>
     </tr>
+    
+    <tr>
+      <td>
+        {% highlight scala %}
+STRING.sha384()
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Returns the SHA-384 hash of the string argument as a string of 96 hexadecimal digits; null if <i>string</i> is null.</p>
+      </td>
+    </tr>    
 
+    <tr>
+      <td>
+        {% highlight scala %}
+STRING.sha512()
+{% endhighlight %}
+      </td>
+      <td>
+        <p>Returns the SHA-512 hash of the string argument as a string of 128 hexadecimal digits; null if <i>string</i> is null.</p>
+      </td>
+    </tr>  
     </tbody>
 </table>
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
@@ -742,11 +742,32 @@ trait ImplicitExpressionOperations {
   def sha1() = Sha1(expr)
 
   /**
+    * Returns the SHA-224 hash of the string argument; null if string is null.
+    *
+    * @return string of 64 hexadecimal digits or null
+    */
+  def sha224() = Sha224(expr)
+
+  /**
     * Returns the SHA-256 hash of the string argument; null if string is null.
     *
     * @return string of 64 hexadecimal digits or null
     */
   def sha256() = Sha256(expr)
+
+  /**
+    * Returns the SHA-384 hash of the string argument; null if string is null.
+    *
+    * @return string of 64 hexadecimal digits or null
+    */
+  def sha384() = Sha384(expr)
+
+  /**
+    * Returns the SHA-512 hash of the string argument; null if string is null.
+    *
+    * @return string of 64 hexadecimal digits or null
+    */
+  def sha512() = Sha512(expr)
 }
 
 /**

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
@@ -768,6 +768,9 @@ trait ImplicitExpressionOperations {
     * @return string of 64 hexadecimal digits or null
     */
   def sha512() = Sha512(expr)
+
+  def sha2(hashLength: Expression) = Sha2(expr, hashLength)
+
 }
 
 /**

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
@@ -1783,11 +1783,6 @@ abstract class CodeGenerator(
   def addReusableMessageDigest(algorithm: String): String = {
     val fieldTerm = newName("messageDigest")
 
-    val field =
-      s"""
-         |final java.security.MessageDigest $fieldTerm;
-         |""".stripMargin
-    reusableMemberStatements.add(field)
 
     val fieldInit =
       s"""
@@ -1801,4 +1796,44 @@ abstract class CodeGenerator(
     reusableInitStatements.add(fieldInit)
     fieldTerm
   }
+
+  /**
+    *
+    * @param hashLength
+    * @return
+    */
+  def addReusableMessageDigest(hashLength: GeneratedExpression): String = {
+    val fieldTerm = newName("messageDigest")
+    val algName = newName("algName")
+
+    val field =
+      s"""
+         |final java.security.MessageDigest $fieldTerm;
+         |""".stripMargin
+    reusableMemberStatements.add(field)
+
+    val fieldInit =
+      s"""
+         |${hashLength.code}
+         |String $algName = ${hashLength.resultTerm};
+         |try {
+         |  $fieldTerm = java.security.MessageDigest.getInstance($algName);
+         |} catch (java.security.NoSuchAlgorithmException e) {
+         |  throw new RuntimeException("Algorithm for " + $algName + " is not available.", e);
+         |}
+         |""".stripMargin
+
+    reusableInitStatements.add(fieldInit)
+    fieldTerm
+  }
+
+  /**
+    *
+    * @param hashLength
+    * @return
+    */
+  def addReusableMessageDigest(hashLength: Int): String = {
+    addReusableMessageDigest("SHA-" + hashLength)
+  }
+
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/FunctionGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/FunctionGenerator.scala
@@ -553,6 +553,12 @@ object FunctionGenerator {
     new HashCalcCallGen("SHA-512")
   )
 
+  addSqlFunction(
+    ScalarSqlFunctions.SHA2,
+    Seq(STRING_TYPE_INFO, INT_TYPE_INFO),
+    new HashCalcCallGen("SHA-2")
+  )
+
   // ----------------------------------------------------------------------------------------------
 
   /**

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/FunctionGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/FunctionGenerator.scala
@@ -530,9 +530,27 @@ object FunctionGenerator {
   )
 
   addSqlFunction(
+    ScalarSqlFunctions.SHA224,
+    Seq(STRING_TYPE_INFO),
+    new HashCalcCallGen("SHA-224")
+  )
+
+  addSqlFunction(
     ScalarSqlFunctions.SHA256,
     Seq(STRING_TYPE_INFO),
     new HashCalcCallGen("SHA-256")
+  )
+
+  addSqlFunction(
+    ScalarSqlFunctions.SHA384,
+    Seq(STRING_TYPE_INFO),
+    new HashCalcCallGen("SHA-384")
+  )
+
+  addSqlFunction(
+    ScalarSqlFunctions.SHA512,
+    Seq(STRING_TYPE_INFO),
+    new HashCalcCallGen("SHA-512")
   )
 
   // ----------------------------------------------------------------------------------------------

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/hashExpressions.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/hashExpressions.scala
@@ -101,3 +101,24 @@ case class Sha512(child: Expression) extends UnaryExpression with InputTypeSpec 
     relBuilder.call(ScalarSqlFunctions.SHA512, child.toRexNode)
   }
 }
+
+case class Sha2(child: Expression, hashLength: Expression)
+    extends BinaryExpression with InputTypeSpec {
+
+  override private[flink] def left = child
+  override private[flink] def right = hashLength
+
+  override private[flink] def resultType: TypeInformation[_] = STRING_TYPE_INFO
+
+  override private[flink] def expectedTypes: Seq[TypeInformation[_]] =
+    STRING_TYPE_INFO :: INT_TYPE_INFO :: Nil
+
+  override def toString: String = s"($child).sha2($hashLength)"
+
+  override private[flink] def toRexNode(implicit relBuilder: RelBuilder): RexNode = {
+    relBuilder.call(ScalarSqlFunctions.SHA2, left.toRexNode, right.toRexNode)
+  }
+
+}
+
+

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/hashExpressions.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/hashExpressions.scala
@@ -50,6 +50,19 @@ case class Sha1(child: Expression) extends UnaryExpression with InputTypeSpec {
   }
 }
 
+case class Sha224(child: Expression) extends UnaryExpression with InputTypeSpec {
+
+  override private[flink] def resultType: TypeInformation[_] = STRING_TYPE_INFO
+
+  override private[flink] def expectedTypes: Seq[TypeInformation[_]] = STRING_TYPE_INFO :: Nil
+
+  override def toString: String = s"($child).sha224()"
+
+  override private[flink] def toRexNode(implicit relBuilder: RelBuilder): RexNode = {
+    relBuilder.call(ScalarSqlFunctions.SHA224, child.toRexNode)
+  }
+}
+
 case class Sha256(child: Expression) extends UnaryExpression with InputTypeSpec {
 
   override private[flink] def resultType: TypeInformation[_] = STRING_TYPE_INFO
@@ -60,5 +73,31 @@ case class Sha256(child: Expression) extends UnaryExpression with InputTypeSpec 
 
   override private[flink] def toRexNode(implicit relBuilder: RelBuilder): RexNode = {
     relBuilder.call(ScalarSqlFunctions.SHA256, child.toRexNode)
+  }
+}
+
+case class Sha384(child: Expression) extends UnaryExpression with InputTypeSpec {
+
+  override private[flink] def resultType: TypeInformation[_] = STRING_TYPE_INFO
+
+  override private[flink] def expectedTypes: Seq[TypeInformation[_]] = STRING_TYPE_INFO :: Nil
+
+  override def toString: String = s"($child).sha384()"
+
+  override private[flink] def toRexNode(implicit relBuilder: RelBuilder): RexNode = {
+    relBuilder.call(ScalarSqlFunctions.SHA384, child.toRexNode)
+  }
+}
+
+case class Sha512(child: Expression) extends UnaryExpression with InputTypeSpec {
+
+  override private[flink] def resultType: TypeInformation[_] = STRING_TYPE_INFO
+
+  override private[flink] def expectedTypes: Seq[TypeInformation[_]] = STRING_TYPE_INFO :: Nil
+
+  override def toString: String = s"($child).sha512()"
+
+  override private[flink] def toRexNode(implicit relBuilder: RelBuilder): RexNode = {
+    relBuilder.call(ScalarSqlFunctions.SHA512, child.toRexNode)
   }
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/sql/ScalarSqlFunctions.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/sql/ScalarSqlFunctions.scala
@@ -121,6 +121,15 @@ object ScalarSqlFunctions {
     SqlFunctionCategory.STRING
   )
 
+  val SHA2 = new SqlFunction(
+    "SHA2",
+    SqlKind.OTHER_FUNCTION,
+    ReturnTypes.ARG0_NULLABLE,
+    InferTypes.RETURN_TYPE,
+    OperandTypes.sequence("'(DATA, HASH_LENGTH)'",
+      OperandTypes.STRING,  OperandTypes.NUMERIC_INTEGER),
+    SqlFunctionCategory.STRING
+  )
 
   val DATE_FORMAT = new SqlFunction(
     "DATE_FORMAT",

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/sql/ScalarSqlFunctions.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/sql/ScalarSqlFunctions.scala
@@ -85,6 +85,15 @@ object ScalarSqlFunctions {
     SqlFunctionCategory.STRING
   )
 
+  val SHA224 = new SqlFunction(
+    "SHA224",
+    SqlKind.OTHER_FUNCTION,
+    ReturnTypes.ARG0_NULLABLE,
+    InferTypes.RETURN_TYPE,
+    OperandTypes.STRING,
+    SqlFunctionCategory.STRING
+  )
+
   val SHA256 = new SqlFunction(
     "SHA256",
     SqlKind.OTHER_FUNCTION,
@@ -93,6 +102,25 @@ object ScalarSqlFunctions {
     OperandTypes.STRING,
     SqlFunctionCategory.STRING
   )
+
+  val SHA384 = new SqlFunction(
+    "SHA384",
+    SqlKind.OTHER_FUNCTION,
+    ReturnTypes.ARG0_NULLABLE,
+    InferTypes.RETURN_TYPE,
+    OperandTypes.STRING,
+    SqlFunctionCategory.STRING
+  )
+
+  val SHA512 = new SqlFunction(
+    "SHA512",
+    SqlKind.OTHER_FUNCTION,
+    ReturnTypes.ARG0_NULLABLE,
+    InferTypes.RETURN_TYPE,
+    OperandTypes.STRING,
+    SqlFunctionCategory.STRING
+  )
+
 
   val DATE_FORMAT = new SqlFunction(
     "DATE_FORMAT",

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
@@ -268,7 +268,9 @@ object FunctionCatalog {
     "sha224" -> classOf[Sha224],
     "sha256" -> classOf[Sha256],
     "sha384" -> classOf[Sha384],
-    "sha512" -> classOf[Sha512]
+    "sha512" -> classOf[Sha512],
+
+    "sha2" -> classOf[Sha2]
   )
 
   /**
@@ -429,6 +431,7 @@ class BasicOperatorTable extends ReflectiveSqlOperatorTable {
     ScalarSqlFunctions.SHA256,
     ScalarSqlFunctions.SHA384,
     ScalarSqlFunctions.SHA512,
+    ScalarSqlFunctions.SHA2,
     // EXTENSIONS
     BasicOperatorTable.TUMBLE,
     BasicOperatorTable.HOP,

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
@@ -265,7 +265,10 @@ object FunctionCatalog {
     // crypto hash
     "md5" -> classOf[Md5],
     "sha1" -> classOf[Sha1],
-    "sha256" -> classOf[Sha256]
+    "sha224" -> classOf[Sha224],
+    "sha256" -> classOf[Sha256],
+    "sha384" -> classOf[Sha384],
+    "sha512" -> classOf[Sha512]
   )
 
   /**
@@ -422,7 +425,10 @@ class BasicOperatorTable extends ReflectiveSqlOperatorTable {
     ScalarSqlFunctions.LOG,
     ScalarSqlFunctions.MD5,
     ScalarSqlFunctions.SHA1,
+    ScalarSqlFunctions.SHA224,
     ScalarSqlFunctions.SHA256,
+    ScalarSqlFunctions.SHA384,
+    ScalarSqlFunctions.SHA512,
     // EXTENSIONS
     BasicOperatorTable.TUMBLE,
     BasicOperatorTable.HOP,

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarFunctionsTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarFunctionsTest.scala
@@ -1757,28 +1757,60 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
       "SHA1('test')",
       expectedSha1)
 
+    // sha224
     testAllApis(
       "test".sha224(),
       "sha224('test')",
       "SHA224('test')",
       expectedSha224)
 
+    // sha-2 224
+    testAllApis(
+      "test".sha2(224),
+      "sha2('test', 224)",
+      "SHA2('test', 224)",
+      expectedSha224)
+
+    // sha256
     testAllApis(
       "test".sha256(),
       "sha256('test')",
       "SHA256('test')",
       expectedSha256)
 
+    // sha-2 256
+    testAllApis(
+      "test".sha2(256),
+      "sha2('test', 256)",
+      "SHA2('test', 256)",
+      expectedSha256)
+
+    // sha384
     testAllApis(
       "test".sha384(),
       "sha384('test')",
       "SHA384('test')",
       expectedSha384)
 
+    // sha-2 384
+    testAllApis(
+      "test".sha2(384),
+      "sha2('test', 384)",
+      "SHA2('test', 384)",
+      expectedSha384)
+
+    // sha512
     testAllApis(
       "test".sha512(),
       "sha512('test')",
       "SHA512('test')",
+      expectedSha512)
+
+    // sha-2 512
+    testAllApis(
+      "test".sha2(512),
+      "sha2('test', 512)",
+      "SHA2('test', 512)",
       expectedSha512)
 
     testAllApis(
@@ -1796,25 +1828,31 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
     testAllApis(
       'f33.sha224(),
       "sha224(f33)",
-      "SHA224(f33)",
+      "SHA2(f33, 224)",
+      "null")
+
+    testAllApis(
+      'f33.sha2(224),
+      "sha2(f33, 224)",
+      "SHA2(f33, 224)",
       "null")
 
     testAllApis(
       'f33.sha256(),
       "sha256(f33)",
-      "SHA256(f33)",
+      "SHA2(f33, 256)",
       "null")
 
     testAllApis(
       'f33.sha384(),
       "sha384(f33)",
-      "SHA384(f33)",
+      "SHA2(f33, 384)",
       "null")
 
     testAllApis(
       'f33.sha512(),
       "sha512(f33)",
-      "SHA512(f33)",
+      "SHA2(f33, 512)",
       "null")
   }
 

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarFunctionsTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarFunctionsTest.scala
@@ -1740,7 +1740,10 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
   def testHashFunctions(): Unit = {
     val expectedMd5 = "098f6bcd4621d373cade4e832627b4f6"
     val expectedSha1 = "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3"
+    val expectedSha224 = "90a3ed9e32b2aaf4c61c410eb925426119e1a9dc53d4286ade99a809"
     val expectedSha256 = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+    val expectedSha384 = "768412320f7b0aa5812fce428dc4706b3cae50e02a64caa16a782249bfe8efc4b7ef1ccb126255d196047dfedf17a0a9" // scalastyle:ignore
+    val expectedSha512 = "ee26b0dd4af7e749aa1a8ee3c10ae9923f618980772e473f8819a5d4940e0db27ac185f8a0e1d5f84f88bc887fd67b143732c304cc5fa9ad8e6f57f50028a8ff" // scalastyle:ignore
 
     testAllApis(
       "test".md5(),
@@ -1755,15 +1758,45 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
       expectedSha1)
 
     testAllApis(
+      "test".sha224(),
+      "sha224('test')",
+      "SHA224('test')",
+      expectedSha224)
+
+    testAllApis(
       "test".sha256(),
       "sha256('test')",
       "SHA256('test')",
       expectedSha256)
 
     testAllApis(
+      "test".sha384(),
+      "sha384('test')",
+      "SHA384('test')",
+      expectedSha384)
+
+    testAllApis(
+      "test".sha512(),
+      "sha512('test')",
+      "SHA512('test')",
+      expectedSha512)
+
+    testAllApis(
       'f33.md5(),
-      "sha256(f33)",
-      "SHA256(f33)",
+      "md5(f33)",
+      "MD5(f33)",
+      "null")
+
+    testAllApis(
+      'f33.sha1(),
+      "sha1(f33)",
+      "SHA1(f33)",
+      "null")
+
+    testAllApis(
+      'f33.sha224(),
+      "sha224(f33)",
+      "SHA224(f33)",
       "null")
 
     testAllApis(
@@ -1773,9 +1806,15 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
       "null")
 
     testAllApis(
-      'f33.sha256(),
-      "sha256(f33)",
-      "SHA256(f33)",
+      'f33.sha384(),
+      "sha384(f33)",
+      "SHA384(f33)",
+      "null")
+
+    testAllApis(
+      'f33.sha512(),
+      "sha512(f33)",
+      "SHA512(f33)",
       "null")
   }
 

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/SqlExpressionTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/SqlExpressionTest.scala
@@ -21,6 +21,7 @@ package org.apache.flink.table.expressions
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.types.Row
 import org.apache.flink.api.java.typeutils.RowTypeInfo
+import org.apache.flink.table.api.ValidationException
 import org.apache.flink.table.expressions.utils.ExpressionTestBase
 import org.junit.Test
 
@@ -146,17 +147,28 @@ class SqlExpressionTest extends ExpressionTestBase {
     testSqlApi("SHA1('test')", "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3")
 
     testSqlApi("SHA224('')", "d14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f")
+    testSqlApi("SHA2('', 224)", "d14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f")
+
     testSqlApi("SHA224('test')", "90a3ed9e32b2aaf4c61c410eb925426119e1a9dc53d4286ade99a809")
+    testSqlApi("SHA2('test', 224)", "90a3ed9e32b2aaf4c61c410eb925426119e1a9dc53d4286ade99a809")
 
     testSqlApi("SHA256('')", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
-    testSqlApi("SHA256('test')", "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08")
+    testSqlApi("SHA2('', 256)", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+
+    testSqlApi("SHA256('test')", "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08")    // scalastyle:ignore
+    testSqlApi("SHA2('test', 256)", "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08") // scalastyle:ignore
 
     testSqlApi("SHA384('')", "38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b") // scalastyle:ignore
+    testSqlApi("SHA2('', 384)", "38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b") // scalastyle:ignore
+
     testSqlApi("SHA384('test')", "768412320f7b0aa5812fce428dc4706b3cae50e02a64caa16a782249bfe8efc4b7ef1ccb126255d196047dfedf17a0a9") // scalastyle:ignore
+    testSqlApi("SHA2('test', 384)", "768412320f7b0aa5812fce428dc4706b3cae50e02a64caa16a782249bfe8efc4b7ef1ccb126255d196047dfedf17a0a9") // scalastyle:ignore
 
     testSqlApi("SHA512('')", "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e") // scalastyle:ignore
-    testSqlApi("SHA512('test')", "ee26b0dd4af7e749aa1a8ee3c10ae9923f618980772e473f8819a5d4940e0db27ac185f8a0e1d5f84f88bc887fd67b143732c304cc5fa9ad8e6f57f50028a8ff") // scalastyle:ignore
+    testSqlApi("SHA2('',512)", "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e") // scalastyle:ignore
 
+    testSqlApi("SHA512('test')", "ee26b0dd4af7e749aa1a8ee3c10ae9923f618980772e473f8819a5d4940e0db27ac185f8a0e1d5f84f88bc887fd67b143732c304cc5fa9ad8e6f57f50028a8ff") // scalastyle:ignore
+    testSqlApi("SHA2('test',512)", "ee26b0dd4af7e749aa1a8ee3c10ae9923f618980772e473f8819a5d4940e0db27ac185f8a0e1d5f84f88bc887fd67b143732c304cc5fa9ad8e6f57f50028a8ff") // scalastyle:ignore
 
     testSqlApi("MD5(CAST(NULL AS VARCHAR))", "null")
     testSqlApi("SHA1(CAST(NULL AS VARCHAR))", "null")
@@ -164,6 +176,17 @@ class SqlExpressionTest extends ExpressionTestBase {
     testSqlApi("SHA256(CAST(NULL AS VARCHAR))", "null")
     testSqlApi("SHA384(CAST(NULL AS VARCHAR))", "null")
     testSqlApi("SHA512(CAST(NULL AS VARCHAR))", "null")
+    testSqlApi("SHA2(CAST(NULL AS VARCHAR), 256)", "null")
+  }
+
+  @Test(expected = classOf[RuntimeException])
+  def testHashFunctionsUnsupportedLength(): Unit = {
+    testSqlApi("SHA2('', 333)", "")
+  }
+
+  @Test(expected = classOf[ValidationException])
+  def testHashFunctionSha2NoParam(): Unit = {
+    testSqlApi("SHA2('')", "")
   }
 
   @Test

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/SqlExpressionTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/SqlExpressionTest.scala
@@ -145,12 +145,25 @@ class SqlExpressionTest extends ExpressionTestBase {
     testSqlApi("SHA1('')", "da39a3ee5e6b4b0d3255bfef95601890afd80709")
     testSqlApi("SHA1('test')", "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3")
 
+    testSqlApi("SHA224('')", "d14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f")
+    testSqlApi("SHA224('test')", "90a3ed9e32b2aaf4c61c410eb925426119e1a9dc53d4286ade99a809")
+
     testSqlApi("SHA256('')", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
     testSqlApi("SHA256('test')", "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08")
 
+    testSqlApi("SHA384('')", "38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b") // scalastyle:ignore
+    testSqlApi("SHA384('test')", "768412320f7b0aa5812fce428dc4706b3cae50e02a64caa16a782249bfe8efc4b7ef1ccb126255d196047dfedf17a0a9") // scalastyle:ignore
+
+    testSqlApi("SHA512('')", "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e") // scalastyle:ignore
+    testSqlApi("SHA512('test')", "ee26b0dd4af7e749aa1a8ee3c10ae9923f618980772e473f8819a5d4940e0db27ac185f8a0e1d5f84f88bc887fd67b143732c304cc5fa9ad8e6f57f50028a8ff") // scalastyle:ignore
+
+
     testSqlApi("MD5(CAST(NULL AS VARCHAR))", "null")
     testSqlApi("SHA1(CAST(NULL AS VARCHAR))", "null")
+    testSqlApi("SHA224(CAST(NULL AS VARCHAR))", "null")
     testSqlApi("SHA256(CAST(NULL AS VARCHAR))", "null")
+    testSqlApi("SHA384(CAST(NULL AS VARCHAR))", "null")
+    testSqlApi("SHA512(CAST(NULL AS VARCHAR))", "null")
   }
 
   @Test


### PR DESCRIPTION
## What is the purpose of the change

This pull request implements SHA224, SHA384, SHA512 support in Flink SQL as discussed in FLINK-6926

## Brief change log

  - Added SHA224, SHA384, SHA512 SQL functions
  - Added relevant unit tests

## Verifying this change

This change added tests and can be verified as follows:
  - Added SQL expression tests
  - Added HashFunctionsTest with testAllApis
  - Validated both correct calculation and behavior for null input

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: don't know
  - The runtime per-record code paths (performance sensitive): don't know
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
