### PR TITLE
[FLINK-8675] Add non-blocking shut down method to RestServerEndpoint

### DIFF
--- a/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
@@ -596,8 +596,11 @@ public class RestClusterClientTest extends TestLogger {
 		}
 
 		@Override
+		protected void startInternal() throws Exception {}
+
+		@Override
 		public void close() throws Exception {
-			shutdown(Time.seconds(5));
+			shutDownAsync().get();
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
@@ -20,7 +20,9 @@ package org.apache.flink.runtime.concurrent;
 
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.util.ExecutorThreadFactory;
+import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.function.RunnableWithException;
 
 import akka.dispatch.OnComplete;
 
@@ -241,6 +243,83 @@ public class FutureUtils {
 		}
 	}
 
+	/**
+	 * Times the given future out after the timeout.
+	 *
+	 * @param future to time out
+	 * @param timeout after which the given future is timed out
+	 * @param timeUnit time unit of the timeout
+	 * @param <T> type of the given future
+	 * @return The timeout enriched future
+	 */
+	public static <T> CompletableFuture<T> orTimeout(CompletableFuture<T> future, long timeout, TimeUnit timeUnit) {
+		if (!future.isDone()) {
+			final ScheduledFuture<?> timeoutFuture = Delayer.delay(new Timeout(future), timeout, timeUnit);
+
+			future.whenComplete((T value, Throwable throwable) -> {
+				if (!timeoutFuture.isDone()) {
+					timeoutFuture.cancel(false);
+				}
+			});
+		}
+
+		return future;
+	}
+
+	// ------------------------------------------------------------------------
+	//  Future actions
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Run the given action after the completion of the given future. The given future can be
+	 * completed normally or exceptionally. In case of an exceptional completion the, the
+	 * action's exception will be added to the initial exception.
+	 *
+	 * @param future to wait for its completion
+	 * @param runnable action which is triggered after the future's completion
+	 * @return Future which is completed after the action has completed. This future can contain an exception,
+	 * if an error occurred in the given future or action.
+	 */
+	public static CompletableFuture<Void> runAfterwards(CompletableFuture<?> future, RunnableWithException runnable) {
+		return runAfterwardsAsync(future, runnable, Executors.directExecutor());
+	}
+
+	/**
+	 * Run the given action after the completion of the given future. The given future can be
+	 * completed normally or exceptionally. In case of an exceptional completion the, the
+	 * action's exception will be added to the initial exception.
+	 *
+	 * @param future to wait for its completion
+	 * @param runnable action which is triggered after the future's completion
+	 * @param executor to run the given action
+	 * @return Future which is completed after the action has completed. This future can contain an exception,
+	 * if an error occurred in the given future or action.
+	 */
+	public static CompletableFuture<Void> runAfterwardsAsync(
+		CompletableFuture<?> future,
+		RunnableWithException runnable,
+		Executor executor) {
+		final CompletableFuture<Void> resultFuture = new CompletableFuture<>();
+
+		future.whenCompleteAsync(
+			(Object ignored, Throwable throwable) -> {
+				try {
+					runnable.run();
+				} catch (Throwable e) {
+					throwable = ExceptionUtils.firstOrSuppressed(e, throwable);
+				}
+
+				if (throwable != null) {
+					resultFuture.completeExceptionally(throwable);
+				} else {
+					resultFuture.complete(null);
+				}
+			},
+			executor);
+
+		return resultFuture;
+	}
+
 	// ------------------------------------------------------------------------
 	//  composing futures
 	// ------------------------------------------------------------------------
@@ -414,6 +493,82 @@ public class FutureUtils {
 		}
 	}
 
