### PR TITLE
[FLINK-3655] [core] Support multiple paths in FileInputFormat

### DIFF
--- a/flink-connectors/flink-orc/src/main/java/org/apache/flink/orc/OrcRowInputFormat.java
+++ b/flink-connectors/flink-orc/src/main/java/org/apache/flink/orc/OrcRowInputFormat.java
@@ -393,6 +393,11 @@ public class OrcRowInputFormat extends FileInputFormat<Row> implements ResultTyp
 		}
 	}
 
+	@Override
+	public boolean supportsMultiPaths() {
+		return true;
+	}
+
 	// --------------------------------------------------------------------------------------------
 	//  Classes to define predicates
 	// --------------------------------------------------------------------------------------------

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/BinaryInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/BinaryInputFormat.java
@@ -111,13 +111,13 @@ public abstract class BinaryInputFormat<T> extends FileInputFormat<T>
 
 	@Override
 	public FileInputSplit[] createInputSplits(int minNumSplits) throws IOException {
-		List<FileStatus> files = this.getFiles();
-
-		final FileSystem fs = getFilePath().getFileSystem();
-		final long blockSize = this.blockSize == NATIVE_BLOCK_SIZE ? fs.getDefaultBlockSize() : this.blockSize;
+		final List<FileStatus> files = this.getFiles();
 
 		final List<FileInputSplit> inputSplits = new ArrayList<FileInputSplit>(minNumSplits);
 		for (FileStatus file : files) {
+			final FileSystem fs = file.getPath().getFileSystem();
+			final long blockSize = this.blockSize == NATIVE_BLOCK_SIZE ? fs.getDefaultBlockSize() : this.blockSize;
+
 			for (long pos = 0, length = file.getLen(); pos < length; pos += blockSize) {
 				long remainingLength = Math.min(pos + blockSize, length) - pos;
 
@@ -132,10 +132,10 @@ public abstract class BinaryInputFormat<T> extends FileInputFormat<T>
 
 		if (inputSplits.size() < minNumSplits) {
 			LOG.warn(String.format(
-				"With the given block size %d, the file %s cannot be split into %d blocks. Filling up with empty splits...",
-				blockSize, getFilePath(), minNumSplits));
+				"With the given block size %d, the files %s cannot be split into %d blocks. Filling up with empty splits...",
+				blockSize, Arrays.toString(getFilePaths()), minNumSplits));
 			FileStatus last = files.get(files.size() - 1);
-			final BlockLocation[] blocks = fs.getFileBlockLocations(last, 0, last.getLen());
+			final BlockLocation[] blocks = last.getPath().getFileSystem().getFileBlockLocations(last, 0, last.getLen());
 			for (int index = files.size(); index < minNumSplits; index++) {
 				inputSplits.add(new FileInputSplit(index, last.getPath(), last.getLen(), 0, blocks[0].getHosts()));
 			}
@@ -146,9 +146,9 @@ public abstract class BinaryInputFormat<T> extends FileInputFormat<T>
 
 	protected List<FileStatus> getFiles() throws IOException {
 		// get all the files that are involved in the splits
-		List<FileStatus> files = new ArrayList<FileStatus>();
+		List<FileStatus> files = new ArrayList<>();
 
-		for (Path filePath: this.filePathList) {
+		for (Path filePath: getFilePaths()) {
 			final FileSystem fs = filePath.getFileSystem();
 			final FileStatus pathFile = fs.getFileStatus(filePath);
 
@@ -172,10 +172,10 @@ public abstract class BinaryInputFormat<T> extends FileInputFormat<T>
 
 		final FileBaseStatistics cachedFileStats = cachedStats instanceof FileBaseStatistics ?
 			(FileBaseStatistics) cachedStats : null;
-			
+
 		try {
 			final ArrayList<FileStatus> allFiles = new ArrayList<FileStatus>(1);
-			final FileBaseStatistics stats = getFileStats(cachedFileStats, this.filePathList, allFiles);
+			final FileBaseStatistics stats = getFileStats(cachedFileStats, getFilePaths(), allFiles);
 			if (stats == null) {
 				return null;
 			}
@@ -187,19 +187,18 @@ public abstract class BinaryInputFormat<T> extends FileInputFormat<T>
 		} catch (IOException ioex) {
 			if (LOG.isWarnEnabled()) {
 				LOG.warn(
-					String.format("Could not determine complete statistics for files in '%s' due to an I/O error",
-					this.filePathList),
+					String.format("Could not determine complete statistics for files '%s' due to an I/O error",
+						Arrays.toString(getFilePaths())),
 					ioex);
 			}
 		} catch (Throwable t) {
 			if (LOG.isErrorEnabled()) {
 				LOG.error(
-					String.format("Unexpected problem while getting the file statistics for file in'%s'",
-					this.filePathList),
+					String.format("Unexpected problem while getting the file statistics for files '%s'",
+						Arrays.toString(getFilePaths())),
 					t);
 			}
 		}
-		
 		// no stats available
 		return null;
 	}

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/DelimitedInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/DelimitedInputFormat.java
@@ -353,33 +353,28 @@ public abstract class DelimitedInputFormat<OT> extends FileInputFormat<OT> imple
 		final int oldLineLengthLimit = this.lineLengthLimit;
 		try {
 
-			final ArrayList<FileStatus> allFiles = new ArrayList<FileStatus>(1);
+			final ArrayList<FileStatus> allFiles = new ArrayList<>(1);
 
-			// let the file input format deal with the up-to-date check and the
-			// basic size
-			final FileBaseStatistics stats = getFileStats(cachedFileStats, this.filePathList, allFiles);
+			// let the file input format deal with the up-to-date check and the basic size
+			final FileBaseStatistics stats = getFileStats(cachedFileStats, getFilePaths(), allFiles);
 			if (stats == null) {
 				return null;
 			}
-
-			// check whether the width per record is already known or the total
-			// size is unknown as well
+			
+			// check whether the width per record is already known or the total size is unknown as well
 			// in both cases, we return the stats as they are
-			if (stats.getAverageRecordWidth() != FileBaseStatistics.AVG_RECORD_BYTES_UNKNOWN
-					|| stats.getTotalInputSize() == FileBaseStatistics.SIZE_UNKNOWN) {
+			if (stats.getAverageRecordWidth() != FileBaseStatistics.AVG_RECORD_BYTES_UNKNOWN ||
+					stats.getTotalInputSize() == FileBaseStatistics.SIZE_UNKNOWN) {
 				return stats;
 			}
 
-			// disabling sampling for unsplittable files since the logic below
-			// assumes splitability.
-			// TODO: Add sampling for unsplittable files. Right now, only
-			// compressed text files are affected by this limitation.
+			// disabling sampling for unsplittable files since the logic below assumes splitability.
+			// TODO: Add sampling for unsplittable files. Right now, only compressed text files are affected by this limitation.
 			if (unsplittable) {
 				return stats;
 			}
-
-			// compute how many samples to take, depending on the defined upper
-			// and lower bound
+			
+			// compute how many samples to take, depending on the defined upper and lower bound
 			final int numSamples;
 			if (this.numLineSamples != NUM_SAMPLES_UNDEFINED) {
 				numSamples = this.numLineSamples;
@@ -388,7 +383,7 @@ public abstract class DelimitedInputFormat<OT> extends FileInputFormat<OT> imple
 				final int calcSamples = (int) (stats.getTotalInputSize() / 1024);
 				numSamples = Math.min(DEFAULT_MAX_NUM_SAMPLES, Math.max(DEFAULT_MIN_NUM_SAMPLES, calcSamples));
 			}
-
+			
 			// check if sampling is disabled.
 			if (numSamples == 0) {
 				return stats;
@@ -396,16 +391,15 @@ public abstract class DelimitedInputFormat<OT> extends FileInputFormat<OT> imple
 			if (numSamples < 0) {
 				throw new RuntimeException("Error: Invalid number of samples: " + numSamples);
 			}
-
-			// make sure that the sampling times out after a while if the file
-			// system does not answer in time
+			
+			
+			// make sure that the sampling times out after a while if the file system does not answer in time
 			this.openTimeout = 10000;
 			// set a small read buffer size
 			this.bufferSize = 4 * 1024;
-			// prevent overly large records, for example if we have an
-			// incorrectly configured delimiter
+			// prevent overly large records, for example if we have an incorrectly configured delimiter
 			this.lineLengthLimit = MAX_SAMPLE_LEN;
-
+			
 			long offset = 0;
 			long totalNumBytes = 0;
 			long stepSize = stats.getTotalInputSize() / numSamples;
@@ -439,20 +433,21 @@ public abstract class DelimitedInputFormat<OT> extends FileInputFormat<OT> imple
 					fileNum++;
 				}
 			}
-
+			
 			// we have the width, store it
-			return new FileBaseStatistics(stats.getLastModificationTime(), stats.getTotalInputSize(),
-					totalNumBytes / (float) samplesTaken);
-
+			return new FileBaseStatistics(stats.getLastModificationTime(),
+				stats.getTotalInputSize(), totalNumBytes / (float) samplesTaken);
+			
 		} catch (IOException ioex) {
 			if (LOG.isWarnEnabled()) {
-				LOG.warn("Could not determine statistics for file(s) in '" + this.filePathList
-						+ "' due to an io error: " + ioex.getMessage());
+				LOG.warn("Could not determine statistics for files '" + Arrays.toString(getFilePaths()) + "' " +
+						 "due to an io error: " + ioex.getMessage());
 			}
-		} catch (Throwable t) {
+		}
+		catch (Throwable t) {
 			if (LOG.isErrorEnabled()) {
-				LOG.error("Unexpected problen while getting the file statistics for file(s) in'" + this.filePathList
-						+ "': " + t.getMessage(), t);
+				LOG.error("Unexpected problem while getting the file statistics for files '" + Arrays.toString(getFilePaths()) + "': "
+						+ t.getMessage(), t);
 			}
 		} finally {
 			// restore properties (even on return)
@@ -460,7 +455,6 @@ public abstract class DelimitedInputFormat<OT> extends FileInputFormat<OT> imple
 			this.bufferSize = oldBufferSize;
 			this.lineLengthLimit = oldLineLengthLimit;
 		}
-
 		
 		// no statistics possible
 		return null;

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/GenericCsvInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/GenericCsvInputFormat.java
@@ -106,6 +106,11 @@ public abstract class GenericCsvInputFormat<OT> extends DelimitedInputFormat<OT>
 		super(filePath, null);
 	}
 
+	@Override
+	public boolean supportsMultiPaths() {
+		return true;
+	}
+
 	// --------------------------------------------------------------------------------------------
 
 	public int getNumberOfFieldsTotal() {
@@ -336,13 +341,13 @@ public abstract class GenericCsvInputFormat<OT> extends DelimitedInputFormat<OT>
 	public void close() throws IOException {
 		if (this.invalidLineCount > 0) {
 			if (LOG.isWarnEnabled()) {
-				LOG.warn("In file \""+ getFilePath() + "\" (split start: " + this.splitStart + ") " + this.invalidLineCount +" invalid line(s) were skipped.");
+				LOG.warn("In file \"" + currentSplit.getPath() + "\" (split start: " + this.splitStart + ") " + this.invalidLineCount +" invalid line(s) were skipped.");
 			}
 		}
 
 		if (this.commentCount > 0) {
 			if (LOG.isInfoEnabled()) {
-				LOG.info("In file \""+  getFilePath() + "\" (split start: " + this.splitStart + ") " + this.commentCount +" comment line(s) were skipped.");
+				LOG.info("In file \"" + currentSplit.getPath() + "\" (split start: " + this.splitStart + ") " + this.commentCount +" comment line(s) were skipped.");
 			}
 		}
 		super.close();
@@ -384,7 +389,7 @@ public abstract class GenericCsvInputFormat<OT> extends DelimitedInputFormat<OT>
 						throw new ParseException("Line could not be parsed: '" + lineAsString + "'\n"
 								+ "ParserError " + parser.getErrorState() + " \n"
 								+ "Expect field types: "+fieldTypesToString() + " \n"
-								+ "in file: " + getFilePath());
+								+ "in file: " + currentSplit.getPath());
 					}
 				}
 				else if (startPos == limit
@@ -408,7 +413,7 @@ public abstract class GenericCsvInputFormat<OT> extends DelimitedInputFormat<OT>
 						String lineAsString = new String(bytes, offset, numBytes, getCharset());
 						throw new ParseException("Line could not be parsed: '" + lineAsString+"'\n"
 								+ "Expect field types: "+fieldTypesToString()+" \n"
-								+ "in file: "+getFilePath());
+								+ "in file: " + currentSplit.getPath());
 					} else {
 						return false;
 					}

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/GenericCsvInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/GenericCsvInputFormat.java
@@ -336,13 +336,13 @@ public abstract class GenericCsvInputFormat<OT> extends DelimitedInputFormat<OT>
 	public void close() throws IOException {
 		if (this.invalidLineCount > 0) {
 			if (LOG.isWarnEnabled()) {
-				LOG.warn("In file \""+ this.filePath + "\" (split start: " + this.splitStart + ") " + this.invalidLineCount +" invalid line(s) were skipped.");
+				LOG.warn("In file \""+ getFilePath() + "\" (split start: " + this.splitStart + ") " + this.invalidLineCount +" invalid line(s) were skipped.");
 			}
 		}
 
 		if (this.commentCount > 0) {
 			if (LOG.isInfoEnabled()) {
-				LOG.info("In file \""+ this.filePath + "\" (split start: " + this.splitStart + ") " + this.commentCount +" comment line(s) were skipped.");
+				LOG.info("In file \""+  getFilePath() + "\" (split start: " + this.splitStart + ") " + this.commentCount +" comment line(s) were skipped.");
 			}
 		}
 		super.close();
@@ -384,7 +384,7 @@ public abstract class GenericCsvInputFormat<OT> extends DelimitedInputFormat<OT>
 						throw new ParseException("Line could not be parsed: '" + lineAsString + "'\n"
 								+ "ParserError " + parser.getErrorState() + " \n"
 								+ "Expect field types: "+fieldTypesToString() + " \n"
-								+ "in file: " + filePath);
+								+ "in file: " + getFilePath());
 					}
 				}
 				else if (startPos == limit
@@ -408,7 +408,7 @@ public abstract class GenericCsvInputFormat<OT> extends DelimitedInputFormat<OT>
 						String lineAsString = new String(bytes, offset, numBytes, getCharset());
 						throw new ParseException("Line could not be parsed: '" + lineAsString+"'\n"
 								+ "Expect field types: "+fieldTypesToString()+" \n"
-								+ "in file: "+filePath);
+								+ "in file: "+getFilePath());
 					} else {
 						return false;
 					}

