### PR TITLE
[FLINK-7856][flip6] Port JobVertexBackPressureHandler to REST endpoint 

### DIFF
--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitor.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitor.java
@@ -224,7 +224,11 @@ public class WebRuntimeMonitor implements WebMonitor {
 		Time delayBetweenSamples = Time.milliseconds(delay);
 
 		backPressureStatsTracker = new BackPressureStatsTracker(
-				stackTraceSamples, cleanUpInterval, numSamples, delayBetweenSamples);
+			stackTraceSamples,
+			cleanUpInterval,
+			numSamples,
+			config.getInteger(WebOptions.BACKPRESSURE_REFRESH_INTERVAL),
+			delayBetweenSamples);
 
 		// --------------------------------------------------------------------
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -33,6 +33,7 @@ import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.highavailability.RunningJobsRegistry;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobStatus;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobmanager.OnCompletionActions;
 import org.apache.flink.runtime.jobmanager.SubmittedJobGraph;
 import org.apache.flink.runtime.jobmanager.SubmittedJobGraphStore;
@@ -49,6 +50,7 @@ import org.apache.flink.runtime.messages.webmonitor.MultipleJobsDetails;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.resourcemanager.ResourceOverview;
+import org.apache.flink.runtime.rest.handler.legacy.backpressure.OperatorBackPressureStats;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.FencedRpcEndpoint;
 import org.apache.flink.runtime.rpc.RpcService;
@@ -66,6 +68,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
@@ -355,6 +358,18 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 			} else {
 				return FutureUtils.completedExceptionally(new FlinkJobNotFoundException(jobId));
 			}
+		}
+	}
+
+	@Override
+	public CompletableFuture<Optional<OperatorBackPressureStats>> getOperatorBackPressureStats(
+			final JobID jobId, final JobVertexID jobVertexId) {
+			final JobManagerRunner jobManagerRunner = jobManagerRunners.get(jobId);
+		if (jobManagerRunner == null) {
+			return FutureUtils.completedExceptionally(new FlinkJobNotFoundException(jobId));
+		} else {
+			return jobManagerRunner.getJobManagerGateway()
+				.getOperatorBackPressureStats(jobId, jobVertexId);
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -50,7 +50,7 @@ import org.apache.flink.runtime.messages.webmonitor.MultipleJobsDetails;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.resourcemanager.ResourceOverview;
-import org.apache.flink.runtime.rest.handler.legacy.backpressure.OperatorBackPressureStats;
+import org.apache.flink.runtime.rest.handler.legacy.backpressure.OperatorBackPressureStatsResponse;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.FencedRpcEndpoint;
 import org.apache.flink.runtime.rpc.RpcService;
@@ -68,7 +68,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
@@ -362,14 +361,14 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 	}
 
 	@Override
-	public CompletableFuture<Optional<OperatorBackPressureStats>> getOperatorBackPressureStats(
+	public CompletableFuture<OperatorBackPressureStatsResponse> requestOperatorBackPressureStats(
 			final JobID jobId, final JobVertexID jobVertexId) {
 			final JobManagerRunner jobManagerRunner = jobManagerRunners.get(jobId);
 		if (jobManagerRunner == null) {
 			return FutureUtils.completedExceptionally(new FlinkJobNotFoundException(jobId));
 		} else {
 			return jobManagerRunner.getJobManagerGateway()
-				.getOperatorBackPressureStats(jobId, jobVertexId);
+				.requestOperatorBackPressureStats(jobId, jobVertexId);
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherRestEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherRestEndpoint.java
@@ -29,7 +29,9 @@ import org.apache.flink.runtime.rest.handler.RestHandlerSpecification;
 import org.apache.flink.runtime.rest.handler.job.BlobServerPortHandler;
 import org.apache.flink.runtime.rest.handler.job.JobSubmitHandler;
 import org.apache.flink.runtime.rest.handler.job.JobTerminationHandler;
+import org.apache.flink.runtime.rest.handler.job.JobVertexBackPressureHandler;
 import org.apache.flink.runtime.rest.messages.JobTerminationHeaders;
+import org.apache.flink.runtime.rest.messages.JobVertexBackPressureHeaders;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.webmonitor.WebMonitorEndpoint;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
@@ -97,9 +99,17 @@ public class DispatcherRestEndpoint extends WebMonitorEndpoint<DispatcherGateway
 			timeout,
 			responseHeaders);
 
+		JobVertexBackPressureHandler jobVertexBackPressureHandler = new JobVertexBackPressureHandler(
+			restAddressFuture,
+			leaderRetriever,
+			timeout,
+			responseHeaders,
+			JobVertexBackPressureHeaders.getInstance());
+
 		handlers.add(Tuple2.of(JobTerminationHeaders.getInstance(), jobTerminationHandler));
 		handlers.add(Tuple2.of(blobServerPortHandler.getMessageHeaders(), blobServerPortHandler));
 		handlers.add(Tuple2.of(jobSubmitHandler.getMessageHeaders(), jobSubmitHandler));
+		handlers.add(Tuple2.of(JobVertexBackPressureHeaders.getInstance(), jobVertexBackPressureHandler));
 
 		return handlers;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherRestEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherRestEndpoint.java
@@ -29,9 +29,7 @@ import org.apache.flink.runtime.rest.handler.RestHandlerSpecification;
 import org.apache.flink.runtime.rest.handler.job.BlobServerPortHandler;
 import org.apache.flink.runtime.rest.handler.job.JobSubmitHandler;
 import org.apache.flink.runtime.rest.handler.job.JobTerminationHandler;
-import org.apache.flink.runtime.rest.handler.job.JobVertexBackPressureHandler;
 import org.apache.flink.runtime.rest.messages.JobTerminationHeaders;
-import org.apache.flink.runtime.rest.messages.JobVertexBackPressureHeaders;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.webmonitor.WebMonitorEndpoint;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
@@ -99,17 +97,9 @@ public class DispatcherRestEndpoint extends WebMonitorEndpoint<DispatcherGateway
 			timeout,
 			responseHeaders);
 
-		JobVertexBackPressureHandler jobVertexBackPressureHandler = new JobVertexBackPressureHandler(
-			restAddressFuture,
-			leaderRetriever,
-			timeout,
-			responseHeaders,
-			JobVertexBackPressureHeaders.getInstance());
-
 		handlers.add(Tuple2.of(JobTerminationHeaders.getInstance(), jobTerminationHandler));
 		handlers.add(Tuple2.of(blobServerPortHandler.getMessageHeaders(), blobServerPortHandler));
 		handlers.add(Tuple2.of(jobSubmitHandler.getMessageHeaders(), jobSubmitHandler));
-		handlers.add(Tuple2.of(JobVertexBackPressureHeaders.getInstance(), jobVertexBackPressureHandler));
 
 		return handlers;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerRunner.java
@@ -170,7 +170,8 @@ public class JobManagerRunner implements LeaderContender, OnCompletionActions, F
 				this,
 				userCodeLoader,
 				restAddress,
-				metricRegistry.getMetricQueryServicePath());
+				metricRegistry.getMetricQueryServicePath(),
+				jobManagerServices.backPressureStatsTracker);
 
 			this.timeout = jobManagerServices.rpcAskTimeout;
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -687,7 +687,7 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 			executionGraph.getKvStateLocationRegistry().notifyKvStateUnregistered(
 					jobVertexId, keyGroupRange, registrationName);
 		} catch (Exception e) {
-			log.error("Failed to notify KvStateRegistry about registration {}.", registrationName);
+			log.error("Failed to notify KvStateRegistry about registration {}.", registrationName, e);
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.WebOptions;
 import org.apache.flink.core.io.InputSplit;
 import org.apache.flink.core.io.InputSplitAssigner;
 import org.apache.flink.metrics.MetricGroup;
@@ -85,6 +86,9 @@ import org.apache.flink.runtime.registration.RetryingRegistration;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
 import org.apache.flink.runtime.resourcemanager.ResourceOverview;
+import org.apache.flink.runtime.rest.handler.legacy.backpressure.BackPressureStatsTracker;
+import org.apache.flink.runtime.rest.handler.legacy.backpressure.OperatorBackPressureStats;
+import org.apache.flink.runtime.rest.handler.legacy.backpressure.StackTraceSampleCoordinator;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.FencedRpcEndpoint;
 import org.apache.flink.runtime.rpc.RpcService;
@@ -194,6 +198,14 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 	private final CompletableFuture<String> restAddressFuture;
 
 	private final String metricQueryServicePath;
+
+	// --------- BackPressure --------
+
+	private final StackTraceSampleCoordinator stackTraceSampleCoordinator;
+
+	private final BackPressureStatsTracker backPressureStatsTracker;
+
+	private final int backPressureStatsRefreshInterval;
 
 	// --------- ResourceManager --------
 
@@ -313,6 +325,13 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 			.orElse(FutureUtils.completedExceptionally(new JobMasterException("The JobMaster has not been started with a REST endpoint.")));
 
 		this.metricQueryServicePath = metricQueryServicePath;
+		this.stackTraceSampleCoordinator = new StackTraceSampleCoordinator(rpcService.getExecutor(), rpcTimeout.toMilliseconds());
+		this.backPressureStatsTracker = new BackPressureStatsTracker(
+			stackTraceSampleCoordinator,
+			configuration.getInteger(WebOptions.BACKPRESSURE_CLEANUP_INTERVAL),
+			configuration.getInteger(WebOptions.BACKPRESSURE_NUM_SAMPLES),
+			Time.milliseconds(configuration.getInteger(WebOptions.BACKPRESSURE_DELAY)));
+		this.backPressureStatsRefreshInterval = configuration.getInteger(WebOptions.BACKPRESSURE_REFRESH_INTERVAL);
 	}
 
 	//----------------------------------------------------------------------------------------------
