### PR TITLE
[FLINK-8365] [State Backend] Relax List type in HeapListState and HeapKeyedStateBackend

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
@@ -40,7 +40,6 @@ import org.apache.flink.runtime.io.async.AbstractAsyncCallableWithResources;
 import org.apache.flink.runtime.io.async.AsyncStoppableTaskWithCallback;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
-import org.apache.flink.runtime.state.ArrayListSerializer;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.runtime.state.DoneFuture;
 import org.apache.flink.runtime.state.HashMapSerializer;
@@ -240,16 +239,7 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 			TypeSerializer<N> namespaceSerializer,
 			ListStateDescriptor<T> stateDesc) throws Exception {
 
-		// the list state does some manual mapping, because the state is typed to the generic
-		// 'List' interface, but we want to use an implementation typed to ArrayList
-		// using a more specialized implementation opens up runtime optimizations
-
-		StateTable<K, N, ArrayList<T>> stateTable = tryRegisterStateTable(
-				stateDesc.getName(),
-				stateDesc.getType(),
-				namespaceSerializer,
-				new ArrayListSerializer<T>(stateDesc.getElementSerializer()));
-
+		StateTable<K, N, List<T>> stateTable = tryRegisterStateTable(namespaceSerializer, stateDesc);
 		return new HeapListState<>(stateDesc, stateTable, keySerializer, namespaceSerializer);
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapListState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapListState.java
@@ -38,7 +38,7 @@ import java.util.List;
  * @param <V> The type of the value.
  */
 public class HeapListState<K, N, V>
-		extends AbstractHeapMergingState<K, N, V, Iterable<V>, ArrayList<V>, ListState<V>, ListStateDescriptor<V>>
+		extends AbstractHeapMergingState<K, N, V, Iterable<V>, List<V>, ListState<V>, ListStateDescriptor<V>>
 		implements InternalListState<N, V> {
 
 	/**
@@ -50,7 +50,7 @@ public class HeapListState<K, N, V>
 	 */
 	public HeapListState(
 			ListStateDescriptor<V> stateDesc,
-			StateTable<K, N, ArrayList<V>> stateTable,
+			StateTable<K, N, List<V>> stateTable,
 			TypeSerializer<K> keySerializer,
 			TypeSerializer<N> namespaceSerializer) {
 		super(stateDesc, stateTable, keySerializer, namespaceSerializer);
@@ -74,8 +74,8 @@ public class HeapListState<K, N, V>
 			return;
 		}
 
-		final StateTable<K, N, ArrayList<V>> map = stateTable;
-		ArrayList<V> list = map.get(namespace);
+		final StateTable<K, N, List<V>> map = stateTable;
+		List<V> list = map.get(namespace);
 
 		if (list == null) {
 			list = new ArrayList<>();
@@ -89,7 +89,7 @@ public class HeapListState<K, N, V>
 		Preconditions.checkState(namespace != null, "No namespace given.");
 		Preconditions.checkState(key != null, "No key given.");
 
-		ArrayList<V> result = stateTable.get(key, namespace);
+		List<V> result = stateTable.get(key, namespace);
 
 		if (result == null) {
 			return null;
@@ -117,7 +117,7 @@ public class HeapListState<K, N, V>
 	// ------------------------------------------------------------------------
 
 	@Override
-	protected ArrayList<V> mergeState(ArrayList<V> a, ArrayList<V> b) {
+	protected List<V> mergeState(List<V> a, List<V> b) {
 		a.addAll(b);
 		return a;
 	}
@@ -128,9 +128,16 @@ public class HeapListState<K, N, V>
 
 		if (values != null && !values.isEmpty()) {
 			final N namespace = currentNamespace;
-			final StateTable<K, N, ArrayList<V>> map = stateTable;
+			final StateTable<K, N, List<V>> map = stateTable;
+			List<V> list = map.get(namespace);
 
-			map.put(namespace, new ArrayList<>(values));
+			if (list == null) {
+				list = new ArrayList<>(values);
+				map.put(namespace, list);
+			} else {
+				list.clear();
+				list.addAll(values);
+			}
 		}
 	}
 
@@ -138,17 +145,16 @@ public class HeapListState<K, N, V>
 	public void addAll(List<V> values) throws Exception {
 		if (values != null && !values.isEmpty()) {
 			final N namespace = currentNamespace;
-			final StateTable<K, N, ArrayList<V>> map = stateTable;
+			final StateTable<K, N, List<V>> map = stateTable;
 
-			ArrayList<V> list = map.get(currentNamespace);
+			List<V> list = map.get(currentNamespace);
 
 			if (list == null) {
-				list = new ArrayList<>();
+				list = new ArrayList<>(values);
+				map.put(namespace, list);
+			} else {
+				list.addAll(values);
 			}
-
-			list.addAll(values);
-
-			map.put(namespace, list);
 		}
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

`stateTable` in `HeapListState` and `HeapKeyedStateBackend#createListState()` are both strongly typed to `ArrayList` right now. Relaxing that to `List` so we can avoid extra copies in some cases.

Well, the copies in `HeapListState#update()` cannot be completely avoided. When users pass in an `AbstractList` to `update()` when there's no state before, it will break and we have to convert it to an `ArrayList` explicitly

## Brief change log

Relax List type in HeapListState and HeapKeyedStateBackend

## Verifying this change

This change is already covered by existing tests, such as *MemoryStateBackendTest*.

## Does this pull request potentially affect one of the following parts:

none

## Documentation

none