### PR TITLE
[FLINK-8101] [es connector] Elasticsearch 6.x (and 5.3+) Flink connector

### DIFF
--- a/flink-connectors/flink-connector-elasticsearch6/pom.xml
+++ b/flink-connectors/flink-connector-elasticsearch6/pom.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor 
+	license agreements. See the NOTICE file distributed with this work for additional 
+	information regarding copyright ownership. The ASF licenses this file to 
+	you under the Apache License, Version 2.0 (the "License"); you may not use 
+	this file except in compliance with the License. You may obtain a copy of 
+	the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required 
+	by applicable law or agreed to in writing, software distributed under the 
+	License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
+	OF ANY KIND, either express or implied. See the License for the specific 
+	language governing permissions and limitations under the License. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.apache.flink</groupId>
+		<artifactId>flink-connectors</artifactId>
+		<version>1.4-SNAPSHOT</version>
+		<relativePath>..</relativePath>
+	</parent>
+
+	<artifactId>flink-connector-elasticsearch6_${scala.binary.version}</artifactId>
+	<name>flink-connector-elasticsearch6</name>
+
+	<packaging>jar</packaging>
+
+	<!-- Allow users to pass custom connector versions -->
+	<properties>
+		<elasticsearch.version>6.1.0</elasticsearch.version>
+	</properties>
+
+	<dependencies>
+
+		<!-- core dependencies -->
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- Dependency for Elasticsearch 5.x Java REST Client -->
+		<dependency>
+			<groupId>org.elasticsearch.client</groupId>
+			<artifactId>elasticsearch-rest-high-level-client</artifactId>
+			<version>${elasticsearch.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.elasticsearch</groupId>
+			<artifactId>elasticsearch</artifactId>
+			<version>${elasticsearch.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.elasticsearch.plugin</groupId>
+			<artifactId>transport-netty4-client</artifactId>
+			<version>${elasticsearch.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<!-- Elasticsearch 5.x uses Log4j2 and no longer detects logging implementations, 
+			making Log4j2 a strict dependency. The following is added so that the Log4j2 
+			API in Elasticsearch 5.x is routed to SLF4J. This way, user projects can 
+			remain flexible in the logging implementation preferred. -->
+
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-to-slf4j</artifactId>
+			<version>2.7</version>
+		</dependency>
+		
+
+		<!-- test dependencies -->
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-test-utils_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+			<type>test-jar</type>
+		</dependency>
+
+		<!-- Including Log4j2 dependencies for tests is required for the embedded 
+			Elasticsearch nodes used in tests to run correctly. -->
+
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-api</artifactId>
+			<version>2.7</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
+			<version>2.7</version>
+			<scope>test</scope>
+		</dependency>
+
+	</dependencies>
+
+	<build>
+		<plugins>
+			<!-- For the tests, we need to exclude the Log4j2 to slf4j adapter dependency 
+				and let Elasticsearch directly use Log4j2, otherwise the embedded Elasticsearch 
+				node used in tests will fail to work. In other words, the connector jar is 
+				routing Elasticsearch 5.x's Log4j2 API's to SLF4J, but for the test builds, 
+				we still stick to directly using Log4j2. -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.12.2</version>
+				<configuration>
+					<classpathDependencyExcludes>
+						<classpathDependencyExclude>org.apache.logging.log4j:log4j-to-slf4j</classpathDependencyExclude>
+					</classpathDependencyExcludes>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/flink-connectors/flink-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/BulkProcessorIndexer.java
+++ b/flink-connectors/flink-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/BulkProcessorIndexer.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.elasticsearch;
+
+import org.elasticsearch.action.DocWriteRequest;
+import org.elasticsearch.action.bulk.BulkProcessor;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Implementation of a {@link RequestIndexer}, using a {@link BulkProcessor}. {@link DocWriteRequest
+ * DocWriteRequests} will be buffered before sending a bulk request to the Elasticsearch cluster.
+ */
+class BulkProcessorIndexer implements RequestIndexer {
+
+	private final BulkProcessor bulkProcessor;
+	private final boolean flushOnCheckpoint;
+	private final AtomicLong numPendingRequestsRef;
+
+	BulkProcessorIndexer(BulkProcessor bulkProcessor, boolean flushOnCheckpoint,
+			AtomicLong numPendingRequestsRef) {
+		this.bulkProcessor = checkNotNull(bulkProcessor);
+		this.flushOnCheckpoint = flushOnCheckpoint;
+		this.numPendingRequestsRef = checkNotNull(numPendingRequestsRef);
+	}
+
+	@Override
+	public void add(DocWriteRequest... actionRequests) {
+		for (DocWriteRequest actionRequest : actionRequests) {
+			if (flushOnCheckpoint) {
+				numPendingRequestsRef.getAndIncrement();
+			}
+			this.bulkProcessor.add(actionRequest);
+		}
+	}
+}

--- a/flink-connectors/flink-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/DocWriteRequestFailureHandler.java
+++ b/flink-connectors/flink-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/DocWriteRequestFailureHandler.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.elasticsearch;
+
+import org.elasticsearch.action.DocWriteRequest;
+
+import java.io.Serializable;
+
+/**
+ * An implementation of {@link DocWriteRequestFailureHandler} is provided by the user to define how failed
+ * {@link ActionRequest ActionRequests} should be handled, e.g. dropping them, reprocessing malformed documents, or
+ * simply requesting them to be sent to Elasticsearch again if the failure is only temporary.
+ *
+ * <p>Example:
+ *
+ * <pre>{@code
+ *
+ *	private static class ExampleActionRequestFailureHandler implements ActionRequestFailureHandler {
+ *
+ *		@Override
+ *		void onFailure(ActionRequest action, Throwable failure, int restStatusCode, RequestIndexer indexer) throws Throwable {
+ *			if (ExceptionUtils.containsThrowable(failure, EsRejectedExecutionException.class)) {
+ *				// full queue; re-add document for indexing
+ *				indexer.add(action);
+ *			} else if (ExceptionUtils.containsThrowable(failure, ElasticsearchParseException.class)) {
+ *				// malformed document; simply drop request without failing sink
+ *			} else {
+ *				// for all other failures, fail the sink;
+ *				// here the failure is simply rethrown, but users can also choose to throw custom exceptions
+ *				throw failure;
+ *			}
+ *		}
+ *	}
+ *
+ * }</pre>
+ *
+ * <p>The above example will let the sink re-add requests that failed due to queue capacity saturation and drop requests
+ * with malformed documents, without failing the sink. For all other failures, the sink will fail.
+ *
+ * <p>Note: For Elasticsearch 1.x, it is not feasible to match the type of the failure because the exact type
+ * could not be retrieved through the older version Java client APIs (thus, the types will be general {@link Exception}s
+ * and only differ in the failure message). In this case, it is recommended to match on the provided REST status code.
+ */
+public interface DocWriteRequestFailureHandler extends Serializable {
+
+	/**
+	 * Handle a failed {@link ActionRequest}.
+	 *
+	 * @param action the {@link ActionRequest} that failed due to the failure
+	 * @param failure the cause of failure
+	 * @param restStatusCode the REST status code of the failure (-1 if none can be retrieved)
+	 * @param indexer request indexer to re-add the failed action, if intended to do so
+	 *
+	 * @throws Throwable if the sink should fail on this failure, the implementation should rethrow
+	 *                   the exception or a custom one
+	 */
+	void onFailure(DocWriteRequest action, Throwable failure, int restStatusCode, RequestIndexer indexer) throws Throwable;
+
+}

--- a/flink-connectors/flink-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchApiCallBridge.java
+++ b/flink-connectors/flink-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchApiCallBridge.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.elasticsearch;
+
+import org.elasticsearch.action.bulk.BulkItemResponse;
+import org.elasticsearch.action.bulk.BulkProcessor;
+import org.elasticsearch.client.RestHighLevelClient;
+
+import javax.annotation.Nullable;
+
+import java.io.Serializable;
+
+/**
+ * An {@link ElasticsearchApiCallBridge} is used to bridge incompatible Elasticsearch Java API calls
+ * across different versions. This includes calls to create Elasticsearch clients, handle failed
+ * item responses, etc. Any incompatible Elasticsearch Java APIs should be bridged using this
+ * interface.
+ * Implementations are allowed to be stateful. For example, for Elasticsearch 1.x, since connecting
+ * via an embedded node is allowed, the call bridge will hold reference to the created embedded
+ * node. Each instance of the sink will hold exactly one instance of the call bridge, and state
+ * cleanup is performed when the sink is closed.
+ */
+public interface ElasticsearchApiCallBridge extends Serializable {
+
+	/**
+	 * Creates an Elasticsearch REST {@link RestHighLevelClient}.
+	 *
+	 * @return The created REST client.
+	 */
+	RestHighLevelClient createClient();
+
+	/**
+	 * Extracts the cause of failure of a bulk item action.
+	 *
+	 * @param bulkItemResponse
+	 *          the bulk item response to extract cause of failure
+	 * @return the extracted {@link Throwable} from the response ({@code null} is the response is
+	 *         successful).
+	 */
+	@Nullable
+	Throwable extractFailureCauseFromBulkItemResponse(BulkItemResponse bulkItemResponse);
+
+	/**
+	 * Set backoff-related configurations on the provided {@link BulkProcessor.Builder}. The builder
+	 * will be later on used to instantiate the actual {@link BulkProcessor}.
+	 *
+	 * @param builder
+	 *          the {@link BulkProcessor.Builder} to configure.
+	 * @param flushBackoffPolicy
+	 *          user-provided backoff retry settings ({@code null} if the user disabled backoff
+	 *          retries).
+	 */
+	void configureBulkProcessorBackoff(BulkProcessor.Builder builder,
+			@Nullable ElasticsearchSinkBase.BulkFlushBackoffPolicy flushBackoffPolicy);
+
+	/**
+	 * Perform any necessary state cleanup.
+	 */
+	void cleanup();
+
+}

--- a/flink-connectors/flink-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkBase.java
+++ b/flink-connectors/flink-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkBase.java
@@ -1,0 +1,438 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.elasticsearch;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
+import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
+import org.apache.flink.util.InstantiationUtil;
+
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.DocWriteRequest;
+import org.elasticsearch.action.bulk.BulkItemResponse;
+import org.elasticsearch.action.bulk.BulkProcessor;
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.rest.RestStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Serializable;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Base class for all Flink Elasticsearch Sinks.
+ *
+ * <p>This class implements the common behaviour across Elasticsearch versions, such as
+ * the use of an internal {@link BulkProcessor} to buffer multiple {@link ActionRequest}s before
+ * sending the requests to the cluster, as well as passing input records to the user provided
+ * {@link ElasticsearchSinkFunction} for processing.
+ *
+ * <p>The version specific API calls for different Elasticsearch versions should be defined by a concrete implementation of
+ * a {@link ElasticsearchApiCallBridge}, which is provided to the constructor of this class. This call bridge is used,
+ * for example, to create a Elasticsearch {@link Client}, handle failed item responses, etc.
+ *
+ * @param <T> Type of the elements handled by this sink
+ */
+public abstract class ElasticsearchSinkBase<T> extends RichSinkFunction<T> implements CheckpointedFunction {
+
+	private static final long serialVersionUID = -1007596293618451942L;
+
+	private static final Logger LOG = LoggerFactory.getLogger(ElasticsearchSinkBase.class);
+
+	// ------------------------------------------------------------------------
+	//  Internal bulk processor configuration
+	// ------------------------------------------------------------------------
+
+	public static final String CONFIG_KEY_BULK_FLUSH_MAX_ACTIONS = "bulk.flush.max.actions";
+	public static final String CONFIG_KEY_BULK_FLUSH_MAX_SIZE_MB = "bulk.flush.max.size.mb";
+	public static final String CONFIG_KEY_BULK_FLUSH_INTERVAL_MS = "bulk.flush.interval.ms";
+	public static final String CONFIG_KEY_BULK_FLUSH_BACKOFF_ENABLE = "bulk.flush.backoff.enable";
+	public static final String CONFIG_KEY_BULK_FLUSH_BACKOFF_TYPE = "bulk.flush.backoff.type";
+	public static final String CONFIG_KEY_BULK_FLUSH_BACKOFF_RETRIES = "bulk.flush.backoff.retries";
+	public static final String CONFIG_KEY_BULK_FLUSH_BACKOFF_DELAY = "bulk.flush.backoff.delay";
+
+	/**
+	 * Used to control whether the retry delay should increase exponentially or remain constant.
+	 */
+	public enum FlushBackoffType {
+		CONSTANT,
+		EXPONENTIAL
+	}
+
+	/**
+	 * Provides a backoff policy for bulk requests. Whenever a bulk request is rejected due to resource constraints
+	 * (i.e. the client's internal thread pool is full), the backoff policy decides how long the bulk processor will
+	 * wait before the operation is retried internally.
+	 *
+	 * <p>This is a proxy for version specific backoff policies.
+	 */
+	public static class BulkFlushBackoffPolicy implements Serializable {
+
+		private static final long serialVersionUID = -6022851996101826049L;
+
+		// the default values follow the Elasticsearch default settings for BulkProcessor
+		private FlushBackoffType backoffType = FlushBackoffType.EXPONENTIAL;
+		private int maxRetryCount = 8;
+		private long delayMillis = 50;
+
+		public FlushBackoffType getBackoffType() {
+			return backoffType;
+		}
+
+		public int getMaxRetryCount() {
+			return maxRetryCount;
+		}
+
+		public long getDelayMillis() {
+			return delayMillis;
+		}
+
+		public void setBackoffType(FlushBackoffType backoffType) {
+			this.backoffType = checkNotNull(backoffType);
+		}
+
+		public void setMaxRetryCount(int maxRetryCount) {
+			checkArgument(maxRetryCount >= 0);
+			this.maxRetryCount = maxRetryCount;
+		}
+
+		public void setDelayMillis(long delayMillis) {
+			checkArgument(delayMillis >= 0);
+			this.delayMillis = delayMillis;
+		}
+	}
+
+	private final Integer bulkProcessorFlushMaxActions;
+	private final Integer bulkProcessorFlushMaxSizeMb;
+	private final Integer bulkProcessorFlushIntervalMillis;
+	private final BulkFlushBackoffPolicy bulkProcessorFlushBackoffPolicy;
+
+	// ------------------------------------------------------------------------
+	//  User-facing API and configuration
+	// ------------------------------------------------------------------------
+
+	/** The user specified config map that we forward to Elasticsearch when we create the {@link Client}. */
+	private final Map<String, String> userConfig;
+
+	/** The function that is used to construct mulitple {@link ActionRequest ActionRequests} from each incoming element. */
+	private final ElasticsearchSinkFunction<T> elasticsearchSinkFunction;
+
+	/** User-provided handler for failed {@link ActionRequest ActionRequests}. */
+	private final DocWriteRequestFailureHandler failureHandler;
+
+	/** If true, the producer will wait until all outstanding action requests have been sent to Elasticsearch. */
+	private boolean flushOnCheckpoint = true;
+
+	/** Provided to the user via the {@link ElasticsearchSinkFunction} to add {@link ActionRequest ActionRequests}. */
+	private transient BulkProcessorIndexer requestIndexer;
+
+	// ------------------------------------------------------------------------
+	//  Internals for the Flink Elasticsearch Sink
+	// ------------------------------------------------------------------------
+
+	/** Call bridge for different version-specific. */
+	private final ElasticsearchApiCallBridge callBridge;
+
+	/**
+	 * Number of pending action requests not yet acknowledged by Elasticsearch.
+	 * This value is maintained only if {@link ElasticsearchSinkBase#flushOnCheckpoint} is {@code true}.
+	 *
+	 * <p>This is incremented whenever the user adds (or re-adds through the {@link ActionRequestFailureHandler}) requests
+	 * to the {@link RequestIndexer}. It is decremented for each completed request of a bulk request, in
+	 * {@link BulkProcessor.Listener#afterBulk(long, BulkRequest, BulkResponse)} and
+	 * {@link BulkProcessor.Listener#afterBulk(long, BulkRequest, Throwable)}.
+	 */
+	private AtomicLong numPendingRequests = new AtomicLong(0);
+
+	/** Elasticsearch client created using the call bridge. */
+	private transient RestHighLevelClient client;
+
+	/** Bulk processor to buffer and send requests to Elasticsearch, created using the client. */
+	private transient BulkProcessor bulkProcessor;
+
+	/**
+	 * This is set from inside the {@link BulkProcessor.Listener} if a {@link Throwable} was thrown in callbacks and
+	 * the user considered it should fail the sink via the
+	 * {@link ActionRequestFailureHandler#onFailure(ActionRequest, Throwable, int, RequestIndexer)} method.
+	 *
+	 * <p>Errors will be checked and rethrown before processing each input element, and when the sink is closed.
+	 */
+	private final AtomicReference<Throwable> failureThrowable = new AtomicReference<>();
+
+	public ElasticsearchSinkBase(
+		ElasticsearchApiCallBridge callBridge,
+		Map<String, String> userConfig,
+		ElasticsearchSinkFunction<T> elasticsearchSinkFunction,
+		DocWriteRequestFailureHandler failureHandler) {
+
+		this.callBridge = checkNotNull(callBridge);
+		this.elasticsearchSinkFunction = checkNotNull(elasticsearchSinkFunction);
+		this.failureHandler = checkNotNull(failureHandler);
+
+		// we eagerly check if the user-provided sink function and failure handler is serializable;
+		// otherwise, if they aren't serializable, users will merely get a non-informative error message
+		// "ElasticsearchSinkBase is not serializable"
+
+		checkArgument(InstantiationUtil.isSerializable(elasticsearchSinkFunction),
+			"The implementation of the provided ElasticsearchSinkFunction is not serializable. " +
+				"The object probably contains or references non-serializable fields.");
+
+		checkArgument(InstantiationUtil.isSerializable(failureHandler),
+			"The implementation of the provided ActionRequestFailureHandler is not serializable. " +
+				"The object probably contains or references non-serializable fields.");
+
+		// extract and remove bulk processor related configuration from the user-provided config,
+		// so that the resulting user config only contains configuration related to the Elasticsearch client.
+
+		checkNotNull(userConfig);
+
+		ParameterTool params = ParameterTool.fromMap(userConfig);
+
+		if (params.has(CONFIG_KEY_BULK_FLUSH_MAX_ACTIONS)) {
+			bulkProcessorFlushMaxActions = params.getInt(CONFIG_KEY_BULK_FLUSH_MAX_ACTIONS);
+			userConfig.remove(CONFIG_KEY_BULK_FLUSH_MAX_ACTIONS);
+		} else {
+			bulkProcessorFlushMaxActions = null;
+		}
+
+		if (params.has(CONFIG_KEY_BULK_FLUSH_MAX_SIZE_MB)) {
+			bulkProcessorFlushMaxSizeMb = params.getInt(CONFIG_KEY_BULK_FLUSH_MAX_SIZE_MB);
+			userConfig.remove(CONFIG_KEY_BULK_FLUSH_MAX_SIZE_MB);
+		} else {
+			bulkProcessorFlushMaxSizeMb = null;
+		}
+
+		if (params.has(CONFIG_KEY_BULK_FLUSH_INTERVAL_MS)) {
+			bulkProcessorFlushIntervalMillis = params.getInt(CONFIG_KEY_BULK_FLUSH_INTERVAL_MS);
+			userConfig.remove(CONFIG_KEY_BULK_FLUSH_INTERVAL_MS);
+		} else {
+			bulkProcessorFlushIntervalMillis = null;
+		}
+
+		boolean bulkProcessorFlushBackoffEnable = params.getBoolean(CONFIG_KEY_BULK_FLUSH_BACKOFF_ENABLE, true);
+		userConfig.remove(CONFIG_KEY_BULK_FLUSH_BACKOFF_ENABLE);
+
+		if (bulkProcessorFlushBackoffEnable) {
+			this.bulkProcessorFlushBackoffPolicy = new BulkFlushBackoffPolicy();
+
+			if (params.has(CONFIG_KEY_BULK_FLUSH_BACKOFF_TYPE)) {
+				bulkProcessorFlushBackoffPolicy.setBackoffType(FlushBackoffType.valueOf(params.get(CONFIG_KEY_BULK_FLUSH_BACKOFF_TYPE)));
+				userConfig.remove(CONFIG_KEY_BULK_FLUSH_BACKOFF_TYPE);
+			}
+
+			if (params.has(CONFIG_KEY_BULK_FLUSH_BACKOFF_RETRIES)) {
+				bulkProcessorFlushBackoffPolicy.setMaxRetryCount(params.getInt(CONFIG_KEY_BULK_FLUSH_BACKOFF_RETRIES));
+				userConfig.remove(CONFIG_KEY_BULK_FLUSH_BACKOFF_RETRIES);
+			}
+
+			if (params.has(CONFIG_KEY_BULK_FLUSH_BACKOFF_DELAY)) {
+				bulkProcessorFlushBackoffPolicy.setDelayMillis(params.getLong(CONFIG_KEY_BULK_FLUSH_BACKOFF_DELAY));
+				userConfig.remove(CONFIG_KEY_BULK_FLUSH_BACKOFF_DELAY);
+			}
+
+		} else {
+			bulkProcessorFlushBackoffPolicy = null;
+		}
+
+		this.userConfig = userConfig;
+	}
+
+	/**
+	 * Disable flushing on checkpoint. When disabled, the sink will not wait for all
+	 * pending action requests to be acknowledged by Elasticsearch on checkpoints.
+	 *
+	 * <p>NOTE: If flushing on checkpoint is disabled, the Flink Elasticsearch Sink does NOT
+	 * provide any strong guarantees for at-least-once delivery of action requests.
+	 */
+	public void disableFlushOnCheckpoint() {
+		this.flushOnCheckpoint = false;
+	}
+
+	@Override
+	public void open(Configuration parameters) throws Exception {
+		client = callBridge.createClient();
+		bulkProcessor = buildBulkProcessor(new BulkProcessorListener());
+		requestIndexer = new BulkProcessorIndexer(bulkProcessor, flushOnCheckpoint, numPendingRequests);
+	}
+
+	@Override
+	public void invoke(T value) throws Exception {
+		// if bulk processor callbacks have previously reported an error, we rethrow the error and fail the sink
+		checkErrorAndRethrow();
+
+		elasticsearchSinkFunction.process(value, getRuntimeContext(), requestIndexer);
+	}
+
+	@Override
+	public void initializeState(FunctionInitializationContext context) throws Exception {
+		// no initialization needed
+	}
+
+	@Override
+	public void snapshotState(FunctionSnapshotContext context) throws Exception {
+		checkErrorAndRethrow();
+
+		if (flushOnCheckpoint) {
+			do {
+				bulkProcessor.flush();
+				checkErrorAndRethrow();
+			} while (numPendingRequests.get() != 0);
+		}
+	}
+
+	@Override
+	public void close() throws Exception {
+		if (bulkProcessor != null) {
+			bulkProcessor.close();
+			bulkProcessor = null;
+		}
+
+		// Right now the client cannot be closed..restore with ES 7
+		if (client != null) {
+			client.close();
+			client = null;
+		}
+
+		callBridge.cleanup();
+
+		// make sure any errors from callbacks are rethrown
+		checkErrorAndRethrow();
+	}
+
+	/**
+	 * Build the {@link BulkProcessor}.
+	 *
+	 * <p>Note: this is exposed for testing purposes.
+	 */
+	@VisibleForTesting
+	protected BulkProcessor buildBulkProcessor(BulkProcessor.Listener listener) {
+		checkNotNull(listener);
+
+		BulkProcessor.Builder bulkProcessorBuilder = BulkProcessor.builder(client::bulkAsync, listener);
+
+		// This makes flush() blocking
+		bulkProcessorBuilder.setConcurrentRequests(0);
+
+		if (bulkProcessorFlushMaxActions != null) {
+			bulkProcessorBuilder.setBulkActions(bulkProcessorFlushMaxActions);
+		}
+
+		if (bulkProcessorFlushMaxSizeMb != null) {
+			bulkProcessorBuilder.setBulkSize(new ByteSizeValue(bulkProcessorFlushMaxSizeMb, ByteSizeUnit.MB));
+		}
+
+		if (bulkProcessorFlushIntervalMillis != null) {
+			bulkProcessorBuilder.setFlushInterval(TimeValue.timeValueMillis(bulkProcessorFlushIntervalMillis));
+		}
+
+		// if backoff retrying is disabled, bulkProcessorFlushBackoffPolicy will be null
+		callBridge.configureBulkProcessorBackoff(bulkProcessorBuilder, bulkProcessorFlushBackoffPolicy);
+
+		return bulkProcessorBuilder.build();
+	}
+
+	private void checkErrorAndRethrow() {
+		Throwable cause = failureThrowable.get();
+		if (cause != null) {
+			throw new RuntimeException("An error occurred in ElasticsearchSink.", cause);
+		}
+	}
+
+	private class BulkProcessorListener implements BulkProcessor.Listener {
+		@Override
+		public void beforeBulk(long executionId, BulkRequest request) { }
+
+		@Override
+		public void afterBulk(long executionId, BulkRequest request, BulkResponse response) {
+			if (response.hasFailures()) {
+				BulkItemResponse itemResponse;
+				Throwable failure;
+				RestStatus restStatus;
+
+				try {
+					for (int i = 0; i < response.getItems().length; i++) {
+						itemResponse = response.getItems()[i];
+						failure = callBridge.extractFailureCauseFromBulkItemResponse(itemResponse);
+						if (failure != null) {
+							LOG.error("Failed Elasticsearch item request: {}", itemResponse.getFailureMessage(), failure);
+
+							restStatus = itemResponse.getFailure().getStatus();
+							if (restStatus == null) {
+								failureHandler.onFailure(request.requests().get(i), failure, -1, requestIndexer);
+							} else {
+								failureHandler.onFailure(request.requests().get(i), failure, restStatus.getStatus(), requestIndexer);
+							}
+						}
+					}
+				} catch (Throwable t) {
+					// fail the sink and skip the rest of the items
+					// if the failure handler decides to throw an exception
+					failureThrowable.compareAndSet(null, t);
+				}
+			}
+
+			if (flushOnCheckpoint) {
+				numPendingRequests.getAndAdd(-request.numberOfActions());
+			}
+		}
+
+		@Override
+		public void afterBulk(long executionId, BulkRequest request, Throwable failure) {
+			LOG.error("Failed Elasticsearch bulk request: {}", failure.getMessage(), failure.getCause());
+
+			try {
+				for (DocWriteRequest action : request.requests()) {
+					failureHandler.onFailure(action, failure, -1, requestIndexer);
+				}
+			} catch (Throwable t) {
+				// fail the sink and skip the rest of the items
+				// if the failure handler decides to throw an exception
+				failureThrowable.compareAndSet(null, t);
+			}
+
+			if (flushOnCheckpoint) {
+				numPendingRequests.getAndAdd(-request.numberOfActions());
+			}
+		}
+	}
+
+	@VisibleForTesting
+	long getNumPendingRequests() {
+		if (flushOnCheckpoint) {
+			return numPendingRequests.get();
+		} else {
+			throw new UnsupportedOperationException(
+				"The number of pending requests is not maintained when flushing on checkpoint is disabled.");
+		}
+	}
+}

--- a/flink-connectors/flink-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkFunction.java
+++ b/flink-connectors/flink-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkFunction.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.elasticsearch;
+
+import org.apache.flink.api.common.functions.Function;
+import org.apache.flink.api.common.functions.RuntimeContext;
+
+import org.elasticsearch.action.ActionRequest;
+
+import java.io.Serializable;
+
+/**
+ * Method that creates multiple {@link org.elasticsearch.action.ActionRequest}s from an element in a Stream.
+ *
+ * <p>This is used by {@link ElasticsearchSink} to prepare elements for sending them to Elasticsearch.
+ *
+ * <p>Example:
+ *
+ * <pre>{@code
+ *					private static class TestElasticSearchSinkFunction implements
+ *						ElasticsearchSinkFunction<Tuple2<Integer, String>> {
+ *
+ *					public IndexRequest createIndexRequest(Tuple2<Integer, String> element) {
+ *						Map<String, Object> json = new HashMap<>();
+ *						json.put("data", element.f1);
+ *
+ *						return Requests.indexRequest()
+ *							.index("my-index")
+ *							.type("my-type")
+ *							.id(element.f0.toString())
+ *							.source(json);
+ *						}
+ *
+ *				public void process(Tuple2<Integer, String> element, RuntimeContext ctx, RequestIndexer indexer) {
+ *					indexer.add(createIndexRequest(element));
+ *				}
+ *		}
+ *
+ * }</pre>
+ *
+ * @param <T> The type of the element handled by this {@code ElasticsearchSinkFunction}
+ *
+ */
+public interface ElasticsearchSinkFunction<T> extends Serializable, Function {
+
+	/**
+	 * Process the incoming element to produce multiple {@link ActionRequest ActionsRequests}. The
+	 * produced requests should be added to the provided {@link RequestIndexer}.
+	 *
+	 * @param element
+	 *          incoming element to process
+	 * @param ctx
+	 *          runtime context containing information about the sink instance
+	 * @param indexer
+	 *          request indexer that {@code ActionRequest} should be added to
+	 */
+	void process(T element, RuntimeContext ctx, RequestIndexer indexer);
+}

--- a/flink-connectors/flink-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/RequestIndexer.java
+++ b/flink-connectors/flink-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/RequestIndexer.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.elasticsearch;
+
+import org.elasticsearch.action.DocWriteRequest;
+
+/**
+ * Users add multiple {@link ActionRequest ActionRequests} to a {@link RequestIndexer} to prepare
+ * them for sending to an Elasticsearch cluster.
+ */
+public interface RequestIndexer {
+
+	/**
+	 * Add multiple {@link ActionRequest} to the indexer to prepare for sending requests to Elasticsearch.
+	 *
+	 * @param actionRequests The multiple {@link ActionRequest} to add.
+	 */
+	void add(DocWriteRequest... actionRequests);
+}

--- a/flink-connectors/flink-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/util/NoOpDocWriteFailureHandler.java
+++ b/flink-connectors/flink-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/util/NoOpDocWriteFailureHandler.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.elasticsearch.util;
+
+import org.apache.flink.streaming.connectors.elasticsearch.DocWriteRequestFailureHandler;
+import org.apache.flink.streaming.connectors.elasticsearch.RequestIndexer;
+
+import org.elasticsearch.action.DocWriteRequest;
+
+/**
+ * An {@link ActionRequestFailureHandler} that simply fails the sink on any failures.
+ */
+public class NoOpDocWriteFailureHandler implements DocWriteRequestFailureHandler {
+
+	private static final long serialVersionUID = 737941343410827885L;
+
+	@Override
+	public void onFailure(DocWriteRequest action, Throwable failure, int restStatusCode, RequestIndexer indexer) throws Throwable {
+		// simply fail the sink
+		throw failure;
+	}
+
+}

--- a/flink-connectors/flink-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/connectors/elasticsearch6/Elasticsearch6ApiCallBridge.java
+++ b/flink-connectors/flink-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/connectors/elasticsearch6/Elasticsearch6ApiCallBridge.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.elasticsearch6;
+
+import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchApiCallBridge;
+import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchSinkBase;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.http.HttpHost;
+
+import org.elasticsearch.action.bulk.BackoffPolicy;
+import org.elasticsearch.action.bulk.BulkItemResponse;
+import org.elasticsearch.action.bulk.BulkProcessor;
+import org.elasticsearch.action.main.MainResponse;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestClientBuilder;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.common.unit.TimeValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Implementation of {@link ElasticsearchApiCallBridge} for Elasticsearch 6.x.
+ */
+public class Elasticsearch6ApiCallBridge implements ElasticsearchApiCallBridge {
+
+	private static final long serialVersionUID = -5222683870097809633L;
+
+	private static final Logger LOG = LoggerFactory.getLogger(Elasticsearch6ApiCallBridge.class);
+
+	/**
+	 * User-provided HttpHost list.
+	 *
+	 */
+	private final HttpHost[] clusterHosts;
+
+	Elasticsearch6ApiCallBridge(List<HttpHost> clusterHosts) {
+		Preconditions.checkArgument(clusterHosts != null && !clusterHosts.isEmpty());
+		this.clusterHosts = clusterHosts.toArray(new HttpHost[0]);
+	}
+
+	@Override
+	public RestHighLevelClient createClient() {
+
+		RestClientBuilder restClientBuilder = RestClient.builder(clusterHosts);
+		RestHighLevelClient esClient = new RestHighLevelClient(restClientBuilder);
+		try {
+			MainResponse info = esClient.info();
+			// verify that we actually are connected to a cluster
+			if (info == null) {
+				throw new RuntimeException(
+						"Elasticsearch client is not connected to any Elasticsearch nodes!");
+			}
+
+			if (LOG.isInfoEnabled()) {
+				LOG.info("Created Elasticsearch REST client, connection ok to ES cluster {}",
+						info.getClusterName());
+			}
+		} catch (IOException e) {
+			LOG.error("Elasticsearch connection error", e);
+			throw new RuntimeException("Elasticsearch connection error", e);
+		}
+
+		return esClient;
+	}
+
+	@Override
+	public Throwable extractFailureCauseFromBulkItemResponse(BulkItemResponse bulkItemResponse) {
+		if (!bulkItemResponse.isFailed()) {
+			return null;
+		} else {
+			return bulkItemResponse.getFailure().getCause();
+		}
+	}
+
+	@Override
+	public void configureBulkProcessorBackoff(BulkProcessor.Builder builder,
+			@Nullable ElasticsearchSinkBase.BulkFlushBackoffPolicy flushBackoffPolicy) {
+
+		BackoffPolicy backoffPolicy;
+		if (flushBackoffPolicy != null) {
+			switch (flushBackoffPolicy.getBackoffType()) {
+			case CONSTANT:
+				backoffPolicy = BackoffPolicy.constantBackoff(
+						new TimeValue(flushBackoffPolicy.getDelayMillis()),
+						flushBackoffPolicy.getMaxRetryCount());
+				break;
+			case EXPONENTIAL:
+			default:
+				backoffPolicy = BackoffPolicy.exponentialBackoff(
+						new TimeValue(flushBackoffPolicy.getDelayMillis()),
+						flushBackoffPolicy.getMaxRetryCount());
+			}
+		} else {
+			backoffPolicy = BackoffPolicy.noBackoff();
+		}
+
+		builder.setBackoffPolicy(backoffPolicy);
+	}
+
+	@Override
+	public void cleanup() {
+		// nothing to cleanup
+	}
+
+}

--- a/flink-connectors/flink-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/connectors/elasticsearch6/ElasticsearchSink.java
+++ b/flink-connectors/flink-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/connectors/elasticsearch6/ElasticsearchSink.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.elasticsearch6;
+
+import org.apache.flink.streaming.connectors.elasticsearch.DocWriteRequestFailureHandler;
+import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchSinkBase;
+import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchSinkFunction;
+import org.apache.flink.streaming.connectors.elasticsearch.util.NoOpDocWriteFailureHandler;
+
+import org.apache.http.HttpHost;
+
+import org.elasticsearch.action.DocWriteRequest;
+import org.elasticsearch.action.bulk.BulkProcessor;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Elasticsearch 5.x sink that requests multiple {@link DocWriteRequest DocWriteRequests}
+ * against a cluster for each incoming element.
+ *
+ * <p>The sink internally uses a {@link RestHighLevelClient} to communicate with an Elasticsearch cluster.
+ * The sink will fail if no cluster can be connected to using the provided hosts passed to the constructor.
+ *
+ * <p>The {@link Map} passed to the constructor is used to create the {@code RestHighLevelClient}. The config keys can be found
+ * in the <a href="https://www.elastic.io">Elasticsearch documentation</a>. An important setting is {@code cluster.name},
+ * which should be set to the name of the cluster that the sink should emit to.
+ *
+ * <p>Internally, the sink will use a {@link BulkProcessor} to send {@link DocWriteRequest DocWriteRequests}.
+ * This will buffer elements before sending a request to the cluster. The behaviour of the
+ * {@code BulkProcessor} can be configured using these config keys:
+ * <ul>
+ *   <li> {@code bulk.flush.max.actions}: Maximum amount of elements to buffer
+ *   <li> {@code bulk.flush.max.size.mb}: Maximum amount of data (in megabytes) to buffer
+ *   <li> {@code bulk.flush.interval.ms}: Interval at which to flush data regardless of the other two
+ *   settings in milliseconds
+ * </ul>
+ *
+ * <p>You also have to provide an {@link ElasticsearchSinkFunction}. This is used to create multiple
+ * {@link ActionRequest ActionRequests} for each incoming element. See the class level documentation of
+ * {@link ElasticsearchSinkFunction} for an example.
+ *
+ * @param <T> Type of the elements handled by this sink
+ */
+public class ElasticsearchSink<T> extends ElasticsearchSinkBase<T> {
+
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * Creates a new {@code ElasticsearchSink} that connects to the cluster using a {@link RestHighLevelClient}.
+	 *
+	 * @param userConfig The map of user settings that are used when constructing the {@link RestHighLevelClient} and {@link BulkProcessor}
+	 * @param clusterHosts The addresses of Elasticsearch nodes to which to connect using a {@link RestHighLevelClient}
+	 * @param elasticsearchSinkFunction This is used to generate multiple {@link DocWriteRequest} from the incoming element
+	 */
+	public ElasticsearchSink(
+		Map<String, String> userConfig,
+		List<HttpHost> clusterHosts,
+		ElasticsearchSinkFunction<T> elasticsearchSinkFunction) {
+
+		this(userConfig, clusterHosts, elasticsearchSinkFunction, new NoOpDocWriteFailureHandler());
+	}
+
+	/**
+	 * Creates a new {@code ElasticsearchSink} that connects to the cluster using a {@link RestHighLevelClient}.
+	 *
+	 * @param userConfig The map of user settings that are used when constructing the {@link RestHighLevelClient} and {@link BulkProcessor}
+	 * @param clusterHosts The addresses of Elasticsearch nodes to which to connect using a {@link RestHighLevelClient}
+	 * @param elasticsearchSinkFunction This is used to generate multiple {@link DocWriteRequest} from the incoming element
+	 * @param failureHandler This is used to handle failed {@link DocWriteRequest}
+	 */
+	public ElasticsearchSink(
+		Map<String, String> userConfig,
+		List<HttpHost> clusterHosts,
+		ElasticsearchSinkFunction<T> elasticsearchSinkFunction,
+		DocWriteRequestFailureHandler failureHandler) {
+
+		super(new Elasticsearch6ApiCallBridge(clusterHosts), userConfig, elasticsearchSinkFunction, failureHandler);
+	}
+}

--- a/flink-connectors/flink-connector-elasticsearch6/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchRestSinkTestBase.java
+++ b/flink-connectors/flink-connector-elasticsearch6/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchRestSinkTestBase.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.elasticsearch;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.streaming.api.datastream.DataStreamSource;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.connectors.elasticsearch.testutils.SourceSinkDataTestKit;
+import org.apache.flink.streaming.util.StreamingMultipleProgramsTestBase;
+
+import org.apache.http.HttpHost;
+
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.cluster.ClusterName;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.rules.TemporaryFolder;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.fail;
+
+/**
+ * Environment preparation and suite of tests for version-specific {@link ElasticsearchSinkBase}
+ * implementations.
+ */
+public abstract class ElasticsearchRestSinkTestBase extends StreamingMultipleProgramsTestBase {
+
+	protected static final boolean RUN_TESTS = false;
+	protected static final String CLUSTER_NAME = "test-cluster";
+	protected static final String ES_TEST_HOST = "localhost";
+	protected static final String ES_TEST_INDEX = "es-flink-test-index";
+	protected static final int ES_TEST_PORT = 9200;
+	protected static RestHighLevelClient esClient;
+
+	@ClassRule
+	public static TemporaryFolder tempFolder = new TemporaryFolder();
+
+	@BeforeClass
+	public static void prepare() throws Exception {
+		if (!RUN_TESTS) {
+			return;
+		}
+		LOG.info("-------------------------------------------------------------------------");
+		LOG.info("    Starting Elasticsearch REST client");
+		LOG.info("-------------------------------------------------------------------------");
+
+		// dynamically load version-specific implementation of the Elasticsearch embedded node
+		// environment
+		esClient = new RestHighLevelClient(
+				RestClient.builder(new HttpHost(ES_TEST_HOST, ES_TEST_PORT, "http")));
+	}
+
+	@AfterClass
+	public static void shutdown() throws Exception {
+		if (!RUN_TESTS) {
+			return;
+		}
+		LOG.info("-------------------------------------------------------------------------");
+		LOG.info("    Shutting down Elasticsearch REST client");
+		LOG.info("-------------------------------------------------------------------------");
+
+		esClient.close();
+
+	}
+
+	/**
+	 * Tests that the Elasticsearch sink works properly using a {@link RestHighLevelClient}.
+	 */
+	public void runClientTest() throws Exception {
+		if (!RUN_TESTS) {
+			return;
+		}
+
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+		DataStreamSource<Tuple2<Integer, String>> source = env
+				.addSource(new SourceSinkDataTestKit.TestDataSourceFunction());
+
+		Map<String, String> userConfig = new HashMap<>();
+		// This instructs the sink to emit after every element, otherwise they would be buffered
+		userConfig.put(ElasticsearchSinkBase.CONFIG_KEY_BULK_FLUSH_MAX_ACTIONS, "1");
+		userConfig.put(ClusterName.CLUSTER_NAME_SETTING.getKey(), CLUSTER_NAME);
+
+		List<HttpHost> clusterHosts = new ArrayList<>();
+		clusterHosts.add(new HttpHost(ES_TEST_HOST, ES_TEST_PORT, "http"));
+		source.addSink(createElasticsearchSink(userConfig, clusterHosts,
+				new SourceSinkDataTestKit.TestElasticsearchSinkFunction(ES_TEST_INDEX)));
+
+		env.execute("Elasticsearch REST client Test");
+
+		// verify the results
+		SourceSinkDataTestKit.verifyProducedSinkData(esClient, ES_TEST_INDEX);
+
+		esClient.close();
+	}
+
+	/**
+	 * Tests that the Elasticsearch sink fails eagerly if the provided list of hosts is
+	 * {@code null}.
+	 */
+	public void runNullClientTest() throws Exception {
+		if (!RUN_TESTS) {
+			return;
+		}
+		Map<String, String> userConfig = new HashMap<>();
+		userConfig.put(ElasticsearchSinkBase.CONFIG_KEY_BULK_FLUSH_MAX_ACTIONS, "1");
+		userConfig.put(ClusterName.CLUSTER_NAME_SETTING.getKey(), CLUSTER_NAME);
+
+		try {
+			createElasticsearchSink(userConfig, null,
+					new SourceSinkDataTestKit.TestElasticsearchSinkFunction(ES_TEST_INDEX));
+		} catch (IllegalArgumentException expectedException) {
+			// test passes
+			return;
+		}
+
+		fail();
+	}
+
+	/**
+	 * Tests that the Elasticsearch sink fails eagerly if the provided list of nodes is
+	 * empty.
+	 */
+	public void runEmptyClientTest() throws Exception {
+		if (!RUN_TESTS) {
+			return;
+		}
+		Map<String, String> userConfig = new HashMap<>();
+		userConfig.put(ElasticsearchSinkBase.CONFIG_KEY_BULK_FLUSH_MAX_ACTIONS, "1");
+		userConfig.put(ClusterName.CLUSTER_NAME_SETTING.getKey(), CLUSTER_NAME);
+
+		try {
+			createElasticsearchSink(userConfig, Collections.<HttpHost>emptyList(),
+					new SourceSinkDataTestKit.TestElasticsearchSinkFunction(ES_TEST_INDEX));
+		} catch (IllegalArgumentException expectedException) {
+			// test passes
+			return;
+		}
+
+		fail();
+	}
+
+	/** Creates a version-specific Elasticsearch sink, using arbitrary hosts. */
+	protected abstract <T> ElasticsearchSinkBase<T> createElasticsearchSink(
+			Map<String, String> userConfig, List<HttpHost> clusterHosts,
+			ElasticsearchSinkFunction<T> elasticsearchSinkFunction);
+}

--- a/flink-connectors/flink-connector-elasticsearch6/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/testutils/SourceSinkDataTestKit.java
+++ b/flink-connectors/flink-connector-elasticsearch6/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/testutils/SourceSinkDataTestKit.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.elasticsearch.testutils;
+
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchSinkFunction;
+import org.apache.flink.streaming.connectors.elasticsearch.RequestIndexer;
+
+import org.elasticsearch.action.get.GetRequest;
+import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.junit.Assert;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This class contains utilities and a pre-defined source function and Elasticsearch Sink function
+ * used to simulate and verify data used in tests.
+ */
+public class SourceSinkDataTestKit {
+
+	private static final int NUM_ELEMENTS = 20;
+
+	private static final String DATA_PREFIX = "message #";
+	private static final String DATA_FIELD_NAME = "data";
+
+	private static final String TYPE_NAME = "flink-es-test-type";
+
+	/**
+	 * A {@link SourceFunction} that generates the elements (id, "message #" + id) with id being 0 -
+	 * 20.
+	 */
+	public static class TestDataSourceFunction implements SourceFunction<Tuple2<Integer, String>> {
+		private static final long serialVersionUID = 1L;
+
+		private volatile boolean running = true;
+
+		@Override
+		public void run(SourceFunction.SourceContext<Tuple2<Integer, String>> ctx) throws Exception {
+			for (int i = 0; i < NUM_ELEMENTS && running; i++) {
+				ctx.collect(Tuple2.of(i, DATA_PREFIX + i));
+			}
+		}
+
+		@Override
+		public void cancel() {
+			running = false;
+		}
+	}
+
+	/**
+	 * A {@link ElasticsearchSinkFunction} that indexes each element it receives to a sepecified
+	 * Elasticsearch index.
+	 */
+	public static class TestElasticsearchSinkFunction
+			implements ElasticsearchSinkFunction<Tuple2<Integer, String>> {
+		private static final long serialVersionUID = 1L;
+
+		private final String index;
+
+		/**
+		 * Create the sink function, specifying a target Elasticsearch index.
+		 *
+		 * @param index
+		 *          Name of the target Elasticsearch index.
+		 */
+		public TestElasticsearchSinkFunction(String index) {
+			this.index = index;
+		}
+
+		public IndexRequest createIndexRequest(Tuple2<Integer, String> element) {
+			Map<String, Object> json = new HashMap<>();
+			json.put(DATA_FIELD_NAME, element.f1);
+
+			return new IndexRequest(index, TYPE_NAME, element.f0.toString()).source(json);
+		}
+
+		@Override
+		public void process(Tuple2<Integer, String> element, RuntimeContext ctx,
+				RequestIndexer indexer) {
+			indexer.add(createIndexRequest(element));
+		}
+	}
+
+	/**
+	 * Verify the results in an Elasticsearch index. The results must first be produced into the index
+	 * using a {@link TestElasticsearchSinkFunction};
+	 *
+	 * @param client
+	 *          The client to use to connect to Elasticsearch
+	 * @param index
+	 *          The index to check
+	 * @throws IOException
+	 *           if any exception occurs
+	 */
+	public static void verifyProducedSinkData(RestHighLevelClient client, String index)
+			throws IOException {
+		for (int i = 0; i < NUM_ELEMENTS; i++) {
+			GetResponse response = client.get(new GetRequest(index, TYPE_NAME, Integer.toString(i)));
+			Assert.assertEquals(DATA_PREFIX + i, response.getSource().get(DATA_FIELD_NAME));
+		}
+	}
+
+}

--- a/flink-connectors/flink-connector-elasticsearch6/src/test/java/org/apache/flink/streaming/connectors/elasticsearch6/ElasticsearchSinkITCase.java
+++ b/flink-connectors/flink-connector-elasticsearch6/src/test/java/org/apache/flink/streaming/connectors/elasticsearch6/ElasticsearchSinkITCase.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.elasticsearch6;
+
+import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchRestSinkTestBase;
+import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchSinkBase;
+import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchSinkFunction;
+
+import org.apache.http.HttpHost;
+
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * IT cases for the {@link ElasticsearchSink}.
+ */
+public class ElasticsearchSinkITCase extends ElasticsearchRestSinkTestBase {
+
+	@Test
+	public void testClient() throws Exception {
+		runClientTest();
+	}
+
+	@Test
+	public void testNullClient() throws Exception {
+		runNullClientTest();
+	}
+
+	@Test
+	public void testEmptyClient() throws Exception {
+		runEmptyClientTest();
+	}
+
+	@Override
+	protected <T> ElasticsearchSinkBase<T> createElasticsearchSink(Map<String, String> userConfig,
+																List<HttpHost> clusterHosts,
+																ElasticsearchSinkFunction<T> elasticsearchSinkFunction) {
+		return new ElasticsearchSink<>(userConfig, clusterHosts, elasticsearchSinkFunction);
+	}
+
+}

--- a/flink-connectors/flink-connector-elasticsearch6/src/test/java/org/apache/flink/streaming/connectors/elasticsearch6/examples/ElasticsearchSinkExample.java
+++ b/flink-connectors/flink-connector-elasticsearch6/src/test/java/org/apache/flink/streaming/connectors/elasticsearch6/examples/ElasticsearchSinkExample.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.elasticsearch6.examples;
+
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchSinkFunction;
+import org.apache.flink.streaming.connectors.elasticsearch.RequestIndexer;
+import org.apache.flink.streaming.connectors.elasticsearch6.ElasticsearchSink;
+
+import org.apache.http.HttpHost;
+
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.client.Requests;
+import org.elasticsearch.cluster.ClusterName;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This example shows how to use the Elasticsearch Sink. Before running it you must ensure that
+ * you have a cluster named "elasticsearch" running or change the name of cluster in the config map.
+ */
+public class ElasticsearchSinkExample {
+
+	public static void main(String[] args) throws Exception {
+
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+		DataStream<String> source = env.generateSequence(0, 20).map(new MapFunction<Long, String>() {
+			@Override
+			public String map(Long value) throws Exception {
+				return "message #" + value;
+			}
+		});
+
+		Map<String, String> userConfig = new HashMap<>();
+		userConfig.put(ClusterName.CLUSTER_NAME_SETTING.getKey(), "elasticsearch");
+		// This instructs the sink to emit after every element, otherwise they would be buffered
+		userConfig.put(ElasticsearchSink.CONFIG_KEY_BULK_FLUSH_MAX_ACTIONS, "1");
+
+		List<HttpHost> clusterHosts = new ArrayList<>();
+		clusterHosts.add(new HttpHost("127.0.0.1", 9200, "http"));
+
+		source.addSink(new ElasticsearchSink<>(userConfig, clusterHosts, new ElasticsearchSinkFunction<String>() {
+			@Override
+			public void process(String element, RuntimeContext ctx, RequestIndexer indexer) {
+				indexer.add(createIndexRequest(element));
+			}
+		}));
+
+		env.execute("Elasticsearch Sink Example");
+	}
+
+	private static IndexRequest createIndexRequest(String element) {
+		Map<String, Object> json = new HashMap<>();
+		json.put("data", element);
+
+		return Requests.indexRequest()
+			.index("my-index")
+			.type("my-type")
+			.id(element)
+			.source(json);
+	}
+}

--- a/flink-connectors/pom.xml
+++ b/flink-connectors/pom.xml
@@ -49,6 +49,7 @@ under the License.
 		<module>flink-connector-elasticsearch</module>
 		<module>flink-connector-elasticsearch2</module>
 		<module>flink-connector-elasticsearch5</module>
+		<module>flink-connector-elasticsearch6</module>
 		<module>flink-connector-rabbitmq</module>
 		<module>flink-connector-twitter</module>
 		<module>flink-connector-nifi</module>


### PR DESCRIPTION
## Purpose of the change : implementation of Flink ES connector  (5.3+)
See https://issues.apache.org/jira/browse/FLINK-8101 and https://issues.apache.org/jira/browse/FLINK-7386

## Brief change log
- Changed "standard" ES connector structor, mainly because there's incompatibility between TransportClient and RestClient and, From ES 5.3+ embedded Node environment is not supported anymore. A running test ES cluster is needed to properly test the code

## Verifying this change
- Set up an ES cluster and properly change ES_TEST_HOST, ES_TEST_PORT and CLUSTER_NAME in the tests (or viceversa: set up a localhost ES cluster listening on http port 9200 with cluster name "test-cluster")
## Does this pull request potentially affect one of the following parts:
  -  Flink ES connectors

## Documentation
  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented?  Javadocs
