### PR TITLE
[FLINK-8792][REST] bad semantic of method name MessageQueryParameter.convertStringToValue

### DIFF
--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/AllowNonRestoredStateQueryParameter.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/AllowNonRestoredStateQueryParameter.java
@@ -39,7 +39,7 @@ public class AllowNonRestoredStateQueryParameter extends MessageQueryParameter<B
 	}
 
 	@Override
-	public String convertStringToValue(final Boolean value) {
+	public String convertValueToString(final Boolean value) {
 		return value.toString();
 	}
 }

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/ParallelismQueryParameter.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/ParallelismQueryParameter.java
@@ -38,7 +38,7 @@ public class ParallelismQueryParameter extends MessageQueryParameter<Integer> {
 	}
 
 	@Override
-	public String convertStringToValue(final Integer value) {
+	public String convertValueToString(final Integer value) {
 		return value.toString();
 	}
 }

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/StringQueryParameter.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/StringQueryParameter.java
@@ -35,7 +35,7 @@ public abstract class StringQueryParameter extends MessageQueryParameter<String>
 	}
 
 	@Override
-	public final String convertStringToValue(final String value) {
+	public final String convertValueToString(final String value) {
 		return value;
 	}
 

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/AllowNonRestoredStateQueryParameterTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/AllowNonRestoredStateQueryParameterTest.java
@@ -34,8 +34,8 @@ public class AllowNonRestoredStateQueryParameterTest extends TestLogger {
 
 	@Test
 	public void testConvertStringToValue() {
-		assertEquals("false", allowNonRestoredStateQueryParameter.convertStringToValue(false));
-		assertEquals("true", allowNonRestoredStateQueryParameter.convertStringToValue(true));
+		assertEquals("false", allowNonRestoredStateQueryParameter.convertValueToString(false));
+		assertEquals("true", allowNonRestoredStateQueryParameter.convertValueToString(true));
 	}
 
 	@Test

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/ParallelismQueryParameterTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/ParallelismQueryParameterTest.java
@@ -33,7 +33,7 @@ public class ParallelismQueryParameterTest extends TestLogger {
 
 	@Test
 	public void testConvertStringToValue()   {
-		assertEquals("42", parallelismQueryParameter.convertStringToValue(42));
+		assertEquals("42", parallelismQueryParameter.convertValueToString(42));
 	}
 
 	@Test

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/MessageQueryParameter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/MessageQueryParameter.java
@@ -58,11 +58,11 @@ public abstract class MessageQueryParameter<X> extends MessageParameter<List<X>>
 		boolean first = true;
 		for (X value : values) {
 			if (first) {
-				sb.append(convertStringToValue(value));
+				sb.append(convertValueToString(value));
 				first = false;
 			} else {
 				sb.append(",");
-				sb.append(convertStringToValue(value));
+				sb.append(convertValueToString(value));
 			}
 		}
 		return sb.toString();
@@ -74,5 +74,5 @@ public abstract class MessageQueryParameter<X> extends MessageParameter<List<X>>
 	 * @param value parameter value
 	 * @return string representation of typed value
 	 */
-	public abstract String convertStringToValue(X value);
+	public abstract String convertValueToString(X value);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/RescalingParallelismQueryParameter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/RescalingParallelismQueryParameter.java
@@ -35,7 +35,7 @@ public class RescalingParallelismQueryParameter extends MessageQueryParameter<In
 	}
 
 	@Override
-	public String convertStringToValue(Integer value) {
+	public String convertValueToString(Integer value) {
 		return value.toString();
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/TerminationModeQueryParameter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/TerminationModeQueryParameter.java
@@ -37,7 +37,7 @@ public class TerminationModeQueryParameter extends MessageQueryParameter<Termina
 	}
 
 	@Override
-	public String convertStringToValue(TerminationMode value) {
+	public String convertValueToString(TerminationMode value) {
 		return value.name().toLowerCase();
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/MetricsFilterParameter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/MetricsFilterParameter.java
@@ -41,7 +41,7 @@ public class MetricsFilterParameter extends MessageQueryParameter<String> {
 	}
 
 	@Override
-	public String convertStringToValue(String value) {
+	public String convertValueToString(String value) {
 		return value;
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointITCase.java
@@ -481,7 +481,7 @@ public class RestServerEndpointITCase extends TestLogger {
 		}
 
 		@Override
-		public String convertStringToValue(JobID value) {
+		public String convertValueToString(JobID value) {
 			return value.toString();
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/util/HandlerRequestUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/util/HandlerRequestUtilsTest.java
@@ -108,7 +108,7 @@ public class HandlerRequestUtilsTest extends TestLogger {
 		}
 
 		@Override
-		public String convertStringToValue(final Boolean value) {
+		public String convertValueToString(final Boolean value) {
 			return value.toString();
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/MessageParametersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/MessageParametersTest.java
@@ -109,7 +109,7 @@ public class MessageParametersTest extends TestLogger {
 		}
 
 		@Override
-		public String convertStringToValue(JobID value) {
+		public String convertValueToString(JobID value) {
 			return value.toString();
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/metrics/MetricsFilterParameterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/metrics/MetricsFilterParameterTest.java
@@ -49,7 +49,7 @@ public class MetricsFilterParameterTest extends TestLogger {
 
 	@Test
 	public void testConversions() {
-		assertThat(metricsFilterParameter.convertStringToValue("test"), equalTo("test"));
+		assertThat(metricsFilterParameter.convertValueToString("test"), equalTo("test"));
 		assertThat(metricsFilterParameter.convertValueFromString("test"), equalTo("test"));
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

*This pull request changed a method name to let it has a good semantic*

## Brief change log

  - *changed method name from `convertStringToValue` to `convertValueToString`*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
