### PR TITLE
[FLINK-8473][webUI] Improve error behavior of JarListHandler

### DIFF
--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/HttpRequestHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/HttpRequestHandler.java
@@ -133,6 +133,10 @@ public class HttpRequestHandler extends SimpleChannelInboundHandler<HttpObject> 
 								String name = file.getFilename();
 
 								File target = new File(tmpDir, UUID.randomUUID() + "_" + name);
+								if (!tmpDir.exists()) {
+									WebRuntimeMonitor.logExternalUploadDirDeletion(tmpDir);
+									WebRuntimeMonitor.checkAndCreateUploadDir(tmpDir);
+								}
 								file.renameTo(target);
 
 								QueryStringEncoder encoder = new QueryStringEncoder(currentRequestPath);

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitor.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitor.java
@@ -188,13 +188,7 @@ public class WebRuntimeMonitor implements WebMonitor {
 		if (webSubmitAllow) {
 			// create storage for uploads
 			this.uploadDir = getUploadDir(config);
-			// the upload directory should either 1. exist and writable or 2. can be created and writable
-			if (!(uploadDir.exists() && uploadDir.canWrite()) && !(uploadDir.mkdirs() && uploadDir.canWrite())) {
-				throw new IOException(
-					String.format("Jar upload directory %s cannot be created or is not writable.",
-						uploadDir.getAbsolutePath()));
-			}
-			LOG.info("Using directory {} for web frontend JAR file uploads", uploadDir);
+			checkAndCreateUploadDir(uploadDir);
 		}
 		else {
 			this.uploadDir = null;
@@ -575,5 +569,29 @@ public class WebRuntimeMonitor implements WebMonitor {
 
 		boolean uploadDirSpecified = configuration.contains(WebOptions.UPLOAD_DIR);
 		return uploadDirSpecified ? baseDir : new File(baseDir, "flink-web-" + UUID.randomUUID());
+	}
+
+	public static void logExternalUploadDirDeletion(File uploadDir) {
+		LOG.warn("Jar storage directory {} has been deleted externally. Previously uploaded jars are no longer available.", uploadDir.getAbsolutePath());
+	}
+
+	/**
+	 * Checks whether the given directory exists and is writable. If it doesn't exist this method will attempt to create
+	 * it.
+	 *
+	 * @param uploadDir directory to check
+	 * @throws IOException if the directory does not exist and cannot be created, or if the directory isn't writable
+	 */
+	public static synchronized void checkAndCreateUploadDir(File uploadDir) throws IOException {
+		if (uploadDir.exists() && uploadDir.canWrite()) {
+			LOG.info("Using directory {} for web frontend JAR file uploads.", uploadDir);
+		} else if (uploadDir.mkdirs() && uploadDir.canWrite()) {
+			LOG.info("Created directory {} for web frontend JAR file uploads.", uploadDir);
+		} else {
+			LOG.warn("Jar upload directory {} cannot be created or is not writable.", uploadDir.getAbsolutePath());
+			throw new IOException(
+				String.format("Jar upload directory %s cannot be created or is not writable.",
+					uploadDir.getAbsolutePath()));
+		}
 	}
 }

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarActionHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarActionHandler.java
@@ -37,11 +37,13 @@ import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.runtime.rest.handler.legacy.AbstractJsonRequestHandler;
 import org.apache.flink.runtime.rest.handler.legacy.JsonFactory;
+import org.apache.flink.runtime.webmonitor.WebRuntimeMonitor;
 import org.apache.flink.util.ExceptionUtils;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.StringWriter;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -65,6 +67,15 @@ public abstract class JarActionHandler extends AbstractJsonRequestHandler {
 	protected Tuple2<JobGraph, ClassLoader> getJobGraphAndClassLoader(JarActionHandlerConfig config) throws Exception {
 		// generate the graph
 		JobGraph graph = null;
+
+		if (!jarDir.exists()) {
+			WebRuntimeMonitor.logExternalUploadDirDeletion(jarDir);
+			try {
+				WebRuntimeMonitor.checkAndCreateUploadDir(jarDir);
+			} catch (IOException ioe) {
+				// the following code will throw an exception since the jar can't be found
+			}
+		}
 
 		PackagedProgram program = new PackagedProgram(
 				new File(jarDir, config.getJarFile()),

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarListHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarListHandler.java
@@ -27,6 +27,9 @@ import org.apache.flink.util.FlinkException;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
@@ -43,6 +46,8 @@ import java.util.jar.Manifest;
  * Handle request for listing uploaded jars.
  */
 public class JarListHandler extends AbstractJsonRequestHandler {
+
+	private static final Logger LOG = LoggerFactory.getLogger(JarListHandler.class);
 
 	static final String JAR_LIST_REST_PATH = "/jars";
 
@@ -76,6 +81,11 @@ public class JarListHandler extends AbstractJsonRequestHandler {
 							return name.endsWith(".jar");
 						}
 					});
+
+					if (list == null) {
+						LOG.warn("Jar storage directory {} has been deleted.", jarDir.getAbsolutePath());
+						list = new File[0];
+					}
 
 					// last modified ascending order
 					Arrays.sort(list, (f1, f2) -> Long.compare(f2.lastModified(), f1.lastModified()));
@@ -145,6 +155,7 @@ public class JarListHandler extends AbstractJsonRequestHandler {
 					return writer.toString();
 				}
 				catch (Exception e) {
+					LOG.warn("Failed to fetch jar list.", e);
 					throw new CompletionException(new FlinkException("Failed to fetch jar list.", e));
 				}
 			},

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarListHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarListHandler.java
@@ -83,7 +83,7 @@ public class JarListHandler extends AbstractJsonRequestHandler {
 					});
 
 					if (list == null) {
-						LOG.warn("Jar storage directory {} has been deleted.", jarDir.getAbsolutePath());
+						LOG.warn("Jar storage directory {} has been deleted externally. Previously uploaded jars are no longer available.", jarDir.getAbsolutePath());
 						list = new File[0];
 					}
 
@@ -155,7 +155,6 @@ public class JarListHandler extends AbstractJsonRequestHandler {
 					return writer.toString();
 				}
 				catch (Exception e) {
-					LOG.warn("Failed to fetch jar list.", e);
 					throw new CompletionException(new FlinkException("Failed to fetch jar list.", e));
 				}
 			},


### PR DESCRIPTION
## What is the purpose of the change

This PR modifies the `JarListHandler` to not crash when the jar storage directory has been deleted. This caused the job-submission-page in the webUI to be completely blank.

We now log a warning (to make debugging easier) and continue on as if the directory was empty (so that the page isn't blank).

## Verifying this change

Manually verified and not covered by tests, like the rest of the handler.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
