### PR TITLE
[FLINK-7712][flip6] Port JarDeleteHandler to new REST endpoint

### DIFF
--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebSubmissionExtension.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebSubmissionExtension.java
@@ -23,6 +23,8 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.client.program.rest.RestClusterClient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.rest.handler.RestHandlerSpecification;
+import org.apache.flink.runtime.webmonitor.handlers.JarDeleteHandler;
+import org.apache.flink.runtime.webmonitor.handlers.JarDeleteHeaders;
 import org.apache.flink.runtime.webmonitor.handlers.JarListHandler;
 import org.apache.flink.runtime.webmonitor.handlers.JarListHeaders;
 import org.apache.flink.runtime.webmonitor.handlers.JarRunHandler;
@@ -91,9 +93,19 @@ public class WebSubmissionExtension implements WebMonitorExtension {
 			executor,
 			restClusterClient);
 
+		final JarDeleteHandler jarDeleteHandler = new JarDeleteHandler(
+			restAddressFuture,
+			leaderRetriever,
+			timeout,
+			responseHeaders,
+			JarDeleteHeaders.getInstance(),
+			jarDir,
+			executor);
+
 		webSubmissionHandlers.add(Tuple2.of(JarUploadMessageHeaders.getInstance(), jarUploadHandler));
 		webSubmissionHandlers.add(Tuple2.of(JarListHeaders.getInstance(), jarListHandler));
 		webSubmissionHandlers.add(Tuple2.of(JarRunHeaders.getInstance(), jarRunHandler));
+		webSubmissionHandlers.add(Tuple2.of(JarDeleteHeaders.getInstance(), jarDeleteHandler));
 	}
 
 	@Override

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebSubmissionExtension.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebSubmissionExtension.java
@@ -30,7 +30,7 @@ import org.apache.flink.runtime.webmonitor.handlers.JarListHeaders;
 import org.apache.flink.runtime.webmonitor.handlers.JarRunHandler;
 import org.apache.flink.runtime.webmonitor.handlers.JarRunHeaders;
 import org.apache.flink.runtime.webmonitor.handlers.JarUploadHandler;
-import org.apache.flink.runtime.webmonitor.handlers.JarUploadMessageHeaders;
+import org.apache.flink.runtime.webmonitor.handlers.JarUploadHeaders;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
 
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelInboundHandler;
@@ -69,7 +69,7 @@ public class WebSubmissionExtension implements WebMonitorExtension {
 			leaderRetriever,
 			timeout,
 			responseHeaders,
-			JarUploadMessageHeaders.getInstance(),
+			JarUploadHeaders.getInstance(),
 			jarDir,
 			executor);
 
@@ -102,7 +102,7 @@ public class WebSubmissionExtension implements WebMonitorExtension {
 			jarDir,
 			executor);
 
