### PR TITLE
[FLINK-8475][config][docs] Integrate HA options

### DIFF
--- a/docs/_includes/generated/high_availability_configuration.html
+++ b/docs/_includes/generated/high_availability_configuration.html
@@ -1,0 +1,36 @@
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 65%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>high-availability</h5></td>
+            <td>"NONE"</td>
+            <td>Defines high-availability mode used for the cluster execution. To enable high-availability, set this mode to "ZOOKEEPER".</td>
+        </tr>
+        <tr>
+            <td><h5>high-availability.cluster-id</h5></td>
+            <td>"/default"</td>
+            <td>The ID of the Flink cluster, used to separate multiple Flink clusters from each other. Needs to be set for standalone clusters but is automatically inferred in YARN and Mesos.</td>
+        </tr>
+        <tr>
+            <td><h5>high-availability.job.delay</h5></td>
+            <td>(none)</td>
+            <td>The time before a JobManager after a fail over recovers the current jobs.</td>
+        </tr>
+        <tr>
+            <td><h5>high-availability.jobmanager.port</h5></td>
+            <td>"0"</td>
+            <td>Optional port (range) used by the job manager in high-availability mode.</td>
+        </tr>
+        <tr>
+            <td><h5>high-availability.storageDir</h5></td>
+            <td>(none)</td>
+            <td>File system path (URI) where Flink persists metadata in high-availability setups.</td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -492,13 +492,7 @@ May be set to -1 to disable this feature.
 
 ### High Availability (HA)
 
-- `high-availability`: Defines the high availability mode used for the cluster execution. Currently, Flink supports the following modes:
-  - `none` (default): No high availability. A single JobManager runs and no JobManager state is checkpointed.
-  - `zookeeper`: Supports the execution of multiple JobManagers and JobManager state checkpointing. Among the group of JobManagers, ZooKeeper elects one of them as the leader which is responsible for the cluster execution. In case of a JobManager failure, a standby JobManager will be elected as the new leader and is given the last checkpointed JobManager state. In order to use the 'zookeeper' mode, it is mandatory to also define the `high-availability.zookeeper.quorum` configuration value.
-
-- `high-availability.cluster-id`: (Default `/default_ns` in standalone cluster mode, or the <yarn-application-id> under YARN) Defines the subdirectory under the root dir where the ZooKeeper HA mode will create znodes. This allows to isolate multiple applications on the same ZooKeeper. Previously this key was named `recovery.zookeeper.path.namespace` and `high-availability.zookeeper.path.namespace`.
-
-Previously this key was named `recovery.mode` and the default value was `standalone`.
+{% include generated/high_availability_configuration.html %}
 
 #### ZooKeeper-based HA Mode
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/HighAvailabilityOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/HighAvailabilityOptions.java
@@ -40,7 +40,9 @@ public class HighAvailabilityOptions {
 	public static final ConfigOption<String> HA_MODE =
 			key("high-availability")
 			.defaultValue("NONE")
-			.withDeprecatedKeys("recovery.mode");
+			.withDeprecatedKeys("recovery.mode")
+			.withDescription("Defines high-availability mode used for the cluster execution." +
+				" To enable high-availability, set this mode to \"ZOOKEEPER\".");
 
 	/**
 	 * The ID of the Flink cluster, used to separate multiple Flink clusters
@@ -49,7 +51,9 @@ public class HighAvailabilityOptions {
 	public static final ConfigOption<String> HA_CLUSTER_ID =
 			key("high-availability.cluster-id")
 			.defaultValue("/default")
-			.withDeprecatedKeys("high-availability.zookeeper.path.namespace", "recovery.zookeeper.path.namespace");
+			.withDeprecatedKeys("high-availability.zookeeper.path.namespace", "recovery.zookeeper.path.namespace")
+			.withDescription("The ID of the Flink cluster, used to separate multiple Flink clusters from each other." +
+				" Needs to be set for standalone clusters but is automatically inferred in YARN and Mesos.");
 
 	/**
 	 * File system path (URI) where Flink persists metadata in high-availability setups.
@@ -57,7 +61,8 @@ public class HighAvailabilityOptions {
 	public static final ConfigOption<String> HA_STORAGE_PATH =
 			key("high-availability.storageDir")
 			.noDefaultValue()
-			.withDeprecatedKeys("high-availability.zookeeper.storageDir", "recovery.zookeeper.storageDir");
+			.withDeprecatedKeys("high-availability.zookeeper.storageDir", "recovery.zookeeper.storageDir")
+			.withDescription("File system path (URI) where Flink persists metadata in high-availability setups.");
 
 
 	// ------------------------------------------------------------------------
@@ -70,7 +75,8 @@ public class HighAvailabilityOptions {
 	public static final ConfigOption<String> HA_JOB_MANAGER_PORT_RANGE =
 			key("high-availability.jobmanager.port")
 			.defaultValue("0")
-			.withDeprecatedKeys("recovery.jobmanager.port");
+			.withDeprecatedKeys("recovery.jobmanager.port")
+			.withDescription("Optional port (range) used by the job manager in high-availability mode.");
 
 	/**
 	 * The time before a JobManager after a fail over recovers the current jobs.
@@ -78,7 +84,8 @@ public class HighAvailabilityOptions {
 	public static final ConfigOption<String> HA_JOB_DELAY =
 			key("high-availability.job.delay")
 			.noDefaultValue()
-			.withDeprecatedKeys("recovery.job.delay");
+			.withDeprecatedKeys("recovery.job.delay")
+			.withDescription("The time before a JobManager after a fail over recovers the current jobs.");
 
 	// ------------------------------------------------------------------------
 	//  ZooKeeper Options


### PR DESCRIPTION
## What is the purpose of the change

This PR integrates the HA `ConfigOptions` into the configuration docs generator.

## Brief change log

* Add missing descriptions to config options (derived from existing description/javadocs)
* integrate HA configuration table into `config.md`