### PR TITLE
[FLINK-8475][config][docs] Integrate RM options

### DIFF
--- a/docs/_includes/generated/resource_manager_configuration.html
+++ b/docs/_includes/generated/resource_manager_configuration.html
@@ -1,0 +1,36 @@
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 65%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>containerized.heap-cutoff-min</h5></td>
+            <td>600</td>
+            <td>Minimum amount of heap memory to remove in containers, as a safety margin.</td>
+        </tr>
+        <tr>
+            <td><h5>containerized.heap-cutoff-ratio</h5></td>
+            <td>0.25</td>
+            <td>Percentage of heap space to remove from containers (YARN / Mesos), to compensate for other JVM memory usage.</td>
+        </tr>
+        <tr>
+            <td><h5>local.number-resourcemanager</h5></td>
+            <td>1</td>
+            <td></td>
+        </tr>
+        <tr>
+            <td><h5>resourcemanager.job.timeout</h5></td>
+            <td>"5 minutes"</td>
+            <td>Timeout for jobs which don't have a job manager as leader assigned.</td>
+        </tr>
+        <tr>
+            <td><h5>resourcemanager.rpc.port</h5></td>
+            <td>0</td>
+            <td></td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -373,8 +373,7 @@ definition. This scheme is used **ONLY** if no other scheme is specified (explic
 
 The configuration keys in this section are independent of the used resource management framework (YARN, Mesos, Standalone, ...)
 
-- `resourcemanager.rpc.port`: The config parameter defining the network port to connect to for communication with the resource manager. By default, the port
-of the JobManager, because the same ActorSystem is used. Its not possible to use this configuration key to define port ranges.
+{% include generated/resource_manager_configuration.html %}
 
 ### YARN
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
@@ -43,7 +43,10 @@ public class ResourceManagerOptions {
 
 	public static final ConfigOption<Integer> IPC_PORT = ConfigOptions
 		.key("resourcemanager.rpc.port")
-		.defaultValue(0);
+		.defaultValue(0)
+		.withDescription("Defines the network port to connect to for communication with the resource manager. By" +
+			" default, the port of the JobManager, because the same ActorSystem is used." +
+			" Its not possible to use this configuration key to define port ranges.");
 
 	/**
 	 * Percentage of heap space to remove from containers (YARN / Mesos), to compensate

--- a/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
@@ -34,7 +34,8 @@ public class ResourceManagerOptions {
 	 */
 	public static final ConfigOption<String> JOB_TIMEOUT = ConfigOptions
 		.key("resourcemanager.job.timeout")
-		.defaultValue("5 minutes");
+		.defaultValue("5 minutes")
+		.withDescription("Timeout for jobs which don't have a job manager as leader assigned.");
 
 	public static final ConfigOption<Integer> LOCAL_NUMBER_RESOURCE_MANAGER = ConfigOptions
 		.key("local.number-resourcemanager")
@@ -51,7 +52,9 @@ public class ResourceManagerOptions {
 	public static final ConfigOption<Float> CONTAINERIZED_HEAP_CUTOFF_RATIO = ConfigOptions
 		.key("containerized.heap-cutoff-ratio")
 		.defaultValue(0.25f)
-		.withDeprecatedKeys("yarn.heap-cutoff-ratio");
+		.withDeprecatedKeys("yarn.heap-cutoff-ratio")
+		.withDescription("Percentage of heap space to remove from containers (YARN / Mesos), to compensate" +
+			" for other JVM memory usage.");
 
 	/**
 	 * Minimum amount of heap memory to remove in containers, as a safety margin.
@@ -59,7 +62,8 @@ public class ResourceManagerOptions {
 	public static final ConfigOption<Integer> CONTAINERIZED_HEAP_CUTOFF_MIN = ConfigOptions
 		.key("containerized.heap-cutoff-min")
 		.defaultValue(600)
-		.withDeprecatedKeys("yarn.heap-cutoff-min");
+		.withDeprecatedKeys("yarn.heap-cutoff-min")
+		.withDescription("Minimum amount of heap memory to remove in containers, as a safety margin.");
 
 	/**
 	 * The timeout for a slot request to be discarded, in milliseconds.


### PR DESCRIPTION
## What is the purpose of the change

This PR integrates the RM `ConfigOptions` into the configuration docs generator.

## Brief change log

* Add missing descriptions to config options (derived from existing description/javadocs)
* integrate RM configuration table into `config.md`