### PR TITLE
[hotfix][JobGraph] Eliminate the conditions of parallelism in isChainable

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -535,7 +535,6 @@ public class StreamingJobGraphGenerator {
 				&& (headOperator.getChainingStrategy() == ChainingStrategy.HEAD ||
 					headOperator.getChainingStrategy() == ChainingStrategy.ALWAYS)
 				&& (edge.getPartitioner() instanceof ForwardPartitioner)
-				&& upStreamVertex.getParallelism() == downStreamVertex.getParallelism()
 				&& streamGraph.isChainingEnabled();
 	}
 


### PR DESCRIPTION
When building StreamGraph, the restriction is added, and the upstream and downstream nodes of the forward are required to have the same parallelism.

When we added edge, we added the following restrictions.

`if (partitioner instanceof ForwardPartitioner) {
  if (upstreamNode.getParallelism() != downstreamNode.getParallelism()) {
    throw new UnsupportedOperationException("Forward partitioning does not allow " +
      "change of parallelism. Upstream operation: " + upstreamNode + " parallelism: " + upstreamNode.getParallelism() +
      ", downstream operation: " + downstreamNode + " parallelism: " + downstreamNode.getParallelism() +
      " You must use another partitioning strategy, such as broadcast, rebalance, shuffle or global.");
  }
}`
