### PR TITLE
[FLINK-8617][TableAPI & SQL] Fix code generation bug while accessing …

### DIFF
--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/MapTypeTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/MapTypeTest.scala
@@ -196,6 +196,34 @@ class MapTypeTest extends MapTypeTestBase {
       "f3.cardinality()",
       "CARDINALITY(f3)",
       "2")
+
+    testAllApis(
+      'f2.at("a") isNotNull,
+      "f2.at('a').isNotNull",
+      "f2['a'] IS NOT NULL",
+      "true"
+    )
+
+    testAllApis(
+      'f2.at("a") isNull,
+      "f2.at('a').isNull",
+      "f2['a'] IS NULL",
+      "false"
+    )
+
+    testAllApis(
+      'f2.at("c") isNotNull,
+      "f2.at('c').isNotNull",
+      "f2['c'] IS NOT NULL",
+      "false"
+    )
+
+    testAllApis(
+      'f2.at("c") isNull,
+      "f2.at('c').isNull",
+      "f2['c'] IS NULL",
+      "true"
+    )
   }
 
   @Test

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/batch/table/CalcITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/batch/table/CalcITCase.scala
@@ -479,9 +479,14 @@ class CalcITCase(
 
     val table = env.fromElements(rowValue).toTable(tEnv, 'a, 'b, 'c)
 
-    val result = table.select(row('a, 'b, 'c), array(12, 'b), map('a, 'c))
+    val result = table.select(
+      row('a, 'b, 'c),
+      array(12, 'b),
+      map('a, 'c),
+      map('a, 'c).at('a) === 'c
+    )
 
-    val expected = "foo,12,1984-07-12 14:34:24.0,[12, 12],{foo=1984-07-12 14:34:24.0}"
+    val expected = "foo,12,1984-07-12 14:34:24.0,[12, 12],{foo=1984-07-12 14:34:24.0},true"
     val results = result.toDataSet[Row].collect()
     TestBaseUtils.compareResultAsText(results.asJava, expected)
 


### PR DESCRIPTION
## What is the purpose of the change
fix code generation error in MapGet


## Brief change log
handle nullTerm of MapGet GeneratedExpression correctly.
fix bug that map(a, b).at(a) = b will result into code generation bug if map's value type is ```SqlTimeTypeInfo``` 

## Verifying this change

*(Please pick either of the following options)*

This change added tests and can be verified as follows:

```
org.apache.flink.table.expressions.MapTypeTest
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): 
     no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: 
     no
  - The serializers: 
     no
  - The runtime per-record code paths (performance sensitive): 
     no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper:
     no
  - The S3 file system connector:  
     no

## Documentation

  - Does this pull request introduce a new feature? 
     no
