### PR TITLE
[FLINK-8698] [flip6] Use Flip-6 MiniCluster for local (Stream)ExecutionEnvironment

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/LocalExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/LocalExecutor.java
@@ -27,17 +27,18 @@ import org.apache.flink.api.common.Program;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.configuration.ResourceManagerOptions;
 import org.apache.flink.optimizer.DataStatistics;
 import org.apache.flink.optimizer.Optimizer;
 import org.apache.flink.optimizer.dag.DataSinkNode;
 import org.apache.flink.optimizer.plan.OptimizedPlan;
 import org.apache.flink.optimizer.plandump.PlanJSONDumpGenerator;
 import org.apache.flink.optimizer.plantranslate.JobGraphGenerator;
-import org.apache.flink.runtime.akka.AkkaUtils;
-import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.jobgraph.JobGraph;
-import org.apache.flink.runtime.messages.JobManagerMessages;
+import org.apache.flink.runtime.minicluster.JobExecutorService;
 import org.apache.flink.runtime.minicluster.LocalFlinkMiniCluster;
+import org.apache.flink.runtime.minicluster.MiniCluster;
+import org.apache.flink.runtime.minicluster.MiniClusterConfiguration;
 
 import java.util.List;
 
@@ -59,11 +60,14 @@ public class LocalExecutor extends PlanExecutor {
 	/** we lock to ensure singleton execution. */
 	private final Object lock = new Object();
 
-	/** The mini cluster on which to execute the local programs. */
-	private LocalFlinkMiniCluster flink;
-
 	/** Custom user configuration for the execution. */
-	private final Configuration configuration;
+	private final Configuration baseConfiguration;
+
+	/** Service for executing Flink jobs. */
+	private JobExecutorService jobExecutorService;
+
+	/** Current job executor service configuration. */
+	private Configuration jobExecutorServiceConfiguration;
 
 	/** Config value for how many slots to provide in the local cluster. */
 	private int taskManagerNumSlots = DEFAULT_TASK_MANAGER_NUM_SLOTS;
@@ -78,7 +82,7 @@ public class LocalExecutor extends PlanExecutor {
 	}
 
 	public LocalExecutor(Configuration conf) {
-		this.configuration = conf != null ? conf : new Configuration();
+		this.baseConfiguration = conf != null ? conf : new Configuration();
 	}
 
 	// ------------------------------------------------------------------------
@@ -106,27 +110,59 @@ public class LocalExecutor extends PlanExecutor {
 	@Override
 	public void start() throws Exception {
 		synchronized (lock) {
-			if (flink == null) {
+			if (jobExecutorService == null) {
 				// create the embedded runtime
-				Configuration configuration = createConfiguration();
-				if (this.configuration != null) {
-					configuration.addAll(this.configuration);
-				}
+				jobExecutorServiceConfiguration = createConfiguration();
+
 				// start it up
-				flink = new LocalFlinkMiniCluster(configuration, true);
-				this.flink.start();
+				jobExecutorService = createJobExecutorService(jobExecutorServiceConfiguration);
 			} else {
 				throw new IllegalStateException("The local executor was already started.");
 			}
 		}
 	}
 
+	private JobExecutorService createJobExecutorService(Configuration configuration) throws Exception {
+		final JobExecutorService newJobExecutorService;
+		if (CoreOptions.FLIP6_MODE.equals(configuration.getString(CoreOptions.MODE))) {
+			final MiniClusterConfiguration miniClusterConfiguration = new MiniClusterConfiguration.Builder()
+				.setConfiguration(configuration)
+				.setNumJobManagers(
+					configuration.getInteger(
+						ConfigConstants.LOCAL_NUMBER_JOB_MANAGER,
+						ConfigConstants.DEFAULT_LOCAL_NUMBER_JOB_MANAGER))
+				.setNumResourceManagers(
+					configuration.getInteger(ResourceManagerOptions.LOCAL_NUMBER_RESOURCE_MANAGER))
+				.setNumTaskManagers(
+					configuration.getInteger(
+						ConfigConstants.LOCAL_NUMBER_TASK_MANAGER,
+						ConfigConstants.DEFAULT_LOCAL_NUMBER_TASK_MANAGER))
+				.setRpcServiceSharing(MiniClusterConfiguration.RpcServiceSharing.SHARED)
+				.setNumSlotsPerTaskManager(
+					configuration.getInteger(
+						ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, 1))
+				.build();
+
+			final MiniCluster miniCluster = new MiniCluster(miniClusterConfiguration);
+			miniCluster.start();
+
+			newJobExecutorService = miniCluster;
+		} else {
+			final LocalFlinkMiniCluster localFlinkMiniCluster = new LocalFlinkMiniCluster(configuration, true);
+			localFlinkMiniCluster.start();
+
+			newJobExecutorService = localFlinkMiniCluster;
+		}
+
+		return newJobExecutorService;
+	}
+
 	@Override
 	public void stop() throws Exception {
 		synchronized (lock) {
-			if (flink != null) {
-				flink.stop();
-				flink = null;
+			if (jobExecutorService != null) {
+				jobExecutorService.terminate().get();
+				jobExecutorService = null;
 			}
 		}
 	}
@@ -134,7 +170,7 @@ public class LocalExecutor extends PlanExecutor {
 	@Override
 	public boolean isRunning() {
 		synchronized (lock) {
-			return flink != null;
+			return jobExecutorService != null;
 		}
 	}
 
@@ -162,7 +198,7 @@ public class LocalExecutor extends PlanExecutor {
 			// check if we start a session dedicated for this execution
 			final boolean shutDownAtEnd;
 
-			if (flink == null) {
+			if (jobExecutorService == null) {
 				shutDownAtEnd = true;
 
 				// configure the number of local slots equal to the parallelism of the local plan
@@ -182,16 +218,18 @@ public class LocalExecutor extends PlanExecutor {
 			}
 
 			try {
-				Configuration configuration = this.flink.configuration();
+				// TODO: Set job's default parallelism to max number of slots
+				final int slotsPerTaskManager = jobExecutorServiceConfiguration.getInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, taskManagerNumSlots);
+				final int numTaskManagers = jobExecutorServiceConfiguration.getInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, 1);
+				plan.setDefaultParallelism(slotsPerTaskManager * numTaskManagers);
 
-				Optimizer pc = new Optimizer(new DataStatistics(), configuration);
+				Optimizer pc = new Optimizer(new DataStatistics(), jobExecutorServiceConfiguration);
 				OptimizedPlan op = pc.compile(plan);
 
-				JobGraphGenerator jgg = new JobGraphGenerator(configuration);
+				JobGraphGenerator jgg = new JobGraphGenerator(jobExecutorServiceConfiguration);
 				JobGraph jobGraph = jgg.compileJobGraph(op, plan.getJobId());
 
-				boolean sysoutPrint = isPrintingStatusDuringExecution();
-				return flink.submitJobAndWait(jobGraph, sysoutPrint);
+				return jobExecutorService.executeJobBlocking(jobGraph);
 			}
 			finally {
 				if (shutDownAtEnd) {
@@ -212,7 +250,7 @@ public class LocalExecutor extends PlanExecutor {
 	public String getOptimizerPlanAsJSON(Plan plan) throws Exception {
 		final int parallelism = plan.getDefaultParallelism() == ExecutionConfig.PARALLELISM_DEFAULT ? 1 : plan.getDefaultParallelism();
 
-		Optimizer pc = new Optimizer(new DataStatistics(), this.configuration);
+		Optimizer pc = new Optimizer(new DataStatistics(), this.baseConfiguration);
 		pc.setDefaultParallelism(parallelism);
 		OptimizedPlan op = pc.compile(plan);
 
@@ -221,20 +259,17 @@ public class LocalExecutor extends PlanExecutor {
 
 	@Override
 	public void endSession(JobID jobID) throws Exception {
-		synchronized (this.lock) {
-			LocalFlinkMiniCluster flink = this.flink;
-			if (flink != null) {
-				ActorGateway leaderGateway = flink.getLeaderGateway(AkkaUtils.getDefaultTimeoutAsFiniteDuration());
-				leaderGateway.tell(new JobManagerMessages.RemoveCachedJob(jobID));
-			}
-		}
+		// no op
 	}
 
 	private Configuration createConfiguration() {
-		Configuration configuration = new Configuration();
-		configuration.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, getTaskManagerNumSlots());
-		configuration.setBoolean(CoreOptions.FILESYTEM_DEFAULT_OVERRIDE, isDefaultOverwriteFiles());
-		return configuration;
+		Configuration newConfiguration = new Configuration();
+		newConfiguration.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, getTaskManagerNumSlots());
+		newConfiguration.setBoolean(CoreOptions.FILESYTEM_DEFAULT_OVERRIDE, isDefaultOverwriteFiles());
+
+		newConfiguration.addAll(baseConfiguration);
+
+		return newConfiguration;
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/FileOutputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/FileOutputFormat.java
@@ -72,7 +72,7 @@ public abstract class FileOutputFormat<IT> extends RichOutputFormat<IT> implemen
 	 * cluster execution, see LocalFlinkMiniCluster.
 	 * @param configuration The configuration to load defaults from
 	 */
-	private static void initDefaultsFromConfiguration(Configuration configuration) {
+	public static void initDefaultsFromConfiguration(Configuration configuration) {
 		final boolean overwrite = configuration.getBoolean(CoreOptions.FILESYTEM_DEFAULT_OVERRIDE);
 	
 		DEFAULT_WRITE_MODE = overwrite ? WriteMode.OVERWRITE : WriteMode.NO_OVERWRITE;

--- a/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
@@ -1093,9 +1093,7 @@ public abstract class ExecutionEnvironment {
 	 * @return A local execution environment with the specified parallelism.
 	 */
 	public static LocalEnvironment createLocalEnvironment(int parallelism) {
-		LocalEnvironment lee = new LocalEnvironment();
-		lee.setParallelism(parallelism);
-		return lee;
+		return createLocalEnvironment(new Configuration(), parallelism);
 	}
 
 	/**
@@ -1107,7 +1105,7 @@ public abstract class ExecutionEnvironment {
 	 * @return A local execution environment with the specified parallelism.
 	 */
 	public static LocalEnvironment createLocalEnvironment(Configuration customConfiguration) {
-		return new LocalEnvironment(customConfiguration);
+		return createLocalEnvironment(customConfiguration, -1);
 	}
 
 	/**
@@ -1127,10 +1125,24 @@ public abstract class ExecutionEnvironment {
 
 		conf.setBoolean(ConfigConstants.LOCAL_START_WEBSERVER, true);
 
-		LocalEnvironment localEnv = new LocalEnvironment(conf);
-		localEnv.setParallelism(defaultLocalDop);
+		return createLocalEnvironment(conf, -1);
+	}
 
-		return localEnv;
+	/**
+	 * Creates a {@link LocalEnvironment} which is used for executing Flink jobs.
+	 *
+	 * @param configuration to start the {@link LocalEnvironment} with
+	 * @param defaultParallelism to initialize the {@link LocalEnvironment} with
+	 * @return {@link LocalEnvironment}
+	 */
+	private static LocalEnvironment createLocalEnvironment(Configuration configuration, int defaultParallelism) {
+		final LocalEnvironment localEnvironment = new LocalEnvironment(configuration);
+
+		if (defaultParallelism > 0) {
+			localEnvironment.setParallelism(defaultParallelism);
+		}
+
+		return localEnvironment;
 	}
 
 	/**

--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/AbstractServerTest.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/AbstractServerTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.queryablestate.network.stats.DisabledKvStateRequestStats
 import org.apache.flink.queryablestate.network.stats.KvStateRequestStats;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.TestLogger;
 
 import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
 
@@ -47,7 +48,7 @@ import java.util.concurrent.CompletableFuture;
 /**
  * Tests general behavior of the {@link AbstractServerBase}.
  */
-public class AbstractServerTest {
+public class AbstractServerTest extends TestLogger {
 
 	@Rule
 	public ExpectedException expectedEx = ExpectedException.none();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolGateway.java
@@ -38,7 +38,7 @@ import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 
 /**
- * The gateway for calls on the {@link SlotPool}. 
+ * The gateway for calls on the {@link SlotPool}.
  */
 public interface SlotPoolGateway extends AllocatedSlotActions, RpcGateway {
 
@@ -55,7 +55,7 @@ public interface SlotPoolGateway extends AllocatedSlotActions, RpcGateway {
 	/**
 	 * Connects the SlotPool to the given ResourceManager. After this method is called, the
 	 * SlotPool will be able to request resources from the given ResourceManager.
-	 * 
+	 *
 	 * @param resourceManagerGateway  The RPC gateway for the resource manager.
 	 */
 	void connectToResourceManager(ResourceManagerGateway resourceManagerGateway);
@@ -64,7 +64,7 @@ public interface SlotPoolGateway extends AllocatedSlotActions, RpcGateway {
 	 * Disconnects the slot pool from its current Resource Manager. After this call, the pool will not
 	 * be able to request further slots from the Resource Manager, and all currently pending requests
 	 * to the resource manager will be canceled.
-	 * 
+	 *
 	 * <p>The slot pool will still be able to serve slots from its internal pool.
 	 */
 	void disconnectResourceManager();
@@ -147,7 +147,7 @@ public interface SlotPoolGateway extends AllocatedSlotActions, RpcGateway {
 	 * @param locationPreferences which define where the allocated slot should be placed, this can also be empty
 	 * @param allowQueuedScheduling true if the slot request can be queued (e.g. the returned future must not be completed)
 	 * @param timeout for the operation
-	 * @return
+	 * @return Future which is completed with the allocated {@link LogicalSlot}
 	 */
 	CompletableFuture<LogicalSlot> allocateSlot(
 			SlotRequestId slotRequestId,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.minicluster;
 
 import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.api.common.io.FileOutputFormat;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
@@ -159,6 +160,8 @@ public class MiniCluster implements JobExecutorService {
 			final boolean useSingleRpcService = miniClusterConfiguration.getRpcServiceSharing() == MiniClusterConfiguration.RpcServiceSharing.SHARED;
 
 			try {
+				initializeIOFormatClasses(configuration);
+
 				LOG.info("Starting Metrics Registry");
 				metricRegistry = createMetricRegistry(configuration);
 
@@ -604,6 +607,11 @@ public class MiniCluster implements JobExecutorService {
 	// ------------------------------------------------------------------------
 	//  miscellaneous utilities
 	// ------------------------------------------------------------------------
+
+	private void initializeIOFormatClasses(Configuration configuration) {
+		// TODO: That we still have to call something like this is a crime against humanity
+		FileOutputFormat.initDefaultsFromConfiguration(configuration);
+	}
 
 	private static Throwable shutDownRpc(RpcService rpcService, Throwable priorException) {
 		if (rpcService != null) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/Flip6LocalStreamEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/Flip6LocalStreamEnvironment.java
@@ -18,9 +18,7 @@
 package org.apache.flink.streaming.api.environment;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.JobExecutionResult;
-import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.jobgraph.JobGraph;
@@ -40,12 +38,9 @@ import org.slf4j.LoggerFactory;
  * parallelism can be set via {@link #setParallelism(int)}.
  */
 @Internal
-public class Flip6LocalStreamEnvironment extends StreamExecutionEnvironment {
+public class Flip6LocalStreamEnvironment extends LocalStreamEnvironment {
 
 	private static final Logger LOG = LoggerFactory.getLogger(Flip6LocalStreamEnvironment.class);
-
-	/** The configuration to use for the mini cluster. */
-	private final Configuration conf;
 
 	/**
 	 * Creates a new mini cluster stream environment that uses the default configuration.
@@ -60,13 +55,7 @@ public class Flip6LocalStreamEnvironment extends StreamExecutionEnvironment {
 	 * @param config The configuration used to configure the local executor.
 	 */
 	public Flip6LocalStreamEnvironment(Configuration config) {
-		if (!ExecutionEnvironment.areExplicitEnvironmentsAllowed()) {
-			throw new InvalidProgramException(
-					"The Flip6LocalStreamEnvironment cannot be used when submitting a program through a client, " +
-							"or running in a TestEnvironment context.");
-		}
-
-		this.conf = config == null ? new Configuration() : config;
+		super(config);
 		setParallelism(1);
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/LocalStreamEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/LocalStreamEnvironment.java
@@ -49,7 +49,7 @@ public class LocalStreamEnvironment extends StreamExecutionEnvironment {
 	private static final Logger LOG = LoggerFactory.getLogger(LocalStreamEnvironment.class);
 
 	/** The configuration to use for the local cluster. */
-	private final Configuration conf;
+	protected final Configuration conf;
 
 	/**
 	 * Creates a new local stream environment that uses the default configuration.


### PR DESCRIPTION
## What is the purpose of the change

Instantiate the Flip-6 `MiniCluster` in the local `(Stream)ExecutionEnvironment` if the Flip-6 mode is enabled. This allows to run Flink jobs on the Flip-6 components from within the IDE.

## Brief change log

- Return `Flip6LocalStreamEnvironment` from `StreamExecutionEnvironment#createLocalEnvironment` if Flip-6 is enabled
- Start Flip-6 `MiniCluster` in `LocalExecutor` if Flip-6 is enabled 

## Verifying this change

- Tested manually

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
