### PR TITLE
[FLINK-8475][config][docs] Integrate HeartbeatManager options 

### DIFF
--- a/docs/_includes/generated/akka_configuration.html
+++ b/docs/_includes/generated/akka_configuration.html
@@ -9,87 +9,87 @@
     <tbody>
         <tr>
             <td><h5>akka.ask.timeout</h5></td>
-            <td>"10 s"</td>
+            <td style="word-wrap: break-word;">"10 s"</td>
             <td>Timeout used for all futures and blocking Akka calls. If Flink fails due to timeouts then you should try to increase this value. Timeouts can be caused by slow machines or a congested network. The timeout value requires a time-unit specifier (ms/s/min/h/d).</td>
         </tr>
         <tr>
             <td><h5>akka.client.timeout</h5></td>
-            <td>"60 s"</td>
+            <td style="word-wrap: break-word;">"60 s"</td>
             <td>Timeout for all blocking calls on the client side.</td>
         </tr>
         <tr>
             <td><h5>akka.framesize</h5></td>
-            <td>"10485760b"</td>
+            <td style="word-wrap: break-word;">"10485760b"</td>
             <td>Maximum size of messages which are sent between the JobManager and the TaskManagers. If Flink fails because messages exceed this limit, then you should increase it. The message size requires a size-unit specifier.</td>
         </tr>
         <tr>
             <td><h5>akka.jvm-exit-on-fatal-error</h5></td>
-            <td>true</td>
+            <td style="word-wrap: break-word;">true</td>
             <td>Exit JVM on fatal Akka errors.</td>
         </tr>
         <tr>
             <td><h5>akka.log.lifecycle.events</h5></td>
-            <td>false</td>
+            <td style="word-wrap: break-word;">false</td>
             <td>Turns on the Akka’s remote logging of events. Set this value to ‘true’ in case of debugging.</td>
         </tr>
         <tr>
             <td><h5>akka.lookup.timeout</h5></td>
-            <td>"10 s"</td>
+            <td style="word-wrap: break-word;">"10 s"</td>
             <td>Timeout used for the lookup of the JobManager. The timeout value has to contain a time-unit specifier (ms/s/min/h/d).</td>
         </tr>
         <tr>
             <td><h5>akka.retry-gate-closed-for</h5></td>
-            <td>50</td>
+            <td style="word-wrap: break-word;">50</td>
             <td>Milliseconds a gate should be closed for after a remote connection was disconnected.</td>
         </tr>
         <tr>
             <td><h5>akka.ssl.enabled</h5></td>
-            <td>true</td>
+            <td style="word-wrap: break-word;">true</td>
             <td>Turns on SSL for Akka’s remote communication. This is applicable only when the global ssl flag security.ssl.enabled is set to true.</td>
         </tr>
         <tr>
             <td><h5>akka.startup-timeout</h5></td>
-            <td>(none)</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>Timeout after which the startup of a remote component is considered being failed.</td>
         </tr>
         <tr>
             <td><h5>akka.tcp.timeout</h5></td>
-            <td>"20 s"</td>
+            <td style="word-wrap: break-word;">"20 s"</td>
             <td>Timeout for all outbound connections. If you should experience problems with connecting to a TaskManager due to a slow network, you should increase this value.</td>
         </tr>
         <tr>
             <td><h5>akka.throughput</h5></td>
-            <td>15</td>
+            <td style="word-wrap: break-word;">15</td>
             <td>Number of messages that are processed in a batch before returning the thread to the pool. Low values denote a fair scheduling whereas high values can increase the performance at the cost of unfairness.</td>
         </tr>
         <tr>
             <td><h5>akka.transport.heartbeat.interval</h5></td>
-            <td>"1000 s"</td>
+            <td style="word-wrap: break-word;">"1000 s"</td>
             <td>Heartbeat interval for Akka’s transport failure detector. Since Flink uses TCP, the detector is not necessary. Therefore, the detector is disabled by setting the interval to a very high value. In case you should need the transport failure detector, set the interval to some reasonable value. The interval value requires a time-unit specifier (ms/s/min/h/d).</td>
         </tr>
         <tr>
             <td><h5>akka.transport.heartbeat.pause</h5></td>
-            <td>"6000 s"</td>
+            <td style="word-wrap: break-word;">"6000 s"</td>
             <td>Acceptable heartbeat pause for Akka’s transport failure detector. Since Flink uses TCP, the detector is not necessary. Therefore, the detector is disabled by setting the pause to a very high value. In case you should need the transport failure detector, set the pause to some reasonable value. The pause value requires a time-unit specifier (ms/s/min/h/d).</td>
         </tr>
         <tr>
             <td><h5>akka.transport.threshold</h5></td>
-            <td>300.0</td>
+            <td style="word-wrap: break-word;">300.0</td>
             <td>Threshold for the transport failure detector. Since Flink uses TCP, the detector is not necessary and, thus, the threshold is set to a high value.</td>
         </tr>
         <tr>
             <td><h5>akka.watch.heartbeat.interval</h5></td>
-            <td>"10 s"</td>
+            <td style="word-wrap: break-word;">"10 s"</td>
             <td>Heartbeat interval for Akka’s DeathWatch mechanism to detect dead TaskManagers. If TaskManagers are wrongly marked dead because of lost or delayed heartbeat messages, then you should decrease this value or increase akka.watch.heartbeat.pause. A thorough description of Akka’s DeathWatch can be found &#60;a href="http://doc.akka.io/docs/akka/snapshot/scala/remoting.html#failure-detector"&#62;here&#60;/a&#62;.</td>
         </tr>
         <tr>
             <td><h5>akka.watch.heartbeat.pause</h5></td>
-            <td>"60 s"</td>
+            <td style="word-wrap: break-word;">"60 s"</td>
             <td>Acceptable heartbeat pause for Akka’s DeathWatch mechanism. A low value does not allow an irregular heartbeat. If TaskManagers are wrongly marked dead because of lost or delayed heartbeat messages, then you should increase this value or decrease akka.watch.heartbeat.interval. Higher value increases the time to detect a dead TaskManager. A thorough description of Akka’s DeathWatch can be found &#60;a href="http://doc.akka.io/docs/akka/snapshot/scala/remoting.html#failure-detector"&#62;here&#60;/a&#62;.</td>
         </tr>
         <tr>
             <td><h5>akka.watch.threshold</h5></td>
-            <td>12</td>
+            <td style="word-wrap: break-word;">12</td>
             <td>Threshold for the DeathWatch failure detector. A low value is prone to false positives whereas a high value increases the time to detect a dead TaskManager. A thorough description of Akka’s DeathWatch can be found &#60;a href="http://doc.akka.io/docs/akka/snapshot/scala/remoting.html#failure-detector"&#62;here&#60;/a&#62;.</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/algorithm_configuration.html
+++ b/docs/_includes/generated/algorithm_configuration.html
@@ -9,17 +9,17 @@
     <tbody>
         <tr>
             <td><h5>taskmanager.runtime.hashjoin-bloom-filters</h5></td>
-            <td>false</td>
+            <td style="word-wrap: break-word;">false</td>
             <td>Flag to activate/deactivate bloom filters in the hybrid hash join implementation. In cases where the hash join needs to spill to disk (datasets larger than the reserved fraction of memory), these bloom filters can greatly reduce the number of spilled records, at the cost some CPU cycles.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.runtime.max-fan</h5></td>
-            <td>128</td>
+            <td style="word-wrap: break-word;">128</td>
             <td>The maximal fan-in for external merge joins and fan-out for spilling hash tables. Limits the number of file handles per operator, but may cause intermediate merging/partitioning, if set too small.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.runtime.sort-spilling-threshold</h5></td>
-            <td>0.8</td>
+            <td style="word-wrap: break-word;">0.8</td>
             <td>A sort operation starts spilling when this fraction of its memory budget is full.</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/blob_server_configuration.html
+++ b/docs/_includes/generated/blob_server_configuration.html
@@ -9,42 +9,42 @@
     <tbody>
         <tr>
             <td><h5>blob.fetch.backlog</h5></td>
-            <td>1000</td>
+            <td style="word-wrap: break-word;">1000</td>
             <td>The config parameter defining the backlog of BLOB fetches on the JobManager.</td>
         </tr>
         <tr>
             <td><h5>blob.fetch.num-concurrent</h5></td>
-            <td>50</td>
+            <td style="word-wrap: break-word;">50</td>
             <td>The config parameter defining the maximum number of concurrent BLOB fetches that the JobManager serves.</td>
         </tr>
         <tr>
             <td><h5>blob.fetch.retries</h5></td>
