### PR TITLE
[FLINK-8787][flip6] Deploying FLIP-6 YARN session with HA fails

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
@@ -482,7 +482,7 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 		flinkConfiguration.setString(ClusterEntrypoint.EXECUTION_MODE, executionMode.toString());
 
 		ApplicationReport report = startAppMaster(
-			new Configuration(flinkConfiguration),
+			flinkConfiguration,
 			yarnClusterEntrypoint,
 			jobGraph,
 			yarnClient,


### PR DESCRIPTION
## What is the purpose of the change

*Do not copy `flinkConfiguration` in `AbstractYarnClusterDescriptor`. There is code that relies on side effects on the configuration object. This is a quick and dirty solution. In future, the descriptor should be made immutable: [FLINK-8799](https://issues.apache.org/jira/browse/FLINK-8799)*

cc: @tillrohrmann 

## Brief change log

  - *Do not copy `flinkConfiguration` in `AbstractYarnClusterDescriptor`*

## Verifying this change

This change added tests and can be verified as follows:

  - *Manually deployed Flink cluster on YARN with HA enabled.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
