### PR TITLE
[hotfix] [table] Fix IndexOutOfBoundsException in DataStreamSortRule.

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/datastream/DataStreamSortRule.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/datastream/DataStreamSortRule.scala
@@ -71,6 +71,10 @@ class DataStreamSortRule
   def checkTimeOrder(sort: FlinkLogicalSort): Boolean = {
     
     val sortCollation = sort.collation
+    if (sortCollation.getFieldCollations.size() == 0) {
+      // no sort fields defined
+      return false
+    }
     // get type of first sort field
     val firstSortType = SortUtil.getFirstSortField(sortCollation, sort.getRowType).getType
     // get direction of first sort field

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/SortUtil.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/SortUtil.scala
@@ -35,6 +35,7 @@ import org.apache.flink.table.api.TableException
 import org.apache.flink.table.calcite.FlinkTypeFactory
 import org.apache.flink.api.common.functions.MapFunction
 import org.apache.flink.table.plan.schema.RowSchema
+import org.apache.flink.util.Preconditions
 
 import java.util.Comparator
 
@@ -60,6 +61,7 @@ object SortUtil {
     inputTypeInfo: TypeInformation[Row],
     execCfg: ExecutionConfig): ProcessFunction[CRow, CRow] = {
 
+    Preconditions.checkArgument(collationSort.getFieldCollations.size() > 0)
     val rowtimeIdx = collationSort.getFieldCollations.get(0).getFieldIndex
 
     val collectionRowComparator = if (collationSort.getFieldCollations.size() > 1) {
@@ -158,6 +160,7 @@ object SortUtil {
    * @return The direction of the first sort field.
    */
   def getFirstSortDirection(collationSort: RelCollation): Direction = {
+    Preconditions.checkArgument(collationSort.getFieldCollations.size() > 0)
     collationSort.getFieldCollations.get(0).direction
   }
   
@@ -169,6 +172,7 @@ object SortUtil {
    * @return The first sort field.
    */
   def getFirstSortField(collationSort: RelCollation, rowType: RelDataType): RelDataTypeField = {
+    Preconditions.checkArgument(collationSort.getFieldCollations.size() > 0)
     val idx = collationSort.getFieldCollations.get(0).getFieldIndex
     rowType.getFieldList.get(idx)
   }


### PR DESCRIPTION
## What is the purpose of the change

Fixes an `IndexOutOfBoundsException` in `DataStreamSortRule` if a plan contains a sort operator without sorting fields (just LIMIT / FETCH).

## Brief change log

* Check number of sort fields before checking type of first field.

## Verifying this change

Not covered by tests. `ORDER BY` without sorting fields are not supported cannot be translated. This change just prevents an exception but does not enable the feature.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **n/a**
