### PR TITLE
[FLINK-8768][network] Let NettyMessageDecoder inherit from LengthFieldBasedFrameDecoder

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyMessage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyMessage.java
@@ -38,7 +38,6 @@ import org.apache.flink.shaded.netty4.io.netty.channel.ChannelHandlerContext;
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelOutboundHandlerAdapter;
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelPromise;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.LengthFieldBasedFrameDecoder;
-import org.apache.flink.shaded.netty4.io.netty.handler.codec.MessageToMessageDecoder;
 
 import javax.annotation.Nullable;
 
@@ -47,7 +46,6 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.net.ProtocolException;
 import java.nio.ByteBuffer;
-import java.util.List;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -188,58 +186,81 @@ public abstract class NettyMessage {
 				ctx.write(msg, promise);
 			}
 		}
-
-		// Create the frame length decoder here as it depends on the encoder
-		//
-		// +------------------+------------------+--------++----------------+
-		// | FRAME LENGTH (4) | MAGIC NUMBER (4) | ID (1) || CUSTOM MESSAGE |
-		// +------------------+------------------+--------++----------------+
-		static LengthFieldBasedFrameDecoder createFrameLengthDecoder() {
-			return new LengthFieldBasedFrameDecoder(Integer.MAX_VALUE, 0, 4, -4, 4);
-		}
 	}
 
