### PR TITLE
[FLINK-8777][state]Improve resource release for local recovery

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskLocalStateStoreImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskLocalStateStoreImpl.java
@@ -116,14 +116,7 @@ public class TaskLocalStateStoreImpl implements TaskLocalStateStore {
 		this.subtaskIndex = subtaskIndex;
 		this.discardExecutor = discardExecutor;
 		this.localRecoveryConfig = localRecoveryConfig;
-<<<<<<< HEAD
-<<<<<<< HEAD
 		this.disposed = false;
-=======
-		this.retrieveWithDiscard = true;
->>>>>>> b4a3ea2c2b... Fix build.
-=======
->>>>>>> 12071658ee... Stefan comments.
 	}
 
 	@Override
@@ -170,22 +163,15 @@ public class TaskLocalStateStoreImpl implements TaskLocalStateStore {
 	@Nullable
 	public TaskStateSnapshot retrieveLocalState(long checkpointID) {
 
-<<<<<<< HEAD
 		TaskStateSnapshot snapshot;
 		synchronized (lock) {
 			snapshot = storedTaskStateByCheckpointID.get(checkpointID);
-		}
-=======
-			Iterator<Map.Entry<Long, TaskStateSnapshot>> entryIterator =
-				storedTaskStateByCheckpointID.entrySet().iterator();
 
-=======
->>>>>>> 12071658ee... Stefan comments.
 			if (retrieveWithDiscard) {
 				// Only the TaskStateSnapshot.checkpointID == checkpointID is useful, we remove the others
 				pruneCheckpoints(checkpointID, false);
 			}
->>>>>>> b4a3ea2c2b... Fix build.
+		}
 
 		if (LOG.isTraceEnabled()) {
 			LOG.trace("Found entry for local state for checkpoint {} in subtask ({} - {} - {}) : {}",

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskLocalStateStoreImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskLocalStateStoreImpl.java
@@ -48,7 +48,7 @@ import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
-import java.util.function.Predicate;
+import java.util.function.LongPredicate;
 
 /**
  * Main implementation of a {@link TaskLocalStateStore}.
@@ -298,7 +298,7 @@ public class TaskLocalStateStoreImpl implements TaskLocalStateStore {
 	/**
 	 * Pruning the useless checkpoints, it should be called only when holding the {@link #lock}.
 	 */
-	private void pruneCheckpoints(Predicate<Long> pruningChecker, boolean breakOnceCheckerFalse) {
+	private void pruneCheckpoints(LongPredicate pruningChecker, boolean breakOnceCheckerFalse) {
 
 		assert Thread.holdsLock(lock);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskLocalStateStoreImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskLocalStateStoreImplTest.java
@@ -72,8 +72,6 @@ public class TaskLocalStateStoreImplTest {
 			subtaskIdx,
 			localRecoveryConfig,
 			Executors.directExecutor());
-
-		this.taskLocalStateStore.setRetrieveWithDiscard(false);
 	}
 
 	@After
@@ -108,14 +106,24 @@ public class TaskLocalStateStoreImplTest {
 		final int chkCount = 3;
 
 		for (int i = 0; i < chkCount; ++i) {
-			Assert.assertNull(taskLocalStateStore.retrieveLocalState(i));
+			Assert.assertNull(taskLocalStateStore.retrieveLocalStateWithoutPruning(i));
 		}
 
 		List<TaskStateSnapshot> taskStateSnapshots = storeStates(chkCount);
 
+		// test retrieve without pruning
 		checkStoredAsExpected(taskStateSnapshots, 0, chkCount);
 
-		Assert.assertNull(taskLocalStateStore.retrieveLocalState(chkCount + 1));
+		Assert.assertNull(taskLocalStateStore.retrieveLocalStateWithoutPruning(chkCount + 1));
+
+		// test retrieve with pruning
+		taskLocalStateStore.retrieveLocalState(chkCount - 1);
+
+		for (int i = 0; i < chkCount - 1; ++i) {
+			Assert.assertNull(taskLocalStateStore.retrieveLocalStateWithoutPruning(i));
+		}
+
+		checkStoredAsExpected(taskStateSnapshots, chkCount - 1, chkCount);
 	}
 
 	/**
@@ -149,14 +157,14 @@ public class TaskLocalStateStoreImplTest {
 	private void checkStoredAsExpected(List<TaskStateSnapshot> history, int off, int len) throws Exception {
 		for (int i = off; i < len; ++i) {
 			TaskStateSnapshot expected = history.get(i);
-			Assert.assertTrue(expected == taskLocalStateStore.retrieveLocalState(i));
+			Assert.assertTrue(expected == taskLocalStateStore.retrieveLocalStateWithoutPruning(i));
 			Mockito.verify(expected, Mockito.never()).discardState();
 		}
 	}
 
 	private void checkPrunedAndDiscarded(List<TaskStateSnapshot> history, int off, int len) throws Exception {
 		for (int i = off; i < len; ++i) {
-			Assert.assertNull(taskLocalStateStore.retrieveLocalState(i));
+			Assert.assertNull(taskLocalStateStore.retrieveLocalStateWithoutPruning(i));
 			Mockito.verify(history.get(i)).discardState();
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskLocalStateStoreImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskLocalStateStoreImplTest.java
@@ -72,6 +72,8 @@ public class TaskLocalStateStoreImplTest {
 			subtaskIdx,
 			localRecoveryConfig,
 			Executors.directExecutor());
+
+		this.taskLocalStateStore.setRetrieveWithDiscard(false);
 	}
 
 	@After


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes [FLINK-8777](https://issues.apache.org/jira/browse/FLINK-8777). When recovery from failed, `TaskLocalStateStoreImpl.retrieveLocalState()` will be invoked, we can release all entry from `storedTaskStateByCheckpointID`  that does not satisfy `entry.checkpointID == checkpointID`, this can prevent the resource leak when job loop in `local checkpoint completed => failed => local checkpoint completed => failed ...`.

## Brief change log

  - release resource in retrieveLocalState
  - change the type of toDiscard from Map to a single entry.

## Verifying this change

This changes can be verified by the exists tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
