### PR TITLE
[FLINK-8475][config][docs] Integrate more ConfigOptions into documentation

### DIFF
--- a/docs/_includes/generated/akka_configuration.html
+++ b/docs/_includes/generated/akka_configuration.html
@@ -1,0 +1,96 @@
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 65%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>akka.ask.timeout</h5></td>
+            <td>"10 s"</td>
+            <td>Timeout used for all futures and blocking Akka calls. If Flink fails due to timeouts then you should try to increase this value. Timeouts can be caused by slow machines or a congested network. The timeout value requires a time-unit specifier (ms/s/min/h/d).</td>
+        </tr>
+        <tr>
+            <td><h5>akka.client.timeout</h5></td>
+            <td>"60 s"</td>
+            <td></td>
+        </tr>
+        <tr>
+            <td><h5>akka.framesize</h5></td>
+            <td>"10485760b"</td>
+            <td>Maximum size of messages which are sent between the JobManager and the TaskManagers. If Flink fails because messages exceed this limit, then you should increase it. The message size requires a size-unit specifier.</td>
+        </tr>
+        <tr>
+            <td><h5>akka.jvm-exit-on-fatal-error</h5></td>
+            <td>true</td>
+            <td></td>
+        </tr>
+        <tr>
+            <td><h5>akka.log.lifecycle.events</h5></td>
+            <td>false</td>
+            <td>Turns on the Akka’s remote logging of events. Set this value to ‘true’ in case of debugging.</td>
+        </tr>
+        <tr>
+            <td><h5>akka.lookup.timeout</h5></td>
+            <td>"10 s"</td>
+            <td>Timeout used for the lookup of the JobManager. The timeout value has to contain a time-unit specifier (ms/s/min/h/d).</td>
+        </tr>
+        <tr>
+            <td><h5>akka.retry-gate-closed-for</h5></td>
+            <td>50</td>
+            <td></td>
+        </tr>
+        <tr>
+            <td><h5>akka.ssl.enabled</h5></td>
+            <td>true</td>
+            <td>Turns on SSL for Akka’s remote communication. This is applicable only when the global ssl flag security.ssl.enabled is set to true.</td>
+        </tr>
+        <tr>
+            <td><h5>akka.startup-timeout</h5></td>
+            <td>(none)</td>
+            <td>Timeout after which the startup of a remote component is considered being failed.</td>
+        </tr>
+        <tr>
+            <td><h5>akka.tcp.timeout</h5></td>
+            <td>"20 s"</td>
+            <td>Timeout for all outbound connections. If you should experience problems with connecting to a TaskManager due to a slow network, you should increase this value.</td>
+        </tr>
+        <tr>
+            <td><h5>akka.throughput</h5></td>
+            <td>15</td>
+            <td>Number of messages that are processed in a batch before returning the thread to the pool. Low values denote a fair scheduling whereas high values can increase the performance at the cost of unfairness.</td>
+        </tr>
+        <tr>
+            <td><h5>akka.transport.heartbeat.interval</h5></td>
+            <td>"1000 s"</td>
+            <td>Heartbeat interval for Akka’s transport failure detector. Since Flink uses TCP, the detector is not necessary. Therefore, the detector is disabled by setting the interval to a very high value. In case you should need the transport failure detector, set the interval to some reasonable value. The interval value requires a time-unit specifier (ms/s/min/h/d).</td>
+        </tr>
+        <tr>
+            <td><h5>akka.transport.heartbeat.pause</h5></td>
+            <td>"6000 s"</td>
+            <td>Acceptable heartbeat pause for Akka’s transport failure detector. Since Flink uses TCP, the detector is not necessary. Therefore, the detector is disabled by setting the pause to a very high value. In case you should need the transport failure detector, set the pause to some reasonable value. The pause value requires a time-unit specifier (ms/s/min/h/d).</td>
+        </tr>
+        <tr>
+            <td><h5>akka.transport.threshold</h5></td>
+            <td>300.0</td>
+            <td>Threshold for the transport failure detector. Since Flink uses TCP, the detector is not necessary and, thus, the threshold is set to a high value.</td>
+        </tr>
+        <tr>
+            <td><h5>akka.watch.heartbeat.interval</h5></td>
+            <td>"10 s"</td>
+            <td>Heartbeat interval for Akka’s DeathWatch mechanism to detect dead TaskManagers. If TaskManagers are wrongly marked dead because of lost or delayed heartbeat messages, then you should decrease this value or increase akka.watch.heartbeat.pause. A thorough description of Akka’s DeathWatch can be found &#60;a href="http://doc.akka.io/docs/akka/snapshot/scala/remoting.html#failure-detector"&#62;here&#60;/a&#62;.</td>
+        </tr>
+        <tr>
+            <td><h5>akka.watch.heartbeat.pause</h5></td>
+            <td>"60 s"</td>
+            <td>Acceptable heartbeat pause for Akka’s DeathWatch mechanism. A low value does not allow an irregular heartbeat. If TaskManagers are wrongly marked dead because of lost or delayed heartbeat messages, then you should increase this value or decrease akka.watch.heartbeat.interval. Higher value increases the time to detect a dead TaskManager. A thorough description of Akka’s DeathWatch can be found &#60;a href="http://doc.akka.io/docs/akka/snapshot/scala/remoting.html#failure-detector"&#62;here&#60;/a&#62;.</td>
+        </tr>
+        <tr>
+            <td><h5>akka.watch.threshold</h5></td>
+            <td>12</td>
+            <td>Threshold for the DeathWatch failure detector. A low value is prone to false positives whereas a high value increases the time to detect a dead TaskManager. A thorough description of Akka’s DeathWatch can be found &#60;a href="http://doc.akka.io/docs/akka/snapshot/scala/remoting.html#failure-detector"&#62;here&#60;/a&#62;.</td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/_includes/generated/blob_server_configuration.html
+++ b/docs/_includes/generated/blob_server_configuration.html
@@ -1,0 +1,51 @@
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 65%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>blob.fetch.backlog</h5></td>
+            <td>1000</td>
+            <td>The config parameter defining the backlog of BLOB fetches on the JobManager.</td>
+        </tr>
+        <tr>
+            <td><h5>blob.fetch.num-concurrent</h5></td>
+            <td>50</td>
+            <td>The config parameter defining the maximum number of concurrent BLOB fetches that the JobManager serves.</td>
+        </tr>
+        <tr>
+            <td><h5>blob.fetch.retries</h5></td>
+            <td>5</td>
+            <td>The config parameter defining number of retires for failed BLOB fetches.</td>
+        </tr>
+        <tr>
+            <td><h5>blob.offload.minsize</h5></td>
+            <td>1048576</td>
+            <td>The minimum size for messages to be offloaded to the BlobServer.</td>
+        </tr>
+        <tr>
+            <td><h5>blob.server.port</h5></td>
+            <td>"0"</td>
+            <td>The config parameter defining the server port of the blob service.</td>
+        </tr>
+        <tr>
+            <td><h5>blob.service.cleanup.interval</h5></td>
+            <td>3600</td>
+            <td>Cleanup interval of the blob caches at the task managers (in seconds).</td>
+        </tr>
+        <tr>
+            <td><h5>blob.service.ssl.enabled</h5></td>
+            <td>true</td>
+            <td>Flag to override ssl support for the blob service transport.</td>
+        </tr>
+        <tr>
+            <td><h5>blob.storage.directory</h5></td>
+            <td>(none)</td>
+            <td>The config parameter defining the storage directory to be used by the blob server.</td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/_includes/generated/checkpointing_configuration.html
+++ b/docs/_includes/generated/checkpointing_configuration.html
@@ -1,0 +1,51 @@
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 65%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>state.backend</h5></td>
+            <td>(none)</td>
+            <td>The state backend to be used to store and checkpoint state.</td>
+        </tr>
+        <tr>
+            <td><h5>state.backend.async</h5></td>
+            <td>true</td>
+            <td>Option whether the state backend should use an asynchronous snapshot method where possible and configurable. Some state backends may not support asynchronous snapshots, or only support asynchronous snapshots, and ignore this option.</td>
+        </tr>
+        <tr>
+            <td><h5>state.backend.fs.memory-threshold</h5></td>
+            <td>1024</td>
+            <td>The minimum size of state data files. All state chunks smaller than that are stored inline in the root checkpoint metadata file.</td>
+        </tr>
+        <tr>
+            <td><h5>state.backend.incremental</h5></td>
+            <td>false</td>
+            <td>Option whether the state backend should create incremental checkpoints, if possible. For an incremental checkpoint, only a diff from the previous checkpoint is stored, rather than the complete checkpoint state. Some state backends may not support incremental checkpoints and ignore this option.</td>
+        </tr>
+        <tr>
+            <td><h5>state.backend.rocksdb.localdir</h5></td>
+            <td>(none)</td>
+            <td>The local directory (on the TaskManager) where RocksDB puts its files.</td>
+        </tr>
+        <tr>
+            <td><h5>state.checkpoints.dir</h5></td>
+            <td>(none)</td>
+            <td>The default directory used for checkpoints. Used by the state backends that write checkpoints to file systems (MemoryStateBackend, FsStateBackend, RocksDBStateBackend).</td>
+        </tr>
+        <tr>
+            <td><h5>state.checkpoints.num-retained</h5></td>
+            <td>1</td>
+            <td>The maximum number of completed checkpoints to retain.</td>
+        </tr>
+        <tr>
+            <td><h5>state.savepoints.dir</h5></td>
+            <td>(none)</td>
+            <td>The default directory for savepoints. Used by the state backends that write savepoints to file systems (MemoryStateBackend, FsStateBackend, RocksDBStateBackend).</td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/_includes/generated/file_system_configuration.html
+++ b/docs/_includes/generated/file_system_configuration.html
@@ -1,0 +1,26 @@
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 65%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>fs.default-scheme</h5></td>
+            <td>(none)</td>
+            <td>The default filesystem scheme, used for paths that do not declare a scheme explicitly.</td>
+        </tr>
+        <tr>
+            <td><h5>fs.output.always-create-directory</h5></td>
+            <td>false</td>
+            <td>File writers running with a parallelism larger than one create a directory for the output file path and put the different result files (one per parallel writer task) into that directory. If this option is set to *true*, writers with a parallelism of 1 will also create a directory and place a single result file into it. If the option is set to *false*, the writer will directly create the file directly at the output path, without creating a containing directory.</td>
+        </tr>
+        <tr>
+            <td><h5>fs.overwrite-files</h5></td>
+            <td>false</td>
+            <td>Specifies whether file output writers should overwrite existing files by default. Set to *true* to overwrite by default, *false* otherwise.</td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/_includes/generated/heartbeat_manager_configuration.html
+++ b/docs/_includes/generated/heartbeat_manager_configuration.html
@@ -1,0 +1,21 @@
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 65%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>heartbeat.interval</h5></td>
+            <td>10000</td>
+            <td>Time interval for requesting heartbeat from sender side.</td>
+        </tr>
+        <tr>
+            <td><h5>heartbeat.timeout</h5></td>
+            <td>50000</td>
+            <td>Timeout for requesting and receiving heartbeat for both sender and receiver sides.</td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/_includes/generated/high_availability_zookeeper_configuration.html
+++ b/docs/_includes/generated/high_availability_zookeeper_configuration.html
@@ -1,0 +1,81 @@
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 65%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>high-availability.zookeeper.client.acl</h5></td>
+            <td>"open"</td>
+            <td>Defines the ACL (open|creator) to be configured on ZK node. The configuration value can be set to “creator” if the ZooKeeper server configuration has the “authProvider” property mapped to use SASLAuthenticationProvider and the cluster is configured to run in secure mode (Kerberos). The ACL options are based on &#60;a href="https://zookeeper.apache.org/doc/r3.1.2/zookeeperProgrammers.html#sc_BuiltinACLSchemes"&#62;this document&#60;a/&#62;</td>
+        </tr>
+        <tr>
+            <td><h5>high-availability.zookeeper.client.connection-timeout</h5></td>
+            <td>15000</td>
+            <td>Defines the connection timeout for ZooKeeper in ms.</td>
+        </tr>
+        <tr>
+            <td><h5>high-availability.zookeeper.client.max-retry-attempts</h5></td>
+            <td>3</td>
+            <td>Defines the number of connection retries before the client gives up.</td>
+        </tr>
+        <tr>
+            <td><h5>high-availability.zookeeper.client.retry-wait</h5></td>
+            <td>5000</td>
+            <td>Defines the pause between consecutive retries in ms.</td>
+        </tr>
+        <tr>
+            <td><h5>high-availability.zookeeper.client.session-timeout</h5></td>
+            <td>60000</td>
+            <td>Defines the session timeout for the ZooKeeper session in ms.</td>
+        </tr>
+        <tr>
+            <td><h5>high-availability.zookeeper.path.checkpoint-counter</h5></td>
+            <td>"/checkpoint-counter"</td>
+            <td>ZooKeeper root path (ZNode) for checkpoint counters.</td>
+        </tr>
+        <tr>
+            <td><h5>high-availability.zookeeper.path.checkpoints</h5></td>
+            <td>"/checkpoints"</td>
+            <td>ZooKeeper root path (ZNode) for completed checkpoints.</td>
+        </tr>
+        <tr>
+            <td><h5>high-availability.zookeeper.path.jobgraphs</h5></td>
+            <td>"/jobgraphs"</td>
+            <td>ZooKeeper root path (ZNode) for job graphs</td>
+        </tr>
+        <tr>
+            <td><h5>high-availability.zookeeper.path.latch</h5></td>
+            <td>"/leaderlatch"</td>
+            <td> Defines the znode of the leader latch which is used to elect the leader.</td>
+        </tr>
+        <tr>
+            <td><h5>high-availability.zookeeper.path.leader</h5></td>
+            <td>"/leader"</td>
+            <td>Defines the znode of the leader which contains the URL to the leader and the current leader session ID.</td>
+        </tr>
+        <tr>
+            <td><h5>high-availability.zookeeper.path.mesos-workers</h5></td>
+            <td>"/mesos-workers"</td>
+            <td>ZooKeeper root path (ZNode) for Mesos workers.</td>
+        </tr>
+        <tr>
+            <td><h5>high-availability.zookeeper.path.root</h5></td>
+            <td>"/flink"</td>
+            <td>The root path under which Flink stores its entries in ZooKeeper.</td>
+        </tr>
+        <tr>
+            <td><h5>high-availability.zookeeper.path.running-registry</h5></td>
+            <td>"/running_job_registry/"</td>
+            <td></td>
+        </tr>
+        <tr>
+            <td><h5>high-availability.zookeeper.quorum</h5></td>
+            <td>(none)</td>
+            <td>The ZooKeeper quorum to use, when running Flink in a high-availability mode with ZooKeeper.</td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/_includes/generated/history_server_configuration.html
+++ b/docs/_includes/generated/history_server_configuration.html
@@ -2,7 +2,7 @@
     <thead>
         <tr>
             <th class="text-left" style="width: 20%">Key</th>
-            <th class="text-left" style="width: 15%">Default Value</th>
+            <th class="text-left" style="width: 15%">Default</th>
             <th class="text-left" style="width: 65%">Description</th>
         </tr>
     </thead>

--- a/docs/_includes/generated/job_manager_configuration.html
+++ b/docs/_includes/generated/job_manager_configuration.html
@@ -1,0 +1,46 @@
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 65%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>jobmanager.archive.fs.dir</h5></td>
+            <td>(none)</td>
+            <td></td>
+        </tr>
+        <tr>
+            <td><h5>jobmanager.execution.attempts-history-size</h5></td>
+            <td>16</td>
+            <td>The maximum number of prior execution attempts kept in history.</td>
+        </tr>
+        <tr>
+            <td><h5>jobmanager.execution.failover-strategy</h5></td>
+            <td>"full"</td>
+            <td>The maximum number of prior execution attempts kept in history.</td>
+        </tr>
+        <tr>
+            <td><h5>jobmanager.heap.mb</h5></td>
+            <td>1024</td>
+            <td>JVM heap size (in megabytes) for the JobManager.</td>
+        </tr>
+        <tr>
+            <td><h5>jobmanager.resourcemanager.reconnect-interval</h5></td>
+            <td>2000</td>
+            <td>This option specifies the interval in order to trigger a resource manager reconnection if the connection to the resource manager has been lost. This option is only intended for internal use.</td>
+        </tr>
+        <tr>
+            <td><h5>jobmanager.rpc.address</h5></td>
+            <td>(none)</td>
+            <td>The config parameter defining the network address to connect to for communication with the job manager. This value is only interpreted in setups where a single JobManager with static name or address exists (simple standalone setups, or container setups with dynamic service name resolution). It is not used in many high-availability setups, when a leader-election service (like ZooKeeper) is used to elect and discover the JobManager leader from potentially multiple standby JobManagers.</td>
+        </tr>
+        <tr>
+            <td><h5>jobmanager.rpc.port</h5></td>
+            <td>6123</td>
+            <td>The config parameter defining the network port to connect to for communication with the job manager. Like jobmanager.rpc.address, this value is only interpreted in setups where a single JobManager with static name/address and port exists (simple standalone setups, or container setups with dynamic service name resolution). This config option is not used in many high-availability setups, when a leader-election service (like ZooKeeper) is used to elect and discover the JobManager leader from potentially multiple standby JobManagers.</td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/_includes/generated/kerberos_configuration.html
+++ b/docs/_includes/generated/kerberos_configuration.html
@@ -2,7 +2,7 @@
     <thead>
         <tr>
             <th class="text-left" style="width: 20%">Key</th>
-            <th class="text-left" style="width: 15%">Default Value</th>
+            <th class="text-left" style="width: 15%">Default</th>
             <th class="text-left" style="width: 65%">Description</th>
         </tr>
     </thead>

--- a/docs/_includes/generated/mesos_configuration.html
+++ b/docs/_includes/generated/mesos_configuration.html
@@ -1,0 +1,72 @@
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 65%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>mesos.failover-timeout</h5></td>
+            <td>600</td>
+            <td>The failover timeout in seconds for the Mesos scheduler, after which running tasks are automatically shut down.</td>
+        </tr>
+        <tr>
+            <td><h5>mesos.initial-tasks</h5></td>
+            <td>0</td>
+            <td>The initial workers to bring up when the master starts</td>
+        </tr>
+        <tr>
+            <td><h5>mesos.master</h5></td>
+            <td>(none)</td>
+            <td>The Mesos master URL. The value should be in one of the following forms:
+&#60;ul&#62;
+    &#60;li&#62;&#60;code&#62;host:port&#60;/code&#62;&#60;/li&#62;
+    &#60;li&#62;&#60;code&#62;zk://host1:port1,host2:port2,.../path&#60;/code&#62;&#60;/li&#62;
+    &#60;li&#62;&#60;code&#62;zk://username:password@host1:port1,host2:port2,.../path&#60;/code&#62;&#60;/li&#62;
+    &#60;li&#62;&#60;code&#62;file:///path/to/file&#60;/code&#62;&#60;/li&#62;
+&#60;/ul&#62;</td>
+        </tr>
+        <tr>
+            <td><h5>mesos.maximum-failed-tasks</h5></td>
+            <td>-1</td>
+            <td>The maximum number of failed workers before the cluster fails. May be set to -1 to disable this feature</td>
+        </tr>
+        <tr>
+            <td><h5>mesos.resourcemanager.artifactserver.port</h5></td>
+            <td>0</td>
+            <td>The config parameter defining the Mesos artifact server port to use. Setting the port to 0 will let the OS choose an available port.</td>
+        </tr>
+        <tr>
+            <td><h5>mesos.resourcemanager.artifactserver.ssl.enabled</h5></td>
+            <td>true</td>
+            <td>Enables SSL for the Flink artifact server. Note that security.ssl.enabled also needs to be set to true encryption to enable encryption.</td>
+        </tr>
+        <tr>
+            <td><h5>mesos.resourcemanager.framework.name</h5></td>
+            <td>"Flink"</td>
+            <td>Mesos framework name</td>
+        </tr>
+        <tr>
+            <td><h5>mesos.resourcemanager.framework.principal</h5></td>
+            <td>(none)</td>
+            <td>Mesos framework principal</td>
+        </tr>
+        <tr>
+            <td><h5>mesos.resourcemanager.framework.role</h5></td>
+            <td>"*"</td>
+            <td>Mesos framework role definition</td>
+        </tr>
+        <tr>
+            <td><h5>mesos.resourcemanager.framework.secret</h5></td>
+            <td>(none)</td>
+            <td>Mesos framework secret</td>
+        </tr>
+        <tr>
+            <td><h5>mesos.resourcemanager.framework.user</h5></td>
+            <td>(none)</td>
+            <td>Mesos framework user</td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/_includes/generated/mesos_task_manager_configuration.html
+++ b/docs/_includes/generated/mesos_task_manager_configuration.html
@@ -1,0 +1,61 @@
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 65%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>mesos.constraints.hard.hostattribute</h5></td>
+            <td>(none)</td>
+            <td>Constraints for task placement on mesos.</td>
+        </tr>
+        <tr>
+            <td><h5>mesos.resourcemanager.tasks.bootstrap-cmd</h5></td>
+            <td>(none)</td>
+            <td></td>
+        </tr>
+        <tr>
+            <td><h5>mesos.resourcemanager.tasks.container.image.name</h5></td>
+            <td>(none)</td>
+            <td>Image name to use for the container.</td>
+        </tr>
+        <tr>
+            <td><h5>mesos.resourcemanager.tasks.container.type</h5></td>
+            <td>"mesos"</td>
+            <td>Type of the containerization used: “mesos” or “docker”.</td>
+        </tr>
+        <tr>
+            <td><h5>mesos.resourcemanager.tasks.container.volumes</h5></td>
+            <td>(none)</td>
+            <td>A comma separated list of [host_path:]container_path[:RO|RW]. This allows for mounting additional volumes into your container.</td>
+        </tr>
+        <tr>
+            <td><h5>mesos.resourcemanager.tasks.cpus</h5></td>
+            <td>0.0</td>
+            <td>CPUs to assign to the Mesos workers.</td>
+        </tr>
+        <tr>
+            <td><h5>mesos.resourcemanager.tasks.hostname</h5></td>
+            <td>(none)</td>
+            <td></td>
+        </tr>
+        <tr>
+            <td><h5>mesos.resourcemanager.tasks.mem</h5></td>
+            <td>1024</td>
+            <td>Memory to assign to the Mesos workers in MB.</td>
+        </tr>
+        <tr>
+            <td><h5>mesos.resourcemanager.tasks.taskmanager-cmd</h5></td>
+            <td>"$FLINK_HOME/bin/mesos-taskmanager.sh"</td>
+            <td></td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.numberOfTaskSlots</h5></td>
+            <td>1</td>
+            <td></td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/_includes/generated/metric_configuration.html
+++ b/docs/_includes/generated/metric_configuration.html
@@ -2,7 +2,7 @@
     <thead>
         <tr>
             <th class="text-left" style="width: 20%">Key</th>
