### PR TITLE
[FLINK-6160] [flip-6] Retry JobManager/ResourceManager connection in …

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerImpl.java
@@ -125,7 +125,8 @@ public class HeartbeatManagerImpl<I, O> implements HeartbeatManager<I, O> {
 					heartbeatTarget,
 					scheduledExecutor,
 					heartbeatListener,
-					heartbeatTimeoutIntervalMs);
+					heartbeatTimeoutIntervalMs,
+					this);
 
 				heartbeatTargets.put(
 					resourceID,
@@ -182,7 +183,7 @@ public class HeartbeatManagerImpl<I, O> implements HeartbeatManager<I, O> {
 	public void receiveHeartbeat(ResourceID heartbeatOrigin, I heartbeatPayload) {
 		if (!stopped) {
 			log.debug("Received heartbeat from {}.", heartbeatOrigin);
-			reportHeartbeat(heartbeatOrigin);
+			reportHeartbeat(heartbeatOrigin, heartbeatPayload);
 
 			if (heartbeatPayload != null) {
 				heartbeatListener.reportPayload(heartbeatOrigin, heartbeatPayload);
@@ -195,7 +196,7 @@ public class HeartbeatManagerImpl<I, O> implements HeartbeatManager<I, O> {
 		if (!stopped) {
 			log.debug("Received heartbeat request from {}.", requestOrigin);
 
-			final HeartbeatTarget<O> heartbeatTarget = reportHeartbeat(requestOrigin);
+			final HeartbeatTarget<O> heartbeatTarget = reportHeartbeat(requestOrigin, heartbeatPayload);
 
 			if (heartbeatTarget != null) {
 				if (heartbeatPayload != null) {
@@ -221,11 +222,11 @@ public class HeartbeatManagerImpl<I, O> implements HeartbeatManager<I, O> {
 		}
 	}
 
-	HeartbeatTarget<O> reportHeartbeat(ResourceID resourceID) {
+	HeartbeatTarget<O> reportHeartbeat(ResourceID resourceID, I heartbeatPayload) {
 		if (heartbeatTargets.containsKey(resourceID)) {
 			HeartbeatManagerImpl.HeartbeatMonitor<O> heartbeatMonitor = heartbeatTargets.get(resourceID);
 			heartbeatMonitor.reportHeartbeat();
-
+			heartbeatMonitor.setHeartBeatPayload(heartbeatPayload);
 			return heartbeatMonitor.getHeartbeatTarget();
 		} else {
 			return null;
@@ -259,6 +260,11 @@ public class HeartbeatManagerImpl<I, O> implements HeartbeatManager<I, O> {
 		/** Maximum heartbeat timeout interval. */
 		private final long heartbeatTimeoutIntervalMs;
 
+		/** Associated heartbeat payload. */
+		private Object heartBeatPayload;
+
+		private final HeartbeatManagerImpl heartbeatManager;
+
 		private volatile ScheduledFuture<?> futureTimeout;
 
 		private final AtomicReference<State> state = new AtomicReference<>(State.RUNNING);
@@ -270,7 +276,8 @@ public class HeartbeatManagerImpl<I, O> implements HeartbeatManager<I, O> {
 			HeartbeatTarget<O> heartbeatTarget,
 			ScheduledExecutor scheduledExecutor,
 			HeartbeatListener<?, O> heartbeatListener,
-			long heartbeatTimeoutIntervalMs) {
+			long heartbeatTimeoutIntervalMs,
+			HeartbeatManagerImpl heartbeatManager) {
 
 			this.resourceID = Preconditions.checkNotNull(resourceID);
 			this.heartbeatTarget = Preconditions.checkNotNull(heartbeatTarget);
@@ -279,6 +286,7 @@ public class HeartbeatManagerImpl<I, O> implements HeartbeatManager<I, O> {
 
 			Preconditions.checkArgument(heartbeatTimeoutIntervalMs >= 0L, "The heartbeat timeout interval has to be larger than 0.");
 			this.heartbeatTimeoutIntervalMs = heartbeatTimeoutIntervalMs;
+			this.heartbeatManager = Preconditions.checkNotNull(heartbeatManager);
 
 			lastHeartbeat = 0L;
 
@@ -291,6 +299,14 @@ public class HeartbeatManagerImpl<I, O> implements HeartbeatManager<I, O> {
 
 		public long getLastHeartbeat() {
 			return lastHeartbeat;
+		}
+
+		public Object getHeartBeatPayload() {
+			return heartBeatPayload;
+		}
+
+		public void setHeartBeatPayload(Object heartBeatPayload) {
+			this.heartBeatPayload = heartBeatPayload;
 		}
 
 		void reportHeartbeat() {
@@ -332,6 +348,8 @@ public class HeartbeatManagerImpl<I, O> implements HeartbeatManager<I, O> {
 		public void run() {
 			// The heartbeat has timed out if we're in state running
 			if (state.compareAndSet(State.RUNNING, State.TIMEOUT)) {
+				heartbeatManager.log.info("Heartbeat time out from resource ID {}. Retrying request heartbeat.", resourceID);
+				heartbeatManager.requestHeartbeat(resourceID, getHeartBeatPayload());
 				heartbeatListener.notifyHeartbeatTimeout(resourceID);
 			}
 		}


### PR DESCRIPTION
## What is the purpose of the change

When timeout comes, retry JobManager/ResourceManager connection in case of timeout

## Brief change log
When timeout, invoke ```requestHeartbeat``` in HeartbeatMonitor thread. Not directly invoke ```notifyHeartbeatTimeout``` and close the connection.

## Verifying this change

This change is already covered by existing tests, but did minor changes. in the TaskExecutorTest.java, change ```testHeartbeatTimeoutWithResourceManager``` behavior to while timeout, does not invoke ```disconnectTaskManager```.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no )

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
