### PR TITLE
[FLINK-8565][tests] Ensure locationBytes.length > 0 in CheckpointOptionsTest

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointOptionsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointOptionsTest.java
@@ -48,7 +48,7 @@ public class CheckpointOptionsTest {
 	@Test
 	public void testSavepoint() throws Exception {
 		final Random rnd = new Random();
-		final byte[] locationBytes = new byte[rnd.nextInt(42)];
+		final byte[] locationBytes = new byte[rnd.nextInt(41) + 1];
 		rnd.nextBytes(locationBytes);
 
 		final CheckpointOptions options = new CheckpointOptions(


### PR DESCRIPTION
This PR fixes a test instability in `CheckpointOptionsTest#testSavepoint`. The tests generated a byte array of a random size, which may also be 0. This caused an `IllegalArgumentException` when being passed to the `CheckpointStorageLocationReference` constructor.

We now add 1 to the randomly picked size, and compensate this addition by reducing the upper bound by 1.