### PR TITLE
[FLINK-8362] [elasticsearch] Shade all ES connector dependencies

### DIFF
--- a/docs/dev/connectors/elasticsearch.md
+++ b/docs/dev/connectors/elasticsearch.md
@@ -440,36 +440,7 @@ For the execution of your Flink program, it is recommended to build a
 so-called uber-jar (executable jar) containing all your dependencies
 (see [here]({{site.baseurl}}/dev/linking.html) for further information).
 
-However, when an uber-jar containing an Elasticsearch sink is executed,
-an `IllegalArgumentException` may occur, which is caused by conflicting
-files of Elasticsearch and it's dependencies in `META-INF/services`:
-
-```
-IllegalArgumentException[An SPI class of type org.apache.lucene.codecs.PostingsFormat with name 'Lucene50' does not exist.  You need to add the corresponding JAR file supporting this SPI to your classpath.  The current classpath supports the following names: [es090, completion090, XBloomFilter]]
-```
-
-If the uber-jar is built using Maven, this issue can be avoided by
-adding the following to the Maven POM file in the plugins section:
-
-~~~xml
-<plugin>
-    <groupId>org.apache.maven.plugins</groupId>
-    <artifactId>maven-shade-plugin</artifactId>
-    <version>2.4.3</version>
-    <executions>
-        <execution>
-            <phase>package</phase>
-            <goals>
-                <goal>shade</goal>
-            </goals>
-            <configuration>
-                <transformers>
-                    <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
-                </transformers>
-            </configuration>
-        </execution>
-    </executions>
-</plugin>
-~~~
+Alternatively, you can put the connector's jar file into Flink's `lib/` folder to make it available
+system-wide, i.e. for all job being run.
 
 {% top %}

--- a/flink-connectors/flink-connector-elasticsearch/pom.xml
+++ b/flink-connectors/flink-connector-elasticsearch/pom.xml
@@ -93,6 +93,106 @@ under the License.
 					<rerunFailingTestsCount>3</rerunFailingTestsCount>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>shade-flink</id>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<shadeTestJar>false</shadeTestJar>
+							<artifactSet>
+								<includes>
+									<include>*:*</include>
+								</includes>
+							</artifactSet>
+							<relocations>
+								<!-- elasticsearch 1.x already shades this but forgets the service file -->
+								<relocation>
+									<pattern>com.fasterxml.jackson</pattern>
+									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch.shaded.org.elasticsearch.common.jackson</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>com.spatial4j</pattern>
+									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch.shaded.com.spatial4j</shadedPattern>
+								</relocation>
+
+								<!-- relocate everything from the flink-connector-elasticsearch base project -->
+								<relocation>
+									<pattern>org.apache.flink.streaming.connectors.elasticsearch.</pattern>
+									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch.shaded.org.apache.flink.streaming.connectors.elasticsearch.</shadedPattern>
+									<excludes>
+										<!-- keep this project's classes as they are -->
+										<exclude>org.apache.flink.streaming.connectors.elasticsearch.Elasticsearch1ApiCallBridge</exclude>
+										<exclude>org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchSink</exclude>
+										<exclude>org.apache.flink.streaming.connectors.elasticsearch.IndexRequestBuilder</exclude>
+										<exclude>org.apache.flink.streaming.connectors.elasticsearch.IndexRequestBuilderWrapperFunction</exclude>
+									</excludes>
+								</relocation>
+								<relocation>
+									<pattern>org.apache</pattern>
+									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch.shaded.org.apache</shadedPattern>
+									<excludes>
+										<!-- keep flink classes as they are (exceptions as above) -->
+										<exclude>org.apache.flink.**</exclude>
+										<exclude>org.apache.log4j.**</exclude> <!-- provided -->
+									</excludes>
+								</relocation>
+
+								<relocation>
+									<pattern>org.antlr</pattern>
+									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch.shaded.org.antlr</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.elasticsearch</pattern>
+									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch.shaded.org.elasticsearch</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.joda</pattern>
+									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch.shaded.org.joda</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.tartarus</pattern>
+									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch.shaded.org.tartarus</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.yaml</pattern>
+									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch.shaded.org.yaml</shadedPattern>
+								</relocation>
+
+							</relocations>
+							<filters>
+								<filter>
+									<artifact>*</artifact>
+									<excludes>
+										<exclude>log4j.properties</exclude>
+										<exclude>config/favicon.ico</exclude>
+										<exclude>mozilla/**</exclude>
+										<exclude>META-INF/maven/com*/**</exclude>
+										<exclude>META-INF/maven/io*/**</exclude>
+										<exclude>META-INF/maven/joda*/**</exclude>
+										<exclude>META-INF/maven/net*/**</exclude>
+										<exclude>META-INF/maven/org.an*/**</exclude>
+										<exclude>META-INF/maven/org.apache.h*/**</exclude>
+										<exclude>META-INF/maven/org.apache.commons/**</exclude>
+										<exclude>META-INF/maven/org.apache.flink/flink-connector-elasticsearch-base*/**</exclude>
+										<exclude>META-INF/maven/org.apache.flink/force-shading/**</exclude>
+										<exclude>META-INF/maven/org.apache.logging*/**</exclude>
+										<exclude>META-INF/maven/org.e*/**</exclude>
+										<exclude>META-INF/maven/org.h*/**</exclude>
+										<exclude>META-INF/maven/org.j*/**</exclude>
+										<exclude>META-INF/maven/org.y*/**</exclude>
+									</excludes>
+								</filter>
+							</filters>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/flink-connectors/flink-connector-elasticsearch/pom.xml
+++ b/flink-connectors/flink-connector-elasticsearch/pom.xml
@@ -121,18 +121,6 @@ under the License.
 									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch.shaded.com.spatial4j</shadedPattern>
 								</relocation>
 
