### PR TITLE
[FLINK-6469] Configure Memory Sizes with units

### DIFF
--- a/docs/_includes/generated/common_section.html
+++ b/docs/_includes/generated/common_section.html
@@ -8,14 +8,14 @@
     </thead>
     <tbody>
         <tr>
-            <td><h5>jobmanager.heap.mb</h5></td>
-            <td style="word-wrap: break-word;">1024</td>
-            <td>JVM heap size (in megabytes) for the JobManager.</td>
+            <td><h5>jobmanager.heap.size</h5></td>
+            <td style="word-wrap: break-word;">"1024m"</td>
+            <td>JVM heap size for the JobManager.</td>
         </tr>
         <tr>
-            <td><h5>taskmanager.heap.mb</h5></td>
-            <td style="word-wrap: break-word;">1024</td>
-            <td>JVM heap size (in megabytes) for the TaskManagers, which are the parallel workers of the system. On YARN setups, this value is automatically configured to the size of the TaskManager's YARN container, minus a certain tolerance value.</td>
+            <td><h5>taskmanager.heap.size</h5></td>
+            <td style="word-wrap: break-word;">"1024m"</td>
+            <td>JVM heap size for the TaskManagers, which are the parallel workers of the system. On YARN setups, this value is automatically configured to the size of the TaskManager's YARN container, minus a certain tolerance value.</td>
         </tr>
         <tr>
             <td><h5>parallelism.default</h5></td>

--- a/docs/_includes/generated/job_manager_configuration.html
+++ b/docs/_includes/generated/job_manager_configuration.html
@@ -23,9 +23,9 @@
             <td>The maximum number of prior execution attempts kept in history.</td>
         </tr>
         <tr>
-            <td><h5>jobmanager.heap.mb</h5></td>
-            <td style="word-wrap: break-word;">1024</td>
-            <td>JVM heap size (in megabytes) for the JobManager.</td>
+            <td><h5>jobmanager.heap.size</h5></td>
+            <td style="word-wrap: break-word;">"1024m"</td>
+            <td>JVM heap size for the JobManager.</td>
         </tr>
         <tr>
             <td><h5>jobmanager.resourcemanager.reconnect-interval</h5></td>

--- a/docs/_includes/generated/task_manager_configuration.html
+++ b/docs/_includes/generated/task_manager_configuration.html
@@ -53,9 +53,9 @@
             <td>Whether the quarantine monitor for task managers shall be started. The quarantine monitor shuts down the actor system if it detects that it has quarantined another actor system or if it has been quarantined by another actor system.</td>
         </tr>
         <tr>
-            <td><h5>taskmanager.heap.mb</h5></td>
-            <td style="word-wrap: break-word;">1024</td>
-            <td>JVM heap size (in megabytes) for the TaskManagers, which are the parallel workers of the system. On YARN setups, this value is automatically configured to the size of the TaskManager's YARN container, minus a certain tolerance value.</td>
+            <td><h5>taskmanager.heap.size</h5></td>
+            <td style="word-wrap: break-word;">"1024m"</td>
+            <td>JVM heap size for the TaskManagers, which are the parallel workers of the system. On YARN setups, this value is automatically configured to the size of the TaskManager's YARN container, minus a certain tolerance value.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.host</h5></td>
@@ -84,13 +84,13 @@
         </tr>
         <tr>
             <td><h5>taskmanager.memory.segment-size</h5></td>
-            <td style="word-wrap: break-word;">32768</td>
-            <td>Size of memory buffers used by the network stack and the memory manager (in bytes).</td>
+            <td style="word-wrap: break-word;">"32768"</td>
+            <td>Size of memory buffers used by the network stack and the memory manager.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.memory.size</h5></td>
-            <td style="word-wrap: break-word;">-1</td>
-            <td>Amount of memory to be allocated by the task manager's memory manager (in megabytes). If not set, a relative fraction will be allocated.</td>
+            <td style="word-wrap: break-word;">"0"</td>
+            <td>Amount of memory to be allocated by the task manager's memory manager. If not set, a relative fraction will be allocated.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.detailed-metrics</h5></td>
@@ -114,13 +114,13 @@
         </tr>
         <tr>
             <td><h5>taskmanager.network.memory.max</h5></td>
-            <td style="word-wrap: break-word;">1073741824</td>
-            <td>Maximum memory size for network buffers (in bytes).</td>
+            <td style="word-wrap: break-word;">"1073741824"</td>
+            <td>Maximum memory size for network buffers.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.memory.min</h5></td>
-            <td style="word-wrap: break-word;">67108864</td>
-            <td>Minimum memory size for network buffers (in bytes).</td>
+            <td style="word-wrap: break-word;">"67108864"</td>
+            <td>Minimum memory size for network buffers.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.request-backoff.initial</h5></td>

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterSpecification.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterSpecification.java
@@ -20,6 +20,7 @@ package org.apache.flink.client.deployment;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.TaskManagerOptions;
 
 /**
@@ -67,8 +68,8 @@ public final class ClusterSpecification {
 	public static ClusterSpecification fromConfiguration(Configuration configuration) {
 		int slots = configuration.getInteger(TaskManagerOptions.NUM_TASK_SLOTS, 1);
 
-		int jobManagerMemoryMb = configuration.getInteger(JobManagerOptions.JOB_MANAGER_HEAP_MEMORY);
-		int taskManagerMemoryMb = configuration.getInteger(TaskManagerOptions.TASK_MANAGER_HEAP_MEMORY);
+		int jobManagerMemoryMb = (int) MemorySize.parse(configuration.getString(JobManagerOptions.JOB_MANAGER_HEAP_MEMORY)).getMebiBytes();
+		int taskManagerMemoryMb = (int) MemorySize.parse(configuration.getString(TaskManagerOptions.TASK_MANAGER_HEAP_MEMORY)).getMebiBytes();
 
 		return new ClusterSpecificationBuilder()
 			.setMasterMemoryMB(jobManagerMemoryMb)

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaShortRetentionTestBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaShortRetentionTestBase.java
@@ -84,7 +84,7 @@ public class KafkaShortRetentionTestBase implements Serializable {
 
 	private static Configuration getConfiguration() {
 		Configuration flinkConfig = new Configuration();
-		flinkConfig.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, 16L);
+		flinkConfig.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "16m");
 		flinkConfig.setString(ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_DELAY, "0 s");
 		return flinkConfig;
 	}

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestBase.java
@@ -134,7 +134,7 @@ public abstract class KafkaTestBase extends TestLogger {
 		Configuration flinkConfig = new Configuration();
 		flinkConfig.setString(AkkaOptions.WATCH_HEARTBEAT_PAUSE, "5 s");
 		flinkConfig.setString(AkkaOptions.WATCH_HEARTBEAT_INTERVAL, "1 s");
-		flinkConfig.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, 16L);
+		flinkConfig.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "16m");
 		flinkConfig.setString(ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_DELAY, "0 s");
 		flinkConfig.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "my_reporter." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, JMXReporter.class.getName());
 		return flinkConfig;

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/manualtests/ManualExactlyOnceTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/manualtests/ManualExactlyOnceTest.java
@@ -79,7 +79,7 @@ public class ManualExactlyOnceTest {
 		final Configuration flinkConfig = new Configuration();
 		flinkConfig.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, 1);
 		flinkConfig.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 8);
-		flinkConfig.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, 16);
+		flinkConfig.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "16m");
 		flinkConfig.setString(ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_DELAY, "0 s");
 
 		LocalFlinkMiniCluster flink = new LocalFlinkMiniCluster(flinkConfig, false);

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/manualtests/ManualExactlyOnceWithStreamReshardingTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/manualtests/ManualExactlyOnceWithStreamReshardingTest.java
@@ -91,7 +91,7 @@ public class ManualExactlyOnceWithStreamReshardingTest {
 		final Configuration flinkConfig = new Configuration();
 		flinkConfig.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, 1);
 		flinkConfig.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 8);
-		flinkConfig.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, 16);
+		flinkConfig.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "16m");
 		flinkConfig.setString(ConfigConstants.RESTART_STRATEGY_FIXED_DELAY_DELAY, "0 s");
 
 		LocalFlinkMiniCluster flink = new LocalFlinkMiniCluster(flinkConfig, false);

--- a/flink-connectors/flink-hbase/src/test/java/org/apache/flink/addons/hbase/HBaseConnectorITCase.java
+++ b/flink-connectors/flink-hbase/src/test/java/org/apache/flink/addons/hbase/HBaseConnectorITCase.java
@@ -363,7 +363,7 @@ public class HBaseConnectorITCase extends HBaseTestingClusterAutostarter {
 		public static void setAsContext() {
 			Configuration config = new Configuration();
 			// the default network buffers size (10% of heap max =~ 150MB) seems to much for this test case
-			config.setLong(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX, 80L << 20); // 80 MB
+			config.setString(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX, String.valueOf(80L << 20)); // 80 MB
 			final LocalEnvironment le = new LocalEnvironment(config);
 
 			initializeContextEnvironment(new ExecutionEnvironmentFactory() {

--- a/flink-contrib/flink-storm/src/main/java/org/apache/flink/storm/api/FlinkLocalCluster.java
+++ b/flink-contrib/flink-storm/src/main/java/org/apache/flink/storm/api/FlinkLocalCluster.java
@@ -88,7 +88,7 @@ public class FlinkLocalCluster {
 			Configuration configuration = new Configuration();
 			configuration.addAll(jobGraph.getJobConfiguration());
 
-			configuration.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, -1L);
+			configuration.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "0");
 			configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, jobGraph.getMaximumParallelism());
 
 			this.flink = new LocalFlinkMiniCluster(configuration, true);

--- a/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
@@ -74,10 +74,20 @@ public class JobManagerOptions {
 			" leader from potentially multiple standby JobManagers.");
 
 	/**
-	 * JVM heap size (in megabytes) for the JobManager.
+	 * JVM heap size for the JobManager with memory size.
 	 */
 	@Documentation.CommonOption(position = Documentation.CommonOption.POSITION_MEMORY)
-	public static final ConfigOption<Integer> JOB_MANAGER_HEAP_MEMORY =
+	public static final ConfigOption<String> JOB_MANAGER_HEAP_MEMORY =
+		key("jobmanager.heap.size")
+		.defaultValue("1024m")
+		.withDescription("JVM heap size for the JobManager.");
+
+	/**
+	 * JVM heap size (in megabytes) for the JobManager.
+	 * @deprecated use {@link #JOB_MANAGER_HEAP_MEMORY}
+	 */
+	@Deprecated
+	public static final ConfigOption<Integer> JOB_MANAGER_HEAP_MEMORY_MB =
 		key("jobmanager.heap.mb")
 		.defaultValue(1024)
 		.withDescription("JVM heap size (in megabytes) for the JobManager.");

--- a/flink-core/src/main/java/org/apache/flink/configuration/MemorySize.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/MemorySize.java
@@ -22,6 +22,12 @@ import org.apache.flink.annotation.PublicEvolving;
 
 import java.util.Locale;
 
+import static org.apache.flink.configuration.MemorySize.MemoryUnit.BYTES;
+import static org.apache.flink.configuration.MemorySize.MemoryUnit.GIGA_BYTES;
+import static org.apache.flink.configuration.MemorySize.MemoryUnit.KILO_BYTES;
+import static org.apache.flink.configuration.MemorySize.MemoryUnit.MEGA_BYTES;
+import static org.apache.flink.configuration.MemorySize.MemoryUnit.TERA_BYTES;
+import static org.apache.flink.configuration.MemorySize.MemoryUnit.hasUnit;
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -33,33 +39,11 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * <p>The size can be parsed from a text expression. If the expression is a pure number,
  * the value will be interpreted as bytes.
  *
