### PR TITLE
[FLINK-8642] Initialize descriptors before use at getBroadcastState().

### DIFF
--- a/flink-examples/flink-examples-streaming/src/main/scala/org/apache/flink/streaming/scala/examples/broadcast/BroadcastExample.scala
+++ b/flink-examples/flink-examples-streaming/src/main/scala/org/apache/flink/streaming/scala/examples/broadcast/BroadcastExample.scala
@@ -68,9 +68,10 @@ object BroadcastExample {
       .connect(broadcastStream)
       .process(new KeyedBroadcastProcessFunction[Int, (Int, Int), Int, String]() {
 
-        val valueState = new ValueStateDescriptor[String]("any", BasicTypeInfo.STRING_TYPE_INFO)
+        private lazy val valueState = new ValueStateDescriptor[String](
+          "any", BasicTypeInfo.STRING_TYPE_INFO)
 
-        val mapStateDesc = new MapStateDescriptor[String, Integer](
+        private lazy val mapStateDesc = new MapStateDescriptor[String, Integer](
           "Broadcast", BasicTypeInfo.STRING_TYPE_INFO, BasicTypeInfo.INT_TYPE_INFO)
 
         @throws[Exception]

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/BroadcastConnectedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/BroadcastConnectedStream.java
@@ -161,7 +161,7 @@ public class BroadcastConnectedStream<IN1, IN2> {
 				"A KeyedBroadcastProcessFunction can only be used with a keyed stream as the second input.");
 
 		TwoInputStreamOperator<IN1, IN2, OUT> operator =
-				new CoBroadcastWithKeyedOperator<>(function, broadcastStateDescriptors);
+				new CoBroadcastWithKeyedOperator<>(clean(function), broadcastStateDescriptors);
 		return transform("Co-Process-Broadcast-Keyed", outTypeInfo, operator);
 	}
 
@@ -212,7 +212,7 @@ public class BroadcastConnectedStream<IN1, IN2> {
 				"A BroadcastProcessFunction can only be used with a non-keyed stream as the second input.");
 
 		TwoInputStreamOperator<IN1, IN2, OUT> operator =
-				new CoBroadcastWithNonKeyedOperator<>(function, broadcastStateDescriptors);
+				new CoBroadcastWithNonKeyedOperator<>(clean(function), broadcastStateDescriptors);
 		return transform("Co-Process-Broadcast", outTypeInfo, operator);
 	}
 

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
@@ -478,9 +478,9 @@ class DataStream[T](stream: JavaStream[T]) {
   @PublicEvolving
   def broadcast(broadcastStateDescriptors: MapStateDescriptor[_, _]*): BroadcastStream[T] = {
     if (broadcastStateDescriptors == null) {
-      throw new NullPointerException("Map function must not be null.")
+      throw new NullPointerException("State Descriptors must not be null.")
     }
-    stream.broadcast(broadcastStateDescriptors: _*)
+    javaStream.broadcast(broadcastStateDescriptors: _*)
   }
 
   /**

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/BroadcastStateITCase.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/BroadcastStateITCase.scala
@@ -41,7 +41,7 @@ class BroadcastStateITCase extends AbstractTestBase {
 
     val timerTimestamp = 100000L
 
-    val DESCRIPTOR = new MapStateDescriptor[Long, String](
+    lazy val DESCRIPTOR = new MapStateDescriptor[Long, String](
       "broadcast-state",
       BasicTypeInfo.LONG_TYPE_INFO.asInstanceOf[TypeInformation[Long]],
       BasicTypeInfo.STRING_TYPE_INFO)
@@ -98,7 +98,7 @@ class TestBroadcastProcessFunction(
         expectedBroadcastState: Map[Long, String])
     extends KeyedBroadcastProcessFunction[Long, Long, String, String] {
 
-  val localDescriptor = new MapStateDescriptor[Long, String](
+  lazy val localDescriptor = new MapStateDescriptor[Long, String](
     "broadcast-state",
     BasicTypeInfo.LONG_TYPE_INFO.asInstanceOf[TypeInformation[Long]],
     BasicTypeInfo.STRING_TYPE_INFO)


### PR DESCRIPTION
## What is the purpose of the change

As the name implies, this PR fixes a bug that could lead to `NPEs` when trying to access the newly introduced broadcast state with not initialized state descriptors. This could manifest itself in the case
where:

1) scala is used and the descriptors are `lazy`
2) the descriptors are initialized in the `open()` method of the `process function`.

## Brief change log

The `context`s passed to the methods of the broadcast process functions now call `.initializeSerializerUnlessSet(...)` on the provided state descriptors.

## Verifying this change

Already existing tests have been modified to trigger the new code path.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