-            <td>5</td>
+            <td style="word-wrap: break-word;">5</td>
             <td>The config parameter defining number of retires for failed BLOB fetches.</td>
         </tr>
         <tr>
             <td><h5>blob.offload.minsize</h5></td>
-            <td>1048576</td>
+            <td style="word-wrap: break-word;">1048576</td>
             <td>The minimum size for messages to be offloaded to the BlobServer.</td>
         </tr>
         <tr>
             <td><h5>blob.server.port</h5></td>
-            <td>"0"</td>
+            <td style="word-wrap: break-word;">"0"</td>
             <td>The config parameter defining the server port of the blob service.</td>
         </tr>
         <tr>
             <td><h5>blob.service.cleanup.interval</h5></td>
-            <td>3600</td>
+            <td style="word-wrap: break-word;">3600</td>
             <td>Cleanup interval of the blob caches at the task managers (in seconds).</td>
         </tr>
         <tr>
             <td><h5>blob.service.ssl.enabled</h5></td>
-            <td>true</td>
+            <td style="word-wrap: break-word;">true</td>
             <td>Flag to override ssl support for the blob service transport.</td>
         </tr>
         <tr>
             <td><h5>blob.storage.directory</h5></td>
-            <td>(none)</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>The config parameter defining the storage directory to be used by the blob server.</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/checkpointing_configuration.html
+++ b/docs/_includes/generated/checkpointing_configuration.html
@@ -9,42 +9,42 @@
     <tbody>
         <tr>
             <td><h5>state.backend</h5></td>
-            <td>(none)</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>The state backend to be used to store and checkpoint state.</td>
         </tr>
         <tr>
             <td><h5>state.backend.async</h5></td>
-            <td>true</td>
+            <td style="word-wrap: break-word;">true</td>
             <td>Option whether the state backend should use an asynchronous snapshot method where possible and configurable. Some state backends may not support asynchronous snapshots, or only support asynchronous snapshots, and ignore this option.</td>
         </tr>
         <tr>
             <td><h5>state.backend.fs.memory-threshold</h5></td>
-            <td>1024</td>
+            <td style="word-wrap: break-word;">1024</td>
             <td>The minimum size of state data files. All state chunks smaller than that are stored inline in the root checkpoint metadata file.</td>
         </tr>
         <tr>
             <td><h5>state.backend.incremental</h5></td>
-            <td>false</td>
+            <td style="word-wrap: break-word;">false</td>
             <td>Option whether the state backend should create incremental checkpoints, if possible. For an incremental checkpoint, only a diff from the previous checkpoint is stored, rather than the complete checkpoint state. Some state backends may not support incremental checkpoints and ignore this option.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.localdir</h5></td>
-            <td>(none)</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>The local directory (on the TaskManager) where RocksDB puts its files.</td>
         </tr>
         <tr>
             <td><h5>state.checkpoints.dir</h5></td>
-            <td>(none)</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>The default directory used for checkpoints. Used by the state backends that write checkpoints to file systems (MemoryStateBackend, FsStateBackend, RocksDBStateBackend).</td>
         </tr>
         <tr>
             <td><h5>state.checkpoints.num-retained</h5></td>
-            <td>1</td>
+            <td style="word-wrap: break-word;">1</td>
             <td>The maximum number of completed checkpoints to retain.</td>
         </tr>
         <tr>
             <td><h5>state.savepoints.dir</h5></td>
-            <td>(none)</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>The default directory for savepoints. Used by the state backends that write savepoints to file systems (MemoryStateBackend, FsStateBackend, RocksDBStateBackend).</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/core_configuration.html
+++ b/docs/_includes/generated/core_configuration.html
@@ -9,27 +9,27 @@
     <tbody>
         <tr>
             <td><h5>classloader.parent-first-patterns</h5></td>
-            <td>"java.;scala.;org.apache.flink.;com.esotericsoftware.kryo;org.apache.hadoop.;javax.annotation.;org.slf4j;org.apache.log4j;org.apache.logging.log4j;ch.qos.logback"</td>
+            <td style="word-wrap: break-word;">"java.;scala.;org.apache.flink.;com.esotericsoftware.kryo;org.apache.hadoop.;javax.annotation.;org.slf4j;org.apache.log4j;org.apache.logging.log4j;ch.qos.logback"</td>
             <td>A (semicolon-separated) list of patterns that specifies which classes should always be resolved through the parent ClassLoader first. A pattern is a simple prefix that is checked against the fully qualified class name.</td>
         </tr>
         <tr>
             <td><h5>classloader.resolve-order</h5></td>
-            <td>"child-first"</td>
+            <td style="word-wrap: break-word;">"child-first"</td>
             <td>Defines the class resolution strategy when loading classes from user code, meaning whether to first check the user code jar ("child-first") or the application classpath ("parent-first"). The default settings indicate to load classes first from the user code jar, which means that user code jars can include and load different dependencies than Flink uses (transitively).</td>
         </tr>
         <tr>
             <td><h5>io.tmp.dirs</h5></td>
-            <td>(none)</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td></td>
         </tr>
         <tr>
             <td><h5>mode</h5></td>
-            <td>"old"</td>
+            <td style="word-wrap: break-word;">"old"</td>
             <td>Switch to select the execution mode. Possible values are 'flip6' and 'old'.</td>
         </tr>
         <tr>
             <td><h5>parallelism.default</h5></td>
-            <td>1</td>
+            <td style="word-wrap: break-word;">1</td>
             <td></td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/environment_configuration.html
+++ b/docs/_includes/generated/environment_configuration.html
@@ -9,32 +9,32 @@
     <tbody>
         <tr>
             <td><h5>env.java.opts</h5></td>
-            <td>(none)</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td></td>
         </tr>
         <tr>
             <td><h5>env.java.opts.jobmanager</h5></td>
-            <td>(none)</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td></td>
         </tr>
         <tr>
             <td><h5>env.java.opts.taskmanager</h5></td>
-            <td>(none)</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td></td>
         </tr>
         <tr>
             <td><h5>env.log.dir</h5></td>
-            <td>(none)</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>Defines the directory where the Flink logs are saved. It has to be an absolute path. (Defaults to the log directory under Flink’s home)</td>
         </tr>
         <tr>
             <td><h5>env.log.max</h5></td>
-            <td>5</td>
+            <td style="word-wrap: break-word;">5</td>
             <td>The maximum number of old log files to keep.</td>
         </tr>
         <tr>
             <td><h5>env.ssh.opts</h5></td>
-            <td>(none)</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>Additional command line options passed to SSH clients when starting or stopping JobManager, TaskManager, and Zookeeper services (start-cluster.sh, stop-cluster.sh, start-zookeeper-quorum.sh, stop-zookeeper-quorum.sh).</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/file_system_configuration.html
+++ b/docs/_includes/generated/file_system_configuration.html
@@ -9,17 +9,17 @@
     <tbody>
         <tr>
             <td><h5>fs.default-scheme</h5></td>
-            <td>(none)</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>The default filesystem scheme, used for paths that do not declare a scheme explicitly. May contain an authority, e.g. host:port in case of a HDFS NameNode.</td>
         </tr>
         <tr>
             <td><h5>fs.output.always-create-directory</h5></td>
-            <td>false</td>
+            <td style="word-wrap: break-word;">false</td>
             <td>File writers running with a parallelism larger than one create a directory for the output file path and put the different result files (one per parallel writer task) into that directory. If this option is set to "true", writers with a parallelism of 1 will also create a directory and place a single result file into it. If the option is set to "false", the writer will directly create the file directly at the output path, without creating a containing directory.</td>
         </tr>
         <tr>
             <td><h5>fs.overwrite-files</h5></td>
-            <td>false</td>
+            <td style="word-wrap: break-word;">false</td>
             <td>Specifies whether file output writers should overwrite existing files by default. Set to "true" to overwrite by default,"false" otherwise.</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/heartbeat_manager_configuration.html
+++ b/docs/_includes/generated/heartbeat_manager_configuration.html
@@ -1,0 +1,21 @@
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 65%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>heartbeat.interval</h5></td>
+            <td style="word-wrap: break-word;">10000</td>
+            <td>Time interval for requesting heartbeat from sender side.</td>
+        </tr>
+        <tr>
+            <td><h5>heartbeat.timeout</h5></td>
+            <td style="word-wrap: break-word;">50000</td>
+            <td>Timeout for requesting and receiving heartbeat for both sender and receiver sides.</td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/_includes/generated/high_availability_configuration.html
+++ b/docs/_includes/generated/high_availability_configuration.html
@@ -9,27 +9,27 @@
     <tbody>
         <tr>
             <td><h5>high-availability</h5></td>
