### PR TITLE
[FLINK-8575][runtime] BackPressureStatsTrackerITCase unstable

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/backpressure/BackPressureStatsTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/backpressure/BackPressureStatsTracker.java
@@ -155,11 +155,13 @@ public class BackPressureStatsTracker {
 	 * @return Back pressure statistics for an operator
 	 */
 	public Optional<OperatorBackPressureStats> getOperatorBackPressureStats(ExecutionJobVertex vertex) {
-		final OperatorBackPressureStats stats = operatorStatsCache.getIfPresent(vertex);
-		if (stats == null || backPressureStatsRefreshInterval <= System.currentTimeMillis() - stats.getEndTimestamp()) {
-			triggerStackTraceSampleInternal(vertex);
+		synchronized (lock) {
+			final OperatorBackPressureStats stats = operatorStatsCache.getIfPresent(vertex);
+			if (stats == null || backPressureStatsRefreshInterval <= System.currentTimeMillis() - stats.getEndTimestamp()) {
+				triggerStackTraceSampleInternal(vertex);
+			}
+			return Optional.ofNullable(stats);
 		}
-		return Optional.ofNullable(stats);
 	}
 
 	/**


### PR DESCRIPTION
## What is the purpose of the change

*This fixes BackPressureStatsTrackerITCase unstability.*


## Brief change log

  - *Add missing synchronization in BackPressureStatsTracker. Operations in method getOperatorBackPressureStats must appear atomic otherwise the stack trace can be sampled multiple times.*

## Verifying this change

This change is already covered by existing tests, such as *BackPressureStatsTrackerITCase*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
