### PR TITLE
[FLINK-8703][tests] Migrate tests from LocalFlinkMiniCluster to MiniClusterResource

### DIFF
--- a/flink-libraries/flink-ml/src/test/scala/org/apache/flink/ml/util/FlinkTestBase.scala
+++ b/flink-libraries/flink-ml/src/test/scala/org/apache/flink/ml/util/FlinkTestBase.scala
@@ -18,8 +18,9 @@
 
 package org.apache.flink.ml.util
 
-import org.apache.flink.runtime.minicluster.LocalFlinkMiniCluster
-import org.apache.flink.test.util.{TestBaseUtils, TestEnvironment}
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.test.util.MiniClusterResource
+import org.apache.flink.test.util.MiniClusterResource.MiniClusterResourceConfiguration
 import org.scalatest.{BeforeAndAfter, Suite}
 
 /** Mixin to start and stop a LocalFlinkMiniCluster automatically for Scala based tests.
@@ -51,27 +52,21 @@ import org.scalatest.{BeforeAndAfter, Suite}
 trait FlinkTestBase extends BeforeAndAfter {
   that: Suite =>
 
-  var cluster: Option[LocalFlinkMiniCluster] = None
+  var cluster: Option[MiniClusterResource] = None
   val parallelism = 4
 
   before {
-    val cl = TestBaseUtils.startCluster(
-      1,
-      parallelism,
-      false,
-      false,
-      true)
-
-    val clusterEnvironment = new TestEnvironment(cl, parallelism, false)
-    clusterEnvironment.setAsContext()
+    val cl = new MiniClusterResource(
+      new MiniClusterResourceConfiguration(new Configuration(), 1, parallelism)
+    )
+    
+    cl.before()
 
     cluster = Some(cl)
   }
 
   after {
-    cluster.foreach(c => TestBaseUtils.stopCluster(c, TestBaseUtils.DEFAULT_TIMEOUT))
-
-    TestEnvironment.unsetAsContext()
+    cluster.foreach(c => c.after())
   }
 
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/AbstractEventTimeWindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/AbstractEventTimeWindowCheckpointingITCase.java
@@ -51,6 +51,7 @@ import org.apache.flink.util.TestLogger;
 
 import org.apache.curator.test.TestingServer;
 import org.junit.After;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -86,8 +87,8 @@ public abstract class AbstractEventTimeWindowCheckpointingITCase extends TestLog
 
 	private static TestingServer zkServer;
 
-	@Rule
-	public TemporaryFolder tempFolder = new TemporaryFolder();
+	@ClassRule
+	public static TemporaryFolder tempFolder = new TemporaryFolder();
 
 	@Rule
 	public TestName name = new TestName();

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/AbstractEventTimeWindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/AbstractEventTimeWindowCheckpointingITCase.java
@@ -26,35 +26,31 @@ import org.apache.flink.api.java.tuple.Tuple;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple4;
 import org.apache.flink.configuration.AkkaOptions;
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.contrib.streaming.state.RocksDBStateBackend;
 import org.apache.flink.core.fs.Path;
-import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
-import org.apache.flink.runtime.highavailability.HighAvailabilityServicesUtils;
-import org.apache.flink.runtime.minicluster.LocalFlinkMiniCluster;
 import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.runtime.state.CheckpointListener;
 import org.apache.flink.runtime.state.filesystem.FsStateBackend;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.checkpoint.ListCheckpointed;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
 import org.apache.flink.streaming.api.functions.source.RichSourceFunction;
 import org.apache.flink.streaming.api.functions.windowing.RichWindowFunction;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
-import org.apache.flink.streaming.util.TestStreamEnvironment;
+import org.apache.flink.test.util.MiniClusterResource;
 import org.apache.flink.test.util.SuccessException;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.TestLogger;
 
 import org.apache.curator.test.TestingServer;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -65,9 +61,6 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.apache.flink.test.checkpointing.AbstractEventTimeWindowCheckpointingITCase.StateBackendEnum.ROCKSDB_INCREMENTAL_ZK;
@@ -91,10 +84,6 @@ public abstract class AbstractEventTimeWindowCheckpointingITCase extends TestLog
 	private static final int MAX_MEM_STATE_SIZE = 20 * 1024 * 1024;
 	private static final int PARALLELISM = 4;
 
-	private static LocalFlinkMiniCluster cluster;
-
-	private static TestStreamEnvironment env;
-
 	private static TestingServer zkServer;
 
 	@Rule
@@ -106,6 +95,13 @@ public abstract class AbstractEventTimeWindowCheckpointingITCase extends TestLog
 	private StateBackendEnum stateBackendEnum;
 	private AbstractStateBackend stateBackend;
 
+	@Rule
+	public final MiniClusterResource miniClusterResource = new MiniClusterResource(
+		new MiniClusterResource.MiniClusterResourceConfiguration(
+			getConfigurationSafe(),
+			2,
+			PARALLELISM / 2));
+
 	AbstractEventTimeWindowCheckpointingITCase(StateBackendEnum stateBackendEnum) {
 		this.stateBackendEnum = stateBackendEnum;
 	}
@@ -114,8 +110,15 @@ public abstract class AbstractEventTimeWindowCheckpointingITCase extends TestLog
 		MEM, FILE, ROCKSDB_FULLY_ASYNC, ROCKSDB_INCREMENTAL, ROCKSDB_INCREMENTAL_ZK, MEM_ASYNC, FILE_ASYNC
 	}
 
-	@Before
-	public void startTestCluster() throws Exception {
+	private Configuration getConfigurationSafe() {
+		try {
+			return getConfiguration();
+		} catch (Exception e) {
+			throw new AssertionError("Could not initialize test.", e);
+		}
+	}
+
+	private Configuration getConfiguration() throws Exception {
 
 		// print a message when starting a test method to avoid Travis' <tt>"Maven produced no
 		// output for xxx seconds."</tt> messages
@@ -133,8 +136,6 @@ public abstract class AbstractEventTimeWindowCheckpointingITCase extends TestLog
 		final File haDir = temporaryFolder.newFolder();
 
 		Configuration config = new Configuration();
-		config.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, 2);
-		config.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, PARALLELISM / 2);
 		config.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, 48L);
 		// the default network buffers size (10% of heap max =~ 150MB) seems to much for this test case
 		config.setLong(TaskManagerOptions.NETWORK_BUFFERS_MEMORY_MAX, 80L << 20); // 80 MB
@@ -145,23 +146,6 @@ public abstract class AbstractEventTimeWindowCheckpointingITCase extends TestLog
 			config.setString(HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, zkServer.getConnectString());
 			config.setString(HighAvailabilityOptions.HA_STORAGE_PATH, haDir.toURI().toString());
 		}
-
-		// purposefully delay in the executor to tease out races
-		final ScheduledExecutorService executor = Executors.newScheduledThreadPool(10);
-		HighAvailabilityServices haServices = HighAvailabilityServicesUtils.createAvailableOrEmbeddedServices(
-			config,
-			new Executor() {
-				@Override
-				public void execute(Runnable command) {
-					executor.schedule(command, 500, MILLISECONDS);
-				}
-			});
-
-		cluster = new LocalFlinkMiniCluster(config, haServices, false);
-		cluster.start();
-
-		env = new TestStreamEnvironment(cluster, PARALLELISM);
-		env.getConfig().setUseSnapshotCompression(true);
 
 		switch (stateBackendEnum) {
 			case MEM:
@@ -206,15 +190,11 @@ public abstract class AbstractEventTimeWindowCheckpointingITCase extends TestLog
 			default:
 				throw new IllegalStateException("No backend selected.");
 		}
+		return config;
 	}
 
 	@After
 	public void stopTestCluster() throws IOException {
-		if (cluster != null) {
-			cluster.stop();
-			cluster = null;
-		}
-
 		if (zkServer != null) {
 			zkServer.stop();
 			zkServer = null;
@@ -236,12 +216,14 @@ public abstract class AbstractEventTimeWindowCheckpointingITCase extends TestLog
 		FailingSource.reset();
 
 		try {
+			StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 			env.setParallelism(PARALLELISM);
 			env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 			env.enableCheckpointing(100);
 			env.setRestartStrategy(RestartStrategies.fixedDelayRestart(3, 0));
 			env.getConfig().disableSysoutLogging();
 			env.setStateBackend(this.stateBackend);
+			env.getConfig().setUseSnapshotCompression(true);
 
 			env
 					.addSource(new FailingSource(numKeys, numElementsPerKey, numElementsPerKey / 3))
@@ -305,6 +287,7 @@ public abstract class AbstractEventTimeWindowCheckpointingITCase extends TestLog
 		FailingSource.reset();
 
 		try {
+			StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 			env.setParallelism(PARALLELISM);
 			env.setMaxParallelism(maxParallelism);
 			env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
@@ -312,6 +295,7 @@ public abstract class AbstractEventTimeWindowCheckpointingITCase extends TestLog
 			env.setRestartStrategy(RestartStrategies.fixedDelayRestart(3, 0));
 			env.getConfig().disableSysoutLogging();
 			env.setStateBackend(this.stateBackend);
+			env.getConfig().setUseSnapshotCompression(true);
 
 			env
 					.addSource(new FailingSource(numKeys, numElementsPerKey, numElementsPerKey / 3))
@@ -371,6 +355,7 @@ public abstract class AbstractEventTimeWindowCheckpointingITCase extends TestLog
 		FailingSource.reset();
 
 		try {
+			StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 			env.setMaxParallelism(2 * PARALLELISM);
 			env.setParallelism(PARALLELISM);
 			env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
@@ -433,12 +418,14 @@ public abstract class AbstractEventTimeWindowCheckpointingITCase extends TestLog
 		FailingSource.reset();
 
 		try {
+			StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 			env.setParallelism(PARALLELISM);
 			env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 			env.enableCheckpointing(100);
 			env.setRestartStrategy(RestartStrategies.fixedDelayRestart(3, 0));
 			env.getConfig().disableSysoutLogging();
 			env.setStateBackend(this.stateBackend);
+			env.getConfig().setUseSnapshotCompression(true);
 
 			env
 					.addSource(new FailingSource(numKeys, numElementsPerKey, numElementsPerKey / 3))
@@ -502,12 +489,14 @@ public abstract class AbstractEventTimeWindowCheckpointingITCase extends TestLog
 		FailingSource.reset();
 
 		try {
+			StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 			env.setParallelism(PARALLELISM);
 			env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 			env.enableCheckpointing(100);
 			env.setRestartStrategy(RestartStrategies.fixedDelayRestart(3, 0));
 			env.getConfig().disableSysoutLogging();
 			env.setStateBackend(this.stateBackend);
+			env.getConfig().setUseSnapshotCompression(true);
 
 			env
 					.addSource(new FailingSource(numKeys, numElementsPerKey, numElementsPerKey / 3))

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/AbstractEventTimeWindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/AbstractEventTimeWindowCheckpointingITCase.java
@@ -92,7 +92,6 @@ public abstract class AbstractEventTimeWindowCheckpointingITCase extends TestLog
 	@Rule
 	public TestName name = new TestName();
 
-	private StateBackendEnum stateBackendEnum;
 	private AbstractStateBackend stateBackend;
 
 	@Rule
@@ -102,13 +101,11 @@ public abstract class AbstractEventTimeWindowCheckpointingITCase extends TestLog
 			2,
 			PARALLELISM / 2));
 
-	AbstractEventTimeWindowCheckpointingITCase(StateBackendEnum stateBackendEnum) {
-		this.stateBackendEnum = stateBackendEnum;
-	}
-
 	enum StateBackendEnum {
 		MEM, FILE, ROCKSDB_FULLY_ASYNC, ROCKSDB_INCREMENTAL, ROCKSDB_INCREMENTAL_ZK, MEM_ASYNC, FILE_ASYNC
 	}
+
+	protected abstract StateBackendEnum getStateBackend();
 
 	private Configuration getConfigurationSafe() {
 		try {
@@ -126,6 +123,7 @@ public abstract class AbstractEventTimeWindowCheckpointingITCase extends TestLog
 			"Starting " + getClass().getCanonicalName() + "#" + name.getMethodName() + ".");
 
 		// Testing HA Scenario / ZKCompletedCheckpointStore with incremental checkpoints
+		StateBackendEnum stateBackendEnum = getStateBackend();
 		if (ROCKSDB_INCREMENTAL_ZK.equals(stateBackendEnum)) {
 			zkServer = new TestingServer();
 			zkServer.start();

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/AsyncFileBackendEventTimeWindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/AsyncFileBackendEventTimeWindowCheckpointingITCase.java
@@ -23,7 +23,8 @@ package org.apache.flink.test.checkpointing;
  */
 public class AsyncFileBackendEventTimeWindowCheckpointingITCase extends AbstractEventTimeWindowCheckpointingITCase {
 
-	public AsyncFileBackendEventTimeWindowCheckpointingITCase() {
-		super(StateBackendEnum.FILE_ASYNC);
+	@Override
+	protected StateBackendEnum getStateBackend() {
+		return StateBackendEnum.FILE_ASYNC;
 	}
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/AsyncMemBackendEventTimeWindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/AsyncMemBackendEventTimeWindowCheckpointingITCase.java
@@ -22,8 +22,8 @@ package org.apache.flink.test.checkpointing;
  * Integration tests for asynchronous memory backend.
  */
 public class AsyncMemBackendEventTimeWindowCheckpointingITCase extends AbstractEventTimeWindowCheckpointingITCase {
-
-	public AsyncMemBackendEventTimeWindowCheckpointingITCase() {
-		super(StateBackendEnum.MEM_ASYNC);
+	@Override
+	protected StateBackendEnum getStateBackend() {
+		return StateBackendEnum.MEM_ASYNC;
 	}
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/FileBackendEventTimeWindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/FileBackendEventTimeWindowCheckpointingITCase.java
@@ -22,8 +22,8 @@ package org.apache.flink.test.checkpointing;
  * Integration tests for file backend.
  */
 public class FileBackendEventTimeWindowCheckpointingITCase extends AbstractEventTimeWindowCheckpointingITCase {
-
-	public FileBackendEventTimeWindowCheckpointingITCase() {
-		super(StateBackendEnum.FILE);
+	@Override
+	protected StateBackendEnum getStateBackend() {
+		return StateBackendEnum.FILE;
 	}
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/HAIncrementalRocksDbBackendEventTimeWindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/HAIncrementalRocksDbBackendEventTimeWindowCheckpointingITCase.java
@@ -23,8 +23,9 @@ package org.apache.flink.test.checkpointing;
  */
 public class HAIncrementalRocksDbBackendEventTimeWindowCheckpointingITCase extends AbstractEventTimeWindowCheckpointingITCase {
 
-	public HAIncrementalRocksDbBackendEventTimeWindowCheckpointingITCase() {
-		super(StateBackendEnum.ROCKSDB_INCREMENTAL_ZK);
+	@Override
+	protected StateBackendEnum getStateBackend() {
+		return StateBackendEnum.ROCKSDB_INCREMENTAL_ZK;
 	}
 
 	@Override

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/IncrementalRocksDbBackendEventTimeWindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/IncrementalRocksDbBackendEventTimeWindowCheckpointingITCase.java
@@ -23,8 +23,9 @@ package org.apache.flink.test.checkpointing;
  */
 public class IncrementalRocksDbBackendEventTimeWindowCheckpointingITCase extends AbstractEventTimeWindowCheckpointingITCase {
 
-	public IncrementalRocksDbBackendEventTimeWindowCheckpointingITCase() {
-		super(StateBackendEnum.ROCKSDB_INCREMENTAL);
+	@Override
+	protected StateBackendEnum getStateBackend() {
+		return StateBackendEnum.ROCKSDB_INCREMENTAL;
 	}
 
 	@Override

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/MemBackendEventTimeWindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/MemBackendEventTimeWindowCheckpointingITCase.java
@@ -23,7 +23,8 @@ package org.apache.flink.test.checkpointing;
  */
 public class MemBackendEventTimeWindowCheckpointingITCase extends AbstractEventTimeWindowCheckpointingITCase {
 
-	public MemBackendEventTimeWindowCheckpointingITCase() {
-		super(StateBackendEnum.MEM);
+	@Override
+	protected StateBackendEnum getStateBackend() {
+		return StateBackendEnum.MEM;
 	}
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RocksDbBackendEventTimeWindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RocksDbBackendEventTimeWindowCheckpointingITCase.java
@@ -23,8 +23,9 @@ package org.apache.flink.test.checkpointing;
  */
 public class RocksDbBackendEventTimeWindowCheckpointingITCase extends AbstractEventTimeWindowCheckpointingITCase {
 
-	public RocksDbBackendEventTimeWindowCheckpointingITCase() {
-		super(StateBackendEnum.ROCKSDB_FULLY_ASYNC);
+	@Override
+	protected StateBackendEnum getStateBackend() {
+		return StateBackendEnum.ROCKSDB_FULLY_ASYNC;
 	}
 
 	@Override

--- a/flink-tests/src/test/java/org/apache/flink/test/operators/CustomDistributionITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/operators/CustomDistributionITCase.java
@@ -27,19 +27,15 @@ import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.io.DiscardingOutputFormat;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.api.java.utils.DataSetUtils;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
-import org.apache.flink.runtime.minicluster.LocalFlinkMiniCluster;
 import org.apache.flink.test.operators.util.CollectionDataSets;
-import org.apache.flink.test.util.TestBaseUtils;
-import org.apache.flink.test.util.TestEnvironment;
+import org.apache.flink.test.util.MiniClusterResource;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.TestLogger;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -52,32 +48,12 @@ import static org.junit.Assert.fail;
 @SuppressWarnings("serial")
 public class CustomDistributionITCase extends TestLogger {
 
-	// ------------------------------------------------------------------------
-	//  The mini cluster that is shared across tests
-	// ------------------------------------------------------------------------
-
-	private static LocalFlinkMiniCluster cluster;
-
-	@BeforeClass
-	public static void setup() throws Exception {
-		cluster = TestBaseUtils.startCluster(1, 8, false, false, true);
-	}
-
-	@AfterClass
-	public static void teardown() throws Exception {
-		TestBaseUtils.stopCluster(cluster, TestBaseUtils.DEFAULT_TIMEOUT);
-	}
-
-	@Before
-	public void prepare() {
-		TestEnvironment clusterEnv = new TestEnvironment(cluster, 1, false);
-		clusterEnv.setAsContext();
-	}
-
-	@After
-	public void cleanup() {
-		TestEnvironment.unsetAsContext();
-	}
+	@ClassRule
+	public static final MiniClusterResource MINI_CLUSTER_RESOURCE = new MiniClusterResource(
+		new MiniClusterResource.MiniClusterResourceConfiguration(
+			new Configuration(),
+			1,
+			8));
 
 	// ------------------------------------------------------------------------
 


### PR DESCRIPTION
## What is the purpose of the change

This PR contains the second batch of test ports from `LocalFlinkMiniCluster` to `MiniClusterResource`. No port required changes to `MiniClusterResource`.

Each test has it's own commit and is self-contained. If a test was not explicitly creating a configuration and the number of taskmanagers/slots matched the settings in `AbstractTestBase` the test was modified to extend that.

Otherwise, a separate `MiniClusterResource` `@ClassRule`/`@Rule` was created.

## Verifying this change

This change is covered by existing tests.
