### PR TITLE
[FLINK-8484][flink-kinesis-connector] Ensure a Kinesis consumer snapshot restoration is able to handle recently closed shards

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisConsumer.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisConsumer.java
@@ -210,18 +210,26 @@ public class FlinkKinesisConsumer<T> extends RichParallelSourceFunction<T> imple
 		for (StreamShardHandle shard : allShards) {
 			StreamShardMetadata kinesisStreamShard = KinesisDataFetcher.convertToStreamShardMetadata(shard);
 			if (sequenceNumsToRestore != null) {
-				// find the sequence number for the given converted kinesis shard in our restored state
-				final SequenceNumber restoredSequenceNumber = findSequenceNumberToRestoreFrom(kinesisStreamShard, sequenceNumsToRestore);
-				if (restoredSequenceNumber != null) {
+
+				// We need to do this to make sure that a shard that was closed after this restored state was taken will be properly
+				// detected and have its sequence numbers restored. A shard will be closed when re-sharding, which can happen when
+				// scaling up & down the Kinesis stream, and if the state is not synchronized, then the equality check of the current
+				// Kinesis shard will not match the stored state, which will cause us to re-read the entire shard from the event horizon.
+				if (updateKinesisShardStateWithMissingEndingSequenceNumber(kinesisStreamShard, sequenceNumsToRestore)) {
+					if (LOG.isInfoEnabled()) {
+						LOG.info("Updated local stored state for shard {} with a new ending number: {}", kinesisStreamShard.getShardId(), sequenceNumsToRestore.get(kinesisStreamShard));
+					}
+				}
+				if (sequenceNumsToRestore.containsKey(kinesisStreamShard)) {
 					// if the shard was already seen and is contained in the state,
 					// just use the sequence number stored in the state
 					fetcher.registerNewSubscribedShardState(
-						new KinesisStreamShardState(kinesisStreamShard, shard, restoredSequenceNumber));
+						new KinesisStreamShardState(kinesisStreamShard, shard, sequenceNumsToRestore.get(kinesisStreamShard)));
 
 					if (LOG.isInfoEnabled()) {
 						LOG.info("Subtask {} is seeding the fetcher with restored shard {}," +
 								" starting state set to the restored sequence number {}",
-							getRuntimeContext().getIndexOfThisSubtask(), shard.toString(), restoredSequenceNumber);
+							getRuntimeContext().getIndexOfThisSubtask(), shard.toString(), sequenceNumsToRestore.get(kinesisStreamShard));
 					}
 				} else {
 					// the shard wasn't discovered in the previous run, therefore should be consumed from the beginning
@@ -270,24 +278,42 @@ public class FlinkKinesisConsumer<T> extends RichParallelSourceFunction<T> imple
 	}
 
 	/**
-	 * Tries to find the {@link SequenceNumber} for a given {@code kinesisStreamShard} in the list of the restored stream shards' metadata,
-	 * by comparing the stream name and shard id for equality.
-	 * @param current				the current Kinesis shard we're trying to find the restored sequence number for
-	 * @param sequenceNumsToRestore	the restored sequence numbers
-	 * @return the sequence number, if any, or {@code null} if no matching shard is found
+	 * Synchronizes the Kinesis shard information from the current Kinesis shard with the restored state, if we find
+	 * a shard that match the shardId and streamName. If we find one, and its ending key is different that what we
+	 * have in our stored state, then we update the stored's shard's metadata's ending number.
+	 *
+	 * @param current				the current Kinesis shard we're trying to synchronize.
+	 * @param sequenceNumsToRestore	the (re)stored shard metadata and their sequence numbers.
+	 * @return {@code true} if the local state was updated with the current Kinesis shard's ending number.
 	 */
 	@VisibleForTesting
-	SequenceNumber findSequenceNumberToRestoreFrom(StreamShardMetadata current, HashMap<StreamShardMetadata, SequenceNumber> sequenceNumsToRestore) {
+	boolean updateKinesisShardStateWithMissingEndingSequenceNumber(StreamShardMetadata current, HashMap<StreamShardMetadata, SequenceNumber> sequenceNumsToRestore) {
 		checkNotNull(current.getStreamName(), "Stream name not set on the current metadata shard");
 		checkNotNull(current.getShardId(), "Shard id not set on the current metadata shard");
 
-		for (final Map.Entry<StreamShardMetadata, SequenceNumber> entry : sequenceNumsToRestore.entrySet()) {
+		// short-circuit: if the current shard doesn't have an ending sequence number, then there's no point in trying to update the local state
+		// since that's the only property that can change.
+		if (current.getEndingSequenceNumber() == null) {
+			return false;
+		}
+
+		// try to find the matching shard based on the id & stream name
+		for (Map.Entry<StreamShardMetadata, SequenceNumber> entry : sequenceNumsToRestore.entrySet()) {
 			if (current.getStreamName().equals(entry.getKey().getStreamName())
 				&& current.getShardId().equals(entry.getKey().getShardId())) {
-				return entry.getValue();
+				// synchronize the local state if the ending sequence number is different
+				if (!current.getEndingSequenceNumber().equals(entry.getKey().getEndingSequenceNumber())) {
+					// ugly, but since the hashcode will change, we'll need to remove it and add it back
+					sequenceNumsToRestore.remove(entry.getKey());
+					entry.getKey().setEndingSequenceNumber(current.getEndingSequenceNumber());
+					sequenceNumsToRestore.put(entry.getKey(), entry.getValue());
+					return true;
+				}
+				// we already found the matching shard
+				break;
 			}
 		}
-		return null;
+		return false;
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisConsumerTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisConsumerTest.java
@@ -62,12 +62,14 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -521,21 +523,89 @@ public class FlinkKinesisConsumerTest {
 	 * This handles the corner case where the stored shard metadata is open (no ending sequence number), but after the
 	 * job restore, the shard has been closed (ending number set) due to re-sharding, and we can no longer rely on
 	 * {@link StreamShardMetadata#equals(Object)} to find back the sequence number in the collection of restored shard metadata.
+	 * <p></p>
+	 * Therefore, we will rely on synchronizing the snapshot's state with the Kinesis shard before attempting to find back
+	 * the sequence number to restore.
 	 */
 	@Test
-	public void testFindSequenceNumberToRestoreFrom() {
+	public void testFindSequenceNumberToRestoreFromIfTheShardHasBeenClosedSinceTheStateWasStored() throws Exception {
+		// ----------------------------------------------------------------------
+		// setup initial state
+		// ----------------------------------------------------------------------
+
+		HashMap<StreamShardHandle, SequenceNumber> fakeRestoredState = getFakeRestoredStore("all");
+
+		// ----------------------------------------------------------------------
+		// mock operator state backend and initial state for initializeState()
+		// ----------------------------------------------------------------------
+
+		TestingListState<Tuple2<StreamShardMetadata, SequenceNumber>> listState = new TestingListState<>();
+		for (Map.Entry<StreamShardHandle, SequenceNumber> state : fakeRestoredState.entrySet()) {
+			listState.add(Tuple2.of(KinesisDataFetcher.convertToStreamShardMetadata(state.getKey()), state.getValue()));
+		}
+
+		OperatorStateStore operatorStateStore = mock(OperatorStateStore.class);
+		when(operatorStateStore.getUnionListState(Matchers.any(ListStateDescriptor.class))).thenReturn(listState);
+
+		StateInitializationContext initializationContext = mock(StateInitializationContext.class);
+		when(initializationContext.getOperatorStateStore()).thenReturn(operatorStateStore);
+		when(initializationContext.isRestored()).thenReturn(true);
+
+		// ----------------------------------------------------------------------
+		// mock fetcher
+		// ----------------------------------------------------------------------
+
+		KinesisDataFetcher mockedFetcher = Mockito.mock(KinesisDataFetcher.class);
+		List<StreamShardHandle> shards = new ArrayList<>();
+
+		// create a fake stream shard handle based on the first entry in the restored state
+		final StreamShardHandle originalStreamShardHandle = fakeRestoredState.keySet().iterator().next();
+		final StreamShardHandle closedStreamShardHandle = new StreamShardHandle(originalStreamShardHandle.getStreamName(), originalStreamShardHandle.getShard());
+		// close the shard handle by setting an ending sequence number
+		final SequenceNumberRange sequenceNumberRange = new SequenceNumberRange();
+		sequenceNumberRange.setEndingSequenceNumber("1293844");
+		closedStreamShardHandle.getShard().setSequenceNumberRange(sequenceNumberRange);
+
+		shards.add(closedStreamShardHandle);
+
+		when(mockedFetcher.discoverNewShardsToSubscribe()).thenReturn(shards);
+		PowerMockito.whenNew(KinesisDataFetcher.class).withAnyArguments().thenReturn(mockedFetcher);
+
+		// assume the given config is correct
+		PowerMockito.mockStatic(KinesisConfigUtil.class);
+		PowerMockito.doNothing().when(KinesisConfigUtil.class);
+
+		// ----------------------------------------------------------------------
+		// start to test fetcher's initial state seeding
+		// ----------------------------------------------------------------------
+
+		TestableFlinkKinesisConsumer consumer = new TestableFlinkKinesisConsumer(
+			"fakeStream", new Properties(), 10, 2);
+		consumer.initializeState(initializationContext);
+		consumer.open(new Configuration());
+		consumer.run(Mockito.mock(SourceFunction.SourceContext.class));
+
+		Mockito.verify(mockedFetcher).registerNewSubscribedShardState(
+			new KinesisStreamShardState(KinesisDataFetcher.convertToStreamShardMetadata(closedStreamShardHandle),
+				closedStreamShardHandle, fakeRestoredState.get(closedStreamShardHandle)));
+	}
+
+	@Test
+	public void testUpdateKinesisShardStateWithMissingEndingSequenceNumber() {
 		final String streamName = "fakeStream1";
 		final String shardId = "shard-000001";
-		final String sequenceNumber = "789";
 
 		Properties config = TestUtils.getStandardProperties();
 		FlinkKinesisConsumer<String> consumer = new FlinkKinesisConsumer<>(streamName, new SimpleStringSchema(), config);
 
-		// having the current kinesis shard we're trying to find the restored state for
+		// having the current Kinesis shard we're trying to find the restored state for
 		final StreamShardMetadata current = new StreamShardMetadata();
 		current.setShardId(shardId);
 		current.setStreamName(streamName);
-		final HashMap<StreamShardMetadata, SequenceNumber> sequenceNumsToRestore = new HashMap<>();
+		current.setEndingSequenceNumber(null);
+
+		final HashMap<StreamShardMetadata, SequenceNumber> sequenceNumsToRestore = new LinkedHashMap<>();
+		assertFalse("Current shard is open, expecting a short-circuit", consumer.updateKinesisShardStateWithMissingEndingSequenceNumber(current, sequenceNumsToRestore));
 
 		// create some non-matching shards
 		final StreamShardMetadata differentStreamName = new StreamShardMetadata();
@@ -550,19 +620,24 @@ public class FlinkKinesisConsumerTest {
 		final StreamShardMetadata match = new StreamShardMetadata();
 		match.setStreamName(streamName);
 		match.setShardId(shardId);
-		// ensure the sequence number isn't set (shard is considered in OPEN state)
+		// ensure the sequence number isn't set (shard is considered in open state)
 		match.setEndingSequenceNumber(null);
 
 		sequenceNumsToRestore.put(differentStreamName, new SequenceNumber("123"));
 		sequenceNumsToRestore.put(differentShardId, new SequenceNumber("456"));
-		sequenceNumsToRestore.put(match, new SequenceNumber(sequenceNumber));
+		sequenceNumsToRestore.put(match, new SequenceNumber("789"));
 
-		assertEquals(sequenceNumber, consumer.findSequenceNumberToRestoreFrom(current, sequenceNumsToRestore).getSequenceNumber());
+		assertFalse("No ending sequence number was set, so no synchronisation was done.", consumer.updateKinesisShardStateWithMissingEndingSequenceNumber(current, sequenceNumsToRestore));
 
-		// alter the ending sequence number (indicating the shard is now closed) and ensure we're still able to find the sequence number
+		// alter the ending sequence number (indicating the shard is now closed)
+		final String endingSequenceNumber = "99999";
+		current.setEndingSequenceNumber(endingSequenceNumber);
+		assertTrue("Shard was closed (ending number set).", consumer.updateKinesisShardStateWithMissingEndingSequenceNumber(current, sequenceNumsToRestore));
+		assertEquals(endingSequenceNumber, match.getEndingSequenceNumber());
+		assertEquals(current, match);
+		assertTrue("Make sure we can still find back our match in the restored sequences ", sequenceNumsToRestore.containsKey(match));
 
-		match.setEndingSequenceNumber("99999");
-		assertEquals(sequenceNumber, consumer.findSequenceNumberToRestoreFrom(current, sequenceNumsToRestore).getSequenceNumber());
+		assertFalse("Ending number was already set, no more need for synchronisation", consumer.updateKinesisShardStateWithMissingEndingSequenceNumber(current, sequenceNumsToRestore));
 	}
 
 	private static final class TestingListState<T> implements ListState<T> {


### PR DESCRIPTION
FLINK-8484: ensure that a state change in the StreamShardMetadata other than `StreamShardMetadata.shardId` or `StreamShardMetadata.streamName` does not result in the shard not being able to be restored. This handles the corner case where a shard might have been closed (ending sequence number set to not-null) since the last savepoint or checkpoint when a job is restarted from a snapshot state.

From the Flink issue [1]/mailing list[2]:

[1] https://issues.apache.org/jira/browse/FLINK-8484
[2] http://apache-flink-user-mailing-list-archive.2336050.n4.nabble.com/Flink-Kinesis-Consumer-re-reading-merged-shards-upon-restart-td17917.html

> We’re using the connector to subscribe to streams varying from 1 to a 100 shards, and used the kinesis-scaling-utils to dynamically scale the Kinesis stream up and down during peak times. What we’ve noticed is that, while we were having closed shards, any Flink job restart with check- or save-point would result in shards being re-read from the event horizon, duplicating our events.

> We started checking the checkpoint state, and found that the shards were stored correctly with the proper sequence number (including for closed shards), but that upon restarts, the older closed shards would be read from the event horizon, as if their restored state would be ignored.

> In the end, we believe that we found the problem: in the FlinkKinesisConsumer’s run() method, we’re trying to find the shard returned from the KinesisDataFetcher against the shards’ metadata from the restoration point, but we do this via a containsKey() call, which means we’ll use the StreamShardMetadata’s equals() method. However, this checks for all properties, including the endingSequenceNumber, which might have changed between the restored state’s checkpoint and our data fetch, thus failing the equality check, failing the containsKey() check, and resulting in the shard being re-read from the event horizon, even though it was present in the restored state.

> We’ve created a workaround where we only check for the shardId and stream name to restore the state of the shards we’ve already seen, and this seems to work correctly. 

## Brief change log
 - Created a new method to synchronize the state of the Kinesis shard before comparing, it has the added benefit of ensuring that the stored snapshot will always be in line with the actual Kinesis shards
- This PR does _not_ introduce shard expiration, so in case of resharding, all (expired) shards' metadata will remain in the snapshot, which can lead to issues when scaling large streams on a continuous basis. This will be handled in another PR. 

## Verifying this change

This change added tests and can be verified as follows:
 - Two new unit tests were added in `FlinkKinesisConsumerTest` called `testFindSequenceNumberToRestoreFromIfTheShardHasBeenClosedSinceTheStateWasStored()` and a higher-level `testUpdateKinesisShardStateWithMissingEndingSequenceNumber()` which tests the synchronization mechanism and ensure a correct comparison.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
