### PR TITLE
[FLINK-8790][State] Improve performance for recovery from incremental checkpoint

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBIncrementalCheckpointUtils.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBIncrementalCheckpointUtils.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.state;
+
+import org.apache.flink.runtime.state.KeyGroupRange;
+
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.RocksDB;
+import org.rocksdb.RocksDBException;
+
+import java.util.List;
+
+/**
+ * Utils for RocksDB Incremental Checkpoint.
+ */
+public class RocksDBIncrementalCheckpointUtils {
+
+	public static void clipDBWithKeyGroupRange(
+		RocksDB db,
+		List<ColumnFamilyHandle> columnFamilyHandles,
+		KeyGroupRange targetGroupRange,
+		KeyGroupRange currentGroupRange,
+		int keyGroupPrefixBytes) throws RocksDBException {
+
+		for (ColumnFamilyHandle columnFamilyHandle : columnFamilyHandles) {
+			if (currentGroupRange.getStartKeyGroup() < targetGroupRange.getStartKeyGroup()) {
+				byte[] beginKey = RocksDBKeySerializationUtils.serializeKeyGroup(
+					currentGroupRange.getStartKeyGroup(), keyGroupPrefixBytes);
+				byte[] endKye = RocksDBKeySerializationUtils.serializeKeyGroup(
+					targetGroupRange.getStartKeyGroup(), keyGroupPrefixBytes);
+				db.deleteRange(columnFamilyHandle, beginKey, endKye);
+			}
+
+			if (currentGroupRange.getEndKeyGroup() > targetGroupRange.getEndKeyGroup()) {
+				byte[] beginKey = RocksDBKeySerializationUtils.serializeKeyGroup(
+					targetGroupRange.getEndKeyGroup() + 1, keyGroupPrefixBytes);
+
+				byte[] endKey = new byte[keyGroupPrefixBytes];
+				for (int i = 0; i < keyGroupPrefixBytes; ++i) {
+					endKey[i] = (byte) (0xFF);
+				}
+				db.deleteRange(columnFamilyHandle, beginKey, endKey);
+			}
+		}
+	}
+
+	public static int evaluateGroupRange(KeyGroupRange range1, KeyGroupRange range2) {
+		int start1 = range1.getStartKeyGroup();
+		int end1 = range1.getEndKeyGroup();
+
+		int start2 = range2.getStartKeyGroup();
+		int end2 = range2.getEndKeyGroup();
+
+		int insectStart = start1;
+		if (start2 > start1) {
+			insectStart = start2;
+		}
+
+		int insectEnd = end1;
+		if (end2 < end1) {
+			insectEnd = end2;
+		}
+		return insectEnd >= insectStart ? insectEnd - insectStart + 1 : 0;
+	}
+}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeySerializationUtils.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeySerializationUtils.java
@@ -138,4 +138,12 @@ public class RocksDBKeySerializationUtils {
 			value >>>= 8;
 		} while (value != 0);
 	}
+
+	public static byte[] serializeKeyGroup(int keyGroup, int keyGroupPrefixBytes) {
+		byte[] startKeyGroupPrefixBytes = new byte[keyGroupPrefixBytes];
+		for (int j = 0; j < keyGroupPrefixBytes; ++j) {
+			startKeyGroupPrefixBytes[j] = (byte) (keyGroup >>> ((keyGroupPrefixBytes - j - 1) * Byte.SIZE));
+		}
+		return startKeyGroupPrefixBytes;
+	}
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
@@ -719,57 +719,40 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 				!Objects.equals(restoreStateHandles.iterator().next().getKeyGroupRange(), stateBackend.keyGroupRange));
 
 			if (hasExtraKeys) {
-				stateBackend.createDB();
-			}
-
-			for (KeyedStateHandle rawStateHandle : restoreStateHandles) {
-
-				if (rawStateHandle instanceof IncrementalKeyedStateHandle) {
-					restoreInstance((IncrementalKeyedStateHandle) rawStateHandle, hasExtraKeys);
-				} else if (rawStateHandle instanceof IncrementalLocalKeyedStateHandle) {
-					Preconditions.checkState(!hasExtraKeys, "Cannot recover from local state after rescaling.");
-					restoreInstance((IncrementalLocalKeyedStateHandle) rawStateHandle);
-				} else {
-					throw new IllegalStateException("Unexpected state handle type, " +
-						"expected " + IncrementalKeyedStateHandle.class +
-						", but found " + rawStateHandle.getClass());
-				}
+				restoreFromMultiHandles(restoreStateHandles);
+			} else {
+				restoreFromSingleHandle(restoreStateHandles.iterator().next());
 			}
 		}
 
 		/**
-		 * Recovery from remote incremental state.
+		 * Recovery from a single remote incremental state.
 		 */
