### PR TITLE
[FLINK-8475][config][docs] Integrate netty options

### DIFF
--- a/docs/_includes/generated/netty_configuration.html
+++ b/docs/_includes/generated/netty_configuration.html
@@ -1,0 +1,46 @@
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 65%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>taskmanager.network.netty.client.connectTimeoutSec</h5></td>
+            <td>120</td>
+            <td>The Netty client connection timeout.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.network.netty.client.numThreads</h5></td>
+            <td>-1</td>
+            <td>The number of Netty client threads.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.network.netty.num-arenas</h5></td>
+            <td>-1</td>
+            <td>The number of Netty arenas.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.network.netty.sendReceiveBufferSize</h5></td>
+            <td>0</td>
+            <td>The Netty send and receive buffer size. This defaults to the system buffer size (cat /proc/sys/net/ipv4/tcp_[rw]mem) and is 4 MiB in modern Linux.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.network.netty.server.backlog</h5></td>
+            <td>0</td>
+            <td> The netty server connection backlog.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.network.netty.server.numThreads</h5></td>
+            <td>-1</td>
+            <td>The number of Netty server threads.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.network.netty.transport</h5></td>
+            <td>"nio"</td>
+            <td>The Netty transport type, either "nio" or "epoll"</td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -380,19 +380,7 @@ The following parameters configure Flink's JobManager and TaskManagers.
 
 These parameters allow for advanced tuning. The default values are sufficient when running concurrent high-throughput jobs on a large cluster.
 
-- `taskmanager.net.num-arenas`: The number of Netty arenas (DEFAULT: **taskmanager.numberOfTaskSlots**).
-
-- `taskmanager.net.server.numThreads`: The number of Netty server threads (DEFAULT: **taskmanager.numberOfTaskSlots**).
-
-- `taskmanager.net.client.numThreads`: The number of Netty client threads (DEFAULT: **taskmanager.numberOfTaskSlots**).
-
-- `taskmanager.net.server.backlog`: The netty server connection backlog.
-
-- `taskmanager.net.client.connectTimeoutSec`: The Netty client connection timeout (DEFAULT: **120 seconds**).
-
-- `taskmanager.net.sendReceiveBufferSize`: The Netty send and receive buffer size. This defaults to the system buffer size (`cat /proc/sys/net/ipv4/tcp_[rw]mem`) and is 4 MiB in modern Linux.
-
-- `taskmanager.net.transport`: The Netty transport type, either "nio" or "epoll" (DEFAULT: **nio**).
+{% include generated/netty_configuration.html %}
 
 ### Web Frontend
 

--- a/flink-docs/pom.xml
+++ b/flink-docs/pom.xml
@@ -188,6 +188,8 @@ under the License.
 									<!--packages with configuration classes-->
 									<arg value="flink-core" />
 									<arg value="org.apache.flink.configuration" />
+									<arg value="flink-runtime" />
+									<arg value="org.apache.flink.runtime.io.network.netty" />
 									<arg value="flink-yarn" />
 									<arg value="org.apache.flink.yarn.configuration" />
 								</java>

