### PR TITLE
[FLINK-8657][doc]Fix incorrect description in the document for externalized checkpoint…

### DIFF
--- a/docs/ops/state/checkpoints.md
+++ b/docs/ops/state/checkpoints.md
@@ -83,8 +83,8 @@ env.setStateBackend(new RocksDBStateBackend("hdfs:///checkpoints-data/");
 ### Difference to Savepoints
 
 Externalized checkpoints have a few differences from [savepoints](savepoints.html). They
-
 - use a state backend specific (low-level) data format, may be incremental.
+- do not support Flink specific features like rescaling.
 
 ### Resuming from an externalized checkpoint
 

--- a/docs/ops/state/checkpoints.md
+++ b/docs/ops/state/checkpoints.md
@@ -83,9 +83,8 @@ env.setStateBackend(new RocksDBStateBackend("hdfs:///checkpoints-data/");
 ### Difference to Savepoints
 
 Externalized checkpoints have a few differences from [savepoints](savepoints.html). They
-- use a state backend specific (low-level) data format,
-- may be incremental,
-- do not support Flink specific features like rescaling.
+
+- use a state backend specific (low-level) data format, may be incremental.
 
 ### Resuming from an externalized checkpoint
 

--- a/docs/ops/state/state_backends.md
+++ b/docs/ops/state/state_backends.md
@@ -56,11 +56,11 @@ that store the values, triggers, etc.
 Upon checkpoints, this state backend will snapshot the state and send it as part of the checkpoint acknowledgement messages to the
 JobManager (master), which stores it on its heap as well.
 
-The MemoryStateBackend can be configured to use asynchronous snapshots. While we strongly encourage the use of asynchronous snapshots to avoid blocking pipelines, please note that this is a new feature and currently not enabled 
-by default. To enable this feature, users can instantiate a `MemoryStateBackend` with the corresponding boolean flag in the constructor set to `true`, e.g.:
+The MemoryStateBackend can be configured to use asynchronous snapshots. While we strongly encourage the use of asynchronous snapshots to avoid blocking pipelines, please note that this is currently enabled 
+by default. To disable this feature, users can instantiate a `MemoryStateBackend` with the corresponding boolean flag in the constructor set to `false`(this should only used for debug), e.g.:
 
 {% highlight java %}
-    new MemoryStateBackend(MAX_MEM_STATE_SIZE, true);
+    new MemoryStateBackend(MAX_MEM_STATE_SIZE, false);
 {% endhighlight %}
 
 Limitations of the MemoryStateBackend:


### PR DESCRIPTION
## What is the purpose of the change

This PR addressed issue [FLINK-8657](https://issues.apache.org/jira/browse/FLINK-8657). I checked that external checkpoint also supported rescale both in code and practice. But in the doc it still note that "do not support Flink specific features like rescaling."

## Brief change log

- Fix incorrect description for externalized checkpoint vs savepoint.
- Fix incorrect description for memory state backend.

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
