### PR TITLE
[FLINK-8243] [orc] OrcTableSource reads input path recursively by default.

### DIFF
--- a/docs/dev/table/sourceSinks.md
+++ b/docs/dev/table/sourceSinks.md
@@ -548,7 +548,7 @@ An `OrcTableSource` is created as shown below:
 Configuration config = new Configuration();
 
 OrcTableSource orcTableSource = OrcTableSource.builder()
-  // path to ORC file(s)
+  // path to ORC file(s). NOTE: By default, directories are recursively scanned.
   .path("file:///path/to/data")
   // schema of ORC files
   .forOrcSchema("struct<name:string,addresses:array<struct<street:string,zip:smallint>>>")
@@ -566,7 +566,7 @@ OrcTableSource orcTableSource = OrcTableSource.builder()
 val config = new Configuration()
 
 val orcTableSource = OrcTableSource.builder()
-  // path to ORC file(s)
+  // path to ORC file(s). NOTE: By default, directories are recursively scanned.
   .path("file:///path/to/data")
   // schema of ORC files
   .forOrcSchema("struct<name:string,addresses:array<struct<street:string,zip:smallint>>>")

--- a/flink-connectors/flink-orc/src/main/java/org/apache/flink/orc/OrcRowInputFormat.java
+++ b/flink-connectors/flink-orc/src/main/java/org/apache/flink/orc/OrcRowInputFormat.java
@@ -394,6 +394,25 @@ public class OrcRowInputFormat extends FileInputFormat<Row> implements ResultTyp
 	}
 
 	// --------------------------------------------------------------------------------------------
+	//  Getter methods for tests
+	// --------------------------------------------------------------------------------------------
+
+	@VisibleForTesting
+	Configuration getConfiguration() {
+		return conf;
+	}
+
+	@VisibleForTesting
+	int getBatchSize() {
+		return batchSize;
+	}
+
+	@VisibleForTesting
+	String getSchema() {
+		return schema.toString();
+	}
+
+	// --------------------------------------------------------------------------------------------
 	//  Classes to define predicates
 	// --------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
## What is the purpose of the change

- enable recursive directory enumeration for `OrcTableSource` (Hive's default behavior)
- expose the configuration in the `OrcTableSource` builder.

## Brief change log

* see purpose above

## Verifying this change

* Unit test to validate configuration of `FileInputFormat` has been added in `OrcTableSourceTest.testBuilder()`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **yes**
  - If yes, how is the feature documented? Java docs of builder + web documentation.
