### PR TITLE
[FLINK-8407][DataStream]Setting the parallelism after a partitioning operation should be forbidden	

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/SingleOutputStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/SingleOutputStreamOperator.java
@@ -26,10 +26,8 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.typeutils.TypeInfoParser;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
-import org.apache.flink.streaming.api.transformations.PartitionTransformation;
 import org.apache.flink.streaming.api.transformations.SideOutputTransformation;
 import org.apache.flink.streaming.api.transformations.StreamTransformation;
-import org.apache.flink.streaming.runtime.partitioner.StreamPartitioner;
 import org.apache.flink.util.OutputTag;
 import org.apache.flink.util.Preconditions;
 
@@ -403,11 +401,6 @@ public class SingleOutputStreamOperator<T> extends DataStream<T> {
 	// ------------------------------------------------------------------------
 	//  Miscellaneous
 	// ------------------------------------------------------------------------
-
-	@Override
-	protected DataStream<T> setConnectionType(StreamPartitioner<T> partitioner) {
-		return new SingleOutputStreamOperator<>(this.getExecutionEnvironment(), new PartitionTransformation<>(this.getTransformation(), partitioner));
-	}
 
 	/**
 	 * Sets the slot sharing group of this operation. Parallel instances of

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/DataStreamTest.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/DataStreamTest.scala
@@ -34,9 +34,15 @@ import org.apache.flink.streaming.runtime.partitioner._
 import org.apache.flink.test.util.AbstractTestBase
 import org.apache.flink.util.Collector
 import org.junit.Assert._
-import org.junit.Test
+import org.junit.{Rule, Test}
+import org.junit.rules.ExpectedException
 
 class DataStreamTest extends AbstractTestBase {
+
+  private val expectedException = ExpectedException.none()
+
+  @Rule
+  def thrownException = expectedException
 
   @Test
   def testNaming(): Unit = {
@@ -299,17 +305,24 @@ class DataStreamTest extends AbstractTestBase {
     assert(4 == env.getStreamGraph.getStreamNode(sink.getTransformation.getId).getParallelism)
   }
 
+
   /**
     * Tests setting the parallelism after a partitioning operation (e.g., broadcast, rescale)
     * should fail.
     */
-  @Test(expected = classOf[UnsupportedOperationException])
+  @Test
   def testParallelismFailAfterPartitioning(): Unit = {
     val env: StreamExecutionEnvironment = StreamExecutionEnvironment.getExecutionEnvironment
 
     val src = env.fromElements(new Tuple2[Long, Long](0L, 0L))
     val map = src.map(_ => (0L, 0L))
-    map.broadcast.setParallelism(1)
+
+    // This could be replaced with other partitioning operations (e.g., rescale, shuffle, forward),
+    // which trigger the setConnectionType() method.
+    val broadcastStream = map.broadcast
+    thrownException.expect(classOf[UnsupportedOperationException])
+    thrownException.expectMessage("cannot set the parallelism")
+    broadcastStream.setParallelism(1)
   }
 
   /**

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/DataStreamTest.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/DataStreamTest.scala
@@ -300,6 +300,19 @@ class DataStreamTest extends AbstractTestBase {
   }
 
   /**
+    * Tests setting the parallelism after a partitioning operation (e.g., broadcast, rescale)
+    * should fail.
+    */
+  @Test(expected = classOf[UnsupportedOperationException])
+  def testParallelismFailAfterPartitioning(): Unit = {
+    val env: StreamExecutionEnvironment = StreamExecutionEnvironment.getExecutionEnvironment
+
+    val src = env.fromElements(new Tuple2[Long, Long](0L, 0L))
+    val map = src.map(_ => (0L, 0L))
+    map.broadcast.setParallelism(1)
+  }
+
+  /**
    * Tests whether resource gets set.
    */
   /*


### PR DESCRIPTION
## What is the purpose of the change

This PR forbids the users to set parallelism after a partitioning operation (e.g., broadcast, rescale).

## Brief change log

Removes the overridden method for `setConnectionType` in `SingleOutputStreamOperator.java`.

## Verifying this change

This change can be verified by the added test `testParallelismFailAfterPartitioning` in `DataStreamTest.scala`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)