### PR TITLE
[FLINK-8557][checkpointing] Remove illegal characters from operator d…

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
@@ -396,10 +396,14 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 		String tempDir = env.getTaskManagerInfo().getTmpDirectories()[0];
 		ensureRocksDBIsLoaded(tempDir);
 
-		lazyInitializeForJob(env, operatorIdentifier);
+		// replace all characters that are not legal for filenames with underscore
+		String fileCompatibleIdentifier = operatorIdentifier.replaceAll("[^a-zA-Z0-9\\-]", "_");
 
-		File instanceBasePath =
-				new File(getNextStoragePath(), "job-" + jobId + "_op-" + operatorIdentifier + "_uuid-" + UUID.randomUUID());
+		lazyInitializeForJob(env, fileCompatibleIdentifier);
+
+		File instanceBasePath = new File(
+			getNextStoragePath(),
+			"job_" + jobId + "_op_" + fileCompatibleIdentifier + "_uuid_" + UUID.randomUUID());
 
 		LocalRecoveryConfig localRecoveryConfig =
 			env.getTaskStateManager().createLocalRecoveryConfig();


### PR DESCRIPTION
## What is the purpose of the change

This fixes the problem that the operator descriptor text is used to construct the instance directory in RocksDB, but can contain characters that are illegal for paths in some file systems. 


## Brief change log

We replace all illegal characters with underscore before constructing the path.


## Verifying this change

Check if RocksDB can be used as state backend on Windows.

This change is a trivial rework / code cleanup without any test coverage.