### PR TITLE
[hotfix][build] Fix duplicate maven enforce plugin declaration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1182,12 +1182,6 @@ under the License.
 							</rules>
 						</configuration>
 					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-enforcer-plugin</artifactId>
-				<executions>
 					<execution>
 						<id>dependency-convergence</id>
 						<goals>


### PR DESCRIPTION
## What is the purpose of the change
Hotfix duplicate `maven-enforce-plugin` declaration.

## Brief change log

 - *Merge duplicate `maven-enforce-plugin` declaration.*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
