### PR TITLE
[FLINK-8364][state backend] Add iterator() to ListState which returns empty iterator when it has no value

### DIFF
--- a/docs/dev/stream/state/state.md
+++ b/docs/dev/stream/state/state.md
@@ -93,9 +93,11 @@ retrieved (scoped to key of the input element as mentioned above, so there will 
 for each key that the operation sees). The value can be set using `update(T)` and retrieved using
 `T value()`.
 
-* `ListState<T>`: This keeps a list of elements. You can append elements and retrieve an `Iterable`
-over all currently stored elements. Elements are added using `add(T)` or `addAll(List<T>)`, the Iterable can
-be retrieved using `Iterable<T> get()`. You can also override the existing list with `update(List<T>)`
+* `ListState<T>`: This keeps a list of elements. You can append elements using `add(T)` or `addAll(List<T>)`,
+and override existing list using `update(List<T>)`. You can retrieve currently stored elements using 
+`Iterable<T> get()` or `Iterator<T> iterator()` - the difference being that, when the state is empty, the
+former method will return `null` which requires special handling while the latter one returns an empty
+iterator which doesn't require special handling.
 
 * `ReducingState<T>`: This keeps a single value that represents the aggregation of all values
 added to the state. The interface is similar to `ListState` but elements added using

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBaseTest.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBaseTest.java
@@ -68,6 +68,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -673,9 +674,9 @@ public class FlinkKafkaConsumerBaseTest {
 		}
 	}
 
