### PR TITLE
[FLINK-8631] [rest] Add support for generic types to the RestClient

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
@@ -32,7 +32,9 @@ import org.apache.flink.runtime.rest.util.RestMapperUtils;
 import org.apache.flink.util.Preconditions;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonParseException;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonParser;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JavaType;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.flink.shaded.netty4.io.netty.bootstrap.Bootstrap;
@@ -68,6 +70,7 @@ import javax.net.ssl.SSLEngine;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
+import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
@@ -165,10 +168,22 @@ public class RestClient {
 			.set(HttpHeaders.Names.HOST, targetAddress + ':' + targetPort)
 			.set(HttpHeaders.Names.CONNECTION, HttpHeaders.Values.CLOSE);
 
-		return submitRequest(targetAddress, targetPort, httpRequest, messageHeaders.getResponseClass());
+		final JavaType responseType;
+
+		final Collection<Class<?>> typeParameters = messageHeaders.getResponseTypeParameters();
+
+		if (typeParameters.isEmpty()) {
+			responseType = objectMapper.constructType(messageHeaders.getResponseClass());
+		} else {
+			responseType = objectMapper.getTypeFactory().constructParametricType(
+				messageHeaders.getResponseClass(),
+				typeParameters.toArray(new Class<?>[typeParameters.size()]));
+		}
+
+		return submitRequest(targetAddress, targetPort, httpRequest, responseType);
 	}
 
-	private <P extends ResponseBody> CompletableFuture<P> submitRequest(String targetAddress, int targetPort, FullHttpRequest httpRequest, Class<P> responseClass) {
+	private <P extends ResponseBody> CompletableFuture<P> submitRequest(String targetAddress, int targetPort, FullHttpRequest httpRequest, JavaType responseType) {
 		final ChannelFuture connectFuture = bootstrap.connect(targetAddress, targetPort);
 
 		final CompletableFuture<Channel> channelFuture = new CompletableFuture<>();
@@ -192,16 +207,17 @@ public class RestClient {
 				},
 				executor)
 			.thenComposeAsync(
-				(JsonResponse rawResponse) -> parseResponse(rawResponse, responseClass),
+				(JsonResponse rawResponse) -> parseResponse(rawResponse, responseType),
 				executor);
 	}
 
-	private static <P extends ResponseBody> CompletableFuture<P> parseResponse(JsonResponse rawResponse, Class<P> responseClass) {
+	private static <P extends ResponseBody> CompletableFuture<P> parseResponse(JsonResponse rawResponse, JavaType responseType) {
 		CompletableFuture<P> responseFuture = new CompletableFuture<>();
+		final JsonParser jsonParser = objectMapper.treeAsTokens(rawResponse.json);
 		try {
-			P response = objectMapper.treeToValue(rawResponse.getJson(), responseClass);
+			P response = objectMapper.readValue(jsonParser, responseType);
 			responseFuture.complete(response);
-		} catch (JsonProcessingException jpe) {
+		} catch (IOException ioe) {
 			// the received response did not matched the expected response type
 
 			// lets see if it is an ErrorResponse instead
@@ -211,10 +227,10 @@ public class RestClient {
 			} catch (JsonProcessingException jpe2) {
 				// if this fails it is either the expected type or response type was wrong, most likely caused
 				// by a client/search MessageHeaders mismatch
-				LOG.error("Received response was neither of the expected type ({}) nor an error. Response={}", responseClass, rawResponse, jpe2);
+				LOG.error("Received response was neither of the expected type ({}) nor an error. Response={}", responseType, rawResponse, jpe2);
 				responseFuture.completeExceptionally(
 					new RestClientException(
-						"Response was neither of the expected type(" + responseClass + ") nor an error.",
+						"Response was neither of the expected type(" + responseType + ") nor an error.",
 						jpe2,
 						rawResponse.getHttpResponseStatus()));
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/MessageHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/MessageHeaders.java
@@ -20,6 +20,9 @@ package org.apache.flink.runtime.rest.messages;
 
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
 
+import java.util.Collection;
+import java.util.Collections;
+
 /**
  * This class links {@link RequestBody}s to {@link ResponseBody}s types and contains meta-data required for their http headers.
  *
@@ -44,4 +47,13 @@ public interface MessageHeaders<R extends RequestBody, P extends ResponseBody, M
 	 * @return http status code of the response
 	 */
 	HttpResponseStatus getResponseStatusCode();
+
+	/**
+	 * Returns the collection of type parameters for the response type.
+	 *
+	 * @return Collection of type parameters for the response type
+	 */
+	default Collection<Class<?>> getResponseTypeParameters() {
+		return Collections.emptyList();
+	}
 }


### PR DESCRIPTION
## What is the purpose of the change

This commit allows the Restclient to receive generic response types. In order
to do this, the MessageHeaders contain now information about the generic
type parameters of the response type.

## Brief change log

- Extend `MessageHeaders` to have `getResponseTypeParameters` method
- Adapt `RestClient` to take type parameters into consideration when receiving a response

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
