### PR TITLE
[FLINK-8480][DataStream] Add Java API for IntervalJoin

### DIFF
--- a/docs/dev/stream/operators/index.md
+++ b/docs/dev/stream/operators/index.md
@@ -310,6 +310,21 @@ dataStream.join(otherStream)
           </td>
         </tr>
         <tr>
+          <td><strong>Interval Join</strong><br>KeyedStream,KeyedStream &rarr; DataStream</td>
+          <td>
+            <p>Join two elements e1 and e2 of two keyed streams with a common key over a given time interval, so that e1.timestamp + lowerBound <= e2.timestamp <= e1.timestamp + upperBound</p>
+    {% highlight java %}
+// this will join the two streams so that
+// key1 == key2 && leftTs - 2 < rightTs < leftTs + 2
+keyedStream.intervalJoin(otherKeyedStream)
+    .between(Time.milliseconds(-2), Time.milliseconds(2)) // lower and upper bound
+    .upperBoundExclusive(true) // optional
+    .lowerBoundExclusive(true) // optional
+    .process(new IntervalJoinFunction() {...});
+    {% endhighlight %}
+          </td>
+        </tr>
+        <tr>
           <td><strong>Window CoGroup</strong><br>DataStream,DataStream &rarr; DataStream</td>
           <td>
             <p>Cogroups two data streams on a given key and a common window.</p>

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/KeyedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/KeyedStream.java
@@ -42,6 +42,7 @@ import org.apache.flink.streaming.api.functions.ProcessFunction;
 import org.apache.flink.streaming.api.functions.aggregation.AggregationFunction;
 import org.apache.flink.streaming.api.functions.aggregation.ComparableAggregator;
 import org.apache.flink.streaming.api.functions.aggregation.SumAggregator;
+import org.apache.flink.streaming.api.functions.co.IntervalJoinFunction;
 import org.apache.flink.streaming.api.functions.query.QueryableAppendingStateOperator;
 import org.apache.flink.streaming.api.functions.query.QueryableValueStateOperator;
 import org.apache.flink.streaming.api.functions.sink.SinkFunction;
@@ -51,6 +52,7 @@ import org.apache.flink.streaming.api.operators.LegacyKeyedProcessOperator;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.operators.StreamGroupedFold;
 import org.apache.flink.streaming.api.operators.StreamGroupedReduce;
+import org.apache.flink.streaming.api.operators.co.IntervalJoinOperator;
 import org.apache.flink.streaming.api.transformations.OneInputTransformation;
 import org.apache.flink.streaming.api.transformations.PartitionTransformation;
 import org.apache.flink.streaming.api.windowing.assigners.GlobalWindows;
@@ -75,6 +77,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Stack;
 import java.util.UUID;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * A {@link KeyedStream} represents a {@link DataStream} on which operator state is
@@ -393,6 +397,185 @@ public class KeyedStream<T, KEY> extends DataStream<T> {
 
 		KeyedProcessOperator<KEY, T, R> operator = new KeyedProcessOperator<>(clean(keyedProcessFunction));
 		return transform("KeyedProcess", outputType, operator);
+	}
+
+	// ------------------------------------------------------------------------
+	//  Joining
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Join elements of this {@link KeyedStream} with elements of another {@link KeyedStream} over
+	 * a time interval that can be specified with {@link IntervalJoin#between(Time, Time)}.
+	 *
+	 * @param otherStream The other keyed stream to join this keyed stream with
+	 * @param <T1> Type parameter of elements in the other stream
+	 * @return An instance of {@link IntervalJoin} with this keyed stream and the other keyed stream
+	 */
+	public <T1> IntervalJoin<T, T1> intervalJoin(KeyedStream<T1, KEY> otherStream) {
+		return new IntervalJoin<>(this, otherStream);
+	}
+
+	/**
+	 * Perform a join over a time interval.
+	 * @param <T1>
+	 * @param <T2>
+	 */
+	public class IntervalJoin<T1, T2> {
+
+		private final KeyedStream<T1, KEY> streamOne;
+		private final KeyedStream<T2, KEY> streamTwo;
+
+		IntervalJoin(
+			KeyedStream<T1, KEY> streamOne,
+			KeyedStream<T2, KEY> streamTwo
+		) {
+
+			this.streamOne = streamOne;
+			this.streamTwo = streamTwo;
+		}
+
+		/**
+		 * Specifies the time boundaries over which the join operation works, so that
+		 * <pre>leftElement.timestamp + lowerBound <= rightElement.timestamp <= leftElement.timestamp + upperBound</pre>
+		 * By default both the lower and the upper bound are inclusive. This can be configured
+		 * with {@link IntervalJoined#lowerBoundExclusive(boolean)} and
+		 * {@link IntervalJoined#upperBoundExclusive(boolean)}
+		 *
+		 * @param lowerBound The lower bound. Needs to be smaller than or equal to the upperBound
+		 * @param upperBound The upper bound. Needs to be bigger than or equal to the lowerBound
+		 */
+		public IntervalJoined<T1, T2, KEY> between(Time lowerBound, Time upperBound) {
+
+			TimeCharacteristic timeCharacteristic =
+				streamOne.getExecutionEnvironment().getStreamTimeCharacteristic();
+
+			if (timeCharacteristic != TimeCharacteristic.EventTime) {
+				throw new UnsupportedTimeCharacteristicException("Time-bounded stream joins are only supported in event time");
+			}
+
+			checkNotNull(lowerBound, "A lower bound needs to be provided for a time-bounded join");
+			checkNotNull(upperBound, "An upper bound needs to be provided for a time-bounded join");
+
+			return new IntervalJoined<>(
+				streamOne,
+				streamTwo,
+				lowerBound.toMilliseconds(),
+				upperBound.toMilliseconds(),
+				true,
+				true,
+				streamOne.keySelector,
+				streamTwo.keySelector
+			);
+		}
+	}
+
+	/**
+	 * IntervalJoined is a container for two streams that have keys for both sides as well as
+	 * the time boundaries over which elements should be joined.
+	 *
+	 * @param <IN1> Input type of elements from the first stream
+	 * @param <IN2> Input type of elements from the second stream
+	 * @param <KEY> The type of the key
+	 */
+	public static class IntervalJoined<IN1, IN2, KEY> {
+
+		private static final String INTERVAL_JOIN_FUNC_NAME = "IntervalJoin";
+
+		private final DataStream<IN1> left;
+		private final DataStream<IN2> right;
+
+		private final long lowerBound;
+		private final long upperBound;
+
+		private final KeySelector<IN1, KEY> keySelector1;
+		private final KeySelector<IN2, KEY> keySelector2;
+
+		private boolean lowerBoundInclusive;
+		private boolean upperBoundInclusive;
+
+		IntervalJoined(
+			DataStream<IN1> left,
+			DataStream<IN2> right,
+			long lowerBound,
+			long upperBound,
+			boolean lowerBoundInclusive,
+			boolean upperBoundInclusive,
+			KeySelector<IN1, KEY> keySelector1,
+			KeySelector<IN2, KEY> keySelector2) {
+
+			this.left = checkNotNull(left);
+			this.right = checkNotNull(right);
+
+			this.lowerBound = lowerBound;
+			this.upperBound = upperBound;
+
+			this.lowerBoundInclusive = lowerBoundInclusive;
+			this.upperBoundInclusive = upperBoundInclusive;
+
+			this.keySelector1 = checkNotNull(keySelector1);
+			this.keySelector2 = checkNotNull(keySelector2);
+		}
+
+		/**
+		 * Configure whether the upper bound should be considered exclusive or inclusive.
+		 */
+		public IntervalJoined<IN1, IN2, KEY> upperBoundExclusive(boolean exclusive) {
+			this.upperBoundInclusive = !exclusive;
+			return this;
+		}
+
+		/**
+		 * Configure whether the lower bound should be considered exclusive or inclusive.
+		 */
+		public IntervalJoined<IN1, IN2, KEY> lowerBoundExclusive(boolean exclusive) {
+			this.lowerBoundInclusive = !exclusive;
+			return this;
+		}
+
+		/**
+		 * Completes the join operation with the user function that is executed for each joined pair
+		 * of elements.
+		 * @param udf The user-defined function
+		 * @param <OUT> The output type
+		 * @return Returns a DataStream
+		 */
+		public <OUT> DataStream<OUT> process(IntervalJoinFunction<IN1, IN2, OUT> udf) {
+
+			ConnectedStreams<IN1, IN2> connected = left.connect(right);
+
+			udf = left.getExecutionEnvironment().clean(udf);
+
+			TypeInformation<OUT> resultType = TypeExtractor.getBinaryOperatorReturnType(
+				udf,
+				IntervalJoinFunction.class,    // IntervalJoinFunction<IN1, IN2, OUT>
+				0,                                //						  0    1    2
+				1,
+				2,
+				new int[]{0},                   // lambda input 1 type arg indices
+				new int[]{1},                   // lambda input 1 type arg indices
+				TypeExtractor.NO_INDEX,         // output arg indices
+				left.getType(),                 // input 1 type information
+				right.getType(),                // input 1 type information
+				INTERVAL_JOIN_FUNC_NAME ,
+				false
+			);
+
+			IntervalJoinOperator<KEY, IN1, IN2, OUT> operator =
+				new IntervalJoinOperator<>(
+					lowerBound,
+					upperBound,
+					lowerBoundInclusive,
+					upperBoundInclusive,
+					left.getType().createSerializer(left.getExecutionConfig()),
+					right.getType().createSerializer(right.getExecutionConfig()),
+					udf
+				);
+
+			return connected
+				.keyBy(keySelector1, keySelector2)
+				.transform(INTERVAL_JOIN_FUNC_NAME , resultType, operator);
+
+		}
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/KeyedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/KeyedStream.java
@@ -461,9 +461,7 @@ public class KeyedStream<T, KEY> extends DataStream<T> {
 				lowerBound.toMilliseconds(),
 				upperBound.toMilliseconds(),
 				true,
-				true,
-				streamOne.getKeySelector(),
-				streamTwo.getKeySelector()
+				true
 			);
 		}
 	}