@@ -403,6 +422,9 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 		if (exception != null) {
 			throw exception;
 		}
+
+		stackTraceSampleCoordinator.shutDown();
+		backPressureStatsTracker.shutDown();
 
 		log.info("Stopped the JobMaster for job " + jobGraph.getName() + '(' + jobGraph.getJobID() + ").");
 	}
@@ -865,6 +887,25 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 		} catch (Exception e) {
 			return FutureUtils.completedExceptionally(e);
 		}
+	}
+
+	@Override
+	public CompletableFuture<Optional<OperatorBackPressureStats>> getOperatorBackPressureStats(
+			final JobID jobId, final JobVertexID jobVertexId) {
+		final ExecutionJobVertex jobVertex = executionGraph.getJobVertex(jobVertexId);
+		if (jobVertex == null) {
+			return FutureUtils.completedExceptionally(new FlinkException("JobVertexID not found " +
+				jobVertexId));
+		}
+
+		final Optional<OperatorBackPressureStats> operatorBackPressureStats =
+			backPressureStatsTracker.getOperatorBackPressureStats(jobVertex);
+		if (!operatorBackPressureStats.isPresent() ||
+			backPressureStatsRefreshInterval <= System.currentTimeMillis() - operatorBackPressureStats.get().getEndTimestamp()) {
+			backPressureStatsTracker.triggerStackTraceSample(jobVertex);
+			return CompletableFuture.completedFuture(Optional.empty());
+		}
+		return CompletableFuture.completedFuture(operatorBackPressureStats);
 	}
 
 	//----------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/RpcTaskManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/RpcTaskManagerGateway.java
