### PR TITLE
[FLINK-8822] RotateLogFile may not work well when sed version is belo…

### DIFF
--- a/flink-dist/src/main/flink-bin/bin/config.sh
+++ b/flink-dist/src/main/flink-bin/bin/config.sh
@@ -396,7 +396,7 @@ rotateLogFilesWithPrefix() {
     while read -r log ; do
         rotateLogFile "$log"
     # find distinct set of log file names, ignoring the rotation number (trailing dot and digit)
-    done < <(find "$dir" ! -type d -path "${prefix}*" | sed -E s/\.[0-9]+$// | sort | uniq)
+    done < <(find "$dir" ! -type d -path "${prefix}*" | sed -r s/\.[0-9]+$// | sort | uniq)
 }
 
 rotateLogFile() {
@@ -485,7 +485,7 @@ TMSlaves() {
         done
     else
         # non-local setup
-        # Stop TaskManager instance(s) using pdsh (Parallel Distributed Shell) when available
+        # starts or stops TaskManager instance(s) using pdsh (Parallel Distributed Shell) when available
         command -v pdsh >/dev/null 2>&1
         if [[ $? -ne 0 ]]; then
             for slave in ${SLAVES[@]}; do


### PR DESCRIPTION
…w 4.2

In bin/config.sh rotateLogFilesWithPrefix(),it use extended regular to process filename with "sed -E",but when sed version is below 4.2,it turns out "sed: invalid option – 'E'"

and RotateLogFile won't work well : There will be only one logfile no matter what is $MAX_LOG_FILE_NUMBER.

so use sed -r may be more suitable.