### PR TITLE
[FLINK-8529] [flip6] Let Yarn entry points use APPLICATION_MASTER_PORT

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnJobClusterEntrypoint.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnJobClusterEntrypoint.java
@@ -38,6 +38,7 @@ import org.apache.flink.runtime.util.SignalHandler;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.yarn.YarnResourceManager;
+import org.apache.flink.yarn.configuration.YarnConfigOptions;
 
 import org.apache.hadoop.yarn.api.ApplicationConstants;
 
@@ -71,6 +72,11 @@ public class YarnJobClusterEntrypoint extends JobClusterEntrypoint {
 	@Override
 	protected SecurityContext installSecurityContext(Configuration configuration) throws Exception {
 		return YarnEntrypointUtils.installSecurityContext(configuration, workingDirectory);
+	}
+
+	@Override
+	protected String getRPCPortRange(Configuration configuration) {
+		return configuration.getString(YarnConfigOptions.APPLICATION_MASTER_PORT);
 	}
 
 	@Override

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnSessionClusterEntrypoint.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnSessionClusterEntrypoint.java
@@ -36,6 +36,7 @@ import org.apache.flink.runtime.util.JvmShutdownSafeguard;
 import org.apache.flink.runtime.util.SignalHandler;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.yarn.YarnResourceManager;
+import org.apache.flink.yarn.configuration.YarnConfigOptions;
 
 import org.apache.hadoop.yarn.api.ApplicationConstants;
 
@@ -61,6 +62,11 @@ public class YarnSessionClusterEntrypoint extends SessionClusterEntrypoint {
 	@Override
 	protected SecurityContext installSecurityContext(Configuration configuration) throws Exception {
 		return YarnEntrypointUtils.installSecurityContext(configuration, workingDirectory);
+	}
+
+	@Override
+	protected String getRPCPortRange(Configuration configuration) {
+		return configuration.getString(YarnConfigOptions.APPLICATION_MASTER_PORT);
 	}
 
 	@Override


### PR DESCRIPTION
## What is the purpose of the change

Let all Yarn entry points use the YarnConfigOptions.APPLICATION_MASTER_PORT option
to specify the valid port range for the common RpcService.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