-            <th class="text-left" style="width: 15%">Default Value</th>
+            <th class="text-left" style="width: 15%">Default</th>
             <th class="text-left" style="width: 65%">Description</th>
         </tr>
     </thead>

--- a/docs/_includes/generated/netty_configuration.html
+++ b/docs/_includes/generated/netty_configuration.html
@@ -1,0 +1,46 @@
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 65%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>taskmanager.network.netty.client.connectTimeoutSec</h5></td>
+            <td>120</td>
+            <td>The Netty client connection timeout.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.network.netty.client.numThreads</h5></td>
+            <td>-1</td>
+            <td>The number of Netty client threads.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.network.netty.num-arenas</h5></td>
+            <td>-1</td>
+            <td>The number of Netty arenas.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.network.netty.sendReceiveBufferSize</h5></td>
+            <td>0</td>
+            <td>The Netty send and receive buffer size. This defaults to the system buffer size (cat /proc/sys/net/ipv4/tcp_[rw]mem) and is 4 MiB in modern Linux.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.network.netty.server.backlog</h5></td>
+            <td>0</td>
+            <td> The netty server connection backlog.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.network.netty.server.numThreads</h5></td>
+            <td>-1</td>
+            <td>The number of Netty server threads.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.network.netty.transport</h5></td>
+            <td>"nio"</td>
+            <td>The Netty transport type, either "nio" or "epoll"</td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/_includes/generated/optimizer_configuration.html
+++ b/docs/_includes/generated/optimizer_configuration.html
@@ -1,0 +1,26 @@
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 65%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>compiler.delimited-informat.max-line-samples</h5></td>
+            <td>10</td>
+            <td>he maximum number of line samples taken by the compiler for delimited inputs. The samples are used to estimate the number of records. This value can be overridden for a specific input with the input format’s parameters.</td>
+        </tr>
+        <tr>
+            <td><h5>compiler.delimited-informat.max-sample-len</h5></td>
+            <td>2097152</td>
+            <td>The maximal length of a line sample that the compiler takes for delimited inputs. If the length of a single sample exceeds this value (possible because of misconfiguration of the parser), the sampling aborts. This value can be overridden for a specific input with the input format’s parameters.</td>
+        </tr>
+        <tr>
+            <td><h5>compiler.delimited-informat.min-line-samples</h5></td>
+            <td>2</td>
+            <td>The minimum number of line samples taken by the compiler for delimited inputs. The samples are used to estimate the number of records. This value can be overridden for a specific input with the input format’s parameters</td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/_includes/generated/queryable_state_configuration.html
+++ b/docs/_includes/generated/queryable_state_configuration.html
@@ -2,7 +2,7 @@
     <thead>
         <tr>
             <th class="text-left" style="width: 20%">Key</th>
-            <th class="text-left" style="width: 15%">Default Value</th>
+            <th class="text-left" style="width: 15%">Default</th>
             <th class="text-left" style="width: 65%">Description</th>
         </tr>
     </thead>

--- a/docs/_includes/generated/rest_configuration.html
+++ b/docs/_includes/generated/rest_configuration.html
@@ -1,0 +1,21 @@
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 65%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>rest.address</h5></td>
+            <td>"localhost"</td>
+            <td>The address that the server binds itself to / the client connects to.</td>
+        </tr>
+        <tr>
+            <td><h5>rest.port</h5></td>
+            <td>9067</td>
+            <td>The port that the server listens on / the client connects to.</td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/_includes/generated/security_configuration.html
+++ b/docs/_includes/generated/security_configuration.html
@@ -1,0 +1,56 @@
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 65%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>security.ssl.algorithms</h5></td>
+            <td>"TLS_RSA_WITH_AES_128_CBC_SHA"</td>
+            <td>The comma separated list of standard SSL algorithms to be supported. Read more &#60;a href="http://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html#ciphersuites"&#62;here&#60;/a&#62;.</td>
+        </tr>
+        <tr>
+            <td><h5>security.ssl.enabled</h5></td>
+            <td>false</td>
+            <td>Turns on SSL for internal network communication. This can be optionally overridden by flags defined in different transport modules.</td>
+        </tr>
+        <tr>
+            <td><h5>security.ssl.key-password</h5></td>
+            <td>(none)</td>
+            <td>The secret to decrypt the server key in the keystore.</td>
+        </tr>
+        <tr>
+            <td><h5>security.ssl.keystore</h5></td>
+            <td>(none)</td>
+            <td>The Java keystore file to be used by the flink endpoint for its SSL Key and Certificate.</td>
+        </tr>
+        <tr>
+            <td><h5>security.ssl.keystore-password</h5></td>
+            <td>(none)</td>
+            <td>The secret to decrypt the keystore file.</td>
+        </tr>
+        <tr>
+            <td><h5>security.ssl.protocol</h5></td>
+            <td>"TLSv1.2"</td>
+            <td>The SSL protocol version to be supported for the ssl transport. Note that it doesn’t support comma separated list.</td>
+        </tr>
+        <tr>
+            <td><h5>security.ssl.truststore</h5></td>
+            <td>(none)</td>
+            <td>The truststore file containing the public CA certificates to be used by flink endpoints to verify the peer’s certificate.</td>
+        </tr>
+        <tr>
+            <td><h5>security.ssl.truststore-password</h5></td>
+            <td>(none)</td>
+            <td>The secret to decrypt the truststore.</td>
+        </tr>
+        <tr>
+            <td><h5>security.ssl.verify-hostname</h5></td>
+            <td>true</td>
+            <td>Flag to enable peer’s hostname verification during ssl handshake.</td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/_includes/generated/slot_manager_configuration.html
+++ b/docs/_includes/generated/slot_manager_configuration.html
@@ -1,0 +1,21 @@
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 65%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>slotmanager.request-timeout</h5></td>
+            <td>600000</td>
+            <td>The timeout for a slot request to be discarded.</td>
+        </tr>
+        <tr>
+            <td><h5>slotmanager.taskmanager-timeout</h5></td>
+            <td>30000</td>
+            <td>The timeout for an idle task manager to be released.</td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/_includes/generated/task_manager_configuration.html
+++ b/docs/_includes/generated/task_manager_configuration.html
@@ -1,0 +1,146 @@
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 65%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>task.cancellation.interval</h5></td>
+            <td>30000</td>
+            <td></td>
+        </tr>
+        <tr>
+            <td><h5>task.cancellation.timeout</h5></td>
+            <td>180000</td>
+            <td></td>
+        </tr>
+        <tr>
+            <td><h5>task.checkpoint.alignment.max-size</h5></td>
+            <td>-1</td>
+            <td></td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.data.port</h5></td>
+            <td>0</td>
+            <td>The task manager’s port used for data exchange operations.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.data.ssl.enabled</h5></td>
+            <td>true</td>
+            <td>Config parameter to override SSL support for taskmanager's data transport.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.exit-on-fatal-akka-error</h5></td>
+            <td>false</td>
+            <td>Whether the quarantine monitor for task managers shall be started. The quarantine monitor shuts down the actor system if it detects that it has quarantined another actor system or if it has been quarantined by another actor system.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.heap.mb</h5></td>
+            <td>1024</td>
+            <td>JVM heap size (in megabytes) for the TaskManagers.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.host</h5></td>
+            <td>(none)</td>
+            <td>The config parameter defining the task manager's hostname.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.initial-registration-pause</h5></td>
+            <td>"500 ms"</td>
+            <td>The initial registration pause between two consecutive registration attempts. The pause is doubled for each new registration attempt until it reaches the maximum registration pause.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.jvm-exit-on-oom</h5></td>
+            <td>false</td>
+            <td>Whether to kill the TaskManager when the task thread throws an OutOfMemoryError.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.maxRegistrationDuration</h5></td>
+            <td>"Inf"</td>
+            <td>Defines the maximum time it can take for the TaskManager registration. If the duration is exceeded without a successful registration, then the TaskManager terminates.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.memory.fraction</h5></td>
+            <td>0.7</td>
+            <td></td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.memory.off-heap</h5></td>
+            <td>false</td>
+            <td></td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.memory.preallocate</h5></td>
+            <td>false</td>
+            <td></td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.memory.segment-size</h5></td>
+            <td>32768</td>
+            <td>Size of memory buffers used by the network stack and the memory manager (in bytes).</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.memory.size</h5></td>
+            <td>-1</td>
+            <td>Amount of memory to be allocated by the task manager's memory manager (in megabytes). If not set, a relative fraction will be allocated.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.network.detailed-metrics</h5></td>
+            <td>false</td>
+            <td>Boolean flag to enable/disable more detailed metrics about inbound/outbound network queue lengths.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.network.memory.buffers-per-channel</h5></td>
+            <td>2</td>
+            <td>Number of network buffers to use for each outgoing/incoming channel (subpartition/input channel).</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.network.memory.floating-buffers-per-gate</h5></td>
+            <td>8</td>
+            <td>Number of extra network buffers to use for each outgoing/incoming gate (result partition/input gate).</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.network.memory.fraction</h5></td>
+            <td>0.1</td>
+            <td>Fraction of JVM memory to use for network buffers.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.network.memory.max</h5></td>
+            <td>1073741824</td>
+            <td>Maximum memory size for network buffers (in bytes).</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.network.memory.min</h5></td>
+            <td>67108864</td>
+            <td>Minimum memory size for network buffers (in bytes).</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.network.request-backoff.initial</h5></td>
+            <td>100</td>
+            <td>Minimum backoff for partition requests of input channels.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.network.request-backoff.max</h5></td>
+            <td>10000</td>
+            <td>Maximum backoff for partition requests of input channels.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.numberOfTaskSlots</h5></td>
+            <td>1</td>
+            <td>The config parameter defining the number of task slots of a task manager.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.refused-registration-pause</h5></td>
+            <td>"10 s"</td>
+            <td>The pause after a registration has been refused by the job manager before retrying to connect.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.rpc.port</h5></td>
+            <td>"0"</td>
+            <td> The task manager’s IPC port. Accepts a list of ports (“50100,50101”), ranges (“50100-50200”) or a combination of both. It is recommended to set a range of ports to avoid collisions when multiple TaskManagers are running on the same machine.</td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/_includes/generated/web_configuration.html
+++ b/docs/_includes/generated/web_configuration.html
@@ -2,7 +2,7 @@
     <thead>
         <tr>
             <th class="text-left" style="width: 20%">Key</th>
-            <th class="text-left" style="width: 15%">Default Value</th>
+            <th class="text-left" style="width: 15%">Default</th>
             <th class="text-left" style="width: 65%">Description</th>
         </tr>
     </thead>

--- a/docs/_includes/generated/yarn_config_configuration.html
+++ b/docs/_includes/generated/yarn_config_configuration.html
@@ -1,0 +1,61 @@
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 65%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>yarn.application-attempts</h5></td>
+            <td>(none)</td>
+            <td>Number of ApplicationMaster restarts. Note that that the entire Flink cluster will restart and the YARN Client will loose the connection. Also, the JobManager address will change and you’ll need to set the JM host:port manually. It is recommended to leave this option at 1.</td>
+        </tr>
+        <tr>
+            <td><h5>yarn.application-master.port</h5></td>
+            <td>"0"</td>
+            <td>With this configuration option, users can specify a port, a range of ports or a list of ports for the Application Master (and JobManager) RPC port. By default we recommend using the default value (0) to let the operating system choose an appropriate port. In particular when multiple AMs are running on the same physical host, fixed port assignments prevent the AM from starting. For example when running Flink on YARN on an environment with a restrictive firewall, this option allows specifying a range of allowed ports.</td>
+        </tr>
+        <tr>
+            <td><h5>yarn.appmaster.rpc.address</h5></td>
+            <td>(none)</td>
+            <td>The hostname or address where the application master RPC system is listening.</td>
+        </tr>
+        <tr>
+            <td><h5>yarn.appmaster.rpc.port</h5></td>
+            <td>-1</td>
+            <td>The port where the application master RPC system is listening.</td>
+        </tr>
+        <tr>
+            <td><h5>yarn.containers.vcores</h5></td>
+            <td>-1</td>
+            <td>The number of virtual cores (vcores) per YARN container. By default, the number of vcores is set to the number of slots per TaskManager, if set, or to 1, otherwise.</td>
+        </tr>
+        <tr>
+            <td><h5>yarn.heartbeat-delay</h5></td>
+            <td>5</td>
+            <td>Time between heartbeats with the ResourceManager in seconds.</td>
+        </tr>
+        <tr>
+            <td><h5>yarn.maximum-failed-containers</h5></td>
+            <td>(none)</td>
+            <td>Maximum number of containers the system is going to reallocate in case of a failure.</td>
+        </tr>
+        <tr>
+            <td><h5>yarn.per-job-cluster.include-user-jar</h5></td>
+            <td>"ORDER"</td>
+            <td>Defines whether user-jars are included in the system class path for per-job-clusters as well as their positioning in the path. They can be positioned at the beginning ("FIRST"), at the end ("LAST"), or be positioned based on their name ("ORDER").</td>
+        </tr>
+        <tr>
+            <td><h5>yarn.properties-file.location</h5></td>
+            <td>(none)</td>
+            <td>When a Flink job is submitted to YARN, the JobManager’s host and the number of available processing slots is written into a properties file, so that the Flink client is able to pick those details up. This configuration parameter allows changing the default location of that file (for example for environments sharing a Flink installation between users).</td>
+        </tr>
+        <tr>
+            <td><h5>yarn.tags</h5></td>
+            <td>(none)</td>
+            <td>A comma-separated list of tags to apply to the Flink YARN application.</td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/_includes/generated/zoo_keeper_configuration.html
+++ b/docs/_includes/generated/zoo_keeper_configuration.html
@@ -2,7 +2,7 @@
     <thead>
         <tr>
             <th class="text-left" style="width: 20%">Key</th>
-            <th class="text-left" style="width: 15%">Default Value</th>
+            <th class="text-left" style="width: 15%">Default</th>
             <th class="text-left" style="width: 65%">Description</th>
         </tr>
     </thead>

--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -322,35 +322,7 @@ The following parameters configure Flink's JobManager and TaskManagers.
 
 ### Distributed Coordination (via Akka)
 