-								<!-- relocate everything from the flink-connector-elasticsearch base project -->
-								<relocation>
-									<pattern>org.apache.flink.streaming.connectors.elasticsearch.</pattern>
-									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch.shaded.org.apache.flink.streaming.connectors.elasticsearch.</shadedPattern>
-									<excludes>
-										<!-- keep this project's classes as they are -->
-										<exclude>org.apache.flink.streaming.connectors.elasticsearch.Elasticsearch1ApiCallBridge</exclude>
-										<exclude>org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchSink</exclude>
-										<exclude>org.apache.flink.streaming.connectors.elasticsearch.IndexRequestBuilder</exclude>
-										<exclude>org.apache.flink.streaming.connectors.elasticsearch.IndexRequestBuilderWrapperFunction</exclude>
-									</excludes>
-								</relocation>
 								<relocation>
 									<pattern>org.apache</pattern>
 									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch.shaded.org.apache</shadedPattern>
@@ -146,10 +134,6 @@ under the License.
 								<relocation>
 									<pattern>org.antlr</pattern>
 									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch.shaded.org.antlr</shadedPattern>
-								</relocation>
-								<relocation>
-									<pattern>org.elasticsearch</pattern>
-									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch.shaded.org.elasticsearch</shadedPattern>
 								</relocation>
 								<relocation>
 									<pattern>org.joda</pattern>
