### PR TITLE
[FLINK-8684] [config] Rework MesosTaskManagerParameters#MESOS_RM_TASK…

### DIFF
--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
@@ -18,10 +18,10 @@
 
 package org.apache.flink.mesos.runtime.clusterframework;
 
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.clusterframework.ContaineredTaskManagerParameters;
 import org.apache.flink.util.Preconditions;
 
@@ -50,9 +50,7 @@ public class MesosTaskManagerParameters {
 	/** Pattern replaced in the {@link #MESOS_TM_HOSTNAME} by the actual task id of the Mesos task. */
 	public static final Pattern TASK_ID_PATTERN = Pattern.compile("_TASK_", Pattern.LITERAL);
 
-	public static final ConfigOption<Integer> MESOS_RM_TASKS_SLOTS =
-		key(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS)
-		.defaultValue(1);
+	public static final ConfigOption<Integer> MESOS_RM_TASKS_SLOTS = TaskManagerOptions.NUM_TASK_SLOTS;
 
 	public static final ConfigOption<Integer> MESOS_RM_TASKS_MEMORY_MB =
 		key("mesos.resourcemanager.tasks.mem")


### PR DESCRIPTION
## What is the purpose of the change
Directly by using ```TaskManagerOptions.NUM_TASK_SLOTS``` as it's alias to rework the ```ConfigOption```. to avoid creating 2 documentation entries of  ```taskmanager.numberOfTaskSlots```.

## Brief change log
Use FLINK-8683 test this change.


## Verifying this change
This change is a trivial rework. 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): (/ no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (/ no )
  - The S3 file system connector: ( no )

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? ( not documented)
