### PR TITLE
[FLINK-8475][config][docs] Integrate BlobServer options

### DIFF
--- a/docs/_includes/generated/blob_server_configuration.html
+++ b/docs/_includes/generated/blob_server_configuration.html
@@ -1,0 +1,51 @@
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 65%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>blob.fetch.backlog</h5></td>
+            <td>1000</td>
+            <td>The config parameter defining the backlog of BLOB fetches on the JobManager.</td>
+        </tr>
+        <tr>
+            <td><h5>blob.fetch.num-concurrent</h5></td>
+            <td>50</td>
+            <td>The config parameter defining the maximum number of concurrent BLOB fetches that the JobManager serves.</td>
+        </tr>
+        <tr>
+            <td><h5>blob.fetch.retries</h5></td>
+            <td>5</td>
+            <td>The config parameter defining number of retires for failed BLOB fetches.</td>
+        </tr>
+        <tr>
+            <td><h5>blob.offload.minsize</h5></td>
+            <td>1048576</td>
+            <td>The minimum size for messages to be offloaded to the BlobServer.</td>
+        </tr>
+        <tr>
+            <td><h5>blob.server.port</h5></td>
+            <td>"0"</td>
+            <td>The config parameter defining the server port of the blob service.</td>
+        </tr>
+        <tr>
+            <td><h5>blob.service.cleanup.interval</h5></td>
+            <td>3600</td>
+            <td>Cleanup interval of the blob caches at the task managers (in seconds).</td>
+        </tr>
+        <tr>
+            <td><h5>blob.service.ssl.enabled</h5></td>
+            <td>true</td>
+            <td>Flag to override ssl support for the blob service transport.</td>
+        </tr>
+        <tr>
+            <td><h5>blob.storage.directory</h5></td>
+            <td>(none)</td>
+            <td>The config parameter defining the storage directory to be used by the blob server.</td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -356,6 +356,10 @@ The following parameters configure Flink's JobManager and TaskManagers.
 
 - `akka.ssl.enabled`: Turns on SSL for Akka's remote communication. This is applicable only when the global ssl flag security.ssl.enabled is set to true (DEFAULT: **true**).
 
+### Blob Server
+
+{% include generated/blob_server_configuration.html %}
+
 ### SSL Settings
 
 - `security.ssl.enabled`: Turns on SSL for internal network communication. This can be optionally overridden by flags defined in different transport modules (DEFAULT: **false**).

--- a/flink-core/src/main/java/org/apache/flink/configuration/BlobServerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/BlobServerOptions.java
@@ -33,28 +33,32 @@ public class BlobServerOptions {
 	 */
 	public static final ConfigOption<String> STORAGE_DIRECTORY =
 		key("blob.storage.directory")
-			.noDefaultValue();
+			.noDefaultValue()
+			.withDescription("The config parameter defining the storage directory to be used by the blob server.");
 
 	/**
 	 * The config parameter defining number of retires for failed BLOB fetches.
 	 */
 	public static final ConfigOption<Integer> FETCH_RETRIES =
 		key("blob.fetch.retries")
-			.defaultValue(5);
+			.defaultValue(5)
+			.withDescription("The config parameter defining number of retires for failed BLOB fetches.");
 
 	/**
 	 * The config parameter defining the maximum number of concurrent BLOB fetches that the JobManager serves.
 	 */
 	public static final ConfigOption<Integer> FETCH_CONCURRENT =
 		key("blob.fetch.num-concurrent")
-			.defaultValue(50);
+			.defaultValue(50)
+			.withDescription("The config parameter defining the maximum number of concurrent BLOB fetches that the JobManager serves.");
 
 	/**
 	 * The config parameter defining the backlog of BLOB fetches on the JobManager.
 	 */
 	public static final ConfigOption<Integer> FETCH_BACKLOG =
 		key("blob.fetch.backlog")
-			.defaultValue(1000);
+			.defaultValue(1000)
+			.withDescription("The config parameter defining the backlog of BLOB fetches on the JobManager.");
 
 	/**
 	 * The config parameter defining the server port of the blob service.
@@ -66,14 +70,16 @@ public class BlobServerOptions {
 	 */
 	public static final ConfigOption<String> PORT =
 		key("blob.server.port")
-			.defaultValue("0");
+			.defaultValue("0")
+			.withDescription("The config parameter defining the server port of the blob service.");
 
 	/**
 	 * Flag to override ssl support for the blob service transport.
 	 */
 	public static final ConfigOption<Boolean> SSL_ENABLED =
 		key("blob.service.ssl.enabled")
-			.defaultValue(true);
+			.defaultValue(true)
+			.withDescription("Flag to override ssl support for the blob service transport.");
 
 	/**
 	 * Cleanup interval of the blob caches at the task managers (in seconds).
@@ -87,11 +93,13 @@ public class BlobServerOptions {
 	public static final ConfigOption<Long> CLEANUP_INTERVAL =
 		key("blob.service.cleanup.interval")
 			.defaultValue(3_600L) // once per hour
-			.withDeprecatedKeys("library-cache-manager.cleanup.interval");
+			.withDeprecatedKeys("library-cache-manager.cleanup.interval")
+			.withDescription("Cleanup interval of the blob caches at the task managers (in seconds).");
 
 	/**
 	 * The minimum size for messages to be offloaded to the BlobServer.
 	 */
 	public static final ConfigOption<Integer> OFFLOAD_MINSIZE = key("blob.offload.minsize")
-		.defaultValue(1_024 * 1_024); // 1MiB by default
+		.defaultValue(1_024 * 1_024) // 1MiB by default
+		.withDescription("The minimum size for messages to be offloaded to the BlobServer.");
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR adds the BlobServer `ConfigOptions` to the full configuration reference.

## Brief change log

* Add missing descriptions to config options (derived from existing description/javadocs)
* integrate BlobServer  configuration table into `config.md`