### PR TITLE
[FLINK-8459][flip6] Implement cancelWithSavepoint in RestClusterClient

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
@@ -327,7 +327,14 @@ public class RestClusterClient<T> extends ClusterClient<T> {
 
 	@Override
 	public String cancelWithSavepoint(JobID jobId, @Nullable String savepointDirectory) throws Exception {
-		throw new UnsupportedOperationException("Not implemented yet.");
+		//step 1 : call triggerSavepoint
+		CompletableFuture<String> savepointPathFuture = triggerSavepoint(jobId, savepointDirectory);
+		final String savepointPath = savepointPathFuture.get();
+
+		//step 2 : call cancel
+		cancel(jobId);
+
+		return savepointPath;
 	}
 
 	@Override

--- a/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
@@ -524,6 +524,77 @@ public class RestClusterClientTest extends TestLogger {
 	}
 
 	@Test
+	public void testCancelWithSavepoint() throws Exception {
+		final String targetSavepointDirectory = "/tmp";
+		final String savepointLocationDefaultDir = "/other/savepoint-0d2fb9-8d5e0106041a";
+		final String savepointLocationRequestedDir = targetSavepointDirectory + "/savepoint-0d2fb9-8d5e0106041a";
+
+		TestJobTerminationHandler terminationHandler = new TestJobTerminationHandler();
+
+		final TestSavepointHandlers testSavepointHandlers = new TestSavepointHandlers();
+		final TestSavepointHandlers.TestSavepointTriggerHandler triggerHandler =
+			testSavepointHandlers.new TestSavepointTriggerHandler(
+				null, targetSavepointDirectory, null, null);
+		final TestSavepointHandlers.TestSavepointHandler savepointHandler =
+			testSavepointHandlers.new TestSavepointHandler(
+				new SavepointInfo(
+					savepointLocationDefaultDir,
+					null),
+				new SavepointInfo(
+					savepointLocationRequestedDir,
+					null),
+				new SavepointInfo(
+					null,
+					new SerializedThrowable(new RuntimeException("expected"))),
+				new RestHandlerException("not found", HttpResponseStatus.NOT_FOUND));
+
+		// fail first HTTP polling attempt, which should not be a problem because of the retries
+		final AtomicBoolean firstPollFailed = new AtomicBoolean();
+		failHttpRequest = (messageHeaders, messageParameters, requestBody) ->
+			messageHeaders instanceof SavepointStatusHeaders && !firstPollFailed.getAndSet(true);
+
+		try (TestRestServerEndpoint ignored = createRestServerEndpoint(
+			triggerHandler,
+			savepointHandler,
+			terminationHandler)) {
+
+			JobID id = new JobID();
+			{
+				String savepointPath = restClusterClient.cancelWithSavepoint(id, null);
+				assertEquals(savepointLocationDefaultDir, savepointPath);
+				Assert.assertTrue(terminationHandler.jobCanceled);
+			}
+
+			{
+				String savepointPath = restClusterClient.cancelWithSavepoint(id, targetSavepointDirectory);
+				assertEquals(savepointLocationRequestedDir, savepointPath);
+				Assert.assertTrue(terminationHandler.jobCanceled);
+			}
+
+			{
+				try {
+					restClusterClient.cancelWithSavepoint(id, null);
+					fail("Expected exception not thrown.");
+				} catch (ExecutionException e) {
+					final Throwable cause = e.getCause();
+					assertThat(cause, instanceOf(SerializedThrowable.class));
+					assertThat(((SerializedThrowable) cause)
+						.deserializeError(ClassLoader.getSystemClassLoader())
+						.getMessage(), equalTo("expected"));
+				}
+			}
+
+			try {
+				restClusterClient.cancelWithSavepoint(new JobID(), null);
+			} catch (final ExecutionException e) {
+				assertTrue(
+					"RestClientException not in causal chain",
+					ExceptionUtils.findThrowable(e, RestClientException.class).isPresent());
+			}
+		}
+	}
+
+	@Test
 	public void testListJobs() throws Exception {
 		try (TestRestServerEndpoint ignored = createRestServerEndpoint(new TestListJobsHandler())) {
 			{


### PR DESCRIPTION
## What is the purpose of the change

This pull request implements cancelWithSavepoint in RestClusterClient for flip6.


## Brief change log

  - split the function into two steps: send REST call `triggerSavepoint` and send REST call `cancel`

## Verifying this change

This change added tests and can be verified as follows:

  - Added a test to check savepoint path and job's termination state is canceled.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
