### PR TITLE
[FLINK-8406] [bucketing sink] Fix proper access of Hadoop File Systems

### DIFF
--- a/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSink.java
+++ b/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSink.java
@@ -1122,7 +1122,8 @@ public class BucketingSink<T>
 		// try to get the Hadoop File System via the Flink File Systems
 		// that way we get the proper configuration
 
-		final org.apache.flink.core.fs.FileSystem flinkFs = org.apache.flink.core.fs.FileSystem.get(path.toUri());
+		final org.apache.flink.core.fs.FileSystem flinkFs =
+				org.apache.flink.core.fs.FileSystem.getUnguardedFileSystem(path.toUri());
 		final FileSystem hadoopFs = (flinkFs instanceof HadoopFileSystem) ?
 				((HadoopFileSystem) flinkFs).getHadoopFileSystem() : null;
 

--- a/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSinkFsInitTest.java
+++ b/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSinkFsInitTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.fs.bucketing;
+
+import org.apache.flink.core.fs.FileSystemSafetyNet;
+import org.apache.flink.core.fs.UnsupportedFileSystemSchemeException;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for the file system initialization of the Bucketing sink.
+ *
+ * <p>NOTE: These tests can probably go away once the bucketing sink has been
+ * migrated to properly use Flink's file system abstraction.
+ */
+public class BucketingSinkFsInitTest {
+
+	@Rule
+	public final TemporaryFolder tempFolder = new TemporaryFolder();
+
+	// ------------------------------------------------------------------------
+
+	// to properly mimic what happens in the runtime task, we need to make sure that
+	// the file system safety net is in place
+
+	@Before
+	public void activateSafetyNet() {
+		FileSystemSafetyNet.initializeSafetyNetForThread();
+	}
+
+	@After
+	public void deactivateSafetyNet() {
+		FileSystemSafetyNet.closeSafetyNetAndGuardedResourcesForThread();
+	}
+
+	// ------------------------------------------------------------------------
+
+	@Test
+	public void testInitForLocalFileSystem() throws Exception {
+		final Path path = new Path(tempFolder.newFolder().toURI());
+		FileSystem fs = BucketingSink.createHadoopFileSystem(path, null);
+
+		assertEquals("file", fs.getUri().getScheme());
+	}
+
+	@Test
+	public void testInitForHadoopFileSystem() throws Exception {
+		final Path path = new Path("hdfs://localhost:51234/some/path/");
+		FileSystem fs = BucketingSink.createHadoopFileSystem(path, null);
+
+		assertEquals("hdfs", fs.getUri().getScheme());
+	}
+
+	@Test(expected = UnsupportedFileSystemSchemeException.class)
+	public void testInitForUnsupportedFileSystem() throws Exception {
+		final Path path = new Path("nofs://localhost:51234/some/path/");
+		BucketingSink.createHadoopFileSystem(path, null);
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

Fixes the access to Hadoop file systems when initializing the BucketingSink.

## Verifying this change

The PR adds a unit test for the problem.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no)**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no)**
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no)**
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
