### PR TITLE
[FLINK-8636] [flip6] Use TaskManagerServices to pass in services to TaskExecutor

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -48,7 +48,6 @@ import org.apache.flink.runtime.util.LeaderRetrievalUtils;
 import org.apache.flink.runtime.util.SignalHandler;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.ExecutorUtils;
-import org.apache.flink.util.Preconditions;
 
 import akka.actor.ActorSystem;
 import org.slf4j.Logger;
@@ -61,6 +60,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * This class is the executable entry point for the task manager in yarn or standalone mode.
@@ -97,8 +97,8 @@ public class TaskManagerRunner implements FatalErrorHandler {
 	private final TaskExecutor taskManager;
 
 	public TaskManagerRunner(Configuration configuration, ResourceID resourceId) throws Exception {
-		this.configuration = Preconditions.checkNotNull(configuration);
-		this.resourceId = Preconditions.checkNotNull(resourceId);
+		this.configuration = checkNotNull(configuration);
+		this.resourceId = checkNotNull(resourceId);
 
 		timeout = AkkaUtils.getTimeoutAsTime(configuration);
 
@@ -270,10 +270,10 @@ public class TaskManagerRunner implements FatalErrorHandler {
 			boolean localCommunicationOnly,
 			FatalErrorHandler fatalErrorHandler) throws Exception {
 
-		Preconditions.checkNotNull(configuration);
-		Preconditions.checkNotNull(resourceID);
-		Preconditions.checkNotNull(rpcService);
-		Preconditions.checkNotNull(highAvailabilityServices);
+		checkNotNull(configuration);
+		checkNotNull(resourceID);
+		checkNotNull(rpcService);
+		checkNotNull(highAvailabilityServices);
 
 		InetAddress remoteAddress = InetAddress.getByName(rpcService.getAddress());
 
@@ -297,20 +297,11 @@ public class TaskManagerRunner implements FatalErrorHandler {
 		return new TaskExecutor(
 			rpcService,
 			taskManagerConfiguration,
-			taskManagerServices.getTaskManagerLocation(),
-			taskManagerServices.getMemoryManager(),
-			taskManagerServices.getIOManager(),
-			taskManagerServices.getTaskStateManager(),
-			taskManagerServices.getNetworkEnvironment(),
 			highAvailabilityServices,
+			taskManagerServices,
 			heartbeatServices,
 			taskManagerMetricGroup,
-			taskManagerServices.getBroadcastVariableManager(),
-			taskManagerServices.getFileCache(),
 			blobCacheService,
-			taskManagerServices.getTaskSlotTable(),
-			taskManagerServices.getJobManagerTable(),
-			taskManagerServices.getJobLeaderService(),
 			fatalErrorHandler);
 	}
 
@@ -346,7 +337,7 @@ public class TaskManagerRunner implements FatalErrorHandler {
 
 		final int rpcPort = configuration.getInteger(ConfigConstants.TASK_MANAGER_IPC_PORT_KEY, 0);
 
-		Preconditions.checkState(rpcPort >= 0 && rpcPort <= 65535, "Invalid value for " +
+		checkState(rpcPort >= 0 && rpcPort <= 65535, "Invalid value for " +
 				"'%s' (port for the TaskManager actor system) : %d - Leave config parameter empty or " +
 				"use 0 to let the system choose port automatically.",
 			ConfigConstants.TASK_MANAGER_IPC_PORT_KEY, rpcPort);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesBuilder.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskexecutor;
+
+import org.apache.flink.core.memory.MemoryType;
+import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
+import org.apache.flink.runtime.filecache.FileCache;
+import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+import org.apache.flink.runtime.io.network.NetworkEnvironment;
+import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.state.TaskExecutorLocalStateStoresManager;
+import org.apache.flink.runtime.taskexecutor.slot.TaskSlotTable;
+import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+
+import static org.mockito.Mockito.mock;
+
+/**
+ * Builder for the {@link TaskManagerServices}.
+ */
+public class TaskManagerServicesBuilder {
+
+	/** TaskManager services. */
+	private TaskManagerLocation taskManagerLocation;
+	private MemoryManager memoryManager;
+	private IOManager ioManager;
+	private NetworkEnvironment networkEnvironment;
+	private BroadcastVariableManager broadcastVariableManager;
+	private FileCache fileCache;
+	private TaskSlotTable taskSlotTable;
+	private JobManagerTable jobManagerTable;
+	private JobLeaderService jobLeaderService;
+	private TaskExecutorLocalStateStoresManager taskStateManager;
+
+	public TaskManagerServicesBuilder() {
+		taskManagerLocation = new LocalTaskManagerLocation();
+		memoryManager = new MemoryManager(
+			MemoryManager.MIN_PAGE_SIZE,
+			1,
+			MemoryManager.MIN_PAGE_SIZE,
+			MemoryType.HEAP,
+			false);
+		ioManager = mock(IOManager.class);
+		networkEnvironment = mock(NetworkEnvironment.class);
+		broadcastVariableManager = new BroadcastVariableManager();
+		fileCache = mock(FileCache.class);
+		taskSlotTable = mock(TaskSlotTable.class);
+		jobManagerTable = new JobManagerTable();
+		jobLeaderService = new JobLeaderService(taskManagerLocation);
+		taskStateManager = new TaskExecutorLocalStateStoresManager();
+
+	}
+
+	public TaskManagerServicesBuilder setTaskManagerLocation(TaskManagerLocation taskManagerLocation) {
+		this.taskManagerLocation = taskManagerLocation;
+		return this;
+	}
+
+	public TaskManagerServicesBuilder setMemoryManager(MemoryManager memoryManager) {
+		this.memoryManager = memoryManager;
+		return this;
+	}
+
+	public TaskManagerServicesBuilder setIoManager(IOManager ioManager) {
+		this.ioManager = ioManager;
+		return this;
+	}
+
+	public TaskManagerServicesBuilder setNetworkEnvironment(NetworkEnvironment networkEnvironment) {
+		this.networkEnvironment = networkEnvironment;
+		return this;
+	}
+
+	public TaskManagerServicesBuilder setBroadcastVariableManager(BroadcastVariableManager broadcastVariableManager) {
+		this.broadcastVariableManager = broadcastVariableManager;
+		return this;
+	}
+
+	public TaskManagerServicesBuilder setFileCache(FileCache fileCache) {
+		this.fileCache = fileCache;
+		return this;
+	}
+
+	public TaskManagerServicesBuilder setTaskSlotTable(TaskSlotTable taskSlotTable) {
+		this.taskSlotTable = taskSlotTable;
+		return this;
+	}
+
+	public TaskManagerServicesBuilder setJobManagerTable(JobManagerTable jobManagerTable) {
+		this.jobManagerTable = jobManagerTable;
+		return this;
+	}
+
+	public TaskManagerServicesBuilder setJobLeaderService(JobLeaderService jobLeaderService) {
+		this.jobLeaderService = jobLeaderService;
+		return this;
+	}
+
+	public TaskManagerServicesBuilder setTaskStateManager(TaskExecutorLocalStateStoresManager taskStateManager) {
+		this.taskStateManager = taskStateManager;
+		return this;
+	}
+
+	public TaskManagerServices build() {
+		return new TaskManagerServices(
+			taskManagerLocation,
+			memoryManager,
+			ioManager,
+			networkEnvironment,
+			broadcastVariableManager,
+			fileCache,
+			taskSlotTable,
+			jobManagerTable,
+			jobLeaderService,
+			taskStateManager);
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

Pass in the TaskExecutor services via the TaskManagerServices instead
of individually.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
