### PR TITLE
[FLINK-8811] [flip6] Add initial implementation of the MiniClusterClient

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/MiniClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/MiniClusterClient.java
@@ -52,7 +52,7 @@ public class MiniClusterClient extends ClusterClient<MiniClusterClient.MiniClust
 	private final MiniCluster miniCluster;
 
 	public MiniClusterClient(@Nonnull Configuration configuration, @Nonnull MiniCluster miniCluster) throws Exception {
-		super(configuration, miniCluster.getHighAvailabilityServices());
+		super(configuration, miniCluster.getHighAvailabilityServices(), true);
 
 		this.miniCluster = miniCluster;
 	}

--- a/flink-clients/src/main/java/org/apache/flink/client/program/MiniClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/MiniClusterClient.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.runtime.clusterframework.messages.GetClusterStatusResponse;
 import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalException;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.minicluster.MiniCluster;
@@ -57,7 +58,7 @@ public class MiniClusterClient extends ClusterClient<MiniClusterClient.MiniClust
 	}
 
 	@Override
-	protected JobSubmissionResult submitJob(JobGraph jobGraph, ClassLoader classLoader) throws ProgramInvocationException {
+	public JobSubmissionResult submitJob(JobGraph jobGraph, ClassLoader classLoader) throws ProgramInvocationException {
 		if (isDetached()) {
 			try {
 				miniCluster.runDetached(jobGraph);
@@ -117,6 +118,10 @@ public class MiniClusterClient extends ClusterClient<MiniClusterClient.MiniClust
 	@Override
 	public Map<String, Object> getAccumulators(JobID jobID, ClassLoader loader) throws Exception {
 		throw new UnsupportedOperationException("MiniClusterClient does not yet support this operation.");
+	}
+
+	public CompletableFuture<JobStatus> getJobStatus(JobID jobId) {
+		return miniCluster.getJobStatus(jobId);
 	}
 
 	@Override

--- a/flink-clients/src/main/java/org/apache/flink/client/program/MiniClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/MiniClusterClient.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.program;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobSubmissionResult;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.client.JobExecutionException;
+import org.apache.flink.runtime.client.JobStatusMessage;
+import org.apache.flink.runtime.clusterframework.messages.GetClusterStatusResponse;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalException;
+import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.minicluster.MiniCluster;
+import org.apache.flink.runtime.util.LeaderConnectionInfo;
+import org.apache.flink.runtime.util.LeaderRetrievalUtils;
+import org.apache.flink.util.FlinkException;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import java.net.URL;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Client to interact with a {@link MiniCluster}.
+ */
+public class MiniClusterClient extends ClusterClient<MiniClusterClient.MiniClusterId> {
+
+	private final MiniCluster miniCluster;
+
+	public MiniClusterClient(@Nonnull Configuration configuration, @Nonnull MiniCluster miniCluster) throws Exception {
+		super(configuration, miniCluster.getHighAvailabilityServices());
+
+		this.miniCluster = miniCluster;
+	}
+
+	@Override
+	protected JobSubmissionResult submitJob(JobGraph jobGraph, ClassLoader classLoader) throws ProgramInvocationException {
+		if (isDetached()) {
+			try {
+				miniCluster.runDetached(jobGraph);
+			} catch (JobExecutionException | InterruptedException e) {
+				throw new ProgramInvocationException(
+					String.format("Could not run job %s in detached mode.", jobGraph.getJobID()),
+					e);
+			}
+
+			return new JobSubmissionResult(jobGraph.getJobID());
+		} else {
+			try {
+				return miniCluster.executeJobBlocking(jobGraph);
+			} catch (JobExecutionException | InterruptedException e) {
+				throw new ProgramInvocationException(
+					String.format("Could not run job %s.", jobGraph.getJobID()),
+					e);
+			}
+		}
+	}
+
+	@Override
+	public void cancel(JobID jobId) throws Exception {
+		throw new UnsupportedOperationException("MiniClusterClient does not yet support this operation.");
+	}
+
+	@Override
+	public String cancelWithSavepoint(JobID jobId, @Nullable String savepointDirectory) throws Exception {
+		throw new UnsupportedOperationException("MiniClusterClient does not yet support this operation.");
+	}
+
+	@Override
+	public void stop(JobID jobId) throws Exception {
+		throw new UnsupportedOperationException("MiniClusterClient does not yet support this operation.");
+	}
+
+	@Override
+	public CompletableFuture<String> triggerSavepoint(JobID jobId, @Nullable String savepointDirectory) throws FlinkException {
+		throw new UnsupportedOperationException("MiniClusterClient does not yet support this operation.");
+	}
+
+	@Override
+	public CompletableFuture<Acknowledge> disposeSavepoint(String savepointPath, Time timeout) throws FlinkException {
+		throw new UnsupportedOperationException("MiniClusterClient does not yet support this operation.");
+	}
+
+	@Override
+	public CompletableFuture<Collection<JobStatusMessage>> listJobs() throws Exception {
+		throw new UnsupportedOperationException("MiniClusterClient does not yet support this operation.");
+	}
+
+	@Override
+	public Map<String, Object> getAccumulators(JobID jobID) throws Exception {
+		throw new UnsupportedOperationException("MiniClusterClient does not yet support this operation.");
+	}
+
+	@Override
+	public Map<String, Object> getAccumulators(JobID jobID, ClassLoader loader) throws Exception {
+		throw new UnsupportedOperationException("MiniClusterClient does not yet support this operation.");
+	}
+
+	@Override
+	public MiniClusterClient.MiniClusterId getClusterId() {
+		return MiniClusterId.INSTANCE;
+	}
+
+	@Override
+	public LeaderConnectionInfo getClusterConnectionInfo() throws LeaderRetrievalException {
+		return LeaderRetrievalUtils.retrieveLeaderConnectionInfo(
+			highAvailabilityServices.getDispatcherLeaderRetriever(),
+			timeout);
+	}
+
+	// ======================================
+	// Legacy methods
+	// ======================================
+
+	@Override
+	public void waitForClusterToBeReady() {
+		// no op
+	}
+
+	@Override
+	public String getWebInterfaceURL() {
+		return miniCluster.getRestAddress().toString();
+	}
+
+	@Override
+	public GetClusterStatusResponse getClusterStatus() {
+		return null;
+	}
+
+	@Override
+	public List<String> getNewMessages() {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public int getMaxSlots() {
+		return 0;
+	}
+
+	@Override
+	public boolean hasUserJarsInClassPath(List<URL> userJarFiles) {
+		return false;
+	}
+
+	enum MiniClusterId {
+		INSTANCE
+	}
+}

--- a/flink-clients/src/main/java/org/apache/flink/client/program/MiniClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/MiniClusterClient.java
@@ -82,7 +82,7 @@ public class MiniClusterClient extends ClusterClient<MiniClusterClient.MiniClust
 
 	@Override
 	public void cancel(JobID jobId) throws Exception {
-		throw new UnsupportedOperationException("MiniClusterClient does not yet support this operation.");
+		miniCluster.cancelJob(jobId);
 	}
 
 	@Override

--- a/flink-clients/src/main/java/org/apache/flink/client/program/StandaloneClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/StandaloneClusterClient.java
@@ -47,8 +47,8 @@ public class StandaloneClusterClient extends ClusterClient<StandaloneClusterId> 
 		super(config);
 	}
 
-	public StandaloneClusterClient(Configuration config, HighAvailabilityServices highAvailabilityServices) {
-		super(config, highAvailabilityServices);
+	public StandaloneClusterClient(Configuration config, HighAvailabilityServices highAvailabilityServices, boolean sharedHaServices) {
+		super(config, highAvailabilityServices, sharedHaServices);
 	}
 
 	@Override

--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
@@ -192,13 +192,6 @@ public class RestClusterClient<T> extends ClusterClient<T> {
 
 	@Override
 	public void shutdown() {
-		try {
-			// we only call this for legacy reasons to shutdown components that are started in the ClusterClient constructor
-			super.shutdown();
-		} catch (Exception e) {
-			log.error("An error occurred during the client shutdown.", e);
-		}
-
 		ExecutorUtils.gracefulShutdown(restClusterClientConfiguration.getRetryDelay(), TimeUnit.MILLISECONDS, retryExecutorService);
 
 		this.restClient.shutdown(Time.seconds(5));
@@ -214,6 +207,13 @@ public class RestClusterClient<T> extends ClusterClient<T> {
 			dispatcherRetrievalService.stop();
 		} catch (Exception e) {
 			log.error("An error occurred during stopping the dispatcherLeaderRetriever", e);
+		}
+
+		try {
+			// we only call this for legacy reasons to shutdown components that are started in the ClusterClient constructor
+			super.shutdown();
+		} catch (Exception e) {
+			log.error("An error occurred during the client shutdown.", e);
 		}
 	}
 

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendModifyTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendModifyTest.java
@@ -121,7 +121,7 @@ public class CliFrontendModifyTest extends TestLogger {
 		private final CompletableFuture<Tuple2<JobID, Integer>> rescaleJobFuture;
 
 		public TestingClusterClient(CompletableFuture<Tuple2<JobID, Integer>> rescaleJobFuture) throws Exception {
-			super(new Configuration(), new TestingHighAvailabilityServices());
+			super(new Configuration(), new TestingHighAvailabilityServices(), false);
 
 			this.rescaleJobFuture = rescaleJobFuture;
 		}

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendSavepointTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendSavepointTest.java
@@ -138,7 +138,8 @@ public class CliFrontendSavepointTest extends TestLogger {
 		try {
 			CliFrontend frontend = new MockedCliFrontend(new StandaloneClusterClient(
 				new Configuration(),
-				new TestingHighAvailabilityServices()));
+				new TestingHighAvailabilityServices(),
+				false));
 
 			String[] parameters = { "invalid job id" };
 			try {
@@ -288,7 +289,7 @@ public class CliFrontendSavepointTest extends TestLogger {
 		private final BiFunction<String, Time, CompletableFuture<Acknowledge>> disposeSavepointFunction;
 
 		DisposeSavepointClusterClient(BiFunction<String, Time, CompletableFuture<Acknowledge>> disposeSavepointFunction) throws Exception {
-			super(new Configuration(), new TestingHighAvailabilityServices());
+			super(new Configuration(), new TestingHighAvailabilityServices(), false);
 
 			this.disposeSavepointFunction = Preconditions.checkNotNull(disposeSavepointFunction);
 		}

--- a/flink-clients/src/test/java/org/apache/flink/client/program/ClientConnectionTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/ClientConnectionTest.java
@@ -140,7 +140,7 @@ public class ClientConnectionTest extends TestLogger {
 
 			highAvailabilityServices.setJobMasterLeaderRetriever(HighAvailabilityServices.DEFAULT_JOB_ID, settableLeaderRetrievalService);
 
-			StandaloneClusterClient client = new StandaloneClusterClient(configuration, highAvailabilityServices);
+			StandaloneClusterClient client = new StandaloneClusterClient(configuration, highAvailabilityServices, true);
 
 			ActorGateway gateway = client.getJobManagerGateway();
 

--- a/flink-clients/src/test/java/org/apache/flink/client/program/ClusterClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/ClusterClientTest.java
@@ -71,7 +71,7 @@ public class ClusterClientTest extends TestLogger {
 		Configuration config = new Configuration();
 		HighAvailabilityServices highAvailabilityServices = mock(HighAvailabilityServices.class);
 
-		StandaloneClusterClient clusterClient = new StandaloneClusterClient(config, highAvailabilityServices);
+		StandaloneClusterClient clusterClient = new StandaloneClusterClient(config, highAvailabilityServices, false);
 
 		clusterClient.shutdown();
 
@@ -333,7 +333,7 @@ public class ClusterClientTest extends TestLogger {
 		private final ActorGateway jobmanagerGateway;
 
 		TestClusterClient(Configuration config, ActorGateway jobmanagerGateway) throws Exception {
-			super(config, new TestingHighAvailabilityServices());
+			super(config, new TestingHighAvailabilityServices(), false);
 			this.jobmanagerGateway = jobmanagerGateway;
 		}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -194,6 +194,8 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 
 				if (exception != null) {
 					throw exception;
+				} else {
+					log.info("Stopped dispatcher {}.", getAddress());
 				}
 			});
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/zookeeper/ZooKeeperHaServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/zookeeper/ZooKeeperHaServices.java
@@ -34,6 +34,8 @@ import org.apache.flink.runtime.util.ZooKeeperUtils;
 import org.apache.flink.util.ExceptionUtils;
 
 import org.apache.curator.framework.CuratorFramework;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.concurrent.Executor;
@@ -79,6 +81,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * cluster and participate in the execution of the same set of jobs.
  */
 public class ZooKeeperHaServices implements HighAvailabilityServices {
+
+	private static final Logger LOG = LoggerFactory.getLogger(ZooKeeperHaServices.class);
 
 	private static final String RESOURCE_MANAGER_LEADER_PATH = "/resource_manager_lock";
 
@@ -211,6 +215,8 @@ public class ZooKeeperHaServices implements HighAvailabilityServices {
 
 	@Override
 	public void closeAndCleanupAllData() throws Exception {
+		LOG.info("Close and clean up all data for ZooKeeperHaServices.");
+
 		Throwable exception = null;
 
 		try {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerRunner.java
@@ -265,8 +265,8 @@ public class JobManagerRunner implements LeaderContender, OnCompletionActions, F
 	@Override
 	public void jobReachedGloballyTerminalState(ArchivedExecutionGraph executionGraph) {
 		// complete the result future with the terminal execution graph
-		resultFuture.complete(executionGraph);
 		unregisterJobFromHighAvailability();
+		resultFuture.complete(executionGraph);
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalService.java
@@ -55,6 +55,8 @@ public class ZooKeeperLeaderRetrievalService implements LeaderRetrievalService, 
 	/** Curator recipe to watch changes of a specific ZooKeeper node. */
 	private final NodeCache cache;
 
+	private final String retrievalPath;
+
 	/** Listener which will be notified about leader changes. */
 	private volatile LeaderRetrievalListener leaderListener;
 
@@ -80,6 +82,7 @@ public class ZooKeeperLeaderRetrievalService implements LeaderRetrievalService, 
 	public ZooKeeperLeaderRetrievalService(CuratorFramework client, String retrievalPath) {
 		this.client = Preconditions.checkNotNull(client, "CuratorFramework client");
 		this.cache = new NodeCache(client, retrievalPath);
+		this.retrievalPath = Preconditions.checkNotNull(retrievalPath);
 
 		this.leaderListener = null;
 		this.lastLeaderAddress = null;
@@ -94,7 +97,7 @@ public class ZooKeeperLeaderRetrievalService implements LeaderRetrievalService, 
 		Preconditions.checkState(leaderListener == null, "ZooKeeperLeaderRetrievalService can " +
 				"only be started once.");
 
-		LOG.info("Starting ZooKeeperLeaderRetrievalService.");
+		LOG.info("Starting ZooKeeperLeaderRetrievalService {}.", retrievalPath);
 
 		synchronized (lock) {
 			leaderListener = listener;
@@ -111,7 +114,7 @@ public class ZooKeeperLeaderRetrievalService implements LeaderRetrievalService, 
 
 	@Override
 	public void stop() throws Exception {
-		LOG.info("Stopping ZooKeeperLeaderRetrievalService.");
+		LOG.info("Stopping ZooKeeperLeaderRetrievalService {}.", retrievalPath);
 
 		synchronized (lock) {
 			if (!running) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -467,7 +467,18 @@ public class MiniCluster implements JobExecutorService, AutoCloseableAsync {
 		} catch (LeaderRetrievalException | InterruptedException e) {
 			return FutureUtils.completedExceptionally(
 				new FlinkException(
-					String.format("Could not retrieve job status for job %s", jobId),
+					String.format("Could not retrieve job status for job %s.", jobId),
+					e));
+		}
+	}
+
+	public CompletableFuture<Acknowledge> cancelJob(JobID jobId) {
+		try {
+			return getDispatcherGateway().cancelJob(jobId, rpcTimeout);
+		} catch (LeaderRetrievalException | InterruptedException e) {
+			return FutureUtils.completedExceptionally(
+				new FlinkException(
+					String.format("Could not cancel job %s.", jobId),
 					e));
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -401,13 +401,6 @@ public class MiniCluster implements JobExecutorService, AutoCloseableAsync {
 					final int numComponents = 2 + miniClusterConfiguration.getNumTaskManagers();
 					final Collection<CompletableFuture<Void>> componentTerminationFutures = new ArrayList<>(numComponents);
 
-					componentTerminationFutures.add(shutDownDispatcher());
-
-					if (resourceManagerRunner != null) {
-						componentTerminationFutures.add(resourceManagerRunner.closeAsync());
-						resourceManagerRunner = null;
-					}
-
 					if (taskManagers != null) {
 						for (TaskExecutor tm : taskManagers) {
 							if (tm != null) {
@@ -416,6 +409,13 @@ public class MiniCluster implements JobExecutorService, AutoCloseableAsync {
 							}
 						}
 						taskManagers = null;
+					}
+
+					componentTerminationFutures.add(shutDownDispatcher());
+
+					if (resourceManagerRunner != null) {
+						componentTerminationFutures.add(resourceManagerRunner.closeAsync());
+						resourceManagerRunner = null;
 					}
 
 					final FutureUtils.ConjunctFuture<Void> componentsTerminationFuture = FutureUtils.completeAll(componentTerminationFutures);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -178,6 +178,13 @@ public class MiniCluster implements JobExecutorService, AutoCloseableAsync {
 		}
 	}
 
+	public HighAvailabilityServices getHighAvailabilityServices() {
+		synchronized (lock) {
+			checkState(running, "MiniCluster is not yet running.");
+			return haServices;
+		}
+	}
+
 	// ------------------------------------------------------------------------
 	//  life cycle
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
@@ -208,11 +208,15 @@ public class SlotManager implements AutoCloseable {
 		LOG.info("Suspending the SlotManager.");
 
 		// stop the timeout checks for the TaskManagers and the SlotRequests
-		taskManagerTimeoutCheck.cancel(false);
-		slotRequestTimeoutCheck.cancel(false);
+		if (taskManagerTimeoutCheck != null) {
+			taskManagerTimeoutCheck.cancel(false);
+			taskManagerTimeoutCheck = null;
+		}
 
-		taskManagerTimeoutCheck = null;
-		slotRequestTimeoutCheck = null;
+		if (slotRequestTimeoutCheck != null) {
+			slotRequestTimeoutCheck.cancel(false);
+			slotRequestTimeoutCheck = null;
+		}
 
 		for (PendingSlotRequest pendingSlotRequest : pendingSlotRequests.values()) {
 			cancelPendingSlotRequest(pendingSlotRequest);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/JobLeaderService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/JobLeaderService.java
@@ -190,7 +190,12 @@ public class JobLeaderService {
 
 		JobLeaderService.JobManagerLeaderListener jobManagerLeaderListener = new JobManagerLeaderListener(jobId);
 
-		jobLeaderServices.put(jobId, Tuple2.of(leaderRetrievalService, jobManagerLeaderListener));
+		final Tuple2<LeaderRetrievalService, JobManagerLeaderListener> oldEntry = jobLeaderServices.put(jobId, Tuple2.of(leaderRetrievalService, jobManagerLeaderListener));
+
+		if (oldEntry != null) {
+			oldEntry.f0.stop();
+			oldEntry.f1.stop();
+		}
 
 		leaderRetrievalService.start(jobManagerLeaderListener);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -259,7 +259,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 	 */
 	@Override
 	public CompletableFuture<Void> postStop() {
-		log.info("Stopping TaskManager {}.", getAddress());
+		log.info("Stopping TaskExecutor {}.", getAddress());
 
 		Throwable throwable = null;
 
@@ -294,6 +294,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 		if (throwable != null) {
 			return FutureUtils.completedExceptionally(new FlinkException("Error while shutting the TaskExecutor down.", throwable));
 		} else {
+			log.info("Stopped TaskExecutor {}.", getAddress());
 			return CompletableFuture.completedFuture(null);
 		}
 	}
@@ -1333,7 +1334,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 	 */
 	void onFatalError(final Throwable t) {
 		try {
-			log.error("Fatal error occurred in TaskExecutor.", t);
+			log.error("Fatal error occurred in TaskExecutor {}.", getAddress(), t);
 		} catch (Throwable ignored) {}
 
 		// The fatal error handler implementation should make sure that this call is non-blocking

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/ScalaUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/ScalaUtils.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.util;
+
+import java.util.Optional;
+
+import scala.Option;
+
+/**
+ * Utilities to convert Scala types into Java types.
+ */
+public class ScalaUtils {
+
+	/**
+	 * Converts a Scala {@link Option} to a {@link Optional}.
+	 *
+	 * @param scalaOption to convert into ta Java {@link Optional}
+	 * @param <T> type of the optional value
+	 * @return Optional of the given option
+	 */
+	public static <T> Optional<T> toJava(Option<T> scalaOption) {
+		if (scalaOption.isEmpty()) {
+			return Optional.empty();
+		} else {
+			return Optional.ofNullable(scalaOption.get());
+		}
+	}
+
+	private ScalaUtils() {}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/ScalaUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/ScalaUtilsTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.util;
+
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import scala.Option;
+
+import static org.apache.flink.runtime.util.ScalaUtils.toJava;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for {@link ScalaUtils} convenience methods.
+ */
+public class ScalaUtilsTest extends TestLogger {
+
+	@Test
+	public void testOptionToOptional() {
+		final String value = "foobar";
+		final Option<String> option = Option.apply(value);
+		final Optional<String> optional = toJava(option);
+
+		assertThat(optional.isPresent(), is(true));
+		assertThat(optional.get(), is(value));
+
+		final Option<String> nullOption = Option.apply(null);
+		final Optional<String> nullOptional = toJava(nullOption);
+
+		assertThat(nullOptional.isPresent(), is(false));
+
+		try {
+			nullOptional.get();
+			fail("Expected NoSuchElementException");
+		} catch (NoSuchElementException ignored) {
+			// ignored
+		}
+
+		final Option<String> emptyOption = Option.empty();
+		final Optional<String> emptyOptional = toJava(emptyOption);
+
+		assertThat(emptyOptional.isPresent(), is(false));
+	}
+}

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/MiniClusterResource.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/MiniClusterResource.java
@@ -19,23 +19,26 @@
 package org.apache.flink.test.util;
 
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.client.program.MiniClusterClient;
+import org.apache.flink.client.program.StandaloneClusterClient;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.minicluster.JobExecutorService;
+import org.apache.flink.runtime.minicluster.LocalFlinkMiniCluster;
 import org.apache.flink.runtime.minicluster.MiniCluster;
 import org.apache.flink.runtime.minicluster.MiniClusterConfiguration;
 import org.apache.flink.streaming.util.TestStreamEnvironment;
+import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.Preconditions;
 
 import org.junit.rules.ExternalResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.annotation.Nonnull;
 
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
@@ -59,6 +62,8 @@ public class MiniClusterResource extends ExternalResource {
 
 	private JobExecutorService jobExecutorService;
 
+	private ClusterClient<?> clusterClient;
+
 	private int numberSlots = -1;
 
 	private TestEnvironment executionEnvironment;
@@ -80,6 +85,10 @@ public class MiniClusterResource extends ExternalResource {
 		return numberSlots;
 	}
 
+	public ClusterClient<?> getClusterClient() {
+		return clusterClient;
+	}
+
 	public TestEnvironment getTestEnvironment() {
 		return executionEnvironment;
 	}
@@ -87,7 +96,7 @@ public class MiniClusterResource extends ExternalResource {
 	@Override
 	public void before() throws Exception {
 
-		jobExecutorService = startJobExecutorService(miniClusterType);
+		startJobExecutorService(miniClusterType);
 
 		numberSlots = miniClusterResourceConfiguration.getNumberSlotsPerTaskManager() * miniClusterResourceConfiguration.getNumberTaskManagers();
 
@@ -102,6 +111,16 @@ public class MiniClusterResource extends ExternalResource {
 		TestStreamEnvironment.unsetAsContext();
 		TestEnvironment.unsetAsContext();
 
+		Exception exception = null;
+
+		try {
+			clusterClient.shutdown();
+		} catch (Exception e) {
+			exception = e;
+		}
+
+		clusterClient = null;
+
 		final CompletableFuture<?> terminationFuture = jobExecutorService.closeAsync();
 
 		try {
@@ -109,40 +128,43 @@ public class MiniClusterResource extends ExternalResource {
 				miniClusterResourceConfiguration.getShutdownTimeout().toMilliseconds(),
 				TimeUnit.MILLISECONDS);
 		} catch (Exception e) {
-			LOG.warn("Could not properly shut down the MiniClusterResource.", e);
+			exception = ExceptionUtils.firstOrSuppressed(e, exception);
 		}
 
 		jobExecutorService = null;
+
+		if (exception != null) {
+			LOG.warn("Could not properly shut down the MiniClusterResource.", exception);
+		}
 	}
 
-	private JobExecutorService startJobExecutorService(MiniClusterType miniClusterType) throws Exception {
-		final JobExecutorService jobExecutorService;
+	private void startJobExecutorService(MiniClusterType miniClusterType) throws Exception {
 		switch (miniClusterType) {
 			case OLD:
-				jobExecutorService = startOldMiniCluster();
+				startOldMiniCluster();
 				break;
 			case FLIP6:
-				jobExecutorService = startFlip6MiniCluster();
+				startFlip6MiniCluster();
 				break;
 			default:
 				throw new FlinkRuntimeException("Unknown MiniClusterType "  + miniClusterType + '.');
 		}
-
-		return jobExecutorService;
 	}
 
-	private JobExecutorService startOldMiniCluster() throws Exception {
+	private void startOldMiniCluster() throws Exception {
 		final Configuration configuration = new Configuration(miniClusterResourceConfiguration.getConfiguration());
 		configuration.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, miniClusterResourceConfiguration.getNumberTaskManagers());
 		configuration.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, miniClusterResourceConfiguration.getNumberSlotsPerTaskManager());
 
-		return TestBaseUtils.startCluster(
+		final LocalFlinkMiniCluster flinkMiniCluster = TestBaseUtils.startCluster(
 			configuration,
 			true);
+
+		jobExecutorService = flinkMiniCluster;
+		clusterClient = new StandaloneClusterClient(configuration, flinkMiniCluster.highAvailabilityServices());
 	}
 
-	@Nonnull
-	private JobExecutorService startFlip6MiniCluster() throws Exception {
+	private void startFlip6MiniCluster() throws Exception {
 		final Configuration configuration = miniClusterResourceConfiguration.getConfiguration();
 
 		// we need to set this since a lot of test expect this because TestBaseUtils.startCluster()
@@ -165,7 +187,8 @@ public class MiniClusterResource extends ExternalResource {
 		// update the port of the rest endpoint
 		configuration.setInteger(RestOptions.REST_PORT, miniCluster.getRestAddress().getPort());
 
-		return miniCluster;
+		jobExecutorService = miniCluster;
+		clusterClient = new MiniClusterClient(configuration, miniCluster);
 	}
 
 	/**

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/MiniClusterResource.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/MiniClusterResource.java
@@ -161,7 +161,7 @@ public class MiniClusterResource extends ExternalResource {
 			true);
 
 		jobExecutorService = flinkMiniCluster;
-		clusterClient = new StandaloneClusterClient(configuration, flinkMiniCluster.highAvailabilityServices());
+		clusterClient = new StandaloneClusterClient(configuration, flinkMiniCluster.highAvailabilityServices(), true);
 	}
 
 	private void startFlip6MiniCluster() throws Exception {

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/AbstractEventTimeWindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/AbstractEventTimeWindowCheckpointingITCase.java
@@ -51,6 +51,7 @@ import org.apache.flink.util.TestLogger;
 
 import org.apache.curator.test.TestingServer;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -87,6 +88,8 @@ public abstract class AbstractEventTimeWindowCheckpointingITCase extends TestLog
 
 	private TestingServer zkServer;
 
+	public MiniClusterResource miniClusterResource;
+
 	@ClassRule
 	public static TemporaryFolder tempFolder = new TemporaryFolder();
 
@@ -94,9 +97,6 @@ public abstract class AbstractEventTimeWindowCheckpointingITCase extends TestLog
 	public TestName name = new TestName();
 
 	private AbstractStateBackend stateBackend;
-
-	@Rule
-	public final MiniClusterResource miniClusterResource = getMiniClusterResource();
 
 	enum StateBackendEnum {
 		MEM, FILE, ROCKSDB_FULLY_ASYNC, ROCKSDB_INCREMENTAL, ROCKSDB_INCREMENTAL_ZK, MEM_ASYNC, FILE_ASYNC
@@ -201,8 +201,19 @@ public abstract class AbstractEventTimeWindowCheckpointingITCase extends TestLog
 		return config;
 	}
 
+	@Before
+	public void setupTestCluster() throws Exception {
+		miniClusterResource = getMiniClusterResource();
+		miniClusterResource.before();
+	}
+
 	@After
 	public void stopTestCluster() throws IOException {
+		if (miniClusterResource != null) {
+			miniClusterResource.after();
+			miniClusterResource = null;
+		}
+
 		if (zkServer != null) {
 			zkServer.stop();
 			zkServer = null;

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/AbstractLocalRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/AbstractLocalRecoveryITCase.java
@@ -78,20 +78,20 @@ public abstract class AbstractLocalRecoveryITCase extends TestLogger {
 	private void executeTest(AbstractEventTimeWindowCheckpointingITCase delegate) throws Exception {
 		delegate.name = testName;
 		try {
-			delegate.miniClusterResource.before();
+			delegate.setupTestCluster();
 			try {
 				delegate.testTumblingTimeWindow();
-				delegate.miniClusterResource.after();
+				delegate.stopTestCluster();
 			} catch (Exception e) {
-				delegate.miniClusterResource.after();
+				delegate.stopTestCluster();
 			}
 
-			delegate.miniClusterResource.before();
+			delegate.setupTestCluster();
 			try {
 				delegate.testSlidingTimeWindow();
-				delegate.miniClusterResource.after();
+				delegate.stopTestCluster();
 			} catch (Exception e) {
-				delegate.miniClusterResource.after();
+				delegate.stopTestCluster();
 			}
 		} finally {
 			delegate.tempFolder.delete();

--- a/flink-tests/src/test/java/org/apache/flink/test/example/client/JobRetrievalITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/example/client/JobRetrievalITCase.java
@@ -79,7 +79,7 @@ public class JobRetrievalITCase extends TestLogger {
 
 		final JobGraph jobGraph = new JobGraph(jobID, "testjob", imalock);
 
-		final ClusterClient<StandaloneClusterId> client = new StandaloneClusterClient(cluster.configuration(), cluster.highAvailabilityServices());
+		final ClusterClient<StandaloneClusterId> client = new StandaloneClusterClient(cluster.configuration(), cluster.highAvailabilityServices(), true);
 
 		// acquire the lock to make sure that the job cannot complete until the job client
 		// has been attached in resumingThread


### PR DESCRIPTION
## What is the purpose of the change

The MiniClusterClient directly talks to the MiniCluster avoiding polling
latencies of the RestClusterClient.

This PR is based on #5599.

cc: @aljoscha 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
