### PR TITLE
[FLINK-8523][network] Stop assigning floating buffers for blocked input channels in exactly-once mode

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannel.java
@@ -66,6 +66,9 @@ public abstract class InputChannel {
 	/** The current backoff (in ms) */
 	private int currentBackoff;
 
+	/** Flag indicating whether this channel is currently blocked or not. */
+	private volatile boolean isBlocked = false;
+
 	protected InputChannel(
 			SingleInputGate inputGate,
 			int channelIndex,
@@ -164,6 +167,14 @@ public abstract class InputChannel {
 	 * Releases all resources of the channel.
 	 */
 	abstract void releaseAllResources() throws IOException;
+
+	protected boolean isBlocked() {
+		return isBlocked;
+	}
+
+	protected void setBlocked(boolean isBlocked) {
+		this.isBlocked = isBlocked;
+	}
 
 	// ------------------------------------------------------------------------
 	// Error notification

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGate.java
@@ -79,4 +79,17 @@ public interface InputGate {
 	void registerListener(InputGateListener listener);
 
 	int getPageSize();
+
+	/**
+	 * Blocks the input channel from which the barrier is already read.
+	 *
+	 * @param channelIndex
+	 * 		The logical channel index means the internal channel index in input gate plus gate's offset.
+	 */
+	void blockInputChannel(int channelIndex);
+
+	/**
+	 * Releases all the blocked input channels when barrier alignment or cancelled.
+	 */
+	void releaseBlockedInputChannels();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -360,8 +360,9 @@ public class RemoteInputChannel extends InputChannel implements BufferRecycler, 
 
 			// Important: double check the isReleased state inside synchronized block, so there is no
 			// race condition when notifyBufferAvailable and releaseAllResources running in parallel.
-			if (isReleased.get() || bufferQueue.getAvailableBufferSize() >= numRequiredBuffers) {
+			if (isReleased.get() || isBlocked() || bufferQueue.getAvailableBufferSize() >= numRequiredBuffers) {
 				buffer.recycleBuffer();
+				isWaitingForFloatingBuffers = false;
 				return false;
 			}
 
@@ -466,7 +467,7 @@ public class RemoteInputChannel extends InputChannel implements BufferRecycler, 
 		synchronized (bufferQueue) {
 			// Important: check the isReleased state inside synchronized block, so there is no
 			// race condition when onSenderBacklog and releaseAllResources running in parallel.
-			if (isReleased.get()) {
+			if (isReleased.get() || isBlocked()) {
 				return;
 			}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/BarrierBuffer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/BarrierBuffer.java
@@ -462,6 +462,7 @@ public class BarrierBuffer implements CheckpointBarrierHandler {
 	private void onBarrier(int channelIndex) throws IOException {
 		if (!blockedChannels[channelIndex]) {
 			blockedChannels[channelIndex] = true;
+			inputGate.blockInputChannel(channelIndex);
 
 			numBarriersReceived++;
 
@@ -484,6 +485,8 @@ public class BarrierBuffer implements CheckpointBarrierHandler {
 		for (int i = 0; i < blockedChannels.length; i++) {
 			blockedChannels[i] = false;
 		}
+
+		inputGate.releaseBlockedInputChannels();
 
 		if (currentBuffered == null) {
 			// common case: no more buffered data

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierBufferMassiveRandomTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/BarrierBufferMassiveRandomTest.java
@@ -180,6 +180,14 @@ public class BarrierBufferMassiveRandomTest {
 		public void registerListener(InputGateListener listener) {}
 
 		@Override
+		public void blockInputChannel(int channelIndex) {
+		}
+
+		@Override
+		public void releaseBlockedInputChannels() {
+		}
+
+		@Override
 		public int getPageSize() {
 			return PAGE_SIZE;
 		}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MockInputGate.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MockInputGate.java
@@ -96,4 +96,12 @@ public class MockInputGate implements InputGate {
 	public void registerListener(InputGateListener listener) {
 	}
 
+	@Override
+	public void blockInputChannel(int channelIndex) {
+	}
+
+	@Override
+	public void releaseBlockedInputChannels() {
+	}
+
 }


### PR DESCRIPTION
## What is the purpose of the change

In exactly-once mode, the input channel is set blocked state when reading barrier from it. And the blocked state will be released after barrier alignment or cancelled.

In credit-based network flow control, we should avoid assigning floating buffers for blocked input channels because the buffers after barrier will not be processed by operator until alignment.

To do so, we can fully make use of floating buffers and speed up barrier alignment in some extent.

## Brief change log

  - *Add `blockInputChannel` and `releaseBlockedInputChannels` in `InputGate` interface*
  - *`UnionInputGate` constructs the mapping from channel index to `InputGate`*
  - *`SingleInputGate` constructs the mapping from channel index to `InputChannel`*
  - *`BarrierBuffer` determines the logic of blocking input channel or releasing it*
  - *Avoid assigning floating buffers for blocked input channels*


## Verifying this change

This change added tests and can be verified as follows:

  - *Added unit tests that validates the floating buffers are not assigned for blocked input channels*
  - *Added unit test that validates the `BarrierBuffer` blocks or releases the `InputChannel` correctly*
  - *Added unit test that validates the `UnionInputGate` and `SingleInputGate` constructs the mapping correctly*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
