### PR TITLE
[FLINK-8423] OperatorChain#pushToOperator catch block may fail with NPE

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
@@ -591,16 +591,20 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>> implements Strea
 				operator.setKeyContextElement1(copy);
 				operator.processElement(copy);
 			} catch (ClassCastException e) {
-				// Enrich error message
-				ClassCastException replace = new ClassCastException(
-					String.format(
-						"%s. Failed to push OutputTag with id '%s' to operator. " +
-						"This can occur when multiple OutputTags with different types " +
-						"but identical names are being used.",
-						e.getMessage(),
-						outputTag.getId()));
+				if (outputTag != null) {
+					// Enrich error message
+					ClassCastException replace = new ClassCastException(
+						String.format(
+							"%s. Failed to push OutputTag with id '%s' to operator. " +
+								"This can occur when multiple OutputTags with different types " +
+								"but identical names are being used.",
+							e.getMessage(),
+							outputTag.getId()));
 
-				throw new ExceptionInChainedOperatorException(replace);
+					throw new ExceptionInChainedOperatorException(replace);
+				} else {
+					throw e;
+				}
 
 			} catch (Exception e) {
 				throw new ExceptionInChainedOperatorException(e);


### PR DESCRIPTION
## What is the purpose of the change
Fix the NPE when outputTag is null.


## Brief change log
Add when outputTag is not null, then do the catch block work.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no )
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (/ no)
  - If yes, how is the feature documented? ( not documented)
