### PR TITLE
[FLINK-8821][TableAPI && SQL] Fix non-terminating decimal error

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/TableConfig.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/TableConfig.scala
@@ -18,6 +18,7 @@
 package org.apache.flink.table.api
 
 import _root_.java.util.TimeZone
+import _root_.java.math.MathContext
 
 import org.apache.flink.table.calcite.CalciteConfig
 
@@ -40,6 +41,12 @@ class TableConfig {
     * Defines the configuration of Calcite for Table API and SQL queries.
     */
   private var calciteConfig = CalciteConfig.DEFAULT
+
+  /**
+    * Defines the default context for decimal division calculation.
+    * MathContext.DECIMAL128 is Same with Scala's default context.
+    */
+  private var decimalDivisionMathContext = MathContext.DECIMAL128
 
   /**
    * Sets the timezone for date/time/timestamp conversions.
@@ -77,6 +84,18 @@ class TableConfig {
     */
   def setCalciteConfig(calciteConfig: CalciteConfig): Unit = {
     this.calciteConfig = calciteConfig
+  }
+
+  /**
+    * Returns the current decimal division MathContext for Table API and SQL queries.
+    */
+  def getDecimalDivisionMathContext: MathContext = decimalDivisionMathContext
+
+  /**
+    * Sets the MathContext for Decimal calculation.
+    */
+  def setDecimalContext(mathContext: MathContext): Unit = {
+    this.decimalDivisionMathContext = mathContext
   }
 }
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/CodeGenerator.scala
@@ -742,56 +742,56 @@ abstract class CodeGenerator(
         val right = operands(1)
         requireNumeric(left)
         requireNumeric(right)
-        generateArithmeticOperator("+", nullCheck, resultType, left, right)
+        generateArithmeticOperator("+", nullCheck, resultType, left, right, config)
 
       case PLUS | DATETIME_PLUS if isTemporal(resultType) =>
         val left = operands.head
         val right = operands(1)
         requireTemporal(left)
         requireTemporal(right)
-        generateTemporalPlusMinus(plus = true, nullCheck, left, right)
+        generateTemporalPlusMinus(plus = true, nullCheck, left, right, config)
 
       case MINUS if isNumeric(resultType) =>
         val left = operands.head
         val right = operands(1)
         requireNumeric(left)
         requireNumeric(right)
-        generateArithmeticOperator("-", nullCheck, resultType, left, right)
+        generateArithmeticOperator("-", nullCheck, resultType, left, right, config)
 
       case MINUS | MINUS_DATE if isTemporal(resultType) =>
         val left = operands.head
         val right = operands(1)
         requireTemporal(left)
         requireTemporal(right)
-        generateTemporalPlusMinus(plus = false, nullCheck, left, right)
+        generateTemporalPlusMinus(plus = false, nullCheck, left, right, config)
 
       case MULTIPLY if isNumeric(resultType) =>
         val left = operands.head
         val right = operands(1)
         requireNumeric(left)
         requireNumeric(right)
-        generateArithmeticOperator("*", nullCheck, resultType, left, right)
+        generateArithmeticOperator("*", nullCheck, resultType, left, right, config)
 
       case MULTIPLY if isTimeInterval(resultType) =>
         val left = operands.head
         val right = operands(1)
         requireTimeInterval(left)
         requireNumeric(right)
-        generateArithmeticOperator("*", nullCheck, resultType, left, right)
+        generateArithmeticOperator("*", nullCheck, resultType, left, right, config)
 
       case DIVIDE | DIVIDE_INTEGER if isNumeric(resultType) =>
         val left = operands.head
         val right = operands(1)
         requireNumeric(left)
         requireNumeric(right)
-        generateArithmeticOperator("/", nullCheck, resultType, left, right)
+        generateArithmeticOperator("/", nullCheck, resultType, left, right, config)
 
       case MOD if isNumeric(resultType) =>
         val left = operands.head
         val right = operands(1)
         requireNumeric(left)
         requireNumeric(right)
-        generateArithmeticOperator("%", nullCheck, resultType, left, right)
+        generateArithmeticOperator("%", nullCheck, resultType, left, right, config)
 
       case UNARY_MINUS if isNumeric(resultType) =>
         val operand = operands.head
@@ -922,7 +922,7 @@ abstract class CodeGenerator(
         val left = operands.head
         val right = operands(1)
         requireString(left)
-        generateArithmeticOperator("+", nullCheck, resultType, left, right)
+        generateArithmeticOperator("+", nullCheck, resultType, left, right, config)
 
       // rows
       case ROW =>

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/ScalarOperators.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/ScalarOperators.scala
@@ -17,12 +17,15 @@
  */
 package org.apache.flink.table.codegen.calls
 
+import java.math.MathContext
+
 import org.apache.calcite.avatica.util.DateTimeUtils.MILLIS_PER_DAY
 import org.apache.calcite.avatica.util.{DateTimeUtils, TimeUnitRange}
 import org.apache.calcite.util.BuiltInMethod
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo._
 import org.apache.flink.api.common.typeinfo._
 import org.apache.flink.api.java.typeutils.{MapTypeInfo, ObjectArrayTypeInfo, RowTypeInfo}
+import org.apache.flink.table.api.TableConfig
 import org.apache.flink.table.codegen.CodeGenUtils._
 import org.apache.flink.table.codegen.calls.CallGenerator.generateCallIfArgsNotNull
 import org.apache.flink.table.codegen.{CodeGenException, CodeGenerator, GeneratedExpression}
@@ -46,7 +49,8 @@ object ScalarOperators {
       nullCheck: Boolean,
       resultType: TypeInformation[_],
       left: GeneratedExpression,
-      right: GeneratedExpression): GeneratedExpression = {
+      right: GeneratedExpression,
+      config: TableConfig): GeneratedExpression = {
 
     val leftCasting = operator match {
       case "%" =>
@@ -68,7 +72,14 @@ object ScalarOperators {
     generateOperatorIfNotNull(nullCheck, resultType, left, right) {
       (leftTerm, rightTerm) =>
         if (isDecimal(resultType)) {
-          s"${leftCasting(leftTerm)}.${arithOpToDecMethod(operator)}(${rightCasting(rightTerm)})"
+          val decMethod = arithOpToDecMethod(operator)
+          operator match {
+            case "/" =>
+              val mathContext = mathContextToString(config.getDecimalDivisionMathContext)
+              s"${leftCasting(leftTerm)}.${decMethod}(${rightCasting(rightTerm)}, ${mathContext})"
+            case _ =>
+              s"${leftCasting(leftTerm)}.${decMethod}(${rightCasting(rightTerm)})"
+          }
         } else {
           s"($resultTypeTerm) (${leftCasting(leftTerm)} $operator ${rightCasting(rightTerm)})"
         }
@@ -814,14 +825,15 @@ object ScalarOperators {
       plus: Boolean,
       nullCheck: Boolean,
       left: GeneratedExpression,
-      right: GeneratedExpression)
+      right: GeneratedExpression,
+      config: TableConfig)
     : GeneratedExpression = {
 
     val op = if (plus) "+" else "-"
 
     (left.resultType, right.resultType) match {
       case (l: TimeIntervalTypeInfo[_], r: TimeIntervalTypeInfo[_]) if l == r =>
-        generateArithmeticOperator(op, nullCheck, l, left, right)
+        generateArithmeticOperator(op, nullCheck, l, left, right, config)
 
       case (SqlTimeTypeInfo.DATE, TimeIntervalTypeInfo.INTERVAL_MILLIS) =>
         generateOperatorIfNotNull(nullCheck, SqlTimeTypeInfo.DATE, left, right) {
@@ -1288,6 +1300,15 @@ object ScalarOperators {
     case "/" => "divide"
     case "%" => "remainder"
     case _ => throw new CodeGenException(s"Unsupported decimal arithmetic operator: '$operator'")
+  }
+
+
+  private def mathContextToString(mathContext: MathContext): String = mathContext match {
+    case MathContext.DECIMAL32 => "java.math.MathContext.DECIMAL32"
+    case MathContext.DECIMAL64 => "java.math.MathContext.DECIMAL64"
+    case MathContext.DECIMAL128 => "java.math.MathContext.DECIMAL128"
+    case MathContext.UNLIMITED => "java.math.MathContext.MathContext.UNLIMITED"
+    case _ => throw new CodeGenException(s"Unsupported decimal MathContext: '$mathContext'")
   }
 
   private def numericCasting(

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/aggfunctions/AvgAggFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/functions/aggfunctions/AvgAggFunction.scala
@@ -17,7 +17,7 @@
  */
 package org.apache.flink.table.functions.aggfunctions
 
-import java.math.{BigDecimal, BigInteger}
+import java.math.{BigDecimal, BigInteger, MathContext}
 import java.lang.{Iterable => JIterable}
 
 import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
@@ -295,7 +295,8 @@ class DecimalAvgAccumulator extends JTuple2[BigDecimal, Long] {
 /**
   * Base class for built-in Big Decimal Avg aggregate function
   */
-class DecimalAvgAggFunction extends AggregateFunction[BigDecimal, DecimalAvgAccumulator] {
+class DecimalAvgAggFunction(context: MathContext)
+  extends AggregateFunction[BigDecimal, DecimalAvgAccumulator] {
 
   override def createAccumulator(): DecimalAvgAccumulator = {
     new DecimalAvgAccumulator
@@ -321,7 +322,7 @@ class DecimalAvgAggFunction extends AggregateFunction[BigDecimal, DecimalAvgAccu
     if (acc.f1 == 0) {
       null.asInstanceOf[BigDecimal]
     } else {
-      acc.f0.divide(BigDecimal.valueOf(acc.f1))
+      acc.f0.divide(BigDecimal.valueOf(acc.f1), context)
     }
   }
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/dataset/DataSetAggregate.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/dataset/DataSetAggregate.scala
@@ -110,7 +110,8 @@ class DataSetAggregate(
         input.getRowType,
         inputDS.getType.asInstanceOf[RowTypeInfo].getFieldTypes,
         rowRelDataType,
-        grouping)
+        grouping,
+        tableEnv.getConfig)
 
     val aggString = aggregationToString(inputType, grouping, getRowType, namedAggregates, Nil)
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/dataset/DataSetWindowAggregate.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/dataset/DataSetWindowAggregate.scala
@@ -25,7 +25,7 @@ import org.apache.calcite.rel.{RelNode, RelWriter, SingleRel}
 import org.apache.flink.api.common.operators.Order
 import org.apache.flink.api.java.DataSet
 import org.apache.flink.api.java.typeutils.{ResultTypeQueryable, RowTypeInfo}
-import org.apache.flink.table.api.{BatchQueryConfig, BatchTableEnvironment}
+import org.apache.flink.table.api.{BatchQueryConfig, BatchTableEnvironment, TableConfig}
 import org.apache.flink.table.calcite.FlinkRelBuilder.NamedWindowProperty
 import org.apache.flink.table.calcite.FlinkTypeFactory
 import org.apache.flink.table.codegen.AggregationCodeGenerator
@@ -127,11 +127,12 @@ class DataSetWindowAggregate(
           generator,
           inputDS,
           isTimeIntervalLiteral(size),
-          caseSensitive)
+          caseSensitive,
+          tableEnv.getConfig)
 
       case SessionGroupWindow(_, timeField, gap)
           if isTimePoint(timeField.resultType) || isLong(timeField.resultType) =>
-        createEventTimeSessionWindowDataSet(generator, inputDS, caseSensitive)
+        createEventTimeSessionWindowDataSet(generator, inputDS, caseSensitive, tableEnv.getConfig)
 
       case SlidingGroupWindow(_, timeField, size, slide)
           if isTimePoint(timeField.resultType) || isLong(timeField.resultType) =>
@@ -141,7 +142,8 @@ class DataSetWindowAggregate(
           isTimeIntervalLiteral(size),
           asLong(size),
           asLong(slide),
-          caseSensitive)
+          caseSensitive,
+          tableEnv.getConfig)
 
       case _ =>
         throw new UnsupportedOperationException(
@@ -153,7 +155,8 @@ class DataSetWindowAggregate(
       generator: AggregationCodeGenerator,
       inputDS: DataSet[Row],
       isTimeWindow: Boolean,
-      isParserCaseSensitive: Boolean): DataSet[Row] = {
+      isParserCaseSensitive: Boolean,
+      tableConfig: TableConfig): DataSet[Row] = {
 
     val input = inputNode.asInstanceOf[DataSetRel]
 
@@ -164,7 +167,8 @@ class DataSetWindowAggregate(
       grouping,
       input.getRowType,
       inputDS.getType.asInstanceOf[RowTypeInfo].getFieldTypes,
-      isParserCaseSensitive)
+      isParserCaseSensitive,
+      tableConfig)
     val groupReduceFunction = createDataSetWindowAggregationGroupReduceFunction(
       generator,
       window,
@@ -173,7 +177,8 @@ class DataSetWindowAggregate(
       inputDS.getType.asInstanceOf[RowTypeInfo].getFieldTypes,
       getRowType,
       grouping,
-      namedProperties)
+      namedProperties,
+      tableConfig)
 
     val mappedInput = inputDS
       .map(mapFunction)
@@ -215,7 +220,8 @@ class DataSetWindowAggregate(
   private[this] def createEventTimeSessionWindowDataSet(
       generator: AggregationCodeGenerator,
       inputDS: DataSet[Row],
-      isParserCaseSensitive: Boolean): DataSet[Row] = {
+      isParserCaseSensitive: Boolean,
+      tableConfig: TableConfig): DataSet[Row] = {
 
     val input = inputNode.asInstanceOf[DataSetRel]
 
@@ -230,7 +236,8 @@ class DataSetWindowAggregate(
       grouping,
       input.getRowType,
       inputDS.getType.asInstanceOf[RowTypeInfo].getFieldTypes,
-      isParserCaseSensitive)
+      isParserCaseSensitive,
+      tableConfig)
 
     val mappedInput = inputDS.map(mapFunction).name(prepareOperatorName)
 
@@ -243,7 +250,8 @@ class DataSetWindowAggregate(
     if (doAllSupportPartialMerge(
       namedAggregates.map(_.getKey),
       inputType,
-      grouping.length)) {
+      grouping.length,
+      tableConfig)) {
 
       // gets the window-start and window-end position  in the intermediate result.
       val windowStartPos = rowTimeFieldPos
@@ -257,7 +265,8 @@ class DataSetWindowAggregate(
           namedAggregates,
           input.getRowType,
           inputDS.getType.asInstanceOf[RowTypeInfo].getFieldTypes,
-          grouping)
+          grouping,
+          tableConfig)
 
         // create groupReduceFunction for calculating the aggregations
         val groupReduceFunction = createDataSetWindowAggregationGroupReduceFunction(
@@ -269,6 +278,7 @@ class DataSetWindowAggregate(
           rowRelDataType,
           grouping,
           namedProperties,
+          tableConfig,
           isInputCombined = true)
 
         mappedInput
@@ -289,7 +299,8 @@ class DataSetWindowAggregate(
           namedAggregates,
           input.getRowType,
           inputDS.getType.asInstanceOf[RowTypeInfo].getFieldTypes,
-          grouping)
+          grouping,
+          tableConfig)
 
         // create groupReduceFunction for calculating the aggregations
         val groupReduceFunction = createDataSetWindowAggregationGroupReduceFunction(
@@ -301,6 +312,7 @@ class DataSetWindowAggregate(
           rowRelDataType,
           grouping,
           namedProperties,
+          tableConfig,
           isInputCombined = true)
 
         mappedInput.sortPartition(rowTimeFieldPos, Order.ASCENDING)
@@ -326,7 +338,8 @@ class DataSetWindowAggregate(
           inputDS.getType.asInstanceOf[RowTypeInfo].getFieldTypes,
           rowRelDataType,
           grouping,
-          namedProperties)
+          namedProperties,
+          tableConfig)
 
         mappedInput.groupBy(groupingKeys: _*)
           .sortGroup(rowTimeFieldPos, Order.ASCENDING)
@@ -343,7 +356,8 @@ class DataSetWindowAggregate(
           inputDS.getType.asInstanceOf[RowTypeInfo].getFieldTypes,
           rowRelDataType,
           grouping,
-          namedProperties)
+          namedProperties,
+          tableConfig)
 
         mappedInput.sortPartition(rowTimeFieldPos, Order.ASCENDING).setParallelism(1)
           .reduceGroup(groupReduceFunction)
@@ -360,7 +374,8 @@ class DataSetWindowAggregate(
       isTimeWindow: Boolean,
       size: Long,
       slide: Long,
-      isParserCaseSensitive: Boolean)
+      isParserCaseSensitive: Boolean,
+      tableConfig: TableConfig)
     : DataSet[Row] = {
 
     val input = inputNode.asInstanceOf[DataSetRel]
@@ -374,7 +389,8 @@ class DataSetWindowAggregate(
       grouping,
       input.getRowType,
       inputDS.getType.asInstanceOf[RowTypeInfo].getFieldTypes,
-      isParserCaseSensitive)
+      isParserCaseSensitive,
+      tableConfig)
 
     val mappedDataSet = inputDS
       .map(mapFunction)
@@ -389,7 +405,8 @@ class DataSetWindowAggregate(
     val isPartial = doAllSupportPartialMerge(
       namedAggregates.map(_.getKey),
       inputType,
-      grouping.length)
+      grouping.length,
+      tableConfig)
 
     // only pre-tumble if it is worth it
     val isLittleTumblingSize = determineLargestTumblingSize(size, slide) <= 1
@@ -411,7 +428,8 @@ class DataSetWindowAggregate(
           grouping,
           input.getRowType,
           inputDS.getType.asInstanceOf[RowTypeInfo].getFieldTypes,
-          isParserCaseSensitive)
+          isParserCaseSensitive,
+          tableConfig)
 
         mappedDataSet.asInstanceOf[DataSet[Row]]
           .groupBy(groupingKeysAndAlignedRowtime: _*)
@@ -451,6 +469,7 @@ class DataSetWindowAggregate(
       rowRelDataType,
       grouping,
       namedProperties,
+      tableConfig,
       isInputCombined = false)
 
     // gets the window-start position in the intermediate result.

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamGroupAggregate.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamGroupAggregate.scala
@@ -138,6 +138,7 @@ class DataStreamGroupAggregate(
       inputSchema.fieldTypeInfos,
       groupings,
       queryConfig,
+      tableEnv.getConfig,
       DataStreamRetractionRules.isAccRetract(this),
       DataStreamRetractionRules.isAccRetract(getInput))
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamGroupWindowAggregate.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamGroupWindowAggregate.scala
@@ -207,7 +207,8 @@ class DataStreamGroupWindowAggregate(
           inputSchema.fieldTypeInfos,
           schema.relDataType,
           grouping,
-          needMerge)
+          needMerge,
+          tableEnv.getConfig)
 
       windowedStream
         .aggregate(aggFunction, windowFunction, accumulatorRowType, aggResultRowType, outRowType)
@@ -232,7 +233,8 @@ class DataStreamGroupWindowAggregate(
           inputSchema.fieldTypeInfos,
           schema.relDataType,
           Array[Int](),
-          needMerge)
+          needMerge,
+          tableEnv.getConfig)
 
       windowedStream
         .aggregate(aggFunction, windowFunction, accumulatorRowType, aggResultRowType, outRowType)

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/AggregateUtil.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/AggregateUtil.scala
@@ -32,7 +32,7 @@ import org.apache.flink.streaming.api.functions.ProcessFunction
 import org.apache.flink.streaming.api.functions.windowing.{AllWindowFunction, WindowFunction}
 import org.apache.flink.streaming.api.windowing.windows.{Window => DataStreamWindow}
 import org.apache.flink.table.api.dataview.DataViewSpec
-import org.apache.flink.table.api.{StreamQueryConfig, TableException}
+import org.apache.flink.table.api.{StreamQueryConfig, TableConfig, TableException}
 import org.apache.flink.table.calcite.FlinkRelBuilder.NamedWindowProperty
 import org.apache.flink.table.calcite.FlinkTypeFactory
 import org.apache.flink.table.codegen.AggregationCodeGenerator
@@ -78,6 +78,7 @@ object AggregateUtil {
       inputTypeInfo: TypeInformation[Row],
       inputFieldTypeInfo: Seq[TypeInformation[_]],
       queryConfig: StreamQueryConfig,
+      tableConfig: TableConfig,
       rowTimeIdx: Option[Int],
       isPartitioned: Boolean,
       isRowsClause: Boolean)
@@ -88,6 +89,7 @@ object AggregateUtil {
         namedAggregates.map(_.getKey),
         aggregateInputType,
         needRetraction = false,
+        tableConfig,
         isStateBackedDataViews = true)
 
     val aggregationStateType: RowTypeInfo = new RowTypeInfo(accTypes: _*)
@@ -159,6 +161,7 @@ object AggregateUtil {
       inputFieldTypes: Seq[TypeInformation[_]],
       groupings: Array[Int],
       queryConfig: StreamQueryConfig,
+      tableConfig: TableConfig,
       generateRetraction: Boolean,
       consumeRetraction: Boolean): ProcessFunction[CRow, CRow] = {
 
@@ -167,6 +170,7 @@ object AggregateUtil {
         namedAggregates.map(_.getKey),
         inputRowType,
         consumeRetraction,
+        tableConfig,
         isStateBackedDataViews = true)
 
     val aggMapping = aggregates.indices.map(_ + groupings.length).toArray
@@ -223,6 +227,7 @@ object AggregateUtil {
       inputFieldTypeInfo: Seq[TypeInformation[_]],
       precedingOffset: Long,
       queryConfig: StreamQueryConfig,
+      tableConfig: TableConfig,
       isRowsClause: Boolean,
       rowTimeIdx: Option[Int])
     : ProcessFunction[CRow, CRow] = {
@@ -233,6 +238,7 @@ object AggregateUtil {
         namedAggregates.map(_.getKey),
         aggregateInputType,
         needRetract,
+        tableConfig,
         isStateBackedDataViews = true)
 
     val aggregationStateType: RowTypeInfo = new RowTypeInfo(accTypes: _*)
@@ -325,14 +331,16 @@ object AggregateUtil {
     groupings: Array[Int],
     inputType: RelDataType,
     inputFieldTypeInfo: Seq[TypeInformation[_]],
-    isParserCaseSensitive: Boolean)
+    isParserCaseSensitive: Boolean,
+    tableConfig: TableConfig)
   : MapFunction[Row, Row] = {
 
     val needRetract = false
     val (aggFieldIndexes, aggregates, accTypes, _) = transformToAggregateFunctions(
       namedAggregates.map(_.getKey),
       inputType,
-      needRetract)
+      needRetract,
+      tableConfig)
 
     val mapReturnType: RowTypeInfo =
       createRowTypeForKeysAndAggregates(
@@ -430,14 +438,16 @@ object AggregateUtil {
       groupings: Array[Int],
       physicalInputRowType: RelDataType,
       physicalInputTypes: Seq[TypeInformation[_]],
-      isParserCaseSensitive: Boolean)
+      isParserCaseSensitive: Boolean,
+      tableConfig: TableConfig)
     : RichGroupReduceFunction[Row, Row] = {
 
     val needRetract = false
     val (aggFieldIndexes, aggregates, accTypes, _) = transformToAggregateFunctions(
       namedAggregates.map(_.getKey),
       physicalInputRowType,
-      needRetract)
+      needRetract,
+      tableConfig)
 
     val returnType: RowTypeInfo = createRowTypeForKeysAndAggregates(
       groupings,
@@ -543,6 +553,7 @@ object AggregateUtil {
       outputType: RelDataType,
       groupings: Array[Int],
       properties: Seq[NamedWindowProperty],
+      tableConfig: TableConfig,
       isInputCombined: Boolean = false)
     : RichGroupReduceFunction[Row, Row] = {
 
@@ -550,7 +561,8 @@ object AggregateUtil {
     val (aggFieldIndexes, aggregates, _, _) = transformToAggregateFunctions(
       namedAggregates.map(_.getKey),
       physicalInputRowType,
-      needRetract)
+      needRetract,
+      tableConfig)
 
     val aggMapping = aggregates.indices.toArray.map(_ + groupings.length)
 
@@ -695,13 +707,15 @@ object AggregateUtil {
     namedAggregates: Seq[CalcitePair[AggregateCall, String]],
     physicalInputRowType: RelDataType,
     physicalInputTypes: Seq[TypeInformation[_]],
-    groupings: Array[Int]): MapPartitionFunction[Row, Row] = {
+    groupings: Array[Int],
+    tableConfig: TableConfig): MapPartitionFunction[Row, Row] = {
 
     val needRetract = false
     val (aggFieldIndexes, aggregates, accTypes, _) = transformToAggregateFunctions(
       namedAggregates.map(_.getKey),
       physicalInputRowType,
-      needRetract)
+      needRetract,
+      tableConfig)
 
     val aggMapping = aggregates.indices.map(_ + groupings.length).toArray
 
@@ -767,14 +781,16 @@ object AggregateUtil {
       namedAggregates: Seq[CalcitePair[AggregateCall, String]],
       physicalInputRowType: RelDataType,
       physicalInputTypes: Seq[TypeInformation[_]],
-      groupings: Array[Int])
+      groupings: Array[Int],
+      tableConfig: TableConfig)
     : GroupCombineFunction[Row, Row] = {
 
     val needRetract = false
     val (aggFieldIndexes, aggregates, accTypes, _) = transformToAggregateFunctions(
       namedAggregates.map(_.getKey),
       physicalInputRowType,
-      needRetract)
+      needRetract,
+      tableConfig)
 
     val aggMapping = aggregates.indices.map(_ + groupings.length).toArray
 
@@ -831,7 +847,8 @@ object AggregateUtil {
       inputType: RelDataType,
       inputFieldTypeInfo: Seq[TypeInformation[_]],
       outputType: RelDataType,
-      groupings: Array[Int]): (
+      groupings: Array[Int],
+      tableConfig: TableConfig): (
         Option[DataSetPreAggFunction],
         Option[TypeInformation[Row]],
         Either[DataSetAggFunction, DataSetFinalAggFunction]) = {
@@ -840,7 +857,8 @@ object AggregateUtil {
     val (aggInFields, aggregates, accTypes, _) = transformToAggregateFunctions(
       namedAggregates.map(_.getKey),
       inputType,
-      needRetract)
+      needRetract,
+      tableConfig)
 
     val (gkeyOutMapping, aggOutMapping) = getOutputMappings(
       namedAggregates,
@@ -992,7 +1010,8 @@ object AggregateUtil {
       inputFieldTypeInfo: Seq[TypeInformation[_]],
       outputType: RelDataType,
       groupingKeys: Array[Int],
-      needMerge: Boolean)
+      needMerge: Boolean,
+      tableConfig: TableConfig)
     : (DataStreamAggFunction[CRow, Row, Row], RowTypeInfo, RowTypeInfo) = {
 
     val needRetract = false
@@ -1000,7 +1019,8 @@ object AggregateUtil {
       transformToAggregateFunctions(
         namedAggregates.map(_.getKey),
         inputType,
-        needRetract)
+        needRetract,
+        tableConfig)
 
     val aggMapping = aggregates.indices.toArray
     val outputArity = aggregates.length
@@ -1036,12 +1056,14 @@ object AggregateUtil {
   private[flink] def doAllSupportPartialMerge(
     aggregateCalls: Seq[AggregateCall],
     inputType: RelDataType,
-    groupKeysCount: Int): Boolean = {
+    groupKeysCount: Int,
+    tableConfig: TableConfig): Boolean = {
 
     val aggregateList = transformToAggregateFunctions(
       aggregateCalls,
       inputType,
-      needRetraction = false)._2
+      needRetraction = false,
+      tableConfig)._2
 
     doAllSupportPartialMerge(aggregateList)
   }
@@ -1121,6 +1143,7 @@ object AggregateUtil {
       aggregateCalls: Seq[AggregateCall],
       aggregateInputType: RelDataType,
       needRetraction: Boolean,
+      tableConfig: TableConfig,
       isStateBackedDataViews: Boolean = false)
   : (Array[Array[Int]],
     Array[TableAggregateFunction[_, _]],
@@ -1251,7 +1274,7 @@ object AggregateUtil {
               case DOUBLE =>
                 new DoubleAvgAggFunction
               case DECIMAL =>
-                new DecimalAvgAggFunction
+                new DecimalAvgAggFunction(tableConfig.getDecimalDivisionMathContext)
               case sqlType: SqlTypeName =>
                 throw new TableException(s"Avg aggregate does no support type: '$sqlType'")
             }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/DecimalTypeTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/DecimalTypeTest.scala
@@ -233,6 +233,13 @@ class DecimalTypeTest extends ExpressionTestBase {
       "-f0",
       "-f0",
       "-123456789.123456789123456789")
+
+    testAllApis(
+      BigDecimal("1") / BigDecimal("3"),
+      "1p / 3p",
+      "CAST('1' AS DECIMAL) / CAST('3' AS DECIMAL)",
+      "0.3333333333333333333333333333333333"
+    )
   }
 
   @Test

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/aggfunctions/AvgFunctionTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/aggfunctions/AvgFunctionTest.scala
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.runtime.aggfunctions
 
-import java.math.BigDecimal
+import java.math.{BigDecimal, MathContext}
 
 import org.apache.flink.table.functions.AggregateFunction
 import org.apache.flink.table.functions.aggfunctions._
@@ -178,17 +178,23 @@ class DecimalAvgAggFunctionTest extends AggFunctionTestBase[BigDecimal, DecimalA
       null,
       null,
       null
+    ),
+    Seq(
+      new BigDecimal("0.3"),
+      new BigDecimal("0.3"),
+      new BigDecimal("0.4")
     )
   )
 
   override def expectedResults: Seq[BigDecimal] = Seq(
     BigDecimal.ZERO,
     BigDecimal.ONE,
-    null
+    null,
+    BigDecimal.ONE.divide(new BigDecimal("3"), MathContext.DECIMAL128)
   )
 
   override def aggregator: AggregateFunction[BigDecimal, DecimalAvgAccumulator] =
-    new DecimalAvgAggFunction()
+    new DecimalAvgAggFunction(MathContext.DECIMAL128)
 
   override def retractFunc = aggregator.getClass.getMethod("retract", accType, classOf[Any])
 }


### PR DESCRIPTION
## What is the purpose of the change
fix non-terminating decimal error in `AvgAggFunction` and general devision
## Brief change log

  - *add MathContext Configuration in `TableConfig`*
  - *set MathContext  to `DecimalAvgAggFunction`*
  - *set MathContext if it's a decimal division*
 
## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.
`org.apache.flink.table.runtime.aggfunctions.AvgFunctionTest`
`org.apache.flink.table.expressions.DecimalTypeTest#testDecimalArithmetic`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):
     no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: 
     no
  - The serializers: 
     no
  - The runtime per-record code paths (performance sensitive): 
     no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: 
    no
  - The S3 file system connector: 
    no
## Documentation

  - Does this pull request introduce a new feature? 
    no