### PR TITLE
[FLINK-8411] Don't allow null in ListState.add()/addAll()

### DIFF
--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBaseTest.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBaseTest.java
@@ -718,6 +718,8 @@ public class FlinkKafkaConsumerBaseTest {
 		@Override
 		public void addAll(List<T> values) throws Exception {
 			if (values != null) {
+				values.forEach(v -> Preconditions.checkNotNull(v, "You cannot add null to a ListState."));
+
 				list.addAll(values);
 			}
 		}

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBaseTest.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBaseTest.java
@@ -72,7 +72,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 
 import static org.apache.flink.util.Preconditions.checkState;
@@ -697,7 +696,7 @@ public class FlinkKafkaConsumerBaseTest {
 
 		@Override
 		public void add(T value) throws Exception {
-			Objects.requireNonNull(value, "You cannot add null to a ListState.");
+			Preconditions.checkNotNull(value, "You cannot add null to a ListState.");
 			list.add(value);
 		}
 

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBaseTest.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBaseTest.java
@@ -72,6 +72,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import static org.apache.flink.util.Preconditions.checkState;
@@ -696,6 +697,7 @@ public class FlinkKafkaConsumerBaseTest {
 
 		@Override
 		public void add(T value) throws Exception {
+			Objects.requireNonNull(value, "You cannot add null to a ListState.");
 			list.add(value);
 		}
 

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBListState.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBListState.java
@@ -168,9 +168,11 @@ public class RocksDBListState<K, N, V>
 
 	@Override
 	public void update(List<V> values) throws Exception {
+		Preconditions.checkNotNull(values, "List of values to add cannot be null.");
+
 		clear();
 
-		if (values != null && !values.isEmpty()) {
+		if (!values.isEmpty()) {
 			try {
 				writeCurrentKeyWithGroupAndNamespace();
 				byte[] key = keySerializationStream.toByteArray();
@@ -189,7 +191,9 @@ public class RocksDBListState<K, N, V>
 
 	@Override
 	public void addAll(List<V> values) throws Exception {
-		if (values != null && !values.isEmpty()) {
+		Preconditions.checkNotNull(values, "List of values to add cannot be null.");
+
+		if (!values.isEmpty()) {
 			try {
 				writeCurrentKeyWithGroupAndNamespace();
 				byte[] key = keySerializationStream.toByteArray();

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBListState.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBListState.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.runtime.state.internal.InternalListState;
+import org.apache.flink.util.Preconditions;
 
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.RocksDBException;
@@ -34,7 +35,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * {@link ListState} implementation that stores state in RocksDB.
@@ -113,7 +113,7 @@ public class RocksDBListState<K, N, V>
 
 	@Override
 	public void add(V value) throws IOException {
-		Objects.requireNonNull(value, "You cannot add null to a ListState.");
+		Preconditions.checkNotNull(value, "You cannot add null to a ListState.");
 
 		try {
 			writeCurrentKeyWithGroupAndNamespace();
@@ -212,7 +212,7 @@ public class RocksDBListState<K, N, V>
 		keySerializationStream.reset();
 		boolean first = true;
 		for (V value : values) {
-			Objects.requireNonNull(value);
+			Preconditions.checkNotNull(value, "You cannot add null to a ListState.");
 			if (first) {
 				first = false;
 			} else {

--- a/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBListState.java
+++ b/flink-contrib/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBListState.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * {@link ListState} implementation that stores state in RocksDB.
@@ -112,9 +113,7 @@ public class RocksDBListState<K, N, V>
 
 	@Override
 	public void add(V value) throws IOException {
-		if (value == null) {
-			return;
-		}
+		Objects.requireNonNull(value, "You cannot add null to a ListState.");
 
 		try {
 			writeCurrentKeyWithGroupAndNamespace();
@@ -213,6 +212,7 @@ public class RocksDBListState<K, N, V>
 		keySerializationStream.reset();
 		boolean first = true;
 		for (V value : values) {
+			Objects.requireNonNull(value);
 			if (first) {
 				first = false;
 			} else {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackend.java
@@ -52,6 +52,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.RunnableFuture;
 
@@ -660,6 +661,7 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 
 		@Override
 		public void add(S value) {
+			Objects.requireNonNull(value, "You cannot add null to a ListState.");
 			internalList.add(value);
 		}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackend.java
@@ -52,7 +52,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.RunnableFuture;
 
@@ -661,7 +660,7 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 
 		@Override
 		public void add(S value) {
-			Objects.requireNonNull(value, "You cannot add null to a ListState.");
+			Preconditions.checkNotNull(value, "You cannot add null to a ListState.");
 			internalList.add(value);
 		}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/UserFacingListState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/UserFacingListState.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.state;
 
 import org.apache.flink.api.common.state.ListState;
-import org.apache.flink.util.Preconditions;
 
 import java.util.Collections;
 import java.util.List;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/UserFacingListState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/UserFacingListState.java
@@ -19,10 +19,10 @@
 package org.apache.flink.runtime.state;
 
 import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.util.Preconditions;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * Simple wrapper list state that exposes empty state properly as an empty list.
@@ -49,7 +49,7 @@ class UserFacingListState<T> implements ListState<T> {
 
 	@Override
 	public void add(T value) throws Exception {
-		Objects.requireNonNull(value, "You cannot add null to a ListState.");
+		Preconditions.checkNotNull(value, "You cannot add null to a ListState.");
 		originalState.add(value);
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/UserFacingListState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/UserFacingListState.java
@@ -49,7 +49,6 @@ class UserFacingListState<T> implements ListState<T> {
 
 	@Override
 	public void add(T value) throws Exception {
-		Preconditions.checkNotNull(value, "You cannot add null to a ListState.");
 		originalState.add(value);
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/UserFacingListState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/UserFacingListState.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.state.ListState;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Simple wrapper list state that exposes empty state properly as an empty list.
@@ -48,6 +49,7 @@ class UserFacingListState<T> implements ListState<T> {
 
 	@Override
 	public void add(T value) throws Exception {
+		Objects.requireNonNull(value, "You cannot add null to a ListState.");
 		originalState.add(value);
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapListState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapListState.java
@@ -28,6 +28,7 @@ import org.apache.flink.util.Preconditions;
 import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Heap-backed partitioned {@link org.apache.flink.api.common.state.ListState} that is snapshotted
@@ -67,9 +68,7 @@ public class HeapListState<K, N, V>
 
 	@Override
 	public void add(V value) {
-		if (value == null) {
-			return;
-		}
+		Objects.requireNonNull(value, "You cannot add null to a ListState.");
 
 		final N namespace = currentNamespace;
 
@@ -134,12 +133,14 @@ public class HeapListState<K, N, V>
 	public void addAll(List<V> values) throws Exception {
 		if (values != null && !values.isEmpty()) {
 			stateTable.transform(currentNamespace, values, (previousState, value) -> {
-				if (previousState != null) {
-					previousState.addAll(value);
-					return previousState;
-				} else {
-					return new ArrayList<>(value);
+				if (previousState == null) {
+					previousState = new ArrayList<>();
 				}
+				for (V v : value) {
+					Objects.requireNonNull(v, "You cannot add null to a ListState.");
+					previousState.add(v);
+				}
+				return previousState;
 			});
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapListState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapListState.java
@@ -28,7 +28,6 @@ import org.apache.flink.util.Preconditions;
 import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * Heap-backed partitioned {@link org.apache.flink.api.common.state.ListState} that is snapshotted
@@ -68,7 +67,7 @@ public class HeapListState<K, N, V>
 
 	@Override
 	public void add(V value) {
-		Objects.requireNonNull(value, "You cannot add null to a ListState.");
+		Preconditions.checkNotNull(value, "You cannot add null to a ListState.");
 
 		final N namespace = currentNamespace;
 
@@ -137,7 +136,7 @@ public class HeapListState<K, N, V>
 					previousState = new ArrayList<>();
 				}
 				for (V v : value) {
-					Objects.requireNonNull(v, "You cannot add null to a ListState.");
+					Preconditions.checkNotNull(v, "You cannot add null to a ListState.");
 					previousState.add(v);
 				}
 				return previousState;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapListState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapListState.java
@@ -121,16 +121,27 @@ public class HeapListState<K, N, V>
 
 	@Override
 	public void update(List<V> values) throws Exception {
-		if (values != null && !values.isEmpty()) {
-			stateTable.put(currentNamespace, new ArrayList<>(values));
-		} else {
+		Preconditions.checkNotNull(values, "List of values to add cannot be null.");
+
+		if (values.isEmpty()) {
 			clear();
+			return;
 		}
+
+		List<V> newStateList = new ArrayList<>();
+		for (V v : values) {
+			Preconditions.checkNotNull(v, "You cannot add null to a ListState.");
+			newStateList.add(v);
+		}
+
+		stateTable.put(currentNamespace, newStateList);
 	}
 
 	@Override
 	public void addAll(List<V> values) throws Exception {
-		if (values != null && !values.isEmpty()) {
+		Preconditions.checkNotNull(values, "List of values to add cannot be null.");
+
+		if (!values.isEmpty()) {
 			stateTable.transform(currentNamespace, values, (previousState, value) -> {
 				if (previousState == null) {
 					previousState = new ArrayList<>();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
@@ -1325,10 +1325,11 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 
 	/**
 	 * This test verifies that all ListState implementations are consistent in not allowing
-	 * adding {@code null}.
+	 * {@link ListState#addAll(List)} to be called with {@code null} entries in the list of entries
+	 * to add.
 	 */
 	@Test
-	public void testListStateAddAllNull() throws Exception {
+	public void testListStateAddAllNullEntries() throws Exception {
 		AbstractKeyedStateBackend<String> keyedBackend = createKeyedBackend(StringSerializer.INSTANCE);
 
 		final ListStateDescriptor<Long> stateDescr = new ListStateDescriptor<>("my-state", Long.class);
@@ -1356,6 +1357,95 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 		}
 	}
 
+	/**
+	 * This test verifies that all ListState implementations are consistent in not allowing
+	 * {@link ListState#addAll(List)} to be called with {@code null}.
+	 */
+	@Test
+	public void testListStateAddAllNull() throws Exception {
+		AbstractKeyedStateBackend<String> keyedBackend = createKeyedBackend(StringSerializer.INSTANCE);
+
+		final ListStateDescriptor<Long> stateDescr = new ListStateDescriptor<>("my-state", Long.class);
+
+		try {
+			ListState<Long> state =
+				keyedBackend.getPartitionedState(
+					VoidNamespace.INSTANCE,
+					VoidNamespaceSerializer.INSTANCE,
+					stateDescr);
+
+			keyedBackend.setCurrentKey("abc");
+			assertNull(state.get());
+
+			expectedException.expect(NullPointerException.class);
+			state.addAll(null);
+		} finally {
+			keyedBackend.close();
+			keyedBackend.dispose();
+		}
+	}
+
+	/**
+	 * This test verifies that all ListState implementations are consistent in not allowing
+	 * {@link ListState#addAll(List)} to be called with {@code null} entries in the list of entries
+	 * to add.
+	 */
+	@Test
+	public void testListStateUpdateNullEntries() throws Exception {
+		AbstractKeyedStateBackend<String> keyedBackend = createKeyedBackend(StringSerializer.INSTANCE);
+
+		final ListStateDescriptor<Long> stateDescr = new ListStateDescriptor<>("my-state", Long.class);
+
+		try {
+			ListState<Long> state =
+				keyedBackend.getPartitionedState(
+					VoidNamespace.INSTANCE,
+					VoidNamespaceSerializer.INSTANCE,
+					stateDescr);
+
+			keyedBackend.setCurrentKey("abc");
+			assertNull(state.get());
+
+			expectedException.expect(NullPointerException.class);
+
+			List<Long> adding = new ArrayList<>();
+			adding.add(3L);
+			adding.add(null);
+			adding.add(5L);
+			state.update(adding);
+		} finally {
+			keyedBackend.close();
+			keyedBackend.dispose();
+		}
+	}
+
+	/**
+	 * This test verifies that all ListState implementations are consistent in not allowing
+	 * {@link ListState#addAll(List)} to be called with {@code null}.
+	 */
+	@Test
+	public void testListStateUpdateNull() throws Exception {
+		AbstractKeyedStateBackend<String> keyedBackend = createKeyedBackend(StringSerializer.INSTANCE);
+
+		final ListStateDescriptor<Long> stateDescr = new ListStateDescriptor<>("my-state", Long.class);
+
+		try {
+			ListState<Long> state =
+				keyedBackend.getPartitionedState(
+					VoidNamespace.INSTANCE,
+					VoidNamespaceSerializer.INSTANCE,
+					stateDescr);
+
+			keyedBackend.setCurrentKey("abc");
+			assertNull(state.get());
+
+			expectedException.expect(NullPointerException.class);
+			state.update(null);
+		} finally {
+			keyedBackend.close();
+			keyedBackend.dispose();
+		}
+	}
 
 	@Test
 	public void testListStateAPIs() throws Exception {
@@ -1373,9 +1463,6 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 			state.add(17L);
 			state.add(11L);
 			assertThat(state.get(), containsInAnyOrder(17L, 11L));
-			// update(null) should remain the value null
-			state.update(null);
-			assertNull(state.get());
 			// update(emptyList) should remain the value null
 			state.update(Collections.emptyList());
 			assertNull(state.get());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
@@ -1295,6 +1295,68 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 		backend.dispose();
 	}
 
+	/**
+	 * This test verifies that all ListState implementations are consistent in not allowing
+	 * adding {@code null}.
+	 */
+	@Test
+	public void testListStateAddNull() throws Exception {
+		AbstractKeyedStateBackend<String> keyedBackend = createKeyedBackend(StringSerializer.INSTANCE);
+
+		final ListStateDescriptor<Long> stateDescr = new ListStateDescriptor<>("my-state", Long.class);
+
+		try {
+			ListState<Long> state =
+				keyedBackend.getPartitionedState(
+					VoidNamespace.INSTANCE,
+					VoidNamespaceSerializer.INSTANCE,
+					stateDescr);
+
+			keyedBackend.setCurrentKey("abc");
+			assertNull(state.get());
+
+			expectedException.expect(NullPointerException.class);
+			state.add(null);
+		} finally {
+			keyedBackend.close();
+			keyedBackend.dispose();
+		}
+	}
+
+	/**
+	 * This test verifies that all ListState implementations are consistent in not allowing
+	 * adding {@code null}.
+	 */
+	@Test
+	public void testListStateAddAllNull() throws Exception {
+		AbstractKeyedStateBackend<String> keyedBackend = createKeyedBackend(StringSerializer.INSTANCE);
+
+		final ListStateDescriptor<Long> stateDescr = new ListStateDescriptor<>("my-state", Long.class);
+
+		try {
+			ListState<Long> state =
+				keyedBackend.getPartitionedState(
+					VoidNamespace.INSTANCE,
+					VoidNamespaceSerializer.INSTANCE,
+					stateDescr);
+
+			keyedBackend.setCurrentKey("abc");
+			assertNull(state.get());
+
+			expectedException.expect(NullPointerException.class);
+
+			List<Long> adding = new ArrayList<>();
+			adding.add(3L);
+			adding.add(null);
+			adding.add(5L);
+			state.addAll(adding);
+		} finally {
+			keyedBackend.close();
+			keyedBackend.dispose();
+		}
+	}
+
+
 	@Test
 	public void testListStateAPIs() throws Exception {
 
@@ -1305,11 +1367,6 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 		try {
 			ListState<Long> state =
 				keyedBackend.getPartitionedState(VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, stateDescr);
-
-			keyedBackend.setCurrentKey("abc");
-			assertNull(state.get());
-			state.add(null);
-			assertNull(state.get());
 
 			keyedBackend.setCurrentKey("def");
 			assertNull(state.get());
@@ -1324,7 +1381,6 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 			assertNull(state.get());
 			state.update(Arrays.asList(10L, 16L));
 			assertThat(state.get(), containsInAnyOrder(16L, 10L));
-			state.add(null);
 			assertThat(state.get(), containsInAnyOrder(16L, 10L));
 
 			keyedBackend.setCurrentKey("abc");
@@ -1332,13 +1388,11 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 
 			keyedBackend.setCurrentKey("g");
 			assertNull(state.get());
-			state.addAll(null);
 			assertNull(state.get());
 			state.addAll(Collections.emptyList());
 			assertNull(state.get());
 			state.addAll(Arrays.asList(3L, 4L));
 			assertThat(state.get(), containsInAnyOrder(3L, 4L));
-			state.addAll(null);
 			assertThat(state.get(), containsInAnyOrder(3L, 4L));
 			state.addAll(new ArrayList<>());
 			assertThat(state.get(), containsInAnyOrder(3L, 4L));
@@ -1347,7 +1401,6 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 			state.addAll(new ArrayList<>());
 			assertThat(state.get(), containsInAnyOrder(3L, 4L, 5L, 6L));
 
-			state.add(null);
 			assertThat(state.get(), containsInAnyOrder(3L, 4L, 5L, 6L));
 			state.update(Arrays.asList(1L, 2L));
 			assertThat(state.get(), containsInAnyOrder(1L, 2L));


### PR DESCRIPTION
R: @StefanRRichter, @bowenli86 

It turns out that this is a bit trickier than assumed earlier: `ListState.addAll()` was not considered and also had inconsistent behaviour between state backends before.