- * <p>To make larger values more compact, the common size suffixes are supported:
- *
- * <ul>
- *     <li>q or 1b or 1bytes (bytes)
- *     <li>1k or 1kb or 1kibibytes (interpreted as kibibytes = 1024 bytes)
- *     <li>1m or 1mb or 1mebibytes (interpreted as mebibytes = 1024 kibibytes)
- *     <li>1g or 1gb or 1gibibytes (interpreted as gibibytes = 1024 mebibytes)
- *     <li>1t or 1tb or 1tebibytes (interpreted as tebibytes = 1024 gibibytes)
- * </ul>
  */
 @PublicEvolving
 public class MemorySize implements java.io.Serializable {
 
 	private static final long serialVersionUID = 1L;
-
-	private static final String[] BYTES_UNITS = { "b", "bytes" };
-
-	private static final String[] KILO_BYTES_UNITS = { "k", "kb", "kibibytes" };
-
-	private static final String[] MEGA_BYTES_UNITS = { "m", "mb", "mebibytes" };
-
-	private static final String[] GIGA_BYTES_UNITS = { "g", "gb", "gibibytes" };
-
-	private static final String[] TERA_BYTES_UNITS = { "t", "tb", "tebibytes" };
-
-	private static final String ALL_UNITS = concatenateUnits(
-			BYTES_UNITS, KILO_BYTES_UNITS, MEGA_BYTES_UNITS, GIGA_BYTES_UNITS, TERA_BYTES_UNITS);
 
 	// ------------------------------------------------------------------------
 
@@ -95,8 +79,8 @@ public class MemorySize implements java.io.Serializable {
 	/**
 	 * Gets the memory size in Mebibytes (= 1024 Kibibytes).
 	 */
-	public long getMebiBytes() {
-		return bytes >> 20;
+	public int getMebiBytes() {
+		return (int) (bytes >> 20);
 	}
 
 	/**
@@ -137,7 +121,6 @@ public class MemorySize implements java.io.Serializable {
 
 	/**
 	 * Parses the given string as as MemorySize.
-	 * The supported expressions are listed under {@link MemorySize}.
 	 *
 	 * @param text The string to parse
 	 * @return The parsed MemorySize
@@ -146,6 +129,23 @@ public class MemorySize implements java.io.Serializable {
 	 */
 	public static MemorySize parse(String text) throws IllegalArgumentException {
 		return new MemorySize(parseBytes(text));
+	}
+
+	/**
+	 * Parses the given string with a default unit.
+	 *
+	 * @param text The string to parse.
+	 * @param defaultUnit specify the default unit.
+	 * @return The parsed MemorySize.
+	 *
+	 * @throws IllegalArgumentException Thrown, if the expression cannot be parsed.
+	 */
+	public static MemorySize parse(String text, MemoryUnit defaultUnit) throws IllegalArgumentException {
+		if (!hasUnit(text)) {
+			return parse(text + defaultUnit.getUnits()[0]);
+		}
+
+		return parse(text);
 	}
 
 	/**
@@ -192,24 +192,24 @@ public class MemorySize implements java.io.Serializable {
 			multiplier = 1L;
 		}
 		else {
-			if (matchesAny(unit, BYTES_UNITS)) {
+			if (matchesAny(unit, BYTES)) {
 				multiplier = 1L;
 			}
-			else if (matchesAny(unit, KILO_BYTES_UNITS)) {
+			else if (matchesAny(unit, KILO_BYTES)) {
 				multiplier = 1024L;
 			}
-			else if (matchesAny(unit, MEGA_BYTES_UNITS)) {
+			else if (matchesAny(unit, MEGA_BYTES)) {
 				multiplier = 1024L * 1024L;
 			}
-			else if (matchesAny(unit, GIGA_BYTES_UNITS)) {
+			else if (matchesAny(unit, GIGA_BYTES)) {
 				multiplier = 1024L * 1024L * 1024L;
 			}
-			else if (matchesAny(unit, TERA_BYTES_UNITS)) {
+			else if (matchesAny(unit, TERA_BYTES)) {
 				multiplier = 1024L * 1024L * 1024L * 1024L;
 			}
 			else {
 				throw new IllegalArgumentException("Memory size unit '" + unit +
-						"' does not match any of the recognized units: " + ALL_UNITS);
+						"' does not match any of the recognized units: " + MemoryUnit.getAllUnits());
 			}
 		}
 
@@ -224,8 +224,8 @@ public class MemorySize implements java.io.Serializable {
 		return result;
 	}
 
-	private static boolean matchesAny(String str, String[] variants) {
-		for (String s : variants) {
+	private static boolean matchesAny(String str, MemoryUnit unit) {
+		for (String s : unit.getUnits()) {
 			if (s.equals(str)) {
 				return true;
 			}
@@ -233,22 +233,79 @@ public class MemorySize implements java.io.Serializable {
 		return false;
 	}
 
-	private static String concatenateUnits(final String[]... allUnits) {
-		final StringBuilder builder = new StringBuilder(128);
+	/**
+	 *  Enum which defines memory unit, mostly used to parse value from configuration file.
+	 *
+	 * <p>To make larger values more compact, the common size suffixes are supported:
+	 *
+	 * <ul>
+	 *     <li>q or 1b or 1bytes (bytes)
+	 *     <li>1k or 1kb or 1kibibytes (interpreted as kibibytes = 1024 bytes)
+	 *     <li>1m or 1mb or 1mebibytes (interpreted as mebibytes = 1024 kibibytes)
+	 *     <li>1g or 1gb or 1gibibytes (interpreted as gibibytes = 1024 mebibytes)
+	 *     <li>1t or 1tb or 1tebibytes (interpreted as tebibytes = 1024 gibibytes)
+	 * </ul>
+	 *
+	 */
+	public enum MemoryUnit {
 
-		for (String[] units : allUnits) {
-			builder.append('(');
+		BYTES(new String[] { "b", "bytes" }),
+		KILO_BYTES(new String[] { "k", "kb", "kibibytes" }),
+		MEGA_BYTES(new String[] { "m", "mb", "mebibytes" }),
+		GIGA_BYTES(new String[] { "g", "gb", "gibibytes" }),
+		TERA_BYTES(new String[] { "t", "tb", "tebibytes" });
 
-			for (String unit : units) {
-				builder.append(unit);
-				builder.append(" | ");
+		private String[] units;
+
+		MemoryUnit(String[] units) {
+			this.units = units;
+		}
+
+		public String[] getUnits() {
+			return units;
+		}
+
+		public static String getAllUnits() {
+			return concatenateUnits(BYTES.getUnits(), KILO_BYTES.getUnits(), MEGA_BYTES.getUnits(), GIGA_BYTES.getUnits(), TERA_BYTES.getUnits());
+		}
+
+		public static boolean hasUnit(String text) {
+			checkNotNull(text, "text");
+
+			final String trimmed = text.trim();
+			checkArgument(!trimmed.isEmpty(), "argument is an empty- or whitespace-only string");
+
+			final int len = trimmed.length();
+			int pos = 0;
+
+			char current;
+			while (pos < len && (current = trimmed.charAt(pos)) >= '0' && current <= '9') {
+				pos++;
+			}
+
+			final String unit = trimmed.substring(pos).trim().toLowerCase(Locale.US);
+
+			return unit.length() > 0;
+		}
+
+		private static String concatenateUnits(final String[]... allUnits) {
+			final StringBuilder builder = new StringBuilder(128);
+
+			for (String[] units : allUnits) {
+				builder.append('(');
+
+				for (String unit : units) {
+					builder.append(unit);
+					builder.append(" | ");
+				}
+
+				builder.setLength(builder.length() - 3);
+				builder.append(") / ");
 			}
 
 			builder.setLength(builder.length() - 3);
-			builder.append(") / ");
+			return builder.toString();
 		}
 
-		builder.setLength(builder.length() - 3);
-		return builder.toString();
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -34,10 +34,23 @@ public class TaskManagerOptions {
 	// ------------------------------------------------------------------------
 
 	/**
-	 * JVM heap size (in megabytes) for the TaskManagers.
+	 * JVM heap size for the TaskManagers with memory size.
 	 */
 	@Documentation.CommonOption(position = Documentation.CommonOption.POSITION_MEMORY)
-	public static final ConfigOption<Integer> TASK_MANAGER_HEAP_MEMORY =
+	public static final ConfigOption<String> TASK_MANAGER_HEAP_MEMORY =
+			key("taskmanager.heap.size")
+			.defaultValue("1024m")
+			.withDescription("JVM heap size for the TaskManagers, which are the parallel workers of" +
+					" the system. On YARN setups, this value is automatically configured to the size of the TaskManager's" +
+					" YARN container, minus a certain tolerance value.");
+
+	/**
+	 * JVM heap size (in megabytes) for the TaskManagers.
+	 *
+	 * @deprecated use {@link #TASK_MANAGER_HEAP_MEMORY}
+	 */
+	@Deprecated
+	public static final ConfigOption<Integer> TASK_MANAGER_HEAP_MEMORY_MB =
 			key("taskmanager.heap.mb")
 			.defaultValue(1024)
 			.withDescription("JVM heap size (in megabytes) for the TaskManagers, which are the parallel workers of" +
@@ -179,19 +192,19 @@ public class TaskManagerOptions {
 	/**
 	 * Size of memory buffers used by the network stack and the memory manager (in bytes).
 	 */
-	public static final ConfigOption<Integer> MEMORY_SEGMENT_SIZE =
+	public static final ConfigOption<String> MEMORY_SEGMENT_SIZE =
 			key("taskmanager.memory.segment-size")
-			.defaultValue(32768)
-			.withDescription("Size of memory buffers used by the network stack and the memory manager (in bytes).");
+			.defaultValue("32768")
+			.withDescription("Size of memory buffers used by the network stack and the memory manager.");
 
 	/**
-	 * Amount of memory to be allocated by the task manager's memory manager (in megabytes). If not
+	 * Amount of memory to be allocated by the task manager's memory manager. If not
 	 * set, a relative fraction will be allocated, as defined by {@link #MANAGED_MEMORY_FRACTION}.
 	 */
-	public static final ConfigOption<Long> MANAGED_MEMORY_SIZE =
+	public static final ConfigOption<String> MANAGED_MEMORY_SIZE =
 			key("taskmanager.memory.size")
-			.defaultValue(-1L)
-			.withDescription("Amount of memory to be allocated by the task manager's memory manager (in megabytes)." +
+			.defaultValue("0")
+			.withDescription("Amount of memory to be allocated by the task manager's memory manager." +
 				" If not set, a relative fraction will be allocated.");
 
 	/**
@@ -257,18 +270,18 @@ public class TaskManagerOptions {
 	/**
 	 * Minimum memory size for network buffers (in bytes).
 	 */
-	public static final ConfigOption<Long> NETWORK_BUFFERS_MEMORY_MIN =
+	public static final ConfigOption<String> NETWORK_BUFFERS_MEMORY_MIN =
 			key("taskmanager.network.memory.min")
-			.defaultValue(64L << 20) // 64 MB
-			.withDescription("Minimum memory size for network buffers (in bytes).");
+			.defaultValue(String.valueOf(64L << 20)) // 64 MB
+			.withDescription("Minimum memory size for network buffers.");
 
 	/**
 	 * Maximum memory size for network buffers (in bytes).
 	 */
-	public static final ConfigOption<Long> NETWORK_BUFFERS_MEMORY_MAX =
+	public static final ConfigOption<String> NETWORK_BUFFERS_MEMORY_MAX =
 			key("taskmanager.network.memory.max")
-			.defaultValue(1024L << 20) // 1 GB
-			.withDescription("Maximum memory size for network buffers (in bytes).");
+			.defaultValue(String.valueOf(1024L << 20)) // 1 GB
+			.withDescription("Maximum memory size for network buffers.");
 
 	/**
 	 * Number of network buffers to use for each outgoing/incoming channel (subpartition/input channel).

--- a/flink-core/src/test/java/org/apache/flink/configuration/MemorySizeTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/MemorySizeTest.java
@@ -24,7 +24,9 @@ import org.junit.Test;
 
 import java.io.IOException;
 
+import static org.apache.flink.configuration.MemorySize.MemoryUnit.MEGA_BYTES;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.fail;
 
 /**
@@ -203,4 +205,19 @@ public class MemorySizeTest {
 	public void testParseNumberTimeUnitOverflow() {
 		MemorySize.parseBytes("100000000000000 tb");
 	}
+
+	@Test
+	public void testParseWithDefaultUnit() {
+		assertEquals(7, MemorySize.parse("7", MEGA_BYTES).getMebiBytes());
+		assertNotEquals(7, MemorySize.parse("7340032", MEGA_BYTES));
+		assertEquals(7, MemorySize.parse("7m", MEGA_BYTES).getMebiBytes());
+		assertEquals(7168, MemorySize.parse("7", MEGA_BYTES).getKibiBytes());
+		assertEquals(7168, MemorySize.parse("7m", MEGA_BYTES).getKibiBytes());
+		assertEquals(7, MemorySize.parse("7 m", MEGA_BYTES).getMebiBytes());
+		assertEquals(7, MemorySize.parse("7mb", MEGA_BYTES).getMebiBytes());
+		assertEquals(7, MemorySize.parse("7 mb", MEGA_BYTES).getMebiBytes());
+		assertEquals(7, MemorySize.parse("7mebibytes", MEGA_BYTES).getMebiBytes());
+		assertEquals(7, MemorySize.parse("7 mebibytes", MEGA_BYTES).getMebiBytes());
+	}
+
 }

--- a/flink-dist/src/main/flink-bin/bin/config.sh
+++ b/flink-dist/src/main/flink-bin/bin/config.sh
@@ -101,8 +101,10 @@ DEFAULT_ENV_SSH_OPTS=""                             # Optional SSH parameters ru
 # CONFIG KEYS: The default values can be overwritten by the following keys in conf/flink-conf.yaml
 ########################################################################################################################
 
-KEY_JOBM_MEM_SIZE="jobmanager.heap.mb"
-KEY_TASKM_MEM_SIZE="taskmanager.heap.mb"
+KEY_JOBM_MEM_SIZE="jobmanager.heap.size"
+KEY_JOBM_MEM_MB="jobmanager.heap.mb"
+KEY_TASKM_MEM_SIZE="taskmanager.heap.size"
+KEY_TASKM_MEM_MB="taskmanager.heap.mb"
 KEY_TASKM_MEM_MANAGED_SIZE="taskmanager.memory.size"
 KEY_TASKM_MEM_MANAGED_FRACTION="taskmanager.memory.fraction"
 KEY_TASKM_OFFHEAP="taskmanager.memory.off-heap"
@@ -127,6 +129,143 @@ KEY_HIGH_AVAILABILITY="high-availability"
 KEY_ZK_HEAP_MB="zookeeper.heap.mb"
 
 KEY_FLINK_MODE="mode"
+
+########################################################################################################################
+# MEMORY SIZE UNIT
+########################################################################################################################
+
+BYTES_UNITS=("b" "bytes")
+KILO_BYTES_UNITS=("k" "kb" "kibibytes")
+MEGA_BYTES_UNITS=("m" "mb" "mebibytes")
+GIGA_BYTES_UNITS=("g" "gb" "gibibytes")
+TERA_BYTES_UNITS=("t" "tb" "tebibytes")
+
+hasUnit() {
+    text=$1
+
+    trimmed=$(echo -e "${text}" | tr -d '[:space:]')
+
+    if [ -z "$trimmed" -o "$trimmed" == " " ]; then
+        echo "$trimmed is an empty- or whitespace-only string"
+	exit 1
+    fi
+
+    len=${#trimmed}
+    pos=0
+
+    while [ $pos -lt $len ]; do
+	current=${trimmed:pos:1}
+	if [[ ! $current < '0' ]] && [[ ! $current > '9' ]]; then
+	    let pos+=1
+	else
+	    break
+	fi
+    done
+
+    number=${trimmed:0:pos}
+
+    unit=${trimmed:$pos}
+    unit=$(echo -e "${unit}" | tr -d '[:space:]')
+    unit=$(echo -e "${unit}" | tr '[A-Z]' '[a-z]')
+
+    [[ ! -z "$unit" ]]
+}
+
+parseBytes() {
+    text=$1
+
+    trimmed=$(echo -e "${text}" | tr -d '[:space:]')
+
+    if [ -z "$trimmed" -o "$trimmed" == " " ]; then
+        echo "$trimmed is an empty- or whitespace-only string"
+	exit 1
+    fi
+
+    len=${#trimmed}
+    pos=0
+
+    while [ $pos -lt $len ]; do
+	current=${trimmed:pos:1}
+	if [[ ! $current < '0' ]] && [[ ! $current > '9' ]]; then
+	    let pos+=1
+	else
+	    break
+	fi
+    done
+
+    number=${trimmed:0:pos}
+
+    unit=${trimmed:$pos}
+    unit=$(echo -e "${unit}" | tr -d '[:space:]')
+    unit=$(echo -e "${unit}" | tr '[A-Z]' '[a-z]')
+
+    if [ -z "$number" ]; then
+        echo "text does not start with a number"
+        exit 1
+    fi
+
+    local multiplier
+    if [ -z "$unit" ]; then
+        multiplier=1
+    else
+        if matchesAny $unit "${BYTES_UNITS[*]}"; then
+            multiplier=1
+        elif matchesAny $unit "${KILO_BYTES_UNITS[*]}"; then
+                multiplier=1024
+        elif matchesAny $unit "${MEGA_BYTES_UNITS[*]}"; then
+                multiplier=`expr 1024 \* 1024`
+        elif matchesAny $unit "${GIGA_BYTES_UNITS[*]}"; then
+                multiplier=`expr 1024 \* 1024 \* 1024`
+        elif matchesAny $unit "${TERA_BYTES_UNITS[*]}"; then
+                multiplier=`expr 1024 \* 1024 \* 1024 \* 1024`
+        else
+            echo "[ERROR] Memory size unit $unit does not match any of the recognized units"
+            exit 1
+        fi
+    fi
+
+    ((result=$number * $multiplier))
+
+    if [ $[result / multiplier] != "$number" ]; then
+        echo "[ERROR] The value $text cannot be re represented as 64bit number of bytes (numeric overflow)."
+        exit 1
+    fi
+
+    echo "$result"
+}
+
+matchesAny() {
+    str=$1
+    variants=$2
+
+    for s in ${variants[*]}; do
+        if [ $str == $s ]; then
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+getKibiBytes() {
+    bytes=$1
+    echo "$(($bytes >>10))"
+}
+
+getMebiBytes() {
+    bytes=$1
+    echo "$(($bytes >> 20))"
+}
+
+getGibiBytes() {
+    bytes=$1
+    echo "$(($bytes >> 30))"
+}
+
+getTebiBytes() {
+    bytes=$1
+    echo "$(($bytes >> 40))"
+}
 
 ########################################################################################################################
 # PATHS AND CONFIG
@@ -216,14 +355,30 @@ if [ -z "${FLINK_JM_HEAP}" ]; then
     FLINK_JM_HEAP=$(readFromConfig ${KEY_JOBM_MEM_SIZE} 0 "${YAML_CONF}")
 fi
 
+# Try read old config key, if new key not exists
+if [ "${FLINK_JM_HEAP}" == 0 ]; then
+    FLINK_JM_HEAP_MB=$(readFromConfig ${KEY_JOBM_MEM_MB} 0 "${YAML_CONF}")
+fi
+
 # Define FLINK_TM_HEAP if it is not already set
 if [ -z "${FLINK_TM_HEAP}" ]; then
     FLINK_TM_HEAP=$(readFromConfig ${KEY_TASKM_MEM_SIZE} 0 "${YAML_CONF}")
 fi
 
+# Try read old config key, if new key not exists
+if [ "${FLINK_TM_HEAP}" == 0 ]; then
+    FLINK_TM_HEAP_MB=$(readFromConfig ${KEY_TASKM_MEM_MB} 0 "${YAML_CONF}")
+fi
+
 # Define FLINK_TM_MEM_MANAGED_SIZE if it is not already set
 if [ -z "${FLINK_TM_MEM_MANAGED_SIZE}" ]; then
     FLINK_TM_MEM_MANAGED_SIZE=$(readFromConfig ${KEY_TASKM_MEM_MANAGED_SIZE} 0 "${YAML_CONF}")
+
+    if hasUnit ${FLINK_TM_MEM_MANAGED_SIZE}; then
+        FLINK_TM_MEM_MANAGED_SIZE=$(getMebiBytes $(parseBytes ${FLINK_TM_MEM_MANAGED_SIZE}))
+    else
+        FLINK_TM_MEM_MANAGED_SIZE=$(getMebiBytes $(parseBytes ${FLINK_TM_MEM_MANAGED_SIZE}"m"))
+    fi
 fi
 
 # Define FLINK_TM_MEM_MANAGED_FRACTION if it is not already set
@@ -250,19 +405,24 @@ fi
 # Define FLINK_TM_NET_BUF_MIN and FLINK_TM_NET_BUF_MAX if not already set (as a fallback)
 if [ -z "${FLINK_TM_NET_BUF_MIN}" -a -z "${FLINK_TM_NET_BUF_MAX}" ]; then
     FLINK_TM_NET_BUF_MIN=$(readFromConfig ${KEY_TASKM_NET_BUF_NR} -1 "${YAML_CONF}")
-    FLINK_TM_NET_BUF_MAX=${FLINK_TM_NET_BUF_MIN}
+    if [ $FLINK_TM_NET_BUF_MIN != -1 ]; then
+        FLINK_TM_NET_BUF_MIN=$(parseBytes ${FLINK_TM_NET_BUF_MIN})
+        FLINK_TM_NET_BUF_MAX=${FLINK_TM_NET_BUF_MIN}
+    fi
 fi
 
 # Define FLINK_TM_NET_BUF_MIN if it is not already set
 if [ -z "${FLINK_TM_NET_BUF_MIN}" -o "${FLINK_TM_NET_BUF_MIN}" = "-1" ]; then
     # default: 64MB = 67108864 bytes (same as the previous default with 2048 buffers of 32k each)
     FLINK_TM_NET_BUF_MIN=$(readFromConfig ${KEY_TASKM_NET_BUF_MIN} 67108864 "${YAML_CONF}")
+    FLINK_TM_NET_BUF_MIN=$(parseBytes ${FLINK_TM_NET_BUF_MIN})
 fi
 
 # Define FLINK_TM_NET_BUF_MAX if it is not already set
 if [ -z "${FLINK_TM_NET_BUF_MAX}" -o "${FLINK_TM_NET_BUF_MAX}" = "-1" ]; then
     # default: 1GB = 1073741824 bytes
     FLINK_TM_NET_BUF_MAX=$(readFromConfig ${KEY_TASKM_NET_BUF_MAX} 1073741824 "${YAML_CONF}")
+    FLINK_TM_NET_BUF_MAX=$(parseBytes ${FLINK_TM_NET_BUF_MAX})
 fi
 
 # Define FLIP if it is not already set
@@ -506,7 +666,7 @@ HAVE_AWK=
 # same as org.apache.flink.runtime.taskexecutor.TaskManagerServices.calculateNetworkBufferMemory(long totalJavaMemorySize, Configuration config)
 calculateNetworkBufferMemory() {
     local network_buffers_bytes
-    if [ "${FLINK_TM_HEAP}" -le "0" ]; then
+    if [ "${FLINK_TM_HEAP_MB}" -le "0" ]; then
         echo "Variable 'FLINK_TM_HEAP' not set (usually read from '${KEY_TASKM_MEM_SIZE}' in ${FLINK_CONF_FILE})."
         exit 1
     fi
@@ -541,13 +701,13 @@ calculateNetworkBufferMemory() {
             exit 1
         fi
 
-        network_buffers_bytes=`awk "BEGIN { x = ${FLINK_TM_HEAP} * 1048576 * ${FLINK_TM_NET_BUF_FRACTION}; netbuf = x > ${FLINK_TM_NET_BUF_MAX} ? ${FLINK_TM_NET_BUF_MAX} : x < ${FLINK_TM_NET_BUF_MIN} ? ${FLINK_TM_NET_BUF_MIN} : x; printf \"%.0f\n\", netbuf }"`
+        network_buffers_bytes=`awk "BEGIN { x = ${FLINK_TM_HEAP_MB} * 1048576 * ${FLINK_TM_NET_BUF_FRACTION}; netbuf = x > ${FLINK_TM_NET_BUF_MAX} ? ${FLINK_TM_NET_BUF_MAX} : x < ${FLINK_TM_NET_BUF_MIN} ? ${FLINK_TM_NET_BUF_MIN} : x; printf \"%.0f\n\", netbuf }"`
     fi
 
     # recalculate the JVM heap memory by taking the network buffers into account
-    local tm_heap_size_bytes=$((${FLINK_TM_HEAP} << 20)) # megabytes to bytes
+    local tm_heap_size_bytes=$((${FLINK_TM_HEAP_MB} << 20)) # megabytes to bytes
     if [[ "${tm_heap_size_bytes}" -le "${network_buffers_bytes}" ]]; then
-        echo "[ERROR] Configured TaskManager memory size (${FLINK_TM_HEAP} MB, from '${KEY_TASKM_MEM_SIZE}') must be larger than the network buffer memory size (${network_buffers_bytes} bytes, from: '${KEY_TASKM_NET_BUF_FRACTION}', '${KEY_TASKM_NET_BUF_MIN}', '${KEY_TASKM_NET_BUF_MAX}', and '${KEY_TASKM_NET_BUF_NR}')."
+        echo "[ERROR] Configured TaskManager memory size (${FLINK_TM_HEAP_MB} MB, from '${KEY_TASKM_MEM_SIZE}') must be larger than the network buffer memory size (${network_buffers_bytes} bytes, from: '${KEY_TASKM_NET_BUF_FRACTION}', '${KEY_TASKM_NET_BUF_MIN}', '${KEY_TASKM_NET_BUF_MAX}', and '${KEY_TASKM_NET_BUF_NR}')."
         exit 1
     fi
 
@@ -556,21 +716,21 @@ calculateNetworkBufferMemory() {
 
 # same as org.apache.flink.runtime.taskexecutor.TaskManagerServices.calculateHeapSizeMB(long totalJavaMemorySizeMB, Configuration config)
 calculateTaskManagerHeapSizeMB() {
-    if [ "${FLINK_TM_HEAP}" -le "0" ]; then
+    if [ "${FLINK_TM_HEAP_MB}" -le "0" ]; then
         echo "Variable 'FLINK_TM_HEAP' not set (usually read from '${KEY_TASKM_MEM_SIZE}' in ${FLINK_CONF_FILE})."
         exit 1
     fi
 
     local network_buffers_mb=$(($(calculateNetworkBufferMemory) >> 20)) # bytes to megabytes
     # network buffers are always off-heap and thus need to be deduced from the heap memory size
-    local tm_heap_size_mb=$((${FLINK_TM_HEAP} - network_buffers_mb))
+    local tm_heap_size_mb=$((${FLINK_TM_HEAP_MB} - network_buffers_mb))
 
     if useOffHeapMemory; then
 
         if [[ "${FLINK_TM_MEM_MANAGED_SIZE}" -gt "0" ]]; then
             # We split up the total memory in heap and off-heap memory
             if [[ "${tm_heap_size_mb}" -le "${FLINK_TM_MEM_MANAGED_SIZE}" ]]; then
-                echo "[ERROR] Remaining TaskManager memory size (${tm_heap_size_mb} MB, from: '${KEY_TASKM_MEM_SIZE}' (${FLINK_TM_HEAP} MB) minus network buffer memory size (${network_buffers_mb} MB, from: '${KEY_TASKM_NET_BUF_FRACTION}', '${KEY_TASKM_NET_BUF_MIN}', '${KEY_TASKM_NET_BUF_MAX}', and '${KEY_TASKM_NET_BUF_NR}')) must be larger than the managed memory size (${FLINK_TM_MEM_MANAGED_SIZE} MB, from: '${KEY_TASKM_MEM_MANAGED_SIZE}')."
+                echo "[ERROR] Remaining TaskManager memory size (${tm_heap_size_mb} MB, from: '${KEY_TASKM_MEM_SIZE}' (${FLINK_TM_HEAP_MB} MB) minus network buffer memory size (${network_buffers_mb} MB, from: '${KEY_TASKM_NET_BUF_FRACTION}', '${KEY_TASKM_NET_BUF_MIN}', '${KEY_TASKM_NET_BUF_MAX}', and '${KEY_TASKM_NET_BUF_NR}')) must be larger than the managed memory size (${FLINK_TM_MEM_MANAGED_SIZE} MB, from: '${KEY_TASKM_MEM_MANAGED_SIZE}')."
                 exit 1
             fi
 

--- a/flink-dist/src/main/flink-bin/bin/jobmanager.sh
+++ b/flink-dist/src/main/flink-bin/bin/jobmanager.sh
@@ -41,13 +41,20 @@ if [[ "${FLINK_MODE}" == "new" ]]; then
 fi
 
 if [[ $STARTSTOP == "start" ]] || [[ $STARTSTOP == "start-foreground" ]]; then
-    if [[ ! ${FLINK_JM_HEAP} =~ $IS_NUMBER ]] || [[ "${FLINK_JM_HEAP}" -lt "0" ]]; then
+    if [ ! -z "${FLINK_JM_HEAP_MB}" ] && [ "${FLINK_JM_HEAP}" == 0 ]; then
+	    echo "used deprecated key \`${KEY_JOBM_MEM_MB}\`, please replace with key \`${KEY_JOBM_MEM_SIZE}\`"
+    else
+	    flink_jm_heap_bytes=$(parseBytes ${FLINK_JM_HEAP})
+	    FLINK_JM_HEAP_MB=$(getMebiBytes ${flink_jm_heap_bytes})
+    fi
+
+    if [[ ! ${FLINK_JM_HEAP_MB} =~ $IS_NUMBER ]] || [[ "${FLINK_JM_HEAP_MB}" -lt "0" ]]; then
         echo "[ERROR] Configured JobManager memory size is not a valid value. Please set '${KEY_JOBM_MEM_SIZE}' in ${FLINK_CONF_FILE}."
         exit 1
     fi
 
-    if [ "${FLINK_JM_HEAP}" -gt "0" ]; then
-        export JVM_ARGS="$JVM_ARGS -Xms"$FLINK_JM_HEAP"m -Xmx"$FLINK_JM_HEAP"m"
+    if [ "${FLINK_JM_HEAP_MB}" -gt "0" ]; then
+        export JVM_ARGS="$JVM_ARGS -Xms"$FLINK_JM_HEAP_MB"m -Xmx"$FLINK_JM_HEAP_MB"m"
     fi
 
     # Add JobManager-specific JVM options

--- a/flink-dist/src/main/flink-bin/bin/taskmanager.sh
+++ b/flink-dist/src/main/flink-bin/bin/taskmanager.sh
@@ -46,12 +46,19 @@ if [[ $STARTSTOP == "start" ]] || [[ $STARTSTOP == "start-foreground" ]]; then
         export JVM_ARGS="$JVM_ARGS -XX:+UseG1GC"
     fi
 
-    if [[ ! ${FLINK_TM_HEAP} =~ ${IS_NUMBER} ]] || [[ "${FLINK_TM_HEAP}" -lt "0" ]]; then
+    if [ ! -z "${FLINK_TM_HEAP_MB}" ] && [ "${FLINK_TM_HEAP}" == 0 ]; then
+	    echo "used deprecated key \`${KEY_TASKM_MEM_MB}\`, pelase replace with key \`${KEY_TASKM_MEM_SIZE}\`"
+    else
+	    flink_tm_heap_bytes=$(parseBytes ${FLINK_TM_HEAP})
+	    FLINK_TM_HEAP_MB=$(getMebiBytes ${flink_tm_heap_bytes})
+    fi
+
+    if [[ ! ${FLINK_TM_HEAP_MB} =~ ${IS_NUMBER} ]] || [[ "${FLINK_TM_HEAP_MB}" -lt "0" ]]; then
         echo "[ERROR] Configured TaskManager JVM heap size is not a number. Please set '${KEY_TASKM_MEM_SIZE}' in ${FLINK_CONF_FILE}."
         exit 1
     fi
 
-    if [ "${FLINK_TM_HEAP}" -gt "0" ]; then
+    if [ "${FLINK_TM_HEAP_MB}" -gt "0" ]; then
 
         TM_HEAP_SIZE=$(calculateTaskManagerHeapSizeMB)
         # Long.MAX_VALUE in TB: This is an upper bound, much less direct memory will be used

--- a/flink-dist/src/main/resources/flink-conf.yaml
+++ b/flink-dist/src/main/resources/flink-conf.yaml
@@ -39,12 +39,12 @@ jobmanager.rpc.port: 6123
 
 # The heap size for the JobManager JVM
 
-jobmanager.heap.mb: 1024
+jobmanager.heap.size: 1024m
 
 
 # The heap size for the TaskManager JVM
 
-taskmanager.heap.mb: 1024
+taskmanager.heap.size: 1024m
 
 
 # The number of task slots that each TaskManager offers. Each slot runs one parallel pipeline.

--- a/flink-dist/src/test/bin/calcTMHeapSizeMB.sh
+++ b/flink-dist/src/test/bin/calcTMHeapSizeMB.sh
@@ -39,4 +39,12 @@ fi
 FLINK_CONF_DIR=${bin}/../../main/resources
 . ${bin}/../../main/flink-bin/bin/config.sh > /dev/null
 
+FLINK_TM_HEAP_MB=$(getMebiBytes $(parseBytes ${FLINK_TM_HEAP}))
+
+if hasUnit ${FLINK_TM_MEM_MANAGED_SIZE}; then
+    FLINK_TM_MEM_MANAGED_SIZE=$(getMebiBytes $(parseBytes ${FLINK_TM_MEM_MANAGED_SIZE}))
+else
+    FLINK_TM_MEM_MANAGED_SIZE=$(getMebiBytes $(parseBytes ${FLINK_TM_MEM_MANAGED_SIZE}"m"))
+fi
+
 calculateTaskManagerHeapSizeMB

--- a/flink-dist/src/test/bin/calcTMNetBufMem.sh
+++ b/flink-dist/src/test/bin/calcTMNetBufMem.sh
@@ -36,4 +36,6 @@ fi
 FLINK_CONF_DIR=${bin}/../../main/resources
 . ${bin}/../../main/flink-bin/bin/config.sh > /dev/null
 
+FLINK_TM_HEAP_MB=$(getMebiBytes $(parseBytes ${FLINK_TM_HEAP}))
+
 calculateNetworkBufferMemory

--- a/flink-dist/src/test/java/org/apache/flink/dist/TaskManagerHeapSizeCalculationJavaBashTest.java
+++ b/flink-dist/src/test/java/org/apache/flink/dist/TaskManagerHeapSizeCalculationJavaBashTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.dist;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.taskexecutor.TaskManagerServices;
 import org.apache.flink.util.OperatingSystem;
@@ -51,7 +52,7 @@ import static org.junit.Assert.assertThat;
 public class TaskManagerHeapSizeCalculationJavaBashTest extends TestLogger {
 
 	/** Key that is used by <tt>config.sh</tt>. */
-	private static final String KEY_TASKM_MEM_SIZE = "taskmanager.heap.mb";
+	private static final String KEY_TASKM_MEM_SIZE = "taskmanager.heap.size";
 
 	/**
 	 * Number of tests with random values.
@@ -73,7 +74,7 @@ public class TaskManagerHeapSizeCalculationJavaBashTest extends TestLogger {
 	 */
 	@Test
 	public void compareNetworkBufShellScriptWithJava() throws Exception {
-		int managedMemSize = TaskManagerOptions.MANAGED_MEMORY_SIZE.defaultValue().intValue();
+		int managedMemSize = Integer.valueOf(TaskManagerOptions.MANAGED_MEMORY_SIZE.defaultValue());
 		float managedMemFrac = TaskManagerOptions.MANAGED_MEMORY_FRACTION.defaultValue();
 
 		// manual tests from org.apache.flink.runtime.taskexecutor.TaskManagerServices.calculateHeapSizeMB()
@@ -102,7 +103,7 @@ public class TaskManagerHeapSizeCalculationJavaBashTest extends TestLogger {
 	 */
 	@Test
 	public void compareHeapSizeShellScriptWithJava() throws Exception {
-		int managedMemSize = TaskManagerOptions.MANAGED_MEMORY_SIZE.defaultValue().intValue();
+		int managedMemSize = Integer.valueOf(TaskManagerOptions.MANAGED_MEMORY_SIZE.defaultValue());
 		float managedMemFrac = TaskManagerOptions.MANAGED_MEMORY_FRACTION.defaultValue();
 
 		// manual tests from org.apache.flink.runtime.taskexecutor.TaskManagerServices.calculateHeapSizeMB()
@@ -157,10 +158,14 @@ public class TaskManagerHeapSizeCalculationJavaBashTest extends TestLogger {
 		config.setBoolean(TaskManagerOptions.MEMORY_OFF_HEAP, useOffHeap);
 
 		config.setFloat(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_FRACTION, netBufMemFrac);
-		config.setLong(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN, netBufMemMin);
-		config.setLong(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX, netBufMemMax);
+		config.setString(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN, String.valueOf(netBufMemMin));
+		config.setString(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX, String.valueOf(netBufMemMax));
 
-		config.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, managedMemSizeMB);
+		if (managedMemSizeMB == 0) {
+			config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "0");
+		} else {
+			config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, managedMemSizeMB + "m");
+		}
 		config.setFloat(TaskManagerOptions.MANAGED_MEMORY_FRACTION, managedMemFrac);
 
 		return config;
@@ -181,13 +186,13 @@ public class TaskManagerHeapSizeCalculationJavaBashTest extends TestLogger {
 		// note: we are testing with integers only here to avoid overly complicated checks for
 		// overflowing or negative Long values - this should be enough for any practical scenario
 		// though
-		long min = (long) TaskManagerOptions.MEMORY_SEGMENT_SIZE.defaultValue() + ran.nextInt(Integer.MAX_VALUE);
+		long min = MemorySize.parse(TaskManagerOptions.MEMORY_SEGMENT_SIZE.defaultValue()).getBytes() + ran.nextInt(Integer.MAX_VALUE);
 		long max = ran.nextInt(Integer.MAX_VALUE) + min;
 
 		int javaMemMB = Math.max((int) (max >> 20), ran.nextInt(Integer.MAX_VALUE)) + 1;
 		boolean useOffHeap = ran.nextBoolean();
 
-		int managedMemSize = TaskManagerOptions.MANAGED_MEMORY_SIZE.defaultValue().intValue();
+		int managedMemSize = Integer.valueOf(TaskManagerOptions.MANAGED_MEMORY_SIZE.defaultValue());
 		float managedMemFrac = TaskManagerOptions.MANAGED_MEMORY_FRACTION.defaultValue();
 
 		if (ran.nextBoolean()) {
@@ -224,10 +229,11 @@ public class TaskManagerHeapSizeCalculationJavaBashTest extends TestLogger {
 		long javaNetworkBufMem = TaskManagerServices.calculateNetworkBufferMemory(totalJavaMemorySizeMB << 20, config);
 
 		String[] command = {"src/test/bin/calcTMNetBufMem.sh",
-			String.valueOf(totalJavaMemorySizeMB),
+			totalJavaMemorySizeMB + "m",
 			String.valueOf(config.getFloat(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_FRACTION)),
-			String.valueOf(config.getLong(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN)),
-			String.valueOf(config.getLong(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX))};
+			config.getString(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN),
+			config.getString(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX)};
+
 		String scriptOutput = executeScript(command);
 
 		long absoluteTolerance = (long) (javaNetworkBufMem * tolerance);
@@ -261,12 +267,12 @@ public class TaskManagerHeapSizeCalculationJavaBashTest extends TestLogger {
 		long javaHeapSizeMB = TaskManagerServices.calculateHeapSizeMB(totalJavaMemorySizeMB, config);
 
 		String[] command = {"src/test/bin/calcTMHeapSizeMB.sh",
-			String.valueOf(totalJavaMemorySizeMB),
+			totalJavaMemorySizeMB + "m",
 			String.valueOf(config.getBoolean(TaskManagerOptions.MEMORY_OFF_HEAP)),
 			String.valueOf(config.getFloat(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_FRACTION)),
-			String.valueOf(config.getLong(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN)),
-			String.valueOf(config.getLong(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX)),
-			String.valueOf(config.getLong(TaskManagerOptions.MANAGED_MEMORY_SIZE)),
+			config.getString(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN),
+			config.getString(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX),
+			config.getString(TaskManagerOptions.MANAGED_MEMORY_SIZE),
 			String.valueOf(config.getFloat(TaskManagerOptions.MANAGED_MEMORY_FRACTION))};
 		String scriptOutput = executeScript(command);
 

--- a/flink-libraries/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
+++ b/flink-libraries/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
@@ -87,7 +87,7 @@ public class LocalExecutorITCase extends TestLogger {
 
 	private static Configuration getConfig() {
 		Configuration config = new Configuration();
-		config.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, 4L);
+		config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "4m");
 		config.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, NUM_TMS);
 		config.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, NUM_SLOTS_PER_TM);
 		config.setBoolean(WebOptions.SUBMIT_ENABLE, false);

--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/HAQueryableStateFsBackendITCase.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/HAQueryableStateFsBackendITCase.java
@@ -95,7 +95,7 @@ public class HAQueryableStateFsBackendITCase extends AbstractQueryableStateTestB
 	private static Configuration getConfig() throws Exception {
 
 		Configuration config = new Configuration();
-		config.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, 4L);
+		config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "4m");
 		config.setInteger(ConfigConstants.LOCAL_NUMBER_JOB_MANAGER, NUM_JMS);
 		config.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, NUM_TMS);
 		config.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, NUM_SLOTS_PER_TM);

--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/HAQueryableStateRocksDBBackendITCase.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/HAQueryableStateRocksDBBackendITCase.java
@@ -95,7 +95,7 @@ public class HAQueryableStateRocksDBBackendITCase extends AbstractQueryableState
 	private static Configuration getConfig() throws Exception {
 
 		Configuration config = new Configuration();
-		config.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, 4L);
+		config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "4m");
 		config.setInteger(ConfigConstants.LOCAL_NUMBER_JOB_MANAGER, NUM_JMS);
 		config.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, NUM_TMS);
 		config.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, NUM_SLOTS_PER_TM);

--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/NonHAQueryableStateFsBackendITCase.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/NonHAQueryableStateFsBackendITCase.java
@@ -78,7 +78,7 @@ public class NonHAQueryableStateFsBackendITCase extends AbstractQueryableStateTe
 
 	private static Configuration getConfig() {
 		Configuration config = new Configuration();
-		config.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, 4L);
+		config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "4m");
 		config.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, NUM_TMS);
 		config.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, NUM_SLOTS_PER_TM);
 		config.setInteger(QueryableStateOptions.CLIENT_NETWORK_THREADS, 1);

--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/NonHAQueryableStateRocksDBBackendITCase.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/NonHAQueryableStateRocksDBBackendITCase.java
@@ -78,7 +78,7 @@ public class NonHAQueryableStateRocksDBBackendITCase extends AbstractQueryableSt
 
 	private static Configuration getConfig() {
 		Configuration config = new Configuration();
-		config.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, 4L);
+		config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "4m");
 		config.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, NUM_TMS);
 		config.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, NUM_SLOTS_PER_TM);
 		config.setInteger(QueryableStateOptions.CLIENT_NETWORK_THREADS, 1);

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/WebFrontendITCase.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/WebFrontendITCase.java
@@ -103,7 +103,7 @@ public class WebFrontendITCase extends TestLogger {
 		} catch (Exception e) {
 			throw new AssertionError("Could not setup test.", e);
 		}
