### PR TITLE
[FLINK-8555][TableAPI & SQL] Fix TableFunction varargs length exceed 254

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/utils/TableSqlFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/utils/TableSqlFunction.scala
@@ -119,7 +119,7 @@ object TableSqlFunction {
     tableFunction: TableFunction[_])
   : SqlOperandTypeChecker = {
 
-    val signatures = getMethodSignatures(tableFunction, "eval")
+    val methods = checkAndExtractMethods(tableFunction, "eval")
 
     /**
       * Operand type checker based on [[TableFunction]] given information.
@@ -130,17 +130,23 @@ object TableSqlFunction {
       }
 
       override def getOperandCountRange: SqlOperandCountRange = {
-        var min = 255
+        var min = 254
         var max = -1
-        signatures.foreach( sig => {
-          var len = sig.length
-          if (len > 0 && sig(sig.length - 1).isArray) {
-            max = 254  // according to JVM spec 4.3.3
-            len = sig.length - 1
+        var isVarargs = false
+        methods.foreach( m => {
+          var len = m.getParameterTypes.length
+          if (len > 0 && m.isVarArgs && m.getParameterTypes()(len - 1).isArray) {
+            isVarargs = true
+            len = len - 1
           }
           max = Math.max(len, max)
           min = Math.min(len, min)
         })
+        if (isVarargs) {
+          // if eval method is varargs, set max to -1 to skip length check in Calcite
+          max = -1
+        }
+
         SqlOperandCountRanges.between(min, max)
       }
 

--- a/flink-libraries/flink-table/src/test/java/org/apache/flink/table/runtime/utils/JavaUserDefinedTableFunctions.java
+++ b/flink-libraries/flink-table/src/test/java/org/apache/flink/table/runtime/utils/JavaUserDefinedTableFunctions.java
@@ -52,4 +52,19 @@ public class JavaUserDefinedTableFunctions {
 			}
 		}
 	}
+
+	/**
+	 * Emit sum of String length of all parameters.
+	 */
+	public static class JavaTableFunc1 extends TableFunction<Integer> {
+		public void eval(String... strs) {
+			int sum = 0;
+			if (strs != null) {
+				for (String str : strs) {
+					sum += str == null ? 0 : str.length();
+				}
+			}
+			collect(sum);
+		}
+	}
 }


### PR DESCRIPTION

## What is the purpose of the change

*Support TableFunction parameters exceeds 254 with Varargs for SQL*


## Brief change log

  - *if table function is varargs, do not check max parameter length, set max length to -1*


## Verifying this change



This change added tests and can be verified as follows:

*(example:)*
  - *SqlITCase.testUDTFWithLongVarargs*


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
