### PR TITLE
[FLINK-8576][QS] Reduce verbosity when classes can't be found

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/query/QueryableStateUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/query/QueryableStateUtils.java
@@ -136,7 +136,7 @@ public final class QueryableStateUtils {
 		} catch (ClassNotFoundException e) {
 			final String msg = "Could not load Queryable State Server. " + ERROR_MESSAGE_ON_LOAD_FAILURE;
 			if (LOG.isDebugEnabled()) {
-				LOG.debug(msg, e);
+				LOG.debug(msg + " Cause: " + e.getMessage());
 			} else {
 				LOG.info(msg);
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/query/QueryableStateUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/query/QueryableStateUtils.java
@@ -36,6 +36,10 @@ public final class QueryableStateUtils {
 
 	private static final Logger LOG = LoggerFactory.getLogger(QueryableStateUtils.class);
 
+	private static final String ERROR_MESSAGE_ON_LOAD_FAILURE =
+		"Probable reason: flink-queryable-state-runtime is not in the classpath. " +
+		"To enable Queryable State, please move the flink-queryable-state-runtime jar from the opt to the lib folder.";
+
 	/**
 	 * Initializes the {@link KvStateClientProxy client proxy} responsible for
 	 * receiving requests from the external (to the cluster) client and forwarding them internally.
@@ -73,9 +77,7 @@ public final class QueryableStateUtils {
 					KvStateRequestStats.class);
 			return constructor.newInstance(address, ports, eventLoopThreads, queryThreads, stats);
 		} catch (ClassNotFoundException e) {
-			final String msg = "Could not load Queryable State Client Proxy. " +
-				"Probable reason: flink-queryable-state-runtime is not in the classpath. " +
-				"To enable Queryable State, please move the flink-queryable-state-runtime jar from the opt to the lib folder.";
+			final String msg = "Could not load Queryable State Client Proxy. " + ERROR_MESSAGE_ON_LOAD_FAILURE;
 			if (LOG.isDebugEnabled()) {
 				LOG.debug(msg + " Cause: " + e.getMessage());
 			} else {
@@ -132,9 +134,7 @@ public final class QueryableStateUtils {
 					KvStateRequestStats.class);
 			return constructor.newInstance(address, ports, eventLoopThreads, queryThreads, kvStateRegistry, stats);
 		} catch (ClassNotFoundException e) {
-			final String msg = "Could not load Queryable State Server. " +
-				"Probable reason: flink-queryable-state-runtime is not in the classpath. " +
-				"Please put the corresponding jar from the opt to the lib folder.";
+			final String msg = "Could not load Queryable State Server. " + ERROR_MESSAGE_ON_LOAD_FAILURE;
 			if (LOG.isDebugEnabled()) {
 				LOG.debug(msg, e);
 			} else {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/query/QueryableStateUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/query/QueryableStateUtils.java
@@ -75,9 +75,9 @@ public final class QueryableStateUtils {
 		} catch (ClassNotFoundException e) {
 			final String msg = "Could not load Queryable State Client Proxy. " +
 				"Probable reason: flink-queryable-state-runtime is not in the classpath. " +
-				"Please put the corresponding jar from the opt to the lib folder.";
+				"To enable Queryable State, please move the flink-queryable-state-runtime jar from the opt to the lib folder.";
 			if (LOG.isDebugEnabled()) {
-				LOG.debug(msg, e);
+				LOG.debug(msg + " Cause: " + e.getMessage());
 			} else {
 				LOG.info(msg);
 			}


### PR DESCRIPTION
This PR reduces the verbosity of DEBUG logging messages when the flink-queryable-state-runtime jar is not on the classpath. Instead of the full stacktrace we now only include the exception message.

I've also modified the message to explicitly mention that this jar is only needed if queryable state is to be used. The previous message made it sound as if this was a critical issue that has to be fixed.