@@ -179,7 +163,6 @@ under the License.
 										<exclude>META-INF/maven/org.an*/**</exclude>
 										<exclude>META-INF/maven/org.apache.h*/**</exclude>
 										<exclude>META-INF/maven/org.apache.commons/**</exclude>
-										<exclude>META-INF/maven/org.apache.flink/flink-connector-elasticsearch-base*/**</exclude>
 										<exclude>META-INF/maven/org.apache.flink/force-shading/**</exclude>
 										<exclude>META-INF/maven/org.apache.logging*/**</exclude>
 										<exclude>META-INF/maven/org.e*/**</exclude>

--- a/flink-connectors/flink-connector-elasticsearch/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-connector-elasticsearch/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,57 @@
+This project includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+-------------------------------------------------------------
+
+This project bundles the following dependencies under
+the Apache Software License 2.0
+
+  - org.apache.lucene : lucene-core version 4.10.4
+  - org.apache.lucene : lucene-analyzers-common version 4.10.4
+  - org.apache.lucene : lucene-grouping version 4.10.4
+  - org.apache.lucene : lucene-highlighter version 4.10.4
+  - org.apache.lucene : lucene-join version 4.10.4
+  - org.apache.lucene : lucene-memory version 4.10.4
+  - org.apache.lucene : lucene-misc version 4.10.4
+  - org.apache.lucene : lucene-queries version 4.10.4
+  - org.apache.lucene : lucene-queryparser version 4.10.4
+  - org.apache.lucene : lucene-sandbox version 4.10.4
+  - org.apache.lucene : lucene-spatial version 4.10.4
+  - org.apache.lucene : lucene-suggest version 4.10.4
+  - com.spatial4j : spatial4j version 0.4.1
+
+===================================
+       Notice for Antlr
+===================================
+
+This project bundles antlr-runtime (v. 3.5) under the BSD 2-Clause License
+
+Copyright (c) 2010 Terence Parr
+
+-----------------------------------------------------------------------------
+** Beginning of "BSD 2-Clause License" text. **
+
+ Copyright (c) 2010 Terence Parr
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ THE POSSIBILITY OF SUCH DAMAGE.

--- a/flink-connectors/flink-connector-elasticsearch/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-connector-elasticsearch/src/main/resources/META-INF/NOTICE
@@ -19,6 +19,54 @@ the Apache Software License 2.0
   - org.apache.lucene : lucene-spatial version 4.10.4
   - org.apache.lucene : lucene-suggest version 4.10.4
   - com.spatial4j : spatial4j version 0.4.1
+  - org.joda : joda-convert (copied classes)
+
+===================================
+       Notice for Yaml
+===================================
+
+This project bundles yaml (v. 1.12) under the Creative Commons License (CC-BY 2.0).
+
+Original project website: http://www.yaml.de
+
+Copyright (c) 2005-2013, Dirk Jesse
+
+YAML under Creative Commons License (CC-BY 2.0)
+===============================================
+
+The YAML framework is published under the Creative Commons Attribution 2.0 License (CC-BY 2.0), which permits
+both private and commercial use (http://creativecommons.org/licenses/by/2.0/).
+
+Condition: For the free use of the YAML framework, a backlink to the YAML homepage (http://www.yaml.de) in a
+suitable place (e.g.: footer of the website or in the imprint) is required.
+
+===================================
+       Notice for Tartarus
+===================================
+
+This project bundles tartarus under the MIT License.
+
+Original source repository: https://github.com/sergiooramas/tartarus
+
+Copyright (c) 2017 Sergio Oramas and Oriol Nieto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 ===================================
        Notice for Antlr

--- a/flink-connectors/flink-connector-elasticsearch/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-connector-elasticsearch/src/main/resources/META-INF/NOTICE
@@ -20,8 +20,8 @@ the Apache Software License 2.0
   - org.apache.lucene : lucene-suggest version 4.10.4
   - com.spatial4j : spatial4j version 0.4.1
   - com.fasterxml.jackson.core : jackson-core version 2.5.3
-  - com.fasterxml.jackson.dataformat : jackson-dataformat-cbor version 2.5.3
-  - com.fasterxml.jackson.dataformat : jackson-dataformat-cbor version 2.5.3
+  - com.fasterxml.jackson.dataformat : jackson-dataformat-smile version 2.5.3
+  - com.fasterxml.jackson.dataformat : jackson-dataformat-yaml version 2.5.3
   - com.fasterxml.jackson.dataformat : jackson-dataformat-cbor version 2.5.3
   - org.joda : joda-convert (copied classes)
 

--- a/flink-connectors/flink-connector-elasticsearch/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-connector-elasticsearch/src/main/resources/META-INF/NOTICE
@@ -19,6 +19,10 @@ the Apache Software License 2.0
   - org.apache.lucene : lucene-spatial version 4.10.4
   - org.apache.lucene : lucene-suggest version 4.10.4
   - com.spatial4j : spatial4j version 0.4.1
+  - com.fasterxml.jackson.core : jackson-core version 2.5.3
+  - com.fasterxml.jackson.dataformat : jackson-dataformat-cbor version 2.5.3
+  - com.fasterxml.jackson.dataformat : jackson-dataformat-cbor version 2.5.3
+  - com.fasterxml.jackson.dataformat : jackson-dataformat-cbor version 2.5.3
   - org.joda : joda-convert (copied classes)
 
 ===================================

--- a/flink-connectors/flink-connector-elasticsearch2/pom.xml
+++ b/flink-connectors/flink-connector-elasticsearch2/pom.xml
@@ -91,4 +91,129 @@ under the License.
 
 	</dependencies>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>shade-flink</id>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<shadeTestJar>false</shadeTestJar>
+							<artifactSet>
+								<includes>
+									<include>*:*</include>
+								</includes>
+							</artifactSet>
+							<relocations>
+								<relocation>
+									<pattern>com.carrotsearch</pattern>
+									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch2.shaded.com.carrotsearch</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>com.fasterxml</pattern>
+									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch2.shaded.com.fasterxml</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>com.google</pattern>
+									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch2.shaded.com.google</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>com.ning</pattern>
+									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch2.shaded.com.ning</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>com.spatial4j</pattern>
+									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch2.shaded.com.spatial4j</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>com.tdunning</pattern>
+									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch2.shaded.com.tdunning</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>com.twitter</pattern>
+									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch2.shaded.com.twitter</shadedPattern>
+								</relocation>
+
+								<!-- relocate everything from the flink-connector-elasticsearch base project -->
+								<relocation>
+									<pattern>org.apache.flink.streaming.connectors.elasticsearch</pattern>
+									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch2.shaded.org.apache.flink.streaming.connectors.elasticsearch</shadedPattern>
+									<excludes>
+										<!-- keep this project's classes as they are -->
+										<exclude>org.apache.flink.streaming.connectors.elasticsearch2.**</exclude>
+									</excludes>
+								</relocation>
+								<relocation>
+									<pattern>org.apache</pattern>
+									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch2.shaded.org.apache</shadedPattern>
+									<excludes>
+										<!-- keep flink classes as they are (exceptions as above) -->
+										<exclude>org.apache.flink.**</exclude>
+										<exclude>org.apache.log4j.**</exclude> <!-- provided -->
+									</excludes>
+								</relocation>
+
+								<relocation>
+									<pattern>org.elasticsearch</pattern>
+									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch2.shaded.org.elasticsearch</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.jboss</pattern>
+									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch2.shaded.org.jboss</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.joda</pattern>
+									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch2.shaded.org.joda</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.HdrHistogram</pattern>
+									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch2.shaded.org.HdrHistogram</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.tartarus</pattern>
+									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch2.shaded.org.tartarus</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.yaml</pattern>
+									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch2.shaded.org.yaml</shadedPattern>
+								</relocation>
+
+							</relocations>
+							<filters>
+								<filter>
+									<artifact>*</artifact>
+									<excludes>
+										<exclude>log4j.properties</exclude>
+										<exclude>config/favicon.ico</exclude>
+										<exclude>mozilla/**</exclude>
+										<exclude>META-INF/maven/com*/**</exclude>
+										<exclude>META-INF/maven/io*/**</exclude>
+										<exclude>META-INF/maven/joda*/**</exclude>
+										<exclude>META-INF/maven/net*/**</exclude>
+										<exclude>META-INF/maven/org.an*/**</exclude>
+										<exclude>META-INF/maven/org.apache.h*/**</exclude>
+										<exclude>META-INF/maven/org.apache.commons/**</exclude>
+										<exclude>META-INF/maven/org.apache.flink/flink-connector-elasticsearch-base*/**</exclude>
+										<exclude>META-INF/maven/org.apache.flink/force-shading/**</exclude>
+										<exclude>META-INF/maven/org.apache.logging*/**</exclude>
+										<exclude>META-INF/maven/org.e*/**</exclude>
+										<exclude>META-INF/maven/org.h*/**</exclude>
+										<exclude>META-INF/maven/org.j*/**</exclude>
+										<exclude>META-INF/maven/org.y*/**</exclude>
+									</excludes>
+								</filter>
+							</filters>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
 </project>

--- a/flink-connectors/flink-connector-elasticsearch2/pom.xml
+++ b/flink-connectors/flink-connector-elasticsearch2/pom.xml
@@ -140,15 +140,6 @@ under the License.
 									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch2.shaded.com.twitter</shadedPattern>
 								</relocation>
 
-								<!-- relocate everything from the flink-connector-elasticsearch base project -->
-								<relocation>
-									<pattern>org.apache.flink.streaming.connectors.elasticsearch</pattern>
-									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch2.shaded.org.apache.flink.streaming.connectors.elasticsearch</shadedPattern>
-									<excludes>
-										<!-- keep this project's classes as they are -->
-										<exclude>org.apache.flink.streaming.connectors.elasticsearch2.**</exclude>
-									</excludes>
-								</relocation>
 								<relocation>
 									<pattern>org.apache</pattern>
 									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch2.shaded.org.apache</shadedPattern>
