### PR TITLE
[FLINK-8741] [kafka] Fix incorrect user code classloader in FlinkKafkaConsumer

### DIFF
--- a/flink-connectors/flink-connector-kafka-0.9/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/Kafka09Fetcher.java
+++ b/flink-connectors/flink-connector-kafka-0.9/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/Kafka09Fetcher.java
@@ -95,7 +95,7 @@ public class Kafka09Fetcher<T> extends AbstractFetcher<T, TopicPartition> {
 				watermarksPunctuated,
 				processingTimeProvider,
 				autoWatermarkInterval,
-				userCodeClassLoader.getParent(),
+				userCodeClassLoader,
 				consumerMetricGroup,
 				useMetrics);
 

--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/kafka/Kafka010Example.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/kafka/Kafka010Example.java
@@ -21,15 +21,25 @@ import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.serialization.SimpleStringSchema;
 import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
+import org.apache.flink.streaming.api.functions.timestamps.AscendingTimestampExtractor;
+import org.apache.flink.streaming.api.functions.timestamps.BoundedOutOfOrdernessTimestampExtractor;
+import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.connectors.kafka.FlinkKafkaConsumer010;
 import org.apache.flink.streaming.connectors.kafka.FlinkKafkaProducer010;
 
+import javax.annotation.Nullable;
 
 /**
  * An example that shows how to read from and write to Kafka. This will read String messages
  * from the input topic, prefix them by a configured prefix and output to the output topic.
+ *
+ * <p>This example also demonstrates using a watermark assigner to generate per-partition
+ * watermarks directly in the Flink Kafka consumer. For demonstration purposes, it is assumed that
+ * the String messages are of formatted as a (message,timestamp) tuple.
  *
  * <p>Example usage:
  * 	--input-topic test-input --output-topic test-output --bootstrap.servers localhost:9092 --zookeeper.connect localhost:2181 --group.id myconsumer
@@ -59,11 +69,15 @@ public class Kafka010Example {
 		// make parameters available in the web interface
 		env.getConfig().setGlobalJobParameters(parameterTool);
 
+		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+
 		DataStream<String> input = env
-				.addSource(new FlinkKafkaConsumer010<>(
+				.addSource(
+					new FlinkKafkaConsumer010<>(
 						parameterTool.getRequired("input-topic"),
 						new SimpleStringSchema(),
-						parameterTool.getProperties()))
+						parameterTool.getProperties())
+					.assignTimestampsAndWatermarks(new CustomWatermarkExtractor()))
 				.map(new PrefixingMapper(prefix));
 
 		input.addSink(
@@ -76,6 +90,9 @@ public class Kafka010Example {
 	}
 
 	private static class PrefixingMapper implements MapFunction<String, String> {
+
+		private static final long serialVersionUID = 1180234853172462378L;
+
 		private final String prefix;
 
 		public PrefixingMapper(String prefix) {
@@ -85,6 +102,34 @@ public class Kafka010Example {
 		@Override
 		public String map(String value) throws Exception {
 			return prefix + value;
+		}
+	}
+
+	/**
+	 * A custom {@link AssignerWithPeriodicWatermarks}, that simply assumes that the input stream
+	 * records are strictly ascending.
+	 *
+	 * <p>Flink also ships some built-in convenience assigners, such as the
+	 * {@link BoundedOutOfOrdernessTimestampExtractor} and {@link AscendingTimestampExtractor}
+	 */
+	private static class CustomWatermarkExtractor implements AssignerWithPeriodicWatermarks<String> {
+
+		private static final long serialVersionUID = -742759155861320823L;
+
+		private long currentTimestamp = Long.MIN_VALUE;
+
+		@Override
+		public long extractTimestamp(String element, long previousElementTimestamp) {
+			// the inputs are assumed to be of format (message,timestamp)
+			long timestamp = Long.valueOf(element.substring(element.indexOf(",") + 1));
+			this.currentTimestamp = timestamp;
+			return timestamp;
+		}
+
+		@Nullable
+		@Override
+		public Watermark getCurrentWatermark() {
+			return new Watermark(currentTimestamp == Long.MIN_VALUE ? Long.MIN_VALUE : currentTimestamp - 1);
 		}
 	}
 }

--- a/test-infra/end-to-end-test/test_streaming_kafka010.sh
+++ b/test-infra/end-to-end-test/test_streaming_kafka010.sh
@@ -70,12 +70,12 @@ $FLINK_DIR/bin/flink run -d build-target/examples/streaming/Kafka010Example.jar 
   --bootstrap.servers localhost:9092 --zookeeper.connect localhost:2181 --group.id myconsumer --auto.offset.reset earliest
 
 # send some data to Kafka
-echo -e "hello\nwhats\nup" | $KAFKA_DIR/bin/kafka-console-producer.sh --broker-list localhost:9092 --topic test-input
+echo -e "hello,45218\nwhats,46213\nup,51348" | $KAFKA_DIR/bin/kafka-console-producer.sh --broker-list localhost:9092 --topic test-input
 
 DATA_FROM_KAFKA=$($KAFKA_DIR/bin/kafka-console-consumer.sh --bootstrap-server localhost:9092 --topic test-output --from-beginning --max-messages 3 2> /dev/null)
 
 # make sure we have actual newlines in the string, not "\n"
-EXPECTED=$(printf "PREFIX:hello\nPREFIX:whats\nPREFIX:up")
+EXPECTED=$(printf "PREFIX:hello,45218\nPREFIX:whats,46213\nPREFIX:up,51348")
 if [[ "$DATA_FROM_KAFKA" != "$EXPECTED" ]]; then
   echo "Output from Flink program does not match expected output."
   echo -e "EXPECTED: --$EXPECTED--"

--- a/test-infra/end-to-end-test/test_streaming_kafka010.sh
+++ b/test-infra/end-to-end-test/test_streaming_kafka010.sh
@@ -64,7 +64,7 @@ $KAFKA_DIR/bin/kafka-topics.sh --create --zookeeper localhost:2181 --replication
 $KAFKA_DIR/bin/kafka-topics.sh --create --zookeeper localhost:2181 --replication-factor 1 --partitions 1 --topic test-output
 
 # run the Flink job (detached mode)
-$FLINK_DIR/bin/flink run -d build-target/examples/streaming/Kafka010Example.jar \
+$FLINK_DIR/bin/flink run -d $FLINK_DIR/examples/streaming/Kafka010Example.jar \
   --input-topic test-input --output-topic test-output \
   --prefix=PREFIX \
   --bootstrap.servers localhost:9092 --zookeeper.connect localhost:2181 --group.id myconsumer --auto.offset.reset earliest

--- a/test-infra/end-to-end-test/test_streaming_kafka010.sh
+++ b/test-infra/end-to-end-test/test_streaming_kafka010.sh
@@ -51,6 +51,7 @@ function kafka_cleanup {
   # make sure to run regular cleanup as well
   cleanup
 }
+trap kafka_cleanup INT
 trap kafka_cleanup EXIT
 
 # zookeeper outputs the "Node does not exist" bit to stderr


### PR DESCRIPTION
## What is the purpose of the change

Fixes the incorrectly used user code classloader in the Flink Kafka Consumer.
Since 010 / 011 versions reuses the `Kafka09Fetcher`, this fix affects all three versions.

To guard this for the future, the `Kafka010Example` has been adapted to demonstrate using a custom watermark assigner. This would have allowed our end-to-end tests to catch the issue.

This PR should also be merged to `release-1.4`.

## Brief change log

The end-to-end tests for Kafka now should be failing, without the user code classloader fix.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
