### PR TITLE
[FLINK-8476][config][HA] Deprecate HA config constants

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -989,16 +989,18 @@ public final class ConfigConstants {
 
 	// --------------------------- High Availability --------------------------
 
-	/** Defines high availability mode used for the cluster execution ("NONE", "ZOOKEEPER"). */
+	/** @deprecated Deprecated in favour of {@link HighAvailabilityOptions#HA_MODE} */
 	@PublicEvolving
+	@Deprecated
 	public static final String HA_MODE = "high-availability";
 
 	/** Ports used by the job manager if not in 'none' recovery mode. */
 	@PublicEvolving
 	public static final String HA_JOB_MANAGER_PORT = "high-availability.jobmanager.port";
 
-	/** The time before the JobManager recovers persisted jobs. */
+	/** @deprecated Deprecated in favour of {@link HighAvailabilityOptions#HA_JOB_DELAY}. */
 	@PublicEvolving
+	@Deprecated
 	public static final String HA_JOB_DELAY = "high-availability.job.delay";
 
 	/** @deprecated Deprecated in favour of {@link #HA_MODE}. */
@@ -1776,7 +1778,9 @@ public final class ConfigConstants {
 
 	// --------------------------- High Availability ---------------------------------
 
+	/** @deprecated Deprecated in favour of {@link HighAvailabilityOptions#HA_MODE} */
 	@PublicEvolving
+	@Deprecated
 	public static final String DEFAULT_HA_MODE = "none";
 
 	/** @deprecated Deprecated in favour of {@link #DEFAULT_HA_MODE} */
@@ -1786,8 +1790,11 @@ public final class ConfigConstants {
 	/**
 	 * Default port used by the job manager if not in standalone recovery mode. If <code>0</code>
 	 * the OS picks a random port port.
+	 *
+	 * @deprecated No longer used.
 	 */
 	@PublicEvolving
+	@Deprecated
 	public static final String DEFAULT_HA_JOB_MANAGER_PORT = "0";
 
 	/** @deprecated Deprecated in favour of {@link #DEFAULT_HA_JOB_MANAGER_PORT} */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/HighAvailabilityMode.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/HighAvailabilityMode.java
@@ -39,7 +39,7 @@ public enum HighAvailabilityMode {
 	 * Return the configured {@link HighAvailabilityMode}.
 	 *
 	 * @param config The config to parse
-	 * @return Configured recovery mode or {@link ConfigConstants#DEFAULT_HA_MODE} if not
+	 * @return Configured recovery mode or {@link HighAvailabilityMode#NONE} if not
 	 * configured.
 	 */
 	public static HighAvailabilityMode fromConfig(Configuration config) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/LeaderRetrievalUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/LeaderRetrievalUtils.java
@@ -23,7 +23,6 @@ import akka.actor.ActorSystem;
 import akka.dispatch.Mapper;
 import akka.dispatch.OnComplete;
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.IllegalConfigurationException;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/LeaderRetrievalUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/LeaderRetrievalUtils.java
@@ -25,6 +25,7 @@ import akka.dispatch.OnComplete;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.instance.ActorGateway;
@@ -255,8 +256,7 @@ public class LeaderRetrievalUtils {
 	}
 
 	/**
-	 * Gets the recovery mode as configured, based on the {@link ConfigConstants#HA_MODE}
-	 * config key.
+	 * Gets the recovery mode as configured, based on {@link HighAvailabilityOptions#HA_MODE}.
 	 * 
 	 * @param config The configuration to read the recovery mode from.
 	 * @return The recovery mode.


### PR DESCRIPTION
## What is the purpose of the change

This PR deprecates multiple HA-related `ConfigConstants`.

## Brief change log

Deprecated:
- CC#HA_MODE as it is completely subsumed by HAOptions#HA_MODE
- CC#HA_JOB_DELAY as it is completely subsumed by HAOptions#HA_JOB_DELAY
- CC#DEFAULT_HA_MODE as subsumed by HAOptions#HA_MODE
	- still used by 2 tests (HighAvailabilityModeTest / TestingUtils (scala))
- CC#DEFAULT_HA_JOB_MANAGER_PORT as it is no longer used

## Verifying this change

Only modifies annotations / javadocs so it shouldn't affect functionality.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