@@ -492,15 +490,13 @@ public class KeyedStream<T, KEY> extends DataStream<T> {
 		private boolean lowerBoundInclusive;
 		private boolean upperBoundInclusive;
 
-		IntervalJoined(
+		public IntervalJoined(
 			KeyedStream<IN1, KEY> left,
 			KeyedStream<IN2, KEY> right,
 			long lowerBound,
 			long upperBound,
 			boolean lowerBoundInclusive,
-			boolean upperBoundInclusive,
-			KeySelector<IN1, KEY> keySelector1,
-			KeySelector<IN2, KEY> keySelector2) {
+			boolean upperBoundInclusive) {
 
 			this.left = checkNotNull(left);
 			this.right = checkNotNull(right);
@@ -511,12 +507,12 @@ public class KeyedStream<T, KEY> extends DataStream<T> {
 			this.lowerBoundInclusive = lowerBoundInclusive;
 			this.upperBoundInclusive = upperBoundInclusive;
 
-			this.keySelector1 = checkNotNull(keySelector1);
-			this.keySelector2 = checkNotNull(keySelector2);
+			this.keySelector1 = left.getKeySelector();
+			this.keySelector2 = right.getKeySelector();
 		}
 
 		/**
-		 * Configure whether the upper bound should be considered exclusive or inclusive.
+		 * Set the upper bound to be exclusive.
 		 */
 		public IntervalJoined<IN1, IN2, KEY> upperBoundExclusive() {
 			this.upperBoundInclusive = false;
@@ -524,7 +520,7 @@ public class KeyedStream<T, KEY> extends DataStream<T> {
 		}
 
 		/**
-		 * Configure whether the lower bound should be considered exclusive or inclusive.
+		 * Set the lower bound to be exclusive.
 		 */
 		public IntervalJoined<IN1, IN2, KEY> lowerBoundExclusive() {
 			this.lowerBoundInclusive = false;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/UnsupportedTimeCharacteristicException.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/UnsupportedTimeCharacteristicException.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.streaming.api.datastream;
 
 import org.apache.flink.annotation.PublicEvolving;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/UnsupportedTimeCharacteristicException.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/UnsupportedTimeCharacteristicException.java
@@ -1,0 +1,17 @@
+package org.apache.flink.streaming.api.datastream;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+/**
+ * An exception that indicates that a time characteristic was used that is not supported in the
+ * current operation.
+ */
+@PublicEvolving
+public class UnsupportedTimeCharacteristicException extends RuntimeException {
+
+	private static final long serialVersionUID = -8109094930338075819L;
+
+	public UnsupportedTimeCharacteristicException(String message) {
+		super(message);
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/co/IntervalJoinFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/co/IntervalJoinFunction.java
@@ -35,7 +35,7 @@ import org.apache.flink.util.OutputTag;
  * @param <OUT> Type of the output
  */
 @PublicEvolving
-public abstract class TimeBoundedJoinFunction<IN1, IN2, OUT> extends AbstractRichFunction {
+public abstract class IntervalJoinFunction<IN1, IN2, OUT> extends AbstractRichFunction {
 
 	private static final long serialVersionUID = -2444626938039012398L;
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/co/ProcessJoinFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/co/ProcessJoinFunction.java
@@ -35,7 +35,7 @@ import org.apache.flink.util.OutputTag;
  * @param <OUT> Type of the output
  */
 @PublicEvolving
-public abstract class IntervalJoinFunction<IN1, IN2, OUT> extends AbstractRichFunction {
+public abstract class ProcessJoinFunction<IN1, IN2, OUT> extends AbstractRichFunction {
 
 	private static final long serialVersionUID = -2444626938039012398L;
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/co/IntervalJoinOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/co/IntervalJoinOperator.java
@@ -36,7 +36,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.runtime.state.StateInitializationContext;
-import org.apache.flink.streaming.api.functions.co.TimeBoundedJoinFunction;
+import org.apache.flink.streaming.api.functions.co.IntervalJoinFunction;
 import org.apache.flink.streaming.api.operators.AbstractUdfStreamOperator;
 import org.apache.flink.streaming.api.operators.InternalTimer;
 import org.apache.flink.streaming.api.operators.InternalTimerService;
@@ -65,7 +65,7 @@ import java.util.Objects;
  * (T1, T2) where t2.ts ∈ [T1.ts + lowerBound, T1.ts + upperBound]. Both the lower and the
  * upper bound can be configured to be either inclusive or exclusive.
  *
- * <p>As soon as elements are joined they are passed to a user-defined {@link TimeBoundedJoinFunction}.
+ * <p>As soon as elements are joined they are passed to a user-defined {@link IntervalJoinFunction}.
  *
  * <p>The basic idea of this implementation is as follows: Whenever we receive an element at
  * {@link #processElement1(StreamRecord)} (a.k.a. the left side), we add it to the left buffer.
@@ -86,13 +86,13 @@ import java.util.Objects;
  * @param <OUT>	The output type created by the user-defined function.
  */
 @Internal
-public class TimeBoundedStreamJoinOperator<K, T1, T2, OUT>
-		extends AbstractUdfStreamOperator<OUT, TimeBoundedJoinFunction<T1, T2, OUT>>
+public class IntervalJoinOperator<K, T1, T2, OUT>
+		extends AbstractUdfStreamOperator<OUT, IntervalJoinFunction<T1, T2, OUT>>
 		implements TwoInputStreamOperator<T1, T2, OUT>, Triggerable<K, String> {
 
 	private static final long serialVersionUID = -5380774605111543454L;
 
-	private static final Logger logger = LoggerFactory.getLogger(TimeBoundedStreamJoinOperator.class);
+	private static final Logger logger = LoggerFactory.getLogger(IntervalJoinOperator.class);
 
 	private static final String LEFT_BUFFER = "LEFT_BUFFER";
 	private static final String RIGHT_BUFFER = "RIGHT_BUFFER";
@@ -115,7 +115,7 @@ public class TimeBoundedStreamJoinOperator<K, T1, T2, OUT>
 	private transient InternalTimerService<String> internalTimerService;
 
 	/**
-	 * Creates a new TimeBoundedStreamJoinOperator.
+	 * Creates a new IntervalJoinOperator.
 	 *
 	 * @param lowerBound          The lower bound for evaluating if elements should be joined
 	 * @param upperBound          The upper bound for evaluating if elements should be joined
@@ -123,17 +123,17 @@ public class TimeBoundedStreamJoinOperator<K, T1, T2, OUT>
 	 *                            the lower bound
 	 * @param upperBoundInclusive Whether or not to include elements where the timestamp matches
 	 *                            the upper bound
-	 * @param udf                 A user-defined {@link TimeBoundedJoinFunction} that gets called
+	 * @param udf                 A user-defined {@link IntervalJoinFunction} that gets called
 	 *                            whenever two elements of T1 and T2 are joined
 	 */
-	public TimeBoundedStreamJoinOperator(
+	public IntervalJoinOperator(
 			long lowerBound,
 			long upperBound,
 			boolean lowerBoundInclusive,
 			boolean upperBoundInclusive,
 			TypeSerializer<T1> leftTypeSerializer,
 			TypeSerializer<T2> rightTypeSerializer,
-			TimeBoundedJoinFunction<T1, T2, OUT> udf) {
+			IntervalJoinFunction<T1, T2, OUT> udf) {
 
 		super(Preconditions.checkNotNull(udf));
 
@@ -179,7 +179,7 @@ public class TimeBoundedStreamJoinOperator<K, T1, T2, OUT>
 	 * Process a {@link StreamRecord} from the left stream. Whenever an {@link StreamRecord}
 	 * arrives at the left stream, it will get added to the left buffer. Possible join candidates
 	 * for that element will be looked up from the right buffer and if the pair lies within the
-	 * user defined boundaries, it gets passed to the {@link TimeBoundedJoinFunction}.
+	 * user defined boundaries, it gets passed to the {@link IntervalJoinFunction}.
 	 *
 	 * @param record An incoming record to be joined
 	 * @throws Exception Can throw an Exception during state access
@@ -193,7 +193,7 @@ public class TimeBoundedStreamJoinOperator<K, T1, T2, OUT>
 	 * Process a {@link StreamRecord} from the right stream. Whenever a {@link StreamRecord}
 	 * arrives at the right stream, it will get added to the right buffer. Possible join candidates
 	 * for that element will be looked up from the left buffer and if the pair lies within the user
-	 * defined boundaries, it gets passed to the {@link TimeBoundedJoinFunction}.
+	 * defined boundaries, it gets passed to the {@link IntervalJoinFunction}.
 	 *
 	 * @param record An incoming record to be joined
 	 * @throws Exception Can throw an exception during state access
@@ -306,18 +306,18 @@ public class TimeBoundedStreamJoinOperator<K, T1, T2, OUT>
 
 	/**
 	 * The context that is available during an invocation of
-	 * {@link TimeBoundedJoinFunction#processElement(Object, Object, TimeBoundedJoinFunction.Context, Collector)}.
+	 * {@link IntervalJoinFunction#processElement(Object, Object, IntervalJoinFunction.Context, Collector)}.
 	 *
 	 * <p>It gives access to the timestamps of the left element in the joined pair, the right one, and that of
 	 * the joined pair. In addition, this context allows to emit elements on a side output.
 	 */
-	private final class ContextImpl extends TimeBoundedJoinFunction<T1, T2, OUT>.Context {
+	private final class ContextImpl extends IntervalJoinFunction<T1, T2, OUT>.Context {
 
 		private long leftTimestamp = Long.MIN_VALUE;
 
 		private long rightTimestamp = Long.MIN_VALUE;
 
-		private ContextImpl(TimeBoundedJoinFunction<T1, T2, OUT> func) {
+		private ContextImpl(IntervalJoinFunction<T1, T2, OUT> func) {
 			func.super();
 		}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/co/IntervalJoinOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/co/IntervalJoinOperatorTest.java
@@ -26,7 +26,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
-import org.apache.flink.streaming.api.functions.co.IntervalJoinFunction;
+import org.apache.flink.streaming.api.functions.co.ProcessJoinFunction;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
@@ -444,7 +444,7 @@ public class IntervalJoinOperatorTest {
 				true,
 				TestElem.serializer(),
 				TestElem.serializer(),
-				new IntervalJoinFunction<TestElem, TestElem, Tuple2<TestElem, TestElem>>() {
+				new ProcessJoinFunction<TestElem, TestElem, Tuple2<TestElem, TestElem>>() {
 					@Override
 					public void processElement(
 						TestElem left,
@@ -480,7 +480,7 @@ public class IntervalJoinOperatorTest {
 				true,
 				TestElem.serializer(),
 				TestElem.serializer(),
-				new IntervalJoinFunction<TestElem, TestElem, Tuple2<TestElem, TestElem>>() {
+				new ProcessJoinFunction<TestElem, TestElem, Tuple2<TestElem, TestElem>>() {
 					@Override
 					public void processElement(
 						TestElem left,
@@ -517,7 +517,7 @@ public class IntervalJoinOperatorTest {
 				true,
 				TestElem.serializer(),
 				TestElem.serializer(),
-				new IntervalJoinFunction<TestElem, TestElem, Tuple2<TestElem, TestElem>>() {
+				new ProcessJoinFunction<TestElem, TestElem, Tuple2<TestElem, TestElem>>() {
 					@Override
 					public void processElement(
 						TestElem left,
@@ -816,7 +816,7 @@ public class IntervalJoinOperatorTest {
 		}
 	}
 
-	private static class PassthroughFunction extends IntervalJoinFunction<TestElem, TestElem, Tuple2<TestElem, TestElem>> {
+	private static class PassthroughFunction extends ProcessJoinFunction<TestElem, TestElem, Tuple2<TestElem, TestElem>> {
 
 		@Override
 		public void processElement(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/co/IntervalJoinOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/co/IntervalJoinOperatorTest.java
@@ -26,7 +26,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
-import org.apache.flink.streaming.api.functions.co.TimeBoundedJoinFunction;
+import org.apache.flink.streaming.api.functions.co.IntervalJoinFunction;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
@@ -52,11 +52,11 @@ import java.util.stream.Collectors;
 
 
 /**
- * Tests for {@link TimeBoundedStreamJoinOperator}.
+ * Tests for {@link IntervalJoinOperator}.
  * Those tests cover correctness and cleaning of state
  */
 @RunWith(Parameterized.class)
-public class TimeBoundedStreamJoinOperatorTest {
+public class IntervalJoinOperatorTest {
 
 	private final boolean lhsFasterThanRhs;
 
@@ -67,7 +67,7 @@ public class TimeBoundedStreamJoinOperatorTest {
 		});
 	}
 
-	public TimeBoundedStreamJoinOperatorTest(boolean lhsFasterThanRhs) {
+	public IntervalJoinOperatorTest(boolean lhsFasterThanRhs) {
 		this.lhsFasterThanRhs = lhsFasterThanRhs;
 	}
 
@@ -436,15 +436,15 @@ public class TimeBoundedStreamJoinOperatorTest {
 	@Test
 	public void testContextCorrectLeftTimestamp() throws Exception {
 
-		TimeBoundedStreamJoinOperator<String, TestElem, TestElem, Tuple2<TestElem, TestElem>> op =
-			new TimeBoundedStreamJoinOperator<>(
+		IntervalJoinOperator<String, TestElem, TestElem, Tuple2<TestElem, TestElem>> op =
+			new IntervalJoinOperator<>(
 				-1,
 				1,
 				true,
 				true,
 				TestElem.serializer(),
 				TestElem.serializer(),
-				new TimeBoundedJoinFunction<TestElem, TestElem, Tuple2<TestElem, TestElem>>() {
+				new IntervalJoinFunction<TestElem, TestElem, Tuple2<TestElem, TestElem>>() {
 					@Override
 					public void processElement(
 						TestElem left,
@@ -472,15 +472,15 @@ public class TimeBoundedStreamJoinOperatorTest {
 
 	@Test
 	public void testReturnsCorrectTimestamp() throws Exception {
-		TimeBoundedStreamJoinOperator<String, TestElem, TestElem, Tuple2<TestElem, TestElem>> op =
-			new TimeBoundedStreamJoinOperator<>(
+		IntervalJoinOperator<String, TestElem, TestElem, Tuple2<TestElem, TestElem>> op =
+			new IntervalJoinOperator<>(
 				-1,
 				1,
 				true,
 				true,
 				TestElem.serializer(),
 				TestElem.serializer(),
-				new TimeBoundedJoinFunction<TestElem, TestElem, Tuple2<TestElem, TestElem>>() {
+				new IntervalJoinFunction<TestElem, TestElem, Tuple2<TestElem, TestElem>>() {
 					@Override
 					public void processElement(
 						TestElem left,
@@ -509,15 +509,15 @@ public class TimeBoundedStreamJoinOperatorTest {
 	@Test
 	public void testContextCorrectRightTimestamp() throws Exception {
 
-		TimeBoundedStreamJoinOperator<String, TestElem, TestElem, Tuple2<TestElem, TestElem>> op =
-			new TimeBoundedStreamJoinOperator<>(
+		IntervalJoinOperator<String, TestElem, TestElem, Tuple2<TestElem, TestElem>> op =
+			new IntervalJoinOperator<>(
 				-1,
 				1,
 				true,
 				true,
 				TestElem.serializer(),
 				TestElem.serializer(),
-				new TimeBoundedJoinFunction<TestElem, TestElem, Tuple2<TestElem, TestElem>>() {
+				new IntervalJoinFunction<TestElem, TestElem, Tuple2<TestElem, TestElem>>() {
 					@Override
 					public void processElement(
 						TestElem left,
@@ -647,8 +647,8 @@ public class TimeBoundedStreamJoinOperatorTest {
 		long upperBound,
 		boolean upperBoundInclusive) throws Exception {
 
-		TimeBoundedStreamJoinOperator<String, TestElem, TestElem, Tuple2<TestElem, TestElem>> operator =
-			new TimeBoundedStreamJoinOperator<>(
+		IntervalJoinOperator<String, TestElem, TestElem, Tuple2<TestElem, TestElem>> operator =
+			new IntervalJoinOperator<>(
 				lowerBound,
 				upperBound,
 				lowerBoundInclusive,
@@ -671,8 +671,8 @@ public class TimeBoundedStreamJoinOperatorTest {
 		long upperBound,
 		boolean upperBoundInclusive) throws Exception {
 
-		TimeBoundedStreamJoinOperator<String, TestElem, TestElem, Tuple2<TestElem, TestElem>> operator =
-			new TimeBoundedStreamJoinOperator<>(
+		IntervalJoinOperator<String, TestElem, TestElem, Tuple2<TestElem, TestElem>> operator =
+			new IntervalJoinOperator<>(
 				lowerBound,
 				upperBound,
 				lowerBoundInclusive,
@@ -694,12 +694,12 @@ public class TimeBoundedStreamJoinOperatorTest {
 
 	private class JoinTestBuilder {
 
-		private TimeBoundedStreamJoinOperator<String, TestElem, TestElem, Tuple2<TestElem, TestElem>> operator;
+		private IntervalJoinOperator<String, TestElem, TestElem, Tuple2<TestElem, TestElem>> operator;
 		private TestHarness testHarness;
 
 		public JoinTestBuilder(
 			TestHarness t,
-			TimeBoundedStreamJoinOperator<String, TestElem, TestElem, Tuple2<TestElem, TestElem>> operator
+			IntervalJoinOperator<String, TestElem, TestElem, Tuple2<TestElem, TestElem>> operator
 		) throws Exception {
 
 			this.testHarness = t;
@@ -816,7 +816,7 @@ public class TimeBoundedStreamJoinOperatorTest {
 		}
 	}
 
-	private static class PassthroughFunction extends TimeBoundedJoinFunction<TestElem, TestElem, Tuple2<TestElem, TestElem>> {
+	private static class PassthroughFunction extends IntervalJoinFunction<TestElem, TestElem, Tuple2<TestElem, TestElem>> {
 
 		@Override
 		public void processElement(

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/KeyedStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/KeyedStream.scala
@@ -133,11 +133,13 @@ class KeyedStream[T, K](javaStream: KeyedJavaStream[T, K]) extends DataStream[T]
     * @tparam IN1 The type parameter of the elements in the first streams
     * @tparam IN2 The The type parameter of the elements in the second stream
     */
-  class IntervalJoin[IN1, IN2, KEY](val streamOne: KeyedStream[IN1, KEY], val streamTwo: KeyedStream[IN2, KEY]) {
+  class IntervalJoin[IN1, IN2, KEY](val streamOne: KeyedStream[IN1, KEY],
+                                    val streamTwo: KeyedStream[IN2, KEY]) {
 
     /**
       * Specifies the time boundaries over which the join operation works, so that
-      * <pre>leftElement.timestamp + lowerBound <= rightElement.timestamp <= leftElement.timestamp + upperBound</pre>
+      * <pre>leftElement.timestamp + lowerBound <= rightElement.timestamp
+      * <= leftElement.timestamp + upperBound</pre>
       * By default both the lower and the upper bound are inclusive. This can be configured
       * with [[IntervalJoined.lowerBoundExclusive]] and
       * [[IntervalJoined.upperBoundExclusive]]

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/IntervalJoinITCase.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/IntervalJoinITCase.scala
@@ -1,12 +1,13 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -97,18 +98,18 @@ class IntervalJoinITCase extends AbstractTestBase {
   }
 }
 
-object companion {
+object Companion {
   val results: ListBuffer[String] = new ListBuffer()
 }
 
 class ResultSink extends SinkFunction[String] {
 
   override def invoke(value: String, context: SinkFunction.Context[_]): Unit = {
-    companion.results.append(value)
+    Companion.results.append(value)
   }
 
   def expectInAnyOrder(expected: String*): Unit = {
-    Assert.assertTrue(expected.toSet.equals(companion.results.toSet))
+    Assert.assertTrue(expected.toSet.equals(Companion.results.toSet))
   }
 }
 
@@ -116,8 +117,18 @@ class TimestampExtractor extends AscendingTimestampExtractor[(String, Long)] {
   override def extractAscendingTimestamp(element: (String, Long)): Long = element._2
 }
 
-class CombineToStringJoinFunction extends ProcessJoinFunction[(String, Long), (String, Long), String] {
-  override def processElement(left: (String, Long), right: (String, Long), ctx: ProcessJoinFunction[(String, Long), (String, Long), String]#Context, out: Collector[String]): Unit = {
+class CombineToStringJoinFunction
+  extends ProcessJoinFunction[(String, Long), (String, Long), String] {
+
+  override def processElement(left: (String, Long),
+                              right: (String, Long),
+                              ctx: ProcessJoinFunction[
+                                (String, Long),
+                                (String, Long),
+                                String
+                                ]#Context,
+                              out: Collector[String]): Unit = {
+
     out.collect(left + ":" + right)
   }
 }

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/IntervalJoinITCase.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/IntervalJoinITCase.scala
@@ -1,0 +1,106 @@
+package org.apache.flink.streaming.api.scala
+
+import org.apache.flink.streaming.api.TimeCharacteristic
+import org.apache.flink.streaming.api.functions.co.ProcessJoinFunction
+import org.apache.flink.streaming.api.functions.sink.SinkFunction
+import org.apache.flink.streaming.api.functions.timestamps.AscendingTimestampExtractor
+import org.apache.flink.streaming.api.windowing.time.Time
+import org.apache.flink.test.util.AbstractTestBase
+import org.apache.flink.util.Collector
+import org.junit.{Assert, Test}
+
+import scala.collection.mutable.ListBuffer
+
+class IntervalJoinITCase extends AbstractTestBase {
+
+  @Test
+  def testInclusiveBounds(): Unit = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
+    env.setParallelism(1)
+
+    val dataStream1 = env.fromElements(("key", 0L), ("key", 1L), ("key", 2L))
+      .assignTimestampsAndWatermarks(new TimestampExtractor())
+      .keyBy(elem => elem._1)
+
+    val dataStream2 = env.fromElements(("key", 0L), ("key", 1L), ("key", 2L))
+      .assignTimestampsAndWatermarks(new TimestampExtractor())
+      .keyBy(elem => elem._1)
+
+    val sink = new ResultSink()
+
+    dataStream1.intervalJoin(dataStream2)
+      .between(Time.milliseconds(0), Time.milliseconds(2))
+      .process(new CombineToStringJoinFunction())
+      .addSink(sink)
+
+    env.execute()
+
+    sink.expectInAnyOrder(
+      "(key,0):(key,0)",
+      "(key,0):(key,1)",
+      "(key,0):(key,2)",
+
+      "(key,1):(key,1)",
+      "(key,1):(key,2)",
+
+      "(key,2):(key,2)"
+    )
+  }
+
+  @Test
+  def testExclusiveBounds(): Unit = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
+    env.setParallelism(1)
+
+    val dataStream1 = env.fromElements(("key", 0L), ("key", 1L), ("key", 2L))
+      .assignTimestampsAndWatermarks(new TimestampExtractor())
+      .keyBy(elem => elem._1)
+
+    val dataStream2 = env.fromElements(("key", 0L), ("key", 1L), ("key", 2L))
+      .assignTimestampsAndWatermarks(new TimestampExtractor())
+      .keyBy(elem => elem._1)
+
+    val sink = new ResultSink()
+
+    dataStream1.intervalJoin(dataStream2)
+      .between(Time.milliseconds(0), Time.milliseconds(2))
+      .lowerBoundExclusive()
+      .upperBoundExclusive()
+      .process(new CombineToStringJoinFunction())
+      .addSink(sink)
+
+    env.execute()
+
+    sink.expectInAnyOrder(
+      "(key,0):(key,1)",
+      "(key,1):(key,2)"
+    )
+  }
+}
+
+object companion {
+  val results: ListBuffer[String] = new ListBuffer()
+}
+
+class ResultSink extends SinkFunction[String] {
+
+  override def invoke(value: String, context: SinkFunction.Context[_]): Unit = {
+    companion.results.append(value)
+  }
+
+  def expectInAnyOrder(expected: String*): Unit = {
+    Assert.assertTrue(expected.toSet.equals(companion.results.toSet))
+  }
+}
+
+class TimestampExtractor extends AscendingTimestampExtractor[(String, Long)] {
+  override def extractAscendingTimestamp(element: (String, Long)): Long = element._2
+}
+
+class CombineToStringJoinFunction extends ProcessJoinFunction[(String, Long), (String, Long), String] {
+  override def processElement(left: (String, Long), right: (String, Long), ctx: ProcessJoinFunction[(String, Long), (String, Long), String]#Context, out: Collector[String]): Unit = {
+    out.collect(left + ":" + right)
+  }
+}

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/IntervalJoinITCase.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/IntervalJoinITCase.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.streaming.api.scala
 
 import org.apache.flink.streaming.api.TimeCharacteristic

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/IntervalJoinITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/IntervalJoinITCase.java
@@ -1,0 +1,452 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.streaming.runtime;
+
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.streaming.api.TimeCharacteristic;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.KeyedStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.co.IntervalJoinFunction;
+import org.apache.flink.streaming.api.functions.sink.SinkFunction;
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.streaming.api.functions.timestamps.AscendingTimestampExtractor;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.api.windowing.time.Time;
+import org.apache.flink.util.Collector;
+
+import org.apache.flink.shaded.guava18.com.google.common.collect.Lists;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Integration tests for interval joins.
+ */
+public class IntervalJoinITCase {
+
+	private static List<String> testResults;
+
+	@Before
+	public void setup() {
+		testResults = new ArrayList<>();
+	}
+
+	@Test
+	public void testCanJoinOverSameKey() throws Exception {
+
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		env.setParallelism(1);
+
+		KeyedStream<Tuple2<String, Integer>, String> streamOne = env.fromElements(
+			Tuple2.of("key", 0),
+			Tuple2.of("key", 1),
+			Tuple2.of("key", 2),
+			Tuple2.of("key", 3),
+			Tuple2.of("key", 4),
+			Tuple2.of("key", 5)
+		)
+			.assignTimestampsAndWatermarks(new AscendingTuple2TimestampExtractor())
+			.keyBy(new Tuple2KeyExtractor());
+
+		KeyedStream<Tuple2<String, Integer>, String> streamTwo = env.fromElements(
+			Tuple2.of("key", 0),
+			Tuple2.of("key", 1),
+			Tuple2.of("key", 2),
+			Tuple2.of("key", 3),
+			Tuple2.of("key", 4),
+			Tuple2.of("key", 5)
+		)
+			.assignTimestampsAndWatermarks(new AscendingTuple2TimestampExtractor())
+			.keyBy(new Tuple2KeyExtractor());
+
+		streamOne
+			.intervalJoin(streamTwo)
+			.between(Time.milliseconds(0), Time.milliseconds(0))
+			.process(new IntervalJoinFunction<Tuple2<String, Integer>, Tuple2<String, Integer>, String>() {
+				@Override
+				public void processElement(Tuple2<String, Integer> left,
+					Tuple2<String, Integer> right, Context ctx,
+					Collector<String> out) throws Exception {
+					out.collect(left + ":" + right);
+				}
+			}).addSink(new ResultSink());
+
+		env.execute();
+
+		expectInAnyOrder(
+			"(key,0):(key,0)",
+			"(key,1):(key,1)",
+			"(key,2):(key,2)",
+			"(key,3):(key,3)",
+			"(key,4):(key,4)",
+			"(key,5):(key,5)"
+		);
+	}
+
+	@Test
+	public void testJoinsCorrectlyWithMultipleKeys() throws Exception {
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		env.setParallelism(1);
+
+		KeyedStream<Tuple2<String, Integer>, String> streamOne = env.fromElements(
+			Tuple2.of("key1", 0),
+			Tuple2.of("key2", 1),
+			Tuple2.of("key1", 2),
+			Tuple2.of("key2", 3),
+			Tuple2.of("key1", 4),
+			Tuple2.of("key2", 5)
+		)
+			.assignTimestampsAndWatermarks(new AscendingTuple2TimestampExtractor())
+			.keyBy(new Tuple2KeyExtractor());
+
+		KeyedStream<Tuple2<String, Integer>, String> streamTwo = env.fromElements(
+			Tuple2.of("key1", 0),
+			Tuple2.of("key2", 1),
+			Tuple2.of("key1", 2),
+			Tuple2.of("key2", 3),
+			Tuple2.of("key1", 4),
+			Tuple2.of("key2", 5)
+		)
+			.assignTimestampsAndWatermarks(new AscendingTuple2TimestampExtractor())
+			.keyBy(new Tuple2KeyExtractor());
+
+		streamOne
+			.intervalJoin(streamTwo)
+			// if it were not keyed then the boundaries [0; 1] would lead to the pairs (1, 1),
+			// (1, 2), (2, 2), (2, 3)..., so that this is not happening is what we are testing here
+			.between(Time.milliseconds(0), Time.milliseconds(1))
+			.process(new CombineToStringJoinFunction())
+			.addSink(new ResultSink());
+
+		env.execute();
+
+		expectInAnyOrder(
+			"(key1,0):(key1,0)",
+			"(key2,1):(key2,1)",
+			"(key1,2):(key1,2)",
+			"(key2,3):(key2,3)",
+			"(key1,4):(key1,4)",
+			"(key2,5):(key2,5)"
+		);
+	}
+
+	@Test
+	public void testBoundedUnorderedStreamsStillJoinCorrectly() throws Exception {
+
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		env.setParallelism(1);
+
+		DataStream<Tuple2<String, Integer>> streamOne = env.addSource(new SourceFunction<Tuple2<String, Integer>>() {
+			@Override
+			public void run(SourceContext<Tuple2<String, Integer>> ctx) {
+				ctx.collectWithTimestamp(Tuple2.of("key", 5), 5L);
+				ctx.collectWithTimestamp(Tuple2.of("key", 1), 1L);
+				ctx.collectWithTimestamp(Tuple2.of("key", 4), 4L);
+				ctx.collectWithTimestamp(Tuple2.of("key", 3), 3L);
+				ctx.collectWithTimestamp(Tuple2.of("key", 2), 2L);
+				ctx.emitWatermark(new Watermark(5));
+				ctx.collectWithTimestamp(Tuple2.of("key", 9), 9L);
+				ctx.collectWithTimestamp(Tuple2.of("key", 8), 8L);
+				ctx.collectWithTimestamp(Tuple2.of("key", 7), 7L);
+				ctx.collectWithTimestamp(Tuple2.of("key", 6), 6L);
+			}
+
+			@Override
+			public void cancel() {
+				// do nothing
+			}
+		});
+
+		DataStream<Tuple2<String, Integer>> streamTwo = env.addSource(new SourceFunction<Tuple2<String, Integer>>() {
+			@Override
+			public void run(SourceContext<Tuple2<String, Integer>> ctx) {
+				ctx.collectWithTimestamp(Tuple2.of("key", 2), 2L);
+				ctx.collectWithTimestamp(Tuple2.of("key", 1), 1L);
+				ctx.collectWithTimestamp(Tuple2.of("key", 3), 3L);
+				ctx.collectWithTimestamp(Tuple2.of("key", 4), 4L);
+				ctx.collectWithTimestamp(Tuple2.of("key", 5), 5L);
+				ctx.emitWatermark(new Watermark(5));
+				ctx.collectWithTimestamp(Tuple2.of("key", 8), 8L);
+				ctx.collectWithTimestamp(Tuple2.of("key", 7), 7L);
+				ctx.collectWithTimestamp(Tuple2.of("key", 9), 9L);
+				ctx.collectWithTimestamp(Tuple2.of("key", 6), 6L);
+			}
+
+			@Override
+			public void cancel() {
+				// do nothing
+			}
+		});
+
+		streamOne
+			.keyBy(new Tuple2KeyExtractor())
+			.intervalJoin(streamTwo.keyBy(new Tuple2KeyExtractor()))
+			.between(Time.milliseconds(-1), Time.milliseconds(1))
+			.process(new CombineToStringJoinFunction())
+			.addSink(new ResultSink());
+
+		env.execute();
+
+		expectInAnyOrder(
+			"(key,1):(key,1)",
+			"(key,1):(key,2)",
+
+			"(key,2):(key,1)",
+			"(key,2):(key,2)",
+			"(key,2):(key,3)",
+
+			"(key,3):(key,2)",
+			"(key,3):(key,3)",
+			"(key,3):(key,4)",
+
+			"(key,4):(key,3)",
+			"(key,4):(key,4)",
+			"(key,4):(key,5)",
+
+			"(key,5):(key,4)",
+			"(key,5):(key,5)",
+			"(key,5):(key,6)",
+
+			"(key,6):(key,5)",
+			"(key,6):(key,6)",
+			"(key,6):(key,7)",
+
+			"(key,7):(key,6)",
+			"(key,7):(key,7)",
+			"(key,7):(key,8)",
+
+			"(key,8):(key,7)",
+			"(key,8):(key,8)",
+			"(key,8):(key,9)",
+
+			"(key,9):(key,8)",
+			"(key,9):(key,9)"
+		);
+	}
+
+	@Test(expected = NullPointerException.class)
+	public void testFailsWithoutUpperBound() {
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		env.setParallelism(1);
+
+		DataStream<Tuple2<String, Integer>> streamOne = env.fromElements(Tuple2.of("1", 1));
+		DataStream<Tuple2<String, Integer>> streamTwo = env.fromElements(Tuple2.of("1", 1));
+
+		streamOne
+			.keyBy(new Tuple2KeyExtractor())
+			.intervalJoin(streamTwo.keyBy(new Tuple2KeyExtractor()))
+			.between(Time.milliseconds(0), null);
+	}
+
+	@Test(expected = NullPointerException.class)
+	public void testFailsWithoutLowerBound() {
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		env.setParallelism(1);
+
+		DataStream<Tuple2<String, Integer>> streamOne = env.fromElements(Tuple2.of("1", 1));
+		DataStream<Tuple2<String, Integer>> streamTwo = env.fromElements(Tuple2.of("1", 1));
+
+		streamOne
+			.keyBy(new Tuple2KeyExtractor())
+			.intervalJoin(streamTwo.keyBy(new Tuple2KeyExtractor()))
+			.between(null, Time.milliseconds(1));
+	}
+
+	@Test
+	public void testBoundsCanBeExclusive() throws Exception {
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		env.setParallelism(1);
+
+		DataStream<Tuple2<String, Integer>> streamOne = env.fromElements(
+			Tuple2.of("key", 0),
+			Tuple2.of("key", 1),
+			Tuple2.of("key", 2)
+		).assignTimestampsAndWatermarks(new AscendingTuple2TimestampExtractor());
+
+		DataStream<Tuple2<String, Integer>> streamTwo = env.fromElements(
+			Tuple2.of("key", 0),
+			Tuple2.of("key", 1),
+			Tuple2.of("key", 2)
+		).assignTimestampsAndWatermarks(new AscendingTuple2TimestampExtractor());
+
+		streamOne.keyBy(new Tuple2KeyExtractor())
+			.intervalJoin(streamTwo.keyBy(new Tuple2KeyExtractor()))
+			.between(Time.milliseconds(0), Time.milliseconds(2))
+			.upperBoundExclusive(true)
+			.lowerBoundExclusive(true)
+			.process(new CombineToStringJoinFunction())
+			.addSink(new ResultSink());
+
+		env.execute();
+
+		expectInAnyOrder(
+			"(key,0):(key,1)",
+			"(key,1):(key,2)"
+		);
+	}
+
+	@Test
+	public void testBoundsCanBeInclusive() throws Exception {
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		env.setParallelism(1);
+
+		DataStream<Tuple2<String, Integer>> streamOne = env.fromElements(
+			Tuple2.of("key", 0),
+			Tuple2.of("key", 1),
+			Tuple2.of("key", 2)
+		).assignTimestampsAndWatermarks(new AscendingTuple2TimestampExtractor());
+
+		DataStream<Tuple2<String, Integer>> streamTwo = env.fromElements(
+			Tuple2.of("key", 0),
+			Tuple2.of("key", 1),
+			Tuple2.of("key", 2)
+		).assignTimestampsAndWatermarks(new AscendingTuple2TimestampExtractor());
+
+		streamOne.keyBy(new Tuple2KeyExtractor())
+			.intervalJoin(streamTwo.keyBy(new Tuple2KeyExtractor()))
+			.between(Time.milliseconds(0), Time.milliseconds(2))
+			.upperBoundExclusive(false)
+			.lowerBoundExclusive(false)
+			.process(new CombineToStringJoinFunction())
+			.addSink(new ResultSink());
+
+		env.execute();
+
+		expectInAnyOrder(
+			"(key,0):(key,0)",
+			"(key,0):(key,1)",
+			"(key,0):(key,2)",
+
+			"(key,1):(key,1)",
+			"(key,1):(key,2)",
+
+			"(key,2):(key,2)"
+		);
+	}
+
+	@Test
+	public void testBoundsAreInclusiveByDefault() throws Exception {
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		env.setParallelism(1);
+
+		DataStream<Tuple2<String, Integer>> streamOne = env.fromElements(
+			Tuple2.of("key", 0),
+			Tuple2.of("key", 1),
+			Tuple2.of("key", 2)
+		).assignTimestampsAndWatermarks(new AscendingTuple2TimestampExtractor());
+
+		DataStream<Tuple2<String, Integer>> streamTwo = env.fromElements(
+			Tuple2.of("key", 0),
+			Tuple2.of("key", 1),
+			Tuple2.of("key", 2)
+		).assignTimestampsAndWatermarks(new AscendingTuple2TimestampExtractor());
+
+		streamOne.keyBy(new Tuple2KeyExtractor())
+			.intervalJoin(streamTwo.keyBy(new Tuple2KeyExtractor()))
+			.between(Time.milliseconds(0), Time.milliseconds(2))
+			.process(new CombineToStringJoinFunction())
+			.addSink(new ResultSink());
+
+		env.execute();
+
+		expectInAnyOrder(
+			"(key,0):(key,0)",
+			"(key,0):(key,1)",
+			"(key,0):(key,2)",
+
+			"(key,1):(key,1)",
+			"(key,1):(key,2)",
+
+			"(key,2):(key,2)"
+		);
+	}
+
+	@Test(expected = RuntimeException.class)
+	public void testExecutionFailsInProcessingTime() throws Exception {
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setStreamTimeCharacteristic(TimeCharacteristic.ProcessingTime);
+		env.setParallelism(1);
+
+		DataStream<Tuple2<String, Integer>> streamOne = env.fromElements(Tuple2.of("1", 1));
+		DataStream<Tuple2<String, Integer>> streamTwo = env.fromElements(Tuple2.of("1", 1));
+
+		streamOne.keyBy(new Tuple2KeyExtractor())
+			.intervalJoin(streamTwo.keyBy(new Tuple2KeyExtractor()))
+			.between(Time.milliseconds(0), Time.milliseconds(0))
+			.process(new IntervalJoinFunction<Tuple2<String, Integer>, Tuple2<String, Integer>, String>() {
+				@Override
+				public void processElement(Tuple2<String, Integer> left,
+					Tuple2<String, Integer> right, Context ctx,
+					Collector<String> out) throws Exception {
+					out.collect(left + ":" + right);
+				}
+			});
+	}
+
+	private static void expectInAnyOrder(String... expected) {
+		List<String> listExpected = Lists.newArrayList(expected);
+		Collections.sort(listExpected);
+		Collections.sort(testResults);
+		Assert.assertEquals(listExpected, testResults);
+	}
+
+	private static class AscendingTuple2TimestampExtractor extends AscendingTimestampExtractor<Tuple2<String, Integer>> {
+		@Override
+		public long extractAscendingTimestamp(Tuple2<String, Integer> element) {
+			return element.f1;
+		}
+	}
+
+	private static class ResultSink implements SinkFunction<String> {
+		@Override
+		public void invoke(String value, Context context) throws Exception {
+			testResults.add(value);
+		}
+	}
+
+	private static class CombineToStringJoinFunction extends IntervalJoinFunction<Tuple2<String, Integer>, Tuple2<String, Integer>, String> {
+		@Override
+		public void processElement(Tuple2<String, Integer> left,
+			Tuple2<String, Integer> right, Context ctx, Collector<String> out) {
+			out.collect(left + ":" + right);
+		}
+	}
+
+	private static class Tuple2KeyExtractor implements KeySelector<Tuple2<String, Integer>, String> {
+
+		@Override
+		public String getKey(Tuple2<String, Integer> value) throws Exception {
+			return value.f0;
+		}
+	}
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/IntervalJoinITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/IntervalJoinITCase.java
@@ -23,7 +23,7 @@ import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.KeyedStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.functions.co.IntervalJoinFunction;
+import org.apache.flink.streaming.api.functions.co.ProcessJoinFunction;
 import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.api.functions.timestamps.AscendingTimestampExtractor;
@@ -85,7 +85,7 @@ public class IntervalJoinITCase {
 		streamOne
 			.intervalJoin(streamTwo)
 			.between(Time.milliseconds(0), Time.milliseconds(0))
-			.process(new IntervalJoinFunction<Tuple2<String, Integer>, Tuple2<String, Integer>, String>() {
+			.process(new ProcessJoinFunction<Tuple2<String, Integer>, Tuple2<String, Integer>, String>() {
 				@Override
 				public void processElement(Tuple2<String, Integer> left,
 					Tuple2<String, Integer> right, Context ctx,
@@ -300,8 +300,8 @@ public class IntervalJoinITCase {
 		streamOne.keyBy(new Tuple2KeyExtractor())
 			.intervalJoin(streamTwo.keyBy(new Tuple2KeyExtractor()))
 			.between(Time.milliseconds(0), Time.milliseconds(2))
-			.upperBoundExclusive(true)
-			.lowerBoundExclusive(true)
+			.upperBoundExclusive()
+			.lowerBoundExclusive()
 			.process(new CombineToStringJoinFunction())
 			.addSink(new ResultSink());
 
@@ -334,8 +334,6 @@ public class IntervalJoinITCase {
 		streamOne.keyBy(new Tuple2KeyExtractor())
 			.intervalJoin(streamTwo.keyBy(new Tuple2KeyExtractor()))
 			.between(Time.milliseconds(0), Time.milliseconds(2))
-			.upperBoundExclusive(false)
-			.lowerBoundExclusive(false)
 			.process(new CombineToStringJoinFunction())
 			.addSink(new ResultSink());
 
@@ -403,7 +401,7 @@ public class IntervalJoinITCase {
 		streamOne.keyBy(new Tuple2KeyExtractor())
 			.intervalJoin(streamTwo.keyBy(new Tuple2KeyExtractor()))
 			.between(Time.milliseconds(0), Time.milliseconds(0))
-			.process(new IntervalJoinFunction<Tuple2<String, Integer>, Tuple2<String, Integer>, String>() {
+			.process(new ProcessJoinFunction<Tuple2<String, Integer>, Tuple2<String, Integer>, String>() {
 				@Override
 				public void processElement(Tuple2<String, Integer> left,
 					Tuple2<String, Integer> right, Context ctx,
@@ -434,7 +432,7 @@ public class IntervalJoinITCase {
 		}
 	}
 
-	private static class CombineToStringJoinFunction extends IntervalJoinFunction<Tuple2<String, Integer>, Tuple2<String, Integer>, String> {
+	private static class CombineToStringJoinFunction extends ProcessJoinFunction<Tuple2<String, Integer>, Tuple2<String, Integer>, String> {
 		@Override
 		public void processElement(Tuple2<String, Integer> left,
 			Tuple2<String, Integer> right, Context ctx, Collector<String> out) {


### PR DESCRIPTION
## What is the purpose of the change

* Add a JavaAPI to the DataStream API to join two streams based on user-defined time boundaries
* Design doc can be found here https://docs.google.com/document/d/16GMH5VM6JJiWj_N0W8y3PtQ1aoJFxsKoOTSYOfqlsRE/edit#heading=h.bgl260hr56g6

## Brief change log
~* Add option`.between(Time, Time)` to streams that are already joined and have their key selectors `where` and `equalTo` defined~
~* Add new inner class `TimeBounded` to `JoinedStreams`, which exposes `process(TimeBoundedJoinFunction)` as well as optional `upperBoundExclusive(boolean)` and `lowerBoundExclusive(boolean)` to the user~
~* Add new integration test `TimeboundedJoinITCase`~
* **Depends on [FLINK-8479] to be merged** This is done

After some discussions there were some significant changes to how the API is designed. I'm going to highlight the main points below:

- We settled with naming this operation *IntervalJoin* and renamed also the operator accordingly
- Add an option `intervalJoin(KeyedStream)` to `KeyedStream`
- Allow user to specify time boundaries with `IntervalJoin#between(Time, Time)`
- Complete operation with `process(IntervalJoinFunction)`

Example

```java
keyedStream.intervalJoin(otherKeyedStream)
    .between(Time.milliseconds(-2), Time.milliseconds(2)) // lower and upper bound
    .upperBoundExclusive(true) // optional
    .lowerBoundExclusive(true) // optional
    .process(new IntervalJoinFunction() {...});
```

## Verifying this change
This change added tests and can be verified as follows: 
- Added integration tests in ~TimeboundedJoinITCase~ `IntervalJoinITCase` that validate parameter translation and execution

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs, Jekyll Documentation