--- a/flink-core/src/test/java/org/apache/flink/api/common/io/BinaryInputFormatTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/io/BinaryInputFormatTest.java
@@ -41,8 +41,12 @@ public class BinaryInputFormatTest {
 		protected Record deserialize(Record record, DataInputView dataInput) {
 			return record;
 		}
-	}
 
+		@Override
+		public boolean supportsMultiPaths() {
+			return true;
+		}
+	}
 
 	@Test
 	public void testCreateInputSplitsWithOneFile() throws IOException {
@@ -75,119 +79,82 @@ public class BinaryInputFormatTest {
 		Assert.assertEquals("3. split has block size length.", blockSize, inputSplits[2].getLength());
 	}
 	
-	private File createBinaryInputFile(String fileName, int blockSize, int numBlocks) throws IOException {
-		// create temporary file with 3 blocks
-		final File tempFile = File.createTempFile(fileName, "tmp");
-		tempFile.deleteOnExit();
-		FileOutputStream fileOutputStream = new FileOutputStream(tempFile);
-		try {
-			for (int i = 0; i < blockSize * numBlocks; i++) {
-				fileOutputStream.write(new byte[] { 1 });
-			}
-		} finally {
-			fileOutputStream.close();
-		}
-		return tempFile;
-	}
-	
 	@Test
 	public void testCreateInputSplitsWithMulitpleFiles() throws IOException {
 		final int blockInfoSize = new BlockInfo().getInfoSize();
 		final int blockSize = blockInfoSize + 8;
-		final int BLOCKS1 = 3;
-		final int BLOCKS2 = 5;
+		final int numBlocks1 = 3;
+		final int numBlocks2 = 5;
 		
-		final File tempFile = createBinaryInputFile("binary_input_format_test", blockSize, BLOCKS1);
-		final File tempFile2 = createBinaryInputFile("binary_input_format_test_2", blockSize, BLOCKS2);
+		final File tempFile1 = createBinaryInputFile("binary_input_format_test", blockSize, numBlocks1);
+		final File tempFile2 = createBinaryInputFile("binary_input_format_test_2", blockSize, numBlocks2);
+		final String pathFile1 = tempFile1.toURI().toString(); 
+		final String pathFile2 = tempFile2.toURI().toString(); 
+		
+		final BinaryInputFormat<Record> inputFormat = new MyBinaryInputFormat();
+		inputFormat.setFilePaths(pathFile1, pathFile2);
+		inputFormat.setBlockSize(blockSize);
+		
+		final int numBlocksTotal = numBlocks1 + numBlocks2;
+		FileInputSplit[] inputSplits = inputFormat.createInputSplits(numBlocksTotal);
+		
+		int numSplitsFile1 = 0;
+		int numSplitsFile2 = 0;
+		
+		Assert.assertEquals("Returns requested numbers of splits.", numBlocksTotal, inputSplits.length);
+		for (int i = 0; i < inputSplits.length; i++) {
+			Assert.assertEquals(String.format("%d. split has block size length.", i), blockSize, inputSplits[i].getLength());
+			if (inputSplits[i].getPath().toString().equals(pathFile1)) {
+				numSplitsFile1++;
+			} else if (inputSplits[i].getPath().toString().equals(pathFile2)) {
+				numSplitsFile2++;
+			} else {
+				Assert.fail("Split does not belong to any input file.");
+			}
+		}
+		Assert.assertEquals(numBlocks1, numSplitsFile1);
+		Assert.assertEquals(numBlocks2, numSplitsFile2);
+	}
 
-		final Configuration config = new Configuration();
-		config.setLong(BinaryInputFormat.BLOCK_SIZE_PARAMETER_KEY, blockSize);
+	@Test
+	public void testGetStatisticsNonExistingFiles() {
+		final MyBinaryInputFormat format = new MyBinaryInputFormat();
+		format.setFilePaths("file:///some/none/existing/directory/", "file:///another/none/existing/directory/");
+		format.configure(new Configuration());
+		
+		BaseStatistics stats = format.getStatistics(null);
+		Assert.assertNull("The file statistics should be null.", stats);
+	}
+	
+	@Test
+	public void testGetStatisticsMultiplePaths() throws IOException {
+		final int blockInfoSize = new BlockInfo().getInfoSize();
+		final int blockSize = blockInfoSize + 8;
+		final int numBlocks1 = 3;
+		final int numBlocks2 = 5;
+		
+		final File tempFile = createBinaryInputFile("binary_input_format_test", blockSize, numBlocks1);
+		final File tempFile2 = createBinaryInputFile("binary_input_format_test_2", blockSize, numBlocks2);
 		
 		final BinaryInputFormat<Record> inputFormat = new MyBinaryInputFormat();
 		inputFormat.setFilePaths(tempFile.toURI().toString(), tempFile2.toURI().toString());
-		
-		inputFormat.configure(config);
-		
-		final int TOTAL_BLOCKS = BLOCKS1 + BLOCKS2;
-		FileInputSplit[] inputSplits = inputFormat.createInputSplits(TOTAL_BLOCKS);
-		
-		Assert.assertEquals("Returns requested numbers of splits.", TOTAL_BLOCKS, inputSplits.length);
-		for (int index = 0; index < inputSplits.length; index++) {
-			Assert.assertEquals(String.format("%d. split has block size length.", index), 
-					blockSize, inputSplits[index].getLength());
-		}
-	}
-	@Test
-	public void testGetStatisticsNonExistingFile() {
-		try {
-			final MyBinaryInputFormat format = new MyBinaryInputFormat();
-			format.setFilePath("file:///some/none/existing/directory/");
-			format.configure(new Configuration());
-			
-			BaseStatistics stats = format.getStatistics(null);
-			Assert.assertNull("The file statistics should be null.", stats);
-		} catch (Exception ex) {
-			ex.printStackTrace();
-			Assert.fail(ex.getMessage());
-		}
-	}
-	
-	@Test
-	public void testGetStatisticsMultipleNonExistingFile() {
-		try {
-			final MyBinaryInputFormat format = new MyBinaryInputFormat();
-			format.setFilePaths("file:///some/none/existing/directory/", "file:///another/none/existing/directory/");
-			format.configure(new Configuration());
-			
-			BaseStatistics stats = format.getStatistics(null);
-			Assert.assertNull("The file statistics should be null.", stats);
-		} catch (Exception ex) {
-			ex.printStackTrace();
-			Assert.fail(ex.getMessage());
-		}
-	}
-	
-	@Test
-	public void testGetStatisticsSinglePaths() {
-		try {
-			final int blockInfoSize = new BlockInfo().getInfoSize();
-			final int blockSize = blockInfoSize + 8;
-			final int BLOCKS = 3;
-			
-			final File tempFile = createBinaryInputFile("binary_input_format_test", blockSize, BLOCKS);
-			final Configuration config = new Configuration();
-			config.setLong(BinaryInputFormat.BLOCK_SIZE_PARAMETER_KEY, blockSize);
-			
-			final BinaryInputFormat<Record> inputFormat = new MyBinaryInputFormat();
-			inputFormat.setFilePath(tempFile.toURI().toString());
-			BaseStatistics stats = inputFormat.getStatistics(null);
-			Assert.assertEquals("The file size statistics is wrong", blockSize * BLOCKS, stats.getTotalInputSize());
-		} catch (Exception ex) {
-			ex.printStackTrace();
-			Assert.fail(ex.getMessage());
-		}
+		inputFormat.setBlockSize(blockSize);
+
+		BaseStatistics stats = inputFormat.getStatistics(null);
+		Assert.assertEquals("The file size statistics is wrong", blockSize * (numBlocks1 + numBlocks2), stats.getTotalInputSize());
 	}
 
-	@Test
-	public void testGetStatisticsMultiplePaths() {
-		try {
-			final int blockInfoSize = new BlockInfo().getInfoSize();
-			final int blockSize = blockInfoSize + 8;
-			final int BLOCKS = 3;
-			final int BLOCKS2 = 5;
-			
-			final File tempFile = createBinaryInputFile("binary_input_format_test", blockSize, BLOCKS);
-			final File tempFile2 = createBinaryInputFile("binary_input_format_test_2", blockSize, BLOCKS2);
-			final Configuration config = new Configuration();
-			config.setLong(BinaryInputFormat.BLOCK_SIZE_PARAMETER_KEY, blockSize);
-			
-			final BinaryInputFormat<Record> inputFormat = new MyBinaryInputFormat();
-			inputFormat.setFilePaths(tempFile.toURI().toString(), tempFile2.toURI().toString());
-			BaseStatistics stats = inputFormat.getStatistics(null);
-			Assert.assertEquals("The file size statistics is wrong", blockSize * (BLOCKS + BLOCKS2), stats.getTotalInputSize());
-		} catch (Exception ex) {
-			ex.printStackTrace();
-			Assert.fail(ex.getMessage());
+	/**
+	 * Creates a temp file with a certain number of blocks of a certain size.
+	 */
+	private File createBinaryInputFile(String fileName, int blockSize, int numBlocks) throws IOException {
+		final File tempFile = File.createTempFile(fileName, "tmp");
+		tempFile.deleteOnExit();
+		try (FileOutputStream fileOutputStream = new FileOutputStream(tempFile)) {
+			for (int i = 0; i < blockSize * numBlocks; i++) {
+				fileOutputStream.write(new byte[]{1});
+			}
 		}
+		return tempFile;
 	}
 }

--- a/flink-core/src/test/java/org/apache/flink/api/common/io/DelimitedInputFormatTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/io/DelimitedInputFormatTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.api.common.io;
 
 import org.apache.commons.lang3.StringUtils;
+
 import org.apache.flink.api.common.io.FileInputFormat.FileBaseStatistics;
 import org.apache.flink.api.common.io.statistics.BaseStatistics;
 import org.apache.flink.configuration.ConfigConstants;
@@ -431,37 +432,42 @@ public class DelimitedInputFormatTest {
 	}
 
 	// -- Statistics --//
+
 	@Test
-	public void testGetStatisticsSingleFileFileDoesNotExist() throws IOException {
-		DelimitedInputFormat<String> format = new MyTextInputFormat();
-		format.setFilePath(new Path("file://path/does/not/really/exist"));
-		
-		FileBaseStatistics stats = format.getStatistics(null);
-		assertNotNull("The file statistics should not be null", stats);
-		
-		assertEquals("The file size from the statistics is wrong.", FileBaseStatistics.SIZE_UNKNOWN, stats.getTotalInputSize());
-	}
-	
-	@Test
-	public void testGetStatisticsSingleFile() throws IOException {
+	public void testGetStatistics() throws IOException {
 		final String myString = "my mocked line 1\nmy mocked line 2\n";
-		final long SIZE = myString.length();
+		final long size = myString.length();
 		final Path filePath = createTempFilePath(myString);
-		
+
+		final String myString2 = "my mocked line 1\nmy mocked line 2\nanother mocked line3\n";
+		final long size2 = myString2.length();
+		final Path filePath2 = createTempFilePath(myString2);
+
+		final long totalSize = size + size2;
+
 		DelimitedInputFormat<String> format = new MyTextInputFormat();
-		format.setFilePath(filePath);
-		
-		FileBaseStatistics stats = format.getStatistics(null);
+		format.setFilePaths(filePath.toUri().toString(), filePath2.toUri().toString());
+
+		FileInputFormat.FileBaseStatistics stats = format.getStatistics(null);
 		assertNotNull(stats);
-		assertEquals("The file size from the statistics is wrong", SIZE, stats.getTotalInputSize());
+		assertEquals("The file size from the statistics is wrong.", totalSize, stats.getTotalInputSize());
 	}
 	
+	@Test
+	public void testGetStatisticsFileDoesNotExist() throws IOException {
+		DelimitedInputFormat<String> format = new MyTextInputFormat();
+		format.setFilePaths("file:///path/does/not/really/exist", "file:///another/path/that/does/not/exist");
+
+		FileBaseStatistics stats = format.getStatistics(null);
+		assertNull("The file statistics should be null.", stats);
+	}
+
 	@Test
 	public void testGetStatisticsSingleFileWithCachedVersion() throws IOException {
 		final String myString = "my mocked line 1\nmy mocked line 2\n";
 		final Path tempFile = createTempFilePath(myString);
-		final long SIZE = myString.length();
-		final long FAKE_SIZE = 10065;
+		final long size = myString.length();
+		final long cachedSize = 10065;
 
 		DelimitedInputFormat<String> format = new MyTextInputFormat();
 		format.setFilePath(tempFile);
@@ -469,65 +475,34 @@ public class DelimitedInputFormatTest {
 
 		FileBaseStatistics stats = format.getStatistics(null);
 		assertNotNull(stats);
-		assertEquals("The file size from the statistics is wrong", SIZE, stats.getTotalInputSize());
+		assertEquals("The file size from the statistics is wrong.", size, stats.getTotalInputSize());
 		
 		format = new MyTextInputFormat();
 		format.setFilePath(tempFile);
 		format.configure(new Configuration());
 		
 		FileBaseStatistics newStats = format.getStatistics(stats);
-		assertEquals("Statistics object was changed", newStats, stats);
+		assertEquals("Statistics object was changed.", newStats, stats);
 		
 		// insert fake stats with the correct modification time. the call should return the fake stats
 		format = new MyTextInputFormat();
 		format.setFilePath(tempFile);
 		format.configure(new Configuration());
 		
-		FileBaseStatistics fakeStats = new FileBaseStatistics(stats.getLastModificationTime(), FAKE_SIZE, BaseStatistics.AVG_RECORD_BYTES_UNKNOWN);
+		FileBaseStatistics fakeStats = new FileBaseStatistics(stats.getLastModificationTime(), cachedSize, BaseStatistics.AVG_RECORD_BYTES_UNKNOWN);
 		BaseStatistics latest = format.getStatistics(fakeStats);
-		assertEquals("The file size from the statistics is wrong.", FAKE_SIZE, latest.getTotalInputSize());
+		assertEquals("The file size from the statistics is wrong.", cachedSize, latest.getTotalInputSize());
 		
 		// insert fake stats with the expired modification time. the call should return new accurate stats
 		format = new MyTextInputFormat();
 		format.setFilePath(tempFile);
 		format.configure(new Configuration());
 		
-		FileBaseStatistics outDatedFakeStats = new FileBaseStatistics(stats.getLastModificationTime()-1, FAKE_SIZE, BaseStatistics.AVG_RECORD_BYTES_UNKNOWN);
+		FileBaseStatistics outDatedFakeStats = new FileBaseStatistics(stats.getLastModificationTime()-1, cachedSize, BaseStatistics.AVG_RECORD_BYTES_UNKNOWN);
 		BaseStatistics reGathered = format.getStatistics(outDatedFakeStats);
-		assertEquals("The file size from the statistics is wrong.", SIZE, reGathered.getTotalInputSize());
+		assertEquals("The file size from the statistics is wrong.", size, reGathered.getTotalInputSize());
 	}
 	
-	@Test
-	public void testGetStatisticsMultipleFileDoesNotExist() throws IOException {
-		DelimitedInputFormat<String> format = new MyTextInputFormat();
-		format.setFilePaths("file://path/does/not/really/exist","file://another/path/that/does/not/exist");
-		
-		FileBaseStatistics stats = format.getStatistics(null);
-		assertNotNull("The file statistics should not be null", stats);
-		
-		assertEquals("The file size from the statistics is wrong.", FileBaseStatistics.SIZE_UNKNOWN, stats.getTotalInputSize());
-	}
-	
-	@Test
-	public void testGetStatisticsMultipleFiles() throws IOException {
-		final String myString = "my mocked line 1\nmy mocked line 2\n";
-		final long SIZE = myString.length();
-		final Path filePath = createTempFilePath(myString);
-
-		final String myString2 = "my mocked line 1\nmy mocked line 2\nanother mocked line3\n";
-		final long SIZE2 = myString2.length();
-		final Path filePath2 = createTempFilePath(myString2);
-
-		final long TOTAL_SIZE = SIZE + SIZE2;
-		
-		DelimitedInputFormat<String> format = new MyTextInputFormat();
-		format.setFilePaths(filePath.toUri().toString(), filePath2.toUri().toString());
-		
-		FileBaseStatistics stats = format.getStatistics(null);
-		assertNotNull(stats);
-		assertEquals("The file size from the statistics is wrong", TOTAL_SIZE, stats.getTotalInputSize());
-	}
-
 	static FileInputSplit createTempFile(String contents) throws IOException {
 		File tempFile = File.createTempFile("test_contents", "tmp");
 		tempFile.deleteOnExit();
@@ -557,17 +532,19 @@ public class DelimitedInputFormatTest {
 		public String readRecord(String reuse, byte[] bytes, int offset, int numBytes) {
 			return new String(bytes, offset, numBytes, ConfigConstants.DEFAULT_CHARSET);
 		}
+
+		@Override
+		public boolean supportsMultiPaths() {
+			return true;
+		}
 	}
 	
 	private static Path createTempFilePath(String contents) throws IOException {
 		File tempFile = File.createTempFile("test_contents", "tmp");
 		tempFile.deleteOnExit();
-		
-		OutputStreamWriter wrt = new OutputStreamWriter(new FileOutputStream(tempFile));
-		try {
+
+		try (OutputStreamWriter wrt = new OutputStreamWriter(new FileOutputStream(tempFile))) {
 			wrt.write(contents);
-		} finally {
-			wrt.close();
 		}
 		return new Path(tempFile.toURI().toString());
 	}

--- a/flink-core/src/test/java/org/apache/flink/api/common/io/DelimitedInputFormatTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/io/DelimitedInputFormatTest.java
@@ -19,6 +19,8 @@
 package org.apache.flink.api.common.io;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.flink.api.common.io.FileInputFormat.FileBaseStatistics;
+import org.apache.flink.api.common.io.statistics.BaseStatistics;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.FileInputSplit;
@@ -428,6 +430,104 @@ public class DelimitedInputFormatTest {
 		format.close();
 	}
 
+	// -- Statistics --//
+	@Test
+	public void testGetStatisticsSingleFileFileDoesNotExist() throws IOException {
+		DelimitedInputFormat<String> format = new MyTextInputFormat();
+		format.setFilePath(new Path("file://path/does/not/really/exist"));
+		
+		FileBaseStatistics stats = format.getStatistics(null);
+		assertNotNull("The file statistics should not be null", stats);
+		
+		assertEquals("The file size from the statistics is wrong.", FileBaseStatistics.SIZE_UNKNOWN, stats.getTotalInputSize());
+	}
+	
+	@Test
+	public void testGetStatisticsSingleFile() throws IOException {
+		final String myString = "my mocked line 1\nmy mocked line 2\n";
+		final long SIZE = myString.length();
+		final Path filePath = createTempFilePath(myString);
+		
+		DelimitedInputFormat<String> format = new MyTextInputFormat();
+		format.setFilePath(filePath);
+		
+		FileBaseStatistics stats = format.getStatistics(null);
+		assertNotNull(stats);
+		assertEquals("The file size from the statistics is wrong", SIZE, stats.getTotalInputSize());
+	}
+	
+	@Test
+	public void testGetStatisticsSingleFileWithCachedVersion() throws IOException {
+		final String myString = "my mocked line 1\nmy mocked line 2\n";
+		final Path tempFile = createTempFilePath(myString);
+		final long SIZE = myString.length();
+		final long FAKE_SIZE = 10065;
+
+		DelimitedInputFormat<String> format = new MyTextInputFormat();
+		format.setFilePath(tempFile);
+		format.configure(new Configuration());
+
+		FileBaseStatistics stats = format.getStatistics(null);
+		assertNotNull(stats);
+		assertEquals("The file size from the statistics is wrong", SIZE, stats.getTotalInputSize());
+		
+		format = new MyTextInputFormat();
+		format.setFilePath(tempFile);
+		format.configure(new Configuration());
+		
+		FileBaseStatistics newStats = format.getStatistics(stats);
+		assertEquals("Statistics object was changed", newStats, stats);
+		
+		// insert fake stats with the correct modification time. the call should return the fake stats
+		format = new MyTextInputFormat();
+		format.setFilePath(tempFile);
+		format.configure(new Configuration());
+		
+		FileBaseStatistics fakeStats = new FileBaseStatistics(stats.getLastModificationTime(), FAKE_SIZE, BaseStatistics.AVG_RECORD_BYTES_UNKNOWN);
+		BaseStatistics latest = format.getStatistics(fakeStats);
+		assertEquals("The file size from the statistics is wrong.", FAKE_SIZE, latest.getTotalInputSize());
+		
+		// insert fake stats with the expired modification time. the call should return new accurate stats
+		format = new MyTextInputFormat();
+		format.setFilePath(tempFile);
+		format.configure(new Configuration());
+		
+		FileBaseStatistics outDatedFakeStats = new FileBaseStatistics(stats.getLastModificationTime()-1, FAKE_SIZE, BaseStatistics.AVG_RECORD_BYTES_UNKNOWN);
+		BaseStatistics reGathered = format.getStatistics(outDatedFakeStats);
+		assertEquals("The file size from the statistics is wrong.", SIZE, reGathered.getTotalInputSize());
+	}
+	
+	@Test
+	public void testGetStatisticsMultipleFileDoesNotExist() throws IOException {
+		DelimitedInputFormat<String> format = new MyTextInputFormat();
+		format.setFilePaths("file://path/does/not/really/exist","file://another/path/that/does/not/exist");
+		
+		FileBaseStatistics stats = format.getStatistics(null);
+		assertNotNull("The file statistics should not be null", stats);
+		
+		assertEquals("The file size from the statistics is wrong.", FileBaseStatistics.SIZE_UNKNOWN, stats.getTotalInputSize());
+	}
+	
+	@Test
+	public void testGetStatisticsMultipleFiles() throws IOException {
+		final String myString = "my mocked line 1\nmy mocked line 2\n";
+		final long SIZE = myString.length();
+		final Path filePath = createTempFilePath(myString);
+
+		final String myString2 = "my mocked line 1\nmy mocked line 2\nanother mocked line3\n";
+		final long SIZE2 = myString2.length();
+		final Path filePath2 = createTempFilePath(myString2);
+
+		final long TOTAL_SIZE = SIZE + SIZE2;
+		
+		DelimitedInputFormat<String> format = new MyTextInputFormat();
+		format.setFilePaths(filePath.toUri().toString(), filePath2.toUri().toString());
+		
+		FileBaseStatistics stats = format.getStatistics(null);
+		assertNotNull(stats);
+		assertEquals("The file size from the statistics is wrong", TOTAL_SIZE, stats.getTotalInputSize());
+	}
+
 	static FileInputSplit createTempFile(String contents) throws IOException {
 		File tempFile = File.createTempFile("test_contents", "tmp");
 		tempFile.deleteOnExit();
@@ -457,5 +557,18 @@ public class DelimitedInputFormatTest {
 		public String readRecord(String reuse, byte[] bytes, int offset, int numBytes) {
 			return new String(bytes, offset, numBytes, ConfigConstants.DEFAULT_CHARSET);
 		}
+	}
+	
+	private static Path createTempFilePath(String contents) throws IOException {
+		File tempFile = File.createTempFile("test_contents", "tmp");
+		tempFile.deleteOnExit();
+		
+		OutputStreamWriter wrt = new OutputStreamWriter(new FileOutputStream(tempFile));
+		try {
+			wrt.write(contents);
+		} finally {
+			wrt.close();
+		}
+		return new Path(tempFile.toURI().toString());
 	}
 }

--- a/flink-core/src/test/java/org/apache/flink/api/common/io/DelimitedInputFormatTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/io/DelimitedInputFormatTest.java
@@ -467,7 +467,7 @@ public class DelimitedInputFormatTest {
 		final String myString = "my mocked line 1\nmy mocked line 2\n";
 		final Path tempFile = createTempFilePath(myString);
 		final long size = myString.length();
-		final long cachedSize = 10065;
+		final long fakeSize = 10065;
 
 		DelimitedInputFormat<String> format = new MyTextInputFormat();
 		format.setFilePath(tempFile);
@@ -489,16 +489,16 @@ public class DelimitedInputFormatTest {
 		format.setFilePath(tempFile);
 		format.configure(new Configuration());
 		
-		FileBaseStatistics fakeStats = new FileBaseStatistics(stats.getLastModificationTime(), cachedSize, BaseStatistics.AVG_RECORD_BYTES_UNKNOWN);
+		FileBaseStatistics fakeStats = new FileBaseStatistics(stats.getLastModificationTime(), fakeSize, BaseStatistics.AVG_RECORD_BYTES_UNKNOWN);
 		BaseStatistics latest = format.getStatistics(fakeStats);
-		assertEquals("The file size from the statistics is wrong.", cachedSize, latest.getTotalInputSize());
+		assertEquals("The file size from the statistics is wrong.", fakeSize, latest.getTotalInputSize());
 		
 		// insert fake stats with the expired modification time. the call should return new accurate stats
 		format = new MyTextInputFormat();
 		format.setFilePath(tempFile);
 		format.configure(new Configuration());
 		
-		FileBaseStatistics outDatedFakeStats = new FileBaseStatistics(stats.getLastModificationTime()-1, cachedSize, BaseStatistics.AVG_RECORD_BYTES_UNKNOWN);
+		FileBaseStatistics outDatedFakeStats = new FileBaseStatistics(stats.getLastModificationTime() - 1, fakeSize, BaseStatistics.AVG_RECORD_BYTES_UNKNOWN);
 		BaseStatistics reGathered = format.getStatistics(outDatedFakeStats);
 		assertEquals("The file size from the statistics is wrong.", size, reGathered.getTotalInputSize());
 	}

--- a/flink-core/src/test/java/org/apache/flink/api/common/io/FileInputFormatTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/io/FileInputFormatTest.java
@@ -53,7 +53,7 @@ public class FileInputFormatTest {
 	@Test
 	public void testGetPathWithoutSettingFirst() {
 		final DummyFileInputFormat format = new DummyFileInputFormat();
-		Assert.assertNull("This should be null", format.getFilePath());
+		Assert.assertNull("Path should be null.", format.getFilePath());
 	}
 	
 	@Test
@@ -71,81 +71,94 @@ public class FileInputFormatTest {
 		Assert.assertEquals("The toString() should be correct.", "File Input (unknown file)", format.toString());
 	}
 	
-	@Test(expected=IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class)
 	public void testSetPathsNull() {
-		final DummyFileInputFormat format = new DummyFileInputFormat();
-		format.setFilePaths((String)null);
+		final MultiDummyFileInputFormat format = new MultiDummyFileInputFormat();
+		format.setFilePaths((String) null);
 	}
 
-	@Test(expected=IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class)
 	public void testSetPathNullString() {
 		final DummyFileInputFormat format = new DummyFileInputFormat();
 		format.setFilePath((String) null);
 	}
 	
-	@Test(expected=IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class)
 	public void testSetPathNullPath() {
 		final DummyFileInputFormat format = new DummyFileInputFormat();
 		format.setFilePath((Path) null);
 	}
 	
-	@Test
-	public void testSetPathNonNull() {
-		final DummyFileInputFormat format = new DummyFileInputFormat();
-		format.setFilePath("/some/imaginary/path");
-	}
-	
-	@Test(expected=IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class)
 	public void testSetPathsOnePathNull() {
-		final DummyFileInputFormat format = new DummyFileInputFormat();
+		final MultiDummyFileInputFormat format = new MultiDummyFileInputFormat();
 		format.setFilePaths("/an/imaginary/path", null);
 	}
 
-	@Test(expected=IllegalArgumentException.class)
+	@Test(expected = IllegalArgumentException.class)
 	public void testSetPathsEmptyArray() {
-		final DummyFileInputFormat format = new DummyFileInputFormat();
+		final MultiDummyFileInputFormat format = new MultiDummyFileInputFormat();
 		format.setFilePaths(new String[0]);
 	}
-	
+
 	@Test
-	public void testSetPathsEmptyString() {
+	public void testSetPath() {
 		final DummyFileInputFormat format = new DummyFileInputFormat();
-		format.setFilePaths("");
-		Assert.assertNull("Path should be null.", format.getFilePath());
-		
-		Path[] paths = format.getFilePaths();
-		Assert.assertNotNull("Paths should not be null.", paths);
-		Assert.assertEquals("Paths size should be 0.", 0, paths.length);
+		format.setFilePath("/some/imaginary/path");
+		Assert.assertEquals(format.getFilePath().toString(), "/some/imaginary/path");
 	}
 	
 	@Test
-	public void testSetPathsOnePath() {
-		final DummyFileInputFormat format = new DummyFileInputFormat();
-		final String myPath = "/an/imaginary/path"; 
+	public void testSetPathsSingle() {
+		final MultiDummyFileInputFormat format = new MultiDummyFileInputFormat();
+		final String myPath = "/an/imaginary/path";
 		format.setFilePaths(myPath);
 		final Path[] filePaths = format.getFilePaths();
 
-		Assert.assertEquals("File path count should be equal.", 1, filePaths.length);
-		Assert.assertEquals("File path should be equal.", myPath, filePaths[0].toUri().toString());
-
-		Assert.assertEquals("First path should be equal.", myPath, format.getFilePath().toUri().toString());
+		Assert.assertEquals(1, filePaths.length);
+		Assert.assertEquals(myPath, filePaths[0].toUri().toString());
 	}
 	
 	@Test
-	public void testSetPathsTwoPaths() {
-		final DummyFileInputFormat format = new DummyFileInputFormat();
-		final String myPath = "/an/imaginary/path"; 
+	public void testSetPathsMulti() {
+		final MultiDummyFileInputFormat format = new MultiDummyFileInputFormat();
+		final String myPath = "/an/imaginary/path";
 		final String myPath2 = "/an/imaginary/path2";
 		
 		format.setFilePaths(myPath, myPath2);
 		final Path[] filePaths = format.getFilePaths();
 
-		Assert.assertEquals("File path count should be equal.", 2, filePaths.length);
-		Assert.assertEquals("File path should be equal.", myPath, filePaths[0].toUri().toString());
-		Assert.assertEquals("File path should be equal.", myPath2, filePaths[1].toUri().toString());
+		Assert.assertEquals(2, filePaths.length);
+		Assert.assertEquals(myPath, filePaths[0].toUri().toString());
+		Assert.assertEquals(myPath2, filePaths[1].toUri().toString());
+	}
 
-		Assert.assertEquals("First path should be equal.", myPath, format.getFilePath().toUri().toString());
-		Assert.assertEquals("The toString() should be correct.", "File Input ([/an/imaginary/path, /an/imaginary/path2])", format.toString());
+	@Test(expected = UnsupportedOperationException.class)
+	public void testMultiPathSetOnSinglePathIF() {
+		final DummyFileInputFormat format = new DummyFileInputFormat();
+		final String myPath = "/an/imaginary/path";
+		final String myPath2 = "/an/imaginary/path2";
+
+		format.setFilePaths(myPath, myPath2);
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void testMultiPathSetOnSinglePathIF2() {
+		final DummyFileInputFormat format = new DummyFileInputFormat();
+		final String myPath = "/an/imaginary/path";
+		final String myPath2 = "/an/imaginary/path2";
+
+		format.setFilePaths(new Path(myPath), new Path(myPath2));
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void testSinglePathGetOnMultiPathIF() {
+		final MultiDummyFileInputFormat format = new MultiDummyFileInputFormat();
+		final String myPath = "/an/imaginary/path";
+		final String myPath2 = "/an/imaginary/path2";
+
+		format.setFilePaths(myPath, myPath2);
+		format.getFilePath();
 	}
 
 	@Test
@@ -159,13 +172,68 @@ public class FileInputFormatTest {
 		Assert.assertEquals("Paths should be equal.", new Path(filePath), format.getFilePath());
 	}
 
-	@Test (expected=RuntimeException.class)
+	@Test (expected = RuntimeException.class)
 	public void testSetFileViaConfigurationEmptyPath() {
 		final DummyFileInputFormat format = new DummyFileInputFormat();
 		final String filePath = null;
 		Configuration conf = new Configuration();
 		conf.setString("input.file.path", filePath);
 		format.configure(conf);
+	}
+	
+	// ------------------------------------------------------------------------
+	//  Input Splits
+	// ------------------------------------------------------------------------
+	
+	@Test
+	public void testCreateInputSplitSingleFile() throws IOException {
+		String tempFile = TestFileUtils.createTempFile("Hello World");
+		FileInputFormat fif = new DummyFileInputFormat();
+		fif.setFilePath(tempFile);
+		
+		fif.configure(new Configuration());
+		FileInputSplit[] splits = fif.createInputSplits(2);
+		
+		Assert.assertEquals(2, splits.length);
+		Assert.assertEquals(tempFile, splits[0].getPath().toString());
+		Assert.assertEquals(tempFile, splits[1].getPath().toString());
+	}
+
+	@Test
+	public void testCreateInputSplitMultiFiles() throws IOException {
+		String tempFile1 = TestFileUtils.createTempFile(21);
+		String tempFile2 = TestFileUtils.createTempFile(22);
+		String tempFile3 = TestFileUtils.createTempFile(23);
+		FileInputFormat fif = new MultiDummyFileInputFormat();
+		fif.setFilePaths(tempFile1, tempFile2, tempFile3);
+
+		fif.configure(new Configuration());
+		FileInputSplit[] splits = fif.createInputSplits(3);
+
+		int numSplitsFile1 = 0;
+		int numSplitsFile2 = 0;
+		int numSplitsFile3 = 0;
+
+		Assert.assertEquals(3, splits.length);
+		for (FileInputSplit fis : splits) {
+			Assert.assertEquals(0, fis.getStart());
+			if (fis.getPath().toString().equals(tempFile1)) {
+				numSplitsFile1++;
+				Assert.assertEquals(21, fis.getLength());
+			} else if (fis.getPath().toString().equals(tempFile2)) {
+				numSplitsFile2++;
+				Assert.assertEquals(22, fis.getLength());
+			} else if (fis.getPath().toString().equals(tempFile3)) {
+				numSplitsFile3++;
+				Assert.assertEquals(23, fis.getLength());
+			} else {
+				Assert.fail("Got split for unknown file.");
+			}
+		}
+		
+		Assert.assertEquals(1, numSplitsFile1);
+		Assert.assertEquals(1, numSplitsFile2);
+		Assert.assertEquals(1, numSplitsFile3);
 	}
 
 	// ------------------------------------------------------------------------
@@ -326,178 +394,100 @@ public class FileInputFormatTest {
 	// -- Multiple Files -- //
 	
 	@Test
-	public void testGetStatisticsMultipleNonExistingFile() {
-		try {
-			final DummyFileInputFormat format = new DummyFileInputFormat();
-			format.setFilePaths("file:///some/none/existing/directory/","file:///another/non/existing/directory/");
-			format.configure(new Configuration());
-			
-			BaseStatistics stats = format.getStatistics(null);
-			Assert.assertNull("The file statistics should be null.", stats);
-		} catch (Exception ex) {
-			ex.printStackTrace();
-			Assert.fail(ex.getMessage());
-		}
+	public void testGetStatisticsMultipleNonExistingFile() throws IOException {
+		final MultiDummyFileInputFormat format = new MultiDummyFileInputFormat();
+		format.setFilePaths("file:///some/none/existing/directory/","file:///another/non/existing/directory/");
+		format.configure(new Configuration());
+		
+		BaseStatistics stats = format.getStatistics(null);
+		Assert.assertNull("The file statistics should be null.", stats);
 	}
 	
 	@Test
-	public void testGetStatisticsMultipleOneFileNoCachedVersion() {
-		try {
-			final long SIZE = 1024 * 500;
-			String tempFile = TestFileUtils.createTempFile(SIZE);
+	public void testGetStatisticsMultipleOneFileNoCachedVersion() throws IOException {
+		final long size1 = 1024 * 500;
+		String tempFile = TestFileUtils.createTempFile(size1);
 
-			final long SIZE2 = 1024 * 505;
-			String tempFile2 = TestFileUtils.createTempFile(SIZE2);
+		final long size2 = 1024 * 505;
+		String tempFile2 = TestFileUtils.createTempFile(size2);
 
-			final long TOTAL_SIZE = SIZE + SIZE2;
-			
-			final DummyFileInputFormat format = new DummyFileInputFormat();
-			format.setFilePaths(tempFile, tempFile2);
-			format.configure(new Configuration());
-			
-			BaseStatistics stats = format.getStatistics(null);
-			Assert.assertEquals("The file size from the statistics is wrong.", TOTAL_SIZE, stats.getTotalInputSize());
-		} catch (Exception ex) {
-			ex.printStackTrace();
-			Assert.fail(ex.getMessage());
-		}
+		final long totalSize = size1 + size2;
+		
+		final MultiDummyFileInputFormat format = new MultiDummyFileInputFormat();
+		format.setFilePaths(tempFile, tempFile2);
+		format.configure(new Configuration());
+		
+		BaseStatistics stats = format.getStatistics(null);
+		Assert.assertEquals("The file size from the statistics is wrong.", totalSize, stats.getTotalInputSize());
 	}
 	
 	@Test
-	public void testGetStatisticsMultipleFilesMultiplePathsNoCachedVersion() {
-		try {
-			final long SIZE1 = 2077;
-			final long SIZE2 = 31909;
-			final long SIZE3 = 10;
-			final long TOTAL = SIZE1 + SIZE2 + SIZE3;
-			
-			String tempDir = TestFileUtils.createTempFileDir(SIZE1, SIZE2, SIZE3);
-			
-			final long SIZE4 = 2051;
-			final long SIZE5 = 31902;
-			final long SIZE6 = 15;
-			final long TOTAL2 = SIZE4 + SIZE5 + SIZE6;
-			String tempDir2 = TestFileUtils.createTempFileDir(SIZE4, SIZE5, SIZE6);
+	public void testGetStatisticsMultipleFilesMultiplePathsNoCachedVersion() throws IOException {
+		final long size1 = 2077;
+		final long size2 = 31909;
+		final long size3 = 10;
+		final long totalSize123 = size1 + size2 + size3;
+		
+		String tempDir = TestFileUtils.createTempFileDir(size1, size2, size3);
+		
+		final long size4 = 2051;
+		final long size5 = 31902;
+		final long size6 = 15;
+		final long totalSize456 = size4 + size5 + size6;
+		String tempDir2 = TestFileUtils.createTempFileDir(size4, size5, size6);
 
-			final DummyFileInputFormat format = new DummyFileInputFormat();
-			format.setFilePaths(tempDir, tempDir2);
-			format.configure(new Configuration());
-			
-			BaseStatistics stats = format.getStatistics(null);
-			Assert.assertEquals("The file size from the statistics is wrong.", TOTAL + TOTAL2, stats.getTotalInputSize());
-		} catch (Exception ex) {
-			ex.printStackTrace();
-			Assert.fail(ex.getMessage());
-		}
+		final MultiDummyFileInputFormat format = new MultiDummyFileInputFormat();
+		format.setFilePaths(tempDir, tempDir2);
+		format.configure(new Configuration());
+		
+		BaseStatistics stats = format.getStatistics(null);
+		Assert.assertEquals("The file size from the statistics is wrong.", totalSize123 + totalSize456, stats.getTotalInputSize());
 	}
 	
 	@Test
-	public void testGetStatisticsMultipleOneFileWithCachedVersion() {
-		try {
-			final long SIZE = 50873;
-			final long FAKE_SIZE = 10065;
-			
-			String tempFile = TestFileUtils.createTempFile(SIZE);
+	public void testGetStatisticsMultipleOneFileWithCachedVersion() throws IOException {
+		final long size1 = 50873;
+		final long cachedSize = 10065;
+		String tempFile1 = TestFileUtils.createTempFile(size1);
 
-			final long SIZE2 = 52573;
-			String tempFile2 = TestFileUtils.createTempFile(SIZE2);
+		final long size2 = 52573;
+		String tempFile2 = TestFileUtils.createTempFile(size2);
 
-			final long SIZE_TOTAL = SIZE + SIZE2;
-			
-			DummyFileInputFormat format = new DummyFileInputFormat();
-			format.setFilePaths(tempFile, tempFile2);
-			format.configure(new Configuration());
-			
-			
-			
-			FileBaseStatistics stats = format.getStatistics(null);
-			Assert.assertEquals("The file size from the statistics is wrong.", SIZE_TOTAL, stats.getTotalInputSize());
-			
-			format = new DummyFileInputFormat();
-			format.setFilePath(tempFile);
-			format.configure(new Configuration());
-			
-			FileBaseStatistics newStats = format.getStatistics(stats);
-			Assert.assertTrue("Statistics object was changed", newStats == stats);
+		final long sizeTotal = size1 + size2;
+		
+		MultiDummyFileInputFormat format = new MultiDummyFileInputFormat();
+		format.setFilePaths(tempFile1, tempFile2);
+		format.configure(new Configuration());
+		
+		FileBaseStatistics stats = format.getStatistics(null);
+		Assert.assertEquals("The file size from the statistics is wrong.", sizeTotal, stats.getTotalInputSize());
+		
+		format = new MultiDummyFileInputFormat();
+		format.setFilePath(tempFile1);
+		format.configure(new Configuration());
+		
+		FileBaseStatistics newStats = format.getStatistics(stats);
+		Assert.assertTrue("Statistics object was changed", newStats == stats);
 
-			// insert fake stats with the correct modification time. the call should return the fake stats
-			format = new DummyFileInputFormat();
-			format.setFilePath(tempFile);
-			format.configure(new Configuration());
-			
-			FileBaseStatistics fakeStats = new FileBaseStatistics(stats.getLastModificationTime(), FAKE_SIZE, BaseStatistics.AVG_RECORD_BYTES_UNKNOWN);
-			BaseStatistics latest = format.getStatistics(fakeStats);
-			Assert.assertEquals("The file size from the statistics is wrong.", FAKE_SIZE, latest.getTotalInputSize());
-			
-			// insert fake stats with the expired modification time. the call should return new accurate stats
-			format = new DummyFileInputFormat();
-			format.setFilePaths(tempFile, tempFile2);
-			format.configure(new Configuration());
-			
-			FileBaseStatistics outDatedFakeStats = new FileBaseStatistics(stats.getLastModificationTime()-1, FAKE_SIZE, BaseStatistics.AVG_RECORD_BYTES_UNKNOWN);
-			BaseStatistics reGathered = format.getStatistics(outDatedFakeStats);
-			Assert.assertEquals("The file size from the statistics is wrong.", SIZE_TOTAL, reGathered.getTotalInputSize());
-			
-		} catch (Exception ex) {
-			ex.printStackTrace();
-			Assert.fail(ex.getMessage());
-		}
+		// insert fake stats with the correct modification time. the call should return the fake stats
+		format = new MultiDummyFileInputFormat();
+		format.setFilePath(tempFile1);
+		format.configure(new Configuration());
+		
+		FileBaseStatistics fakeStats = new FileBaseStatistics(stats.getLastModificationTime(), cachedSize, BaseStatistics.AVG_RECORD_BYTES_UNKNOWN);
+		BaseStatistics latest = format.getStatistics(fakeStats);
+		Assert.assertEquals("The file size from the statistics is wrong.", cachedSize, latest.getTotalInputSize());
+		
+		// insert fake stats with the expired modification time. the call should return new accurate stats
+		format = new MultiDummyFileInputFormat();
+		format.setFilePaths(tempFile1, tempFile2);
+		format.configure(new Configuration());
+		
+		FileBaseStatistics outDatedFakeStats = new FileBaseStatistics(stats.getLastModificationTime()-1, cachedSize, BaseStatistics.AVG_RECORD_BYTES_UNKNOWN);
+		BaseStatistics reGathered = format.getStatistics(outDatedFakeStats);
+		Assert.assertEquals("The file size from the statistics is wrong.", sizeTotal, reGathered.getTotalInputSize());
 	}
 	
-	@Test
-	public void testGetStatisticsMultipleFilesMultiplePathsWithCachedVersion() {
-		try {
-			final long SIZE1 = 2077;
-			final long SIZE2 = 31909;
-			final long SIZE3 = 10;
-
-			final long SIZE4 = 2177;
-			final long SIZE5 = 33909;
-			final long SIZE6 = 18;
-
-			final long TOTAL = SIZE1 + SIZE2 + SIZE3 + SIZE4 + SIZE5 + SIZE6;
-			final long FAKE_SIZE = 10065;
-			
-			String tempDir = TestFileUtils.createTempFileDir(SIZE1, SIZE2, SIZE3);
-			String tempDir2 = TestFileUtils.createTempFileDir(SIZE4, SIZE5, SIZE6);
-			
-			DummyFileInputFormat format = new DummyFileInputFormat();
-			format.setFilePaths(tempDir, tempDir2);
-			format.configure(new Configuration());
-			
-			FileBaseStatistics stats = format.getStatistics(null);
-			Assert.assertEquals("The file size from the statistics is wrong.", TOTAL, stats.getTotalInputSize());
-			
-			format = new DummyFileInputFormat();
-			format.setFilePaths(tempDir, tempDir2);
-			format.configure(new Configuration());
-			
-			FileBaseStatistics newStats = format.getStatistics(stats);
-			Assert.assertTrue("Statistics object was changed", newStats == stats);
-
-			// insert fake stats with the correct modification time. the call should return the fake stats
-			format = new DummyFileInputFormat();
-			format.setFilePaths(tempDir, tempDir2);
-			format.configure(new Configuration());
-			
-			FileBaseStatistics fakeStats = new FileBaseStatistics(stats.getLastModificationTime(), FAKE_SIZE, BaseStatistics.AVG_RECORD_BYTES_UNKNOWN);
-			BaseStatistics latest = format.getStatistics(fakeStats);
-			Assert.assertEquals("The file size from the statistics is wrong.", FAKE_SIZE, latest.getTotalInputSize());
-			
-			// insert fake stats with the correct modification time. the call should return the fake stats
-			format = new DummyFileInputFormat();
-			format.setFilePaths(tempDir, tempDir2);
-			format.configure(new Configuration());
-			
-			FileBaseStatistics outDatedFakeStats = new FileBaseStatistics(stats.getLastModificationTime()-1, FAKE_SIZE, BaseStatistics.AVG_RECORD_BYTES_UNKNOWN);
-			BaseStatistics reGathered = format.getStatistics(outDatedFakeStats);
-			Assert.assertEquals("The file size from the statistics is wrong.", TOTAL, reGathered.getTotalInputSize());
-			
-		} catch (Exception ex) {
-			ex.printStackTrace();
-			Assert.fail(ex.getMessage());
-		}
-	}
 	// ------------------------------------------------------------------------
 	//  Unsplittable input files
 	// ------------------------------------------------------------------------
@@ -745,7 +735,7 @@ public class FileInputFormatTest {
 
 	private class DummyFileInputFormat extends FileInputFormat<IntValue> {
 		private static final long serialVersionUID = 1L;
-		
+
 		@Override
 		public boolean reachedEnd() throws IOException {
 			return true;
@@ -754,6 +744,15 @@ public class FileInputFormatTest {
 		@Override
 		public IntValue nextRecord(IntValue record) throws IOException {
 			return null;
+		}
+	}
+
+	private class MultiDummyFileInputFormat extends DummyFileInputFormat {
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public boolean supportsMultiPaths() {
+			return true;
 		}
 	}
 

--- a/flink-core/src/test/java/org/apache/flink/api/common/io/FileInputFormatTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/io/FileInputFormatTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.FSDataInputStream;
 import org.apache.flink.core.fs.FileInputSplit;
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.testutils.TestFileUtils;
 import org.apache.flink.types.IntValue;
 
@@ -48,6 +49,124 @@ public class FileInputFormatTest {
 
 	@Rule
 	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	@Test
+	public void testGetPathWithoutSettingFirst() {
+		final DummyFileInputFormat format = new DummyFileInputFormat();
+		Assert.assertNull("This should be null", format.getFilePath());
+	}
+	
+	@Test
+	public void testGetPathsWithoutSettingFirst() {
+		final DummyFileInputFormat format = new DummyFileInputFormat();
+		
+		Path[] paths = format.getFilePaths();
+		Assert.assertNotNull("Paths should not be null.", paths);
+		Assert.assertEquals("Paths size should be 0.", 0, paths.length);
+	}
+	
+	@Test
+	public void testToStringWithoutPathSet() {
+		final DummyFileInputFormat format = new DummyFileInputFormat();
+		Assert.assertEquals("The toString() should be correct.", "File Input (unknown file)", format.toString());
+	}
+	
+	@Test(expected=IllegalArgumentException.class)
+	public void testSetPathsNull() {
+		final DummyFileInputFormat format = new DummyFileInputFormat();
+		format.setFilePaths((String)null);
+	}
+
+	@Test(expected=IllegalArgumentException.class)
+	public void testSetPathNullString() {
+		final DummyFileInputFormat format = new DummyFileInputFormat();
+		format.setFilePath((String) null);
+	}
+	
+	@Test(expected=IllegalArgumentException.class)
+	public void testSetPathNullPath() {
+		final DummyFileInputFormat format = new DummyFileInputFormat();
+		format.setFilePath((Path) null);
+	}
+	
+	@Test
+	public void testSetPathNonNull() {
+		final DummyFileInputFormat format = new DummyFileInputFormat();
+		format.setFilePath("/some/imaginary/path");
+	}
+	
+	@Test(expected=IllegalArgumentException.class)
+	public void testSetPathsOnePathNull() {
+		final DummyFileInputFormat format = new DummyFileInputFormat();
+		format.setFilePaths("/an/imaginary/path", null);
+	}
+
+	@Test(expected=IllegalArgumentException.class)
+	public void testSetPathsEmptyArray() {
+		final DummyFileInputFormat format = new DummyFileInputFormat();
+		format.setFilePaths(new String[0]);
+	}
+	
+	@Test
+	public void testSetPathsEmptyString() {
+		final DummyFileInputFormat format = new DummyFileInputFormat();
+		format.setFilePaths("");
+		Assert.assertNull("Path should be null.", format.getFilePath());
+		
+		Path[] paths = format.getFilePaths();
+		Assert.assertNotNull("Paths should not be null.", paths);
+		Assert.assertEquals("Paths size should be 0.", 0, paths.length);
+	}
+	
+	@Test
+	public void testSetPathsOnePath() {
+		final DummyFileInputFormat format = new DummyFileInputFormat();
+		final String myPath = "/an/imaginary/path"; 
+		format.setFilePaths(myPath);
+		final Path[] filePaths = format.getFilePaths();
+
+		Assert.assertEquals("File path count should be equal.", 1, filePaths.length);
+		Assert.assertEquals("File path should be equal.", myPath, filePaths[0].toUri().toString());
+
+		Assert.assertEquals("First path should be equal.", myPath, format.getFilePath().toUri().toString());
+	}
+	
+	@Test
+	public void testSetPathsTwoPaths() {
+		final DummyFileInputFormat format = new DummyFileInputFormat();
+		final String myPath = "/an/imaginary/path"; 
+		final String myPath2 = "/an/imaginary/path2";
+		
+		format.setFilePaths(myPath, myPath2);
+		final Path[] filePaths = format.getFilePaths();
+
+		Assert.assertEquals("File path count should be equal.", 2, filePaths.length);
+		Assert.assertEquals("File path should be equal.", myPath, filePaths[0].toUri().toString());
+		Assert.assertEquals("File path should be equal.", myPath2, filePaths[1].toUri().toString());
+
+		Assert.assertEquals("First path should be equal.", myPath, format.getFilePath().toUri().toString());
+		Assert.assertEquals("The toString() should be correct.", "File Input ([/an/imaginary/path, /an/imaginary/path2])", format.toString());
+	}
+
+	@Test
+	public void testSetFileViaConfiguration() {
+		final DummyFileInputFormat format = new DummyFileInputFormat();
+		final String filePath = "file:///some/none/existing/directory/";
+		Configuration conf = new Configuration();
+		conf.setString("input.file.path", filePath);
+		format.configure(conf);
+
+		Assert.assertEquals("Paths should be equal.", new Path(filePath), format.getFilePath());
+	}
+
+	@Test (expected=RuntimeException.class)
+	public void testSetFileViaConfigurationEmptyPath() {
+		final DummyFileInputFormat format = new DummyFileInputFormat();
+		final String filePath = null;
+		Configuration conf = new Configuration();
+		conf.setString("input.file.path", filePath);
+		format.configure(conf);
+	}
 
 	// ------------------------------------------------------------------------
 	//  Statistics
@@ -203,7 +322,182 @@ public class FileInputFormatTest {
 			Assert.fail(ex.getMessage());
 		}
 	}
+	
+	// -- Multiple Files -- //
+	
+	@Test
+	public void testGetStatisticsMultipleNonExistingFile() {
+		try {
+			final DummyFileInputFormat format = new DummyFileInputFormat();
+			format.setFilePaths("file:///some/none/existing/directory/","file:///another/non/existing/directory/");
+			format.configure(new Configuration());
+			
+			BaseStatistics stats = format.getStatistics(null);
+			Assert.assertNull("The file statistics should be null.", stats);
+		} catch (Exception ex) {
+			ex.printStackTrace();
+			Assert.fail(ex.getMessage());
+		}
+	}
+	
+	@Test
+	public void testGetStatisticsMultipleOneFileNoCachedVersion() {
+		try {
+			final long SIZE = 1024 * 500;
+			String tempFile = TestFileUtils.createTempFile(SIZE);
 
+			final long SIZE2 = 1024 * 505;
+			String tempFile2 = TestFileUtils.createTempFile(SIZE2);
+
+			final long TOTAL_SIZE = SIZE + SIZE2;
+			
+			final DummyFileInputFormat format = new DummyFileInputFormat();
+			format.setFilePaths(tempFile, tempFile2);
+			format.configure(new Configuration());
+			
+			BaseStatistics stats = format.getStatistics(null);
+			Assert.assertEquals("The file size from the statistics is wrong.", TOTAL_SIZE, stats.getTotalInputSize());
+		} catch (Exception ex) {
+			ex.printStackTrace();
+			Assert.fail(ex.getMessage());
+		}
+	}
+	
+	@Test
+	public void testGetStatisticsMultipleFilesMultiplePathsNoCachedVersion() {
+		try {
+			final long SIZE1 = 2077;
+			final long SIZE2 = 31909;
+			final long SIZE3 = 10;
+			final long TOTAL = SIZE1 + SIZE2 + SIZE3;
+			
+			String tempDir = TestFileUtils.createTempFileDir(SIZE1, SIZE2, SIZE3);
+			
+			final long SIZE4 = 2051;
+			final long SIZE5 = 31902;
+			final long SIZE6 = 15;
+			final long TOTAL2 = SIZE4 + SIZE5 + SIZE6;
+			String tempDir2 = TestFileUtils.createTempFileDir(SIZE4, SIZE5, SIZE6);
+
+			final DummyFileInputFormat format = new DummyFileInputFormat();
+			format.setFilePaths(tempDir, tempDir2);
+			format.configure(new Configuration());
+			
+			BaseStatistics stats = format.getStatistics(null);
+			Assert.assertEquals("The file size from the statistics is wrong.", TOTAL + TOTAL2, stats.getTotalInputSize());
+		} catch (Exception ex) {
+			ex.printStackTrace();
+			Assert.fail(ex.getMessage());
+		}
+	}
+	
+	@Test
+	public void testGetStatisticsMultipleOneFileWithCachedVersion() {
+		try {
+			final long SIZE = 50873;
+			final long FAKE_SIZE = 10065;
+			
+			String tempFile = TestFileUtils.createTempFile(SIZE);
+
+			final long SIZE2 = 52573;
+			String tempFile2 = TestFileUtils.createTempFile(SIZE2);
+
+			final long SIZE_TOTAL = SIZE + SIZE2;
+			
+			DummyFileInputFormat format = new DummyFileInputFormat();
+			format.setFilePaths(tempFile, tempFile2);
+			format.configure(new Configuration());
+			
+			
+			
+			FileBaseStatistics stats = format.getStatistics(null);
+			Assert.assertEquals("The file size from the statistics is wrong.", SIZE_TOTAL, stats.getTotalInputSize());
+			
+			format = new DummyFileInputFormat();
+			format.setFilePath(tempFile);
+			format.configure(new Configuration());
+			
+			FileBaseStatistics newStats = format.getStatistics(stats);
+			Assert.assertTrue("Statistics object was changed", newStats == stats);
+
+			// insert fake stats with the correct modification time. the call should return the fake stats
+			format = new DummyFileInputFormat();
+			format.setFilePath(tempFile);
+			format.configure(new Configuration());
+			
+			FileBaseStatistics fakeStats = new FileBaseStatistics(stats.getLastModificationTime(), FAKE_SIZE, BaseStatistics.AVG_RECORD_BYTES_UNKNOWN);
+			BaseStatistics latest = format.getStatistics(fakeStats);
+			Assert.assertEquals("The file size from the statistics is wrong.", FAKE_SIZE, latest.getTotalInputSize());
+			
+			// insert fake stats with the expired modification time. the call should return new accurate stats
+			format = new DummyFileInputFormat();
+			format.setFilePaths(tempFile, tempFile2);
+			format.configure(new Configuration());
+			
+			FileBaseStatistics outDatedFakeStats = new FileBaseStatistics(stats.getLastModificationTime()-1, FAKE_SIZE, BaseStatistics.AVG_RECORD_BYTES_UNKNOWN);
+			BaseStatistics reGathered = format.getStatistics(outDatedFakeStats);
+			Assert.assertEquals("The file size from the statistics is wrong.", SIZE_TOTAL, reGathered.getTotalInputSize());
+			
+		} catch (Exception ex) {
+			ex.printStackTrace();
+			Assert.fail(ex.getMessage());
+		}
+	}
+	
+	@Test
+	public void testGetStatisticsMultipleFilesMultiplePathsWithCachedVersion() {
+		try {
+			final long SIZE1 = 2077;
+			final long SIZE2 = 31909;
+			final long SIZE3 = 10;
+
+			final long SIZE4 = 2177;
+			final long SIZE5 = 33909;
+			final long SIZE6 = 18;
+
+			final long TOTAL = SIZE1 + SIZE2 + SIZE3 + SIZE4 + SIZE5 + SIZE6;
+			final long FAKE_SIZE = 10065;
+			
+			String tempDir = TestFileUtils.createTempFileDir(SIZE1, SIZE2, SIZE3);
+			String tempDir2 = TestFileUtils.createTempFileDir(SIZE4, SIZE5, SIZE6);
+			
+			DummyFileInputFormat format = new DummyFileInputFormat();
+			format.setFilePaths(tempDir, tempDir2);
+			format.configure(new Configuration());
+			
+			FileBaseStatistics stats = format.getStatistics(null);
+			Assert.assertEquals("The file size from the statistics is wrong.", TOTAL, stats.getTotalInputSize());
+			
+			format = new DummyFileInputFormat();
+			format.setFilePaths(tempDir, tempDir2);
+			format.configure(new Configuration());
+			
+			FileBaseStatistics newStats = format.getStatistics(stats);
+			Assert.assertTrue("Statistics object was changed", newStats == stats);
+
+			// insert fake stats with the correct modification time. the call should return the fake stats
+			format = new DummyFileInputFormat();
+			format.setFilePaths(tempDir, tempDir2);
+			format.configure(new Configuration());
+			
+			FileBaseStatistics fakeStats = new FileBaseStatistics(stats.getLastModificationTime(), FAKE_SIZE, BaseStatistics.AVG_RECORD_BYTES_UNKNOWN);
+			BaseStatistics latest = format.getStatistics(fakeStats);
+			Assert.assertEquals("The file size from the statistics is wrong.", FAKE_SIZE, latest.getTotalInputSize());
+			
+			// insert fake stats with the correct modification time. the call should return the fake stats
+			format = new DummyFileInputFormat();
+			format.setFilePaths(tempDir, tempDir2);
+			format.configure(new Configuration());
+			
+			FileBaseStatistics outDatedFakeStats = new FileBaseStatistics(stats.getLastModificationTime()-1, FAKE_SIZE, BaseStatistics.AVG_RECORD_BYTES_UNKNOWN);
+			BaseStatistics reGathered = format.getStatistics(outDatedFakeStats);
+			Assert.assertEquals("The file size from the statistics is wrong.", TOTAL, reGathered.getTotalInputSize());
+			
+		} catch (Exception ex) {
+			ex.printStackTrace();
+			Assert.fail(ex.getMessage());
+		}
+	}
 	// ------------------------------------------------------------------------
 	//  Unsplittable input files
 	// ------------------------------------------------------------------------
@@ -451,7 +745,7 @@ public class FileInputFormatTest {
 
 	private class DummyFileInputFormat extends FileInputFormat<IntValue> {
 		private static final long serialVersionUID = 1L;
-
+		
 		@Override
 		public boolean reachedEnd() throws IOException {
 			return true;

--- a/flink-core/src/test/java/org/apache/flink/api/common/io/FileInputFormatTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/io/FileInputFormatTest.java
@@ -107,9 +107,23 @@ public class FileInputFormatTest {
 		format.setFilePath("/some/imaginary/path");
 		Assert.assertEquals(format.getFilePath().toString(), "/some/imaginary/path");
 	}
-	
+
 	@Test
-	public void testSetPathsSingle() {
+	public void testSetPathOnMulti() {
+		final MultiDummyFileInputFormat format = new MultiDummyFileInputFormat();
+		final String myPath = "/an/imaginary/path";
+		format.setFilePath(myPath);
+		final Path[] filePaths = format.getFilePaths();
+
+		Assert.assertEquals(1, filePaths.length);
+		Assert.assertEquals(myPath, filePaths[0].toUri().toString());
+
+		// ensure backwards compatibility
+		Assert.assertEquals(myPath, format.filePath.toUri().toString());
+	}
+
+	@Test
+	public void testSetPathsSingleWithMulti() {
 		final MultiDummyFileInputFormat format = new MultiDummyFileInputFormat();
 		final String myPath = "/an/imaginary/path";
 		format.setFilePaths(myPath);
@@ -117,6 +131,9 @@ public class FileInputFormatTest {
 
 		Assert.assertEquals(1, filePaths.length);
 		Assert.assertEquals(myPath, filePaths[0].toUri().toString());
+
+		// ensure backwards compatibility
+		Assert.assertEquals(myPath, format.filePath.toUri().toString());
 	}
 	
 	@Test
@@ -332,7 +349,7 @@ public class FileInputFormatTest {
 			format.setFilePath(tempFile);
 			format.configure(new Configuration());
 			
-			FileBaseStatistics outDatedFakeStats = new FileBaseStatistics(stats.getLastModificationTime()-1, FAKE_SIZE, BaseStatistics.AVG_RECORD_BYTES_UNKNOWN);
+			FileBaseStatistics outDatedFakeStats = new FileBaseStatistics(stats.getLastModificationTime() - 1, FAKE_SIZE, BaseStatistics.AVG_RECORD_BYTES_UNKNOWN);
 			BaseStatistics reGathered = format.getStatistics(outDatedFakeStats);
 			Assert.assertEquals("The file size from the statistics is wrong.", SIZE, reGathered.getTotalInputSize());
 			
@@ -381,7 +398,7 @@ public class FileInputFormatTest {
 			format.setFilePath(tempDir);
 			format.configure(new Configuration());
 			
-			FileBaseStatistics outDatedFakeStats = new FileBaseStatistics(stats.getLastModificationTime()-1, FAKE_SIZE, BaseStatistics.AVG_RECORD_BYTES_UNKNOWN);
+			FileBaseStatistics outDatedFakeStats = new FileBaseStatistics(stats.getLastModificationTime() - 1, FAKE_SIZE, BaseStatistics.AVG_RECORD_BYTES_UNKNOWN);
 			BaseStatistics reGathered = format.getStatistics(outDatedFakeStats);
 			Assert.assertEquals("The file size from the statistics is wrong.", TOTAL, reGathered.getTotalInputSize());
 			
@@ -447,7 +464,7 @@ public class FileInputFormatTest {
 	@Test
 	public void testGetStatisticsMultipleOneFileWithCachedVersion() throws IOException {
 		final long size1 = 50873;
-		final long cachedSize = 10065;
+		final long fakeSize = 10065;
 		String tempFile1 = TestFileUtils.createTempFile(size1);
 
 		final long size2 = 52573;
@@ -474,16 +491,16 @@ public class FileInputFormatTest {
 		format.setFilePath(tempFile1);
 		format.configure(new Configuration());
 		
-		FileBaseStatistics fakeStats = new FileBaseStatistics(stats.getLastModificationTime(), cachedSize, BaseStatistics.AVG_RECORD_BYTES_UNKNOWN);
+		FileBaseStatistics fakeStats = new FileBaseStatistics(stats.getLastModificationTime(), fakeSize, BaseStatistics.AVG_RECORD_BYTES_UNKNOWN);
 		BaseStatistics latest = format.getStatistics(fakeStats);
-		Assert.assertEquals("The file size from the statistics is wrong.", cachedSize, latest.getTotalInputSize());
+		Assert.assertEquals("The file size from the statistics is wrong.", fakeSize, latest.getTotalInputSize());
 		
 		// insert fake stats with the expired modification time. the call should return new accurate stats
 		format = new MultiDummyFileInputFormat();
 		format.setFilePaths(tempFile1, tempFile2);
 		format.configure(new Configuration());
 		
-		FileBaseStatistics outDatedFakeStats = new FileBaseStatistics(stats.getLastModificationTime()-1, cachedSize, BaseStatistics.AVG_RECORD_BYTES_UNKNOWN);
+		FileBaseStatistics outDatedFakeStats = new FileBaseStatistics(stats.getLastModificationTime() - 1, fakeSize, BaseStatistics.AVG_RECORD_BYTES_UNKNOWN);
 		BaseStatistics reGathered = format.getStatistics(outDatedFakeStats);
 		Assert.assertEquals("The file size from the statistics is wrong.", sizeTotal, reGathered.getTotalInputSize());
 	}

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroInputFormat.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroInputFormat.java
@@ -172,6 +172,11 @@ public class AvroInputFormat<E> extends FileInputFormat<E> implements ResultType
 		}
 	}
 
+	@Override
+	public boolean supportsMultiPaths() {
+		return true;
+	}
+
 	// --------------------------------------------------------------------------------------------
 	//  Checkpointing
 	// --------------------------------------------------------------------------------------------

--- a/flink-java/src/main/java/org/apache/flink/api/java/io/CsvInputFormat.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/io/CsvInputFormat.java
@@ -27,6 +27,7 @@ import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.StringUtils;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 /**
  * InputFormat that reads csv files.
@@ -157,7 +158,7 @@ public abstract class CsvInputFormat<OUT> extends GenericCsvInputFormat<OUT> {
 
 	@Override
 	public String toString() {
-		return "CSV Input (" + StringUtils.showControlCharacters(String.valueOf(getFieldDelimiter())) + ") " + getFilePath();
+		return "CSV Input (" + StringUtils.showControlCharacters(String.valueOf(getFieldDelimiter())) + ") " + Arrays.toString(getFilePaths());
 	}
 
 }

--- a/flink-java/src/main/java/org/apache/flink/api/java/io/TextInputFormat.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/io/TextInputFormat.java
@@ -101,4 +101,9 @@ public class TextInputFormat extends DelimitedInputFormat<String> {
 	public String toString() {
 		return "TextInputFormat (" + Arrays.toString(getFilePaths()) + ") - " + this.charsetName;
 	}
+
+	@Override
+	public boolean supportsMultiPaths() {
+		return true;
+	}
 }

--- a/flink-java/src/main/java/org/apache/flink/api/java/io/TextInputFormat.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/io/TextInputFormat.java
@@ -25,6 +25,7 @@ import org.apache.flink.core.fs.Path;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.util.Arrays;
 
 /**
  * Input Format that reads text files. Each line results in another element.
@@ -98,6 +99,6 @@ public class TextInputFormat extends DelimitedInputFormat<String> {
 
 	@Override
 	public String toString() {
-		return "TextInputFormat (" + getFilePath() + ") - " + this.charsetName;
+		return "TextInputFormat (" + Arrays.toString(getFilePaths()) + ") - " + this.charsetName;
 	}
 }

--- a/flink-java/src/main/java/org/apache/flink/api/java/io/TextValueInputFormat.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/io/TextValueInputFormat.java
@@ -134,6 +134,6 @@ public class TextValueInputFormat extends DelimitedInputFormat<StringValue> {
 
 	@Override
 	public String toString() {
-		return "TextValueInputFormat (" + getFilePath() + ") - " + this.charsetName + (this.skipInvalidLines ? "(skipping invalid lines)" : "");
+		return "TextValueInputFormat (" + Arrays.toString(getFilePaths()) + ") - " + this.charsetName + (this.skipInvalidLines ? "(skipping invalid lines)" : "");
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileMonitoringFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileMonitoringFunction.java
@@ -114,8 +114,12 @@ public class ContinuousFileMonitoringFunction<OUT>
 				"allowed one (" + MIN_MONITORING_INTERVAL + " ms)."
 		);
 
+		Preconditions.checkArgument(
+			format.getFilePaths().length == 1,
+			"FileInputFormats with multiple paths are not supported yet.");
+
 		this.format = Preconditions.checkNotNull(format, "Unspecified File Input Format.");
-		this.path = Preconditions.checkNotNull(format.getFilePath().toString(), "Unspecified Path.");
+		this.path = Preconditions.checkNotNull(format.getFilePaths()[0].toString(), "Unspecified Path.");
 
 		this.interval = interval;
 		this.watchType = watchType;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/ContinuousFileProcessingRescalingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/ContinuousFileProcessingRescalingTest.java
@@ -274,7 +274,7 @@ public class ContinuousFileProcessingRescalingTest {
 		public FileInputSplit[] createInputSplits(int minNumSplits) throws IOException {
 			FileInputSplit[] splits = new FileInputSplit[minNumSplits];
 			for (int i = 0; i < minNumSplits; i++) {
-				splits[i] = new FileInputSplit(i, getFilePath(), i * linesPerSplit + 1, linesPerSplit, null);
+				splits[i] = new FileInputSplit(i, getFilePaths()[0], i * linesPerSplit + 1, linesPerSplit, null);
 			}
 			return splits;
 		}


### PR DESCRIPTION
## What is the purpose of the change

* Add support to `FileInputFormat` to read from multiple paths. At the moment only a single path is supported that can be recursively read if the path is a directory.
* Maintain compatibility with existing input formats that extend `FileInputFormat`

This PR is an extension / rework of PR #1990.

## Brief change log

`FileInputFormat` is declared as `@Public` interface.

* deprecate the `protected` variable `FileInputFormat.filePath` of type `Path`. We need to store more than one path to support multiple paths.
* deprecate the method `FileInputFormat.getFilePath()`. We need to return a list of paths.
* add a private member variable to `FileInputFormat` to store multiple paths.
* add methods to set and get multiple paths.
* add a `deprecated` method `public boolean FileInputFormat.supportsMultiPaths()` with default implementation `return false;` that input formats can override if they support multiple paths. If the method returns `true`, the deprecated `filePath` variable is not used anymore and will always be `null`. 
* changed all public sub classes of `FileInputFormat` to not directly access the deprecated `filePath` variable but use the more generic `getFilePaths()` method.
* We cannot override `supportsMultiPaths` in `DelimitedInputFormat` and `BinaryInputFormat` because they are part of the public API and not final.

## Verifying this change

* added a couple of tests to validate that splits and statistics are correctly generated.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **YES**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **yes**
  - If yes, how is the feature documented? Only in JavaDocs so far.
