### PR TITLE
[FLINK-8477][Window]Add api to support user to skip serval broken window

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/EvictingWindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/EvictingWindowOperator.java
@@ -81,20 +81,21 @@ public class EvictingWindowOperator<K, IN, OUT, W extends Window>
 	// ------------------------------------------------------------------------
 
 	public EvictingWindowOperator(WindowAssigner<? super IN, W> windowAssigner,
-								  TypeSerializer<W> windowSerializer,
-								  KeySelector<IN, K> keySelector,
-								  TypeSerializer<K> keySerializer,
-								  StateDescriptor<? extends ListState<StreamRecord<IN>>, ?> windowStateDescriptor,
-								  InternalWindowFunction<Iterable<IN>, OUT, K, W> windowFunction,
-								  Trigger<? super IN, ? super W> trigger,
-								  Evictor<? super IN, ? super W> evictor,
-								  long allowedLateness,
-								  OutputTag<IN> lateDataOutputTag) {
+			TypeSerializer<W> windowSerializer,
+			KeySelector<IN, K> keySelector,
+			TypeSerializer<K> keySerializer,
+			StateDescriptor<? extends ListState<StreamRecord<IN>>, ?> windowStateDescriptor,
+			InternalWindowFunction<Iterable<IN>, OUT, K, W> windowFunction,
+			Trigger<? super IN, ? super W> trigger,
+			Evictor<? super IN, ? super W> evictor,
+			long allowedLateness,
+			OutputTag<IN> lateDataOutputTag) {
 
 		this(windowAssigner, windowSerializer, keySelector,
 			keySerializer, windowStateDescriptor, windowFunction, trigger, evictor, allowedLateness, lateDataOutputTag, 0);
 
 	}
+
 	public EvictingWindowOperator(WindowAssigner<? super IN, W> windowAssigner,
 			TypeSerializer<W> windowSerializer,
 			KeySelector<IN, K> keySelector,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
@@ -594,18 +594,18 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 			if (nowResult.isFire()) {
 				if (toBeSkippedWindows.size() == toSkipWindowCount) {
 					if (toBeSkippedWindows.contains(window)) {
-						if (nowResult.isPurge()){
+						if (nowResult.isPurge()) {
 							nowResult = TriggerResult.PURGE;
-						}else {
+						} else {
 							nowResult = TriggerResult.CONTINUE;
 						}
 					}
 				} else {
 					toBeSkippedWindows.add(window);
 					LOG.info("This window is add to skipped list: {}", window);
-					if (nowResult.isPurge()){
+					if (nowResult.isPurge()) {
 						nowResult = TriggerResult.PURGE;
-					}else {
+					} else {
 						nowResult = TriggerResult.CONTINUE;
 					}
 				}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
@@ -196,8 +196,9 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 		OutputTag<IN> lateDataOutputTag) {
 
 		this(windowAssigner, windowSerializer, keySelector, keySerializer, windowStateDescriptor,
-			windowFunction, trigger,allowedLateness, lateDataOutputTag, 0);
+			windowFunction, trigger, allowedLateness, lateDataOutputTag, 0);
 	}
+
 	/**
 	 * Creates a new {@code WindowOperator} based on the given policies and user functions.
 	 */

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
@@ -594,12 +594,20 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 			if (nowResult.isFire()) {
 				if (toBeSkippedWindows.size() == toSkipWindowCount) {
 					if (toBeSkippedWindows.contains(window)) {
-						nowResult = TriggerResult.CONTINUE;
+						if (nowResult.isPurge()){
+							nowResult = TriggerResult.PURGE;
+						}else {
+							nowResult = TriggerResult.CONTINUE;
+						}
 					}
 				} else {
 					toBeSkippedWindows.add(window);
 					LOG.info("This window is add to skipped list: {}", window);
-					nowResult = TriggerResult.CONTINUE;
+					if (nowResult.isPurge()){
+						nowResult = TriggerResult.PURGE;
+					}else {
+						nowResult = TriggerResult.CONTINUE;
+					}
 				}
 			}
 		}

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/WindowedStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/WindowedStream.scala
@@ -74,6 +74,15 @@ class WindowedStream[T, K, W <: Window](javaStream: JavaWStream[T, K, W]) {
   }
 
   /**
+    * Sets the count of window need to be skipped when start or restart job.
+    */
+  @PublicEvolving
+  def setSkipWindowNum(toSkipWindowCount: Integer): WindowedStream[T, K, W] = {
+    javaStream.setSkipWindowNum(toSkipWindowCount)
+    this
+  }
+
+  /**
    * Send late arriving data to the side output identified by the given [[OutputTag]]. Data
    * is considered late after the watermark has passed the end of the window plus the allowed
    * lateness set using [[allowedLateness(Time)]].

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/WindowedStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/WindowedStream.scala
@@ -77,7 +77,7 @@ class WindowedStream[T, K, W <: Window](javaStream: JavaWStream[T, K, W]) {
     * Sets the count of window need to be skipped when start or restart job.
     */
   @PublicEvolving
-  def setSkipWindowNum(toSkipWindowCount: Integer): WindowedStream[T, K, W] = {
+  def setSkipWindowNum(toSkipWindowCount: Int): WindowedStream[T, K, W] = {
     javaStream.setSkipWindowNum(toSkipWindowCount)
     this
   }


### PR DESCRIPTION
In production, some application like monitor type , it need the accuarcy data,but in this scenario: if we start a job at 10:45:20s with a 1min window aggregate, we may produce a broken data of 10:45min ,so may lead to mistake. We can support a user api to choose to skip serveral windows to avoid the broken data by user self.

## Brief change log

  - add a streaming api 


