### PR TITLE
[FLINK-8649] [scala api] Pass on TypeInfo in StreamExecutionEnvironment.createInput

### DIFF
--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
@@ -595,7 +595,7 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
    */
   @PublicEvolving
   def createInput[T: TypeInformation](inputFormat: InputFormat[T, _]): DataStream[T] =
-    if (inputFormat.isInstanceOf[ResultTypeQueryable[T]]) {
+    if (inputFormat.isInstanceOf[ResultTypeQueryable[_]]) {
       asScalaStream(javaEnv.createInput(inputFormat))
     } else {
       asScalaStream(javaEnv.createInput(inputFormat, implicitly[TypeInformation[T]]))

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
@@ -23,6 +23,7 @@ import org.apache.flink.annotation.{Internal, Public, PublicEvolving}
 import org.apache.flink.api.common.io.{FileInputFormat, FilePathFilter, InputFormat}
 import org.apache.flink.api.common.restartstrategy.RestartStrategies.RestartStrategyConfiguration
 import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.typeutils.ResultTypeQueryable
 import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer
 import org.apache.flink.api.scala.ClosureCleaner
 import org.apache.flink.configuration.Configuration
@@ -594,7 +595,11 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
    */
   @PublicEvolving
   def createInput[T: TypeInformation](inputFormat: InputFormat[T, _]): DataStream[T] =
-    asScalaStream(javaEnv.createInput(inputFormat))
+    if (inputFormat.isInstanceOf[ResultTypeQueryable[T]]) {
+      asScalaStream(javaEnv.createInput(inputFormat))
+    } else {
+      asScalaStream(javaEnv.createInput(inputFormat, implicitly[TypeInformation[T]]))
+    }
 
   /**
    * Create a DataStream using a user defined source function for arbitrary

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/DataStreamTest.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/DataStreamTest.scala
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.api.scala
 
 import java.lang
+
 import org.apache.flink.api.common.functions._
 import org.apache.flink.api.java.io.ParallelIteratorInputFormat
 import org.apache.flink.api.java.typeutils.TypeExtractor

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/DataStreamTest.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/DataStreamTest.scala
@@ -19,8 +19,8 @@
 package org.apache.flink.streaming.api.scala
 
 import java.lang
-
 import org.apache.flink.api.common.functions._
+import org.apache.flink.api.java.io.ParallelIteratorInputFormat
 import org.apache.flink.api.java.typeutils.TypeExtractor
 import org.apache.flink.streaming.api.collector.selector.OutputSelector
 import org.apache.flink.streaming.api.functions.ProcessFunction
@@ -649,6 +649,12 @@ class DataStreamTest extends AbstractTestBase {
     val sg = env.getStreamGraph
 
     assert(sg.getIterationSourceSinkPairs.size() == 2)
+  }
+
+  @Test
+  def testCreateInputPassesOnTypeInfo(): Unit = {
+    StreamExecutionEnvironment.getExecutionEnvironment.createInput[Tuple1[Integer]](
+      new ParallelIteratorInputFormat[Tuple1[Integer]](null))
   }
 
   /////////////////////////////////////////////////////////////


### PR DESCRIPTION
## What is the purpose of the change

In the Scala API, modify `StreamExecutionEnvironment.createInput` to pass through the implicitly got TypeInfo to the java `createInput` call. With the old code, the Java API tries to figure out the TypeInfo on its own, which doesn't always work as well as the TypeInfo creation of the Scala API.

Note that if the input format implements `ResultTypeQueryable`, then we would like to retain the old behaviour, so we just do the call into the Java API in the old way in this case. (`ResultTypeQueryable` can sometimes give a better type than the Scala TypeInfo creation, e.g. when the result type depends on parametrization of the input format.)

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
