### PR TITLE
[FLINK-8673] [flip6] Use JobManagerRunner#resultFuture for success and failure communication

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/MiniDispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/MiniDispatcher.java
@@ -124,8 +124,8 @@ public class MiniDispatcher extends Dispatcher {
 	}
 
 	@Override
-	protected void jobFinishedByOther(JobID jobId) {
-		super.jobFinishedByOther(jobId);
+	protected void jobNotFinished(JobID jobId) {
+		super.jobNotFinished(jobId);
 
 		// shut down since we have done our job
 		shutDown();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerRunner.java
@@ -51,7 +51,6 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -72,12 +71,6 @@ public class JobManagerRunner implements LeaderContender, OnCompletionActions, F
 	/** The job graph needs to run. */
 	private final JobGraph jobGraph;
 
-	/** The listener to notify once the job completes - either successfully or unsuccessfully. */
-	private final OnCompletionActions toNotifyOnComplete;
-
-	/** The handler to call in case of fatal (unrecoverable) errors. */
-	private final FatalErrorHandler errorHandler;
-
 	/** Used to check whether a job needs to be run. */
 	private final RunningJobsRegistry runningJobsRegistry;
 
@@ -93,6 +86,8 @@ public class JobManagerRunner implements LeaderContender, OnCompletionActions, F
 	private final Time rpcTimeout;
 
 	private final CompletableFuture<ArchivedExecutionGraph> resultFuture;
+
+	private final CompletableFuture<Void> terminationFuture;
 
 	/** flag marking the runner as shut down. */
 	private volatile boolean shutdown;
@@ -119,17 +114,16 @@ public class JobManagerRunner implements LeaderContender, OnCompletionActions, F
 			final BlobServer blobServer,
 			final JobManagerSharedServices jobManagerSharedServices,
 			final MetricRegistry metricRegistry,
-			final OnCompletionActions toNotifyOnComplete,
-			final FatalErrorHandler errorHandler,
 			@Nullable final String restAddress) throws Exception {
 
 		JobManagerMetricGroup jobManagerMetrics = null;
 
+		this.resultFuture = new CompletableFuture<>();
+		this.terminationFuture = new CompletableFuture<>();
+
 		// make sure we cleanly shut down out JobManager services if initialization fails
 		try {
 			this.jobGraph = checkNotNull(jobGraph);
-			this.toNotifyOnComplete = checkNotNull(toNotifyOnComplete);
-			this.errorHandler = checkNotNull(errorHandler);
 			this.jobManagerSharedServices = checkNotNull(jobManagerSharedServices);
 
 			checkArgument(jobGraph.getNumberOfVertices() > 0, "The given job is empty");
@@ -176,14 +170,15 @@ public class JobManagerRunner implements LeaderContender, OnCompletionActions, F
 				userCodeLoader,
 				restAddress,
 				metricRegistry.getMetricQueryServicePath());
-
-			this.resultFuture = new CompletableFuture<>();
 		}
 		catch (Throwable t) {
 			// clean up everything
 			if (jobManagerMetrics != null) {
 				jobManagerMetrics.close();
 			}
+
+			terminationFuture.completeExceptionally(t);
+			resultFuture.completeExceptionally(t);
 
 			throw new JobExecutionException(jobGraph.getJobID(), "Could not set up JobManager", t);
 		}
@@ -225,34 +220,43 @@ public class JobManagerRunner implements LeaderContender, OnCompletionActions, F
 
 	private CompletableFuture<Void> shutdownInternally() {
 		synchronized (lock) {
-			shutdown = true;
+			if (!shutdown) {
+				shutdown = true;
 
-			jobManager.shutDown();
+				jobManager.shutDown();
 
-			return jobManager.getTerminationFuture()
-				.thenAccept(
-					ignored -> {
-						Throwable exception = null;
+				final CompletableFuture<Boolean> jobManagerTerminationFuture = jobManager.getTerminationFuture();
+
+				jobManagerTerminationFuture.whenComplete(
+					(Boolean ignored, Throwable throwable) -> {
 						try {
 							leaderElectionService.stop();
 						} catch (Throwable t) {
-							exception = ExceptionUtils.firstOrSuppressed(t, exception);
+							throwable = ExceptionUtils.firstOrSuppressed(t, ExceptionUtils.stripCompletionException(throwable));
 						}
 
 						// make all registered metrics go away
 						try {
 							jobManagerMetricGroup.close();
 						} catch (Throwable t) {
-							exception = ExceptionUtils.firstOrSuppressed(t, exception);
+							throwable = ExceptionUtils.firstOrSuppressed(t, throwable);
 						}
 
-						if (exception != null) {
-							throw new CompletionException(new FlinkException("Could not properly shut down the JobManagerRunner.", exception));
+						if (throwable != null) {
+							terminationFuture.completeExceptionally(
+								new FlinkException("Could not properly shut down the JobManagerRunner", throwable));
+						} else {
+							terminationFuture.complete(null);
 						}
-
-						// cancel the result future if not already completed
-						resultFuture.cancel(false);
 					});
+
+				terminationFuture.whenComplete(
+					(Void ignored, Throwable throwable) -> {
+						resultFuture.completeExceptionally(new JobNotFinishedException(jobGraph.getJobID()));
+					});
+			}
+
+			return terminationFuture;
 		}
 	}
 
@@ -267,16 +271,7 @@ public class JobManagerRunner implements LeaderContender, OnCompletionActions, F
 	public void jobReachedGloballyTerminalState(ArchivedExecutionGraph executionGraph) {
 		// complete the result future with the terminal execution graph
 		resultFuture.complete(executionGraph);
-
-		try {
-			unregisterJobFromHighAvailability();
-			shutdownInternally();
-		}
-		finally {
-			if (toNotifyOnComplete != null) {
-				toNotifyOnComplete.jobReachedGloballyTerminalState(executionGraph);
-			}
-		}
+		unregisterJobFromHighAvailability();
 	}
 
 	/**
@@ -284,14 +279,7 @@ public class JobManagerRunner implements LeaderContender, OnCompletionActions, F
 	 */
 	@Override
 	public void jobFinishedByOther() {
-		try {
-			shutdownInternally();
-		}
-		finally {
-			if (toNotifyOnComplete != null) {
-				toNotifyOnComplete.jobFinishedByOther();
-			}
-		}
+		resultFuture.completeExceptionally(new JobNotFinishedException(jobGraph.getJobID()));
 	}
 
 	/**
@@ -306,17 +294,7 @@ public class JobManagerRunner implements LeaderContender, OnCompletionActions, F
 			log.error("JobManager runner encountered a fatal error.", exception);
 		} catch (Throwable ignored) {}
 
-		// in any case, notify our handler, so it can react fast
-		try {
-			if (errorHandler != null) {
-				errorHandler.onFatalError(exception);
-			}
-		}
-		finally {
-			// the shutdown may not even needed any more, if the fatal error
-			// handler kills the process. that is fine, a process kill cleans up better than anything.
-			shutdownInternally();
-		}
+		resultFuture.completeExceptionally(exception);
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobNotFinishedException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobNotFinishedException.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.JobException;
+
+/**
+ * Exception indicating that a Flink job has not been finished.
+ */
+public class JobNotFinishedException extends JobException {
+	private static final long serialVersionUID = 611413276562570622L;
+
+	public JobNotFinishedException(JobID jobId) {
+		super("The job (" + jobId + ") has been not been finished.");
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcService.java
@@ -130,13 +130,13 @@ public interface RpcService {
 	/**
 	 * Gets the executor, provided by this RPC service. This executor can be used for example for
 	 * the {@code handleAsync(...)} or {@code thenAcceptAsync(...)} methods of futures.
-	 * 
+	 *
 	 * <p><b>IMPORTANT:</b> This executor does not isolate the method invocations against
 	 * any concurrent invocations and is therefore not suitable to run completion methods of futures
 	 * that modify state of an {@link RpcEndpoint}. For such operations, one needs to use the
 	 * {@link RpcEndpoint#getMainThreadExecutor() MainThreadExecutionContext} of that
 	 * {@code RpcEndpoint}.
-	 * 
+	 *
 	 * @return The execution context provided by the RPC service
 	 */
 	Executor getExecutor();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobManagerRunnerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobManagerRunnerTest.java
@@ -18,7 +18,204 @@
 
 package org.apache.flink.runtime.jobmaster;
 
-public class JobManagerRunnerTest {
+import org.apache.flink.configuration.BlobServerOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.blob.BlobServer;
+import org.apache.flink.runtime.blob.VoidBlobStore;
+import org.apache.flink.runtime.checkpoint.StandaloneCheckpointRecoveryFactory;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
+import org.apache.flink.runtime.heartbeat.HeartbeatServices;
+import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobStatus;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.leaderelection.TestingLeaderElectionService;
+import org.apache.flink.runtime.leaderelection.TestingLeaderRetrievalService;
+import org.apache.flink.runtime.metrics.MetricRegistry;
+import org.apache.flink.runtime.metrics.NoOpMetricRegistry;
+import org.apache.flink.runtime.rest.handler.legacy.utils.ArchivedExecutionGraphBuilder;
+import org.apache.flink.runtime.rpc.TestingRpcService;
+import org.apache.flink.runtime.testtasks.NoOpInvokable;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import javax.annotation.Nonnull;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for the {@link JobManagerRunner}
+ */
+public class JobManagerRunnerTest extends TestLogger {
+
+	@ClassRule
+	public static TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	private static Configuration configuration;
+
+	private static TestingRpcService rpcService;
+
+	private static BlobServer blobServer;
+
+	private static HeartbeatServices heartbeatServices = new HeartbeatServices(1000L, 1000L);
+
+	private static JobManagerSharedServices jobManagerSharedServices;
+
+	private static MetricRegistry metricRegistry;
+
+	private static JobGraph jobGraph;
+
+	private static ArchivedExecutionGraph archivedExecutionGraph;
+
+	private TestingHighAvailabilityServices haServices;
+
+	@BeforeClass
+	public static void setupClass() throws Exception {
+		configuration = new Configuration();
+		rpcService = new TestingRpcService();
+
+		configuration.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+
+		blobServer = new BlobServer(
+			configuration,
+			new VoidBlobStore());
+
+		jobManagerSharedServices = JobManagerSharedServices.fromConfiguration(configuration, blobServer);
+
+		metricRegistry = NoOpMetricRegistry.INSTANCE;
+
+		final JobVertex jobVertex = new JobVertex("Test vertex");
+		jobVertex.setInvokableClass(NoOpInvokable.class);
+		jobGraph = new JobGraph(jobVertex);
+
+		archivedExecutionGraph = new ArchivedExecutionGraphBuilder()
+			.setJobID(jobGraph.getJobID())
+			.setState(JobStatus.FINISHED)
+			.build();
+	}
+
+	@Before
+	public void setup() {
+		haServices = new TestingHighAvailabilityServices();
+		haServices.setJobMasterLeaderElectionService(jobGraph.getJobID(), new TestingLeaderElectionService());
+		haServices.setResourceManagerLeaderRetriever(new TestingLeaderRetrievalService());
+		haServices.setCheckpointRecoveryFactory(new StandaloneCheckpointRecoveryFactory());
+	}
+
+	@After
+	public void tearDown() {
+
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		if (jobManagerSharedServices != null) {
+			jobManagerSharedServices.shutdown();
+		}
+
+		if (blobServer != null) {
+			blobServer.close();
+		}
+
+		if (rpcService != null) {
+			rpcService.stopService();
+		}
+	}
 	
-	// TODO: Test that 
+	@Test
+	public void testJobCompletion() throws Exception {
+		final JobManagerRunner jobManagerRunner = createJobManagerRunner();
+
+		try {
+			jobManagerRunner.start();
+
+			final CompletableFuture<ArchivedExecutionGraph> resultFuture = jobManagerRunner.getResultFuture();
+
+			assertThat(resultFuture.isDone(), is(false));
+
+			jobManagerRunner.jobReachedGloballyTerminalState(archivedExecutionGraph);
+
+			assertThat(resultFuture.get(), is(archivedExecutionGraph));
+		} finally {
+			jobManagerRunner.shutdown();
+		}
+	}
+
+	@Test
+	public void testJobFinishedByOther() throws Exception {
+		final JobManagerRunner jobManagerRunner = createJobManagerRunner();
+
+		try {
+			jobManagerRunner.start();
+
+			final CompletableFuture<ArchivedExecutionGraph> resultFuture = jobManagerRunner.getResultFuture();
+
+			assertThat(resultFuture.isDone(), is(false));
+
+			jobManagerRunner.jobFinishedByOther();
+
+			try {
+				resultFuture.get();
+				fail("Should have failed.");
+			} catch (ExecutionException ee) {
+				assertThat(ExceptionUtils.stripExecutionException(ee), instanceOf(JobNotFinishedException.class));
+			}
+		} finally {
+			jobManagerRunner.shutdown();
+		}
+	}
+
+	@Test
+	public void testShutDown() throws Exception {
+		final JobManagerRunner jobManagerRunner = createJobManagerRunner();
+
+		try {
+			jobManagerRunner.start();
+
+			final CompletableFuture<ArchivedExecutionGraph> resultFuture = jobManagerRunner.getResultFuture();
+
+			assertThat(resultFuture.isDone(), is(false));
+
+			jobManagerRunner.shutdown();
+
+			try {
+				resultFuture.get();
+				fail("Should have failed.");
+			} catch (ExecutionException ee) {
+				assertThat(ExceptionUtils.stripExecutionException(ee), instanceOf(JobNotFinishedException.class));
+			}
+		} finally {
+			jobManagerRunner.shutdown();
+		}
+	}
+
+	@Nonnull
+	private JobManagerRunner createJobManagerRunner() throws Exception {
+		return new JobManagerRunner(
+			ResourceID.generate(),
+			jobGraph,
+			configuration,
+			rpcService,
+			haServices,
+			heartbeatServices,
+			blobServer,
+			jobManagerSharedServices,
+			metricRegistry,
+			null);
+	}
 }


### PR DESCRIPTION
## What is the purpose of the change

This commit removes the OnCompletionActions and FatalErrorHandler from the
JobManagerRunner. Instead it communicates a successful job execution of the
failure case through the JobManagerRunner#resultFuture.

Furthermore, this commit no longer allows the JobManagerRunner to shut down itself.
All shut down logic must be triggered by the owner of the JobManagerRunner.

This PR is based on #5494.

## Verifying this change

This change added tests and can be verified as follows: `JobManagerRunnerTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
