### PR TITLE
[FLINK-8778] Migrate queryable state ITCases to use MiniClusterResource

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
@@ -981,7 +981,7 @@ public abstract class ClusterClient<T> {
 	 * @param jobGraph The JobGraph to be submitted
 	 * @return JobSubmissionResult
 	 */
-	protected abstract JobSubmissionResult submitJob(JobGraph jobGraph, ClassLoader classLoader)
+	public abstract JobSubmissionResult submitJob(JobGraph jobGraph, ClassLoader classLoader)
 		throws ProgramInvocationException;
 
 	/**

--- a/flink-clients/src/main/java/org/apache/flink/client/program/StandaloneClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/StandaloneClusterClient.java
@@ -107,7 +107,7 @@ public class StandaloneClusterClient extends ClusterClient<StandaloneClusterId> 
 	}
 
 	@Override
-	protected JobSubmissionResult submitJob(JobGraph jobGraph, ClassLoader classLoader)
+	public JobSubmissionResult submitJob(JobGraph jobGraph, ClassLoader classLoader)
 			throws ProgramInvocationException {
 		if (isDetached()) {
 			return super.runDetached(jobGraph, classLoader);

--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
@@ -35,6 +35,7 @@ import org.apache.flink.runtime.clusterframework.messages.GetClusterStatusRespon
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.concurrent.ScheduledExecutorServiceAdapter;
 import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalException;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
@@ -61,6 +62,8 @@ import org.apache.flink.runtime.rest.messages.RequestBody;
 import org.apache.flink.runtime.rest.messages.ResponseBody;
 import org.apache.flink.runtime.rest.messages.TerminationModeQueryParameter;
 import org.apache.flink.runtime.rest.messages.TriggerId;
+import org.apache.flink.runtime.rest.messages.job.JobDetailsHeaders;
+import org.apache.flink.runtime.rest.messages.job.JobDetailsInfo;
 import org.apache.flink.runtime.rest.messages.job.JobExecutionResultHeaders;
 import org.apache.flink.runtime.rest.messages.job.JobSubmitHeaders;
 import org.apache.flink.runtime.rest.messages.job.JobSubmitRequestBody;
@@ -253,6 +256,17 @@ public class RestClusterClient<T> extends ClusterClient<T> {
 				throw new ProgramInvocationException(e);
 			}
 		}
+	}
+
+	@Override
+	public CompletableFuture<JobStatus> getJobStatus(JobID jobId) {
+		JobDetailsHeaders detailsHeaders = JobDetailsHeaders.getInstance();
+		final JobMessageParameters  params = new JobMessageParameters();
+		params.jobPathParameter.resolve(jobId);
+
+		CompletableFuture<JobDetailsInfo> responseFuture = sendRequest(detailsHeaders, params);
+
+		return responseFuture.thenApply(JobDetailsInfo::getJobStatus);
 	}
 
 	/**

--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
@@ -220,7 +220,7 @@ public class RestClusterClient<T> extends ClusterClient<T> {
 	}
 
 	@Override
-	protected JobSubmissionResult submitJob(JobGraph jobGraph, ClassLoader classLoader) throws ProgramInvocationException {
+	public JobSubmissionResult submitJob(JobGraph jobGraph, ClassLoader classLoader) throws ProgramInvocationException {
 		log.info("Submitting job {}.", jobGraph.getJobID());
 
 		final CompletableFuture<JobSubmitResponseBody> jobSubmissionFuture = submitJob(jobGraph);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
@@ -224,6 +224,77 @@ public class FutureUtils {
 	}
 
 	/**
+	 * Retry the given operation with the given delay in between successful completions where the
+	 * result does not match a given predicate.
+	 *
+	 * @param operation to retry
+	 * @param retries number of retries
+	 * @param retryDelay delay between retries
+	 * @param retryPredicate Predicate to test whether the result is acceptable
+	 * @param scheduledExecutor executor to be used for the retry operation
+	 * @param <T> type of the result
+	 * @return Future which retries the given operation a given amount of times and delays the retry in case of failures
+	 */
+	public static <T> CompletableFuture<T> retrySuccesfulWithDelay(
+		final Supplier<CompletableFuture<T>> operation,
+		final long retries,
+		final Time retryDelay,
+		final Predicate<T> retryPredicate,
+		final ScheduledExecutor scheduledExecutor) {
+
+		final CompletableFuture<T> resultFuture = new CompletableFuture<>();
+
+		retrySuccessfulOperationWithDelay(
+			resultFuture,
+			operation,
+			retries,
+			retryDelay,
+			retryPredicate,
+			scheduledExecutor);
+
+		return resultFuture;
+	}
+
+	private static <T> void retrySuccessfulOperationWithDelay(
+		final CompletableFuture<T> resultFuture,
+		final Supplier<CompletableFuture<T>> operation,
+		final long retries,
+		final Time retryDelay,
+		final Predicate<T> retryPredicate,
+		final ScheduledExecutor scheduledExecutor) {
+
+		if (!resultFuture.isDone()) {
+			final CompletableFuture<T> operationResultFuture = operation.get();
+
+			operationResultFuture.whenComplete(
+				(t, throwable) -> {
+					if (throwable != null) {
+						if (throwable instanceof CancellationException) {
+							resultFuture.completeExceptionally(new RetryException("Operation future was cancelled.", throwable));
+						} else {
+							resultFuture.completeExceptionally(throwable);
+						}
+					} else {
+						if (retries > 0 && !retryPredicate.test(t)) {
+							final ScheduledFuture<?> scheduledFuture = scheduledExecutor.schedule(
+								() -> retrySuccessfulOperationWithDelay(resultFuture, operation, retries - 1, retryDelay, retryPredicate, scheduledExecutor),
+								retryDelay.toMilliseconds(),
+								TimeUnit.MILLISECONDS);
+
+							resultFuture.whenComplete(
+								(innerT, innerThrowable) -> scheduledFuture.cancel(false));
+						} else {
+							resultFuture.complete(t);
+						}
+					}
+				});
+
+			resultFuture.whenComplete(
+				(t, throwable) -> operationResultFuture.cancel(false));
+		}
+	}
+
+	/**
 	 * Exception with which the returned future is completed if the {@link #retry(Supplier, int, Executor)}
 	 * operation fails.
 	 */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
@@ -322,5 +322,13 @@ public class RestClient {
 		public HttpResponseStatus getHttpResponseStatus() {
 			return httpResponseStatus;
 		}
+
+		@Override
+		public String toString() {
+			return "JsonResponse{" +
+				"json=" + json +
+				", httpResponseStatus=" + httpResponseStatus +
+				'}';
+		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobDetailsInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobDetailsInfo.java
@@ -50,7 +50,7 @@ public class JobDetailsInfo implements ResponseBody {
 
 	public static final String FIELD_NAME_JOB_NAME = "name";
 
-	public static final String FIELD_NAME_IS_STOPPABLE = "isStoppable";
+	public static final String FIELD_NAME_IS_STOPPABLE = "stoppable";
 
 	public static final String FIELD_NAME_JOB_STATUS = "state";
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobDetailsInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobDetailsInfo.java
@@ -165,6 +165,54 @@ public class JobDetailsInfo implements ResponseBody {
 		return Objects.hash(jobId, name, isStoppable, jobStatus, startTime, endTime, duration, now, timestamps, jobVertexInfos, jobVerticesPerState, jsonPlan);
 	}
 
+	public JobID getJobId() {
+		return jobId;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public boolean isStoppable() {
+		return isStoppable;
+	}
+
+	public JobStatus getJobStatus() {
+		return jobStatus;
+	}
+
+	public long getStartTime() {
+		return startTime;
+	}
+
+	public long getEndTime() {
+		return endTime;
+	}
+
+	public long getDuration() {
+		return duration;
+	}
+
+	public long getNow() {
+		return now;
+	}
+
+	public Map<JobStatus, Long> getTimestamps() {
+		return timestamps;
+	}
+
+	public Collection<JobVertexDetailsInfo> getJobVertexInfos() {
+		return jobVertexInfos;
+	}
+
+	public Map<ExecutionState, Integer> getJobVerticesPerState() {
+		return jobVerticesPerState;
+	}
+
+	public String getJsonPlan() {
+		return jsonPlan;
+	}
+
 	// ---------------------------------------------------
 	// Static inner classes
 	// ---------------------------------------------------

--- a/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/AbstractOperatorRestoreTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/AbstractOperatorRestoreTestBase.java
@@ -19,55 +19,38 @@
 package org.apache.flink.test.state.operator.restore;
 
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
-import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.runtime.akka.AkkaUtils;
-import org.apache.flink.runtime.akka.ListeningBehaviour;
 import org.apache.flink.runtime.checkpoint.savepoint.SavepointSerializers;
-import org.apache.flink.runtime.clusterframework.types.ResourceID;
-import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
-import org.apache.flink.runtime.highavailability.HighAvailabilityServicesUtils;
-import org.apache.flink.runtime.instance.ActorGateway;
-import org.apache.flink.runtime.instance.AkkaActorGateway;
+import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
-import org.apache.flink.runtime.jobmanager.JobManager;
-import org.apache.flink.runtime.messages.JobManagerMessages;
-import org.apache.flink.runtime.metrics.NoOpMetricRegistry;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
-import org.apache.flink.runtime.taskmanager.TaskManager;
-import org.apache.flink.runtime.testingUtils.TestingJobManager;
-import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages;
-import org.apache.flink.runtime.testingUtils.TestingMemoryArchivist;
-import org.apache.flink.runtime.testingUtils.TestingTaskManager;
-import org.apache.flink.runtime.testingUtils.TestingTaskManagerMessages;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
-import org.apache.flink.runtime.util.LeaderRetrievalUtils;
 import org.apache.flink.streaming.api.CheckpointingMode;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.graph.StreamingJobGraphGenerator;
+import org.apache.flink.test.util.MiniClusterResource;
 import org.apache.flink.util.TestLogger;
 
-import akka.actor.ActorRef;
-import akka.actor.ActorSystem;
-import akka.actor.PoisonPill;
-import org.junit.AfterClass;
-import org.junit.Assert;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.net.URL;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
-import scala.Option;
-import scala.Tuple2;
-import scala.concurrent.Await;
-import scala.concurrent.Future;
+import scala.concurrent.duration.Deadline;
 import scala.concurrent.duration.FiniteDuration;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * Abstract class to verify that it is possible to migrate a savepoint across upgraded Flink versions and that the
@@ -79,16 +62,20 @@ import scala.concurrent.duration.FiniteDuration;
  */
 public abstract class AbstractOperatorRestoreTestBase extends TestLogger {
 
+	private static final int NUM_TMS = 2;
+	private static final int NUM_SLOTS_PER_TM = 4;
+	private static final FiniteDuration TEST_TIMEOUT = new FiniteDuration(10000L, TimeUnit.SECONDS);
+
 	@Rule
 	public final TemporaryFolder tmpFolder = new TemporaryFolder();
 
-	private static ActorSystem actorSystem = null;
-	private static HighAvailabilityServices highAvailabilityServices = null;
-	private static ActorGateway jobManager = null;
-	private static ActorGateway archiver = null;
-	private static ActorGateway taskManager = null;
+	@ClassRule
+	public static MiniClusterResource miniClusterResource = new MiniClusterResource(
+		new MiniClusterResource.MiniClusterResourceConfiguration(
+			new Configuration(),
+			NUM_TMS,
+			NUM_SLOTS_PER_TM));
 
-	private static final FiniteDuration timeout = new FiniteDuration(30L, TimeUnit.SECONDS);
 	private final boolean allowNonRestoredState;
 
 	protected AbstractOperatorRestoreTestBase() {
@@ -104,91 +91,21 @@ public abstract class AbstractOperatorRestoreTestBase extends TestLogger {
 		SavepointSerializers.setFailWhenLegacyStateDetected(false);
 	}
 
-	@BeforeClass
-	public static void setupCluster() throws Exception {
-		final Configuration configuration = new Configuration();
-
-		FiniteDuration timeout = new FiniteDuration(30L, TimeUnit.SECONDS);
-
-		actorSystem = AkkaUtils.createLocalActorSystem(new Configuration());
-
-		highAvailabilityServices = HighAvailabilityServicesUtils.createAvailableOrEmbeddedServices(
-			configuration,
-			TestingUtils.defaultExecutor());
-
-		Tuple2<ActorRef, ActorRef> master = JobManager.startJobManagerActors(
-			configuration,
-			actorSystem,
-			TestingUtils.defaultExecutor(),
-			TestingUtils.defaultExecutor(),
-			highAvailabilityServices,
-			NoOpMetricRegistry.INSTANCE,
-			Option.empty(),
-			Option.apply("jm"),
-			Option.apply("arch"),
-			TestingJobManager.class,
-			TestingMemoryArchivist.class);
-
-		jobManager = LeaderRetrievalUtils.retrieveLeaderGateway(
-			highAvailabilityServices.getJobManagerLeaderRetriever(HighAvailabilityServices.DEFAULT_JOB_ID),
-			actorSystem,
-			timeout);
-
-		archiver = new AkkaActorGateway(master._2(), jobManager.leaderSessionID());
-
-		Configuration tmConfig = new Configuration();
-		tmConfig.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, 4);
-
-		ActorRef taskManagerRef = TaskManager.startTaskManagerComponentsAndActor(
-			tmConfig,
-			ResourceID.generate(),
-			actorSystem,
-			highAvailabilityServices,
-			NoOpMetricRegistry.INSTANCE,
-			"localhost",
-			Option.apply("tm"),
-			true,
-			TestingTaskManager.class);
-
-		taskManager = new AkkaActorGateway(taskManagerRef, jobManager.leaderSessionID());
-
-		// Wait until connected
-		Object msg = new TestingTaskManagerMessages.NotifyWhenRegisteredAtJobManager(jobManager.actor());
-		Await.ready(taskManager.ask(msg, timeout), timeout);
-	}
-
-	@AfterClass
-	public static void tearDownCluster() throws Exception {
-		if (highAvailabilityServices != null) {
-			highAvailabilityServices.closeAndCleanupAllData();
-		}
-
-		if (actorSystem != null) {
-			actorSystem.shutdown();
-		}
-
-		if (archiver != null) {
-			archiver.actor().tell(PoisonPill.getInstance(), ActorRef.noSender());
-		}
-
-		if (jobManager != null) {
-			jobManager.actor().tell(PoisonPill.getInstance(), ActorRef.noSender());
-		}
-
-		if (taskManager != null) {
-			taskManager.actor().tell(PoisonPill.getInstance(), ActorRef.noSender());
-		}
-	}
-
 	@Test
 	public void testMigrationAndRestore() throws Throwable {
+		ClassLoader classLoader = this.getClass().getClassLoader();
+		ClusterClient<?> clusterClient = miniClusterResource.getClusterClient();
+		clusterClient.setDetached(true);
+		final Deadline deadline = TEST_TIMEOUT.fromNow();
+
 		// submit job with old version savepoint and create a migrated savepoint in the new version
-		String savepointPath = migrateJob();
+		String savepointPath = migrateJob(classLoader, clusterClient, deadline);
 		// restore from migrated new version savepoint
-		restoreJob(savepointPath);
+		restoreJob(classLoader, clusterClient, deadline, savepointPath);
 	}
 
-	private String migrateJob() throws Throwable {
+	private String migrateJob(ClassLoader classLoader, ClusterClient<?> clusterClient, Deadline deadline) throws Throwable {
+
 		URL savepointResource = AbstractOperatorRestoreTestBase.class.getClassLoader().getResource("operatorstate/" + getMigrationSavepointName());
 		if (savepointResource == null) {
 			throw new IllegalArgumentException("Savepoint file does not exist.");
@@ -196,83 +113,75 @@ public abstract class AbstractOperatorRestoreTestBase extends TestLogger {
 		JobGraph jobToMigrate = createJobGraph(ExecutionMode.MIGRATE);
 		jobToMigrate.setSavepointRestoreSettings(SavepointRestoreSettings.forPath(savepointResource.getFile()));
 
-		Object msg;
-		Object result;
+		assertNotNull(jobToMigrate.getJobID());
 
-		// Submit job graph
-		msg = new JobManagerMessages.SubmitJob(jobToMigrate, ListeningBehaviour.DETACHED);
-		result = Await.result(jobManager.ask(msg, timeout), timeout);
+		clusterClient.submitJob(jobToMigrate, classLoader);
 
-		if (result instanceof JobManagerMessages.JobResultFailure) {
-			JobManagerMessages.JobResultFailure failure = (JobManagerMessages.JobResultFailure) result;
-			throw new Exception(failure.cause());
-		}
-		Assert.assertSame(JobManagerMessages.JobSubmitSuccess.class, result.getClass());
+		CompletableFuture<JobStatus> jobStatusFuture = FutureUtils.retrySuccesfulWithDelay(
+			() -> clusterClient.getJobStatus(jobToMigrate.getJobID()),
+			deadline.timeLeft().toMillis() / 50,
+			Time.milliseconds(50),
+			(jobStatus) -> jobStatus.equals(JobStatus.RUNNING),
+			TestingUtils.defaultScheduledExecutor());
 
-		// Wait for all tasks to be running
-		msg = new TestingJobManagerMessages.WaitForAllVerticesToBeRunning(jobToMigrate.getJobID());
-		Await.result(jobManager.ask(msg, timeout), timeout);
+		assertEquals(JobStatus.RUNNING, jobStatusFuture.get(deadline.timeLeft().toMillis(), TimeUnit.MILLISECONDS));
 
 		// Trigger savepoint
 		File targetDirectory = tmpFolder.newFolder();
-		msg = new JobManagerMessages.CancelJobWithSavepoint(jobToMigrate.getJobID(), targetDirectory.getAbsolutePath());
+		String savepointPath = null;
 
 		// FLINK-6918: Retry cancel with savepoint message in case that StreamTasks were not running
 		// TODO: The retry logic should be removed once the StreamTask lifecycle has been fixed (see FLINK-4714)
-		boolean retry = true;
-		for (int i = 0; retry && i < 10; i++) {
-			Future<Object> future = jobManager.ask(msg, timeout);
-			result = Await.result(future, timeout);
-
-			if (result instanceof JobManagerMessages.CancellationFailure) {
-				Thread.sleep(50L);
-			} else {
-				retry = false;
+		while (deadline.hasTimeLeft() && savepointPath == null) {
+			try {
+				savepointPath = clusterClient.cancelWithSavepoint(
+					jobToMigrate.getJobID(),
+					targetDirectory.getAbsolutePath());
+			} catch (Exception e) {
+				if (!e.toString().matches(".* savepoint for the job .* failed.*")) {
+					throw e;
+				}
 			}
 		}
 
-		if (result instanceof JobManagerMessages.CancellationFailure) {
-			JobManagerMessages.CancellationFailure failure = (JobManagerMessages.CancellationFailure) result;
-			throw new Exception(failure.cause());
-		}
+		assertNotNull(savepointPath);
 
-		String savepointPath = ((JobManagerMessages.CancellationSuccess) result).savepointPath();
+		jobStatusFuture = FutureUtils.retrySuccesfulWithDelay(
+			() -> clusterClient.getJobStatus(jobToMigrate.getJobID()),
+			deadline.timeLeft().toMillis() / 50,
+			Time.milliseconds(50),
+			(jobStatus) -> jobStatus.equals(JobStatus.CANCELED),
+			TestingUtils.defaultScheduledExecutor());
 
-		// Wait until canceled
-		msg = new TestingJobManagerMessages.NotifyWhenJobStatus(jobToMigrate.getJobID(), JobStatus.CANCELED);
-		Await.ready(jobManager.ask(msg, timeout), timeout);
+		assertEquals(JobStatus.CANCELED, jobStatusFuture.get(deadline.timeLeft().toMillis(), TimeUnit.MILLISECONDS));
 
 		return savepointPath;
 	}
 
-	private void restoreJob(String savepointPath) throws Exception {
+	private void restoreJob(ClassLoader classLoader, ClusterClient<?> clusterClient, Deadline deadline, String savepointPath) throws Exception {
 		JobGraph jobToRestore = createJobGraph(ExecutionMode.RESTORE);
 		jobToRestore.setSavepointRestoreSettings(SavepointRestoreSettings.forPath(savepointPath, allowNonRestoredState));
 
-		Object msg;
-		Object result;
+		assertNotNull(jobToRestore.getJobID());
 
-		// Submit job graph
-		msg = new JobManagerMessages.SubmitJob(jobToRestore, ListeningBehaviour.DETACHED);
-		result = Await.result(jobManager.ask(msg, timeout), timeout);
+		clusterClient.submitJob(jobToRestore, classLoader);
 
-		if (result instanceof JobManagerMessages.JobResultFailure) {
-			JobManagerMessages.JobResultFailure failure = (JobManagerMessages.JobResultFailure) result;
-			throw new Exception(failure.cause());
-		}
-		Assert.assertSame(JobManagerMessages.JobSubmitSuccess.class, result.getClass());
+		CompletableFuture<JobStatus> jobStatusFuture =
+			clusterClient.getJobStatus(jobToRestore.getJobID());
 
-		msg = new JobManagerMessages.RequestJobStatus(jobToRestore.getJobID());
-		JobStatus status = ((JobManagerMessages.CurrentJobStatus) Await.result(jobManager.ask(msg, timeout), timeout)).status();
-		while (!status.isTerminalState()) {
-			status = ((JobManagerMessages.CurrentJobStatus) Await.result(jobManager.ask(msg, timeout), timeout)).status();
+		while (deadline.hasTimeLeft()
+			&& !jobStatusFuture.get(deadline.timeLeft().toMillis(), TimeUnit.MILLISECONDS).equals(JobStatus.FINISHED)) {
+
+			Thread.sleep(50);
+			jobStatusFuture =
+				clusterClient.getJobStatus(jobToRestore.getJobID());
 		}
 
-		Assert.assertEquals(JobStatus.FINISHED, status);
+		assertEquals(JobStatus.FINISHED, jobStatusFuture.get(deadline.timeLeft().toMillis(), TimeUnit.MILLISECONDS));
 	}
 
 	private JobGraph createJobGraph(ExecutionMode mode) {
-		StreamExecutionEnvironment env = StreamExecutionEnvironment.createLocalEnvironment();
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 		env.enableCheckpointing(500, CheckpointingMode.EXACTLY_ONCE);
 		env.setRestartStrategy(RestartStrategies.noRestart());
 		env.setStateBackend(new MemoryStateBackend());


### PR DESCRIPTION
This also covers https://issues.apache.org/jira/browse/FLINK-8757 and https://issues.apache.org/jira/browse/FLINK-8758.

R: @tillrohrmann or @GJL 

CC: @zentol because of the whole test-porting business, @kl0u because it's QS and because of test porting

For now, the tests don't succeed in FLIP-6 mode (you have to activate the `flip-6` Maven profile). When you start a single test in IntelliJ it succeeds, when you start the complete suite only the first test succeeds and the others stall.