### PR TITLE
[FLINK-8130][docs] Fix snapshot javadoc link

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -31,7 +31,7 @@ version: "1.5-SNAPSHOT"
 # For stable releases, leave the bugfix version out (e.g. 1.2). For snapshot
 # release this should be the same as the regular version
 version_title: "1.5-SNAPSHOT"
-version_javadocs: "1.5-SNAPSHOT"
+version_javadocs: "1.5"
 
 # This suffix is appended to the Scala-dependent Maven artifact names
 scala_version_suffix: "_2.11"


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes the snapshot javadoc link that is currently broken. Currently the website tries to access `https://ci.apache.org/projects/flink/flink-docs-release-1.5-SNAPSHOT/api/java/` but the working link is `https://ci.apache.org/projects/flink/flink-docs-release-1.5/api/java/`.

This was broken by accident when switching master to 1.5 .