### PR TITLE
[FLINK-8827] When FLINK_CONF_DIR contains spaces, execute zookeeper r…

### DIFF
--- a/flink-dist/src/main/flink-bin/bin/start-zookeeper-quorum.sh
+++ b/flink-dist/src/main/flink-bin/bin/start-zookeeper-quorum.sh
@@ -24,8 +24,8 @@ bin=`cd "$bin"; pwd`
 
 # Starts a ZooKeeper quorum as configured in $FLINK_CONF/zoo.cfg
 
-ZK_CONF=$FLINK_CONF_DIR/zoo.cfg
-if [ ! -f $ZK_CONF ]; then
+ZK_CONF="$FLINK_CONF_DIR/zoo.cfg"
+if [ ! -f "$ZK_CONF" ]; then
     echo "[ERROR] No ZooKeeper configuration file found in '$ZK_CONF'."
     exit 1
 fi
@@ -43,4 +43,4 @@ while read server ; do
     else
         echo "[WARN] Parse error. Skipping config entry '$server'."
     fi
-done < <(grep "^server\." $ZK_CONF)
+done < <(grep "^server\." "$ZK_CONF")

--- a/flink-dist/src/main/flink-bin/bin/stop-zookeeper-quorum.sh
+++ b/flink-dist/src/main/flink-bin/bin/stop-zookeeper-quorum.sh
@@ -24,8 +24,8 @@ bin=`cd "$bin"; pwd`
 
 # Stops a ZooKeeper quorum as configured in $FLINK_CONF/zoo.cfg
 
-ZK_CONF=$FLINK_CONF_DIR/zoo.cfg
-if [ ! -f $ZK_CONF ]; then
+ZK_CONF="$FLINK_CONF_DIR/zoo.cfg"
+if [ ! -f "$ZK_CONF" ]; then
     echo "[ERROR] No ZooKeeper configuration file found in '$ZK_CONF'."
     exit 1
 fi
@@ -43,4 +43,4 @@ while read server ; do
     else
         echo "[WARN] Parse error. Skipping config entry '$server'."
     fi
-done < <(grep "^server\." $ZK_CONF)
+done < <(grep "^server\." "$ZK_CONF")

--- a/flink-dist/src/main/flink-bin/bin/zookeeper.sh
+++ b/flink-dist/src/main/flink-bin/bin/zookeeper.sh
@@ -33,8 +33,8 @@ bin=`cd "$bin"; pwd`
 
 . "$bin"/config.sh
 
-ZK_CONF=$FLINK_CONF_DIR/zoo.cfg
-if [ ! -f $ZK_CONF ]; then
+ZK_CONF="$FLINK_CONF_DIR/zoo.cfg"
+if [ ! -f "$ZK_CONF" ]; then
     echo "[ERROR] No ZooKeeper configuration file found in '$ZK_CONF'."
     exit 1
 fi


### PR DESCRIPTION
…elated scripts failed

When the path of FLINK_CONF_DIR including spaces, executing zookeeper related scripts failed with the following error message: Expect binary expression.
