### PR TITLE
[FLINK-8496][metrics] Create missing "Network" group

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/util/MetricUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/util/MetricUtils.java
@@ -83,7 +83,10 @@ public class MetricUtils {
 
 		// Initialize the TM metrics
 		instantiateStatusMetrics(statusGroup);
-		instantiateNetworkMetrics(statusGroup, network);
+
+		MetricGroup networkGroup = statusGroup
+			.addGroup("Network");
+		instantiateNetworkMetrics(networkGroup, network);
 
 		return taskManagerMetricGroup;
 	}


### PR DESCRIPTION
## What is the purpose of the change

This PR reverts a change to the metric names for the AvailableMemorySegments/TotalMemorySegments metrics. The "Network" MetricGroup creation as accidentally removed in a previous refactoring (7fb7e0b9775d1773d20e63732130ae140781a6f2) causing the metric to no longer be displayed in the UI.

## Verifying this change

Start a cluster and check the Memory Segment metrics in the taskmanager tab, which should be greater than 0.