@@ -159,10 +150,6 @@ under the License.
 									</excludes>
 								</relocation>
 
-								<relocation>
-									<pattern>org.elasticsearch</pattern>
-									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch2.shaded.org.elasticsearch</shadedPattern>
-								</relocation>
 								<relocation>
 									<pattern>org.jboss</pattern>
 									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch2.shaded.org.jboss</shadedPattern>
@@ -199,7 +186,6 @@ under the License.
 										<exclude>META-INF/maven/org.an*/**</exclude>
 										<exclude>META-INF/maven/org.apache.h*/**</exclude>
 										<exclude>META-INF/maven/org.apache.commons/**</exclude>
-										<exclude>META-INF/maven/org.apache.flink/flink-connector-elasticsearch-base*/**</exclude>
 										<exclude>META-INF/maven/org.apache.flink/force-shading/**</exclude>
 										<exclude>META-INF/maven/org.apache.logging*/**</exclude>
 										<exclude>META-INF/maven/org.e*/**</exclude>

--- a/flink-connectors/flink-connector-elasticsearch2/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-connector-elasticsearch2/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,86 @@
+This project includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+-------------------------------------------------------------
+
+This project bundles the following dependencies under
+the Apache Software License 2.0
+
+  - org.apache.lucene : lucene-core version 5.5.0
+  - org.apache.lucene : lucene-analyzers-common version 5.5.0
+  - org.apache.lucene : lucene-backward-codecs version 5.5.0
+  - org.apache.lucene : lucene-grouping version 5.5.0
+  - org.apache.lucene : lucene-highlighter version 5.5.0
+  - org.apache.lucene : lucene-join version 5.5.0
+  - org.apache.lucene : lucene-memory version 5.5.0
+  - org.apache.lucene : lucene-misc version 5.5.0
+  - org.apache.lucene : lucene-queries version 5.5.0
+  - org.apache.lucene : lucene-queryparser version 5.5.0
+  - org.apache.lucene : lucene-sandbox version 5.5.0
+  - org.apache.lucene : lucene-spatial version 5.5.0
+  - org.apache.lucene : lucene-spatial-extras version 5.5.0
+  - org.apache.lucene : lucene-spatial3d version 5.5.0
+  - org.apache.lucene : lucene-suggest version 5.5.0
+  - com.carrotsearch : hppc version 0.7.1
+  - com.google.guava : guava version 18.0
+  - com.google.code.findbugs : jsr305 version 1.3.9
+  - com.ning : compress-lzf version 1.0.2
+  - com.spatial4j : spatial4j version 0.5
+  - com.twitter : chill-java version 0.7.4
+  - com.fasterxml.jackson.core : jackson-core version 2.6.6
+  - com.fasterxml.jackson.dataformat : jackson-dataformat-cbor version 2.6.6
+  - com.fasterxml.jackson.dataformat : jackson-dataformat-cbor version 2.6.6
+  - com.fasterxml.jackson.dataformat : jackson-dataformat-cbor version 2.6.6
+  - com.tdunning : t-digest version 3.0
+  - io.netty : netty version 3.10.5.Final
+  - joda-time : joda-time version 2.5
+
+===================================
+       Notice for HdrHistogram
+===================================
+
+This project bundles HdrHistogram (v. 2.1.9) under the BSD 2-Clause License
+
+Original source repository: https://github.com/HdrHistogram/HdrHistogram
+
+The code in this repository code was Written by Gil Tene, Michael Barker,
+and Matt Warren, and released to the public domain, as explained at
+http://creativecommons.org/publicdomain/zero/1.0/
+
+For users of this code who wish to consume it under the "BSD" license
+rather than under the public domain or CC0 contribution text mentioned
+above, the code found under this directory is *also* provided under the
+following license (commonly referred to as the BSD 2-Clause License). This
+license does not detract from the above stated release of the code into
+the public domain, and simply represents an additional license granted by
+the Author.
+
+-----------------------------------------------------------------------------
+** Beginning of "BSD 2-Clause License" text. **
+
+ Copyright (c) 2012, 2013, 2014, 2015, 2016 Gil Tene
+ Copyright (c) 2014 Michael Barker
+ Copyright (c) 2014 Matt Warren
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ THE POSSIBILITY OF SUCH DAMAGE.

--- a/flink-connectors/flink-connector-elasticsearch2/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-connector-elasticsearch2/src/main/resources/META-INF/NOTICE
@@ -36,6 +36,53 @@ the Apache Software License 2.0
   - joda-time : joda-time version 2.5
 
 ===================================
+       Notice for Yaml
+===================================
+
+This project bundles yaml (v. 1.15) under the Creative Commons License (CC-BY 2.0).
+
+Original project website: http://www.yaml.de
+
+Copyright (c) 2005-2013, Dirk Jesse
+
+YAML under Creative Commons License (CC-BY 2.0)
+===============================================
+
+The YAML framework is published under the Creative Commons Attribution 2.0 License (CC-BY 2.0), which permits
+both private and commercial use (http://creativecommons.org/licenses/by/2.0/).
+
+Condition: For the free use of the YAML framework, a backlink to the YAML homepage (http://www.yaml.de) in a
+suitable place (e.g.: footer of the website or in the imprint) is required.
+
+===================================
+       Notice for Tartarus
+===================================
+
+This project bundles tartarus under the MIT License.
+
+Original source repository: https://github.com/sergiooramas/tartarus
+
+Copyright (c) 2017 Sergio Oramas and Oriol Nieto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+===================================
        Notice for HdrHistogram
 ===================================
 

--- a/flink-connectors/flink-connector-elasticsearch2/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-connector-elasticsearch2/src/main/resources/META-INF/NOTICE
@@ -28,8 +28,8 @@ the Apache Software License 2.0
   - com.spatial4j : spatial4j version 0.5
   - com.twitter : chill-java version 0.7.4
   - com.fasterxml.jackson.core : jackson-core version 2.6.6
-  - com.fasterxml.jackson.dataformat : jackson-dataformat-cbor version 2.6.6
-  - com.fasterxml.jackson.dataformat : jackson-dataformat-cbor version 2.6.6
+  - com.fasterxml.jackson.dataformat : jackson-dataformat-smile version 2.6.6
+  - com.fasterxml.jackson.dataformat : jackson-dataformat-yaml version 2.6.6
   - com.fasterxml.jackson.dataformat : jackson-dataformat-cbor version 2.6.6
   - com.tdunning : t-digest version 3.0
   - io.netty : netty version 3.10.5.Final

--- a/flink-connectors/flink-connector-elasticsearch5/pom.xml
+++ b/flink-connectors/flink-connector-elasticsearch5/pom.xml
@@ -225,6 +225,10 @@ under the License.
 									<pattern>org.yaml</pattern>
 									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch5.shaded.org.yaml</shadedPattern>
 								</relocation>
+								<relocation>
+									<pattern>joptsimple</pattern>
+									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch5.shaded.joptsimple</shadedPattern>
+								</relocation>
 							</relocations>
 							<filters>
 								<filter>

--- a/flink-connectors/flink-connector-elasticsearch5/pom.xml
+++ b/flink-connectors/flink-connector-elasticsearch5/pom.xml
@@ -124,7 +124,6 @@ under the License.
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
 			<version>2.7</version>
-			<scope>test</scope>
 		</dependency>
 
 		<dependency>
@@ -208,15 +207,6 @@ under the License.
 									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch5.shaded.joptsimple</shadedPattern>
 								</relocation>
 
-								<!-- relocate everything from the flink-connector-elasticsearch base project -->
-								<relocation>
-									<pattern>org.apache.flink.streaming.connectors.elasticsearch</pattern>
-									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch5.shaded.org.apache.flink.streaming.connectors.elasticsearch</shadedPattern>
-									<excludes>
-										<!-- keep this project's classes as they are -->
-										<exclude>org.apache.flink.streaming.connectors.elasticsearch5.**</exclude>
-									</excludes>
-								</relocation>
 								<relocation>
 									<pattern>org.apache</pattern>
 									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch5.shaded.org.apache</shadedPattern>
@@ -227,10 +217,6 @@ under the License.
 									</excludes>
 								</relocation>
 
-								<relocation>
-									<pattern>org.elasticsearch</pattern>
-									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch5.shaded.org.elasticsearch</shadedPattern>
-								</relocation>
 								<relocation>
 									<pattern>org.HdrHistogram</pattern>
 									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch5.shaded.org.HdrHistogram</shadedPattern>
@@ -267,13 +253,23 @@ under the License.
 										<exclude>META-INF/maven/org.an*/**</exclude>
 										<exclude>META-INF/maven/org.apache.h*/**</exclude>
 										<exclude>META-INF/maven/org.apache.commons/**</exclude>
-										<exclude>META-INF/maven/org.apache.flink/flink-connector-elasticsearch-base*/**</exclude>
 										<exclude>META-INF/maven/org.apache.flink/force-shading/**</exclude>
 										<exclude>META-INF/maven/org.apache.logging*/**</exclude>
 										<exclude>META-INF/maven/org.e*/**</exclude>
 										<exclude>META-INF/maven/org.h*/**</exclude>
 										<exclude>META-INF/maven/org.j*/**</exclude>
 										<exclude>META-INF/maven/org.y*/**</exclude>
