### PR TITLE
[FLINK-8475][config][docs] Integrate SSL options

### DIFF
--- a/docs/_includes/generated/security_configuration.html
+++ b/docs/_includes/generated/security_configuration.html
@@ -1,0 +1,56 @@
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 65%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>security.ssl.algorithms</h5></td>
+            <td>"TLS_RSA_WITH_AES_128_CBC_SHA"</td>
+            <td>The comma separated list of standard SSL algorithms to be supported. Read more &#60;a href="http://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html#ciphersuites"&#62;here&#60;/a&#62;.</td>
+        </tr>
+        <tr>
+            <td><h5>security.ssl.enabled</h5></td>
+            <td>false</td>
+            <td>Turns on SSL for internal network communication. This can be optionally overridden by flags defined in different transport modules.</td>
+        </tr>
+        <tr>
+            <td><h5>security.ssl.key-password</h5></td>
+            <td>(none)</td>
+            <td>The secret to decrypt the server key in the keystore.</td>
+        </tr>
+        <tr>
+            <td><h5>security.ssl.keystore</h5></td>
+            <td>(none)</td>
+            <td>The Java keystore file to be used by the flink endpoint for its SSL Key and Certificate.</td>
+        </tr>
+        <tr>
+            <td><h5>security.ssl.keystore-password</h5></td>
+            <td>(none)</td>
+            <td>The secret to decrypt the keystore file.</td>
+        </tr>
+        <tr>
+            <td><h5>security.ssl.protocol</h5></td>
+            <td>"TLSv1.2"</td>
+            <td>The SSL protocol version to be supported for the ssl transport. Note that it doesn’t support comma separated list.</td>
+        </tr>
+        <tr>
+            <td><h5>security.ssl.truststore</h5></td>
+            <td>(none)</td>
+            <td>The truststore file containing the public CA certificates to be used by flink endpoints to verify the peer’s certificate.</td>
+        </tr>
+        <tr>
+            <td><h5>security.ssl.truststore-password</h5></td>
+            <td>(none)</td>
+            <td>The secret to decrypt the truststore.</td>
+        </tr>
+        <tr>
+            <td><h5>security.ssl.verify-hostname</h5></td>
+            <td>true</td>
+            <td>Flag to enable peer’s hostname verification during ssl handshake.</td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -358,23 +358,7 @@ The following parameters configure Flink's JobManager and TaskManagers.
 
 ### SSL Settings
 
-- `security.ssl.enabled`: Turns on SSL for internal network communication. This can be optionally overridden by flags defined in different transport modules (DEFAULT: **false**).
-
-- `security.ssl.keystore`: The Java keystore file to be used by the flink endpoint for its SSL Key and Certificate.
-
-- `security.ssl.keystore-password`: The secret to decrypt the keystore file.
-
-- `security.ssl.key-password`: The secret to decrypt the server key in the keystore.
-
-- `security.ssl.truststore`: The truststore file containing the public CA certificates to be used by flink endpoints to verify the peer's certificate.
-
-- `security.ssl.truststore-password`: The secret to decrypt the truststore.
-
-- `security.ssl.protocol`: The SSL protocol version to be supported for the ssl transport (DEFAULT: **TLSv1.2**). Note that it doesn't support comma separated list.
-
-- `security.ssl.algorithms`: The comma separated list of standard SSL algorithms to be supported. Read more [here](http://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html#ciphersuites) (DEFAULT: **TLS_RSA_WITH_AES_128_CBC_SHA**).
-
-- `security.ssl.verify-hostname`: Flag to enable peer's hostname verification during ssl handshake (DEFAULT: **true**).
+{% include generated/security_configuration.html %}
 
 ### Network communication (via Netty)
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/SecurityOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/SecurityOptions.java
@@ -86,49 +86,59 @@ public class SecurityOptions {
 	 */
 	public static final ConfigOption<Boolean> SSL_ENABLED =
 		key("security.ssl.enabled")
-			.defaultValue(false);
+			.defaultValue(false)
+			.withDescription("Turns on SSL for internal network communication. This can be optionally overridden by" +
+				" flags defined in different transport modules.");
 
 	/**
 	 * The Java keystore file containing the flink endpoint key and certificate.
 	 */
 	public static final ConfigOption<String> SSL_KEYSTORE =
 		key("security.ssl.keystore")
-			.noDefaultValue();
+			.noDefaultValue()
+			.withDescription("The Java keystore file to be used by the flink endpoint for its SSL Key and Certificate.");
 
 	/**
 	 * Secret to decrypt the keystore file.
 	 */
 	public static final ConfigOption<String> SSL_KEYSTORE_PASSWORD =
 		key("security.ssl.keystore-password")
-			.noDefaultValue();
+			.noDefaultValue()
+			.withDescription("The secret to decrypt the keystore file.");
 
 	/**
 	 * Secret to decrypt the server key.
 	 */
 	public static final ConfigOption<String> SSL_KEY_PASSWORD =
 		key("security.ssl.key-password")
-			.noDefaultValue();
+			.noDefaultValue()
+			.withDescription("The secret to decrypt the server key in the keystore.");
 
 	/**
 	 * The truststore file containing the public CA certificates to verify the ssl peers.
 	 */
 	public static final ConfigOption<String> SSL_TRUSTSTORE =
 		key("security.ssl.truststore")
-			.noDefaultValue();
+			.noDefaultValue()
+			.withDescription("The truststore file containing the public CA certificates to be used by flink endpoints" +
+				" to verify the peer’s certificate.");
 
 	/**
 	 * Secret to decrypt the truststore.
 	 */
 	public static final ConfigOption<String> SSL_TRUSTSTORE_PASSWORD =
 		key("security.ssl.truststore-password")
-			.noDefaultValue();
+			.noDefaultValue()
+			.withDescription("The secret to decrypt the truststore.");
 
 	/**
 	 * SSL protocol version to be supported.
 	 */
 	public static final ConfigOption<String> SSL_PROTOCOL =
 		key("security.ssl.protocol")
-			.defaultValue("TLSv1.2");
+			.defaultValue("TLSv1.2")
+			.withDescription("The SSL protocol version to be supported for the ssl transport. Note that it doesn’t" +
+				" support comma separated list.");
 
 	/**
 	 * The standard SSL algorithms to be supported.
@@ -137,12 +147,15 @@ public class SecurityOptions {
 	 */
 	public static final ConfigOption<String> SSL_ALGORITHMS =
 		key("security.ssl.algorithms")
-			.defaultValue("TLS_RSA_WITH_AES_128_CBC_SHA");
+			.defaultValue("TLS_RSA_WITH_AES_128_CBC_SHA")
+			.withDescription("The comma separated list of standard SSL algorithms to be supported. Read more" +
+				" <a href=\"http://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html#ciphersuites\">here</a>.");
 
 	/**
 	 * Flag to enable/disable hostname verification for the ssl connections.
 	 */
 	public static final ConfigOption<Boolean> SSL_VERIFY_HOSTNAME =
 		key("security.ssl.verify-hostname")
-			.defaultValue(true);
+			.defaultValue(true)
+			.withDescription("Flag to enable peer’s hostname verification during ssl handshake.");
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR integrates the SSL `ConfigOptions` into the configuration docs generator.

## Brief change log

* Add missing descriptions to config options (derived from existing description/javadocs)
* integrate ssl configuration table into `config.md`