### PR TITLE
[FLINK-7836][Client] specifying node label for flink job to run on yarn

### DIFF
--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -262,6 +262,8 @@ Action "run" compiles and runs a program.
      -z,--zookeeperNamespace <zookeeperNamespace>   Namespace to create the
                                                     Zookeeper sub-paths for high
                                                     availability mode
+     -nl,--nodeLabel <nodeLabelExpression>          Specify YARN node label for 
+                                                    the YARN application
 
   Options for yarn-cluster mode:
      -yD <arg>                            Dynamic properties
@@ -285,6 +287,8 @@ Action "run" compiles and runs a program.
                                           MB]
      -yz,--yarnzookeeperNamespace <arg>   Namespace to create the Zookeeper
                                           sub-paths for high availability mode
+     -ynl,--yarnnodeLabel <arg>           Specify YARN node label for 
+                                          the YARN application 
 
 
 

--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -262,8 +262,6 @@ Action "run" compiles and runs a program.
      -z,--zookeeperNamespace <zookeeperNamespace>   Namespace to create the
                                                     Zookeeper sub-paths for high
                                                     availability mode
-     -nl,--nodeLabel <nodeLabelExpression>          Specify YARN node label for 
-                                                    the YARN application
 
   Options for yarn-cluster mode:
      -yD <arg>                            Dynamic properties

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
@@ -1345,6 +1345,7 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 		private final Method applicationTagsMethod;
 		private final Method attemptFailuresValidityIntervalMethod;
 		private final Method keepContainersMethod;
+		@Nullable
 		private final Method nodeLabelExpressionMethod;
 
 		private ApplicationSubmissionContextReflector(Class<ApplicationSubmissionContext> clazz) {

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
@@ -136,6 +136,8 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 
 	private String zookeeperNamespace;
 
+	private String nodeLabel;
+
 	/** Optional Jar file to include in the system class loader of all application nodes
 	 * (for per-job submission). */
 	private final Set<File> userJarFiles = new HashSet<>();
@@ -319,6 +321,14 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 
 	public void setZookeeperNamespace(String zookeeperNamespace) {
 		this.zookeeperNamespace = zookeeperNamespace;
+	}
+
+	public String getNodeLabel() {
+		return nodeLabel;
+	}
+
+	public void setNodeLabel(String nodeLabel) {
+		this.nodeLabel = nodeLabel;
 	}
 
 	// -------------------------------------------------------------
@@ -979,6 +989,16 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 		appContext.setApplicationType("Apache Flink");
 		appContext.setAMContainerSpec(amContainer);
 		appContext.setResource(capability);
+
+		if (nodeLabel != null) {
+			try {
+				Method method = appContext.getClass().getMethod("setNodeLabelExpression", String.class);
+				method.invoke(appContext, nodeLabel);
+			} catch (NoSuchMethodException e) {
+				LOG.warn("Ignoring node label setting because the version of YARN does not support it");
+			}
+		}
+
 		if (yarnQueue != null) {
 			appContext.setQueue(yarnQueue);
 		}

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
@@ -128,6 +128,7 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<ApplicationId
 	private final Option slots;
 	private final Option detached;
 	private final Option zookeeperNamespace;
+	private final Option nodeLabel;
 	private final Option help;
 
 	/**
@@ -203,6 +204,7 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<ApplicationId
 		streaming = new Option(shortPrefix + "st", longPrefix + "streaming", false, "Start Flink in streaming mode");
 		name = new Option(shortPrefix + "nm", longPrefix + "name", true, "Set a custom name for the application on YARN");
 		zookeeperNamespace = new Option(shortPrefix + "z", longPrefix + "zookeeperNamespace", true, "Namespace to create the Zookeeper sub-paths for high availability mode");
+		nodeLabel = new Option(shortPrefix + "nl", longPrefix + "nodeLabel", true, "Specify YARN node label for the YARN application");
 		help = new Option(shortPrefix + "h", longPrefix + "help", false, "Help for the Yarn session CLI.");
 
 		allOptions = new Options();
@@ -220,6 +222,7 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<ApplicationId
 		allOptions.addOption(name);
 		allOptions.addOption(applicationId);
 		allOptions.addOption(zookeeperNamespace);
+		allOptions.addOption(nodeLabel);
 		allOptions.addOption(help);
 
 		// try loading a potential yarn properties file
@@ -359,6 +362,11 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<ApplicationId
 		if (cmd.hasOption(zookeeperNamespace.getOpt())) {
 			String zookeeperNamespaceValue = cmd.getOptionValue(this.zookeeperNamespace.getOpt());
 			yarnClusterDescriptor.setZookeeperNamespace(zookeeperNamespaceValue);
+		}
+
+		if (cmd.hasOption(nodeLabel.getOpt())) {
+			String nodeLabelValue = cmd.getOptionValue(this.nodeLabel.getOpt());
+			yarnClusterDescriptor.setNodeLabel(nodeLabelValue);
 		}
 
 		return yarnClusterDescriptor;

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/FlinkYarnSessionCliTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/FlinkYarnSessionCliTest.java
@@ -133,6 +133,25 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 		assertEquals(zkNamespaceCliInput, descriptor.getZookeeperNamespace());
 	}
 
+	@Test
+	public void testNodeLabelProperty() throws Exception {
+		String nodeLabelCliInput = "flink_test_nodelabel";
+
+		String[] params = new String[] { "-yn", "2", "-ynl", nodeLabelCliInput };
+
+		FlinkYarnSessionCli yarnCLI = new FlinkYarnSessionCli(
+			new Configuration(),
+			tmp.getRoot().getAbsolutePath(),
+			"y",
+			"yarn");
+
+		CommandLine commandLine = yarnCLI.parseCommandLineOptions(params, true);
+
+		AbstractYarnClusterDescriptor descriptor = yarnCLI.createClusterDescriptor(commandLine);
+
+		assertEquals(nodeLabelCliInput, descriptor.getNodeLabel());
+	}
+
 	/**
 	 * Test that the CliFrontend is able to pick up the .yarn-properties file from a specified location.
 	 */


### PR DESCRIPTION
## What is the purpose of the change

*This pull request support flink on yarn to specify yarn node label for yarn flink application both flink session and single job mode*


## Brief change log

  - *define a new command option to specify a yarn node label*
  - *set the node label for the application through reflection (to support low version hadoop)*
  - *add command line option description*


## Verifying this change

This change without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
