### PR TITLE
[FLINK-8674][runtime] Improve performance of flushAlways in StreamRecordWriter

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/ResultPartitionWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/ResultPartitionWriter.java
@@ -52,7 +52,12 @@ public interface ResultPartitionWriter {
 	void addBufferConsumer(BufferConsumer bufferConsumer, int subpartitionIndex) throws IOException;
 
 	/**
-	 * Manually trigger consumption from enqueued {@link BufferConsumer BufferConsumers}.
+	 * Manually trigger consumption from enqueued {@link BufferConsumer BufferConsumers} in all subpartitions.
 	 */
-	void flush();
+	void flushAll();
+
+	/**
+	 * Manually trigger consumption from enqueued {@link BufferConsumer BufferConsumers} in one specified subpartition.
+	 */
+	void flush(int subpartitionIndex);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
@@ -258,10 +258,15 @@ public class ResultPartition implements ResultPartitionWriter, BufferPoolOwner {
 	}
 
 	@Override
-	public void flush() {
+	public void flushAll() {
 		for (ResultSubpartition subpartition : subpartitions) {
 			subpartition.flush();
 		}
+	}
+
+	@Override
+	public void flush(int subpartitionIndex) {
+		subpartitions[subpartitionIndex].flush();
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/shipping/OutputCollector.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/shipping/OutputCollector.java
@@ -82,7 +82,7 @@ public class OutputCollector<T> implements Collector<T> {
 	public void close() {
 		for (RecordWriter<?> writer : writers) {
 			writer.clearBuffers();
-			writer.flush();
+			writer.flushAll();
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/AbstractCollectingResultPartitionWriter.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/AbstractCollectingResultPartitionWriter.java
@@ -88,12 +88,17 @@ public abstract class AbstractCollectingResultPartitionWriter implements ResultP
 	}
 
 	@Override
-	public synchronized void flush() {
+	public synchronized void flushAll() {
 		try {
 			processBufferConsumers();
 		} catch (IOException e) {
 			throw new RuntimeException(e);
 		}
+	}
+
+	@Override
+	public void flush(int subpartitionIndex) {
+		flushAll();
 	}
 
 	protected abstract void deserializeBuffer(Buffer buffer) throws IOException;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/RecordWriterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/RecordWriterTest.java
@@ -130,7 +130,7 @@ public class RecordWriterTest {
 
 					try {
 						recordWriter.emit(val);
-						recordWriter.flush();
+						recordWriter.flushAll();
 
 						recordWriter.emit(val);
 					}
@@ -183,7 +183,7 @@ public class RecordWriterTest {
 
 		// This should not throw an Exception iff the serializer state
 		// has been cleared as expected.
-		recordWriter.flush();
+		recordWriter.flushAll();
 	}
 
 	/**
@@ -362,7 +362,7 @@ public class RecordWriterTest {
 		RecordWriter<IntValue> writer = new RecordWriter<>(partition);
 
 		writer.broadcastEmit(new IntValue(0));
-		writer.flush();
+		writer.flushAll();
 
 		// Verify added to all queues
 		assertEquals(1, queues[0].size());
@@ -426,7 +426,11 @@ public class RecordWriterTest {
 		}
 
 		@Override
-		public void flush() {
+		public void flushAll() {
+		}
+
+		@Override
+		public void flush(int subpartitionIndex) {
 		}
 	}
 
@@ -479,7 +483,11 @@ public class RecordWriterTest {
 		}
 
 		@Override
-		public void flush() {
+		public void flushAll() {
+		}
+
+		@Override
+		public void flush(int subpartitionIndex) {
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/SlotCountExceedingParallelismTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/SlotCountExceedingParallelismTest.java
@@ -145,7 +145,7 @@ public class SlotCountExceedingParallelismTest extends TestLogger {
 				for (int i = 0; i < numberOfTimesToSend; i++) {
 					writer.emit(subtaskIndex);
 				}
-				writer.flush();
+				writer.flushAll();
 			}
 			finally {
 				writer.clearBuffers();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/ScheduleOrUpdateConsumersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/ScheduleOrUpdateConsumersTest.java
@@ -157,7 +157,7 @@ public class ScheduleOrUpdateConsumersTest extends TestLogger {
 					for (int i = 0; i < numberOfTimesToSend; i++) {
 						writer.emit(subtaskIndex);
 					}
-					writer.flush();
+					writer.flushAll();
 				}
 				finally {
 					writer.clearBuffers();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskCancelAsyncProducerConsumerITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskCancelAsyncProducerConsumerITCase.java
@@ -223,7 +223,7 @@ public class TaskCancelAsyncProducerConsumerITCase extends TestLogger {
 					while (true) {
 						current.setValue(current.getValue() + 1);
 						recordWriter.emit(current);
-						recordWriter.flush();
+						recordWriter.flushAll();
 					}
 				} catch (Exception e) {
 					ASYNC_PRODUCER_EXCEPTION = e;

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/Tasks.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/Tasks.scala
@@ -36,7 +36,7 @@ object Tasks {
       try{
         writer.emit(new IntValue(42))
         writer.emit(new IntValue(1337))
-        writer.flush()
+        writer.flushAll()
       }finally{
         writer.clearBuffers()
       }
@@ -65,7 +65,7 @@ object Tasks {
           writer.emit(record)
         }
 
-        writer.flush()
+        writer.flushAll()
       } finally {
         writer.clearBuffers()
       }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/RecordWriterOutput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/RecordWriterOutput.java
@@ -153,7 +153,7 @@ public class RecordWriterOutput<OUT> implements OperatorChain.WatermarkGaugeExpo
 	}
 
 	public void flush() throws IOException {
-		recordWriter.flush();
+		recordWriter.flushAll();
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamRecordWriter.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamRecordWriter.java
@@ -43,9 +43,6 @@ public class StreamRecordWriter<T extends IOReadableWritable> extends RecordWrit
 	/** The thread that periodically flushes the output, to give an upper latency bound. */
 	private final OutputFlusher outputFlusher;
 
-	/** Flag indicating whether the output should be flushed after every element. */
-	private final boolean flushAlways;
-
 	/** The exception encountered in the flushing thread. */
 	private Throwable flusherException;
 
@@ -58,20 +55,17 @@ public class StreamRecordWriter<T extends IOReadableWritable> extends RecordWrit
 			ChannelSelector<T> channelSelector,
 			long timeout,
 			String taskName) {
-		super(writer, channelSelector);
+		super(writer, channelSelector, timeout == 0);
 
 		checkArgument(timeout >= -1);
 
 		if (timeout == -1) {
-			flushAlways = false;
 			outputFlusher = null;
 		}
 		else if (timeout == 0) {
-			flushAlways = true;
 			outputFlusher = null;
 		}
 		else {
-			flushAlways = false;
 			String threadName = taskName == null ?
 				DEFAULT_OUTPUT_FLUSH_THREAD_NAME : "Output Timeout Flusher - " + taskName;
 
@@ -84,27 +78,18 @@ public class StreamRecordWriter<T extends IOReadableWritable> extends RecordWrit
 	public void emit(T record) throws IOException, InterruptedException {
 		checkErroneous();
 		super.emit(record);
-		if (flushAlways) {
-			flush();
-		}
 	}
 
 	@Override
 	public void broadcastEmit(T record) throws IOException, InterruptedException {
 		checkErroneous();
 		super.broadcastEmit(record);
-		if (flushAlways) {
-			flush();
-		}
 	}
 
 	@Override
 	public void randomEmit(T record) throws IOException, InterruptedException {
 		checkErroneous();
 		super.randomEmit(record);
-		if (flushAlways) {
-			flush();
-		}
 	}
 
 	/**
@@ -182,7 +167,7 @@ public class StreamRecordWriter<T extends IOReadableWritable> extends RecordWrit
 
 					// any errors here should let the thread come to a halt and be
 					// recognized by the writer
-					flush();
+					flushAll();
 				}
 			}
 			catch (Throwable t) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/LongRecordWriterThread.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/LongRecordWriterThread.java
@@ -93,7 +93,7 @@ public class LongRecordWriterThread extends CheckedThread {
 		}
 		value.setValue(records);
 		recordWriter.broadcastEmit(value);
-		recordWriter.flush();
+		recordWriter.flushAll();
 
 		finishSendingRecords();
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkPointToPointBenchmark.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkPointToPointBenchmark.java
@@ -55,7 +55,7 @@ public class StreamNetworkPointToPointBenchmark {
 		value.setValue(records);
 		recordWriter.broadcastEmit(value);
 		if (flushAfterLastEmit) {
-			recordWriter.flush();
+			recordWriter.flushAll();
 		}
 
 		recordsReceived.get(RECEIVER_TIMEOUT, TimeUnit.MILLISECONDS);

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/NetworkStackThroughputITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/NetworkStackThroughputITCase.java
@@ -106,7 +106,7 @@ public class NetworkStackThroughputITCase extends TestLogger {
 				}
 			}
 			finally {
-				writer.flush();
+				writer.flushAll();
 			}
 		}
 	}
@@ -139,7 +139,7 @@ public class NetworkStackThroughputITCase extends TestLogger {
 			}
 			finally {
 				reader.clearBuffers();
-				writer.flush();
+				writer.flushAll();
 			}
 		}
 	}


### PR DESCRIPTION
This PR reduces the number of data notifications in case of `flushAlways = true`. Instead of notifying all of the channels/subpartitions, notify only the one that has just been written to.

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
