### PR TITLE
[FLINK-8357] [conf] Enable rolling in default log settings

### DIFF
--- a/flink-dist/src/main/flink-bin/conf/log4j-cli.properties
+++ b/flink-dist/src/main/flink-bin/conf/log4j-cli.properties
@@ -19,10 +19,12 @@
 log4j.rootLogger=INFO, file
 
 # Log all infos in the given file
-log4j.appender.file=org.apache.log4j.FileAppender
+log4j.appender.file=org.apache.log4j.RollingFileAppender
 log4j.appender.file.file=${log.file}
 log4j.appender.file.append=false
 log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.MaxFileSize=200MB
+log4j.appender.file.MaxBackupIndex=30
 log4j.appender.file.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p %-60c %x - %m%n
 
 

--- a/flink-dist/src/main/flink-bin/conf/log4j.properties
+++ b/flink-dist/src/main/flink-bin/conf/log4j.properties
@@ -31,10 +31,12 @@ log4j.logger.org.apache.hadoop=INFO
 log4j.logger.org.apache.zookeeper=INFO
 
 # Log all infos in the given file
-log4j.appender.file=org.apache.log4j.FileAppender
+log4j.appender.file=org.apache.log4j.RollingFileAppender
 log4j.appender.file.file=${log.file}
 log4j.appender.file.append=false
 log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.MaxFileSize=200MB
+log4j.appender.file.MaxBackupIndex=30
 log4j.appender.file.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p %-60c %x - %m%n
 
 # Suppress the irrelevant (wrong) warnings from the Netty channel handler

--- a/flink-dist/src/main/flink-bin/conf/logback-yarn.xml
+++ b/flink-dist/src/main/flink-bin/conf/logback-yarn.xml
@@ -17,8 +17,14 @@
   -->
 
 <configuration>
-    <appender name="file" class="ch.qos.logback.core.FileAppender">
+    <appender name="file" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${log.file}</file>
+		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+			<!-- daily rollover -->
+			<fileNamePattern>${log.file}.%d{yyyy-MM-dd}</fileNamePattern>
+			<maxHistory>30</maxHistory>
+			<totalSizeCap>6GB</totalSizeCap>
+		</rollingPolicy>
         <append>false</append>
         <encoder>
             <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{60} %X{sourceThread} - %msg%n</pattern>

--- a/flink-dist/src/main/flink-bin/conf/logback.xml
+++ b/flink-dist/src/main/flink-bin/conf/logback.xml
@@ -17,8 +17,14 @@
   -->
 
 <configuration>
-    <appender name="file" class="ch.qos.logback.core.FileAppender">
+    <appender name="file" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${log.file}</file>
+		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+			<!-- daily rollover -->
+			<fileNamePattern>${log.file}.%d{yyyy-MM-dd}</fileNamePattern>
+			<maxHistory>30</maxHistory>
+			<totalSizeCap>6GB</totalSizeCap>
+		</rollingPolicy>
         <append>false</append>
         <encoder>
             <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{60} %X{sourceThread} - %msg%n</pattern>


### PR DESCRIPTION
## What is the purpose of the change

*Enable rolling in default log settings.*

## Brief change log

  - *Change log4j-cli.properties default log ```FileAppender``` to ```DailyRollingFileAppender```, also did in log4j.properties file.*
  - *Change logback ```logback-yarn.xml``` and ```logback.xml```  default FileAppender to  ```RollingFileAppender```.*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): (don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: ( no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not documented)
