### PR TITLE
[FLINK-8475][config][docs] Integrate Environment options

### DIFF
--- a/docs/_includes/generated/environment_configuration.html
+++ b/docs/_includes/generated/environment_configuration.html
@@ -1,0 +1,41 @@
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 65%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>env.java.opts</h5></td>
+            <td>(none)</td>
+            <td></td>
+        </tr>
+        <tr>
+            <td><h5>env.java.opts.jobmanager</h5></td>
+            <td>(none)</td>
+            <td></td>
+        </tr>
+        <tr>
+            <td><h5>env.java.opts.taskmanager</h5></td>
+            <td>(none)</td>
+            <td></td>
+        </tr>
+        <tr>
+            <td><h5>env.log.dir</h5></td>
+            <td>(none)</td>
+            <td>Defines the directory where the Flink logs are saved. It has to be an absolute path. (Defaults to the log directory under Flink’s home)</td>
+        </tr>
+        <tr>
+            <td><h5>env.log.max</h5></td>
+            <td>5</td>
+            <td>The maximum number of old log files to keep.</td>
+        </tr>
+        <tr>
+            <td><h5>env.ssh.opts</h5></td>
+            <td>(none)</td>
+            <td>Additional command line options passed to SSH clients when starting or stopping JobManager, TaskManager, and Zookeeper services (start-cluster.sh, stop-cluster.sh, start-zookeeper-quorum.sh, stop-zookeeper-quorum.sh).</td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -534,11 +534,7 @@ Previously this key was named `recovery.mode` and the default value was `standal
 
 ### Environment
 
-- `env.log.dir`: (Defaults to the `log` directory under Flink's home) Defines the directory where the Flink logs are saved. It has to be an absolute path.
-
-- `env.log.max`: (Default: `5`) The maximum number of old log files to keep.
-
-- `env.ssh.opts`: Additional command line options passed to SSH clients when starting or stopping JobManager, TaskManager, and Zookeeper services (start-cluster.sh, stop-cluster.sh, start-zookeeper-quorum.sh, stop-zookeeper-quorum.sh).
+{% include generated/environment_configuration.html %}
 
 ### Queryable State
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
@@ -26,6 +26,9 @@ import static org.apache.flink.configuration.ConfigOptions.key;
  * The set of configuration options for core parameters.
  */
 @PublicEvolving
+@ConfigGroups(groups = {
+	@ConfigGroup(name = "Environment", keyPrefix = "env")
+})
 public class CoreOptions {
 
 	// ------------------------------------------------------------------------
@@ -96,6 +99,24 @@ public class CoreOptions {
 	public static final ConfigOption<String> FLINK_TM_JVM_OPTIONS = ConfigOptions
 		.key("env.java.opts.taskmanager")
 		.defaultValue("");
+
+	public static final ConfigOption<String> FLINK_LOG_DIR = ConfigOptions
+		.key("env.log.dir")
+		.noDefaultValue()
+		.withDescription("Defines the directory where the Flink logs are saved. It has to be an absolute path." +
+			" (Defaults to the log directory under Flink’s home)");
+
+	public static final ConfigOption<Integer> FLINK_LOG_MAX = ConfigOptions
+		.key("env.log.max")
+		.defaultValue(5)
+		.withDescription("The maximum number of old log files to keep.");
+
+	public static final ConfigOption<String> FLINK_SSH_OPTIONS = ConfigOptions
+		.key("env.ssh.opts")
+		.noDefaultValue()
+		.withDescription("Additional command line options passed to SSH clients when starting or stopping JobManager," +
+			" TaskManager, and Zookeeper services (start-cluster.sh, stop-cluster.sh, start-zookeeper-quorum.sh," +
+			" stop-zookeeper-quorum.sh).");
 
 	// ------------------------------------------------------------------------
 	//  generic io


### PR DESCRIPTION
## What is the purpose of the change

This PR integrates the environment `ConfigOptions` into the configuration docs generator.

Note that the newly added config options are only evaluated in the shell scripts, which is rather unfortunate and may cause the docs to be outdated should we not find a way to guard this with tests.

## Brief change log

* Add missing descriptions to config options (derived from existing description/javadocs)
* integrate environment configuration table into `config.md`