### PR TITLE
[FLINK-8475][config][docs] Integrate YARN options

### DIFF
--- a/docs/_includes/generated/yarn_config_configuration.html
+++ b/docs/_includes/generated/yarn_config_configuration.html
@@ -1,0 +1,61 @@
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 65%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>yarn.application-attempts</h5></td>
+            <td>(none)</td>
+            <td>Number of ApplicationMaster restarts. Note that that the entire Flink cluster will restart and the YARN Client will loose the connection. Also, the JobManager address will change and you’ll need to set the JM host:port manually. It is recommended to leave this option at 1.</td>
+        </tr>
+        <tr>
+            <td><h5>yarn.application-master.port</h5></td>
+            <td>"0"</td>
+            <td>With this configuration option, users can specify a port, a range of ports or a list of ports for the Application Master (and JobManager) RPC port. By default we recommend using the default value (0) to let the operating system choose an appropriate port. In particular when multiple AMs are running on the same physical host, fixed port assignments prevent the AM from starting. For example when running Flink on YARN on an environment with a restrictive firewall, this option allows specifying a range of allowed ports.</td>
+        </tr>
+        <tr>
+            <td><h5>yarn.appmaster.rpc.address</h5></td>
+            <td>(none)</td>
+            <td>The hostname or address where the application master RPC system is listening.</td>
+        </tr>
+        <tr>
+            <td><h5>yarn.appmaster.rpc.port</h5></td>
+            <td>-1</td>
+            <td>The port where the application master RPC system is listening.</td>
+        </tr>
+        <tr>
+            <td><h5>yarn.containers.vcores</h5></td>
+            <td>-1</td>
+            <td>The number of virtual cores (vcores) per YARN container. By default, the number of vcores is set to the number of slots per TaskManager, if set, or to 1, otherwise.</td>
+        </tr>
+        <tr>
+            <td><h5>yarn.heartbeat-delay</h5></td>
+            <td>5</td>
+            <td>Time between heartbeats with the ResourceManager in seconds.</td>
+        </tr>
+        <tr>
+            <td><h5>yarn.maximum-failed-containers</h5></td>
+            <td>(none)</td>
+            <td>Maximum number of containers the system is going to reallocate in case of a failure.</td>
+        </tr>
+        <tr>
+            <td><h5>yarn.per-job-cluster.include-user-jar</h5></td>
+            <td>"ORDER"</td>
+            <td>Defines whether user-jars are included in the system class path for per-job-clusters as well as their positioning in the path. They can be positioned at the beginning ("FIRST"), at the end ("LAST"), or be positioned based on their name ("ORDER").</td>
+        </tr>
+        <tr>
+            <td><h5>yarn.properties-file.location</h5></td>
+            <td>(none)</td>
+            <td>When a Flink job is submitted to YARN, the JobManager’s host and the number of available processing slots is written into a properties file, so that the Flink client is able to pick those details up. This configuration parameter allows changing the default location of that file (for example for environments sharing a Flink installation between users).</td>
+        </tr>
+        <tr>
+            <td><h5>yarn.tags</h5></td>
+            <td>(none)</td>
+            <td>A comma-separated list of tags to apply to the Flink YARN application.</td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -408,38 +408,7 @@ of the JobManager, because the same ActorSystem is used. Its not possible to use
 
 ### YARN
 