+									</excludes>
+								</filter>
+								<!--
+								  Since we relocate the dependency, the paths specified in the providers file
+								  will be incorrect. We exclude it here, and re-package a new providers file
+								  with the correct re-located paths.
+								-->
+								<filter>
+									<artifact>org.apache.logging.log4j:log4j-to-slf4j</artifact>
+									<excludes>
+										<exclude>META-INF/log4j-provider.properties</exclude>
 									</excludes>
 								</filter>
 							</filters>

--- a/flink-connectors/flink-connector-elasticsearch5/pom.xml
+++ b/flink-connectors/flink-connector-elasticsearch5/pom.xml
@@ -189,24 +189,13 @@ under the License.
 									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch5.shaded.com.sun</shadedPattern>
 								</relocation>
 								<relocation>
-									<pattern>com.github</pattern>
-									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch5.shaded.com.github</shadedPattern>
-								</relocation>
-								<relocation>
 									<pattern>com.tdunning</pattern>
 									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch5.shaded.com.tdunning</shadedPattern>
 								</relocation>
-
 								<relocation>
 									<pattern>io.netty</pattern>
 									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch5.shaded.io.netty</shadedPattern>
 								</relocation>
-
-								<relocation>
-									<pattern>joptsimple</pattern>
-									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch5.shaded.joptsimple</shadedPattern>
-								</relocation>
-
 								<relocation>
 									<pattern>org.apache</pattern>
 									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch5.shaded.org.apache</shadedPattern>
@@ -216,7 +205,6 @@ under the License.
 										<exclude>org.apache.log4j.**</exclude> <!-- provided -->
 									</excludes>
 								</relocation>
-
 								<relocation>
 									<pattern>org.HdrHistogram</pattern>
 									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch5.shaded.org.HdrHistogram</shadedPattern>
@@ -237,7 +225,6 @@ under the License.
 									<pattern>org.yaml</pattern>
 									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch5.shaded.org.yaml</shadedPattern>
 								</relocation>
-
 							</relocations>
 							<filters>
 								<filter>