-	@ChannelHandler.Sharable
-	static class NettyMessageDecoder extends MessageToMessageDecoder<ByteBuf> {
+	/**
+	 * Message decoder based on netty's {@link LengthFieldBasedFrameDecoder} but avoiding the
+	 * additional memory copy inside {@link #extractFrame(ChannelHandlerContext, ByteBuf, int, int)}
+	 * since we completely decode the {@link ByteBuf} inside {@link #decode(ChannelHandlerContext,
+	 * ByteBuf)} and will not re-use it afterwards.
+	 *
+	 * <p>The frame-length encoder will be based on this transmission scheme created by {@link NettyMessage#allocateBuffer(ByteBufAllocator, byte, int)}:
+	 * <pre>
+	 * +------------------+------------------+--------++----------------+
+	 * | FRAME LENGTH (4) | MAGIC NUMBER (4) | ID (1) || CUSTOM MESSAGE |
+	 * +------------------+------------------+--------++----------------+
+	 * </pre>
+	 */
+	static class NettyMessageDecoder extends LengthFieldBasedFrameDecoder {
+
+		/**
+		 * Creates a new message decoded with the required frame properties.
+		 */
+		NettyMessageDecoder() {
+			super(Integer.MAX_VALUE, 0, 4, -4, 4);
+		}
 
 		@Override
-		protected void decode(ChannelHandlerContext ctx, ByteBuf msg, List<Object> out) throws Exception {
-			int magicNumber = msg.readInt();
-
-			if (magicNumber != MAGIC_NUMBER) {
-				throw new IllegalStateException("Network stream corrupted: received incorrect magic number.");
+		protected Object decode(ChannelHandlerContext ctx, ByteBuf in) throws Exception {
+			ByteBuf msg = (ByteBuf) super.decode(ctx, in);
+			if (msg == null) {
+				return null;
 			}
 
-			byte msgId = msg.readByte();
+			try {
+				int magicNumber = msg.readInt();
 
-			final NettyMessage decodedMsg;
-			switch (msgId) {
-				case BufferResponse.ID:
-					decodedMsg = BufferResponse.readFrom(msg);
-					break;
-				case PartitionRequest.ID:
-					decodedMsg = PartitionRequest.readFrom(msg);
-					break;
-				case TaskEventRequest.ID:
-					decodedMsg = TaskEventRequest.readFrom(msg, getClass().getClassLoader());
-					break;
-				case ErrorResponse.ID:
-					decodedMsg = ErrorResponse.readFrom(msg);
-					break;
-				case CancelPartitionRequest.ID:
-					decodedMsg = CancelPartitionRequest.readFrom(msg);
-					break;
-				case CloseRequest.ID:
-					decodedMsg = CloseRequest.readFrom(msg);
-					break;
-				case AddCredit.ID:
-					decodedMsg = AddCredit.readFrom(msg);
-					break;
-				default:
-					throw new ProtocolException("Received unknown message from producer: " + msg);
+				if (magicNumber != MAGIC_NUMBER) {
+					throw new IllegalStateException(
+						"Network stream corrupted: received incorrect magic number.");
+				}
+
+				byte msgId = msg.readByte();
+
+				final NettyMessage decodedMsg;
+				switch (msgId) {
+					case BufferResponse.ID:
+						decodedMsg = BufferResponse.readFrom(msg);
+						break;
+					case PartitionRequest.ID:
+						decodedMsg = PartitionRequest.readFrom(msg);
+						break;
+					case TaskEventRequest.ID:
+						decodedMsg = TaskEventRequest.readFrom(msg, getClass().getClassLoader());
+						break;
+					case ErrorResponse.ID:
+						decodedMsg = ErrorResponse.readFrom(msg);
+						break;
+					case CancelPartitionRequest.ID:
+						decodedMsg = CancelPartitionRequest.readFrom(msg);
+						break;
+					case CloseRequest.ID:
+						decodedMsg = CloseRequest.readFrom(msg);
+						break;
+					case AddCredit.ID:
+						decodedMsg = AddCredit.readFrom(msg);
+						break;
+					default:
+						throw new ProtocolException(
+							"Received unknown message from producer: " + msg);
+				}
+
+				return decodedMsg;
+			} finally {
+				// ByteToMessageDecoder cleanup (only the BufferResponse holds on to the decoded
+				// msg but already retain()s the buffer once)
+				msg.release();
 			}
-
-			out.add(decodedMsg);
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyProtocol.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyProtocol.java
@@ -24,8 +24,6 @@ import org.apache.flink.runtime.io.network.partition.ResultPartitionProvider;
 
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelHandler;
 
-import static org.apache.flink.runtime.io.network.netty.NettyMessage.NettyMessageEncoder.createFrameLengthDecoder;
-
 /**
  * Defines the server and client channel handlers, i.e. the protocol, used by netty.
  */
@@ -33,8 +31,6 @@ public class NettyProtocol {
 
 	private final NettyMessage.NettyMessageEncoder
 		messageEncoder = new NettyMessage.NettyMessageEncoder();
-
-	private final NettyMessage.NettyMessageDecoder messageDecoder = new NettyMessage.NettyMessageDecoder();
 
 	private final ResultPartitionProvider partitionProvider;
 	private final TaskEventDispatcher taskEventDispatcher;
@@ -64,14 +60,9 @@ public class NettyProtocol {
 	 * |    +----------+----------+                        |               |
 	 * |              /|\                                  |               |
 	 * |               |                                   |               |
-	 * |    +----------+----------+                        |               |
-	 * |    | Message decoder     |                        |               |
-	 * |    +----------+----------+                        |               |
-	 * |              /|\                                  |               |
-	 * |               |                                   |               |
-	 * |    +----------+----------+                        |               |
-	 * |    | Frame decoder       |                        |               |
-	 * |    +----------+----------+                        |               |
+	 * |   +-----------+-----------+                       |               |
+	 * |   | Message+Frame decoder |                       |               |
+	 * |   +-----------+-----------+                       |               |
 	 * |              /|\                                  |               |
 	 * +---------------+-----------------------------------+---------------+
 	 * |               | (1) client request               \|/
@@ -92,8 +83,7 @@ public class NettyProtocol {
 
 		return new ChannelHandler[] {
 			messageEncoder,
-			createFrameLengthDecoder(),
-			messageDecoder,
+			new NettyMessage.NettyMessageDecoder(),
 			serverHandler,
 			queueOfPartitionQueues
 		};
@@ -115,14 +105,9 @@ public class NettyProtocol {
 	 * |    +----------+----------+            +-----------+----------+    |
 	 * |              /|\                                 \|/              |
 	 * |               |                                   |               |
-	 * |    +----------+----------+                        |               |
-	 * |    | Message decoder     |                        |               |
-	 * |    +----------+----------+                        |               |
-	 * |              /|\                                  |               |
-	 * |               |                                   |               |
-	 * |    +----------+----------+                        |               |
-	 * |    | Frame decoder       |                        |               |
-	 * |    +----------+----------+                        |               |
+	 * |    +----------+------------+                      |               |
+	 * |    | Message+Frame decoder |                      |               |
+	 * |    +----------+------------+                      |               |
 	 * |              /|\                                  |               |
 	 * +---------------+-----------------------------------+---------------+
 	 * |               | (3) server response              \|/ (2) client request
@@ -142,8 +127,7 @@ public class NettyProtocol {
 				new PartitionRequestClientHandler();
 		return new ChannelHandler[] {
 			messageEncoder,
-			createFrameLengthDecoder(),
-			messageDecoder,
+			new NettyMessage.NettyMessageDecoder(),
 			networkClientHandler};
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyMessageSerializationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyMessageSerializationTest.java
@@ -46,7 +46,6 @@ public class NettyMessageSerializationTest {
 
 	private final EmbeddedChannel channel = new EmbeddedChannel(
 			new NettyMessage.NettyMessageEncoder(), // outbound messages
-			NettyMessage.NettyMessageEncoder.createFrameLengthDecoder(), // inbound messages
 			new NettyMessage.NettyMessageDecoder()); // inbound messages
 
 	private final Random random = new Random();


### PR DESCRIPTION
## What is the purpose of the change

Instead of being two steps in the channel pipeline, `NettyMessageDecoder` could derive from `LengthFieldBasedFrameDecoder` to reduce overhead and give us more control over the protocol.

As a first step, we will use this to override the `#extractFrame()` method to restore the old Netty 4.0.27 behaviour for non-credit based code paths which had a bug with Netty >= 4.0.28 (see FLINK-8759).

## Brief change log

- make `NettyMessageDecoder` inherit from `LengthFieldBasedFrameDecoder` (beware that this changes the decoder from a `MessageToMessageDecoder` to a `ByteToMessageDecoder` with different cleanup invariants!)

## Verifying this change

This change is already covered by existing tests, such as `NettyMessageSerializationTest` or other network tests using the encoding/decoding pipeline.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no** (only per buffer)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? (JavaDocs)
