### PR TITLE
[FLINK-8748] [flip6] Cancel slot allocations for alternatively completed slot requests

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -354,11 +354,10 @@ public class CheckpointCoordinator {
 	 * @throws IllegalStateException If no savepoint directory has been
 	 *                               specified and no default savepoint directory has been
 	 *                               configured
-	 * @throws Exception             Failures during triggering are forwarded
 	 */
 	public CompletableFuture<CompletedCheckpoint> triggerSavepoint(
 			long timestamp,
-			@Nullable String targetLocation) throws Exception {
+			@Nullable String targetLocation) {
 
 		CheckpointProperties props = CheckpointProperties.forSavepoint();
 
@@ -371,7 +370,7 @@ public class CheckpointCoordinator {
 		if (triggerResult.isSuccess()) {
 			return triggerResult.getPendingCheckpoint().getCompletionFuture();
 		} else {
-			Throwable cause = new Exception("Failed to trigger savepoint: " + triggerResult.getFailureReason().message());
+			Throwable cause = new CheckpointTriggerException("Failed to trigger savepoint.", triggerResult.getFailureReason());
 			return FutureUtils.completedExceptionally(cause);
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointTriggerException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointTriggerException.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint;
+
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.Preconditions;
+
+/**
+ * Exceptions which indicate that a checkpoint triggering has failed.
+ *
+ */
+public class CheckpointTriggerException extends FlinkException {
+
+	private static final long serialVersionUID = -3330160816161901752L;
+
+	private final CheckpointDeclineReason checkpointDeclineReason;
+
+	public CheckpointTriggerException(String message, CheckpointDeclineReason checkpointDeclineReason) {
+		super(message + " Decline reason: " + checkpointDeclineReason.message());
+		this.checkpointDeclineReason = Preconditions.checkNotNull(checkpointDeclineReason);
+	}
+
+	public CheckpointDeclineReason getCheckpointDeclineReason() {
+		return checkpointDeclineReason;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -993,7 +993,7 @@ public class ExecutionGraph implements AccessExecutionGraph {
 					} else {
 						resultThrowable = strippedThrowable;
 					}
-
+					
 					throw new CompletionException(resultThrowable);
 				});
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -639,6 +639,9 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 				if (executionGraph == currentExecutionGraph) {
 					executionGraph = restoredExecutionGraph;
 
+					// register self as job status change listener
+					executionGraph.registerJobStatusListener(new JobManagerJobStatusListener());
+
 					scheduleExecutionGraph();
 
 					return Acknowledge.get();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -522,7 +522,7 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 
 		// 4. take a savepoint
 		final CompletableFuture<String> savepointFuture = triggerSavepoint(
-			jobMasterConfiguration.getTmpDirectory(),
+			null,
 			timeout)
 			.handleAsync(
 				(String savepointPath, Throwable throwable) -> {
@@ -1055,7 +1055,7 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 
 	@Override
 	public CompletableFuture<String> triggerSavepoint(
-		final String targetDirectory,
+		@Nullable final String targetDirectory,
 		final Time timeout) {
 		try {
 			return executionGraph.getCheckpointCoordinator()

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
@@ -44,6 +44,8 @@ import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 
+import javax.annotation.Nullable;
+
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 
@@ -254,12 +256,13 @@ public interface JobMasterGateway extends
 	/**
 	 * Triggers taking a savepoint of the executed job.
 	 *
-	 * @param targetDirectory to which to write the savepoint data
+	 * @param targetDirectory to which to write the savepoint data or null if the
+	 *                           default savepoint directory should be used
 	 * @param timeout for the rpc call
 	 * @return Future which is completed with the savepoint path once completed
 	 */
 	CompletableFuture<String> triggerSavepoint(
-		final String targetDirectory,
+		@Nullable final String targetDirectory,
 		final Time timeout);
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
@@ -227,6 +227,14 @@ public class SlotPool extends RpcEndpoint implements SlotPoolGateway, AllocatedS
 
 		validateRunsInMainThread();
 
+		// cancel all pending allocations --> we can request these slots
+		// again after we regained the leadership
+		Set<AllocationID> allocationIds = pendingRequests.keySetB();
+
+		for (AllocationID allocationId : allocationIds) {
+			resourceManagerGateway.cancelSlotRequest(allocationId);
+		}
+
 		// suspend this RPC endpoint
 		stop();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSharingManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSharingManager.java
@@ -537,9 +537,8 @@ public class SlotSharingManager {
 				if (parent != null) {
 					// we remove ourselves from our parent if we no longer have children
 					parent.releaseChild(getGroupId());
-				} else {
+				} else if (allTaskSlots.remove(getSlotRequestId()) != null) {
 					// we are the root node --> remove the root node from the list of task slots
-					allTaskSlots.remove(getSlotRequestId());
 
 					if (!slotContextFuture.isDone() || slotContextFuture.isCompletedExceptionally()) {
 						synchronized (lock) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSharingManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSharingManager.java
@@ -418,9 +418,9 @@ public class SlotSharingManager {
 		private MultiTaskSlot(
 				SlotRequestId slotRequestId,
 				@Nullable AbstractID groupId,
-				MultiTaskSlot parent,
+				@Nullable MultiTaskSlot parent,
 				CompletableFuture<? extends SlotContext> slotContextFuture,
-				SlotRequestId allocatedSlotRequestId) {
+				@Nullable SlotRequestId allocatedSlotRequestId) {
 			super(slotRequestId, groupId);
 
 			this.parent = parent;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
@@ -292,11 +292,13 @@ public class SlotManager implements AutoCloseable {
 		PendingSlotRequest pendingSlotRequest = pendingSlotRequests.remove(allocationId);
 
 		if (null != pendingSlotRequest) {
+			LOG.debug("Cancel slot request {}.", allocationId);
+
 			cancelPendingSlotRequest(pendingSlotRequest);
 
 			return true;
 		} else {
-			LOG.debug("No pending slot request with allocation id {} found.", allocationId);
+			LOG.debug("No pending slot request with allocation id {} found. Ignoring unregistration request.", allocationId);
 
 			return false;
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
@@ -56,6 +56,7 @@ import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.TestTaskStateManager;
 import org.apache.flink.runtime.util.TestingTaskManagerRuntimeInfo;
 import org.apache.flink.util.SerializedValue;
+import org.apache.flink.util.TestLogger;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -78,7 +79,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class TaskAsyncCallTest {
+public class TaskAsyncCallTest extends TestLogger {
 
 	/** Number of expected checkpoints. */
 	private static int numCalls;
@@ -289,7 +290,7 @@ public class TaskAsyncCallTest {
 
 			// wait forever (until canceled)
 			synchronized (this) {
-				while (error == null && lastCheckpointId < numCalls) {
+				while (error == null) {
 					wait();
 				}
 			}

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/JobManagerITCase.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/JobManagerITCase.scala
@@ -25,7 +25,7 @@ import akka.testkit.{ImplicitSender, TestKit}
 import akka.util.Timeout
 import org.apache.flink.api.common.JobID
 import org.apache.flink.runtime.akka.ListeningBehaviour
-import org.apache.flink.runtime.checkpoint.{CheckpointRetentionPolicy, CheckpointCoordinator, CompletedCheckpoint}
+import org.apache.flink.runtime.checkpoint._
 import org.apache.flink.runtime.client.JobExecutionException
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType
 import org.apache.flink.runtime.jobgraph.tasks.{CheckpointCoordinatorConfiguration, JobCheckpointingSettings}
@@ -857,7 +857,7 @@ class JobManagerITCase(_system: ActorSystem)
 
           // Mock the checkpoint coordinator
           val checkpointCoordinator = mock(classOf[CheckpointCoordinator])
-          doThrow(new Exception("Expected Test Exception"))
+          doThrow(new IllegalStateException("Expected Test Exception"))
             .when(checkpointCoordinator)
             .triggerSavepoint(org.mockito.Matchers.anyLong(), org.mockito.Matchers.anyString())
 
@@ -872,7 +872,7 @@ class JobManagerITCase(_system: ActorSystem)
 
           // Verify the response
           response.jobId should equal(jobGraph.getJobID())
-          response.cause.getCause.getClass should equal(classOf[Exception])
+          response.cause.getCause.getClass should equal(classOf[IllegalStateException])
           response.cause.getCause.getMessage should equal("Expected Test Exception")
         }
       }
@@ -913,7 +913,7 @@ class JobManagerITCase(_system: ActorSystem)
 
           // Mock the checkpoint coordinator
           val checkpointCoordinator = mock(classOf[CheckpointCoordinator])
-          doThrow(new Exception("Expected Test Exception"))
+          doThrow(new IllegalStateException("Expected Test Exception"))
             .when(checkpointCoordinator)
             .triggerSavepoint(org.mockito.Matchers.anyLong(), org.mockito.Matchers.anyString())
           val savepointPathPromise = new CompletableFuture[CompletedCheckpoint]()
@@ -982,7 +982,7 @@ class JobManagerITCase(_system: ActorSystem)
 
           // Mock the checkpoint coordinator
           val checkpointCoordinator = mock(classOf[CheckpointCoordinator])
-          doThrow(new Exception("Expected Test Exception"))
+          doThrow(new IllegalStateException("Expected Test Exception"))
             .when(checkpointCoordinator)
             .triggerSavepoint(org.mockito.Matchers.anyLong(), org.mockito.Matchers.anyString())
 


### PR DESCRIPTION
## What is the purpose of the change

If a slot request is fulfilled with a different AllocatedSlot in the SlotPool,
then we cancel the slot request sent to the ResourceManager.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
