### PR TITLE
[FLINK-8533] [checkpointing] Support MasterTriggerRestoreHook state reinitialization

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -321,6 +321,10 @@ public class CheckpointCoordinator {
 				periodicScheduling = false;
 				triggerRequestQueued = false;
 
+				// shut down the hooks
+				MasterHooks.close(masterHooks.values(), LOG);
+				masterHooks.clear();
+
 				// shut down the thread that handles the timeouts and pending triggers
 				timer.shutdownNow();
 
@@ -1008,6 +1012,11 @@ public class CheckpointCoordinator {
 			}
 
 			LOG.debug("Status of the shared state registry after restore: {}.", sharedStateRegistry);
+
+			// Instruct the master hooks to initialize their state (unconditionally)
+			LOG.debug("Initializing the master hooks.");
+			MasterTriggerRestoreHook.HookInitializationContext context = new MasterTriggerRestoreHook.HookInitializationContext() {};
+			MasterHooks.initializeState(masterHooks.values(), context, LOG);
 
 			// Restore from the latest checkpoint
 			CompletedCheckpoint latest = completedCheckpointStore.getLatestCheckpoint();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -1013,11 +1013,6 @@ public class CheckpointCoordinator {
 
 			LOG.debug("Status of the shared state registry after restore: {}.", sharedStateRegistry);
 
-			// Instruct the master hooks to initialize their state (unconditionally)
-			LOG.debug("Initializing the master hooks.");
-			MasterTriggerRestoreHook.HookInitializationContext context = new MasterTriggerRestoreHook.HookInitializationContext() {};
-			MasterHooks.initializeState(masterHooks.values(), context, LOG);
-
 			// Restore from the latest checkpoint
 			CompletedCheckpoint latest = completedCheckpointStore.getLatestCheckpoint();
 
@@ -1025,6 +1020,9 @@ public class CheckpointCoordinator {
 				if (errorIfNoCheckpoint) {
 					throw new IllegalStateException("No completed checkpoint available");
 				} else {
+					LOG.debug("Resetting the master hooks.");
+					MasterHooks.reset(masterHooks.values(), LOG);
+
 					return false;
 				}
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/MasterTriggerRestoreHook.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/MasterTriggerRestoreHook.java
@@ -64,6 +64,26 @@ public interface MasterTriggerRestoreHook<T> {
 	String getIdentifier();
 
 	/**
+	 * This method is called by the checkpoint coordinator to initialize the hook when
+	 * execution is started or restarted.  Hooks typically set up their state storing data structures in this method.
+	 *
+	 * @param context the context for initializing the hook
+	 * @throws Exception Exceptions encountered when calling the hook will cause execution to fail.
+	 */
+	default void initializeState(HookInitializationContext context) throws Exception {
+
+	}
+
+	/**
+	 * Tear-down method for the hook.
+	 *
+	 * @throws Exception Exceptions encountered when calling close will be logged.
+	 */
+	default void close() throws Exception {
+
+	}
+
+	/**
 	 * This method is called by the checkpoint coordinator prior when triggering a checkpoint, prior
 	 * to sending the "trigger checkpoint" messages to the source tasks.
 	 * 
@@ -137,5 +157,12 @@ public interface MasterTriggerRestoreHook<T> {
 		 * Instantiates the {@code MasterTriggerRestoreHook}.
 		 */
 		<V> MasterTriggerRestoreHook<V> create();
+	}
+
+	/**
+	 * The hook initialization context.
+	 */
+	interface HookInitializationContext {
+
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/hooks/MasterHooks.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/hooks/MasterHooks.java
@@ -51,25 +51,24 @@ public class MasterHooks {
 	// ------------------------------------------------------------------------
 
 	/**
-	 * Initializes the state of the master hooks.
+	 * Resets the master hooks.
 	 *
-	 * @param hooks The hooks to initialize
+	 * @param hooks The hooks to reset
 	 *
 	 * @throws FlinkException Thrown, if the hooks throw an exception.
 	 */
-	public static void initializeState(
+	public static void reset(
 		Collection<MasterTriggerRestoreHook<?>> hooks,
-		MasterTriggerRestoreHook.HookInitializationContext context,
 		final Logger log) throws FlinkException {
 
 		for (MasterTriggerRestoreHook<?> hook : hooks) {
 			final String id = hook.getIdentifier();
 			try {
-				hook.initializeState(context);
+				hook.reset();
 			}
 			catch (Throwable t) {
 				ExceptionUtils.rethrowIfFatalErrorOrOOM(t);
-				throw new FlinkException("Error while initializing checkpoint master hook '" + id + '\'', t);
+				throw new FlinkException("Error while resetting checkpoint master hook '" + id + '\'', t);
 			}
 		}
 	}
@@ -90,7 +89,7 @@ public class MasterHooks {
 				hook.close();
 			}
 			catch (Throwable t) {
-				log.warn("Failed to cleanly close a master hook (" + hook.getIdentifier() + ")", t);
+				log.warn("Failed to cleanly close a checkpoint master hook (" + hook.getIdentifier() + ")", t);
 			}
 		}
 	}
@@ -342,13 +341,13 @@ public class MasterHooks {
 		}
 
 		@Override
-		public void initializeState(HookInitializationContext context) throws Exception {
+		public void reset() throws Exception {
 			final Thread thread = Thread.currentThread();
 			final ClassLoader originalClassLoader = thread.getContextClassLoader();
 			thread.setContextClassLoader(userClassLoader);
 
 			try {
-				hook.initializeState(context);
+				hook.reset();
 			}
 			finally {
 				thread.setContextClassLoader(originalClassLoader);

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -1358,10 +1358,6 @@ class JobManager(
                   throw new SuppressRestartsException(e)
               }
             }
-            else {
-              // give the coordinator an opportunity to initialize master hooks
-              executionGraph.restoreLatestCheckpointedState(false, false)
-            }
 
             try {
               submittedJobGraphs.putJobGraph(new SubmittedJobGraph(jobGraph, jobInfo))

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -1358,6 +1358,10 @@ class JobManager(
                   throw new SuppressRestartsException(e)
               }
             }
+            else {
+              // give the coordinator an opportunity to initialize master hooks
+              executionGraph.restoreLatestCheckpointedState(false, false)
+            }
 
             try {
               submittedJobGraphs.putJobGraph(new SubmittedJobGraph(jobGraph, jobInfo))

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorMasterHooksTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorMasterHooksTest.java
@@ -24,15 +24,15 @@ import org.apache.flink.runtime.concurrent.Executors;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.messages.checkpoint.AcknowledgeCheckpoint;
 import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
-
 import org.apache.flink.runtime.state.testutils.TestCompletedCheckpointStorageLocation;
-import org.junit.Test;
 
+import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -118,6 +118,39 @@ public class CheckpointCoordinatorMasterHooksTest {
 			cc.addMasterHook(hook);
 			fail("expected an exception");
 		} catch (IllegalArgumentException ignored) {}
+	}
+
+	@Test
+	public void testHookStateInitialization() throws Exception {
+		final String id1 = "id1";
+		final String id2 = "id2";
+
+		final MasterTriggerRestoreHook<String> hook1 = mockGeneric(MasterTriggerRestoreHook.class);
+		when(hook1.getIdentifier()).thenReturn(id1);
+		final MasterTriggerRestoreHook<String> hook2 = mockGeneric(MasterTriggerRestoreHook.class);
+		when(hook2.getIdentifier()).thenReturn(id2);
+
+		// create the checkpoint coordinator
+		final JobID jid = new JobID();
+		final ExecutionAttemptID execId = new ExecutionAttemptID();
+		final ExecutionVertex ackVertex = mockExecutionVertex(execId);
+		final CheckpointCoordinator cc = instantiateCheckpointCoordinator(jid, ackVertex);
+
+		cc.addMasterHook(hook1);
+		cc.addMasterHook(hook2);
+
+		// initialize the hooks
+		cc.restoreLatestCheckpointedState(
+			Collections.<JobVertexID, ExecutionJobVertex>emptyMap(),
+			false,
+			false);
+		verify(hook1, times(1)).initializeState(any(MasterTriggerRestoreHook.HookInitializationContext.class));
+		verify(hook2, times(1)).initializeState(any(MasterTriggerRestoreHook.HookInitializationContext.class));
+
+		// shutdown
+		cc.shutdown(JobStatus.CANCELED);
+		verify(hook1, times(1)).close();
+		verify(hook2, times(1)).close();
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorMasterHooksTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorMasterHooksTest.java
@@ -121,7 +121,7 @@ public class CheckpointCoordinatorMasterHooksTest {
 	}
 
 	@Test
-	public void testHookStateInitialization() throws Exception {
+	public void testHookReset() throws Exception {
 		final String id1 = "id1";
 		final String id2 = "id2";
 
@@ -144,8 +144,8 @@ public class CheckpointCoordinatorMasterHooksTest {
 			Collections.<JobVertexID, ExecutionJobVertex>emptyMap(),
 			false,
 			false);
-		verify(hook1, times(1)).initializeState(any(MasterTriggerRestoreHook.HookInitializationContext.class));
-		verify(hook2, times(1)).initializeState(any(MasterTriggerRestoreHook.HookInitializationContext.class));
+		verify(hook1, times(1)).reset();
+		verify(hook2, times(1)).reset();
 
 		// shutdown
 		cc.shutdown(JobStatus.CANCELED);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/hooks/MasterHooksTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/hooks/MasterHooksTest.java
@@ -70,7 +70,12 @@ public class MasterHooksTest extends TestLogger {
 			}
 
 			@Override
-			public void initializeState(HookInitializationContext context) throws Exception {
+			public void reset() throws Exception {
+				assertEquals(userClassLoader, Thread.currentThread().getContextClassLoader());
+			}
+
+			@Override
+			public void close() throws Exception {
 				assertEquals(userClassLoader, Thread.currentThread().getContextClassLoader());
 			}
 
@@ -119,6 +124,11 @@ public class MasterHooksTest extends TestLogger {
 		// verify createCheckpointDataSerializer
 		wrapped.createCheckpointDataSerializer();
 		verify(hook, times(1)).createCheckpointDataSerializer();
+		assertEquals(originalClassLoader, thread.getContextClassLoader());
+
+		// verify close
+		wrapped.close();
+		verify(hook, times(1)).close();
 		assertEquals(originalClassLoader, thread.getContextClassLoader());
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/hooks/MasterHooksTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/hooks/MasterHooksTest.java
@@ -69,6 +69,11 @@ public class MasterHooksTest extends TestLogger {
 				return id;
 			}
 
+			@Override
+			public void initializeState(HookInitializationContext context) throws Exception {
+				assertEquals(userClassLoader, Thread.currentThread().getContextClassLoader());
+			}
+
 			@Nullable
 			@Override
 			public CompletableFuture<String> triggerCheckpoint(long checkpointId, long timestamp, Executor executor) throws Exception {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerStartupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerStartupTest.java
@@ -70,7 +70,9 @@ public class JobManagerStartupTest extends TestLogger {
 	@After
 	public void after() {
 		// Cleanup test directory
-		assertTrue(blobStorageDirectory.delete());
+		if (blobStorageDirectory != null) {
+			assertTrue(blobStorageDirectory.delete());
+		}
 	}
 
 	/**

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/graph/WithMasterCheckpointHookConfigTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/graph/WithMasterCheckpointHookConfigTest.java
@@ -116,6 +116,16 @@ public class WithMasterCheckpointHookConfigTest extends TestLogger {
 		}
 
 		@Override
+		public void initializeState(HookInitializationContext context) throws Exception {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void close() throws Exception {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
 		public CompletableFuture<String> triggerCheckpoint(long checkpointId, long timestamp, Executor executor) {
 			throw new UnsupportedOperationException();
 		}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/graph/WithMasterCheckpointHookConfigTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/graph/WithMasterCheckpointHookConfigTest.java
@@ -116,7 +116,7 @@ public class WithMasterCheckpointHookConfigTest extends TestLogger {
 		}
 
 		@Override
-		public void initializeState(HookInitializationContext context) throws Exception {
+		public void reset() throws Exception {
 			throw new UnsupportedOperationException();
 		}
 


### PR DESCRIPTION
Signed-off-by: Eron Wright <eronwright@gmail.com>

## What is the purpose of the change
Support MasterTriggerRestoreHook state re-initialization, to eliminate an edge case involving execution restarts where no checkpoint state is available.

## Brief change log
- extend `MasterTriggerRestoreHook` with `reset` method and with `close` method.
- invoke `reset` upon job restore, in the special case that no checkpoint data is available.

## Verifying this change
- Revised test: `CheckpointCoordinatorMasterHooksTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  **yes**
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **yes**
  - The S3 file system connector:  no

## Documentation
  - Does this pull request introduce a new feature?  no

