### PR TITLE
[FLINK-8677] [flip6] Make ClusterEntrypoint shut down non-blocking

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/ExecutorUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/ExecutorUtils.java
@@ -21,6 +21,7 @@ package org.apache.flink.util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
@@ -73,5 +74,25 @@ public class ExecutorUtils {
 				hasTimeLeft = timeLeft > 0L;
 			}
 		}
+	}
+
+	/**
+	 * Shuts the given {@link ExecutorService} down in a non-blocking fashion. The shut down will
+	 * be executed by a thread from the common fork-join pool.
+	 *
+	 * <p>The executor services will be shut down gracefully for the given timeout period. Afterwards
+	 * {@link ExecutorService#shutdownNow()} will be called.
+	 *
+	 * @param timeout before {@link ExecutorService#shutdownNow()} is called
+	 * @param unit time unit of the timeout
+	 * @param executorServices to shut down
+	 * @return Future which is completed once the {@link ExecutorService} are shut down
+	 */
+	public static CompletableFuture<Void> nonBlockingShutdown(long timeout, TimeUnit unit, ExecutorService... executorServices) {
+		return CompletableFuture.supplyAsync(
+			() -> {
+				gracefulShutdown(timeout, unit, executorServices);
+				return null;
+			});
 	}
 }

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosSessionClusterEntrypoint.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosSessionClusterEntrypoint.java
@@ -28,6 +28,7 @@ import org.apache.flink.mesos.util.MesosConfiguration;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.runtime.clusterframework.ContainerSpecification;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
 import org.apache.flink.runtime.entrypoint.SessionClusterEntrypoint;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
@@ -42,7 +43,6 @@ import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.util.EnvironmentInformation;
 import org.apache.flink.runtime.util.JvmShutdownSafeguard;
 import org.apache.flink.runtime.util.SignalHandler;
-import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.Preconditions;
 
 import org.apache.commons.cli.CommandLine;
@@ -51,6 +51,8 @@ import org.apache.commons.cli.Options;
 import org.apache.commons.cli.PosixParser;
 
 import javax.annotation.Nullable;
+
+import java.util.concurrent.CompletableFuture;
 
 /**
  * Entry point for Mesos session clusters.
@@ -141,26 +143,16 @@ public class MesosSessionClusterEntrypoint extends SessionClusterEntrypoint {
 	}
 
 	@Override
-	protected void stopClusterServices(boolean cleanupHaData) throws FlinkException {
-		Throwable exception = null;
+	protected CompletableFuture<Void> stopClusterServices(boolean cleanupHaData) {
+		final CompletableFuture<Void> serviceShutDownFuture = super.stopClusterServices(cleanupHaData);
 
-		try {
-			super.stopClusterServices(cleanupHaData);
-		} catch (Throwable t) {
-			exception = t;
-		}
-
-		if (mesosServices != null) {
-			try {
-				mesosServices.close(cleanupHaData);
-			} catch (Throwable t) {
-				exception = t;
-			}
-		}
-
-		if (exception != null) {
-			throw new FlinkException("Could not properly shut down the Mesos session cluster entry point.", exception);
-		}
+		return FutureUtils.runAfterwards(
+			serviceShutDownFuture,
+			() -> {
+				if (mesosServices != null) {
+					mesosServices.close(cleanupHaData);
+				}
+			});
 	}
 
 	public static void main(String[] args) {

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosApplicationMasterRunner.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosApplicationMasterRunner.java
@@ -433,7 +433,7 @@ public class MesosApplicationMasterRunner {
 
 		if (metricRegistry != null) {
 			try {
-				metricRegistry.shutdown();
+				metricRegistry.shutdown().get();
 			} catch (Throwable t) {
 				LOG.error("Could not shut down metric registry.", t);
 			}

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManager.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManager.java
@@ -333,8 +333,7 @@ public class MesosResourceManager extends ResourceManager<RegisteredMesosWorkerN
 	}
 
 	@Override
-	public void postStop() throws Exception {
-		Exception exception = null;
+	public CompletableFuture<Void> postStop() {
 		FiniteDuration stopTimeout = new FiniteDuration(5L, TimeUnit.SECONDS);
 
 		CompletableFuture<Boolean> stopTaskMonitorFuture = stopActor(taskMonitor, stopTimeout);
@@ -355,22 +354,11 @@ public class MesosResourceManager extends ResourceManager<RegisteredMesosWorkerN
 			stopLaunchCoordinatorFuture,
 			stopReconciliationCoordinatorFuture);
 
-		// wait for the future to complete or to time out
-		try {
-			stopFuture.get();
-		} catch (Exception e) {
-			exception = e;
-		}
+		final CompletableFuture<Void> terminationFuture = super.postStop();
 
-		try {
-			super.postStop();
-		} catch (Exception e) {
-			exception = ExceptionUtils.firstOrSuppressed(e, exception);
-		}
-
-		if (exception != null) {
-			throw new ResourceManagerException("Could not properly shut down the ResourceManager.", exception);
-		}
+		return stopFuture.thenCombine(
+			terminationFuture,
+			(Void voidA, Void voidB) -> null);
 	}
 
 	@Override

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
@@ -510,7 +510,7 @@ public class MesosResourceManagerTest extends TestLogger {
 
 		@Override
 		public void close() throws Exception {
-			rpcService.stopService();
+			rpcService.stopService().get();
 		}
 	}
 

--- a/flink-metrics/flink-metrics-dropwizard/src/test/java/org/apache/flink/dropwizard/ScheduledDropwizardReporterTest.java
+++ b/flink-metrics/flink-metrics-dropwizard/src/test/java/org/apache/flink/dropwizard/ScheduledDropwizardReporterTest.java
@@ -74,7 +74,7 @@ public class ScheduledDropwizardReporterTest {
 	 * Tests that the registered metrics' names don't contain invalid characters.
 	 */
 	@Test