--- a/flink-connectors/flink-connector-elasticsearch5/pom.xml
+++ b/flink-connectors/flink-connector-elasticsearch5/pom.xml
@@ -155,6 +155,132 @@ under the License.
 					</classpathDependencyExcludes>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>shade-flink</id>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<shadeTestJar>false</shadeTestJar>
+							<artifactSet>
+								<includes>
+									<include>*:*</include>
+								</includes>
+							</artifactSet>
+							<relocations>
+								<relocation>
+									<pattern>com.carrotsearch</pattern>
+									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch5.shaded.com.carrotsearch</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>com.fasterxml</pattern>
+									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch5.shaded.com.fasterxml</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>com.github</pattern>
+									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch5.shaded.com.github</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>com.sun</pattern>
+									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch5.shaded.com.sun</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>com.github</pattern>
+									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch5.shaded.com.github</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>com.tdunning</pattern>
+									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch5.shaded.com.tdunning</shadedPattern>
+								</relocation>
+
+								<relocation>
+									<pattern>io.netty</pattern>
+									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch5.shaded.io.netty</shadedPattern>
+								</relocation>
+
+								<relocation>
+									<pattern>joptsimple</pattern>
+									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch5.shaded.joptsimple</shadedPattern>
+								</relocation>
+
+								<!-- relocate everything from the flink-connector-elasticsearch base project -->
+								<relocation>
+									<pattern>org.apache.flink.streaming.connectors.elasticsearch</pattern>
+									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch5.shaded.org.apache.flink.streaming.connectors.elasticsearch</shadedPattern>
+									<excludes>
+										<!-- keep this project's classes as they are -->
+										<exclude>org.apache.flink.streaming.connectors.elasticsearch5.**</exclude>
+									</excludes>
+								</relocation>
+								<relocation>
+									<pattern>org.apache</pattern>
+									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch5.shaded.org.apache</shadedPattern>
+									<excludes>
+										<!-- keep flink classes as they are (exceptions as above) -->
+										<exclude>org.apache.flink.**</exclude>
+										<exclude>org.apache.log4j.**</exclude> <!-- provided -->
+									</excludes>
+								</relocation>
+
+								<relocation>
+									<pattern>org.elasticsearch</pattern>
+									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch5.shaded.org.elasticsearch</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.HdrHistogram</pattern>
+									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch5.shaded.org.HdrHistogram</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.jboss</pattern>
+									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch5.shaded.org.jboss</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.joda</pattern>
+									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch5.shaded.org.joda</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.tartarus</pattern>
+									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch5.shaded.org.tartarus</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.yaml</pattern>
+									<shadedPattern>org.apache.flink.streaming.connectors.elasticsearch5.shaded.org.yaml</shadedPattern>
+								</relocation>
+
+							</relocations>
+							<filters>
+								<filter>
+									<artifact>*</artifact>
+									<excludes>
+										<exclude>log4j.properties</exclude>
+										<exclude>config/favicon.ico</exclude>
+										<exclude>mozilla/**</exclude>
+										<exclude>META-INF/maven/com*/**</exclude>
+										<exclude>META-INF/maven/io*/**</exclude>
+										<exclude>META-INF/maven/joda*/**</exclude>
+										<exclude>META-INF/maven/net*/**</exclude>
+										<exclude>META-INF/maven/org.an*/**</exclude>
+										<exclude>META-INF/maven/org.apache.h*/**</exclude>
+										<exclude>META-INF/maven/org.apache.commons/**</exclude>
+										<exclude>META-INF/maven/org.apache.flink/flink-connector-elasticsearch-base*/**</exclude>
+										<exclude>META-INF/maven/org.apache.flink/force-shading/**</exclude>
+										<exclude>META-INF/maven/org.apache.logging*/**</exclude>
+										<exclude>META-INF/maven/org.e*/**</exclude>
+										<exclude>META-INF/maven/org.h*/**</exclude>
+										<exclude>META-INF/maven/org.j*/**</exclude>
+										<exclude>META-INF/maven/org.y*/**</exclude>
+									</excludes>
+								</filter>
+							</filters>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/flink-connectors/flink-connector-elasticsearch5/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-connector-elasticsearch5/src/main/resources/META-INF/NOTICE
@@ -44,6 +44,53 @@ the Apache Software License 2.0
   - com.github.spullara.mustache.java : compiler version 0.9.3
 
 ===================================
