### PR TITLE
[FLINK-8559][RocksDB] Release resources if snapshot operation fails

### DIFF
--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
@@ -377,7 +377,13 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 				checkpointId,
 				checkpointTimestamp);
 
-		snapshotOperation.takeSnapshot();
+		try {
+			snapshotOperation.takeSnapshot();
+		} catch (Exception e) {
+			snapshotOperation.stop();
+			snapshotOperation.releaseResources(true);
+			throw e;
+		}
 
 		return new FutureTask<KeyedStateHandle>(
 			new Callable<KeyedStateHandle>() {


### PR DESCRIPTION
## What is the purpose of the change

This PR ensures that RocksDB resources are released if `RocksDBIncrementalSnapshotOperation#takeSnapshot` throws an Exception.

We now catch the exception, cancel the SnapshotOperation, and re-throw the original exception.

## Verifying this change

I've verified this manually by running `JobManagerHACheckpointRecoveryITCase` on Windows where `takeSnapshot` fails due to FLINK-8557.

I couldn't come up with proper test. The method hardly does anything in the first place and every solution i could think of would depend a lot on implementation details (like mocking `Checkpoint.create()` to throw an exception).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

@StefanRRichter 