### PR TITLE
[FLINK-8747][bugfix] The tag of waiting for floating buffers in RemoteInputChannel should be updated properly

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -338,7 +338,7 @@ public class RemoteInputChannel extends InputChannel implements BufferRecycler, 
 	}
 
 	@VisibleForTesting
-	public boolean isWaitingForFloatingBuffers() {
+	boolean isWaitingForFloatingBuffers() {
 		return isWaitingForFloatingBuffers;
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -337,6 +337,11 @@ public class RemoteInputChannel extends InputChannel implements BufferRecycler, 
 		return numRequiredBuffers - initialCredit;
 	}
 
+	@VisibleForTesting
+	public boolean isWaitingForFloatingBuffers() {
+		return isWaitingForFloatingBuffers;
+	}
+
 	/**
 	 * The Buffer pool notifies this channel of an available floating buffer. If the channel is released or
 	 * currently does not need extra buffers, the buffer should be recycled to the buffer pool. Otherwise,
@@ -362,6 +367,7 @@ public class RemoteInputChannel extends InputChannel implements BufferRecycler, 
 			// Important: double check the isReleased state inside synchronized block, so there is no
 			// race condition when notifyBufferAvailable and releaseAllResources running in parallel.
 			if (isReleased.get() || bufferQueue.getAvailableBufferSize() >= numRequiredBuffers) {
+				isWaitingForFloatingBuffers = false;
 				buffer.recycleBuffer();
 				return false;
 			}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
@@ -355,7 +355,7 @@ public class RemoteInputChannelTest {
 				13, inputChannel.getNumberOfAvailableBuffers());
 			assertEquals("There should be 16 buffers required in the channel",
 				16, inputChannel.getNumberOfRequiredBuffers());
-			assertEquals("There should be 0 buffer available in local pool",
+			assertEquals("There should be 0 buffers available in local pool",
 				0, bufferPool.getNumberOfAvailableMemorySegments());
 			assertTrue(inputChannel.isWaitingForFloatingBuffers());
 
@@ -369,7 +369,7 @@ public class RemoteInputChannelTest {
 				13, inputChannel.getNumberOfAvailableBuffers());
 			assertEquals("There should be 18 buffers required in the channel",
 				18, inputChannel.getNumberOfRequiredBuffers());
-			assertEquals("There should be 0 buffer available in local pool",
+			assertEquals("There should be 0 buffers available in local pool",
 				0, bufferPool.getNumberOfAvailableMemorySegments());
 			assertTrue(inputChannel.isWaitingForFloatingBuffers());
 
@@ -383,7 +383,7 @@ public class RemoteInputChannelTest {
 				14, inputChannel.getNumberOfAvailableBuffers());
 			assertEquals("There should be 18 buffers required in the channel",
 				18, inputChannel.getNumberOfRequiredBuffers());
-			assertEquals("There should be 0 buffer available in local pool",
+			assertEquals("There should be 0 buffers available in local pool",
 				0, bufferPool.getNumberOfAvailableMemorySegments());
 			assertTrue(inputChannel.isWaitingForFloatingBuffers());
 
@@ -397,7 +397,7 @@ public class RemoteInputChannelTest {
 				15, inputChannel.getNumberOfAvailableBuffers());
 			assertEquals("There should be 18 buffers required in the channel",
 				18, inputChannel.getNumberOfRequiredBuffers());
-			assertEquals("There should be 0 buffer available in local pool",
+			assertEquals("There should be 0 buffers available in local pool",
 				0, bufferPool.getNumberOfAvailableMemorySegments());
 			assertTrue(inputChannel.isWaitingForFloatingBuffers());
 
@@ -411,7 +411,7 @@ public class RemoteInputChannelTest {
 				15, inputChannel.getNumberOfAvailableBuffers());
 			assertEquals("There should be 15 buffers required in the channel",
 				15, inputChannel.getNumberOfRequiredBuffers());
-			assertEquals("There should be 0 buffer available in local pool",
+			assertEquals("There should be 0 buffers available in local pool",
 				0, bufferPool.getNumberOfAvailableMemorySegments());
 			assertTrue(inputChannel.isWaitingForFloatingBuffers());
 
@@ -439,7 +439,7 @@ public class RemoteInputChannelTest {
 				16, inputChannel.getNumberOfAvailableBuffers());
 			assertEquals("There should be 17 buffers required in the channel",
 				17, inputChannel.getNumberOfRequiredBuffers());
-			assertEquals("There should be 0 buffer available in local pool",
+			assertEquals("There should be 0 buffers available in local pool",
 				0, bufferPool.getNumberOfAvailableMemorySegments());
 			assertTrue(inputChannel.isWaitingForFloatingBuffers());
 
@@ -490,7 +490,7 @@ public class RemoteInputChannelTest {
 				14, inputChannel.getNumberOfAvailableBuffers());
 			assertEquals("There should be 14 buffers required in the channel",
 				14, inputChannel.getNumberOfRequiredBuffers());
-			assertEquals("There should be 0 buffer available in local pool",
+			assertEquals("There should be 0 buffers available in local pool",
 				0, bufferPool.getNumberOfAvailableMemorySegments());
 
 			// Recycle one floating buffer
@@ -569,7 +569,7 @@ public class RemoteInputChannelTest {
 				14, inputChannel.getNumberOfAvailableBuffers());
 			assertEquals("There should be 14 buffers required in the channel",
 				14, inputChannel.getNumberOfRequiredBuffers());
-			assertEquals("There should be 0 buffer available in local pool",
+			assertEquals("There should be 0 buffers available in local pool",
 				0, bufferPool.getNumberOfAvailableMemorySegments());
 
 			// Decrease the backlog to make the number of available buffers more than required buffers
@@ -582,7 +582,7 @@ public class RemoteInputChannelTest {
 				14, inputChannel.getNumberOfAvailableBuffers());
 			assertEquals("There should be 12 buffers required in the channel",
 				12, inputChannel.getNumberOfRequiredBuffers());
-			assertEquals("There should be 0 buffer available in local pool",
+			assertEquals("There should be 0 buffers available in local pool",
 				0, bufferPool.getNumberOfAvailableMemorySegments());
 
 			// Recycle one exclusive buffer


### PR DESCRIPTION
## What is the purpose of the change

*In credit-based flow control mode, when the number of available buffers is less than required buffers (backlog + initialCredit), the `RemoteInputChannel` will request floating buffers from `BufferProvider`. If not get enough available floating buffers, the `RemoteInputChannel` registers itself as listener in `BufferProvider` and updates the tag `isWaitingForFloatingBuffers` as true to avoid registration repeatedly.*

 *When a floating buffer is recycled to `BufferProvider`, it will notify the listener of available buffer. But the listener may not need floating buffers currently if the available buffers is not less than required buffers, then the floating buffers will be returned to BufferProvider directly. Most importantly, the tag `isWaitingForFloatingBuffers` should also be updated as false, otherwise the `RemoteInputChannel` will not request floating buffers any more after the available buffers less than required buffers.*

*There are two scenarios for causing the above issue:*

- The recycled exclusive buffers increase the total available buffers which is equal to or more than required buffers.
- The decreased sender's backlog resulting the available buffers equal to required buffers.

## Brief change log

  - *Updates the tag `isWaitingForFloatingBuffers` false on `notifyBufferAvailable` if current available buffers is not less than required buffers*

## Verifying this change

This change added tests and can be verified as follows:

  - *Modify `RemoteInputChannelTest#testAvailableBuffersLessThanRequiredBuffers to cover this case*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