-            <td>"NONE"</td>
+            <td style="word-wrap: break-word;">"NONE"</td>
             <td>Defines high-availability mode used for the cluster execution. To enable high-availability, set this mode to "ZOOKEEPER".</td>
         </tr>
         <tr>
             <td><h5>high-availability.cluster-id</h5></td>
-            <td>"/default"</td>
+            <td style="word-wrap: break-word;">"/default"</td>
             <td>The ID of the Flink cluster, used to separate multiple Flink clusters from each other. Needs to be set for standalone clusters but is automatically inferred in YARN and Mesos.</td>
         </tr>
         <tr>
             <td><h5>high-availability.job.delay</h5></td>
-            <td>(none)</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>The time before a JobManager after a fail over recovers the current jobs.</td>
         </tr>
         <tr>
             <td><h5>high-availability.jobmanager.port</h5></td>
-            <td>"0"</td>
+            <td style="word-wrap: break-word;">"0"</td>
             <td>Optional port (range) used by the job manager in high-availability mode.</td>
         </tr>
         <tr>
             <td><h5>high-availability.storageDir</h5></td>
-            <td>(none)</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>File system path (URI) where Flink persists metadata in high-availability setups.</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/high_availability_zookeeper_configuration.html
+++ b/docs/_includes/generated/high_availability_zookeeper_configuration.html
@@ -9,72 +9,72 @@
     <tbody>
         <tr>
             <td><h5>high-availability.zookeeper.client.acl</h5></td>
-            <td>"open"</td>
+            <td style="word-wrap: break-word;">"open"</td>
             <td>Defines the ACL (open|creator) to be configured on ZK node. The configuration value can be set to “creator” if the ZooKeeper server configuration has the “authProvider” property mapped to use SASLAuthenticationProvider and the cluster is configured to run in secure mode (Kerberos).</td>
         </tr>
         <tr>
             <td><h5>high-availability.zookeeper.client.connection-timeout</h5></td>
-            <td>15000</td>
+            <td style="word-wrap: break-word;">15000</td>
             <td>Defines the connection timeout for ZooKeeper in ms.</td>
         </tr>
         <tr>
             <td><h5>high-availability.zookeeper.client.max-retry-attempts</h5></td>
-            <td>3</td>
+            <td style="word-wrap: break-word;">3</td>
             <td>Defines the number of connection retries before the client gives up.</td>
         </tr>
         <tr>
             <td><h5>high-availability.zookeeper.client.retry-wait</h5></td>
-            <td>5000</td>
+            <td style="word-wrap: break-word;">5000</td>
             <td>Defines the pause between consecutive retries in ms.</td>
         </tr>
         <tr>
             <td><h5>high-availability.zookeeper.client.session-timeout</h5></td>
-            <td>60000</td>
+            <td style="word-wrap: break-word;">60000</td>
             <td>Defines the session timeout for the ZooKeeper session in ms.</td>
         </tr>
         <tr>
             <td><h5>high-availability.zookeeper.path.checkpoint-counter</h5></td>
-            <td>"/checkpoint-counter"</td>
+            <td style="word-wrap: break-word;">"/checkpoint-counter"</td>
             <td>ZooKeeper root path (ZNode) for checkpoint counters.</td>
         </tr>
         <tr>
             <td><h5>high-availability.zookeeper.path.checkpoints</h5></td>
-            <td>"/checkpoints"</td>
+            <td style="word-wrap: break-word;">"/checkpoints"</td>
             <td>ZooKeeper root path (ZNode) for completed checkpoints.</td>
         </tr>
         <tr>
             <td><h5>high-availability.zookeeper.path.jobgraphs</h5></td>
-            <td>"/jobgraphs"</td>
+            <td style="word-wrap: break-word;">"/jobgraphs"</td>
             <td>ZooKeeper root path (ZNode) for job graphs</td>
         </tr>
         <tr>
             <td><h5>high-availability.zookeeper.path.latch</h5></td>
-            <td>"/leaderlatch"</td>
+            <td style="word-wrap: break-word;">"/leaderlatch"</td>
             <td> Defines the znode of the leader latch which is used to elect the leader.</td>
         </tr>
         <tr>
             <td><h5>high-availability.zookeeper.path.leader</h5></td>
-            <td>"/leader"</td>
+            <td style="word-wrap: break-word;">"/leader"</td>
             <td>Defines the znode of the leader which contains the URL to the leader and the current leader session ID.</td>
         </tr>
         <tr>
             <td><h5>high-availability.zookeeper.path.mesos-workers</h5></td>
-            <td>"/mesos-workers"</td>
+            <td style="word-wrap: break-word;">"/mesos-workers"</td>
             <td>ZooKeeper root path (ZNode) for Mesos workers.</td>
         </tr>
         <tr>
             <td><h5>high-availability.zookeeper.path.root</h5></td>
-            <td>"/flink"</td>
+            <td style="word-wrap: break-word;">"/flink"</td>
             <td>The root path under which Flink stores its entries in ZooKeeper.</td>
         </tr>
         <tr>
             <td><h5>high-availability.zookeeper.path.running-registry</h5></td>
-            <td>"/running_job_registry/"</td>
+            <td style="word-wrap: break-word;">"/running_job_registry/"</td>
             <td></td>
         </tr>
         <tr>
             <td><h5>high-availability.zookeeper.quorum</h5></td>
-            <td>(none)</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>The ZooKeeper quorum to use, when running Flink in a high-availability mode with ZooKeeper.</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/history_server_configuration.html
+++ b/docs/_includes/generated/history_server_configuration.html
@@ -9,37 +9,37 @@
     <tbody>
         <tr>
             <td><h5>historyserver.archive.fs.dir</h5></td>
-            <td>(none)</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>Comma separated list of directories to fetch archived jobs from. The history server will monitor these directories for archived jobs. You can configure the JobManager to archive jobs to a directory via `jobmanager.archive.fs.dir`.</td>
         </tr>
         <tr>
             <td><h5>historyserver.archive.fs.refresh-interval</h5></td>
-            <td>10000</td>
+            <td style="word-wrap: break-word;">10000</td>
             <td>Interval in milliseconds for refreshing the archived job directories.</td>
         </tr>
         <tr>
             <td><h5>historyserver.web.address</h5></td>
-            <td>(none)</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>Address of the HistoryServer's web interface.</td>
         </tr>
         <tr>
             <td><h5>historyserver.web.port</h5></td>
-            <td>8082</td>
+            <td style="word-wrap: break-word;">8082</td>
             <td>Port of the HistoryServers's web interface.</td>
         </tr>
         <tr>
             <td><h5>historyserver.web.refresh-interval</h5></td>
-            <td>10000</td>
+            <td style="word-wrap: break-word;">10000</td>
             <td></td>
         </tr>
         <tr>
             <td><h5>historyserver.web.ssl.enabled</h5></td>
-            <td>false</td>
+            <td style="word-wrap: break-word;">false</td>
             <td>Enable HTTPs access to the HistoryServer web frontend. This is applicable only when the global SSL flag security.ssl.enabled is set to true.</td>
         </tr>
         <tr>
             <td><h5>historyserver.web.tmpdir</h5></td>
-            <td>(none)</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>This configuration parameter allows defining the Flink web directory to be used by the history server web interface. The web interface will copy its static files into the directory.</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/job_manager_configuration.html
+++ b/docs/_includes/generated/job_manager_configuration.html
@@ -9,67 +9,57 @@
     <tbody>
         <tr>
             <td><h5>jobmanager.archive.fs.dir</h5></td>
-            <td>(none)</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td></td>
         </tr>
         <tr>
             <td><h5>jobmanager.execution.attempts-history-size</h5></td>
-            <td>16</td>
+            <td style="word-wrap: break-word;">16</td>
             <td>The maximum number of prior execution attempts kept in history.</td>
         </tr>
         <tr>
             <td><h5>jobmanager.execution.failover-strategy</h5></td>
-            <td>"full"</td>
+            <td style="word-wrap: break-word;">"full"</td>
             <td>The maximum number of prior execution attempts kept in history.</td>
         </tr>
         <tr>
             <td><h5>jobmanager.heap.mb</h5></td>
-            <td>1024</td>
+            <td style="word-wrap: break-word;">1024</td>
             <td>JVM heap size (in megabytes) for the JobManager.</td>
         </tr>
         <tr>
             <td><h5>jobmanager.resourcemanager.reconnect-interval</h5></td>
