### PR TITLE
[FLINK-8475][config][docs] Integrate REST options

### DIFF
--- a/docs/_includes/generated/rest_configuration.html
+++ b/docs/_includes/generated/rest_configuration.html
@@ -1,0 +1,41 @@
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 65%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>rest.address</h5></td>
+            <td>"localhost"</td>
+            <td>The address that the server binds itself to / the client connects to.</td>
+        </tr>
+        <tr>
+            <td><h5>rest.await-leader-timeout</h5></td>
+            <td>30000</td>
+            <td>The time in ms that the client waits for the leader address, e.g., Dispatcher or WebMonitorEndpoint</td>
+        </tr>
+        <tr>
+            <td><h5>rest.connection-timeout</h5></td>
+            <td>15000</td>
+            <td>The maximum time in ms for the client to establish a TCP connection.</td>
+        </tr>
+        <tr>
+            <td><h5>rest.port</h5></td>
+            <td>9067</td>
+            <td>The port that the server listens on / the client connects to.</td>
+        </tr>
+        <tr>
+            <td><h5>rest.retry.delay</h5></td>
+            <td>3000</td>
+            <td>The time in ms that the client waits between retries (See also `rest.retry.max-attempts`).</td>
+        </tr>
+        <tr>
+            <td><h5>rest.retry.max-attempts</h5></td>
+            <td>20</td>
+            <td>The number of retries the client will attempt if a retryable operations fails.</td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -356,6 +356,10 @@ The following parameters configure Flink's JobManager and TaskManagers.
 
 - `akka.ssl.enabled`: Turns on SSL for Akka's remote communication. This is applicable only when the global ssl flag security.ssl.enabled is set to true (DEFAULT: **true**).
 
+### REST
+
+{% include generated/rest_configuration.html %}
+
 ### SSL Settings
 
 - `security.ssl.enabled`: Turns on SSL for internal network communication. This can be optionally overridden by flags defined in different transport modules (DEFAULT: **false**).


### PR DESCRIPTION
## What is the purpose of the change

This PR adds the REST `ConfigOptions` to the full configuration reference.