### PR TITLE
[FLINK-8665] [rest] Let RpcEndpoint#postStop return completion future

### DIFF
--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManager.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManager.java
@@ -333,8 +333,7 @@ public class MesosResourceManager extends ResourceManager<RegisteredMesosWorkerN
 	}
 
 	@Override
-	public void postStop() throws Exception {
-		Exception exception = null;
+	public CompletableFuture<Void> postStop() {
 		FiniteDuration stopTimeout = new FiniteDuration(5L, TimeUnit.SECONDS);
 
 		CompletableFuture<Boolean> stopTaskMonitorFuture = stopActor(taskMonitor, stopTimeout);
@@ -355,22 +354,11 @@ public class MesosResourceManager extends ResourceManager<RegisteredMesosWorkerN
 			stopLaunchCoordinatorFuture,
 			stopReconciliationCoordinatorFuture);
 
-		// wait for the future to complete or to time out
-		try {
-			stopFuture.get();
-		} catch (Exception e) {
-			exception = e;
-		}
+		final CompletableFuture<Void> terminationFuture = super.postStop();
 
-		try {
-			super.postStop();
-		} catch (Exception e) {
-			exception = ExceptionUtils.firstOrSuppressed(e, exception);
-		}
-
-		if (exception != null) {
-			throw new ResourceManagerException("Could not properly shut down the ResourceManager.", exception);
-		}
+		return stopFuture.thenCombine(
+			terminationFuture,
+			(Void voidA, Void voidB) -> null);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -213,7 +213,7 @@ public abstract class ClusterEntrypoint implements FatalErrorHandler {
 
 			// TODO: Make shutDownAndTerminate non blocking to not use the global executor
 			dispatcher.getTerminationFuture().whenCompleteAsync(
-				(Boolean success, Throwable throwable) -> {
+				(Void value, Throwable throwable) -> {
 					if (throwable != null) {
 						LOG.info("Could not properly terminate the Dispatcher.", throwable);
 					}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedLeaderService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedLeaderService.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
+
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
@@ -38,7 +39,7 @@ import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * A simple leader election service, which selects a leader among contenders and notifies listeners.
- * 
+ *
  * <p>An election service for contenders can be created via {@link #createLeaderElectionService()},
  * a listener service for leader observers can be created via {@link #createLeaderRetrievalService()}.
  */
@@ -54,19 +55,19 @@ public class EmbeddedLeaderService {
 
 	private final Set<EmbeddedLeaderRetrievalService> listeners;
 
-	/** proposed leader, which has been notified of leadership grant, but has not confirmed */
+	/** proposed leader, which has been notified of leadership grant, but has not confirmed. */
 	private EmbeddedLeaderElectionService currentLeaderProposed;
 
-	/** actual leader that has confirmed leadership and of which listeners have been notified */
+	/** actual leader that has confirmed leadership and of which listeners have been notified. */
 	private EmbeddedLeaderElectionService currentLeaderConfirmed;
 
-	/** fencing UID for the current leader (or proposed leader) */
+	/** fencing UID for the current leader (or proposed leader). */
 	private UUID currentLeaderSessionId;
 
-	/** the cached address of the current leader */
+	/** the cached address of the current leader. */
 	private String currentLeaderAddress;
 
-	/** flag marking the service as terminated */
+	/** flag marking the service as terminated. */
 	private boolean shutdown;
 
 	// ------------------------------------------------------------------------
@@ -83,7 +84,7 @@ public class EmbeddedLeaderService {
 
 	/**
 	 * Shuts down this leader election service.
-	 * 
+	 *
 	 * <p>This method does not perform a clean revocation of the leader status and
 	 * no notification to any leader listeners. It simply notifies all contenders
 	 * and listeners that the service is no longer available.
@@ -364,7 +365,7 @@ public class EmbeddedLeaderService {
 			if (running) {
 				running = false;
 				isLeader = false;
-				contender.handleError(cause);
+				contender.revokeLeadership();
 				contender = null;
 			}
 		}
@@ -392,7 +393,6 @@ public class EmbeddedLeaderService {
 		public void shutdown(Exception cause) {
 			if (running) {
 				running = false;
-				listener.handleError(cause);
 				listener = null;
 			}
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -94,7 +94,6 @@ import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.util.clock.SystemClock;
 import org.apache.flink.runtime.webmonitor.WebMonitorUtils;
-import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.Preconditions;
@@ -116,7 +115,6 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -359,8 +357,8 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 	 * Suspend the job and shutdown all other services including rpc.
 	 */
 	@Override
-	public void postStop() throws Exception {
-		log.info("Stopping the JobMaster for job " + jobGraph.getName() + '(' + jobGraph.getJobID() + ").");
+	public CompletableFuture<Void> postStop() {
+		log.info("Stopping the JobMaster for job {}({}).", jobGraph.getName(), jobGraph.getJobID());
 
 		// disconnect from all registered TaskExecutors
 		final Set<ResourceID> taskManagerResourceIds = new HashSet<>(registeredTaskManagers.keySet());
@@ -379,28 +377,8 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 
 		// shut down will internally release all registered slots
 		slotPool.shutDown();
-		CompletableFuture<Void> terminationFuture = slotPool.getTerminationFuture();
 
-		Exception exception = null;
-
-		// wait for the slot pool shut down
-		try {
-			terminationFuture.get(rpcTimeout.toMilliseconds(), TimeUnit.MILLISECONDS);
-		} catch (Exception e) {
-			exception = e;
-		}
-
-		try {
-			super.postStop();
-		} catch (Exception e) {
-			exception = ExceptionUtils.firstOrSuppressed(e, exception);
-		}
-
-		if (exception != null) {
-			throw exception;
-		}
-
-		log.info("Stopped the JobMaster for job " + jobGraph.getName() + '(' + jobGraph.getJobID() + ").");
+		return slotPool.getTerminationFuture();
 	}
 
 	//----------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -379,7 +379,7 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 
 		// shut down will internally release all registered slots
 		slotPool.shutDown();
-		CompletableFuture<Boolean> terminationFuture = slotPool.getTerminationFuture();
+		CompletableFuture<Void> terminationFuture = slotPool.getTerminationFuture();
 
 		Exception exception = null;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
@@ -204,7 +204,7 @@ public class SlotPool extends RpcEndpoint implements SlotPoolGateway, AllocatedS
 	}
 
 	@Override
-	public void postStop() throws Exception {
+	public CompletableFuture<Void> postStop() {
 		// cancel all pending allocations
 		Set<AllocationID> allocationIds = pendingRequests.keySetB();
 
@@ -219,7 +219,7 @@ public class SlotPool extends RpcEndpoint implements SlotPoolGateway, AllocatedS
 
 		clear();
 
-		super.postStop();
+		return CompletableFuture.completedFuture(null);
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -33,13 +33,9 @@ import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServicesUtils;
 import org.apache.flink.runtime.jobgraph.JobGraph;
-import org.apache.flink.runtime.leaderelection.LeaderAddressAndId;
-import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.metrics.MetricRegistryImpl;
-import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
-import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerRunner;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
@@ -377,7 +373,6 @@ public class MiniCluster implements JobExecutorService {
 			blobCacheService = null;
 		}
 
-
 		// shut down the blob server
 		if (blobServer != null) {
 			try {
@@ -401,52 +396,6 @@ public class MiniCluster implements JobExecutorService {
 		// if anything went wrong, throw the first error with all the additional suppressed exceptions
 		if (exception != null) {
 			ExceptionUtils.rethrowException(exception, "Error while shutting down mini cluster");
-		}
-	}
-
-	public void waitUntilTaskManagerRegistrationsComplete() throws Exception {
-		LeaderRetrievalService rmMasterListener = null;
-		CompletableFuture<LeaderAddressAndId> addressAndIdFuture;
-
-		try {
-			synchronized (lock) {
-				checkState(running, "FlinkMiniCluster is not running");
-
-				OneTimeLeaderListenerFuture listenerFuture = new OneTimeLeaderListenerFuture();
-				rmMasterListener = haServices.getResourceManagerLeaderRetriever();
-				rmMasterListener.start(listenerFuture);
-				addressAndIdFuture = listenerFuture.future();
-			}
-
-			final LeaderAddressAndId addressAndId = addressAndIdFuture.get();
-
-			final ResourceManagerGateway resourceManager = commonRpcService
-				.connect(
-					addressAndId.leaderAddress(),
-					new ResourceManagerId(addressAndId.leaderId()),
-					ResourceManagerGateway.class)
-				.get();
-
-			final int numTaskManagersToWaitFor = taskManagers.length;
-
-			// poll and wait until enough TaskManagers are available
-			while (true) {
-				int numTaskManagersAvailable = resourceManager.getNumberOfRegisteredTaskManagers().get();
-
-				if (numTaskManagersAvailable >= numTaskManagersToWaitFor) {
-					break;
-				}
-				Thread.sleep(2);
-			}
-		}
-		finally {
-			try {
-				if (rmMasterListener != null) {
-					rmMasterListener.stop();
-				}
-			} catch (Exception e) {
-				LOG.warn("Error shutting down leader listener for ResourceManager");
-			}
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -213,7 +213,7 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 	}
 
 	@Override
-	public void postStop() throws Exception {
+	public CompletableFuture<Void> postStop() {
 		Exception exception = null;
 
 		taskManagerHeartbeatManager.stop();
@@ -240,14 +240,11 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 
 		clearState();
 
-		try {
-			super.postStop();
-		} catch (Exception e) {
-			exception = ExceptionUtils.firstOrSuppressed(e, exception);
-		}
-
 		if (exception != null) {
-			ExceptionUtils.rethrowException(exception, "Error while shutting the ResourceManager down.");
+			return FutureUtils.completedExceptionally(
+				new FlinkException("Could not properly shut down the ResourceManager.", exception));
+		} else {
+			return CompletableFuture.completedFuture(null);
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/FencedRpcEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/FencedRpcEndpoint.java
@@ -35,7 +35,7 @@ import java.util.concurrent.CompletableFuture;
  *
  * @param <F> type of the fencing token
  */
-public class FencedRpcEndpoint<F extends Serializable> extends RpcEndpoint {
+public abstract class FencedRpcEndpoint<F extends Serializable> extends RpcEndpoint {
 
 	private volatile F fencingToken;
 	private volatile MainThreadExecutor fencedMainThreadExecutor;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcEndpoint.java
@@ -228,7 +228,7 @@ public abstract class RpcEndpoint implements RpcGateway {
 	 *
 	 * @return Future which is completed when the rpc endpoint has been terminated.
 	 */
-	public CompletableFuture<Boolean> getTerminationFuture() {
+	public CompletableFuture<Void> getTerminationFuture() {
 		return rpcServer.getTerminationFuture();
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcEndpoint.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.rpc;
 
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.util.Preconditions;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,17 +38,15 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * Base class for RPC endpoints. Distributed components which offer remote procedure calls have to
- * extend the RPC endpoint base class. An RPC endpoint is backed by an {@link RpcService}. 
- * 
+ * extend the RPC endpoint base class. An RPC endpoint is backed by an {@link RpcService}.
+ *
  * <h1>Endpoint and Gateway</h1>
- * 
  * To be done...
- * 
  * <h1>Single Threaded Endpoint Execution </h1>
- * 
+ *
  * <p>All RPC calls on the same endpoint are called by the same thread
  * (referred to as the endpoint's <i>main thread</i>).
- * Thus, by executing all state changing operations within the main 
+ * Thus, by executing all state changing operations within the main
  * thread, we don't have to reason about concurrent accesses, in the same way in the Actor Model
  * of Erlang or Akka.
  *
@@ -60,16 +59,16 @@ public abstract class RpcEndpoint implements RpcGateway {
 
 	// ------------------------------------------------------------------------
 
-	/** RPC service to be used to start the RPC server and to obtain rpc gateways */
+	/** RPC service to be used to start the RPC server and to obtain rpc gateways. */
 	private final RpcService rpcService;
 
-	/** Unique identifier for this rpc endpoint */
+	/** Unique identifier for this rpc endpoint. */
 	private final String endpointId;
 
-	/** Interface to access the underlying rpc server */
+	/** Interface to access the underlying rpc server. */
 	protected final RpcServer rpcServer;
 
-	/** A reference to the endpoint's main thread, if the current method is called by the main thread */
+	/** A reference to the endpoint's main thread, if the current method is called by the main thread. */
 	final AtomicReference<Thread> currentMainThread = new AtomicReference<>(null);
 
 	/** The main thread executor to be used to execute future callbacks in the main thread
@@ -78,7 +77,7 @@ public abstract class RpcEndpoint implements RpcGateway {
 
 	/**
 	 * Initializes the RPC endpoint.
-	 * 
+	 *
 	 * @param rpcService The RPC server that dispatches calls to this RPC endpoint.
 	 * @param endpointId Unique identifier for this endpoint
 	 */
@@ -117,7 +116,7 @@ public abstract class RpcEndpoint implements RpcGateway {
 	 * Starts the rpc endpoint. This tells the underlying rpc server that the rpc endpoint is ready
 	 * to process remote procedure calls.
 	 *
-	 * IMPORTANT: Whenever you override this method, call the parent implementation to enable
+	 * <p>IMPORTANT: Whenever you override this method, call the parent implementation to enable
 	 * rpc processing. It is advised to make the parent call last.
 	 *
 	 * @throws Exception indicating that something went wrong while starting the RPC endpoint
@@ -140,7 +139,7 @@ public abstract class RpcEndpoint implements RpcGateway {
 	 * <p>This method is called when the RpcEndpoint is being shut down. The method is guaranteed
 	 * to be executed in the main thread context and can be used to clean up internal state.
 	 *
-	 * IMPORTANT: This method should never be called directly by the user.
+	 * <p>IMPORTANT: This method should never be called directly by the user.
 	 *
 	 * @throws Exception if an error occurs. The exception is returned as result of the termination future.
 	 */
@@ -288,15 +287,15 @@ public abstract class RpcEndpoint implements RpcGateway {
 
 	/**
 	 * Validates that the method call happens in the RPC endpoint's main thread.
-	 * 
+	 *
 	 * <p><b>IMPORTANT:</b> This check only happens when assertions are enabled,
 	 * such as when running tests.
-	 * 
+	 *
 	 * <p>This can be used for additional checks, like
 	 * <pre>{@code
 	 * protected void concurrencyCriticalMethod() {
 	 *     validateRunsInMainThread();
-	 *     
+	 *
 	 *     // some critical stuff
 	 * }
 	 * }</pre>
@@ -308,7 +307,7 @@ public abstract class RpcEndpoint implements RpcGateway {
 	// ------------------------------------------------------------------------
 	//  Utilities
 	// ------------------------------------------------------------------------
-	
+
 	/**
 	 * Executor which executes runnables in the main thread context.
 	 */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcEndpoint.java
@@ -141,9 +141,10 @@ public abstract class RpcEndpoint implements RpcGateway {
 	 *
 	 * <p>IMPORTANT: This method should never be called directly by the user.
 	 *
-	 * @throws Exception if an error occurs. The exception is returned as result of the termination future.
+	 * @return Future which is completed once all post stop actions are completed. If an error
+	 * occurs this future is completed exceptionally
 	 */
-	public void postStop() throws Exception {}
+	public abstract CompletableFuture<Void> postStop();
 
 	/**
 	 * Triggers the shut down of the rpc endpoint. The shut down is executed asynchronously.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcServer.java
@@ -30,5 +30,5 @@ public interface RpcServer extends StartStoppable, MainThreadExecutable, RpcGate
 	 *
 	 * @return Future indicating when the rpc endpoint has been terminated
 	 */
-	CompletableFuture<Boolean> getTerminationFuture();
+	CompletableFuture<Void> getTerminationFuture();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaInvocationHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaInvocationHandler.java
@@ -84,7 +84,7 @@ class AkkaInvocationHandler implements InvocationHandler, AkkaBasedEndpoint, Rpc
 
 	// null if gateway; otherwise non-null
 	@Nullable
-	private final CompletableFuture<Boolean> terminationFuture;
+	private final CompletableFuture<Void> terminationFuture;
 
 	AkkaInvocationHandler(
 			String address,
@@ -92,7 +92,7 @@ class AkkaInvocationHandler implements InvocationHandler, AkkaBasedEndpoint, Rpc
 			ActorRef rpcEndpoint,
 			Time timeout,
 			long maximumFramesize,
-			@Nullable CompletableFuture<Boolean> terminationFuture) {
+			@Nullable CompletableFuture<Void> terminationFuture) {
 
 		this.address = Preconditions.checkNotNull(address);
 		this.hostname = Preconditions.checkNotNull(hostname);
@@ -341,7 +341,7 @@ class AkkaInvocationHandler implements InvocationHandler, AkkaBasedEndpoint, Rpc
 	}
 
 	@Override
-	public CompletableFuture<Boolean> getTerminationFuture() {
+	public CompletableFuture<Void> getTerminationFuture() {
 		return terminationFuture;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcService.java
@@ -190,7 +190,7 @@ public class AkkaRpcService implements RpcService {
 	public <C extends RpcEndpoint & RpcGateway> RpcServer startServer(C rpcEndpoint) {
 		checkNotNull(rpcEndpoint, "rpc endpoint");
 
-		CompletableFuture<Boolean> terminationFuture = new CompletableFuture<>();
+		CompletableFuture<Void> terminationFuture = new CompletableFuture<>();
 		final Props akkaRpcActorProps;
 
 		if (rpcEndpoint instanceof FencedRpcEndpoint) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/FencedAkkaInvocationHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/FencedAkkaInvocationHandler.java
@@ -60,7 +60,7 @@ public class FencedAkkaInvocationHandler<F extends Serializable> extends AkkaInv
 			ActorRef rpcEndpoint,
 			Time timeout,
 			long maximumFramesize,
-			@Nullable CompletableFuture<Boolean> terminationFuture,
+			@Nullable CompletableFuture<Void> terminationFuture,
 			Supplier<F> fencingTokenSupplier) {
 		super(address, hostname, rpcEndpoint, timeout, maximumFramesize, terminationFuture);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -254,7 +254,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 	 * Called to shut down the TaskManager. The method closes all TaskManager services.
 	 */
 	@Override
-	public void postStop() throws Exception {
+	public CompletableFuture<Void> postStop() {
 		log.info("Stopping TaskManager {}.", getAddress());
 
 		Throwable throwable = null;
@@ -281,17 +281,11 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 			throwable = ExceptionUtils.firstOrSuppressed(t, throwable);
 		}
 
-		try {
-			super.postStop();
-		} catch (Throwable e) {
-			throwable = ExceptionUtils.firstOrSuppressed(e, throwable);
-		}
-
 		if (throwable != null) {
-			ExceptionUtils.rethrowException(throwable, "Error while shutting the TaskExecutor down.");
+			return FutureUtils.completedExceptionally(new FlinkException("Error while shutting the TaskExecutor down.", throwable));
+		} else {
+			return CompletableFuture.completedFuture(null);
 		}
-
-		log.info("Stopped TaskManager {}.", getAddress());
 	}
 
 	// ======================================================================

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -188,7 +188,7 @@ public class TaskManagerRunner implements FatalErrorHandler {
 	}
 
 	// export the termination future for caller to know it is terminated
-	public CompletableFuture<Boolean> getTerminationFuture() {
+	public CompletableFuture<Void> getTerminationFuture() {
 		return taskManager.getTerminationFuture();
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/MiniDispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/MiniDispatcherTest.java
@@ -218,7 +218,7 @@ public class MiniDispatcherTest extends TestLogger {
 
 			completeActions.jobReachedGloballyTerminalState(archivedExecutionGraph);
 
-			final CompletableFuture<Boolean> terminationFuture = miniDispatcher.getTerminationFuture();
+			final CompletableFuture<Void> terminationFuture = miniDispatcher.getTerminationFuture();
 
 			assertThat(terminationFuture.isDone(), is(false));
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/AsyncCallsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/AsyncCallsTest.java
@@ -333,6 +333,11 @@ public class AsyncCallsTest extends TestLogger {
 		public boolean hasConcurrentAccess() {
 			return concurrentAccess;
 		}
+
+		@Override
+		public CompletableFuture<Void> postStop() {
+			return CompletableFuture.completedFuture(null);
+		}
 	}
 
 	public interface FencedTestGateway extends FencedRpcGateway<UUID> {
@@ -376,6 +381,11 @@ public class AsyncCallsTest extends TestLogger {
 			setFencingToken(fencingToken);
 
 			return CompletableFuture.completedFuture(Acknowledge.get());
+		}
+
+		@Override
+		public CompletableFuture<Void> postStop() {
+			return CompletableFuture.completedFuture(null);
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/FencedRpcEndpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/FencedRpcEndpointTest.java
@@ -301,6 +301,11 @@ public class FencedRpcEndpointTest extends TestLogger {
 			this(rpcService, value, null);
 		}
 
+		@Override
+		public CompletableFuture<Void> postStop() {
+			return CompletableFuture.completedFuture(null);
+		}
+
 		protected FencedTestingEndpoint(RpcService rpcService, String value, UUID initialFencingToken) {
 			super(rpcService);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/RpcEndpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/RpcEndpointTest.java
@@ -170,6 +170,11 @@ public class RpcEndpointTest extends TestLogger {
 		public CompletableFuture<Integer> foobar() {
 			return CompletableFuture.completedFuture(foobarValue);
 		}
+
+		@Override
+		public CompletableFuture<Void> postStop() {
+			return CompletableFuture.completedFuture(null);
+		}
 	}
 
 	public static class ExtendedEndpoint extends BaseEndpoint implements ExtendedGateway, DifferentGateway {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActorTest.java
@@ -18,21 +18,25 @@
 
 package org.apache.flink.runtime.rpc.akka;
 
-import akka.actor.ActorSystem;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.rpc.RpcEndpoint;
 import org.apache.flink.runtime.rpc.RpcGateway;
 import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.runtime.rpc.RpcUtils;
+import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.rpc.akka.exceptions.AkkaRpcException;
 import org.apache.flink.runtime.rpc.exceptions.RpcConnectionException;
 import org.apache.flink.testutils.category.Flip6;
 import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.TestLogger;
 
+import akka.actor.ActorSystem;
 import org.hamcrest.core.Is;
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -53,18 +57,21 @@ public class AkkaRpcActorTest extends TestLogger {
 	//  shared test members
 	// ------------------------------------------------------------------------
 
-	private static ActorSystem actorSystem = AkkaUtils.createDefaultActorSystem();
-
 	private static Time timeout = Time.milliseconds(10000L);
 
-	private static AkkaRpcService akkaRpcService =
-		new AkkaRpcService(actorSystem, timeout);
+	private static AkkaRpcService akkaRpcService;
+
+
+	@BeforeClass
+	public static void setup() {
+		akkaRpcService = new TestingRpcService();
+	}
 
 	@AfterClass
 	public static void shutdown() {
-		akkaRpcService.stopService();
-		actorSystem.shutdown();
-		actorSystem.awaitTermination();
+		if (akkaRpcService != null) {
+			akkaRpcService.stopService();
+		}
 	}
 
 	/**
@@ -185,7 +192,7 @@ public class AkkaRpcActorTest extends TestLogger {
 
 		CompletableFuture.runAsync(
 			() -> rpcEndpoint.shutDown(),
-			actorSystem.dispatcher());
+			akkaRpcService.getExecutor());
 
 		// wait until the rpc endpoint has terminated
 		terminationFuture.get();
@@ -290,6 +297,33 @@ public class AkkaRpcActorTest extends TestLogger {
 		}
 	}
 
+	/**
+	 * Tests that the {@link AkkaRpcActor} only completes after the asynchronous
+	 * post stop action has completed.
+	 */
+	@Test
+	public void testActorTerminationWithAsynchronousPostStopAction() throws Exception {
+		final CompletableFuture<Void> postStopFuture = new CompletableFuture<>();
+		final AsynchronousPostStopEndpoint endpoint = new AsynchronousPostStopEndpoint(akkaRpcService, postStopFuture);
+
+		try {
+			endpoint.start();
+
+			final CompletableFuture<Void> terminationFuture = endpoint.getTerminationFuture();
+
+			endpoint.shutDown();
+
+			assertFalse(terminationFuture.isDone());
+
+			postStopFuture.complete(null);
+
+			// the postStopFuture completion should allow the endpoint to terminate
+			terminationFuture.get();
+		} finally {
+			RpcUtils.terminateRpcEndpoint(endpoint, timeout);
+		}
+	}
+
 	// ------------------------------------------------------------------------
 	//  Test Actors and Interfaces
 	// ------------------------------------------------------------------------
@@ -303,7 +337,19 @@ public class AkkaRpcActorTest extends TestLogger {
 		void tell(String message);
 	}
 
-	private static class DummyRpcEndpoint extends RpcEndpoint implements DummyRpcGateway {
+	private static class TestRpcEndpoint extends RpcEndpoint {
+
+		protected TestRpcEndpoint(RpcService rpcService) {
+			super(rpcService);
+		}
+
+		@Override
+		public CompletableFuture<Void> postStop() {
+			return CompletableFuture.completedFuture(null);
+		}
+	}
+
+	private static class DummyRpcEndpoint extends TestRpcEndpoint implements DummyRpcGateway {
 
 		private volatile int _foobar = 42;
 
@@ -327,7 +373,7 @@ public class AkkaRpcActorTest extends TestLogger {
 		CompletableFuture<Integer> doStuff();
 	}
 
-	private static class ExceptionalEndpoint extends RpcEndpoint implements ExceptionalGateway {
+	private static class ExceptionalEndpoint extends TestRpcEndpoint implements ExceptionalGateway {
 
 		protected ExceptionalEndpoint(RpcService rpcService) {
 			super(rpcService);
@@ -339,7 +385,7 @@ public class AkkaRpcActorTest extends TestLogger {
 		}
 	}
 
-	private static class ExceptionalFutureEndpoint extends RpcEndpoint implements ExceptionalGateway {
+	private static class ExceptionalFutureEndpoint extends TestRpcEndpoint implements ExceptionalGateway {
 
 		protected ExceptionalFutureEndpoint(RpcService rpcService) {
 			super(rpcService);
@@ -373,8 +419,9 @@ public class AkkaRpcActorTest extends TestLogger {
 		}
 
 		@Override
-		public void postStop() {
+		public CompletableFuture<Void> postStop() {
 			validateRunsInMainThread();
+			return CompletableFuture.completedFuture(null);
 		}
 	}
 
@@ -387,8 +434,8 @@ public class AkkaRpcActorTest extends TestLogger {
 		}
 
 		@Override
-		public void postStop() throws Exception {
-			throw new PostStopException("Test exception.");
+		public CompletableFuture<Void> postStop() {
+			return FutureUtils.completedExceptionally(new PostStopException("Test exception."));
 		}
 
 		private static class PostStopException extends FlinkException {
@@ -398,6 +445,24 @@ public class AkkaRpcActorTest extends TestLogger {
 			public PostStopException(String message) {
 				super(message);
 			}
+		}
+	}
+
+	// ------------------------------------------------------------------------
+
+	private static class AsynchronousPostStopEndpoint extends RpcEndpoint {
+
+		private final CompletableFuture<Void> postStopFuture;
+
+		protected AsynchronousPostStopEndpoint(RpcService rpcService, CompletableFuture<Void> postStopFuture) {
+			super(rpcService);
+
+			this.postStopFuture = Preconditions.checkNotNull(postStopFuture);
+		}
+
+		@Override
+		public CompletableFuture<Void> postStop() {
+			return postStopFuture;
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActorTest.java
@@ -179,7 +179,7 @@ public class AkkaRpcActorTest extends TestLogger {
 		final DummyRpcEndpoint rpcEndpoint = new DummyRpcEndpoint(akkaRpcService);
 		rpcEndpoint.start();
 
-		CompletableFuture<Boolean> terminationFuture = rpcEndpoint.getTerminationFuture();
+		CompletableFuture<Void> terminationFuture = rpcEndpoint.getTerminationFuture();
 
 		assertFalse(terminationFuture.isDone());
 
@@ -240,7 +240,7 @@ public class AkkaRpcActorTest extends TestLogger {
 
 		rpcEndpoint.shutDown();
 
-		CompletableFuture<Boolean> terminationFuture = rpcEndpoint.getTerminationFuture();
+		CompletableFuture<Void> terminationFuture = rpcEndpoint.getTerminationFuture();
 
 		try {
 			terminationFuture.get();
@@ -259,7 +259,7 @@ public class AkkaRpcActorTest extends TestLogger {
 
 		simpleRpcEndpoint.shutDown();
 
-		CompletableFuture<Boolean> terminationFuture = simpleRpcEndpoint.getTerminationFuture();
+		CompletableFuture<Void> terminationFuture = simpleRpcEndpoint.getTerminationFuture();
 
 		// check that we executed the postStop method in the main thread, otherwise an exception
 		// would be thrown here.
@@ -279,7 +279,7 @@ public class AkkaRpcActorTest extends TestLogger {
 
 			rpcEndpoint.start();
 
-			CompletableFuture<Boolean> terminationFuture = rpcEndpoint.getTerminationFuture();
+			CompletableFuture<Void> terminationFuture = rpcEndpoint.getTerminationFuture();
 
 			rpcService.stopService();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/MainThreadValidationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/MainThreadValidationTest.java
@@ -30,6 +30,8 @@ import org.apache.flink.util.TestLogger;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+import java.util.concurrent.CompletableFuture;
+
 import static org.junit.Assert.assertTrue;
 
 @Category(Flip6.class)
@@ -88,6 +90,11 @@ public class MainThreadValidationTest extends TestLogger {
 
 		public TestEndpoint(RpcService rpcService) {
 			super(rpcService);
+		}
+
+		@Override
+		public CompletableFuture<Void> postStop() {
+			return CompletableFuture.completedFuture(null);
 		}
 
 		@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/MessageSerializationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/MessageSerializationTest.java
@@ -184,6 +184,11 @@ public class MessageSerializationTest extends TestLogger {
 		public void foobar(Object object) throws InterruptedException {
 			queue.put(object);
 		}
+
+		@Override
+		public CompletableFuture<Void> postStop() {
+			return CompletableFuture.completedFuture(null);
+		}
 	}
 
 	private static class NonSerializableObject {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/retriever/impl/RpcGatewayRetrieverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/retriever/impl/RpcGatewayRetrieverTest.java
@@ -139,5 +139,10 @@ public class RpcGatewayRetrieverTest extends TestLogger {
 		public UUID getFencingToken() {
 			return HighAvailabilityServices.DEFAULT_LEADER_ID;
 		}
+
+		@Override
+		public CompletableFuture<Void> postStop() {
+			return CompletableFuture.completedFuture(null);
+		}
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

The RpcEndpoint#postStop method returns a CompletableFuture<Void> which is
completed once all post stop actions have completed. The termination future
of the respective RpcEndpoint is only completed afterwards.

This PR is based on #5496.

## Verifying this change

This change is already covered by existing tests, such as `AkkaRpcActorTest#testActorTerminationWithAsynchronousPostStopAction`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