+       Notice for Yaml
+===================================
+
+This project bundles yaml (v. 1.15) under the Creative Commons License (CC-BY 2.0).
+
+Original project website: http://www.yaml.de
+
+Copyright (c) 2005-2013, Dirk Jesse
+
+YAML under Creative Commons License (CC-BY 2.0)
+===============================================
+
+The YAML framework is published under the Creative Commons Attribution 2.0 License (CC-BY 2.0), which permits
+both private and commercial use (http://creativecommons.org/licenses/by/2.0/).
+
+Condition: For the free use of the YAML framework, a backlink to the YAML homepage (http://www.yaml.de) in a
+suitable place (e.g.: footer of the website or in the imprint) is required.
+
+===================================
+       Notice for Tartarus
+===================================
+
+This project bundles tartarus under the MIT License.
+
+Original source repository: https://github.com/sergiooramas/tartarus
+
+Copyright (c) 2017 Sergio Oramas and Oriol Nieto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+===================================
        Notice for scopt
 ===================================
 

--- a/flink-connectors/flink-connector-elasticsearch5/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-connector-elasticsearch5/src/main/resources/META-INF/NOTICE
@@ -91,6 +91,35 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ===================================
+       Notice for joptsimple
+===================================
+
+This project bundles joptsimple under the MIT License.
+
+Original source repository: https://github.com/jopt-simple/jopt-simple
+
+Copyright (c) 2004-2016 Paul R. Holser, Jr.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+===================================
        Notice for scopt
 ===================================
 

--- a/flink-connectors/flink-connector-elasticsearch5/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-connector-elasticsearch5/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,125 @@
+This project includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+-------------------------------------------------------------
+
+This project bundles the following dependencies under
+the Apache Software License 2.0
+
+  - org.apache.lucene : lucene-core version 6.3.0
+  - org.apache.lucene : lucene-analyzers-common version 6.3.0
+  - org.apache.lucene : lucene-backward-codecs version 6.3.0
+  - org.apache.lucene : lucene-grouping version 6.3.0
+  - org.apache.lucene : lucene-highlighter version 6.3.0
+  - org.apache.lucene : lucene-join version 6.3.0
+  - org.apache.lucene : lucene-memory version 6.3.0
+  - org.apache.lucene : lucene-misc version 6.3.0
+  - org.apache.lucene : lucene-queries version 6.3.0
+  - org.apache.lucene : lucene-queryparser version 6.3.0
+  - org.apache.lucene : lucene-sandbox version 6.3.0
+  - org.apache.lucene : lucene-spatial version 6.3.0
+  - org.apache.lucene : lucene-spatial-extras version 6.3.0
+  - org.apache.lucene : lucene-spatial3d version 6.3.0
+  - org.apache.lucene : lucene-suggest version 6.3.0
+  - org.apache.httpcomponents : httpclient version 4.5.3
+  - org.apache.httpcomponents : httpcore version 4.4.6
+  - org.apache.httpcomponents : httpasynclcient version 4.1.2
+  - org.apache.httpcomponents : httpcore-nio version 4.4.5
+  - com.carrotsearch : hppc version 0.7.1
+  - com.fasterxml.jackson.core : jackson-core version 2.8.1
+  - com.fasterxml.jackson.dataformat : jackson-dataformat-cbor version 2.8.1
+  - com.fasterxml.jackson.dataformat : jackson-dataformat-cbor version 2.8.1
+  - com.fasterxml.jackson.dataformat : jackson-dataformat-cbor version 2.8.1
+  - com.tdunning : t-digest version 3.0
+  - io.netty : netty version 3.10.6.Final
+  - io.netty : netty-buffer version 4.1.6.Final
+  - io.netty : netty-codec version 4.1.6.Final
+  - io.netty : netty-codec-http version 4.1.6.Final
+  - io.netty : netty-common version 4.1.6.Final
+  - io.netty : netty-handler version 4.1.6.Final
+  - io.netty : netty-resolver version 4.1.6.Final
+  - io.netty : netty-transport version 4.1.6.Final
+  - org.jboss.netty : netty version 3.2.0.Final
+  - joda-time : joda-time version 2.5
+  - com.github.spullara.mustache.java : compiler version 0.9.3
+
+===================================
+       Notice for scopt
+===================================
+
+This project bundles scopt (v. 3.5.0) underr the MIT License.
+
+Original source repository: https://github.com/scopt/scopt
+
+scopt - Copyright (c) scopt contributors
+
+See source files for details.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+``Software''), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED ``AS IS'', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+===================================
+       Notice for HdrHistogram
+===================================
+
+This project bundles HdrHistogram (v. 2.1.9) under the BSD 2-Clause License
+
+Original source repository: https://github.com/HdrHistogram/HdrHistogram
+
+The code in this repository code was Written by Gil Tene, Michael Barker,
+and Matt Warren, and released to the public domain, as explained at
+http://creativecommons.org/publicdomain/zero/1.0/
+
+For users of this code who wish to consume it under the "BSD" license
+rather than under the public domain or CC0 contribution text mentioned
+above, the code found under this directory is *also* provided under the
+following license (commonly referred to as the BSD 2-Clause License). This
+license does not detract from the above stated release of the code into
+the public domain, and simply represents an additional license granted by
+the Author.
+
+-----------------------------------------------------------------------------
+** Beginning of "BSD 2-Clause License" text. **
+
+ Copyright (c) 2012, 2013, 2014, 2015, 2016 Gil Tene
+ Copyright (c) 2014 Michael Barker
+ Copyright (c) 2014 Matt Warren
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ THE POSSIBILITY OF SUCH DAMAGE.

--- a/flink-connectors/flink-connector-elasticsearch5/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-connector-elasticsearch5/src/main/resources/META-INF/NOTICE
@@ -27,8 +27,8 @@ the Apache Software License 2.0
   - org.apache.httpcomponents : httpcore-nio version 4.4.5
   - com.carrotsearch : hppc version 0.7.1
   - com.fasterxml.jackson.core : jackson-core version 2.8.1
-  - com.fasterxml.jackson.dataformat : jackson-dataformat-cbor version 2.8.1
-  - com.fasterxml.jackson.dataformat : jackson-dataformat-cbor version 2.8.1
+  - com.fasterxml.jackson.dataformat : jackson-dataformat-smile version 2.8.1
+  - com.fasterxml.jackson.dataformat : jackson-dataformat-yaml version 2.8.1
   - com.fasterxml.jackson.dataformat : jackson-dataformat-cbor version 2.8.1
   - com.tdunning : t-digest version 3.0
   - io.netty : netty version 3.10.6.Final

--- a/flink-connectors/flink-connector-elasticsearch5/src/main/resources/META-INF/log4j-provider.properties
+++ b/flink-connectors/flink-connector-elasticsearch5/src/main/resources/META-INF/log4j-provider.properties
@@ -1,0 +1,23 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the “License”); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an “AS IS” BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Since we relocate the log4j2-to-slf4j dependency,
+# we also re-package this provider file with the correct relocated paths
+# (the original provider file with the incorrect paths is excluded)
+
+LoggerContextFactory = org.apache.flink.streaming.connectors.elasticsearch5.shaded.org.apache.logging.slf4j.SLF4JLoggerContextFactory
+Log4jAPIVersion = 2.0.0
+FactoryPriority= 15
+ThreadContextMap = org.apache.flink.streaming.connectors.elasticsearch5.shaded.org.apache.logging.slf4j.MDCContextMap

