### PR TITLE
[FLINK-8694][runtime] Workaround notifyDataAvailable race condition

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamRecordWriter.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamRecordWriter.java
@@ -62,14 +62,11 @@ public class StreamRecordWriter<T extends IOReadableWritable> extends RecordWrit
 		if (timeout == -1) {
 			outputFlusher = null;
 		}
-		else if (timeout == 0) {
-			outputFlusher = null;
-		}
 		else {
 			String threadName = taskName == null ?
 				DEFAULT_OUTPUT_FLUSH_THREAD_NAME : "Output Timeout Flusher - " + taskName;
 
-			outputFlusher = new OutputFlusher(threadName, timeout);
+			outputFlusher = new OutputFlusher(threadName, Math.max(1, timeout));
 			outputFlusher.start();
 		}
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkThroughputBenchmarkTests.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkThroughputBenchmarkTests.java
@@ -53,6 +53,14 @@ public class StreamNetworkThroughputBenchmarkTests {
 	}
 
 	@Test
+	public void largeRemoteAlwaysFlush() throws Exception {
+		StreamNetworkThroughputBenchmark env = new StreamNetworkThroughputBenchmark();
+		env.setUp(4, 10, 0, false);
+		env.executeBenchmark(1_000_000);
+		env.tearDown();
+	}
+
+	@Test
 	public void pointToMultiPointBenchmark() throws Exception {
 		StreamNetworkThroughputBenchmark benchmark = new StreamNetworkThroughputBenchmark();
 		benchmark.setUp(1, 100, 100);


### PR DESCRIPTION
Currently there is a race condition that may result in igonoring some notifyDataAvailable calls.
This is not a big problem as long as OutputFlasher will flush the records in next iteration. However
in flushAlways case, where the OutpuFlasher is turned off it can lead to data never being sent over
the network.

This fix walk arounds the problem by enabling OutputFlasher for flushAlways as well and adds stress test
for flushAlways (without this fix this test is dead locking).

This race condtition doesn't have effects on non streaming cases.

## Verifying this change

This change added a small stress test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / no ****/ don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
