### PR TITLE
[FLINK-8515] update RocksDBMapState to replace deprecated remove() with delete()

### DIFF
--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBMapState.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBMapState.java
@@ -128,7 +128,7 @@ public class RocksDBMapState<K, N, UK, UV>
 	public void remove(UK userKey) throws IOException, RocksDBException {
 		byte[] rawKeyBytes = serializeUserKeyWithCurrentKeyAndNamespace(userKey);
 
-		backend.db.remove(columnFamily, writeOptions, rawKeyBytes);
+		backend.db.delete(columnFamily, writeOptions, rawKeyBytes);
 	}
 
 	@Override
@@ -340,7 +340,7 @@ public class RocksDBMapState<K, N, UK, UV>
 			rawValueBytes = null;
 
 			try {
-				db.remove(columnFamily, writeOptions, rawKeyBytes);
+				db.delete(columnFamily, writeOptions, rawKeyBytes);
 			} catch (RocksDBException e) {
 				throw new RuntimeException("Error while removing data from RocksDB.", e);
 			}


### PR DESCRIPTION
## What is the purpose of the change

RocksDBMapState is currently using `rocksdb#remove()` which is deprecated. Should be replaced with `rocksdb#delete()`

## Brief change log

update RocksDBMapState to replace deprecated remove() with delete()

## Verifying this change

This change is already covered by existing tests, such as `StateBackendTestBase#testMapState()`

## Does this pull request potentially affect one of the following parts:

none

## Documentation

none