### PR TITLE
[FLINK-7857][flip6] Port JobVertexDetails to REST endpoint

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobVertexDetailsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobVertexDetailsHandler.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.job;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
+import org.apache.flink.runtime.executiongraph.AccessExecutionJobVertex;
+import org.apache.flink.runtime.executiongraph.AccessExecutionVertex;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.rest.NotFoundException;
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.legacy.ExecutionGraphCache;
+import org.apache.flink.runtime.rest.handler.legacy.metrics.MetricFetcher;
+import org.apache.flink.runtime.rest.handler.util.MutableIOMetrics;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.JobIDPathParameter;
+import org.apache.flink.runtime.rest.messages.JobVertexDetailsInfo;
+import org.apache.flink.runtime.rest.messages.JobVertexIdPathParameter;
+import org.apache.flink.runtime.rest.messages.JobVertexMessageParameters;
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+import org.apache.flink.runtime.rest.messages.job.metrics.IOMetricsInfo;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+import org.apache.flink.runtime.webmonitor.RestfulGateway;
+import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+/**
+ * Request handler for the job vertex details.
+ */
+public class JobVertexDetailsHandler extends AbstractExecutionGraphHandler<JobVertexDetailsInfo, JobVertexMessageParameters> {
+	private final MetricFetcher<? extends RestfulGateway> metricFetcher;
+
+	public JobVertexDetailsHandler(
+			CompletableFuture<String> localRestAddress,
+			GatewayRetriever<? extends RestfulGateway> leaderRetriever,
+			Time timeout,
+			Map<String, String> responseHeaders,
+			MessageHeaders<EmptyRequestBody, JobVertexDetailsInfo, JobVertexMessageParameters> messageHeaders,
+			ExecutionGraphCache executionGraphCache,
+			Executor executor,
+			MetricFetcher<? extends RestfulGateway> metricFetcher) {
+		super(
+			localRestAddress,
+			leaderRetriever,
+			timeout,
+			responseHeaders,
+			messageHeaders,
+			executionGraphCache,
+			executor);
+		this.metricFetcher = metricFetcher;
+	}
+
+	@Override
+	protected JobVertexDetailsInfo handleRequest(HandlerRequest<EmptyRequestBody, JobVertexMessageParameters> request, AccessExecutionGraph executionGraph) {
+		JobID jobID = request.getPathParameter(JobIDPathParameter.class);
+		JobVertexID jobVertexID = request.getPathParameter(JobVertexIdPathParameter.class);
+		AccessExecutionJobVertex jobVertex = executionGraph.getJobVertex(jobVertexID);
+
+		List<JobVertexDetailsInfo.VertexTaskDetail> subtasks = new ArrayList<>();
+		final long now = System.currentTimeMillis();
+		int num = 0;
+		for (AccessExecutionVertex vertex : jobVertex.getTaskVertices()) {
+			final ExecutionState status = vertex.getExecutionState();
+
+			TaskManagerLocation location = vertex.getCurrentAssignedResourceLocation();
+			String locationString = location == null ? "(unassigned)" : location.getHostname() + ":" + location.dataPort();
+
+			long startTime = vertex.getStateTimestamp(ExecutionState.DEPLOYING);
+			if (startTime == 0) {
+				startTime = -1;
+			}
+			long endTime = status.isTerminal() ? vertex.getStateTimestamp(status) : -1;
+			long duration = startTime > 0 ? ((endTime > 0 ? endTime : now) - startTime) : -1;
+
+			MutableIOMetrics counts = new MutableIOMetrics();
+			counts.addIOMetrics(
+				vertex.getCurrentExecutionAttempt(),
+				metricFetcher,
+				jobID.toString(),
+				jobVertex.getJobVertexId().toString());
+			subtasks.add(new JobVertexDetailsInfo.VertexTaskDetail(
+				num,
+				status,
+				vertex.getCurrentExecutionAttempt().getAttemptNumber(),
+				locationString,
+				startTime,
+				endTime,
+				duration,
+				new IOMetricsInfo(
+					counts.getNumBytesInLocal() + counts.getNumBytesInRemote(),
+					counts.isNumBytesInLocalComplete() && counts.isNumBytesInRemoteComplete(),
+					counts.getNumBytesOut(),
+					counts.isNumBytesOutComplete(),
+					counts.getNumRecordsIn(),
+					counts.isNumRecordsInComplete(),
+					counts.getNumRecordsOut(),
+					counts.isNumRecordsOutComplete())));
+
+			num++;
+		}
+
+		return new JobVertexDetailsInfo(
+			jobVertex.getJobVertexId(),
+			jobVertex.getName(),
+			jobVertex.getParallelism(),
+			now,
+			subtasks);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobVertexDetailsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobVertexDetailsHandler.java
@@ -74,10 +74,16 @@ public class JobVertexDetailsHandler extends AbstractExecutionGraphHandler<JobVe
 	}
 
 	@Override
-	protected JobVertexDetailsInfo handleRequest(HandlerRequest<EmptyRequestBody, JobVertexMessageParameters> request, AccessExecutionGraph executionGraph) {
+	protected JobVertexDetailsInfo handleRequest(
+			HandlerRequest<EmptyRequestBody, JobVertexMessageParameters> request,
+			AccessExecutionGraph executionGraph) throws NotFoundException {
 		JobID jobID = request.getPathParameter(JobIDPathParameter.class);
 		JobVertexID jobVertexID = request.getPathParameter(JobVertexIdPathParameter.class);
 		AccessExecutionJobVertex jobVertex = executionGraph.getJobVertex(jobVertexID);
+
+		if (jobVertex == null) {
+			throw new NotFoundException(String.format("JobVertex %s not found", jobVertexID));
+		}
 
 		List<JobVertexDetailsInfo.VertexTaskDetail> subtasks = new ArrayList<>();
 		final long now = System.currentTimeMillis();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobVertexDetailsHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobVertexDetailsHeaders.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages;
+
+import org.apache.flink.runtime.rest.HttpMethodWrapper;
+import org.apache.flink.runtime.rest.handler.job.JobVertexDetailsHandler;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+/**
+ * Message headers for the {@link JobVertexDetailsHandler}.
+ */
+public class JobVertexDetailsHeaders implements MessageHeaders<EmptyRequestBody, JobVertexDetailsInfo, JobVertexMessageParameters> {
+
+	private static final JobVertexDetailsHeaders INSTANCE = new JobVertexDetailsHeaders();
+
+	public static final String URL = "/jobs/:" + JobIDPathParameter.KEY + "/vertices/:" + JobVertexIdPathParameter.KEY;
+
+	@Override
+	public Class<EmptyRequestBody> getRequestClass() {
+		return EmptyRequestBody.class;
+	}
+
+	@Override
+	public Class<JobVertexDetailsInfo> getResponseClass() {
+		return JobVertexDetailsInfo.class;
+	}
+
+	@Override
+	public HttpResponseStatus getResponseStatusCode() {
+		return HttpResponseStatus.OK;
+	}
+
+	@Override
+	public JobVertexMessageParameters getUnresolvedMessageParameters() {
+		return new JobVertexMessageParameters();
+	}
+
+	@Override
+	public HttpMethodWrapper getHttpMethod() {
+		return HttpMethodWrapper.GET;
+	}
+
+	@Override
+	public String getTargetRestEndpointURL() {
+		return URL;
+	}
+
+	public static JobVertexDetailsHeaders getInstance() {
+		return INSTANCE;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobVertexDetailsInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobVertexDetailsInfo.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages;
+
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.rest.handler.job.JobVertexDetailsHandler;
+import org.apache.flink.runtime.rest.messages.job.metrics.IOMetricsInfo;
+import org.apache.flink.runtime.rest.messages.json.JobVertexIDDeserializer;
+import org.apache.flink.runtime.rest.messages.json.JobVertexIDSerializer;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+import java.util.List;
+import java.util.Objects;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Response type of the {@link JobVertexDetailsHandler}.
+ */
+public class JobVertexDetailsInfo implements ResponseBody {
+	public static final String FIELD_NAME_VERTEX_ID = "id";
+	public static final String FIELD_NAME_VERTEX_NAME = "name";
+	public static final String FIELD_NAME_PARALLELISM = "parallelism";
+	public static final String FIELD_NAME_NOW = "now";
+	public static final String FIELD_NAME_SUBTASKS = "subtasks";
+
+	@JsonProperty(FIELD_NAME_VERTEX_ID)
+	@JsonSerialize(using = JobVertexIDSerializer.class)
+	private final JobVertexID id;
+
+	@JsonProperty(FIELD_NAME_VERTEX_NAME)
+	private final String name;
+
+	@JsonProperty(FIELD_NAME_PARALLELISM)
+	private final int parallelism;
+
+	@JsonProperty(FIELD_NAME_NOW)
+	private final long now;
+
+	@JsonProperty(FIELD_NAME_SUBTASKS)
+	private final List<VertexTaskDetail> subtasks;
+
+	@JsonCreator
+	public JobVertexDetailsInfo(
+			@JsonDeserialize(using = JobVertexIDDeserializer.class) @JsonProperty(FIELD_NAME_VERTEX_ID) JobVertexID id,
+			@JsonProperty(FIELD_NAME_VERTEX_NAME) String name,
+			@JsonProperty(FIELD_NAME_PARALLELISM) int parallelism,
+			@JsonProperty(FIELD_NAME_NOW) long now,
+			@JsonProperty(FIELD_NAME_SUBTASKS) List<VertexTaskDetail> subtasks) {
+		this.id = checkNotNull(id);
+		this.name = checkNotNull(name);
+		this.parallelism = parallelism;
+		this.now = now;
+		this.subtasks = checkNotNull(subtasks);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+
+		if (null == o || this.getClass() != o.getClass()) {
+			return false;
+		}
+
+		JobVertexDetailsInfo that = (JobVertexDetailsInfo) o;
+		return Objects.equals(id, that.id) &&
+			Objects.equals(name, that.name) &&
+			parallelism == that.parallelism &&
+			now == that.now &&
+			Objects.equals(subtasks, that.subtasks);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(id, name, parallelism, now, subtasks);
+	}
+
+	//---------------------------------------------------------------------------------
+	// Static helper classes
+	//---------------------------------------------------------------------------------
+
+	/**
+	 * Vertex task detail class.
+	 */
+	public static final class VertexTaskDetail {
+		public static final String FIELD_NAME_SUBTASK = "subtask";
+		public static final String FIELD_NAME_STATUS = "status";
+		public static final String FIELD_NAME_ATTEMPT = "attempt";
+		public static final String FIELD_NAME_HOST = "host";
+		public static final String FIELD_NAME_START_TIME = "start_time";
+		public static final String FIELD_NAME_END_TIME = "end-time";
+		public static final String FIELD_NAME_DURATION = "duration";
+		public static final String FIELD_NAME_METRICS = "metrics";
+
+		@JsonProperty(FIELD_NAME_SUBTASK)
+		private final int subtask;
+
+		@JsonProperty(FIELD_NAME_STATUS)
+		private final ExecutionState status;
+
+		@JsonProperty(FIELD_NAME_ATTEMPT)
+		private final int attempt;
+
+		@JsonProperty(FIELD_NAME_HOST)
+		private final String host;
+
+		@JsonProperty(FIELD_NAME_START_TIME)
+		private final long startTime;
+
+		@JsonProperty(FIELD_NAME_END_TIME)
+		private final long endTime;
+
+		@JsonProperty(FIELD_NAME_DURATION)
+		private final long duration;
+
+		@JsonProperty(FIELD_NAME_METRICS)
+		private final IOMetricsInfo metrics;
+
+		@JsonCreator
+		public VertexTaskDetail(
+				@JsonProperty(FIELD_NAME_SUBTASK) int subtask,
+				@JsonProperty(FIELD_NAME_STATUS) ExecutionState status,
+				@JsonProperty(FIELD_NAME_ATTEMPT) int attempt,
+				@JsonProperty(FIELD_NAME_HOST) String host,
+				@JsonProperty(FIELD_NAME_START_TIME) long startTime,
+				@JsonProperty(FIELD_NAME_END_TIME) long endTime,
+				@JsonProperty(FIELD_NAME_DURATION) long duration,
+				@JsonProperty(FIELD_NAME_METRICS) IOMetricsInfo metrics) {
+			this.subtask = subtask;
+			this.status = checkNotNull(status);
+			this.attempt = attempt;
+			this.host = checkNotNull(host);
+			this.startTime = startTime;
+			this.endTime = endTime;
+			this.duration = duration;
+			this.metrics = checkNotNull(metrics);
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+
+			if (null == o || this.getClass() != o.getClass()) {
+				return false;
+			}
+
+			VertexTaskDetail that = (VertexTaskDetail) o;
+			return subtask == that.subtask &&
+				Objects.equals(status, that.status) &&
+				attempt == that.attempt &&
+				Objects.equals(host, that.host) &&
+				startTime == that.startTime &&
+				endTime == that.endTime &&
+				duration == that.duration &&
+				Objects.equals(metrics, that.metrics);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(subtask, status, attempt, host, startTime, endTime, duration, metrics);
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
@@ -42,6 +42,7 @@ import org.apache.flink.runtime.rest.handler.job.JobIdsHandler;
 import org.apache.flink.runtime.rest.handler.job.JobPlanHandler;
 import org.apache.flink.runtime.rest.handler.job.JobVertexAccumulatorsHandler;
 import org.apache.flink.runtime.rest.handler.job.JobVertexBackPressureHandler;
+import org.apache.flink.runtime.rest.handler.job.JobVertexDetailsHandler;
 import org.apache.flink.runtime.rest.handler.job.JobVertexTaskManagersHandler;
 import org.apache.flink.runtime.rest.handler.job.JobsOverviewHandler;
 import org.apache.flink.runtime.rest.handler.job.SubtaskCurrentAttemptDetailsHandler;
@@ -80,6 +81,7 @@ import org.apache.flink.runtime.rest.messages.JobIdsWithStatusesOverviewHeaders;
 import org.apache.flink.runtime.rest.messages.JobPlanHeaders;
 import org.apache.flink.runtime.rest.messages.JobVertexAccumulatorsHeaders;
 import org.apache.flink.runtime.rest.messages.JobVertexBackPressureHeaders;
+import org.apache.flink.runtime.rest.messages.JobVertexDetailsHeaders;
 import org.apache.flink.runtime.rest.messages.JobVertexTaskManagersHeaders;
 import org.apache.flink.runtime.rest.messages.JobsOverviewHeaders;
 import org.apache.flink.runtime.rest.messages.SubtasksTimesHeaders;
@@ -449,6 +451,16 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
 			responseHeaders,
 			JobVertexBackPressureHeaders.getInstance());
 
+		final JobVertexDetailsHandler jobVertexDetailsHandler = new JobVertexDetailsHandler(
+			restAddressFuture,
+			leaderRetriever,
+			timeout,
+			responseHeaders,
+			JobVertexDetailsHeaders.getInstance(),
+			executionGraphCache,
+			executor,
+			metricFetcher);
+
 		final File tmpDir = restConfiguration.getTmpDir();
 
 		Optional<StaticFileServerHandler<T>> optWebContent;
@@ -495,6 +507,7 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
 		handlers.add(Tuple2.of(SubtaskCurrentAttemptDetailsHeaders.getInstance(), subtaskCurrentAttemptDetailsHandler));
 		handlers.add(Tuple2.of(JobVertexTaskManagersHeaders.getInstance(), jobVertexTaskManagersHandler));
 		handlers.add(Tuple2.of(JobVertexBackPressureHeaders.getInstance(), jobVertexBackPressureHandler));
+		handlers.add(Tuple2.of(JobVertexDetailsHeaders.getInstance(), jobVertexDetailsHandler));
 
 		optWebContent.ifPresent(
 			webContent -> handlers.add(Tuple2.of(WebContentHandlerSpecification.getInstance(), webContent)));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/JobVertexDetailsInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/JobVertexDetailsInfoTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages;
+
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.rest.messages.job.metrics.IOMetricsInfo;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+/**
+ * Tests that the {@link JobVertexDetailsInfo} can be marshalled and unmarshalled.
+ */
+public class JobVertexDetailsInfoTest extends RestResponseMarshallingTestBase<JobVertexDetailsInfo> {
+	@Override
+	protected Class<JobVertexDetailsInfo> getTestResponseClass() {
+		return JobVertexDetailsInfo.class;
+	}
+
+	@Override
+	protected JobVertexDetailsInfo getTestResponseInstance() throws Exception {
+		final Random random = new Random();
+		final IOMetricsInfo jobVertexMetrics = new IOMetricsInfo(
+			random.nextLong(),
+			random.nextBoolean(),
+			random.nextLong(),
+			random.nextBoolean(),
+			random.nextLong(),
+			random.nextBoolean(),
+			random.nextLong(),
+			random.nextBoolean());
+		List<JobVertexDetailsInfo.VertexTaskDetail> vertexTaskDetailList = new ArrayList<>();
+		vertexTaskDetailList.add(new JobVertexDetailsInfo.VertexTaskDetail(
+			0,
+			ExecutionState.CREATED,
+			random.nextInt(),
+			"local1",
+			System.currentTimeMillis(),
+			System.currentTimeMillis(),
+			1L,
+			jobVertexMetrics));
+		vertexTaskDetailList.add(new JobVertexDetailsInfo.VertexTaskDetail(
+			1,
+			ExecutionState.FAILED,
+			random.nextInt(),
+			"local2",
+			System.currentTimeMillis(),
+			System.currentTimeMillis(),
+			1L,
+			jobVertexMetrics));
+		vertexTaskDetailList.add(new JobVertexDetailsInfo.VertexTaskDetail(
+			2,
+			ExecutionState.FINISHED,
+			random.nextInt(),
+			"local3",
+			System.currentTimeMillis(),
+			System.currentTimeMillis(),
+			1L,
+			jobVertexMetrics));
+
+		return new JobVertexDetailsInfo(
+			new JobVertexID(),
+			"jobVertex" + random.nextLong(),
+			random.nextInt(),
+			System.currentTimeMillis(),
+			vertexTaskDetailList);
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

*Port JobVertexDetails to REST endpoint)*

This PR is based on #5035 

cc: @tillrohrmann 

## Brief change log

  - *Add JobVertexDetailsHandler*
  - *Add JobVertexDetailsInfo and related class*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added test case JobVertexDetailsInfoTest*
  - *Ran a job locally and queried for job vertex details using*
```
curl -v  http://127.0.0.1:9065/jobs/934645a2724ae2aeed9e30306998bb89/vertices/90bea66de1c231edf33913ecd54406c1
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