-		config.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, 12L);
+		config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "12m");
 		config.setBoolean(ConfigConstants.LOCAL_START_WEBSERVER, true);
 
 		return config;

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/minicluster/LocalFlinkMiniCluster.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/minicluster/LocalFlinkMiniCluster.scala
@@ -367,8 +367,8 @@ class LocalFlinkMiniCluster(
 
   def setMemory(config: Configuration): Unit = {
     // set this only if no memory was pre-configured
-    if (config.getLong(TaskManagerOptions.MANAGED_MEMORY_SIZE) ==
-        TaskManagerOptions.MANAGED_MEMORY_SIZE.defaultValue()) {
+    if (config.getString(TaskManagerOptions.MANAGED_MEMORY_SIZE).equals(
+      TaskManagerOptions.MANAGED_MEMORY_SIZE.defaultValue())) {
 
       val numTaskManager = config.getInteger(
         ConfigConstants.LOCAL_NUMBER_TASK_MANAGER,
@@ -387,7 +387,7 @@ class LocalFlinkMiniCluster(
       memorySize -= TaskManagerServices.calculateNetworkBufferMemory(memorySize, config)
       memorySize = (memorySize * memoryFraction).toLong
       memorySize >>= 20 // bytes to megabytes
-      config.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, memorySize)
+      config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, memorySize + "m")
     }
   }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerTest.java
@@ -639,7 +639,7 @@ public class JobManagerTest extends TestLogger {
 				leaderId);
 
 		Configuration tmConfig = new Configuration();
-		tmConfig.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, 4L);
+		tmConfig.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "4m");
 		tmConfig.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 8);
 
 		ActorRef taskManager = TaskManager.startTaskManagerComponentsAndActor(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/NetworkBufferCalculationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/NetworkBufferCalculationTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.taskexecutor;
 
+import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.memory.MemoryType;
 import org.apache.flink.runtime.taskmanager.NetworkEnvironmentConfiguration;
@@ -42,13 +43,13 @@ public class NetworkBufferCalculationTest extends TestLogger {
 	public void calculateNetworkBufFromHeapSize() throws Exception {
 		TaskManagerServicesConfiguration tmConfig;
 
-		tmConfig = getTmConfig(TaskManagerOptions.MANAGED_MEMORY_SIZE.defaultValue(),
+		tmConfig = getTmConfig(Long.valueOf(TaskManagerOptions.MANAGED_MEMORY_SIZE.defaultValue()),
 			TaskManagerOptions.MANAGED_MEMORY_FRACTION.defaultValue(),
 			0.1f, 60L << 20, 1L << 30, MemoryType.HEAP);
 		assertEquals((100L << 20) + 1 /* one too many due to floating point imprecision */,
 			TaskManagerServices.calculateNetworkBufferMemory(tmConfig, 900L << 20)); // 900MB
 
-		tmConfig = getTmConfig(TaskManagerOptions.MANAGED_MEMORY_SIZE.defaultValue(),
+		tmConfig = getTmConfig(Long.valueOf(TaskManagerOptions.MANAGED_MEMORY_SIZE.defaultValue()),
 			TaskManagerOptions.MANAGED_MEMORY_FRACTION.defaultValue(),
 			0.2f, 60L << 20, 1L << 30, MemoryType.HEAP);
 		assertEquals((200L << 20) + 3 /* slightly too many due to floating point imprecision */,
@@ -86,7 +87,7 @@ public class NetworkBufferCalculationTest extends TestLogger {
 			networkBufFraction,
 			networkBufMin,
 			networkBufMax,
-			TaskManagerOptions.MEMORY_SEGMENT_SIZE.defaultValue(),
+			(int) MemorySize.parse(TaskManagerOptions.MEMORY_SEGMENT_SIZE.defaultValue()).getBytes(),
 			null,
 			TaskManagerOptions.NETWORK_REQUEST_BACKOFF_INITIAL.defaultValue(),
 			TaskManagerOptions.NETWORK_REQUEST_BACKOFF_MAX.defaultValue(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfigurationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfigurationTest.java
@@ -58,8 +58,8 @@ public class TaskManagerServicesConfigurationTest extends TestLogger {
 
 		// fully defined:
 		config.setFloat(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_FRACTION, 0.1f);
-		config.setLong(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN, 1024);
-		config.setLong(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX, 2048);
+		config.setString(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN, "1024");
+		config.setString(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX, "2048");
 
 		assertTrue(TaskManagerServicesConfiguration.hasNewNetworkBufConf(config));
 
@@ -67,19 +67,19 @@ public class TaskManagerServicesConfigurationTest extends TestLogger {
 		config = new Configuration();
 		config.setFloat(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_FRACTION, 0.1f);
 		assertTrue(TaskManagerServicesConfiguration.hasNewNetworkBufConf(config));
-		config.setLong(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX, 1024);
+		config.setString(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX, "1024");
 		assertTrue(TaskManagerServicesConfiguration.hasNewNetworkBufConf(config));
 
 		config = new Configuration();
-		config.setLong(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN, 1024);
+		config.setString(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN, "1024");
 		assertTrue(TaskManagerServicesConfiguration.hasNewNetworkBufConf(config));
 		config.setFloat(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_FRACTION, 0.1f);
 		assertTrue(TaskManagerServicesConfiguration.hasNewNetworkBufConf(config));
 
 		config = new Configuration();
-		config.setLong(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX, 1024);
+		config.setString(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX, "1024");
 		assertTrue(TaskManagerServicesConfiguration.hasNewNetworkBufConf(config));
-		config.setLong(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN, 1024);
+		config.setString(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN, "1024");
 		assertTrue(TaskManagerServicesConfiguration.hasNewNetworkBufConf(config));
 	}
 
@@ -102,11 +102,11 @@ public class TaskManagerServicesConfigurationTest extends TestLogger {
 		assertTrue(TaskManagerServicesConfiguration.hasNewNetworkBufConf(config1));
 
 		config1 = config.clone();
-		config1.setLong(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN, 1024);
+		config1.setString(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN, "1024");
 		assertTrue(TaskManagerServicesConfiguration.hasNewNetworkBufConf(config1));
 
 		config1 = config.clone();
-		config1.setLong(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX, 1024);
+		config1.setString(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX, "1024");
 		assertTrue(TaskManagerServicesConfiguration.hasNewNetworkBufConf(config1));
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.taskexecutor;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.util.TestLogger;
 
@@ -46,13 +47,13 @@ public class TaskManagerServicesTest extends TestLogger {
 		config.setInteger(TaskManagerOptions.NETWORK_NUM_BUFFERS, 1);
 
 		// note: actual network buffer memory size is independent of the totalJavaMemorySize
-		assertEquals(TaskManagerOptions.MEMORY_SEGMENT_SIZE.defaultValue().longValue(),
+		assertEquals(MemorySize.parse(TaskManagerOptions.MEMORY_SEGMENT_SIZE.defaultValue()).getBytes(),
 			TaskManagerServices.calculateNetworkBufferMemory(10L << 20, config));
-		assertEquals(TaskManagerOptions.MEMORY_SEGMENT_SIZE.defaultValue().longValue(),
+		assertEquals(MemorySize.parse(TaskManagerOptions.MEMORY_SEGMENT_SIZE.defaultValue()).getBytes(),
 			TaskManagerServices.calculateNetworkBufferMemory(64L << 20, config));
 
 		// test integer overflow in the memory size
-		int numBuffers = (int) ((2L << 32) / TaskManagerOptions.MEMORY_SEGMENT_SIZE.defaultValue()); // 2^33
+		int numBuffers = (int) ((2L << 32) / MemorySize.parse(TaskManagerOptions.MEMORY_SEGMENT_SIZE.defaultValue()).getBytes()); // 2^33
 		config.setInteger(TaskManagerOptions.NETWORK_NUM_BUFFERS, numBuffers);
 		assertEquals(2L << 32, TaskManagerServices.calculateNetworkBufferMemory(2L << 33, config));
 	}
@@ -69,8 +70,8 @@ public class TaskManagerServicesTest extends TestLogger {
 
 		// (1) defaults
 		final Float defaultFrac = TaskManagerOptions.NETWORK_BUFFERS_MEMORY_FRACTION.defaultValue();
-		final Long defaultMin = TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN.defaultValue();
-		final Long defaultMax = TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX.defaultValue();
+		final Long defaultMin = MemorySize.parse(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN.defaultValue()).getBytes();
+		final Long defaultMax = MemorySize.parse(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX.defaultValue()).getBytes();
 		assertEquals(enforceBounds((long) (defaultFrac * (10L << 20)), defaultMin, defaultMax),
 			TaskManagerServices.calculateNetworkBufferMemory((64L << 20 + 1), config));
 		assertEquals(enforceBounds((long) (defaultFrac * (10L << 30)), defaultMin, defaultMax),
@@ -87,8 +88,9 @@ public class TaskManagerServicesTest extends TestLogger {
 	 */
 	private static void calculateNetworkBufNew(final Configuration config) {
 		// (2) fixed size memory
-		config.setLong(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN, 1L << 20); // 1MB
-		config.setLong(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX, 1L << 20); // 1MB
+		config.setString(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN, String.valueOf(1L << 20)); // 1MB
+		config.setString(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX, String.valueOf(1L << 20)); // 1MB
+
 
 		// note: actual network buffer memory size is independent of the totalJavaMemorySize
 		assertEquals(1 << 20, TaskManagerServices.calculateNetworkBufferMemory(10L << 20, config));
@@ -101,11 +103,12 @@ public class TaskManagerServicesTest extends TestLogger {
 			float frac = Math.max(ran.nextFloat(), Float.MIN_VALUE);
 			config.setFloat(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_FRACTION, frac);
 
-			long min = Math.max(TaskManagerOptions.MEMORY_SEGMENT_SIZE.defaultValue(), ran.nextLong());
-			config.setLong(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN, min);
+			long min = Math.max(MemorySize.parse(TaskManagerOptions.MEMORY_SEGMENT_SIZE.defaultValue()).getBytes(), ran.nextLong());
+			config.setString(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN, String.valueOf(min));
+
 
 			long max = Math.max(min, ran.nextLong());
-			config.setLong(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX, max);
+			config.setString(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX, String.valueOf(max));
 
 			long javaMem = Math.max(max + 1, ran.nextLong());
 
@@ -139,8 +142,9 @@ public class TaskManagerServicesTest extends TestLogger {
 		config.setInteger(TaskManagerOptions.NETWORK_NUM_BUFFERS, 1);
 
 		final Float defaultFrac = TaskManagerOptions.NETWORK_BUFFERS_MEMORY_FRACTION.defaultValue();
-		final Long defaultMin = TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN.defaultValue();
-		final Long defaultMax = TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX.defaultValue();
+		final Long defaultMin = MemorySize.parse(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN.defaultValue()).getBytes();
+		final Long defaultMax = MemorySize.parse(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX.defaultValue()).getBytes();
+
 
 		// old + 1 new parameter = new:
 		Configuration config1 = config.clone();
@@ -151,16 +155,16 @@ public class TaskManagerServicesTest extends TestLogger {
 			TaskManagerServices.calculateNetworkBufferMemory((10L << 30), config1));
 
 		config1 = config.clone();
-		long newMin = TaskManagerOptions.MEMORY_SEGMENT_SIZE.defaultValue(); // smallest value possible
-		config1.setLong(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN, newMin);
+		long newMin = MemorySize.parse(TaskManagerOptions.MEMORY_SEGMENT_SIZE.defaultValue()).getBytes(); // smallest value possible
+		config1.setString(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN, String.valueOf(newMin));
 		assertEquals(enforceBounds((long) (defaultFrac * (10L << 20)), newMin, defaultMax),
 			TaskManagerServices.calculateNetworkBufferMemory((10L << 20), config1));
 		assertEquals(enforceBounds((long) (defaultFrac * (10L << 30)), newMin, defaultMax),
 			TaskManagerServices.calculateNetworkBufferMemory((10L << 30), config1));
 
 		config1 = config.clone();
-		long newMax = Math.max(64L << 20 + 1, TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN.defaultValue());
-		config1.setLong(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX, newMax);
+		long newMax = Math.max(64L << 20 + 1, MemorySize.parse(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN.defaultValue()).getBytes());
+		config1.setString(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX, String.valueOf(newMax));
 		assertEquals(enforceBounds((long) (defaultFrac * (10L << 20)), defaultMin, newMax),
 			TaskManagerServices.calculateNetworkBufferMemory((64L << 20 + 1), config1));
 		assertEquals(enforceBounds((long) (defaultFrac * (10L << 30)), defaultMin, newMax),
@@ -192,8 +196,8 @@ public class TaskManagerServicesTest extends TestLogger {
 	public void calculateHeapSizeMB() throws Exception {
 		Configuration config = new Configuration();
 		config.setFloat(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_FRACTION, 0.1f);
-		config.setLong(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN, 64L << 20); // 64MB
-		config.setLong(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX, 1L << 30); // 1GB
+		config.setString(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN, String.valueOf(64L << 20)); // 64MB
+		config.setString(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX, String.valueOf(1L << 30)); // 1GB
 
 		config.setBoolean(TaskManagerOptions.MEMORY_OFF_HEAP, false);
 		assertEquals(900, TaskManagerServices.calculateHeapSizeMB(1000, config));
@@ -204,10 +208,10 @@ public class TaskManagerServicesTest extends TestLogger {
 
 		config.setBoolean(TaskManagerOptions.MEMORY_OFF_HEAP, true);
 		config.setFloat(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_FRACTION, 0.1f);
-		config.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, 10); // 10MB
+		config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "10m"); // 10MB
 		assertEquals(890, TaskManagerServices.calculateHeapSizeMB(1000, config));
 
-		config.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, -1); // use fraction of given memory
+		config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "0"); // use fraction of given memory
 		config.setFloat(TaskManagerOptions.MANAGED_MEMORY_FRACTION, 0.1f); // 10%
 		assertEquals(810, TaskManagerServices.calculateHeapSizeMB(1000, config));
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/LegacyTaskCancelAsyncProducerConsumerITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/LegacyTaskCancelAsyncProducerConsumerITCase.java
@@ -83,7 +83,7 @@ public class LegacyTaskCancelAsyncProducerConsumerITCase extends TestLogger {
 			Configuration config = new Configuration();
 			config.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, 1);
 			config.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, 1);
-			config.setInteger(TaskManagerOptions.MEMORY_SEGMENT_SIZE, 4096);
+			config.setString(TaskManagerOptions.MEMORY_SEGMENT_SIZE, "4096");
 			config.setInteger(TaskManagerOptions.NETWORK_NUM_BUFFERS, 9);
 
 			flink = new TestingCluster(config, true);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskCancelAsyncProducerConsumerITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskCancelAsyncProducerConsumerITCase.java
@@ -75,7 +75,7 @@ public class TaskCancelAsyncProducerConsumerITCase extends TestLogger {
 
 		// Cluster
 		Configuration config = new Configuration();
-		config.setInteger(TaskManagerOptions.MEMORY_SEGMENT_SIZE, 4096);
+		config.setString(TaskManagerOptions.MEMORY_SEGMENT_SIZE, "4096");
 		config.setInteger(TaskManagerOptions.NETWORK_NUM_BUFFERS, 9);
 
 		MiniClusterConfiguration miniClusterConfiguration = new MiniClusterConfiguration.Builder()

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerProcessReapingTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerProcessReapingTestBase.java
@@ -247,7 +247,7 @@ public abstract class TaskManagerProcessReapingTestBase extends TestLogger {
 			Configuration cfg = new Configuration();
 			cfg.setString(JobManagerOptions.ADDRESS, "localhost");
 			cfg.setInteger(JobManagerOptions.PORT, jobManagerPort);
-			cfg.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, 4L);
+			cfg.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "4m");
 			cfg.setInteger(TaskManagerOptions.NETWORK_NUM_BUFFERS, 256);
 
 			final HighAvailabilityServices highAvailabilityServices = HighAvailabilityServicesUtils.createHighAvailabilityServices(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerStartupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerStartupTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
@@ -147,7 +148,7 @@ public class TaskManagerStartupTest extends TestLogger {
 		try {
 			Configuration cfg = new Configuration();
 			cfg.setString(CoreOptions.TMP_DIRS, nonWritable.getAbsolutePath());
-			cfg.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, 4L);
+			cfg.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "4m");
 			cfg.setString(JobManagerOptions.ADDRESS, "localhost");
 			cfg.setInteger(JobManagerOptions.PORT, 21656);
 
@@ -195,7 +196,7 @@ public class TaskManagerStartupTest extends TestLogger {
 			cfg.setBoolean(TaskManagerOptions.MANAGED_MEMORY_PRE_ALLOCATE, true);
 
 			// something invalid
-			cfg.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, -42L);
+			cfg.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "-42m");
 			try {
 				TaskManager.runTaskManager(
 					"localhost",
@@ -211,8 +212,8 @@ public class TaskManagerStartupTest extends TestLogger {
 
 			// something ridiculously high
 			final long memSize = (((long) Integer.MAX_VALUE - 1) *
-					TaskManagerOptions.MEMORY_SEGMENT_SIZE.defaultValue()) >> 20;
-			cfg.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, memSize);
+				MemorySize.parse(TaskManagerOptions.MEMORY_SEGMENT_SIZE.defaultValue()).getBytes()) >> 20;
+			cfg.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, memSize + "m");
 			try {
 				TaskManager.runTaskManager(
 					"localhost",
@@ -248,7 +249,7 @@ public class TaskManagerStartupTest extends TestLogger {
 			final Configuration cfg = new Configuration();
 			cfg.setString(ConfigConstants.TASK_MANAGER_HOSTNAME_KEY, "localhost");
 			cfg.setInteger(TaskManagerOptions.DATA_PORT, blocker.getLocalPort());
-			cfg.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, 1L);
+			cfg.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "1m");
 			ActorSystem actorSystem = AkkaUtils.createLocalActorSystem(cfg);
 			TaskManager.startTaskManagerComponentsAndActor(
 				cfg,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
@@ -1570,7 +1570,7 @@ public class TaskManagerTest extends TestLogger {
 			// set the memory segment to the smallest size possible, because we have to fill one
 			// memory buffer to trigger the schedule or update consumers message to the downstream
 			// operators
-			configuration.setInteger(TaskManagerOptions.MEMORY_SEGMENT_SIZE, 4096);
+			configuration.setString(TaskManagerOptions.MEMORY_SEGMENT_SIZE, "4096");
 
 			final JobID jid = new JobID();
 			final JobVertexID vid = new JobVertexID();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/TaskManagerProcess.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/TaskManagerProcess.java
@@ -103,7 +103,7 @@ public class TaskManagerProcess extends TestJvmProcess {
 				Configuration config = ParameterTool.fromArgs(args).getConfiguration();
 
 				if (!config.contains(TaskManagerOptions.MANAGED_MEMORY_SIZE)) {
-					config.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, 4L);
+					config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "4m");
 				}
 
 				if (!config.contains(TaskManagerOptions.NETWORK_NUM_BUFFERS)) {

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingUtils.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingUtils.scala
@@ -262,7 +262,7 @@ object TestingUtils {
 
     val resultingConfiguration = new Configuration()
 
-    resultingConfiguration.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, 10L)
+    resultingConfiguration.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "10m")
 
     resultingConfiguration.addAll(configuration)
 

--- a/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkShell.scala
+++ b/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkShell.scala
@@ -50,11 +50,11 @@ object FlinkShell {
   /** YARN configuration object */
   case class YarnConfig(
     containers: Option[Int] = None,
-    jobManagerMemory: Option[Int] = None,
+    jobManagerMemory: Option[String] = None,
     name: Option[String] = None,
     queue: Option[String] = None,
     slots: Option[Int] = None,
-    taskManagerMemory: Option[Int] = None
+    taskManagerMemory: Option[String] = None
   )
 
   /** Buffered reader to substitute input in test */
@@ -97,10 +97,10 @@ object FlinkShell {
           (x, c) =>
             c.copy(yarnConfig = Some(ensureYarnConfig(c).copy(containers = Some(x))))
         } text "Number of YARN container to allocate (= Number of TaskManagers)",
-        opt[Int]("jobManagerMemory") abbr ("jm") valueName ("arg") action {
+        opt[String]("jobManagerMemory") abbr ("jm") valueName ("arg") action {
           (x, c) =>
             c.copy(yarnConfig = Some(ensureYarnConfig(c).copy(jobManagerMemory = Some(x))))
-        } text "Memory for JobManager container [in MB]",
+        } text "Memory for JobManager container",
         opt[String]("name") abbr ("nm") action {
           (x, c) => c.copy(yarnConfig = Some(ensureYarnConfig(c).copy(name = Some(x))))
         } text "Set a custom name for the application on YARN",
@@ -110,10 +110,10 @@ object FlinkShell {
         opt[Int]("slots") abbr ("s") valueName ("<arg>") action {
           (x, c) => c.copy(yarnConfig = Some(ensureYarnConfig(c).copy(slots = Some(x))))
         } text "Number of slots per TaskManager",
-        opt[Int]("taskManagerMemory") abbr ("tm") valueName ("<arg>") action {
+        opt[String]("taskManagerMemory") abbr ("tm") valueName ("<arg>") action {
           (x, c) =>
             c.copy(yarnConfig = Some(ensureYarnConfig(c).copy(taskManagerMemory = Some(x))))
-        } text "Memory per TaskManager container [in MB]",
+        } text "Memory per TaskManager container",
         opt[(String)] ("addclasspath") abbr("a") valueName("<path/to/jar>") action {
           case (x, c) =>
             val xArray = x.split(":")

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/LegacyLocalStreamEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/LegacyLocalStreamEnvironment.java
@@ -78,7 +78,7 @@ public class LegacyLocalStreamEnvironment extends LocalStreamEnvironment {
 		Configuration configuration = new Configuration();
 		configuration.addAll(jobGraph.getJobConfiguration());
 
-		configuration.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, -1L);
+		configuration.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "0");
 		configuration.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, jobGraph.getMaximumParallelism());
 
 		// add (and override) the settings with what the user defined

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/LocalStreamEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/LocalStreamEnvironment.java
@@ -94,7 +94,7 @@ public class LocalStreamEnvironment extends StreamExecutionEnvironment {
 
 		Configuration configuration = new Configuration();
 		configuration.addAll(jobGraph.getJobConfiguration());
-		configuration.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, -1L);
+		configuration.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "0");
 
 		// add (and override) the settings with what the user defined
 		configuration.addAll(this.configuration);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkBenchmarkEnvironment.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkBenchmarkEnvironment.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.runtime.io.benchmark;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.io.IOReadableWritable;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
@@ -66,7 +67,7 @@ import static org.apache.flink.util.ExceptionUtils.suppressExceptions;
  */
 public class StreamNetworkBenchmarkEnvironment<T extends IOReadableWritable> {
 
-	private static final int BUFFER_SIZE = TaskManagerOptions.MEMORY_SEGMENT_SIZE.defaultValue();
+	private static final int BUFFER_SIZE = (int) MemorySize.parse(TaskManagerOptions.MEMORY_SEGMENT_SIZE.defaultValue()).getBytes();
 
 	private static final int NUM_SLOTS_AND_THREADS = 1;
 

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/MiniClusterResource.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/MiniClusterResource.java
@@ -225,7 +225,7 @@ public class MiniClusterResource extends ExternalResource {
 		}
 
 		if (!configuration.contains(TaskManagerOptions.MANAGED_MEMORY_SIZE)) {
-			configuration.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, TestBaseUtils.TASK_MANAGER_MEMORY_SIZE);
+			configuration.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, TestBaseUtils.TASK_MANAGER_MEMORY_SIZE);
 		}
 
 		// set rest port to 0 to avoid clashes with concurrent MiniClusters

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestBaseUtils.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestBaseUtils.java
@@ -95,7 +95,7 @@ public class TestBaseUtils extends TestLogger {
 
 	protected static final int MINIMUM_HEAP_SIZE_MB = 192;
 
-	protected static final long TASK_MANAGER_MEMORY_SIZE = 80;
+	protected static final String TASK_MANAGER_MEMORY_SIZE = "80m";
 
 	protected static final long DEFAULT_AKKA_ASK_TIMEOUT = 1000;
 
@@ -181,7 +181,7 @@ public class TestBaseUtils extends TestLogger {
 		}
 
 		if (!config.contains(TaskManagerOptions.MANAGED_MEMORY_SIZE)) {
-			config.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, TASK_MANAGER_MEMORY_SIZE);
+			config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, TASK_MANAGER_MEMORY_SIZE);
 		}
 
 		LocalFlinkMiniCluster cluster =  new LocalFlinkMiniCluster(config, singleActorSystem);

--- a/flink-tests/src/test/java/org/apache/flink/test/accumulators/AccumulatorErrorITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/accumulators/AccumulatorErrorITCase.java
@@ -58,7 +58,7 @@ public class AccumulatorErrorITCase extends TestLogger {
 
 	public static Configuration getConfiguration() {
 		Configuration config = new Configuration();
-		config.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, 12L);
+		config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "12m");
 		return config;
 	}
 

--- a/flink-tests/src/test/java/org/apache/flink/test/cancelling/CancelingTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/cancelling/CancelingTestBase.java
@@ -76,7 +76,7 @@ public abstract class CancelingTestBase extends TestLogger {
 		Configuration config = new Configuration();
 		config.setBoolean(CoreOptions.FILESYTEM_DEFAULT_OVERRIDE, true);
 		config.setString(AkkaOptions.ASK_TIMEOUT, TestingUtils.DEFAULT_AKKA_ASK_TIMEOUT());
-		config.setInteger(TaskManagerOptions.MEMORY_SEGMENT_SIZE, 4096);
+		config.setString(TaskManagerOptions.MEMORY_SEGMENT_SIZE, "4096");
 		config.setInteger(TaskManagerOptions.NETWORK_NUM_BUFFERS, 2048);
 
 		return config;

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/AbstractEventTimeWindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/AbstractEventTimeWindowCheckpointingITCase.java
@@ -190,9 +190,9 @@ public abstract class AbstractEventTimeWindowCheckpointingITCase extends TestLog
 		final File haDir = temporaryFolder.newFolder();
 
 		Configuration config = new Configuration();
-		config.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, 48L);
+		config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "48m");
 		// the default network buffers size (10% of heap max =~ 150MB) seems to much for this test case
-		config.setLong(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX, 80L << 20); // 80 MB
+		config.setString(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX, String.valueOf(80L << 20)); // 80 MB
 		config.setString(AkkaOptions.FRAMESIZE, String.valueOf(MAX_MEM_STATE_SIZE) + "b");
 
 		if (zkServer != null) {

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeAllWindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeAllWindowCheckpointingITCase.java
@@ -75,7 +75,7 @@ public class EventTimeAllWindowCheckpointingITCase extends TestLogger {
 
 	private static Configuration getConfiguration() {
 		Configuration config = new Configuration();
-		config.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, 48L);
+		config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "48m");
 		config.setString(AkkaOptions.LOOKUP_TIMEOUT, "60 s");
 		config.setString(AkkaOptions.ASK_TIMEOUT, "60 s");
 		return config;

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/KeyedStateCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/KeyedStateCheckpointingITCase.java
@@ -88,7 +88,7 @@ public class KeyedStateCheckpointingITCase extends TestLogger {
 
 	private static Configuration getConfiguration() {
 		Configuration config = new Configuration();
-		config.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, 12L);
+		config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "12m");
 		return config;
 	}
 

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
@@ -562,7 +562,7 @@ public class SavepointITCase extends TestLogger {
 
 		Configuration config = new Configuration();
 		config.addAll(jobGraph.getJobConfiguration());
-		config.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, -1L);
+		config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "0");
 		final File checkpointDir = new File(tmpDir, "checkpoints");
 		final File savepointDir = new File(tmpDir, "savepoints");
 

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/WindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/WindowCheckpointingITCase.java
@@ -83,7 +83,7 @@ public class WindowCheckpointingITCase extends TestLogger {
 
 	private static Configuration getConfiguration() {
 		Configuration config = new Configuration();
-		config.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, 48L);
+		config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "48m");
 		return config;
 	}
 

--- a/flink-tests/src/test/java/org/apache/flink/test/classloading/ClassLoaderITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/classloading/ClassLoaderITCase.java
@@ -115,7 +115,7 @@ public class ClassLoaderITCase extends TestLogger {
 				FOLDER.newFolder().getAbsoluteFile().toURI().toString());
 
 		// required as we otherwise run out of memory
-		config.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, 80);
+		config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "80m");
 
 		testCluster = new MiniCluster(
 			new MiniClusterConfiguration.Builder()

--- a/flink-tests/src/test/java/org/apache/flink/test/example/failing/JobSubmissionFailsITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/example/failing/JobSubmissionFailsITCase.java
@@ -60,7 +60,7 @@ public class JobSubmissionFailsITCase extends TestLogger {
 
 	private static Configuration getConfiguration() {
 		Configuration config = new Configuration();
-		config.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, 4L);
+		config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "4m");
 		return config;
 	}
 

--- a/flink-tests/src/test/java/org/apache/flink/test/manual/StreamingScalabilityAndLatency.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/manual/StreamingScalabilityAndLatency.java
@@ -49,7 +49,7 @@ public class StreamingScalabilityAndLatency {
 
 		try {
 			Configuration config = new Configuration();
-			config.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, 80L);
+			config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "80m");
 			config.setInteger(TaskManagerOptions.NETWORK_NUM_BUFFERS, 20000);
 
 			config.setInteger("taskmanager.net.server.numThreads", 1);

--- a/flink-tests/src/test/java/org/apache/flink/test/misc/CustomSerializationITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/misc/CustomSerializationITCase.java
@@ -59,7 +59,7 @@ public class CustomSerializationITCase extends TestLogger {
 
 	public static Configuration getConfiguration() {
 		Configuration config = new Configuration();
-		config.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, 30L);
+		config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "30m");
 		return config;
 	}
 

--- a/flink-tests/src/test/java/org/apache/flink/test/misc/SuccessAfterNetworkBuffersFailureITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/misc/SuccessAfterNetworkBuffersFailureITCase.java
@@ -61,7 +61,7 @@ public class SuccessAfterNetworkBuffersFailureITCase extends TestLogger {
 
 	private static Configuration getConfiguration() {
 		Configuration config = new Configuration();
-		config.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, 80L);
+		config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "80m");
 		config.setInteger(TaskManagerOptions.NETWORK_NUM_BUFFERS, 800);
 		return config;
 	}

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/AbstractTaskManagerProcessFailureRecoveryTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/AbstractTaskManagerProcessFailureRecoveryTest.java
@@ -404,7 +404,7 @@ public abstract class AbstractTaskManagerProcessFailureRecoveryTest extends Test
 				Configuration cfg = new Configuration();
 				cfg.setString(JobManagerOptions.ADDRESS, "localhost");
 				cfg.setInteger(JobManagerOptions.PORT, jobManagerPort);
-				cfg.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, 4L);
+				cfg.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "4m");
 				cfg.setInteger(TaskManagerOptions.NETWORK_NUM_BUFFERS, 100);
 				cfg.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 2);
 				cfg.setString(AkkaOptions.ASK_TIMEOUT, "100 s");

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/JobManagerHAProcessFailureBatchRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/JobManagerHAProcessFailureBatchRecoveryITCase.java
@@ -267,7 +267,7 @@ public class JobManagerHAProcessFailureBatchRecoveryITCase extends TestLogger {
 			jmProcess[0].startProcess();
 
 			// Task manager configuration
-			config.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, 4L);
+			config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "4m");
 			config.setInteger(TaskManagerOptions.NETWORK_NUM_BUFFERS, 100);
 			config.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 2);
 

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/TaskManagerFailureRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/TaskManagerFailureRecoveryITCase.java
@@ -78,7 +78,7 @@ public class TaskManagerFailureRecoveryITCase extends TestLogger {
 			Configuration config = new Configuration();
 			config.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, 2);
 			config.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, parallelism);
-			config.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, 16L);
+			config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "16m");
 
 			config.setString(AkkaOptions.WATCH_HEARTBEAT_INTERVAL, "500 ms");
 			config.setString(AkkaOptions.WATCH_HEARTBEAT_PAUSE, "20 s");

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/IPv6HostnamesITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/IPv6HostnamesITCase.java
@@ -78,7 +78,7 @@ public class IPv6HostnamesITCase extends TestLogger {
 		Configuration config = new Configuration();
 		config.setString(JobManagerOptions.ADDRESS, addressString);
 		config.setString(ConfigConstants.TASK_MANAGER_HOSTNAME_KEY, addressString);
-		config.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, 16L);
+		config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "16m");
 		return config;
 	}
 

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/TimestampITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/TimestampITCase.java
@@ -87,7 +87,7 @@ public class TimestampITCase extends TestLogger {
 
 	private static Configuration getConfiguration() {
 		Configuration config = new Configuration();
-		config.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, 12L);
+		config.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "12m");
 		return config;
 	}
 

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionCapacitySchedulerITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionCapacitySchedulerITCase.java
@@ -107,8 +107,8 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
 		LOG.info("Starting testClientStartup()");
 		runWithArgs(new String[]{"-j", flinkUberjar.getAbsolutePath(), "-t", flinkLibFolder.getAbsolutePath(),
 						"-n", "1",
-						"-jm", "768",
-						"-tm", "1024", "-qu", "qa-team"},
+						"-jm", "768m",
+						"-tm", "1024m", "-qu", "qa-team"},
 				"Number of connected TaskManagers changed to 1. Slots available: 1", null, RunTypes.YARN_SESSION, 0);
 		LOG.info("Finished testClientStartup()");
 	}
