### PR TITLE
[hotfix][StreamingJobGraphGenerator] modify the classification of partitioner in connect

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -495,12 +495,7 @@ public class StreamingJobGraphGenerator {
 
 		StreamPartitioner<?> partitioner = edge.getPartitioner();
 		JobEdge jobEdge;
-		if (partitioner instanceof ForwardPartitioner) {
-			jobEdge = downStreamVertex.connectNewDataSetAsInput(
-				headVertex,
-				DistributionPattern.POINTWISE,
-				ResultPartitionType.PIPELINED_BOUNDED);
-		} else if (partitioner instanceof RescalePartitioner){
+		if (partitioner instanceof ForwardPartitioner || partitioner instanceof RescalePartitioner) {
 			jobEdge = downStreamVertex.connectNewDataSetAsInput(
 				headVertex,
 				DistributionPattern.POINTWISE,


### PR DESCRIPTION
I think that it is better to divide the partitioner into two categories according to DistributionPattern.