### PR TITLE
[FLINK-8733][network] fix SpillableSubpartition#spillFinishedBufferConsumers() not counting spilled bytes

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartition.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.io.network.partition;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.io.disk.iomanager.BufferFileWriter;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
@@ -240,7 +241,8 @@ class SpillableSubpartition extends ResultSubpartition {
 		return 0;
 	}
 
-	private long spillFinishedBufferConsumers() throws IOException {
+	@VisibleForTesting
+	protected long spillFinishedBufferConsumers() throws IOException {
 		long spilledBytes = 0;
 
 		while (!buffers.isEmpty()) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartition.java
@@ -247,6 +247,7 @@ class SpillableSubpartition extends ResultSubpartition {
 			BufferConsumer bufferConsumer = buffers.peek();
 			Buffer buffer = bufferConsumer.build();
 			updateStatistics(buffer);
+			spilledBytes += buffer.getSize();
 			spillWriter.writeBlock(buffer);
 
 			if (bufferConsumer.isFinished()) {


### PR DESCRIPTION
## What is the purpose of the change

With [FLINK-8583], `SpillableSubpartition` lost the counting of spilled bytes which is added again by this PR.

## Brief change log

- count spilled bytes in `SpillableSubpartition`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