-	private static final class TestingListState<T> implements ListState<T> {
+	private static final class TestingListState<V> implements ListState<V> {
 
-		private final List<T> list = new ArrayList<>();
+		private final List<V> list = new ArrayList<>();
 		private boolean clearCalled = false;
 
 		@Override
@@ -685,16 +686,26 @@ public class FlinkKafkaConsumerBaseTest {
 		}
 
 		@Override
-		public Iterable<T> get() throws Exception {
+		public Iterable<V> get() {
 			return list;
 		}
 
 		@Override
-		public void add(T value) throws Exception {
+		public Iterator<V> iterator() {
+			Iterable<V> iterable = get();
+			if (iterable == null) {
+				return Collections.emptyIterator();
+			}
+
+			return iterable.iterator();
+		}
+
+		@Override
+		public void add(V value) throws Exception {
 			list.add(value);
 		}
 
-		public List<T> getList() {
+		public List<V> getList() {
 			return list;
 		}
 
@@ -703,14 +714,14 @@ public class FlinkKafkaConsumerBaseTest {
 		}
 
 		@Override
-		public void update(List<T> values) throws Exception {
+		public void update(List<V> values) throws Exception {
 			clear();
 
 			addAll(values);
 		}
 
 		@Override
-		public void addAll(List<T> values) throws Exception {
+		public void addAll(List<V> values) throws Exception {
 			if (values != null) {
 				list.addAll(values);
 			}

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisConsumerTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisConsumerTest.java
@@ -61,7 +61,9 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -515,9 +517,9 @@ public class FlinkKinesisConsumerTest {
 		assertTrue(typeInformation.createSerializer(new ExecutionConfig()) instanceof PojoSerializer);
 	}
 
-	private static final class TestingListState<T> implements ListState<T> {
+	private static final class TestingListState<V> implements ListState<V> {
 
-		private final List<T> list = new ArrayList<>();
+		private final List<V> list = new ArrayList<>();
 		private boolean clearCalled = false;
 
 		@Override
@@ -527,16 +529,26 @@ public class FlinkKinesisConsumerTest {
 		}
 
 		@Override
-		public Iterable<T> get() throws Exception {
+		public Iterable<V> get() {
 			return list;
 		}
 
 		@Override
-		public void add(T value) throws Exception {
+		public Iterator<V> iterator() {
+			Iterable<V> iterable = get();
+			if (iterable == null) {
+				return Collections.emptyIterator();
+			}
+
+			return iterable.iterator();
+		}
+
+		@Override
+		public void add(V value) throws Exception {
 			list.add(value);
 		}
 
-		public List<T> getList() {
+		public List<V> getList() {
 			return list;
 		}
 
@@ -545,14 +557,14 @@ public class FlinkKinesisConsumerTest {
 		}
 
 		@Override
-		public void update(List<T> values) throws Exception {
+		public void update(List<V> values) throws Exception {
 			list.clear();
 
 			addAll(values);
 		}
 
 		@Override
-		public void addAll(List<T> values) throws Exception {
+		public void addAll(List<V> values) throws Exception {
 			if (values != null) {
 				list.addAll(values);
 			}

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBListState.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBListState.java
@@ -33,6 +33,8 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -106,8 +108,19 @@ public class RocksDBListState<K, N, V>
 			}
 			return result;
 		} catch (IOException | RocksDBException e) {
-			throw new RuntimeException("Error while retrieving data from RocksDB", e);
+			throw new RuntimeException("Error while retrieving data from RocksDB via get()", e);
 		}
+	}
+
+	@Override
+	public Iterator<V> iterator() {
+		Iterable<V> iterable = get();
+
+		if (iterable == null) {
+			return Collections.emptyIterator();
+		}
+
+		return iterable.iterator();
 	}
 
 	@Override

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/AppendingState.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/AppendingState.java
@@ -57,7 +57,7 @@ public interface AppendingState<IN, OUT> extends State {
 	 * 
 	 * @throws Exception Thrown if the system cannot access the state.
 	 */
-	OUT get() throws Exception ;
+	OUT get() throws Exception;
 
 	/**
 	 * Updates the operator state accessible by {@link #get()} by adding the given value
@@ -71,5 +71,4 @@ public interface AppendingState<IN, OUT> extends State {
 	 * @throws IOException Thrown if the system cannot access the state.
 	 */
 	void add(IN value) throws Exception;
-	
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/ListState.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/ListState.java
@@ -20,6 +20,7 @@ package org.apache.flink.api.common.state;
 
 import org.apache.flink.annotation.PublicEvolving;
 
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -36,6 +37,17 @@ import java.util.List;
  */
 @PublicEvolving
 public interface ListState<T> extends MergingState<T, Iterable<T>> {
+	/**
+	 * Returns an iterator of values in the state. If there is no value, the iterator will not have
+	 * any elements.
+	 *
+	 * This is added as complement of {@link #get()}. When using {@link #get()}, developers need to
+	 * consider the case of getting a `null`. This method instead takes care of that for developers.
+	 *
+	 * @return An iterator of state values. The iterator doesn't have elements if the state is empty.
+	 */
+	Iterator<T> iterator();
+
 	/**
 	 * Updates the operator state accessible by {@link #get()} by updating existing values to
 	 * to the given list of values. The next time {@link #get()} is called (for the same state

--- a/flink-queryable-state/flink-queryable-state-client-java/src/main/java/org/apache/flink/queryablestate/client/state/ImmutableListState.java
+++ b/flink-queryable-state/flink-queryable-state-client-java/src/main/java/org/apache/flink/queryablestate/client/state/ImmutableListState.java
@@ -25,6 +25,8 @@ import org.apache.flink.queryablestate.client.state.serialization.KvStateSeriali
 import org.apache.flink.util.Preconditions;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -46,6 +48,16 @@ public final class ImmutableListState<V> extends ImmutableState implements ListS
 	@Override
 	public Iterable<V> get() {
 		return listState;
+	}
+
+	@Override
+	public Iterator<V> iterator() {
+		Iterable<V> iterable = get();
+		if (iterable == null) {
+			return Collections.emptyIterator();
+		}
+
+		return iterable.iterator();
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackend.java
@@ -47,7 +47,9 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -468,6 +470,16 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 		@Override
 		public Iterable<S> get() {
 			return internalList;
+		}
+
+		@Override
+		public Iterator<S> iterator() {
+			Iterable<S> iterable = get();
+			if (iterable == null) {
+				return Collections.emptyIterator();
+			}
+
+			return iterable.iterator();
 		}
 
 		@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/UserFacingListState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/UserFacingListState.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.state;
 import org.apache.flink.api.common.state.ListState;
 
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -32,8 +33,6 @@ class UserFacingListState<T> implements ListState<T> {
 
 	private final ListState<T> originalState;
 
-	private final Iterable<T> emptyState = Collections.emptyList();
-
 	UserFacingListState(ListState<T> originalState) {
 		this.originalState = originalState;
 	}
@@ -42,8 +41,22 @@ class UserFacingListState<T> implements ListState<T> {
 
 	@Override
 	public Iterable<T> get() throws Exception {
-		Iterable<T> original = originalState.get();
-		return original != null ? original : emptyState;
+		return originalState.get();
+	}
+
+	@Override
+	public Iterator<T> iterator() {
+		try {
+			Iterable<T> iterable = get();
+
+			if (iterable == null) {
+				return Collections.emptyIterator();
+			}
+
+			return iterable.iterator();
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
 	}
 
 	@Override
@@ -55,7 +68,7 @@ class UserFacingListState<T> implements ListState<T> {
 	public void clear() {
 		originalState.clear();
 	}
-
+	
 	@Override
 	public void update(List<T> values) throws Exception {
 		originalState.update(values);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapListState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapListState.java
@@ -27,6 +27,8 @@ import org.apache.flink.util.Preconditions;
 
 import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -63,6 +65,16 @@ public class HeapListState<K, N, V>
 	@Override
 	public Iterable<V> get() {
 		return stateTable.get(currentNamespace);
+	}
+
+	@Override
+	public Iterator<V> iterator() {
+		Iterable<V> iterable = get();
+		if (iterable == null) {
+			return Collections.emptyIterator();
+		}
+
+		return iterable.iterator();
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
@@ -1300,6 +1300,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 			assertNull(state.get());
 			state.add(null);
 			assertNull(state.get());
+			assertFalse(state.iterator().hasNext());
 
 			keyedBackend.setCurrentKey("def");
 			assertNull(state.get());
@@ -1312,8 +1313,10 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 			// update(emptyList) should remain the value null
 			state.update(Collections.emptyList());
 			assertNull(state.get());
+			assertFalse(state.iterator().hasNext());
 			state.update(Arrays.asList(10L, 16L));
 			assertThat(state.get(), containsInAnyOrder(16L, 10L));
+			assertThat(() -> state.iterator(), containsInAnyOrder(16L, 10L));
 			state.add(null);
 			assertThat(state.get(), containsInAnyOrder(16L, 10L));
 
@@ -1324,8 +1327,10 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 			assertNull(state.get());
 			state.addAll(null);
 			assertNull(state.get());
+			assertFalse(state.iterator().hasNext());
 			state.addAll(Collections.emptyList());
 			assertNull(state.get());
+			assertFalse(state.iterator().hasNext());
 			state.addAll(Arrays.asList(3L, 4L));
 			assertThat(state.get(), containsInAnyOrder(3L, 4L));
 			state.addAll(null);
@@ -1339,6 +1344,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 
 			state.add(null);
 			assertThat(state.get(), containsInAnyOrder(3L, 4L, 5L, 6L));
+			assertThat(() -> state.iterator(), containsInAnyOrder(3L, 4L, 5L, 6L));
 			state.update(Arrays.asList(1L, 2L));
 			assertThat(state.get(), containsInAnyOrder(1L, 2L));
 
@@ -1357,6 +1363,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 
 			keyedBackend.setCurrentKey("g");
 			assertThat(state.get(), containsInAnyOrder(1L, 2L, 3L, 2L, 1L));
+			assertThat(() -> state.iterator(), containsInAnyOrder(1L, 2L, 3L, 2L, 1L));
 			state.update(Arrays.asList(5L, 6L));
 			assertThat(state.get(), containsInAnyOrder(5L, 6L));
 			state.clear();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContextTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContextTest.java
@@ -63,6 +63,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doAnswer;
@@ -213,7 +214,7 @@ public class StreamingRuntimeContextTest {
 	}
 
 	@Test
-	public void testListStateReturnsEmptyListByDefault() throws Exception {
+	public void testListStateReturnsNullByDefault() throws Exception {
 
 		StreamingRuntimeContext context = new StreamingRuntimeContext(
 				createListPlainMockOp(),
@@ -224,8 +225,7 @@ public class StreamingRuntimeContextTest {
 		ListState<String> state = context.getListState(descr);
 
 		Iterable<String> value = state.get();
-		assertNotNull(value);
-		assertFalse(value.iterator().hasNext());
+		assertNull(value);
 	}
 
 	@Test


### PR DESCRIPTION
## What is the purpose of the change

Add iterator() to ListState which returns empty iterator when it has no value

## Brief change log

Add iterator() to ListState which returns empty iterator when it has no value

## Verifying this change

This change added tests and can be verified by extending `StateBackendTestBase#testListStateAPIs()`

## Does this pull request potentially affect one of the following parts:

  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs / JavaDocs)