+	/**
+	 * Creates a {@link ConjunctFuture} which is only completed after all given futures have completed.
+	 * Unlike {@link FutureUtils#waitForAll(Collection)}, the resulting future won't be completed directly
+	 * if one of the given futures is completed exceptionally. Instead, all occurring exception will be
+	 * collected and combined to a single exception. If at least on exception occurs, then the resulting
+	 * future will be completed exceptionally.
+	 *
+	 * @param futuresToComplete futures to complete
+	 * @return Future which is completed after all given futures have been completed.
+	 */
+	public static ConjunctFuture<Void> completeAll(Collection<? extends CompletableFuture<?>> futuresToComplete) {
+		return new CompletionConjunctFuture(futuresToComplete);
+	}
+
+	/**
+	 * {@link ConjunctFuture} implementation which is completed after all the given futures have been
+	 * completed. Exceptional completions of the input futures will be recorded but it won't trigger the
+	 * early completion of this future.
+	 */
+	private static final class CompletionConjunctFuture extends ConjunctFuture<Void> {
+
+		private final Object lock = new Object();
+
+		private final int numFuturesTotal;
+
+		private int futuresCompleted;
+
+		private Throwable globalThrowable;
+
+		private CompletionConjunctFuture(Collection<? extends CompletableFuture<?>> futuresToComplete) {
+			numFuturesTotal = futuresToComplete.size();
+
+			futuresCompleted = 0;
+
+			globalThrowable = null;
+
+			if (futuresToComplete.isEmpty()) {
+				complete(null);
+			} else {
+				for (CompletableFuture<?> completableFuture : futuresToComplete) {
+					completableFuture.whenComplete(this::completeFuture);
+				}
+			}
+		}
+
+		private void completeFuture(Object ignored, Throwable throwable) {
+			synchronized (lock) {
+				futuresCompleted++;
+
+				if (throwable != null) {
+					globalThrowable = ExceptionUtils.firstOrSuppressed(throwable, globalThrowable);
+				}
+
+				if (futuresCompleted == numFuturesTotal) {
+					if (globalThrowable != null) {
+						completeExceptionally(globalThrowable);
+					} else {
+						complete(null);
+					}
+				}
+			}
+		}
+
+		@Override
+		public int getNumFuturesTotal() {
+			return numFuturesTotal;
+		}
+
+		@Override
+		public int getNumFuturesCompleted() {
+			synchronized (lock) {
+				return futuresCompleted;
+			}
+		}
+	}
+
 	// ------------------------------------------------------------------------
 	//  Helper methods
 	// ------------------------------------------------------------------------
@@ -478,29 +633,6 @@ public class FutureUtils {
 		}, Executors.directExecutionContext());
 
 		return result;