@@ -129,8 +129,8 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
 				"-yj", flinkUberjar.getAbsolutePath(), "-yt", flinkLibFolder.getAbsolutePath(),
 				"-yn", "1",
 				"-ys", "2", //test that the job is executed with a DOP of 2
-				"-yjm", "768",
-				"-ytm", "1024", exampleJarLocation.getAbsolutePath()},
+				"-yjm", "768m",
+				"-ytm", "1024m", exampleJarLocation.getAbsolutePath()},
 			/* test succeeded after this string */
 			"Program execution finished",
 			/* prohibited strings: (to verify the parallelism) */
@@ -172,10 +172,10 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
 				"-yj", flinkUberjar.getAbsolutePath(), "-yt", flinkLibFolder.getAbsolutePath(),
 				"-yn", "1",
 				"-ys", "2", //test that the job is executed with a DOP of 2
-				"-yjm", "768",
-				"-ytm", String.valueOf(taskManagerMemoryMB),
+				"-yjm", "768m",
+				"-ytm", taskManagerMemoryMB + "m",
 				"-yD", "taskmanager.memory.off-heap=true",
-				"-yD", "taskmanager.memory.size=" + offHeapMemory,
+				"-yD", "taskmanager.memory.size=" + offHeapMemory + "m",
 				"-yD", "taskmanager.memory.preallocate=true", exampleJarLocation.getAbsolutePath()},
 			/* test succeeded after this string */
 			"Program execution finished",
