### PR TITLE
[FLINK-7805][flip6] Add HA capabilities to YarnResourceManager

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionService.java
@@ -199,7 +199,7 @@ public class ZooKeeperLeaderElectionService implements LeaderElectionService, Le
 				}
 			}
 		} else {
-			LOG.warn("The leader session ID {} was confirmed even though the" +
+			LOG.warn("The leader session ID {} was confirmed even though the " +
 					"corresponding JobManager was not elected as the leader.", leaderSessionID);
 		}
 	}

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionCapacitySchedulerITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionCapacitySchedulerITCase.java
@@ -416,7 +416,7 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
 	 * Test a fire-and-forget job submission to a YARN cluster.
 	 */
 	@Test(timeout = 60000)
-	public void testDetachedPerJobYarnCluster() throws IOException {
+	public void testDetachedPerJobYarnCluster() throws Exception {
 		LOG.info("Starting testDetachedPerJobYarnCluster()");
 
 		File exampleJarLocation = new File("target/programs/BatchWordCount.jar");
@@ -432,7 +432,7 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
 	 * Test a fire-and-forget job submission to a YARN cluster.
 	 */
 	@Test(timeout = 60000)
-	public void testDetachedPerJobYarnClusterWithStreamingJob() throws IOException {
+	public void testDetachedPerJobYarnClusterWithStreamingJob() throws Exception {
 		LOG.info("Starting testDetachedPerJobYarnClusterWithStreamingJob()");
 
 		File exampleJarLocation = new File("target/programs/StreamingWordCount.jar");
@@ -444,7 +444,7 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
 		LOG.info("Finished testDetachedPerJobYarnClusterWithStreamingJob()");
 	}
 
-	private void testDetachedPerJobYarnClusterInternal(String job) throws IOException {
+	private void testDetachedPerJobYarnClusterInternal(String job) throws Exception {
 		YarnClient yc = YarnClient.createYarnClient();
 		yc.init(YARN_CONFIGURATION);
 		yc.start();
@@ -575,9 +575,6 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
 			} while (rep.getYarnApplicationState() == YarnApplicationState.RUNNING);
 
 			verifyApplicationTags(rep);
-		} catch (Throwable t) {
-			LOG.warn("Error while detached yarn session was running", t);
-			Assert.fail(t.getMessage());
 		} finally {
 
 			//cleanup the yarn-properties file
@@ -625,7 +622,7 @@ public class YARNSessionCapacitySchedulerITCase extends YarnTestBase {
 		@SuppressWarnings("unchecked")
 		Set<String> applicationTags = (Set<String>) applicationTagsMethod.invoke(report);
 
-		Assert.assertEquals(applicationTags, Collections.singleton("test-tag"));
+		Assert.assertEquals(Collections.singleton("test-tag"), applicationTags);
 	}
 
 	@After

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
@@ -102,7 +102,7 @@ public abstract class YarnTestBase extends TestLogger {
 			"Started SelectChannelConnector@0.0.0.0:8081" // Jetty should start on a random port in YARN mode.
 	};
 
-	/** These strings are white-listed, overriding teh prohibited strings. */
+	/** These strings are white-listed, overriding the prohibited strings. */
 	protected static final String[] WHITELISTED_STRINGS = {
 		"akka.remote.RemoteTransportExceptionNoStackTrace",
 		// workaround for annoying InterruptedException logging:

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
@@ -482,7 +482,7 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 		flinkConfiguration.setString(ClusterEntrypoint.EXECUTION_MODE, executionMode.toString());
 
 		ApplicationReport report = startAppMaster(
-			new Configuration(flinkConfiguration),
+			flinkConfiguration,
 			yarnClusterEntrypoint,
 			jobGraph,
 			yarnClient,

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/RegisterApplicationMasterResponseReflector.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/RegisterApplicationMasterResponseReflector.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.yarn;
+
+import org.apache.flink.annotation.VisibleForTesting;
+
+import org.apache.hadoop.yarn.api.protocolrecords.RegisterApplicationMasterResponse;
+import org.apache.hadoop.yarn.api.records.Container;
+import org.slf4j.Logger;
+
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Looks up the method {@link RegisterApplicationMasterResponse#getContainersFromPreviousAttempts()}
+ * once and saves the method. This saves computation time on subsequent calls.
+ */
+class RegisterApplicationMasterResponseReflector {
+
+	private final Logger logger;
+
+	/**
+	 * Reflected method {@link RegisterApplicationMasterResponse#getContainersFromPreviousAttempts()}.
+	 */
+	private Method method;
+
+	RegisterApplicationMasterResponseReflector(final Logger log) {
+		this(log, RegisterApplicationMasterResponse.class);
+	}
+
+	@VisibleForTesting
+	RegisterApplicationMasterResponseReflector(final Logger log, final Class<?> clazz) {
+		this.logger = requireNonNull(log);
+		requireNonNull(clazz);
+
+		try {
+			method = clazz.getMethod("getContainersFromPreviousAttempts");
+		} catch (NoSuchMethodException e) {
+			// that happens in earlier Hadoop versions (pre 2.2)
+			logger.info("Cannot reconnect to previously allocated containers. " +
+				"This YARN version does not support 'getContainersFromPreviousAttempts()'");
+		}
+	}
+
+	/**
+	 * Checks if a YARN application still has registered containers. If the application master
+	 * registered at the ResourceManager for the first time, this list will be empty. If the
+	 * application master registered a repeated time (after a failure and recovery), this list
+	 * will contain the containers that were previously allocated.
+	 *
+	 * @param response The response object from the registration at the ResourceManager.
+	 * @return A list with containers from previous application attempt.
+	 */
+	List<Container> getContainersFromPreviousAttempts(final RegisterApplicationMasterResponse response) {
+		return getContainersFromPreviousAttemptsUnsafe(response);
+	}
+
+	/**
+	 * Same as {@link #getContainersFromPreviousAttempts(RegisterApplicationMasterResponse)} but
+	 * allows to pass objects that are not of type {@link RegisterApplicationMasterResponse}.
+	 */
+	@VisibleForTesting
+	List<Container> getContainersFromPreviousAttemptsUnsafe(final Object response) {
+		if (method != null && response != null) {
+			try {
+				@SuppressWarnings("unchecked")
+				final List<Container> containers = (List<Container>) method.invoke(response);
+				if (containers != null && !containers.isEmpty()) {
+					logger.info("Recovered {} containers from previous attempts ({}).", containers.size(), containers);
+					return containers;
+				}
+			} catch (Exception t) {
+				logger.error("Error invoking 'getContainersFromPreviousAttempts()'", t);
+			}
+		}
+
+		return Collections.emptyList();
+	}
+
+	@VisibleForTesting
+	Method getMethod() {
+		return method;
+	}
+}

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
@@ -320,7 +320,7 @@ public final class Utils {
 	 *
 	 * @return The launch context for the TaskManager processes.
 	 *
-	 * @throws Exception Thrown if teh launch context could not be created, for example if
+	 * @throws Exception Thrown if the launch context could not be created, for example if
 	 *				   the resources could not be copied.
 	 */
 	static ContainerLaunchContext createTaskExecutorContext(

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/RegisterApplicationMasterResponseReflectorTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/RegisterApplicationMasterResponseReflectorTest.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.yarn;
+
+import org.apache.hadoop.util.VersionInfo;
+import org.apache.hadoop.yarn.api.protocolrecords.RegisterApplicationMasterResponse;
+import org.apache.hadoop.yarn.api.records.Container;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assume.assumeTrue;
+
+/**
+ * Tests for {@link RegisterApplicationMasterResponseReflector}.
+ */
+public class RegisterApplicationMasterResponseReflectorTest {
+
+	private static final Logger LOG = LoggerFactory.getLogger(RegisterApplicationMasterResponseReflectorTest.class);
+
+	@Mock
+	private Container mockContainer;
+
+	@Before
+	public void setUp() {
+		MockitoAnnotations.initMocks(this);
+	}
+
+	@Test
+	public void testCallsMethodIfPresent() {
+		final RegisterApplicationMasterResponseReflector registerApplicationMasterResponseReflector =
+			new RegisterApplicationMasterResponseReflector(LOG, HasMethod.class);
+
+		final List<Container> containersFromPreviousAttemptsUnsafe =
+			registerApplicationMasterResponseReflector.getContainersFromPreviousAttemptsUnsafe(new
+				HasMethod());
+
+		assertThat(containersFromPreviousAttemptsUnsafe, hasSize(1));
+	}
+
+	@Test
+	public void testDoesntCallMethodIfAbsent() {
+		final RegisterApplicationMasterResponseReflector registerApplicationMasterResponseReflector =
+			new RegisterApplicationMasterResponseReflector(LOG, HasMethod.class);
+
+		final List<Container> containersFromPreviousAttemptsUnsafe =
+			registerApplicationMasterResponseReflector.getContainersFromPreviousAttemptsUnsafe(new
+				Object());
+
+		assertThat(containersFromPreviousAttemptsUnsafe, empty());
+	}
+
+	@Test
+	public void testGetMethodReflectiveHadoop22() {
+		assumeTrue(
+			"Method getContainersFromPreviousAttempts is not supported by Hadoop: " +
+				VersionInfo.getVersion(),
+			isHadoopVersionGreaterThanOrEquals(2, 2));
+
+		final RegisterApplicationMasterResponseReflector registerApplicationMasterResponseReflector =
+			new RegisterApplicationMasterResponseReflector(LOG);
+
+		final Method method = registerApplicationMasterResponseReflector.getMethod();
+		assertThat(method, notNullValue());
+	}
+
+	private static boolean isHadoopVersionGreaterThanOrEquals(final int major, final int minor) {
+		final String[] splitVersion = VersionInfo.getVersion().split("\\.");
+		final int[] versions = Arrays.stream(splitVersion).mapToInt(Integer::parseInt).toArray();
+		return versions[0] >= major && versions[1] >= minor;
+	}
+
+	/**
+	 * Class which has a method with the same signature as
+	 * {@link RegisterApplicationMasterResponse#getContainersFromPreviousAttempts()}.
+	 */
+	private class HasMethod {
+
+		/**
+		 * Called from {@link #testCallsMethodIfPresent()}.
+		 */
+		@SuppressWarnings("unused")
+		public List<Container> getContainersFromPreviousAttempts() {
+			return Collections.singletonList(mockContainer);
+		}
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

*Recover previously running containers after a restart of the ApplicationMaster.
This is a port of a feature that was already implemented prior to FLIP-6.*

cc: @tillrohrmann 

This PR is based on #5591.

## Brief change log

  - *Extract `RegisterApplicationMasterResponseReflector` class into separate file.*
  - *Use `RegisterApplicationMasterResponseReflector` from within `YarnResourceManager`*

## Verifying this change

This change added tests and can be verified as follows:
  - *Added unit tests for `RegisterApplicationMasterResponseReflector`*
  - *Manually deployed a cluster on YARN with HA enabled. Submitted a job, and killed the master several times. Verified that the right log messages were generated ("Recovered X containers from previous attempts [...]"), and that the taskmanager resource ids remained the same.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
