### PR TITLE
[FLINK-8274] [table] Split generated methods for preventing compiler exceptions

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/TableConfig.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/TableConfig.scala
@@ -42,6 +42,12 @@ class TableConfig {
   private var calciteConfig = CalciteConfig.DEFAULT
 
   /**
+    * Specifies a threshold where generated code will be split into sub-function calls. Java has a
+    * maximum method length of 64 KB. This setting allows for finer granularity if necessary.
+    */
+  private var maxGeneratedCodeLength: Int = 64000 // just an estimate
+
+  /**
    * Sets the timezone for date/time/timestamp conversions.
    */
   def setTimeZone(timeZone: TimeZone): Unit = {
@@ -52,12 +58,12 @@ class TableConfig {
   /**
    * Returns the timezone for date/time/timestamp conversions.
    */
-  def getTimeZone = timeZone
+  def getTimeZone: TimeZone = timeZone
 
   /**
    * Returns the NULL check. If enabled, all fields need to be checked for NULL first.
    */
-  def getNullCheck = nullCheck
+  def getNullCheck: Boolean = nullCheck
 
   /**
    * Sets the NULL check. If enabled, all fields need to be checked for NULL first.
@@ -77,6 +83,25 @@ class TableConfig {
     */
   def setCalciteConfig(calciteConfig: CalciteConfig): Unit = {
     this.calciteConfig = calciteConfig
+  }
+
+  /**
+    * Returns the current threshold where generated code will be split into sub-function calls.
+    * Java has a maximum method length of 64 KB. This setting allows for finer granularity if
+    * necessary. Default is 64000.
+    */
+  def getMaxGeneratedCodeLength: Int = maxGeneratedCodeLength
+
+  /**
+    * Returns the current threshold where generated code will be split into sub-function calls.
+    * Java has a maximum method length of 64 KB. This setting allows for finer granularity if
+    * necessary. Default is 64000.
+    */
+  def setMaxGeneratedCodeLength(maxGeneratedCodeLength: Int): Unit = {
+    if (maxGeneratedCodeLength <= 0) {
+      throw new IllegalArgumentException("Length must be greater than 0.")
+    }
+    this.maxGeneratedCodeLength = maxGeneratedCodeLength
   }
 }
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/InputFormatCodeGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/InputFormatCodeGenerator.scala
@@ -71,12 +71,16 @@ class InputFormatCodeGenerator(
         }
 
         @Override
-        public Object nextRecord(Object reuse) {
+        public Object nextRecord(Object reuse) throws java.io.IOException {
           switch (nextIdx) {
             ${records.zipWithIndex.map { case (r, i) =>
               s"""
                  |case $i:
+                 |try {
                  |  $r
+                 |} catch (Exception e) {
+                 |  throw new java.io.IOException(e);
+                 |}
                  |break;
                        """.stripMargin
             }.mkString("\n")}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/batch/table/CorrelateITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/batch/table/CorrelateITCase.scala
@@ -81,6 +81,21 @@ class CorrelateITCase(
     TestBaseUtils.compareResultAsText(results.asJava, expected)
   }
 
+  @Test
+  def testLeftOuterJoinWithSplit(): Unit = {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val tableEnv = TableEnvironment.getTableEnvironment(env, config)
+    tableEnv.getConfig.setMaxGeneratedCodeLength(1) // split every field
+    val in = testData(env).toTable(tableEnv).as('a, 'b, 'c)
+
+    val func2 = new TableFunc2
+    val result = in.leftOuterJoin(func2('c) as ('s, 'l)).select('c, 's, 'l).toDataSet[Row]
+    val results = result.collect()
+    val expected = "Jack#22,Jack,4\n" + "Jack#22,22,2\n" + "John#19,John,4\n" +
+      "John#19,19,2\n" + "Anna#44,Anna,4\n" + "Anna#44,44,2\n" + "nosharp,null,null"
+    TestBaseUtils.compareResultAsText(results.asJava, expected)
+  }
+
   /**
     * Common join predicates are temporarily forbidden (see FLINK-7865).
     */

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/utils/StreamTestData.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/utils/StreamTestData.scala
@@ -25,6 +25,12 @@ import scala.collection.mutable
 
 object StreamTestData {
 
+  def getSingletonDataStream(env: StreamExecutionEnvironment): DataStream[(Int, Long, String)] = {
+    val data = new mutable.MutableList[(Int, Long, String)]
+    data.+=((1, 42L, "Hi"))
+    env.fromCollection(data)
+  }
+
   def getSmall3TupleDataStream(env: StreamExecutionEnvironment): DataStream[(Int, Long, String)] = {
     val data = new mutable.MutableList[(Int, Long, String)]
     data.+=((1, 1L, "Hi"))

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/utils/StreamingWithStateTestBase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/utils/StreamingWithStateTestBase.scala
@@ -18,6 +18,7 @@
 package org.apache.flink.table.runtime.utils
 
 import org.apache.flink.contrib.streaming.state.RocksDBStateBackend
+import org.apache.flink.runtime.state.StateBackend
 import org.apache.flink.test.util.AbstractTestBase
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
@@ -29,7 +30,7 @@ class StreamingWithStateTestBase extends AbstractTestBase {
   @Rule
   def tempFolder: TemporaryFolder = _tempFolder
 
-  def getStateBackend: RocksDBStateBackend = {
+  def getStateBackend: StateBackend = {
     val dbPath = tempFolder.newFolder().getAbsolutePath
     val checkpointPath = tempFolder.newFolder().toURI.toString
     val backend = new RocksDBStateBackend(checkpointPath)


### PR DESCRIPTION
## What is the purpose of the change

This PR splits a result record into multiple methods that evaluate a field. This prevents compiler exceptions such as mentioned in FLINK-8274. In comparison to #5174 this PR prevents the exception for all generated functions and also covers corner cases such as timestamps.

## Brief change log

- Splitting added to code generation classes

## Verifying this change

See added unit tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? JavaDocs