@@ -83,7 +83,13 @@ public class RpcTaskManagerGateway implements TaskManagerGateway {
 			int maxStackTraceDepth,
 			Time timeout) {
 
-		throw new UnsupportedOperationException("Operation is not yet supported.");
+		return taskExecutorGateway.requestStackTraceSample(
+			executionAttemptID,
+			sampleId,
+			numSamples,
+			delayBetweenSamples,
+			maxStackTraceDepth,
+			timeout);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobVertexBackPressureHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobVertexBackPressureHandler.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.job;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.dispatcher.DispatcherGateway;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.rest.handler.AbstractRestHandler;
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.RestHandlerException;
+import org.apache.flink.runtime.rest.messages.EmptyJobVertexBackPressureInfo;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.JobIDPathParameter;
+import org.apache.flink.runtime.rest.messages.JobVertexBackPressureInfo;
+import org.apache.flink.runtime.rest.messages.JobVertexIdPathParameter;
+import org.apache.flink.runtime.rest.messages.JobVertexMessageParameters;
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+
+import javax.annotation.Nonnull;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Request handler for the job vertex back pressure.
+ */
+public class JobVertexBackPressureHandler extends AbstractRestHandler<DispatcherGateway, EmptyRequestBody, JobVertexBackPressureInfo, JobVertexMessageParameters> {
+
+	public JobVertexBackPressureHandler(
+			CompletableFuture<String> localRestAddress,
+			GatewayRetriever<DispatcherGateway> leaderRetriever,
+			Time timeout,
+			Map<String, String> responseHeaders,
+			MessageHeaders<EmptyRequestBody, JobVertexBackPressureInfo, JobVertexMessageParameters> messageHeaders) {
+		super(localRestAddress, leaderRetriever, timeout, responseHeaders, messageHeaders);
+	}
+
+	@Override
+	protected CompletableFuture<JobVertexBackPressureInfo> handleRequest(@Nonnull HandlerRequest<EmptyRequestBody, JobVertexMessageParameters> request, @Nonnull DispatcherGateway gateway) throws RestHandlerException {
+		JobID jobId = request.getPathParameter(JobIDPathParameter.class);
+		JobVertexID jobVertexID = request.getPathParameter(JobVertexIdPathParameter.class);
+		///TODO Get JobVertexBackPressureInfo from DispatcherGateway with JobID and JobVertexID here
+
+		return CompletableFuture.completedFuture(EmptyJobVertexBackPressureInfo.getInstance());
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobVertexBackPressureHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobVertexBackPressureHandler.java
@@ -62,11 +62,12 @@ public class JobVertexBackPressureHandler extends AbstractRestHandler<RestfulGat
 		final JobID jobId = request.getPathParameter(JobIDPathParameter.class);
 		final JobVertexID jobVertexId = request.getPathParameter(JobVertexIdPathParameter.class);
 		return gateway
-			.getOperatorBackPressureStats(jobId, jobVertexId)
+			.requestOperatorBackPressureStats(jobId, jobVertexId)
 			.thenApply(
-				operatorBackPressureStatsOptional -> operatorBackPressureStatsOptional
-					.map(JobVertexBackPressureHandler::createJobVertexBackPressureInfo)
-					.orElse(JobVertexBackPressureInfo.deprecated()));
+				operatorBackPressureStats ->
+					operatorBackPressureStats.getOperatorBackPressureStats().map(
+						JobVertexBackPressureHandler::createJobVertexBackPressureInfo).orElse(
+						JobVertexBackPressureInfo.deprecated()));
 	}
 
 	private static JobVertexBackPressureInfo createJobVertexBackPressureInfo(
@@ -93,7 +94,7 @@ public class JobVertexBackPressureHandler extends AbstractRestHandler<RestfulGat
 	 *
 	 * @return Back pressure level ('ok', 'low', or 'high')
 	 */
-	static JobVertexBackPressureInfo.VertexBackPressureLevel getBackPressureLevel(double backPressureRatio) {
+	private static JobVertexBackPressureInfo.VertexBackPressureLevel getBackPressureLevel(double backPressureRatio) {
 		if (backPressureRatio <= 0.10) {
 			return JobVertexBackPressureInfo.VertexBackPressureLevel.OK;
 		} else if (backPressureRatio <= 0.5) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/backpressure/BackPressureStatsTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/backpressure/BackPressureStatsTracker.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.rest.handler.legacy.backpressure;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
@@ -99,6 +100,8 @@ public class BackPressureStatsTracker {
 
 	private final int numSamples;
 
+	private final int backPressureStatsRefreshInterval;
+
 	private final Time delayBetweenSamples;
 
 	/** Flag indicating whether the stats tracker has been shut down. */
@@ -115,6 +118,7 @@ public class BackPressureStatsTracker {
 			StackTraceSampleCoordinator coordinator,
 			int cleanUpInterval,
 			int numSamples,
+			int backPressureStatsRefreshInterval,
 			Time delayBetweenSamples) {
 
 		this.coordinator = checkNotNull(coordinator, "Stack trace sample coordinator");
@@ -124,6 +128,11 @@ public class BackPressureStatsTracker {
 
 		checkArgument(numSamples >= 1, "Number of samples");
 		this.numSamples = numSamples;
+
+		checkArgument(
+			backPressureStatsRefreshInterval >= 0,
+			"backPressureStatsRefreshInterval must be greater than or equal to 0");
+		this.backPressureStatsRefreshInterval = backPressureStatsRefreshInterval;
 
 		this.delayBetweenSamples = checkNotNull(delayBetweenSamples, "Delay between samples");
 
@@ -139,14 +148,18 @@ public class BackPressureStatsTracker {
 	}
 
 	/**
-	 * Returns back pressure statistics for a operator.
+	 * Returns back pressure statistics for a operator. Automatically triggers stack trace sampling
+	 * if statistics are not available or outdated.
 	 *
 	 * @param vertex Operator to get the stats for.
-	 *
 	 * @return Back pressure statistics for an operator
 	 */
 	public Optional<OperatorBackPressureStats> getOperatorBackPressureStats(ExecutionJobVertex vertex) {
-		return Optional.ofNullable(operatorStatsCache.getIfPresent(vertex));
+		final OperatorBackPressureStats stats = operatorStatsCache.getIfPresent(vertex);
+		if (stats == null || backPressureStatsRefreshInterval <= System.currentTimeMillis() - stats.getEndTimestamp()) {
+			triggerStackTraceSampleInternal(vertex);
+		}
+		return Optional.ofNullable(stats);
 	}
 
 	/**
@@ -157,15 +170,15 @@ public class BackPressureStatsTracker {
 	 * @param vertex Operator to get the stats for.
 	 * @return Flag indicating whether a sample with triggered.
 	 */
-	@SuppressWarnings("unchecked")
-	public boolean triggerStackTraceSample(ExecutionJobVertex vertex) {
+	@VisibleForTesting
+	boolean triggerStackTraceSampleInternal(final ExecutionJobVertex vertex) {
 		synchronized (lock) {
 			if (shutDown) {
 				return false;
 			}
 
 			if (!pendingStats.contains(vertex) &&
-					!vertex.getGraph().getState().isGloballyTerminalState()) {
+				!vertex.getGraph().getState().isGloballyTerminalState()) {
 
 				Executor executor = vertex.getGraph().getFutureExecutor();
 
@@ -178,10 +191,10 @@ public class BackPressureStatsTracker {
 					}
 
 					CompletableFuture<StackTraceSample> sample = coordinator.triggerStackTraceSample(
-							vertex.getTaskVertices(),
-							numSamples,
-							delayBetweenSamples,
-							MAX_STACK_TRACE_DEPTH);
+						vertex.getTaskVertices(),
+						numSamples,
+						delayBetweenSamples,
+						MAX_STACK_TRACE_DEPTH);
 
 					sample.handleAsync(new StackTraceSampleCompletionCallback(vertex), executor);
 
@@ -191,6 +204,21 @@ public class BackPressureStatsTracker {
 
 			return false;
 		}
+	}
+
+	/**
+	 * Triggers a stack trace sample for a operator to gather the back pressure
+	 * statistics. If there is a sample in progress for the operator, the call
+	 * is ignored.
+	 *
+	 * @param vertex Operator to get the stats for.
+	 * @return Flag indicating whether a sample with triggered.
+	 * @deprecated {@link #getOperatorBackPressureStats(ExecutionJobVertex)} will trigger
+	 * stack trace sampling automatically.
+	 */
+	@Deprecated
+	public boolean triggerStackTraceSample(ExecutionJobVertex vertex) {
+		return triggerStackTraceSampleInternal(vertex);
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/backpressure/BackPressureStatsTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/backpressure/BackPressureStatsTracker.java
@@ -74,7 +74,7 @@ public class BackPressureStatsTracker {
 	static final String EXPECTED_CLASS_NAME = "org.apache.flink.runtime.io.network.buffer.LocalBufferPool";
 
 	/** Expected method name for back pressure indicating stack trace element. */
-	static final String EXPECTED_METHOD_NAME = "requestBufferBlocking";
+	static final String EXPECTED_METHOD_NAME = "requestBufferBuilderBlocking";
 
 	/** Lock guarding trigger operations. */
 	private final Object lock = new Object();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/backpressure/OperatorBackPressureStats.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/backpressure/OperatorBackPressureStats.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.rest.handler.legacy.backpressure;
 
+import java.io.Serializable;
 import java.util.Arrays;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
@@ -30,7 +31,9 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * back pressure ratio denotes the ratio of traces indicating back pressure
  * to the total number of sampled traces.
  */
-public class OperatorBackPressureStats {
+public class OperatorBackPressureStats implements Serializable {
+
+	private static final long serialVersionUID = 1L;
 
 	/** ID of the corresponding sample. */
 	private final int sampleId;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/backpressure/OperatorBackPressureStatsResponse.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/backpressure/OperatorBackPressureStatsResponse.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.legacy.backpressure;
+
+import javax.annotation.Nullable;
+
+import java.io.Serializable;
+import java.util.Optional;
+
+/**
+ * Wrapper for {@link OperatorBackPressureStats}.
+ */
+public class OperatorBackPressureStatsResponse implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	@Nullable
+	private final OperatorBackPressureStats operatorBackPressureStats;
+
+	private OperatorBackPressureStatsResponse(@Nullable final OperatorBackPressureStats operatorBackPressureStats) {
+		this.operatorBackPressureStats = operatorBackPressureStats;
+	}
+
+	public static OperatorBackPressureStatsResponse of(@Nullable final OperatorBackPressureStats operatorBackPressureStats) {
+		return new OperatorBackPressureStatsResponse(operatorBackPressureStats);
+	}
+
+	public Optional<OperatorBackPressureStats> getOperatorBackPressureStats() {
+		return Optional.ofNullable(operatorBackPressureStats);
+	}
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/EmptyJobVertexBackPressureInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/EmptyJobVertexBackPressureInfo.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages;
+
+import org.apache.flink.runtime.rest.handler.job.JobVertexBackPressureHandler;
+
+import java.util.ArrayList;
+
+/**
+ * Empty response of the {@link JobVertexBackPressureHandler}.
+ */
+public class EmptyJobVertexBackPressureInfo extends JobVertexBackPressureInfo {
+
+	private static final EmptyJobVertexBackPressureInfo INSTANCE = new EmptyJobVertexBackPressureInfo();
+
+	private EmptyJobVertexBackPressureInfo() {
+		super(null, null, System.currentTimeMillis(), new ArrayList<>());
+	}
+
+	public static EmptyJobVertexBackPressureInfo getInstance() {
+		return INSTANCE;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobVertexBackPressureHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobVertexBackPressureHeaders.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages;
+
+import org.apache.flink.runtime.rest.HttpMethodWrapper;
+import org.apache.flink.runtime.rest.handler.job.JobVertexBackPressureHandler;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+/**
+ * Message headers for the {@link JobVertexBackPressureHandler}.
+ */
+public class JobVertexBackPressureHeaders implements MessageHeaders<EmptyRequestBody, JobVertexBackPressureInfo, JobVertexMessageParameters> {
+
+	private static final JobVertexBackPressureHeaders INSTANCE = new JobVertexBackPressureHeaders();
+
+	private static final String URL = "/jobs/:" + JobIDPathParameter.KEY + "/vertices/:" + JobVertexIdPathParameter.KEY + "/backpressure";
+
+	@Override
+	public Class<EmptyRequestBody> getRequestClass() {
+		return EmptyRequestBody.class;
+	}
+
+	@Override
+	public Class<JobVertexBackPressureInfo> getResponseClass() {
+		return JobVertexBackPressureInfo.class;
+	}
+
+	@Override
+	public HttpResponseStatus getResponseStatusCode() {
+		return HttpResponseStatus.OK;
+	}
+
+	@Override
+	public JobVertexMessageParameters getUnresolvedMessageParameters() {
+		return new JobVertexMessageParameters();
+	}
+
+	@Override
+	public HttpMethodWrapper getHttpMethod() {
+		return HttpMethodWrapper.GET;
+	}
+
+	@Override
+	public String getTargetRestEndpointURL() {
+		return URL;
+	}
+
+	public static JobVertexBackPressureHeaders getInstance() {
+		return INSTANCE;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobVertexBackPressureInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobVertexBackPressureInfo.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages;
+
+import org.apache.flink.runtime.rest.handler.job.JobVertexBackPressureHandler;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Objects;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Response type of the {@link JobVertexBackPressureHandler}.
+ */
+public class JobVertexBackPressureInfo implements ResponseBody {
+
+	public static final String FIELD_NAME_STATUS = "status";
+	public static final String FIELD_NAME_BACKPRESSURE_LEVEL = "backpressure-level";
+	public static final String FIELD_NAME_END_TIMESTAMP = "end-timestamp";
+	public static final String FIELD_NAME_SUBTASKS = "subtasks";
+
+	@JsonProperty(FIELD_NAME_STATUS)
+	private final VertexBackPressureStatus status;
+
+	@JsonProperty(FIELD_NAME_BACKPRESSURE_LEVEL)
+	private final VertexBackPressureLevel backpressureLevel;
+
+	@JsonProperty(FIELD_NAME_END_TIMESTAMP)
+	private final long endTimestamp;
+
+	@JsonProperty(FIELD_NAME_SUBTASKS)
+	protected final List<SubtaskBackPressureInfo> subtasks;
+
+	@JsonCreator
+	public JobVertexBackPressureInfo(
+		@JsonProperty(FIELD_NAME_STATUS) VertexBackPressureStatus status,
+		@JsonProperty(FIELD_NAME_BACKPRESSURE_LEVEL) VertexBackPressureLevel backpressureLevel,
+		@JsonProperty(FIELD_NAME_END_TIMESTAMP) long endTimestamp,
+		@JsonProperty(FIELD_NAME_SUBTASKS) List<SubtaskBackPressureInfo> subtasks) {
+		this.status = status;
+		this.backpressureLevel = backpressureLevel;
+		this.endTimestamp = endTimestamp;
+		this.subtasks = checkNotNull(subtasks);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		JobVertexBackPressureInfo that = (JobVertexBackPressureInfo) o;
+		return Objects.equals(status, that.status) &&
+			Objects.equals(backpressureLevel, that.backpressureLevel) &&
+			Objects.equals(endTimestamp, that.endTimestamp) &&
+			Objects.equals(subtasks, that.subtasks);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(status, backpressureLevel, endTimestamp, subtasks);
+	}
+
+	//---------------------------------------------------------------------------------
+	// Static helper classes
+	//---------------------------------------------------------------------------------
+
+	/**
+	 * Nested class to encapsulate the sub tasks back pressure.
+	 */
+	public static final class SubtaskBackPressureInfo {
+
+		public static final String FIELD_NAME_SUBTASK = "subtask";
+		public static final String FIELD_NAME_BACKPRESSURE_LEVEL = "backpressure-level";
+		public static final String FIELD_NAME_RATIO = "ratio";
+
+		@JsonProperty(FIELD_NAME_SUBTASK)
+		private final int subtask;
+
+		@JsonProperty(FIELD_NAME_BACKPRESSURE_LEVEL)
+		private final VertexBackPressureLevel backpressureLevel;
+
+		@JsonProperty(FIELD_NAME_RATIO)
+		private final double ratio;
+
+		public SubtaskBackPressureInfo(
+			@JsonProperty(FIELD_NAME_SUBTASK) int subtask,
+			@JsonProperty(FIELD_NAME_BACKPRESSURE_LEVEL) VertexBackPressureLevel backpressureLevel,
+			@JsonProperty(FIELD_NAME_RATIO) double ratio) {
+			this.subtask = subtask;
+			this.backpressureLevel = checkNotNull(backpressureLevel);
+			this.ratio = ratio;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+			SubtaskBackPressureInfo that = (SubtaskBackPressureInfo) o;
+			return subtask == that.subtask &&
+				ratio == that.ratio &&
+				Objects.equals(backpressureLevel, that.backpressureLevel);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(subtask, backpressureLevel, ratio);
+		}
+	}
+
+	/**
+	 * Status of vertex back-pressure.
+	 */
+	public enum VertexBackPressureStatus {
+		DEPRECATED("deprecated"), OK("ok");
+
+		private String status;
+
+		VertexBackPressureStatus(String status) {
+			this.status = status;
+		}
+
+		@Override
+		public String toString() {
+			return status;
+		}
+	}
+
+	/**
+	 * Level of vertex back-pressure.
+	 */
+	public enum VertexBackPressureLevel {
+		OK("ok"), LOW("low"), HIGH("high");
+
+		private String level;
+
+		VertexBackPressureLevel(String level) {
+			this.level = level;
+		}
+
+		@Override
+		public String toString() {
+			return level;
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobVertexBackPressureInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobVertexBackPressureInfo.java
@@ -25,6 +25,9 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInc
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonValue;
 
+import javax.annotation.Nullable;
+
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -41,6 +44,13 @@ public class JobVertexBackPressureInfo implements ResponseBody {
 	public static final String FIELD_NAME_END_TIMESTAMP = "end-timestamp";
 	public static final String FIELD_NAME_SUBTASKS = "subtasks";
 
+	/** Immutable singleton instance denoting that the back pressure stats are not available. */
+	private static final JobVertexBackPressureInfo DEPRECATED_JOB_VERTEX_BACK_PRESSURE_INFO = new JobVertexBackPressureInfo(
+		VertexBackPressureStatus.DEPRECATED,
+		null,
+		null,
+		null);
+
 	@JsonProperty(FIELD_NAME_STATUS)
 	private final VertexBackPressureStatus status;
 
@@ -51,7 +61,7 @@ public class JobVertexBackPressureInfo implements ResponseBody {
 	private final Long endTimestamp;
 
 	@JsonProperty(FIELD_NAME_SUBTASKS)
-	protected final List<SubtaskBackPressureInfo> subtasks;
+	private final List<SubtaskBackPressureInfo> subtasks;
 
 	@JsonCreator
 	public JobVertexBackPressureInfo(
@@ -66,11 +76,7 @@ public class JobVertexBackPressureInfo implements ResponseBody {
 	}
 
 	public static JobVertexBackPressureInfo deprecated() {
-		return new JobVertexBackPressureInfo(
-			VertexBackPressureStatus.DEPRECATED,
-			null,
-			null,
-			null);
+		return DEPRECATED_JOB_VERTEX_BACK_PRESSURE_INFO;
 	}
 
 	@Override
@@ -91,6 +97,25 @@ public class JobVertexBackPressureInfo implements ResponseBody {
 	@Override
 	public int hashCode() {
 		return Objects.hash(status, backpressureLevel, endTimestamp, subtasks);
+	}
+
+	public VertexBackPressureStatus getStatus() {
+		return status;
+	}
+
+	@Nullable
+	public VertexBackPressureLevel getBackpressureLevel() {
+		return backpressureLevel;
+	}
+
+	@Nullable
+	public Long getEndTimestamp() {
+		return endTimestamp;
+	}
+
+	@Nullable
+	public List<SubtaskBackPressureInfo> getSubtasks() {
+		return subtasks == null ? null : Collections.unmodifiableList(subtasks);
 	}
 
 	//---------------------------------------------------------------------------------
@@ -141,6 +166,18 @@ public class JobVertexBackPressureInfo implements ResponseBody {
 		@Override
 		public int hashCode() {
 			return Objects.hash(subtask, backpressureLevel, ratio);
+		}
+
+		public int getSubtask() {
+			return subtask;
+		}
+
+		public VertexBackPressureLevel getBackpressureLevel() {
+			return backpressureLevel;
+		}
+
+		public double getRatio() {
+			return ratio;
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobVertexBackPressureInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobVertexBackPressureInfo.java
@@ -21,7 +21,9 @@ package org.apache.flink.runtime.rest.messages;
 import org.apache.flink.runtime.rest.handler.job.JobVertexBackPressureHandler;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonValue;
 
 import java.util.List;
 import java.util.Objects;
@@ -31,6 +33,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /**
  * Response type of the {@link JobVertexBackPressureHandler}.
  */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class JobVertexBackPressureInfo implements ResponseBody {
 
 	public static final String FIELD_NAME_STATUS = "status";
@@ -45,7 +48,7 @@ public class JobVertexBackPressureInfo implements ResponseBody {
 	private final VertexBackPressureLevel backpressureLevel;
 
 	@JsonProperty(FIELD_NAME_END_TIMESTAMP)
-	private final long endTimestamp;
+	private final Long endTimestamp;
 
 	@JsonProperty(FIELD_NAME_SUBTASKS)
 	protected final List<SubtaskBackPressureInfo> subtasks;
@@ -54,12 +57,20 @@ public class JobVertexBackPressureInfo implements ResponseBody {
 	public JobVertexBackPressureInfo(
 		@JsonProperty(FIELD_NAME_STATUS) VertexBackPressureStatus status,
 		@JsonProperty(FIELD_NAME_BACKPRESSURE_LEVEL) VertexBackPressureLevel backpressureLevel,
-		@JsonProperty(FIELD_NAME_END_TIMESTAMP) long endTimestamp,
+		@JsonProperty(FIELD_NAME_END_TIMESTAMP) Long endTimestamp,
 		@JsonProperty(FIELD_NAME_SUBTASKS) List<SubtaskBackPressureInfo> subtasks) {
 		this.status = status;
 		this.backpressureLevel = backpressureLevel;
 		this.endTimestamp = endTimestamp;
-		this.subtasks = checkNotNull(subtasks);
+		this.subtasks = subtasks;
+	}
+
+	public static JobVertexBackPressureInfo deprecated() {
+		return new JobVertexBackPressureInfo(
+			VertexBackPressureStatus.DEPRECATED,
+			null,
+			null,
+			null);
 	}
 
 	@Override
@@ -145,6 +156,7 @@ public class JobVertexBackPressureInfo implements ResponseBody {
 			this.status = status;
 		}
 
+		@JsonValue
 		@Override
 		public String toString() {
 			return status;
@@ -163,6 +175,7 @@ public class JobVertexBackPressureInfo implements ResponseBody {
 			this.level = level;
 		}
 
+		@JsonValue
 		@Override
 		public String toString() {
 			return level;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -353,14 +353,14 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 		}
 
 		if (numSamples > 1) {
-			scheduleRunAsync(() -> runAsync(() -> requestStackTraceSample(
+			scheduleRunAsync(() -> requestStackTraceSample(
 				executionAttemptId,
 				sampleId,
 				numSamples - 1,
 				delayBetweenSamples,
 				maxStackTraceDepth,
 				currentTraces,
-				resultFuture)), delayBetweenSamples.getSize(), delayBetweenSamples.getUnit());
+				resultFuture), delayBetweenSamples.getSize(), delayBetweenSamples.getUnit());
 			return resultFuture;
 		} else {
 			resultFuture.complete(new StackTraceSampleResponse(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.SlotID;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
+import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.execution.librarycache.BlobLibraryCacheManager;
 import org.apache.flink.runtime.execution.librarycache.LibraryCacheManager;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
@@ -57,6 +58,7 @@ import org.apache.flink.runtime.jobmaster.JobMasterId;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalListener;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.messages.StackTraceSampleResponse;
 import org.apache.flink.runtime.metrics.groups.TaskManagerMetricGroup;
 import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
 import org.apache.flink.runtime.registration.RegistrationConnectionListener;
@@ -66,10 +68,10 @@ import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcEndpoint;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.akka.AkkaRpcServiceUtils;
+import org.apache.flink.runtime.state.TaskExecutorLocalStateStoresManager;
 import org.apache.flink.runtime.state.TaskLocalStateStore;
 import org.apache.flink.runtime.state.TaskStateManager;
 import org.apache.flink.runtime.state.TaskStateManagerImpl;
-import org.apache.flink.runtime.state.TaskExecutorLocalStateStoresManager;
 import org.apache.flink.runtime.taskexecutor.exceptions.CheckpointException;
 import org.apache.flink.runtime.taskexecutor.exceptions.PartitionException;
 import org.apache.flink.runtime.taskexecutor.exceptions.SlotAllocationException;
@@ -97,12 +99,16 @@ import org.apache.flink.util.Preconditions;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
@@ -304,6 +310,84 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 	// ======================================================================
 	//  RPC methods
 	// ======================================================================
+
+	@Override
+	public CompletableFuture<StackTraceSampleResponse> requestStackTraceSample(
+			final ExecutionAttemptID executionAttemptId,
+			final int sampleId,
+			final int numSamples,
+			final Time delayBetweenSamples,
+			final int maxStackTraceDepth,
+			final Time timeout) {
+		return requestStackTraceSample(
+			executionAttemptId,
+			sampleId,
+			numSamples,
+			delayBetweenSamples,
+			maxStackTraceDepth,
+			new ArrayList<>(numSamples),
+			new CompletableFuture<>());
+	}
+
+	private CompletableFuture<StackTraceSampleResponse> requestStackTraceSample(
+			final ExecutionAttemptID executionAttemptId,
+			final int sampleId,
+			final int numSamples,
+			final Time delayBetweenSamples,
+			final int maxStackTraceDepth,
+			final List<StackTraceElement[]> currentTraces,
+			final CompletableFuture<StackTraceSampleResponse> resultFuture) {
+
+		if (numSamples > 0) {
+			getRpcService().getScheduledExecutor().schedule(() -> runAsync(() -> {
+				final Optional<StackTraceElement[]> stackTrace = getStackTrace(executionAttemptId, maxStackTraceDepth);
+				if (stackTrace.isPresent()) {
+					currentTraces.add(stackTrace.get());
+				} else if (!currentTraces.isEmpty()) {
+					resultFuture.complete(new StackTraceSampleResponse(
+						sampleId,
+						executionAttemptId,
+						currentTraces));
+				} else {
+					throw new IllegalStateException(String.format("Cannot sample task %s. " +
+							"Either the task is not known to the task manager or it is not running.",
+						executionAttemptId));
+				}
+				requestStackTraceSample(
+					executionAttemptId,
+					sampleId,
+					numSamples - 1,
+					delayBetweenSamples,
+					maxStackTraceDepth,
+					currentTraces,
+					resultFuture);
+			}), delayBetweenSamples.getSize(), delayBetweenSamples.getUnit());
+			return resultFuture;
+		} else {
+			resultFuture.complete(new StackTraceSampleResponse(
+				sampleId,
+				executionAttemptId,
+				currentTraces));
+			return resultFuture;
+		}
+	}
+
+	private Optional<StackTraceElement[]> getStackTrace(
+			final ExecutionAttemptID executionAttemptId, final int maxStackTraceDepth) {
+		final Task task = taskSlotTable.getTask(executionAttemptId);
+
+		if (task != null && task.getExecutionState() == ExecutionState.RUNNING) {
+			final StackTraceElement[] stackTrace = task.getExecutingThread().getStackTrace();
+
+			if (maxStackTraceDepth > 0) {
+				return Optional.of(Arrays.copyOfRange(stackTrace, 0, Math.min(maxStackTraceDepth, stackTrace.length)));
+			} else {
+				return Optional.of(stackTrace);
+			}
+		} else {
+			return Optional.empty();
+		}
+	}
 
 	// ----------------------------------------------------------------------
 	// Task lifecycle RPCs

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.PartitionInfo;
 import org.apache.flink.runtime.jobmaster.JobMasterId;
 import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.messages.StackTraceSampleResponse;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
 import org.apache.flink.runtime.rpc.RpcGateway;
 import org.apache.flink.runtime.rpc.RpcTimeout;
@@ -58,6 +59,14 @@ public interface TaskExecutorGateway extends RpcGateway {
 		AllocationID allocationId,
 		String targetAddress,
 		ResourceManagerId resourceManagerId,
+		@RpcTimeout Time timeout);
+
+	CompletableFuture<StackTraceSampleResponse> requestStackTraceSample(
+		ExecutionAttemptID executionAttemptId,
+		int sampleId,
+		int numSamples,
+		Time delayBetweenSamples,
+		int maxStackTraceDepth,
 		@RpcTimeout Time timeout);
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/RestfulGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/RestfulGateway.java
@@ -30,7 +30,6 @@ import org.apache.flink.runtime.messages.FlinkJobNotFoundException;
 import org.apache.flink.runtime.messages.webmonitor.ClusterOverview;
 import org.apache.flink.runtime.messages.webmonitor.MultipleJobsDetails;
 import org.apache.flink.runtime.metrics.dump.MetricQueryService;
-import org.apache.flink.runtime.rest.handler.legacy.backpressure.OperatorBackPressureStats;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.OperatorBackPressureStatsResponse;
 import org.apache.flink.runtime.rpc.RpcEndpoint;
 import org.apache.flink.runtime.rpc.RpcGateway;
@@ -132,7 +131,7 @@ public interface RestfulGateway extends RpcGateway {
 	 *
 	 * @param jobId       Job for which the stats are requested.
 	 * @param jobVertexId JobVertex for which the stats are requested.
-	 * @return A Future to the {@link OperatorBackPressureStats} or {@code null} if the stats are
+	 * @return A Future to the {@link OperatorBackPressureStatsResponse} or {@code null} if the stats are
 	 * not available (yet).
 	 */
 	default CompletableFuture<OperatorBackPressureStatsResponse> requestOperatorBackPressureStats(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/RestfulGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/RestfulGateway.java
@@ -25,15 +25,18 @@ import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.jobgraph.JobStatus;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.messages.FlinkJobNotFoundException;
 import org.apache.flink.runtime.messages.webmonitor.ClusterOverview;
 import org.apache.flink.runtime.messages.webmonitor.MultipleJobsDetails;
 import org.apache.flink.runtime.metrics.dump.MetricQueryService;
+import org.apache.flink.runtime.rest.handler.legacy.backpressure.OperatorBackPressureStats;
 import org.apache.flink.runtime.rpc.RpcEndpoint;
 import org.apache.flink.runtime.rpc.RpcGateway;
 import org.apache.flink.runtime.rpc.RpcTimeout;
 
 import java.util.Collection;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -123,4 +126,11 @@ public interface RestfulGateway extends RpcGateway {
 			@RpcTimeout Time timeout) {
 		throw new UnsupportedOperationException();
 	}
+
+	default CompletableFuture<Optional<OperatorBackPressureStats>> getOperatorBackPressureStats(
+			JobID jobId,
+			JobVertexID jobVertexId) {
+		throw new UnsupportedOperationException();
+	}
+
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/RestfulGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/RestfulGateway.java
@@ -31,12 +31,12 @@ import org.apache.flink.runtime.messages.webmonitor.ClusterOverview;
 import org.apache.flink.runtime.messages.webmonitor.MultipleJobsDetails;
 import org.apache.flink.runtime.metrics.dump.MetricQueryService;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.OperatorBackPressureStats;
+import org.apache.flink.runtime.rest.handler.legacy.backpressure.OperatorBackPressureStatsResponse;
 import org.apache.flink.runtime.rpc.RpcEndpoint;
 import org.apache.flink.runtime.rpc.RpcGateway;
 import org.apache.flink.runtime.rpc.RpcTimeout;
 
 import java.util.Collection;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -127,7 +127,15 @@ public interface RestfulGateway extends RpcGateway {
 		throw new UnsupportedOperationException();
 	}
 
-	default CompletableFuture<Optional<OperatorBackPressureStats>> getOperatorBackPressureStats(
+	/**
+	 * Requests the statistics on operator back pressure.
+	 *
+	 * @param jobId       Job for which the stats are requested.
+	 * @param jobVertexId JobVertex for which the stats are requested.
+	 * @return A Future to the {@link OperatorBackPressureStats} or {@code null} if the stats are
+	 * not available (yet).
+	 */
+	default CompletableFuture<OperatorBackPressureStatsResponse> requestOperatorBackPressureStats(
 			JobID jobId,
 			JobVertexID jobVertexId) {
 		throw new UnsupportedOperationException();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
@@ -40,6 +40,7 @@ import org.apache.flink.runtime.rest.handler.job.JobExecutionResultHandler;
 import org.apache.flink.runtime.rest.handler.job.JobIdsHandler;
 import org.apache.flink.runtime.rest.handler.job.JobPlanHandler;
 import org.apache.flink.runtime.rest.handler.job.JobVertexAccumulatorsHandler;
+import org.apache.flink.runtime.rest.handler.job.JobVertexBackPressureHandler;
 import org.apache.flink.runtime.rest.handler.job.JobVertexTaskManagersHandler;
 import org.apache.flink.runtime.rest.handler.job.JobsOverviewHandler;
 import org.apache.flink.runtime.rest.handler.job.SubtaskCurrentAttemptDetailsHandler;
@@ -72,6 +73,7 @@ import org.apache.flink.runtime.rest.messages.JobExceptionsHeaders;
 import org.apache.flink.runtime.rest.messages.JobIdsWithStatusesOverviewHeaders;
 import org.apache.flink.runtime.rest.messages.JobPlanHeaders;
 import org.apache.flink.runtime.rest.messages.JobVertexAccumulatorsHeaders;
+import org.apache.flink.runtime.rest.messages.JobVertexBackPressureHeaders;
 import org.apache.flink.runtime.rest.messages.JobVertexTaskManagersHeaders;
 import org.apache.flink.runtime.rest.messages.JobsOverviewHeaders;
 import org.apache.flink.runtime.rest.messages.SubtasksTimesHeaders;
@@ -427,6 +429,13 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
 			metricFetcher
 		);
 
+		JobVertexBackPressureHandler jobVertexBackPressureHandler = new JobVertexBackPressureHandler(
+			restAddressFuture,
+			leaderRetriever,
+			timeout,
+			responseHeaders,
+			JobVertexBackPressureHeaders.getInstance());
+
 		final File tmpDir = restConfiguration.getTmpDir();
 
 		Optional<StaticFileServerHandler<T>> optWebContent;
@@ -472,6 +481,7 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
 		handlers.add(Tuple2.of(SubtaskExecutionAttemptAccumulatorsHeaders.getInstance(), subtaskExecutionAttemptAccumulatorsHandler));
 		handlers.add(Tuple2.of(SubtaskCurrentAttemptDetailsHeaders.getInstance(), subtaskCurrentAttemptDetailsHandler));
 		handlers.add(Tuple2.of(JobVertexTaskManagersHeaders.getInstance(), jobVertexTaskManagersHandler));
+		handlers.add(Tuple2.of(JobVertexBackPressureHeaders.getInstance(), jobVertexBackPressureHandler));
 
 		// This handler MUST be added last, as it otherwise masks all subsequent GET handlers
 		optWebContent.ifPresent(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -41,6 +41,8 @@ import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.registration.RegistrationResponse;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
 import org.apache.flink.runtime.resourcemanager.utils.TestingResourceManagerGateway;
+import org.apache.flink.runtime.rest.handler.legacy.backpressure.BackPressureStatsTracker;
+import org.apache.flink.runtime.rest.handler.legacy.backpressure.StackTraceSampleCoordinator;
 import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGateway;
 import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
@@ -127,7 +129,10 @@ public class JobMasterTest extends TestLogger {
 				testingFatalErrorHandler,
 				FlinkUserCodeClassLoaders.parentFirst(new URL[0], JobMasterTest.class.getClassLoader()),
 				null,
-				null);
+				null,
+				new BackPressureStatsTracker(
+					new StackTraceSampleCoordinator(scheduledExecutor, testingTimeout.toMilliseconds()),
+					60000, 100, 60000, Time.milliseconds(50)));
 
 			CompletableFuture<Acknowledge> startFuture = jobMaster.start(jobMasterId, testingTimeout);
 
@@ -229,7 +234,10 @@ public class JobMasterTest extends TestLogger {
 				testingFatalErrorHandler,
 				FlinkUserCodeClassLoaders.parentFirst(new URL[0], JobMasterTest.class.getClassLoader()),
 				null,
-				null);
+				null,
+				new BackPressureStatsTracker(
+					new StackTraceSampleCoordinator(scheduledExecutor, testingTimeout.toMilliseconds()),
+					60000, 100, 60000, Time.milliseconds(50)));
 
 			CompletableFuture<Acknowledge> startFuture = jobMaster.start(jobMasterId, testingTimeout);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -60,6 +60,9 @@ import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 
+/**
+ * Tests for {@link JobMaster}.
+ */
 @Category(Flip6.class)
 public class JobMasterTest extends TestLogger {
 
@@ -139,8 +142,6 @@ public class JobMasterTest extends TestLogger {
 
 			// wait for the completion of the registration
 			registrationResponse.get();
-
-			System.out.println("foobar");
 
 			final ResourceID heartbeatResourceId = heartbeatResourceIdFuture.get(testingTimeout.toMilliseconds(), TimeUnit.MILLISECONDS);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobVertexBackPressureHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobVertexBackPressureHandlerTest.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.job;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.legacy.backpressure.OperatorBackPressureStats;
+import org.apache.flink.runtime.rest.handler.legacy.backpressure.OperatorBackPressureStatsResponse;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.JobIDPathParameter;
+import org.apache.flink.runtime.rest.messages.JobVertexBackPressureHeaders;
+import org.apache.flink.runtime.rest.messages.JobVertexBackPressureInfo;
+import org.apache.flink.runtime.rest.messages.JobVertexBackPressureInfo.VertexBackPressureStatus;
+import org.apache.flink.runtime.rest.messages.JobVertexIdPathParameter;
+import org.apache.flink.runtime.rest.messages.JobVertexMessageParameters;
+import org.apache.flink.runtime.webmonitor.TestingRestfulGateway;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.runtime.rest.messages.JobVertexBackPressureInfo.VertexBackPressureLevel.HIGH;
+import static org.apache.flink.runtime.rest.messages.JobVertexBackPressureInfo.VertexBackPressureLevel.LOW;
+import static org.apache.flink.runtime.rest.messages.JobVertexBackPressureInfo.VertexBackPressureLevel.OK;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for {@link JobVertexBackPressureHandler}.
+ */
+public class JobVertexBackPressureHandlerTest {
+
+	/**
+	 * Job ID for which {@link OperatorBackPressureStats} exist.
+	 */
+	private static final JobID TEST_JOB_ID_BACK_PRESSURE_STATS_AVAILABLE = new JobID();
+
+	/**
+	 * Job ID for which {@link OperatorBackPressureStats} are not available.
+	 */
+	private static final JobID TEST_JOB_ID_BACK_PRESSURE_STATS_ABSENT = new JobID();
+
+	private TestingRestfulGateway restfulGateway;
+
+	private JobVertexBackPressureHandler jobVertexBackPressureHandler;
+
+	@Before
+	public void setUp() {
+		restfulGateway = TestingRestfulGateway.newBuilder().setRequestOeratorBackPressureStatsFunction(
+			(jobId, jobVertexId) -> {
+				if (jobId.equals(TEST_JOB_ID_BACK_PRESSURE_STATS_AVAILABLE)) {
+					return CompletableFuture.completedFuture(OperatorBackPressureStatsResponse.of(new OperatorBackPressureStats(
+						4711,
+						Integer.MAX_VALUE,
+						new double[]{1.0, 0.5, 0.1}
+					)));
+				} else if (jobId.equals(TEST_JOB_ID_BACK_PRESSURE_STATS_ABSENT)) {
+					return CompletableFuture.completedFuture(OperatorBackPressureStatsResponse.of(null));
+				} else {
+					throw new AssertionError();
+				}
+			}
+		).build();
+		jobVertexBackPressureHandler = new JobVertexBackPressureHandler(
+			CompletableFuture.completedFuture("localhost:12345"),
+			() -> CompletableFuture.completedFuture(restfulGateway),
+			Time.seconds(10),
+			Collections.emptyMap(),
+			JobVertexBackPressureHeaders.getInstance()
+		);
+	}
+
+	@Test
+	public void testGetBackPressure() throws Exception {
+		final Map<String, String> pathParameters = new HashMap<>();
+		pathParameters.put(JobIDPathParameter.KEY, TEST_JOB_ID_BACK_PRESSURE_STATS_AVAILABLE.toString());
+		pathParameters.put(JobVertexIdPathParameter.KEY, new JobVertexID().toString());
+
+		final HandlerRequest<EmptyRequestBody, JobVertexMessageParameters> request =
+			new HandlerRequest<>(
+				EmptyRequestBody.getInstance(),
+				new JobVertexMessageParameters(), pathParameters, Collections.emptyMap());
+
+		final CompletableFuture<JobVertexBackPressureInfo> jobVertexBackPressureInfoCompletableFuture =
+			jobVertexBackPressureHandler.handleRequest(request, restfulGateway);
+		final JobVertexBackPressureInfo jobVertexBackPressureInfo = jobVertexBackPressureInfoCompletableFuture.get();
+
+		assertThat(jobVertexBackPressureInfo.getStatus(), equalTo(VertexBackPressureStatus.OK));
+		assertThat(jobVertexBackPressureInfo.getBackpressureLevel(), equalTo(HIGH));
+
+		assertThat(jobVertexBackPressureInfo.getSubtasks()
+			.stream()
+			.map(JobVertexBackPressureInfo.SubtaskBackPressureInfo::getRatio)
+			.collect(Collectors.toList()), contains(1.0, 0.5, 0.1));
+
+		assertThat(jobVertexBackPressureInfo.getSubtasks()
+			.stream()
+			.map(JobVertexBackPressureInfo.SubtaskBackPressureInfo::getBackpressureLevel)
+			.collect(Collectors.toList()), contains(HIGH, LOW, OK));
+
+		assertThat(jobVertexBackPressureInfo.getSubtasks()
+			.stream()
+			.map(JobVertexBackPressureInfo.SubtaskBackPressureInfo::getSubtask)
+			.collect(Collectors.toList()), contains(0, 1, 2));
+	}
+
+	@Test
+	public void testAbsentBackPressure() throws Exception {
+		final Map<String, String> pathParameters = new HashMap<>();
+		pathParameters.put(JobIDPathParameter.KEY, TEST_JOB_ID_BACK_PRESSURE_STATS_ABSENT.toString());
+		pathParameters.put(JobVertexIdPathParameter.KEY, new JobVertexID().toString());
+
+		final HandlerRequest<EmptyRequestBody, JobVertexMessageParameters> request =
+			new HandlerRequest<>(
+				EmptyRequestBody.getInstance(),
+				new JobVertexMessageParameters(), pathParameters, Collections.emptyMap());
+
+		final CompletableFuture<JobVertexBackPressureInfo> jobVertexBackPressureInfoCompletableFuture =
+			jobVertexBackPressureHandler.handleRequest(request, restfulGateway);
+		final JobVertexBackPressureInfo jobVertexBackPressureInfo = jobVertexBackPressureInfoCompletableFuture.get();
+
+		assertThat(jobVertexBackPressureInfo.getStatus(), equalTo(VertexBackPressureStatus.DEPRECATED));
+	}
+
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/JobVertexBackPressureHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/JobVertexBackPressureHandlerTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.runtime.concurrent.Executors;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.BackPressureStatsTracker;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.OperatorBackPressureStats;
+import org.apache.flink.util.TestLogger;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
@@ -43,7 +44,7 @@ import static org.mockito.Mockito.when;
 /**
  * Tests for back pressure handler responses.
  */
-public class JobVertexBackPressureHandlerTest {
+public class JobVertexBackPressureHandlerTest extends TestLogger {
 	@Test
 	public void testGetPaths() {
 		JobVertexBackPressureHandler handler = new JobVertexBackPressureHandler(mock(ExecutionGraphCache.class), Executors.directExecutor(), mock(BackPressureStatsTracker.class), 0);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/backpressure/BackPressureStatsTrackerITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/backpressure/BackPressureStatsTrackerITCase.java
@@ -32,6 +32,7 @@ import org.apache.flink.runtime.highavailability.HighAvailabilityServicesUtils;
 import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.instance.AkkaActorGateway;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.BufferBuilder;
 import org.apache.flink.runtime.io.network.buffer.BufferPool;
 import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
 import org.apache.flink.runtime.jobgraph.JobGraph;
@@ -320,9 +321,9 @@ public class BackPressureStatsTrackerITCase extends TestLogger {
 		@Override
 		public void invoke() throws Exception {
 			while (true) {
-				Buffer buffer = testBufferPool.requestBufferBlocking();
+				final BufferBuilder bufferBuilder = testBufferPool.requestBufferBuilderBlocking();
 				// Got a buffer, yay!
-				buffer.recycleBuffer();
+				bufferBuilder.build().recycleBuffer();
 
 				new CountDownLatch(1).await();
 			}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/backpressure/BackPressureStatsTrackerITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/backpressure/BackPressureStatsTrackerITCase.java
@@ -183,6 +183,7 @@ public class BackPressureStatsTrackerITCase extends TestLogger {
 								coordinator,
 								100 * 1000,
 								20,
+								Integer.MAX_VALUE,
 								Time.milliseconds(10L));
 
 							int numAttempts = 10;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/backpressure/BackPressureStatsTrackerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/backpressure/BackPressureStatsTrackerTest.java
@@ -88,10 +88,10 @@ public class BackPressureStatsTrackerTest extends TestLogger {
 		Time delayBetweenSamples = Time.milliseconds(100L);
 
 		BackPressureStatsTracker tracker = new BackPressureStatsTracker(
-				sampleCoordinator, 9999, numSamples, delayBetweenSamples);
+				sampleCoordinator, 9999, numSamples, Integer.MAX_VALUE, delayBetweenSamples);
 
-		// Trigger
-		Assert.assertTrue("Failed to trigger", tracker.triggerStackTraceSample(jobVertex));
+		// getOperatorBackPressureStats triggers stack trace sampling
+		Assert.assertFalse(tracker.getOperatorBackPressureStats(jobVertex).isPresent());
 
 		Mockito.verify(sampleCoordinator).triggerStackTraceSample(
 				Matchers.eq(taskVertices),
@@ -100,7 +100,7 @@ public class BackPressureStatsTrackerTest extends TestLogger {
 				Matchers.eq(BackPressureStatsTracker.MAX_STACK_TRACE_DEPTH));
 
 		// Trigger again for pending request, should not fire
-		Assert.assertFalse("Unexpected trigger", tracker.triggerStackTraceSample(jobVertex));
+		Assert.assertFalse("Unexpected trigger", tracker.triggerStackTraceSampleInternal(jobVertex));
 
 		Assert.assertTrue(!tracker.getOperatorBackPressureStats(jobVertex).isPresent());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/JobVertexBackPressureInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/JobVertexBackPressureInfoTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Tests that the {@link JobVertexBackPressureInfo} can be marshalled and unmarshalled.
+ */
+public class JobVertexBackPressureInfoTest extends RestResponseMarshallingTestBase<JobVertexBackPressureInfo> {
+	@Override
+	protected Class<JobVertexBackPressureInfo> getTestResponseClass() {
+		return JobVertexBackPressureInfo.class;
+	}
+
+	@Override
+	protected JobVertexBackPressureInfo getTestResponseInstance() throws Exception {
+		List<JobVertexBackPressureInfo.SubtaskBackPressureInfo> subtaskList = new ArrayList<>();
+		subtaskList.add(new JobVertexBackPressureInfo.SubtaskBackPressureInfo(0, JobVertexBackPressureInfo.VertexBackPressureLevel.LOW, 0.1));
+		subtaskList.add(new JobVertexBackPressureInfo.SubtaskBackPressureInfo(1, JobVertexBackPressureInfo.VertexBackPressureLevel.OK, 0.4));
+		subtaskList.add(new JobVertexBackPressureInfo.SubtaskBackPressureInfo(2, JobVertexBackPressureInfo.VertexBackPressureLevel.HIGH, 0.9));
+		return new JobVertexBackPressureInfo(
+					JobVertexBackPressureInfo.VertexBackPressureStatus.OK,
+					JobVertexBackPressureInfo.VertexBackPressureLevel.LOW,
+					System.currentTimeMillis(),
+					subtaskList);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/VertexBackPressureLevelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/VertexBackPressureLevelTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.rest.messages;
 
 import org.apache.flink.runtime.rest.util.RestMapperUtils;
+import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
 
@@ -27,7 +28,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * Tests for {@link JobVertexBackPressureInfo.VertexBackPressureLevel}.
  */
-public class VertexBackPressureLevelTest {
+public class VertexBackPressureLevelTest extends TestLogger {
 
 	/**
 	 * Tests that the enum values are serialized correctly.

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/VertexBackPressureLevelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/VertexBackPressureLevelTest.java
@@ -18,22 +18,29 @@
 
 package org.apache.flink.runtime.rest.messages;
 
-import org.apache.flink.runtime.rest.handler.job.JobVertexBackPressureHandler;
+import org.apache.flink.runtime.rest.util.RestMapperUtils;
 
-import java.util.ArrayList;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
- * Empty response of the {@link JobVertexBackPressureHandler}.
+ * Tests for {@link JobVertexBackPressureInfo.VertexBackPressureLevel}.
  */
-public class EmptyJobVertexBackPressureInfo extends JobVertexBackPressureInfo {
+public class VertexBackPressureLevelTest {
 
-	private static final EmptyJobVertexBackPressureInfo INSTANCE = new EmptyJobVertexBackPressureInfo();
-
-	private EmptyJobVertexBackPressureInfo() {
-		super(null, null, System.currentTimeMillis(), new ArrayList<>());
+	/**
+	 * Tests that the enum values are serialized correctly.
+	 * Clients, such as the Web UI, expect values to be lower case.
+	 */
+	@Test
+	public void testJsonValue() throws Exception {
+		assertEquals("\"ok\"", RestMapperUtils.getStrictObjectMapper()
+			.writeValueAsString(JobVertexBackPressureInfo.VertexBackPressureLevel.OK));
+		assertEquals("\"low\"", RestMapperUtils.getStrictObjectMapper()
+			.writeValueAsString(JobVertexBackPressureInfo.VertexBackPressureLevel.LOW));
+		assertEquals("\"high\"", RestMapperUtils.getStrictObjectMapper()
+			.writeValueAsString(JobVertexBackPressureInfo.VertexBackPressureLevel.HIGH));
 	}
 
-	public static EmptyJobVertexBackPressureInfo getInstance() {
-		return INSTANCE;
-	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/VertexBackPressureStatusTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/VertexBackPressureStatusTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.rest.messages;
 
 import org.apache.flink.runtime.rest.util.RestMapperUtils;
+import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
 
@@ -27,7 +28,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * Tests for {@link JobVertexBackPressureInfo.VertexBackPressureStatus}.
  */
-public class VertexBackPressureStatusTest {
+public class VertexBackPressureStatusTest extends TestLogger {
 
 	/**
 	 * Tests that the enum values are serialized correctly.

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/VertexBackPressureStatusTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/VertexBackPressureStatusTest.java
@@ -18,24 +18,27 @@
 
 package org.apache.flink.runtime.rest.messages;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
+import org.apache.flink.runtime.rest.util.RestMapperUtils;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
- * Message parameters for job vertex REST handlers.
+ * Tests for {@link JobVertexBackPressureInfo.VertexBackPressureStatus}.
  */
-public class JobVertexMessageParameters extends JobMessageParameters {
+public class VertexBackPressureStatusTest {
 
-	public final JobVertexIdPathParameter jobVertexIdPathParameter = new JobVertexIdPathParameter();
-
-	@Override
-	public Collection<MessagePathParameter<?>> getPathParameters() {
-		return Arrays.asList(jobPathParameter, jobVertexIdPathParameter);
+	/**
+	 * Tests that the enum values are serialized correctly.
+	 * Clients, such as the Web UI, expect values to be lower case.
+	 */
+	@Test
+	public void testJsonValue() throws Exception {
+		assertEquals("\"ok\"", RestMapperUtils.getStrictObjectMapper()
+			.writeValueAsString(JobVertexBackPressureInfo.VertexBackPressureStatus.OK));
+		assertEquals("\"deprecated\"", RestMapperUtils.getStrictObjectMapper()
+			.writeValueAsString(JobVertexBackPressureInfo.VertexBackPressureStatus.DEPRECATED));
 	}
 
-	@Override
-	public Collection<MessageQueryParameter<?>> getQueryParameters() {
-		return Collections.emptySet();
-	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGateway.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.PartitionInfo;
 import org.apache.flink.runtime.jobmaster.JobMasterId;
 import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.messages.StackTraceSampleResponse;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
 import org.apache.flink.testutils.category.Flip6;
 import org.apache.flink.util.Preconditions;
@@ -73,6 +74,17 @@ public class TestingTaskExecutorGateway implements TaskExecutorGateway {
 	@Override
 	public CompletableFuture<Acknowledge> requestSlot(SlotID slotId, JobID jobId, AllocationID allocationId, String targetAddress, ResourceManagerId resourceManagerId, Time timeout) {
 		return CompletableFuture.completedFuture(Acknowledge.get());
+	}
+
+	@Override
+	public CompletableFuture<StackTraceSampleResponse> requestStackTraceSample(
+			final ExecutionAttemptID executionAttemptId,
+			final int sampleId,
+			final int numSamples,
+			final Time delayBetweenSamples,
+			final int maxStackTraceDepth,
+			final Time timeout) {
+		throw new UnsupportedOperationException();
 	}
 
 	@Override


### PR DESCRIPTION
## What is the purpose of the change

Port JobVertexBackPressureHandler to REST endpoint

PR is based on #4893 

@tillrohrmann 

## Brief change log

  - *Add JobVertexBackPressureInfo class to describe the json format response*
  - *Add JobVertexBackPressureHandler to deal with back pressure in rest server*

## Verifying this change

This change added tests and can be verified as follows:

- *Manually tested: `curl -v "localhost:9067/jobs/<jobid>/vertices/<vertexid>/backpressure"  | jq .`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
