### PR TITLE
[FLINK-8689][table]Add runtime support of distinct filter using MapView for codegen

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/aggfunctions/DistinctAggDelegateFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/aggfunctions/DistinctAggDelegateFunction.scala
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.functions.aggfunctions
+
+import java.util
+
+import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
+import org.apache.flink.api.java.typeutils.{PojoField, PojoTypeInfo}
+import org.apache.flink.table.api.dataview.MapView
+import org.apache.flink.table.dataview.MapViewTypeInfo
+import org.apache.flink.table.functions.AggregateFunction
+
+class DistinctAccumulator[E, ACC] (var mapView: MapView[E, Integer], var realAcc: ACC) {
+  def this() {
+    this(null, null.asInstanceOf[ACC])
+  }
+
+  def getRealAcc: ACC = realAcc
+
+  def canEqual(a: Any): Boolean = a.isInstanceOf[DistinctAccumulator[E, ACC]]
+
+  override def equals(that: Any): Boolean =
+    that match {
+      case that: DistinctAccumulator[E, ACC] => that.canEqual(this) &&
+        this.mapView == that.mapView
+      case _ => false
+    }
+
+}
+
+class DistinctAggDelegateFunction[E, ACC](elementTypeInfo: TypeInformation[_],
+                                          var realAgg: AggregateFunction[_, ACC])
+  extends AggregateFunction[util.Map[E, Integer], DistinctAccumulator[E, ACC]] {
+
+  def getRealAgg: AggregateFunction[_, ACC] = realAgg
+
+  override def createAccumulator(): DistinctAccumulator[E, ACC] = {
+    new DistinctAccumulator[E, ACC](
+      new MapView[E, Integer](
+        elementTypeInfo.asInstanceOf[TypeInformation[E]],
+        BasicTypeInfo.INT_TYPE_INFO),
+      realAgg.createAccumulator())
+  }
+
+  def accumulate(acc: DistinctAccumulator[E, ACC], element: E): Boolean = {
+    if (element != null) {
+      if (acc.mapView.contains(element)) {
+        acc.mapView.put(element, acc.mapView.get(element) + 1)
+        false
+      } else {
+        acc.mapView.put(element, 1)
+        true
+      }
+    } else {
+      false
+    }
+  }
+
+  def accumulate(acc: DistinctAccumulator[E, ACC], element: E, count: Int): Boolean = {
+    if (element != null) {
+      if (acc.mapView.contains(element)) {
+        acc.mapView.put(element, acc.mapView.get(element) + count)
+        false
+      } else {
+        acc.mapView.put(element, count)
+        true
+      }
+    } else {
+      false
+    }
+  }
+
+  def retract(acc: DistinctAccumulator[E, ACC], element: E): Boolean = {
+    if (element != null) {
+      val count = acc.mapView.get(element)
+      if (count == 1) {
+        acc.mapView.remove(element)
+        true
+      } else {
+        acc.mapView.put(element, count - 1)
+        false
+      }
+    } else {
+      false
+    }
+  }
+
+  def resetAccumulator(acc: DistinctAccumulator[E, ACC]): Unit = {
+    acc.mapView.clear()
+  }
+
+  override def getValue(acc: DistinctAccumulator[E, ACC]): util.Map[E, Integer] = {
+    acc.mapView.map
+  }
+
+  override def getAccumulatorType: TypeInformation[DistinctAccumulator[E, ACC]] = {
+    val clazz = classOf[DistinctAccumulator[E, ACC]]
+    val pojoFields = new util.ArrayList[PojoField]
+    pojoFields.add(new PojoField(clazz.getDeclaredField("mapView"),
+      new MapViewTypeInfo[E, Integer](
+        elementTypeInfo.asInstanceOf[TypeInformation[E]], BasicTypeInfo.INT_TYPE_INFO)))
+    pojoFields.add(new PojoField(clazz.getDeclaredField("realAcc"),
+      realAgg.getAccumulatorType))
+    new PojoTypeInfo[DistinctAccumulator[E, ACC]](clazz, pojoFields)
+  }
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/OverAggregate.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/OverAggregate.scala
@@ -70,7 +70,12 @@ trait OverAggregate {
 
     val aggStrings = namedAggregates.map(_.getKey).map(
       a => s"${a.getAggregation}(${
-        if (a.getArgList.size() > 0) {
+        val prefix = if (a.isDistinct) {
+          "DISTINCT "
+        } else {
+          ""
+        }
+        prefix + (if (a.getArgList.size() > 0) {
           a.getArgList.asScala.map { arg =>
             // index to constant
             if (arg >= inputType.getFieldCount) {
@@ -83,7 +88,7 @@ trait OverAggregate {
           }.mkString(", ")
         } else {
           "*"
-        }
+        })
       })")
 
     (inFields ++ aggStrings).zip(outFields).map {

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/AggregateUtil.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/AggregateUtil.scala
@@ -1393,6 +1393,21 @@ object AggregateUtil {
             throw new TableException(s"unsupported Function: '${unSupported.getName}'")
         }
       }
+
+      // create distinct accumulator delegate
+      if (aggregateCall.isDistinct) {
+        val currAgg = aggregates(index)
+        if (aggFieldIndexes(index).length != 1) {
+          throw new TableException(
+            s"Distinct Aggregate Function only support single argument at this time!")
+        }
+        val relDataType = aggregateInputType.getFieldList.get(aggFieldIndexes(index)(0)).getType
+        aggregates(index) = new DistinctAggDelegateFunction(
+          FlinkTypeFactory.toTypeInfo(relDataType),
+          currAgg
+        )
+        accTypes(index) = aggregates(index).getAccumulatorType
+      }
     }
 
     val accSpecs = new Array[Seq[DataViewSpec[_]]](aggregateCalls.size)


### PR DESCRIPTION

## What is the purpose of the change

- Adding in runtime support using distinct aggregation delegate to support distinct filtering using MapView. This is only fixing the currently broken over-window aggregate with distinct filter, however this change is meant to be used by other distinct operations on datastream such as group window aggregate, group aggregate, etc.


## Brief change log

  - Adding a new DistinctAggDelegateFunction and DistinctAccumulator that encapsulates any real aggregate function.
  - change codegen to specifically generate distinct filter before invoking the actual aggregate function.
  - adding in more codegen specifically for using delegates on merge and reset.

## Verifying this change

This change added tests and can be verified as follows:

  - Added over-window unit-test to verify generated plan before codegen.
  - Added integration tests for testing distinct over-window aggregate end-to-end.

## Does this pull request potentially affect one of the following parts:

no

## Documentation

this does not expose and additional external facing functionality, which will come in separated PR.
