### PR TITLE
[hotfix][REST] Fix CONTENT_TYPE header

### DIFF
--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitorITCase.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/WebRuntimeMonitorITCase.java
@@ -334,7 +334,7 @@ public class WebRuntimeMonitorITCase extends TestLogger {
 				HttpTestClient.SimpleHttpResponse response = client.getNextResponse();
 
 				assertEquals(HttpResponseStatus.SERVICE_UNAVAILABLE, response.getStatus());
-				assertEquals(MimeTypes.getMimeTypeForExtension("json"), response.getType());
+				assertEquals("application/json; charset=UTF-8", response.getType());
 				assertTrue(response.getContent().contains("refresh"));
 			}
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/util/HandlerUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/util/HandlerUtils.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.rest.handler.util;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.runtime.rest.messages.ErrorResponseBody;
 import org.apache.flink.runtime.rest.messages.ResponseBody;
+import org.apache.flink.runtime.rest.util.RestConstants;
 import org.apache.flink.runtime.rest.util.RestMapperUtils;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
@@ -149,7 +150,7 @@ public class HandlerUtils {
 			@Nonnull Map<String, String> headers) {
 		HttpResponse response = new DefaultHttpResponse(HTTP_1_1, statusCode);
 
-		response.headers().set(CONTENT_TYPE, "application/json");
+		response.headers().set(CONTENT_TYPE, RestConstants.REST_CONTENT_TYPE);
 
 		for (Map.Entry<String, String> headerEntry : headers.entrySet()) {
 			response.headers().set(headerEntry.getKey(), headerEntry.getValue());


### PR DESCRIPTION
This PR reverts an accidental modification to the REST CONTENT_TYPE header used by the new rest handlers.

This constants was introduced in https://issues.apache.org/jira/browse/FLINK-7226.