@@ -195,8 +195,8 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
 		LOG.info("Starting testTaskManagerFailure()");
 		Runner runner = startWithArgs(new String[]{"-j", flinkUberjar.getAbsolutePath(), "-t", flinkLibFolder.getAbsolutePath(),
 				"-n", "1",
-				"-jm", "768",
-				"-tm", "1024",
+				"-jm", "768m",
+				"-tm", "1024m",
 				"-s", "3", // set the slots 3 to check if the vCores are set properly!
 				"-nm", "customName",
 				"-Dfancy-configuration-value=veryFancy",
@@ -374,8 +374,8 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
 			runWithArgs(new String[]{"-j", flinkUberjar.getAbsolutePath(),
 				"-t", flinkLibFolder.getAbsolutePath(),
 				"-n", "1",
-				"-jm", "768",
-				"-tm", "1024",
+				"-jm", "768m",
+				"-tm", "1024m",
 				"-qu", "doesntExist"}, "to unknown queue: doesntExist", null, RunTypes.YARN_SESSION, 1);
 		} catch (Exception e) {
 			assertTrue(ExceptionUtils.findThrowableWithMessage(e, "to unknown queue: doesntExist").isPresent());
@@ -401,8 +401,8 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
 				"-yt", flinkLibFolder.getAbsolutePath(),
 				"-yn", "1",
 				"-ys", "2",
-				"-yjm", "768",
-				"-ytm", "1024", exampleJarLocation.getAbsolutePath()},
+				"-yjm", "768m",
+				"-ytm", "1024m", exampleJarLocation.getAbsolutePath()},
 				/* test succeeded after this string */
 			"Program execution finished",
 			/* prohibited strings: (we want to see "DataSink (...) (2/2) switched to FINISHED") */
