### PR TITLE
[FLINK-8676][state]Memory Leak in AbstractKeyedStateBackend.applyToAllKeys() when backend is base on RocksDB

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
@@ -52,6 +52,7 @@ import org.apache.flink.util.Preconditions;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.stream.Stream;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -289,24 +290,23 @@ public abstract class AbstractKeyedStateBackend<K>
 			final StateDescriptor<S, T> stateDescriptor,
 			final KeyedStateFunction<K, S> function) throws Exception {
 
-		try {
-			getKeys(stateDescriptor.getName(), namespace)
-					.forEach((K key) -> {
-						setCurrentKey(key);
-						try {
-							function.process(
-									key,
-									getPartitionedState(
-											namespace,
-											namespaceSerializer,
-											stateDescriptor)
-							);
-						} catch (Throwable e) {
-							// we wrap the checked exception in an unchecked
-							// one and catch it (and re-throw it) later.
-							throw new RuntimeException(e);
-						}
-					});
+		try (Stream<K> keysStream = getKeys(stateDescriptor.getName(), namespace)) {
+			keysStream.forEach((K key) -> {
+				setCurrentKey(key);
+				try {
+					function.process(
+						key,
+						getPartitionedState(
+							namespace,
+							namespaceSerializer,
+							stateDescriptor)
+					);
+				} catch (Throwable e) {
+					// we wrap the checked exception in an unchecked
+					// one and catch it (and re-throw it) later.
+					throw new RuntimeException(e);
+				}
+			});
 		} catch (RuntimeException e) {
 			throw e;
 		}


### PR DESCRIPTION
## What is the purpose of the change

This PR addressed issue [FLINK-8676](https://issues.apache.org/jira/browse/FLINK-8676). `AbstractKeyedStateBackend.applyToAllKeys() ` uses backend's `getKeys(stateName, namespace)` to get all keys that belong to `namespace`. But, in `RocksDBKeyedStateBackend.getKeys()` if just return a object which wrap a `rocksdb iterator`, that is dangous, because rocksdb will ping the resources that belong to the iterator into memory till `iterator.close()` is invoked, but it wasn't invoked right now. This could lead to memory leak finally.

## Brief change log

- Ensure Stream.close() could be invoked to avoid memory leak.

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
