### PR TITLE
[FLINK-8678] [flip6] Make RpcService shut down non blocking

### DIFF
--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
@@ -510,7 +510,7 @@ public class MesosResourceManagerTest extends TestLogger {
 
 		@Override
 		public void close() throws Exception {
-			rpcService.stopService();
+			rpcService.stopService().get();
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -437,7 +437,7 @@ public abstract class ClusterEntrypoint implements FatalErrorHandler {
 
 			if (commonRpcService != null) {
 				try {
-					commonRpcService.stopService();
+					commonRpcService.stopService().get();
 				} catch (Throwable t) {
 					exception = ExceptionUtils.firstOrSuppressed(t, exception);
 				}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -377,7 +377,6 @@ public class MiniCluster implements JobExecutorService {
 			blobCacheService = null;
 		}
 
-
 		// shut down the blob server
 		if (blobServer != null) {
 			try {
@@ -608,7 +607,7 @@ public class MiniCluster implements JobExecutorService {
 	private static Throwable shutDownRpc(RpcService rpcService, Throwable priorException) {
 		if (rpcService != null) {
 			try {
-				rpcService.stopService();
+				rpcService.stopService().get();
 			}
 			catch (Throwable t) {
 				return firstOrSuppressed(t, priorException);
@@ -625,7 +624,7 @@ public class MiniCluster implements JobExecutorService {
 			for (RpcService service : rpcServices) {
 				try {
 					if (service != null) {
-						service.stopService();
+						service.stopService().get();
 					}
 				}
 				catch (Throwable t) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcService.java
@@ -116,9 +116,12 @@ public interface RpcService {
 	void stopServer(RpcServer selfGateway);
 
 	/**
-	 * Stop the rpc service shutting down all started rpc servers.
+	 * Trigger the asynchronous stopping of the {@link RpcService}.
+	 *
+	 * @return Future which is completed once the {@link RpcService} has been
+	 * fully stopped.
 	 */
-	void stopService();
+	CompletableFuture<Void> stopService();
 
 	/**
 	 * Returns a future indicating when the RPC service has been shut down.
@@ -130,13 +133,13 @@ public interface RpcService {
 	/**
 	 * Gets the executor, provided by this RPC service. This executor can be used for example for
 	 * the {@code handleAsync(...)} or {@code thenAcceptAsync(...)} methods of futures.
-	 * 
+	 *
 	 * <p><b>IMPORTANT:</b> This executor does not isolate the method invocations against
 	 * any concurrent invocations and is therefore not suitable to run completion methods of futures
 	 * that modify state of an {@link RpcEndpoint}. For such operations, one needs to use the
 	 * {@link RpcEndpoint#getMainThreadExecutor() MainThreadExecutionContext} of that
 	 * {@code RpcEndpoint}.
-	 * 
+	 *
 	 * @return The execution context provided by the RPC service
 	 */
 	Executor getExecutor();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcUtils.java
@@ -50,7 +50,7 @@ public class RpcUtils {
 		while (clazz != null) {
 			for (Class<?> interfaze : clazz.getInterfaces()) {
 				if (RpcGateway.class.isAssignableFrom(interfaze)) {
-					interfaces.add((Class<? extends RpcGateway>)interfaze);
+					interfaces.add((Class<? extends RpcGateway>) interfaze);
 				}
 			}
 
@@ -65,13 +65,26 @@ public class RpcUtils {
 	 *
 	 * @param rpcEndpoint to terminate
 	 * @param timeout for this operation
-	 * @throws ExecutionException if a problem occurs
+	 * @throws ExecutionException if a problem occurred
 	 * @throws InterruptedException if the operation has been interrupted
 	 * @throws TimeoutException if a timeout occurred
 	 */
 	public static void terminateRpcEndpoint(RpcEndpoint rpcEndpoint, Time timeout) throws ExecutionException, InterruptedException, TimeoutException {
 		rpcEndpoint.shutDown();
 		rpcEndpoint.getTerminationFuture().get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+	}
+
+	/**
+	 * Shuts the given rpc service down and waits for its termination.
+	 *
+	 * @param rpcService to shut down
+	 * @param timeout for this operation
+	 * @throws InterruptedException if the operation has been interrupted
+	 * @throws ExecutionException if a problem occurred
+	 * @throws TimeoutException if a timeout occurred
+	 */
+	public static void terminateRpcService(RpcService rpcService, Time timeout) throws InterruptedException, ExecutionException, TimeoutException {
+		rpcService.stopService().get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
 	}
 
 	// We don't want this class to be instantiable

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcService.java
@@ -42,6 +42,7 @@ import akka.actor.Address;
 import akka.actor.Identify;
 import akka.actor.PoisonPill;
 import akka.actor.Props;
+import akka.actor.Terminated;
 import akka.dispatch.Futures;
 import akka.dispatch.Mapper;
 import akka.pattern.Patterns;
@@ -98,6 +99,8 @@ public class AkkaRpcService implements RpcService {
 
 	private final ScheduledExecutor internalScheduledExecutor;
 
+	private final CompletableFuture<Void> terminationFuture;
+
 	private volatile boolean stopped;
 
 	public AkkaRpcService(final ActorSystem actorSystem, final Time timeout) {
@@ -126,6 +129,8 @@ public class AkkaRpcService implements RpcService {
 		}
 
 		internalScheduledExecutor = new ActorSystemScheduledExecutorAdapter(actorSystem);
+
+		terminationFuture = new CompletableFuture<>();
 
 		stopped = false;
 	}
@@ -311,33 +316,40 @@ public class AkkaRpcService implements RpcService {
 	}
 
 	@Override
-	public void stopService() {
-		LOG.info("Stopping Akka RPC service.");
-
+	public CompletableFuture<Void> stopService() {
 		synchronized (lock) {
 			if (stopped) {
-				return;
+				return terminationFuture;
 			}
 
 			stopped = true;
-
 		}
 
-		actorSystem.shutdown();
-		actorSystem.awaitTermination();
+		LOG.info("Stopping Akka RPC service.");
 
-		synchronized (lock) {
-			actors.clear();
-		}
+		final CompletableFuture<Terminated> actorSytemTerminationFuture = FutureUtils.toJava(actorSystem.terminate());
 
-		LOG.info("Stopped Akka RPC service.");
+		actorSytemTerminationFuture.whenComplete(
+			(Terminated ignored, Throwable throwable) -> {
+				synchronized (lock) {
+					actors.clear();
+				}
+
+				if (throwable != null) {
+					terminationFuture.completeExceptionally(throwable);
+				} else {
+					terminationFuture.complete(null);
+				}
+
+				LOG.info("Stopped Akka RPC service.");
+			});
+
+		return terminationFuture;
 	}
 
 	@Override
 	public CompletableFuture<Void> getTerminationFuture() {
-		return CompletableFuture.runAsync(
-			actorSystem::awaitTermination,
-			getExecutor());
+		return terminationFuture;
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -171,7 +171,15 @@ public class TaskManagerRunner implements FatalErrorHandler {
 				exception = ExceptionUtils.firstOrSuppressed(e, exception);
 			}
 
-			rpcService.stopService();
+			try {
+				rpcService.stopService().get();
+			} catch (InterruptedException ie) {
+				exception = ExceptionUtils.firstOrSuppressed(ie, exception);
+
+				Thread.currentThread().interrupt();
+			} catch (Exception e) {
+				exception = ExceptionUtils.firstOrSuppressed(e, exception);
+			}
 
 			try {
 				highAvailabilityServices.close();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/ResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/ResourceManagerTest.java
@@ -53,6 +53,7 @@ import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
 import org.apache.flink.runtime.resourcemanager.StandaloneResourceManager;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
+import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.taskexecutor.SlotReport;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
@@ -578,7 +579,7 @@ public class ResourceManagerTest extends TestLogger {
 			verify(taskExecutorGateway, Mockito.timeout(timeout.toMilliseconds())).disconnectResourceManager(any(TimeoutException.class));
 
 		} finally {
-			rpcService.stopService();
+			RpcUtils.terminateRpcService(rpcService, timeout);
 		}
 	}
 
@@ -680,7 +681,7 @@ public class ResourceManagerTest extends TestLogger {
 			verify(jobMasterGateway, Mockito.timeout(timeout.toMilliseconds())).disconnectResourceManager(eq(rmLeaderId), any(TimeoutException.class));
 
 		} finally {
-			rpcService.stopService();
+			RpcUtils.terminateRpcService(rpcService, timeout);
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -79,6 +79,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.hamcrest.Matchers.contains;
@@ -134,9 +135,9 @@ public class DispatcherTest extends TestLogger {
 	}
 
 	@AfterClass
-	public static void teardown() {
+	public static void teardown() throws InterruptedException, ExecutionException, TimeoutException {
 		if (rpcService != null) {
-			rpcService.stopService();
+			RpcUtils.terminateRpcService(rpcService, TIMEOUT);
 
 			rpcService = null;
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/MiniDispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/MiniDispatcherTest.java
@@ -63,6 +63,8 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -137,13 +139,13 @@ public class MiniDispatcherTest extends TestLogger {
 	}
 
 	@AfterClass
-	public static void teardownClass() throws IOException {
+	public static void teardownClass() throws IOException, InterruptedException, ExecutionException, TimeoutException {
 		if (blobServer != null) {
 			blobServer.close();
 		}
 
 		if (rpcService != null) {
-			rpcService.stopService();
+			RpcUtils.terminateRpcService(rpcService, timeout);
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/SchedulerTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/SchedulerTestBase.java
@@ -117,7 +117,7 @@ public class SchedulerTestBase extends TestLogger {
 		}
 
 		if (rpcService != null) {
-			rpcService.stopService();
+			rpcService.stopService().get();
 			rpcService = null;
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -39,6 +39,7 @@ import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.registration.RegistrationResponse;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
 import org.apache.flink.runtime.resourcemanager.utils.TestingResourceManagerGateway;
+import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGateway;
 import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
@@ -151,7 +152,7 @@ public class JobMasterTest extends TestLogger {
 
 		} finally {
 			jobManagerSharedServices.shutdown();
-			rpc.stopService();
+			RpcUtils.terminateRpcService(rpc, testingTimeout);
 		}
 	}
 
@@ -252,7 +253,7 @@ public class JobMasterTest extends TestLogger {
 
 		} finally {
 			jobManagerSharedServices.shutdown();
-			rpc.stopService();
+			RpcUtils.terminateRpcService(rpc, testingTimeout);
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolRpcTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolRpcTest.java
@@ -91,9 +91,9 @@ public class SlotPoolRpcTest extends TestLogger {
 	}
 
 	@AfterClass
-	public static  void shutdown() {
+	public static  void shutdown() throws InterruptedException, ExecutionException, TimeoutException {
 		if (rpcService != null) {
-			rpcService.stopService();
+			RpcUtils.terminateRpcService(rpcService, timeout);
 			rpcService = null;
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolSchedulingTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolSchedulingTestBase.java
@@ -64,9 +64,9 @@ public class SlotPoolSchedulingTestBase extends TestLogger {
 	}
 
 	@AfterClass
-	public static void teardown() {
+	public static void teardown() throws ExecutionException, InterruptedException {
 		if (testingRpcService != null) {
-			testingRpcService.stopService();
+			testingRpcService.stopService().get();
 			testingRpcService = null;
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolTest.java
@@ -105,7 +105,7 @@ public class SlotPoolTest extends TestLogger {
 
 	@After
 	public void tearDown() throws Exception {
-		rpcService.stopService();
+		RpcUtils.terminateRpcService(rpcService, timeout);
 	}
 
 	@Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/registration/RetryingRegistrationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/registration/RetryingRegistrationTest.java
@@ -25,6 +25,8 @@ import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.util.TestLogger;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.slf4j.LoggerFactory;
@@ -53,6 +55,20 @@ import static org.mockito.Mockito.when;
  */
 public class RetryingRegistrationTest extends TestLogger {
 
+	private TestingRpcService rpcService;
+
+	@Before
+	public void setup() {
+		rpcService = new TestingRpcService();
+	}
+
+	@After
+	public void tearDown() throws ExecutionException, InterruptedException {
+		if (rpcService != null) {
+			rpcService.stopService().get();
+		}
+	}
+
 	@Test
 	public void testSimpleSuccessfulRegistration() throws Exception {
 		final String testId = "laissez les bon temps roulez";
@@ -61,12 +77,11 @@ public class RetryingRegistrationTest extends TestLogger {
 
 		// an endpoint that immediately returns success
 		TestRegistrationGateway testGateway = new TestRegistrationGateway(new TestRegistrationSuccess(testId));
-		TestingRpcService rpc = new TestingRpcService();
 
 		try {
-			rpc.registerGateway(testEndpointAddress, testGateway);
+			rpcService.registerGateway(testEndpointAddress, testGateway);
 
-			TestRetryingRegistration registration = new TestRetryingRegistration(rpc, testEndpointAddress, leaderId);
+			TestRetryingRegistration registration = new TestRetryingRegistration(rpcService, testEndpointAddress, leaderId);
 			registration.startRegistration();
 
 			CompletableFuture<Tuple2<TestRegistrationGateway, TestRegistrationSuccess>> future = registration.getFuture();
@@ -84,7 +99,6 @@ public class RetryingRegistrationTest extends TestLogger {
 		}
 		finally {
 			testGateway.stop();
-			rpc.stopService();
 		}
 	}
 
@@ -173,14 +187,12 @@ public class RetryingRegistrationTest extends TestLogger {
 				new TestRegistrationSuccess(testId) // success
 		);
 
-		TestingRpcService rpc = new TestingRpcService();
-
 		try {
-			rpc.registerGateway(testEndpointAddress, testGateway);
+			rpcService.registerGateway(testEndpointAddress, testGateway);
 
 			final long initialTimeout = 20L;
 			TestRetryingRegistration registration = new TestRetryingRegistration(
-				rpc,
+				rpcService,
 				testEndpointAddress,
 				leaderId,
 				initialTimeout,
@@ -206,7 +218,6 @@ public class RetryingRegistrationTest extends TestLogger {
 			assertTrue("retries did not properly back off", elapsedMillis >= 3 * initialTimeout);
 		}
 		finally {
-			rpc.stopService();
 			testGateway.stop();
 		}
 	}
@@ -217,8 +228,6 @@ public class RetryingRegistrationTest extends TestLogger {
 		final String testEndpointAddress = "<test-address>";
 		final UUID leaderId = UUID.randomUUID();
 
-		TestingRpcService rpc = new TestingRpcService();
-
 		TestRegistrationGateway testGateway = new TestRegistrationGateway(
 				null, // timeout
 				new RegistrationResponse.Decline("no reason "),
@@ -227,9 +236,9 @@ public class RetryingRegistrationTest extends TestLogger {
 		);
 
 		try {
-			rpc.registerGateway(testEndpointAddress, testGateway);
+			rpcService.registerGateway(testEndpointAddress, testGateway);
 
-			TestRetryingRegistration registration = new TestRetryingRegistration(rpc, testEndpointAddress, leaderId);
+			TestRetryingRegistration registration = new TestRetryingRegistration(rpcService, testEndpointAddress, leaderId);
 
 			long started = System.nanoTime();
 			registration.startRegistration();
@@ -251,7 +260,6 @@ public class RetryingRegistrationTest extends TestLogger {
 		}
 		finally {
 			testGateway.stop();
-			rpc.stopService();
 		}
 	}
 
@@ -262,39 +270,32 @@ public class RetryingRegistrationTest extends TestLogger {
 		final String testEndpointAddress = "<test-address>";
 		final UUID leaderId = UUID.randomUUID();
 
-		TestingRpcService rpc = new TestingRpcService();
+		// gateway that upon calls first responds with a failure, then with a success
+		TestRegistrationGateway testGateway = mock(TestRegistrationGateway.class);
 
-		try {
-			// gateway that upon calls first responds with a failure, then with a success
-			TestRegistrationGateway testGateway = mock(TestRegistrationGateway.class);
+		when(testGateway.registrationCall(any(UUID.class), anyLong())).thenReturn(
+				FutureUtils.completedExceptionally(new Exception("test exception")),
+				CompletableFuture.completedFuture(new TestRegistrationSuccess(testId)));
 
-			when(testGateway.registrationCall(any(UUID.class), anyLong())).thenReturn(
-					FutureUtils.completedExceptionally(new Exception("test exception")),
-					CompletableFuture.completedFuture(new TestRegistrationSuccess(testId)));
+		rpcService.registerGateway(testEndpointAddress, testGateway);
 
-			rpc.registerGateway(testEndpointAddress, testGateway);
+		TestRetryingRegistration registration = new TestRetryingRegistration(rpcService, testEndpointAddress, leaderId);
 
-			TestRetryingRegistration registration = new TestRetryingRegistration(rpc, testEndpointAddress, leaderId);
+		long started = System.nanoTime();
+		registration.startRegistration();
 
-			long started = System.nanoTime();
-			registration.startRegistration();
+		CompletableFuture<Tuple2<TestRegistrationGateway, TestRegistrationSuccess>> future = registration.getFuture();
+		Tuple2<TestRegistrationGateway, TestRegistrationSuccess> success =
+				future.get(10, TimeUnit.SECONDS);
 
-			CompletableFuture<Tuple2<TestRegistrationGateway, TestRegistrationSuccess>> future = registration.getFuture();
-			Tuple2<TestRegistrationGateway, TestRegistrationSuccess> success =
-					future.get(10, TimeUnit.SECONDS);
+		long finished = System.nanoTime();
+		long elapsedMillis = (finished - started) / 1000000;
 
-			long finished = System.nanoTime();
-			long elapsedMillis = (finished - started) / 1000000;
+		assertEquals(testId, success.f1.getCorrelationId());
 
-			assertEquals(testId, success.f1.getCorrelationId());
-
-			// validate that some retry-delay / back-off behavior happened
-			assertTrue("retries did not properly back off",
-					elapsedMillis >= TestRetryingRegistration.DELAY_ON_ERROR);
-		}
-		finally {
-			rpc.stopService();
-		}
+		// validate that some retry-delay / back-off behavior happened
+		assertTrue("retries did not properly back off",
+				elapsedMillis >= TestRetryingRegistration.DELAY_ON_ERROR);
 	}
 
 	@Test
@@ -302,29 +303,22 @@ public class RetryingRegistrationTest extends TestLogger {
 		final String testEndpointAddress = "my-test-address";
 		final UUID leaderId = UUID.randomUUID();
 
-		TestingRpcService rpc = new TestingRpcService();
+		CompletableFuture<RegistrationResponse> result = new CompletableFuture<>();
 
-		try {
-			CompletableFuture<RegistrationResponse> result = new CompletableFuture<>();
+		TestRegistrationGateway testGateway = mock(TestRegistrationGateway.class);
+		when(testGateway.registrationCall(any(UUID.class), anyLong())).thenReturn(result);
 
-			TestRegistrationGateway testGateway = mock(TestRegistrationGateway.class);
-			when(testGateway.registrationCall(any(UUID.class), anyLong())).thenReturn(result);
+		rpcService.registerGateway(testEndpointAddress, testGateway);
 
-			rpc.registerGateway(testEndpointAddress, testGateway);
+		TestRetryingRegistration registration = new TestRetryingRegistration(rpcService, testEndpointAddress, leaderId);
+		registration.startRegistration();
 
-			TestRetryingRegistration registration = new TestRetryingRegistration(rpc, testEndpointAddress, leaderId);
-			registration.startRegistration();
+		// cancel and fail the current registration attempt
+		registration.cancel();
+		result.completeExceptionally(new TimeoutException());
 
-			// cancel and fail the current registration attempt
-			registration.cancel();
-			result.completeExceptionally(new TimeoutException());
-
-			// there should not be a second registration attempt
-			verify(testGateway, atMost(1)).registrationCall(any(UUID.class), anyLong());
-		}
-		finally {
-			rpc.stopService();
-		}
+		// there should not be a second registration attempt
+		verify(testGateway, atMost(1)).registrationCall(any(UUID.class), anyLong());
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerHATest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerHATest.java
@@ -126,7 +126,7 @@ public class ResourceManagerHATest extends TestLogger {
 				testingFatalErrorHandler.rethrowError();
 			}
 		} finally {
-			rpcService.stopService();
+			rpcService.stopService().get();
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerJobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerJobMasterTest.java
@@ -37,6 +37,7 @@ import org.apache.flink.runtime.metrics.MetricRegistryImpl;
 import org.apache.flink.runtime.resourcemanager.exceptions.ResourceManagerException;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.registration.RegistrationResponse;
 import org.apache.flink.runtime.rpc.exceptions.FencingTokenException;
@@ -73,7 +74,7 @@ public class ResourceManagerJobMasterTest extends TestLogger {
 
 	@After
 	public void teardown() throws Exception {
-		rpcService.stopService();
+		RpcUtils.terminateRpcService(rpcService, timeout);
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTaskExecutorTest.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.metrics.MetricRegistryImpl;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerInfo;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.registration.RegistrationResponse;
 import org.apache.flink.runtime.rpc.exceptions.FencingTokenException;
@@ -105,7 +106,7 @@ public class ResourceManagerTaskExecutorTest extends TestLogger {
 
 	@After
 	public void teardown() throws Exception {
-		rpcService.stopService();
+		RpcUtils.terminateRpcService(rpcService, timeout);
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTest.java
@@ -46,6 +46,7 @@ import org.junit.experimental.categories.Category;
 
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 
 @Category(Flip6.class)
 public class ResourceManagerTest extends TestLogger {
@@ -54,18 +55,13 @@ public class ResourceManagerTest extends TestLogger {
 
 	@Before
 	public void setUp() {
-		if (rpcService != null) {
-			rpcService.stopService();
-			rpcService = null;
-		}
-
 		rpcService = new TestingRpcService();
 	}
 
 	@After
-	public void tearDown() {
+	public void tearDown() throws ExecutionException, InterruptedException {
 		if (rpcService != null) {
-			rpcService.stopService();
+			rpcService.stopService().get();
 			rpcService = null;
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/FencedRpcEndpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/FencedRpcEndpointTest.java
@@ -60,8 +60,7 @@ public class FencedRpcEndpointTest extends TestLogger {
 	@AfterClass
 	public static void teardown() throws ExecutionException, InterruptedException, TimeoutException {
 		if (rpcService != null) {
-			rpcService.stopService();
-			rpcService.getTerminationFuture().get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+			RpcUtils.terminateRpcService(rpcService, timeout);
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/RpcConnectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/RpcConnectionTest.java
@@ -23,17 +23,21 @@ import akka.actor.ActorSystem;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.rpc.akka.AkkaRpcService;
 import org.apache.flink.runtime.rpc.exceptions.RpcConnectionException;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
 import org.apache.flink.testutils.category.Flip6;
+import org.apache.flink.util.TestLogger;
 
+import akka.actor.Terminated;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import scala.Option;
 import scala.Tuple2;
 
+import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -46,10 +50,10 @@ import static org.junit.Assert.*;
  * connect to an RpcEndpoint.
  */
 @Category(Flip6.class)
-public class RpcConnectionTest {
+public class RpcConnectionTest extends TestLogger {
 
 	@Test
-	public void testConnectFailure() {
+	public void testConnectFailure() throws Exception {
 		ActorSystem actorSystem = null;
 		RpcService rpcService = null;
 		try {
@@ -77,12 +81,25 @@ public class RpcConnectionTest {
 			fail("wrong exception: " + t);
 		}
 		finally {
+			final CompletableFuture<Void> rpcTerminationFuture;
+
 			if (rpcService != null) {
-				rpcService.stopService();
+				rpcTerminationFuture = rpcService.stopService();
+			} else {
+				rpcTerminationFuture = CompletableFuture.completedFuture(null);
 			}
+
+			final CompletableFuture<Terminated> actorSystemTerminationFuture;
+
 			if (actorSystem != null) {
-				actorSystem.shutdown();
+				actorSystemTerminationFuture = FutureUtils.toJava(actorSystem.terminate());
+			} else {
+				actorSystemTerminationFuture = CompletableFuture.completedFuture(null);
 			}
+
+			FutureUtils
+				.waitForAll(Arrays.asList(rpcTerminationFuture, actorSystemTerminationFuture))
+				.get();
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/RpcEndpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/RpcEndpointTest.java
@@ -20,20 +20,21 @@ package org.apache.flink.runtime.rpc;
 
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.rpc.akka.AkkaRpcService;
 import org.apache.flink.testutils.category.Flip6;
 import org.apache.flink.util.TestLogger;
 
 import akka.actor.ActorSystem;
+import akka.actor.Terminated;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-
-import scala.concurrent.duration.FiniteDuration;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -56,21 +57,13 @@ public class RpcEndpointTest extends TestLogger {
 
 	@AfterClass
 	public static void teardown() throws Exception {
-		if (rpcService != null) {
-			rpcService.stopService();
-		}
 
-		if (actorSystem != null) {
-			actorSystem.shutdown();
-		}
+		final CompletableFuture<Void> rpcTerminationFuture = rpcService.stopService();
+		final CompletableFuture<Terminated> actorSystemTerminationFuture = FutureUtils.toJava(actorSystem.terminate());
 
-		if (rpcService != null) {
-			rpcService.getTerminationFuture().get(TIMEOUT.toMilliseconds(), TimeUnit.MILLISECONDS);
-		}
-
-		if (actorSystem != null) {
-			actorSystem.awaitTermination(new FiniteDuration(TIMEOUT.toMilliseconds(), TimeUnit.MILLISECONDS));
-		}
+		FutureUtils
+			.waitForAll(Arrays.asList(rpcTerminationFuture, actorSystemTerminationFuture))
+			.get(TIMEOUT.toMilliseconds(), TimeUnit.MILLISECONDS);
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/TestingRpcService.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/TestingRpcService.java
@@ -74,9 +74,15 @@ public class TestingRpcService extends AkkaRpcService {
 	// ------------------------------------------------------------------------
 
 	@Override
-	public void stopService() {
-		super.stopService();
-		registeredConnections.clear();
+	public CompletableFuture<Void> stopService() {
+		final CompletableFuture<Void> terminationFuture = super.stopService();
+
+		terminationFuture.whenComplete(
+			(Void ignored, Throwable throwable) -> {
+				registeredConnections.clear();
+			});
+
+		return terminationFuture;
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceTest.java
@@ -27,10 +27,12 @@ import org.apache.flink.testutils.category.Flip6;
 import org.apache.flink.util.TestLogger;
 
 import akka.actor.ActorSystem;
+import akka.actor.Terminated;
 import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+import java.util.Arrays;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -59,10 +61,13 @@ public class AkkaRpcServiceTest extends TestLogger {
 			new AkkaRpcService(actorSystem, timeout);
 
 	@AfterClass
-	public static void shutdown() {
-		akkaRpcService.stopService();
-		actorSystem.shutdown();
-		actorSystem.awaitTermination(FutureUtils.toFiniteDuration(timeout));
+	public static void shutdown() throws InterruptedException, ExecutionException, TimeoutException {
+		final CompletableFuture<Void> rpcTerminationFuture = akkaRpcService.stopService();
+		final CompletableFuture<Terminated> actorSystemTerminationFuture = FutureUtils.toJava(actorSystem.terminate());
+
+		FutureUtils
+			.waitForAll(Arrays.asList(rpcTerminationFuture, actorSystemTerminationFuture))
+			.get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/MainThreadValidationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/MainThreadValidationTest.java
@@ -70,7 +70,7 @@ public class MainThreadValidationTest extends TestLogger {
 			testEndpoint.shutDown();
 		}
 		finally {
-			akkaRpcService.stopService();
+			akkaRpcService.stopService().get();
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/MessageSerializationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/MessageSerializationTest.java
@@ -18,16 +18,18 @@
 
 package org.apache.flink.runtime.rpc.akka;
 
-import akka.actor.ActorSystem;
-import com.typesafe.config.Config;
-import com.typesafe.config.ConfigValueFactory;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.rpc.RpcEndpoint;
 import org.apache.flink.runtime.rpc.RpcGateway;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.testutils.category.Flip6;
 import org.apache.flink.util.TestLogger;
+
+import akka.actor.ActorSystem;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigValueFactory;
 import org.hamcrest.core.Is;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -35,8 +37,13 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
@@ -67,15 +74,17 @@ public class MessageSerializationTest extends TestLogger {
 	}
 
 	@AfterClass
-	public static void teardown() {
-		akkaRpcService1.stopService();
-		akkaRpcService2.stopService();
+	public static void teardown() throws InterruptedException, ExecutionException, TimeoutException {
+		final Collection<CompletableFuture<?>> terminationFutures = new ArrayList<>(4);
 
-		actorSystem1.shutdown();
-		actorSystem2.shutdown();
+		terminationFutures.add(akkaRpcService1.stopService());
+		terminationFutures.add(FutureUtils.toJava(actorSystem1.terminate()));
+		terminationFutures.add(akkaRpcService2.stopService());
+		terminationFutures.add(FutureUtils.toJava(actorSystem2.terminate()));
 
-		actorSystem1.awaitTermination();
-		actorSystem2.awaitTermination();
+		FutureUtils
+			.waitForAll(terminationFutures)
+			.get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorITCase.java
@@ -48,6 +48,7 @@ import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.resourcemanager.SlotRequest;
 import org.apache.flink.runtime.resourcemanager.StandaloneResourceManager;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
+import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
 import org.apache.flink.runtime.taskexecutor.slot.TaskSlotTable;
@@ -220,7 +221,7 @@ public class TaskExecutorITCase extends TestLogger {
 				testingFatalErrorHandler.rethrowError();
 			}
 
-			rpcService.stopService();
+			RpcUtils.terminateRpcService(rpcService, timeout);
 		}
 
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -189,7 +189,7 @@ public class TaskExecutorTest extends TestLogger {
 	@After
 	public void teardown() throws Exception {
 		if (rpc != null) {
-			rpc.stopService();
+			RpcUtils.terminateRpcService(rpc, timeout);
 			rpc = null;
 		}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/retriever/impl/RpcGatewayRetrieverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/retriever/impl/RpcGatewayRetrieverTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.rpc.FencedRpcGateway;
 import org.apache.flink.runtime.rpc.RpcEndpoint;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.RpcTimeout;
+import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.util.TestLogger;
 
@@ -58,9 +59,7 @@ public class RpcGatewayRetrieverTest extends TestLogger {
 	@AfterClass
 	public static void teardown() throws InterruptedException, ExecutionException, TimeoutException {
 		if (rpcService != null) {
-			rpcService.stopService();
-			rpcService.getTerminationFuture().get(TIMEOUT.toMilliseconds(), TimeUnit.MILLISECONDS);
-
+			RpcUtils.terminateRpcService(rpcService, TIMEOUT);
 			rpcService = null;
 		}
 	}

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
@@ -308,7 +308,7 @@ public class YarnResourceManagerTest extends TestLogger {
 		 * Stop the Akka actor system.
 		 */
 		public void stopResourceManager() throws Exception {
-			rpcService.stopService();
+			rpcService.stopService().get();
 		}
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

Changes the RpcService#stopService method to be non blocking. Instead
of waiting until the RpcService has stopped, it returns the termination
future which is completed once the RpcService has been completelyshut
down.

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
