### PR TITLE
[FLINK-8520][cassandra] Fix race condition

### DIFF
--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraSinkBase.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraSinkBase.java
@@ -134,8 +134,8 @@ public abstract class CassandraSinkBase<IN, V> extends RichSinkFunction<IN> impl
 	}
 
 	private void waitForPendingUpdates() throws InterruptedException {
-		while (updatesPending.get() > 0) {
-			synchronized (updatesPending) {
+		synchronized (updatesPending) {
+			while (updatesPending.get() > 0) {
 				updatesPending.wait();
 			}
 		}


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes a deadlock that could happen if a callback is executed during `CassandraSinkBase#waitForPendingUpdates`.

waitForPendingUpdates:
```
U1: while (updatesPending.get() > 0)
U2:     synchronized (updatesPending)
U3:         updatesPending.wait();
```

callback:
```
C1: int pending = updatesPending.decrementAndGet();
C2: if (pending == 0)
C3:	synchronized (updatesPending)
C4:	    updatesPending.notifyAll();
```

Sequence causing deadlock: U1 -> C1 ... C4 -> U2 -> U3
(`updatesPending == 1` at the start of sequence)

This was fixed by switching lines U1 and U2:
```
U2: synchronized (updatesPending)
U1: 	while (updatesPending.get() > 0)
U3: 	    updatesPending.wait();
```

If C1 runs
* before U2, then waitForPendingUpdates sees that `updatesPending == 0` and exits without waiting
* after U2, then waitForPendingUpdates is guaranteed to call wait() before the callback calls notifyAll()

## Verifying this change

The deadlock was reproduced by introducing `OneShotLatches` into the callback/waitForPendingUpdates to force the above execution sequence.

Don't think we can test this properly since it's a timing problem.
