### PR TITLE
[FLINK-8621][prometheus][tests] Remove endpointIsUnavailableAfterReporterIsClosed()

### DIFF
--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusReporter.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusReporter.java
@@ -98,6 +98,7 @@ public class PrometheusReporter implements MetricReporter {
 		while (ports.hasNext()) {
 			int port = ports.next();
 			try {
+				// internally accesses CollectorRegistry.defaultRegistry
 				httpServer = new HTTPServer(port);
 				this.port = port;
 				LOG.info("Started PrometheusReporter HTTP server on port {}.", port);

--- a/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTest.java
+++ b/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTest.java
@@ -44,6 +44,8 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.util.Arrays;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
 
 import static org.apache.flink.metrics.prometheus.PrometheusReporter.ARG_PORT;
 import static org.hamcrest.Matchers.containsString;
@@ -65,6 +67,8 @@ public class PrometheusReporterTest extends TestLogger {
 	private static final String DEFAULT_LABELS = "{" + DIMENSIONS + ",}";
 	private static final String SCOPE_PREFIX = "flink_taskmanager_";
 
+	private static final PortRangeProvider portRangeProvider = new PortRangeProvider();
+
 	@Rule
 	public ExpectedException thrown = ExpectedException.none();
 
@@ -74,7 +78,7 @@ public class PrometheusReporterTest extends TestLogger {
 
 	@Before
 	public void setupReporter() {
-		registry = new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(createConfigWithOneReporter("test1", "9400-9500")));
+		registry = new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(createConfigWithOneReporter("test1", portRangeProvider.next())));
 		metricGroup = new FrontMetricGroup<>(0, new TaskManagerMetricGroup(registry, HOST_NAME, TASK_MANAGER));
 		reporter = (PrometheusReporter) registry.getReporters().get(0);
 	}
@@ -234,7 +238,7 @@ public class PrometheusReporterTest extends TestLogger {
 
 	@Test
 	public void cannotStartTwoReportersOnSamePort() {
-		final MetricRegistryImpl fixedPort1 = new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(createConfigWithOneReporter("test1", "9400-9500")));
+		final MetricRegistryImpl fixedPort1 = new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(createConfigWithOneReporter("test1", portRangeProvider.next())));
 		assertThat(fixedPort1.getReporters(), hasSize(1));
 
 		PrometheusReporter firstReporter = (PrometheusReporter) fixedPort1.getReporters().get(0);
@@ -248,8 +252,9 @@ public class PrometheusReporterTest extends TestLogger {
 
 	@Test
 	public void canStartTwoReportersWhenUsingPortRange() {
-		final MetricRegistryImpl portRange1 = new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(createConfigWithOneReporter("test1", "9200-9300")));
-		final MetricRegistryImpl portRange2 = new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(createConfigWithOneReporter("test2", "9200-9300")));
+		String portRange = portRangeProvider.next();
+		final MetricRegistryImpl portRange1 = new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(createConfigWithOneReporter("test1", portRange)));
+		final MetricRegistryImpl portRange2 = new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(createConfigWithOneReporter("test2", portRange)));
 
 		assertThat(portRange1.getReporters(), hasSize(1));
 		assertThat(portRange2.getReporters(), hasSize(1));
@@ -277,5 +282,33 @@ public class PrometheusReporterTest extends TestLogger {
 	@After
 	public void closeReporterAndShutdownRegistry() {
 		registry.shutdown();
+	}
+
+	/**
+	 * Utility class providing distinct port ranges.
+	 */
+	private static class PortRangeProvider implements Iterator<String> {
+
+		private int base = 9000;
+
+		@Override
+		public boolean hasNext() {
+			return base < 14000; // arbitrary limit that should be sufficient for test purposes
+		}
+
+		/**
+		 * Returns the next port range containing exactly 100 ports.
+		 *
+		 * @return next port range
+		 */
+		public synchronized String next() {
+			if (!hasNext()) {
+				throw new NoSuchElementException();
+			}
+			int lowEnd = base;
+			int highEnd = base + 99;
+			base += 100;
+			return String.valueOf(lowEnd) + "-" + String.valueOf(highEnd);
+		}
 	}
 }

--- a/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTest.java
+++ b/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTest.java
@@ -156,15 +156,6 @@ public class PrometheusReporterTest extends TestLogger {
 	}
 
 	@Test
-	public void endpointIsUnavailableAfterReporterIsClosed() throws UnirestException {
-		MetricRegistryImpl registry = new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(createConfigWithOneReporter("test1", "9400-9500")));
-		PrometheusReporter reporter = (PrometheusReporter) registry.getReporters().get(0);
-		reporter.close();
-		thrown.expect(UnirestException.class);
-		pollMetrics(reporter.getPort());
-	}
-
-	@Test
 	public void invalidCharactersAreReplacedWithUnderscore() {
 		assertThat(PrometheusReporter.replaceInvalidChars(""), equalTo(""));
 		assertThat(PrometheusReporter.replaceInvalidChars("abc"), equalTo("abc"));


### PR DESCRIPTION
## What is the purpose of the change

This PR removes an unstable test for the PrometheusReporter. The test verified that the metrics could no longer be polled when the reporter was shutdown, however if any other process were to start a server on the same port (which is free after the reporter shutdown) the test would fail.

We could theoretically check in that case that it wasn't our reporter that responded, but that's a bit tricky to do with how the reporter currently works (singleton registry).

This PR also contains 2 minor changes:
* one commit adds a comment to the prometheus reporter to better reflect how the `HTTPServer` is used
* one commit adds a utility port-range generator to prevent port-conflicts caused by copy&pasting