### PR TITLE
[FLINK-8814] Control over the extension of part files created by BucketingSink

### DIFF
--- a/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSink.java
+++ b/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSink.java
@@ -226,7 +226,12 @@ public class BucketingSink<T>
 	/**
 	 * The default prefix for part files.
 	 */
-	private static final String DEFAULT_PART_REFIX = "part";
+	private static final String DEFAULT_PART_PREFIX = "part";
+
+	/**
+	 * The default suffix for part files.
+	 */
+	private static final String DEFAULT_PART_SUFFIX = null;
 
 	/**
 	 * The default timeout for asynchronous operations such as recoverLease and truncate (in {@code ms}).
@@ -263,7 +268,8 @@ public class BucketingSink<T>
 	private String validLengthSuffix = DEFAULT_VALID_SUFFIX;
 	private String validLengthPrefix = DEFAULT_VALID_PREFIX;
 
-	private String partPrefix = DEFAULT_PART_REFIX;
+	private String partPrefix = DEFAULT_PART_PREFIX;
+	private String partSuffix = DEFAULT_PART_SUFFIX;
 
 	private boolean useTruncate = true;
 
@@ -528,6 +534,10 @@ public class BucketingSink<T>
 				fs.exists(getInProgressPathFor(partPath))) {
 			bucketState.partCounter++;
 			partPath = new Path(bucketPath, partPrefix + "-" + subtaskIndex + "-" + bucketState.partCounter);
+		}
+
+		if (partSuffix != null) {
+			partPath = partPath.suffix(partSuffix);
 		}
 
 		// increase, so we don't have to check for this name next time
@@ -983,6 +993,14 @@ public class BucketingSink<T>
 	 */
 	public BucketingSink<T> setValidLengthPrefix(String validLengthPrefix) {
 		this.validLengthPrefix = validLengthPrefix;
+		return this;
+	}
+
+	/**
+	 * Sets the prefix of part files.  The default is no suffix.
+	 */
+	public BucketingSink<T> setPartSuffix(String partSuffix) {
+		this.partSuffix = partSuffix;
 		return this;
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

Popular tools like hue and the avro connector for spark require files stored on hdfs to have the .avro extension. This patch makes it possible to configure a part file suffix

## Brief change log

- adds support for partSuffix in BucketingSink

## Verifying this change

The basic functionality of BucketingSink is verified by BucketingSinkTest. The structure of this test makes it awkward to test this in isolation

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