-	public void testAddingMetrics() throws NoSuchFieldException, IllegalAccessException {
+	public void testAddingMetrics() throws Exception {
 		Configuration configuration = new Configuration();
 		String taskName = "test\"Ta\"..sk";
 		String jobName = "testJ\"ob:-!ax..?";
@@ -131,7 +131,7 @@ public class ScheduledDropwizardReporterTest {
 
 		assertEquals(expectedCounterName, counters.get(myCounter));
 
-		metricRegistry.shutdown();
+		metricRegistry.shutdown().get();
 	}
 
 	/**

--- a/flink-metrics/flink-metrics-dropwizard/src/test/java/org/apache/flink/dropwizard/metrics/DropwizardFlinkHistogramWrapperTest.java
+++ b/flink-metrics/flink-metrics-dropwizard/src/test/java/org/apache/flink/dropwizard/metrics/DropwizardFlinkHistogramWrapperTest.java
@@ -150,7 +150,7 @@ public class DropwizardFlinkHistogramWrapperTest extends TestLogger {
 			assertEquals(0, testingReporter.getMetrics().size());
 		} finally {
 			if (registry != null) {
-				registry.shutdown();
+				registry.shutdown().get();
 			}
 		}
 	}

--- a/flink-metrics/flink-metrics-jmx/src/test/java/org/apache/flink/metrics/jmx/JMXReporterTest.java
+++ b/flink-metrics/flink-metrics-jmx/src/test/java/org/apache/flink/metrics/jmx/JMXReporterTest.java
@@ -145,7 +145,7 @@ public class JMXReporterTest extends TestLogger {
 		rep1.notifyOfRemovedMetric(g2, "rep2", null);
 
 		mg.close();
-		reg.shutdown();
+		reg.shutdown().get();
 	}
 
 	/**
@@ -219,7 +219,7 @@ public class JMXReporterTest extends TestLogger {
 		rep1.close();
 		rep2.close();
 		mg.close();
-		reg.shutdown();
+		reg.shutdown().get();
 	}
 
 	/**
@@ -266,7 +266,7 @@ public class JMXReporterTest extends TestLogger {
 
 		} finally {
 			if (registry != null) {
-				registry.shutdown();
+				registry.shutdown().get();
 			}
 		}
 	}
@@ -306,7 +306,7 @@ public class JMXReporterTest extends TestLogger {
 
 		} finally {
 			if (registry != null) {
-				registry.shutdown();
+				registry.shutdown().get();
 			}
 		}
 	}

--- a/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTaskScopeTest.java
+++ b/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTaskScopeTest.java
@@ -90,9 +90,9 @@ public class PrometheusReporterTaskScopeTest {
 	}
 
 	@After
-	public void shutdownRegistry() {
+	public void shutdownRegistry() throws Exception {
 		if (registry != null) {
-			registry.shutdown();
+			registry.shutdown().get();
 		}
 	}
 

--- a/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTest.java
+++ b/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTest.java
@@ -84,9 +84,9 @@ public class PrometheusReporterTest extends TestLogger {
 	}
 
 	@After
-	public void shutdownRegistry() {
+	public void shutdownRegistry() throws Exception {
 		if (registry != null) {
-			registry.shutdown();
+			registry.shutdown().get();
 		}
 	}
 
@@ -237,7 +237,7 @@ public class PrometheusReporterTest extends TestLogger {
 	}
 
 	@Test
-	public void cannotStartTwoReportersOnSamePort() {
+	public void cannotStartTwoReportersOnSamePort() throws Exception {
 		final MetricRegistryImpl fixedPort1 = new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(createConfigWithOneReporter("test1", portRangeProvider.next())));
 		assertThat(fixedPort1.getReporters(), hasSize(1));
 
@@ -246,12 +246,12 @@ public class PrometheusReporterTest extends TestLogger {
 		final MetricRegistryImpl fixedPort2 = new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(createConfigWithOneReporter("test2", String.valueOf(firstReporter.getPort()))));
 		assertThat(fixedPort2.getReporters(), hasSize(0));
 
-		fixedPort1.shutdown();
-		fixedPort2.shutdown();
+		fixedPort1.shutdown().get();
+		fixedPort2.shutdown().get();
 	}
 
 	@Test
-	public void canStartTwoReportersWhenUsingPortRange() {
+	public void canStartTwoReportersWhenUsingPortRange() throws Exception {
 		String portRange = portRangeProvider.next();
 		final MetricRegistryImpl portRange1 = new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(createConfigWithOneReporter("test1", portRange)));
 		final MetricRegistryImpl portRange2 = new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(createConfigWithOneReporter("test2", portRange)));
@@ -259,8 +259,8 @@ public class PrometheusReporterTest extends TestLogger {
 		assertThat(portRange1.getReporters(), hasSize(1));
 		assertThat(portRange2.getReporters(), hasSize(1));
 
-		portRange1.shutdown();
-		portRange2.shutdown();
+		portRange1.shutdown().get();
+		portRange2.shutdown().get();
 	}
 
 	private String addMetricAndPollResponse(Metric metric, String metricName) throws UnirestException {
@@ -280,8 +280,8 @@ public class PrometheusReporterTest extends TestLogger {
 	}
 
 	@After
-	public void closeReporterAndShutdownRegistry() {
-		registry.shutdown();
+	public void closeReporterAndShutdownRegistry() throws Exception {
+		registry.shutdown().get();
 	}
 
 	/**

--- a/flink-metrics/flink-metrics-slf4j/src/test/java/org/apache/flink/metrics/slf4j/Slf4jReporterTest.java
+++ b/flink-metrics/flink-metrics-slf4j/src/test/java/org/apache/flink/metrics/slf4j/Slf4jReporterTest.java
@@ -76,8 +76,8 @@ public class Slf4jReporterTest extends TestLogger {
 	}
 
 	@AfterClass
-	public static void tearDown() {
-		registry.shutdown();
+	public static void tearDown() throws Exception {
+		registry.shutdown().get();
 	}
 
 	@Test

--- a/flink-metrics/flink-metrics-statsd/src/test/java/org/apache/flink/metrics/statsd/StatsDReporterTest.java
+++ b/flink-metrics/flink-metrics-statsd/src/test/java/org/apache/flink/metrics/statsd/StatsDReporterTest.java
@@ -73,7 +73,7 @@ public class StatsDReporterTest extends TestLogger {
 	 * Tests that the registered metrics' names don't contain invalid characters.
 	 */
 	@Test
-	public void testAddingMetrics() throws NoSuchFieldException, IllegalAccessException {
+	public void testAddingMetrics() throws Exception {
 		Configuration configuration = new Configuration();
 		String taskName = "testTask";
 		String jobName = "testJob:-!ax..?";
@@ -124,7 +124,7 @@ public class StatsDReporterTest extends TestLogger {
 
 		assertEquals(expectedCounterName, counters.get(myCounter));
 
-		metricRegistry.shutdown();
+		metricRegistry.shutdown().get();
 	}
 
 	/**
@@ -187,7 +187,7 @@ public class StatsDReporterTest extends TestLogger {
 
 		} finally {
 			if (registry != null) {
-				registry.shutdown();
+				registry.shutdown().get();
 			}
 
 			if (receiver != null) {
@@ -247,7 +247,7 @@ public class StatsDReporterTest extends TestLogger {
 
 		} finally {
 			if (registry != null) {
-				registry.shutdown();
+				registry.shutdown().get();
 			}
 
 			if (receiver != null) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/akka/ActorUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/akka/ActorUtils.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.akka;
+
+import org.apache.flink.runtime.concurrent.FutureUtils;
+
+import akka.actor.ActorRef;
+import akka.actor.Kill;
+import akka.pattern.Patterns;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import scala.concurrent.Future;
+import scala.concurrent.duration.FiniteDuration;
+
+/**
+ * Utility functions for the interaction with Akka {@link akka.actor.Actor}.
+ */
+public class ActorUtils {
+
+	private static final Logger LOG = LoggerFactory.getLogger(ActorUtils.class);
+
+	/**
+	 * Shuts the given {@link akka.actor.Actor} down in a non blocking fashion. The method first tries to
+	 * gracefully shut them down. If this is not successful, then the actors will be terminated by sending
+	 * a {@link akka.actor.Kill} message.
+	 *
+	 * @param gracePeriod for the graceful shutdown
+	 * @param timeUnit time unit of the grace period
+	 * @param actors to shut down
+	 * @return Future which is completed once all actors have been shut down gracefully or forceful
+	 * kill messages have been sent to all actors. Occurring errors will be suppressed into one error.
+	 */
+	public static CompletableFuture<Void> nonBlockingShutDown(long gracePeriod, TimeUnit timeUnit, ActorRef... actors) {
+		final Collection<CompletableFuture<Void>> terminationFutures = new ArrayList<>(actors.length);
+		final FiniteDuration timeout = new FiniteDuration(gracePeriod, timeUnit);
+
+		for (ActorRef actor : actors) {
+			try {
+				final Future<Boolean> booleanFuture = Patterns.gracefulStop(actor, timeout);
+				final CompletableFuture<Void> terminationFuture = FutureUtils.toJava(booleanFuture)
+					.<Void>thenApply(ignored -> null)
+					.exceptionally((Throwable throwable) -> {
+						if (throwable instanceof TimeoutException) {
+							// the actor did not gracefully stop within the grace period --> Let's kill him
+							actor.tell(Kill.getInstance(), ActorRef.noSender());
+							return null;
+						} else {
+							throw new CompletionException(throwable);
+						}
+					});
+
+				terminationFutures.add(terminationFuture);
+			} catch (IllegalStateException ignored) {
+				// this can happen if the underlying actor system has been stopped before shutting
+				// the actor down
+				LOG.debug("The actor {} has already been stopped because the " +
+					"underlying ActorSystem has already been shut down.", actor.path());
+			}
+		}
+
+		return FutureUtils.completeAll(terminationFutures);
+	}
+
+	private ActorUtils() {}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -156,16 +156,20 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 	//------------------------------------------------------
 
 	@Override
-	public void postStop() throws Exception {
+	public CompletableFuture<Void> postStop() {
 		log.info("Stopping dispatcher {}.", getAddress());
-		Throwable exception = null;
+		Exception exception = null;
 
-		clearState();
+		try {
+			clearState();
+		} catch (Exception e) {
+			exception = ExceptionUtils.firstOrSuppressed(e, exception);
+		}
 
 		try {
 			jobManagerSharedServices.shutdown();
-		} catch (Throwable t) {
-			exception = ExceptionUtils.firstOrSuppressed(t, exception);
+		} catch (Exception e) {
+			exception = ExceptionUtils.firstOrSuppressed(e, exception);
 		}
 
 		try {
@@ -180,16 +184,12 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 			exception = ExceptionUtils.firstOrSuppressed(e, exception);
 		}
 
-		try {
-			super.postStop();
-		} catch (Exception e) {
-			exception = ExceptionUtils.firstOrSuppressed(e, exception);
-		}
-
 		if (exception != null) {
-			throw new FlinkException("Could not properly terminate the Dispatcher.", exception);
+			return FutureUtils.completedExceptionally(
+				new FlinkException("Could not properly terminate the Dispatcher.", exception));
+		} else {
+			return CompletableFuture.completedFuture(null);
 		}
-		log.info("Stopped dispatcher {}.", getAddress());
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -213,7 +213,7 @@ public abstract class ClusterEntrypoint implements FatalErrorHandler {
 
 			// TODO: Make shutDownAndTerminate non blocking to not use the global executor
 			dispatcher.getTerminationFuture().whenCompleteAsync(
-				(Boolean success, Throwable throwable) -> {
+				(Void value, Throwable throwable) -> {
 					if (throwable != null) {
 						LOG.info("Could not properly terminate the Dispatcher.", throwable);
 					}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -34,6 +34,7 @@ import org.apache.flink.runtime.blob.TransientBlobService;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.dispatcher.ArchivedExecutionGraphStore;
 import org.apache.flink.runtime.dispatcher.Dispatcher;
@@ -63,7 +64,6 @@ import org.apache.flink.runtime.webmonitor.retriever.MetricQueryServiceRetriever
 import org.apache.flink.runtime.webmonitor.retriever.impl.AkkaQueryServiceRetriever;
 import org.apache.flink.runtime.webmonitor.retriever.impl.RpcGatewayRetriever;
 import org.apache.flink.util.ExceptionUtils;
-import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.Preconditions;
 
 import akka.actor.ActorSystem;
@@ -75,6 +75,8 @@ import javax.annotation.concurrent.GuardedBy;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -104,9 +106,11 @@ public abstract class ClusterEntrypoint implements FatalErrorHandler {
 
 	private final Configuration configuration;
 
-	private final CompletableFuture<Boolean> terminationFuture;
+	private final CompletableFuture<Void> terminationFuture;
 
 	private final AtomicBoolean isTerminating = new AtomicBoolean(false);
+
+	private final AtomicBoolean isShutDown = new AtomicBoolean(false);
 
 	@GuardedBy("lock")
 	private MetricRegistryImpl metricRegistry;
@@ -144,12 +148,15 @@ public abstract class ClusterEntrypoint implements FatalErrorHandler {
 	@GuardedBy("lock")
 	private TransientBlobCache transientBlobCache;
 
+	@GuardedBy("lock")
+	private ClusterInformation clusterInformation;
+
 	protected ClusterEntrypoint(Configuration configuration) {
 		this.configuration = Preconditions.checkNotNull(configuration);
 		this.terminationFuture = new CompletableFuture<>();
 	}
 
-	public CompletableFuture<Boolean> getTerminationFuture() {
+	public CompletableFuture<Void> getTerminationFuture() {
 		return terminationFuture;
 	}
 
@@ -211,8 +218,7 @@ public abstract class ClusterEntrypoint implements FatalErrorHandler {
 				heartbeatServices,
 				metricRegistry);
 
-			// TODO: Make shutDownAndTerminate non blocking to not use the global executor
-			dispatcher.getTerminationFuture().whenCompleteAsync(
+			dispatcher.getTerminationFuture().whenComplete(
 				(Void value, Throwable throwable) -> {
 					if (throwable != null) {
 						LOG.info("Could not properly terminate the Dispatcher.", throwable);
@@ -250,6 +256,18 @@ public abstract class ClusterEntrypoint implements FatalErrorHandler {
 			// start the MetricQueryService
 			final ActorSystem actorSystem = ((AkkaRpcService) commonRpcService).getActorSystem();
 			metricRegistry.startQueryService(actorSystem, null);
+
+			archivedExecutionGraphStore = createSerializableExecutionGraphStore(configuration, commonRpcService.getScheduledExecutor());
+
+			clusterInformation = new ClusterInformation(
+				commonRpcService.getAddress(),
+				blobServer.getPort());
+
+			transientBlobCache = new TransientBlobCache(
+				configuration,
+				new InetSocketAddress(
+					clusterInformation.getBlobServerHostname(),
+					clusterInformation.getBlobServerPort()));
 		}
 	}
 
@@ -261,21 +279,9 @@ public abstract class ClusterEntrypoint implements FatalErrorHandler {
 			HeartbeatServices heartbeatServices,
 			MetricRegistry metricRegistry) throws Exception {
 		synchronized (lock) {
-			archivedExecutionGraphStore = createSerializableExecutionGraphStore(configuration, rpcService.getScheduledExecutor());
-
 			dispatcherLeaderRetrievalService = highAvailabilityServices.getDispatcherLeaderRetriever();
 
 			resourceManagerRetrievalService = highAvailabilityServices.getResourceManagerLeaderRetriever();
-
-			final ClusterInformation clusterInformation = new ClusterInformation(
-				rpcService.getAddress(),
-				blobServer.getPort());
-
-			transientBlobCache = new TransientBlobCache(
-				configuration,
-				new InetSocketAddress(
-					clusterInformation.getBlobServerHostname(),
-					clusterInformation.getBlobServerPort()));
 
 			LeaderGatewayRetriever<DispatcherGateway> dispatcherGatewayRetriever = new RpcGatewayRetriever<>(
 				rpcService,
@@ -376,44 +382,11 @@ public abstract class ClusterEntrypoint implements FatalErrorHandler {
 		return new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(configuration));
 	}
 
-	private void shutDown(boolean cleanupHaData) throws FlinkException {
-		LOG.info("Stopping {}.", getClass().getSimpleName());
-
-		Throwable exception = null;
-
+	protected CompletableFuture<Void> stopClusterServices(boolean cleanupHaData) {
 		synchronized (lock) {
+			Throwable exception = null;
 
-			try {
-				stopClusterComponents();
-			} catch (Throwable t) {
-				exception = ExceptionUtils.firstOrSuppressed(t, exception);
-			}
-
-			try {
-				stopClusterServices(cleanupHaData);
-			} catch (Throwable t) {
-				exception = ExceptionUtils.firstOrSuppressed(t, exception);
-			}
-
-			terminationFuture.complete(true);
-		}
-
-		if (exception != null) {
-			throw new FlinkException("Could not properly shut down the cluster entrypoint.", exception);
-		}
-	}
-
-	protected void stopClusterServices(boolean cleanupHaData) throws FlinkException {
-		Throwable exception = null;
-
-		synchronized (lock) {
-			if (metricRegistry != null) {
-				try {
-					metricRegistry.shutdown();
-				} catch (Throwable t) {
-					exception = t;
-				}
-			}
+			final Collection<CompletableFuture<Void>> terminationFutures = new ArrayList<>(3);
 
 			if (blobServer != null) {
 				try {
@@ -435,60 +408,6 @@ public abstract class ClusterEntrypoint implements FatalErrorHandler {
 				}
 			}
 
-			if (commonRpcService != null) {
-				try {
-					commonRpcService.stopService().get();
-				} catch (Throwable t) {
-					exception = ExceptionUtils.firstOrSuppressed(t, exception);
-				}
-			}
-		}
-
-		if (exception != null) {
-			throw new FlinkException("Could not properly shut down the cluster services.", exception);
-		}
-	}
-
-	protected void stopClusterComponents() throws Exception {
-		synchronized (lock) {
-			Throwable exception = null;
-
-			if (webMonitorEndpoint != null) {
-				webMonitorEndpoint.shutDownAsync().get();
-			}
-
-			if (dispatcherLeaderRetrievalService != null) {
-				try {
-					dispatcherLeaderRetrievalService.stop();
-				} catch (Throwable t) {
-					exception = ExceptionUtils.firstOrSuppressed(t, exception);
-				}
-			}
-
-			if (dispatcher != null) {
-				try {
-					dispatcher.shutDown();
-				} catch (Throwable t) {
-					exception = ExceptionUtils.firstOrSuppressed(t, exception);
-				}
-			}
-
-			if (resourceManagerRetrievalService != null) {
-				try {
-					resourceManagerRetrievalService.stop();
-				} catch (Throwable t) {
-					exception = ExceptionUtils.firstOrSuppressed(t, exception);
-				}
-			}
-
-			if (resourceManager != null) {
-				try {
-					resourceManager.shutDown();
-				} catch (Throwable t) {
-					exception = ExceptionUtils.firstOrSuppressed(t, exception);
-				}
-			}
-
 			if (archivedExecutionGraphStore != null) {
 				try {
 					archivedExecutionGraphStore.close();
@@ -505,9 +424,64 @@ public abstract class ClusterEntrypoint implements FatalErrorHandler {
 				}
 			}
 
-			if (exception != null) {
-				throw new FlinkException("Could not properly shut down the session cluster entry point.", exception);
+			if (metricRegistry != null) {
+				terminationFutures.add(metricRegistry.shutdown());
 			}
+
+			if (commonRpcService != null) {
+				terminationFutures.add(commonRpcService.stopService());
+			}
+
+			if (exception != null) {
+				terminationFutures.add(FutureUtils.completedExceptionally(exception));
+			}
+
+			return FutureUtils.completeAll(terminationFutures);
+		}
+	}
+
+	protected CompletableFuture<Void> stopClusterComponents() {
+		synchronized (lock) {
+
+			Exception exception = null;
+
+			final Collection<CompletableFuture<Void>> terminationFutures = new ArrayList<>(4);
+
+			if (dispatcherLeaderRetrievalService != null) {
+				try {
+					dispatcherLeaderRetrievalService.stop();
+				} catch (Exception e) {
+					exception = ExceptionUtils.firstOrSuppressed(e, exception);
+				}
+			}
+
+			if (resourceManagerRetrievalService != null) {
+				try {
+					resourceManagerRetrievalService.stop();
+				} catch (Exception e) {
+					exception = ExceptionUtils.firstOrSuppressed(e, exception);
+				}
+			}
+
+			if (webMonitorEndpoint != null) {
+				terminationFutures.add(webMonitorEndpoint.shutDownAsync());
+			}
+
+			if (dispatcher != null) {
+				dispatcher.shutDown();
+				terminationFutures.add(dispatcher.getTerminationFuture());
+			}
+
+			if (resourceManager != null) {
+				resourceManager.shutDown();
+				terminationFutures.add(resourceManager.getTerminationFuture());
+			}
+
+			if (exception != null) {
+				terminationFutures.add(FutureUtils.completedExceptionally(exception));
+			}
+
+			return FutureUtils.completeAll(terminationFutures);
 		}
 	}
 
@@ -522,6 +496,33 @@ public abstract class ClusterEntrypoint implements FatalErrorHandler {
 	// Internal methods
 	// --------------------------------------------------
 
+	private CompletableFuture<Void> shutDownAsync(boolean cleanupHaData) {
+		if (isShutDown.compareAndSet(false, true)) {
+			LOG.info("Stopping {}.", getClass().getSimpleName());
+
+			final CompletableFuture<Void> componentShutdownFuture = stopClusterComponents();
+
+			componentShutdownFuture.whenComplete(
+				(Void ignored1, Throwable componentThrowable) -> {
+					final CompletableFuture<Void> serviceShutdownFuture = stopClusterServices(cleanupHaData);
+
+					serviceShutdownFuture.whenComplete(
+						(Void ignored2, Throwable serviceThrowable) -> {
+							if (serviceThrowable != null) {
+								terminationFuture.completeExceptionally(
+									ExceptionUtils.firstOrSuppressed(serviceThrowable, componentThrowable));
+							} else if (componentThrowable != null) {
+								terminationFuture.completeExceptionally(componentThrowable);
+							} else {
+								terminationFuture.complete(null);
+							}
+						});
+				});
+		}
+
+		return terminationFuture;
+	}
+
 	private void shutDownAndTerminate(
 		int returnCode,
 		ApplicationStatus applicationStatus,
@@ -533,13 +534,14 @@ public abstract class ClusterEntrypoint implements FatalErrorHandler {
 			applicationStatus);
 
 		if (isTerminating.compareAndSet(false, true)) {
-			try {
-				shutDown(cleanupHaData);
-			} catch (Throwable t) {
-				LOG.info("Could not properly shut down cluster entrypoint.", t);
-			}
+			shutDownAsync(cleanupHaData).whenComplete(
+				(Void ignored, Throwable t) -> {
+					if (t != null) {
+						LOG.info("Could not properly shut down cluster entrypoint.", t);
+					}
 
-			System.exit(returnCode);
+					System.exit(returnCode);
+				});
 		} else {
 			LOG.debug("Concurrent termination call detected. Ignoring termination call with return code {} and application status {}.",
 				returnCode,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -437,7 +437,7 @@ public abstract class ClusterEntrypoint implements FatalErrorHandler {
 
 			if (commonRpcService != null) {
 				try {
-					commonRpcService.stopService();
+					commonRpcService.stopService().get();
 				} catch (Throwable t) {
 					exception = ExceptionUtils.firstOrSuppressed(t, exception);
 				}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedLeaderService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedLeaderService.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
+
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
@@ -38,7 +39,7 @@ import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * A simple leader election service, which selects a leader among contenders and notifies listeners.
- * 
+ *
  * <p>An election service for contenders can be created via {@link #createLeaderElectionService()},
  * a listener service for leader observers can be created via {@link #createLeaderRetrievalService()}.
  */
@@ -54,19 +55,19 @@ public class EmbeddedLeaderService {
 
 	private final Set<EmbeddedLeaderRetrievalService> listeners;
 
-	/** proposed leader, which has been notified of leadership grant, but has not confirmed */
+	/** proposed leader, which has been notified of leadership grant, but has not confirmed. */
 	private EmbeddedLeaderElectionService currentLeaderProposed;
 
-	/** actual leader that has confirmed leadership and of which listeners have been notified */
+	/** actual leader that has confirmed leadership and of which listeners have been notified. */
 	private EmbeddedLeaderElectionService currentLeaderConfirmed;
 
-	/** fencing UID for the current leader (or proposed leader) */
+	/** fencing UID for the current leader (or proposed leader). */
 	private UUID currentLeaderSessionId;
 
-	/** the cached address of the current leader */
+	/** the cached address of the current leader. */
 	private String currentLeaderAddress;
 
-	/** flag marking the service as terminated */
+	/** flag marking the service as terminated. */
 	private boolean shutdown;
 
 	// ------------------------------------------------------------------------
@@ -83,7 +84,7 @@ public class EmbeddedLeaderService {
 
 	/**
 	 * Shuts down this leader election service.
-	 * 
+	 *
 	 * <p>This method does not perform a clean revocation of the leader status and
 	 * no notification to any leader listeners. It simply notifies all contenders
 	 * and listeners that the service is no longer available.
@@ -364,7 +365,7 @@ public class EmbeddedLeaderService {
 			if (running) {
 				running = false;
 				isLeader = false;
-				contender.handleError(cause);
+				contender.revokeLeadership();
 				contender = null;
 			}
 		}
@@ -392,7 +393,6 @@ public class EmbeddedLeaderService {
 		public void shutdown(Exception cause) {
 			if (running) {
 				running = false;
-				listener.handleError(cause);
 				listener = null;
 			}
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerRunner.java
@@ -225,10 +225,10 @@ public class JobManagerRunner implements LeaderContender, OnCompletionActions, F
 
 				jobManager.shutDown();
 
-				final CompletableFuture<Boolean> jobManagerTerminationFuture = jobManager.getTerminationFuture();
+				final CompletableFuture<Void> jobManagerTerminationFuture = jobManager.getTerminationFuture();
 
 				jobManagerTerminationFuture.whenComplete(
-					(Boolean ignored, Throwable throwable) -> {
+					(Void ignored, Throwable throwable) -> {
 						try {
 							leaderElectionService.stop();
 						} catch (Throwable t) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -99,7 +99,6 @@ import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.util.clock.SystemClock;
 import org.apache.flink.runtime.webmonitor.WebMonitorUtils;
-import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.Preconditions;
@@ -123,7 +122,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -387,8 +385,8 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 	 * Suspend the job and shutdown all other services including rpc.
 	 */
 	@Override
-	public void postStop() throws Exception {
-		log.info("Stopping the JobMaster for job " + jobGraph.getName() + '(' + jobGraph.getJobID() + ").");
+	public CompletableFuture<Void> postStop() {
+		log.info("Stopping the JobMaster for job {}({}).", jobGraph.getName(), jobGraph.getJobID());
 
 		// disconnect from all registered TaskExecutors
 		final Set<ResourceID> taskManagerResourceIds = new HashSet<>(registeredTaskManagers.keySet());
@@ -407,28 +405,8 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 
 		// shut down will internally release all registered slots
 		slotPool.shutDown();
-		CompletableFuture<Void> terminationFuture = slotPool.getTerminationFuture();
 
-		Exception exception = null;
-
-		// wait for the slot pool shut down
-		try {
-			terminationFuture.get(rpcTimeout.toMilliseconds(), TimeUnit.MILLISECONDS);
-		} catch (Exception e) {
-			exception = e;
-		}
-
-		try {
-			super.postStop();
-		} catch (Exception e) {
-			exception = ExceptionUtils.firstOrSuppressed(e, exception);
-		}
-
-		if (exception != null) {
-			throw exception;
-		}
-
-		log.info("Stopped the JobMaster for job " + jobGraph.getName() + '(' + jobGraph.getJobID() + ").");
+		return slotPool.getTerminationFuture();
 	}
 
 	//----------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -407,7 +407,7 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 
 		// shut down will internally release all registered slots
 		slotPool.shutDown();
-		CompletableFuture<Boolean> terminationFuture = slotPool.getTerminationFuture();
+		CompletableFuture<Void> terminationFuture = slotPool.getTerminationFuture();
 
 		Exception exception = null;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
@@ -199,7 +199,7 @@ public class SlotPool extends RpcEndpoint implements SlotPoolGateway, AllocatedS
 	}
 
 	@Override
-	public void postStop() throws Exception {
+	public CompletableFuture<Void> postStop() {
 		// cancel all pending allocations
 		Set<AllocationID> allocationIds = pendingRequests.keySetB();
 
@@ -214,7 +214,7 @@ public class SlotPool extends RpcEndpoint implements SlotPoolGateway, AllocatedS
 
 		clear();
 
-		super.postStop();
+		return CompletableFuture.completedFuture(null);
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricRegistryImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricRegistryImpl.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.metrics;
 
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
@@ -28,34 +29,35 @@ import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.View;
 import org.apache.flink.metrics.reporter.MetricReporter;
 import org.apache.flink.metrics.reporter.Scheduled;
+import org.apache.flink.runtime.akka.ActorUtils;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.metrics.dump.MetricQueryService;
 import org.apache.flink.runtime.metrics.groups.AbstractMetricGroup;
 import org.apache.flink.runtime.metrics.groups.FrontMetricGroup;
 import org.apache.flink.runtime.metrics.scope.ScopeFormats;
 import org.apache.flink.runtime.util.ExecutorThreadFactory;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.ExecutorUtils;
+import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.Preconditions;
 
 import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
-import akka.actor.Kill;
-import akka.pattern.Patterns;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.TimerTask;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-
-import scala.concurrent.Await;
-import scala.concurrent.Future;
-import scala.concurrent.duration.FiniteDuration;
 
 /**
  * A MetricRegistry keeps track of all registered {@link Metric Metrics}. It serves as the
@@ -66,8 +68,14 @@ public class MetricRegistryImpl implements MetricRegistry {
 
 	private final Object lock = new Object();
 
-	private List<MetricReporter> reporters;
-	private ScheduledExecutorService executor;
+	private final List<MetricReporter> reporters;
+	private final ScheduledExecutorService executor;
+
+	private final ScopeFormats scopeFormats;
+	private final char globalDelimiter;
+	private final List<Character> delimiters;
+
+	private final CompletableFuture<Void> terminationFuture;
 
 	@Nullable
 	private ActorRef queryService;
@@ -77,9 +85,7 @@ public class MetricRegistryImpl implements MetricRegistry {
 
 	private ViewUpdater viewUpdater;
 
-	private final ScopeFormats scopeFormats;
-	private final char globalDelimiter;
-	private final List<Character> delimiters = new ArrayList<>();
+	private boolean isShutdown;
 
 	/**
 	 * Creates a new MetricRegistry and starts the configured reporter.
@@ -87,9 +93,12 @@ public class MetricRegistryImpl implements MetricRegistry {
 	public MetricRegistryImpl(MetricRegistryConfiguration config) {
 		this.scopeFormats = config.getScopeFormats();
 		this.globalDelimiter = config.getDelimiter();
+		this.delimiters = new ArrayList<>(10);
+		this.terminationFuture = new CompletableFuture<>();
+		this.isShutdown = false;
 
 		// second, instantiate any custom configured reporters
-		this.reporters = new ArrayList<>();
+		this.reporters = new ArrayList<>(4);
 
 		List<Tuple2<String, Configuration>> reporterConfigurations = config.getReporterConfigurations();
 
@@ -226,71 +235,72 @@ public class MetricRegistryImpl implements MetricRegistry {
 	 */
 	public boolean isShutdown() {
 		synchronized (lock) {
-			return reporters == null && executor.isShutdown();
+			return isShutdown;
 		}
 	}
 
 	/**
 	 * Shuts down this registry and the associated {@link MetricReporter}.
+	 *
+	 * <p>NOTE: This operation is asynchronous and returns a future which is completed
+	 * once the shutdown operation has been completed.
+	 *
+	 * @return Future which is completed once the {@link MetricRegistryImpl}
+	 * is shut down.
 	 */
-	public void shutdown() {
+	public CompletableFuture<Void> shutdown() {
 		synchronized (lock) {
-			Future<Boolean> stopFuture = null;
-			FiniteDuration stopTimeout = null;
+			if (isShutdown) {
+				return terminationFuture;
+			} else {
+				isShutdown = true;
+				final Collection<CompletableFuture<Void>> terminationFutures = new ArrayList<>(3);
+				final Time gracePeriod = Time.seconds(1L);
 
-			if (queryService != null) {
-				stopTimeout = new FiniteDuration(1L, TimeUnit.SECONDS);
+				if (queryService != null) {
+					final CompletableFuture<Void> queryServiceTerminationFuture = ActorUtils.nonBlockingShutDown(
+						gracePeriod.toMilliseconds(),
+						TimeUnit.MILLISECONDS,
+						queryService);
 
-				try {
-					stopFuture = Patterns.gracefulStop(queryService, stopTimeout);
-				} catch (IllegalStateException ignored) {
-					// this can happen if the underlying actor system has been stopped before shutting
-					// the metric registry down
-					// TODO: Pull the MetricQueryService actor out of the MetricRegistry
-					LOG.debug("The metric query service actor has already been stopped because the " +
-						"underlying ActorSystem has already been shut down.");
+					terminationFutures.add(queryServiceTerminationFuture);
 				}
-			}
 
-			if (reporters != null) {
+				Throwable throwable = null;
 				for (MetricReporter reporter : reporters) {
 					try {
 						reporter.close();
 					} catch (Throwable t) {
-						LOG.warn("Metrics reporter did not shut down cleanly", t);
+						throwable = ExceptionUtils.firstOrSuppressed(t, throwable);
 					}
 				}
-				reporters = null;
-			}
-			shutdownExecutor();
+				reporters.clear();
 
-			if (stopFuture != null) {
-				boolean stopped = false;
-
-				try {
-					stopped = Await.result(stopFuture, stopTimeout);
-				} catch (Exception e) {
-					LOG.warn("Query actor did not properly stop.", e);
+				if (throwable != null) {
+					terminationFutures.add(
+						FutureUtils.completedExceptionally(
+							new FlinkException("Could not shut down the metric reporters properly.", throwable)));
 				}
 
-				if (!stopped) {
-					// the query actor did not stop in time, let's kill him
-					queryService.tell(Kill.getInstance(), ActorRef.noSender());
-				}
-			}
-		}
-	}
+				final CompletableFuture<Void> executorShutdownFuture = ExecutorUtils.nonBlockingShutdown(
+					gracePeriod.toMilliseconds(),
+					TimeUnit.MILLISECONDS,
+					executor);
 
-	private void shutdownExecutor() {
-		if (executor != null) {
-			executor.shutdown();
+				terminationFutures.add(executorShutdownFuture);
 
-			try {
-				if (!executor.awaitTermination(1L, TimeUnit.SECONDS)) {
-					executor.shutdownNow();
-				}
-			} catch (InterruptedException e) {
-				executor.shutdownNow();
+				FutureUtils
+					.completeAll(terminationFutures)
+					.whenComplete(
+						(Void ignored, Throwable error) -> {
+							if (error != null) {
+								terminationFuture.completeExceptionally(error);
+							} else {
+								terminationFuture.complete(null);
+							}
+						});
+
+				return terminationFuture;
 			}
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -756,7 +756,7 @@ public class MiniCluster implements JobExecutorService, AutoCloseableAsync {
 	private static Throwable shutDownRpc(RpcService rpcService, Throwable priorException) {
 		if (rpcService != null) {
 			try {
-				rpcService.stopService();
+				rpcService.stopService().get();
 			}
 			catch (Throwable t) {
 				return ExceptionUtils.firstOrSuppressed(t, priorException);
@@ -773,7 +773,7 @@ public class MiniCluster implements JobExecutorService, AutoCloseableAsync {
 			for (RpcService service : rpcServices) {
 				try {
 					if (service != null) {
-						service.stopService();
+						service.stopService().get();
 					}
 				}
 				catch (Throwable t) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -65,6 +65,7 @@ import org.apache.flink.util.AutoCloseableAsync;
 import org.apache.flink.util.ExceptionUtils;
 
 import akka.actor.ActorSystem;
+import com.typesafe.config.Config;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -634,12 +635,17 @@ public class MiniCluster implements JobExecutorService, AutoCloseableAsync {
 			boolean remoteEnabled,
 			String bindAddress) {
 
-		ActorSystem actorSystem;
+		final Config akkaConfig;
+
 		if (remoteEnabled) {
-			actorSystem = AkkaUtils.createActorSystem(configuration, bindAddress, 0);
+			akkaConfig = AkkaUtils.getAkkaConfig(configuration, bindAddress, 0);
 		} else {
-			actorSystem = AkkaUtils.createLocalActorSystem(configuration);
+			akkaConfig = AkkaUtils.getAkkaConfig(configuration);
 		}
+
+		final Config effectiveAkkaConfig = AkkaUtils.testDispatcherConfig().withFallback(akkaConfig);
+
+		final ActorSystem actorSystem = AkkaUtils.createActorSystem(effectiveAkkaConfig);
 
 		return new AkkaRpcService(actorSystem, askTimeout);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -213,7 +213,7 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 	}
 
 	@Override
-	public void postStop() throws Exception {
+	public CompletableFuture<Void> postStop() {
 		Exception exception = null;
 
 		taskManagerHeartbeatManager.stop();
@@ -240,14 +240,11 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 
 		clearState();
 
-		try {
-			super.postStop();
-		} catch (Exception e) {
-			exception = ExceptionUtils.firstOrSuppressed(e, exception);
-		}
-
 		if (exception != null) {
-			ExceptionUtils.rethrowException(exception, "Error while shutting the ResourceManager down.");
+			return FutureUtils.completedExceptionally(
+				new FlinkException("Could not properly shut down the ResourceManager.", exception));
+		} else {
+			return CompletableFuture.completedFuture(null);
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/FencedRpcEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/FencedRpcEndpoint.java
@@ -35,7 +35,7 @@ import java.util.concurrent.CompletableFuture;
  *
  * @param <F> type of the fencing token
  */
-public class FencedRpcEndpoint<F extends Serializable> extends RpcEndpoint {
+public abstract class FencedRpcEndpoint<F extends Serializable> extends RpcEndpoint {
 
 	private volatile F fencingToken;
 	private volatile MainThreadExecutor fencedMainThreadExecutor;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcEndpoint.java
@@ -228,7 +228,7 @@ public abstract class RpcEndpoint implements RpcGateway {
 	 *
 	 * @return Future which is completed when the rpc endpoint has been terminated.
 	 */
-	public CompletableFuture<Boolean> getTerminationFuture() {
+	public CompletableFuture<Void> getTerminationFuture() {
 		return rpcServer.getTerminationFuture();
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcEndpoint.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.rpc;
 
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.util.Preconditions;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,17 +38,15 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * Base class for RPC endpoints. Distributed components which offer remote procedure calls have to
- * extend the RPC endpoint base class. An RPC endpoint is backed by an {@link RpcService}. 
- * 
+ * extend the RPC endpoint base class. An RPC endpoint is backed by an {@link RpcService}.
+ *
  * <h1>Endpoint and Gateway</h1>
- * 
  * To be done...
- * 
  * <h1>Single Threaded Endpoint Execution </h1>
- * 
+ *
  * <p>All RPC calls on the same endpoint are called by the same thread
  * (referred to as the endpoint's <i>main thread</i>).
- * Thus, by executing all state changing operations within the main 
+ * Thus, by executing all state changing operations within the main
  * thread, we don't have to reason about concurrent accesses, in the same way in the Actor Model
  * of Erlang or Akka.
  *
@@ -60,16 +59,16 @@ public abstract class RpcEndpoint implements RpcGateway {
 
 	// ------------------------------------------------------------------------
 
-	/** RPC service to be used to start the RPC server and to obtain rpc gateways */
+	/** RPC service to be used to start the RPC server and to obtain rpc gateways. */
 	private final RpcService rpcService;
 
-	/** Unique identifier for this rpc endpoint */
+	/** Unique identifier for this rpc endpoint. */
 	private final String endpointId;
 
-	/** Interface to access the underlying rpc server */
+	/** Interface to access the underlying rpc server. */
 	protected final RpcServer rpcServer;
 
-	/** A reference to the endpoint's main thread, if the current method is called by the main thread */
+	/** A reference to the endpoint's main thread, if the current method is called by the main thread. */
 	final AtomicReference<Thread> currentMainThread = new AtomicReference<>(null);
 
 	/** The main thread executor to be used to execute future callbacks in the main thread
@@ -78,7 +77,7 @@ public abstract class RpcEndpoint implements RpcGateway {
 
 	/**
 	 * Initializes the RPC endpoint.
-	 * 
+	 *
 	 * @param rpcService The RPC server that dispatches calls to this RPC endpoint.
 	 * @param endpointId Unique identifier for this endpoint
 	 */
@@ -117,7 +116,7 @@ public abstract class RpcEndpoint implements RpcGateway {
 	 * Starts the rpc endpoint. This tells the underlying rpc server that the rpc endpoint is ready
 	 * to process remote procedure calls.
 	 *
-	 * IMPORTANT: Whenever you override this method, call the parent implementation to enable
+	 * <p>IMPORTANT: Whenever you override this method, call the parent implementation to enable
 	 * rpc processing. It is advised to make the parent call last.
 	 *
 	 * @throws Exception indicating that something went wrong while starting the RPC endpoint
@@ -140,7 +139,7 @@ public abstract class RpcEndpoint implements RpcGateway {
 	 * <p>This method is called when the RpcEndpoint is being shut down. The method is guaranteed
 	 * to be executed in the main thread context and can be used to clean up internal state.
 	 *
-	 * IMPORTANT: This method should never be called directly by the user.
+	 * <p>IMPORTANT: This method should never be called directly by the user.
 	 *
 	 * @throws Exception if an error occurs. The exception is returned as result of the termination future.
 	 */
@@ -288,15 +287,15 @@ public abstract class RpcEndpoint implements RpcGateway {
 
 	/**
 	 * Validates that the method call happens in the RPC endpoint's main thread.
-	 * 
+	 *
 	 * <p><b>IMPORTANT:</b> This check only happens when assertions are enabled,
 	 * such as when running tests.
-	 * 
+	 *
 	 * <p>This can be used for additional checks, like
 	 * <pre>{@code
 	 * protected void concurrencyCriticalMethod() {
 	 *     validateRunsInMainThread();
-	 *     
+	 *
 	 *     // some critical stuff
 	 * }
 	 * }</pre>
@@ -308,7 +307,7 @@ public abstract class RpcEndpoint implements RpcGateway {
 	// ------------------------------------------------------------------------
 	//  Utilities
 	// ------------------------------------------------------------------------
-	
+
 	/**
 	 * Executor which executes runnables in the main thread context.
 	 */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcEndpoint.java
@@ -141,9 +141,10 @@ public abstract class RpcEndpoint implements RpcGateway {
 	 *
 	 * <p>IMPORTANT: This method should never be called directly by the user.
 	 *
-	 * @throws Exception if an error occurs. The exception is returned as result of the termination future.
+	 * @return Future which is completed once all post stop actions are completed. If an error
+	 * occurs this future is completed exceptionally
 	 */
-	public void postStop() throws Exception {}
+	public abstract CompletableFuture<Void> postStop();
 
 	/**
 	 * Triggers the shut down of the rpc endpoint. The shut down is executed asynchronously.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcServer.java
@@ -30,5 +30,5 @@ public interface RpcServer extends StartStoppable, MainThreadExecutable, RpcGate
 	 *
 	 * @return Future indicating when the rpc endpoint has been terminated
 	 */
-	CompletableFuture<Boolean> getTerminationFuture();
+	CompletableFuture<Void> getTerminationFuture();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcService.java
@@ -116,9 +116,12 @@ public interface RpcService {
 	void stopServer(RpcServer selfGateway);
 
 	/**
-	 * Stop the rpc service shutting down all started rpc servers.
+	 * Trigger the asynchronous stopping of the {@link RpcService}.
+	 *
+	 * @return Future which is completed once the {@link RpcService} has been
+	 * fully stopped.
 	 */
-	void stopService();
+	CompletableFuture<Void> stopService();
 
 	/**
 	 * Returns a future indicating when the RPC service has been shut down.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcUtils.java
@@ -50,7 +50,7 @@ public class RpcUtils {
 		while (clazz != null) {
 			for (Class<?> interfaze : clazz.getInterfaces()) {
 				if (RpcGateway.class.isAssignableFrom(interfaze)) {
-					interfaces.add((Class<? extends RpcGateway>)interfaze);
+					interfaces.add((Class<? extends RpcGateway>) interfaze);
 				}
 			}
 
@@ -65,13 +65,26 @@ public class RpcUtils {
 	 *
 	 * @param rpcEndpoint to terminate
 	 * @param timeout for this operation
-	 * @throws ExecutionException if a problem occurs
+	 * @throws ExecutionException if a problem occurred
 	 * @throws InterruptedException if the operation has been interrupted
 	 * @throws TimeoutException if a timeout occurred
 	 */
 	public static void terminateRpcEndpoint(RpcEndpoint rpcEndpoint, Time timeout) throws ExecutionException, InterruptedException, TimeoutException {
 		rpcEndpoint.shutDown();
 		rpcEndpoint.getTerminationFuture().get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+	}
+
+	/**
+	 * Shuts the given rpc service down and waits for its termination.
+	 *
+	 * @param rpcService to shut down
+	 * @param timeout for this operation
+	 * @throws InterruptedException if the operation has been interrupted
+	 * @throws ExecutionException if a problem occurred
+	 * @throws TimeoutException if a timeout occurred
+	 */
+	public static void terminateRpcService(RpcService rpcService, Time timeout) throws InterruptedException, ExecutionException, TimeoutException {
+		rpcService.stopService().get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
 	}
 
 	// We don't want this class to be instantiable

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaInvocationHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaInvocationHandler.java
@@ -84,7 +84,7 @@ class AkkaInvocationHandler implements InvocationHandler, AkkaBasedEndpoint, Rpc
 
 	// null if gateway; otherwise non-null
 	@Nullable
-	private final CompletableFuture<Boolean> terminationFuture;
+	private final CompletableFuture<Void> terminationFuture;
 
 	AkkaInvocationHandler(
 			String address,
@@ -92,7 +92,7 @@ class AkkaInvocationHandler implements InvocationHandler, AkkaBasedEndpoint, Rpc
 			ActorRef rpcEndpoint,
 			Time timeout,
 			long maximumFramesize,
-			@Nullable CompletableFuture<Boolean> terminationFuture) {
+			@Nullable CompletableFuture<Void> terminationFuture) {
 
 		this.address = Preconditions.checkNotNull(address);
 		this.hostname = Preconditions.checkNotNull(hostname);
@@ -341,7 +341,7 @@ class AkkaInvocationHandler implements InvocationHandler, AkkaBasedEndpoint, Rpc
 	}
 
 	@Override
-	public CompletableFuture<Boolean> getTerminationFuture() {
+	public CompletableFuture<Void> getTerminationFuture() {
 		return terminationFuture;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcService.java
@@ -42,6 +42,7 @@ import akka.actor.Address;
 import akka.actor.Identify;
 import akka.actor.PoisonPill;
 import akka.actor.Props;
+import akka.actor.Terminated;
 import akka.dispatch.Futures;
 import akka.dispatch.Mapper;
 import akka.pattern.Patterns;
@@ -98,6 +99,8 @@ public class AkkaRpcService implements RpcService {
 
 	private final ScheduledExecutor internalScheduledExecutor;
 
+	private final CompletableFuture<Void> terminationFuture;
+
 	private volatile boolean stopped;
 
 	public AkkaRpcService(final ActorSystem actorSystem, final Time timeout) {
@@ -126,6 +129,8 @@ public class AkkaRpcService implements RpcService {
 		}
 
 		internalScheduledExecutor = new ActorSystemScheduledExecutorAdapter(actorSystem);
+
+		terminationFuture = new CompletableFuture<>();
 
 		stopped = false;
 	}
@@ -311,33 +316,40 @@ public class AkkaRpcService implements RpcService {
 	}
 
 	@Override
-	public void stopService() {
-		LOG.info("Stopping Akka RPC service.");
-
+	public CompletableFuture<Void> stopService() {
 		synchronized (lock) {
 			if (stopped) {
-				return;
+				return terminationFuture;
 			}
 
 			stopped = true;
-
 		}
 
-		actorSystem.shutdown();
-		actorSystem.awaitTermination();
+		LOG.info("Stopping Akka RPC service.");
 
-		synchronized (lock) {
-			actors.clear();
-		}
+		final CompletableFuture<Terminated> actorSytemTerminationFuture = FutureUtils.toJava(actorSystem.terminate());
 
-		LOG.info("Stopped Akka RPC service.");
+		actorSytemTerminationFuture.whenComplete(
+			(Terminated ignored, Throwable throwable) -> {
+				synchronized (lock) {
+					actors.clear();
+				}
+
+				if (throwable != null) {
+					terminationFuture.completeExceptionally(throwable);
+				} else {
+					terminationFuture.complete(null);
+				}
+
+				LOG.info("Stopped Akka RPC service.");
+			});
+
+		return terminationFuture;
 	}
 
 	@Override
 	public CompletableFuture<Void> getTerminationFuture() {
-		return CompletableFuture.runAsync(
-			actorSystem::awaitTermination,
-			getExecutor());
+		return terminationFuture;
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcService.java
@@ -195,7 +195,7 @@ public class AkkaRpcService implements RpcService {
 	public <C extends RpcEndpoint & RpcGateway> RpcServer startServer(C rpcEndpoint) {
 		checkNotNull(rpcEndpoint, "rpc endpoint");
 
-		CompletableFuture<Boolean> terminationFuture = new CompletableFuture<>();
+		CompletableFuture<Void> terminationFuture = new CompletableFuture<>();
 		final Props akkaRpcActorProps;
 
 		if (rpcEndpoint instanceof FencedRpcEndpoint) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/FencedAkkaInvocationHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/FencedAkkaInvocationHandler.java
@@ -60,7 +60,7 @@ public class FencedAkkaInvocationHandler<F extends Serializable> extends AkkaInv
 			ActorRef rpcEndpoint,
 			Time timeout,
 			long maximumFramesize,
-			@Nullable CompletableFuture<Boolean> terminationFuture,
+			@Nullable CompletableFuture<Void> terminationFuture,
 			Supplier<F> fencingTokenSupplier) {
 		super(address, hostname, rpcEndpoint, timeout, maximumFramesize, terminationFuture);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -254,7 +254,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 	 * Called to shut down the TaskManager. The method closes all TaskManager services.
 	 */
 	@Override
-	public void postStop() throws Exception {
+	public CompletableFuture<Void> postStop() {
 		log.info("Stopping TaskManager {}.", getAddress());
 
 		Throwable throwable = null;
@@ -281,17 +281,11 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 			throwable = ExceptionUtils.firstOrSuppressed(t, throwable);
 		}
 
-		try {
-			super.postStop();
-		} catch (Throwable e) {
-			throwable = ExceptionUtils.firstOrSuppressed(e, throwable);
-		}
-
 		if (throwable != null) {
-			ExceptionUtils.rethrowException(throwable, "Error while shutting the TaskExecutor down.");
+			return FutureUtils.completedExceptionally(new FlinkException("Error while shutting the TaskExecutor down.", throwable));
+		} else {
+			return CompletableFuture.completedFuture(null);
 		}
-
-		log.info("Stopped TaskManager {}.", getAddress());
 	}
 
 	// ======================================================================

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -198,7 +198,7 @@ public class TaskManagerRunner implements FatalErrorHandler {
 	}
 
 	// export the termination future for caller to know it is terminated
-	public CompletableFuture<Boolean> getTerminationFuture() {
+	public CompletableFuture<Void> getTerminationFuture() {
 		return taskManager.getTerminationFuture();
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -173,7 +173,15 @@ public class TaskManagerRunner implements FatalErrorHandler {
 				exception = ExceptionUtils.firstOrSuppressed(e, exception);
 			}
 
-			rpcService.stopService();
+			try {
+				rpcService.stopService().get();
+			} catch (InterruptedException ie) {
+				exception = ExceptionUtils.firstOrSuppressed(ie, exception);
+
+				Thread.currentThread().interrupt();
+			} catch (Exception e) {
+				exception = ExceptionUtils.firstOrSuppressed(e, exception);
+			}
 
 			try {
 				highAvailabilityServices.close();

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -2054,7 +2054,7 @@ object JobManager {
     }
 
     try {
-      metricRegistry.shutdown()
+      metricRegistry.shutdown().get()
     } catch {
       case t: Throwable =>
         LOG.warn("Could not properly shut down the metric registry.", t)

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/minicluster/FlinkMiniCluster.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/minicluster/FlinkMiniCluster.scala
@@ -468,7 +468,7 @@ abstract class FlinkMiniCluster(
 
     Await.ready(Future.sequence(jmFutures ++ tmFutures ++ rmFutures), timeout)
 
-    metricRegistryOpt.foreach(_.shutdown())
+    metricRegistryOpt.foreach(_.shutdown().get())
 
     if (!useSingleActorSystem) {
       taskManagerActorSystems foreach {

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -1900,7 +1900,7 @@ object TaskManager {
 
     // shut down the metric query service
     try {
-      metricRegistry.shutdown()
+      metricRegistry.shutdown().get()
     } catch {
       case t: Throwable =>
         LOG.error("Could not properly shut down the metric registry.", t)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/ResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/ResourceManagerTest.java
@@ -53,6 +53,7 @@ import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
 import org.apache.flink.runtime.resourcemanager.StandaloneResourceManager;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
+import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.taskexecutor.SlotReport;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
@@ -578,7 +579,7 @@ public class ResourceManagerTest extends TestLogger {
 			verify(taskExecutorGateway, Mockito.timeout(timeout.toMilliseconds())).disconnectResourceManager(any(TimeoutException.class));
 
 		} finally {
-			rpcService.stopService();
+			RpcUtils.terminateRpcService(rpcService, timeout);
 		}
 	}
 
@@ -680,7 +681,7 @@ public class ResourceManagerTest extends TestLogger {
 			verify(jobMasterGateway, Mockito.timeout(timeout.toMilliseconds())).disconnectResourceManager(eq(rmLeaderId), any(TimeoutException.class));
 
 		} finally {
-			rpcService.stopService();
+			RpcUtils.terminateRpcService(rpcService, timeout);
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -134,9 +134,9 @@ public class DispatcherTest extends TestLogger {
 	}
 
 	@AfterClass
-	public static void teardownClass() {
+	public static void teardownClass() throws Exception {
 		if (rpcService != null) {
-			rpcService.stopService();
+			RpcUtils.terminateRpcService(rpcService, TIMEOUT);
 
 			rpcService = null;
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/MiniDispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/MiniDispatcherTest.java
@@ -222,7 +222,7 @@ public class MiniDispatcherTest extends TestLogger {
 
 			resultFuture.complete(archivedExecutionGraph);
 
-			final CompletableFuture<Boolean> terminationFuture = miniDispatcher.getTerminationFuture();
+			final CompletableFuture<Void> terminationFuture = miniDispatcher.getTerminationFuture();
 
 			assertThat(terminationFuture.isDone(), is(false));
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/MiniDispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/MiniDispatcherTest.java
@@ -61,6 +61,8 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -143,13 +145,13 @@ public class MiniDispatcherTest extends TestLogger {
 	}
 
 	@AfterClass
-	public static void teardownClass() throws IOException {
+	public static void teardownClass() throws IOException, InterruptedException, ExecutionException, TimeoutException {
 		if (blobServer != null) {
 			blobServer.close();
 		}
 
 		if (rpcService != null) {
-			rpcService.stopService();
+			RpcUtils.terminateRpcService(rpcService, timeout);
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/SchedulerTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/SchedulerTestBase.java
@@ -117,7 +117,7 @@ public class SchedulerTestBase extends TestLogger {
 		}
 
 		if (rpcService != null) {
-			rpcService.stopService();
+			rpcService.stopService().get();
 			rpcService = null;
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolRpcTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolRpcTest.java
@@ -92,9 +92,9 @@ public class SlotPoolRpcTest extends TestLogger {
 	}
 
 	@AfterClass
-	public static  void shutdown() {
+	public static  void shutdown() throws InterruptedException, ExecutionException, TimeoutException {
 		if (rpcService != null) {
-			rpcService.stopService();
+			RpcUtils.terminateRpcService(rpcService, timeout);
 			rpcService = null;
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolSchedulingTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolSchedulingTestBase.java
@@ -64,9 +64,9 @@ public class SlotPoolSchedulingTestBase extends TestLogger {
 	}
 
 	@AfterClass
-	public static void teardown() {
+	public static void teardown() throws ExecutionException, InterruptedException {
 		if (testingRpcService != null) {
-			testingRpcService.stopService();
+			testingRpcService.stopService().get();
 			testingRpcService = null;
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolTest.java
@@ -104,7 +104,7 @@ public class SlotPoolTest extends TestLogger {
 
 	@After
 	public void tearDown() throws Exception {
-		rpcService.stopService();
+		RpcUtils.terminateRpcService(rpcService, timeout);
 	}
 
 	@Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/MetricRegistryImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/MetricRegistryImplTest.java
@@ -59,12 +59,12 @@ public class MetricRegistryImplTest extends TestLogger {
 	private static final char GLOBAL_DEFAULT_DELIMITER = '.';
 
 	@Test
-	public void testIsShutdown() {
+	public void testIsShutdown() throws Exception {
 		MetricRegistryImpl metricRegistry = new MetricRegistryImpl(MetricRegistryConfiguration.defaultMetricRegistryConfiguration());
 
 		Assert.assertFalse(metricRegistry.isShutdown());
 
-		metricRegistry.shutdown();
+		metricRegistry.shutdown().get();
 
 		Assert.assertTrue(metricRegistry.isShutdown());
 	}
@@ -73,7 +73,7 @@ public class MetricRegistryImplTest extends TestLogger {
 	 * Verifies that the reporter name list is correctly used to determine which reporters should be instantiated.
 	 */
 	@Test
-	public void testReporterInclusion() {
+	public void testReporterInclusion() throws Exception {
 		Configuration config = new Configuration();
 
 		config.setString(MetricOptions.REPORTERS_LIST, "test");
@@ -87,7 +87,7 @@ public class MetricRegistryImplTest extends TestLogger {
 		Assert.assertTrue(TestReporter1.wasOpened);
 		Assert.assertFalse(TestReporter11.wasOpened);
 
-		metricRegistry.shutdown();
+		metricRegistry.shutdown().get();
 	}
 
 	/**
@@ -106,7 +106,7 @@ public class MetricRegistryImplTest extends TestLogger {
 	 * Verifies that multiple reporters are instantiated correctly.
 	 */
 	@Test
-	public void testMultipleReporterInstantiation() {
+	public void testMultipleReporterInstantiation() throws Exception {
 		Configuration config = new Configuration();
 
 		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test1." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, TestReporter11.class.getName());
@@ -121,7 +121,7 @@ public class MetricRegistryImplTest extends TestLogger {
 		Assert.assertTrue(TestReporter12.wasOpened);
 		Assert.assertTrue(TestReporter13.wasOpened);
 
-		metricRegistry.shutdown();
+		metricRegistry.shutdown().get();
 	}
 
 	/**
@@ -164,14 +164,14 @@ public class MetricRegistryImplTest extends TestLogger {
 	 * Verifies that configured arguments are properly forwarded to the reporter.
 	 */
 	@Test
-	public void testReporterArgumentForwarding() {
+	public void testReporterArgumentForwarding() throws Exception {
 		Configuration config = new Configuration();
 
 		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, TestReporter2.class.getName());
 		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test.arg1", "hello");
 		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test.arg2", "world");
 
-		new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(config)).shutdown();
+		new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(config)).shutdown().get();
 
 		Assert.assertEquals("hello", TestReporter2.mc.getString("arg1", null));
 		Assert.assertEquals("world", TestReporter2.mc.getString("arg2", null));
@@ -190,11 +190,9 @@ public class MetricRegistryImplTest extends TestLogger {
 
 	/**
 	 * Verifies that reporters implementing the Scheduled interface are regularly called to report the metrics.
-	 *
-	 * @throws InterruptedException
 	 */
 	@Test
-	public void testReporterScheduling() throws InterruptedException {
+	public void testReporterScheduling() throws Exception {
 		Configuration config = new Configuration();
 
 		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, TestReporter3.class.getName());
@@ -225,7 +223,7 @@ public class MetricRegistryImplTest extends TestLogger {
 		}
 		Assert.assertTrue("No report was triggered.", TestReporter3.reportCount > 0);
 
-		registry.shutdown();
+		registry.shutdown().get();
 	}
 
 	/**
@@ -244,7 +242,7 @@ public class MetricRegistryImplTest extends TestLogger {
 	 * Verifies that reporters are notified of added/removed metrics.
 	 */
 	@Test
-	public void testReporterNotifications() {
+	public void testReporterNotifications() throws Exception {
 		Configuration config = new Configuration();
 		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test1." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, TestReporter6.class.getName());
 		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test2." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, TestReporter7.class.getName());
@@ -268,7 +266,7 @@ public class MetricRegistryImplTest extends TestLogger {
 		assertTrue(TestReporter7.removedMetric instanceof Counter);
 		assertEquals("rootCounter", TestReporter7.removedMetricName);
 
-		registry.shutdown();
+		registry.shutdown().get();
 	}
 
 	/**
@@ -338,7 +336,7 @@ public class MetricRegistryImplTest extends TestLogger {
 	}
 
 	@Test
-	public void testConfigurableDelimiter() {
+	public void testConfigurableDelimiter() throws Exception {
 		Configuration config = new Configuration();
 		config.setString(MetricOptions.SCOPE_DELIMITER, "_");
 		config.setString(MetricOptions.SCOPE_NAMING_TM, "A.B.C.D.E");
@@ -348,11 +346,11 @@ public class MetricRegistryImplTest extends TestLogger {
 		TaskManagerMetricGroup tmGroup = new TaskManagerMetricGroup(registry, "host", "id");
 		assertEquals("A_B_C_D_E_name", tmGroup.getMetricIdentifier("name"));
 
-		registry.shutdown();
+		registry.shutdown().get();
 	}
 
 	@Test
-	public void testConfigurableDelimiterForReporters() {
+	public void testConfigurableDelimiterForReporters() throws Exception {
 		Configuration config = new Configuration();
 		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test1." + ConfigConstants.METRICS_REPORTER_SCOPE_DELIMITER, "_");
 		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test1." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, TestReporter.class.getName());
@@ -370,11 +368,11 @@ public class MetricRegistryImplTest extends TestLogger {
 		assertEquals(GLOBAL_DEFAULT_DELIMITER, registry.getDelimiter(3));
 		assertEquals(GLOBAL_DEFAULT_DELIMITER, registry.getDelimiter(-1));
 
-		registry.shutdown();
+		registry.shutdown().get();
 	}
 
 	@Test
-	public void testConfigurableDelimiterForReportersInGroup() {
+	public void testConfigurableDelimiterForReportersInGroup() throws Exception {
 		Configuration config = new Configuration();
 		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test1." + ConfigConstants.METRICS_REPORTER_SCOPE_DELIMITER, "_");
 		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test1." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, TestReporter8.class.getName());
@@ -395,7 +393,7 @@ public class MetricRegistryImplTest extends TestLogger {
 		TaskManagerMetricGroup group = new TaskManagerMetricGroup(registry, "host", "id");
 		group.counter("C");
 		group.close();
-		registry.shutdown();
+		registry.shutdown().get();
 		assertEquals(4, TestReporter8.numCorrectDelimitersForRegister);
 		assertEquals(4, TestReporter8.numCorrectDelimitersForUnregister);
 	}
@@ -415,7 +413,7 @@ public class MetricRegistryImplTest extends TestLogger {
 
 		ActorRef queryServiceActor = registry.getQueryService();
 
-		registry.shutdown();
+		registry.shutdown().get();
 
 		try {
 			Await.result(actorSystem.actorSelection(queryServiceActor.path()).resolveOne(timeout), timeout);
@@ -471,7 +469,7 @@ public class MetricRegistryImplTest extends TestLogger {
 		assertEquals(metric, TestReporter7.removedMetric);
 		assertEquals("counter", TestReporter7.removedMetricName);
 
-		registry.shutdown();
+		registry.shutdown().get();
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/TaskManagerMetricsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/TaskManagerMetricsTest.java
@@ -162,7 +162,7 @@ public class TaskManagerMetricsTest extends TestLogger {
 				highAvailabilityServices.closeAndCleanupAllData();
 			}
 
-			metricRegistry.shutdown();
+			metricRegistry.shutdown().get();
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroupTest.java
@@ -44,7 +44,7 @@ public class AbstractMetricGroupTest {
 	 * called and the parent is null.
 	 */
 	@Test
-	public void testGetAllVariables() {
+	public void testGetAllVariables() throws Exception {
 		MetricRegistryImpl registry = new MetricRegistryImpl(MetricRegistryConfiguration.defaultMetricRegistryConfiguration());
 
 		AbstractMetricGroup group = new AbstractMetricGroup<AbstractMetricGroup<?>>(registry, new String[0], null) {
@@ -60,7 +60,7 @@ public class AbstractMetricGroupTest {
 		};
 		assertTrue(group.getAllVariables().isEmpty());
 
-		registry.shutdown();
+		registry.shutdown().get();
 	}
 
 	// ========================================================================
@@ -101,7 +101,7 @@ public class AbstractMetricGroupTest {
 				}
 			}
 		} finally {
-			testRegistry.shutdown();
+			testRegistry.shutdown().get();
 		}
 	}
 
@@ -176,7 +176,7 @@ public class AbstractMetricGroupTest {
 	}
 
 	@Test
-	public void testScopeGenerationWithoutReporters() {
+	public void testScopeGenerationWithoutReporters() throws Exception {
 		Configuration config = new Configuration();
 		config.setString(MetricOptions.SCOPE_NAMING_TM, "A.B.C.D");
 		MetricRegistryImpl testRegistry = new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(config));
@@ -193,7 +193,7 @@ public class AbstractMetricGroupTest {
 			assertEquals("A.X.C.D.1", group.getMetricIdentifier("1", FILTER_B, -1));
 			assertEquals("A.X.C.D.1", group.getMetricIdentifier("1", FILTER_B, 2));
 		} finally {
-			testRegistry.shutdown();
+			testRegistry.shutdown().get();
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/JobManagerGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/JobManagerGroupTest.java
@@ -44,7 +44,7 @@ public class JobManagerGroupTest extends TestLogger {
 	// ------------------------------------------------------------------------
 
 	@Test
-	public void addAndRemoveJobs() {
+	public void addAndRemoveJobs() throws Exception {
 		MetricRegistryImpl registry = new MetricRegistryImpl(MetricRegistryConfiguration.defaultMetricRegistryConfiguration());
 		final JobManagerMetricGroup group = new JobManagerMetricGroup(registry, "localhost");
 
@@ -72,11 +72,11 @@ public class JobManagerGroupTest extends TestLogger {
 		assertTrue(jmJobGroup21.isClosed());
 		assertEquals(0, group.numRegisteredJobMetricGroups());
 
-		registry.shutdown();
+		registry.shutdown().get();
 	}
 
 	@Test
-	public void testCloseClosesAll() {
+	public void testCloseClosesAll() throws Exception {
 		MetricRegistryImpl registry = new MetricRegistryImpl(MetricRegistryConfiguration.defaultMetricRegistryConfiguration());
 		final JobManagerMetricGroup group = new JobManagerMetricGroup(registry, "localhost");
 
@@ -94,7 +94,7 @@ public class JobManagerGroupTest extends TestLogger {
 		assertTrue(jmJobGroup11.isClosed());
 		assertTrue(jmJobGroup21.isClosed());
 
-		registry.shutdown();
+		registry.shutdown().get();
 	}
 
 	// ------------------------------------------------------------------------
@@ -102,18 +102,18 @@ public class JobManagerGroupTest extends TestLogger {
 	// ------------------------------------------------------------------------
 
 	@Test
-	public void testGenerateScopeDefault() {
+	public void testGenerateScopeDefault() throws Exception {
 		MetricRegistryImpl registry = new MetricRegistryImpl(MetricRegistryConfiguration.defaultMetricRegistryConfiguration());
 		JobManagerMetricGroup group = new JobManagerMetricGroup(registry, "localhost");
 
 		assertArrayEquals(new String[]{"localhost", "jobmanager"}, group.getScopeComponents());
 		assertEquals("localhost.jobmanager.name", group.getMetricIdentifier("name"));
 
-		registry.shutdown();
+		registry.shutdown().get();
 	}
 
 	@Test
-	public void testGenerateScopeCustom() {
+	public void testGenerateScopeCustom() throws Exception {
 		Configuration cfg = new Configuration();
 		cfg.setString(MetricOptions.SCOPE_NAMING_JM, "constant.<host>.foo.<host>");
 		MetricRegistryImpl registry = new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(cfg));
@@ -123,7 +123,7 @@ public class JobManagerGroupTest extends TestLogger {
 		assertArrayEquals(new String[]{"constant", "host", "foo", "host"}, group.getScopeComponents());
 		assertEquals("constant.host.foo.host.name", group.getMetricIdentifier("name"));
 
-		registry.shutdown();
+		registry.shutdown().get();
 	}
 
 	@Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/JobManagerJobGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/JobManagerJobGroupTest.java
@@ -38,7 +38,7 @@ import static org.junit.Assert.assertEquals;
 public class JobManagerJobGroupTest extends TestLogger {
 
 	@Test
-	public void testGenerateScopeDefault() {
+	public void testGenerateScopeDefault() throws Exception {
 		MetricRegistryImpl registry = new MetricRegistryImpl(MetricRegistryConfiguration.defaultMetricRegistryConfiguration());
 
 		JobManagerMetricGroup tmGroup = new JobManagerMetricGroup(registry, "theHostName");
@@ -52,11 +52,11 @@ public class JobManagerJobGroupTest extends TestLogger {
 				"theHostName.jobmanager.myJobName.name",
 				jmGroup.getMetricIdentifier("name"));
 
-		registry.shutdown();
+		registry.shutdown().get();
 	}
 
 	@Test
-	public void testGenerateScopeCustom() {
+	public void testGenerateScopeCustom() throws Exception {
 		Configuration cfg = new Configuration();
 		cfg.setString(MetricOptions.SCOPE_NAMING_JM, "abc");
 		cfg.setString(MetricOptions.SCOPE_NAMING_JM_JOB, "some-constant.<job_name>");
@@ -75,11 +75,11 @@ public class JobManagerJobGroupTest extends TestLogger {
 				"some-constant.myJobName.name",
 				jmGroup.getMetricIdentifier("name"));
 
-		registry.shutdown();
+		registry.shutdown().get();
 	}
 
 	@Test
-	public void testGenerateScopeCustomWildcard() {
+	public void testGenerateScopeCustomWildcard() throws Exception {
 		Configuration cfg = new Configuration();
 		cfg.setString(MetricOptions.SCOPE_NAMING_JM, "peter");
 		cfg.setString(MetricOptions.SCOPE_NAMING_JM_JOB, "*.some-constant.<job_id>");
@@ -98,7 +98,7 @@ public class JobManagerJobGroupTest extends TestLogger {
 				"peter.some-constant." + jid + ".name",
 				jmGroup.getMetricIdentifier("name"));
 
-		registry.shutdown();
+		registry.shutdown().get();
 	}
 
 	@Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/MetricGroupRegistrationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/MetricGroupRegistrationTest.java
@@ -44,7 +44,7 @@ public class MetricGroupRegistrationTest extends TestLogger {
 	 * Verifies that group methods instantiate the correct metric with the given name.
 	 */
 	@Test
-	public void testMetricInstantiation() {
+	public void testMetricInstantiation() throws Exception {
 		Configuration config = new Configuration();
 		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, TestReporter1.class.getName());
 
@@ -85,7 +85,7 @@ public class MetricGroupRegistrationTest extends TestLogger {
 
 		Assert.assertEquals(histogram, TestReporter1.lastPassedMetric);
 		assertEquals("histogram", TestReporter1.lastPassedName);
-		registry.shutdown();
+		registry.shutdown().get();
 	}
 
 	/**
@@ -107,7 +107,7 @@ public class MetricGroupRegistrationTest extends TestLogger {
 	 * Verifies that when attempting to create a group with the name of an existing one the existing one will be returned instead.
 	 */
 	@Test
-	public void testDuplicateGroupName() {
+	public void testDuplicateGroupName() throws Exception {
 		Configuration config = new Configuration();
 
 		MetricRegistryImpl registry = new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(config));
@@ -119,6 +119,6 @@ public class MetricGroupRegistrationTest extends TestLogger {
 		MetricGroup group3 = root.addGroup("group");
 		Assert.assertTrue(group1 == group2 && group2 == group3);
 
-		registry.shutdown();
+		registry.shutdown().get();
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/MetricGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/MetricGroupTest.java
@@ -62,8 +62,8 @@ public class MetricGroupTest extends TestLogger {
 	}
 
 	@After
-	public void shutdownRegistry() {
-		this.registry.shutdown();
+	public void shutdownRegistry() throws Exception {
+		this.registry.shutdown().get();
 		this.registry = null;
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/OperatorGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/OperatorGroupTest.java
@@ -32,6 +32,8 @@ import org.apache.flink.runtime.metrics.util.DummyCharacterFilter;
 import org.apache.flink.util.AbstractID;
 import org.apache.flink.util.TestLogger;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Map;
@@ -45,10 +47,22 @@ import static org.junit.Assert.assertNotNull;
  */
 public class OperatorGroupTest extends TestLogger {
 
-	@Test
-	public void testGenerateScopeDefault() {
-		MetricRegistryImpl registry = new MetricRegistryImpl(MetricRegistryConfiguration.defaultMetricRegistryConfiguration());
+	private MetricRegistryImpl registry;
 
+	@Before
+	public void setup() {
+		registry = new MetricRegistryImpl(MetricRegistryConfiguration.defaultMetricRegistryConfiguration());
+	}
+
+	@After
+	public void teardown() throws Exception {
+		if (registry != null) {
+			registry.shutdown().get();
+		}
+	}
+
+	@Test
+	public void testGenerateScopeDefault() throws Exception {
 		TaskManagerMetricGroup tmGroup = new TaskManagerMetricGroup(registry, "theHostName", "test-tm-id");
 		TaskManagerJobMetricGroup jmGroup = new TaskManagerJobMetricGroup(registry, tmGroup, new JobID(), "myJobName");
 		TaskMetricGroup taskGroup = new TaskMetricGroup(
@@ -62,12 +76,10 @@ public class OperatorGroupTest extends TestLogger {
 		assertEquals(
 				"theHostName.taskmanager.test-tm-id.myJobName.myOpName.11.name",
 				opGroup.getMetricIdentifier("name"));
-
-		registry.shutdown();
 	}
 
 	@Test
-	public void testGenerateScopeCustom() {
+	public void testGenerateScopeCustom() throws Exception {
 		Configuration cfg = new Configuration();
 		cfg.setString(MetricOptions.SCOPE_NAMING_OPERATOR, "<tm_id>.<job_id>.<task_id>.<operator_name>.<operator_id>");
 		MetricRegistryImpl registry = new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(cfg));
@@ -91,14 +103,12 @@ public class OperatorGroupTest extends TestLogger {
 				String.format("%s.%s.%s.%s.%s.name", tmID, jid, vertexId, operatorName, operatorID),
 				operatorGroup.getMetricIdentifier("name"));
 		} finally {
-			registry.shutdown();
+			registry.shutdown().get();
 		}
 	}
 
 	@Test
-	public void testIOMetricGroupInstantiation() {
-		MetricRegistryImpl registry = new MetricRegistryImpl(MetricRegistryConfiguration.defaultMetricRegistryConfiguration());
-
+	public void testIOMetricGroupInstantiation() throws Exception {
 		TaskManagerMetricGroup tmGroup = new TaskManagerMetricGroup(registry, "theHostName", "test-tm-id");
 		TaskManagerJobMetricGroup jmGroup = new TaskManagerJobMetricGroup(registry, tmGroup, new JobID(), "myJobName");
 		TaskMetricGroup taskGroup = new TaskMetricGroup(
@@ -108,14 +118,10 @@ public class OperatorGroupTest extends TestLogger {
 		assertNotNull(opGroup.getIOMetricGroup());
 		assertNotNull(opGroup.getIOMetricGroup().getNumRecordsInCounter());
 		assertNotNull(opGroup.getIOMetricGroup().getNumRecordsOutCounter());
-
-		registry.shutdown();
 	}
 
 	@Test
 	public void testVariables() {
-		MetricRegistryImpl registry = new MetricRegistryImpl(MetricRegistryConfiguration.defaultMetricRegistryConfiguration());
-
 		JobID jid = new JobID();
 		JobVertexID tid = new JobVertexID();
 		AbstractID eid = new AbstractID();
@@ -140,8 +146,6 @@ public class OperatorGroupTest extends TestLogger {
 		testVariable(variables, ScopeFormat.SCOPE_TASK_ATTEMPT_NUM, "0");
 		testVariable(variables, ScopeFormat.SCOPE_OPERATOR_ID, oid.toString());
 		testVariable(variables, ScopeFormat.SCOPE_OPERATOR_NAME, "myOpName");
-
-		registry.shutdown();
 	}
 
 	private static void testVariable(Map<String, String> variables, String key, String expectedValue) {
@@ -156,7 +160,6 @@ public class OperatorGroupTest extends TestLogger {
 		JobVertexID vid = new JobVertexID();
 		AbstractID eid = new AbstractID();
 		OperatorID oid = new OperatorID();
-		MetricRegistryImpl registry = new MetricRegistryImpl(MetricRegistryConfiguration.defaultMetricRegistryConfiguration());
 		TaskManagerMetricGroup tm = new TaskManagerMetricGroup(registry, "host", "id");
 		TaskManagerJobMetricGroup job = new TaskManagerJobMetricGroup(registry, tm, jid, "jobname");
 		TaskMetricGroup task = new TaskMetricGroup(registry, job, vid, eid, "taskName", 4, 5);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/registration/RetryingRegistrationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/registration/RetryingRegistrationTest.java
@@ -25,6 +25,8 @@ import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.util.TestLogger;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.slf4j.LoggerFactory;
@@ -53,6 +55,20 @@ import static org.mockito.Mockito.when;
  */
 public class RetryingRegistrationTest extends TestLogger {
 
+	private TestingRpcService rpcService;
+
+	@Before
+	public void setup() {
+		rpcService = new TestingRpcService();
+	}
+
+	@After
+	public void tearDown() throws ExecutionException, InterruptedException {
+		if (rpcService != null) {
+			rpcService.stopService().get();
+		}
+	}
+
 	@Test
 	public void testSimpleSuccessfulRegistration() throws Exception {
 		final String testId = "laissez les bon temps roulez";
@@ -61,12 +77,11 @@ public class RetryingRegistrationTest extends TestLogger {
 
 		// an endpoint that immediately returns success
 		TestRegistrationGateway testGateway = new TestRegistrationGateway(new TestRegistrationSuccess(testId));
-		TestingRpcService rpc = new TestingRpcService();
 
 		try {
-			rpc.registerGateway(testEndpointAddress, testGateway);
+			rpcService.registerGateway(testEndpointAddress, testGateway);
 
-			TestRetryingRegistration registration = new TestRetryingRegistration(rpc, testEndpointAddress, leaderId);
+			TestRetryingRegistration registration = new TestRetryingRegistration(rpcService, testEndpointAddress, leaderId);
 			registration.startRegistration();
 
 			CompletableFuture<Tuple2<TestRegistrationGateway, TestRegistrationSuccess>> future = registration.getFuture();
@@ -84,7 +99,6 @@ public class RetryingRegistrationTest extends TestLogger {
 		}
 		finally {
 			testGateway.stop();
-			rpc.stopService();
 		}
 	}
 
@@ -173,14 +187,12 @@ public class RetryingRegistrationTest extends TestLogger {
 				new TestRegistrationSuccess(testId) // success
 		);
 
-		TestingRpcService rpc = new TestingRpcService();
-
 		try {
-			rpc.registerGateway(testEndpointAddress, testGateway);
+			rpcService.registerGateway(testEndpointAddress, testGateway);
 
 			final long initialTimeout = 20L;
 			TestRetryingRegistration registration = new TestRetryingRegistration(
-				rpc,
+				rpcService,
 				testEndpointAddress,
 				leaderId,
 				initialTimeout,
@@ -206,7 +218,6 @@ public class RetryingRegistrationTest extends TestLogger {
 			assertTrue("retries did not properly back off", elapsedMillis >= 3 * initialTimeout);
 		}
 		finally {
-			rpc.stopService();
 			testGateway.stop();
 		}
 	}
@@ -217,8 +228,6 @@ public class RetryingRegistrationTest extends TestLogger {
 		final String testEndpointAddress = "<test-address>";
 		final UUID leaderId = UUID.randomUUID();
 
-		TestingRpcService rpc = new TestingRpcService();
-
 		TestRegistrationGateway testGateway = new TestRegistrationGateway(
 				null, // timeout
 				new RegistrationResponse.Decline("no reason "),
@@ -227,9 +236,9 @@ public class RetryingRegistrationTest extends TestLogger {
 		);
 
 		try {
-			rpc.registerGateway(testEndpointAddress, testGateway);
+			rpcService.registerGateway(testEndpointAddress, testGateway);
 
-			TestRetryingRegistration registration = new TestRetryingRegistration(rpc, testEndpointAddress, leaderId);
+			TestRetryingRegistration registration = new TestRetryingRegistration(rpcService, testEndpointAddress, leaderId);
 
 			long started = System.nanoTime();
 			registration.startRegistration();
@@ -251,7 +260,6 @@ public class RetryingRegistrationTest extends TestLogger {
 		}
 		finally {
 			testGateway.stop();
-			rpc.stopService();
 		}
 	}
 
@@ -262,39 +270,32 @@ public class RetryingRegistrationTest extends TestLogger {
 		final String testEndpointAddress = "<test-address>";
 		final UUID leaderId = UUID.randomUUID();
 
-		TestingRpcService rpc = new TestingRpcService();
+		// gateway that upon calls first responds with a failure, then with a success
+		TestRegistrationGateway testGateway = mock(TestRegistrationGateway.class);
 
-		try {
-			// gateway that upon calls first responds with a failure, then with a success
-			TestRegistrationGateway testGateway = mock(TestRegistrationGateway.class);
+		when(testGateway.registrationCall(any(UUID.class), anyLong())).thenReturn(
+				FutureUtils.completedExceptionally(new Exception("test exception")),
+				CompletableFuture.completedFuture(new TestRegistrationSuccess(testId)));
 
-			when(testGateway.registrationCall(any(UUID.class), anyLong())).thenReturn(
-					FutureUtils.completedExceptionally(new Exception("test exception")),
-					CompletableFuture.completedFuture(new TestRegistrationSuccess(testId)));
+		rpcService.registerGateway(testEndpointAddress, testGateway);
 
-			rpc.registerGateway(testEndpointAddress, testGateway);
+		TestRetryingRegistration registration = new TestRetryingRegistration(rpcService, testEndpointAddress, leaderId);
 
-			TestRetryingRegistration registration = new TestRetryingRegistration(rpc, testEndpointAddress, leaderId);
+		long started = System.nanoTime();
+		registration.startRegistration();
 
-			long started = System.nanoTime();
-			registration.startRegistration();
+		CompletableFuture<Tuple2<TestRegistrationGateway, TestRegistrationSuccess>> future = registration.getFuture();
+		Tuple2<TestRegistrationGateway, TestRegistrationSuccess> success =
+				future.get(10, TimeUnit.SECONDS);
 
-			CompletableFuture<Tuple2<TestRegistrationGateway, TestRegistrationSuccess>> future = registration.getFuture();
-			Tuple2<TestRegistrationGateway, TestRegistrationSuccess> success =
-					future.get(10, TimeUnit.SECONDS);
+		long finished = System.nanoTime();
+		long elapsedMillis = (finished - started) / 1000000;
 
-			long finished = System.nanoTime();
-			long elapsedMillis = (finished - started) / 1000000;
+		assertEquals(testId, success.f1.getCorrelationId());
 
-			assertEquals(testId, success.f1.getCorrelationId());
-
-			// validate that some retry-delay / back-off behavior happened
-			assertTrue("retries did not properly back off",
-					elapsedMillis >= TestRetryingRegistration.DELAY_ON_ERROR);
-		}
-		finally {
-			rpc.stopService();
-		}
+		// validate that some retry-delay / back-off behavior happened
+		assertTrue("retries did not properly back off",
+				elapsedMillis >= TestRetryingRegistration.DELAY_ON_ERROR);
 	}
 
 	@Test
@@ -302,29 +303,22 @@ public class RetryingRegistrationTest extends TestLogger {
 		final String testEndpointAddress = "my-test-address";
 		final UUID leaderId = UUID.randomUUID();
 
-		TestingRpcService rpc = new TestingRpcService();
+		CompletableFuture<RegistrationResponse> result = new CompletableFuture<>();
 
-		try {
-			CompletableFuture<RegistrationResponse> result = new CompletableFuture<>();
+		TestRegistrationGateway testGateway = mock(TestRegistrationGateway.class);
+		when(testGateway.registrationCall(any(UUID.class), anyLong())).thenReturn(result);
 
-			TestRegistrationGateway testGateway = mock(TestRegistrationGateway.class);
-			when(testGateway.registrationCall(any(UUID.class), anyLong())).thenReturn(result);
+		rpcService.registerGateway(testEndpointAddress, testGateway);
 
-			rpc.registerGateway(testEndpointAddress, testGateway);
+		TestRetryingRegistration registration = new TestRetryingRegistration(rpcService, testEndpointAddress, leaderId);
+		registration.startRegistration();
 
-			TestRetryingRegistration registration = new TestRetryingRegistration(rpc, testEndpointAddress, leaderId);
-			registration.startRegistration();
+		// cancel and fail the current registration attempt
+		registration.cancel();
+		result.completeExceptionally(new TimeoutException());
 
-			// cancel and fail the current registration attempt
-			registration.cancel();
-			result.completeExceptionally(new TimeoutException());
-
-			// there should not be a second registration attempt
-			verify(testGateway, atMost(1)).registrationCall(any(UUID.class), anyLong());
-		}
-		finally {
-			rpc.stopService();
-		}
+		// there should not be a second registration attempt
+		verify(testGateway, atMost(1)).registrationCall(any(UUID.class), anyLong());
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerHATest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerHATest.java
@@ -126,7 +126,7 @@ public class ResourceManagerHATest extends TestLogger {
 				testingFatalErrorHandler.rethrowError();
 			}
 		} finally {
-			rpcService.stopService();
+			rpcService.stopService().get();
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerJobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerJobMasterTest.java
@@ -37,6 +37,7 @@ import org.apache.flink.runtime.metrics.MetricRegistryImpl;
 import org.apache.flink.runtime.resourcemanager.exceptions.ResourceManagerException;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.registration.RegistrationResponse;
 import org.apache.flink.runtime.rpc.exceptions.FencingTokenException;
@@ -73,7 +74,7 @@ public class ResourceManagerJobMasterTest extends TestLogger {
 
 	@After
 	public void teardown() throws Exception {
-		rpcService.stopService();
+		RpcUtils.terminateRpcService(rpcService, timeout);
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTaskExecutorTest.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.metrics.MetricRegistryImpl;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerInfo;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.registration.RegistrationResponse;
 import org.apache.flink.runtime.rpc.exceptions.FencingTokenException;
@@ -105,7 +106,7 @@ public class ResourceManagerTaskExecutorTest extends TestLogger {
 
 	@After
 	public void teardown() throws Exception {
-		rpcService.stopService();
+		RpcUtils.terminateRpcService(rpcService, timeout);
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTest.java
@@ -46,6 +46,7 @@ import org.junit.experimental.categories.Category;
 
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 
 @Category(Flip6.class)
 public class ResourceManagerTest extends TestLogger {
@@ -54,18 +55,13 @@ public class ResourceManagerTest extends TestLogger {
 
 	@Before
 	public void setUp() {
-		if (rpcService != null) {
-			rpcService.stopService();
-			rpcService = null;
-		}
-
 		rpcService = new TestingRpcService();
 	}
 
 	@After
-	public void tearDown() {
+	public void tearDown() throws ExecutionException, InterruptedException {
 		if (rpcService != null) {
-			rpcService.stopService();
+			rpcService.stopService().get();
 			rpcService = null;
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/AsyncCallsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/AsyncCallsTest.java
@@ -340,6 +340,11 @@ public class AsyncCallsTest extends TestLogger {
 		public boolean hasConcurrentAccess() {
 			return concurrentAccess;
 		}
+
+		@Override
+		public CompletableFuture<Void> postStop() {
+			return CompletableFuture.completedFuture(null);
+		}
 	}
 
 	public interface FencedTestGateway extends FencedRpcGateway<UUID> {
@@ -383,6 +388,11 @@ public class AsyncCallsTest extends TestLogger {
 			setFencingToken(fencingToken);
 
 			return CompletableFuture.completedFuture(Acknowledge.get());
+		}
+
+		@Override
+		public CompletableFuture<Void> postStop() {
+			return CompletableFuture.completedFuture(null);
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/FencedRpcEndpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/FencedRpcEndpointTest.java
@@ -60,8 +60,7 @@ public class FencedRpcEndpointTest extends TestLogger {
 	@AfterClass
 	public static void teardown() throws ExecutionException, InterruptedException, TimeoutException {
 		if (rpcService != null) {
-			rpcService.stopService();
-			rpcService.getTerminationFuture().get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+			RpcUtils.terminateRpcService(rpcService, timeout);
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/FencedRpcEndpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/FencedRpcEndpointTest.java
@@ -300,6 +300,11 @@ public class FencedRpcEndpointTest extends TestLogger {
 			this(rpcService, value, null);
 		}
 
+		@Override
+		public CompletableFuture<Void> postStop() {
+			return CompletableFuture.completedFuture(null);
+		}
+
 		protected FencedTestingEndpoint(RpcService rpcService, String value, UUID initialFencingToken) {
 			super(rpcService);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/RpcConnectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/RpcConnectionTest.java
@@ -23,17 +23,21 @@ import akka.actor.ActorSystem;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.rpc.akka.AkkaRpcService;
 import org.apache.flink.runtime.rpc.exceptions.RpcConnectionException;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
 import org.apache.flink.testutils.category.Flip6;
+import org.apache.flink.util.TestLogger;
 
+import akka.actor.Terminated;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import scala.Option;
 import scala.Tuple2;
 
+import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -46,10 +50,10 @@ import static org.junit.Assert.*;
  * connect to an RpcEndpoint.
  */
 @Category(Flip6.class)
-public class RpcConnectionTest {
+public class RpcConnectionTest extends TestLogger {
 
 	@Test
-	public void testConnectFailure() {
+	public void testConnectFailure() throws Exception {
 		ActorSystem actorSystem = null;
 		RpcService rpcService = null;
 		try {
@@ -77,12 +81,25 @@ public class RpcConnectionTest {
 			fail("wrong exception: " + t);
 		}
 		finally {
+			final CompletableFuture<Void> rpcTerminationFuture;
+
 			if (rpcService != null) {
-				rpcService.stopService();
+				rpcTerminationFuture = rpcService.stopService();
+			} else {
+				rpcTerminationFuture = CompletableFuture.completedFuture(null);
 			}
+
+			final CompletableFuture<Terminated> actorSystemTerminationFuture;
+
 			if (actorSystem != null) {
-				actorSystem.shutdown();
+				actorSystemTerminationFuture = FutureUtils.toJava(actorSystem.terminate());
+			} else {
+				actorSystemTerminationFuture = CompletableFuture.completedFuture(null);
 			}
+
+			FutureUtils
+				.waitForAll(Arrays.asList(rpcTerminationFuture, actorSystemTerminationFuture))
+				.get();
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/RpcEndpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/RpcEndpointTest.java
@@ -163,6 +163,11 @@ public class RpcEndpointTest extends TestLogger {
 		public CompletableFuture<Integer> foobar() {
 			return CompletableFuture.completedFuture(foobarValue);
 		}
+
+		@Override
+		public CompletableFuture<Void> postStop() {
+			return CompletableFuture.completedFuture(null);
+		}
 	}
 
 	public static class ExtendedEndpoint extends BaseEndpoint implements ExtendedGateway, DifferentGateway {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/RpcEndpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/RpcEndpointTest.java
@@ -20,20 +20,21 @@ package org.apache.flink.runtime.rpc;
 
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.rpc.akka.AkkaRpcService;
 import org.apache.flink.testutils.category.Flip6;
 import org.apache.flink.util.TestLogger;
 
 import akka.actor.ActorSystem;
+import akka.actor.Terminated;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-
-import scala.concurrent.duration.FiniteDuration;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -56,21 +57,13 @@ public class RpcEndpointTest extends TestLogger {
 
 	@AfterClass
 	public static void teardown() throws Exception {
-		if (rpcService != null) {
-			rpcService.stopService();
-		}
 
-		if (actorSystem != null) {
-			actorSystem.shutdown();
-		}
+		final CompletableFuture<Void> rpcTerminationFuture = rpcService.stopService();
+		final CompletableFuture<Terminated> actorSystemTerminationFuture = FutureUtils.toJava(actorSystem.terminate());
 
-		if (rpcService != null) {
-			rpcService.getTerminationFuture().get(TIMEOUT.toMilliseconds(), TimeUnit.MILLISECONDS);
-		}
-
-		if (actorSystem != null) {
-			actorSystem.awaitTermination(new FiniteDuration(TIMEOUT.toMilliseconds(), TimeUnit.MILLISECONDS));
-		}
+		FutureUtils
+			.waitForAll(Arrays.asList(rpcTerminationFuture, actorSystemTerminationFuture))
+			.get(TIMEOUT.toMilliseconds(), TimeUnit.MILLISECONDS);
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/TestingRpcService.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/TestingRpcService.java
@@ -74,9 +74,15 @@ public class TestingRpcService extends AkkaRpcService {
 	// ------------------------------------------------------------------------
 
 	@Override
-	public void stopService() {
-		super.stopService();
-		registeredConnections.clear();
+	public CompletableFuture<Void> stopService() {
+		final CompletableFuture<Void> terminationFuture = super.stopService();
+
+		terminationFuture.whenComplete(
+			(Void ignored, Throwable throwable) -> {
+				registeredConnections.clear();
+			});
+
+		return terminationFuture;
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActorTest.java
@@ -18,26 +18,28 @@
 
 package org.apache.flink.runtime.rpc.akka;
 
-import akka.actor.ActorSystem;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.rpc.RpcEndpoint;
 import org.apache.flink.runtime.rpc.RpcGateway;
 import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.runtime.rpc.RpcUtils;
+import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.rpc.akka.exceptions.AkkaRpcException;
 import org.apache.flink.runtime.rpc.exceptions.RpcConnectionException;
 import org.apache.flink.testutils.category.Flip6;
 import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.TestLogger;
 
-import akka.actor.Terminated;
+import akka.actor.ActorSystem;
 import org.hamcrest.core.Is;
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -56,21 +58,19 @@ public class AkkaRpcActorTest extends TestLogger {
 	//  shared test members
 	// ------------------------------------------------------------------------
 
-	private static ActorSystem actorSystem = AkkaUtils.createDefaultActorSystem();
-
 	private static Time timeout = Time.milliseconds(10000L);
 
-	private static AkkaRpcService akkaRpcService =
-		new AkkaRpcService(actorSystem, timeout);
+	private static AkkaRpcService akkaRpcService;
+
+
+	@BeforeClass
+	public static void setup() {
+		akkaRpcService = new TestingRpcService();
+	}
 
 	@AfterClass
 	public static void shutdown() throws InterruptedException, ExecutionException, TimeoutException {
-		final CompletableFuture<Void> rpcTerminationFuture = akkaRpcService.stopService();
-		final CompletableFuture<Terminated> actorSystemTerminationFuture = FutureUtils.toJava(actorSystem.terminate());
-
-		FutureUtils
-			.waitForAll(Arrays.asList(rpcTerminationFuture, actorSystemTerminationFuture))
-			.get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+		RpcUtils.terminateRpcService(akkaRpcService, timeout);
 	}
 
 	/**
@@ -191,7 +191,7 @@ public class AkkaRpcActorTest extends TestLogger {
 
 		CompletableFuture.runAsync(
 			() -> rpcEndpoint.shutDown(),
-			actorSystem.dispatcher());
+			akkaRpcService.getExecutor());
 
 		// wait until the rpc endpoint has terminated
 		terminationFuture.get();
@@ -296,6 +296,33 @@ public class AkkaRpcActorTest extends TestLogger {
 		}
 	}
 
+	/**
+	 * Tests that the {@link AkkaRpcActor} only completes after the asynchronous
+	 * post stop action has completed.
+	 */
+	@Test
+	public void testActorTerminationWithAsynchronousPostStopAction() throws Exception {
+		final CompletableFuture<Void> postStopFuture = new CompletableFuture<>();
+		final AsynchronousPostStopEndpoint endpoint = new AsynchronousPostStopEndpoint(akkaRpcService, postStopFuture);
+
+		try {
+			endpoint.start();
+
+			final CompletableFuture<Void> terminationFuture = endpoint.getTerminationFuture();
+
+			endpoint.shutDown();
+
+			assertFalse(terminationFuture.isDone());
+
+			postStopFuture.complete(null);
+
+			// the postStopFuture completion should allow the endpoint to terminate
+			terminationFuture.get();
+		} finally {
+			RpcUtils.terminateRpcEndpoint(endpoint, timeout);
+		}
+	}
+
 	// ------------------------------------------------------------------------
 	//  Test Actors and Interfaces
 	// ------------------------------------------------------------------------
@@ -309,7 +336,19 @@ public class AkkaRpcActorTest extends TestLogger {
 		void tell(String message);
 	}
 
-	private static class DummyRpcEndpoint extends RpcEndpoint implements DummyRpcGateway {
+	private static class TestRpcEndpoint extends RpcEndpoint {
+
+		protected TestRpcEndpoint(RpcService rpcService) {
+			super(rpcService);
+		}
+
+		@Override
+		public CompletableFuture<Void> postStop() {
+			return CompletableFuture.completedFuture(null);
+		}
+	}
+
+	private static class DummyRpcEndpoint extends TestRpcEndpoint implements DummyRpcGateway {
 
 		private volatile int _foobar = 42;
 
@@ -333,7 +372,7 @@ public class AkkaRpcActorTest extends TestLogger {
 		CompletableFuture<Integer> doStuff();
 	}
 
-	private static class ExceptionalEndpoint extends RpcEndpoint implements ExceptionalGateway {
+	private static class ExceptionalEndpoint extends TestRpcEndpoint implements ExceptionalGateway {
 
 		protected ExceptionalEndpoint(RpcService rpcService) {
 			super(rpcService);
@@ -345,7 +384,7 @@ public class AkkaRpcActorTest extends TestLogger {
 		}
 	}
 
-	private static class ExceptionalFutureEndpoint extends RpcEndpoint implements ExceptionalGateway {
+	private static class ExceptionalFutureEndpoint extends TestRpcEndpoint implements ExceptionalGateway {
 
 		protected ExceptionalFutureEndpoint(RpcService rpcService) {
 			super(rpcService);
@@ -379,8 +418,9 @@ public class AkkaRpcActorTest extends TestLogger {
 		}
 
 		@Override
-		public void postStop() {
+		public CompletableFuture<Void> postStop() {
 			validateRunsInMainThread();
+			return CompletableFuture.completedFuture(null);
 		}
 	}
 
@@ -393,8 +433,8 @@ public class AkkaRpcActorTest extends TestLogger {
 		}
 
 		@Override
-		public void postStop() throws Exception {
-			throw new PostStopException("Test exception.");
+		public CompletableFuture<Void> postStop() {
+			return FutureUtils.completedExceptionally(new PostStopException("Test exception."));
 		}
 
 		private static class PostStopException extends FlinkException {
@@ -404,6 +444,24 @@ public class AkkaRpcActorTest extends TestLogger {
 			public PostStopException(String message) {
 				super(message);
 			}
+		}
+	}
+
+	// ------------------------------------------------------------------------
+
+	private static class AsynchronousPostStopEndpoint extends RpcEndpoint {
+
+		private final CompletableFuture<Void> postStopFuture;
+
+		protected AsynchronousPostStopEndpoint(RpcService rpcService, CompletableFuture<Void> postStopFuture) {
+			super(rpcService);
+
+			this.postStopFuture = Preconditions.checkNotNull(postStopFuture);
+		}
+
+		@Override
+		public CompletableFuture<Void> postStop() {
+			return postStopFuture;
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActorTest.java
@@ -185,7 +185,7 @@ public class AkkaRpcActorTest extends TestLogger {
 		final DummyRpcEndpoint rpcEndpoint = new DummyRpcEndpoint(akkaRpcService);
 		rpcEndpoint.start();
 
-		CompletableFuture<Boolean> terminationFuture = rpcEndpoint.getTerminationFuture();
+		CompletableFuture<Void> terminationFuture = rpcEndpoint.getTerminationFuture();
 
 		assertFalse(terminationFuture.isDone());
 
@@ -246,7 +246,7 @@ public class AkkaRpcActorTest extends TestLogger {
 
 		rpcEndpoint.shutDown();
 
-		CompletableFuture<Boolean> terminationFuture = rpcEndpoint.getTerminationFuture();
+		CompletableFuture<Void> terminationFuture = rpcEndpoint.getTerminationFuture();
 
 		try {
 			terminationFuture.get();
@@ -265,7 +265,7 @@ public class AkkaRpcActorTest extends TestLogger {
 
 		simpleRpcEndpoint.shutDown();
 
-		CompletableFuture<Boolean> terminationFuture = simpleRpcEndpoint.getTerminationFuture();
+		CompletableFuture<Void> terminationFuture = simpleRpcEndpoint.getTerminationFuture();
 
 		// check that we executed the postStop method in the main thread, otherwise an exception
 		// would be thrown here.
@@ -285,7 +285,7 @@ public class AkkaRpcActorTest extends TestLogger {
 
 			rpcEndpoint.start();
 
-			CompletableFuture<Boolean> terminationFuture = rpcEndpoint.getTerminationFuture();
+			CompletableFuture<Void> terminationFuture = rpcEndpoint.getTerminationFuture();
 
 			rpcService.stopService();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceTest.java
@@ -27,10 +27,12 @@ import org.apache.flink.testutils.category.Flip6;
 import org.apache.flink.util.TestLogger;
 
 import akka.actor.ActorSystem;
+import akka.actor.Terminated;
 import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+import java.util.Arrays;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -59,10 +61,13 @@ public class AkkaRpcServiceTest extends TestLogger {
 			new AkkaRpcService(actorSystem, timeout);
 
 	@AfterClass
-	public static void shutdown() {
-		akkaRpcService.stopService();
-		actorSystem.shutdown();
-		actorSystem.awaitTermination(FutureUtils.toFiniteDuration(timeout));
+	public static void shutdown() throws InterruptedException, ExecutionException, TimeoutException {
+		final CompletableFuture<Void> rpcTerminationFuture = akkaRpcService.stopService();
+		final CompletableFuture<Terminated> actorSystemTerminationFuture = FutureUtils.toJava(actorSystem.terminate());
+
+		FutureUtils
+			.waitForAll(Arrays.asList(rpcTerminationFuture, actorSystemTerminationFuture))
+			.get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/MainThreadValidationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/MainThreadValidationTest.java
@@ -70,7 +70,7 @@ public class MainThreadValidationTest extends TestLogger {
 			testEndpoint.shutDown();
 		}
 		finally {
-			akkaRpcService.stopService();
+			akkaRpcService.stopService().get();
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/MainThreadValidationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/MainThreadValidationTest.java
@@ -30,6 +30,8 @@ import org.apache.flink.util.TestLogger;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+import java.util.concurrent.CompletableFuture;
+
 import static org.junit.Assert.assertTrue;
 
 @Category(Flip6.class)
@@ -88,6 +90,11 @@ public class MainThreadValidationTest extends TestLogger {
 
 		public TestEndpoint(RpcService rpcService) {
 			super(rpcService);
+		}
+
+		@Override
+		public CompletableFuture<Void> postStop() {
+			return CompletableFuture.completedFuture(null);
 		}
 
 		@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/MessageSerializationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/MessageSerializationTest.java
@@ -193,6 +193,11 @@ public class MessageSerializationTest extends TestLogger {
 		public void foobar(Object object) throws InterruptedException {
 			queue.put(object);
 		}
+
+		@Override
+		public CompletableFuture<Void> postStop() {
+			return CompletableFuture.completedFuture(null);
+		}
 	}
 
 	private static class NonSerializableObject {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/MessageSerializationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/MessageSerializationTest.java
@@ -18,16 +18,18 @@
 
 package org.apache.flink.runtime.rpc.akka;
 
-import akka.actor.ActorSystem;
-import com.typesafe.config.Config;
-import com.typesafe.config.ConfigValueFactory;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.rpc.RpcEndpoint;
 import org.apache.flink.runtime.rpc.RpcGateway;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.testutils.category.Flip6;
 import org.apache.flink.util.TestLogger;
+
+import akka.actor.ActorSystem;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigValueFactory;
 import org.hamcrest.core.Is;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -35,8 +37,13 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
@@ -67,15 +74,17 @@ public class MessageSerializationTest extends TestLogger {
 	}
 
 	@AfterClass
-	public static void teardown() {
-		akkaRpcService1.stopService();
-		akkaRpcService2.stopService();
+	public static void teardown() throws InterruptedException, ExecutionException, TimeoutException {
+		final Collection<CompletableFuture<?>> terminationFutures = new ArrayList<>(4);
 
-		actorSystem1.shutdown();
-		actorSystem2.shutdown();
+		terminationFutures.add(akkaRpcService1.stopService());
+		terminationFutures.add(FutureUtils.toJava(actorSystem1.terminate()));
+		terminationFutures.add(akkaRpcService2.stopService());
+		terminationFutures.add(FutureUtils.toJava(actorSystem2.terminate()));
 
-		actorSystem1.awaitTermination();
-		actorSystem2.awaitTermination();
+		FutureUtils
+			.waitForAll(terminationFutures)
+			.get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorITCase.java
@@ -48,6 +48,7 @@ import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.resourcemanager.SlotRequest;
 import org.apache.flink.runtime.resourcemanager.StandaloneResourceManager;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
+import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
 import org.apache.flink.runtime.taskexecutor.slot.TaskSlotTable;
@@ -220,7 +221,7 @@ public class TaskExecutorITCase extends TestLogger {
 				testingFatalErrorHandler.rethrowError();
 			}
 
-			rpcService.stopService();
+			RpcUtils.terminateRpcService(rpcService, timeout);
 		}
 
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -189,7 +189,7 @@ public class TaskExecutorTest extends TestLogger {
 	@After
 	public void teardown() throws Exception {
 		if (rpc != null) {
-			rpc.stopService();
+			RpcUtils.terminateRpcService(rpc, timeout);
 			rpc = null;
 		}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/retriever/impl/RpcGatewayRetrieverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/retriever/impl/RpcGatewayRetrieverTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.rpc.FencedRpcGateway;
 import org.apache.flink.runtime.rpc.RpcEndpoint;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.RpcTimeout;
+import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.util.TestLogger;
 
@@ -58,9 +59,7 @@ public class RpcGatewayRetrieverTest extends TestLogger {
 	@AfterClass
 	public static void teardown() throws InterruptedException, ExecutionException, TimeoutException {
 		if (rpcService != null) {
-			rpcService.stopService();
-			rpcService.getTerminationFuture().get(TIMEOUT.toMilliseconds(), TimeUnit.MILLISECONDS);
-
+			RpcUtils.terminateRpcService(rpcService, TIMEOUT);
 			rpcService = null;
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/retriever/impl/RpcGatewayRetrieverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/retriever/impl/RpcGatewayRetrieverTest.java
@@ -138,5 +138,10 @@ public class RpcGatewayRetrieverTest extends TestLogger {
 		public UUID getFencingToken() {
 			return HighAvailabilityServices.DEFAULT_LEADER_ID;
 		}
+
+		@Override
+		public CompletableFuture<Void> postStop() {
+			return CompletableFuture.completedFuture(null);
+		}
 	}
 }

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnApplicationMasterRunner.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnApplicationMasterRunner.java
@@ -457,7 +457,7 @@ public class YarnApplicationMasterRunner {
 
 		if (metricRegistry != null) {
 			try {
-				metricRegistry.shutdown();
+				metricRegistry.shutdown().get();
 			} catch (Throwable t) {
 				LOG.error("Could not properly shut down the metric registry.", t);
 			}

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
@@ -308,7 +308,7 @@ public class YarnResourceManagerTest extends TestLogger {
 		 * Stop the Akka actor system.
 		 */
 		public void stopResourceManager() throws Exception {
-			rpcService.stopService();
+			rpcService.stopService().get();
 		}
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

Makes the ClusterEntrypoint shut down method non-blocking. This also removes
the need to run the Dispatcher#terminationFuture callback in the common
Fork-Join pool.

This PR is based on #5499, #5511 and #5504.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