-		private void restoreInstance(
-			IncrementalKeyedStateHandle restoreStateHandle,
-			boolean hasExtraKeys) throws Exception {
+		void restoreFromSingleHandle(KeyedStateHandle rawStateHandle) throws Exception {
 
-			// read state data
-			Path temporaryRestoreInstancePath = new Path(
-				stateBackend.instanceBasePath.getAbsolutePath(),
-				UUID.randomUUID().toString());
+			IncrementalLocalKeyedStateHandle localKeyedStateHandle;
+			List<RegisteredKeyedBackendStateMetaInfo.Snapshot<?, ?>> stateMetaInfoSnapshots;
+			List<ColumnFamilyDescriptor> columnFamilyDescriptors;
 
-			try {
+			if (rawStateHandle instanceof IncrementalKeyedStateHandle) {
 
-				transferAllStateDataToDirectory(restoreStateHandle, temporaryRestoreInstancePath);
+				// Recovery from remote incremental state.
+				Path temporaryRestoreInstancePath = new Path(
+					stateBackend.instanceBasePath.getAbsolutePath(),
+					UUID.randomUUID().toString());
 
-				// read meta data
-				List<RegisteredKeyedBackendStateMetaInfo.Snapshot<?, ?>> stateMetaInfoSnapshots =
-					readMetaData(restoreStateHandle.getMetaStateHandle());
+				try {
+					IncrementalKeyedStateHandle restoreStateHandle = (IncrementalKeyedStateHandle) rawStateHandle;
 
-				List<ColumnFamilyDescriptor> columnFamilyDescriptors =
-					createAndRegisterColumnFamilyDescriptors(stateMetaInfoSnapshots);
+					// read state data
+					transferAllStateDataToDirectory(restoreStateHandle, temporaryRestoreInstancePath);
 
-				if (hasExtraKeys) {
-					restoreKeyGroupsShardWithTemporaryHelperInstance(
-						temporaryRestoreInstancePath,
-						columnFamilyDescriptors,
-						stateMetaInfoSnapshots);
-				} else {
+					stateMetaInfoSnapshots = readMetaData(restoreStateHandle.getMetaStateHandle());
+					columnFamilyDescriptors = createAndRegisterColumnFamilyDescriptors(stateMetaInfoSnapshots);
 
 					// since we transferred all remote state to a local directory, we can use the same code as for
 					// local recovery.
-					IncrementalLocalKeyedStateHandle localKeyedStateHandle = new IncrementalLocalKeyedStateHandle(
+					localKeyedStateHandle = new IncrementalLocalKeyedStateHandle(
 						restoreStateHandle.getBackendIdentifier(),
 						restoreStateHandle.getCheckpointId(),
 						new DirectoryStateHandle(temporaryRestoreInstancePath),
@@ -781,30 +764,286 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 						localKeyedStateHandle,
 						columnFamilyDescriptors,
 						stateMetaInfoSnapshots);
+				} finally {
+					FileSystem restoreFileSystem = temporaryRestoreInstancePath.getFileSystem();
+					if (restoreFileSystem.exists(temporaryRestoreInstancePath)) {
+						restoreFileSystem.delete(temporaryRestoreInstancePath, true);
+					}
 				}
-			} finally {
-				FileSystem restoreFileSystem = temporaryRestoreInstancePath.getFileSystem();
-				if (restoreFileSystem.exists(temporaryRestoreInstancePath)) {
-					restoreFileSystem.delete(temporaryRestoreInstancePath, true);
-				}
+			} else if (rawStateHandle instanceof IncrementalLocalKeyedStateHandle) {
+
+				// Recovery from local incremental state.
+				localKeyedStateHandle = (IncrementalLocalKeyedStateHandle) rawStateHandle;
+				stateMetaInfoSnapshots = readMetaData(localKeyedStateHandle.getMetaDataState());
+				columnFamilyDescriptors = createAndRegisterColumnFamilyDescriptors(stateMetaInfoSnapshots);
+
+				restoreLocalStateIntoFullInstance(
+					localKeyedStateHandle,
+					columnFamilyDescriptors,
+					stateMetaInfoSnapshots);
+			} else {
+				throw new IllegalStateException("Unexpected state handle type, " +
+					"expected " + IncrementalKeyedStateHandle.class +
+					", but found " + rawStateHandle.getClass());
 			}
 		}
 
 		/**
-		 * Recovery from local incremental state.
+		 * Recovery from multi incremental states.
+		 * In case of rescaling, this method creates a temporary RocksDB instance for a key-groups shard. All contents
+		 * from the temporary instance are copied into the real restore instance and then the temporary instance is
+		 * discarded.
 		 */
-		private void restoreInstance(IncrementalLocalKeyedStateHandle localKeyedStateHandle) throws Exception {
+		void restoreFromMultiHandles(Collection<KeyedStateHandle> restoreStateHandles) throws Exception {
+
+			KeyGroupRange targetKeyGroupRange = stateBackend.keyGroupRange;
+
+			chooseTheBestStateHandleToInit(restoreStateHandles, targetKeyGroupRange);
+
+			int targetStartKeyGroup = stateBackend.getKeyGroupRange().getStartKeyGroup();
+			byte[] targetStartKeyGroupPrefixBytes = new byte[stateBackend.keyGroupPrefixBytes];
+			for (int j = 0; j < stateBackend.keyGroupPrefixBytes; ++j) {
+				targetStartKeyGroupPrefixBytes[j] = (byte) (targetStartKeyGroup >>> ((stateBackend.keyGroupPrefixBytes - j - 1) * Byte.SIZE));
+			}
+
+			for (KeyedStateHandle rawStateHandle : restoreStateHandles) {
+
+				if (!(rawStateHandle instanceof IncrementalLocalKeyedStateHandle)) {
+					throw new IllegalStateException("Unexpected state handle type, " +
+						"expected " + IncrementalKeyedStateHandle.class +
+						", but found " + rawStateHandle.getClass());
+				}
+
+				Path temporaryRestoreInstancePath = new Path(stateBackend.instanceBasePath.getAbsolutePath() + UUID.randomUUID().toString());
+				try (RestoreDBInfo tmpRestoreDBInfo = restoreDBFromStateHandle(
+						(IncrementalKeyedStateHandle) rawStateHandle,
+						temporaryRestoreInstancePath,
+						targetKeyGroupRange,
+						stateBackend.keyGroupPrefixBytes);
+					ColumnFamilyHandle defaultColumnFamilyHandle = tmpRestoreDBInfo.columnFamilyHandles.remove(0)) {
+
+					List<ColumnFamilyDescriptor> tmpColumnFamilyDescriptors = tmpRestoreDBInfo.columnFamilyDescriptors;
+					List<ColumnFamilyHandle> tmpColumnFamilyHandles = tmpRestoreDBInfo.columnFamilyHandles;
+
+					// iterating only the requested descriptors automatically skips the default column family handle
+					for (int i = 0; i < tmpColumnFamilyDescriptors.size(); ++i) {
+						ColumnFamilyHandle tmpColumnFamilyHandle = tmpColumnFamilyHandles.get(i);
+						ColumnFamilyDescriptor tmpColumnFamilyDescriptor = tmpColumnFamilyDescriptors.get(i);
+
+						ColumnFamilyHandle targetColumnFamilyHandle = getOrRegisterColumnFamilyHandle(
+							tmpColumnFamilyDescriptor, null, tmpRestoreDBInfo.stateMetaInfoSnapshots.get(i));
+
+						try (RocksIterator iterator = tmpRestoreDBInfo.db.newIterator(tmpColumnFamilyHandle)) {
+
+							iterator.seek(targetStartKeyGroupPrefixBytes);
+							while (iterator.isValid()) {
+								// DB has been clip by target key group range, so we do not need to do key rang check in this loop
+								stateBackend.db.put(targetColumnFamilyHandle, iterator.key(), iterator.value());
+								iterator.next();
+							}
+						} // releases native iterator resources
+					}
+				} finally {
+					FileSystem restoreFileSystem = temporaryRestoreInstancePath.getFileSystem();
+					if (restoreFileSystem.exists(temporaryRestoreInstancePath)) {
+						restoreFileSystem.delete(temporaryRestoreInstancePath, true);
+					}
+				}
+			}
+		}
+
+		private void clipDBWithKeyGroupRange(
+			RocksDB db,
+			List<ColumnFamilyHandle> columnFamilyHandles,
+			KeyGroupRange targetGroupRange,
+			KeyGroupRange currentGroupRange,
+			int keyGroupPrefixBytes) throws RocksDBException {
+
+			for (ColumnFamilyHandle columnFamilyHandle: columnFamilyHandles) {
+				if (currentGroupRange.getStartKeyGroup() < targetGroupRange.getStartKeyGroup()) {
+					byte[] beginKey = serializeKeyGroup(currentGroupRange.getStartKeyGroup(), keyGroupPrefixBytes);
+					byte[] endKye = serializeKeyGroup(targetGroupRange.getStartKeyGroup(), keyGroupPrefixBytes);
+					db.deleteRange(columnFamilyHandle, beginKey, endKye);
+				}
+
+				if (currentGroupRange.getEndKeyGroup() > targetGroupRange.getEndKeyGroup()) {
+					byte[] beginKey = serializeKeyGroup(targetGroupRange.getEndKeyGroup() + 1, keyGroupPrefixBytes);
+					byte[] endKey = new byte[keyGroupPrefixBytes];
+					for (int i = 0; i < keyGroupPrefixBytes; ++i) {
+						endKey[i] |= 1;
+					}
+					db.deleteRange(columnFamilyHandle, beginKey, endKey);
+				}
+			}
+		}
+
+		private byte[] serializeKeyGroup(int keyGroup, int keyGroupPrefixBytes) {
+			byte[] startKeyGroupPrefixBytes = new byte[keyGroupPrefixBytes];
+			for (int j = 0; j < keyGroupPrefixBytes; ++j) {
+				startKeyGroupPrefixBytes[j] = (byte) (keyGroup >>> ((stateBackend.keyGroupPrefixBytes - j - 1) * Byte.SIZE));
+			}
+			return startKeyGroupPrefixBytes;
+		}
+
+		private class RestoreDBInfo implements AutoCloseable {
+			private RocksDB db;
+			private List<ColumnFamilyHandle> columnFamilyHandles;
+			private List<ColumnFamilyDescriptor> columnFamilyDescriptors;
+			private List<RegisteredKeyedBackendStateMetaInfo.Snapshot<?, ?>> stateMetaInfoSnapshots;
+
+			public RestoreDBInfo(RocksDB db,
+								List<ColumnFamilyHandle> columnFamilyHandles,
+								List<ColumnFamilyDescriptor> columnFamilyDescriptors,
+								List<RegisteredKeyedBackendStateMetaInfo.Snapshot<?, ?>> stateMetaInfoSnapshots) {
+				this.db = db;
+				this.columnFamilyHandles = columnFamilyHandles;
+				this.columnFamilyDescriptors = columnFamilyDescriptors;
+				this.stateMetaInfoSnapshots = stateMetaInfoSnapshots;
+			}
+
+			@Override
+			public void close() throws Exception {
+				for (ColumnFamilyHandle columnFamilyHandle : columnFamilyHandles) {
+					IOUtils.closeQuietly(columnFamilyHandle);
+				}
+				IOUtils.closeQuietly(db);
+			}
+		}
+
+		private RestoreDBInfo restoreDBFromStateHandle(
+			IncrementalKeyedStateHandle restoreStateHandle,
+			Path temporaryRestoreInstancePath,
+			KeyGroupRange targetKeyGroupRange,
+			int keyGroupPrefixBytes) throws Exception {
+
+			transferAllStateDataToDirectory(restoreStateHandle, temporaryRestoreInstancePath);
+
 			// read meta data
 			List<RegisteredKeyedBackendStateMetaInfo.Snapshot<?, ?>> stateMetaInfoSnapshots =
-				readMetaData(localKeyedStateHandle.getMetaDataState());
+				readMetaData(restoreStateHandle.getMetaStateHandle());
 
 			List<ColumnFamilyDescriptor> columnFamilyDescriptors =
 				createAndRegisterColumnFamilyDescriptors(stateMetaInfoSnapshots);
 
-			restoreLocalStateIntoFullInstance(
-				localKeyedStateHandle,
+			List<ColumnFamilyHandle> columnFamilyHandles =
+				new ArrayList<>(stateMetaInfoSnapshots.size() + 1);
+
+			for (RegisteredKeyedBackendStateMetaInfo.Snapshot<?, ?> stateMetaInfoSnapshot : stateMetaInfoSnapshots) {
+
+				ColumnFamilyDescriptor columnFamilyDescriptor = new ColumnFamilyDescriptor(
+					stateMetaInfoSnapshot.getName().getBytes(ConfigConstants.DEFAULT_CHARSET),
+					stateBackend.columnOptions);
+
+				columnFamilyDescriptors.add(columnFamilyDescriptor);
+			}
+
+			RocksDB restoreDb = stateBackend.openDB(
+				temporaryRestoreInstancePath.getPath(),
 				columnFamilyDescriptors,
-				stateMetaInfoSnapshots);
+				columnFamilyHandles);
+
+			clipDBWithKeyGroupRange(
+				restoreDb,
+				columnFamilyHandles,
+				targetKeyGroupRange,
+				restoreStateHandle.getKeyGroupRange(),
+				keyGroupPrefixBytes);
+
+			return new RestoreDBInfo(restoreDb, columnFamilyHandles, columnFamilyDescriptors, stateMetaInfoSnapshots);
+		}
+
+		private int evaluateGroupRange(KeyGroupRange range1, KeyGroupRange range2) {
+			int start1 = range1.getStartKeyGroup();
+			int end1 = range1.getEndKeyGroup();
+
+			int start2 = range2.getStartKeyGroup();
+			int end2 = range2.getEndKeyGroup();
+
+			int insectStart = start1;
+			if (start2 > start1) {
+				insectStart = start2;
+			}
+
+			int insectEnd = end1;
+			if (end2 < end1) {
+				insectEnd = end2;
+			}
+			return insectEnd - insectStart + 1;
+		}
+
+		private ColumnFamilyHandle getOrRegisterColumnFamilyHandle(
+			ColumnFamilyDescriptor columnFamilyDescriptor,
+			ColumnFamilyHandle columnFamilyHandle,
+			RegisteredKeyedBackendStateMetaInfo.Snapshot<?, ?> stateMetaInfoSnapshot) throws RocksDBException {
+
+			Tuple2<ColumnFamilyHandle, RegisteredKeyedBackendStateMetaInfo<?, ?>> registeredStateMetaInfoEntry =
+				stateBackend.kvStateInformation.get(stateMetaInfoSnapshot.getName());
+
+			if (null == registeredStateMetaInfoEntry) {
+				RegisteredKeyedBackendStateMetaInfo<?, ?> stateMetaInfo =
+					new RegisteredKeyedBackendStateMetaInfo<>(
+						stateMetaInfoSnapshot.getStateType(),
+						stateMetaInfoSnapshot.getName(),
+						stateMetaInfoSnapshot.getNamespaceSerializer(),
+						stateMetaInfoSnapshot.getStateSerializer());
+
+				registeredStateMetaInfoEntry =
+					new Tuple2<>(
+						columnFamilyHandle != null ? columnFamilyHandle : stateBackend.db.createColumnFamily(columnFamilyDescriptor),
+						stateMetaInfo);
+
+				stateBackend.kvStateInformation.put(
+					stateMetaInfoSnapshot.getName(),
+					registeredStateMetaInfoEntry);
+			}
+
+			return registeredStateMetaInfoEntry.f0;
+		}
+
+		private void chooseTheBestStateHandleToInit(
+			Collection<KeyedStateHandle> restoreStateHandles,
+			KeyGroupRange targetKeyGroupRange) throws Exception {
+
+			int evalScore = Integer.MIN_VALUE;
+			IncrementalKeyedStateHandle bestInitStateHandle = null;
+			for (KeyedStateHandle rawStateHandle : restoreStateHandles) {
+				int tmpEvalScore = evaluateGroupRange(targetKeyGroupRange, rawStateHandle.getKeyGroupRange());
+				if (evalScore < tmpEvalScore) {
+					evalScore = tmpEvalScore;
+					bestInitStateHandle = (IncrementalKeyedStateHandle) rawStateHandle;
+				}
+			}
+			restoreStateHandles.remove(bestInitStateHandle);
+
+			RestoreDBInfo restoreDBInfo = null;
+			Path instancePath = new Path(stateBackend.instanceRocksDBPath.getAbsolutePath());
+			try {
+				restoreDBInfo = restoreDBFromStateHandle(
+					bestInitStateHandle,
+					instancePath,
+					targetKeyGroupRange,
+					stateBackend.keyGroupPrefixBytes);
+
+				stateBackend.db = restoreDBInfo.db;
+
+				stateBackend.defaultColumnFamily = restoreDBInfo.columnFamilyHandles.remove(0);
+
+				for (int i = 0; i < restoreDBInfo.stateMetaInfoSnapshots.size(); ++i) {
+					getOrRegisterColumnFamilyHandle(
+						restoreDBInfo.columnFamilyDescriptors.get(i),
+						restoreDBInfo.columnFamilyHandles.get(i),
+						restoreDBInfo.stateMetaInfoSnapshots.get(i));
+				}
+			} catch (Exception e) {
+				if (restoreDBInfo != null) {
+					restoreDBInfo.close();
+				}
+				FileSystem restoreFileSystem = instancePath.getFileSystem();
+				if (restoreFileSystem.exists(instancePath)) {
+					restoreFileSystem.delete(instancePath, true);
+				}
+				throw e;
+			}
 		}
 
 		/**
@@ -1018,96 +1257,6 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 					outputStream.close();
 				}
 			}
-		}
-
-		/**
-		 * In case of rescaling, this method creates a temporary RocksDB instance for a key-groups shard. All contents
-		 * from the temporary instance are copied into the real restore instance and then the temporary instance is
-		 * discarded.
-		 */
-		private void restoreKeyGroupsShardWithTemporaryHelperInstance(
-			Path restoreInstancePath,
-			List<ColumnFamilyDescriptor> columnFamilyDescriptors,
-			List<RegisteredKeyedBackendStateMetaInfo.Snapshot<?, ?>> stateMetaInfoSnapshots) throws Exception {
-
-			List<ColumnFamilyHandle> columnFamilyHandles =
-				new ArrayList<>(1 + columnFamilyDescriptors.size());
-
-			try (RocksDB restoreDb = stateBackend.openDB(
-				restoreInstancePath.getPath(),
-				columnFamilyDescriptors,
-				columnFamilyHandles)) {
-
-				final ColumnFamilyHandle defaultColumnFamily = columnFamilyHandles.remove(0);
-
-				Preconditions.checkState(columnFamilyHandles.size() == columnFamilyDescriptors.size());
-
-				try {
-					for (int i = 0; i < columnFamilyDescriptors.size(); ++i) {
-						ColumnFamilyHandle columnFamilyHandle = columnFamilyHandles.get(i);
-						ColumnFamilyDescriptor columnFamilyDescriptor = columnFamilyDescriptors.get(i);
-						RegisteredKeyedBackendStateMetaInfo.Snapshot<?, ?> stateMetaInfoSnapshot = stateMetaInfoSnapshots.get(i);
-
-						Tuple2<ColumnFamilyHandle, RegisteredKeyedBackendStateMetaInfo<?, ?>> registeredStateMetaInfoEntry =
-							stateBackend.kvStateInformation.get(stateMetaInfoSnapshot.getName());
-
-						if (null == registeredStateMetaInfoEntry) {
-
-							RegisteredKeyedBackendStateMetaInfo<?, ?> stateMetaInfo =
-								new RegisteredKeyedBackendStateMetaInfo<>(
-									stateMetaInfoSnapshot.getStateType(),
-									stateMetaInfoSnapshot.getName(),
-									stateMetaInfoSnapshot.getNamespaceSerializer(),
-									stateMetaInfoSnapshot.getStateSerializer());
-
-							registeredStateMetaInfoEntry =
-								new Tuple2<>(
-									stateBackend.db.createColumnFamily(columnFamilyDescriptor),
-									stateMetaInfo);
-
-							stateBackend.kvStateInformation.put(
-								stateMetaInfoSnapshot.getName(),
-								registeredStateMetaInfoEntry);
-						}
-
-						ColumnFamilyHandle targetColumnFamilyHandle = registeredStateMetaInfoEntry.f0;
-
-						try (RocksIterator iterator = restoreDb.newIterator(columnFamilyHandle)) {
-
-							int startKeyGroup = stateBackend.getKeyGroupRange().getStartKeyGroup();
-							byte[] startKeyGroupPrefixBytes = new byte[stateBackend.keyGroupPrefixBytes];
-							for (int j = 0; j < stateBackend.keyGroupPrefixBytes; ++j) {
-								startKeyGroupPrefixBytes[j] = (byte) (startKeyGroup >>> ((stateBackend.keyGroupPrefixBytes - j - 1) * Byte.SIZE));
-							}
-
-							iterator.seek(startKeyGroupPrefixBytes);
-
-							while (iterator.isValid()) {
-
-								int keyGroup = 0;
-								for (int j = 0; j < stateBackend.keyGroupPrefixBytes; ++j) {
-									keyGroup = (keyGroup << Byte.SIZE) + iterator.key()[j];
-								}
-
-								if (stateBackend.keyGroupRange.contains(keyGroup)) {
-									stateBackend.db.put(targetColumnFamilyHandle,
-										iterator.key(), iterator.value());
-								}
-
-								iterator.next();
-							}
-						} // releases native iterator resources
-					}
-				} finally {
-
-					//release native tmp db column family resources
-					IOUtils.closeQuietly(defaultColumnFamily);
-
-					for (ColumnFamilyHandle flinkColumnFamilyHandle : columnFamilyHandles) {
-						IOUtils.closeQuietly(flinkColumnFamilyHandle);
-					}
-				}
-			} // releases native tmp db resources
 		}
 	}
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBIncrementalCheckpointUtilsTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBIncrementalCheckpointUtilsTest.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.state;
+
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.core.memory.ByteArrayOutputStreamWithPos;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.runtime.state.KeyGroupRange;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import org.rocksdb.ColumnFamilyDescriptor;
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.RocksDB;
+import org.rocksdb.RocksDBException;
+
+import java.io.IOException;
+import java.util.Collections;
+
+/**
+ * Tests to guard {@link RocksDBIncrementalCheckpointUtils}.
+ */
+public class RocksDBIncrementalCheckpointUtilsTest {
+
+	@Rule
+	public final TemporaryFolder tmp = new TemporaryFolder();
+
+	@Test
+	public void testClipDBWithKeyGroupRange() throws Exception {
+
+		testClipDBWithKeyGroupRangeHelper(new KeyGroupRange(0, 1), new KeyGroupRange(0, 2), 1);
+
+		testClipDBWithKeyGroupRangeHelper(new KeyGroupRange(0, 1), new KeyGroupRange(0, 1), 1);
+
+		testClipDBWithKeyGroupRangeHelper(new KeyGroupRange(0, 1), new KeyGroupRange(1, 2), 1);
+
+		testClipDBWithKeyGroupRangeHelper(new KeyGroupRange(0, 1), new KeyGroupRange(2, 4), 1);
+
+		testClipDBWithKeyGroupRangeHelper(new KeyGroupRange(Byte.MAX_VALUE - 15, Byte.MAX_VALUE), new KeyGroupRange(Byte.MAX_VALUE - 10, Byte.MAX_VALUE), 1);
+
+		testClipDBWithKeyGroupRangeHelper(new KeyGroupRange(Short.MAX_VALUE - 15, Short.MAX_VALUE), new KeyGroupRange(Short.MAX_VALUE - 10, Short.MAX_VALUE), 2);
+
+		testClipDBWithKeyGroupRangeHelper(new KeyGroupRange(Byte.MAX_VALUE - 15, Byte.MAX_VALUE - 1), new KeyGroupRange(Byte.MAX_VALUE - 10, Byte.MAX_VALUE), 1);
+
+		testClipDBWithKeyGroupRangeHelper(new KeyGroupRange(Short.MAX_VALUE - 15, Short.MAX_VALUE - 1), new KeyGroupRange(Short.MAX_VALUE - 10, Short.MAX_VALUE), 2);
+	}
+
+	void testClipDBWithKeyGroupRangeHelper(
+		KeyGroupRange targetGroupRange,
+		KeyGroupRange currentGroupRange,
+		int keyGroupPrefixBytes) throws RocksDBException, IOException {
+
+		RocksDB rocksDB = RocksDB.open(tmp.newFolder().getAbsolutePath());
+		ColumnFamilyHandle columnFamilyHandle = null;
+		try {
+
+			columnFamilyHandle = rocksDB.createColumnFamily(new ColumnFamilyDescriptor("test".getBytes()));
+
+			int currentGroupRangeStart = currentGroupRange.getStartKeyGroup();
+			int currentGroupRangeEnd = currentGroupRange.getEndKeyGroup();
+
+			for (int i = currentGroupRangeStart; i <= currentGroupRangeEnd; ++i) {
+				ByteArrayOutputStreamWithPos outputStreamWithPos = new ByteArrayOutputStreamWithPos(32);
+				DataOutputView outputView = new DataOutputViewStreamWrapper(outputStreamWithPos);
+				for (int j = 0; j < 100; ++j) {
+					outputStreamWithPos.reset();
+					RocksDBKeySerializationUtils.writeKeyGroup(i, keyGroupPrefixBytes, outputView);
+					RocksDBKeySerializationUtils.writeKey(
+						j,
+						IntSerializer.INSTANCE,
+						outputStreamWithPos,
+						new DataOutputViewStreamWrapper(outputStreamWithPos),
+						false);
+					rocksDB.put(columnFamilyHandle, outputStreamWithPos.toByteArray(), String.valueOf(j).getBytes());
+				}
+			}
+
+			for (int i = currentGroupRangeStart; i <= currentGroupRangeEnd; ++i) {
+				ByteArrayOutputStreamWithPos outputStreamWithPos = new ByteArrayOutputStreamWithPos(32);
+				DataOutputView outputView = new DataOutputViewStreamWrapper(outputStreamWithPos);
+				for (int j = 0; j < 100; ++j) {
+					outputStreamWithPos.reset();
+					RocksDBKeySerializationUtils.writeKeyGroup(i, keyGroupPrefixBytes, outputView);
+					RocksDBKeySerializationUtils.writeKey(
+						j,
+						IntSerializer.INSTANCE,
+						outputStreamWithPos,
+						new DataOutputViewStreamWrapper(outputStreamWithPos),
+						false);
+					byte[] value = rocksDB.get(columnFamilyHandle, outputStreamWithPos.toByteArray());
+					Assert.assertEquals(String.valueOf(j), new String(value));
+				}
+			}
+
+			RocksDBIncrementalCheckpointUtils.clipDBWithKeyGroupRange(
+				rocksDB,
+				Collections.singletonList(columnFamilyHandle),
+				targetGroupRange,
+				currentGroupRange,
+				keyGroupPrefixBytes);
+
+			for (int i = currentGroupRangeStart; i <= currentGroupRangeEnd; ++i) {
+				ByteArrayOutputStreamWithPos outputStreamWithPos = new ByteArrayOutputStreamWithPos(32);
+				DataOutputView outputView = new DataOutputViewStreamWrapper(outputStreamWithPos);
+				for (int j = 0; j < 100; ++j) {
+					outputStreamWithPos.reset();
+					RocksDBKeySerializationUtils.writeKeyGroup(i, keyGroupPrefixBytes, outputView);
+					RocksDBKeySerializationUtils.writeKey(
+						j,
+						IntSerializer.INSTANCE,
+						outputStreamWithPos,
+						new DataOutputViewStreamWrapper(outputStreamWithPos),
+						false);
+					byte[] value = rocksDB.get(
+						columnFamilyHandle, outputStreamWithPos.toByteArray());
+					if (targetGroupRange.contains(i)) {
+						Assert.assertEquals(String.valueOf(j), new String(value));
+					} else {
+						Assert.assertNull(value);
+					}
+				}
+			}
+		} finally {
+			if (columnFamilyHandle != null)	 {
+				columnFamilyHandle.close();
+			}
+
+			if (rocksDB != null) {
+				rocksDB.close();
+			}
+		}
+	}
+
+	@Test
+	public void testEvaluateGroupRange() throws Exception {
+		KeyGroupRange range1 = new KeyGroupRange(0, 9);
+		KeyGroupRange range2 = new KeyGroupRange(0, 9);
+
+		Assert.assertEquals(10, RocksDBIncrementalCheckpointUtils.evaluateGroupRange(range1, range2));
+
+		KeyGroupRange range3 = new KeyGroupRange(0, 9);
+		KeyGroupRange range4 = new KeyGroupRange(9, 10);
+
+		Assert.assertEquals(1, RocksDBIncrementalCheckpointUtils.evaluateGroupRange(range3, range4));
+
+		KeyGroupRange range5 = new KeyGroupRange(0, 9);
+		KeyGroupRange range6 = new KeyGroupRange(10, 12);
+
+		Assert.assertEquals(0, RocksDBIncrementalCheckpointUtils.evaluateGroupRange(range5, range6));
+
+		KeyGroupRange range7 = new KeyGroupRange(0, 9);
+		KeyGroupRange range8 = new KeyGroupRange(1, 2);
+
+		Assert.assertEquals(2, RocksDBIncrementalCheckpointUtils.evaluateGroupRange(range7, range8));
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes [FLINK-8790](https://issues.apache.org/jira/browse/FLINK-8790). When there are multi state handle to be restored, we can improve the performance as follow:

- 1. Choose the best state handle to init the target db
- 2. Use the other state handles to create tmp db, and clip the tmp db according to the target key group range (via rocksdb.deleteRange()), this can help use get rid of the `key group check` in 
`data insertion loop` and also help us get rid of traversing the useless records.

## Brief change log

  - Improve the performance when restoring from multi state handles

## Verifying this change
The changes can be verified by the exists tests and below unit test can also help to verify it.
 - RocksDBIncrementalCheckpointUtilsTest.java

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)

## Documentation

  - Does this pull request introduce a new feature? (no)
