### PR TITLE
[FLINK-8787][flip6] Deploying FLIP-6 YARN session with HA fails

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
@@ -161,7 +161,7 @@ public abstract class ClusterClient<T> {
 	 * @param highAvailabilityServices HighAvailabilityServices to use for leader retrieval
 	 */
 	public ClusterClient(Configuration flinkConfig, HighAvailabilityServices highAvailabilityServices) {
-		this.flinkConfig = new UnmodifiableConfiguration(Preconditions.checkNotNull(flinkConfig));
+		this.flinkConfig = new UnmodifiableConfiguration(flinkConfig);
 		this.compiler = new Optimizer(new DataStatistics(), new DefaultCostEstimator(), flinkConfig);
 
 		this.timeout = AkkaUtils.getClientTimeout(flinkConfig);

--- a/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.common.accumulators.AccumulatorHelper;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.UnmodifiableConfiguration;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.optimizer.CompilerException;
 import org.apache.flink.optimizer.DataStatistics;
@@ -160,7 +161,7 @@ public abstract class ClusterClient<T> {
 	 * @param highAvailabilityServices HighAvailabilityServices to use for leader retrieval
 	 */
 	public ClusterClient(Configuration flinkConfig, HighAvailabilityServices highAvailabilityServices) {
-		this.flinkConfig = Preconditions.checkNotNull(flinkConfig);
+		this.flinkConfig = new UnmodifiableConfiguration(Preconditions.checkNotNull(flinkConfig));
 		this.compiler = new Optimizer(new DataStatistics(), new DefaultCostEstimator(), flinkConfig);
 
 		this.timeout = AkkaUtils.getClientTimeout(flinkConfig);

--- a/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
@@ -37,6 +37,8 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * Lightweight configuration object which stores key/value pairs.
  */
@@ -76,6 +78,7 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
 	 * @param other The configuration to copy the entries from.
 	 */
 	public Configuration(Configuration other) {
+		requireNonNull(other, "configuration must not be null");
 		this.confData = new HashMap<>(other.confData);
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

*Deploying FLIP-6 YARN session with HA fails because the ZooKeeper namespace is not set correctly. The namespace is `/flink/default` but it should include the YARN application id.*

cc: @tillrohrmann 

## Brief change log

  - *Use defensive copies of `Configuration` objects in `AbstractYarnClusterDescriptor`. Never modify existing configuration.*
  - *Ensure that zk namespace configuration reaches RestClusterClient*

## Verifying this change

This change added tests and can be verified as follows:

  - *Manually deployed Flink on YARN with HA enabled.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
