### PR TITLE
[FLINK-8799][YARN] Make AbstractYarnClusterDescriptor immutable

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
@@ -142,6 +142,54 @@ public class YarnConfigOptions {
 		.defaultValue("")
 		.withDescription("A comma-separated list of tags to apply to the Flink YARN application.");
 
+	/**
+	 * A command option to specify the application will submit to which YARN queue.
+	 */
+	public static final ConfigOption<String> YARN_QUEUE =
+		key("yarn.queue")
+		.noDefaultValue()
+		.withDescription("A command option to specify the application will submit to which YARN queue.");
+
+	/**
+	 * A command option to specify whether the application submission uses detached mode or not.
+	 */
+	public static final ConfigOption<Boolean> DETACHED_MODE =
+		key("yarn.detached-mode")
+		.defaultValue(false)
+		.withDescription("A command option to specify whether the application submission uses detached mode or not.");
+
+	/**
+	 * A command option to specify the encoded dynamic properties.
+	 */
+	public static final ConfigOption<String> DYNAMIC_PROPERTIES_ENCODED =
+		key("yarn.dynamic-properties-encoded")
+		.noDefaultValue()
+		.withDescription("A command option to specify the encoded dynamic properties.");
+
+	/**
+	 * A command option to specify the flink jar path.
+	 */
+	public static final ConfigOption<String> FLINK_JAR =
+		key("yarn.flink-jar")
+		.noDefaultValue()
+		.withDescription("A command option to specify the flink jar path.");
+
+	/**
+	 * A command option to specify the flink application name.
+	 */
+	public static final ConfigOption<String> YARN_APPLICATION_NAME =
+		key("yarn.application-name")
+		.noDefaultValue()
+		.withDescription("A command option to specify the flink application name.");
+
+	/**
+	 * A comma-separated list of ship paths.
+	 */
+	public static final ConfigOption<String> YARN_SHIP_PATHS =
+		key("yarn.ship-paths")
+		.noDefaultValue()
+		.withDescription("A comma-separated list of ship paths.");
+
 	// ------------------------------------------------------------------------
 
 	/** This class is not meant to be instantiated. */

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/FlinkYarnSessionCliTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/FlinkYarnSessionCliTest.java
@@ -133,6 +133,42 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 		assertEquals(zkNamespaceCliInput, descriptor.getZookeeperNamespace());
 	}
 
+	@Test
+	public void testNameProperty() throws Exception {
+		String testName = "testFlinkApplication";
+		String[] params = new String[] {"-yn", "2", "-ynm", testName};
+
+		FlinkYarnSessionCli yarnCLI = new FlinkYarnSessionCli(
+			new Configuration(),
+			tmp.getRoot().getAbsolutePath(),
+			"y",
+			"yarn");
+
+		CommandLine commandLine = yarnCLI.parseCommandLineOptions(params, true);
+
+		AbstractYarnClusterDescriptor descriptor = yarnCLI.createClusterDescriptor(commandLine);
+
+		assertEquals(testName, descriptor.getCustomName());
+	}
+
+	@Test
+	public void testFlinkJarPathProperty() throws Exception {
+		String testFlinkJarPathCliInput = "/path/to/flink.jar";
+		String[] params = new String[] {"-yn", "2", "-yj", testFlinkJarPathCliInput};
+
+		FlinkYarnSessionCli yarnCLI = new FlinkYarnSessionCli(
+			new Configuration(),
+			tmp.getRoot().getAbsolutePath(),
+			"y",
+			"yarn");
+
+		CommandLine commandLine = yarnCLI.parseCommandLineOptions(params, true);
+
+		AbstractYarnClusterDescriptor descriptor = yarnCLI.createClusterDescriptor(commandLine);
+
+		assertEquals(testFlinkJarPathCliInput, new File(descriptor.getFlinkJarPath().toUri()).getAbsolutePath());
+	}
+
 	/**
 	 * Test that the CliFrontend is able to pick up the .yarn-properties file from a specified location.
 	 */


### PR DESCRIPTION
## What is the purpose of the change

*This pull request Make AbstractYarnClusterDescriptor immutable*


## Brief change log

  - *removed or closed some setter accessor in class `AbstractYarnClusterDescriptor`*
  - *deleted some set property code and replaced with adding option to `Configuration` instance*
  - *fetch the config item from `Configuration` and init the field for `AbstractYarnClusterDescriptor`*
  - *add some config to `YarnConfigOptions`*
  - *fixed some old test cast and some new test case for refactored config properties*


## Verifying this change

This change added tests and can be verified as follows:

  - *fixed some old test cast and some new test case for refactored config properties such as flink jar path and name and so on*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not documented)