-- `akka.ask.timeout`: Timeout used for all futures and blocking Akka calls. If Flink fails due to timeouts then you should try to increase this value. Timeouts can be caused by slow machines or a congested network. The timeout value requires a time-unit specifier (ms/s/min/h/d) (DEFAULT: **10 s**).
-
-- `akka.lookup.timeout`: Timeout used for the lookup of the JobManager. The timeout value has to contain a time-unit specifier (ms/s/min/h/d) (DEFAULT: **10 s**).
-
-- `akka.client.timeout`: Timeout used by Flink clients (e.g. `CliFrontend`, `ClusterClient`) when communicating with the Flink cluster. The timeout value has to contain a time-unit specifier (ms/s/min/h/d) (DEFAULT: **60 s**).
-
-- `akka.framesize`: Maximum size of messages which are sent between the JobManager and the TaskManagers. If Flink fails because messages exceed this limit, then you should increase it. The message size requires a size-unit specifier (DEFAULT: **10485760b**).
-
-- `akka.watch.heartbeat.interval`: Heartbeat interval for Akka's DeathWatch mechanism to detect dead TaskManagers. If TaskManagers are wrongly marked dead because of lost or delayed heartbeat messages, then you should decrease this value or increase `akka.watch.heartbeat.pause`. A thorough description of Akka's DeathWatch can be found [here](http://doc.akka.io/docs/akka/snapshot/scala/remoting.html#failure-detector) (DEFAULT: **10 s**).
-
-- `akka.watch.heartbeat.pause`: Acceptable heartbeat pause for Akka's DeathWatch mechanism. A low value does not allow an irregular heartbeat. If TaskManagers are wrongly marked dead because of lost or delayed heartbeat messages, then you should increase this value or decrease `akka.watch.heartbeat.interval`. Higher value increases the time to detect a dead TaskManager. A thorough description of Akka's DeathWatch can be found [here](http://doc.akka.io/docs/akka/snapshot/scala/remoting.html#failure-detector) (DEFAULT: **60 s**).
-
-- `akka.watch.threshold`: Threshold for the DeathWatch failure detector. A low value is prone to false positives whereas a high value increases the time to detect a dead TaskManager. A thorough description of Akka's DeathWatch can be found [here](http://doc.akka.io/docs/akka/snapshot/scala/remoting.html#failure-detector) (DEFAULT: **12**).
-
-- `akka.transport.heartbeat.interval`: Heartbeat interval for Akka's transport failure detector. Since Flink uses TCP, the detector is not necessary. Therefore, the detector is disabled by setting the interval to a very high value. In case you should need the transport failure detector, set the interval to some reasonable value. The interval value requires a time-unit specifier (ms/s/min/h/d) (DEFAULT: **1000 s**).
-
-- `akka.transport.heartbeat.pause`: Acceptable heartbeat pause for Akka's transport failure detector. Since Flink uses TCP, the detector is not necessary. Therefore, the detector is disabled by setting the pause to a very high value. In case you should need the transport failure detector, set the pause to some reasonable value. The pause value requires a time-unit specifier (ms/s/min/h/d) (DEFAULT: **6000 s**).
-
-- `akka.transport.threshold`: Threshold for the transport failure detector. Since Flink uses TCP, the detector is not necessary and, thus, the threshold is set to a high value (DEFAULT: **300**).
-
-- `akka.tcp.timeout`: Timeout for all outbound connections. If you should experience problems with connecting to a TaskManager due to a slow network, you should increase this value (DEFAULT: **20 s**).
-
-- `akka.throughput`: Number of messages that are processed in a batch before returning the thread to the pool. Low values denote a fair scheduling whereas high values can increase the performance at the cost of unfairness (DEFAULT: **15**).
-
-- `akka.log.lifecycle.events`: Turns on the Akka's remote logging of events. Set this value to 'true' in case of debugging (DEFAULT: **false**).
-
-- `akka.startup-timeout`: Timeout after which the startup of a remote component is considered being failed (DEFAULT: **akka.ask.timeout**).
-
-- `akka.ssl.enabled`: Turns on SSL for Akka's remote communication. This is applicable only when the global ssl flag security.ssl.enabled is set to true (DEFAULT: **true**).
+{% include generated/akka_configuration.html %}
 
 ### SSL Settings
 

--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -309,38 +309,7 @@ of the JobManager, because the same ActorSystem is used. Its not possible to use
 
 ### YARN
 
-- `containerized.heap-cutoff-ratio`: (Default 0.25) Percentage of heap space to remove from containers started by YARN. When a user requests a certain amount of memory for each TaskManager container (for example 4 GB), we can not pass this amount as the maximum heap space for the JVM (`-Xmx` argument) because the JVM is also allocating memory outside the heap. YARN is very strict with killing containers which are using more memory than requested. Therefore, we remove this fraction of the memory from the requested heap as a safety margin and add it to the memory used off-heap.
-
-- `containerized.heap-cutoff-min`: (Default 600 MB) Minimum amount of memory to cut off the requested heap size.
-
-- `yarn.maximum-failed-containers` (Default: number of requested containers). Maximum number of containers the system is going to reallocate in case of a failure.
-
-- `yarn.application-attempts` (Default: 1). Number of ApplicationMaster restarts. Note that that the entire Flink cluster will restart and the YARN Client will loose the connection. Also, the JobManager address will change and you'll need to set the JM host:port manually. It is recommended to leave this option at 1.
-
-- `yarn.heartbeat-delay` (Default: 5 seconds). Time between heartbeats with the ResourceManager.
-
-- `yarn.properties-file.location` (Default: temp directory). When a Flink job is submitted to YARN, the JobManager's host and the number of available processing slots is written into a properties file, so that the Flink client is able to pick those details up. This configuration parameter allows changing the default location of that file (for example for environments sharing a Flink installation between users)
-
-- `yarn.containers.vcores` The number of virtual cores (vcores) per YARN container. By default, the number of `vcores` is set to the number of slots per TaskManager, if set, or to 1, otherwise.
-
-- `containerized.master.env.`*ENV_VAR1=value* Configuration values prefixed with `containerized.master.env.` will be passed as environment variables to the ApplicationMaster/JobManager process. For example for passing `LD_LIBRARY_PATH` as an env variable to the ApplicationMaster, set:
-
-    `containerized.master.env.LD_LIBRARY_PATH: "/usr/lib/native"`
-
-- `containerized.taskmanager.env.` Similar to the configuration prefix about, this prefix allows setting custom environment variables for the TaskManager processes.
-
-- `yarn.container-start-command-template`: Flink uses the following template when starting on YARN:
-`%java% %jvmmem% %jvmopts% %logging% %class% %args% %redirects%`. This configuration parameter allows users
-to pass custom settings (such as JVM paths, arguments etc.). Note that in most cases, it is sufficient to
-use the `env.java.opts` setting, which is the `%jvmopts%` variable in the String.
-
-- `yarn.application-master.port` (Default: 0, which lets the OS choose an ephemeral port) With this configuration option, users can specify a port, a range of ports or a list of ports for the  Application Master (and JobManager) RPC port. By default we recommend using the default value (0) to let the operating system choose an appropriate port. In particular when multiple AMs are running on the  same physical host, fixed port assignments prevent the AM from starting.
-
-  For example when running Flink on YARN on an environment with a restrictive firewall, this option allows specifying a range of allowed ports.
-
-- `yarn.tags` A comma-separated list of tags to apply to the Flink YARN application.
-
-- `yarn.per-job-cluster.include-user-jar` (Default: ORDER) Control whether and how the user-jar is included in the system class path for per-job clusters. Setting this parameter to `DISABLED` causes the jar to be included in the user class path instead. Setting this parameter to one of `FIRST`, `LAST` or `ORDER` causes the jar to be included in the system class path, with the jar either being placed at the beginning of the class path (`FIRST`), at the end (`LAST`), or based on the lexicographic order (`ORDER`).
+{% include generated/yarn_config_configuration.html %}
 
 ### Mesos
 

--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -332,19 +332,7 @@ The following parameters configure Flink's JobManager and TaskManagers.
 
 These parameters allow for advanced tuning. The default values are sufficient when running concurrent high-throughput jobs on a large cluster.
 
-- `taskmanager.net.num-arenas`: The number of Netty arenas (DEFAULT: **taskmanager.numberOfTaskSlots**).
-
-- `taskmanager.net.server.numThreads`: The number of Netty server threads (DEFAULT: **taskmanager.numberOfTaskSlots**).
-
-- `taskmanager.net.client.numThreads`: The number of Netty client threads (DEFAULT: **taskmanager.numberOfTaskSlots**).
-
-- `taskmanager.net.server.backlog`: The netty server connection backlog.
-
-- `taskmanager.net.client.connectTimeoutSec`: The Netty client connection timeout (DEFAULT: **120 seconds**).
-
-- `taskmanager.net.sendReceiveBufferSize`: The Netty send and receive buffer size. This defaults to the system buffer size (`cat /proc/sys/net/ipv4/tcp_[rw]mem`) and is 4 MiB in modern Linux.
-
-- `taskmanager.net.transport`: The Netty transport type, either "nio" or "epoll" (DEFAULT: **nio**).
+{% include generated/netty_configuration.html %}
 
 ### Web Frontend
 

--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -290,11 +290,7 @@ These parameters allow for advanced tuning. The default values are sufficient wh
 
 ### Compiler/Optimizer
 
-- `compiler.delimited-informat.max-line-samples`: The maximum number of line samples taken by the compiler for delimited inputs. The samples are used to estimate the number of records. This value can be overridden for a specific input with the input format's parameters (DEFAULT: 10).
-
-- `compiler.delimited-informat.min-line-samples`: The minimum number of line samples taken by the compiler for delimited inputs. The samples are used to estimate the number of records. This value can be overridden for a specific input with the input format's parameters (DEFAULT: 2).
-
-- `compiler.delimited-informat.max-sample-len`: The maximal length of a line sample that the compiler takes for delimited inputs. If the length of a single sample exceeds this value (possible because of misconfiguration of the parser), the sampling aborts. This value can be overridden for a specific input with the input format's parameters (DEFAULT: 2097152 (= 2 MiBytes)).
+{% include generated/optimizer_configuration.html %}
 
 ### Runtime Algorithms
 

--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -258,13 +258,14 @@ These parameters configure the default HDFS used by Flink. Setups that do not sp
 
 - `fs.hdfs.hdfssite`: The absolute path of Hadoop's own configuration file "hdfs-site.xml" (DEFAULT: null).
 
-### JobManager &amp; TaskManager
+### JobManager
 
-The following parameters configure Flink's JobManager and TaskManagers.
+{% include generated/job_manager_configuration.html %}
 
-- `jobmanager.rpc.address`: The external address of the JobManager, which is the master/coordinator of the distributed system (DEFAULT: **localhost**). **Note:** The address (host name or IP) should be accessible by all nodes including the client.
+### TaskManager
 
-- `jobmanager.rpc.port`: The port number of the JobManager (DEFAULT: **6123**).
+The following parameters configure Flink's TaskManagers.
+
 
 - `taskmanager.hostname`: The hostname of the network interface that the TaskManager binds to. By default, the TaskManager searches for network interfaces that can connect to the JobManager and other TaskManagers. This option can be used to define a hostname if that strategy fails for some reason. Because different TaskManagers need different values for this option, it usually is specified in an additional non-shared TaskManager-specific config file.
 
@@ -273,8 +274,6 @@ The following parameters configure Flink's JobManager and TaskManagers.
 - `taskmanager.data.port`: The task manager's port used for data exchange operations (DEFAULT: **0**, which lets the OS choose a free port).
 
 - `taskmanager.data.ssl.enabled`: Enable SSL support for the taskmanager data transport. This is applicable only when the global ssl flag security.ssl.enabled is set to true (DEFAULT: **true**)
-
-- `jobmanager.heap.mb`: JVM heap size (in megabytes) for the JobManager (DEFAULT: **256**).
 
 - `taskmanager.heap.mb`: JVM heap size (in megabytes) for the TaskManagers, which are the parallel workers of the system. In contrast to Hadoop, Flink runs operators (e.g., join, aggregate) and user-defined functions (e.g., Map, Reduce, CoGroup) inside the TaskManager (including sorting/hashing/caching), so this value should be as large as possible (DEFAULT: **512**). On YARN setups, this value is automatically configured to the size of the TaskManager's YARN container, minus a certain tolerance value.
 
@@ -318,7 +317,6 @@ The following parameters configure Flink's JobManager and TaskManagers.
 
 - `taskmanager.exit-on-fatal-akka-error`: Whether the TaskManager shall be terminated in case of a fatal Akka error (quarantining event). (DEFAULT: **false**)
 
-- `jobmanager.tdd.offload.minsize`: Maximum size of the `TaskDeploymentDescriptor`'s serialized task and job information to still transmit them via RPC. Larger blobs may be offloaded to the BLOB server. (DEFAULT: **1 KiB**).
 
 ### Distributed Coordination (via Akka)
 

--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -278,6 +278,10 @@ These parameters configure the default HDFS used by Flink. Setups that do not sp
 
 {% include generated/heartbeat_manager_configuration.html %}
 
+### REST
+
+{% include generated/rest_configuration.html %}
+
 ### SSL Settings
 
 {% include generated/security_configuration.html %}

--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -399,27 +399,7 @@ Previously this key was named `recovery.mode` and the default value was `standal
 
 #### ZooKeeper-based HA Mode
 
-- `high-availability.zookeeper.quorum`: Defines the ZooKeeper quorum URL which is used to connect to the ZooKeeper cluster when the 'zookeeper' HA mode is selected. Previously this key was named `recovery.zookeeper.quorum`.
-
-- `high-availability.zookeeper.path.root`: (Default `/flink`) Defines the root dir under which the ZooKeeper HA mode will create namespace directories. Previously this ket was named `recovery.zookeeper.path.root`.
-
-- `high-availability.zookeeper.path.latch`: (Default `/leaderlatch`) Defines the znode of the leader latch which is used to elect the leader. Previously this key was named `recovery.zookeeper.path.latch`.
-
-- `high-availability.zookeeper.path.leader`: (Default `/leader`) Defines the znode of the leader which contains the URL to the leader and the current leader session ID. Previously this key was named `recovery.zookeeper.path.leader`.
-
-- `high-availability.storageDir`: Defines the directory in the state backend where the JobManager metadata will be stored (ZooKeeper only keeps pointers to it). Required for HA. Previously this key was named `recovery.zookeeper.storageDir` and `high-availability.zookeeper.storageDir`.
-
-- `high-availability.zookeeper.client.session-timeout`: (Default `60000`) Defines the session timeout for the ZooKeeper session in ms. Previously this key was named `recovery.zookeeper.client.session-timeout`
-
-- `high-availability.zookeeper.client.connection-timeout`: (Default `15000`) Defines the connection timeout for ZooKeeper in ms. Previously this key was named `recovery.zookeeper.client.connection-timeout`.
-
-- `high-availability.zookeeper.client.retry-wait`: (Default `5000`) Defines the pause between consecutive retries in ms. Previously this key was named `recovery.zookeeper.client.retry-wait`.
-
-- `high-availability.zookeeper.client.max-retry-attempts`: (Default `3`) Defines the number of connection retries before the client gives up. Previously this key was named `recovery.zookeeper.client.max-retry-attempts`.
-
-- `high-availability.job.delay`: (Default `akka.ask.timeout`) Defines the delay before persisted jobs are recovered in case of a master recovery situation. Previously this key was named `recovery.job.delay`.
-
-- `high-availability.zookeeper.client.acl`: (Default `open`) Defines the ACL (open\|creator) to be configured on ZK node. The configuration value can be set to "creator" if the ZooKeeper server configuration has the "authProvider" property mapped to use SASLAuthenticationProvider and the cluster is configured to run in secure mode (Kerberos). The ACL options are based on https://zookeeper.apache.org/doc/r3.1.2/zookeeperProgrammers.html#sc_BuiltinACLSchemes
+{% include generated/high_availability_zookeeper_configuration.html %}
 
 ### ZooKeeper Security
 

--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -264,59 +264,7 @@ These parameters configure the default HDFS used by Flink. Setups that do not sp
 
 ### TaskManager
 
-The following parameters configure Flink's TaskManagers.
-
-
-- `taskmanager.hostname`: The hostname of the network interface that the TaskManager binds to. By default, the TaskManager searches for network interfaces that can connect to the JobManager and other TaskManagers. This option can be used to define a hostname if that strategy fails for some reason. Because different TaskManagers need different values for this option, it usually is specified in an additional non-shared TaskManager-specific config file.
-
-- `taskmanager.rpc.port`: The task manager's IPC port (DEFAULT: **0**, which lets the OS choose a free port). Flink also accepts a list of ports ("50100,50101"), ranges ("50100-50200") or a combination of both. It is recommended to set a range of ports to avoid collisions when multiple TaskManagers are running on the same machine.
-
-- `taskmanager.data.port`: The task manager's port used for data exchange operations (DEFAULT: **0**, which lets the OS choose a free port).
-
-- `taskmanager.data.ssl.enabled`: Enable SSL support for the taskmanager data transport. This is applicable only when the global ssl flag security.ssl.enabled is set to true (DEFAULT: **true**)
-
-- `taskmanager.heap.mb`: JVM heap size (in megabytes) for the TaskManagers, which are the parallel workers of the system. In contrast to Hadoop, Flink runs operators (e.g., join, aggregate) and user-defined functions (e.g., Map, Reduce, CoGroup) inside the TaskManager (including sorting/hashing/caching), so this value should be as large as possible (DEFAULT: **512**). On YARN setups, this value is automatically configured to the size of the TaskManager's YARN container, minus a certain tolerance value.
-
-- `taskmanager.numberOfTaskSlots`: The number of parallel operator or user function instances that a single TaskManager can run (DEFAULT: **1**). If this value is larger than 1, a single TaskManager takes multiple instances of a function or operator. That way, the TaskManager can utilize multiple CPU cores, but at the same time, the available memory is divided between the different operator or function instances. This value is typically proportional to the number of physical CPU cores that the TaskManager's machine has (e.g., equal to the number of cores, or half the number of cores).
-
-- `taskmanager.tmp.dirs`: The directory for temporary files, or a list of directories separated by the system's directory delimiter (for example ':' (colon) on Linux/Unix). If multiple directories are specified, then the temporary files will be distributed across the directories in a round robin fashion. The I/O manager component will spawn one reading and one writing thread per directory. A directory may be listed multiple times to have the I/O manager use multiple threads for it (for example if it is physically stored on a very fast disc or RAID) (DEFAULT: **The system's tmp dir**).
-
-- `taskmanager.network.memory.fraction`: Fraction of JVM memory to use for network buffers. This determines how many streaming data exchange channels a TaskManager can have at the same time and how well buffered the channels are. If a job is rejected or you get a warning that the system has not enough buffers available, increase this value or the min/max values below. Also note, that `taskmanager.network.memory.min` and `taskmanager.network.memory.max` may override this fraction. (DEFAULT: **0.1**)
-
-- `taskmanager.network.memory.min`: Minimum memory size for network buffers in bytes (DEFAULT: **64 MB**). Previously, this was determined from `taskmanager.network.numberOfBuffers` and `taskmanager.memory.segment-size`.
-
-- `taskmanager.network.memory.max`: Maximum memory size for network buffers in bytes (DEFAULT: **1 GB**). Previously, this was determined from `taskmanager.network.numberOfBuffers` and `taskmanager.memory.segment-size`.
-
-- `taskmanager.network.numberOfBuffers` (deprecated, replaced by the three parameters above): The number of buffers available to the network stack. This number determines how many streaming data exchange channels a TaskManager can have at the same time and how well buffered the channels are. If a job is rejected or you get a warning that the system has not enough buffers available, increase this value (DEFAULT: **2048**). If set, it will be mapped to `taskmanager.network.memory.min` and `taskmanager.network.memory.max` based on `taskmanager.memory.segment-size`.
-
-- `taskmanager.memory.size`: The amount of memory (in megabytes) that the task manager reserves on the JVM's heap space for sorting, hash tables, and caching of intermediate results. If unspecified (-1), the memory manager will take a fixed ratio of the heap memory available to the JVM, as specified by `taskmanager.memory.fraction`. (DEFAULT: **-1**)
-
-- `taskmanager.memory.fraction`: The relative amount of memory (with respect to `taskmanager.heap.mb`, after subtracting the amount of memory used by network buffers) that the task manager reserves for sorting, hash tables, and caching of intermediate results. For example, a value of `0.8` means that a task manager reserves 80% of its memory (on-heap or off-heap depending on `taskmanager.memory.off-heap`) for internal data buffers, leaving 20% of free memory for the task manager's heap for objects created by user-defined functions. (DEFAULT: 0.7) This parameter is only evaluated, if `taskmanager.memory.size` is not set.
-
-- `taskmanager.debug.memory.startLogThread`: Causes the TaskManagers to periodically log memory and Garbage collection statistics. The statistics include current heap-, off-heap, and other memory pool utilization, as well as the time spent on garbage collection, by heap memory pool.
-
-- `taskmanager.debug.memory.logIntervalMs`: The interval (in milliseconds) in which the TaskManagers log the memory and garbage collection statistics. Only has an effect, if `taskmanager.debug.memory.startLogThread` is set to true.
-
-- `taskmanager.maxRegistrationDuration`: Defines the maximum time it can take for the TaskManager registration. If the duration is exceeded without a successful registration, then the TaskManager terminates. The max registration duration requires a time unit specifier (ms/s/min/h/d) (e.g. "10 min"). (DEFAULT: **Inf**)
-
-- `taskmanager.initial-registration-pause`: The initial registration pause between two consecutive registration attempts. The pause is doubled for each new registration attempt until it reaches the maximum registration pause. The initial registration pause requires a time unit specifier (ms/s/min/h/d) (e.g. "5 s"). (DEFAULT: **500 ms**)
-
-- `taskmanager.max-registration-pause`: The maximum registration pause between two consecutive registration attempts. The max registration pause requires a time unit specifier (ms/s/min/h/d) (e.g. "5 s"). (DEFAULT: **30 s**)
-
-- `taskmanager.refused-registration-pause`: The pause after a registration has been refused by the job manager before retrying to connect. The refused registration pause requires a time unit specifier (ms/s/min/h/d) (e.g. "5 s"). (DEFAULT: **10 s**)
-
-- `taskmanager.jvm-exit-on-oom`: Indicates that the TaskManager should immediately terminate the JVM if the task thread throws an `OutOfMemoryError` (DEFAULT: **false**).
-
-- `blob.fetch.retries`: The number of retries for the TaskManager to download BLOBs (such as JAR files) from the JobManager (DEFAULT: **50**).
-
-- `blob.fetch.num-concurrent`: The number concurrent BLOB fetches (such as JAR file downloads) that the JobManager serves (DEFAULT: **50**).
-
-- `blob.fetch.backlog`: The maximum number of queued BLOB fetches (such as JAR file downloads) that the JobManager allows (DEFAULT: **1000**).
-
-- `task.cancellation-interval`: Time interval between two successive task cancellation attempts in milliseconds (DEFAULT: **30000**).
-
-- `taskmanager.exit-on-fatal-akka-error`: Whether the TaskManager shall be terminated in case of a fatal Akka error (quarantining event). (DEFAULT: **false**)
-
+{% include generated/task_manager_configuration.html %}
 
 ### Distributed Coordination (via Akka)
 

--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -527,9 +527,7 @@ You have to configure `jobmanager.archive.fs.dir` in order to archive terminated
 
 The configuration keys in this section are relevant for the SlotManager running in the Flip-6 ResourceManager
 
-- `slotmanager.request-timeout`: Timeout after which a slot request will be discarded by the SlotManager. The value is specified in milli seconds (DEFAULT: `300000`).
-
-- `slotmanager.taskmanager-timeout`: Timeout after which an idling task manager's container is released (DEFAULT: `30000`).
+{% include generated/slot_manager_configuration.html %}
 
 ## Background
 

--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -326,23 +326,7 @@ The following parameters configure Flink's JobManager and TaskManagers.
 
 ### SSL Settings
 
-- `security.ssl.enabled`: Turns on SSL for internal network communication. This can be optionally overridden by flags defined in different transport modules (DEFAULT: **false**).
-
-- `security.ssl.keystore`: The Java keystore file to be used by the flink endpoint for its SSL Key and Certificate.
-
-- `security.ssl.keystore-password`: The secret to decrypt the keystore file.
-
-- `security.ssl.key-password`: The secret to decrypt the server key in the keystore.
-
-- `security.ssl.truststore`: The truststore file containing the public CA certificates to be used by flink endpoints to verify the peer's certificate.
-
-- `security.ssl.truststore-password`: The secret to decrypt the truststore.
-
-- `security.ssl.protocol`: The SSL protocol version to be supported for the ssl transport (DEFAULT: **TLSv1.2**). Note that it doesn't support comma separated list.
-
-- `security.ssl.algorithms`: The comma separated list of standard SSL algorithms to be supported. Read more [here](http://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html#ciphersuites) (DEFAULT: **TLS_RSA_WITH_AES_128_CBC_SHA**).
-
-- `security.ssl.verify-hostname`: Flag to enable peer's hostname verification during ssl handshake (DEFAULT: **true**).
+{% include generated/security_configuration.html %}
 
 ### Network communication (via Netty)
 

--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -270,6 +270,10 @@ These parameters configure the default HDFS used by Flink. Setups that do not sp
 
 {% include generated/akka_configuration.html %}
 
+### Blob Server
+
+{% include generated/blob_server_configuration.html %}
+
 ### SSL Settings
 
 {% include generated/security_configuration.html %}

--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -396,16 +396,7 @@ These parameters allow for advanced tuning. The default values are sufficient wh
 
 ### File Systems
 
-The parameters define the behavior of tasks that create result files.
-
-- `fs.default-scheme`: The default filesystem scheme to be used, with the necessary authority to contact, e.g. the host:port of the NameNode in the case of HDFS (if needed).
-By default, this is set to `file:///` which points to the local filesystem. This means that the local
-filesystem is going to be used to search for user-specified files **without** an explicit scheme
-definition. This scheme is used **ONLY** if no other scheme is specified (explicitly) in the user-provided `URI`.
-
-- `fs.overwrite-files`: Specifies whether file output writers should overwrite existing files by default. Set to *true* to overwrite by default, *false* otherwise. (DEFAULT: false)
-
-- `fs.output.always-create-directory`: File writers running with a parallelism larger than one create a directory for the output file path and put the different result files (one per parallel writer task) into that directory. If this option is set to *true*, writers with a parallelism of 1 will also create a directory and place a single result file into it. If the option is set to *false*, the writer will directly create the file directly at the output path, without creating a containing directory. (DEFAULT: false)
+{% include generated/file_system_configuration.html %}
 
 ### Compiler/Optimizer
 

--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -274,6 +274,10 @@ These parameters configure the default HDFS used by Flink. Setups that do not sp
 
 {% include generated/blob_server_configuration.html %}
 
+### Heartbeat Manager
+
+{% include generated/heartbeat_manager_configuration.html %}
+
 ### SSL Settings
 
 {% include generated/security_configuration.html %}

--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -313,48 +313,11 @@ of the JobManager, because the same ActorSystem is used. Its not possible to use
 
 ### Mesos
 
+{% include generated/mesos_configuration.html %}
 
-- `mesos.initial-tasks`: The initial workers to bring up when the master starts (**DEFAULT**: The number of workers specified at cluster startup).
+#### Mesos TaskManager
 
-- `mesos.constraints.hard.hostattribute`: Constraints for task placement on mesos (**DEFAULT**: None).
-
-- `mesos.maximum-failed-tasks`: The maximum number of failed workers before the cluster fails (**DEFAULT**: Number of initial workers).
-May be set to -1 to disable this feature.
-
-- `mesos.master`: The Mesos master URL. The value should be in one of the following forms:
-  * `host:port`
-  * `zk://host1:port1,host2:port2,.../path`
-  * `zk://username:password@host1:port1,host2:port2,.../path`
-  * `file:///path/to/file`
-
-
-- `mesos.failover-timeout`: The failover timeout in seconds for the Mesos scheduler, after which running tasks are automatically shut down (**DEFAULT:** 600).
-
-- `mesos.resourcemanager.artifactserver.port`:The config parameter defining the Mesos artifact server port to use. Setting the port to 0 will let the OS choose an available port.
-
-- `mesos.resourcemanager.framework.name`: Mesos framework name (**DEFAULT:** Flink)
-
-- `mesos.resourcemanager.framework.role`: Mesos framework role definition (**DEFAULT:** *)
-
-- `mesos.resourcemanager.framework.principal`: Mesos framework principal (**NO DEFAULT**)
-
-- `mesos.resourcemanager.framework.secret`: Mesos framework secret (**NO DEFAULT**)
-
-- `mesos.resourcemanager.framework.user`: Mesos framework user (**DEFAULT:**"")
-
-- `mesos.resourcemanager.artifactserver.ssl.enabled`: Enables SSL for the Flink artifact server (**DEFAULT**: true). Note that `security.ssl.enabled` also needs to be set to `true` encryption to enable encryption.
-
-- `mesos.resourcemanager.tasks.mem`: Memory to assign to the Mesos workers in MB (**DEFAULT**: 1024)
-
-- `mesos.resourcemanager.tasks.cpus`: CPUs to assign to the Mesos workers (**DEFAULT**: 0.0)
-
-- `mesos.resourcemanager.tasks.container.type`: Type of the containerization used: "mesos" or "docker" (DEFAULT: mesos);
-
-- `mesos.resourcemanager.tasks.container.image.name`: Image name to use for the container (**NO DEFAULT**)
-
-- `mesos.resourcemanager.tasks.container.volumes`: A comma separated list of `[host_path:]`container_path`[:RO|RW]`. This allows for mounting additional volumes into your container. (**NO DEFAULT**)
-
-- `high-availability.zookeeper.path.mesos-workers`: The ZooKeeper root path for persisting the Mesos worker information.
+{% include generated/mesos_task_manager_configuration.html %}
 
 ### High Availability (HA)
 

--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -361,6 +361,10 @@ Previously this key was named `recovery.mode` and the default value was `standal
 
 - `env.ssh.opts`: Additional command line options passed to SSH clients when starting or stopping JobManager, TaskManager, and Zookeeper services (start-cluster.sh, stop-cluster.sh, start-zookeeper-quorum.sh, stop-zookeeper-quorum.sh).
 
+### Checkpointing
+
+{% include generated/checkpointing_configuration.html %}
+
 ### Queryable State
 
 {% include generated/queryable_state_configuration.html %}

--- a/flink-clients/src/main/java/org/apache/flink/client/LocalExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/LocalExecutor.java
@@ -26,6 +26,7 @@ import org.apache.flink.api.common.PlanExecutor;
 import org.apache.flink.api.common.Program;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.optimizer.DataStatistics;
 import org.apache.flink.optimizer.Optimizer;
 import org.apache.flink.optimizer.dag.DataSinkNode;
@@ -232,7 +233,7 @@ public class LocalExecutor extends PlanExecutor {
 	private Configuration createConfiguration() {
 		Configuration configuration = new Configuration();
 		configuration.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, getTaskManagerNumSlots());
-		configuration.setBoolean(ConfigConstants.FILESYSTEM_DEFAULT_OVERWRITE_KEY, isDefaultOverwriteFiles());
+		configuration.setBoolean(CoreOptions.FILESYTEM_DEFAULT_OVERRIDE, isDefaultOverwriteFiles());
 		return configuration;
 	}
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/DelimitedInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/DelimitedInputFormat.java
@@ -21,9 +21,9 @@ package org.apache.flink.api.common.io;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.io.statistics.BaseStatistics;
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.GlobalConfiguration;
+import org.apache.flink.configuration.OptimizerOptions;
 import org.apache.flink.core.fs.FileInputSplit;
 import org.apache.flink.core.fs.FileStatus;
 import org.apache.flink.core.fs.FileSystem;
@@ -97,20 +97,18 @@ public abstract class DelimitedInputFormat<OT> extends FileInputFormat<OT> imple
 	}
 
 	protected static void loadConfigParameters(Configuration parameters) {
-		int maxSamples = parameters.getInteger(ConfigConstants.DELIMITED_FORMAT_MAX_LINE_SAMPLES_KEY,
-				ConfigConstants.DEFAULT_DELIMITED_FORMAT_MAX_LINE_SAMPLES);
-		int minSamples = parameters.getInteger(ConfigConstants.DELIMITED_FORMAT_MIN_LINE_SAMPLES_KEY,
-			ConfigConstants.DEFAULT_DELIMITED_FORMAT_MIN_LINE_SAMPLES);
+		int maxSamples = parameters.getInteger(OptimizerOptions.DELIMITED_FORMAT_MAX_LINE_SAMPLES);
+		int minSamples = parameters.getInteger(OptimizerOptions.DELIMITED_FORMAT_MIN_LINE_SAMPLES);
 		
 		if (maxSamples < 0) {
 			LOG.error("Invalid default maximum number of line samples: " + maxSamples + ". Using default value of " +
-				ConfigConstants.DEFAULT_DELIMITED_FORMAT_MAX_LINE_SAMPLES);
-			maxSamples = ConfigConstants.DEFAULT_DELIMITED_FORMAT_MAX_LINE_SAMPLES;
+				OptimizerOptions.DELIMITED_FORMAT_MAX_LINE_SAMPLES.key());
+			maxSamples = OptimizerOptions.DELIMITED_FORMAT_MAX_LINE_SAMPLES.defaultValue();
 		}
 		if (minSamples < 0) {
 			LOG.error("Invalid default minimum number of line samples: " + minSamples + ". Using default value of " +
-				ConfigConstants.DEFAULT_DELIMITED_FORMAT_MIN_LINE_SAMPLES);
-			minSamples = ConfigConstants.DEFAULT_DELIMITED_FORMAT_MIN_LINE_SAMPLES;
+				OptimizerOptions.DELIMITED_FORMAT_MIN_LINE_SAMPLES.key());
+			minSamples = OptimizerOptions.DELIMITED_FORMAT_MIN_LINE_SAMPLES.defaultValue();
 		}
 		
 		DEFAULT_MAX_NUM_SAMPLES = maxSamples;
@@ -123,10 +121,9 @@ public abstract class DelimitedInputFormat<OT> extends FileInputFormat<OT> imple
 			DEFAULT_MIN_NUM_SAMPLES = minSamples;
 		}
 		
-		int maxLen = parameters.getInteger(ConfigConstants.DELIMITED_FORMAT_MAX_SAMPLE_LENGTH_KEY,
-				ConfigConstants.DEFAULT_DELIMITED_FORMAT_MAX_SAMPLE_LEN);
+		int maxLen = parameters.getInteger(OptimizerOptions.DELIMITED_FORMAT_MAX_SAMPLE_LEN);
 		if (maxLen <= 0) {
-			maxLen = ConfigConstants.DEFAULT_DELIMITED_FORMAT_MAX_SAMPLE_LEN;
+			maxLen = OptimizerOptions.DELIMITED_FORMAT_MAX_SAMPLE_LEN.defaultValue();
 			LOG.error("Invalid value for the maximum sample record length. Using defailt value of " + maxLen + '.');
 		} else if (maxLen < DEFAULT_READ_BUFFER_SIZE) {
 			maxLen = DEFAULT_READ_BUFFER_SIZE;

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/FileOutputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/FileOutputFormat.java
@@ -22,10 +22,10 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 
 import org.apache.flink.annotation.Public;
+import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.GlobalConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.FSDataOutputStream;
 import org.apache.flink.core.fs.FileSystem;
@@ -73,15 +73,11 @@ public abstract class FileOutputFormat<IT> extends RichOutputFormat<IT> implemen
 	 * @param configuration The configuration to load defaults from
 	 */
 	private static void initDefaultsFromConfiguration(Configuration configuration) {
-		final boolean overwrite = configuration.getBoolean(
-				ConfigConstants.FILESYSTEM_DEFAULT_OVERWRITE_KEY,
-				ConfigConstants.DEFAULT_FILESYSTEM_OVERWRITE);
+		final boolean overwrite = configuration.getBoolean(CoreOptions.FILESYTEM_DEFAULT_OVERRIDE);
 	
 		DEFAULT_WRITE_MODE = overwrite ? WriteMode.OVERWRITE : WriteMode.NO_OVERWRITE;
 		
-		final boolean alwaysCreateDirectory = configuration.getBoolean(
-			ConfigConstants.FILESYSTEM_OUTPUT_ALWAYS_CREATE_DIRECTORY_KEY,
-			ConfigConstants.DEFAULT_FILESYSTEM_ALWAYS_CREATE_DIRECTORY);
+		final boolean alwaysCreateDirectory = configuration.getBoolean(CoreOptions.FILESYSTEM_OUTPUT_ALWAYS_CREATE_DIRECTORY);
 	
 		DEFAULT_OUTPUT_DIRECTORY_MODE = alwaysCreateDirectory ? OutputDirectoryMode.ALWAYS : OutputDirectoryMode.PARONLY;
 	}

--- a/flink-core/src/main/java/org/apache/flink/configuration/AkkaOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/AkkaOptions.java
@@ -22,7 +22,6 @@ import org.apache.flink.annotation.PublicEvolving;
 
 /**
  * Akka configuration options.
- * TODO: Migrate other akka config options to this file
  */
 @PublicEvolving
 public class AkkaOptions {
@@ -32,98 +31,135 @@ public class AkkaOptions {
 	 */
 	public static final ConfigOption<String> ASK_TIMEOUT = ConfigOptions
 		.key("akka.ask.timeout")
-		.defaultValue("10 s");
+		.defaultValue("10 s")
+		.withDescription("Timeout used for all futures and blocking Akka calls. If Flink fails due to timeouts then you" +
+			" should try to increase this value. Timeouts can be caused by slow machines or a congested network. The" +
+			" timeout value requires a time-unit specifier (ms/s/min/h/d).");
 
 	/**
 	 * The Akka death watch heartbeat interval.
 	 */
 	public static final ConfigOption<String> WATCH_HEARTBEAT_INTERVAL = ConfigOptions
 		.key("akka.watch.heartbeat.interval")
-		.defaultValue(ASK_TIMEOUT.defaultValue());
+		.defaultValue(ASK_TIMEOUT.defaultValue())
+		.withDescription("Heartbeat interval for Akka’s DeathWatch mechanism to detect dead TaskManagers. If" +
+			" TaskManagers are wrongly marked dead because of lost or delayed heartbeat messages, then you should" +
+			" decrease this value or increase akka.watch.heartbeat.pause. A thorough description of Akka’s DeathWatch" +
+			" can be found <a href=\"http://doc.akka.io/docs/akka/snapshot/scala/remoting.html#failure-detector\">here</a>.");
 
 	/**
 	 * The maximum acceptable Akka death watch heartbeat pause.
 	 */
 	public static final ConfigOption<String> WATCH_HEARTBEAT_PAUSE = ConfigOptions
 		.key("akka.watch.heartbeat.pause")
-		.defaultValue("60 s");
-
+		.defaultValue("60 s")
+		.withDescription("Acceptable heartbeat pause for Akka’s DeathWatch mechanism. A low value does not allow an" +
+			" irregular heartbeat. If TaskManagers are wrongly marked dead because of lost or delayed heartbeat messages," +
+			" then you should increase this value or decrease akka.watch.heartbeat.interval. Higher value increases the" +
+			" time to detect a dead TaskManager. A thorough description of Akka’s DeathWatch can be found" +
+			" <a href=\"http://doc.akka.io/docs/akka/snapshot/scala/remoting.html#failure-detector\">here</a>.");
 	/**
 	 * The Akka tcp connection timeout.
 	 */
 	public static final ConfigOption<String> TCP_TIMEOUT = ConfigOptions
 		.key("akka.tcp.timeout")
-		.defaultValue("20 s");
+		.defaultValue("20 s")
+		.withDescription("Timeout for all outbound connections. If you should experience problems with connecting to a" +
+			" TaskManager due to a slow network, you should increase this value.");
 
 	/**
 	 * Timeout for the startup of the actor system.
 	 */
 	public static final ConfigOption<String> STARTUP_TIMEOUT = ConfigOptions
 		.key("akka.startup-timeout")
-		.noDefaultValue();
+		.noDefaultValue()
+		.withDescription("Timeout after which the startup of a remote component is considered being failed.");
 
 	/**
 	 * Heartbeat interval of the transport failure detector.
 	 */
 	public static final ConfigOption<String> TRANSPORT_HEARTBEAT_INTERVAL = ConfigOptions
 		.key("akka.transport.heartbeat.interval")
-		.defaultValue("1000 s");
+		.defaultValue("1000 s")
+		.withDescription("Heartbeat interval for Akka’s transport failure detector. Since Flink uses TCP, the detector" +
+			" is not necessary. Therefore, the detector is disabled by setting the interval to a very high value. In" +
+			" case you should need the transport failure detector, set the interval to some reasonable value. The" +
+			" interval value requires a time-unit specifier (ms/s/min/h/d).");
 
 	/**
 	 * Allowed heartbeat pause for the transport failure detector.
 	 */
 	public static final ConfigOption<String> TRANSPORT_HEARTBEAT_PAUSE = ConfigOptions
 		.key("akka.transport.heartbeat.pause")
-		.defaultValue("6000 s");
+		.defaultValue("6000 s")
+		.withDescription("Acceptable heartbeat pause for Akka’s transport failure detector. Since Flink uses TCP, the" +
+			" detector is not necessary. Therefore, the detector is disabled by setting the pause to a very high value." +
+			" In case you should need the transport failure detector, set the pause to some reasonable value." +
+			" The pause value requires a time-unit specifier (ms/s/min/h/d).");
 
 	/**
 	 * Detection threshold of transport failure detector.
 	 */
 	public static final ConfigOption<Double> TRANSPORT_THRESHOLD = ConfigOptions
 		.key("akka.transport.threshold")
-		.defaultValue(300.0);
+		.defaultValue(300.0)
+		.withDescription("Threshold for the transport failure detector. Since Flink uses TCP, the detector is not" +
+			" necessary and, thus, the threshold is set to a high value.");
 
 	/**
 	 * Detection threshold for the phi accrual watch failure detector.
 	 */
 	public static final ConfigOption<Integer> WATCH_THRESHOLD = ConfigOptions
 		.key("akka.watch.threshold")
-		.defaultValue(12);
+		.defaultValue(12)
+		.withDescription("Threshold for the DeathWatch failure detector. A low value is prone to false positives whereas" +
+			" a high value increases the time to detect a dead TaskManager. A thorough description of Akka’s DeathWatch" +
+			" can be found <a href=\"http://doc.akka.io/docs/akka/snapshot/scala/remoting.html#failure-detector\">here</a>.");
 
 	/**
 	 * Override SSL support for the Akka transport.
 	 */
 	public static final ConfigOption<Boolean> SSL_ENABLED = ConfigOptions
 		.key("akka.ssl.enabled")
-		.defaultValue(true);
+		.defaultValue(true)
+		.withDescription("Turns on SSL for Akka’s remote communication. This is applicable only when the global ssl flag" +
+			" security.ssl.enabled is set to true.");
 
 	/**
 	 * Maximum framesize of akka messages.
 	 */
 	public static final ConfigOption<String> FRAMESIZE = ConfigOptions
 		.key("akka.framesize")
-		.defaultValue("10485760b");
+		.defaultValue("10485760b")
+		.withDescription("Maximum size of messages which are sent between the JobManager and the TaskManagers. If Flink" +
+			" fails because messages exceed this limit, then you should increase it. The message size requires a" +
+			" size-unit specifier.");
 
 	/**
 	 * Maximum number of messages until another actor is executed by the same thread.
 	 */
 	public static final ConfigOption<Integer> DISPATCHER_THROUGHPUT = ConfigOptions
 		.key("akka.throughput")
-		.defaultValue(15);
+		.defaultValue(15)
+		.withDescription("Number of messages that are processed in a batch before returning the thread to the pool. Low" +
+			" values denote a fair scheduling whereas high values can increase the performance at the cost of unfairness.");
 
 	/**
 	 * Log lifecycle events.
 	 */
 	public static final ConfigOption<Boolean> LOG_LIFECYCLE_EVENTS = ConfigOptions
 		.key("akka.log.lifecycle.events")
-		.defaultValue(false);
+		.defaultValue(false)
+		.withDescription("Turns on the Akka’s remote logging of events. Set this value to ‘true’ in case of debugging.");
 
 	/**
 	 * Timeout for all blocking calls that look up remote actors.
 	 */
 	public static final ConfigOption<String> LOOKUP_TIMEOUT = ConfigOptions
 		.key("akka.lookup.timeout")
-		.defaultValue("10 s");
+		.defaultValue("10 s")
+		.withDescription("Timeout used for the lookup of the JobManager. The timeout value has to contain a time-unit" +
+			" specifier (ms/s/min/h/d).");
 
 	/**
 	 * Timeout for all blocking calls on the client side.

--- a/flink-core/src/main/java/org/apache/flink/configuration/BlobServerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/BlobServerOptions.java
@@ -33,28 +33,32 @@ public class BlobServerOptions {
 	 */
 	public static final ConfigOption<String> STORAGE_DIRECTORY =
 		key("blob.storage.directory")
-			.noDefaultValue();
+			.noDefaultValue()
+			.withDescription("The config parameter defining the storage directory to be used by the blob server.");
 
 	/**
 	 * The config parameter defining number of retires for failed BLOB fetches.
 	 */
 	public static final ConfigOption<Integer> FETCH_RETRIES =
 		key("blob.fetch.retries")
-			.defaultValue(5);
+			.defaultValue(5)
+			.withDescription("The config parameter defining number of retires for failed BLOB fetches.");
 
 	/**
 	 * The config parameter defining the maximum number of concurrent BLOB fetches that the JobManager serves.
 	 */
 	public static final ConfigOption<Integer> FETCH_CONCURRENT =
 		key("blob.fetch.num-concurrent")
-			.defaultValue(50);
+			.defaultValue(50)
+			.withDescription("The config parameter defining the maximum number of concurrent BLOB fetches that the JobManager serves.");
 
 	/**
 	 * The config parameter defining the backlog of BLOB fetches on the JobManager.
 	 */
 	public static final ConfigOption<Integer> FETCH_BACKLOG =
 		key("blob.fetch.backlog")
-			.defaultValue(1000);
+			.defaultValue(1000)
+			.withDescription("The config parameter defining the backlog of BLOB fetches on the JobManager.");
 
 	/**
 	 * The config parameter defining the server port of the blob service.
@@ -66,14 +70,16 @@ public class BlobServerOptions {
 	 */
 	public static final ConfigOption<String> PORT =
 		key("blob.server.port")
-			.defaultValue("0");
+			.defaultValue("0")
+			.withDescription("The config parameter defining the server port of the blob service.");
 
 	/**
 	 * Flag to override ssl support for the blob service transport.
 	 */
 	public static final ConfigOption<Boolean> SSL_ENABLED =
 		key("blob.service.ssl.enabled")
-			.defaultValue(true);
+			.defaultValue(true)
+			.withDescription("Flag to override ssl support for the blob service transport.");
 
 	/**
 	 * Cleanup interval of the blob caches at the task managers (in seconds).
@@ -87,11 +93,13 @@ public class BlobServerOptions {
 	public static final ConfigOption<Long> CLEANUP_INTERVAL =
 		key("blob.service.cleanup.interval")
 			.defaultValue(3_600L) // once per hour
-			.withDeprecatedKeys("library-cache-manager.cleanup.interval");
+			.withDeprecatedKeys("library-cache-manager.cleanup.interval")
+			.withDescription("Cleanup interval of the blob caches at the task managers (in seconds).");
 
 	/**
 	 * The minimum size for messages to be offloaded to the BlobServer.
 	 */
 	public static final ConfigOption<Integer> OFFLOAD_MINSIZE = key("blob.offload.minsize")
-		.defaultValue(1_024 * 1_024); // 1MiB by default
+		.defaultValue(1_024 * 1_024) // 1MiB by default
+		.withDescription("The minimum size for messages to be offloaded to the BlobServer.");
 }

--- a/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
@@ -31,12 +31,14 @@ public class CheckpointingOptions {
 	/** The state backend to be used to store and checkpoint state. */
 	public static final ConfigOption<String> STATE_BACKEND = ConfigOptions
 			.key("state.backend")
-			.noDefaultValue();
+			.noDefaultValue()
+			.withDescription("The state backend to be used to store and checkpoint state.");
 
 	/** The maximum number of completed checkpoints to retain.*/
 	public static final ConfigOption<Integer> MAX_RETAINED_CHECKPOINTS = ConfigOptions
 			.key("state.checkpoints.num-retained")
-			.defaultValue(1);
+			.defaultValue(1)
+			.withDescription("The maximum number of completed checkpoints to retain.");
 
 	/** Option whether the state backend should use an asynchronous snapshot method where
 	 * possible and configurable.
@@ -45,7 +47,10 @@ public class CheckpointingOptions {
 	 * asynchronous snapshots, and ignore this option. */
 	public static final ConfigOption<Boolean> ASYNC_SNAPSHOTS = ConfigOptions
 			.key("state.backend.async")
-			.defaultValue(true);
+			.defaultValue(true)
+			.withDescription("Option whether the state backend should use an asynchronous snapshot method where" +
+				" possible and configurable. Some state backends may not support asynchronous snapshots, or only support" +
+				" asynchronous snapshots, and ignore this option.");
 
 	/** Option whether the state backend should create incremental checkpoints,
 	 * if possible. For an incremental checkpoint, only a diff from the previous
@@ -55,7 +60,11 @@ public class CheckpointingOptions {
 	 * this option.*/
 	public static final ConfigOption<Boolean> INCREMENTAL_CHECKPOINTS = ConfigOptions
 			.key("state.backend.incremental")
-			.defaultValue(false);
+			.defaultValue(false)
+			.withDescription("Option whether the state backend should create incremental checkpoints, if possible. For" +
+				" an incremental checkpoint, only a diff from the previous checkpoint is stored, rather than the" +
+				" complete checkpoint state. Some state backends may not support incremental checkpoints and ignore" +
+				" this option.");
 
 	// ------------------------------------------------------------------------
 	//  Options specific to the file-system-based state backends
@@ -66,19 +75,25 @@ public class CheckpointingOptions {
 	public static final ConfigOption<String> SAVEPOINT_DIRECTORY = ConfigOptions
 			.key("state.savepoints.dir")
 			.noDefaultValue()
-			.withDeprecatedKeys("savepoints.state.backend.fs.dir");
+			.withDeprecatedKeys("savepoints.state.backend.fs.dir")
+			.withDescription("The default directory for savepoints. Used by the state backends that write savepoints to" +
+				" file systems (MemoryStateBackend, FsStateBackend, RocksDBStateBackend).");
 
 	/** The default directory used for checkpoints. Used by the state backends that write
 	 * checkpoints to file systems (MemoryStateBackend, FsStateBackend, RocksDBStateBackend). */
 	public static final ConfigOption<String> CHECKPOINTS_DIRECTORY = ConfigOptions
 			.key("state.checkpoints.dir")
-			.noDefaultValue();
+			.noDefaultValue()
+			.withDescription("The default directory used for checkpoints. Used by the state backends that write" +
+				" checkpoints to file systems (MemoryStateBackend, FsStateBackend, RocksDBStateBackend).");
 
 	/** The minimum size of state data files. All state chunks smaller than that
 	 * are stored inline in the root checkpoint metadata file. */
 	public static final ConfigOption<Integer> FS_SMALL_FILE_THRESHOLD = ConfigOptions
 			.key("state.backend.fs.memory-threshold")
-			.defaultValue(1024);
+			.defaultValue(1024)
+			.withDescription("The minimum size of state data files. All state chunks smaller than that are stored" +
+				" inline in the root checkpoint metadata file.");
 
 	// ------------------------------------------------------------------------
 	//  Options specific to the RocksDB state backend
@@ -88,5 +103,6 @@ public class CheckpointingOptions {
 	public static final ConfigOption<String> ROCKSDB_LOCAL_DIRECTORIES = ConfigOptions
 			.key("state.backend.rocksdb.localdir")
 			.noDefaultValue()
-			.withDeprecatedKeys("state.backend.rocksdb.checkpointdir");
+			.withDeprecatedKeys("state.backend.rocksdb.checkpointdir")
+			.withDescription("The local directory (on the TaskManager) where RocksDB puts its files.");
 }

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -188,7 +188,10 @@ public final class ConfigConstants {
 
 	/**
 	 * The config parameter defining the task manager's hostname.
+	 *
+	 * @deprecated use {@link TaskManagerOptions#HOST} instead
 	 */
+	@Deprecated
 	public static final String TASK_MANAGER_HOSTNAME_KEY = "taskmanager.hostname";
 
 	/**
@@ -204,7 +207,10 @@ public final class ConfigConstants {
 
 	/**
 	 * Config parameter to override SSL support for taskmanager's data transport.
+	 *
+	 * @deprecated use {@link TaskManagerOptions#DATA_SSL_ENABLED} instead
 	 */
+	@Deprecated
 	public static final String TASK_MANAGER_DATA_SSL_ENABLED = "taskmanager.data.ssl.enabled";
 
 	/**
@@ -281,7 +287,10 @@ public final class ConfigConstants {
 
 	/**
 	 * The config parameter defining the number of task slots of a task manager.
+	 *
+	 * @deprecated use {@link TaskManagerOptions#NUM_TASK_SLOTS} instead
 	 */
+	@Deprecated
 	public static final String TASK_MANAGER_NUM_TASK_SLOTS = "taskmanager.numberOfTaskSlots";
 
 	/**
@@ -297,13 +306,19 @@ public final class ConfigConstants {
 	/**
 	 * Defines the maximum time it can take for the TaskManager registration. If the duration is
 	 * exceeded without a successful registration, then the TaskManager terminates.
+	 *
+	 * @deprecated use {@link TaskManagerOptions#MAX_REGISTRATION_DURATION} instead
 	 */
+	@Deprecated
 	public static final String TASK_MANAGER_MAX_REGISTRATION_DURATION = "taskmanager.maxRegistrationDuration";
 
 	/**
 	 * The initial registration pause between two consecutive registration attempts. The pause
 	 * is doubled for each new registration attempt until it reaches the maximum registration pause.
+	 *
+	 * @deprecated use {@link TaskManagerOptions#INITIAL_REGISTRATION_PAUSE} instead
 	 */
+	@Deprecated
 	public static final String TASK_MANAGER_INITIAL_REGISTRATION_PAUSE = "taskmanager.initial-registration-pause";
 
 	/**
@@ -313,7 +328,10 @@ public final class ConfigConstants {
 
 	/**
 	 * The pause after a registration has been refused by the job manager before retrying to connect.
+	 *
+	 * @deprecated use {@link TaskManagerOptions#REFUSED_REGISTRATION_PAUSE} instead
 	 */
+	@Deprecated
 	public static final String TASK_MANAGER_REFUSED_REGISTRATION_PAUSE = "taskmanager.refused-registration-pause";
 
 	/**
@@ -1342,12 +1360,18 @@ public final class ConfigConstants {
 	/**
 	 * The default network port the task manager expects to receive transfer envelopes on. The {@code 0} means that
 	 * the TaskManager searches for a free port.
+	 *
+	 * @deprecated use {@link TaskManagerOptions#DATA_PORT} instead
 	 */
+	@Deprecated
 	public static final int DEFAULT_TASK_MANAGER_DATA_PORT = 0;
 
 	/**
 	 * The default value to override ssl support for task manager's data transport.
+	 *
+	 * @deprecated use {@link TaskManagerOptions#DATA_SSL_ENABLED} instead
 	 */
+	@Deprecated
 	public static final boolean DEFAULT_TASK_MANAGER_DATA_SSL_ENABLED = true;
 
 	/**
@@ -1400,12 +1424,18 @@ public final class ConfigConstants {
 
 	/**
 	 * The default task manager's maximum registration duration.
+	 *
+	 * @deprecated use {@link TaskManagerOptions#MAX_REGISTRATION_DURATION} instead
 	 */
+	@Deprecated
 	public static final String DEFAULT_TASK_MANAGER_MAX_REGISTRATION_DURATION = "Inf";
 
 	/**
 	 * The default task manager's initial registration pause.
+	 *
+	 * @deprecated use {@link TaskManagerOptions#INITIAL_REGISTRATION_PAUSE} instead
 	 */
+	@Deprecated
 	public static final String DEFAULT_TASK_MANAGER_INITIAL_REGISTRATION_PAUSE = "500 ms";
 
 	/**
@@ -1415,7 +1445,10 @@ public final class ConfigConstants {
 
 	/**
 	 * The default task manager's refused registration pause.
+	 *
+	 * @deprecated use {@link TaskManagerOptions#REFUSED_REGISTRATION_PAUSE} instead
 	 */
+	@Deprecated
 	public static final String DEFAULT_TASK_MANAGER_REFUSED_REGISTRATION_PAUSE = "10 s";
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -677,18 +677,27 @@ public final class ConfigConstants {
 	/**
 	 * The maximum number of line samples to be taken by the delimited input format, if no
 	 * other value is specified for the data source.
+	 *
+	 * @deprecated use {@link OptimizerOptions#DELIMITED_FORMAT_MAX_LINE_SAMPLES} instead
 	 */
+	@Deprecated
 	public static final String DELIMITED_FORMAT_MAX_LINE_SAMPLES_KEY = "compiler.delimited-informat.max-line-samples";
 
 	/**
 	 * The minimum number of line samples to be taken by the delimited input format, if no
 	 * other value is specified for the data source.
+	 *
+	 * @deprecated use {@link OptimizerOptions#DELIMITED_FORMAT_MIN_LINE_SAMPLES} instead
 	 */
+	@Deprecated
 	public static final String DELIMITED_FORMAT_MIN_LINE_SAMPLES_KEY = "compiler.delimited-informat.min-line-samples";
 
 	/**
 	 * The maximum length of a single sampled record before the sampling is aborted.
+	 *
+	 * @deprecated use {@link OptimizerOptions#DELIMITED_FORMAT_MAX_SAMPLE_LEN} instead
 	 */
+	@Deprecated
 	public static final String DELIMITED_FORMAT_MAX_SAMPLE_LENGTH_KEY = "compiler.delimited-informat.max-sample-len";
 
 
@@ -1588,17 +1597,26 @@ public final class ConfigConstants {
 
 	/**
 	 * The default maximum number of line samples taken by the delimited input format.
+	 *
+	 * @deprecated use {@link OptimizerOptions#DELIMITED_FORMAT_MAX_LINE_SAMPLES} instead
 	 */
+	@Deprecated
 	public static final int DEFAULT_DELIMITED_FORMAT_MAX_LINE_SAMPLES = 10;
 
 	/**
 	 * The default minimum number of line samples taken by the delimited input format.
+	 *
+	 * @deprecated use {@link OptimizerOptions#DELIMITED_FORMAT_MIN_LINE_SAMPLES} instead
 	 */
+	@Deprecated
 	public static final int DEFAULT_DELIMITED_FORMAT_MIN_LINE_SAMPLES = 2;
 
 	/**
 	 * The default maximum sample length before sampling is aborted (2 MiBytes).
+	 *
+	 * @deprecated use {@link OptimizerOptions#DELIMITED_FORMAT_MAX_SAMPLE_LEN} instead
 	 */
+	@Deprecated
 	public static final int DEFAULT_DELIMITED_FORMAT_MAX_SAMPLE_LEN = 2 * 1024 * 1024;
 
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -640,12 +640,18 @@ public final class ConfigConstants {
 
 	/**
 	 * Key to specify whether the file systems should simply overwrite existing files.
+	 *
+	 * @deprecated Use {@link CoreOptions#FILESYTEM_DEFAULT_OVERRIDE} instead.
 	 */
+	@Deprecated
 	public static final String FILESYSTEM_DEFAULT_OVERWRITE_KEY = "fs.overwrite-files";
 
 	/**
 	 * Key to specify whether the file systems should always create a directory for the output, even with a parallelism of one.
+	 *
+	 * @deprecated Use {@link CoreOptions#FILESYSTEM_OUTPUT_ALWAYS_CREATE_DIRECTORY} instead.
 	 */
+	@Deprecated
 	public static final String FILESYSTEM_OUTPUT_ALWAYS_CREATE_DIRECTORY_KEY = "fs.output.always-create-directory";
 
 	// ---------------------------- Compiler -------------------------------
@@ -1538,7 +1544,10 @@ public final class ConfigConstants {
 
 	/**
 	 * The default behavior for output directory creating (create only directory when parallelism &gt; 1).
+	 *
+	 * @deprecated Use {@link CoreOptions#FILESYSTEM_OUTPUT_ALWAYS_CREATE_DIRECTORY} instead.
 	 */
+	@Deprecated
 	public static final boolean DEFAULT_FILESYSTEM_ALWAYS_CREATE_DIRECTORY = false;
 
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
@@ -26,6 +26,9 @@ import static org.apache.flink.configuration.ConfigOptions.key;
  * The set of configuration options for core parameters.
  */
 @PublicEvolving
+@ConfigGroups(groups = {
+	@ConfigGroup(name = "FileSystem", keyPrefix = "fs")
+})
 public class CoreOptions {
 
 	// ------------------------------------------------------------------------
@@ -127,7 +130,24 @@ public class CoreOptions {
 	 */
 	public static final ConfigOption<String> DEFAULT_FILESYSTEM_SCHEME = ConfigOptions
 			.key("fs.default-scheme")
-			.noDefaultValue();
+			.noDefaultValue()
+			.withDescription("The default filesystem scheme, used for paths that do not declare a scheme explicitly.");
+
+	/**
+	 * Specifies whether file output writers should overwrite existing files by default.
+	 */
+	public static final ConfigOption<Boolean> FILESYTEM_DEFAULT_OVERRIDE =
+		key("fs.overwrite-files")
+			.defaultValue(false)
+			.withDescription("Specifies whether file output writers should overwrite existing files by default. Set to *true* to overwrite by default, *false* otherwise.");
+
+	/**
+	 * Specifies whether the file systems should always create a directory for the output, even with a parallelism of one.
+	 */
+	public static final ConfigOption<Boolean> FILESYSTEM_OUTPUT_ALWAYS_CREATE_DIRECTORY =
+		key("fs.output.always-create-directory")
+			.defaultValue(false)
+			.withDescription("File writers running with a parallelism larger than one create a directory for the output file path and put the different result files (one per parallel writer task) into that directory. If this option is set to *true*, writers with a parallelism of 1 will also create a directory and place a single result file into it. If the option is set to *false*, the writer will directly create the file directly at the output path, without creating a containing directory.");
 
 	/**
 	 * The total number of input plus output connections that a file system for the given scheme may open.

--- a/flink-core/src/main/java/org/apache/flink/configuration/HeartbeatManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/HeartbeatManagerOptions.java
@@ -31,12 +31,14 @@ public class HeartbeatManagerOptions {
 	/** Time interval for requesting heartbeat from sender side. */
 	public static final ConfigOption<Long> HEARTBEAT_INTERVAL =
 			key("heartbeat.interval")
-			.defaultValue(10000L);
+			.defaultValue(10000L)
+			.withDescription("Time interval for requesting heartbeat from sender side.");
 
 	/** Timeout for requesting and receiving heartbeat for both sender and receiver sides. */
 	public static final ConfigOption<Long> HEARTBEAT_TIMEOUT =
 			key("heartbeat.timeout")
-			.defaultValue(50000L);
+			.defaultValue(50000L)
+			.withDescription("Timeout for requesting and receiving heartbeat for both sender and receiver sides.");
 
 	// ------------------------------------------------------------------------
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/HighAvailabilityOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/HighAvailabilityOptions.java
@@ -26,6 +26,9 @@ import static org.apache.flink.configuration.ConfigOptions.key;
  * The set of configuration options relating to high-availability settings.
  */
 @PublicEvolving
+@ConfigGroups(groups = {
+	@ConfigGroup(name = "HighAvailabilityZookeeper", keyPrefix = "high-availability.zookeeper")
+})
 public class HighAvailabilityOptions {
 
 	// ------------------------------------------------------------------------
@@ -90,7 +93,8 @@ public class HighAvailabilityOptions {
 	public static final ConfigOption<String> HA_ZOOKEEPER_QUORUM =
 			key("high-availability.zookeeper.quorum")
 			.noDefaultValue()
-			.withDeprecatedKeys("recovery.zookeeper.quorum");
+			.withDeprecatedKeys("recovery.zookeeper.quorum")
+			.withDescription("The ZooKeeper quorum to use, when running Flink in a high-availability mode with ZooKeeper.");
 
 	/**
 	 * The root path under which Flink stores its entries in ZooKeeper.
@@ -98,42 +102,50 @@ public class HighAvailabilityOptions {
 	public static final ConfigOption<String> HA_ZOOKEEPER_ROOT =
 			key("high-availability.zookeeper.path.root")
 			.defaultValue("/flink")
-			.withDeprecatedKeys("recovery.zookeeper.path.root");
+			.withDeprecatedKeys("recovery.zookeeper.path.root")
+			.withDescription("The root path under which Flink stores its entries in ZooKeeper.");
 
 	public static final ConfigOption<String> HA_ZOOKEEPER_LATCH_PATH =
 			key("high-availability.zookeeper.path.latch")
 			.defaultValue("/leaderlatch")
-			.withDeprecatedKeys("recovery.zookeeper.path.latch");
+			.withDeprecatedKeys("recovery.zookeeper.path.latch")
+			.withDescription(" Defines the znode of the leader latch which is used to elect the leader.");
 
 	/** ZooKeeper root path (ZNode) for job graphs. */
 	public static final ConfigOption<String> HA_ZOOKEEPER_JOBGRAPHS_PATH =
 			key("high-availability.zookeeper.path.jobgraphs")
 			.defaultValue("/jobgraphs")
-			.withDeprecatedKeys("recovery.zookeeper.path.jobgraphs");
+			.withDeprecatedKeys("recovery.zookeeper.path.jobgraphs")
+			.withDescription("ZooKeeper root path (ZNode) for job graphs");
 
 	public static final ConfigOption<String> HA_ZOOKEEPER_LEADER_PATH =
 			key("high-availability.zookeeper.path.leader")
 			.defaultValue("/leader")
-			.withDeprecatedKeys("recovery.zookeeper.path.leader");
+			.withDeprecatedKeys("recovery.zookeeper.path.leader")
+			.withDescription("Defines the znode of the leader which contains the URL to the leader and the current" +
+				" leader session ID.");
 
 	/** ZooKeeper root path (ZNode) for completed checkpoints. */
 	public static final ConfigOption<String> HA_ZOOKEEPER_CHECKPOINTS_PATH =
 			key("high-availability.zookeeper.path.checkpoints")
 			.defaultValue("/checkpoints")
-			.withDeprecatedKeys("recovery.zookeeper.path.checkpoints");
+			.withDeprecatedKeys("recovery.zookeeper.path.checkpoints")
+			.withDescription("ZooKeeper root path (ZNode) for completed checkpoints.");
 
 	/** ZooKeeper root path (ZNode) for checkpoint counters. */
 	public static final ConfigOption<String> HA_ZOOKEEPER_CHECKPOINT_COUNTER_PATH =
 			key("high-availability.zookeeper.path.checkpoint-counter")
 			.defaultValue("/checkpoint-counter")
-			.withDeprecatedKeys("recovery.zookeeper.path.checkpoint-counter");
+			.withDeprecatedKeys("recovery.zookeeper.path.checkpoint-counter")
+			.withDescription("ZooKeeper root path (ZNode) for checkpoint counters.");
 
 	/** ZooKeeper root path (ZNode) for Mesos workers. */
 	@PublicEvolving
 	public static final ConfigOption<String> HA_ZOOKEEPER_MESOS_WORKERS_PATH =
 			key("high-availability.zookeeper.path.mesos-workers")
 			.defaultValue("/mesos-workers")
-			.withDeprecatedKeys("recovery.zookeeper.path.mesos-workers");
+			.withDeprecatedKeys("recovery.zookeeper.path.mesos-workers")
+			.withDescription("ZooKeeper root path (ZNode) for Mesos workers.");
 
 	// ------------------------------------------------------------------------
 	//  ZooKeeper Client Settings
@@ -142,22 +154,26 @@ public class HighAvailabilityOptions {
 	public static final ConfigOption<Integer> ZOOKEEPER_SESSION_TIMEOUT =
 			key("high-availability.zookeeper.client.session-timeout")
 			.defaultValue(60000)
-			.withDeprecatedKeys("recovery.zookeeper.client.session-timeout");
+			.withDeprecatedKeys("recovery.zookeeper.client.session-timeout")
+			.withDescription("Defines the session timeout for the ZooKeeper session in ms.");
 
 	public static final ConfigOption<Integer> ZOOKEEPER_CONNECTION_TIMEOUT =
 			key("high-availability.zookeeper.client.connection-timeout")
 			.defaultValue(15000)
-			.withDeprecatedKeys("recovery.zookeeper.client.connection-timeout");
+			.withDeprecatedKeys("recovery.zookeeper.client.connection-timeout")
+			.withDescription("Defines the connection timeout for ZooKeeper in ms.");
 
 	public static final ConfigOption<Integer> ZOOKEEPER_RETRY_WAIT =
 			key("high-availability.zookeeper.client.retry-wait")
 			.defaultValue(5000)
-			.withDeprecatedKeys("recovery.zookeeper.client.retry-wait");
+			.withDeprecatedKeys("recovery.zookeeper.client.retry-wait")
+			.withDescription("Defines the pause between consecutive retries in ms.");
 
 	public static final ConfigOption<Integer> ZOOKEEPER_MAX_RETRY_ATTEMPTS =
 			key("high-availability.zookeeper.client.max-retry-attempts")
 			.defaultValue(3)
-			.withDeprecatedKeys("recovery.zookeeper.client.max-retry-attempts");
+			.withDeprecatedKeys("recovery.zookeeper.client.max-retry-attempts")
+			.withDescription("Defines the number of connection retries before the client gives up.");
 
 	public static final ConfigOption<String> ZOOKEEPER_RUNNING_JOB_REGISTRY_PATH =
 			key("high-availability.zookeeper.path.running-registry")
@@ -165,7 +181,12 @@ public class HighAvailabilityOptions {
 
 	public static final ConfigOption<String> ZOOKEEPER_CLIENT_ACL =
 			key("high-availability.zookeeper.client.acl")
-			.defaultValue("open");
+			.defaultValue("open")
+			.withDescription("Defines the ACL (open|creator) to be configured on ZK node. The configuration value can be" +
+				" set to “creator” if the ZooKeeper server configuration has the “authProvider” property mapped to use" +
+				" SASLAuthenticationProvider and the cluster is configured to run in secure mode (Kerberos). The ACL" +
+				" options are based on" +
+				" <a href=\"https://zookeeper.apache.org/doc/r3.1.2/zookeeperProgrammers.html#sc_BuiltinACLSchemes\">this document<a/>");
 
 	// ------------------------------------------------------------------------
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
@@ -40,7 +40,14 @@ public class JobManagerOptions {
 	 */
 	public static final ConfigOption<String> ADDRESS =
 		key("jobmanager.rpc.address")
-		.noDefaultValue();
+		.noDefaultValue()
+		.withDescription("The config parameter defining the network address to connect to" +
+			" for communication with the job manager." +
+			" This value is only interpreted in setups where a single JobManager with static" +
+			" name or address exists (simple standalone setups, or container setups with dynamic" +
+			" service name resolution). It is not used in many high-availability setups, when a" +
+			" leader-election service (like ZooKeeper) is used to elect and discover the JobManager" +
+			" leader from potentially multiple standby JobManagers.");
 
 	/**
 	 * The config parameter defining the network port to connect to
@@ -55,14 +62,23 @@ public class JobManagerOptions {
 	 */
 	public static final ConfigOption<Integer> PORT =
 		key("jobmanager.rpc.port")
-		.defaultValue(6123);
+		.defaultValue(6123)
+		.withDescription("The config parameter defining the network port to connect to" +
+			" for communication with the job manager." +
+			" Like " + ADDRESS.key() + ", this value is only interpreted in setups where" +
+			" a single JobManager with static name/address and port exists (simple standalone setups," +
+			" or container setups with dynamic service name resolution)." +
+			" This config option is not used in many high-availability setups, when a" +
+			" leader-election service (like ZooKeeper) is used to elect and discover the JobManager" +
+			" leader from potentially multiple standby JobManagers.");
 
 	/**
 	 * JVM heap size (in megabytes) for the JobManager.
 	 */
 	public static final ConfigOption<Integer> JOB_MANAGER_HEAP_MEMORY =
 		key("jobmanager.heap.mb")
-		.defaultValue(1024);
+		.defaultValue(1024)
+		.withDescription("JVM heap size (in megabytes) for the JobManager.");
 
 	/**
 	 * The maximum number of prior execution attempts kept in history.
@@ -70,14 +86,16 @@ public class JobManagerOptions {
 	public static final ConfigOption<Integer> MAX_ATTEMPTS_HISTORY_SIZE =
 		key("jobmanager.execution.attempts-history-size")
 			.defaultValue(16)
-			.withDeprecatedKeys("job-manager.max-attempts-history-size");
+			.withDeprecatedKeys("job-manager.max-attempts-history-size")
+			.withDescription("The maximum number of prior execution attempts kept in history.");
 
 	/**
 	 * The maximum number of prior execution attempts kept in history.
 	 */
 	public static final ConfigOption<String> EXECUTION_FAILOVER_STRATEGY =
 		key("jobmanager.execution.failover-strategy")
-			.defaultValue("full");
+			.defaultValue("full")
+			.withDescription("The maximum number of prior execution attempts kept in history.");
 
 	/**
 	 * This option specifies the interval in order to trigger a resource manager reconnection if the connection
@@ -87,7 +105,9 @@ public class JobManagerOptions {
 	 */
 	public static final ConfigOption<Long> RESOURCE_MANAGER_RECONNECT_INTERVAL =
 		key("jobmanager.resourcemanager.reconnect-interval")
-		.defaultValue(2000L);
+		.defaultValue(2000L)
+		.withDescription("This option specifies the interval in order to trigger a resource manager reconnection if the connection" +
+			" to the resource manager has been lost. This option is only intended for internal use.");
 
 	/**
 	 * The location where the JobManager stores the archives of completed jobs.

--- a/flink-core/src/main/java/org/apache/flink/configuration/OptimizerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/OptimizerOptions.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.configuration;
+
+import static org.apache.flink.configuration.ConfigOptions.key;
+
+/**
+ * Configuration options for the optimizer.
+ */
+public class OptimizerOptions {
+
+	/**
+	 * The maximum number of line samples taken by the compiler for delimited inputs. The samples are used to estimate
+	 * the number of records. This value can be overridden for a specific input with the input format’s parameters.
+	 */
+	public static final ConfigOption<Integer> DELIMITED_FORMAT_MAX_LINE_SAMPLES =
+		key("compiler.delimited-informat.max-line-samples")
+			.defaultValue(10)
+			.withDescription("he maximum number of line samples taken by the compiler for delimited inputs. The samples" +
+				" are used to estimate the number of records. This value can be overridden for a specific input with the" +
+				" input format’s parameters.");
+
+	/**
+	 * The minimum number of line samples taken by the compiler for delimited inputs. The samples are used to estimate
+	 * the number of records. This value can be overridden for a specific input with the input format’s parameters.
+	 */
+	public static final ConfigOption<Integer> DELIMITED_FORMAT_MIN_LINE_SAMPLES =
+		key("compiler.delimited-informat.min-line-samples")
+			.defaultValue(2)
+			.withDescription("The minimum number of line samples taken by the compiler for delimited inputs. The samples" +
+				" are used to estimate the number of records. This value can be overridden for a specific input with the" +
+				" input format’s parameters");
+
+	/**
+	 * The maximal length of a line sample that the compiler takes for delimited inputs. If the length of a single
+	 * sample exceeds this value (possible because of misconfiguration of the parser), the sampling aborts. This value
+	 * can be overridden for a specific input with the input format’s parameters.
+	 */
+	public static final ConfigOption<Integer> DELIMITED_FORMAT_MAX_SAMPLE_LEN =
+		key("compiler.delimited-informat.max-sample-len")
+			.defaultValue(2097152)
+			.withDescription("The maximal length of a line sample that the compiler takes for delimited inputs. If the" +
+				" length of a single sample exceeds this value (possible because of misconfiguration of the parser)," +
+				" the sampling aborts. This value can be overridden for a specific input with the input format’s" +
+				" parameters.");
+}

--- a/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
@@ -24,6 +24,9 @@ import org.apache.flink.annotation.PublicEvolving;
  * The set of configuration options relating to the ResourceManager.
  */
 @PublicEvolving
+@ConfigGroups(groups = {
+	@ConfigGroup(name = "SlotManager", keyPrefix = "slotmanager")
+})
 public class ResourceManagerOptions {
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/configuration/RestOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/RestOptions.java
@@ -33,12 +33,14 @@ public class RestOptions {
 	 */
 	public static final ConfigOption<String> REST_ADDRESS =
 		key("rest.address")
-			.defaultValue("localhost");
+			.defaultValue("localhost")
+			.withDescription("The address that the server binds itself to / the client connects to.");
 
 	/**
 	 * The port that the server listens on / the client connects to.
 	 */
 	public static final ConfigOption<Integer> REST_PORT =
 		key("rest.port")
-			.defaultValue(9067);
+			.defaultValue(9067)
+			.withDescription("The port that the server listens on / the client connects to.");
 }

--- a/flink-core/src/main/java/org/apache/flink/configuration/SecurityOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/SecurityOptions.java
@@ -86,49 +86,59 @@ public class SecurityOptions {
 	 */
 	public static final ConfigOption<Boolean> SSL_ENABLED =
 		key("security.ssl.enabled")
-			.defaultValue(false);
+			.defaultValue(false)
+			.withDescription("Turns on SSL for internal network communication. This can be optionally overridden by" +
+				" flags defined in different transport modules.");
 
 	/**
 	 * The Java keystore file containing the flink endpoint key and certificate.
 	 */
 	public static final ConfigOption<String> SSL_KEYSTORE =
 		key("security.ssl.keystore")
-			.noDefaultValue();
+			.noDefaultValue()
+			.withDescription("The Java keystore file to be used by the flink endpoint for its SSL Key and Certificate.");
 
 	/**
 	 * Secret to decrypt the keystore file.
 	 */
 	public static final ConfigOption<String> SSL_KEYSTORE_PASSWORD =
 		key("security.ssl.keystore-password")
-			.noDefaultValue();
+			.noDefaultValue()
+			.withDescription("The secret to decrypt the keystore file.");
 
 	/**
 	 * Secret to decrypt the server key.
 	 */
 	public static final ConfigOption<String> SSL_KEY_PASSWORD =
 		key("security.ssl.key-password")
-			.noDefaultValue();
+			.noDefaultValue()
+			.withDescription("The secret to decrypt the server key in the keystore.");
 
 	/**
 	 * The truststore file containing the public CA certificates to verify the ssl peers.
 	 */
 	public static final ConfigOption<String> SSL_TRUSTSTORE =
 		key("security.ssl.truststore")
-			.noDefaultValue();
+			.noDefaultValue()
+			.withDescription("The truststore file containing the public CA certificates to be used by flink endpoints" +
+				" to verify the peer’s certificate.");
 
 	/**
 	 * Secret to decrypt the truststore.
 	 */
 	public static final ConfigOption<String> SSL_TRUSTSTORE_PASSWORD =
 		key("security.ssl.truststore-password")
-			.noDefaultValue();
+			.noDefaultValue()
+			.withDescription("The secret to decrypt the truststore.");
 
 	/**
 	 * SSL protocol version to be supported.
 	 */
 	public static final ConfigOption<String> SSL_PROTOCOL =
 		key("security.ssl.protocol")
-			.defaultValue("TLSv1.2");
+			.defaultValue("TLSv1.2")
+			.withDescription("The SSL protocol version to be supported for the ssl transport. Note that it doesn’t" +
+				" support comma separated list.");
 
 	/**
 	 * The standard SSL algorithms to be supported.
@@ -137,12 +147,15 @@ public class SecurityOptions {
 	 */
 	public static final ConfigOption<String> SSL_ALGORITHMS =
 		key("security.ssl.algorithms")
-			.defaultValue("TLS_RSA_WITH_AES_128_CBC_SHA");
+			.defaultValue("TLS_RSA_WITH_AES_128_CBC_SHA")
+			.withDescription("The comma separated list of standard SSL algorithms to be supported. Read more" +
+				" <a href=\"http://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html#ciphersuites\">here</a>.");
 
 	/**
 	 * Flag to enable/disable hostname verification for the ssl connections.
 	 */
 	public static final ConfigOption<Boolean> SSL_VERIFY_HOSTNAME =
 		key("security.ssl.verify-hostname")
-			.defaultValue(true);
+			.defaultValue(true)
+			.withDescription("Flag to enable peer’s hostname verification during ssl handshake.");
 }

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -39,14 +39,16 @@ public class TaskManagerOptions {
 	 */
 	public static final ConfigOption<Integer> TASK_MANAGER_HEAP_MEMORY =
 			key("taskmanager.heap.mb")
-			.defaultValue(1024);
+			.defaultValue(1024)
+			.withDescription("JVM heap size (in megabytes) for the TaskManagers.");
 
 	/**
 	 * Whether to kill the TaskManager when the task thread throws an OutOfMemoryError.
 	 */
 	public static final ConfigOption<Boolean> KILL_ON_OUT_OF_MEMORY =
 			key("taskmanager.jvm-exit-on-oom")
-			.defaultValue(false);
+			.defaultValue(false)
+			.withDescription("Whether to kill the TaskManager when the task thread throws an OutOfMemoryError.");
 
 	/**
 	 * Whether the quarantine monitor for task managers shall be started. The quarantine monitor
@@ -55,7 +57,18 @@ public class TaskManagerOptions {
 	 */
 	public static final ConfigOption<Boolean> EXIT_ON_FATAL_AKKA_ERROR =
 			key("taskmanager.exit-on-fatal-akka-error")
-			.defaultValue(false);
+			.defaultValue(false)
+			.withDescription("Whether the quarantine monitor for task managers shall be started. The quarantine monitor" +
+				" shuts down the actor system if it detects that it has quarantined another actor system" +
+				" or if it has been quarantined by another actor system.");
+
+	/**
+	 * The config parameter defining the task manager's hostname.
+	 */
+	public static final ConfigOption<String> HOST =
+		key("taskmanager.host")
+			.noDefaultValue()
+			.withDescription("The config parameter defining the task manager's hostname.");
 
 	/**
 	 * The default network port range the task manager expects incoming IPC connections. The {@code "0"} means that
@@ -63,7 +76,63 @@ public class TaskManagerOptions {
 	 */
 	public static final ConfigOption<String> RPC_PORT =
 		key("taskmanager.rpc.port")
-			.defaultValue("0");
+			.defaultValue("0")
+			.withDescription(" The task manager’s IPC port. Accepts a list of ports (“50100,50101”), ranges" +
+				" (“50100-50200”) or a combination of both. It is recommended to set a range of ports to avoid" +
+				" collisions when multiple TaskManagers are running on the same machine.");
+
+	/**
+	 * The default network port the task manager expects to receive transfer envelopes on. The {@code 0} means that
+	 * the TaskManager searches for a free port.
+	 */
+	public static final ConfigOption<Integer> DATA_PORT =
+		key("taskmanager.data.port")
+			.defaultValue(0)
+			.withDescription("The task manager’s port used for data exchange operations.");
+
+	/**
+	 * Config parameter to override SSL support for taskmanager's data transport.
+	 */
+	public static final ConfigOption<Boolean> DATA_SSL_ENABLED =
+		key("taskmanager.data.ssl.enabled")
+			.defaultValue(true)
+			.withDescription("Config parameter to override SSL support for taskmanager's data transport.");
+
+	/**
+	 * The initial registration pause between two consecutive registration attempts. The pause
+	 * is doubled for each new registration attempt until it reaches the maximum registration pause.
+	 */
+	public static final ConfigOption<String> INITIAL_REGISTRATION_PAUSE =
+		key("taskmanager.initial-registration-pause")
+			.defaultValue("500 ms")
+			.withDescription("The initial registration pause between two consecutive registration attempts. The pause" +
+				" is doubled for each new registration attempt until it reaches the maximum registration pause.");
+
+	/**
+	 * The pause after a registration has been refused by the job manager before retrying to connect.
+	 */
+	public static final ConfigOption<String> REFUSED_REGISTRATION_PAUSE =
+		key("taskmanager.refused-registration-pause")
+			.defaultValue("10 s")
+			.withDescription("The pause after a registration has been refused by the job manager before retrying to connect.");
+
+	/**
+	 * Defines the maximum time it can take for the TaskManager registration. If the duration is
+	 * exceeded without a successful registration, then the TaskManager terminates.
+	 */
+	public static final ConfigOption<String> MAX_REGISTRATION_DURATION =
+		key("taskmanager.maxRegistrationDuration")
+			.defaultValue("Inf")
+			.withDescription("Defines the maximum time it can take for the TaskManager registration. If the duration is" +
+				" exceeded without a successful registration, then the TaskManager terminates.");
+
+	/**
+	 * The config parameter defining the number of task slots of a task manager.
+	 */
+	public static final ConfigOption<Integer> NUM_TASK_SLOTS =
+		key("taskmanager.numberOfTaskSlots")
+			.defaultValue(1)
+			.withDescription("The config parameter defining the number of task slots of a task manager.");
 
 	// ------------------------------------------------------------------------
 	//  Managed Memory Options
@@ -74,7 +143,8 @@ public class TaskManagerOptions {
 	 */
 	public static final ConfigOption<Integer> MEMORY_SEGMENT_SIZE =
 			key("taskmanager.memory.segment-size")
-			.defaultValue(32768);
+			.defaultValue(32768)
+			.withDescription("Size of memory buffers used by the network stack and the memory manager (in bytes).");
 
 	/**
 	 * Amount of memory to be allocated by the task manager's memory manager (in megabytes). If not
@@ -82,7 +152,9 @@ public class TaskManagerOptions {
 	 */
 	public static final ConfigOption<Long> MANAGED_MEMORY_SIZE =
 			key("taskmanager.memory.size")
-			.defaultValue(-1L);
+			.defaultValue(-1L)
+			.withDescription("Amount of memory to be allocated by the task manager's memory manager (in megabytes)." +
+				" If not set, a relative fraction will be allocated.");
 
 	/**
 	 * Fraction of free memory allocated by the memory manager if {@link #MANAGED_MEMORY_SIZE} is
@@ -128,21 +200,24 @@ public class TaskManagerOptions {
 	 */
 	public static final ConfigOption<Float> NETWORK_BUFFERS_MEMORY_FRACTION =
 			key("taskmanager.network.memory.fraction")
-			.defaultValue(0.1f);
+			.defaultValue(0.1f)
+			.withDescription("Fraction of JVM memory to use for network buffers.");
 
 	/**
 	 * Minimum memory size for network buffers (in bytes).
 	 */
 	public static final ConfigOption<Long> NETWORK_BUFFERS_MEMORY_MIN =
 			key("taskmanager.network.memory.min")
-			.defaultValue(64L << 20); // 64 MB
+			.defaultValue(64L << 20) // 64 MB
+			.withDescription("Minimum memory size for network buffers (in bytes).");
 
 	/**
 	 * Maximum memory size for network buffers (in bytes).
 	 */
 	public static final ConfigOption<Long> NETWORK_BUFFERS_MEMORY_MAX =
 			key("taskmanager.network.memory.max")
-			.defaultValue(1024L << 20); // 1 GB
+			.defaultValue(1024L << 20) // 1 GB
+			.withDescription("Maximum memory size for network buffers (in bytes).");
 
 	/**
 	 * Number of network buffers to use for each outgoing/incoming channel (subpartition/input channel).
@@ -151,14 +226,16 @@ public class TaskManagerOptions {
 	 */
 	public static final ConfigOption<Integer> NETWORK_BUFFERS_PER_CHANNEL =
 			key("taskmanager.network.memory.buffers-per-channel")
-			.defaultValue(2);
+			.defaultValue(2)
+			.withDescription("Number of network buffers to use for each outgoing/incoming channel (subpartition/input channel).");
 
 	/**
 	 * Number of extra network buffers to use for each outgoing/incoming gate (result partition/input gate).
 	 */
 	public static final ConfigOption<Integer> NETWORK_EXTRA_BUFFERS_PER_GATE =
 			key("taskmanager.network.memory.floating-buffers-per-gate")
-			.defaultValue(8);
+			.defaultValue(8)
+			.withDescription("Number of extra network buffers to use for each outgoing/incoming gate (result partition/input gate).");
 
 	/**
 	 * Minimum backoff for partition requests of input channels.
@@ -166,7 +243,8 @@ public class TaskManagerOptions {
 	public static final ConfigOption<Integer> NETWORK_REQUEST_BACKOFF_INITIAL =
 			key("taskmanager.network.request-backoff.initial")
 			.defaultValue(100)
-			.withDeprecatedKeys("taskmanager.net.request-backoff.initial");
+			.withDeprecatedKeys("taskmanager.net.request-backoff.initial")
+			.withDescription("Minimum backoff for partition requests of input channels.");
 
 	/**
 	 * Maximum backoff for partition requests of input channels.
@@ -174,7 +252,8 @@ public class TaskManagerOptions {
 	public static final ConfigOption<Integer> NETWORK_REQUEST_BACKOFF_MAX =
 			key("taskmanager.network.request-backoff.max")
 			.defaultValue(10000)
-			.withDeprecatedKeys("taskmanager.net.request-backoff.max");
+			.withDeprecatedKeys("taskmanager.net.request-backoff.max")
+			.withDescription("Maximum backoff for partition requests of input channels.");
 
 	/**
 	 * Boolean flag to enable/disable more detailed metrics about inbound/outbound network queue
@@ -182,7 +261,8 @@ public class TaskManagerOptions {
 	 */
 	public static final ConfigOption<Boolean> NETWORK_DETAILED_METRICS =
 			key("taskmanager.network.detailed-metrics")
-			.defaultValue(false);
+			.defaultValue(false)
+			.withDescription("Boolean flag to enable/disable more detailed metrics about inbound/outbound network queue lengths.");
 
 	// ------------------------------------------------------------------------
 	//  Task Options

--- a/flink-core/src/test/java/org/apache/flink/api/common/io/DelimitedInputFormatSamplingTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/io/DelimitedInputFormatSamplingTest.java
@@ -20,8 +20,8 @@
 package org.apache.flink.api.common.io;
 
 import org.apache.flink.api.common.io.statistics.BaseStatistics;
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.OptimizerOptions;
 import org.apache.flink.testutils.TestConfigUtils;
 import org.apache.flink.testutils.TestFileSystem;
 import org.apache.flink.testutils.TestFileUtils;
@@ -78,8 +78,8 @@ public class DelimitedInputFormatSamplingTest {
 		try {
 			// make sure we do 4 samples
 			CONFIG = TestConfigUtils.loadGlobalConf(
-				new String[] { ConfigConstants.DELIMITED_FORMAT_MIN_LINE_SAMPLES_KEY,
-								ConfigConstants.DELIMITED_FORMAT_MAX_LINE_SAMPLES_KEY },
+				new String[] { OptimizerOptions.DELIMITED_FORMAT_MIN_LINE_SAMPLES.key(),
+								OptimizerOptions.DELIMITED_FORMAT_MAX_LINE_SAMPLES.key() },
 				new String[] { "4", "4" });
 
 
@@ -230,7 +230,7 @@ public class DelimitedInputFormatSamplingTest {
 	@Test
 	public void testSamplingOverlyLongRecord() {
 		try {
-			final String tempFile = TestFileUtils.createTempFile(2 * ConfigConstants.DEFAULT_DELIMITED_FORMAT_MAX_SAMPLE_LEN);
+			final String tempFile = TestFileUtils.createTempFile(2 * OptimizerOptions.DELIMITED_FORMAT_MAX_SAMPLE_LEN.defaultValue());
 			final Configuration conf = new Configuration();
 			
 			final TestDelimitedInputFormat format = new TestDelimitedInputFormat(CONFIG);

--- a/flink-docs/pom.xml
+++ b/flink-docs/pom.xml
@@ -53,6 +53,11 @@ under the License.
 			<artifactId>flink-yarn_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-mesos_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+		</dependency>
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
@@ -192,6 +197,10 @@ under the License.
 									<arg value="org.apache.flink.runtime.io.network.netty" />
 									<arg value="flink-yarn" />
 									<arg value="org.apache.flink.yarn.configuration" />
+									<arg value="flink-mesos" />
+									<arg value="org.apache.flink.mesos.configuration" />
+									<arg value="flink-mesos" />
+									<arg value="org.apache.flink.mesos.runtime.clusterframework" />
 								</java>
 							</target>
 						</configuration>

--- a/flink-docs/pom.xml
+++ b/flink-docs/pom.xml
@@ -188,6 +188,8 @@ under the License.
 									<!--packages with configuration classes-->
 									<arg value="flink-core" />
 									<arg value="org.apache.flink.configuration" />
+									<arg value="flink-runtime" />
+									<arg value="org.apache.flink.runtime.io.network.netty" />
 									<arg value="flink-yarn" />
 									<arg value="org.apache.flink.yarn.configuration" />
 								</java>

--- a/flink-docs/src/main/java/org/apache/flink/docs/configuration/ConfigOptionsDocGenerator.java
+++ b/flink-docs/src/main/java/org/apache/flink/docs/configuration/ConfigOptionsDocGenerator.java
@@ -147,7 +147,7 @@ public class ConfigOptionsDocGenerator {
 		htmlTable.append("    <thead>\n");
 		htmlTable.append("        <tr>\n");
 		htmlTable.append("            <th class=\"text-left\" style=\"width: 20%\">Key</th>\n");
-		htmlTable.append("            <th class=\"text-left\" style=\"width: 15%\">Default Value</th>\n");
+		htmlTable.append("            <th class=\"text-left\" style=\"width: 15%\">Default</th>\n");
 		htmlTable.append("            <th class=\"text-left\" style=\"width: 65%\">Description</th>\n");
 		htmlTable.append("        </tr>\n");
 		htmlTable.append("    </thead>\n");

--- a/flink-docs/src/main/java/org/apache/flink/docs/configuration/ConfigOptionsDocGenerator.java
+++ b/flink-docs/src/main/java/org/apache/flink/docs/configuration/ConfigOptionsDocGenerator.java
@@ -70,7 +70,7 @@ public class ConfigOptionsDocGenerator {
 	private static void createTable(String rootDir, String module, String packageName, String outputDirectory) throws IOException, ClassNotFoundException {
 		Path configDir = Paths.get(rootDir, module, "src/main/java", packageName.replaceAll("\\.", "/"));
 
-		Pattern p = Pattern.compile("(([a-zA-Z]*)(Options|Config))\\.java");
+		Pattern p = Pattern.compile("(([a-zA-Z]*)(Options|Config|Parameters))\\.java");
 		try (DirectoryStream<Path> stream = Files.newDirectoryStream(configDir)) {
 			for (Path entry : stream) {
 				String fileName = entry.getFileName().toString();

--- a/flink-docs/src/main/java/org/apache/flink/docs/configuration/ConfigOptionsDocGenerator.java
+++ b/flink-docs/src/main/java/org/apache/flink/docs/configuration/ConfigOptionsDocGenerator.java
@@ -70,8 +70,8 @@ public class ConfigOptionsDocGenerator {
 	private static void createTable(String rootDir, String module, String packageName, String outputDirectory) throws IOException, ClassNotFoundException {
 		Path configDir = Paths.get(rootDir, module, "src/main/java", packageName.replaceAll("\\.", "/"));
 
-		Pattern p = Pattern.compile("(([a-zA-Z]*)(Options))\\.java");
-		try (DirectoryStream<Path> stream = Files.newDirectoryStream(configDir, "*Options.java")) {
+		Pattern p = Pattern.compile("(([a-zA-Z]*)(Options|Config))\\.java");
+		try (DirectoryStream<Path> stream = Files.newDirectoryStream(configDir)) {
 			for (Path entry : stream) {
 				String fileName = entry.getFileName().toString();
 				Matcher matcher = p.matcher(fileName);

--- a/flink-docs/src/test/java/org/apache/flink/docs/configuration/ConfigOptionsDocGeneratorTest.java
+++ b/flink-docs/src/test/java/org/apache/flink/docs/configuration/ConfigOptionsDocGeneratorTest.java
@@ -55,7 +55,7 @@ public class ConfigOptionsDocGeneratorTest {
 			"    <thead>\n" +
 			"        <tr>\n" +
 			"            <th class=\"text-left\" style=\"width: 20%\">Key</th>\n" +
-			"            <th class=\"text-left\" style=\"width: 15%\">Default Value</th>\n" +
+			"            <th class=\"text-left\" style=\"width: 15%\">Default</th>\n" +
 			"            <th class=\"text-left\" style=\"width: 65%\">Description</th>\n" +
 			"        </tr>\n" +
 			"    </thead>\n" +
@@ -118,7 +118,7 @@ public class ConfigOptionsDocGeneratorTest {
 			"    <thead>\n" +
 			"        <tr>\n" +
 			"            <th class=\"text-left\" style=\"width: 20%\">Key</th>\n" +
-			"            <th class=\"text-left\" style=\"width: 15%\">Default Value</th>\n" +
+			"            <th class=\"text-left\" style=\"width: 15%\">Default</th>\n" +
 			"            <th class=\"text-left\" style=\"width: 65%\">Description</th>\n" +
 			"        </tr>\n" +
 			"    </thead>\n" +
@@ -135,7 +135,7 @@ public class ConfigOptionsDocGeneratorTest {
 			"    <thead>\n" +
 			"        <tr>\n" +
 			"            <th class=\"text-left\" style=\"width: 20%\">Key</th>\n" +
-			"            <th class=\"text-left\" style=\"width: 15%\">Default Value</th>\n" +
+			"            <th class=\"text-left\" style=\"width: 15%\">Default</th>\n" +
 			"            <th class=\"text-left\" style=\"width: 65%\">Description</th>\n" +
 			"        </tr>\n" +
 			"    </thead>\n" +
@@ -152,7 +152,7 @@ public class ConfigOptionsDocGeneratorTest {
 			"    <thead>\n" +
 			"        <tr>\n" +
 			"            <th class=\"text-left\" style=\"width: 20%\">Key</th>\n" +
-			"            <th class=\"text-left\" style=\"width: 15%\">Default Value</th>\n" +
+			"            <th class=\"text-left\" style=\"width: 15%\">Default</th>\n" +
 			"            <th class=\"text-left\" style=\"width: 65%\">Description</th>\n" +
 			"        </tr>\n" +
 			"    </thead>\n" +

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/configuration/MesosOptions.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/configuration/MesosOptions.java
@@ -32,7 +32,8 @@ public class MesosOptions {
 	 */
 	public static final ConfigOption<Integer> INITIAL_TASKS =
 		key("mesos.initial-tasks")
-			.defaultValue(0);
+			.defaultValue(0)
+			.withDescription("The initial workers to bring up when the master starts");
 
 	/**
 	 * The maximum number of failed Mesos tasks before entirely stopping
@@ -42,7 +43,9 @@ public class MesosOptions {
 	 */
 	public static final ConfigOption<Integer> MAX_FAILED_TASKS =
 		key("mesos.maximum-failed-tasks")
-			.defaultValue(-1);
+			.defaultValue(-1)
+			.withDescription("The maximum number of failed workers before the cluster fails. May be set to -1 to disable" +
+				" this feature");
 
 	/**
 	 * The Mesos master URL.
@@ -59,14 +62,23 @@ public class MesosOptions {
 	 */
 	public static final ConfigOption<String> MASTER_URL =
 		key("mesos.master")
-			.noDefaultValue();
+			.noDefaultValue()
+			.withDescription("The Mesos master URL. The value should be in one of the following forms:\n" +
+				"<ul>\n" +
+				"    <li><code>host:port</code></li>\n" +
+				"    <li><code>zk://host1:port1,host2:port2,.../path</code></li>\n" +
+				"    <li><code>zk://username:password@host1:port1,host2:port2,.../path</code></li>\n" +
+				"    <li><code>file:///path/to/file</code></li>\n" +
+				"</ul>");
 
 	/**
 	 * The failover timeout for the Mesos scheduler, after which running tasks are automatically shut down.
 	 */
 	public static final ConfigOption<Integer> FAILOVER_TIMEOUT_SECONDS =
 		key("mesos.failover-timeout")
-			.defaultValue(600);
+			.defaultValue(600)
+			.withDescription("The failover timeout in seconds for the Mesos scheduler, after which running tasks are" +
+				" automatically shut down.");
 
 	/**
 	 * The config parameter defining the Mesos artifact server port to use.
@@ -74,33 +86,42 @@ public class MesosOptions {
 	 */
 	public static final ConfigOption<Integer> ARTIFACT_SERVER_PORT =
 		key("mesos.resourcemanager.artifactserver.port")
-			.defaultValue(0);
+			.defaultValue(0)
+			.withDescription("The config parameter defining the Mesos artifact server port to use. Setting the port to" +
+				" 0 will let the OS choose an available port.");
 
 	public static final ConfigOption<String> RESOURCEMANAGER_FRAMEWORK_NAME =
 		key("mesos.resourcemanager.framework.name")
-			.defaultValue("Flink");
+			.defaultValue("Flink")
+			.withDescription("Mesos framework name");
 
 	public static final ConfigOption<String> RESOURCEMANAGER_FRAMEWORK_ROLE =
 		key("mesos.resourcemanager.framework.role")
-			.defaultValue("*");
+			.defaultValue("*")
+			.withDescription("Mesos framework role definition");
 
 	public static final ConfigOption<String> RESOURCEMANAGER_FRAMEWORK_PRINCIPAL =
 		key("mesos.resourcemanager.framework.principal")
-			.noDefaultValue();
+			.noDefaultValue()
+			.withDescription("Mesos framework principal");
 
 	public static final ConfigOption<String> RESOURCEMANAGER_FRAMEWORK_SECRET =
 		key("mesos.resourcemanager.framework.secret")
-			.noDefaultValue();
+			.noDefaultValue()
+			.withDescription("Mesos framework secret");
 
 	public static final ConfigOption<String> RESOURCEMANAGER_FRAMEWORK_USER =
 		key("mesos.resourcemanager.framework.user")
-			.defaultValue("");
+			.defaultValue("")
+			.withDescription("Mesos framework user");
 
 	/**
 	 * Config parameter to override SSL support for the Artifact Server.
 	 */
 	public static final ConfigOption<Boolean> ARTIFACT_SERVER_SSL_ENABLED =
 		key("mesos.resourcemanager.artifactserver.ssl.enabled")
-			.defaultValue(true);
+			.defaultValue(true)
+			.withDescription("Enables SSL for the Flink artifact server. Note that security.ssl.enabled also needs to" +
+				" be set to true encryption to enable encryption.");
 
 }

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
@@ -56,19 +56,23 @@ public class MesosTaskManagerParameters {
 
 	public static final ConfigOption<Integer> MESOS_RM_TASKS_MEMORY_MB =
 		key("mesos.resourcemanager.tasks.mem")
-		.defaultValue(1024);
+		.defaultValue(1024)
+		.withDescription("Memory to assign to the Mesos workers in MB.");
 
 	public static final ConfigOption<Double> MESOS_RM_TASKS_CPUS =
 		key("mesos.resourcemanager.tasks.cpus")
-		.defaultValue(0.0);
+		.defaultValue(0.0)
+		.withDescription("CPUs to assign to the Mesos workers.");
 
 	public static final ConfigOption<String> MESOS_RM_CONTAINER_TYPE =
 		key("mesos.resourcemanager.tasks.container.type")
-		.defaultValue("mesos");
+		.defaultValue("mesos")
+		.withDescription("Type of the containerization used: “mesos” or “docker”.");
 
 	public static final ConfigOption<String> MESOS_RM_CONTAINER_IMAGE_NAME =
 		key("mesos.resourcemanager.tasks.container.image.name")
-		.noDefaultValue();
+		.noDefaultValue()
+		.withDescription("Image name to use for the container.");
 
 	public static final ConfigOption<String> MESOS_TM_HOSTNAME =
 		key("mesos.resourcemanager.tasks.hostname")
@@ -84,11 +88,14 @@ public class MesosTaskManagerParameters {
 
 	public static final ConfigOption<String> MESOS_RM_CONTAINER_VOLUMES =
 		key("mesos.resourcemanager.tasks.container.volumes")
-		.noDefaultValue();
+		.noDefaultValue()
+		.withDescription("A comma separated list of [host_path:]container_path[:RO|RW]. This allows for mounting" +
+			" additional volumes into your container.");
 
 	public static final ConfigOption<String> MESOS_CONSTRAINTS_HARD_HOSTATTR =
 		key("mesos.constraints.hard.hostattribute")
-		.noDefaultValue();
+		.noDefaultValue()
+		.withDescription("Constraints for task placement on mesos.");
 
 	/**
 	 * Value for {@code MESOS_RESOURCEMANAGER_TASKS_CONTAINER_TYPE} setting. Tells to use the Mesos containerizer.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/BootstrapTools.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/BootstrapTools.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.configuration.WebOptions;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
@@ -244,7 +245,7 @@ public class BootstrapTools {
 			cfg.setInteger(JobManagerOptions.PORT, jobManagerPort);
 		}
 
-		cfg.setString(ConfigConstants.TASK_MANAGER_MAX_REGISTRATION_DURATION, registrationTimeout.toString());
+		cfg.setString(TaskManagerOptions.MAX_REGISTRATION_DURATION, registrationTimeout.toString());
 		if (numSlots != -1){
 			cfg.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, numSlots);
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConfig.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConfig.java
@@ -18,10 +18,10 @@
 
 package org.apache.flink.runtime.io.network.netty;
 
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.net.SSLUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -212,8 +212,7 @@ public class NettyConfig {
 	}
 
 	public boolean getSSLEnabled() {
-		return config.getBoolean(ConfigConstants.TASK_MANAGER_DATA_SSL_ENABLED,
-				ConfigConstants.DEFAULT_TASK_MANAGER_DATA_SSL_ENABLED)
+		return config.getBoolean(TaskManagerOptions.DATA_SSL_ENABLED)
 			&& SSLUtils.getSSLEnabled(config);
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConfig.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConfig.java
@@ -43,37 +43,45 @@ public class NettyConfig {
 	public static final ConfigOption<Integer> NUM_ARENAS = ConfigOptions
 			.key("taskmanager.network.netty.num-arenas")
 			.defaultValue(-1)
-			.withDeprecatedKeys("taskmanager.net.num-arenas");
+			.withDeprecatedKeys("taskmanager.net.num-arenas")
+			.withDescription("The number of Netty arenas.");
 
 	public static final ConfigOption<Integer> NUM_THREADS_SERVER = ConfigOptions
 			.key("taskmanager.network.netty.server.numThreads")
 			.defaultValue(-1)
-			.withDeprecatedKeys("taskmanager.net.server.numThreads");
+			.withDeprecatedKeys("taskmanager.net.server.numThreads")
+			.withDescription("The number of Netty server threads.");
 
 	public static final ConfigOption<Integer> NUM_THREADS_CLIENT = ConfigOptions
 			.key("taskmanager.network.netty.client.numThreads")
 			.defaultValue(-1)
-			.withDeprecatedKeys("taskmanager.net.client.numThreads");
+			.withDeprecatedKeys("taskmanager.net.client.numThreads")
+			.withDescription("The number of Netty client threads.");
 
 	public static final ConfigOption<Integer> CONNECT_BACKLOG = ConfigOptions
 			.key("taskmanager.network.netty.server.backlog")
 			.defaultValue(0) // default: 0 => Netty's default
-			.withDeprecatedKeys("taskmanager.net.server.backlog");
+			.withDeprecatedKeys("taskmanager.net.server.backlog")
+			.withDescription(" The netty server connection backlog.");
 
 	public static final ConfigOption<Integer> CLIENT_CONNECT_TIMEOUT_SECONDS = ConfigOptions
 			.key("taskmanager.network.netty.client.connectTimeoutSec")
 			.defaultValue(120) // default: 120s = 2min
-			.withDeprecatedKeys("taskmanager.net.client.connectTimeoutSec");
+			.withDeprecatedKeys("taskmanager.net.client.connectTimeoutSec")
+			.withDescription("The Netty client connection timeout.");
 
 	public static final ConfigOption<Integer> SEND_RECEIVE_BUFFER_SIZE = ConfigOptions
 			.key("taskmanager.network.netty.sendReceiveBufferSize")
 			.defaultValue(0) // default: 0 => Netty's default
-			.withDeprecatedKeys("taskmanager.net.sendReceiveBufferSize");
+			.withDeprecatedKeys("taskmanager.net.sendReceiveBufferSize")
+			.withDescription("The Netty send and receive buffer size. This defaults to the system buffer size" +
+				" (cat /proc/sys/net/ipv4/tcp_[rw]mem) and is 4 MiB in modern Linux.");
 
 	public static final ConfigOption<String> TRANSPORT_TYPE = ConfigOptions
 			.key("taskmanager.network.netty.transport")
 			.defaultValue("nio")
-			.withDeprecatedKeys("taskmanager.net.transport");
+			.withDeprecatedKeys("taskmanager.net.transport")
+			.withDescription("The Netty transport type, either \"nio\" or \"epoll\"");
 
 	// ------------------------------------------------------------------------
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerConfiguration.java
@@ -167,9 +167,7 @@ public class TaskManagerConfiguration implements TaskManagerRuntimeInfo {
 		final Time finiteRegistrationDuration;
 
 		try {
-			Duration maxRegistrationDuration = Duration.create(configuration.getString(
-				ConfigConstants.TASK_MANAGER_MAX_REGISTRATION_DURATION,
-				ConfigConstants.DEFAULT_TASK_MANAGER_MAX_REGISTRATION_DURATION));
+			Duration maxRegistrationDuration = Duration.create(configuration.getString(TaskManagerOptions.MAX_REGISTRATION_DURATION));
 			if (maxRegistrationDuration.isFinite()) {
 				finiteRegistrationDuration = Time.milliseconds(maxRegistrationDuration.toMillis());
 			} else {
@@ -177,14 +175,12 @@ public class TaskManagerConfiguration implements TaskManagerRuntimeInfo {
 			}
 		} catch (NumberFormatException e) {
 			throw new IllegalArgumentException("Invalid format for parameter " +
-				ConfigConstants.TASK_MANAGER_MAX_REGISTRATION_DURATION, e);
+				TaskManagerOptions.MAX_REGISTRATION_DURATION.key(), e);
 		}
 
 		final Time initialRegistrationPause;
 		try {
-			Duration pause = Duration.create(configuration.getString(
-				ConfigConstants.TASK_MANAGER_INITIAL_REGISTRATION_PAUSE,
-				ConfigConstants.DEFAULT_TASK_MANAGER_INITIAL_REGISTRATION_PAUSE));
+			Duration pause = Duration.create(configuration.getString(TaskManagerOptions.INITIAL_REGISTRATION_PAUSE));
 			if (pause.isFinite()) {
 				initialRegistrationPause = Time.milliseconds(pause.toMillis());
 			} else {
@@ -192,7 +188,7 @@ public class TaskManagerConfiguration implements TaskManagerRuntimeInfo {
 			}
 		} catch (NumberFormatException e) {
 			throw new IllegalArgumentException("Invalid format for parameter " +
-				ConfigConstants.TASK_MANAGER_INITIAL_REGISTRATION_PAUSE, e);
+				TaskManagerOptions.INITIAL_REGISTRATION_PAUSE.key(), e);
 		}
 
 		final Time maxRegistrationPause;
@@ -207,14 +203,12 @@ public class TaskManagerConfiguration implements TaskManagerRuntimeInfo {
 			}
 		} catch (NumberFormatException e) {
 			throw new IllegalArgumentException("Invalid format for parameter " +
-				ConfigConstants.TASK_MANAGER_INITIAL_REGISTRATION_PAUSE, e);
+				TaskManagerOptions.INITIAL_REGISTRATION_PAUSE.key(), e);
 		}
 
 		final Time refusedRegistrationPause;
 		try {
-			Duration pause = Duration.create(configuration.getString(
-				ConfigConstants.TASK_MANAGER_REFUSED_REGISTRATION_PAUSE,
-				ConfigConstants.DEFAULT_TASK_MANAGER_REFUSED_REGISTRATION_PAUSE));
+			Duration pause = Duration.create(configuration.getString(TaskManagerOptions.REFUSED_REGISTRATION_PAUSE));
 			if (pause.isFinite()) {
 				refusedRegistrationPause = Time.milliseconds(pause.toMillis());
 			} else {
@@ -222,7 +216,7 @@ public class TaskManagerConfiguration implements TaskManagerRuntimeInfo {
 			}
 		} catch (NumberFormatException e) {
 			throw new IllegalArgumentException("Invalid format for parameter " +
-				ConfigConstants.TASK_MANAGER_INITIAL_REGISTRATION_PAUSE, e);
+				TaskManagerOptions.INITIAL_REGISTRATION_PAUSE.key(), e);
 		}
 
 		final boolean exitOnOom = configuration.getBoolean(TaskManagerOptions.KILL_ON_OUT_OF_MEMORY);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfiguration.java
@@ -257,10 +257,9 @@ public class TaskManagerServicesConfiguration {
 
 		// ----> hosts / ports for communication and data exchange
 
-		int dataport = configuration.getInteger(ConfigConstants.TASK_MANAGER_DATA_PORT_KEY,
-			ConfigConstants.DEFAULT_TASK_MANAGER_DATA_PORT);
+		int dataport = configuration.getInteger(TaskManagerOptions.DATA_PORT);
 
-		checkConfigParameter(dataport >= 0, dataport, ConfigConstants.TASK_MANAGER_DATA_PORT_KEY,
+		checkConfigParameter(dataport >= 0, dataport, TaskManagerOptions.DATA_PORT.key(),
 			"Leave config parameter empty or use 0 to let the system choose a port automatically.");
 
 		checkConfigParameter(slots >= 1, slots, ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS,

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/minicluster/LocalFlinkMiniCluster.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/minicluster/LocalFlinkMiniCluster.scala
@@ -205,9 +205,7 @@ class LocalFlinkMiniCluster(
 
     val rpcPortIterator = NetUtils.getPortRangeFromString(rpcPortRange)
 
-    val dataPort = config.getInteger(
-      ConfigConstants.TASK_MANAGER_DATA_PORT_KEY,
-      ConfigConstants.DEFAULT_TASK_MANAGER_DATA_PORT)
+    val dataPort = config.getInteger(TaskManagerOptions.DATA_PORT)
 
     if (rpcPortIterator.hasNext) {
       val rpcPort = rpcPortIterator.next()
@@ -216,7 +214,7 @@ class LocalFlinkMiniCluster(
       }
     }
     if (dataPort > 0) {
-      config.setInteger(ConfigConstants.TASK_MANAGER_DATA_PORT_KEY, dataPort + index)
+      config.setInteger(TaskManagerOptions.DATA_PORT, dataPort + index)
     }
 
     val localExecution = numTaskManagers == 1

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerRegistrationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerRegistrationTest.java
@@ -26,6 +26,7 @@ import akka.testkit.JavaTestKit;
 import org.apache.flink.configuration.AkkaOptions;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.blob.VoidBlobStore;
 import org.apache.flink.runtime.clusterframework.FlinkResourceManager;
@@ -267,7 +268,7 @@ public class TaskManagerRegistrationTest extends TestLogger {
 			try {
 				// registration timeout of 1 second
 				Configuration tmConfig = new Configuration();
-				tmConfig.setString(ConfigConstants.TASK_MANAGER_MAX_REGISTRATION_DURATION, "500 ms");
+				tmConfig.setString(TaskManagerOptions.MAX_REGISTRATION_DURATION, "500 ms");
 
 				highAvailabilityServices.setJobMasterLeaderRetriever(
 					HighAvailabilityServices.DEFAULT_JOB_ID,
@@ -325,7 +326,7 @@ public class TaskManagerRegistrationTest extends TestLogger {
 
 				FiniteDuration refusedRegistrationPause = new FiniteDuration(500, TimeUnit.MILLISECONDS);
 				Configuration tmConfig = new Configuration(config);
-				tmConfig.setString(ConfigConstants.TASK_MANAGER_REFUSED_REGISTRATION_PAUSE, refusedRegistrationPause.toString());
+				tmConfig.setString(TaskManagerOptions.REFUSED_REGISTRATION_PAUSE, refusedRegistrationPause.toString());
 
 				highAvailabilityServices.setJobMasterLeaderRetriever(
 					HighAvailabilityServices.DEFAULT_JOB_ID,
@@ -407,8 +408,8 @@ public class TaskManagerRegistrationTest extends TestLogger {
 				long maxDelay = 30000;
 
 				Configuration tmConfig = new Configuration(config);
-				tmConfig.setString(ConfigConstants.TASK_MANAGER_REFUSED_REGISTRATION_PAUSE, refusedRegistrationPause + " ms");
-				tmConfig.setString(ConfigConstants.TASK_MANAGER_INITIAL_REGISTRATION_PAUSE, initialRegistrationPause + " ms");
+				tmConfig.setString(TaskManagerOptions.REFUSED_REGISTRATION_PAUSE, refusedRegistrationPause + " ms");
+				tmConfig.setString(TaskManagerOptions.INITIAL_REGISTRATION_PAUSE, initialRegistrationPause + " ms");
 
 				// we make the test actor (the test kit) the JobManager to intercept
 				// the messages

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerStartupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerStartupTest.java
@@ -244,7 +244,7 @@ public class TaskManagerStartupTest extends TestLogger {
 
 			final Configuration cfg = new Configuration();
 			cfg.setString(ConfigConstants.TASK_MANAGER_HOSTNAME_KEY, "localhost");
-			cfg.setInteger(ConfigConstants.TASK_MANAGER_DATA_PORT_KEY, blocker.getLocalPort());
+			cfg.setInteger(TaskManagerOptions.DATA_PORT, blocker.getLocalPort());
 			cfg.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, 1L);
 
 			TaskManager.startTaskManagerComponentsAndActor(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
@@ -960,7 +960,7 @@ public class TaskManagerTest extends TestLogger {
 
 				final int dataPort = NetUtils.getAvailablePort();
 				Configuration config = new Configuration();
-				config.setInteger(ConfigConstants.TASK_MANAGER_DATA_PORT_KEY, dataPort);
+				config.setInteger(TaskManagerOptions.DATA_PORT, dataPort);
 				config.setInteger(TaskManagerOptions.NETWORK_REQUEST_BACKOFF_INITIAL, 100);
 				config.setInteger(TaskManagerOptions.NETWORK_REQUEST_BACKOFF_MAX, 200);
 
@@ -1173,7 +1173,7 @@ public class TaskManagerTest extends TestLogger {
 
 				final int dataPort = NetUtils.getAvailablePort();
 				Configuration config = new Configuration();
-				config.setInteger(ConfigConstants.TASK_MANAGER_DATA_PORT_KEY, dataPort);
+				config.setInteger(TaskManagerOptions.DATA_PORT, dataPort);
 				config.setInteger(TaskManagerOptions.NETWORK_REQUEST_BACKOFF_INITIAL, 100);
 				config.setInteger(TaskManagerOptions.NETWORK_REQUEST_BACKOFF_MAX, 200);
 				config.setString(ConfigConstants.TASK_MANAGER_LOG_PATH_KEY, "/i/dont/exist");

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestBaseUtils.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestBaseUtils.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.java.tuple.Tuple;
 import org.apache.flink.configuration.AkkaOptions;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.configuration.WebOptions;
@@ -149,7 +150,7 @@ public class TestBaseUtils extends TestLogger {
 		Files.createFile(new File(logDir, "jobmanager.out").toPath());
 
 		config.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, TASK_MANAGER_MEMORY_SIZE);
-		config.setBoolean(ConfigConstants.FILESYSTEM_DEFAULT_OVERWRITE_KEY, true);
+		config.setBoolean(CoreOptions.FILESYTEM_DEFAULT_OVERRIDE, true);
 
 		config.setString(AkkaOptions.ASK_TIMEOUT, DEFAULT_AKKA_ASK_TIMEOUT + "s");
 		config.setString(AkkaOptions.STARTUP_TIMEOUT, DEFAULT_AKKA_STARTUP_TIMEOUT);

--- a/flink-tests/src/test/java/org/apache/flink/test/cancelling/CancelingTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/cancelling/CancelingTestBase.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.Plan;
 import org.apache.flink.configuration.AkkaOptions;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.optimizer.DataStatistics;
 import org.apache.flink.optimizer.Optimizer;
@@ -87,7 +88,7 @@ public abstract class CancelingTestBase extends TestLogger {
 	public void startCluster() throws Exception {
 		verifyJvmOptions();
 		Configuration config = new Configuration();
-		config.setBoolean(ConfigConstants.FILESYSTEM_DEFAULT_OVERWRITE_KEY, true);
+		config.setBoolean(CoreOptions.FILESYTEM_DEFAULT_OVERRIDE, true);
 		config.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, 2);
 		config.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, 4);
 		config.setString(AkkaOptions.ASK_TIMEOUT, TestingUtils.DEFAULT_AKKA_ASK_TIMEOUT());

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/jobmanager/JobManagerFailsITCase.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/runtime/jobmanager/JobManagerFailsITCase.scala
@@ -20,7 +20,7 @@ package org.apache.flink.api.scala.runtime.jobmanager
 
 import akka.actor.ActorSystem
 import akka.testkit.{ImplicitSender, TestKit}
-import org.apache.flink.configuration.{ConfigConstants, Configuration, JobManagerOptions}
+import org.apache.flink.configuration.{ConfigConstants, Configuration, JobManagerOptions, TaskManagerOptions}
 import org.apache.flink.runtime.akka.{AkkaUtils, ListeningBehaviour}
 import org.apache.flink.runtime.jobgraph.{JobGraph, JobVertex}
 import org.apache.flink.runtime.messages.Acknowledge
@@ -136,7 +136,7 @@ class JobManagerFailsITCase(_system: ActorSystem)
     config.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, numSlots)
     config.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, numTaskmanagers)
     config.setInteger(JobManagerOptions.PORT, 0)
-    config.setString(ConfigConstants.TASK_MANAGER_INITIAL_REGISTRATION_PAUSE, "50 ms")
+    config.setString(TaskManagerOptions.INITIAL_REGISTRATION_PAUSE, "50 ms")
     config.setString(ConfigConstants.TASK_MANAGER_MAX_REGISTARTION_PAUSE, "100 ms")
 
     val cluster = new TestingCluster(config, singleActorSystem = false)

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
@@ -19,8 +19,8 @@
 package org.apache.flink.yarn;
 
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.runtime.clusterframework.ContaineredTaskManagerParameters;
@@ -422,7 +422,7 @@ public class YarnResourceManager extends ResourceManager<YarnWorkerNode> impleme
 				taskManagerParameters.taskManagerTotalMemoryMB(),
 				taskManagerParameters.taskManagerHeapSizeMB(),
 				taskManagerParameters.taskManagerDirectMemoryLimitMB());
-		int timeout = flinkConfig.getInteger(ConfigConstants.TASK_MANAGER_MAX_REGISTRATION_DURATION,
+		int timeout = flinkConfig.getInteger(TaskManagerOptions.MAX_REGISTRATION_DURATION.key(),
 				DEFAULT_TASK_MANAGER_REGISTRATION_DURATION);
 		FiniteDuration teRegistrationTimeout = new FiniteDuration(timeout, TimeUnit.SECONDS);
 		final Configuration taskManagerConfig = BootstrapTools.generateTaskManagerConfiguration(

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
@@ -34,14 +34,16 @@ public class YarnConfigOptions {
 	 */
 	public static final ConfigOption<String> APP_MASTER_RPC_ADDRESS =
 			key("yarn.appmaster.rpc.address")
-			.noDefaultValue();
+			.noDefaultValue()
+			.withDescription("The hostname or address where the application master RPC system is listening.");
 
 	/**
 	 * The port where the application master RPC system is listening.
 	 */
 	public static final ConfigOption<Integer> APP_MASTER_RPC_PORT =
 			key("yarn.appmaster.rpc.port")
-			.defaultValue(-1);
+			.defaultValue(-1)
+			.withDescription("The port where the application master RPC system is listening.");
 
 	/**
 	 * Defines whether user-jars are included in the system class path for per-job-clusters as well as their positioning
@@ -50,14 +52,19 @@ public class YarnConfigOptions {
 	 */
 	public static final ConfigOption<String> CLASSPATH_INCLUDE_USER_JAR =
 		key("yarn.per-job-cluster.include-user-jar")
-			.defaultValue("ORDER");
+			.defaultValue("ORDER")
+			.withDescription("Defines whether user-jars are included in the system class path for per-job-clusters as" +
+				" well as their positioning in the path. They can be positioned at the beginning (\"FIRST\"), at the" +
+				" end (\"LAST\"), or be positioned based on their name (\"ORDER\").");
 
 	/**
 	 * The vcores exposed by YARN.
 	 */
 	public static final ConfigOption<Integer> VCORES =
 		key("yarn.containers.vcores")
-		.defaultValue(-1);
+		.defaultValue(-1)
+		.withDescription("The number of virtual cores (vcores) per YARN container. By default, the number of vcores" +
+			" is set to the number of slots per TaskManager, if set, or to 1, otherwise.");
 
 	/**
 	 * The maximum number of failed YARN containers before entirely stopping
@@ -68,7 +75,8 @@ public class YarnConfigOptions {
 	 */
 	public static final ConfigOption<String> MAX_FAILED_CONTAINERS =
 		key("yarn.maximum-failed-containers")
-		.noDefaultValue();
+		.noDefaultValue()
+		.withDescription("Maximum number of containers the system is going to reallocate in case of a failure.");
 
 	/**
 	 * Set the number of retries for failed YARN ApplicationMasters/JobManagers in high
@@ -79,14 +87,18 @@ public class YarnConfigOptions {
 	 */
 	public static final ConfigOption<String> APPLICATION_ATTEMPTS =
 		key("yarn.application-attempts")
-		.noDefaultValue();
+		.noDefaultValue()
+		.withDescription("Number of ApplicationMaster restarts. Note that that the entire Flink cluster will restart" +
+			" and the YARN Client will loose the connection. Also, the JobManager address will change and you’ll need" +
+			" to set the JM host:port manually. It is recommended to leave this option at 1.");
 
 	/**
 	 * The heartbeat interval between the Application Master and the YARN Resource Manager.
 	 */
 	public static final ConfigOption<Integer> HEARTBEAT_DELAY_SECONDS =
 		key("yarn.heartbeat-delay")
-		.defaultValue(5);
+		.defaultValue(5)
+		.withDescription("Time between heartbeats with the ResourceManager in seconds.");
 
 	/**
 	 * When a Flink job is submitted to YARN, the JobManager's host and the number of available
@@ -97,7 +109,11 @@ public class YarnConfigOptions {
 	 */
 	public static final ConfigOption<String> PROPERTIES_FILE_LOCATION =
 		key("yarn.properties-file.location")
-		.noDefaultValue();
+		.noDefaultValue()
+		.withDescription("When a Flink job is submitted to YARN, the JobManager’s host and the number of available" +
+			" processing slots is written into a properties file, so that the Flink client is able to pick those" +
+			" details up. This configuration parameter allows changing the default location of that file" +
+			" (for example for environments sharing a Flink installation between users).");
 
 	/**
 	 * The config parameter defining the Akka actor system port for the ApplicationMaster and
@@ -109,14 +125,21 @@ public class YarnConfigOptions {
 	 */
 	public static final ConfigOption<String> APPLICATION_MASTER_PORT =
 		key("yarn.application-master.port")
-		.defaultValue("0");
+		.defaultValue("0")
+		.withDescription("With this configuration option, users can specify a port, a range of ports or a list of ports" +
+			" for the Application Master (and JobManager) RPC port. By default we recommend using the default value (0)" +
+			" to let the operating system choose an appropriate port. In particular when multiple AMs are running on" +
+			" the same physical host, fixed port assignments prevent the AM from starting. For example when running" +
+			" Flink on YARN on an environment with a restrictive firewall, this option allows specifying a range of" +
+			" allowed ports.");
 
 	/**
 	 * A comma-separated list of strings to use as YARN application tags.
 	 */
 	public static final ConfigOption<String> APPLICATION_TAGS =
 		key("yarn.tags")
-		.defaultValue("");
+		.defaultValue("")
+		.withDescription("A comma-separated list of tags to apply to the Flink YARN application.");
 
 	// ------------------------------------------------------------------------
 


### PR DESCRIPTION
## What is the purpose of the change

This PR significantly extends the integration of ConfigOptions into the configuration documentation. The only sections left to integrate are High-availability, ResourceManager and core options.

Each section was integrated in it's own commit that is essentially self-contained.

Most commits are straight-forward and revolve around setting up the description via `ConfigOption#withDescription`, generating the table and including it in `config.md`.

Some commits also include migration of existing `ConfigConstants` to `ConfigOptions`, but overall very few changes were made.

This PR also includes a minor modification to the generated tables which renames the "Default Value" column to "Default" to save some space.

## Verifying this change

The documentation changes can be verified by building the docs locally as described in in `flink/docs/README.md`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
