### PR TITLE
[FLINK-6464][streaming] Stabilize default window operator names

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/WindowedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/WindowedStream.java
@@ -67,6 +67,8 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.util.OutputTag;
 import org.apache.flink.util.Preconditions;
 
+import javax.annotation.Nullable;
+
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -269,7 +271,7 @@ public class WindowedStream<T, K, W extends Window> {
 		String callLocation = Utils.getCallLocationName();
 		String udfName = "WindowedStream." + callLocation;
 
-		String opName;
+		final String opName = generateOperatorName(windowAssigner, trigger, evictor, udfName);
 		KeySelector<T, K> keySel = input.getKeySelector();
 
 		OneInputStreamOperator<T, R> operator;
@@ -281,8 +283,6 @@ public class WindowedStream<T, K, W extends Window> {
 
 			ListStateDescriptor<StreamRecord<T>> stateDesc =
 				new ListStateDescriptor<>("window-contents", streamRecordSerializer);
-
-			opName = "TriggerWindow(" + windowAssigner + ", " + stateDesc + ", " + trigger + ", " + evictor + ", " + udfName + ")";
 
 			operator =
 				new EvictingWindowOperator<>(windowAssigner,
@@ -300,8 +300,6 @@ public class WindowedStream<T, K, W extends Window> {
 			ReducingStateDescriptor<T> stateDesc = new ReducingStateDescriptor<>("window-contents",
 				reduceFunction,
 				input.getType().createSerializer(getExecutionEnvironment().getConfig()));
-
-			opName = "TriggerWindow(" + windowAssigner + ", " + stateDesc + ", " + trigger + ", " + udfName + ")";
 
 			operator =
 				new WindowOperator<>(windowAssigner,
@@ -362,7 +360,7 @@ public class WindowedStream<T, K, W extends Window> {
 		String callLocation = Utils.getCallLocationName();
 		String udfName = "WindowedStream." + callLocation;
 
-		String opName;
+		final String opName = generateOperatorName(windowAssigner, trigger, evictor, udfName);
 		KeySelector<T, K> keySel = input.getKeySelector();
 
 		OneInputStreamOperator<T, R> operator;
@@ -374,8 +372,6 @@ public class WindowedStream<T, K, W extends Window> {
 
 			ListStateDescriptor<StreamRecord<T>> stateDesc =
 					new ListStateDescriptor<>("window-contents", streamRecordSerializer);
-
-			opName = "TriggerWindow(" + windowAssigner + ", " + stateDesc + ", " + trigger + ", " + evictor + ", " + udfName + ")";
 
 			operator =
 					new EvictingWindowOperator<>(windowAssigner,
@@ -393,8 +389,6 @@ public class WindowedStream<T, K, W extends Window> {
 			ReducingStateDescriptor<T> stateDesc = new ReducingStateDescriptor<>("window-contents",
 					reduceFunction,
 					input.getType().createSerializer(getExecutionEnvironment().getConfig()));
-
-			opName = "TriggerWindow(" + windowAssigner + ", " + stateDesc + ", " + trigger + ", " + udfName + ")";
 
 			operator =
 					new WindowOperator<>(windowAssigner,
@@ -526,7 +520,7 @@ public class WindowedStream<T, K, W extends Window> {
 		String callLocation = Utils.getCallLocationName();
 		String udfName = "WindowedStream." + callLocation;
 
-		String opName;
+		final String opName = generateOperatorName(windowAssigner, trigger, evictor, udfName);
 		KeySelector<T, K> keySel = input.getKeySelector();
 
 		OneInputStreamOperator<T, R> operator;
@@ -538,8 +532,6 @@ public class WindowedStream<T, K, W extends Window> {
 
 			ListStateDescriptor<StreamRecord<T>> stateDesc =
 				new ListStateDescriptor<>("window-contents", streamRecordSerializer);
-
-			opName = "TriggerWindow(" + windowAssigner + ", " + stateDesc + ", " + trigger + ", " + evictor + ", " + udfName + ")";
 
 			operator = new EvictingWindowOperator<>(windowAssigner,
 				windowAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
@@ -555,8 +547,6 @@ public class WindowedStream<T, K, W extends Window> {
 		} else {
 			FoldingStateDescriptor<T, ACC> stateDesc = new FoldingStateDescriptor<>("window-contents",
 				initialValue, foldFunction, foldAccumulatorType.createSerializer(getExecutionEnvironment().getConfig()));
-
-			opName = "TriggerWindow(" + windowAssigner + ", " + stateDesc + ", " + trigger + ", " + udfName + ")";
 
 			operator = new WindowOperator<>(windowAssigner,
 				windowAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
@@ -640,7 +630,7 @@ public class WindowedStream<T, K, W extends Window> {
 		String callLocation = Utils.getCallLocationName();
 		String udfName = "WindowedStream." + callLocation;
 
-		String opName;
+		final String opName = generateOperatorName(windowAssigner, trigger, evictor, udfName);
 		KeySelector<T, K> keySel = input.getKeySelector();
 
 		OneInputStreamOperator<T, R> operator;
@@ -652,8 +642,6 @@ public class WindowedStream<T, K, W extends Window> {
 
 			ListStateDescriptor<StreamRecord<T>> stateDesc =
 					new ListStateDescriptor<>("window-contents", streamRecordSerializer);
-
-			opName = "TriggerWindow(" + windowAssigner + ", " + stateDesc + ", " + trigger + ", " + evictor + ", " + udfName + ")";
 
 			operator =
 					new EvictingWindowOperator<>(windowAssigner,
@@ -672,8 +660,6 @@ public class WindowedStream<T, K, W extends Window> {
 					initialValue,
 					foldFunction,
 					foldResultType.createSerializer(getExecutionEnvironment().getConfig()));
-
-			opName = "TriggerWindow(" + windowAssigner + ", " + stateDesc + ", " + trigger + ", " + udfName + ")";
 
 			operator =
 					new WindowOperator<>(windowAssigner,
@@ -835,7 +821,7 @@ public class WindowedStream<T, K, W extends Window> {
 		String callLocation = Utils.getCallLocationName();
 		String udfName = "WindowedStream." + callLocation;
 
-		String opName;
+		final String opName = generateOperatorName(windowAssigner, trigger, evictor, udfName);
 		KeySelector<T, K> keySel = input.getKeySelector();
 
 		OneInputStreamOperator<T, R> operator;
@@ -847,8 +833,6 @@ public class WindowedStream<T, K, W extends Window> {
 
 			ListStateDescriptor<StreamRecord<T>> stateDesc =
 					new ListStateDescriptor<>("window-contents", streamRecordSerializer);
-
-			opName = "TriggerWindow(" + windowAssigner + ", " + stateDesc + ", " + trigger + ", " + evictor + ", " + udfName + ")";
 
 			operator = new EvictingWindowOperator<>(windowAssigner,
 					windowAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
@@ -864,8 +848,6 @@ public class WindowedStream<T, K, W extends Window> {
 		} else {
 			AggregatingStateDescriptor<T, ACC, V> stateDesc = new AggregatingStateDescriptor<>("window-contents",
 					aggregateFunction, accumulatorType.createSerializer(getExecutionEnvironment().getConfig()));
-
-			opName = "TriggerWindow(" + windowAssigner + ", " + stateDesc + ", " + trigger + ", " + udfName + ")";
 
 			operator = new WindowOperator<>(windowAssigner,
 					windowAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
@@ -994,7 +976,7 @@ public class WindowedStream<T, K, W extends Window> {
 		String callLocation = Utils.getCallLocationName();
 		String udfName = "WindowedStream." + callLocation;
 
-		String opName;
+		final String opName = generateOperatorName(windowAssigner, trigger, evictor, udfName);
 		KeySelector<T, K> keySel = input.getKeySelector();
 
 		OneInputStreamOperator<T, R> operator;
@@ -1006,8 +988,6 @@ public class WindowedStream<T, K, W extends Window> {
 
 			ListStateDescriptor<StreamRecord<T>> stateDesc =
 					new ListStateDescriptor<>("window-contents", streamRecordSerializer);
-
-			opName = "TriggerWindow(" + windowAssigner + ", " + stateDesc + ", " + trigger + ", " + evictor + ", " + udfName + ")";
 
 			operator = new EvictingWindowOperator<>(windowAssigner,
 					windowAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
@@ -1023,8 +1003,6 @@ public class WindowedStream<T, K, W extends Window> {
 		} else {
 			AggregatingStateDescriptor<T, ACC, V> stateDesc = new AggregatingStateDescriptor<>("window-contents",
 					aggregateFunction, accumulatorType.createSerializer(getExecutionEnvironment().getConfig()));
-
-			opName = "TriggerWindow(" + windowAssigner + ", " + stateDesc + ", " + trigger + ", " + udfName + ")";
 
 			operator = new WindowOperator<>(windowAssigner,
 					windowAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
@@ -1120,7 +1098,7 @@ public class WindowedStream<T, K, W extends Window> {
 
 		String udfName = "WindowedStream." + callLocation;
 
-		String opName;
+		final String opName = generateOperatorName(windowAssigner, trigger, evictor, udfName);
 		KeySelector<T, K> keySel = input.getKeySelector();
 
 		WindowOperator<K, T, Iterable<T>, R, W> operator;
@@ -1132,8 +1110,6 @@ public class WindowedStream<T, K, W extends Window> {
 
 			ListStateDescriptor<StreamRecord<T>> stateDesc =
 					new ListStateDescriptor<>("window-contents", streamRecordSerializer);
-
-			opName = "TriggerWindow(" + windowAssigner + ", " + stateDesc + ", " + trigger + ", " + evictor + ", " + udfName + ")";
 
 			operator =
 				new EvictingWindowOperator<>(windowAssigner,
@@ -1150,8 +1126,6 @@ public class WindowedStream<T, K, W extends Window> {
 		} else {
 			ListStateDescriptor<T> stateDesc = new ListStateDescriptor<>("window-contents",
 				input.getType().createSerializer(getExecutionEnvironment().getConfig()));
-
-			opName = "TriggerWindow(" + windowAssigner + ", " + stateDesc + ", " + trigger + ", " + udfName + ")";
 
 			operator =
 				new WindowOperator<>(windowAssigner,
@@ -1216,7 +1190,7 @@ public class WindowedStream<T, K, W extends Window> {
 		String callLocation = Utils.getCallLocationName();
 		String udfName = "WindowedStream." + callLocation;
 
-		String opName;
+		final String opName = generateOperatorName(windowAssigner, trigger, evictor, udfName);
 		KeySelector<T, K> keySel = input.getKeySelector();
 
 		OneInputStreamOperator<T, R> operator;
@@ -1228,8 +1202,6 @@ public class WindowedStream<T, K, W extends Window> {
 
 			ListStateDescriptor<StreamRecord<T>> stateDesc =
 					new ListStateDescriptor<>("window-contents", streamRecordSerializer);
-
-			opName = "TriggerWindow(" + windowAssigner + ", " + stateDesc + ", " + trigger + ", " + evictor + ", " + udfName + ")";
 
 			operator =
 				new EvictingWindowOperator<>(windowAssigner,
@@ -1247,8 +1219,6 @@ public class WindowedStream<T, K, W extends Window> {
 			ReducingStateDescriptor<T> stateDesc = new ReducingStateDescriptor<>("window-contents",
 				reduceFunction,
 				input.getType().createSerializer(getExecutionEnvironment().getConfig()));
-
-			opName = "TriggerWindow(" + windowAssigner + ", " + stateDesc + ", " + trigger + ", " + udfName + ")";
 
 			operator =
 				new WindowOperator<>(windowAssigner,
@@ -1319,7 +1289,7 @@ public class WindowedStream<T, K, W extends Window> {
 		String callLocation = Utils.getCallLocationName();
 		String udfName = "WindowedStream." + callLocation;
 
-		String opName;
+		final String opName = generateOperatorName(windowAssigner, trigger, evictor, udfName);
 		KeySelector<T, K> keySel = input.getKeySelector();
 
 		OneInputStreamOperator<T, R> operator;
@@ -1331,8 +1301,6 @@ public class WindowedStream<T, K, W extends Window> {
 
 			ListStateDescriptor<StreamRecord<T>> stateDesc =
 					new ListStateDescriptor<>("window-contents", streamRecordSerializer);
-
-			opName = "TriggerWindow(" + windowAssigner + ", " + stateDesc + ", " + trigger + ", " + evictor + ", " + udfName + ")";
 
 			operator = new EvictingWindowOperator<>(windowAssigner,
 				windowAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
@@ -1349,8 +1317,6 @@ public class WindowedStream<T, K, W extends Window> {
 			FoldingStateDescriptor<T, R> stateDesc = new FoldingStateDescriptor<>("window-contents",
 				initialValue, foldFunction, resultType.createSerializer(getExecutionEnvironment().getConfig()));
 
-			opName = "TriggerWindow(" + windowAssigner + ", " + stateDesc + ", " + trigger + ", " + udfName + ")";
-
 			operator = new WindowOperator<>(windowAssigner,
 				windowAssigner.getWindowSerializer(getExecutionEnvironment().getConfig()),
 				keySel,
@@ -1363,6 +1329,19 @@ public class WindowedStream<T, K, W extends Window> {
 		}
 
 		return input.transform(opName, resultType, operator);
+	}
+
+	private static String generateOperatorName(
+			WindowAssigner<?, ?> assigner,
+			Trigger<?, ?> trigger,
+			@Nullable Evictor<?, ?> evictor,
+			String udfName) {
+		return "Window(" +
+			assigner + ", " +
+			trigger.getClass().getSimpleName() + ", " +
+			(evictor == null ? "" : evictor.getClass().getSimpleName() + ", ") +
+			udfName +
+			")";
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/WindowedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/WindowedStream.java
@@ -1314,7 +1314,7 @@ public class WindowedStream<T, K, W extends Window> {
 			if (interfaces.length == 0) {
 				// extends an existing class (like RichMapFunction)
 				Class<?> functionSuperClass = functionClass.getSuperclass();
-				return functionSuperClass.getSimpleName() + functionSuperClass.getName().substring(functionSuperClass.getEnclosingClass().getName().length());
+				return functionSuperClass.getSimpleName() + functionClass.getName().substring(functionClass.getEnclosingClass().getName().length());
 			} else {
 				// implements a Function interface
 				Class<?> functionInterface = functionClass.getInterfaces()[0];


### PR DESCRIPTION
## What is the purpose of the change

This PR modifies the generation of default operator names for window operators to be more concise, and more importantly, stable across job submissions.

Example: SocketTextWordCount

Before:
```
TriggerWindow(TumblingProcessingTimeWindows(5000), ReducingStateDescriptor{serializer=org.apache.flink.api.java.typeutils.runtime.PojoSerializer@591ae253, reduceFunction=org.apache.flink.streaming.examples.socket.SocketWindowWordCount$1@48974e45}, ProcessingTimeTrigger(), WindowedStream.reduce(WindowedStream.java:241))
```

After:
```
Window(TumblingProcessingTimeWindows(5000), ProcessingTimeTrigger, WindowedStream.reduce(WindowedStream.java:243))
```

## Brief change log

* create shared static utility method to generate names
* remove state-descriptor from operator name
* replace `TriggerWindow` with `Window`
* trigger/assigner are now included with their simple class name instead of fully qualified class name + object reference

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
