### PR TITLE
[FLINK-8817][Distributed Coordination] Decrement numPendingContainerRequests only after requesting container successfully

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
@@ -342,7 +342,6 @@ public class YarnResourceManager extends ResourceManager<YarnWorkerNode> impleme
 				numPendingContainerRequests);
 
 			if (numPendingContainerRequests > 0) {
-				numPendingContainerRequests--;
 
 				final String containerIdStr = container.getId().toString();
 
@@ -356,6 +355,7 @@ public class YarnResourceManager extends ResourceManager<YarnWorkerNode> impleme
 						container.getNodeId().getHost());
 
 					nodeManagerClient.startContainer(container, taskExecutorLaunchContext);
+					numPendingContainerRequests--;
 				} catch (Throwable t) {
 					log.error("Could not start TaskManager in container {}.", container.getId(), t);
 


### PR DESCRIPTION
## What is the purpose of the change

This PR address [FLINK-8817](https://issues.apache.org/jira/browse/FLINK-8817), We should decrement numPendingContainerRequests only when request container successfully. Otherwise, the re-requested container can be released.

## Brief change log

- Decrement numPendingContainerRequests only when request container successfully

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation
    no