### PR TITLE
[FLINK-8469] [State Backend] [RocksDB] relocate and unify RocksDB option params in RocksDBPerformanceTest

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,2 @@
+git fetch upstream
+git rebase upstream/master

--- a/update.sh
+++ b/update.sh
@@ -1,2 +1,0 @@
-git fetch upstream
-git rebase upstream/master


### PR DESCRIPTION
## What is the purpose of the change

- the two unit tests in RocksDBPerformanceTest share the same lots of option params
- the params are put in try-with-resource clause, which is not good.

This PR moves out RocksDB option params out of try-with-resource clause, and unifies them in RocksDBPerformanceTest

## Brief change log

This PR moves out RocksDB option params out of try-with-resource clause, and unifies them in RocksDBPerformanceTest

## Verifying this change

This change is already covered by existing tests, such as *RocksDBPerformanceTest*.

## Does this pull request potentially affect one of the following parts:

none

## Documentation

none