### PR TITLE
[FLINK-8574][travis] Add timestamp to logging messages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -120,6 +120,7 @@ before_install:
    - "rm apache-maven-3.2.5-bin.zip"
    - "export M2_HOME=$PWD/apache-maven-3.2.5"
    - "export PATH=$M2_HOME/bin:$PATH"
+   - "export MAVEN_OPTS=\"-Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss.SSS\""
 # just in case: clean up the .m2 home and remove invalid jar files
    - 'test ! -d $HOME/.m2/repository/ || find $HOME/.m2/repository/ -name "*.jar" -exec sh -c ''if ! zip -T {} >/dev/null ; then echo "deleting invalid file: {}"; rm {} ; fi'' \;'
 


### PR DESCRIPTION
With this PR logging statements on travis also include a timestamp( e.g. `09:00:27.972`). This allows us to better judge how long each part of build takes, in particular plugins.