### PR TITLE
[hotfix][codestyle] Refactor equals for StreamRecord

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/streamrecord/StreamRecord.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/streamrecord/StreamRecord.java
@@ -19,6 +19,8 @@ package org.apache.flink.streaming.runtime.streamrecord;
 
 import org.apache.flink.annotation.Internal;
 
+import java.util.Objects;
+
 /**
  * One value in a data stream. This stores the value and an optional associated timestamp.
  *
@@ -168,15 +170,13 @@ public final class StreamRecord<T> extends StreamElement {
 		if (this == o) {
 			return true;
 		}
-		else if (o != null && getClass() == o.getClass()) {
-			StreamRecord<?> that = (StreamRecord<?>) o;
-			return this.hasTimestamp == that.hasTimestamp &&
-					(!this.hasTimestamp || this.timestamp == that.timestamp) &&
-					(this.value == null ? that.value == null : this.value.equals(that.value));
-		}
-		else {
+		if (!(o instanceof StreamRecord)) {
 			return false;
 		}
+		StreamRecord<?> that = (StreamRecord<?>) o;
+		return hasTimestamp == that.hasTimestamp &&
+			(!hasTimestamp || timestamp == that.timestamp) &&
+			Objects.equals(value, that.value);
 	}
 
 	@Override


### PR DESCRIPTION
## What is the purpose of the change

Removing nested `IF`s for `StreamRecord#equals` method without changing the comparison logic.


## Brief change log

  - *refactors StreamRecord#equals method*


## Verifying this change

This change is already covered by existing tests, such as *StreamRecordTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
