### PR TITLE
[FLINK-8626] Introduce BackPressureStatsTracker interface

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerRunner.java
@@ -172,7 +172,7 @@ public class JobManagerRunner implements LeaderContender, OnCompletionActions, F
 				userCodeLoader,
 				restAddress,
 				metricRegistry.getMetricQueryServicePath(),
-				jobManagerServices.backPressureStatsTracker);
+				jobManagerServices.backPressureStatsTrackerImpl);
 
 			this.timeout = jobManagerServices.rpcAskTimeout;
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/backpressure/BackPressureStatsTrackerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/backpressure/BackPressureStatsTrackerImpl.java
@@ -1,0 +1,363 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.legacy.backpressure;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
+import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.jobgraph.JobStatus;
+
+import org.apache.flink.shaded.guava18.com.google.common.cache.Cache;
+import org.apache.flink.shaded.guava18.com.google.common.cache.CacheBuilder;
+import org.apache.flink.shaded.guava18.com.google.common.collect.Maps;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Back pressure statistics tracker.
+ *
+ * <p>Back pressure is determined by sampling running tasks. If a task is
+ * slowed down by back pressure it will be stuck in memory requests to a
+ * {@link org.apache.flink.runtime.io.network.buffer.LocalBufferPool}.
+ *
+ * <p>The back pressured stack traces look like this:
+ *
+ * <pre>
+ * java.lang.Object.wait(Native Method)
+ * o.a.f.[...].LocalBufferPool.requestBuffer(LocalBufferPool.java:163)
+ * o.a.f.[...].LocalBufferPool.requestBufferBlocking(LocalBufferPool.java:133) <--- BLOCKING
+ * request
+ * [...]
+ * </pre>
+ */
+public class BackPressureStatsTrackerImpl implements BackPressureStatsTracker {
+
+	private static final Logger LOG = LoggerFactory.getLogger(BackPressureStatsTrackerImpl.class);
+
+	/** Maximum stack trace depth for samples. */
+	static final int MAX_STACK_TRACE_DEPTH = 3;
+
+	/** Expected class name for back pressure indicating stack trace element. */
+	static final String EXPECTED_CLASS_NAME = "org.apache.flink.runtime.io.network.buffer.LocalBufferPool";
+
+	/** Expected method name for back pressure indicating stack trace element. */
+	static final String EXPECTED_METHOD_NAME = "requestBufferBuilderBlocking";
+
+	/** Lock guarding trigger operations. */
+	private final Object lock = new Object();
+
+	/* Stack trace sample coordinator. */
+	private final StackTraceSampleCoordinator coordinator;
+
+	/**
+	 * Completed stats. Important: Job vertex IDs need to be scoped by job ID,
+	 * because they are potentially constant across runs messing up the cached
+	 * data.
+	 */
+	private final Cache<ExecutionJobVertex, OperatorBackPressureStats> operatorStatsCache;
+
+	/** Pending in progress stats. Important: Job vertex IDs need to be scoped
+	 * by job ID, because they are potentially constant across runs messing up
+	 * the cached data.*/
+	private final Set<ExecutionJobVertex> pendingStats = new HashSet<>();
+
+	/** Cleanup interval for completed stats cache. */
+	private final int cleanUpInterval;
+
+	private final int numSamples;
+
+	private final int backPressureStatsRefreshInterval;
+
+	private final Time delayBetweenSamples;
+
+	/** Flag indicating whether the stats tracker has been shut down. */
+	private boolean shutDown;
+
+	/**
+	 * Creates a back pressure statistics tracker.
+	 *
+	 * @param cleanUpInterval     Clean up interval for completed stats.
+	 * @param numSamples          Number of stack trace samples when determining back pressure.
+	 * @param delayBetweenSamples Delay between samples when determining back pressure.
+	 */
+	public BackPressureStatsTrackerImpl(
+			StackTraceSampleCoordinator coordinator,
+			int cleanUpInterval,
+			int numSamples,
+			int backPressureStatsRefreshInterval,
+			Time delayBetweenSamples) {
+
+		this.coordinator = checkNotNull(coordinator, "Stack trace sample coordinator");
+
+		checkArgument(cleanUpInterval >= 0, "Clean up interval");
+		this.cleanUpInterval = cleanUpInterval;
+
+		checkArgument(numSamples >= 1, "Number of samples");
+		this.numSamples = numSamples;
+
+		checkArgument(
+			backPressureStatsRefreshInterval >= 0,
+			"backPressureStatsRefreshInterval must be greater than or equal to 0");
+		this.backPressureStatsRefreshInterval = backPressureStatsRefreshInterval;
+
+		this.delayBetweenSamples = checkNotNull(delayBetweenSamples, "Delay between samples");
+
+		this.operatorStatsCache = CacheBuilder.newBuilder()
+				.concurrencyLevel(1)
+				.expireAfterAccess(cleanUpInterval, TimeUnit.MILLISECONDS)
+				.build();
+	}
+
+	/** Cleanup interval for completed stats cache. */
+	public long getCleanUpInterval() {
+		return cleanUpInterval;
+	}
+
+	/**
+	 * Returns back pressure statistics for a operator. Automatically triggers stack trace sampling
+	 * if statistics are not available or outdated.
+	 *
+	 * @param vertex Operator to get the stats for.
+	 * @return Back pressure statistics for an operator
+	 */
+	public Optional<OperatorBackPressureStats> getOperatorBackPressureStats(ExecutionJobVertex vertex) {
+		synchronized (lock) {
+			final OperatorBackPressureStats stats = operatorStatsCache.getIfPresent(vertex);
+			if (stats == null || backPressureStatsRefreshInterval <= System.currentTimeMillis() - stats.getEndTimestamp()) {
+				triggerStackTraceSampleInternal(vertex);
+			}
+			return Optional.ofNullable(stats);
+		}
+	}
+
+	/**
+	 * Triggers a stack trace sample for a operator to gather the back pressure
+	 * statistics. If there is a sample in progress for the operator, the call
+	 * is ignored.
+	 *
+	 * @param vertex Operator to get the stats for.
+	 * @return Flag indicating whether a sample with triggered.
+	 */
+	private boolean triggerStackTraceSampleInternal(final ExecutionJobVertex vertex) {
+		assert(Thread.holdsLock(lock));
+
+		if (shutDown) {
+			return false;
+		}
+
+		if (!pendingStats.contains(vertex) &&
+			!vertex.getGraph().getState().isGloballyTerminalState()) {
+
+			Executor executor = vertex.getGraph().getFutureExecutor();
+
+			// Only trigger if still active job
+			if (executor != null) {
+				pendingStats.add(vertex);
+
+				if (LOG.isDebugEnabled()) {
+					LOG.debug("Triggering stack trace sample for tasks: " + Arrays.toString(vertex.getTaskVertices()));
+				}
+
+				CompletableFuture<StackTraceSample> sample = coordinator.triggerStackTraceSample(
+					vertex.getTaskVertices(),
+					numSamples,
+					delayBetweenSamples,
+					MAX_STACK_TRACE_DEPTH);
+
+				sample.handleAsync(new StackTraceSampleCompletionCallback(vertex), executor);
+
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Triggers a stack trace sample for a operator to gather the back pressure
+	 * statistics. If there is a sample in progress for the operator, the call
+	 * is ignored.
+	 *
+	 * @param vertex Operator to get the stats for.
+	 * @return Flag indicating whether a sample with triggered.
+	 * @deprecated {@link #getOperatorBackPressureStats(ExecutionJobVertex)} will trigger
+	 * stack trace sampling automatically.
+	 */
+	@Deprecated
+	public boolean triggerStackTraceSample(ExecutionJobVertex vertex) {
+		synchronized (lock) {
+			return triggerStackTraceSampleInternal(vertex);
+		}
+	}
+
+	/**
+	 * Cleans up the operator stats cache if it contains timed out entries.
+	 *
+	 * <p>The Guava cache only evicts as maintenance during normal operations.
+	 * If this handler is inactive, it will never be cleaned.
+	 */
+	public void cleanUpOperatorStatsCache() {
+		operatorStatsCache.cleanUp();
+	}
+
+	/**
+	 * Shuts down the stats tracker.
+	 *
+	 * <p>Invalidates the cache and clears all pending stats.
+	 */
+	public void shutDown() {
+		synchronized (lock) {
+			if (!shutDown) {
+				operatorStatsCache.invalidateAll();
+				pendingStats.clear();
+
+				shutDown = true;
+			}
+		}
+	}
+
+	/**
+	 * Invalidates the cache (irrespective of clean up interval).
+	 */
+	void invalidateOperatorStatsCache() {
+		operatorStatsCache.invalidateAll();
+	}
+
+	/**
+	 * Callback on completed stack trace sample.
+	 */
+	class StackTraceSampleCompletionCallback implements BiFunction<StackTraceSample, Throwable, Void> {
+
+		private final ExecutionJobVertex vertex;
+
+		public StackTraceSampleCompletionCallback(ExecutionJobVertex vertex) {
+			this.vertex = vertex;
+		}
+
+		@Override
+		public Void apply(StackTraceSample stackTraceSample, Throwable throwable) {
+			synchronized (lock) {
+				try {
+					if (shutDown) {
+						return null;
+					}
+
+					// Job finished, ignore.
+					JobStatus jobState = vertex.getGraph().getState();
+					if (jobState.isGloballyTerminalState()) {
+						LOG.debug("Ignoring sample, because job is in state " + jobState + ".");
+					} else if (stackTraceSample != null) {
+						OperatorBackPressureStats stats = createStatsFromSample(stackTraceSample);
+						operatorStatsCache.put(vertex, stats);
+					} else {
+						LOG.debug("Failed to gather stack trace sample.", throwable);
+					}
+				} catch (Throwable t) {
+					LOG.error("Error during stats completion.", t);
+				} finally {
+					pendingStats.remove(vertex);
+				}
+
+				return null;
+			}
+		}
+
+		/**
+		 * Creates the back pressure stats from a stack trace sample.
+		 *
+		 * @param sample Stack trace sample to base stats on.
+		 *
+		 * @return Back pressure stats
+		 */
+		private OperatorBackPressureStats createStatsFromSample(StackTraceSample sample) {
+			Map<ExecutionAttemptID, List<StackTraceElement[]>> traces = sample.getStackTraces();
+
+			// Map task ID to subtask index, because the web interface expects
+			// it like that.
+			Map<ExecutionAttemptID, Integer> subtaskIndexMap = Maps
+					.newHashMapWithExpectedSize(traces.size());
+
+			Set<ExecutionAttemptID> sampledTasks = sample.getStackTraces().keySet();
+
+			for (ExecutionVertex task : vertex.getTaskVertices()) {
+				ExecutionAttemptID taskId = task.getCurrentExecutionAttempt().getAttemptId();
+				if (sampledTasks.contains(taskId)) {
+					subtaskIndexMap.put(taskId, task.getParallelSubtaskIndex());
+				} else {
+					LOG.debug("Outdated sample. A task, which is part of the " +
+							"sample has been reset.");
+				}
+			}
+
+			// Ratio of blocked samples to total samples per sub task. Array
+			// position corresponds to sub task index.
+			double[] backPressureRatio = new double[traces.size()];
+
+			for (Entry<ExecutionAttemptID, List<StackTraceElement[]>> entry : traces.entrySet()) {
+				int backPressureSamples = 0;
+
+				List<StackTraceElement[]> taskTraces = entry.getValue();
+
+				for (StackTraceElement[] trace : taskTraces) {
+					for (int i = trace.length - 1; i >= 0; i--) {
+						StackTraceElement elem = trace[i];
+
+						if (elem.getClassName().equals(EXPECTED_CLASS_NAME) &&
+								elem.getMethodName().equals(EXPECTED_METHOD_NAME)) {
+
+							backPressureSamples++;
+							break; // Continue with next stack trace
+						}
+					}
+				}
+
+				int subtaskIndex = subtaskIndexMap.get(entry.getKey());
+
+				int size = taskTraces.size();
+				double ratio = (size > 0)
+						? ((double) backPressureSamples) / size
+						: 0;
+
+				backPressureRatio[subtaskIndex] = ratio;
+			}
+
+			return new OperatorBackPressureStats(
+					sample.getSampleId(),
+					sample.getEndTime(),
+					backPressureRatio);
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/backpressure/VoidBackPressureStatsTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/backpressure/VoidBackPressureStatsTracker.java
@@ -23,16 +23,14 @@ import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import java.util.Optional;
 
 /**
- * Interface for a tracker of back pressure statistics for {@link ExecutionJobVertex}.
+ * {@link BackPressureStatsTracker} implementation which returns always no back pressure statistics.
  */
-public interface BackPressureStatsTracker {
+public enum VoidBackPressureStatsTracker implements BackPressureStatsTracker {
 
-	/**
-	 * Returns back pressure statistics for a operator. Automatically triggers stack trace sampling
-	 * if statistics are not available or outdated.
-	 *
-	 * @param vertex Operator to get the stats for.
-	 * @return Back pressure statistics for an operator
-	 */
-	Optional<OperatorBackPressureStats> getOperatorBackPressureStats(ExecutionJobVertex vertex);
+	INSTANCE {
+		@Override
+		public Optional<OperatorBackPressureStats> getOperatorBackPressureStats(ExecutionJobVertex vertex) {
+			return Optional.empty();
+		}
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/backpressure/VoidBackPressureStatsTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/backpressure/VoidBackPressureStatsTracker.java
@@ -23,7 +23,7 @@ import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import java.util.Optional;
 
 /**
- * {@link BackPressureStatsTracker} implementation which returns always no back pressure statistics.
+ * {@link BackPressureStatsTracker} implementation which always returns no back pressure statistics.
  */
 public enum VoidBackPressureStatsTracker implements BackPressureStatsTracker {
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -40,8 +40,7 @@ import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.registration.RegistrationResponse;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
 import org.apache.flink.runtime.resourcemanager.utils.TestingResourceManagerGateway;
-import org.apache.flink.runtime.rest.handler.legacy.backpressure.BackPressureStatsTracker;
-import org.apache.flink.runtime.rest.handler.legacy.backpressure.StackTraceSampleCoordinator;
+import org.apache.flink.runtime.rest.handler.legacy.backpressure.VoidBackPressureStatsTracker;
 import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGateway;
 import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
@@ -125,9 +124,7 @@ public class JobMasterTest extends TestLogger {
 				FlinkUserCodeClassLoaders.parentFirst(new URL[0], JobMasterTest.class.getClassLoader()),
 				null,
 				null,
-				new BackPressureStatsTracker(
-					new StackTraceSampleCoordinator(scheduledExecutor, testingTimeout.toMilliseconds()),
-					60000, 100, 60000, Time.milliseconds(50)));
+				VoidBackPressureStatsTracker.INSTANCE);
 
 			CompletableFuture<Acknowledge> startFuture = jobMaster.start(jobMasterId, testingTimeout);
 
@@ -226,9 +223,7 @@ public class JobMasterTest extends TestLogger {
 				FlinkUserCodeClassLoaders.parentFirst(new URL[0], JobMasterTest.class.getClassLoader()),
 				null,
 				null,
-				new BackPressureStatsTracker(
-					new StackTraceSampleCoordinator(scheduledExecutor, testingTimeout.toMilliseconds()),
-					60000, 100, 60000, Time.milliseconds(50)));
+				VoidBackPressureStatsTracker.INSTANCE);
 
 			CompletableFuture<Acknowledge> startFuture = jobMaster.start(jobMasterId, testingTimeout);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/JobVertexBackPressureHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/JobVertexBackPressureHandlerTest.java
@@ -20,7 +20,7 @@ package org.apache.flink.runtime.rest.handler.legacy;
 
 import org.apache.flink.runtime.concurrent.Executors;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
-import org.apache.flink.runtime.rest.handler.legacy.backpressure.BackPressureStatsTracker;
+import org.apache.flink.runtime.rest.handler.legacy.backpressure.BackPressureStatsTrackerImpl;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.OperatorBackPressureStats;
 import org.apache.flink.util.TestLogger;
 
@@ -47,7 +47,7 @@ import static org.mockito.Mockito.when;
 public class JobVertexBackPressureHandlerTest extends TestLogger {
 	@Test
 	public void testGetPaths() {
-		JobVertexBackPressureHandler handler = new JobVertexBackPressureHandler(mock(ExecutionGraphCache.class), Executors.directExecutor(), mock(BackPressureStatsTracker.class), 0);
+		JobVertexBackPressureHandler handler = new JobVertexBackPressureHandler(mock(ExecutionGraphCache.class), Executors.directExecutor(), mock(BackPressureStatsTrackerImpl.class), 0);
 		String[] paths = handler.getPaths();
 		Assert.assertEquals(1, paths.length);
 		Assert.assertEquals("/jobs/:jobid/vertices/:vertexid/backpressure", paths[0]);
@@ -57,7 +57,7 @@ public class JobVertexBackPressureHandlerTest extends TestLogger {
 	@Test
 	public void testResponseNoStatsAvailable() throws Exception {
 		ExecutionJobVertex jobVertex = mock(ExecutionJobVertex.class);
-		BackPressureStatsTracker statsTracker = mock(BackPressureStatsTracker.class);
+		BackPressureStatsTrackerImpl statsTracker = mock(BackPressureStatsTrackerImpl.class);
 
 		when(statsTracker.getOperatorBackPressureStats(any(ExecutionJobVertex.class)))
 				.thenReturn(Optional.empty());
@@ -88,7 +88,7 @@ public class JobVertexBackPressureHandlerTest extends TestLogger {
 	@Test
 	public void testResponseStatsAvailable() throws Exception {
 		ExecutionJobVertex jobVertex = mock(ExecutionJobVertex.class);
-		BackPressureStatsTracker statsTracker = mock(BackPressureStatsTracker.class);
+		BackPressureStatsTrackerImpl statsTracker = mock(BackPressureStatsTrackerImpl.class);
 
 		OperatorBackPressureStats stats = new OperatorBackPressureStats(
 				0, System.currentTimeMillis(), new double[] { 0.31, 0.48, 1.0, 0.0 });
@@ -150,7 +150,7 @@ public class JobVertexBackPressureHandlerTest extends TestLogger {
 	@Test
 	public void testResponsePassedRefreshInterval() throws Exception {
 		ExecutionJobVertex jobVertex = mock(ExecutionJobVertex.class);
-		BackPressureStatsTracker statsTracker = mock(BackPressureStatsTracker.class);
+		BackPressureStatsTrackerImpl statsTracker = mock(BackPressureStatsTrackerImpl.class);
 
 		OperatorBackPressureStats stats = new OperatorBackPressureStats(
 				0, System.currentTimeMillis(), new double[] { 0.31, 0.48, 1.0, 0.0 });

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/backpressure/BackPressureStatsTrackerImplITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/backpressure/BackPressureStatsTrackerImplITCase.java
@@ -66,7 +66,7 @@ import static org.apache.flink.runtime.testingUtils.TestingJobManagerMessages.Wa
 /**
  * Simple back pressured task test.
  */
-public class BackPressureStatsTrackerITCase extends TestLogger {
+public class BackPressureStatsTrackerImplITCase extends TestLogger {
 
 	private static NetworkBufferPool networkBufferPool;
 	private static ActorSystem testActorSystem;
@@ -179,7 +179,7 @@ public class BackPressureStatsTrackerITCase extends TestLogger {
 									testActorSystem.dispatcher(), 60000);
 
 							// Verify back pressure (clean up interval can be ignored)
-							BackPressureStatsTracker statsTracker = new BackPressureStatsTracker(
+							BackPressureStatsTrackerImpl statsTracker = new BackPressureStatsTrackerImpl(
 								coordinator,
 								100 * 1000,
 								20,
@@ -290,7 +290,7 @@ public class BackPressureStatsTrackerITCase extends TestLogger {
 	 * Triggers a new stats sample.
 	 */
 	private OperatorBackPressureStats triggerStatsSample(
-			BackPressureStatsTracker statsTracker,
+			BackPressureStatsTrackerImpl statsTracker,
 			ExecutionJobVertex vertex) throws InterruptedException {
 
 		statsTracker.invalidateOperatorStatsCache();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/backpressure/BackPressureStatsTrackerImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/backpressure/BackPressureStatsTrackerImplTest.java
@@ -42,9 +42,9 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
 /**
- * Tests for the BackPressureStatsTracker.
+ * Tests for the BackPressureStatsTrackerImpl.
  */
-public class BackPressureStatsTrackerTest extends TestLogger {
+public class BackPressureStatsTrackerImplTest extends TestLogger {
 
 	/** Tests simple statistics with fake stack traces. */
 	@Test
@@ -87,7 +87,7 @@ public class BackPressureStatsTrackerTest extends TestLogger {
 		int numSamples = 100;
 		Time delayBetweenSamples = Time.milliseconds(100L);
 
-		BackPressureStatsTracker tracker = new BackPressureStatsTracker(
+		BackPressureStatsTrackerImpl tracker = new BackPressureStatsTrackerImpl(
 				sampleCoordinator, 9999, numSamples, Integer.MAX_VALUE, delayBetweenSamples);
 
 		// getOperatorBackPressureStats triggers stack trace sampling
@@ -97,7 +97,7 @@ public class BackPressureStatsTrackerTest extends TestLogger {
 				Matchers.eq(taskVertices),
 				Matchers.eq(numSamples),
 				Matchers.eq(delayBetweenSamples),
-				Matchers.eq(BackPressureStatsTracker.MAX_STACK_TRACE_DEPTH));
+				Matchers.eq(BackPressureStatsTrackerImpl.MAX_STACK_TRACE_DEPTH));
 
 		// Request back pressure stats again. This should not trigger another sample request
 		Assert.assertTrue(!tracker.getOperatorBackPressureStats(jobVertex).isPresent());
@@ -106,7 +106,7 @@ public class BackPressureStatsTrackerTest extends TestLogger {
 				Matchers.eq(taskVertices),
 				Matchers.eq(numSamples),
 				Matchers.eq(delayBetweenSamples),
-				Matchers.eq(BackPressureStatsTracker.MAX_STACK_TRACE_DEPTH));
+				Matchers.eq(BackPressureStatsTrackerImpl.MAX_STACK_TRACE_DEPTH));
 
 		Assert.assertTrue(!tracker.getOperatorBackPressureStats(jobVertex).isPresent());
 
@@ -154,8 +154,8 @@ public class BackPressureStatsTrackerTest extends TestLogger {
 	private StackTraceElement[] createStackTrace(boolean isBackPressure) {
 		if (isBackPressure) {
 			return new StackTraceElement[] { new StackTraceElement(
-					BackPressureStatsTracker.EXPECTED_CLASS_NAME,
-					BackPressureStatsTracker.EXPECTED_METHOD_NAME,
+					BackPressureStatsTrackerImpl.EXPECTED_CLASS_NAME,
+					BackPressureStatsTrackerImpl.EXPECTED_METHOD_NAME,
 					"LocalBufferPool.java",
 					133) };
 		} else {


### PR DESCRIPTION
## What is the purpose of the change

Renames BackPressureStatsTracker into BackPressureStatsTrackerImpl and introduce
a BackPressureStatsTracker interface. This will make testing easier when we don't
have to set up all the different components.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
