### PR TITLE
[FLINK-8489][ES] Prevent side-effects when modifying user-config

### DIFF
--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkBase.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkBase.java
@@ -41,6 +41,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.Serializable;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
@@ -215,6 +216,9 @@ public abstract class ElasticsearchSinkBase<T> extends RichSinkFunction<T> imple
 		// so that the resulting user config only contains configuration related to the Elasticsearch client.
 
 		checkNotNull(userConfig);
+
+		// copy config so we can remove entries without side-effects
+		userConfig = new HashMap<>(userConfig);
 
 		ParameterTool params = ParameterTool.fromMap(userConfig);
 

--- a/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkBaseTest.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkBaseTest.java
@@ -58,6 +58,26 @@ import static org.mockito.Mockito.when;
  */
 public class ElasticsearchSinkBaseTest {
 
+	/**
+	 * Verifies that the collection given to the sink is not modified.
+	 */
+	@Test
+	public void testCollectionArgumentNotModified() {
+		Map<String, String> userConfig = new HashMap<>();
+		userConfig.put(ElasticsearchSinkBase.CONFIG_KEY_BULK_FLUSH_BACKOFF_DELAY, "1");
+		userConfig.put(ElasticsearchSinkBase.CONFIG_KEY_BULK_FLUSH_BACKOFF_ENABLE, "true");
+		userConfig.put(ElasticsearchSinkBase.CONFIG_KEY_BULK_FLUSH_BACKOFF_RETRIES, "1");
+		userConfig.put(ElasticsearchSinkBase.CONFIG_KEY_BULK_FLUSH_BACKOFF_TYPE, "CONSTANT");
+		userConfig.put(ElasticsearchSinkBase.CONFIG_KEY_BULK_FLUSH_INTERVAL_MS, "1");
+		userConfig.put(ElasticsearchSinkBase.CONFIG_KEY_BULK_FLUSH_MAX_ACTIONS, "1");
+		userConfig.put(ElasticsearchSinkBase.CONFIG_KEY_BULK_FLUSH_MAX_SIZE_MB, "1");
+
+		new DummyElasticsearchSink<>(
+			Collections.unmodifiableMap(userConfig),
+			new SimpleSinkFunction<String>(),
+			new NoOpFailureHandler());
+	}
+
 	/** Tests that any item failure in the listener callbacks is rethrown on an immediately following invoke call. */
 	@Test
 	public void testItemFailureRethrownOnInvoke() throws Throwable {

--- a/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkTestBase.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkTestBase.java
@@ -163,7 +163,7 @@ public abstract class ElasticsearchSinkTestBase extends AbstractTestBase {
 		userConfig.put("cluster.name", "my-transport-client-cluster");
 
 		source.addSink(createElasticsearchSinkForEmbeddedNode(
-			userConfig, new SourceSinkDataTestKit.TestElasticsearchSinkFunction("test")));
+			Collections.unmodifiableMap(userConfig), new SourceSinkDataTestKit.TestElasticsearchSinkFunction("test")));
 
 		try {
 			env.execute("Elasticsearch Transport Client Test");

--- a/flink-connectors/flink-connector-elasticsearch/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkITCase.java
+++ b/flink-connectors/flink-connector-elasticsearch/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkITCase.java
@@ -34,6 +34,7 @@ import org.junit.Test;
 
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -113,13 +114,14 @@ public class ElasticsearchSinkITCase extends ElasticsearchSinkTestBase {
 
 		// Elasticsearch 1.x requires this setting when using
 		// LocalTransportAddress to connect to a local embedded node
+		userConfig = new HashMap<>(userConfig);
 		userConfig.put("node.local", "true");
 
 		List<TransportAddress> transports = new ArrayList<>();
 		transports.add(new LocalTransportAddress("1"));
 
 		return new ElasticsearchSink<>(
-			userConfig,
+			Collections.unmodifiableMap(userConfig),
 			transports,
 			elasticsearchSinkFunction);
 	}


### PR DESCRIPTION
## What is the purpose of the change

The `ElasticsearchSinkBase` constructor was removing entries from a user-provided collection. We now copy the collection to prevent side-effects.
