### PR TITLE
[FLINK-8544] [Kafka Connector] Handle null message key in JSONKeyValueDeserializationSc…

### DIFF
--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/util/serialization/JSONKeyValueDeserializationSchema.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/util/serialization/JSONKeyValueDeserializationSchema.java
@@ -56,8 +56,12 @@ public class JSONKeyValueDeserializationSchema implements KeyedDeserializationSc
 			mapper = new ObjectMapper();
 		}
 		ObjectNode node = mapper.createObjectNode();
-		node.set("key", mapper.readValue(messageKey, JsonNode.class));
-		node.set("value", mapper.readValue(message, JsonNode.class));
+		if (messageKey != null) {
+			node.set("key", mapper.readValue(messageKey, JsonNode.class));
+		}
+		if (message != null) {
+			node.set("value", mapper.readValue(message, JsonNode.class));
+		}
 		if (includeMetadata) {
 			node.putObject("metadata")
 				.put("offset", offset)

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/JSONKeyValueDeserializationSchemaTest.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/JSONKeyValueDeserializationSchemaTest.java
@@ -51,6 +51,40 @@ public class JSONKeyValueDeserializationSchemaTest {
 	}
 
 	@Test
+	public void testDeserializeWithoutKey() throws IOException {
+		ObjectMapper mapper = new ObjectMapper();
+		byte[] serializedKey = null;
+
+		ObjectNode initialValue = mapper.createObjectNode();
+		initialValue.put("word", "world");
+		byte[] serializedValue = mapper.writeValueAsBytes(initialValue);
+
+		JSONKeyValueDeserializationSchema schema = new JSONKeyValueDeserializationSchema(false);
+		ObjectNode deserializedValue = schema.deserialize(serializedKey, serializedValue, "", 0, 0);
+
+		Assert.assertTrue(deserializedValue.get("metadata") == null);
+		Assert.assertTrue(deserializedValue.get("key") == null);
+		Assert.assertEquals("world", deserializedValue.get("value").get("word").asText());
+	}
+
+	@Test
+	public void testDeserializeWithoutValue() throws IOException {
+		ObjectMapper mapper = new ObjectMapper();
+		ObjectNode initialKey = mapper.createObjectNode();
+		initialKey.put("index", 4);
+		byte[] serializedKey = mapper.writeValueAsBytes(initialKey);
+
+		byte[] serializedValue = null;
+
+		JSONKeyValueDeserializationSchema schema = new JSONKeyValueDeserializationSchema(false);
+		ObjectNode deserializedValue = schema.deserialize(serializedKey, serializedValue, "", 0, 0);
+
+		Assert.assertTrue(deserializedValue.get("metadata") == null);
+		Assert.assertEquals(4, deserializedValue.get("key").get("index").asInt());
+		Assert.assertTrue(deserializedValue.get("value") == null);
+	}
+
+	@Test
 	public void testDeserializeWithMetadata() throws IOException {
 		ObjectMapper mapper = new ObjectMapper();
 		ObjectNode initialKey = mapper.createObjectNode();


### PR DESCRIPTION
## What is the purpose of the change

This pull request fix a NPE thrown in JSONKeyValueDeserializationSchema when the message key is null, allowing JSONKeyValueDeserializationSchema to be used to retrieve message metadata even if the message key is null.

The NPE is caused by deserializing the message key without verification.

## Brief change log

  - Check nullity before deserializing the message key.

## Verifying this change

This change added tests and can be verified as follows:

  - Added unit tests for deserializing a message with null key.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no
## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
