### PR TITLE
[FLINK-8754][flip6] Make TaskManagerInfo implement Serializable

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/taskmanager/TaskManagerInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/taskmanager/TaskManagerInfo.java
@@ -31,12 +31,13 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonPro
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
+import java.io.Serializable;
 import java.util.Objects;
 
 /**
  * Base class containing information for a {@link TaskExecutor}.
  */
-public class TaskManagerInfo implements ResponseBody {
+public class TaskManagerInfo implements ResponseBody, Serializable {
 
 	public static final String FIELD_NAME_RESOURCE_ID = "id";
 
@@ -51,6 +52,8 @@ public class TaskManagerInfo implements ResponseBody {
 	public static final String FIELD_NAME_NUMBER_AVAILABLE_SLOTS = "freeSlots";
 
 	public static final String FIELD_NAME_HARDWARE = "hardware";
+
+	private static final long serialVersionUID = 1L;
 
 	@JsonProperty(FIELD_NAME_RESOURCE_ID)
 	@JsonSerialize(using = ResourceIDSerializer.class)


### PR DESCRIPTION
## What is the purpose of the change

*`TaskManagerInfo` can be returned from RPC calls, e.g., `ResourceManagerGateway#requestTaskManagerInfo(ResourceID, Time)`. All messages passed via RPC must be serializable. This PR makes `TaskManagerInfo` serializable.*


## Brief change log

  - *Make TaskManagerInfo implement Serializable*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
