### PR TITLE
[FLINK-8749] [flip6] Release slots when scheduling operation is canceled

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -354,11 +354,10 @@ public class CheckpointCoordinator {
 	 * @throws IllegalStateException If no savepoint directory has been
 	 *                               specified and no default savepoint directory has been
 	 *                               configured
-	 * @throws Exception             Failures during triggering are forwarded
 	 */
 	public CompletableFuture<CompletedCheckpoint> triggerSavepoint(
 			long timestamp,
-			@Nullable String targetLocation) throws Exception {
+			@Nullable String targetLocation) {
 
 		CheckpointProperties props = CheckpointProperties.forSavepoint();
 
@@ -371,7 +370,7 @@ public class CheckpointCoordinator {
 		if (triggerResult.isSuccess()) {
 			return triggerResult.getPendingCheckpoint().getCompletionFuture();
 		} else {
-			Throwable cause = new Exception("Failed to trigger savepoint: " + triggerResult.getFailureReason().message());
+			Throwable cause = new CheckpointTriggerException("Failed to trigger savepoint.", triggerResult.getFailureReason());
 			return FutureUtils.completedExceptionally(cause);
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointTriggerException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointTriggerException.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint;
+
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.Preconditions;
+
+/**
+ * Exceptions which indicate that a checkpoint triggering has failed.
+ *
+ */
+public class CheckpointTriggerException extends FlinkException {
+
+	private static final long serialVersionUID = -3330160816161901752L;
+
+	private final CheckpointDeclineReason checkpointDeclineReason;
+
+	public CheckpointTriggerException(String message, CheckpointDeclineReason checkpointDeclineReason) {
+		super(message + " Decline reason: " + checkpointDeclineReason.message());
+		this.checkpointDeclineReason = Preconditions.checkNotNull(checkpointDeclineReason);
+	}
+
+	public CheckpointDeclineReason getCheckpointDeclineReason() {
+		return checkpointDeclineReason;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -993,7 +993,7 @@ public class ExecutionGraph implements AccessExecutionGraph {
 					} else {
 						resultThrowable = strippedThrowable;
 					}
-
+					
 					throw new CompletionException(resultThrowable);
 				});
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -91,6 +91,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
@@ -891,9 +892,12 @@ public class ExecutionGraph implements AccessExecutionGraph {
 			}
 
 			if (state == JobStatus.RUNNING && currentGlobalModVersion == globalModVersion) {
-				schedulingFuture = newSchedulingFuture.whenCompleteAsync(
+				schedulingFuture = newSchedulingFuture;
+
+				newSchedulingFuture.whenCompleteAsync(
 					(Void ignored, Throwable throwable) -> {
-						if (throwable != null) {
+						if (throwable != null && !(throwable instanceof CancellationException)) {
+							// only fail if the scheduling future was not canceled
 							failGlobal(ExceptionUtils.stripCompletionException(throwable));
 						}
 					},
@@ -963,7 +967,7 @@ public class ExecutionGraph implements AccessExecutionGraph {
 		// the future fails once one slot future fails.
 		final ConjunctFuture<Collection<Execution>> allAllocationsFuture = FutureUtils.combineAll(allAllocationFutures);
 
-		return allAllocationsFuture
+		final CompletableFuture<Void> currentSchedulingFuture = allAllocationsFuture
 			.thenAccept(
 				(Collection<Execution> executionsToDeploy) -> {
 					for (Execution execution : executionsToDeploy) {
@@ -976,7 +980,7 @@ public class ExecutionGraph implements AccessExecutionGraph {
 									t));
 						}
 					}
-			})
+				})
 			// Generate a more specific failure message for the eager scheduling
 			.exceptionally(
 				(Throwable throwable) -> {
@@ -993,9 +997,19 @@ public class ExecutionGraph implements AccessExecutionGraph {
 					} else {
 						resultThrowable = strippedThrowable;
 					}
-					
+
 					throw new CompletionException(resultThrowable);
 				});
+
+		currentSchedulingFuture.whenComplete(
+			(Void ignored, Throwable throwable) -> {
+				if (throwable instanceof CancellationException) {
+					// cancel the individual allocation futures
+					allAllocationsFuture.cancel(false);
+				}
+			});
+
+		return currentSchedulingFuture;
 	}
 
 	public void cancel() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/scheduler/Scheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/scheduler/Scheduler.java
@@ -26,12 +26,15 @@ import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.instance.Instance;
 import org.apache.flink.runtime.instance.InstanceDiedException;
 import org.apache.flink.runtime.instance.InstanceListener;
+import org.apache.flink.runtime.instance.SlotSharingGroupId;
 import org.apache.flink.runtime.jobmaster.LogicalSlot;
 import org.apache.flink.runtime.instance.SharedSlot;
 import org.apache.flink.runtime.instance.SimpleSlot;
+import org.apache.flink.runtime.jobmaster.SlotRequestId;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.instance.SlotSharingGroupAssignment;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
@@ -142,6 +145,7 @@ public class Scheduler implements InstanceListener, SlotAvailabilityListener, Sl
 
 	@Override
 	public CompletableFuture<LogicalSlot> allocateSlot(
+			SlotRequestId slotRequestId,
 			ScheduledUnit task,
 			boolean allowQueued,
 			Collection<TaskManagerLocation> preferredLocations,
@@ -165,6 +169,11 @@ public class Scheduler implements InstanceListener, SlotAvailabilityListener, Sl
 		} catch (NoResourceAvailableException e) {
 			return FutureUtils.completedExceptionally(e);
 		}
+	}
+
+	@Override
+	public CompletableFuture<Acknowledge> cancelSlotRequest(SlotRequestId slotRequestId, @Nullable SlotSharingGroupId slotSharingGroupId, Throwable cause) {
+		return CompletableFuture.completedFuture(Acknowledge.get());
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -639,6 +639,9 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 				if (executionGraph == currentExecutionGraph) {
 					executionGraph = restoredExecutionGraph;
 
+					// register self as job status change listener
+					executionGraph.registerJobStatusListener(new JobManagerJobStatusListener());
+
 					scheduleExecutionGraph();
 
 					return Acknowledge.get();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -468,26 +468,13 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 		}
 
 		// 1. Check whether we can rescale the job & rescale the respective vertices
-		for (JobVertexID jobVertexId : operators) {
-			final JobVertex jobVertex = jobGraph.findVertexByID(jobVertexId);
+		try {
+			rescaleJobGraph(operators, newParallelism, rescalingBehaviour);
+		} catch (FlinkException e) {
+			final String msg = String.format("Cannot rescale job %s.", jobGraph.getName());
 
-			// update max parallelism in case that it has not been configured
-			final ExecutionJobVertex executionJobVertex = executionGraph.getJobVertex(jobVertexId);
-
-			if (executionJobVertex != null) {
-				jobVertex.setMaxParallelism(executionJobVertex.getMaxParallelism());
-			}
-
-			try {
-				rescalingBehaviour.acceptWithException(jobVertex, newParallelism);
-			} catch (FlinkException e) {
-				final String msg = String.format("Cannot rescale job %s.", jobGraph.getName());
-
-				log.info(msg, e);
-
-				return FutureUtils.completedExceptionally(
-					new JobModificationException(msg, e));
-			}
+			log.info(msg, e);
+			return FutureUtils.completedExceptionally(new JobModificationException(msg, e));
 		}
 
 		final ExecutionGraph currentExecutionGraph = executionGraph;
@@ -521,82 +508,11 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 		checkpointCoordinator.stopCheckpointScheduler();
 
 		// 4. take a savepoint
-		final CompletableFuture<String> savepointFuture = triggerSavepoint(
-			null,
-			timeout)
-			.handleAsync(
-				(String savepointPath, Throwable throwable) -> {
-					if (throwable != null) {
-						final Throwable strippedThrowable = ExceptionUtils.stripCompletionException(throwable);
-						if (strippedThrowable instanceof CheckpointTriggerException) {
-							final CheckpointTriggerException checkpointTriggerException = (CheckpointTriggerException) strippedThrowable;
+		final CompletableFuture<String> savepointFuture = getJobModificationSavepoint(timeout);
 
-							if (checkpointTriggerException.getCheckpointDeclineReason() == CheckpointDeclineReason.NOT_ALL_REQUIRED_TASKS_RUNNING) {
-								return lastInternalSavepoint;
-							} else {
-								throw new CompletionException(checkpointTriggerException);
-							}
-						} else {
-							throw new CompletionException(strippedThrowable);
-						}
-					} else {
-						final String savepointToDispose = lastInternalSavepoint;
-						lastInternalSavepoint = savepointPath;
-
-						if (savepointToDispose != null) {
-							// dispose the old savepoint asynchronously
-							CompletableFuture.runAsync(
-								() -> disposeSavepoint(savepointToDispose),
-								scheduledExecutorService);
-						}
-
-						return lastInternalSavepoint;
-					}
-				},
-				getMainThreadExecutor());
-
-		final CompletableFuture<ExecutionGraph> executionGraphFuture = savepointFuture
-			.thenApplyAsync(
-				(@Nullable String savepointPath) -> {
-					if (savepointPath != null) {
-						try {
-							tryRestoreExecutionGraphFromSavepoint(newExecutionGraph, SavepointRestoreSettings.forPath(savepointPath, false));
-						} catch (Exception e) {
-							final String message = String.format("Could not restore from temporary rescaling savepoint. This might indicate " +
-									"that the savepoint %s got corrupted. Deleting this savepoint as a precaution.",
-								savepointPath);
-
-							log.info(message);
-
-							CompletableFuture
-								.runAsync(
-									() -> {
-										if (savepointPath.equals(lastInternalSavepoint)) {
-											lastInternalSavepoint = null;
-										}
-									},
-									getMainThreadExecutor())
-								.thenRunAsync(
-									() -> disposeSavepoint(savepointPath),
-									scheduledExecutorService);
-
-							throw new CompletionException(new JobModificationException(message, e));
-						}
-					} else {
-						try {
-							tryRestoreExecutionGraphFromSavepoint(newExecutionGraph, jobGraph.getSavepointRestoreSettings());
-						} catch (Exception e) {
-							final String message = String.format("Could not restore from initial savepoint. This might indicate " +
-								"that the savepoint %s got corrupted.", jobGraph.getSavepointRestoreSettings().getRestorePath());
-
-							log.info(message);
-
-							throw new CompletionException(new JobModificationException(message, e));
-						}
-					}
-
-					return newExecutionGraph;
-				}, scheduledExecutorService)
+		final CompletableFuture<ExecutionGraph> executionGraphFuture = restoreExecutionGraphFromRescalingSavepoint(
+			newExecutionGraph,
+			savepointFuture)
 			.handleAsync(
 				(ExecutionGraph executionGraph, Throwable failure) -> {
 					if (failure != null) {
@@ -1330,6 +1246,130 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 		}
 
 		slotPoolGateway.disconnectResourceManager();
+	}
+
+	/**
+	 * Restore the given {@link ExecutionGraph} from the rescaling savepoint. If the {@link ExecutionGraph} could
+	 * be restored, then this savepoint will be recorded as the latest successful modification savepoint. A previous
+	 * savepoint will be disposed. If the rescaling savepoint is empty, the job will be restored from the initially
+	 * provided savepoint.
+	 *
+	 * @param newExecutionGraph to restore
+	 * @param savepointFuture containing the path to the internal modification savepoint
+	 * @return Future which is completed with the restored {@link ExecutionGraph}
+	 */
+	private CompletableFuture<ExecutionGraph> restoreExecutionGraphFromRescalingSavepoint(ExecutionGraph newExecutionGraph, CompletableFuture<String> savepointFuture) {
+		return savepointFuture
+			.thenApplyAsync(
+				(@Nullable String savepointPath) -> {
+					if (savepointPath != null) {
+						try {
+							tryRestoreExecutionGraphFromSavepoint(newExecutionGraph, SavepointRestoreSettings.forPath(savepointPath, false));
+						} catch (Exception e) {
+							final String message = String.format("Could not restore from temporary rescaling savepoint. This might indicate " +
+									"that the savepoint %s got corrupted. Deleting this savepoint as a precaution.",
+								savepointPath);
+
+							log.info(message);
+
+							CompletableFuture
+								.runAsync(
+									() -> {
+										if (savepointPath.equals(lastInternalSavepoint)) {
+											lastInternalSavepoint = null;
+										}
+									},
+									getMainThreadExecutor())
+								.thenRunAsync(
+									() -> disposeSavepoint(savepointPath),
+									scheduledExecutorService);
+
+							throw new CompletionException(new JobModificationException(message, e));
+						}
+					} else {
+						// No rescaling savepoint, restart from the initial savepoint or none
+						try {
+							tryRestoreExecutionGraphFromSavepoint(newExecutionGraph, jobGraph.getSavepointRestoreSettings());
+						} catch (Exception e) {
+							final String message = String.format("Could not restore from initial savepoint. This might indicate " +
+								"that the savepoint %s got corrupted.", jobGraph.getSavepointRestoreSettings().getRestorePath());
+
+							log.info(message);
+
+							throw new CompletionException(new JobModificationException(message, e));
+						}
+					}
+
+					return newExecutionGraph;
+				}, scheduledExecutorService);
+	}
+
+	/**
+	 * Takes an internal savepoint for job modification purposes. If the savepoint was not successful because
+	 * not all tasks were running, it returns the last successful modification savepoint.
+	 *
+	 * @param timeout for the operation
+	 * @return Future which is completed with the savepoint path or the last successful modification savepoint if the
+	 * former was not successful
+	 */
+	private CompletableFuture<String> getJobModificationSavepoint(Time timeout) {
+		return triggerSavepoint(
+			null,
+			timeout)
+			.handleAsync(
+				(String savepointPath, Throwable throwable) -> {
+					if (throwable != null) {
+						final Throwable strippedThrowable = ExceptionUtils.stripCompletionException(throwable);
+						if (strippedThrowable instanceof CheckpointTriggerException) {
+							final CheckpointTriggerException checkpointTriggerException = (CheckpointTriggerException) strippedThrowable;
+
+							if (checkpointTriggerException.getCheckpointDeclineReason() == CheckpointDeclineReason.NOT_ALL_REQUIRED_TASKS_RUNNING) {
+								return lastInternalSavepoint;
+							} else {
+								throw new CompletionException(checkpointTriggerException);
+							}
+						} else {
+							throw new CompletionException(strippedThrowable);
+						}
+					} else {
+						final String savepointToDispose = lastInternalSavepoint;
+						lastInternalSavepoint = savepointPath;
+
+						if (savepointToDispose != null) {
+							// dispose the old savepoint asynchronously
+							CompletableFuture.runAsync(
+								() -> disposeSavepoint(savepointToDispose),
+								scheduledExecutorService);
+						}
+
+						return lastInternalSavepoint;
+					}
+				},
+				getMainThreadExecutor());
+	}
+
+	/**
+	 * Rescales the given operators of the {@link JobGraph} of this {@link JobMaster} with respect to given
+	 * parallelism and {@link RescalingBehaviour}.
+	 *
+	 * @param operators to rescale
+	 * @param newParallelism new parallelism for these operators
+	 * @param rescalingBehaviour of the rescaling operation
+	 * @throws FlinkException if the {@link JobGraph} could not be rescaled
+	 */
+	private void rescaleJobGraph(Collection<JobVertexID> operators, int newParallelism, RescalingBehaviour rescalingBehaviour) throws FlinkException {
+		for (JobVertexID jobVertexId : operators) {
+			final JobVertex jobVertex = jobGraph.findVertexByID(jobVertexId);
+
+			// update max parallelism in case that it has not been configured
+			final ExecutionJobVertex executionJobVertex = executionGraph.getJobVertex(jobVertexId);
+
+			if (executionJobVertex != null) {
+				jobVertex.setMaxParallelism(executionJobVertex.getMaxParallelism());
+			}
+
+			rescalingBehaviour.acceptWithException(jobVertex, newParallelism);
+		}
 	}
 
 	//----------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -522,7 +522,7 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 
 		// 4. take a savepoint
 		final CompletableFuture<String> savepointFuture = triggerSavepoint(
-			jobMasterConfiguration.getTmpDirectory(),
+			null,
 			timeout)
 			.handleAsync(
 				(String savepointPath, Throwable throwable) -> {
@@ -1055,7 +1055,7 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 
 	@Override
 	public CompletableFuture<String> triggerSavepoint(
-		final String targetDirectory,
+		@Nullable final String targetDirectory,
 		final Time timeout) {
 		try {
 			return executionGraph.getCheckpointCoordinator()

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
@@ -44,6 +44,8 @@ import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 
+import javax.annotation.Nullable;
+
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 
@@ -254,12 +256,13 @@ public interface JobMasterGateway extends
 	/**
 	 * Triggers taking a savepoint of the executed job.
 	 *
-	 * @param targetDirectory to which to write the savepoint data
+	 * @param targetDirectory to which to write the savepoint data or null if the
+	 *                           default savepoint directory should be used
 	 * @param timeout for the rpc call
 	 * @return Future which is completed with the savepoint path once completed
 	 */
 	CompletableFuture<String> triggerSavepoint(
-		final String targetDirectory,
+		@Nullable final String targetDirectory,
 		final Time timeout);
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
@@ -1571,14 +1571,14 @@ public class SlotPool extends RpcEndpoint implements SlotPoolGateway, AllocatedS
 
 		@Override
 		public CompletableFuture<LogicalSlot> allocateSlot(
+				SlotRequestId slotRequestId,
 				ScheduledUnit task,
 				boolean allowQueued,
 				Collection<TaskManagerLocation> preferredLocations,
 				Time timeout) {
 
-			final SlotRequestId requestId = new SlotRequestId();
 			CompletableFuture<LogicalSlot> slotFuture = gateway.allocateSlot(
-				requestId,
+				slotRequestId,
 				task,
 				ResourceProfile.UNKNOWN,
 				preferredLocations,
@@ -1589,13 +1589,21 @@ public class SlotPool extends RpcEndpoint implements SlotPoolGateway, AllocatedS
 				(LogicalSlot slot, Throwable failure) -> {
 					if (failure != null) {
 						gateway.releaseSlot(
-							requestId,
+							slotRequestId,
 							task.getSlotSharingGroupId(),
 							failure);
 					}
 			});
 
 			return slotFuture;
+		}
+
+		@Override
+		public CompletableFuture<Acknowledge> cancelSlotRequest(
+				SlotRequestId slotRequestId,
+				@Nullable SlotSharingGroupId slotSharingGroupId,
+				Throwable cause) {
+			return gateway.releaseSlot(slotRequestId, slotSharingGroupId, cause);
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
@@ -227,6 +227,14 @@ public class SlotPool extends RpcEndpoint implements SlotPoolGateway, AllocatedS
 
 		validateRunsInMainThread();
 
+		// cancel all pending allocations --> we can request these slots
+		// again after we regained the leadership
+		Set<AllocationID> allocationIds = pendingRequests.keySetB();
+
+		for (AllocationID allocationId : allocationIds) {
+			resourceManagerGateway.cancelSlotRequest(allocationId);
+		}
+
 		// suspend this RPC endpoint
 		stop();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotProvider.java
@@ -19,16 +19,21 @@
 package org.apache.flink.runtime.jobmaster.slotpool;
 
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.runtime.jobmaster.LogicalSlot;
+import org.apache.flink.runtime.instance.SlotSharingGroupId;
 import org.apache.flink.runtime.jobmanager.scheduler.ScheduledUnit;
+import org.apache.flink.runtime.jobmaster.LogicalSlot;
+import org.apache.flink.runtime.jobmaster.SlotRequestId;
+import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+
+import javax.annotation.Nullable;
 
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 
 /**
  * The slot provider is responsible for preparing slots for ready-to-run tasks.
- * 
+ *
  * <p>It supports two allocating modes:
  * <ul>
  *     <li>Immediate allocating: A request for a task slot immediately gets satisfied, we can call
@@ -49,8 +54,44 @@ public interface SlotProvider {
 	 * @return The future of the allocation
 	 */
 	CompletableFuture<LogicalSlot> allocateSlot(
+		SlotRequestId slotRequestId,
 		ScheduledUnit task,
 		boolean allowQueued,
 		Collection<TaskManagerLocation> preferredLocations,
 		Time timeout);
+
+	/**
+	 * Allocating slot with specific requirement.
+	 *
+	 * @param task The task to allocate the slot for
+	 * @param allowQueued Whether allow the task be queued if we do not have enough resource
+	 * @param preferredLocations preferred locations for the slot allocation
+	 * @param timeout after which the allocation fails with a timeout exception
+	 * @return The future of the allocation
+	 */
+	default CompletableFuture<LogicalSlot> allocateSlot(
+		ScheduledUnit task,
+		boolean allowQueued,
+		Collection<TaskManagerLocation> preferredLocations,
+		Time timeout) {
+		return allocateSlot(
+			new SlotRequestId(),
+			task,
+			allowQueued,
+			preferredLocations,
+			timeout);
+	}
+
+	/**
+	 * Cancels the slot request with the given {@link SlotRequestId} and {@link SlotSharingGroupId}.
+	 *
+	 * @param slotRequestId identifying the slot request to cancel
+	 * @param slotSharingGroupId identifying the slot request to cancel
+	 * @param cause of the cancellation
+	 * @return Future which is completed once the slot request has been cancelled
+	 */
+	CompletableFuture<Acknowledge> cancelSlotRequest(
+		SlotRequestId slotRequestId,
+		@Nullable SlotSharingGroupId slotSharingGroupId,
+		Throwable cause);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSharingManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSharingManager.java
@@ -537,9 +537,8 @@ public class SlotSharingManager {
 				if (parent != null) {
 					// we remove ourselves from our parent if we no longer have children
 					parent.releaseChild(getGroupId());
-				} else {
+				} else if (allTaskSlots.remove(getSlotRequestId()) != null) {
 					// we are the root node --> remove the root node from the list of task slots
-					allTaskSlots.remove(getSlotRequestId());
 
 					if (!slotContextFuture.isDone() || slotContextFuture.isCompletedExceptionally()) {
 						synchronized (lock) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSharingManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSharingManager.java
@@ -418,9 +418,9 @@ public class SlotSharingManager {
 		private MultiTaskSlot(
 				SlotRequestId slotRequestId,
 				@Nullable AbstractID groupId,
-				MultiTaskSlot parent,
+				@Nullable MultiTaskSlot parent,
 				CompletableFuture<? extends SlotContext> slotContextFuture,
-				SlotRequestId allocatedSlotRequestId) {
+				@Nullable SlotRequestId allocatedSlotRequestId) {
 			super(slotRequestId, groupId);
 
 			this.parent = parent;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
@@ -292,11 +292,13 @@ public class SlotManager implements AutoCloseable {
 		PendingSlotRequest pendingSlotRequest = pendingSlotRequests.remove(allocationId);
 
 		if (null != pendingSlotRequest) {
+			LOG.debug("Cancel slot request {}.", allocationId);
+
 			cancelPendingSlotRequest(pendingSlotRequest);
 
 			return true;
 		} else {
-			LOG.debug("No pending slot request with allocation id {} found.", allocationId);
+			LOG.debug("No pending slot request with allocation id {} found. Ignoring unregistration request.", allocationId);
 
 			return false;
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/FutureUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/FutureUtilsTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -40,6 +41,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static org.hamcrest.CoreMatchers.containsString;
@@ -422,6 +424,38 @@ public class FutureUtilsTest extends TestLogger {
 
 			assertThat(suppressed, is(not(emptyArray())));
 			assertThat(suppressed, arrayContaining(suppressedException));
+		}
+	}
+
+	@Test
+	public void testCancelWaitingConjunctFuture() {
+		cancelConjunctFuture(inputFutures -> FutureUtils.waitForAll(inputFutures));
+	}
+
+	@Test
+	public void testCancelResultConjunctFuture() {
+		cancelConjunctFuture(inputFutures -> FutureUtils.combineAll(inputFutures));
+	}
+
+	@Test
+	public void testCancelCompleteConjunctFuture() {
+		cancelConjunctFuture(inputFutures -> FutureUtils.completeAll(inputFutures));
+	}
+
+	private void cancelConjunctFuture(Function<Collection<? extends CompletableFuture<?>>, FutureUtils.ConjunctFuture<?>> conjunctFutureFactory) {
+		final int numInputFutures = 10;
+		final Collection<CompletableFuture<Void>> inputFutures = new ArrayList<>(numInputFutures);
+
+		for (int i = 0; i < numInputFutures; i++) {
+			inputFutures.add(new CompletableFuture<>());
+		}
+
+		final FutureUtils.ConjunctFuture<?> conjunctFuture = conjunctFutureFactory.apply(inputFutures);
+
+		conjunctFuture.cancel(false);
+
+		for (CompletableFuture<Void> inputFuture : inputFutures) {
+			assertThat(inputFuture.isCancelled(), is(true));
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphMetricsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphMetricsTest.java
@@ -27,13 +27,14 @@ import org.apache.flink.runtime.execution.SuppressRestartsException;
 import org.apache.flink.runtime.executiongraph.metrics.RestartTimeGauge;
 import org.apache.flink.runtime.executiongraph.restart.RestartCallback;
 import org.apache.flink.runtime.executiongraph.restart.RestartStrategy;
-import org.apache.flink.runtime.jobmaster.LogicalSlot;
-import org.apache.flink.runtime.jobmaster.TestingLogicalSlot;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobmanager.scheduler.ScheduledUnit;
 import org.apache.flink.runtime.jobmanager.scheduler.Scheduler;
+import org.apache.flink.runtime.jobmaster.LogicalSlot;
+import org.apache.flink.runtime.jobmaster.SlotRequestId;
+import org.apache.flink.runtime.jobmaster.TestingLogicalSlot;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
 import org.apache.flink.util.SerializedValue;
@@ -79,7 +80,7 @@ public class ExecutionGraphMetricsTest extends TestLogger {
 
 			CompletableFuture<LogicalSlot> slotFuture1 = CompletableFuture.completedFuture(new TestingLogicalSlot());
 			CompletableFuture<LogicalSlot> slotFuture2 = CompletableFuture.completedFuture(new TestingLogicalSlot());
-			when(scheduler.allocateSlot(any(ScheduledUnit.class), anyBoolean(), any(Collection.class), any(Time.class))).thenReturn(slotFuture1, slotFuture2);
+			when(scheduler.allocateSlot(any(SlotRequestId.class), any(ScheduledUnit.class), anyBoolean(), any(Collection.class), any(Time.class))).thenReturn(slotFuture1, slotFuture2);
 
 			TestingRestartStrategy testingRestartStrategy = new TestingRestartStrategy();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionTest.java
@@ -22,13 +22,16 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.restart.NoRestartStrategy;
 import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
-import org.apache.flink.runtime.jobmaster.LogicalSlot;
 import org.apache.flink.runtime.instance.SimpleSlot;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobmanager.scheduler.LocationPreferenceConstraint;
 import org.apache.flink.runtime.jobmanager.scheduler.SchedulerTestUtils;
+import org.apache.flink.runtime.jobmaster.LogicalSlot;
 import org.apache.flink.runtime.jobmaster.SlotOwner;
+import org.apache.flink.runtime.jobmaster.SlotRequestId;
+import org.apache.flink.runtime.jobmaster.TestingLogicalSlot;
+import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
@@ -39,10 +42,14 @@ import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -55,7 +62,7 @@ public class ExecutionTest extends TestLogger {
 
 	/**
 	 * Tests that slots are released if we cannot assign the allocated resource to the
-	 * Execution. In this case, a concurrent cancellation precedes the assignment.
+	 * Execution.
 	 */
 	@Test
 	public void testSlotReleaseOnFailedResourceAssignment() throws Exception {
@@ -85,6 +92,8 @@ public class ExecutionTest extends TestLogger {
 			0,
 			new SimpleAckingTaskManagerGateway());
 
+		final LogicalSlot otherSlot = new TestingLogicalSlot();
+
 		CompletableFuture<Execution> allocationFuture = execution.allocateAndAssignSlotForExecution(
 			slotProvider,
 			false,
@@ -95,11 +104,8 @@ public class ExecutionTest extends TestLogger {
 
 		assertEquals(ExecutionState.SCHEDULED, execution.getState());
 
-		// cancelling the execution should move it into state CANCELED; this happens before
-		// the slot future has been completed
-		execution.cancel();
-
-		assertEquals(ExecutionState.CANCELED, execution.getState());
+		// assign a different resource to the execution
+		assertTrue(execution.tryAssignResource(otherSlot));
 
 		// completing now the future should cause the slot to be released
 		slotFuture.complete(slot);
@@ -211,6 +217,54 @@ public class ExecutionTest extends TestLogger {
 		execution.cancelingComplete();
 
 		assertEquals(slot, slotOwner.getReturnedSlotFuture().get());
+	}
+
+	/**
+	 * Tests that a slot allocation from a {@link SlotProvider} is cancelled if the
+	 * {@link Execution} is cancelled.
+	 */
+	@Test
+	public void testSlotAllocationCancellationWhenExecutionCancelled() throws Exception {
+		final JobVertexID jobVertexId = new JobVertexID();
+		final JobVertex jobVertex = new JobVertex("test vertex", jobVertexId);
+		jobVertex.setInvokableClass(NoOpInvokable.class);
+
+		final ProgrammedSlotProvider slotProvider = new ProgrammedSlotProvider(1);
+		final CompletableFuture<LogicalSlot> slotFuture = new CompletableFuture<>();
+		slotProvider.addSlot(jobVertexId, 0, slotFuture);
+
+		final ExecutionGraph executionGraph = ExecutionGraphTestUtils.createSimpleTestGraph(
+			new JobID(),
+			slotProvider,
+			new NoRestartStrategy(),
+			jobVertex);
+
+		final ExecutionJobVertex executionJobVertex = executionGraph.getJobVertex(jobVertexId);
+
+		final Execution currentExecutionAttempt = executionJobVertex.getTaskVertices()[0].getCurrentExecutionAttempt();
+
+		final CompletableFuture<Execution> allocationFuture = currentExecutionAttempt.allocateAndAssignSlotForExecution(
+			slotProvider,
+			false,
+			LocationPreferenceConstraint.ALL,
+			TestingUtils.infiniteTime());
+
+		assertThat(allocationFuture.isDone(), is(false));
+
+		assertThat(slotProvider.getSlotRequestedFuture(jobVertexId, 0).get(), is(true));
+
+		final Set<SlotRequestId> slotRequests = slotProvider.getSlotRequests();
+		assertThat(slotRequests, hasSize(1));
+
+		assertThat(currentExecutionAttempt.getState(), is(ExecutionState.SCHEDULED));
+
+		currentExecutionAttempt.cancel();
+		assertThat(currentExecutionAttempt.getState(), is(ExecutionState.CANCELED));
+
+		assertThat(allocationFuture.isCompletedExceptionally(), is(true));
+
+		final Set<SlotRequestId> canceledSlotRequests = slotProvider.getCanceledSlotRequests();
+		assertThat(canceledSlotRequests, equalTo(slotRequests));
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexSchedulingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexSchedulingTest.java
@@ -30,10 +30,10 @@ import org.apache.flink.runtime.jobmanager.scheduler.ScheduledUnit;
 import org.apache.flink.runtime.jobmanager.scheduler.Scheduler;
 import org.apache.flink.runtime.jobmanager.slots.ActorTaskManagerGateway;
 import org.apache.flink.runtime.jobmaster.LogicalSlot;
+import org.apache.flink.runtime.jobmaster.SlotRequestId;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 
 import org.junit.Test;
-import org.mockito.Matchers;
 
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
@@ -67,7 +67,7 @@ public class ExecutionVertexSchedulingTest {
 			Scheduler scheduler = mock(Scheduler.class);
 			CompletableFuture<LogicalSlot> future = new CompletableFuture<>();
 			future.complete(slot);
-			when(scheduler.allocateSlot(Matchers.any(ScheduledUnit.class), anyBoolean(), any(Collection.class), any(Time.class))).thenReturn(future);
+			when(scheduler.allocateSlot(any(SlotRequestId.class), any(ScheduledUnit.class), anyBoolean(), any(Collection.class), any(Time.class))).thenReturn(future);
 
 			assertEquals(ExecutionState.CREATED, vertex.getExecutionState());
 			// try to deploy to the slot
@@ -99,7 +99,7 @@ public class ExecutionVertexSchedulingTest {
 			final CompletableFuture<LogicalSlot> future = new CompletableFuture<>();
 
 			Scheduler scheduler = mock(Scheduler.class);
-			when(scheduler.allocateSlot(Matchers.any(ScheduledUnit.class), anyBoolean(), any(Collection.class), any(Time.class))).thenReturn(future);
+			when(scheduler.allocateSlot(any(SlotRequestId.class), any(ScheduledUnit.class), anyBoolean(), any(Collection.class), any(Time.class))).thenReturn(future);
 
 			assertEquals(ExecutionState.CREATED, vertex.getExecutionState());
 			// try to deploy to the slot
@@ -133,7 +133,7 @@ public class ExecutionVertexSchedulingTest {
 			Scheduler scheduler = mock(Scheduler.class);
 			CompletableFuture<LogicalSlot> future = new CompletableFuture<>();
 			future.complete(slot);
-			when(scheduler.allocateSlot(Matchers.any(ScheduledUnit.class), anyBoolean(), any(Collection.class), any(Time.class))).thenReturn(future);
+			when(scheduler.allocateSlot(any(SlotRequestId.class), any(ScheduledUnit.class), anyBoolean(), any(Collection.class), any(Time.class))).thenReturn(future);
 
 			assertEquals(ExecutionState.CREATED, vertex.getExecutionState());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ProgrammedSlotProvider.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ProgrammedSlotProvider.java
@@ -19,15 +19,23 @@
 package org.apache.flink.runtime.executiongraph;
 
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.instance.SlotSharingGroupId;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobmanager.scheduler.ScheduledUnit;
 import org.apache.flink.runtime.jobmaster.LogicalSlot;
+import org.apache.flink.runtime.jobmaster.SlotRequestId;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
+import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 
+import javax.annotation.Nullable;
+
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
@@ -42,6 +50,10 @@ class ProgrammedSlotProvider implements SlotProvider {
 	private final Map<JobVertexID, CompletableFuture<LogicalSlot>[]> slotFutures = new HashMap<>();
 
 	private final Map<JobVertexID, CompletableFuture<Boolean>[]> slotFutureRequested = new HashMap<>();
+
+	private final Set<SlotRequestId> slotRequests = new HashSet<>();
+
+	private final Set<SlotRequestId> canceledSlotRequests = new HashSet<>();
 
 	private final int parallelism;
 
@@ -92,8 +104,17 @@ class ProgrammedSlotProvider implements SlotProvider {
 		return slotFutureRequested.get(jobVertexId)[subtaskIndex];
 	}
 
+	public Set<SlotRequestId> getSlotRequests() {
+		return Collections.unmodifiableSet(slotRequests);
+	}
+
+	public Set<SlotRequestId> getCanceledSlotRequests() {
+		return Collections.unmodifiableSet(canceledSlotRequests);
+	}
+
 	@Override
 	public CompletableFuture<LogicalSlot> allocateSlot(
+			SlotRequestId slotRequestId,
 			ScheduledUnit task,
 			boolean allowQueued,
 			Collection<TaskManagerLocation> preferredLocations,
@@ -106,11 +127,18 @@ class ProgrammedSlotProvider implements SlotProvider {
 			CompletableFuture<LogicalSlot> future = forTask[subtask];
 			if (future != null) {
 				slotFutureRequested.get(vertexId)[subtask].complete(true);
+				slotRequests.add(slotRequestId);
 
 				return future;
 			}
 		}
 
 		throw new IllegalArgumentException("No registered slot future for task " + vertexId + " (" + subtask + ')');
+	}
+
+	@Override
+	public CompletableFuture<Acknowledge> cancelSlotRequest(SlotRequestId slotRequestId, @Nullable SlotSharingGroupId slotSharingGroupId, Throwable cause) {
+		canceledSlotRequests.add(slotRequestId);
+		return CompletableFuture.completedFuture(Acknowledge.get());
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/utils/SimpleSlotProvider.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/utils/SimpleSlotProvider.java
@@ -23,9 +23,11 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.instance.SlotSharingGroupId;
 import org.apache.flink.runtime.jobmaster.LogicalSlot;
 import org.apache.flink.runtime.instance.SimpleSlot;
 import org.apache.flink.runtime.instance.Slot;
+import org.apache.flink.runtime.jobmaster.SlotRequestId;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.jobmanager.scheduler.NoResourceAvailableException;
 import org.apache.flink.runtime.jobmanager.scheduler.ScheduledUnit;
@@ -33,12 +35,17 @@ import org.apache.flink.runtime.instance.SimpleSlotContext;
 import org.apache.flink.runtime.jobmaster.SlotContext;
 import org.apache.flink.runtime.jobmaster.SlotOwner;
 import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
+import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nullable;
 
 import java.net.InetAddress;
 import java.util.ArrayDeque;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.concurrent.CompletableFuture;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
@@ -49,7 +56,11 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  */
 public class SimpleSlotProvider implements SlotProvider, SlotOwner {
 
+	private final Object lock = new Object();
+
 	private final ArrayDeque<SlotContext> slots;
+
+	private final HashMap<SlotRequestId, SlotContext> allocatedSlots;
 
 	public SimpleSlotProvider(JobID jobId, int numSlots) {
 		this(jobId, numSlots, new SimpleAckingTaskManagerGateway());
@@ -69,30 +80,47 @@ public class SimpleSlotProvider implements SlotProvider, SlotOwner {
 				taskManagerGateway);
 			slots.add(as);
 		}
+
+		allocatedSlots = new HashMap<>(slots.size());
 	}
 
 	@Override
 	public CompletableFuture<LogicalSlot> allocateSlot(
+			SlotRequestId slotRequestId,
 			ScheduledUnit task,
 			boolean allowQueued,
 			Collection<TaskManagerLocation> preferredLocations,
 			Time allocationTimeout) {
 		final SlotContext slot;
 
-		synchronized (slots) {
+		synchronized (lock) {
 			if (slots.isEmpty()) {
 				slot = null;
 			} else {
 				slot = slots.removeFirst();
 			}
+			if (slot != null) {
+				SimpleSlot result = new SimpleSlot(slot, this, 0);
+				allocatedSlots.put(slotRequestId, slot);
+				return CompletableFuture.completedFuture(result);
+			}
+			else {
+				return FutureUtils.completedExceptionally(new NoResourceAvailableException());
+			}
 		}
+	}
 
-		if (slot != null) {
-			SimpleSlot result = new SimpleSlot(slot, this, 0);
-			return CompletableFuture.completedFuture(result);
-		}
-		else {
-			return FutureUtils.completedExceptionally(new NoResourceAvailableException());
+	@Override
+	public CompletableFuture<Acknowledge> cancelSlotRequest(SlotRequestId slotRequestId, @Nullable SlotSharingGroupId slotSharingGroupId, Throwable cause) {
+		synchronized (lock) {
+			final SlotContext slotContext = allocatedSlots.remove(slotRequestId);
+
+			if (slotContext != null) {
+				slots.add(slotContext);
+				return CompletableFuture.completedFuture(Acknowledge.get());
+			} else {
+				return FutureUtils.completedExceptionally(new FlinkException("Unknown slot request id " + slotRequestId + '.'));
+			}
 		}
 	}
 
@@ -102,14 +130,15 @@ public class SimpleSlotProvider implements SlotProvider, SlotOwner {
 
 		final Slot slot = ((Slot) logicalSlot);
 
-		synchronized (slots) {
+		synchronized (lock) {
 			slots.add(slot.getSlotContext());
+			allocatedSlots.remove(logicalSlot.getSlotRequestId());
 		}
 		return CompletableFuture.completedFuture(true);
 	}
 
 	public int getNumberOfAvailableSlots() {
-		synchronized (slots) {
+		synchronized (lock) {
 			return slots.size();
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/SchedulerTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/SchedulerTestBase.java
@@ -25,15 +25,17 @@ import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
 import org.apache.flink.runtime.instance.Instance;
-import org.apache.flink.runtime.jobmaster.LogicalSlot;
-import org.apache.flink.runtime.jobmaster.slotpool.SlotSharingManager;
-import org.apache.flink.runtime.jobmaster.slotpool.SlotPool;
-import org.apache.flink.runtime.jobmaster.slotpool.SlotPoolGateway;
-import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.instance.SlotSharingGroupId;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
 import org.apache.flink.runtime.jobmaster.JobMasterId;
+import org.apache.flink.runtime.jobmaster.LogicalSlot;
+import org.apache.flink.runtime.jobmaster.SlotRequestId;
+import org.apache.flink.runtime.jobmaster.slotpool.SlotPool;
+import org.apache.flink.runtime.jobmaster.slotpool.SlotPoolGateway;
+import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
+import org.apache.flink.runtime.jobmaster.slotpool.SlotSharingManager;
+import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.rpc.TestingRpcService;
@@ -48,6 +50,8 @@ import org.apache.flink.util.TestLogger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.runners.Parameterized;
+
+import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -152,8 +156,13 @@ public class SchedulerTestBase extends TestLogger {
 		}
 
 		@Override
-		public CompletableFuture<LogicalSlot> allocateSlot(ScheduledUnit task, boolean allowQueued, Collection<TaskManagerLocation> preferredLocations, Time allocationTimeout) {
+		public CompletableFuture<LogicalSlot> allocateSlot(SlotRequestId slotRequestId, ScheduledUnit task, boolean allowQueued, Collection<TaskManagerLocation> preferredLocations, Time allocationTimeout) {
 			return scheduler.allocateSlot(task, allowQueued, preferredLocations, allocationTimeout);
+		}
+
+		@Override
+		public CompletableFuture<Acknowledge> cancelSlotRequest(SlotRequestId slotRequestId, @Nullable SlotSharingGroupId slotSharingGroupId, Throwable cause) {
+			return CompletableFuture.completedFuture(Acknowledge.get());
 		}
 
 		@Override
@@ -340,7 +349,7 @@ public class SchedulerTestBase extends TestLogger {
 		}
 
 		@Override
-		public CompletableFuture<LogicalSlot> allocateSlot(ScheduledUnit task, boolean allowQueued, Collection<TaskManagerLocation> preferredLocations, Time allocationTimeout) {
+		public CompletableFuture<LogicalSlot> allocateSlot(SlotRequestId slotRequestId, ScheduledUnit task, boolean allowQueued, Collection<TaskManagerLocation> preferredLocations, Time allocationTimeout) {
 			return slotProvider.allocateSlot(task, allowQueued, preferredLocations, allocationTimeout).thenApply(
 				(LogicalSlot logicalSlot) -> {
 					switch (logicalSlot.getLocality()) {
@@ -362,6 +371,11 @@ public class SchedulerTestBase extends TestLogger {
 
 					return logicalSlot;
 				});
+		}
+
+		@Override
+		public CompletableFuture<Acknowledge> cancelSlotRequest(SlotRequestId slotRequestId, @Nullable SlotSharingGroupId slotSharingGroupId, Throwable cause) {
+			return CompletableFuture.completedFuture(Acknowledge.get());
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
@@ -56,6 +56,7 @@ import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.TestTaskStateManager;
 import org.apache.flink.runtime.util.TestingTaskManagerRuntimeInfo;
 import org.apache.flink.util.SerializedValue;
+import org.apache.flink.util.TestLogger;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -78,7 +79,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class TaskAsyncCallTest {
+public class TaskAsyncCallTest extends TestLogger {
 
 	/** Number of expected checkpoints. */
 	private static int numCalls;
@@ -289,7 +290,7 @@ public class TaskAsyncCallTest {
 
 			// wait forever (until canceled)
 			synchronized (this) {
-				while (error == null && lastCheckpointId < numCalls) {
+				while (error == null) {
 					wait();
 				}
 			}

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/JobManagerITCase.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/jobmanager/JobManagerITCase.scala
@@ -25,7 +25,7 @@ import akka.testkit.{ImplicitSender, TestKit}
 import akka.util.Timeout
 import org.apache.flink.api.common.JobID
 import org.apache.flink.runtime.akka.ListeningBehaviour
-import org.apache.flink.runtime.checkpoint.{CheckpointRetentionPolicy, CheckpointCoordinator, CompletedCheckpoint}
+import org.apache.flink.runtime.checkpoint._
 import org.apache.flink.runtime.client.JobExecutionException
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType
 import org.apache.flink.runtime.jobgraph.tasks.{CheckpointCoordinatorConfiguration, JobCheckpointingSettings}
@@ -857,7 +857,7 @@ class JobManagerITCase(_system: ActorSystem)
 
           // Mock the checkpoint coordinator
           val checkpointCoordinator = mock(classOf[CheckpointCoordinator])
-          doThrow(new Exception("Expected Test Exception"))
+          doThrow(new IllegalStateException("Expected Test Exception"))
             .when(checkpointCoordinator)
             .triggerSavepoint(org.mockito.Matchers.anyLong(), org.mockito.Matchers.anyString())
 
@@ -872,7 +872,7 @@ class JobManagerITCase(_system: ActorSystem)
 
           // Verify the response
           response.jobId should equal(jobGraph.getJobID())
-          response.cause.getCause.getClass should equal(classOf[Exception])
+          response.cause.getCause.getClass should equal(classOf[IllegalStateException])
           response.cause.getCause.getMessage should equal("Expected Test Exception")
         }
       }
@@ -913,7 +913,7 @@ class JobManagerITCase(_system: ActorSystem)
 
           // Mock the checkpoint coordinator
           val checkpointCoordinator = mock(classOf[CheckpointCoordinator])
-          doThrow(new Exception("Expected Test Exception"))
+          doThrow(new IllegalStateException("Expected Test Exception"))
             .when(checkpointCoordinator)
             .triggerSavepoint(org.mockito.Matchers.anyLong(), org.mockito.Matchers.anyString())
           val savepointPathPromise = new CompletableFuture[CompletedCheckpoint]()
@@ -982,7 +982,7 @@ class JobManagerITCase(_system: ActorSystem)
 
           // Mock the checkpoint coordinator
           val checkpointCoordinator = mock(classOf[CheckpointCoordinator])
-          doThrow(new Exception("Expected Test Exception"))
+          doThrow(new IllegalStateException("Expected Test Exception"))
             .when(checkpointCoordinator)
             .triggerSavepoint(org.mockito.Matchers.anyLong(), org.mockito.Matchers.anyString())
 


### PR DESCRIPTION
## What is the purpose of the change

Release slots when the scheduling operation is canceled in the `ExecutionGraph`.

## Brief changelog

- Added `SlotProvider#cancelSlotRequest`
- Adapted `ConjunctFuture` to cancel the individual futures of the conjunction

## Verifying this change

Tested manually.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
