### PR TITLE
[FLINK-8816][ResourceManager] Remove the oldWorker only after starting newWorker successfully

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotProvider.java
@@ -46,9 +46,10 @@ public interface SlotProvider {
 	/**
 	 * Allocating slot with specific requirement.
 	 *
+	 * @param slotRequestId The id of the request
 	 * @param task The task to allocate the slot for
 	 * @param allowQueued Whether allow the task be queued if we do not have enough resource
-	 * @param preferredLocations preferred locations for the slot allocation
+	 * @param slotProfile profile of the requested slot
 	 * @param timeout after which the allocation fails with a timeout exception
 	 * @return The future of the allocation
 	 */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -679,14 +679,6 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 			SlotReport slotReport,
 			int dataPort,
 			HardwareDescription hardwareDescription) {
-		WorkerRegistration<WorkerType> oldRegistration = taskExecutors.remove(taskExecutorResourceId);
-		if (oldRegistration != null) {
-			// TODO :: suggest old taskExecutor to stop itself
-			log.info("Replacing old instance of worker for ResourceID {}", taskExecutorResourceId);
-
-			// remove old task manager registration from slot manager
-			slotManager.unregisterTaskManager(oldRegistration.getInstanceID());
-		}
 
 		final WorkerType newWorker = workerStarted(taskExecutorResourceId);
 
@@ -695,6 +687,16 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 				"not recognize it", taskExecutorResourceId, taskExecutorAddress);
 			return new RegistrationResponse.Decline("unrecognized TaskExecutor");
 		} else {
+
+			WorkerRegistration<WorkerType> oldRegistration = taskExecutors.remove(taskExecutorResourceId);
+			if (oldRegistration != null) {
+				// TODO :: suggest old taskExecutor to stop itself
+				log.info("Replacing old instance of worker for ResourceID {}", taskExecutorResourceId);
+
+				// remove old task manager registration from slot manager
+				slotManager.unregisterTaskManager(oldRegistration.getInstanceID());
+			}
+
 			WorkerRegistration<WorkerType> registration =
 				new WorkerRegistration<>(taskExecutorGateway, newWorker, dataPort, hardwareDescription);
 


### PR DESCRIPTION
## What is the purpose of the change

This PR address [FLINK-8816](https://issues.apache.org/jira/browse/FLINK-8816), We should remove the oldWorker only after starting newWorker successfully in `ResourceManager#registerTaskExecutorInternal` and javadoc for `SlotProvider#allocateSlot` is outdated.

## Brief change log

- Fix bug `registerTaskExecutorInternal()`, remove old worker after starting newWorker successfully.
- Fix javadoc for SlotProvider#allocateSlot.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation
    no