### PR TITLE
[FLINK-6214] WindowAssigners do not allow negative offsets

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/TumblingEventTimeWindows.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/TumblingEventTimeWindows.java
@@ -111,7 +111,11 @@ public class TumblingEventTimeWindows extends WindowAssigner<Object, TimeWindow>
 	 * @return The time policy.
 	 */
 	public static TumblingEventTimeWindows of(Time size, Time offset) {
-		return new TumblingEventTimeWindows(size.toMilliseconds(), offset.toMilliseconds());
+		long sizeMilliSeconds = size.toMilliseconds();
+		long offsetMilliseconds = offset.toMilliseconds();
+
+		return new TumblingEventTimeWindows(sizeMilliSeconds,
+			offsetMilliseconds < 0 ? sizeMilliSeconds + offsetMilliseconds : offsetMilliseconds);
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/TumblingProcessingTimeWindows.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/TumblingProcessingTimeWindows.java
@@ -107,7 +107,11 @@ public class TumblingProcessingTimeWindows extends WindowAssigner<Object, TimeWi
 	 * @return The time policy.
 	 */
 	public static TumblingProcessingTimeWindows of(Time size, Time offset) {
-		return new TumblingProcessingTimeWindows(size.toMilliseconds(), offset.toMilliseconds());
+		long sizeMilliSeconds = size.toMilliseconds();
+		long offsetMilliseconds = offset.toMilliseconds();
+
+		return new TumblingProcessingTimeWindows(sizeMilliSeconds,
+			offsetMilliseconds < 0 ? sizeMilliSeconds + offsetMilliseconds : offsetMilliseconds);
 	}
 
 	@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/TumblingEventTimeWindowsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/TumblingEventTimeWindowsTest.java
@@ -69,6 +69,18 @@ public class TumblingEventTimeWindowsTest extends TestLogger {
 	}
 
 	@Test
+	public void testWindowAssignmentWithNegativeOffset() {
+		WindowAssigner.WindowAssignerContext mockContext =
+			mock(WindowAssigner.WindowAssignerContext.class);
+
+		TumblingEventTimeWindows assigner = TumblingEventTimeWindows.of(Time.milliseconds(5000), Time.milliseconds(-100));
+
+		assertThat(assigner.assignWindows("String", 100L, mockContext), contains(timeWindow(-100, 4900)));
+		assertThat(assigner.assignWindows("String", 4899L, mockContext), contains(timeWindow(-100, 4900)));
+		assertThat(assigner.assignWindows("String", 4900L, mockContext), contains(timeWindow(4900, 9900)));
+	}
+
+	@Test
 	public void testTimeUnits() {
 		// sanity check with one other time unit
 
@@ -93,13 +105,6 @@ public class TumblingEventTimeWindowsTest extends TestLogger {
 
 		try {
 			TumblingEventTimeWindows.of(Time.seconds(10), Time.seconds(20));
-			fail("should fail");
-		} catch (IllegalArgumentException e) {
-			assertThat(e.toString(), containsString("0 <= offset < size"));
-		}
-
-		try {
-			TumblingEventTimeWindows.of(Time.seconds(10), Time.seconds(-1));
 			fail("should fail");
 		} catch (IllegalArgumentException e) {
 			assertThat(e.toString(), containsString("0 <= offset < size"));

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/TumblingProcessingTimeWindowsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/TumblingProcessingTimeWindowsTest.java
@@ -80,6 +80,23 @@ public class TumblingProcessingTimeWindowsTest extends TestLogger {
 	}
 
 	@Test
+	public void testWindowAssignmentWithNegativeOffset() {
+		WindowAssigner.WindowAssignerContext mockContext =
+			mock(WindowAssigner.WindowAssignerContext.class);
+
+		TumblingProcessingTimeWindows assigner = TumblingProcessingTimeWindows.of(Time.milliseconds(5000), Time.milliseconds(-100));
+
+		when(mockContext.getCurrentProcessingTime()).thenReturn(100L);
+		assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext), contains(timeWindow(-100, 4900)));
+
+		when(mockContext.getCurrentProcessingTime()).thenReturn(4899L);
+		assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext), contains(timeWindow(-100, 4900)));
+
+		when(mockContext.getCurrentProcessingTime()).thenReturn(4900L);
+		assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext), contains(timeWindow(4900, 9900)));
+	}
+
+	@Test
 	public void testTimeUnits() {
 		// sanity check with one other time unit
 
@@ -109,13 +126,6 @@ public class TumblingProcessingTimeWindowsTest extends TestLogger {
 
 		try {
 			TumblingProcessingTimeWindows.of(Time.seconds(10), Time.seconds(20));
-			fail("should fail");
-		} catch (IllegalArgumentException e) {
-			assertThat(e.toString(), containsString("0 <= offset < size"));
-		}
-
-		try {
-			TumblingProcessingTimeWindows.of(Time.seconds(10), Time.seconds(-1));
 			fail("should fail");
 		} catch (IllegalArgumentException e) {
 			assertThat(e.toString(), containsString("0 <= offset < size"));


### PR DESCRIPTION
## What is the purpose of the change

The javadoc of TumblingEventTimeWindows and TumblingProcessingTimeWindows suggest that it is possible to use negative offsets but in practice this is not supported. This patch remedies this situation

## Brief change log

- updated behavior of TumblingEventTimeWindows & TumblingProcessingTimeWindows

## Verifying this change

This change added tests and can be verified as follows:

- Added testWindowAssignmentWithNegativeOffset method in TumblingEventTimeWindowsTest & TumblingProcessingTimeWindowsTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
