### PR TITLE
[FLINK-8718][DataStream] Set maxParallelism on non-parallel DataStreamSource

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSource.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSource.java
@@ -31,31 +31,32 @@ import org.apache.flink.streaming.api.transformations.SourceTransformation;
 @Public
 public class DataStreamSource<T> extends SingleOutputStreamOperator<T> {
 
-	boolean isParallel;
-
-	public DataStreamSource(StreamExecutionEnvironment environment,
-			TypeInformation<T> outTypeInfo, StreamSource<T, ?> operator,
-			boolean isParallel, String sourceName) {
+	public DataStreamSource(
+			StreamExecutionEnvironment environment,
+			TypeInformation<T> outTypeInfo,
+			StreamSource<T, ?> operator,
+			boolean isParallel,
+			String sourceName) {
 		super(environment, new SourceTransformation<>(sourceName, operator, outTypeInfo, environment.getParallelism()));
 
-		this.isParallel = isParallel;
 		if (!isParallel) {
-			setParallelism(1);
+			forceNonParallel();
 		}
 	}
 
 	public DataStreamSource(SingleOutputStreamOperator<T> operator) {
 		super(operator.environment, operator.getTransformation());
-		this.isParallel = true;
 	}
 
 	@Override
-	public DataStreamSource<T> setParallelism(int parallelism) {
-		if (parallelism != 1 && !isParallel) {
-			throw new IllegalArgumentException("Source: " + transformation.getId() + " is not a parallel source");
-		} else {
-			super.setParallelism(parallelism);
-			return this;
-		}
+	public DataStreamSource<T> setParallelism(final int parallelism) {
+		super.setParallelism(parallelism);
+		return this;
+	}
+
+	@Override
+	public DataStreamSource<T> setMaxParallelism(final int maxParallelism) {
+		super.setMaxParallelism(maxParallelism);
+		return this;
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/datastream/DataStreamSourceTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/datastream/DataStreamSourceTest.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.datastream;
+
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.UUID;
+import java.util.stream.StreamSupport;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for {@link DataStreamSource}.
+ */
+public class DataStreamSourceTest {
+
+	private StreamExecutionEnvironment env;
+
+	private DataStreamSource<String> dataStreamSource;
+
+	@Before
+	public void setUp() {
+		env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+		dataStreamSource = env.addSource(new NoOpSourceFunction());
+		dataStreamSource.name(UUID.randomUUID().toString());
+
+		dataStreamSource.print();
+	}
+
+	@Test
+	public void testSetParallelismOneIfSourceIsNonParallel() {
+		final JobVertex testSourceVertex = StreamSupport.stream(env
+				.getStreamGraph()
+				.getJobGraph()
+				.getVertices()
+				.spliterator(),
+			false)
+			.filter(jobVertex -> jobVertex.getName().contains(dataStreamSource.getName()))
+			.findFirst()
+			.orElseThrow(() -> new AssertionError("testSource vertex not found"));
+
+		assertThat(testSourceVertex.getMaxParallelism(), equalTo(1));
+		assertThat(testSourceVertex.getParallelism(), equalTo(1));
+	}
+
+	@Test
+	public void testCannotSetMaxParallelism() {
+		try {
+			dataStreamSource.setMaxParallelism(2);
+			fail("Setting maxParallelism should fail.");
+		} catch (final IllegalArgumentException e) {
+			assertThat(e.getMessage(), containsString("The maximum parallelism of non parallel operator must be 1."));
+		}
+	}
+
+	@Test
+	public void testCannotSetParallelism() {
+		try {
+			dataStreamSource.setParallelism(2);
+			fail("Setting parallelism should fail.");
+		} catch (final IllegalArgumentException e) {
+			assertThat(e.getMessage(), containsString("The parallelism of non parallel operator must be 1."));
+		}
+	}
+
+	private static class NoOpSourceFunction implements SourceFunction<String> {
+
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public void run(final SourceContext<String> ctx) throws Exception {
+		}
+
+		@Override
+		public void cancel() {
+		}
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

*Set maxParallelism to 1 on `org.apache.flink.streaming.api.datastream.DataStreamSource` if the operator is non-parallel.*

cc: @tillrohrmann @bowenli86 @aljoscha 

## Brief change log

  - *Call `forceNonParallel()` if source operator is non-parallel.*
  - *Unit test `DataStreamSource`.*
  
## Verifying this change

This change added tests and can be verified as follows:

  - *Added unit tests for `DataStreamSource`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