-            <td>2000</td>
+            <td style="word-wrap: break-word;">2000</td>
             <td>This option specifies the interval in order to trigger a resource manager reconnection if the connection to the resource manager has been lost. This option is only intended for internal use.</td>
         </tr>
         <tr>
             <td><h5>jobmanager.rpc.address</h5></td>
-            <td>(none)</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>The config parameter defining the network address to connect to for communication with the job manager. This value is only interpreted in setups where a single JobManager with static name or address exists (simple standalone setups, or container setups with dynamic service name resolution). It is not used in many high-availability setups, when a leader-election service (like ZooKeeper) is used to elect and discover the JobManager leader from potentially multiple standby JobManagers.</td>
         </tr>
         <tr>
             <td><h5>jobmanager.rpc.port</h5></td>
-            <td>6123</td>
+            <td style="word-wrap: break-word;">6123</td>
             <td>The config parameter defining the network port to connect to for communication with the job manager. Like jobmanager.rpc.address, this value is only interpreted in setups where a single JobManager with static name/address and port exists (simple standalone setups, or container setups with dynamic service name resolution). This config option is not used in many high-availability setups, when a leader-election service (like ZooKeeper) is used to elect and discover the JobManager leader from potentially multiple standby JobManagers.</td>
         </tr>
         <tr>
             <td><h5>jobstore.cache-size</h5></td>
-            <td>52428800</td>
+            <td style="word-wrap: break-word;">52428800</td>
             <td>The job store cache size in bytes which is used to keep completed jobs in memory.</td>
         </tr>
         <tr>
             <td><h5>jobstore.expiration-time</h5></td>
-            <td>3600</td>
+            <td style="word-wrap: break-word;">3600</td>
             <td>The time in seconds after which a completed job expires and is purged from the job store.</td>
         </tr>
         <tr>
-            <td><h5>slot.allocation.resourcemanager.timeout</h5></td>
-            <td>300000</td>
-            <td>The timeout in milliseconds for allocation a slot from Resource Manager.</td>
-        </tr>
-        <tr>
             <td><h5>slot.idle.timeout</h5></td>
-            <td>300000</td>
+            <td style="word-wrap: break-word;">20000</td>
             <td>The timeout in milliseconds for a idle slot in Slot Pool.</td>
         </tr>
         <tr>
-            <td><h5>slot.request.resourcemanager.timeout</h5></td>
-            <td>10000</td>
-            <td>The timeout in milliseconds for sending a request to Resource Manager.</td>
-        </tr>
-        <tr>
             <td><h5>slot.request.timeout</h5></td>
-            <td>600000</td>
+            <td style="word-wrap: break-word;">300000</td>
             <td>The timeout in milliseconds for requesting a slot from Slot Pool.</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/kerberos_configuration.html
+++ b/docs/_includes/generated/kerberos_configuration.html
@@ -9,22 +9,22 @@
     <tbody>
         <tr>
             <td><h5>security.kerberos.login.contexts</h5></td>
-            <td>(none)</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>A comma-separated list of login contexts to provide the Kerberos credentials to (for example, `Client,KafkaClient` to use the credentials for ZooKeeper authentication and for Kafka authentication)</td>
         </tr>
         <tr>
             <td><h5>security.kerberos.login.keytab</h5></td>
-            <td>(none)</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>Absolute path to a Kerberos keytab file that contains the user credentials.</td>
         </tr>
         <tr>
             <td><h5>security.kerberos.login.principal</h5></td>
-            <td>(none)</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>Kerberos principal name associated with the keytab.</td>
         </tr>
         <tr>
             <td><h5>security.kerberos.login.use-ticket-cache</h5></td>
-            <td>true</td>
+            <td style="word-wrap: break-word;">true</td>
             <td>Indicates whether to read from your Kerberos ticket cache.</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/mesos_configuration.html
+++ b/docs/_includes/generated/mesos_configuration.html
@@ -9,57 +9,57 @@
     <tbody>
         <tr>
             <td><h5>mesos.failover-timeout</h5></td>
-            <td>600</td>
+            <td style="word-wrap: break-word;">600</td>
             <td>The failover timeout in seconds for the Mesos scheduler, after which running tasks are automatically shut down.</td>
         </tr>
         <tr>
             <td><h5>mesos.initial-tasks</h5></td>
-            <td>0</td>
+            <td style="word-wrap: break-word;">0</td>
             <td>The initial workers to bring up when the master starts</td>
         </tr>
         <tr>
             <td><h5>mesos.master</h5></td>
-            <td>(none)</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>The Mesos master URL. The value should be in one of the following forms: "host:port", "zk://host1:port1,host2:port2,.../path", "zk://username:password@host1:port1,host2:port2,.../path" or "file:///path/to/file"</td>
         </tr>
         <tr>
             <td><h5>mesos.maximum-failed-tasks</h5></td>
-            <td>-1</td>
+            <td style="word-wrap: break-word;">-1</td>
             <td>The maximum number of failed workers before the cluster fails. May be set to -1 to disable this feature</td>
         </tr>
         <tr>
             <td><h5>mesos.resourcemanager.artifactserver.port</h5></td>
-            <td>0</td>
+            <td style="word-wrap: break-word;">0</td>
             <td>The config parameter defining the Mesos artifact server port to use. Setting the port to 0 will let the OS choose an available port.</td>
         </tr>
         <tr>
             <td><h5>mesos.resourcemanager.artifactserver.ssl.enabled</h5></td>
-            <td>true</td>
+            <td style="word-wrap: break-word;">true</td>
             <td>Enables SSL for the Flink artifact server. Note that security.ssl.enabled also needs to be set to true encryption to enable encryption.</td>
         </tr>
         <tr>
             <td><h5>mesos.resourcemanager.framework.name</h5></td>
-            <td>"Flink"</td>
+            <td style="word-wrap: break-word;">"Flink"</td>
             <td>Mesos framework name</td>
         </tr>
         <tr>
             <td><h5>mesos.resourcemanager.framework.principal</h5></td>
-            <td>(none)</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>Mesos framework principal</td>
         </tr>
         <tr>
             <td><h5>mesos.resourcemanager.framework.role</h5></td>
-            <td>"*"</td>
+            <td style="word-wrap: break-word;">"*"</td>
             <td>Mesos framework role definition</td>
         </tr>
         <tr>
             <td><h5>mesos.resourcemanager.framework.secret</h5></td>
-            <td>(none)</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>Mesos framework secret</td>
         </tr>
         <tr>
             <td><h5>mesos.resourcemanager.framework.user</h5></td>
-            <td>(none)</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>Mesos framework user</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/mesos_task_manager_configuration.html
+++ b/docs/_includes/generated/mesos_task_manager_configuration.html
@@ -9,62 +9,62 @@
     <tbody>
         <tr>
             <td><h5>mesos.constraints.hard.hostattribute</h5></td>
-            <td>(none)</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>Constraints for task placement on mesos.</td>
         </tr>
         <tr>
             <td><h5>mesos.resourcemanager.tasks.bootstrap-cmd</h5></td>
-            <td>(none)</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td></td>
         </tr>
         <tr>
             <td><h5>mesos.resourcemanager.tasks.container.docker.parameters</h5></td>
-            <td>(none)</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>Custom parameters to be passed into docker run command when using the docker containerizer. Comma separated list of "key=value" pairs. The "value" may contain '='.</td>
         </tr>
         <tr>
             <td><h5>mesos.resourcemanager.tasks.container.image.name</h5></td>
-            <td>(none)</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>Image name to use for the container.</td>
         </tr>
         <tr>
             <td><h5>mesos.resourcemanager.tasks.container.type</h5></td>
-            <td>"mesos"</td>
+            <td style="word-wrap: break-word;">"mesos"</td>
             <td>Type of the containerization used: “mesos” or “docker”.</td>
         </tr>
         <tr>
             <td><h5>mesos.resourcemanager.tasks.container.volumes</h5></td>
-            <td>(none)</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>A comma separated list of [host_path:]container_path[:RO|RW]. This allows for mounting additional volumes into your container.</td>
         </tr>
         <tr>
             <td><h5>mesos.resourcemanager.tasks.cpus</h5></td>
-            <td>0.0</td>
+            <td style="word-wrap: break-word;">0.0</td>
             <td>CPUs to assign to the Mesos workers.</td>
         </tr>
         <tr>
             <td><h5>mesos.resourcemanager.tasks.gpus</h5></td>
