### PR TITLE
[FLINK-8694][runtime] Fix notifyDataAvailable race condition

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/CreditBasedSequenceNumberingViewReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/CreditBasedSequenceNumberingViewReader.java
@@ -30,7 +30,6 @@ import org.apache.flink.runtime.io.network.partition.consumer.InputChannelID;
 import org.apache.flink.runtime.io.network.partition.consumer.LocalInputChannel;
 
 import java.io.IOException;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Simple wrapper for the subpartition view used in the new network credit-based mode.
@@ -43,8 +42,6 @@ class CreditBasedSequenceNumberingViewReader implements BufferAvailabilityListen
 	private final Object requestLock = new Object();
 
 	private final InputChannelID receiverId;
-
-	private final AtomicBoolean buffersAvailable = new AtomicBoolean();
 
 	private final PartitionRequestQueue requestQueue;
 
@@ -118,7 +115,7 @@ class CreditBasedSequenceNumberingViewReader implements BufferAvailabilityListen
 	@Override
 	public boolean isAvailable() {
 		// BEWARE: this must be in sync with #isAvailable()!
-		return buffersAvailable.get() &&
+		return hasBuffersAvailable() &&
 			(numCreditsAvailable > 0 || subpartitionView.nextBufferIsEvent());
 	}
 