-		webSubmissionHandlers.add(Tuple2.of(JarUploadMessageHeaders.getInstance(), jarUploadHandler));
+		webSubmissionHandlers.add(Tuple2.of(JarUploadHeaders.getInstance(), jarUploadHandler));
 		webSubmissionHandlers.add(Tuple2.of(JarListHeaders.getInstance(), jarListHandler));
 		webSubmissionHandlers.add(Tuple2.of(JarRunHeaders.getInstance(), jarRunHandler));
 		webSubmissionHandlers.add(Tuple2.of(JarDeleteHeaders.getInstance(), jarDeleteHandler));

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarDeleteHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarDeleteHandler.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.webmonitor.handlers;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.rest.handler.AbstractRestHandler;
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.RestHandlerException;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.EmptyResponseBody;
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+import org.apache.flink.runtime.webmonitor.RestfulGateway;
+import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+import javax.annotation.Nonnull;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executor;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Handles requests for deletion of jars.
+ */
+public class JarDeleteHandler
+		extends AbstractRestHandler<RestfulGateway, EmptyRequestBody, EmptyResponseBody, JarDeleteMessageParameters> {
+
+	private final Path jarDir;
+
+	private final Executor executor;
+
+	public JarDeleteHandler(
+			final CompletableFuture<String> localRestAddress,
+			final GatewayRetriever<? extends RestfulGateway> leaderRetriever,
+			final Time timeout,
+			final Map<String, String> responseHeaders,
+			final MessageHeaders<EmptyRequestBody, EmptyResponseBody, JarDeleteMessageParameters> messageHeaders,
+			final Path jarDir,
+			final Executor executor) {
+		super(localRestAddress, leaderRetriever, timeout, responseHeaders, messageHeaders);
+		this.jarDir = requireNonNull(jarDir);
+		this.executor = requireNonNull(executor);
+	}
+
+	@Override
+	protected CompletableFuture<EmptyResponseBody> handleRequest(
+			@Nonnull final HandlerRequest<EmptyRequestBody, JarDeleteMessageParameters> request,
+			@Nonnull final RestfulGateway gateway) throws RestHandlerException {
+
+		final String jarId = request.getPathParameter(JarIdPathParameter.class);
+		return CompletableFuture.supplyAsync(() -> {
+			final Path jarToDelete = jarDir.resolve(jarId);
+			if (!Files.exists(jarToDelete)) {
+				throw new CompletionException(new RestHandlerException(
+					String.format("File %s does not exist in %s.", jarId, jarDir),
+					HttpResponseStatus.BAD_REQUEST));
+			} else {
+				try {
+					Files.delete(jarToDelete);
+					return EmptyResponseBody.getInstance();
+				} catch (final IOException e) {
+					throw new CompletionException(new RestHandlerException(
+						String.format("Failed to delete jar %s.", jarToDelete),
+						HttpResponseStatus.INTERNAL_SERVER_ERROR,
+						e));
+				}
+			}
+		}, executor);
+	}
+}

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarDeleteHeaders.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarDeleteHeaders.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.webmonitor.handlers;
+
+import org.apache.flink.runtime.rest.HttpMethodWrapper;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.EmptyResponseBody;
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+/**
+ * Message headers for {@link JarDeleteHandler}.
+ */
+public class JarDeleteHeaders implements MessageHeaders<EmptyRequestBody, EmptyResponseBody, JarDeleteMessageParameters> {
+
+	private static final JarDeleteHeaders INSTANCE = new JarDeleteHeaders();
+
+	@Override
+	public Class<EmptyResponseBody> getResponseClass() {
+		return EmptyResponseBody.class;
+	}
+
+	@Override
+	public HttpResponseStatus getResponseStatusCode() {
+		return HttpResponseStatus.OK;
+	}
+
+	@Override
+	public Class<EmptyRequestBody> getRequestClass() {
+		return EmptyRequestBody.class;
+	}
+
+	@Override
+	public JarDeleteMessageParameters getUnresolvedMessageParameters() {
+		return new JarDeleteMessageParameters();
+	}
+
+	@Override
+	public HttpMethodWrapper getHttpMethod() {
+		return HttpMethodWrapper.DELETE;
+	}
+
+	@Override
+	public String getTargetRestEndpointURL() {
+		return "/jars/:" + JarIdPathParameter.KEY;
+	}
+
+	public static JarDeleteHeaders getInstance() {
+		return INSTANCE;
+	}
+
+}

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarDeleteMessageParameters.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarDeleteMessageParameters.java
@@ -18,34 +18,27 @@
 
 package org.apache.flink.runtime.webmonitor.handlers;
 
-import org.apache.flink.runtime.rest.messages.ConversionException;
+import org.apache.flink.runtime.rest.messages.MessageParameters;
 import org.apache.flink.runtime.rest.messages.MessagePathParameter;
+import org.apache.flink.runtime.rest.messages.MessageQueryParameter;
 
-import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.Collections;
 
 /**
- * Path parameter to identify uploaded jar files.
+ * Message parameters for {@link JarDeleteHandler}.
  */