@@ -468,12 +468,12 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
 				"-yj", flinkUberjar.getAbsolutePath(),
 				"-yt", flinkLibFolder.getAbsolutePath(),
 				"-yn", "1",
-				"-yjm", "768",
+				"-yjm", "768m",
 				// test if the cutoff is passed correctly (only useful when larger than the value
 				// of containerized.heap-cutoff-min (default: 600MB)
 				"-yD", "yarn.heap-cutoff-ratio=0.7",
 				"-yD", "yarn.tags=test-tag",
-				"-ytm", "1024",
+				"-ytm", "1024m",
 				"-ys", "2", // test requesting slots from YARN.
 				"-p", "2",
 				"--detached", job,

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
@@ -108,10 +108,10 @@ public class YARNSessionFIFOITCase extends YarnTestBase {
 		args.add("1");
 
 		args.add("-jm");
-		args.add("768");
+		args.add("768m");
 
 		args.add("-tm");
-		args.add("1024");
+		args.add("1024m");
 
 		if (SecureTestEnvironment.getTestKeytab() != null) {
 			args.add("-D" + SecurityOptions.KERBEROS_LOGIN_KEYTAB.key() + "=" + SecureTestEnvironment.getTestKeytab());
@@ -260,8 +260,8 @@ public class YARNSessionFIFOITCase extends YarnTestBase {
 		LOG.info("Starting testResourceComputation()");
 		runWithArgs(new String[]{"-j", flinkUberjar.getAbsolutePath(), "-t", flinkLibFolder.getAbsolutePath(),
 				"-n", "5",
-				"-jm", "256",
-				"-tm", "1585"}, "Number of connected TaskManagers changed to", null, RunTypes.YARN_SESSION, 0);
+				"-jm", "256m",
+				"-tm", "1585m"}, "Number of connected TaskManagers changed to", null, RunTypes.YARN_SESSION, 0);
 		LOG.info("Finished testResourceComputation()");
 		checkForLogString("This YARN session requires 8437MB of memory in the cluster. There are currently only 8192MB available.");
 	}
