### PR TITLE
[FLINK-8808] [flip6] Allow RestClusterClient to connect to local dispatcher

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/ScalaUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/ScalaUtils.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.util;
+
+import java.util.Optional;
+
+import scala.Option;
+
+/**
+ * Utilities to convert Scala types into Java types.
+ */
+public class ScalaUtils {
+
+	/**
+	 * Converts a Scala {@link Option} to a {@link Optional}.
+	 *
+	 * @param scalaOption to convert into ta Java {@link Optional}
+	 * @param <T> type of the optional value
+	 * @return Optional of the given option
+	 */
+	public static <T> Optional<T> toJava(Option<T> scalaOption) {
+		if (scalaOption.isEmpty()) {
+			return Optional.empty();
+		} else {
+			return Optional.ofNullable(scalaOption.get());
+		}
+	}
+
+	private ScalaUtils() {}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/ScalaUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/ScalaUtilsTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.util;
+
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import scala.Option;
+
+import static org.apache.flink.runtime.util.ScalaUtils.toJava;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for {@link ScalaUtils} convenience methods.
+ */
+public class ScalaUtilsTest extends TestLogger {
+
+	@Test
+	public void testOptionToOptional() {
+		final String value = "foobar";
+		final Option<String> option = Option.apply(value);
+		final Optional<String> optional = toJava(option);
+
+		assertThat(optional.isPresent(), is(true));
+		assertThat(optional.get(), is(value));
+
+		final Option<String> nullOption = Option.apply(null);
+		final Optional<String> nullOptional = toJava(nullOption);
+
+		assertThat(nullOptional.isPresent(), is(false));
+
+		try {
+			nullOptional.get();
+			fail("Expected NoSuchElementException");
+		} catch (NoSuchElementException ignored) {
+			// ignored
+		}
+
+		final Option<String> emptyOption = Option.empty();
+		final Optional<String> emptyOptional = toJava(emptyOption);
+
+		assertThat(emptyOptional.isPresent(), is(false));
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

The RestClusterClient resolves a dispatcher address without an explicit host
to 'localhost'. That way we allow the RestClusterClient to talk to a Dispatcher
which runs in a local ActorSystem.

cc: @aljoscha 

## Verifying this change

- Added `ScalaUtilsTest#testOptionToOptional`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