-public class JarIdPathParameter extends MessagePathParameter<String> {
+public class JarDeleteMessageParameters extends MessageParameters {
 
-	public static final String KEY = "jarid";
+	private JarIdPathParameter jarIdPathParameter = new JarIdPathParameter();
 
-	protected JarIdPathParameter() {
-		super(KEY);
+	@Override
+	public Collection<MessagePathParameter<?>> getPathParameters() {
+		return Collections.singletonList(jarIdPathParameter);
 	}
 
 	@Override
-	protected String convertFromString(final String value) throws ConversionException {
-		final Path path = Paths.get(value);
-		if (path.getParent() != null) {
-			throw new ConversionException(String.format("%s must be a filename only (%s)", KEY, path));
-		}
-		return value;
-	}
-
-	@Override
-	protected String convertToString(final String value) {
-		return value;
+	public Collection<MessageQueryParameter<?>> getQueryParameters() {
+		return Collections.emptyList();
 	}
 }

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarUploadHeaders.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarUploadHeaders.java
@@ -28,11 +28,11 @@ import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseSt
 /**
  * {@link MessageHeaders} for uploading jars.
  */
-public final class JarUploadMessageHeaders implements MessageHeaders<FileUpload, JarUploadResponseBody, EmptyMessageParameters> {
+public final class JarUploadHeaders implements MessageHeaders<FileUpload, JarUploadResponseBody, EmptyMessageParameters> {
 
-	private static final JarUploadMessageHeaders INSTANCE = new JarUploadMessageHeaders();
+	private static final JarUploadHeaders INSTANCE = new JarUploadHeaders();
 
-	private JarUploadMessageHeaders() {}
+	private JarUploadHeaders() {}
 
 	@Override
 	public Class<JarUploadResponseBody> getResponseClass() {
@@ -64,7 +64,7 @@ public final class JarUploadMessageHeaders implements MessageHeaders<FileUpload,
 		return "/jars/upload";
 	}
 
-	public static JarUploadMessageHeaders getInstance() {
+	public static JarUploadHeaders getInstance() {
 		return INSTANCE;
 	}
 }

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarDeleteHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarDeleteHandlerTest.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.webmonitor.handlers;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.concurrent.Executors;
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.HandlerRequestException;
+import org.apache.flink.runtime.rest.handler.RestHandlerException;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.webmonitor.RestfulGateway;
+import org.apache.flink.runtime.webmonitor.TestingRestfulGateway;
+import org.apache.flink.util.ExceptionUtils;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Unit tests for {@link JarDeleteHandler}.
+ */
+public class JarDeleteHandlerTest {
+
+	private static final String TEST_JAR_NAME = "test.jar";
+
+	private JarDeleteHandler jarDeleteHandler;
+
+	private RestfulGateway restfulGateway;
+
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	private Path jarDir;
+
+	@Before
+	public void setUp() throws Exception {
+		jarDir = temporaryFolder.newFolder().toPath();
+		restfulGateway = TestingRestfulGateway.newBuilder().build();
+		jarDeleteHandler = new JarDeleteHandler(
+			CompletableFuture.completedFuture("localhost:12345"),
+			() -> CompletableFuture.completedFuture(restfulGateway),
+			Time.seconds(10),
+			Collections.emptyMap(),
+			new JarDeleteHeaders(),
+			jarDir,
+			Executors.directExecutor()
+		);
+
+		Files.createFile(jarDir.resolve(TEST_JAR_NAME));
+	}
+
+	@Test
+	public void testDeleteJarById() throws Exception {
+		assertThat(Files.exists(jarDir.resolve(TEST_JAR_NAME)), equalTo(true));
+
+		final HandlerRequest<EmptyRequestBody, JarDeleteMessageParameters> request = createRequest(TEST_JAR_NAME);
+		jarDeleteHandler.handleRequest(request, restfulGateway).get();
+
+		assertThat(Files.exists(jarDir.resolve(TEST_JAR_NAME)), equalTo(false));
+	}
+
+	@Test
+	public void testDeleteUnknownJar() throws Exception {
+		final HandlerRequest<EmptyRequestBody, JarDeleteMessageParameters> request = createRequest("doesnotexist.jar");
+		try {
+			jarDeleteHandler.handleRequest(request, restfulGateway).get();
+		} catch (final ExecutionException e) {
+			final Throwable throwable = ExceptionUtils.stripCompletionException(e.getCause());
+			assertThat(throwable, instanceOf(RestHandlerException.class));
+
+			final RestHandlerException restHandlerException = (RestHandlerException) throwable;
+			assertThat(restHandlerException.getMessage(), containsString("File doesnotexist.jar does not exist in"));
+			assertThat(restHandlerException.getHttpResponseStatus(), equalTo(HttpResponseStatus.BAD_REQUEST));
+		}
+	}
+
+	@Test
+	public void testFailedDelete() throws Exception {
+		makeJarDirReadOnly();
+
+		final HandlerRequest<EmptyRequestBody, JarDeleteMessageParameters> request = createRequest(TEST_JAR_NAME);
+		try {
+			jarDeleteHandler.handleRequest(request, restfulGateway).get();
+		} catch (final ExecutionException e) {
+			final Throwable throwable = ExceptionUtils.stripCompletionException(e.getCause());
+			assertThat(throwable, instanceOf(RestHandlerException.class));
+
+			final RestHandlerException restHandlerException = (RestHandlerException) throwable;
+			assertThat(restHandlerException.getMessage(), containsString("Failed to delete jar"));
+			assertThat(restHandlerException.getHttpResponseStatus(), equalTo(HttpResponseStatus.INTERNAL_SERVER_ERROR));
+		}
+	}
+
+	private static HandlerRequest<EmptyRequestBody, JarDeleteMessageParameters> createRequest(
+			final String jarFileName) throws HandlerRequestException {
+		return new HandlerRequest<>(
+			EmptyRequestBody.getInstance(),
+			new JarDeleteMessageParameters(),
+			Collections.singletonMap(JarIdPathParameter.KEY, jarFileName),
+			Collections.emptyMap());
+	}
+
+	private void makeJarDirReadOnly() {
+		try {
+			Files.setPosixFilePermissions(jarDir, new HashSet<>(Arrays.asList(
+				PosixFilePermission.OTHERS_READ,
+				PosixFilePermission.GROUP_READ,
+				PosixFilePermission.OWNER_READ,
+				PosixFilePermission.OTHERS_EXECUTE,
+				PosixFilePermission.GROUP_EXECUTE,
+				PosixFilePermission.OWNER_EXECUTE)));
+		} catch (final Exception e) {
+			Assume.assumeNoException(e);
+		}
+	}
+
+}

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarDeleteHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarDeleteHandlerTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
 import org.apache.flink.runtime.webmonitor.RestfulGateway;
 import org.apache.flink.runtime.webmonitor.TestingRestfulGateway;
 import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.TestLogger;
 
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
 
@@ -53,7 +54,7 @@ import static org.junit.Assert.assertThat;
 /**
  * Unit tests for {@link JarDeleteHandler}.
  */
-public class JarDeleteHandlerTest {
+public class JarDeleteHandlerTest extends TestLogger {
 
 	private static final String TEST_JAR_NAME = "test.jar";
 

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarDeleteHeadersTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarDeleteHeadersTest.java
@@ -18,34 +18,25 @@
 
 package org.apache.flink.runtime.webmonitor.handlers;
 
-import org.apache.flink.runtime.rest.messages.ConversionException;
-import org.apache.flink.runtime.rest.messages.MessagePathParameter;
+import org.apache.flink.runtime.rest.HttpMethodWrapper;
 
-import java.nio.file.Path;
-import java.nio.file.Paths;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
 
 /**
- * Path parameter to identify uploaded jar files.
+ * Tests for {@link JarDeleteHeaders}.
  */
-public class JarIdPathParameter extends MessagePathParameter<String> {
+public class JarDeleteHeadersTest {
 
-	public static final String KEY = "jarid";
-
-	protected JarIdPathParameter() {
-		super(KEY);
+	@Test
+	public void testUrl() {
+		assertThat(JarDeleteHeaders.getInstance().getTargetRestEndpointURL(), equalTo("/jars/:" + JarIdPathParameter.KEY));
 	}
 
-	@Override
-	protected String convertFromString(final String value) throws ConversionException {
-		final Path path = Paths.get(value);
-		if (path.getParent() != null) {
-			throw new ConversionException(String.format("%s must be a filename only (%s)", KEY, path));
-		}
-		return value;
-	}
-
-	@Override
-	protected String convertToString(final String value) {
-		return value;
+	@Test
+	public void testHttpMethod() {
+		assertThat(JarDeleteHeaders.getInstance().getHttpMethod(), equalTo(HttpMethodWrapper.DELETE));
 	}
 }

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarDeleteHeadersTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarDeleteHeadersTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.webmonitor.handlers;
 
 import org.apache.flink.runtime.rest.HttpMethodWrapper;
+import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
 
@@ -28,7 +29,7 @@ import static org.junit.Assert.assertThat;
 /**
  * Tests for {@link JarDeleteHeaders}.
  */
-public class JarDeleteHeadersTest {
+public class JarDeleteHeadersTest extends TestLogger {
 
 	@Test
 	public void testUrl() {

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarIdPathParameterTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarIdPathParameterTest.java
@@ -19,33 +19,35 @@
 package org.apache.flink.runtime.webmonitor.handlers;
 
 import org.apache.flink.runtime.rest.messages.ConversionException;
-import org.apache.flink.runtime.rest.messages.MessagePathParameter;
 
-import java.nio.file.Path;
-import java.nio.file.Paths;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
- * Path parameter to identify uploaded jar files.
+ * Tests for {@link JarIdPathParameter}.
  */
-public class JarIdPathParameter extends MessagePathParameter<String> {
+public class JarIdPathParameterTest {
 
-	public static final String KEY = "jarid";
+	private JarIdPathParameter jarIdPathParameter = new JarIdPathParameter();
 
-	protected JarIdPathParameter() {
-		super(KEY);
+	@Test(expected = ConversionException.class)
+	public void testJarIdWithParentDir() throws Exception {
+		jarIdPathParameter.convertFromString("../../test.jar");
 	}
 
-	@Override
-	protected String convertFromString(final String value) throws ConversionException {
-		final Path path = Paths.get(value);
-		if (path.getParent() != null) {
-			throw new ConversionException(String.format("%s must be a filename only (%s)", KEY, path));
-		}
-		return value;
+	@Test
+	public void testConvertFromString() throws Exception {
+		final String expectedJarId = "test.jar";
+		final String jarId = jarIdPathParameter.convertFromString(expectedJarId);
+		assertEquals(expectedJarId, jarId);
 	}
 
-	@Override
-	protected String convertToString(final String value) {
-		return value;
+	@Test
+	public void testConvertToString() throws Exception {
+		final String expected = "test.jar";
+		final String toString = jarIdPathParameter.convertToString(expected);
+		assertEquals(expected, toString);
 	}
+
 }

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarIdPathParameterTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarIdPathParameterTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.webmonitor.handlers;
 
 import org.apache.flink.runtime.rest.messages.ConversionException;
+import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
 
@@ -27,7 +28,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * Tests for {@link JarIdPathParameter}.
  */
-public class JarIdPathParameterTest {
+public class JarIdPathParameterTest extends TestLogger {
 
 	private JarIdPathParameter jarIdPathParameter = new JarIdPathParameter();
 

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarListInfoTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarListInfoTest.java
@@ -16,10 +16,9 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.webmonitor.handlers.ng;
+package org.apache.flink.runtime.webmonitor.handlers;
 
 import org.apache.flink.runtime.rest.messages.RestResponseMarshallingTestBase;
-import org.apache.flink.runtime.webmonitor.handlers.JarListInfo;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarUploadHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarUploadHandlerTest.java
@@ -75,7 +75,7 @@ public class JarUploadHandlerTest extends TestLogger {
 			() -> CompletableFuture.completedFuture(mockDispatcherGateway),
 			Time.seconds(10),
 			Collections.emptyMap(),
-			JarUploadMessageHeaders.getInstance(),
+			JarUploadHeaders.getInstance(),
 			jarDir,
 			Executors.directExecutor());
 	}


### PR DESCRIPTION
## What is the purpose of the change

*Enable deletion of jars from Web UI in flip6 mode.*

cc: @tillrohrmann 

## Brief change log

  - *Implement JarDeleteHandler.*
  - *Add verification to JarIdPathParameter so that user cannot escape from jar dir.*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added unit tests for new classes.*
  - *Manually uploaded and deleted a jar.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
