### PR TITLE
[FLINK-8242] [orc] Fix predicate push-down of OrcTableSource

### DIFF
--- a/flink-connectors/flink-orc/src/main/java/org/apache/flink/orc/OrcTableSource.java
+++ b/flink-connectors/flink-orc/src/main/java/org/apache/flink/orc/OrcTableSource.java
@@ -52,6 +52,8 @@ import org.apache.flink.util.Preconditions;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.ql.io.sarg.PredicateLeaf;
 import org.apache.orc.TypeDescription;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -79,6 +81,8 @@ import java.util.List;
  */
 public class OrcTableSource
 	implements BatchTableSource<Row>, ProjectableTableSource<Row>, FilterableTableSource<Row> {
+
+	private static final Logger LOG = LoggerFactory.getLogger(OrcTableSource.class);
 
 	private static final int DEFAULT_BATCH_SIZE = 1000;
 
@@ -186,7 +190,10 @@ public class OrcTableSource
 		for (Expression pred : predicates) {
 			Predicate orcPred = toOrcPredicate(pred);
 			if (orcPred != null) {
+				LOG.info("Predicate [{}] converted into OrcPredicate [{}] and pushed into OrcTableSource for path {}.", pred, orcPred, path);
 				orcPredicates.add(orcPred);
+			} else {
+				LOG.info("Predicate [{}] could not be pushed into OrcTableSource for path {}.", pred, path);
 			}
 		}
 
@@ -235,17 +242,32 @@ public class OrcTableSource
 
 			if (!isValid(binComp)) {
 				// not a valid predicate
+				LOG.debug("Unsupported predicate [{}] cannot be pushed into OrcTableSource.", pred);
 				return null;
 			}
 			PredicateLeaf.Type litType = getLiteralType(binComp);
 			if (litType == null) {
 				// unsupported literal type
+				LOG.debug("Unsupported predicate [{}] cannot be pushed into OrcTableSource.", pred);
 				return null;
 			}
 
 			boolean literalOnRight = literalOnRight(binComp);
 			String colName = getColumnName(binComp);
-			Serializable literal = (Serializable) getLiteral(binComp);
+
+			// fetch literal and ensure it is serializable
+			Object literalObj = getLiteral(binComp);
+			Serializable literal;
+			// validate that literal is serializable
+			if (literalObj instanceof Serializable) {
+				literal = (Serializable) literalObj;
+			} else {
+				LOG.warn("Encountered a non-serializable literal of type {}. " +
+						"Cannot push predicate [{}] into OrcTableSource. " +
+						"This is a bug and should be reported.",
+						literalObj.getClass().getCanonicalName(), pred);
+				return null;
+			}
 
 			if (pred instanceof EqualTo) {
 				return new OrcRowInputFormat.Equals(colName, litType, literal);
@@ -282,6 +304,7 @@ public class OrcTableSource
 				}
 			} else {
 				// unsupported predicate
+				LOG.debug("Unsupported predicate [{}] cannot be pushed into OrcTableSource.", pred);
 				return null;
 			}
 		} else if (pred instanceof UnaryExpression) {
@@ -289,11 +312,13 @@ public class OrcTableSource
 			UnaryExpression unary = (UnaryExpression) pred;
 			if (!isValid(unary)) {
 				// not a valid predicate
+				LOG.debug("Unsupported predicate [{}] cannot be pushed into OrcTableSource.", pred);
 				return null;
 			}
 			PredicateLeaf.Type colType = toOrcType(((UnaryExpression) pred).child().resultType());
 			if (colType == null) {
 				// unsupported type
+				LOG.debug("Unsupported predicate [{}] cannot be pushed into OrcTableSource.", pred);
 				return null;
 			}
 
@@ -306,10 +331,12 @@ public class OrcTableSource
 					new OrcRowInputFormat.IsNull(colName, colType));
 			} else {
 				// unsupported predicate
+				LOG.debug("Unsupported predicate [{}] cannot be pushed into OrcTableSource.", pred);
 				return null;
 			}
 		} else {
 			// unsupported predicate
+			LOG.debug("Unsupported predicate [{}] cannot be pushed into OrcTableSource.", pred);
 			return null;
 		}
 	}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/util/RexProgramExtractor.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/util/RexProgramExtractor.scala
@@ -29,8 +29,9 @@ import org.apache.flink.table.calcite.FlinkTypeFactory
 import org.apache.flink.table.expressions.{And, Expression, Literal, Or, ResolvedFieldReference}
 import org.apache.flink.table.validate.FunctionCatalog
 import org.apache.flink.util.Preconditions
-
 import java.sql.{Date, Time, Timestamp}
+
+import org.slf4j.{Logger, LoggerFactory}
 
 import scala.collection.JavaConversions._
 import scala.collection.JavaConverters._
@@ -38,6 +39,8 @@ import scala.collection.mutable
 import scala.util.{Failure, Success, Try}
 
 object RexProgramExtractor {
+
+  lazy val LOG: Logger = LoggerFactory.getLogger(getClass)
 
   /**
     * Extracts the indices of input fields which accessed by the RexProgram.
@@ -214,7 +217,13 @@ class RexNodeToExpressionConverter(
         // convert to BigDecimal
         literal.getValueAs(classOf[java.math.BigDecimal])
 
-      case _ => literal.getValue
+      case _ =>
+        // Literal type is not supported.
+        RexProgramExtractor.LOG.debug(
+          "Literal {} of SQL type {} is not supported and cannot be converted. " +
+            "Please reach out to the community if you think this type should be supported.",
+          Array(literal, literal.getType): _*)
+        return None
     }
 
     Some(Literal(literalValue, literalType))


### PR DESCRIPTION
## What is the purpose of the change

* Fix `ClassClassException` in `OrcTableSource` caused by hard cast to `Serializable`
* Fix translation of Calcite literals with `NlString`

## Brief change log

* add check to `OrcTableSource` before casting to `Serializable`
* add logging to `OrcTableSource` for predicate push-down
* add fallback for Calcite literal translation for `NlString` literals

## Verifying this change

* adds a test to `OrcTableSourceTest.testApplyPredicate()`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **n/a**
