### PR TITLE
[FLINK-8494][config] Migrate CC#DEFAULT_PARALLELISM_KEY

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -33,6 +33,7 @@ import org.apache.flink.client.program.ProgramMissingJobException;
 import org.apache.flink.client.program.ProgramParametrizationException;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.core.fs.FileSystem;
@@ -133,9 +134,7 @@ public class CliFrontend {
 		}
 
 		this.clientTimeout = AkkaUtils.getClientTimeout(this.configuration);
-		this.defaultParallelism = configuration.getInteger(
-			ConfigConstants.DEFAULT_PARALLELISM_KEY,
-			ConfigConstants.DEFAULT_PARALLELISM);
+		this.defaultParallelism = configuration.getInteger(CoreOptions.DEFAULT_PARALLELISM);
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -42,7 +42,10 @@ public final class ConfigConstants {
 
 	/**
 	 * The config parameter defining the default parallelism for jobs.
+	 *
+	 * @deprecated use {@link CoreOptions#DEFAULT_PARALLELISM} instead
 	 */
+	@Deprecated
 	public static final String DEFAULT_PARALLELISM_KEY = "parallelism.default";
 
 	// ---------------------------- Restart strategies ------------------------
@@ -1266,7 +1269,10 @@ public final class ConfigConstants {
 
 	/**
 	 * The default parallelism for operations.
+	 *
+	 * @deprecated use {@link CoreOptions#DEFAULT_PARALLELISM} instead
 	 */
+	@Deprecated
 	public static final int DEFAULT_PARALLELISM = 1;
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
@@ -114,9 +114,9 @@ public class CoreOptions {
 	//  program
 	// ------------------------------------------------------------------------
 
-	public static final ConfigOption<Integer> DEFAULT_PARALLELISM_KEY = ConfigOptions
+	public static final ConfigOption<Integer> DEFAULT_PARALLELISM = ConfigOptions
 		.key("parallelism.default")
-		.defaultValue(-1);
+		.defaultValue(1);
 
 	// ------------------------------------------------------------------------
 	//  file systems

--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/Optimizer.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/Optimizer.java
@@ -23,6 +23,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.optimizer.traversals.BinaryUnionReplacer;
 import org.apache.flink.optimizer.traversals.BranchesVisitor;
 import org.apache.flink.optimizer.traversals.GraphCreatingVisitor;
@@ -41,7 +42,6 @@ import org.apache.flink.optimizer.plan.PlanNode;
 import org.apache.flink.optimizer.plan.SinkJoinerPlanNode;
 import org.apache.flink.optimizer.plan.SinkPlanNode;
 import org.apache.flink.optimizer.postpass.OptimizerPostPass;
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.optimizer.traversals.RangePartitionRewriter;
 import org.apache.flink.util.InstantiationUtil;
 
@@ -348,14 +348,14 @@ public class Optimizer {
 		this.costEstimator = estimator;
 
 		// determine the default parallelism
-		this.defaultParallelism = config.getInteger(
-				ConfigConstants.DEFAULT_PARALLELISM_KEY,
-				ConfigConstants.DEFAULT_PARALLELISM);
+		this.defaultParallelism = config.getInteger(CoreOptions.DEFAULT_PARALLELISM);
 
 		if (defaultParallelism < 1) {
-			LOG.warn("Config value " + defaultParallelism + " for option "
-					+ ConfigConstants.DEFAULT_PARALLELISM + " is invalid. Ignoring and using a value of 1.");
-			this.defaultParallelism = 1;
+			this.defaultParallelism = CoreOptions.DEFAULT_PARALLELISM.defaultValue();
+			LOG.warn("Config value {} for option {} is invalid. Ignoring and using a value of {}.",
+				defaultParallelism,
+				CoreOptions.DEFAULT_PARALLELISM.key(),
+				defaultParallelism);
 		}
 	}
 	

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamPlanEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamPlanEnvironment.java
@@ -22,7 +22,7 @@ import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.client.program.OptimizerPlanEnvironment;
 import org.apache.flink.client.program.PreviewPlanEnvironment;
-import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.streaming.api.graph.StreamGraph;
 
@@ -44,9 +44,7 @@ public class StreamPlanEnvironment extends StreamExecutionEnvironment {
 			setParallelism(parallelism);
 		} else {
 			// determine parallelism
-			setParallelism(GlobalConfiguration.loadConfiguration().getInteger(
-					ConfigConstants.DEFAULT_PARALLELISM_KEY,
-					ConfigConstants.DEFAULT_PARALLELISM));
+			setParallelism(GlobalConfiguration.loadConfiguration().getInteger(CoreOptions.DEFAULT_PARALLELISM));
 		}
 	}
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
@@ -26,6 +26,7 @@ import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
@@ -541,7 +542,7 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<ApplicationId
 		if (propParallelism != null) { // maybe the property is not set
 			try {
 				int parallelism = Integer.parseInt(propParallelism);
-				effectiveConfiguration.setInteger(ConfigConstants.DEFAULT_PARALLELISM_KEY, parallelism);
+				effectiveConfiguration.setInteger(CoreOptions.DEFAULT_PARALLELISM, parallelism);
 
 				logAndSysout("YARN properties set default parallelism to " + parallelism);
 			}


### PR DESCRIPTION
## What is the purpose of the change

This PR migrates `ConfigOptions#DEFAULT_PARALLELLISM_KEY` to a `ConfigOption`.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
