### PR TITLE
[FLINK-8475][config][docs] Integrate SlotManager options

### DIFF
--- a/docs/_includes/generated/slot_manager_configuration.html
+++ b/docs/_includes/generated/slot_manager_configuration.html
@@ -1,0 +1,21 @@
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 65%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>slotmanager.request-timeout</h5></td>
+            <td>600000</td>
+            <td>The timeout for a slot request to be discarded.</td>
+        </tr>
+        <tr>
+            <td><h5>slotmanager.taskmanager-timeout</h5></td>
+            <td>30000</td>
+            <td>The timeout for an idle task manager to be released.</td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -588,9 +588,7 @@ You have to configure `jobmanager.archive.fs.dir` in order to archive terminated
 
 The configuration keys in this section are relevant for the SlotManager running in the Flip-6 ResourceManager
 
-- `slotmanager.request-timeout`: Timeout after which a slot request will be discarded by the SlotManager. The value is specified in milli seconds (DEFAULT: `300000`).
-
-- `slotmanager.taskmanager-timeout`: Timeout after which an idling task manager's container is released (DEFAULT: `30000`).
+{% include generated/slot_manager_configuration.html %}
 
 ## Background
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
@@ -24,6 +24,9 @@ import org.apache.flink.annotation.PublicEvolving;
  * The set of configuration options relating to the ResourceManager.
  */
 @PublicEvolving
+@ConfigGroups(groups = {
+	@ConfigGroup(name = "SlotManager", keyPrefix = "slotmanager")
+})
 public class ResourceManagerOptions {
 
 	/**


### PR DESCRIPTION
## What is the purpose of the change

This PR integrates the SlotManager `ConfigOptions` into the configuration docs generator.

## Brief change log

* Add `ConfigGroup` for slotmanager config options
* integrate slotmanager configuration table into `config.md`