-            <td>0</td>
+            <td style="word-wrap: break-word;">0</td>
             <td></td>
         </tr>
         <tr>
             <td><h5>mesos.resourcemanager.tasks.hostname</h5></td>
-            <td>(none)</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td></td>
         </tr>
         <tr>
             <td><h5>mesos.resourcemanager.tasks.mem</h5></td>
-            <td>1024</td>
+            <td style="word-wrap: break-word;">1024</td>
             <td>Memory to assign to the Mesos workers in MB.</td>
         </tr>
         <tr>
             <td><h5>mesos.resourcemanager.tasks.taskmanager-cmd</h5></td>
-            <td>"$FLINK_HOME/bin/mesos-taskmanager.sh"</td>
+            <td style="word-wrap: break-word;">"$FLINK_HOME/bin/mesos-taskmanager.sh"</td>
             <td></td>
         </tr>
         <tr>
             <td><h5>taskmanager.numberOfTaskSlots</h5></td>
-            <td>1</td>
+            <td style="word-wrap: break-word;">1</td>
             <td></td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/metric_configuration.html
+++ b/docs/_includes/generated/metric_configuration.html
@@ -9,62 +9,62 @@
     <tbody>
         <tr>
             <td><h5>metrics.latency.history-size</h5></td>
-            <td>128</td>
+            <td style="word-wrap: break-word;">128</td>
             <td>Defines the number of measured latencies to maintain at each operator.</td>
         </tr>
         <tr>
             <td><h5>metrics.reporter.&#60;name&#62;.&#60;parameter&#62;</h5></td>
-            <td>(none)</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>Configures the parameter &#60;parameter&#62; for the reporter named &#60;name&#62;.</td>
         </tr>
         <tr>
             <td><h5>metrics.reporter.&#60;name&#62;.class</h5></td>
-            <td>(none)</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>The reporter class to use for the reporter named &#60;name&#62;.</td>
         </tr>
         <tr>
             <td><h5>metrics.reporter.&#60;name&#62;.interval</h5></td>
-            <td>(none)</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>The reporter interval to use for the reporter named &#60;name&#62;.</td>
         </tr>
         <tr>
             <td><h5>metrics.reporters</h5></td>
-            <td>(none)</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td></td>
         </tr>
         <tr>
             <td><h5>metrics.scope.delimiter</h5></td>
-            <td>"."</td>
+            <td style="word-wrap: break-word;">"."</td>
             <td></td>
         </tr>
         <tr>
             <td><h5>metrics.scope.jm</h5></td>
-            <td>"&#60;host&#62;.jobmanager"</td>
+            <td style="word-wrap: break-word;">"&#60;host&#62;.jobmanager"</td>
             <td>Defines the scope format string that is applied to all metrics scoped to a JobManager.</td>
         </tr>
         <tr>
             <td><h5>metrics.scope.jm.job</h5></td>
-            <td>"&#60;host&#62;.jobmanager.&#60;job_name&#62;"</td>
+            <td style="word-wrap: break-word;">"&#60;host&#62;.jobmanager.&#60;job_name&#62;"</td>
             <td>Defines the scope format string that is applied to all metrics scoped to a job on a JobManager.</td>
         </tr>
         <tr>
             <td><h5>metrics.scope.operator</h5></td>
-            <td>"&#60;host&#62;.taskmanager.&#60;tm_id&#62;.&#60;job_name&#62;.&#60;operator_name&#62;.&#60;subtask_index&#62;"</td>
+            <td style="word-wrap: break-word;">"&#60;host&#62;.taskmanager.&#60;tm_id&#62;.&#60;job_name&#62;.&#60;operator_name&#62;.&#60;subtask_index&#62;"</td>
             <td>Defines the scope format string that is applied to all metrics scoped to an operator.</td>
         </tr>
         <tr>
             <td><h5>metrics.scope.task</h5></td>
-            <td>"&#60;host&#62;.taskmanager.&#60;tm_id&#62;.&#60;job_name&#62;.&#60;task_name&#62;.&#60;subtask_index&#62;"</td>
+            <td style="word-wrap: break-word;">"&#60;host&#62;.taskmanager.&#60;tm_id&#62;.&#60;job_name&#62;.&#60;task_name&#62;.&#60;subtask_index&#62;"</td>
             <td>Defines the scope format string that is applied to all metrics scoped to a task.</td>
         </tr>
         <tr>
             <td><h5>metrics.scope.tm</h5></td>
-            <td>"&#60;host&#62;.taskmanager.&#60;tm_id&#62;"</td>
+            <td style="word-wrap: break-word;">"&#60;host&#62;.taskmanager.&#60;tm_id&#62;"</td>
             <td>Defines the scope format string that is applied to all metrics scoped to a TaskManager.</td>
         </tr>
         <tr>
             <td><h5>metrics.scope.tm.job</h5></td>
-            <td>"&#60;host&#62;.taskmanager.&#60;tm_id&#62;.&#60;job_name&#62;"</td>
+            <td style="word-wrap: break-word;">"&#60;host&#62;.taskmanager.&#60;tm_id&#62;.&#60;job_name&#62;"</td>
             <td>Defines the scope format string that is applied to all metrics scoped to a job on a TaskManager.</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/netty_configuration.html
+++ b/docs/_includes/generated/netty_configuration.html
@@ -9,37 +9,37 @@
     <tbody>
         <tr>
             <td><h5>taskmanager.network.netty.client.connectTimeoutSec</h5></td>
-            <td>120</td>
+            <td style="word-wrap: break-word;">120</td>
             <td>The Netty client connection timeout.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.netty.client.numThreads</h5></td>
-            <td>-1</td>
+            <td style="word-wrap: break-word;">-1</td>
             <td>The number of Netty client threads.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.netty.num-arenas</h5></td>
-            <td>-1</td>
+            <td style="word-wrap: break-word;">-1</td>
             <td>The number of Netty arenas.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.netty.sendReceiveBufferSize</h5></td>
-            <td>0</td>
+            <td style="word-wrap: break-word;">0</td>
             <td>The Netty send and receive buffer size. This defaults to the system buffer size (cat /proc/sys/net/ipv4/tcp_[rw]mem) and is 4 MiB in modern Linux.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.netty.server.backlog</h5></td>
-            <td>0</td>
+            <td style="word-wrap: break-word;">0</td>
             <td> The netty server connection backlog.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.netty.server.numThreads</h5></td>
-            <td>-1</td>
+            <td style="word-wrap: break-word;">-1</td>
             <td>The number of Netty server threads.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.netty.transport</h5></td>
-            <td>"nio"</td>
+            <td style="word-wrap: break-word;">"nio"</td>
             <td>The Netty transport type, either "nio" or "epoll"</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/optimizer_configuration.html
+++ b/docs/_includes/generated/optimizer_configuration.html
@@ -9,17 +9,17 @@
     <tbody>
         <tr>
             <td><h5>compiler.delimited-informat.max-line-samples</h5></td>
-            <td>10</td>
+            <td style="word-wrap: break-word;">10</td>
             <td>he maximum number of line samples taken by the compiler for delimited inputs. The samples are used to estimate the number of records. This value can be overridden for a specific input with the input format’s parameters.</td>
         </tr>
         <tr>
             <td><h5>compiler.delimited-informat.max-sample-len</h5></td>
-            <td>2097152</td>
+            <td style="word-wrap: break-word;">2097152</td>
             <td>The maximal length of a line sample that the compiler takes for delimited inputs. If the length of a single sample exceeds this value (possible because of misconfiguration of the parser), the sampling aborts. This value can be overridden for a specific input with the input format’s parameters.</td>
         </tr>
         <tr>
             <td><h5>compiler.delimited-informat.min-line-samples</h5></td>
-            <td>2</td>
+            <td style="word-wrap: break-word;">2</td>
             <td>The minimum number of line samples taken by the compiler for delimited inputs. The samples are used to estimate the number of records. This value can be overridden for a specific input with the input format’s parameters</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/queryable_state_configuration.html
+++ b/docs/_includes/generated/queryable_state_configuration.html
@@ -9,37 +9,37 @@
     <tbody>
         <tr>
             <td><h5>query.client.network-threads</h5></td>
