### PR TITLE
[FLINK-8730][REST] JSON serialize entire SerializedThrowable

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/SerializedThrowable.java
+++ b/flink-core/src/main/java/org/apache/flink/util/SerializedThrowable.java
@@ -25,8 +25,6 @@ import java.lang.ref.WeakReference;
 import java.util.HashSet;
 import java.util.Set;
 
-import static java.util.Objects.requireNonNull;
-
 /**
  * Utility class for dealing with user-defined Throwable types that are serialized (for
  * example during RPC/Actor communication), but cannot be resolved with the default
@@ -62,18 +60,6 @@ public class SerializedThrowable extends Exception implements Serializable {
 	 */
 	public SerializedThrowable(Throwable exception) {
 		this(exception, new HashSet<>());
-	}
-
-	/**
-	 * Creates a new SerializedThrowable from a serialized exception provided as a byte array.
-	 */
-	public SerializedThrowable(
-			final byte[] serializedException,
-			final String originalErrorClassName,
-			final String fullStringifiedStackTrace) {
-		this.serializedException = requireNonNull(serializedException);
-		this.originalErrorClassName = requireNonNull(originalErrorClassName);
-		this.fullStringifiedStackTrace = requireNonNull(fullStringifiedStackTrace);
 	}
 
 	private SerializedThrowable(Throwable exception, Set<Throwable> alreadySeen) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/json/SerializedThrowableSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/json/SerializedThrowableSerializer.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.rest.messages.json;
 
+import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.SerializedThrowable;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator;
@@ -33,11 +34,11 @@ public class SerializedThrowableSerializer extends StdSerializer<SerializedThrow
 
 	private static final long serialVersionUID = 1L;
 
-	static final String FIELD_NAME_SERIALIZED_EXCEPTION = "serialized-exception";
-
 	static final String FIELD_NAME_CLASS = "class";
 
 	static final String FIELD_NAME_STACK_TRACE = "stack-trace";
+
+	static final String FIELD_NAME_SERIALIZED_THROWABLE = "serialized-throwable";
 
 	public SerializedThrowableSerializer() {
 		super(SerializedThrowable.class);
@@ -48,7 +49,7 @@ public class SerializedThrowableSerializer extends StdSerializer<SerializedThrow
 		gen.writeStartObject();
 		gen.writeStringField(FIELD_NAME_CLASS, value.getOriginalErrorClassName());
 		gen.writeStringField(FIELD_NAME_STACK_TRACE, value.getFullStringifiedStackTrace());
-		gen.writeBinaryField(FIELD_NAME_SERIALIZED_EXCEPTION, value.getSerializedException());
+		gen.writeBinaryField(FIELD_NAME_SERIALIZED_THROWABLE, InstantiationUtil.serializeObject(value));
 		gen.writeEndObject();
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/json/SerializedThrowableSerializerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/json/SerializedThrowableSerializerTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.json;
+
+import org.apache.flink.util.SerializedThrowable;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.module.SimpleModule;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for {@link SerializedThrowableSerializer} and {@link SerializedThrowableDeserializer}.
+ */
+public class SerializedThrowableSerializerTest {
+
+	private ObjectMapper objectMapper = new ObjectMapper();
+
+	@Before
+	public void setUp() {
+		final SimpleModule simpleModule = new SimpleModule();
+		simpleModule.addDeserializer(SerializedThrowable.class, new SerializedThrowableDeserializer());
+		simpleModule.addSerializer(SerializedThrowable.class, new SerializedThrowableSerializer());
+
+		objectMapper = new ObjectMapper();
+		objectMapper.registerModule(simpleModule);
+	}
+
+	@Test
+	public void testSerializationDeserialization() throws Exception {
+		final String lastExceptionMessage = "message";
+		final String causeMessage = "cause";
+
+		final SerializedThrowable serializedThrowable = new SerializedThrowable(
+			new RuntimeException(lastExceptionMessage,
+				new RuntimeException(causeMessage)));
+		final String json = objectMapper.writeValueAsString(serializedThrowable);
+		final SerializedThrowable deserializedSerializedThrowable = objectMapper.readValue(
+			json,
+			SerializedThrowable.class);
+
+		assertThat(deserializedSerializedThrowable.getMessage(), equalTo(lastExceptionMessage));
+		assertThat(deserializedSerializedThrowable.getFullStringifiedStackTrace(), equalTo(serializedThrowable.getFullStringifiedStackTrace()));
+
+		assertThat(deserializedSerializedThrowable.getCause().getMessage(), equalTo(causeMessage));
+		assertThat(deserializedSerializedThrowable.getCause(), instanceOf(SerializedThrowable.class));
+	}
+
+}


### PR DESCRIPTION
## What is the purpose of the change

*For the JSON representation, do not only serialize the serialized exception but the entire SerializedThrowable object. This makes it possible to throw the SerializedThrowable itself without deserializing it.*

cc: @tillrohrmann 

## Brief change log
  - *Change JSON serialization of SerializedThrowable.*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added unit tests for `SerializedThrowableSerializer`. Previously, only `JobExecutionResultResponseBodyTest` covered it.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
