### PR TITLE
[FLINK-6571][tests] Catch InterruptedException in StreamSourceOperato…

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorTest.java
@@ -339,7 +339,11 @@ public class StreamSourceOperatorTest {
 		@Override
 		public void run(SourceContext<T> ctx) throws Exception {
 			while (running) {
-				Thread.sleep(20);
+				try {
+					Thread.sleep(20);
+				} catch (InterruptedException ignored) {
+					Thread.currentThread().interrupt();
+				}
 			}
 		}
 


### PR DESCRIPTION
## What is the purpose of the change

This PR resolves a test instability in the StreamSourceOperatorTest, where the `InfiniteSource` could fail due to an `InterruptedException`.