### PR TITLE
[FLINK-8475][config][docs] Integrate Core options

### DIFF
--- a/docs/_includes/generated/core_configuration.html
+++ b/docs/_includes/generated/core_configuration.html
@@ -1,0 +1,36 @@
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 65%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>classloader.parent-first-patterns</h5></td>
+            <td>"java.;scala.;org.apache.flink.;com.esotericsoftware.kryo;org.apache.hadoop.;javax.annotation.;org.slf4j;org.apache.log4j;org.apache.logging.log4j;ch.qos.logback"</td>
+            <td>A (semicolon-separated) list of patterns that specifies which classes should always be resolved through the parent ClassLoader first. A pattern is a simple prefix that is checked against the fully qualified class name.</td>
+        </tr>
+        <tr>
+            <td><h5>classloader.resolve-order</h5></td>
+            <td>"child-first"</td>
+            <td>Defines the class resolution strategy when loading classes from user code, meaning whether to first check the user code jar ("child-first") or the application classpath ("parent-first"). The default settings indicate to load classes first from the user code jar, which means that user code jars can include and load different dependencies than Flink uses (transitively).</td>
+        </tr>
+        <tr>
+            <td><h5>io.tmp.dirs</h5></td>
+            <td>(none)</td>
+            <td></td>
+        </tr>
+        <tr>
+            <td><h5>mode</h5></td>
+            <td>"old"</td>
+            <td>Switch to select the execution mode. Possible values are 'flip6' and 'old'.</td>
+        </tr>
+        <tr>
+            <td><h5>parallelism.default</h5></td>
+            <td>1</td>
+            <td></td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -262,6 +262,10 @@ These parameters configure the default HDFS used by Flink. Setups that do not sp
 
 - `fs.hdfs.hdfssite`: The absolute path of Hadoop's own configuration file "hdfs-site.xml" (DEFAULT: null).
 
+### Core
+
+{% include generated/core_configuration.html %}
+
 ### JobManager &amp; TaskManager
 
 The following parameters configure Flink's JobManager and TaskManagers.

--- a/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
@@ -45,7 +45,11 @@ public class CoreOptions {
 	 */
 	public static final ConfigOption<String> CLASSLOADER_RESOLVE_ORDER = ConfigOptions
 		.key("classloader.resolve-order")
-		.defaultValue("child-first");
+		.defaultValue("child-first")
+		.withDescription("Defines the class resolution strategy when loading classes from user code, meaning whether to" +
+			" first check the user code jar (\"child-first\") or the application classpath (\"parent-first\")." +
+			" The default settings indicate to load classes first from the user code jar, which means that user code" +
+			" jars can include and load different dependencies than Flink uses (transitively).");
 
 	/**
 	 * The namespace patterns for classes that are loaded with a preference from the
@@ -79,7 +83,10 @@ public class CoreOptions {
 	 */
 	public static final ConfigOption<String> ALWAYS_PARENT_FIRST_LOADER = ConfigOptions
 		.key("classloader.parent-first-patterns")
-		.defaultValue("java.;scala.;org.apache.flink.;com.esotericsoftware.kryo;org.apache.hadoop.;javax.annotation.;org.slf4j;org.apache.log4j;org.apache.logging.log4j;ch.qos.logback");
+		.defaultValue("java.;scala.;org.apache.flink.;com.esotericsoftware.kryo;org.apache.hadoop.;javax.annotation.;org.slf4j;org.apache.log4j;org.apache.logging.log4j;ch.qos.logback")
+		.withDescription("A (semicolon-separated) list of patterns that specifies which classes should always be" +
+			" resolved through the parent ClassLoader first. A pattern is a simple prefix that is checked against" +
+			" the fully qualified class name.");
 
 	// ------------------------------------------------------------------------
 	//  process parameters

--- a/flink-docs/src/main/java/org/apache/flink/docs/configuration/ConfigOptionsDocGenerator.java
+++ b/flink-docs/src/main/java/org/apache/flink/docs/configuration/ConfigOptionsDocGenerator.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.ConfigGroup;
 import org.apache.flink.configuration.ConfigGroups;
 import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.WebOptions;
 
 import java.io.IOException;
@@ -174,7 +175,7 @@ public class ConfigOptionsDocGenerator {
 		// This is a temporary hack that should be removed once FLINK-6490 is resolved.
 		// These options use System.getProperty("java.io.tmpdir") as the default.
 		// As a result the generated table contains an actual path as the default, which is simply wrong.
-		if (option == WebOptions.TMP_DIR || option.key().equals("python.dc.tmp.dir")) {
+		if (option == WebOptions.TMP_DIR || option.key().equals("python.dc.tmp.dir") || option == CoreOptions.TMP_DIRS) {
 			defaultValue = null;
 		}
 		return "" +


### PR DESCRIPTION
## What is the purpose of the change

This PR integrates the core `ConfigOptions` into the configuration docs generator.

Do note that i cheated a bit and manually cut out the fs/env options from the table that are moved to separate tables in #5468 and #5459.

## Brief change log

* Add missing descriptions to config options (derived from existing description/javadocs)
* integrate core configuration table into `config.md`
* added `CoreOptions#TMP_DIRS` to the set of options for which the generated overrides the default