-	}
-
-	/**
-	 * Times the given future out after the timeout.
-	 *
-	 * @param future to time out
-	 * @param timeout after which the given future is timed out
-	 * @param timeUnit time unit of the timeout
-	 * @param <T> type of the given future
-	 * @return The timeout enriched future
-	 */
-	public static <T> CompletableFuture<T> orTimeout(CompletableFuture<T> future, long timeout, TimeUnit timeUnit) {
-		if (!future.isDone()) {
-			final ScheduledFuture<?> timeoutFuture = Delayer.delay(new Timeout(future), timeout, timeUnit);
-
-			future.whenComplete((T value, Throwable throwable) -> {
-				if (!timeoutFuture.isDone()) {
-					timeoutFuture.cancel(false);
-				}
-			});
-		}
-
-		return future;
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
@@ -33,6 +33,7 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -282,6 +283,20 @@ public class FutureUtils {
 	 */
 	public static CompletableFuture<Void> runAfterwards(CompletableFuture<?> future, RunnableWithException runnable) {
 		return runAfterwardsAsync(future, runnable, Executors.directExecutor());
+	}
+
+	/**
+	 * Run the given action after the completion of the given future. The given future can be
+	 * completed normally or exceptionally. In case of an exceptional completion the, the
+	 * action's exception will be added to the initial exception.
+	 *
+	 * @param future to wait for its completion
+	 * @param runnable action which is triggered after the future's completion
+	 * @return Future which is completed after the action has completed. This future can contain an exception,
+	 * if an error occurred in the given future or action.
+	 */
+	public static CompletableFuture<Void> runAfterwardsAsync(CompletableFuture<?> future, RunnableWithException runnable) {
+		return runAfterwardsAsync(future, runnable, ForkJoinPool.commonPool());
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -454,7 +454,7 @@ public abstract class ClusterEntrypoint implements FatalErrorHandler {
 			Throwable exception = null;
 
 			if (webMonitorEndpoint != null) {
-				webMonitorEndpoint.shutdown(Time.seconds(10L));
+				webMonitorEndpoint.shutDownAsync().get();
 			}
 
 			if (dispatcherLeaderRetrievalService != null) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/FutureUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/FutureUtilsTest.java
@@ -27,7 +27,9 @@ import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
@@ -41,10 +43,15 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.Matchers.arrayContaining;
+import static org.hamcrest.Matchers.emptyArray;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Tests for the utility methods in {@link FutureUtils}.
@@ -268,6 +275,153 @@ public class FutureUtilsTest extends TestLogger {
 			assertThat(e.getMessage(), containsString("Could not complete the operation"));
 		} finally {
 			retryExecutor.shutdownNow();
+		}
+	}
+
+	@Test
+	public void testRunAfterwards() throws Exception {
+		final CompletableFuture<Void> inputFuture = new CompletableFuture<>();
+		final OneShotLatch runnableLatch = new OneShotLatch();
+
+		final CompletableFuture<Void> runFuture = FutureUtils.runAfterwards(
+			inputFuture,
+			runnableLatch::trigger);
+
+		assertThat(runnableLatch.isTriggered(), is(false));
+		assertThat(runFuture.isDone(), is(false));
+
+		inputFuture.complete(null);
+
+		assertThat(runnableLatch.isTriggered(), is(true));
+		assertThat(runFuture.isDone(), is(true));
+
+		// check that this future is not exceptionally completed
+		runFuture.get();
+	}
+
+	@Test
+	public void testRunAfterwardsExceptional() throws Exception {
+		final CompletableFuture<Void> inputFuture = new CompletableFuture<>();
+		final OneShotLatch runnableLatch = new OneShotLatch();
+		final FlinkException testException = new FlinkException("Test exception");
+
+		final CompletableFuture<Void> runFuture = FutureUtils.runAfterwards(
+			inputFuture,
+			runnableLatch::trigger);
+
+		assertThat(runnableLatch.isTriggered(), is(false));
+		assertThat(runFuture.isDone(), is(false));
+
+		inputFuture.completeExceptionally(testException);
+
+		assertThat(runnableLatch.isTriggered(), is(true));
+		assertThat(runFuture.isDone(), is(true));
+
+		try {
+			runFuture.get();
+			fail("Expected an exceptional completion");
+		} catch (ExecutionException ee) {
+			assertThat(ExceptionUtils.stripExecutionException(ee), is(testException));
+		}
+	}
+
+	@Test
+	public void testCompleteAll() throws Exception {
+		final CompletableFuture<String> inputFuture1 = new CompletableFuture<>();
+		final CompletableFuture<Integer> inputFuture2 = new CompletableFuture<>();
+
+		final List<CompletableFuture<?>> futuresToComplete = Arrays.asList(inputFuture1, inputFuture2);
+		final FutureUtils.ConjunctFuture<Void> completeFuture = FutureUtils.completeAll(futuresToComplete);
+
+		assertThat(completeFuture.isDone(), is(false));
+		assertThat(completeFuture.getNumFuturesCompleted(), is(0));
+		assertThat(completeFuture.getNumFuturesTotal(), is(futuresToComplete.size()));
+
+		inputFuture2.complete(42);
+
+		assertThat(completeFuture.isDone(), is(false));
+		assertThat(completeFuture.getNumFuturesCompleted(), is(1));
+
+		inputFuture1.complete("foobar");
+
+		assertThat(completeFuture.isDone(), is(true));
+		assertThat(completeFuture.getNumFuturesCompleted(), is(2));
+
+		completeFuture.get();
+	}
+
+	@Test
+	public void testCompleteAllPartialExceptional() throws Exception {
+		final CompletableFuture<String> inputFuture1 = new CompletableFuture<>();
+		final CompletableFuture<Integer> inputFuture2 = new CompletableFuture<>();
+
+		final List<CompletableFuture<?>> futuresToComplete = Arrays.asList(inputFuture1, inputFuture2);
+		final FutureUtils.ConjunctFuture<Void> completeFuture = FutureUtils.completeAll(futuresToComplete);
+
+		assertThat(completeFuture.isDone(), is(false));
+		assertThat(completeFuture.getNumFuturesCompleted(), is(0));
+		assertThat(completeFuture.getNumFuturesTotal(), is(futuresToComplete.size()));
+
+		final FlinkException testException1 = new FlinkException("Test exception 1");
+		inputFuture2.completeExceptionally(testException1);
+
+		assertThat(completeFuture.isDone(), is(false));
+		assertThat(completeFuture.getNumFuturesCompleted(), is(1));
+
+		inputFuture1.complete("foobar");
+
+		assertThat(completeFuture.isDone(), is(true));
+		assertThat(completeFuture.getNumFuturesCompleted(), is(2));
+
+		try {
+			completeFuture.get();
+			fail("Expected an exceptional completion");
+		} catch (ExecutionException ee) {
+			assertThat(ExceptionUtils.stripExecutionException(ee), is(testException1));
+		}
+	}
+
+	@Test
+	public void testCompleteAllExceptional() throws Exception {
+		final CompletableFuture<String> inputFuture1 = new CompletableFuture<>();
+		final CompletableFuture<Integer> inputFuture2 = new CompletableFuture<>();
+
+		final List<CompletableFuture<?>> futuresToComplete = Arrays.asList(inputFuture1, inputFuture2);
+		final FutureUtils.ConjunctFuture<Void> completeFuture = FutureUtils.completeAll(futuresToComplete);
+
+		assertThat(completeFuture.isDone(), is(false));
+		assertThat(completeFuture.getNumFuturesCompleted(), is(0));
+		assertThat(completeFuture.getNumFuturesTotal(), is(futuresToComplete.size()));
+
+		final FlinkException testException1 = new FlinkException("Test exception 1");
+		inputFuture1.completeExceptionally(testException1);
+
+		assertThat(completeFuture.isDone(), is(false));
+		assertThat(completeFuture.getNumFuturesCompleted(), is(1));
+
+		final FlinkException testException2 = new FlinkException("Test exception 2");
+		inputFuture2.completeExceptionally(testException2);
+
+		assertThat(completeFuture.isDone(), is(true));
+		assertThat(completeFuture.getNumFuturesCompleted(), is(2));
+
+		try {
+			completeFuture.get();
+			fail("Expected an exceptional completion");
+		} catch (ExecutionException ee) {
+			final Throwable actual = ExceptionUtils.stripExecutionException(ee);
+
+			final Throwable[] suppressed = actual.getSuppressed();
+			final FlinkException suppressedException;
+
+			if (actual.equals(testException1)) {
+				 suppressedException = testException2;
+			} else {
+				suppressedException = testException1;
+			}
+
+			assertThat(suppressed, is(not(emptyArray())));
+			assertThat(suppressed, arrayContaining(suppressedException));
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointITCase.java
@@ -136,14 +136,14 @@ public class RestServerEndpointITCase extends TestLogger {
 	}
 
 	@After
-	public void teardown() {
+	public void teardown() throws Exception {
 		if (restClient != null) {
 			restClient.shutdown(timeout);
 			restClient = null;
 		}
 
 		if (serverEndpoint != null) {
-			serverEndpoint.shutdown(timeout);
+			serverEndpoint.shutDownAsync().get();
 			serverEndpoint = null;
 		}
 	}
@@ -316,6 +316,9 @@ public class RestServerEndpointITCase extends TestLogger {
 				Tuple2.of(new TestHeaders(), testHandler),
 				Tuple2.of(TestUploadHeaders.INSTANCE, testUploadHandler));
 		}
+
+		@Override
+		protected void startInternal() throws Exception {}
 	}
 
 	private static class TestHandler extends AbstractRestHandler<RestfulGateway, TestRequest, TestResponse, TestParameters> {


### PR DESCRIPTION
## What is the purpose of the change

Make shut down method of RestServerEndpoint non blocking.

This PR is based on #5503.

## Verifying this change

This change is already covered by existing tests, such as `RestServerEndpointITCase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
