### PR TITLE
[FLINK-8524][JavaDoc] Fix JavaDoc for TypeExtractor.getBinaryReturnType

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
@@ -653,7 +653,7 @@ public class TypeExtractor {
 	 * @param outputTypeArgumentIndex Index of output type in the class specification
 	 * @param lambdaInput1TypeArgumentIndices Table of indices of the type argument specifying the first input type. See example.
 	 * @param lambdaInput2TypeArgumentIndices Table of indices of the type argument specifying the second input type. See example.
-	 * @param lambdaOutputTypeArgumentIndices Table of indices of the type argument specifying the input type. See example.
+	 * @param lambdaOutputTypeArgumentIndices Table of indices of the type argument specifying the output type. See example.
 	 * @param in1Type Type of the left side input elements (In case of an iterable, it is the element type)
 	 * @param in2Type Type of the right side input elements (In case of an iterable, it is the element type)
 	 * @param functionName Function name


### PR DESCRIPTION
## What is the purpose of the change
Fix JavaDoc for TypeExtractor.getBinaryReturnType

## Brief change log
The JavaDoc stated that the parameter `lambdaOutputTypeArgumentIndices` was a
table of indices of the type argument specifying the *input type*, where it
actually is a table of indices of the type argument specifying the *output
type*. This is now fixed.
  
## Verifying this change
This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation
  - Does this pull request introduce a new feature? no
