### PR TITLE
[FLINK-8633] [flip6] Expose rescaling of jobs via the Dispatcher

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/function/BiConsumerWithException.java
+++ b/flink-core/src/main/java/org/apache/flink/util/function/BiConsumerWithException.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.util.function;
+
+import java.util.function.BiConsumer;
+
+/**
+ * A checked extension of the {@link BiConsumer} interface.
+ *
+ * @param <T> type of the first argument
+ * @param <U> type of the second argument
+ * @param <E> type of the thrown exception
+ */
+@FunctionalInterface
+public interface BiConsumerWithException<T, U, E extends Throwable> extends BiConsumer<T, U> {
+
+	/**
+	 * Performs this operation on the given arguments.
+	 *
+	 * @param t the first input argument
+	 * @param u the second input argument
+	 * @throws E in case of an error
+	 */
+	void acceptWithException(T t, U u) throws E;
+
+	@Override
+	default void accept(T t, U u) {
+		try {
+			acceptWithException(t, u);
+		} catch (Throwable e) {
+			throw new RuntimeException(e);
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/Checkpoints.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/Checkpoints.java
@@ -246,7 +246,7 @@ public class Checkpoints {
 		try (InputStream in = metadataHandle.openInputStream();
 			DataInputStream dis = new DataInputStream(in)) {
 
-				savepoint = loadCheckpointMetadata(dis, classLoader);
+			savepoint = loadCheckpointMetadata(dis, classLoader);
 		}
 
 		Exception exception = null;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -40,6 +40,7 @@ import org.apache.flink.runtime.jobmaster.JobManagerRunner;
 import org.apache.flink.runtime.jobmaster.JobManagerSharedServices;
 import org.apache.flink.runtime.jobmaster.JobNotFinishedException;
 import org.apache.flink.runtime.jobmaster.JobResult;
+import org.apache.flink.runtime.jobmaster.RescalingBehaviour;
 import org.apache.flink.runtime.leaderelection.LeaderContender;
 import org.apache.flink.runtime.leaderelection.LeaderElectionService;
 import org.apache.flink.runtime.messages.Acknowledge;
@@ -310,6 +311,17 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 			return FutureUtils.completedExceptionally(new FlinkJobNotFoundException(jobId));
 		} else {
 			return jobManagerRunner.getJobManagerGateway().stop(timeout);
+		}
+	}
+
+	@Override
+	public CompletableFuture<Acknowledge> rescaleJob(JobID jobId, int newParallelism, RescalingBehaviour rescalingBehaviour, Time timeout) {
+		JobManagerRunner jobManagerRunner = jobManagerRunners.get(jobId);
+
+		if (jobManagerRunner == null) {
+			return FutureUtils.completedExceptionally(new FlinkJobNotFoundException(jobId));
+		} else {
+			return jobManagerRunner.getJobManagerGateway().rescaleJob(newParallelism, rescalingBehaviour, timeout);
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -128,7 +128,7 @@ import static org.apache.flink.util.Preconditions.checkState;
  *
  * <h2>Global and local failover</h2>
  *
- * The Execution Graph has two failover modes: <i>global failover</i> and <i>local failover</i>.
+ * <p>The Execution Graph has two failover modes: <i>global failover</i> and <i>local failover</i>.
  *
  * <p>A <b>global failover</b> aborts the task executions for all vertices and restarts whole
  * data flow graph from the last completed checkpoint. Global failover is considered the
@@ -151,7 +151,7 @@ import static org.apache.flink.util.Preconditions.checkState;
 public class ExecutionGraph implements AccessExecutionGraph {
 
 	/** In place updater for the execution graph's current state. Avoids having to use an
-	 * AtomicReference and thus makes the frequent read access a bit faster */
+	 * AtomicReference and thus makes the frequent read access a bit faster. */
 	private static final AtomicReferenceFieldUpdater<ExecutionGraph, JobStatus> STATE_UPDATER =
 			AtomicReferenceFieldUpdater.newUpdater(ExecutionGraph.class, JobStatus.class, "state");
 
@@ -172,38 +172,38 @@ public class ExecutionGraph implements AccessExecutionGraph {
 	/** Job specific information like the job id, job name, job configuration, etc. */
 	private final JobInformation jobInformation;
 
-	/** Serialized job information or a blob key pointing to the offloaded job information */
+	/** Serialized job information or a blob key pointing to the offloaded job information. */
 	private final Either<SerializedValue<JobInformation>, PermanentBlobKey> jobInformationOrBlobKey;
 
 	/** The executor which is used to execute futures. */
 	private final ScheduledExecutorService futureExecutor;
 
-	/** The executor which is used to execute blocking io operations */
+	/** The executor which is used to execute blocking io operations. */
 	private final Executor ioExecutor;
 
 	/** {@code true} if all source tasks are stoppable. */
 	private boolean isStoppable = true;
 
-	/** All job vertices that are part of this graph */
+	/** All job vertices that are part of this graph. */
 	private final ConcurrentHashMap<JobVertexID, ExecutionJobVertex> tasks;
 
-	/** All vertices, in the order in which they were created **/
+	/** All vertices, in the order in which they were created. **/
 	private final List<ExecutionJobVertex> verticesInCreationOrder;
 
-	/** All intermediate results that are part of this graph */
+	/** All intermediate results that are part of this graph. */
 	private final ConcurrentHashMap<IntermediateDataSetID, IntermediateResult> intermediateResults;
 
-	/** The currently executed tasks, for callbacks */
+	/** The currently executed tasks, for callbacks. */
 	private final ConcurrentHashMap<ExecutionAttemptID, Execution> currentExecutions;
 
 	/** Listeners that receive messages when the entire job switches it status
-	 * (such as from RUNNING to FINISHED) */
+	 * (such as from RUNNING to FINISHED). */
 	private final List<JobStatusListener> jobStatusListeners;
 
-	/** Listeners that receive messages whenever a single task execution changes its status */
+	/** Listeners that receive messages whenever a single task execution changes its status. */
 	private final List<ExecutionStatusListener> executionListeners;
 
-	/** The implementation that decides how to recover the failures of tasks */
+	/** The implementation that decides how to recover the failures of tasks. */
 	private final FailoverStrategy failoverStrategy;
 
 	/** Timestamps (in milliseconds as returned by {@code System.currentTimeMillis()} when
@@ -212,28 +212,28 @@ public class ExecutionGraph implements AccessExecutionGraph {
 	 * at {@code stateTimestamps[RUNNING.ordinal()]}. */
 	private final long[] stateTimestamps;
 
-	/** The timeout for all messages that require a response/acknowledgement */
+	/** The timeout for all messages that require a response/acknowledgement. */
 	private final Time rpcTimeout;
 
 	/** The timeout for slot allocations. */
 	private final Time allocationTimeout;
 
-	/** Strategy to use for restarts */
+	/** Strategy to use for restarts. */
 	private final RestartStrategy restartStrategy;
 
-	/** The slot provider to use for allocating slots for tasks as they are needed */
+	/** The slot provider to use for allocating slots for tasks as they are needed. */
 	private final SlotProvider slotProvider;
 
-	/** The classloader for the user code. Needed for calls into user code classes */
+	/** The classloader for the user code. Needed for calls into user code classes. */
 	private final ClassLoader userClassLoader;
 
 	/** Registered KvState instances reported by the TaskManagers. */
 	private final KvStateLocationRegistry kvStateLocationRegistry;
 
-	/** Blob writer used to offload RPC messages */
+	/** Blob writer used to offload RPC messages. */
 	private final BlobWriter blobWriter;
 
-	/** The total number of vertices currently in the execution graph */
+	/** The total number of vertices currently in the execution graph. */
 	private int numVerticesTotal;
 
 	// ------ Configuration of the Execution -------
@@ -251,18 +251,18 @@ public class ExecutionGraph implements AccessExecutionGraph {
 
 	private final AtomicInteger verticesFinished;
 
-	/** Current status of the job execution */
+	/** Current status of the job execution. */
 	private volatile JobStatus state = JobStatus.CREATED;
 
-	/** A future that completes once the job has reached a terminal state */
+	/** A future that completes once the job has reached a terminal state. */
 	private volatile CompletableFuture<JobStatus> terminationFuture;
 
 	/** On each global recovery, this version is incremented. The version breaks conflicts
-	 * between concurrent restart attempts by local failover strategies */
+	 * between concurrent restart attempts by local failover strategies. */
 	private volatile long globalModVersion;
 
 	/** The exception that caused the job to fail. This is set to the first root exception
-	 * that was not recoverable and triggered job failure */
+	 * that was not recoverable and triggered job failure. */
 	private volatile Throwable failureCause;
 
 	/** The extended failure cause information for the job. This exists in addition to 'failureCause',
@@ -272,7 +272,7 @@ public class ExecutionGraph implements AccessExecutionGraph {
 
 	// ------ Fields that are relevant to the execution and need to be cleared before archiving  -------
 
-	/** The coordinator for checkpoints, if snapshot checkpoints are enabled */
+	/** The coordinator for checkpoints, if snapshot checkpoints are enabled. */
 	private CheckpointCoordinator checkpointCoordinator;
 
 	/** Checkpoint stats tracker separate from the coordinator in order to be
@@ -567,7 +567,8 @@ public class ExecutionGraph implements AccessExecutionGraph {
 	// --------------------------------------------------------------------------------------------
 
 	/**
-	 * Returns a list of BLOB keys referring to the JAR files required to run this job
+	 * Returns a list of BLOB keys referring to the JAR files required to run this job.
+	 *
 	 * @return list of BLOB keys referring to the JAR files required to run this job
 	 */
 	public Collection<PermanentBlobKey> getRequiredJarFiles() {
@@ -575,7 +576,8 @@ public class ExecutionGraph implements AccessExecutionGraph {
 	}
 
 	/**
-	 * Returns a list of classpaths referring to the directories/JAR files required to run this job
+	 * Returns a list of classpaths referring to the directories/JAR files required to run this job.
+	 *
 	 * @return list of classpaths referring to the directories/JAR files required to run this job
 	 */
 	public Collection<URL> getRequiredClasspaths() {
@@ -1036,10 +1038,10 @@ public class ExecutionGraph implements AccessExecutionGraph {
 	/**
 	 * Suspends the current ExecutionGraph.
 	 *
-	 * The JobStatus will be directly set to SUSPENDED iff the current state is not a terminal
+	 * <p>The JobStatus will be directly set to SUSPENDED iff the current state is not a terminal
 	 * state. All ExecutionJobVertices will be canceled and the onTerminalState() is executed.
 	 *
-	 * The SUSPENDED state is a local terminal state which stops the execution of the job but does
+	 * <p>The SUSPENDED state is a local terminal state which stops the execution of the job but does
 	 * not remove the job from the HA job store so that it can be recovered by another JobManager.
 	 *
 	 * @param suspensionCause Cause of the suspension
@@ -1472,7 +1474,7 @@ public class ExecutionGraph implements AccessExecutionGraph {
 	/**
 	 * Updates the state of one of the ExecutionVertex's Execution attempts.
 	 * If the new status if "FINISHED", this also updates the accumulators.
-	 * 
+	 *
 	 * @param state The state update.
 	 * @return True, if the task update was properly applied, false, if the execution attempt was not found.
 	 */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -1038,10 +1038,10 @@ public class ExecutionGraph implements AccessExecutionGraph {
 	/**
 	 * Suspends the current ExecutionGraph.
 	 *
-	 * <p>The JobStatus will be directly set to SUSPENDED iff the current state is not a terminal
+	 * <p>The JobStatus will be directly set to SUSPENDING iff the current state is not a terminal
 	 * state. All ExecutionJobVertices will be canceled and the onTerminalState() is executed.
 	 *
-	 * <p>The SUSPENDED state is a local terminal state which stops the execution of the job but does
+	 * <p>The SUSPENDING state is a local terminal state which stops the execution of the job but does
 	 * not remove the job from the HA job store so that it can be recovered by another JobManager.
 	 *
 	 * @param suspensionCause Cause of the suspension
@@ -1050,24 +1050,34 @@ public class ExecutionGraph implements AccessExecutionGraph {
 		while (true) {
 			JobStatus currentState = state;
 
-			if (currentState.isTerminalState()) {
+			if (currentState.isTerminalState() || currentState == JobStatus.SUSPENDING) {
 				// stay in a terminal state
 				return;
-			} else if (transitionState(currentState, JobStatus.SUSPENDED, suspensionCause)) {
+			} else if (transitionState(currentState, JobStatus.SUSPENDING, suspensionCause)) {
 				initFailureCause(suspensionCause);
 
 				// make sure no concurrent local actions interfere with the cancellation
 				incrementGlobalModVersion();
 
+				final ArrayList<CompletableFuture<Void>> executionJobVertexTerminationFutures = new ArrayList<>(verticesInCreationOrder.size());
+
 				for (ExecutionJobVertex ejv: verticesInCreationOrder) {
-					ejv.cancel();
+					executionJobVertexTerminationFutures.add(ejv.cancelWithFuture());
 				}
 
-				synchronized (progressLock) {
-					onTerminalState(JobStatus.SUSPENDED);
+				final ConjunctFuture<Void> jobVerticesTerminationFuture = FutureUtils.waitForAll(executionJobVertexTerminationFutures);
 
-					LOG.info("Job {} has been suspended.", getJobID());
-				}
+				jobVerticesTerminationFuture.whenComplete(
+					(Void ignored, Throwable throwable) -> {
+						if (throwable != null) {
+							LOG.debug("Flink could not properly clean up resource after suspension.", throwable);
+						}
+
+						// the globalModVersion does not play a role because there is no way
+						// currently to leave the SUSPENDING state
+						allVerticesInTerminalState(-1L);
+						LOG.info("Job {} has been suspended.", getJobID());
+					});
 
 				return;
 			}
@@ -1090,6 +1100,7 @@ public class ExecutionGraph implements AccessExecutionGraph {
 			JobStatus current = state;
 			// stay in these states
 			if (current == JobStatus.FAILING ||
+				current == JobStatus.SUSPENDING ||
 				current == JobStatus.SUSPENDED ||
 				current.isGloballyTerminalState()) {
 				return;
@@ -1155,7 +1166,7 @@ public class ExecutionGraph implements AccessExecutionGraph {
 				} else if (current == JobStatus.FAILED) {
 					LOG.info("Failed job during restart. Aborting restart.");
 					return;
-				} else if (current == JobStatus.SUSPENDED) {
+				} else if (current == JobStatus.SUSPENDING || current == JobStatus.SUSPENDED) {
 					LOG.info("Suspended job during restart. Aborting restart.");
 					return;
 				} else if (current != JobStatus.RESTARTING) {
@@ -1240,7 +1251,13 @@ public class ExecutionGraph implements AccessExecutionGraph {
 		return null;
 	}
 
-	@VisibleForTesting
+	/**
+	 * Returns the termination future of this {@link ExecutionGraph}. The termination future
+	 * is completed with the terminal {@link JobStatus} once the ExecutionGraph reaches this
+	 * terminal state and all {@link Execution} have been terminated.
+	 *
+	 * @return Termination future of this {@link ExecutionGraph}.
+	 */
 	public CompletableFuture<JobStatus> getTerminationFuture() {
 		return terminationFuture;
 	}
@@ -1380,9 +1397,11 @@ public class ExecutionGraph implements AccessExecutionGraph {
 				}
 				// concurrent job status change, let's check again
 			}
-			else if (current == JobStatus.SUSPENDED) {
-				// we've already cleaned up when entering the SUSPENDED state
-				break;
+			else if (current == JobStatus.SUSPENDING) {
+				if (transitionState(current, JobStatus.SUSPENDED)) {
+					onTerminalState(JobStatus.SUSPENDED);
+					break;
+				}
 			}
 			else if (current.isGloballyTerminalState()) {
 				LOG.warn("Job has entered globally terminal state without waiting for all " +

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobStatus.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobStatus.java
@@ -47,6 +47,9 @@ public enum JobStatus {
 	/** The job is currently undergoing a reset and total restart */
 	RESTARTING(TerminalState.NON_TERMINAL),
 
+	/** The job has been suspended and is currently waiting for the cleanup to complete */
+	SUSPENDING(TerminalState.NON_TERMINAL),
+
 	/**
 	 * The job has been suspended which means that it has been stopped but not been removed from a
 	 * potential HA job store.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/ZooKeeperSubmittedJobGraphStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/ZooKeeperSubmittedJobGraphStore.java
@@ -372,7 +372,7 @@ public class ZooKeeperSubmittedJobGraphStore implements SubmittedJobGraphStore {
 				break;
 
 				case CONNECTION_SUSPENDED: {
-					LOG.warn("ZooKeeper connection SUSPENDED. Changes to the submitted job " +
+					LOG.warn("ZooKeeper connection SUSPENDING. Changes to the submitted job " +
 						"graphs are not monitored (temporarily).");
 				}
 				break;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterConfiguration.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.jobmaster;
 
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ConfigurationUtils;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.runtime.akka.AkkaUtils;
@@ -36,16 +37,20 @@ public class JobMasterConfiguration {
 
 	private final Time slotIdleTimeout;
 
+	private final String tmpDirectory;
+
 	private final Configuration configuration;
 
 	public JobMasterConfiguration(
 			Time rpcTimeout,
 			Time slotRequestTimeout,
 			Time slotIdleTimeout,
+			String tmpDirectory,
 			Configuration configuration) {
 		this.rpcTimeout = Preconditions.checkNotNull(rpcTimeout);
 		this.slotRequestTimeout = Preconditions.checkNotNull(slotRequestTimeout);
 		this.slotIdleTimeout = Preconditions.checkNotNull(slotIdleTimeout);
+		this.tmpDirectory = Preconditions.checkNotNull(tmpDirectory);
 		this.configuration = Preconditions.checkNotNull(configuration);
 	}
 
@@ -59,6 +64,10 @@ public class JobMasterConfiguration {
 
 	public Time getSlotIdleTimeout() {
 		return slotIdleTimeout;
+	}
+
+	public String getTmpDirectory() {
+		return tmpDirectory;
 	}
 
 	public Configuration getConfiguration() {
@@ -78,10 +87,13 @@ public class JobMasterConfiguration {
 		final Time slotRequestTimeout = Time.milliseconds(configuration.getLong(JobManagerOptions.SLOT_REQUEST_TIMEOUT));
 		final Time slotIdleTimeout = Time.milliseconds(configuration.getLong(JobManagerOptions.SLOT_IDLE_TIMEOUT));
 
+		final String tmpDirectory = ConfigurationUtils.parseTempDirectories(configuration)[0];
+
 		return new JobMasterConfiguration(
 			rpcTimeout,
 			slotRequestTimeout,
 			slotIdleTimeout,
+			tmpDirectory,
 			configuration);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
@@ -73,6 +73,34 @@ public interface JobMasterGateway extends
 	CompletableFuture<Acknowledge> stop(@RpcTimeout Time timeout);
 
 	/**
+	 * Triggers rescaling of the executed job.
+	 *
+	 * @param newParallelism new parallelism of the job
+	 * @param rescalingBehaviour defining how strict the rescaling has to be executed
+	 * @param timeout of this operation
+	 * @return Future which is completed with {@link Acknowledge} once the rescaling was successful
+	 */
+	CompletableFuture<Acknowledge> rescaleJob(
+		int newParallelism,
+		RescalingBehaviour rescalingBehaviour,
+		@RpcTimeout Time timeout);
+
+	/**
+	 * Triggers rescaling of the given set of operators.
+	 *
+	 * @param operators set of operators which shall be rescaled
+	 * @param newParallelism new parallelism of the given set of operators
+	 * @param rescalingBehaviour defining how strict the rescaling has to be executed
+	 * @param timeout of this operation
+	 * @return Future which is completed with {@link Acknowledge} once the rescaling was successful
+	 */
+	CompletableFuture<Acknowledge> rescaleOperators(
+		Collection<JobVertexID> operators,
+		int newParallelism,
+		RescalingBehaviour rescalingBehaviour,
+		@RpcTimeout Time timeout);
+
+	/**
 	 * Updates the task execution state for a given task.
 	 *
 	 * @param taskExecutionState New task execution state for a given task

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/RescalingBehaviour.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/RescalingBehaviour.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster;
+
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.function.BiConsumerWithException;
+
+/**
+ * Definition of the rescaling behaviour.
+ */
+public enum RescalingBehaviour implements BiConsumerWithException<JobVertex, Integer, FlinkException> {
+	// rescaling is only executed if the operator can be set to the given parallelism
+	STRICT {
+		@Override
+		public void acceptWithException(JobVertex jobVertex, Integer newParallelism) throws FlinkException {
+			if (jobVertex.getMaxParallelism() < newParallelism) {
+				throw new FlinkException("Cannot rescale vertex " + jobVertex.getName() +
+					" because its maximum parallelism " + jobVertex.getMaxParallelism() +
+					" is smaller than the new parallelism " + newParallelism + '.');
+			} else {
+				jobVertex.setParallelism(newParallelism);
+			}
+		}
+	},
+	// the new parallelism will be the minimum of the given parallelism and the maximum parallelism
+	RELAXED {
+		@Override
+		public void acceptWithException(JobVertex jobVertex, Integer newParallelism) {
+			jobVertex.setParallelism(Math.min(jobVertex.getMaxParallelism(), newParallelism));
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/exceptions/JobMasterException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/exceptions/JobMasterException.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.exceptions;
+
+import org.apache.flink.runtime.jobmaster.JobMaster;
+import org.apache.flink.util.FlinkException;
+
+/**
+ * Base class for all {@link JobMaster} related exceptions.
+ */
+public class JobMasterException extends FlinkException {
+	private static final long serialVersionUID = 2941885469739200908L;
+
+	public JobMasterException(String message) {
+		super(message);
+	}
+
+	public JobMasterException(Throwable cause) {
+		super(cause);
+	}
+
+	public JobMasterException(String message, Throwable cause) {
+		super(message, cause);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/exceptions/JobModificationException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/exceptions/JobModificationException.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.exceptions;
+
+/**
+ * Base class for all exception which originate from a failed job modification.
+ */
+public class JobModificationException extends JobMasterException {
+
+	private static final long serialVersionUID = 2374146694058970746L;
+
+	public JobModificationException(String message) {
+		super(message);
+	}
+
+	public JobModificationException(Throwable cause) {
+		super(cause);
+	}
+
+	public JobModificationException(String message, Throwable cause) {
+		super(message, cause);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/ExecutionGraphCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/ExecutionGraphCache.java
@@ -91,19 +91,22 @@ public class ExecutionGraphCache implements Closeable {
 
 			if (oldEntry != null) {
 				if (currentTime < oldEntry.getTTL()) {
-					if (oldEntry.getExecutionGraphFuture().isDone() && !oldEntry.getExecutionGraphFuture().isCompletedExceptionally()) {
+					final CompletableFuture<AccessExecutionGraph> executionGraphFuture = oldEntry.getExecutionGraphFuture();
+					if (executionGraphFuture.isDone() && !executionGraphFuture.isCompletedExceptionally()) {
 
 						// TODO: Remove once we no longer request the actual ExecutionGraph from the JobManager but only the ArchivedExecutionGraph
 						try {
-							if (oldEntry.getExecutionGraphFuture().get().getState() != JobStatus.SUSPENDED) {
-								return oldEntry.getExecutionGraphFuture();
+							final AccessExecutionGraph executionGraph = executionGraphFuture.get();
+							if (executionGraph.getState() != JobStatus.SUSPENDING &&
+								executionGraph.getState() != JobStatus.SUSPENDED) {
+								return executionGraphFuture;
 							}
 							// send a new request to get the ExecutionGraph from the new leader
 						} catch (InterruptedException | ExecutionException e) {
 							throw new RuntimeException("Could not retrieve ExecutionGraph from the orderly completed future. This should never happen.", e);
 						}
-					} else if (!oldEntry.getExecutionGraphFuture().isDone()) {
-						return oldEntry.getExecutionGraphFuture();
+					} else if (!executionGraphFuture.isDone()) {
+						return executionGraphFuture;
 					}
 					// otherwise it must be completed exceptionally
 				}
@@ -135,7 +138,8 @@ public class ExecutionGraphCache implements Closeable {
 							newEntry.getExecutionGraphFuture().complete(executionGraph);
 
 							// TODO: Remove once we no longer request the actual ExecutionGraph from the JobManager but only the ArchivedExecutionGraph
-							if (executionGraph.getState() == JobStatus.SUSPENDED) {
+							if (executionGraph.getState() == JobStatus.SUSPENDING ||
+								executionGraph.getState() == JobStatus.SUSPENDED) {
 								// remove the entry in case of suspension --> triggers new request when accessed next time
 								cachedExecutionGraphs.remove(jobId, newEntry);
 							}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/RestfulGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/RestfulGateway.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobmaster.JobResult;
+import org.apache.flink.runtime.jobmaster.RescalingBehaviour;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.messages.FlinkJobNotFoundException;
 import org.apache.flink.runtime.messages.webmonitor.ClusterOverview;
@@ -169,4 +170,20 @@ public interface RestfulGateway extends RpcGateway {
 		throw new UnsupportedOperationException();
 	}
 
+	/**
+	 * Trigger rescaling of the given job.
+	 *
+	 * @param jobId specifying the job to rescale
+	 * @param newParallelism new parallelism of the job
+	 * @param rescalingBehaviour defining how strict the rescaling has to be executed
+	 * @param timeout of this operation
+	 * @return Future which is completed with {@link Acknowledge} once the rescaling was successful
+	 */
+	default CompletableFuture<Acknowledge> rescaleJob(
+			JobID jobId,
+			int newParallelism,
+			RescalingBehaviour rescalingBehaviour,
+			@RpcTimeout Time timeout) {
+		throw new UnsupportedOperationException();
+	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
@@ -172,6 +172,7 @@ public class ArchivedExecutionGraphTest extends TestLogger {
 		assertEquals(runtimeGraph.getStatusTimestamp(JobStatus.CANCELED), archivedGraph.getStatusTimestamp(JobStatus.CANCELED));
 		assertEquals(runtimeGraph.getStatusTimestamp(JobStatus.FINISHED), archivedGraph.getStatusTimestamp(JobStatus.FINISHED));
 		assertEquals(runtimeGraph.getStatusTimestamp(JobStatus.RESTARTING), archivedGraph.getStatusTimestamp(JobStatus.RESTARTING));
+		assertEquals(runtimeGraph.getStatusTimestamp(JobStatus.SUSPENDING), archivedGraph.getStatusTimestamp(JobStatus.SUSPENDING));
 		assertEquals(runtimeGraph.getStatusTimestamp(JobStatus.SUSPENDED), archivedGraph.getStatusTimestamp(JobStatus.SUSPENDED));
 		assertEquals(runtimeGraph.isStoppable(), archivedGraph.isStoppable());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphSuspendTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphSuspendTest.java
@@ -49,7 +49,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 public class ExecutionGraphSuspendTest extends TestLogger {
 
 	/**
-	 * Going into SUSPENDED out of CREATED should immediately cancel everything and
+	 * Going into SUSPENDING out of CREATED should immediately cancel everything and
 	 * not send out RPC calls.
 	 */
 	@Test
@@ -72,7 +72,7 @@ public class ExecutionGraphSuspendTest extends TestLogger {
 	}
 
 	/**
-	 * Going into SUSPENDED out of DEPLOYING vertices should cancel all vertices once with RPC calls.
+	 * Going into SUSPENDING out of DEPLOYING vertices should cancel all vertices once with RPC calls.
 	 */
 	@Test
 	public void testSuspendedOutOfDeploying() throws Exception {
@@ -88,15 +88,20 @@ public class ExecutionGraphSuspendTest extends TestLogger {
 
 		eg.suspend(new Exception("suspend"));
 
-		assertEquals(JobStatus.SUSPENDED, eg.getState());
+		assertEquals(JobStatus.SUSPENDING, eg.getState());
+
 		validateAllVerticesInState(eg, ExecutionState.CANCELING);
 		validateCancelRpcCalls(gateway, parallelism);
+
+		ExecutionGraphTestUtils.completeCancellingForAllVertices(eg);
+
+		assertEquals(JobStatus.SUSPENDED, eg.getState());
 
 		ensureCannotLeaveSuspendedState(eg, gateway);
 	}
 
 	/**
-	 * Going into SUSPENDED out of RUNNING vertices should cancel all vertices once with RPC calls.
+	 * Going into SUSPENDING out of RUNNING vertices should cancel all vertices once with RPC calls.
 	 */
 	@Test
 	public void testSuspendedOutOfRunning() throws Exception {
@@ -114,15 +119,21 @@ public class ExecutionGraphSuspendTest extends TestLogger {
 
 		eg.suspend(new Exception("suspend"));
 
-		assertEquals(JobStatus.SUSPENDED, eg.getState());
+		assertEquals(JobStatus.SUSPENDING, eg.getState());
+
 		validateAllVerticesInState(eg, ExecutionState.CANCELING);
+
 		validateCancelRpcCalls(gateway, parallelism);
+
+		ExecutionGraphTestUtils.completeCancellingForAllVertices(eg);
+
+		assertEquals(JobStatus.SUSPENDED, eg.getState());
 
 		ensureCannotLeaveSuspendedState(eg, gateway);
 	}
 
 	/**
-	 * Suspending from FAILING goes to SUSPENDED and sends no additional RPC calls
+	 * Suspending from FAILING goes to SUSPENDING and sends no additional RPC calls
 	 */
 	@Test
 	public void testSuspendedOutOfFailing() throws Exception {
@@ -140,9 +151,13 @@ public class ExecutionGraphSuspendTest extends TestLogger {
 
 		// suspend
 		eg.suspend(new Exception("suspend"));
-		assertEquals(JobStatus.SUSPENDED, eg.getState());
+		assertEquals(JobStatus.SUSPENDING, eg.getState());
+
+		ensureCannotLeaveSuspendingState(eg, gateway);
 
 		ExecutionGraphTestUtils.completeCancellingForAllVertices(eg);
+
+		assertEquals(JobStatus.SUSPENDED, eg.getState());
 
 		ensureCannotLeaveSuspendedState(eg, gateway);
 	}
@@ -176,7 +191,7 @@ public class ExecutionGraphSuspendTest extends TestLogger {
 	}
 
 	/**
-	 * Suspending from CANCELING goes to SUSPENDED and sends no additional RPC calls. 
+	 * Suspending from CANCELING goes to SUSPENDING and sends no additional RPC calls.
 	 */
 	@Test
 	public void testSuspendedOutOfCanceling() throws Exception {
@@ -194,9 +209,13 @@ public class ExecutionGraphSuspendTest extends TestLogger {
 
 		// suspend
 		eg.suspend(new Exception("suspend"));
-		assertEquals(JobStatus.SUSPENDED, eg.getState());
+		assertEquals(JobStatus.SUSPENDING, eg.getState());
+
+		ensureCannotLeaveSuspendingState(eg, gateway);
 
 		ExecutionGraphTestUtils.completeCancellingForAllVertices(eg);
+
+		assertEquals(JobStatus.SUSPENDED, eg.getState());
 
 		ensureCannotLeaveSuspendedState(eg, gateway);
 	}
@@ -273,6 +292,27 @@ public class ExecutionGraphSuspendTest extends TestLogger {
 
 		eg.suspend(new Exception("suspend again"));
 		assertEquals(JobStatus.SUSPENDED, eg.getState());
+		verifyNoMoreInteractions(gateway);
+
+		for (ExecutionVertex ev : eg.getAllExecutionVertices()) {
+			assertEquals(0, ev.getCurrentExecutionAttempt().getAttemptNumber());
+		}
+	}
+
+	private static void ensureCannotLeaveSuspendingState(ExecutionGraph eg, TaskManagerGateway gateway) {
+		assertEquals(JobStatus.SUSPENDING, eg.getState());
+		reset(gateway);
+
+		eg.failGlobal(new Exception("fail"));
+		assertEquals(JobStatus.SUSPENDING, eg.getState());
+		verifyNoMoreInteractions(gateway);
+
+		eg.cancel();
+		assertEquals(JobStatus.SUSPENDING, eg.getState());
+		verifyNoMoreInteractions(gateway);
+
+		eg.suspend(new Exception("suspend again"));
+		assertEquals(JobStatus.SUSPENDING, eg.getState());
 		verifyNoMoreInteractions(gateway);
 
 		for (ExecutionVertex ev : eg.getAllExecutionVertices()) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGateway.java
@@ -34,6 +34,7 @@ import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobmaster.JobMasterGateway;
 import org.apache.flink.runtime.jobmaster.JobMasterId;
+import org.apache.flink.runtime.jobmaster.RescalingBehaviour;
 import org.apache.flink.runtime.jobmaster.SerializedInputSplit;
 import org.apache.flink.runtime.jobmaster.message.ClassloadingProps;
 import org.apache.flink.runtime.messages.Acknowledge;
@@ -63,6 +64,16 @@ public class TestingJobMasterGateway implements JobMasterGateway {
 
 	@Override
 	public CompletableFuture<Acknowledge> stop(Time timeout) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public CompletableFuture<Acknowledge> rescaleJob(int newParallelism, RescalingBehaviour rescalingBehaviour, Time timeout) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public CompletableFuture<Acknowledge> rescaleOperators(Collection<JobVertexID> operators, int newParallelism, RescalingBehaviour rescalingBehaviour, Time timeout) {
 		throw new UnsupportedOperationException();
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/JobAccumulatorsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/JobAccumulatorsHandlerTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.rest.handler.legacy.utils.ArchivedJobGenerationUtils;
 import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
 import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
+import org.apache.flink.util.TestLogger;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ArrayNode;
@@ -38,7 +39,7 @@ import static org.mockito.Mockito.mock;
 /**
  * Tests for the JobAccumulatorsHandler.
  */
-public class JobAccumulatorsHandlerTest {
+public class JobAccumulatorsHandlerTest extends TestLogger {
 
 	@Test
 	public void testArchiver() throws Exception {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/JobConfigHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/JobConfigHandlerTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.rest.handler.legacy.utils.ArchivedJobGenerationUtils;
 import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
 import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
+import org.apache.flink.util.TestLogger;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
 
@@ -39,7 +40,7 @@ import static org.mockito.Mockito.mock;
 /**
  * Tests for the JobConfigHandler.
  */
-public class JobConfigHandlerTest {
+public class JobConfigHandlerTest extends TestLogger {
 
 	@Test
 	public void testArchiver() throws Exception {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/JobDetailsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/JobDetailsHandlerTest.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.rest.handler.legacy.utils.ArchivedJobGenerationUtils;
 import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
 import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
+import org.apache.flink.util.TestLogger;
 
 import org.apache.flink.shaded.guava18.com.google.common.collect.Lists;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
@@ -46,7 +47,7 @@ import static org.mockito.Mockito.mock;
 /**
  * Tests for the JobDetailsHandler.
  */
-public class JobDetailsHandlerTest {
+public class JobDetailsHandlerTest extends TestLogger {
 
 	@Test
 	public void testArchiver() throws Exception {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/JobPlanHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/JobPlanHandlerTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.rest.handler.legacy.utils.ArchivedJobGenerationUtils;
 import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
 import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
+import org.apache.flink.util.TestLogger;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -34,7 +35,7 @@ import static org.mockito.Mockito.mock;
 /**
  * Tests for the JobPlanHandler.
  */
-public class JobPlanHandlerTest {
+public class JobPlanHandlerTest extends TestLogger {
 
 	@Test
 	public void testArchiver() throws Exception {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/JobVertexAccumulatorsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/JobVertexAccumulatorsHandlerTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.executiongraph.AccessExecutionJobVertex;
 import org.apache.flink.runtime.rest.handler.legacy.utils.ArchivedJobGenerationUtils;
 import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
 import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
+import org.apache.flink.util.TestLogger;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ArrayNode;
@@ -40,7 +41,7 @@ import static org.mockito.Mockito.mock;
 /**
  * Tests for the JobVertexAccumulatorsHandler.
  */
-public class JobVertexAccumulatorsHandlerTest {
+public class JobVertexAccumulatorsHandlerTest extends TestLogger {
 
 	@Test
 	public void testArchiver() throws Exception {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/JobVertexDetailsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/JobVertexDetailsHandlerTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.rest.handler.legacy.utils.ArchivedJobGenerationU
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
 import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
+import org.apache.flink.util.TestLogger;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ArrayNode;
@@ -42,7 +43,7 @@ import static org.mockito.Mockito.mock;
 /**
  * Tests for the JobVertexDetailsHandler.
  */
-public class JobVertexDetailsHandlerTest {
+public class JobVertexDetailsHandlerTest extends TestLogger {
 
 	@Test
 	public void testArchiver() throws Exception {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/utils/ArchivedJobGenerationUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/utils/ArchivedJobGenerationUtils.java
@@ -135,7 +135,7 @@ public class ArchivedJobGenerationUtils {
 			.setTasks(tasks)
 			.setFailureCause(new ErrorInfo(new Exception("jobException"), originalAttempt.getStateTimestamp(ExecutionState.FAILED)))
 			.setState(JobStatus.FINISHED)
-			.setStateTimestamps(new long[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10})
+			.setStateTimestamps(new long[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11})
 			.setArchivedUserAccumulators(new StringifiedAccumulatorResult[]{acc1, acc2})
 			.build();
 	}


### PR DESCRIPTION
## What is the purpose of the change

This commit exposes the JobMaster#rescaleJob via the Dispatcher. This will
allow it to call this functionality from a REST handler.

This PR is based on #5446.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