--- a/flink-docs/src/main/java/org/apache/flink/docs/configuration/ConfigOptionsDocGenerator.java
+++ b/flink-docs/src/main/java/org/apache/flink/docs/configuration/ConfigOptionsDocGenerator.java
@@ -70,8 +70,8 @@ public class ConfigOptionsDocGenerator {
 	private static void createTable(String rootDir, String module, String packageName, String outputDirectory) throws IOException, ClassNotFoundException {
 		Path configDir = Paths.get(rootDir, module, "src/main/java", packageName.replaceAll("\\.", "/"));
 
-		Pattern p = Pattern.compile("(([a-zA-Z]*)(Options))\\.java");
-		try (DirectoryStream<Path> stream = Files.newDirectoryStream(configDir, "*Options.java")) {
+		Pattern p = Pattern.compile("(([a-zA-Z]*)(Options|Config))\\.java");
+		try (DirectoryStream<Path> stream = Files.newDirectoryStream(configDir)) {
 			for (Path entry : stream) {
 				String fileName = entry.getFileName().toString();
 				Matcher matcher = p.matcher(fileName);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConfig.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConfig.java
@@ -43,37 +43,45 @@ public class NettyConfig {
 	public static final ConfigOption<Integer> NUM_ARENAS = ConfigOptions
 			.key("taskmanager.network.netty.num-arenas")
 			.defaultValue(-1)
-			.withDeprecatedKeys("taskmanager.net.num-arenas");
+			.withDeprecatedKeys("taskmanager.net.num-arenas")
+			.withDescription("The number of Netty arenas.");
 
 	public static final ConfigOption<Integer> NUM_THREADS_SERVER = ConfigOptions
 			.key("taskmanager.network.netty.server.numThreads")
 			.defaultValue(-1)
-			.withDeprecatedKeys("taskmanager.net.server.numThreads");
+			.withDeprecatedKeys("taskmanager.net.server.numThreads")
+			.withDescription("The number of Netty server threads.");
 
 	public static final ConfigOption<Integer> NUM_THREADS_CLIENT = ConfigOptions
 			.key("taskmanager.network.netty.client.numThreads")
 			.defaultValue(-1)
-			.withDeprecatedKeys("taskmanager.net.client.numThreads");
+			.withDeprecatedKeys("taskmanager.net.client.numThreads")
+			.withDescription("The number of Netty client threads.");
 
 	public static final ConfigOption<Integer> CONNECT_BACKLOG = ConfigOptions
 			.key("taskmanager.network.netty.server.backlog")
 			.defaultValue(0) // default: 0 => Netty's default
-			.withDeprecatedKeys("taskmanager.net.server.backlog");
+			.withDeprecatedKeys("taskmanager.net.server.backlog")
+			.withDescription(" The netty server connection backlog.");
 
 	public static final ConfigOption<Integer> CLIENT_CONNECT_TIMEOUT_SECONDS = ConfigOptions
 			.key("taskmanager.network.netty.client.connectTimeoutSec")
 			.defaultValue(120) // default: 120s = 2min
-			.withDeprecatedKeys("taskmanager.net.client.connectTimeoutSec");
+			.withDeprecatedKeys("taskmanager.net.client.connectTimeoutSec")
+			.withDescription("The Netty client connection timeout.");
 
 	public static final ConfigOption<Integer> SEND_RECEIVE_BUFFER_SIZE = ConfigOptions
 			.key("taskmanager.network.netty.sendReceiveBufferSize")
 			.defaultValue(0) // default: 0 => Netty's default
-			.withDeprecatedKeys("taskmanager.net.sendReceiveBufferSize");
+			.withDeprecatedKeys("taskmanager.net.sendReceiveBufferSize")
+			.withDescription("The Netty send and receive buffer size. This defaults to the system buffer size" +
+				" (cat /proc/sys/net/ipv4/tcp_[rw]mem) and is 4 MiB in modern Linux.");
 
 	public static final ConfigOption<String> TRANSPORT_TYPE = ConfigOptions
 			.key("taskmanager.network.netty.transport")
 			.defaultValue("nio")
-			.withDeprecatedKeys("taskmanager.net.transport");
+			.withDeprecatedKeys("taskmanager.net.transport")
+			.withDescription("The Netty transport type, either \"nio\" or \"epoll\"");
 
 	// ------------------------------------------------------------------------
 


### PR DESCRIPTION
## What is the purpose of the change

This PR integrates the Netty `ConfigOptions` into the configuration docs generator.

## Brief change log

* extend generator configuration to pick up `NettyConfig` class in flink-runtime
* update generator file matching to accept `NettyConfig`
* Add missing descriptions to config options (derived from existing description/javadocs)
* integrate netty configuration table into `config.md`