@@ -288,8 +288,8 @@ public class YARNSessionFIFOITCase extends YarnTestBase {
 		LOG.info("Starting testfullAlloc()");
 		runWithArgs(new String[]{"-j", flinkUberjar.getAbsolutePath(), "-t", flinkLibFolder.getAbsolutePath(),
 				"-n", "2",
-				"-jm", "256",
-				"-tm", "3840"}, "Number of connected TaskManagers changed to", null, RunTypes.YARN_SESSION, 0);
+				"-jm", "256m",
+				"-tm", "3840m"}, "Number of connected TaskManagers changed to", null, RunTypes.YARN_SESSION, 0);
 		LOG.info("Finished testfullAlloc()");
 		checkForLogString("There is not enough memory available in the YARN cluster. The TaskManager(s) require 3840MB each. NodeManagers available: [4096, 4096]\n" +
 				"After allocating the JobManager (512MB) and (1/2) TaskManagers, the following NodeManagers are available: [3584, 256]");

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnConfigurationITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnConfigurationITCase.java
@@ -87,8 +87,8 @@ public class YarnConfigurationITCase extends YarnTestBase {
 
 		// disable heap cutoff min
 		configuration.setInteger(ResourceManagerOptions.CONTAINERIZED_HEAP_CUTOFF_MIN, 0);
-		configuration.setLong(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN, (1L << 20));
-		configuration.setLong(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX, (4L << 20));
+		configuration.setString(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MIN, String.valueOf(1L << 20));
+		configuration.setString(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX, String.valueOf(4L << 20));
 
 		final YarnConfiguration yarnConfiguration = getYarnConfiguration();
 		final YarnClusterDescriptor clusterDescriptor = new YarnClusterDescriptor(

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
@@ -859,9 +859,9 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 			TaskManagerOptions.NUM_TASK_SLOTS,
 			clusterSpecification.getSlotsPerTaskManager());
 
-		configuration.setInteger(
+		configuration.setString(
 			TaskManagerOptions.TASK_MANAGER_HEAP_MEMORY,
-			clusterSpecification.getTaskManagerMemoryMB());
+			clusterSpecification.getTaskManagerMemoryMB() + "m");
 
 		// Upload the flink configuration
 		// write out configuration file

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
@@ -20,6 +20,7 @@ package org.apache.flink.yarn;
 
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.ContaineredTaskManagerParameters;
@@ -161,7 +162,7 @@ public class YarnResourceManager extends ResourceManager<YarnWorkerNode> impleme
 		numPendingContainerRequests = 0;
 
 		this.webInterfaceUrl = webInterfaceUrl;
-		this.defaultTaskManagerMemoryMB = flinkConfig.getInteger(TaskManagerOptions.TASK_MANAGER_HEAP_MEMORY);
+		this.defaultTaskManagerMemoryMB = (int) MemorySize.parse(flinkConfig.getString(TaskManagerOptions.TASK_MANAGER_HEAP_MEMORY)).getMebiBytes();
 		this.defaultNumSlots = flinkConfig.getInteger(TaskManagerOptions.NUM_TASK_SLOTS);
 		this.defaultCpus = flinkConfig.getInteger(YarnConfigOptions.VCORES, defaultNumSlots);
 	}

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
@@ -27,6 +27,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.messages.GetClusterStatusResponse;
@@ -385,10 +386,10 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<ApplicationId
 		}
 
 		// JobManager Memory
