### PR TITLE
[FLINK-8800][REST] Reduce logging of all requests to TRACE

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/AbstractHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/AbstractHandler.java
@@ -84,8 +84,8 @@ public abstract class AbstractHandler<T extends RestfulGateway, R extends Reques
 
 	@Override
 	protected void respondAsLeader(ChannelHandlerContext ctx, Routed routed, T gateway) throws Exception {
-		if (log.isDebugEnabled()) {
-			log.debug("Received request " + routed.request().getUri() + '.');
+		if (log.isTraceEnabled()) {
+			log.trace("Received request " + routed.request().getUri() + '.');
 		}
 
 		final HttpRequest httpRequest = routed.request();


### PR DESCRIPTION
The `AbstractHandler` is logging a DEBUG message for every received request. This can make the debug logs really noisy, so we're reducing it to TRACE.