-            <td>0</td>
+            <td style="word-wrap: break-word;">0</td>
             <td>Number of network (Netty's event loop) Threads for queryable state client.</td>
         </tr>
         <tr>
             <td><h5>query.proxy.network-threads</h5></td>
-            <td>0</td>
+            <td style="word-wrap: break-word;">0</td>
             <td>Number of network (Netty's event loop) Threads for queryable state proxy.</td>
         </tr>
         <tr>
             <td><h5>query.proxy.ports</h5></td>
-            <td>"9069"</td>
+            <td style="word-wrap: break-word;">"9069"</td>
             <td>The port range of the queryable state proxy. The specified range can be a single port: "9123", a range of ports: "50100-50200", or a list of ranges and ports: "50100-50200,50300-50400,51234".</td>
         </tr>
         <tr>
             <td><h5>query.proxy.query-threads</h5></td>
-            <td>0</td>
+            <td style="word-wrap: break-word;">0</td>
             <td>Number of query Threads for queryable state proxy. Uses the number of slots if set to 0.</td>
         </tr>
         <tr>
             <td><h5>query.server.network-threads</h5></td>
-            <td>0</td>
+            <td style="word-wrap: break-word;">0</td>
             <td>Number of network (Netty's event loop) Threads for queryable state server.</td>
         </tr>
         <tr>
             <td><h5>query.server.ports</h5></td>
-            <td>"9067"</td>
+            <td style="word-wrap: break-word;">"9067"</td>
             <td>The port range of the queryable state server. The specified range can be a single port: "9123", a range of ports: "50100-50200", or a list of ranges and ports: "50100-50200,50300-50400,51234".</td>
         </tr>
         <tr>
             <td><h5>query.server.query-threads</h5></td>
-            <td>0</td>
+            <td style="word-wrap: break-word;">0</td>
             <td>Number of query Threads for queryable state server. Uses the number of slots if set to 0.</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/resource_manager_configuration.html
+++ b/docs/_includes/generated/resource_manager_configuration.html
@@ -9,27 +9,27 @@
     <tbody>
         <tr>
             <td><h5>containerized.heap-cutoff-min</h5></td>
-            <td>600</td>
+            <td style="word-wrap: break-word;">600</td>
             <td>Minimum amount of heap memory to remove in containers, as a safety margin.</td>
         </tr>
         <tr>
             <td><h5>containerized.heap-cutoff-ratio</h5></td>
-            <td>0.25</td>
+            <td style="word-wrap: break-word;">0.25</td>
             <td>Percentage of heap space to remove from containers (YARN / Mesos), to compensate for other JVM memory usage.</td>
         </tr>
         <tr>
             <td><h5>local.number-resourcemanager</h5></td>
-            <td>1</td>
+            <td style="word-wrap: break-word;">1</td>
             <td></td>
         </tr>
         <tr>
             <td><h5>resourcemanager.job.timeout</h5></td>
-            <td>"5 minutes"</td>
+            <td style="word-wrap: break-word;">"5 minutes"</td>
             <td>Timeout for jobs which don't have a job manager as leader assigned.</td>
         </tr>
         <tr>
             <td><h5>resourcemanager.rpc.port</h5></td>
-            <td>0</td>
+            <td style="word-wrap: break-word;">0</td>
             <td>Defines the network port to connect to for communication with the resource manager. By default, the port of the JobManager, because the same ActorSystem is used. Its not possible to use this configuration key to define port ranges.</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/rest_configuration.html
+++ b/docs/_includes/generated/rest_configuration.html
@@ -9,32 +9,32 @@
     <tbody>
         <tr>
             <td><h5>rest.address</h5></td>
-            <td>"localhost"</td>
+            <td style="word-wrap: break-word;">"localhost"</td>
             <td>The address that the server binds itself to / the client connects to.</td>
         </tr>
         <tr>
             <td><h5>rest.await-leader-timeout</h5></td>
-            <td>30000</td>
+            <td style="word-wrap: break-word;">30000</td>
             <td>The time in ms that the client waits for the leader address, e.g., Dispatcher or WebMonitorEndpoint</td>
         </tr>
         <tr>
             <td><h5>rest.connection-timeout</h5></td>
-            <td>15000</td>
+            <td style="word-wrap: break-word;">15000</td>
             <td>The maximum time in ms for the client to establish a TCP connection.</td>
         </tr>
         <tr>
             <td><h5>rest.port</h5></td>
-            <td>9065</td>
+            <td style="word-wrap: break-word;">9065</td>
             <td>The port that the server listens on / the client connects to.</td>
         </tr>
         <tr>
             <td><h5>rest.retry.delay</h5></td>
-            <td>3000</td>
+            <td style="word-wrap: break-word;">3000</td>
             <td>The time in ms that the client waits between retries (See also `rest.retry.max-attempts`).</td>
         </tr>
         <tr>
             <td><h5>rest.retry.max-attempts</h5></td>
-            <td>20</td>
+            <td style="word-wrap: break-word;">20</td>
             <td>The number of retries the client will attempt if a retryable operations fails.</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/security_configuration.html
+++ b/docs/_includes/generated/security_configuration.html
@@ -9,47 +9,47 @@
     <tbody>
         <tr>
             <td><h5>security.ssl.algorithms</h5></td>
-            <td>"TLS_RSA_WITH_AES_128_CBC_SHA"</td>
+            <td style="word-wrap: break-word;">"TLS_RSA_WITH_AES_128_CBC_SHA"</td>
             <td>The comma separated list of standard SSL algorithms to be supported. Read more &#60;a href="http://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html#ciphersuites"&#62;here&#60;/a&#62;.</td>
         </tr>
         <tr>
             <td><h5>security.ssl.enabled</h5></td>
-            <td>false</td>
+            <td style="word-wrap: break-word;">false</td>
             <td>Turns on SSL for internal network communication. This can be optionally overridden by flags defined in different transport modules.</td>
         </tr>
         <tr>
             <td><h5>security.ssl.key-password</h5></td>
-            <td>(none)</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>The secret to decrypt the server key in the keystore.</td>
         </tr>
         <tr>
             <td><h5>security.ssl.keystore</h5></td>
-            <td>(none)</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>The Java keystore file to be used by the flink endpoint for its SSL Key and Certificate.</td>
         </tr>
         <tr>
             <td><h5>security.ssl.keystore-password</h5></td>
-            <td>(none)</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>The secret to decrypt the keystore file.</td>
         </tr>
         <tr>
             <td><h5>security.ssl.protocol</h5></td>
-            <td>"TLSv1.2"</td>
+            <td style="word-wrap: break-word;">"TLSv1.2"</td>
             <td>The SSL protocol version to be supported for the ssl transport. Note that it doesn’t support comma separated list.</td>
         </tr>
         <tr>
             <td><h5>security.ssl.truststore</h5></td>
-            <td>(none)</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>The truststore file containing the public CA certificates to be used by flink endpoints to verify the peer’s certificate.</td>
         </tr>
         <tr>
             <td><h5>security.ssl.truststore-password</h5></td>
-            <td>(none)</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>The secret to decrypt the truststore.</td>
         </tr>
         <tr>
             <td><h5>security.ssl.verify-hostname</h5></td>
-            <td>true</td>
+            <td style="word-wrap: break-word;">true</td>
             <td>Flag to enable peer’s hostname verification during ssl handshake.</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/slot_manager_configuration.html
+++ b/docs/_includes/generated/slot_manager_configuration.html
@@ -9,12 +9,12 @@
     <tbody>
         <tr>
             <td><h5>slotmanager.request-timeout</h5></td>
-            <td>600000</td>
+            <td style="word-wrap: break-word;">600000</td>
             <td>The timeout for a slot request to be discarded.</td>
         </tr>
         <tr>
             <td><h5>slotmanager.taskmanager-timeout</h5></td>
-            <td>30000</td>
+            <td style="word-wrap: break-word;">30000</td>
             <td>The timeout for an idle task manager to be released.</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/task_manager_configuration.html
+++ b/docs/_includes/generated/task_manager_configuration.html
@@ -9,152 +9,152 @@
     <tbody>
         <tr>
             <td><h5>task.cancellation.interval</h5></td>
-            <td>30000</td>
+            <td style="word-wrap: break-word;">30000</td>
             <td>Time interval between two successive task cancellation attempts in milliseconds.</td>
         </tr>
         <tr>
             <td><h5>task.cancellation.timeout</h5></td>
-            <td>180000</td>
+            <td style="word-wrap: break-word;">180000</td>
             <td>Timeout in milliseconds after which a task cancellation times out and leads to a fatal TaskManager error. A value of 0 deactivates the watch dog.</td>
         </tr>
         <tr>
             <td><h5>task.checkpoint.alignment.max-size</h5></td>
-            <td>-1</td>
+            <td style="word-wrap: break-word;">-1</td>
             <td>The maximum number of bytes that a checkpoint alignment may buffer. If the checkpoint alignment buffers more than the configured amount of data, the checkpoint is aborted (skipped). A value of -1 indicates that there is no limit.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.data.port</h5></td>
-            <td>0</td>
+            <td style="word-wrap: break-word;">0</td>
             <td>The task manager’s port used for data exchange operations.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.data.ssl.enabled</h5></td>
-            <td>true</td>
+            <td style="word-wrap: break-word;">true</td>
             <td>Enable SSL support for the taskmanager data transport. This is applicable only when the global ssl flag security.ssl.enabled is set to true</td>
         </tr>
         <tr>
             <td><h5>taskmanager.debug.memory.logIntervalMs</h5></td>
-            <td>5000</td>
+            <td style="word-wrap: break-word;">5000</td>
             <td>The interval (in ms) for the log thread to log the current memory usage.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.debug.memory.startLogThread</h5></td>
-            <td>false</td>
+            <td style="word-wrap: break-word;">false</td>
             <td>Flag indicating whether to start a thread, which repeatedly logs the memory usage of the JVM.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.exit-on-fatal-akka-error</h5></td>
-            <td>false</td>
+            <td style="word-wrap: break-word;">false</td>
             <td>Whether the quarantine monitor for task managers shall be started. The quarantine monitor shuts down the actor system if it detects that it has quarantined another actor system or if it has been quarantined by another actor system.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.heap.mb</h5></td>
-            <td>1024</td>
+            <td style="word-wrap: break-word;">1024</td>
             <td>JVM heap size (in megabytes) for the TaskManagers, which are the parallel workers of the system. On YARN setups, this value is automatically configured to the size of the TaskManager's YARN container, minus a certain tolerance value.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.host</h5></td>
-            <td>(none)</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>The hostname of the network interface that the TaskManager binds to. By default, the TaskManager searches for network interfaces that can connect to the JobManager and other TaskManagers. This option can be used to define a hostname if that strategy fails for some reason. Because different TaskManagers need different values for this option, it usually is specified in an additional non-shared TaskManager-specific config file.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.initial-registration-pause</h5></td>
-            <td>"500 ms"</td>
+            <td style="word-wrap: break-word;">"500 ms"</td>
             <td>The initial registration pause between two consecutive registration attempts. The pause is doubled for each new registration attempt until it reaches the maximum registration pause.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.jvm-exit-on-oom</h5></td>
-            <td>false</td>
+            <td style="word-wrap: break-word;">false</td>
             <td>Whether to kill the TaskManager when the task thread throws an OutOfMemoryError.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.max-registration-pause</h5></td>
-            <td>"30 s"</td>
+            <td style="word-wrap: break-word;">"30 s"</td>
             <td>The maximum registration pause between two consecutive registration attempts. The max registration pause requires a time unit specifier (ms/s/min/h/d).</td>
         </tr>
         <tr>
             <td><h5>taskmanager.maxRegistrationDuration</h5></td>
-            <td>"Inf"</td>
+            <td style="word-wrap: break-word;">"Inf"</td>
             <td>Defines the maximum time it can take for the TaskManager registration. If the duration is exceeded without a successful registration, then the TaskManager terminates.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.memory.fraction</h5></td>
-            <td>0.7</td>
+            <td style="word-wrap: break-word;">0.7</td>
             <td>The relative amount of memory (after subtracting the amount of memory used by network buffers) that the task manager reserves for sorting, hash tables, and caching of intermediate results. For example, a value of `0.8` means that a task manager reserves 80% of its memory for internal data buffers, leaving 20% of free memory for the task manager's heap for objects created by user-defined functions. This parameter is only evaluated, if taskmanager.memory.size is not set.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.memory.off-heap</h5></td>
-            <td>false</td>
+            <td style="word-wrap: break-word;">false</td>
             <td>Memory allocation method (JVM heap or off-heap), used for managed memory of the TaskManager as well as the network buffers.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.memory.preallocate</h5></td>
-            <td>false</td>
+            <td style="word-wrap: break-word;">false</td>
             <td>Whether TaskManager managed memory should be pre-allocated when the TaskManager is starting.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.memory.segment-size</h5></td>
-            <td>32768</td>
+            <td style="word-wrap: break-word;">32768</td>
             <td>Size of memory buffers used by the network stack and the memory manager (in bytes).</td>
         </tr>
         <tr>
             <td><h5>taskmanager.memory.size</h5></td>
-            <td>-1</td>
+            <td style="word-wrap: break-word;">-1</td>
             <td>Amount of memory to be allocated by the task manager's memory manager (in megabytes). If not set, a relative fraction will be allocated.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.detailed-metrics</h5></td>
-            <td>false</td>
+            <td style="word-wrap: break-word;">false</td>
             <td>Boolean flag to enable/disable more detailed metrics about inbound/outbound network queue lengths.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.memory.buffers-per-channel</h5></td>
-            <td>2</td>
+            <td style="word-wrap: break-word;">2</td>
             <td>Number of network buffers to use for each outgoing/incoming channel (subpartition/input channel).</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.memory.floating-buffers-per-gate</h5></td>
-            <td>8</td>
+            <td style="word-wrap: break-word;">8</td>
             <td>Number of extra network buffers to use for each outgoing/incoming gate (result partition/input gate).</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.memory.fraction</h5></td>
-            <td>0.1</td>
+            <td style="word-wrap: break-word;">0.1</td>
             <td>Fraction of JVM memory to use for network buffers. This determines how many streaming data exchange channels a TaskManager can have at the same time and how well buffered the channels are. If a job is rejected or you get a warning that the system has not enough buffers available, increase this value or the min/max values below. Also note, that "taskmanager.network.memory.min"` and "taskmanager.network.memory.max" may override this fraction.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.memory.max</h5></td>
-            <td>1073741824</td>
+            <td style="word-wrap: break-word;">1073741824</td>
             <td>Maximum memory size for network buffers (in bytes).</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.memory.min</h5></td>
-            <td>67108864</td>
+            <td style="word-wrap: break-word;">67108864</td>
             <td>Minimum memory size for network buffers (in bytes).</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.request-backoff.initial</h5></td>
-            <td>100</td>
+            <td style="word-wrap: break-word;">100</td>
             <td>Minimum backoff for partition requests of input channels.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.request-backoff.max</h5></td>
-            <td>10000</td>
+            <td style="word-wrap: break-word;">10000</td>
             <td>Maximum backoff for partition requests of input channels.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.numberOfTaskSlots</h5></td>
-            <td>1</td>
+            <td style="word-wrap: break-word;">1</td>
             <td>The number of parallel operator or user function instances that a single TaskManager can run. If this value is larger than 1, a single TaskManager takes multiple instances of a function or operator. That way, the TaskManager can utilize multiple CPU cores, but at the same time, the available memory is divided between the different operator or function instances. This value is typically proportional to the number of physical CPU cores that the TaskManager's machine has (e.g., equal to the number of cores, or half the number of cores).</td>
         </tr>
         <tr>
             <td><h5>taskmanager.refused-registration-pause</h5></td>
-            <td>"10 s"</td>
+            <td style="word-wrap: break-word;">"10 s"</td>
             <td>The pause after a registration has been refused by the job manager before retrying to connect.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.rpc.port</h5></td>
-            <td>"0"</td>
+            <td style="word-wrap: break-word;">"0"</td>
             <td> The task manager’s IPC port. Accepts a list of ports (“50100,50101”), ranges (“50100-50200”) or a combination of both. It is recommended to set a range of ports to avoid collisions when multiple TaskManagers are running on the same machine.</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/web_configuration.html
+++ b/docs/_includes/generated/web_configuration.html
@@ -9,82 +9,82 @@
     <tbody>
         <tr>
             <td><h5>web.access-control-allow-origin</h5></td>
-            <td>"*"</td>
+            <td style="word-wrap: break-word;">"*"</td>
             <td></td>
         </tr>
         <tr>
             <td><h5>web.address</h5></td>
-            <td>(none)</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td></td>
         </tr>
         <tr>
             <td><h5>web.backpressure.cleanup-interval</h5></td>
-            <td>600000</td>
+            <td style="word-wrap: break-word;">600000</td>
             <td></td>
         </tr>
         <tr>
             <td><h5>web.backpressure.delay-between-samples</h5></td>
-            <td>50</td>
+            <td style="word-wrap: break-word;">50</td>
             <td></td>
         </tr>
         <tr>
             <td><h5>web.backpressure.num-samples</h5></td>
-            <td>100</td>
+            <td style="word-wrap: break-word;">100</td>
             <td></td>
         </tr>
         <tr>
             <td><h5>web.backpressure.refresh-interval</h5></td>
-            <td>60000</td>
+            <td style="word-wrap: break-word;">60000</td>
             <td></td>
         </tr>
         <tr>
             <td><h5>web.checkpoints.history</h5></td>
-            <td>10</td>
+            <td style="word-wrap: break-word;">10</td>
             <td></td>
         </tr>
         <tr>
             <td><h5>web.history</h5></td>
-            <td>5</td>
+            <td style="word-wrap: break-word;">5</td>
             <td></td>
         </tr>
         <tr>
             <td><h5>web.log.path</h5></td>
-            <td>(none)</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td></td>
         </tr>
         <tr>
             <td><h5>web.port</h5></td>
-            <td>8081</td>
+            <td style="word-wrap: break-word;">8081</td>
             <td></td>
         </tr>
         <tr>
             <td><h5>web.refresh-interval</h5></td>
-            <td>3000</td>
+            <td style="word-wrap: break-word;">3000</td>
             <td></td>
         </tr>
         <tr>
             <td><h5>web.ssl.enabled</h5></td>
-            <td>true</td>
+            <td style="word-wrap: break-word;">true</td>
             <td></td>
         </tr>
         <tr>
             <td><h5>web.submit.enable</h5></td>
-            <td>true</td>
+            <td style="word-wrap: break-word;">true</td>
             <td></td>
         </tr>
         <tr>
             <td><h5>web.timeout</h5></td>
-            <td>10000</td>
+            <td style="word-wrap: break-word;">10000</td>
             <td></td>
         </tr>
         <tr>
             <td><h5>web.tmpdir</h5></td>
-            <td>(none)</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td></td>
         </tr>
         <tr>
             <td><h5>web.upload.dir</h5></td>
-            <td>(none)</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td></td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/yarn_config_configuration.html
+++ b/docs/_includes/generated/yarn_config_configuration.html
@@ -9,52 +9,52 @@
     <tbody>
         <tr>
             <td><h5>yarn.application-attempts</h5></td>
-            <td>(none)</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>Number of ApplicationMaster restarts. Note that that the entire Flink cluster will restart and the YARN Client will loose the connection. Also, the JobManager address will change and you’ll need to set the JM host:port manually. It is recommended to leave this option at 1.</td>
         </tr>
         <tr>
             <td><h5>yarn.application-master.port</h5></td>
-            <td>"0"</td>
+            <td style="word-wrap: break-word;">"0"</td>
             <td>With this configuration option, users can specify a port, a range of ports or a list of ports for the Application Master (and JobManager) RPC port. By default we recommend using the default value (0) to let the operating system choose an appropriate port. In particular when multiple AMs are running on the same physical host, fixed port assignments prevent the AM from starting. For example when running Flink on YARN on an environment with a restrictive firewall, this option allows specifying a range of allowed ports.</td>
         </tr>
         <tr>
             <td><h5>yarn.appmaster.rpc.address</h5></td>
-            <td>(none)</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>The hostname or address where the application master RPC system is listening.</td>
         </tr>
         <tr>
             <td><h5>yarn.appmaster.rpc.port</h5></td>
-            <td>-1</td>
+            <td style="word-wrap: break-word;">-1</td>
             <td>The port where the application master RPC system is listening.</td>
         </tr>
         <tr>
             <td><h5>yarn.containers.vcores</h5></td>
-            <td>-1</td>
+            <td style="word-wrap: break-word;">-1</td>
             <td>The number of virtual cores (vcores) per YARN container. By default, the number of vcores is set to the number of slots per TaskManager, if set, or to 1, otherwise.</td>
         </tr>
         <tr>
             <td><h5>yarn.heartbeat-delay</h5></td>
-            <td>5</td>
+            <td style="word-wrap: break-word;">5</td>
             <td>Time between heartbeats with the ResourceManager in seconds.</td>
         </tr>
         <tr>
             <td><h5>yarn.maximum-failed-containers</h5></td>
-            <td>(none)</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>Maximum number of containers the system is going to reallocate in case of a failure.</td>
         </tr>
         <tr>
             <td><h5>yarn.per-job-cluster.include-user-jar</h5></td>
-            <td>"ORDER"</td>
-            <td>Defines whether user-jars are included in the system class path for per-job-clusters as well as their positioning in the path. They can be positioned at the beginning ("FIRST"), at the end ("LAST"), or be positioned based on their name ("ORDER").</td>
+            <td style="word-wrap: break-word;">"ORDER"</td>
+            <td>Defines whether user-jars are included in the system class path for per-job-clusters as well as their positioning in the path. They can be positioned at the beginning ("FIRST"), at the end ("LAST"), or be positioned based on their name ("ORDER"). Setting this parameter to "DISABLED" causes the jar to be included in the user class path instead.</td>
         </tr>
         <tr>
             <td><h5>yarn.properties-file.location</h5></td>
-            <td>(none)</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>When a Flink job is submitted to YARN, the JobManager’s host and the number of available processing slots is written into a properties file, so that the Flink client is able to pick those details up. This configuration parameter allows changing the default location of that file (for example for environments sharing a Flink installation between users).</td>
         </tr>
         <tr>
             <td><h5>yarn.tags</h5></td>
-            <td>(none)</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>A comma-separated list of tags to apply to the Flink YARN application.</td>
         </tr>
     </tbody>

--- a/docs/_includes/generated/zoo_keeper_configuration.html
+++ b/docs/_includes/generated/zoo_keeper_configuration.html
@@ -9,17 +9,17 @@
     <tbody>
         <tr>
             <td><h5>zookeeper.sasl.disable</h5></td>
-            <td>false</td>
+            <td style="word-wrap: break-word;">false</td>
             <td></td>
         </tr>
         <tr>
             <td><h5>zookeeper.sasl.login-context-name</h5></td>
-            <td>"Client"</td>
+            <td style="word-wrap: break-word;">"Client"</td>
             <td></td>
         </tr>
         <tr>
             <td><h5>zookeeper.sasl.service-name</h5></td>
-            <td>"zookeeper"</td>
+            <td style="word-wrap: break-word;">"zookeeper"</td>
             <td></td>
         </tr>
     </tbody>

--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -286,6 +286,10 @@ These parameters configure the default HDFS used by Flink. Setups that do not sp
 
 {% include generated/blob_server_configuration.html %}
 
+### Heartbeat Manager
+
+{% include generated/heartbeat_manager_configuration.html %}
+
 ### SSL Settings
 
 {% include generated/security_configuration.html %}

--- a/flink-core/src/main/java/org/apache/flink/configuration/HeartbeatManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/HeartbeatManagerOptions.java
@@ -31,12 +31,14 @@ public class HeartbeatManagerOptions {
 	/** Time interval for requesting heartbeat from sender side. */
 	public static final ConfigOption<Long> HEARTBEAT_INTERVAL =
 			key("heartbeat.interval")
-			.defaultValue(10000L);
+			.defaultValue(10000L)
+			.withDescription("Time interval for requesting heartbeat from sender side.");
 
 	/** Timeout for requesting and receiving heartbeat for both sender and receiver sides. */
 	public static final ConfigOption<Long> HEARTBEAT_TIMEOUT =
 			key("heartbeat.timeout")
-			.defaultValue(50000L);
+			.defaultValue(50000L)
+			.withDescription("Timeout for requesting and receiving heartbeat for both sender and receiver sides.");
 
 	// ------------------------------------------------------------------------
 

--- a/flink-docs/src/main/java/org/apache/flink/docs/configuration/ConfigOptionsDocGenerator.java
+++ b/flink-docs/src/main/java/org/apache/flink/docs/configuration/ConfigOptionsDocGenerator.java
@@ -181,7 +181,7 @@ public class ConfigOptionsDocGenerator {
 		return "" +
 			"        <tr>\n" +
 			"            <td><h5>" + escapeCharacters(option.key()) + "</h5></td>\n" +
-			"            <td>" + escapeCharacters(defaultValueToHtml(defaultValue)) + "</td>\n" +
+			"            <td style=\"word-wrap: break-word;\">" + escapeCharacters(defaultValueToHtml(defaultValue)) + "</td>\n" +
 			"            <td>" + escapeCharacters(option.description()) + "</td>\n" +
 			"        </tr>\n";
 	}


### PR DESCRIPTION
## What is the purpose of the change

This PR integrates the HeartbeatManager `ConfigOptions` into the configuration docs generator.

Based on #5506.

## Brief change log

* Add missing descriptions to config options (derived from existing description/javadocs)
* integrate HeartbeatManager configuration table into `config.md`