@@ -154,14 +151,13 @@ class CreditBasedSequenceNumberingViewReader implements BufferAvailabilityListen
 
 	@VisibleForTesting
 	boolean hasBuffersAvailable() {
-		return buffersAvailable.get();
+		return subpartitionView.isAvailable();
 	}
 
 	@Override
 	public BufferAndAvailability getNextBuffer() throws IOException, InterruptedException {
 		BufferAndBacklog next = subpartitionView.getNextBuffer();
 		if (next != null) {
-			buffersAvailable.set(next.isMoreAvailable());
 			sequenceNumber++;
 
 			if (next.buffer().isBuffer() && --numCreditsAvailable < 0) {
@@ -197,7 +193,6 @@ class CreditBasedSequenceNumberingViewReader implements BufferAvailabilityListen
 
 	@Override
 	public void notifyDataAvailable() {
-		buffersAvailable.set(true);
 		requestQueue.notifyReaderNonEmpty(this);
 	}
 
@@ -206,7 +201,6 @@ class CreditBasedSequenceNumberingViewReader implements BufferAvailabilityListen
 		return "CreditBasedSequenceNumberingViewReader{" +
 			"requestLock=" + requestLock +
 			", receiverId=" + receiverId +
-			", buffersAvailable=" + buffersAvailable.get() +
 			", sequenceNumber=" + sequenceNumber +
 			", numCreditsAvailable=" + numCreditsAvailable +
 			", isRegisteredAsAvailable=" + isRegisteredAsAvailable +

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
@@ -27,6 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
 
 import java.io.IOException;
 
@@ -48,6 +49,9 @@ class PipelinedSubpartition extends ResultSubpartition {
 	/** Flag indicating whether the subpartition has been finished. */
 	private boolean isFinished;
 
+	@GuardedBy("buffers")
+	private boolean flushRequested;
+
 	/** Flag indicating whether the subpartition has been released. */
 	private volatile boolean isReleased;
 
@@ -65,9 +69,11 @@ class PipelinedSubpartition extends ResultSubpartition {
 	@Override
 	public void flush() {
 		synchronized (buffers) {
-			if (readView != null) {
-				readView.notifyDataAvailable();
+			if (buffers.isEmpty()) {
+				return;
 			}
+			flushRequested = !buffers.isEmpty();
+			notifyDataAvailable();
 		}
 	}
 
@@ -93,7 +99,7 @@ class PipelinedSubpartition extends ResultSubpartition {
 
 			if (finish) {
 				isFinished = true;
-				notifyDataAvailable();
+				flush();
 			}
 			else {
 				maybeNotifyDataAvailable();
@@ -138,17 +144,28 @@ class PipelinedSubpartition extends ResultSubpartition {
 		synchronized (buffers) {
 			Buffer buffer = null;
 
+			if (buffers.isEmpty()) {
+				flushRequested = false;
+			}
+
 			while (!buffers.isEmpty()) {
 				BufferConsumer bufferConsumer = buffers.peek();
 
 				buffer = bufferConsumer.build();
+
 				checkState(bufferConsumer.isFinished() || buffers.size() == 1,
 					"When there are multiple buffers, an unfinished bufferConsumer can not be at the head of the buffers queue.");
+
+				if (buffers.size() == 1) {
+					// turn off flushRequested flag if we drained all of the available data
+					flushRequested = false;
+				}
 
 				if (bufferConsumer.isFinished()) {
 					buffers.pop().close();
 					decreaseBuffersInBacklogUnsafe(bufferConsumer.isBuffer());
 				}
+
 				if (buffer.readableBytes() > 0) {
 					break;
 				}
@@ -169,7 +186,7 @@ class PipelinedSubpartition extends ResultSubpartition {
 			// will be 2 or more.
 			return new BufferAndBacklog(
 				buffer,
-				getNumberOfFinishedBuffers() > 0,
+				isAvailableUnsafe(),
 				getBuffersInBacklog(),
 				_nextBufferIsEvent());
 		}
@@ -211,11 +228,21 @@ class PipelinedSubpartition extends ResultSubpartition {
 
 			readView = new PipelinedSubpartitionView(this, availabilityListener);
 			if (!buffers.isEmpty()) {
-				readView.notifyDataAvailable();
+				notifyDataAvailable();
 			}
 		}
 
 		return readView;
+	}
+
+	public boolean isAvailable() {
+		synchronized (buffers) {
+			return isAvailableUnsafe();
+		}
+	}
+
+	private boolean isAvailableUnsafe() {
+		return flushRequested || getNumberOfFinishedBuffers() > 0;
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionView.java
@@ -81,6 +81,11 @@ class PipelinedSubpartitionView implements ResultSubpartitionView {
 	}
 
 	@Override
+	public boolean isAvailable() {
+		return parent.isAvailable();
+	}
+
+	@Override
 	public Throwable getFailureCause() {
 		return parent.getFailureCause();
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartitionView.java
@@ -57,4 +57,6 @@ public interface ResultSubpartitionView {
 	 * Returns whether the next buffer is an event or not.
 	 */
 	boolean nextBufferIsEvent();
+
+	boolean isAvailable();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartition.java
@@ -209,7 +209,6 @@ class SpillableSubpartition extends ResultSubpartition {
 					parent.getBufferProvider().getMemorySegmentSize(),
 					availabilityListener);
 			}
-
 			return readView;
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpilledSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SpilledSubpartitionView.java
@@ -220,6 +220,14 @@ class SpilledSubpartitionView implements ResultSubpartitionView, NotificationLis
 	}
 
 	@Override
+	public synchronized boolean isAvailable() {
+		if (nextBuffer != null) {
+			return true;
+		}
+		return !fileReader.hasReachedEndOfFile();
+	}
+
+	@Override
 	public Throwable getFailureCause() {
 		return parent.getFailureCause();
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/BufferOrEvent.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/BufferOrEvent.java
@@ -39,7 +39,7 @@ public class BufferOrEvent {
 	 * This is not needed outside of the input gate unioning logic and cannot
 	 * be set outside of the consumer package.
 	 */
-	private final boolean moreAvailable;
+	private boolean moreAvailable;
 
 	private int channelIndex;
 
@@ -98,5 +98,9 @@ public class BufferOrEvent {
 	public String toString() {
 		return String.format("BufferOrEvent [%s, channelIndex = %d]",
 				isBuffer() ? buffer : event, channelIndex);
+	}
+
+	public void setMoreAvailable(boolean moreAvailable) {
+		this.moreAvailable = moreAvailable;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -540,6 +540,7 @@ public class SingleInputGate implements InputGate {
 		// will come for that channel
 		if (result.get().moreAvailable()) {
 			queueChannel(currentChannel);
+			moreAvailable = true;
 		}
 
 		final Buffer buffer = result.get().buffer();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGate.java
@@ -177,13 +177,6 @@ public class UnionInputGate implements InputGate, InputGateListener {
 			}
 		}
 
-		if (bufferOrEvent.moreAvailable()) {
-			// this buffer or event was now removed from the non-empty gates queue
-			// we re-add it in case it has more data, because in that case no "non-empty" notification
-			// will come for that gate
-			queueInputGate(inputGate);
-		}
-
 		// Set the channel index to identify the input channel (across all unioned input gates)
 		final int channelIndexOffset = inputGateToIndexOffsetMap.get(inputGate);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/BufferBuilderTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/BufferBuilderTestUtils.java
@@ -38,6 +38,10 @@ public class BufferBuilderTestUtils {
 		return createFilledBufferBuilder(size, 0);
 	}
 
+	public static BufferBuilder createFilledBufferBuilder(int dataSize) {
+		return createFilledBufferBuilder(BUFFER_SIZE, dataSize);
+	}
+
 	public static BufferBuilder createFilledBufferBuilder(int size, int dataSize) {
 		checkArgument(size >= dataSize);
 		BufferBuilder bufferBuilder = new BufferBuilder(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CancelPartitionRequestTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CancelPartitionRequestTest.java
@@ -220,6 +220,11 @@ public class CancelPartitionRequestTest {
 		}
 
 		@Override
+		public boolean isAvailable() {
+			return true;
+		}
+
+		@Override
 		public Throwable getFailureCause() {
 			return null;
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueueTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueueTest.java
@@ -66,7 +66,7 @@ public class PartitionRequestQueueTest {
 		CreditBasedSequenceNumberingViewReader reader1 = new CreditBasedSequenceNumberingViewReader(new InputChannelID(0, 0), 10, queue);
 		CreditBasedSequenceNumberingViewReader reader2 = new CreditBasedSequenceNumberingViewReader(new InputChannelID(1, 1), 10, queue);
 
-		reader1.requestSubpartitionView((partitionId, index, availabilityListener) -> new NotReleasedResultSubpartitionView(), new ResultPartitionID(), 0);
+		reader1.requestSubpartitionView((partitionId, index, availabilityListener) -> new EmptyAlwaysAvailableResultSubpartitionView(), new ResultPartitionID(), 0);
 		reader1.notifyDataAvailable();
 		assertTrue(reader1.isAvailable());
 		assertFalse(reader1.isRegisteredAsAvailable());
@@ -178,6 +178,11 @@ public class PartitionRequestQueueTest {
 				buffers,
 				false);
 		}
+
+		@Override
+		public boolean isAvailable() {
+			return buffersInBacklog.get() > 0;
+		}
 	}
 
 	private static class ReadOnlyBufferResultSubpartitionView extends DefaultBufferResultSubpartitionView {
@@ -197,14 +202,19 @@ public class PartitionRequestQueueTest {
 		}
 	}
 
-	private static class NotReleasedResultSubpartitionView extends NoOpResultSubpartitionView {
+	private static class EmptyAlwaysAvailableResultSubpartitionView extends NoOpResultSubpartitionView {
 		@Override
 		public boolean isReleased() {
 			return false;
 		}
+
+		@Override
+		public boolean isAvailable() {
+			return true;
+		}
 	}
 
-	private static class ReleasedResultSubpartitionView extends NoOpResultSubpartitionView {
+	private static class ReleasedResultSubpartitionView extends EmptyAlwaysAvailableResultSubpartitionView {
 		@Override
 		public boolean isReleased() {
 			return true;
@@ -261,6 +271,11 @@ public class PartitionRequestQueueTest {
 	private static class NextIsEventResultSubpartitionView extends NoOpResultSubpartitionView {
 		@Override
 		public boolean nextBufferIsEvent() {
+			return true;
+		}
+
+		@Override
+		public boolean isAvailable() {
 			return true;
 		}
 	}
@@ -385,6 +400,11 @@ public class PartitionRequestQueueTest {
 
 		@Override
 		public boolean nextBufferIsEvent() {
+			return false;
+		}
+
+		@Override
+		public boolean isAvailable() {
 			return false;
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SubpartitionTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SubpartitionTestBase.java
@@ -30,6 +30,7 @@ import static org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils.
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
@@ -142,5 +143,9 @@ public abstract class SubpartitionTestBase extends TestLogger {
 		assertEquals(expectedReadableBufferSize, bufferAndBacklog.buffer().readableBytes());
 		assertEquals(expectedIsMoreAvailable, bufferAndBacklog.isMoreAvailable());
 		assertEquals(expectedBuffersInBacklog, bufferAndBacklog.buffersInBacklog());
+	}
+
+	protected void assertNoNextBuffer(ResultSubpartitionView readView) throws IOException, InterruptedException {
+		assertNull(readView.getNextBuffer());
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
@@ -77,14 +77,7 @@ public class SingleInputGateTest {
 	@Test(timeout = 120 * 1000)
 	public void testBasicGetNextLogic() throws Exception {
 		// Setup
-		final SingleInputGate inputGate = new SingleInputGate(
-			"Test Task Name", new JobID(),
-			new IntermediateDataSetID(), ResultPartitionType.PIPELINED,
-			0, 2,
-			mock(TaskActions.class),
-			UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup());
-
-		assertEquals(ResultPartitionType.PIPELINED, inputGate.getConsumedPartitionType());
+		final SingleInputGate inputGate = createInputGate();
 
 		final TestInputChannel[] inputChannels = new TestInputChannel[]{
 			new TestInputChannel(inputGate, 0),
@@ -135,14 +128,8 @@ public class SingleInputGateTest {
 			any(BufferAvailabilityListener.class))).thenReturn(iterator);
 
 		// Setup reader with one local and one unknown input channel
-		final IntermediateDataSetID resultId = new IntermediateDataSetID();
 
-		final SingleInputGate inputGate = new SingleInputGate(
-				"Test Task Name", new JobID(),
-				resultId, ResultPartitionType.PIPELINED,
-				0, 2,
-				mock(TaskActions.class),
-				UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup());
+		final SingleInputGate inputGate = createInputGate();
 		final BufferPool bufferPool = mock(BufferPool.class);
 		when(bufferPool.getNumberOfRequiredMemorySegments()).thenReturn(2);
 
@@ -190,14 +177,7 @@ public class SingleInputGateTest {
 	 */
 	@Test
 	public void testUpdateChannelBeforeRequest() throws Exception {
-		SingleInputGate inputGate = new SingleInputGate(
-			"t1",
-			new JobID(),
-			new IntermediateDataSetID(),
-			ResultPartitionType.PIPELINED,
-			0,
-			1,
-			mock(TaskActions.class), UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup());
+		SingleInputGate inputGate = createInputGate(1);
 
 		ResultPartitionManager partitionManager = mock(ResultPartitionManager.class);
 
@@ -230,15 +210,7 @@ public class SingleInputGateTest {
 		final AtomicReference<Exception> asyncException = new AtomicReference<>();
 
 		// Setup the input gate with a single channel that does nothing
-		final SingleInputGate inputGate = new SingleInputGate(
-			"InputGate",
-			new JobID(),
-			new IntermediateDataSetID(),
-			ResultPartitionType.PIPELINED,
-			0,
-			1,
-			mock(TaskActions.class),
-			UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup());
+		final SingleInputGate inputGate = createInputGate(1);
 
 		InputChannel unknown = new UnknownInputChannel(
 			inputGate,
@@ -410,15 +382,7 @@ public class SingleInputGateTest {
 	 */
 	@Test
 	public void testRequestBuffersWithUnknownInputChannel() throws Exception {
-		final SingleInputGate inputGate = new SingleInputGate(
-			"t1",
-			new JobID(),
-			new IntermediateDataSetID(),
-			ResultPartitionType.PIPELINED_BOUNDED,
-			0,
-			1,
-			mock(TaskActions.class),
-			UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup());
+		final SingleInputGate inputGate = createInputGate(1);
 
 		UnknownInputChannel unknown = mock(UnknownInputChannel.class);
 		final ResultPartitionID resultPartitionId = new ResultPartitionID();
@@ -442,6 +406,26 @@ public class SingleInputGateTest {
 	}
 
 	// ---------------------------------------------------------------------------------------------
+
+	private static SingleInputGate createInputGate() {
+		return createInputGate(2);
+	}
+
+	private static SingleInputGate createInputGate(int numberOfInputChannels) {
+		SingleInputGate inputGate = new SingleInputGate(
+			"Test Task Name",
+			new JobID(),
+			new IntermediateDataSetID(),
+			ResultPartitionType.PIPELINED,
+			0,
+			numberOfInputChannels,
+			mock(TaskActions.class),
+			UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup());
+
+		assertEquals(ResultPartitionType.PIPELINED, inputGate.getConsumedPartitionType());
+
+		return inputGate;
+	}
 
 	static void verifyBufferOrEvent(
 		InputGate inputGate,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/TestInputChannel.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/TestInputChannel.java
@@ -56,20 +56,28 @@ public class TestInputChannel {
 	}
 
 	public TestInputChannel read(Buffer buffer) throws IOException, InterruptedException {
+		return read(buffer, true);
+	}
+
+	public TestInputChannel read(Buffer buffer, boolean moreAvailable) throws IOException, InterruptedException {
 		if (stubbing == null) {
-			stubbing = when(mock.getNextBuffer()).thenReturn(Optional.of(new BufferAndAvailability(buffer, true, 0)));
+			stubbing = when(mock.getNextBuffer()).thenReturn(Optional.of(new BufferAndAvailability(buffer, moreAvailable, 0)));
 		} else {
-			stubbing = stubbing.thenReturn(Optional.of(new BufferAndAvailability(buffer, true, 0)));
+			stubbing = stubbing.thenReturn(Optional.of(new BufferAndAvailability(buffer, moreAvailable, 0)));
 		}
 
 		return this;
 	}
 
 	public TestInputChannel readBuffer() throws IOException, InterruptedException {
+		return readBuffer(true);
+	}
+
+	public TestInputChannel readBuffer(boolean moreAvailable) throws IOException, InterruptedException {
 		final Buffer buffer = mock(Buffer.class);
 		when(buffer.isBuffer()).thenReturn(true);
 
-		return read(buffer);
+		return read(buffer, moreAvailable);
 	}
 
 	public TestInputChannel readEndOfPartitionEvent() throws IOException, InterruptedException {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGateTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.taskmanager.TaskActions;
 
 import org.junit.Test;
 
+import static org.apache.flink.runtime.io.network.partition.consumer.SingleInputGateTest.verifyBufferOrEvent;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -93,22 +94,22 @@ public class UnionInputGateTest {
 		ig2.notifyChannelNonEmpty(inputChannels[1][3].getInputChannel());
 		ig2.notifyChannelNonEmpty(inputChannels[1][4].getInputChannel());
 
-		SingleInputGateTest.verifyBufferOrEvent(union, true, 0); // gate 1, channel 0
-		SingleInputGateTest.verifyBufferOrEvent(union, true, 3); // gate 2, channel 0
-		SingleInputGateTest.verifyBufferOrEvent(union, true, 1); // gate 1, channel 1
-		SingleInputGateTest.verifyBufferOrEvent(union, true, 4); // gate 2, channel 1
-		SingleInputGateTest.verifyBufferOrEvent(union, true, 2); // gate 1, channel 2
-		SingleInputGateTest.verifyBufferOrEvent(union, true, 5); // gate 2, channel 1
-		SingleInputGateTest.verifyBufferOrEvent(union, false, 0); // gate 1, channel 0
-		SingleInputGateTest.verifyBufferOrEvent(union, true, 6); // gate 2, channel 1
-		SingleInputGateTest.verifyBufferOrEvent(union, false, 1); // gate 1, channel 1
-		SingleInputGateTest.verifyBufferOrEvent(union, true, 7); // gate 2, channel 1
-		SingleInputGateTest.verifyBufferOrEvent(union, false, 2); // gate 1, channel 2
-		SingleInputGateTest.verifyBufferOrEvent(union, false, 3); // gate 2, channel 0
-		SingleInputGateTest.verifyBufferOrEvent(union, false, 4); // gate 2, channel 1
-		SingleInputGateTest.verifyBufferOrEvent(union, false, 5); // gate 2, channel 2
-		SingleInputGateTest.verifyBufferOrEvent(union, false, 6); // gate 2, channel 3
-		SingleInputGateTest.verifyBufferOrEvent(union, false, 7); // gate 2, channel 4
+		verifyBufferOrEvent(union, true, 0, true); // gate 1, channel 0
+		verifyBufferOrEvent(union, true, 3, true); // gate 2, channel 0
+		verifyBufferOrEvent(union, true, 1, true); // gate 1, channel 1
+		verifyBufferOrEvent(union, true, 4, true); // gate 2, channel 1
+		verifyBufferOrEvent(union, true, 2, true); // gate 1, channel 2
+		verifyBufferOrEvent(union, true, 5, true); // gate 2, channel 1
+		verifyBufferOrEvent(union, false, 0, true); // gate 1, channel 0
+		verifyBufferOrEvent(union, true, 6, true); // gate 2, channel 1
+		verifyBufferOrEvent(union, false, 1, true); // gate 1, channel 1
+		verifyBufferOrEvent(union, true, 7, true); // gate 2, channel 1
+		verifyBufferOrEvent(union, false, 2, true); // gate 1, channel 2
+		verifyBufferOrEvent(union, false, 3, true); // gate 2, channel 0
+		verifyBufferOrEvent(union, false, 4, true); // gate 2, channel 1
+		verifyBufferOrEvent(union, false, 5, true); // gate 2, channel 2
+		verifyBufferOrEvent(union, false, 6, true); // gate 2, channel 3
+		verifyBufferOrEvent(union, false, 7, false); // gate 2, channel 4
 
 		// Return null when the input gate has received all end-of-partition events
 		assertTrue(union.isFinished());

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkThroughputBenchmarkTests.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkThroughputBenchmarkTests.java
@@ -53,6 +53,14 @@ public class StreamNetworkThroughputBenchmarkTests {
 	}
 
 	@Test
+	public void largeRemoteAlwaysFlush() throws Exception {
+		StreamNetworkThroughputBenchmark env = new StreamNetworkThroughputBenchmark();
+		env.setUp(1, 1, 0, false);
+		env.executeBenchmark(1_000_000);
+		env.tearDown();
+	}
+
+	@Test
 	public void pointToMultiPointBenchmark() throws Exception {
 		StreamNetworkThroughputBenchmark benchmark = new StreamNetworkThroughputBenchmark();
 		benchmark.setUp(1, 100, 100);

--- a/flink-tests/src/test/java/org/apache/flink/test/misc/SuccessAfterNetworkBuffersFailureITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/misc/SuccessAfterNetworkBuffersFailureITCase.java
@@ -65,38 +65,20 @@ public class SuccessAfterNetworkBuffersFailureITCase extends TestLogger {
 	}
 
 	@Test
-	public void testSuccessfulProgramAfterFailure() {
+	public void testSuccessfulProgramAfterFailure() throws Exception {
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+
+		runConnectedComponents(env);
+
 		try {
-			ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-
-			try {
-				runConnectedComponents(env);
-			}
-			catch (Exception e) {
-				e.printStackTrace();
-				fail("Program Execution should have succeeded.");
-			}
-
-			try {
-				runKMeans(env);
-				fail("This program execution should have failed.");
-			}
-			catch (JobExecutionException e) {
-				assertTrue(e.getCause().getMessage().contains("Insufficient number of network buffers"));
-			}
-
-			try {
-				runConnectedComponents(env);
-			}
-			catch (Exception e) {
-				e.printStackTrace();
-				fail("Program Execution should have succeeded.");
-			}
+			runKMeans(env);
+			fail("This program execution should have failed.");
 		}
-		catch (Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
+		catch (JobExecutionException e) {
+			assertTrue(e.getCause().getMessage().contains("Insufficient number of network buffers"));
 		}
+
+		runConnectedComponents(env);
 	}
 
 	private static void runConnectedComponents(ExecutionEnvironment env) throws Exception {


### PR DESCRIPTION
This fixes two bugs in network stack:
https://issues.apache.org/jira/browse/FLINK-8760
https://issues.apache.org/jira/browse/FLINK-8694

## Brief change log

Please check individual commit messages.

## Verifying this change

This PR adds new tests covering the previously bugged cases.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