-- `containerized.heap-cutoff-ratio`: (Default 0.25) Percentage of heap space to remove from containers started by YARN. When a user requests a certain amount of memory for each TaskManager container (for example 4 GB), we can not pass this amount as the maximum heap space for the JVM (`-Xmx` argument) because the JVM is also allocating memory outside the heap. YARN is very strict with killing containers which are using more memory than requested. Therefore, we remove this fraction of the memory from the requested heap as a safety margin and add it to the memory used off-heap.
-
-- `containerized.heap-cutoff-min`: (Default 600 MB) Minimum amount of memory to cut off the requested heap size.
-
-- `yarn.maximum-failed-containers` (Default: number of requested containers). Maximum number of containers the system is going to reallocate in case of a failure.
-
-- `yarn.application-attempts` (Default: 1). Number of ApplicationMaster restarts. Note that that the entire Flink cluster will restart and the YARN Client will loose the connection. Also, the JobManager address will change and you'll need to set the JM host:port manually. It is recommended to leave this option at 1.
-
-- `yarn.heartbeat-delay` (Default: 5 seconds). Time between heartbeats with the ResourceManager.
-
-- `yarn.properties-file.location` (Default: temp directory). When a Flink job is submitted to YARN, the JobManager's host and the number of available processing slots is written into a properties file, so that the Flink client is able to pick those details up. This configuration parameter allows changing the default location of that file (for example for environments sharing a Flink installation between users)
-
-- `yarn.containers.vcores` The number of virtual cores (vcores) per YARN container. By default, the number of `vcores` is set to the number of slots per TaskManager, if set, or to 1, otherwise.
-
-- `containerized.master.env.`*ENV_VAR1=value* Configuration values prefixed with `containerized.master.env.` will be passed as environment variables to the ApplicationMaster/JobManager process. For example for passing `LD_LIBRARY_PATH` as an env variable to the ApplicationMaster, set:
-
-    `containerized.master.env.LD_LIBRARY_PATH: "/usr/lib/native"`
-
-- `containerized.taskmanager.env.` Similar to the configuration prefix about, this prefix allows setting custom environment variables for the TaskManager processes.
-
-- `yarn.container-start-command-template`: Flink uses the following template when starting on YARN:
-`%java% %jvmmem% %jvmopts% %logging% %class% %args% %redirects%`. This configuration parameter allows users
-to pass custom settings (such as JVM paths, arguments etc.). Note that in most cases, it is sufficient to
-use the `env.java.opts` setting, which is the `%jvmopts%` variable in the String.
-
-- `yarn.application-master.port` (Default: 0, which lets the OS choose an ephemeral port) With this configuration option, users can specify a port, a range of ports or a list of ports for the  Application Master (and JobManager) RPC port. By default we recommend using the default value (0) to let the operating system choose an appropriate port. In particular when multiple AMs are running on the  same physical host, fixed port assignments prevent the AM from starting.
-
-  For example when running Flink on YARN on an environment with a restrictive firewall, this option allows specifying a range of allowed ports.
-
-- `yarn.tags` A comma-separated list of tags to apply to the Flink YARN application.
-
-- `yarn.per-job-cluster.include-user-jar` (Default: ORDER) Control whether and how the user-jar is included in the system class path for per-job clusters. Setting this parameter to `DISABLED` causes the jar to be included in the user class path instead. Setting this parameter to one of `FIRST`, `LAST` or `ORDER` causes the jar to be included in the system class path, with the jar either being placed at the beginning of the class path (`FIRST`), at the end (`LAST`), or based on the lexicographic order (`ORDER`).
+{% include generated/yarn_config_configuration.html %}
 
 ### Mesos
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
@@ -34,14 +34,16 @@ public class YarnConfigOptions {
 	 */
 	public static final ConfigOption<String> APP_MASTER_RPC_ADDRESS =
 			key("yarn.appmaster.rpc.address")
-			.noDefaultValue();
+			.noDefaultValue()
+			.withDescription("The hostname or address where the application master RPC system is listening.");
 
 	/**
 	 * The port where the application master RPC system is listening.
 	 */
 	public static final ConfigOption<Integer> APP_MASTER_RPC_PORT =
 			key("yarn.appmaster.rpc.port")
-			.defaultValue(-1);
+			.defaultValue(-1)
+			.withDescription("The port where the application master RPC system is listening.");
 
 	/**
 	 * Defines whether user-jars are included in the system class path for per-job-clusters as well as their positioning
@@ -50,14 +52,19 @@ public class YarnConfigOptions {
 	 */
 	public static final ConfigOption<String> CLASSPATH_INCLUDE_USER_JAR =
 		key("yarn.per-job-cluster.include-user-jar")
-			.defaultValue("ORDER");
+			.defaultValue("ORDER")
+			.withDescription("Defines whether user-jars are included in the system class path for per-job-clusters as" +
+				" well as their positioning in the path. They can be positioned at the beginning (\"FIRST\"), at the" +
+				" end (\"LAST\"), or be positioned based on their name (\"ORDER\").");
 
 	/**
 	 * The vcores exposed by YARN.
 	 */
 	public static final ConfigOption<Integer> VCORES =
 		key("yarn.containers.vcores")
-		.defaultValue(-1);
+		.defaultValue(-1)
+		.withDescription("The number of virtual cores (vcores) per YARN container. By default, the number of vcores" +
+			" is set to the number of slots per TaskManager, if set, or to 1, otherwise.");
 
 	/**
 	 * The maximum number of failed YARN containers before entirely stopping
@@ -68,7 +75,8 @@ public class YarnConfigOptions {
 	 */
 	public static final ConfigOption<String> MAX_FAILED_CONTAINERS =
 		key("yarn.maximum-failed-containers")
-		.noDefaultValue();
+		.noDefaultValue()
+		.withDescription("Maximum number of containers the system is going to reallocate in case of a failure.");
 
 	/**
 	 * Set the number of retries for failed YARN ApplicationMasters/JobManagers in high
@@ -79,14 +87,18 @@ public class YarnConfigOptions {
 	 */
 	public static final ConfigOption<String> APPLICATION_ATTEMPTS =
 		key("yarn.application-attempts")
-		.noDefaultValue();
+		.noDefaultValue()
+		.withDescription("Number of ApplicationMaster restarts. Note that that the entire Flink cluster will restart" +
+			" and the YARN Client will loose the connection. Also, the JobManager address will change and you’ll need" +
+			" to set the JM host:port manually. It is recommended to leave this option at 1.");
 
 	/**
 	 * The heartbeat interval between the Application Master and the YARN Resource Manager.
 	 */
 	public static final ConfigOption<Integer> HEARTBEAT_DELAY_SECONDS =
 		key("yarn.heartbeat-delay")
-		.defaultValue(5);
+		.defaultValue(5)
+		.withDescription("Time between heartbeats with the ResourceManager in seconds.");
 
 	/**
 	 * When a Flink job is submitted to YARN, the JobManager's host and the number of available
@@ -97,7 +109,11 @@ public class YarnConfigOptions {
 	 */
 	public static final ConfigOption<String> PROPERTIES_FILE_LOCATION =
 		key("yarn.properties-file.location")
-		.noDefaultValue();
+		.noDefaultValue()
+		.withDescription("When a Flink job is submitted to YARN, the JobManager’s host and the number of available" +
+			" processing slots is written into a properties file, so that the Flink client is able to pick those" +
+			" details up. This configuration parameter allows changing the default location of that file" +
+			" (for example for environments sharing a Flink installation between users).");
 
 	/**
 	 * The config parameter defining the Akka actor system port for the ApplicationMaster and
@@ -109,14 +125,21 @@ public class YarnConfigOptions {
 	 */
 	public static final ConfigOption<String> APPLICATION_MASTER_PORT =
 		key("yarn.application-master.port")
-		.defaultValue("0");
+		.defaultValue("0")
+		.withDescription("With this configuration option, users can specify a port, a range of ports or a list of ports" +
+			" for the Application Master (and JobManager) RPC port. By default we recommend using the default value (0)" +
+			" to let the operating system choose an appropriate port. In particular when multiple AMs are running on" +
+			" the same physical host, fixed port assignments prevent the AM from starting. For example when running" +
+			" Flink on YARN on an environment with a restrictive firewall, this option allows specifying a range of" +
+			" allowed ports.");
 
 	/**
 	 * A comma-separated list of strings to use as YARN application tags.
 	 */
 	public static final ConfigOption<String> APPLICATION_TAGS =
 		key("yarn.tags")
-		.defaultValue("");
+		.defaultValue("")
+		.withDescription("A comma-separated list of tags to apply to the Flink YARN application.");
 
 	// ------------------------------------------------------------------------
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
@@ -55,7 +55,8 @@ public class YarnConfigOptions {
 			.defaultValue("ORDER")
 			.withDescription("Defines whether user-jars are included in the system class path for per-job-clusters as" +
 				" well as their positioning in the path. They can be positioned at the beginning (\"FIRST\"), at the" +
-				" end (\"LAST\"), or be positioned based on their name (\"ORDER\").");
+				" end (\"LAST\"), or be positioned based on their name (\"ORDER\"). Setting this parameter to" +
+				" \"DISABLED\" causes the jar to be included in the user class path instead.");
 
 	/**
 	 * The vcores exposed by YARN.


### PR DESCRIPTION
## What is the purpose of the change

This PR integrates the YARN `ConfigOptions` into the configuration docs generator.

## Brief change log

* Add missing descriptions to config options (derived from existing description/javadocs)
* integrate YARN  configuration table into `config.md`