### PR TITLE
[FLINK-6206] [runtime] Use LOG.error() when logging failure state changes

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -1264,7 +1264,7 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 			if (error == null) {
 				LOG.info("{} ({}) switched from {} to {}.", getVertex().getTaskNameWithSubtaskIndex(), getAttemptId(), currentState, targetState);
 			} else {
-				LOG.info("{} ({}) switched from {} to {}.", getVertex().getTaskNameWithSubtaskIndex(), getAttemptId(), currentState, targetState, error);
+				LOG.error("{} ({}) switched from {} to {}.", getVertex().getTaskNameWithSubtaskIndex(), getAttemptId(), currentState, targetState, error);
 			}
 
 			if (targetState.isTerminal()) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -1300,7 +1300,11 @@ public class ExecutionGraph implements AccessExecutionGraph {
 
 		// now do the actual state transition
 		if (STATE_UPDATER.compareAndSet(this, current, newState)) {
-			LOG.info("Job {} ({}) switched from state {} to {}.", getJobName(), getJobID(), current, newState, error);
+			if (error == null) {
+				LOG.info("Job {} ({}) switched from state {} to {}.", getJobName(), getJobID(), current, newState);
+			} else {
+				LOG.error("Job {} ({}) switched from state {} to {}.", getJobName(), getJobID(), current, newState, error);
+			}
 
 			stateTimestamps[newState.ordinal()] = System.currentTimeMillis();
 			notifyJobStatusChange(newState, error);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -924,7 +924,7 @@ public class Task implements Runnable, TaskActions, CheckpointListener {
 			if (cause == null) {
 				LOG.info("{} ({}) switched from {} to {}.", taskNameWithSubtask, executionId, currentState, newState);
 			} else {
-				LOG.info("{} ({}) switched from {} to {}.", taskNameWithSubtask, executionId, currentState, newState, cause);
+				LOG.error("{} ({}) switched from {} to {}.", taskNameWithSubtask, executionId, currentState, newState, cause);
 			}
 
 			return true;


### PR DESCRIPTION
It's very inconvenient to have these logged with `INFO`. It makes it hard to detect errors when inspecting logs with, say, Kibana.