### PR TITLE
[FLINK-8667] expose key in KeyedBroadcastProcessFunction#onTimer()

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/co/KeyedBroadcastProcessFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/co/KeyedBroadcastProcessFunction.java
@@ -118,7 +118,7 @@ public abstract class KeyedBroadcastProcessFunction<KS, IN1, IN2, OUT> extends B
 	 * @throws Exception This method may throw exceptions. Throwing an exception will cause the operation
 	 *                   to fail and may trigger recovery.
 	 */
-	public void onTimer(final long timestamp, final OnTimerContext<KS> ctx, final Collector<OUT> out) throws Exception {
+	public void onTimer(final long timestamp, final OnTimerContext ctx, final Collector<OUT> out) throws Exception {
 		// the default implementation does nothing.
 	}
 
@@ -163,7 +163,7 @@ public abstract class KeyedBroadcastProcessFunction<KS, IN1, IN2, OUT> extends B
 	/**
 	 * Information available in an invocation of {@link #onTimer(long, OnTimerContext, Collector)}.
 	 */
-	public abstract class OnTimerContext<KS> extends KeyedReadOnlyContext {
+	public abstract class OnTimerContext extends KeyedReadOnlyContext {
 
 		/**
 		 * The {@link TimeDomain} of the firing timer, i.e. if it is event or processing time timer.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/co/KeyedBroadcastProcessFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/co/KeyedBroadcastProcessFunction.java
@@ -118,7 +118,7 @@ public abstract class KeyedBroadcastProcessFunction<KS, IN1, IN2, OUT> extends B
 	 * @throws Exception This method may throw exceptions. Throwing an exception will cause the operation
 	 *                   to fail and may trigger recovery.
 	 */
-	public void onTimer(final long timestamp, final OnTimerContext ctx, final Collector<OUT> out) throws Exception {
+	public void onTimer(final long timestamp, final OnTimerContext<KS> ctx, final Collector<OUT> out) throws Exception {
 		// the default implementation does nothing.
 	}
 
@@ -163,12 +163,16 @@ public abstract class KeyedBroadcastProcessFunction<KS, IN1, IN2, OUT> extends B
 	/**
 	 * Information available in an invocation of {@link #onTimer(long, OnTimerContext, Collector)}.
 	 */
-	public abstract class OnTimerContext extends KeyedReadOnlyContext {
+	public abstract class OnTimerContext<KS> extends KeyedReadOnlyContext {
 
 		/**
-		 * The {@link TimeDomain} of the firing timer, i.e. if it is
-		 * event or processing time timer.
+		 * The {@link TimeDomain} of the firing timer, i.e. if it is event or processing time timer.
 		 */
 		public abstract TimeDomain timeDomain();
+
+		/**
+		 * Get the key of the firing timer.
+		 */
+		public abstract KS getCurrentKey();
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/co/KeyedBroadcastProcessFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/co/KeyedBroadcastProcessFunction.java
@@ -166,7 +166,8 @@ public abstract class KeyedBroadcastProcessFunction<KS, IN1, IN2, OUT> extends B
 	public abstract class OnTimerContext extends KeyedReadOnlyContext {
 
 		/**
-		 * The {@link TimeDomain} of the firing timer, i.e. if it is event or processing time timer.
+		 * The {@link TimeDomain} of the firing timer, i.e. if it is
+		 * event or processing time timer.
 		 */
 		public abstract TimeDomain timeDomain();
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/co/CoBroadcastWithKeyedOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/co/CoBroadcastWithKeyedOperator.java
@@ -288,7 +288,7 @@ public class CoBroadcastWithKeyedOperator<KS, IN1, IN2, OUT>
 		}
 	}
 
-	private class OnTimerContextImpl extends KeyedBroadcastProcessFunction<KS, IN1, IN2, OUT>.OnTimerContext {
+	private class OnTimerContextImpl<KS> extends KeyedBroadcastProcessFunction<KS, IN1, IN2, OUT>.OnTimerContext<KS> {
 
 		private final ExecutionConfig config;
 
@@ -322,6 +322,11 @@ public class CoBroadcastWithKeyedOperator<KS, IN1, IN2, OUT>
 		public TimeDomain timeDomain() {
 			checkState(timeDomain != null);
 			return timeDomain;
+		}
+
+		@Override
+		public KS getCurrentKey() {
+			return timer.getKey();
 		}
 
 		@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/co/CoBroadcastWithKeyedOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/co/CoBroadcastWithKeyedOperator.java
@@ -288,7 +288,7 @@ public class CoBroadcastWithKeyedOperator<KS, IN1, IN2, OUT>
 		}
 	}
 
-	private class OnTimerContextImpl<KS> extends KeyedBroadcastProcessFunction<KS, IN1, IN2, OUT>.OnTimerContext<KS> {
+	private class OnTimerContextImpl extends KeyedBroadcastProcessFunction<KS, IN1, IN2, OUT>.OnTimerContext {
 
 		private final ExecutionConfig config;
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/DataStreamTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/DataStreamTest.java
@@ -757,7 +757,7 @@ public class DataStreamTest extends TestLogger {
 		};
 
 		DataStream<Integer> processed = src
-						.process(processFunction);
+				.process(processFunction);
 
 		processed.addSink(new DiscardingSink<Integer>());
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/DataStreamTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/DataStreamTest.java
@@ -740,12 +740,18 @@ public class DataStreamTest extends TestLogger {
 			private static final long serialVersionUID = 1L;
 
 			@Override
-			public void processElement(Long value, Context ctx, Collector<Integer> out) throws Exception {
+			public void processElement(
+					Long value,
+					Context ctx,
+					Collector<Integer> out) throws Exception {
 				// Do nothing
 			}
 
 			@Override
-			public void onTimer(long timestamp, OnTimerContext ctx, Collector<Integer> out) throws Exception {
+			public void onTimer(
+					long timestamp,
+					OnTimerContext ctx,
+					Collector<Integer> out) throws Exception {
 				// Do nothing
 			}
 		};

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/DataStreamTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/DataStreamTest.java
@@ -701,19 +701,13 @@ public class DataStreamTest extends TestLogger {
 			private static final long serialVersionUID = 1L;
 
 			@Override
-			public void processElement(
-					Long value,
-					Context ctx,
-					Collector<Integer> out) throws Exception {
-
+			public void processElement(Long value, Context ctx, Collector<Integer> out) throws Exception {
+				// Do nothing
 			}
 
 			@Override
-			public void onTimer(
-					long timestamp,
-					OnTimerContext ctx,
-					Collector<Integer> out) throws Exception {
-
+			public void onTimer(long timestamp, OnTimerContext ctx, Collector<Integer> out) throws Exception {
+				// Do nothing
 			}
 		};
 
@@ -740,24 +734,17 @@ public class DataStreamTest extends TestLogger {
 			private static final long serialVersionUID = 1L;
 
 			@Override
-			public void processElement(
-					Long value,
-					Context ctx,
-					Collector<Integer> out) throws Exception {
-
+			public void processElement(Long value, Context ctx, Collector<Integer> out) throws Exception {
+				// Do nothing
 			}
 
 			@Override
-			public void onTimer(
-					long timestamp,
-					OnTimerContext ctx,
-					Collector<Integer> out) throws Exception {
-
+			public void onTimer(long timestamp, OnTimerContext ctx, Collector<Integer> out) throws Exception {
+				// Do nothing
 			}
 		};
 
-		DataStream<Integer> processed = src
-				.process(processFunction);
+		DataStream<Integer> processed = src.process(processFunction);
 
 		processed.addSink(new DiscardingSink<Integer>());
 
@@ -801,12 +788,12 @@ public class DataStreamTest extends TestLogger {
 				new BroadcastProcessFunction<Long, String, String>() {
 					@Override
 					public void processBroadcastElement(String value, Context ctx, Collector<String> out) throws Exception {
-						// do nothing
+						// Do nothing
 					}
 
 					@Override
 					public void processElement(Long value, ReadOnlyContext ctx, Collector<String> out) throws Exception {
-						// do nothing
+						// Do nothing
 					}
 				});
 	}
@@ -847,12 +834,12 @@ public class DataStreamTest extends TestLogger {
 				new KeyedBroadcastProcessFunction<String, Long, String, String>() {
 					@Override
 					public void processBroadcastElement(String value, KeyedContext ctx, Collector<String> out) throws Exception {
-						// do nothing
+						// Do nothing
 					}
 
 					@Override
 					public void processElement(Long value, KeyedReadOnlyContext ctx, Collector<String> out) throws Exception {
-						// do nothing
+						// Do nothing
 					}
 				});
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/DataStreamTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/DataStreamTest.java
@@ -701,12 +701,18 @@ public class DataStreamTest extends TestLogger {
 			private static final long serialVersionUID = 1L;
 
 			@Override
-			public void processElement(Long value, Context ctx, Collector<Integer> out) throws Exception {
+			public void processElement(
+					Long value,
+					Context ctx,
+					Collector<Integer> out) throws Exception {
 				// Do nothing
 			}
 
 			@Override
-			public void onTimer(long timestamp, OnTimerContext ctx, Collector<Integer> out) throws Exception {
+			public void onTimer(
+					long timestamp,
+					OnTimerContext ctx,
+					Collector<Integer> out) throws Exception {
 				// Do nothing
 			}
 		};
@@ -744,7 +750,8 @@ public class DataStreamTest extends TestLogger {
 			}
 		};
 
-		DataStream<Integer> processed = src.process(processFunction);
+		DataStream<Integer> processed = src
+						.process(processFunction);
 
 		processed.addSink(new DiscardingSink<Integer>());
 
@@ -788,12 +795,12 @@ public class DataStreamTest extends TestLogger {
 				new BroadcastProcessFunction<Long, String, String>() {
 					@Override
 					public void processBroadcastElement(String value, Context ctx, Collector<String> out) throws Exception {
-						// Do nothing
+						// do nothing
 					}
 
 					@Override
 					public void processElement(Long value, ReadOnlyContext ctx, Collector<String> out) throws Exception {
-						// Do nothing
+						// do nothing
 					}
 				});
 	}
@@ -834,12 +841,12 @@ public class DataStreamTest extends TestLogger {
 				new KeyedBroadcastProcessFunction<String, Long, String, String>() {
 					@Override
 					public void processBroadcastElement(String value, KeyedContext ctx, Collector<String> out) throws Exception {
-						// Do nothing
+						// do nothing
 					}
 
 					@Override
 					public void processElement(Long value, KeyedReadOnlyContext ctx, Collector<String> out) throws Exception {
-						// Do nothing
+						// do nothing
 					}
 				});
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/co/CoBroadcastWithKeyedOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/co/CoBroadcastWithKeyedOperatorTest.java
@@ -38,7 +38,6 @@ import org.apache.flink.util.Collector;
 import org.apache.flink.util.OutputTag;
 import org.apache.flink.util.Preconditions;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -53,6 +52,11 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.Function;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Tests for the {@link CoBroadcastWithKeyedOperator}.
@@ -148,7 +152,7 @@ public class CoBroadcastWithKeyedOperatorTest {
 							while (it.hasNext()) {
 								list.add(it.next());
 							}
-							Assert.assertEquals(expectedKeyedStates.get(key), list);
+							assertEquals(expectedKeyedStates.get(key), list);
 						}
 					});
 		}
@@ -161,12 +165,13 @@ public class CoBroadcastWithKeyedOperatorTest {
 
 	@Test
 	public void testFunctionWithTimer() throws Exception {
+		final String expectedKey = "6";
 
 		try (
 				TwoInputStreamOperatorTestHarness<String, Integer, String> testHarness = getInitializedTestHarness(
 						BasicTypeInfo.STRING_TYPE_INFO,
 						new IdentityKeySelector<>(),
-						new FunctionWithTimerOnKeyed(41L))
+						new FunctionWithTimerOnKeyed(41L, expectedKey))
 		) {
 			testHarness.processWatermark1(new Watermark(10L));
 			testHarness.processWatermark2(new Watermark(10L));
@@ -174,8 +179,8 @@ public class CoBroadcastWithKeyedOperatorTest {
 
 			testHarness.processWatermark1(new Watermark(40L));
 			testHarness.processWatermark2(new Watermark(40L));
-			testHarness.processElement1(new StreamRecord<>("6", 13L));
-			testHarness.processElement1(new StreamRecord<>("6", 15L));
+			testHarness.processElement1(new StreamRecord<>(expectedKey, 13L));
+			testHarness.processElement1(new StreamRecord<>(expectedKey, 15L));
 
 			testHarness.processWatermark1(new Watermark(50L));
 			testHarness.processWatermark2(new Watermark(50L));
@@ -203,9 +208,11 @@ public class CoBroadcastWithKeyedOperatorTest {
 		private static final long serialVersionUID = 7496674620398203933L;
 
 		private final long timerTS;
+		private final String expectedKey;
 
-		FunctionWithTimerOnKeyed(long timerTS) {
+		FunctionWithTimerOnKeyed(long timerTS, String expectedKey) {
 			this.timerTS = timerTS;
+			this.expectedKey = expectedKey;
 		}
 
 		@Override
@@ -220,7 +227,8 @@ public class CoBroadcastWithKeyedOperatorTest {
 		}
 
 		@Override
-		public void onTimer(long timestamp, OnTimerContext ctx, Collector<String> out) throws Exception {
+		public void onTimer(long timestamp, OnTimerContext<String> ctx, Collector<String> out) throws Exception {
+			assertEquals(expectedKey, ctx.getCurrentKey());
 			out.collect("TIMER:" + timestamp);
 		}
 	}
@@ -293,7 +301,6 @@ public class CoBroadcastWithKeyedOperatorTest {
 
 	@Test
 	public void testFunctionWithBroadcastState() throws Exception {
-
 		final Map<String, Integer> expectedBroadcastState = new HashMap<>();
 		expectedBroadcastState.put("5.key", 5);
 		expectedBroadcastState.put("34.key", 34);
@@ -301,11 +308,13 @@ public class CoBroadcastWithKeyedOperatorTest {
 		expectedBroadcastState.put("12.key", 12);
 		expectedBroadcastState.put("98.key", 98);
 
+		final String expectedKey = "trigger";
+
 		try (
 				TwoInputStreamOperatorTestHarness<String, Integer, String> testHarness = getInitializedTestHarness(
 						BasicTypeInfo.STRING_TYPE_INFO,
 						new IdentityKeySelector<>(),
-						new FunctionWithBroadcastState("key", expectedBroadcastState, 41L))
+						new FunctionWithBroadcastState("key", expectedBroadcastState, 41L, expectedKey))
 		) {
 			testHarness.processWatermark1(new Watermark(10L));
 			testHarness.processWatermark2(new Watermark(10L));
@@ -316,7 +325,7 @@ public class CoBroadcastWithKeyedOperatorTest {
 			testHarness.processElement2(new StreamRecord<>(12, 16L));
 			testHarness.processElement2(new StreamRecord<>(98, 19L));
 
-			testHarness.processElement1(new StreamRecord<>("trigger", 13L));
+			testHarness.processElement1(new StreamRecord<>(expectedKey, 13L));
 
 			testHarness.processElement2(new StreamRecord<>(51, 21L));
 
@@ -324,29 +333,29 @@ public class CoBroadcastWithKeyedOperatorTest {
 			testHarness.processWatermark2(new Watermark(50L));
 
 			Queue<Object> output = testHarness.getOutput();
-			Assert.assertEquals(3L, output.size());
+			assertEquals(3L, output.size());
 
 			Object firstRawWm = output.poll();
-			Assert.assertTrue(firstRawWm instanceof Watermark);
+			assertTrue(firstRawWm instanceof Watermark);
 			Watermark firstWm = (Watermark) firstRawWm;
-			Assert.assertEquals(10L, firstWm.getTimestamp());
+			assertEquals(10L, firstWm.getTimestamp());
 
 			Object rawOutputElem = output.poll();
-			Assert.assertTrue(rawOutputElem instanceof StreamRecord);
+			assertTrue(rawOutputElem instanceof StreamRecord);
 			StreamRecord<?> outputRec = (StreamRecord<?>) rawOutputElem;
-			Assert.assertTrue(outputRec.getValue() instanceof String);
+			assertTrue(outputRec.getValue() instanceof String);
 			String outputElem = (String) outputRec.getValue();
 
 			expectedBroadcastState.put("51.key", 51);
 			List<Map.Entry<String, Integer>> expectedEntries = new ArrayList<>();
 			expectedEntries.addAll(expectedBroadcastState.entrySet());
 			String expected = "TS:41 " + mapToString(expectedEntries);
-			Assert.assertEquals(expected, outputElem);
+			assertEquals(expected, outputElem);
 
 			Object secondRawWm = output.poll();
-			Assert.assertTrue(secondRawWm instanceof Watermark);
+			assertTrue(secondRawWm instanceof Watermark);
 			Watermark secondWm = (Watermark) secondRawWm;
-			Assert.assertEquals(50L, secondWm.getTimestamp());
+			assertEquals(50L, secondWm.getTimestamp());
 		}
 	}
 
@@ -357,15 +366,17 @@ public class CoBroadcastWithKeyedOperatorTest {
 		private final String keyPostfix;
 		private final Map<String, Integer> expectedBroadcastState;
 		private final long timerTs;
+		private final String expectedKey;
 
 		FunctionWithBroadcastState(
 				final String keyPostfix,
 				final Map<String, Integer> expectedBroadcastState,
-				final long timerTs
-		) {
+				final long timerTs,
+				final String expectedKey) {
 			this.keyPostfix = Preconditions.checkNotNull(keyPostfix);
 			this.expectedBroadcastState = Preconditions.checkNotNull(expectedBroadcastState);
 			this.timerTs = timerTs;
+			this.expectedKey = expectedKey;
 		}
 
 		@Override
@@ -381,26 +392,28 @@ public class CoBroadcastWithKeyedOperatorTest {
 			Iterator<Map.Entry<String, Integer>> iter = broadcastStateIt.iterator();
 
 			for (int i = 0; i < expectedBroadcastState.size(); i++) {
-				Assert.assertTrue(iter.hasNext());
+				assertTrue(iter.hasNext());
 
 				Map.Entry<String, Integer> entry = iter.next();
-				Assert.assertTrue(expectedBroadcastState.containsKey(entry.getKey()));
-				Assert.assertEquals(expectedBroadcastState.get(entry.getKey()), entry.getValue());
+				assertTrue(expectedBroadcastState.containsKey(entry.getKey()));
+				assertEquals(expectedBroadcastState.get(entry.getKey()), entry.getValue());
 			}
 
-			Assert.assertFalse(iter.hasNext());
+			assertFalse(iter.hasNext());
 
 			ctx.timerService().registerEventTimeTimer(timerTs);
 		}
 
 		@Override
-		public void onTimer(long timestamp, OnTimerContext ctx, Collector<String> out) throws Exception {
+		public void onTimer(long timestamp, OnTimerContext<String> ctx, Collector<String> out) throws Exception {
 			final Iterator<Map.Entry<String, Integer>> iter = ctx.getBroadcastState(STATE_DESCRIPTOR).immutableEntries().iterator();
 
 			final List<Map.Entry<String, Integer>> map = new ArrayList<>();
 			while (iter.hasNext()) {
 				map.add(iter.next());
 			}
+
+			assertEquals(expectedKey, ctx.getCurrentKey());
 			final String mapToStr = mapToString(map);
 			out.collect("TS:" + timestamp + " " + mapToStr);
 		}
@@ -485,22 +498,22 @@ public class CoBroadcastWithKeyedOperatorTest {
 			Queue<?> output2 = testHarness2.getOutput();
 			Queue<?> output3 = testHarness3.getOutput();
 
-			Assert.assertEquals(expected.size(), output1.size());
+			assertEquals(expected.size(), output1.size());
 			for (Object o: output1) {
 				StreamRecord<String> rec = (StreamRecord<String>) o;
-				Assert.assertTrue(expected.contains(rec.getValue()));
+				assertTrue(expected.contains(rec.getValue()));
 			}
 
-			Assert.assertEquals(expected.size(), output2.size());
+			assertEquals(expected.size(), output2.size());
 			for (Object o: output2) {
 				StreamRecord<String> rec = (StreamRecord<String>) o;
-				Assert.assertTrue(expected.contains(rec.getValue()));
+				assertTrue(expected.contains(rec.getValue()));
 			}
 
-			Assert.assertEquals(expected.size(), output3.size());
+			assertEquals(expected.size(), output3.size());
 			for (Object o: output3) {
 				StreamRecord<String> rec = (StreamRecord<String>) o;
-				Assert.assertTrue(expected.contains(rec.getValue()));
+				assertTrue(expected.contains(rec.getValue()));
 			}
 		}
 	}
@@ -583,16 +596,16 @@ public class CoBroadcastWithKeyedOperatorTest {
 			Queue<?> output1 = testHarness1.getOutput();
 			Queue<?> output2 = testHarness2.getOutput();
 
-			Assert.assertEquals(expected.size(), output1.size());
+			assertEquals(expected.size(), output1.size());
 			for (Object o: output1) {
 				StreamRecord<String> rec = (StreamRecord<String>) o;
-				Assert.assertTrue(expected.contains(rec.getValue()));
+				assertTrue(expected.contains(rec.getValue()));
 			}
 
-			Assert.assertEquals(expected.size(), output2.size());
+			assertEquals(expected.size(), output2.size());
 			for (Object o: output2) {
 				StreamRecord<String> rec = (StreamRecord<String>) o;
-				Assert.assertTrue(expected.contains(rec.getValue()));
+				assertTrue(expected.contains(rec.getValue()));
 			}
 		}
 	}
@@ -653,12 +666,12 @@ public class CoBroadcastWithKeyedOperatorTest {
 			testHarness.processWatermark2(new Watermark(10L));
 			testHarness.processElement2(new StreamRecord<>(5, 12L));
 		} catch (NullPointerException e) {
-			Assert.assertEquals("No key set. This method should not be called outside of a keyed context.", e.getMessage());
+			assertEquals("No key set. This method should not be called outside of a keyed context.", e.getMessage());
 			exceptionThrown = true;
 		}
 
 		if (!exceptionThrown) {
-			Assert.fail("No exception thrown");
+			fail("No exception thrown");
 		}
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/co/CoBroadcastWithKeyedOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/co/CoBroadcastWithKeyedOperatorTest.java
@@ -227,7 +227,7 @@ public class CoBroadcastWithKeyedOperatorTest {
 		}
 
 		@Override
-		public void onTimer(long timestamp, OnTimerContext<String> ctx, Collector<String> out) throws Exception {
+		public void onTimer(long timestamp, OnTimerContext ctx, Collector<String> out) throws Exception {
 			assertEquals(expectedKey, ctx.getCurrentKey());
 			out.collect("TIMER:" + timestamp);
 		}
@@ -405,7 +405,7 @@ public class CoBroadcastWithKeyedOperatorTest {
 		}
 
 		@Override
-		public void onTimer(long timestamp, OnTimerContext<String> ctx, Collector<String> out) throws Exception {
+		public void onTimer(long timestamp, OnTimerContext ctx, Collector<String> out) throws Exception {
 			final Iterator<Map.Entry<String, Integer>> iter = ctx.getBroadcastState(STATE_DESCRIPTOR).immutableEntries().iterator();
 
 			final List<Map.Entry<String, Integer>> map = new ArrayList<>();

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/BroadcastStateITCase.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/BroadcastStateITCase.scala
@@ -125,7 +125,7 @@ class TestBroadcastProcessFunction(
   @throws[Exception]
   override def onTimer(
       timestamp: Long,
-      ctx: KeyedBroadcastProcessFunction[Long, Long, String, String]#OnTimerContext,
+      ctx: KeyedBroadcastProcessFunction[Long, Long, String, String]#OnTimerContext[Long],
       out: Collector[String]): Unit = {
 
     var map = Map[Long, String]()

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/BroadcastStateITCase.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/BroadcastStateITCase.scala
@@ -125,7 +125,7 @@ class TestBroadcastProcessFunction(
   @throws[Exception]
   override def onTimer(
       timestamp: Long,
-      ctx: KeyedBroadcastProcessFunction[Long, Long, String, String]#OnTimerContext[Long],
+      ctx: KeyedBroadcastProcessFunction[Long, Long, String, String]#OnTimerContext,
       out: Collector[String]): Unit = {
 
     var map = Map[Long, String]()

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/BroadcastStateITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/BroadcastStateITCase.java
@@ -181,7 +181,7 @@ public class BroadcastStateITCase {
 		}
 
 		@Override
-		public void onTimer(long timestamp, OnTimerContext<Long> ctx, Collector<String> out) throws Exception {
+		public void onTimer(long timestamp, OnTimerContext ctx, Collector<String> out) throws Exception {
 			assertEquals(timerToExpectedKey.get(timestamp), ctx.getCurrentKey());
 
 			Map<Long, String> map = new HashMap<>();

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/BroadcastStateITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/BroadcastStateITCase.java
@@ -90,7 +90,7 @@ public class BroadcastStateITCase {
 
 		// the timestamp should be high enough to trigger the timer after all the elements arrive.
 		final DataStream<String> output = srcOne.connect(broadcast).process(
-				new TestBroadcastProcessFunction(1000L, expected));
+				new TestBroadcastProcessFunction(100000L, expected));
 
 		output
 				.addSink(new TestSink(expected.size()))

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/BroadcastStateITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/BroadcastStateITCase.java
@@ -32,13 +32,14 @@ import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.util.Collector;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import javax.annotation.Nullable;
 
 import java.util.HashMap;
 import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * ITCase for the {@link org.apache.flink.api.common.state.BroadcastState}.
@@ -89,7 +90,7 @@ public class BroadcastStateITCase {
 
 		// the timestamp should be high enough to trigger the timer after all the elements arrive.
 		final DataStream<String> output = srcOne.connect(broadcast).process(
-				new TestBroadcastProcessFunction(100000L, expected));
+				new TestBroadcastProcessFunction(1000L, expected));
 
 		output
 				.addSink(new TestSink(expected.size()))
@@ -120,7 +121,7 @@ public class BroadcastStateITCase {
 			super.close();
 
 			// make sure that all the timers fired
-			Assert.assertEquals(expectedOutputCounter, outputCounter);
+			assertEquals(expectedOutputCounter, outputCounter);
 		}
 	}
 
@@ -145,17 +146,15 @@ public class BroadcastStateITCase {
 		private static final long serialVersionUID = 7616910653561100842L;
 
 		private final Map<Long, String> expectedState;
+		private final Map<Long, Long> timerToExpectedKey = new HashMap<>();
 
-		private final long timerTimestamp;
+		private long nextTimerTimestamp;
 
 		private transient MapStateDescriptor<Long, String> descriptor;
 
-		TestBroadcastProcessFunction(
-				final long timerTS,
-				final Map<Long, String> expectedBroadcastState
-		) {
+		TestBroadcastProcessFunction(final long initialTimerTimestamp, final Map<Long, String> expectedBroadcastState) {
 			expectedState = expectedBroadcastState;
-			timerTimestamp = timerTS;
+			nextTimerTimestamp = initialTimerTimestamp;
 		}
 
 		@Override
@@ -169,7 +168,10 @@ public class BroadcastStateITCase {
 
 		@Override
 		public void processElement(Long value, KeyedReadOnlyContext ctx, Collector<String> out) throws Exception {
-			ctx.timerService().registerEventTimeTimer(timerTimestamp);
+			long currentTime = nextTimerTimestamp;
+			nextTimerTimestamp++;
+			ctx.timerService().registerEventTimeTimer(currentTime);
+			timerToExpectedKey.put(currentTime, value);
 		}
 
 		@Override
@@ -179,15 +181,15 @@ public class BroadcastStateITCase {
 		}
 
 		@Override
-		public void onTimer(long timestamp, OnTimerContext ctx, Collector<String> out) throws Exception {
-			Assert.assertEquals(timerTimestamp, timestamp);
+		public void onTimer(long timestamp, OnTimerContext<Long> ctx, Collector<String> out) throws Exception {
+			assertEquals(timerToExpectedKey.get(timestamp), ctx.getCurrentKey());
 
 			Map<Long, String> map = new HashMap<>();
 			for (Map.Entry<Long, String> entry : ctx.getBroadcastState(descriptor).immutableEntries()) {
 				map.put(entry.getKey(), entry.getValue());
 			}
 
-			Assert.assertEquals(expectedState, map);
+			assertEquals(expectedState, map);
 
 			out.collect(Long.toString(timestamp));
 		}


### PR DESCRIPTION
## What is the purpose of the change

Expose key in `KeyedBroadcastProcessFunction#onTimer(OnTimerContext<Key>)`.

Hopefully this PR can make it into 1.5.0, in which release`KeyedBroadcastProcessFunction` will be out. Otherwise, we need to think about compatibility and it will be much harder to expose key in `KeyedBroadcastProcessFunction#onTimer()`.

## Brief change log

Expose key in `KeyedBroadcastProcessFunction#onTimer(OnTimerContext<Key>)`

## Verifying this change

This change is already covered by existing tests, such as *BroadcastStateITCase*.

## Does this pull request potentially affect one of the following parts:

  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
