### PR TITLE
[FLINK-8736][network] fix memory segment offsets for slices of slices being wrong

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/ReadOnlySlicedNetworkBuffer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/ReadOnlySlicedNetworkBuffer.java
@@ -38,7 +38,7 @@ import java.nio.ReadOnlyBufferException;
  */
 public final class ReadOnlySlicedNetworkBuffer extends ReadOnlyByteBuf implements Buffer {
 
-	private final int index;
+	private final int memorySegmentOffset;
 
 	/**
 	 * Creates a buffer which shares the memory segment of the given buffer and exposed the given
@@ -53,7 +53,7 @@ public final class ReadOnlySlicedNetworkBuffer extends ReadOnlyByteBuf implement
 	 */
 	ReadOnlySlicedNetworkBuffer(NetworkBuffer buffer, int index, int length) {
 		super(new SlicedByteBuf(buffer, index, length));
-		this.index = index;
+		this.memorySegmentOffset = buffer.getMemorySegmentOffset() + index;
 	}
 
 	/**
@@ -66,10 +66,11 @@ public final class ReadOnlySlicedNetworkBuffer extends ReadOnlyByteBuf implement
 	 * @param buffer the buffer to derive from
 	 * @param index the index to start from
 	 * @param length the length of the slice
+	 * @param memorySegmentOffset <tt>buffer</tt>'s absolute offset in the backing {@link MemorySegment}
 	 */
-	private ReadOnlySlicedNetworkBuffer(ByteBuf buffer, int index, int length) {
+	private ReadOnlySlicedNetworkBuffer(ByteBuf buffer, int index, int length, int memorySegmentOffset) {
 		super(new SlicedByteBuf(buffer, index, length));
-		this.index = index;
+		this.memorySegmentOffset = memorySegmentOffset + index;
 	}
 
 	@Override
@@ -102,7 +103,7 @@ public final class ReadOnlySlicedNetworkBuffer extends ReadOnlyByteBuf implement
 
 	@Override
 	public int getMemorySegmentOffset() {
-		return ((Buffer) unwrap()).getMemorySegmentOffset() + index;
+		return memorySegmentOffset;
 	}
 
 	@Override
@@ -133,7 +134,7 @@ public final class ReadOnlySlicedNetworkBuffer extends ReadOnlyByteBuf implement
 
 	@Override
 	public ReadOnlySlicedNetworkBuffer readOnlySlice(int index, int length) {
-		return new ReadOnlySlicedNetworkBuffer(super.unwrap(), index, length);
+		return new ReadOnlySlicedNetworkBuffer(super.unwrap(), index, length, memorySegmentOffset);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
@@ -265,6 +265,8 @@ class PipelinedSubpartition extends ResultSubpartition {
 	}
 
 	private int getNumberOfFinishedBuffers() {
+		assert Thread.holdsLock(buffers);
+
 		if (buffers.size() == 1 && buffers.peekLast().isFinished()) {
 			return 1;
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartition.java
@@ -241,6 +241,7 @@ class SpillableSubpartition extends ResultSubpartition {
 	}
 
 	private long spillFinishedBufferConsumers() throws IOException {
+		assert Thread.holdsLock(buffers);
 		long spilledBytes = 0;
 
 		while (!buffers.isEmpty()) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -144,7 +144,7 @@ public class SingleInputGate implements InputGate {
 	 * Field guaranteeing uniqueness for inputChannelsWithData queue. Both of those fields should be unified
 	 * onto one.
 	 */
-	private final BitSet enqueuedInputChannelsWithData = new BitSet();
+	private final BitSet enqueuedInputChannelsWithData;
 
 	private final BitSet channelsWithEndOfPartitionEvents;
 
@@ -205,6 +205,7 @@ public class SingleInputGate implements InputGate {
 
 		this.inputChannels = new HashMap<>(numberOfInputChannels);
 		this.channelsWithEndOfPartitionEvents = new BitSet(numberOfInputChannels);
+		this.enqueuedInputChannelsWithData = new BitSet(numberOfInputChannels);
 
 		this.taskActions = checkNotNull(taskActions);
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/AbstractCollectingResultPartitionWriter.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/AbstractCollectingResultPartitionWriter.java
@@ -76,7 +76,7 @@ public abstract class AbstractCollectingResultPartitionWriter implements ResultP
 			Buffer buffer = bufferConsumer.build();
 			try {
 				deserializeBuffer(buffer);
-				if (!bufferConsumers.peek().isFinished()) {
+				if (!bufferConsumer.isFinished()) {
 					break;
 				}
 				bufferConsumers.pop().close();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/RecordWriterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/RecordWriterTest.java
@@ -41,11 +41,8 @@ import org.apache.flink.types.IntValue;
 import org.apache.flink.util.XORShiftRandom;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.IOException;
 import java.util.ArrayDeque;
@@ -71,8 +68,6 @@ import static org.mockito.Mockito.when;
 /**
  * Tests for the {@link RecordWriter}.
  */
-@PrepareForTest({EventSerializer.class})
-@RunWith(PowerMockRunner.class)
 public class RecordWriterTest {
 
 	// ---------------------------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartitionTest.java
@@ -225,7 +225,6 @@ public class SpillableSubpartitionTest extends SubpartitionTestBase {
 		assertTrue(read.buffer().isBuffer());
 		assertEquals(2, partition.getBuffersInBacklog());
 		assertEquals(partition.getBuffersInBacklog(), read.buffersInBacklog());
-		assertNotSame(bufferConsumer, read);
 		assertFalse(read.buffer().isRecycled());
 		read.buffer().recycleBuffer();
 		assertTrue(read.buffer().isRecycled());
@@ -237,7 +236,6 @@ public class SpillableSubpartitionTest extends SubpartitionTestBase {
 		assertTrue(read.buffer().isBuffer());
 		assertEquals(1, partition.getBuffersInBacklog());
 		assertEquals(partition.getBuffersInBacklog(), read.buffersInBacklog());
-		assertNotSame(bufferConsumer, read);
 		assertFalse(read.buffer().isRecycled());
 		read.buffer().recycleBuffer();
 		assertTrue(read.buffer().isRecycled());


### PR DESCRIPTION
## What is the purpose of the change

[FLINK-8588] introduced memory segment offsets to the `Buffer` classes but the offsets of slices of slices do not account for their parent's slice offset. Also, unit tests for this added feature were missing.

## Brief change log

- store the absolute `memorySegmentOffset` in `ReadOnlySlicedNetworkBuffer` instances to fix memory segment offsets for slices of slices
- clean up `RecordWriterTest`: remove the `PowerMockRunner` which is not needed anymore
- further cleanup and minor improvements, e.g. additional assertions

## Verifying this change

This change added tests and can be verified as follows:

- adapted `ReadOnlySlicedBufferTest` to include tests for the memory segment offsets

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
