### PR TITLE
[FLINK-8573] [client] Add more information for printing JobID for fai…

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
@@ -484,7 +484,8 @@ public abstract class ClusterClient<T> {
 
 			return lastJobExecutionResult;
 		} catch (JobExecutionException e) {
-			throw new ProgramInvocationException("The program execution failed: " + e.getMessage(), e);
+			throw new ProgramInvocationException("The program execution failed: " + e.getMessage() +
+				". The job ID: " + jobGraph.getJobID(), e);
 		}
 	}
 
@@ -516,7 +517,8 @@ public abstract class ClusterClient<T> {
 				classLoader);
 			return new JobSubmissionResult(jobGraph.getJobID());
 		} catch (JobExecutionException e) {
-			throw new ProgramInvocationException("The program execution failed: " + e.getMessage(), e);
+			throw new ProgramInvocationException("The program execution failed: " + e.getMessage() +
+				". The job ID: " + jobGraph.getJobID(), e);
 		}
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

*Print JobID for failed jobs*

## Brief change log

Add jobid information when job failed.


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: ( no)
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? (  no)
  - If yes, how is the feature documented? ( not documented)