-		final int jobManagerMemoryMB = configuration.getInteger(JobManagerOptions.JOB_MANAGER_HEAP_MEMORY);
+		final int jobManagerMemoryMB = (int) MemorySize.parse(configuration.getString(JobManagerOptions.JOB_MANAGER_HEAP_MEMORY)).getMebiBytes();
 
 		// Task Managers memory
-		final int taskManagerMemoryMB = configuration.getInteger(TaskManagerOptions.TASK_MANAGER_HEAP_MEMORY);
+		final int taskManagerMemoryMB = (int) MemorySize.parse(configuration.getString(TaskManagerOptions.TASK_MANAGER_HEAP_MEMORY)).getMebiBytes();
 
 		int slotsPerTaskManager = configuration.getInteger(TaskManagerOptions.NUM_TASK_SLOTS);
 
@@ -499,11 +500,11 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<ApplicationId
 		}
 
 		if (commandLine.hasOption(jmMemory.getOpt())) {
-			effectiveConfiguration.setInteger(JobManagerOptions.JOB_MANAGER_HEAP_MEMORY, Integer.parseInt(commandLine.getOptionValue(jmMemory.getOpt())));
+			effectiveConfiguration.setString(JobManagerOptions.JOB_MANAGER_HEAP_MEMORY, commandLine.getOptionValue(jmMemory.getOpt()));
 		}
 
 		if (commandLine.hasOption(tmMemory.getOpt())) {
-			effectiveConfiguration.setInteger(TaskManagerOptions.TASK_MANAGER_HEAP_MEMORY, Integer.parseInt(commandLine.getOptionValue(tmMemory.getOpt())));
+			effectiveConfiguration.setString(TaskManagerOptions.TASK_MANAGER_HEAP_MEMORY, commandLine.getOptionValue(tmMemory.getOpt()));
 		}
 
 		if (commandLine.hasOption(slots.getOpt())) {

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/FlinkYarnSessionCliTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/FlinkYarnSessionCliTest.java
@@ -302,11 +302,11 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 		final int taskManagerMemory = 7331;
 		final int slotsPerTaskManager = 30;
 
-		configuration.setInteger(JobManagerOptions.JOB_MANAGER_HEAP_MEMORY, jobManagerMemory);
-		configuration.setInteger(TaskManagerOptions.TASK_MANAGER_HEAP_MEMORY, taskManagerMemory);
+		configuration.setString(JobManagerOptions.JOB_MANAGER_HEAP_MEMORY, jobManagerMemory + "m");
+		configuration.setString(TaskManagerOptions.TASK_MANAGER_HEAP_MEMORY, taskManagerMemory + "m");
 		configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, slotsPerTaskManager);
 
-		final String[] args = {"-yjm", String.valueOf(jobManagerMemory), "-ytm", String.valueOf(taskManagerMemory), "-ys", String.valueOf(slotsPerTaskManager)};
+		final String[] args = {"-yjm", String.valueOf(jobManagerMemory) + "m", "-ytm", String.valueOf(taskManagerMemory) + "m", "-ys", String.valueOf(slotsPerTaskManager)};
 		final FlinkYarnSessionCli flinkYarnSessionCli = new FlinkYarnSessionCli(
 			configuration,
 			tmp.getRoot().getAbsolutePath(),
@@ -330,9 +330,9 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 	public void testConfigurationClusterSpecification() throws Exception {
 		final Configuration configuration = new Configuration();
 		final int jobManagerMemory = 1337;
-		configuration.setInteger(JobManagerOptions.JOB_MANAGER_HEAP_MEMORY, jobManagerMemory);
+		configuration.setString(JobManagerOptions.JOB_MANAGER_HEAP_MEMORY, jobManagerMemory + "m");
 		final int taskManagerMemory = 7331;
-		configuration.setInteger(TaskManagerOptions.TASK_MANAGER_HEAP_MEMORY, taskManagerMemory);
+		configuration.setString(TaskManagerOptions.TASK_MANAGER_HEAP_MEMORY, taskManagerMemory + "m");
 		final int slotsPerTaskManager = 42;
 		configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, slotsPerTaskManager);
 


### PR DESCRIPTION
## What is the purpose of the change
Configure Memory Sizes with units, refactored the code, config file and the scripts where refer to the memory configuration.

This PR is base on [FLINK-6470 - Add a utility to parse memory sizes with units](https://issues.apache.org/jira/browse/FLINK-6470) of the [FLINK-6469 - Configure Memory Sizes with units](https://issues.apache.org/jira/browse/FLINK-6469).

## Brief change log
* implement the `MemorySize` logic on `bin/config.sh` to parse the memory config with unit
* refactor `bin/jobmanager.sh` and `bin/taskmanager.sh` for old and new key's compatibility
* in `conf/flink-conf.yaml` ,retained but deprecated the config key `jobmanager.heap.mb` , `taskmanager.heap.mb` and introduced `jobmanager.heap.size`, `taskmanager.heap.size` with the unit `m`
* refactor the `JobManagerOptions` and `TaskManagerOptions` about those config items and related code 
* refactor related test case
* multi-cluster deployment mode (standalone, YARN...) support

## Does this pull request potentially affect one of the following parts:
* Dependencies (does it add or upgrade a dependency): (no)
* The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
* The serializers: (no)
* The runtime per-record code paths (performance sensitive): (no)
* Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
* The S3 file system connector: (no)
## Documentation
* Does this pull request introduce a new feature? (no)
* If yes, how is the feature documented? (not applicable)