### PR TITLE
[FLINK-8409] [kafka] Fix potential NPE in KafkaConsumerThread

### DIFF
--- a/flink-connectors/flink-connector-kafka-0.9/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/KafkaConsumerThread.java
+++ b/flink-connectors/flink-connector-kafka-0.9/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/KafkaConsumerThread.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.connectors.kafka.internal;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.streaming.connectors.kafka.internals.ClosableBlockingQueue;
 import org.apache.flink.streaming.connectors.kafka.internals.KafkaCommitCallback;
@@ -70,8 +71,8 @@ public class KafkaConsumerThread extends Thread {
 	/** The handover of data and exceptions between the consumer thread and the task thread. */
 	private final Handover handover;
 
-	/** The next offsets that the main thread should commit. */
-	private final AtomicReference<Map<TopicPartition, OffsetAndMetadata>> nextOffsetsToCommit;
+	/** The next offsets that the main thread should commit and the commit callback. */
+	private final AtomicReference<Tuple2<Map<TopicPartition, OffsetAndMetadata>, KafkaCommitCallback>> nextOffsetsToCommit;
 
 	/** The configuration for the Kafka consumer. */
 	private final Properties kafkaProperties;
@@ -111,9 +112,6 @@ public class KafkaConsumerThread extends Thread {
 
 	/** Flag tracking whether the latest commit request has completed. */
 	private volatile boolean commitInProgress;
-
-	/** User callback to be invoked when commits completed. */
-	private volatile KafkaCommitCallback offsetCommitCallback;
 
 	public KafkaConsumerThread(
 			Logger log,
@@ -190,9 +188,6 @@ public class KafkaConsumerThread extends Thread {
 				return;
 			}
 
-			// The callback invoked by Kafka once an offset commit is complete
-			final OffsetCommitCallback offsetCommitCallback = new CommitCallback();
-
 			// the latest bulk of records. May carry across the loop if the thread is woken up
 			// from blocking on the handover
 			ConsumerRecords<byte[], byte[]> records = null;
@@ -208,15 +203,16 @@ public class KafkaConsumerThread extends Thread {
 				// check if there is something to commit
 				if (!commitInProgress) {
 					// get and reset the work-to-be committed, so we don't repeatedly commit the same
-					final Map<TopicPartition, OffsetAndMetadata> toCommit = nextOffsetsToCommit.getAndSet(null);
+					final Tuple2<Map<TopicPartition, OffsetAndMetadata>, KafkaCommitCallback> commitOffsetsAndCallback =
+							nextOffsetsToCommit.getAndSet(null);
 
-					if (toCommit != null) {
+					if (commitOffsetsAndCallback != null) {
 						log.debug("Sending async offset commit request to Kafka broker");
 
 						// also record that a commit is already in progress
 						// the order here matters! first set the flag, then send the commit command.
 						commitInProgress = true;
-						consumer.commitAsync(toCommit, offsetCommitCallback);
+						consumer.commitAsync(commitOffsetsAndCallback.f0, new CommitCallback(commitOffsetsAndCallback.f1));
 					}
 				}
 
@@ -326,12 +322,11 @@ public class KafkaConsumerThread extends Thread {
 			@Nonnull KafkaCommitCallback commitCallback) {
 
 		// record the work to be committed by the main consumer thread and make sure the consumer notices that
-		if (nextOffsetsToCommit.getAndSet(offsetsToCommit) != null) {
+		if (nextOffsetsToCommit.getAndSet(Tuple2.of(offsetsToCommit, commitCallback)) != null) {
 			log.warn("Committing offsets to Kafka takes longer than the checkpoint interval. " +
 					"Skipping commit of previous offsets because newer complete checkpoint offsets are available. " +
 					"This does not compromise Flink's checkpoint integrity.");
 		}
-		this.offsetCommitCallback = commitCallback;
 
 		// if the consumer is blocked in a poll() or handover operation, wake it up to commit soon
 		handover.wakeupProducer();
@@ -489,15 +484,21 @@ public class KafkaConsumerThread extends Thread {
 
 	private class CommitCallback implements OffsetCommitCallback {
 
+		private final KafkaCommitCallback internalCommitCallback;
+
+		CommitCallback(KafkaCommitCallback internalCommitCallback) {
+			this.internalCommitCallback = checkNotNull(internalCommitCallback);
+		}
+
 		@Override
 		public void onComplete(Map<TopicPartition, OffsetAndMetadata> offsets, Exception ex) {
 			commitInProgress = false;
 
 			if (ex != null) {
 				log.warn("Committing offsets to Kafka failed. This does not compromise Flink's checkpoints.", ex);
-				offsetCommitCallback.onException(ex);
+				internalCommitCallback.onException(ex);
 			} else {
-				offsetCommitCallback.onSuccess();
+				internalCommitCallback.onSuccess();
 			}
 		}
 	}

--- a/flink-connectors/flink-connector-kafka-0.9/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/KafkaConsumerThread.java
+++ b/flink-connectors/flink-connector-kafka-0.9/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/KafkaConsumerThread.java
@@ -507,7 +507,7 @@ public class KafkaConsumerThread extends Thread {
 	 * Utility exception that serves as a signal for the main loop to continue through the loop
 	 * if a reassignment attempt was aborted due to an pre-reassignment wakeup call on the consumer.
 	 */
-	private class AbortedReassignmentException extends Exception {
+	private static class AbortedReassignmentException extends Exception {
 		private static final long serialVersionUID = 1L;
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes a race condition that may lead to a NPE in the async callbacks for Kafka offset committing.

The following lines in the KafkaConsumerThread::setOffsetsToCommit(...) suggests a race condition with the asynchronous callback from committing offsets to Kafka:

```
// record the work to be committed by the main consumer thread and make sure the consumer notices that
if (nextOffsetsToCommit.getAndSet(offsetsToCommit) != null) {
    log.warn("Committing offsets to Kafka takes longer than the checkpoint interval. " +
        "Skipping commit of previous offsets because newer complete checkpoint offsets are available. " +
        "This does not compromise Flink's checkpoint integrity.");
}
this.offsetCommitCallback = commitCallback;
```

In the main consumer thread's main loop, `nextOffsetsToCommit` will be checked if there are any offsets to commit. If so, an asynchronous offset commit operation will be performed. The NPE happens in the case when the commit completes, but `this.offsetCommitCallback = commitCallback;` is not yet reached.

This PR fixes this by making setting the `commitCallback` and `nextOffsetsToCommit` an atomic operation.

## Verifying this change

No new tests were added.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