--- a/tools/travis_mvn_watchdog.sh
+++ b/tools/travis_mvn_watchdog.sh
@@ -449,7 +449,7 @@ check_shaded_artifacts_connector_elasticsearch() {
 	VARIANT=$1
 	find flink-connectors/flink-connector-elasticsearch${VARIANT}/target/flink-connector-elasticsearch${VARIANT}*.jar ! -name "*-tests.jar" -exec jar tf {} \; > allClasses
 
-	UNSHADED_CLASSES=`cat allClasses | grep -v -e '^META-INF' -e '^assets' -e "^org/apache/flink/streaming/connectors/elasticsearch${VARIANT}/" | grep '\.class$'`
+	UNSHADED_CLASSES=`cat allClasses | grep -v -e '^META-INF' -e '^assets' -e "^org/apache/flink/streaming/connectors/elasticsearch${VARIANT}/" -e "^org/elasticsearch/" | grep '\.class$'`
 	if [ "$?" == "0" ]; then
 		echo "=============================================================================="
 		echo "Detected unshaded dependencies in flink-connector-elasticsearch${VARIANT}'s fat jar:"

--- a/tools/travis_mvn_watchdog.sh
+++ b/tools/travis_mvn_watchdog.sh
@@ -449,7 +449,7 @@ check_shaded_artifacts_connector_elasticsearch() {
 	VARIANT=$1
 	find flink-connectors/flink-connector-elasticsearch${VARIANT}/target/flink-connector-elasticsearch${VARIANT}*.jar ! -name "*-tests.jar" -exec jar tf {} \; > allClasses
 
-	UNSHADED_CLASSES=`cat allClasses | grep -v -e '^META-INF' -e '^assets' -e "^org/apache/flink/streaming/connectors/elasticsearch${VARIANT}/" -e "^org/elasticsearch/" | grep '\.class$'`
+	UNSHADED_CLASSES=`cat allClasses | grep -v -e '^META-INF' -e '^assets' -e "^org/apache/flink/streaming/connectors/elasticsearch/" -e "^org/apache/flink/streaming/connectors/elasticsearch${VARIANT}/" -e "^org/elasticsearch/" | grep '\.class$'`
 	if [ "$?" == "0" ]; then
 		echo "=============================================================================="
 		echo "Detected unshaded dependencies in flink-connector-elasticsearch${VARIANT}'s fat jar:"

--- a/tools/travis_mvn_watchdog.sh
+++ b/tools/travis_mvn_watchdog.sh
@@ -444,6 +444,32 @@ check_shaded_artifacts_s3_fs() {
 	return 0
 }
 
+# Check the elasticsearch connectors' fat jars for illegal or missing artifacts
+check_shaded_artifacts_connector_elasticsearch() {
+	VARIANT=$1
+	find flink-connectors/flink-connector-elasticsearch${VARIANT}/target/flink-connector-elasticsearch${VARIANT}*.jar ! -name "*-tests.jar" -exec jar tf {} \; > allClasses
+
+	UNSHADED_CLASSES=`cat allClasses | grep -v -e '^META-INF' -e '^assets' -e "^org/apache/flink/streaming/connectors/elasticsearch${VARIANT}/" | grep '\.class$'`
+	if [ "$?" == "0" ]; then
+		echo "=============================================================================="
+		echo "Detected unshaded dependencies in flink-connector-elasticsearch${VARIANT}'s fat jar:"
+		echo "${UNSHADED_CLASSES}"
+		echo "=============================================================================="
+		return 1
+	fi
+
+	UNSHADED_SERVICES=`cat allClasses | grep '^META-INF/services/' | grep -v -e '^META-INF/services/org\.apache\.flink\.core\.fs\.FileSystemFactory$' -e "^META-INF/services/org\.apache\.flink\.fs\.s3${VARIANT}\.shaded" -e '^META-INF/services/'`
+	if [ "$?" == "0" ]; then
+		echo "=============================================================================="
+		echo "Detected unshaded service files in flink-connector-elasticsearch${VARIANT}'s fat jar:"
+		echo "${UNSHADED_SERVICES}"
+		echo "=============================================================================="
+		return 1
+	fi
+
+	return 0
+}
+
 # =============================================================================
 # WATCHDOG
 # =============================================================================
@@ -523,6 +549,9 @@ case $TEST in
 			check_shaded_artifacts_s3_fs hadoop
 			EXIT_CODE=$(($EXIT_CODE+$?))
 			check_shaded_artifacts_s3_fs presto
+			check_shaded_artifacts_connector_elasticsearch ""
+			check_shaded_artifacts_connector_elasticsearch 2
+			check_shaded_artifacts_connector_elasticsearch 5
 			EXIT_CODE=$(($EXIT_CODE+$?))
 		else
 			echo "=============================================================================="


### PR DESCRIPTION
## What is the purpose of the change

This is an extended version of Nico's work in #5243.

This version additionally removes shading of the Elasticsearch connector base dependencies, as well as Elasticsearch itself.

It also fixes a Log4j2-to-SLF4j bridge adapter issue with Elasticsearch 5, which occurred because of the shading.

## Brief change log

- Remove shading of ES connector base + Elasticsearch dependencies
- Fix Log4j2-to-SLF4j shading to also include shading of log4j-core
- Add NOTICE files to all ES connector versions, stating all bundled dependencies and their licenses.

## Verifying this change

Manually verified.
All ES connectors work in the IDE, and in cluster jobs, without dependency clashes.
Elasticsearch logs are also correctly routed to TM logs.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
