### PR TITLE
[FLINK-8475][config][docs] Integrate HA-ZK options

### DIFF
--- a/docs/_includes/generated/high_availability_zookeeper_configuration.html
+++ b/docs/_includes/generated/high_availability_zookeeper_configuration.html
@@ -1,0 +1,81 @@
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 65%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>high-availability.zookeeper.client.acl</h5></td>
+            <td>"open"</td>
+            <td>Defines the ACL (open|creator) to be configured on ZK node. The configuration value can be set to “creator” if the ZooKeeper server configuration has the “authProvider” property mapped to use SASLAuthenticationProvider and the cluster is configured to run in secure mode (Kerberos).</td>
+        </tr>
+        <tr>
+            <td><h5>high-availability.zookeeper.client.connection-timeout</h5></td>
+            <td>15000</td>
+            <td>Defines the connection timeout for ZooKeeper in ms.</td>
+        </tr>
+        <tr>
+            <td><h5>high-availability.zookeeper.client.max-retry-attempts</h5></td>
+            <td>3</td>
+            <td>Defines the number of connection retries before the client gives up.</td>
+        </tr>
+        <tr>
+            <td><h5>high-availability.zookeeper.client.retry-wait</h5></td>
+            <td>5000</td>
+            <td>Defines the pause between consecutive retries in ms.</td>
+        </tr>
+        <tr>
+            <td><h5>high-availability.zookeeper.client.session-timeout</h5></td>
+            <td>60000</td>
+            <td>Defines the session timeout for the ZooKeeper session in ms.</td>
+        </tr>
+        <tr>
+            <td><h5>high-availability.zookeeper.path.checkpoint-counter</h5></td>
+            <td>"/checkpoint-counter"</td>
+            <td>ZooKeeper root path (ZNode) for checkpoint counters.</td>
+        </tr>
+        <tr>
+            <td><h5>high-availability.zookeeper.path.checkpoints</h5></td>
+            <td>"/checkpoints"</td>
+            <td>ZooKeeper root path (ZNode) for completed checkpoints.</td>
+        </tr>
+        <tr>
+            <td><h5>high-availability.zookeeper.path.jobgraphs</h5></td>
+            <td>"/jobgraphs"</td>
+            <td>ZooKeeper root path (ZNode) for job graphs</td>
+        </tr>
+        <tr>
+            <td><h5>high-availability.zookeeper.path.latch</h5></td>
+            <td>"/leaderlatch"</td>
+            <td> Defines the znode of the leader latch which is used to elect the leader.</td>
+        </tr>
+        <tr>
+            <td><h5>high-availability.zookeeper.path.leader</h5></td>
+            <td>"/leader"</td>
+            <td>Defines the znode of the leader which contains the URL to the leader and the current leader session ID.</td>
+        </tr>
+        <tr>
+            <td><h5>high-availability.zookeeper.path.mesos-workers</h5></td>
+            <td>"/mesos-workers"</td>
+            <td>ZooKeeper root path (ZNode) for Mesos workers.</td>
+        </tr>
+        <tr>
+            <td><h5>high-availability.zookeeper.path.root</h5></td>
+            <td>"/flink"</td>
+            <td>The root path under which Flink stores its entries in ZooKeeper.</td>
+        </tr>
+        <tr>
+            <td><h5>high-availability.zookeeper.path.running-registry</h5></td>
+            <td>"/running_job_registry/"</td>
+            <td></td>
+        </tr>
+        <tr>
+            <td><h5>high-availability.zookeeper.quorum</h5></td>
+            <td>(none)</td>
+            <td>The ZooKeeper quorum to use, when running Flink in a high-availability mode with ZooKeeper.</td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -502,27 +502,7 @@ Previously this key was named `recovery.mode` and the default value was `standal
 
 #### ZooKeeper-based HA Mode
 
-- `high-availability.zookeeper.quorum`: Defines the ZooKeeper quorum URL which is used to connect to the ZooKeeper cluster when the 'zookeeper' HA mode is selected. Previously this key was named `recovery.zookeeper.quorum`.
-
-- `high-availability.zookeeper.path.root`: (Default `/flink`) Defines the root dir under which the ZooKeeper HA mode will create namespace directories. Previously this ket was named `recovery.zookeeper.path.root`.
-
-- `high-availability.zookeeper.path.latch`: (Default `/leaderlatch`) Defines the znode of the leader latch which is used to elect the leader. Previously this key was named `recovery.zookeeper.path.latch`.
-
-- `high-availability.zookeeper.path.leader`: (Default `/leader`) Defines the znode of the leader which contains the URL to the leader and the current leader session ID. Previously this key was named `recovery.zookeeper.path.leader`.
-
-- `high-availability.storageDir`: Defines the directory in the state backend where the JobManager metadata will be stored (ZooKeeper only keeps pointers to it). Required for HA. Previously this key was named `recovery.zookeeper.storageDir` and `high-availability.zookeeper.storageDir`.
-
-- `high-availability.zookeeper.client.session-timeout`: (Default `60000`) Defines the session timeout for the ZooKeeper session in ms. Previously this key was named `recovery.zookeeper.client.session-timeout`
-
-- `high-availability.zookeeper.client.connection-timeout`: (Default `15000`) Defines the connection timeout for ZooKeeper in ms. Previously this key was named `recovery.zookeeper.client.connection-timeout`.
-
-- `high-availability.zookeeper.client.retry-wait`: (Default `5000`) Defines the pause between consecutive retries in ms. Previously this key was named `recovery.zookeeper.client.retry-wait`.
-
-- `high-availability.zookeeper.client.max-retry-attempts`: (Default `3`) Defines the number of connection retries before the client gives up. Previously this key was named `recovery.zookeeper.client.max-retry-attempts`.
-
-- `high-availability.job.delay`: (Default `akka.ask.timeout`) Defines the delay before persisted jobs are recovered in case of a master recovery situation. Previously this key was named `recovery.job.delay`.
-
-- `high-availability.zookeeper.client.acl`: (Default `open`) Defines the ACL (open\|creator) to be configured on ZK node. The configuration value can be set to "creator" if the ZooKeeper server configuration has the "authProvider" property mapped to use SASLAuthenticationProvider and the cluster is configured to run in secure mode (Kerberos). The ACL options are based on https://zookeeper.apache.org/doc/r3.1.2/zookeeperProgrammers.html#sc_BuiltinACLSchemes
+{% include generated/high_availability_zookeeper_configuration.html %}
 
 ### ZooKeeper Security
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/HighAvailabilityOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/HighAvailabilityOptions.java
@@ -26,6 +26,9 @@ import static org.apache.flink.configuration.ConfigOptions.key;
  * The set of configuration options relating to high-availability settings.
  */
 @PublicEvolving
+@ConfigGroups(groups = {
+	@ConfigGroup(name = "HighAvailabilityZookeeper", keyPrefix = "high-availability.zookeeper")
+})
 public class HighAvailabilityOptions {
 
 	// ------------------------------------------------------------------------
@@ -90,7 +93,8 @@ public class HighAvailabilityOptions {
 	public static final ConfigOption<String> HA_ZOOKEEPER_QUORUM =
 			key("high-availability.zookeeper.quorum")
 			.noDefaultValue()
-			.withDeprecatedKeys("recovery.zookeeper.quorum");
+			.withDeprecatedKeys("recovery.zookeeper.quorum")
+			.withDescription("The ZooKeeper quorum to use, when running Flink in a high-availability mode with ZooKeeper.");
 
 	/**
 	 * The root path under which Flink stores its entries in ZooKeeper.
@@ -98,42 +102,50 @@ public class HighAvailabilityOptions {
 	public static final ConfigOption<String> HA_ZOOKEEPER_ROOT =
 			key("high-availability.zookeeper.path.root")
 			.defaultValue("/flink")
-			.withDeprecatedKeys("recovery.zookeeper.path.root");
+			.withDeprecatedKeys("recovery.zookeeper.path.root")
+			.withDescription("The root path under which Flink stores its entries in ZooKeeper.");
 
 	public static final ConfigOption<String> HA_ZOOKEEPER_LATCH_PATH =
 			key("high-availability.zookeeper.path.latch")
 			.defaultValue("/leaderlatch")
-			.withDeprecatedKeys("recovery.zookeeper.path.latch");
+			.withDeprecatedKeys("recovery.zookeeper.path.latch")
+			.withDescription(" Defines the znode of the leader latch which is used to elect the leader.");
 
 	/** ZooKeeper root path (ZNode) for job graphs. */
 	public static final ConfigOption<String> HA_ZOOKEEPER_JOBGRAPHS_PATH =
 			key("high-availability.zookeeper.path.jobgraphs")
 			.defaultValue("/jobgraphs")
-			.withDeprecatedKeys("recovery.zookeeper.path.jobgraphs");
+			.withDeprecatedKeys("recovery.zookeeper.path.jobgraphs")
+			.withDescription("ZooKeeper root path (ZNode) for job graphs");
 
 	public static final ConfigOption<String> HA_ZOOKEEPER_LEADER_PATH =
 			key("high-availability.zookeeper.path.leader")
 			.defaultValue("/leader")
-			.withDeprecatedKeys("recovery.zookeeper.path.leader");
+			.withDeprecatedKeys("recovery.zookeeper.path.leader")
+			.withDescription("Defines the znode of the leader which contains the URL to the leader and the current" +
+				" leader session ID.");
 
 	/** ZooKeeper root path (ZNode) for completed checkpoints. */
 	public static final ConfigOption<String> HA_ZOOKEEPER_CHECKPOINTS_PATH =
 			key("high-availability.zookeeper.path.checkpoints")
 			.defaultValue("/checkpoints")
-			.withDeprecatedKeys("recovery.zookeeper.path.checkpoints");
+			.withDeprecatedKeys("recovery.zookeeper.path.checkpoints")
+			.withDescription("ZooKeeper root path (ZNode) for completed checkpoints.");
 
 	/** ZooKeeper root path (ZNode) for checkpoint counters. */
 	public static final ConfigOption<String> HA_ZOOKEEPER_CHECKPOINT_COUNTER_PATH =
 			key("high-availability.zookeeper.path.checkpoint-counter")
 			.defaultValue("/checkpoint-counter")
-			.withDeprecatedKeys("recovery.zookeeper.path.checkpoint-counter");
+			.withDeprecatedKeys("recovery.zookeeper.path.checkpoint-counter")
+			.withDescription("ZooKeeper root path (ZNode) for checkpoint counters.");
 
 	/** ZooKeeper root path (ZNode) for Mesos workers. */
 	@PublicEvolving
 	public static final ConfigOption<String> HA_ZOOKEEPER_MESOS_WORKERS_PATH =
 			key("high-availability.zookeeper.path.mesos-workers")
 			.defaultValue("/mesos-workers")
-			.withDeprecatedKeys("recovery.zookeeper.path.mesos-workers");
+			.withDeprecatedKeys("recovery.zookeeper.path.mesos-workers")
+			.withDescription("ZooKeeper root path (ZNode) for Mesos workers.");
 
 	// ------------------------------------------------------------------------
 	//  ZooKeeper Client Settings
@@ -142,22 +154,26 @@ public class HighAvailabilityOptions {
 	public static final ConfigOption<Integer> ZOOKEEPER_SESSION_TIMEOUT =
 			key("high-availability.zookeeper.client.session-timeout")
 			.defaultValue(60000)
-			.withDeprecatedKeys("recovery.zookeeper.client.session-timeout");
+			.withDeprecatedKeys("recovery.zookeeper.client.session-timeout")
+			.withDescription("Defines the session timeout for the ZooKeeper session in ms.");
 
 	public static final ConfigOption<Integer> ZOOKEEPER_CONNECTION_TIMEOUT =
 			key("high-availability.zookeeper.client.connection-timeout")
 			.defaultValue(15000)
-			.withDeprecatedKeys("recovery.zookeeper.client.connection-timeout");
+			.withDeprecatedKeys("recovery.zookeeper.client.connection-timeout")
+			.withDescription("Defines the connection timeout for ZooKeeper in ms.");
 
 	public static final ConfigOption<Integer> ZOOKEEPER_RETRY_WAIT =
 			key("high-availability.zookeeper.client.retry-wait")
 			.defaultValue(5000)
-			.withDeprecatedKeys("recovery.zookeeper.client.retry-wait");
+			.withDeprecatedKeys("recovery.zookeeper.client.retry-wait")
+			.withDescription("Defines the pause between consecutive retries in ms.");
 
 	public static final ConfigOption<Integer> ZOOKEEPER_MAX_RETRY_ATTEMPTS =
 			key("high-availability.zookeeper.client.max-retry-attempts")
 			.defaultValue(3)
-			.withDeprecatedKeys("recovery.zookeeper.client.max-retry-attempts");
+			.withDeprecatedKeys("recovery.zookeeper.client.max-retry-attempts")
+			.withDescription("Defines the number of connection retries before the client gives up.");
 
 	public static final ConfigOption<String> ZOOKEEPER_RUNNING_JOB_REGISTRY_PATH =
 			key("high-availability.zookeeper.path.running-registry")
@@ -165,7 +181,10 @@ public class HighAvailabilityOptions {
 
 	public static final ConfigOption<String> ZOOKEEPER_CLIENT_ACL =
 			key("high-availability.zookeeper.client.acl")
-			.defaultValue("open");
+			.defaultValue("open")
+			.withDescription("Defines the ACL (open|creator) to be configured on ZK node. The configuration value can be" +
+				" set to “creator” if the ZooKeeper server configuration has the “authProvider” property mapped to use" +
+				" SASLAuthenticationProvider and the cluster is configured to run in secure mode (Kerberos).");
 
 	// ------------------------------------------------------------------------
 


### PR DESCRIPTION
## What is the purpose of the change

This PR integrates the Zookeeper HA `ConfigOptions` into the configuration docs generator.

## Brief change log

* Add `ConfigGroup` for zookeeper HA config options
* integrate zookeeper HA configuration table into `config.md`