### PR TITLE
[hotfix] fix javadoc link of ClusterClient#triggerSavepoint

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
@@ -657,7 +657,7 @@ public abstract class ClusterClient<T> {
 
 	/**
 	 * Triggers a savepoint for the job identified by the job id. The savepoint will be written to the given savepoint
-	 * directory, or {@link org.apache.flink.configuration.CoreOptions#SAVEPOINT_DIRECTORY} if it is null.
+	 * directory, or {@link org.apache.flink.configuration.CheckpointingOptions#SAVEPOINT_DIRECTORY} if it is null.
 	 *
 	 * @param jobId job id
 	 * @param savepointDirectory directory the savepoint should be written to


### PR DESCRIPTION
## What is the purpose of the change

fix javadoc link of ClusterClient#triggerSavepoint