### PR TITLE
[FLINK-8485] [client] Unblock JobSubmissionClientActor#tryToSubmitJob

### DIFF
--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
@@ -249,7 +249,7 @@ object AkkaUtils {
          |    default-dispatcher {
          |      fork-join-executor {
          |        parallelism-factor = 1.0
-         |        parallelism-min = 1
+         |        parallelism-min = 2
          |        parallelism-max = 4
          |      }
          |    }


### PR DESCRIPTION
## What is the purpose of the change

The JobSubmissionClientActor blocked a ActorSystem's dispatcher thread when requesting
the BlobServer port from the cluster. This fails when using the FlinkMiniCluster on a
single core machine because we set the number of threads to 1.

This commit unblocks the JobSubmissionClientActor#tryToSubmitJob method and sets the
lower limit of dispatcher threads to 2 when using the FlinkMiniCluster.

## Brief change log

- Unblock `JobSubmissionClientActor#tryToSubmitJob`
- Set lower limit of `ActorSystem` threads to 2

## Verifying this change

- Verified manually

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
