### PR TITLE
[FLINK-4387][QS][tests] don't wait and process requests at Netty servers after shutdown request

### DIFF
--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/ClientTest.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/ClientTest.java
@@ -111,7 +111,8 @@ public class ClientTest {
 	@After
 	public void tearDown() throws Exception {
 		if (nioGroup != null) {
-			nioGroup.shutdownGracefully();
+			// note: no "quiet period" to not trigger Netty#4357
+			nioGroup.shutdownGracefully(0, 10, TimeUnit.SECONDS);
 		}
 	}
 

--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/KvStateServerTest.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/KvStateServerTest.java
@@ -79,7 +79,8 @@ public class KvStateServerTest {
 	@AfterClass
 	public static void tearDown() throws Exception {
 		if (NIO_GROUP != null) {
-			NIO_GROUP.shutdownGracefully();
+			// note: no "quiet period" to not trigger Netty#4357
+			NIO_GROUP.shutdownGracefully(0, 10, TimeUnit.SECONDS);
 		}
 	}
 
@@ -191,7 +192,8 @@ public class KvStateServerTest {
 			if (bootstrap != null) {
 				EventLoopGroup group = bootstrap.group();
 				if (group != null) {
-					group.shutdownGracefully();
+					// note: no "quiet period" to not trigger Netty#4357
+					group.shutdownGracefully(0, 10, TimeUnit.SECONDS);
 				}
 			}
 		}


### PR DESCRIPTION
## What is the purpose of the change

There is a race condition on an assertion in Netty's event loop that may cause
tests to fail when finished early.

This was fixed in 4.0.33.Final via https://github.com/netty/netty/issues/4357 but we currently still rely on Netty 4.0.27.Final, hence the bug fix for the tests where this bug can be immanent.

## Brief change log

- in QueryableState tests, do not wait for a "quiet period" for further events to arrive and process, this is not needed here and circumvents the bug

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **JavaDocs**
