### PR TITLE
[FLINK-8838] [table] Add Support for UNNEST a MultiSet type field.

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/logical/LogicalUnnestRule.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/logical/LogicalUnnestRule.scala
@@ -109,7 +109,7 @@ class LogicalUnnestRule(
                 ImmutableList.of(new RelDataTypeFieldImpl("f0", 0, componentType)))
             case _: RelRecordType => componentType
             case _ => throw TableException(
-              s"Unsupported multiset component type in UNNEST: ${componentType.toString}")
+              s"Unsupported component type in UNNEST: ${componentType.toString}")
           }
 
           // create table function scan

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/util/ExplodeFunctionUtil.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/util/ExplodeFunctionUtil.scala
@@ -24,92 +24,208 @@ import org.apache.flink.api.common.typeinfo.{BasicArrayTypeInfo, BasicTypeInfo, 
 import org.apache.flink.api.java.typeutils.{MultisetTypeInfo, ObjectArrayTypeInfo}
 import org.apache.flink.table.functions.TableFunction
 
-import scala.collection.JavaConverters._
-
 class ObjectExplodeTableFunc extends TableFunction[Object] {
   def eval(arr: Array[Object]): Unit = {
-    arr.foreach(collect)
+    if (null != arr) {
+      var i = 0
+      while (i < arr.length) {
+        collect(arr(i))
+        i += 1
+      }
+    }
   }
 
   def eval(map: util.Map[Object, Integer]): Unit = {
-    CommonCollect.collect(map, collect)
+    if (null != map) {
+      val it = map.entrySet().iterator()
+      while(it.hasNext) {
+        val item = it.next()
+        var i = 0
+        while (i < item.getValue) {
+          collect(item.getKey)
+          i += 1
+        }
+      }
+    }
   }
 }
 
 class FloatExplodeTableFunc extends TableFunction[Float] {
   def eval(arr: Array[Float]): Unit = {
-    arr.foreach(collect)
+    if (null != arr) {
+      var i = 0
+      while (i < arr.length) {
+        collect(arr(i))
+        i += 1
+      }
+    }
   }
 
   def eval(map: util.Map[Float, Integer]): Unit = {
-    CommonCollect.collect(map, collect)
+    if (null != map) {
+      val it = map.entrySet().iterator()
+      while(it.hasNext) {
+        val item = it.next()
+        var i = 0
+        while (i < item.getValue) {
+          collect(item.getKey)
+          i += 1
+        }
+      }
+    }
   }
 }
 
 class ShortExplodeTableFunc extends TableFunction[Short] {
   def eval(arr: Array[Short]): Unit = {
-    arr.foreach(collect)
+    if (null != arr) {
+      var i = 0
+      while (i < arr.length) {
+        collect(arr(i))
+        i += 1
+      }
+    }
   }
 
   def eval(map: util.Map[Short, Integer]): Unit = {
-    CommonCollect.collect(map, collect)
+    if (null != map) {
+      val it = map.entrySet().iterator()
+      while(it.hasNext) {
+        val item = it.next()
+        var i = 0
+        while (i < item.getValue) {
+          collect(item.getKey)
+          i += 1
+        }
+      }
+    }
   }
 }
 class IntExplodeTableFunc extends TableFunction[Int] {
   def eval(arr: Array[Int]): Unit = {
-    arr.foreach(collect)
+    if (null != arr) {
+      var i = 0
+      while (i < arr.length) {
+        collect(arr(i))
+        i += 1
+      }
+    }
   }
 
   def eval(map: util.Map[Int, Integer]): Unit = {
-    CommonCollect.collect(map, collect)
+    if (null != map) {
+      val it = map.entrySet().iterator()
+      while(it.hasNext) {
+        val item = it.next()
+        var i = 0
+        while (i < item.getValue) {
+          collect(item.getKey)
+          i += 1
+        }
+      }
+    }
   }
 }
 
 class LongExplodeTableFunc extends TableFunction[Long] {
   def eval(arr: Array[Long]): Unit = {
-    arr.foreach(collect)
+    if (null != arr) {
+      var i = 0
+      while (i < arr.length) {
+        collect(arr(i))
+        i += 1
+      }
+    }
   }
 
   def eval(map: util.Map[Long, Integer]): Unit = {
-    CommonCollect.collect(map, collect)
+    if (null != map) {
+      val it = map.entrySet().iterator()
+      while(it.hasNext) {
+        val item = it.next()
+        var i = 0
+        while (i < item.getValue) {
+          collect(item.getKey)
+          i += 1
+        }
+      }
+    }
   }
 }
 
 class DoubleExplodeTableFunc extends TableFunction[Double] {
   def eval(arr: Array[Double]): Unit = {
-    arr.foreach(collect)
+    if (null != arr) {
+      var i = 0
+      while (i < arr.length) {
+        collect(arr(i))
+        i += 1
+      }
+    }
   }
 
   def eval(map: util.Map[Double, Integer]): Unit = {
-    CommonCollect.collect(map, collect)
+    if (null != map) {
+      val it = map.entrySet().iterator()
+      while(it.hasNext) {
+        val item = it.next()
+        var i = 0
+        while (i < item.getValue) {
+          collect(item.getKey)
+          i += 1
+        }
+      }
+    }
   }
 }
 
 class ByteExplodeTableFunc extends TableFunction[Byte] {
   def eval(arr: Array[Byte]): Unit = {
-    arr.foreach(collect)
+    if (null != arr) {
+      var i = 0
+      while (i < arr.length) {
+        collect(arr(i))
+        i += 1
+      }
+    }
   }
 
   def eval(map: util.Map[Byte, Integer]): Unit = {
-    CommonCollect.collect(map, collect)
+    if (null != map) {
+      val it = map.entrySet().iterator()
+      while(it.hasNext) {
+        val item = it.next()
+        var i = 0
+        while (i < item.getValue) {
+          collect(item.getKey)
+          i += 1
+        }
+      }
+    }
   }
 }
 
 class BooleanExplodeTableFunc extends TableFunction[Boolean] {
   def eval(arr: Array[Boolean]): Unit = {
-    arr.foreach(collect)
+    if (null != arr) {
+      var i = 0
+      while (i < arr.length) {
+        collect(arr(i))
+        i += 1
+      }
+    }
   }
 
   def eval(map: util.Map[Boolean, Integer]): Unit = {
-    CommonCollect.collect(map, collect)
-  }
-}
-
-object CommonCollect {
-  def collect[T](map: util.Map[T, Integer], collectFunc: (T) => Unit): Unit = {
-    map.asScala.foreach{ e =>
-      for (i <- 0 until e._2) {
-        collectFunc(e._1)
+    if (null != map) {
+      val it = map.entrySet().iterator()
+      while(it.hasNext) {
+        val item = it.next()
+        var i = 0
+        while (i < item.getValue) {
+          collect(item.getKey)
+          i += 1
+        }
       }
     }
   }
@@ -138,7 +254,6 @@ object ExplodeFunctionUtil {
       case BasicTypeInfo.FLOAT_TYPE_INFO => new FloatExplodeTableFunc
       case BasicTypeInfo.DOUBLE_TYPE_INFO => new DoubleExplodeTableFunc
       case BasicTypeInfo.BYTE_TYPE_INFO => new ByteExplodeTableFunc
-      case BasicTypeInfo.BOOLEAN_TYPE_INFO => new BooleanExplodeTableFunc
       case BasicTypeInfo.BOOLEAN_TYPE_INFO => new BooleanExplodeTableFunc
       case _ => new ObjectExplodeTableFunc
     }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/util/ExplodeFunctionUtil.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/util/ExplodeFunctionUtil.scala
@@ -116,7 +116,7 @@ object CommonCollect {
 }
 
 object ExplodeFunctionUtil {
-  def explodeTableFuncFromType(ti: TypeInformation[_]):TableFunction[_] = {
+  def explodeTableFuncFromType(ti: TypeInformation[_]): TableFunction[_] = {
     ti match {
       case pat: PrimitiveArrayTypeInfo[_] => createTableFuncByType(pat.getComponentType)
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/util/ExplodeFunctionUtil.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/util/ExplodeFunctionUtil.scala
@@ -18,13 +18,21 @@
 
 package org.apache.flink.table.plan.util
 
+import java.util
+
 import org.apache.flink.api.common.typeinfo.{BasicArrayTypeInfo, BasicTypeInfo, PrimitiveArrayTypeInfo, TypeInformation}
-import org.apache.flink.api.java.typeutils.ObjectArrayTypeInfo
+import org.apache.flink.api.java.typeutils.{MultisetTypeInfo, ObjectArrayTypeInfo}
 import org.apache.flink.table.functions.TableFunction
+
+import scala.collection.JavaConverters._
 
 class ObjectExplodeTableFunc extends TableFunction[Object] {
   def eval(arr: Array[Object]): Unit = {
     arr.foreach(collect)
+  }
+
+  def eval(map: util.Map[Object, Integer]): Unit = {
+    CommonCollect.collect(map, collect)
   }
 }
 
@@ -32,16 +40,28 @@ class FloatExplodeTableFunc extends TableFunction[Float] {
   def eval(arr: Array[Float]): Unit = {
     arr.foreach(collect)
   }
+
+  def eval(map: util.Map[Float, Integer]): Unit = {
+    CommonCollect.collect(map, collect)
+  }
 }
 
 class ShortExplodeTableFunc extends TableFunction[Short] {
   def eval(arr: Array[Short]): Unit = {
     arr.foreach(collect)
   }
+
+  def eval(map: util.Map[Short, Integer]): Unit = {
+    CommonCollect.collect(map, collect)
+  }
 }
 class IntExplodeTableFunc extends TableFunction[Int] {
   def eval(arr: Array[Int]): Unit = {
     arr.foreach(collect)
+  }
+
+  def eval(map: util.Map[Int, Integer]): Unit = {
+    CommonCollect.collect(map, collect)
   }
 }
 
@@ -49,11 +69,19 @@ class LongExplodeTableFunc extends TableFunction[Long] {
   def eval(arr: Array[Long]): Unit = {
     arr.foreach(collect)
   }
+
+  def eval(map: util.Map[Long, Integer]): Unit = {
+    CommonCollect.collect(map, collect)
+  }
 }
 
 class DoubleExplodeTableFunc extends TableFunction[Double] {
   def eval(arr: Array[Double]): Unit = {
     arr.foreach(collect)
+  }
+
+  def eval(map: util.Map[Double, Integer]): Unit = {
+    CommonCollect.collect(map, collect)
   }
 }
 
@@ -61,31 +89,58 @@ class ByteExplodeTableFunc extends TableFunction[Byte] {
   def eval(arr: Array[Byte]): Unit = {
     arr.foreach(collect)
   }
+
+  def eval(map: util.Map[Byte, Integer]): Unit = {
+    CommonCollect.collect(map, collect)
+  }
 }
 
 class BooleanExplodeTableFunc extends TableFunction[Boolean] {
   def eval(arr: Array[Boolean]): Unit = {
     arr.foreach(collect)
   }
+
+  def eval(map: util.Map[Boolean, Integer]): Unit = {
+    CommonCollect.collect(map, collect)
+  }
+}
+
+object CommonCollect {
+  def collect[T](map: util.Map[T, Integer], collectFunc: (T) => Unit): Unit = {
+    map.asScala.foreach{ e =>
+      for (i <- 0 until e._2) {
+        collectFunc(e._1)
+      }
+    }
+  }
 }
 
 object ExplodeFunctionUtil {
   def explodeTableFuncFromType(ti: TypeInformation[_]):TableFunction[_] = {
     ti match {
-      case pat: PrimitiveArrayTypeInfo[_] => {
-        pat.getComponentType match {
-          case BasicTypeInfo.INT_TYPE_INFO => new IntExplodeTableFunc
-          case BasicTypeInfo.LONG_TYPE_INFO => new LongExplodeTableFunc
-          case BasicTypeInfo.SHORT_TYPE_INFO => new ShortExplodeTableFunc
-          case BasicTypeInfo.FLOAT_TYPE_INFO => new FloatExplodeTableFunc
-          case BasicTypeInfo.DOUBLE_TYPE_INFO => new DoubleExplodeTableFunc
-          case BasicTypeInfo.BYTE_TYPE_INFO => new ByteExplodeTableFunc
-          case BasicTypeInfo.BOOLEAN_TYPE_INFO => new BooleanExplodeTableFunc
-        }
-      }
+      case pat: PrimitiveArrayTypeInfo[_] => createTableFuncByType(pat.getComponentType)
+
       case _: ObjectArrayTypeInfo[_, _] => new ObjectExplodeTableFunc
+
       case _: BasicArrayTypeInfo[_, _] => new ObjectExplodeTableFunc
-      case _ => throw new UnsupportedOperationException(ti.toString + "IS NOT supported")
+
+      case mt: MultisetTypeInfo[_] => createTableFuncByType(mt.getElementTypeInfo)
+
+      case _ => throw new UnsupportedOperationException(ti.toString + " IS NOT supported")
+    }
+  }
+
+  def createTableFuncByType(typeInfo: TypeInformation[_]): TableFunction[_] = {
+    typeInfo match {
+      case BasicTypeInfo.INT_TYPE_INFO => new IntExplodeTableFunc
+      case BasicTypeInfo.LONG_TYPE_INFO => new LongExplodeTableFunc
+      case BasicTypeInfo.SHORT_TYPE_INFO => new ShortExplodeTableFunc
+      case BasicTypeInfo.FLOAT_TYPE_INFO => new FloatExplodeTableFunc
+      case BasicTypeInfo.DOUBLE_TYPE_INFO => new DoubleExplodeTableFunc
+      case BasicTypeInfo.BYTE_TYPE_INFO => new ByteExplodeTableFunc
+      case BasicTypeInfo.BOOLEAN_TYPE_INFO => new BooleanExplodeTableFunc
+      case BasicTypeInfo.BOOLEAN_TYPE_INFO => new BooleanExplodeTableFunc
+      case _ => new ObjectExplodeTableFunc
     }
   }
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/util/ExplodeFunctionUtil.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/util/ExplodeFunctionUtil.scala
@@ -26,204 +26,103 @@ import org.apache.flink.table.functions.TableFunction
 
 class ObjectExplodeTableFunc extends TableFunction[Object] {
   def eval(arr: Array[Object]): Unit = {
-    if (null != arr) {
-      var i = 0
-      while (i < arr.length) {
-        collect(arr(i))
-        i += 1
-      }
-    }
+    CommonCollect.collectArray(arr, collect)
   }
 
   def eval(map: util.Map[Object, Integer]): Unit = {
-    if (null != map) {
-      val it = map.entrySet().iterator()
-      while(it.hasNext) {
-        val item = it.next()
-        var i = 0
-        while (i < item.getValue) {
-          collect(item.getKey)
-          i += 1
-        }
-      }
-    }
+    CommonCollect.collect(map, collect)
   }
 }
 
 class FloatExplodeTableFunc extends TableFunction[Float] {
   def eval(arr: Array[Float]): Unit = {
-    if (null != arr) {
-      var i = 0
-      while (i < arr.length) {
-        collect(arr(i))
-        i += 1
-      }
-    }
+    CommonCollect.collectArray(arr, collect)
   }
 
   def eval(map: util.Map[Float, Integer]): Unit = {
-    if (null != map) {
-      val it = map.entrySet().iterator()
-      while(it.hasNext) {
-        val item = it.next()
-        var i = 0
-        while (i < item.getValue) {
-          collect(item.getKey)
-          i += 1
-        }
-      }
-    }
+    CommonCollect.collect(map, collect)
   }
 }
 
 class ShortExplodeTableFunc extends TableFunction[Short] {
   def eval(arr: Array[Short]): Unit = {
-    if (null != arr) {
-      var i = 0
-      while (i < arr.length) {
-        collect(arr(i))
-        i += 1
-      }
-    }
+    CommonCollect.collectArray(arr, collect)
   }
 
   def eval(map: util.Map[Short, Integer]): Unit = {
-    if (null != map) {
-      val it = map.entrySet().iterator()
-      while(it.hasNext) {
-        val item = it.next()
-        var i = 0
-        while (i < item.getValue) {
-          collect(item.getKey)
-          i += 1
-        }
-      }
-    }
+    CommonCollect.collect(map, collect)
   }
 }
 class IntExplodeTableFunc extends TableFunction[Int] {
   def eval(arr: Array[Int]): Unit = {
-    if (null != arr) {
-      var i = 0
-      while (i < arr.length) {
-        collect(arr(i))
-        i += 1
-      }
-    }
+    CommonCollect.collectArray(arr, collect)
   }
 
   def eval(map: util.Map[Int, Integer]): Unit = {
-    if (null != map) {
-      val it = map.entrySet().iterator()
-      while(it.hasNext) {
-        val item = it.next()
-        var i = 0
-        while (i < item.getValue) {
-          collect(item.getKey)
-          i += 1
-        }
-      }
-    }
+    CommonCollect.collect(map, collect)
   }
 }
 
 class LongExplodeTableFunc extends TableFunction[Long] {
   def eval(arr: Array[Long]): Unit = {
-    if (null != arr) {
-      var i = 0
-      while (i < arr.length) {
-        collect(arr(i))
-        i += 1
-      }
-    }
+    CommonCollect.collectArray(arr, collect)
   }
 
   def eval(map: util.Map[Long, Integer]): Unit = {
-    if (null != map) {
-      val it = map.entrySet().iterator()
-      while(it.hasNext) {
-        val item = it.next()
-        var i = 0
-        while (i < item.getValue) {
-          collect(item.getKey)
-          i += 1
-        }
-      }
-    }
+    CommonCollect.collect(map, collect)
   }
 }
 
 class DoubleExplodeTableFunc extends TableFunction[Double] {
   def eval(arr: Array[Double]): Unit = {
-    if (null != arr) {
-      var i = 0
-      while (i < arr.length) {
-        collect(arr(i))
-        i += 1
-      }
-    }
+    CommonCollect.collectArray(arr, collect)
   }
 
   def eval(map: util.Map[Double, Integer]): Unit = {
-    if (null != map) {
-      val it = map.entrySet().iterator()
-      while(it.hasNext) {
-        val item = it.next()
-        var i = 0
-        while (i < item.getValue) {
-          collect(item.getKey)
-          i += 1
-        }
-      }
-    }
+    CommonCollect.collect(map, collect)
   }
 }
 
 class ByteExplodeTableFunc extends TableFunction[Byte] {
   def eval(arr: Array[Byte]): Unit = {
-    if (null != arr) {
-      var i = 0
-      while (i < arr.length) {
-        collect(arr(i))
-        i += 1
-      }
-    }
+    CommonCollect.collectArray(arr, collect)
   }
 
   def eval(map: util.Map[Byte, Integer]): Unit = {
-    if (null != map) {
-      val it = map.entrySet().iterator()
-      while(it.hasNext) {
-        val item = it.next()
-        var i = 0
-        while (i < item.getValue) {
-          collect(item.getKey)
-          i += 1
-        }
-      }
-    }
+    CommonCollect.collect(map, collect)
   }
 }
 
 class BooleanExplodeTableFunc extends TableFunction[Boolean] {
   def eval(arr: Array[Boolean]): Unit = {
-    if (null != arr) {
+    CommonCollect.collectArray(arr, collect)
+  }
+
+  def eval(map: util.Map[Boolean, Integer]): Unit = {
+    CommonCollect.collect(map, collect)
+  }
+}
+
+object CommonCollect {
+
+  def collectArray[T](array: Array[T], collectFunc: (T) => Unit): Unit = {
+    if (null != array) {
       var i = 0
-      while (i < arr.length) {
-        collect(arr(i))
+      while (i < array.length) {
+        collectFunc(array(i))
         i += 1
       }
     }
   }
 
-  def eval(map: util.Map[Boolean, Integer]): Unit = {
+  def collect[T](map: util.Map[T, Integer], collectFunc: (T) => Unit): Unit = {
     if (null != map) {
       val it = map.entrySet().iterator()
       while(it.hasNext) {
         val item = it.next()
         var i = 0
         while (i < item.getValue) {
-          collect(item.getKey)
+          collectFunc(item.getKey)
           i += 1
         }
       }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/batch/sql/AggregateITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/batch/sql/AggregateITCase.scala
@@ -368,6 +368,36 @@ class AggregateITCase(
   }
 
   @Test
+  def testUnnestMultisetFromTumbleWindowAggregateCollectResult(): Unit = {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env, config)
+
+    val sqlQuery =
+      "SELECT b, COLLECT(b) as `set`" +
+        "FROM T " +
+        "GROUP BY b, TUMBLE(ts, INTERVAL '3' SECOND)"
+
+    val ds = CollectionDataSets.get3TupleDataSet(env)
+      // create timestamps
+      .map(x => (x._1, x._2, x._3, toTimestamp(x._1 * 1000)))
+    tEnv.registerDataSet("T", ds, 'a, 'b, 'c, 'ts)
+
+    val view1 = tEnv.sqlQuery(sqlQuery)
+    tEnv.registerTable("v1", view1)
+
+    val sqlQuery1 = "SELECT b, s FROM v1 t1, unnest(t1.`set`) AS A(s) where b < 3"
+    val result = tEnv.sqlQuery(sqlQuery1).toDataSet[Row].collect()
+
+    val expected = Seq(
+      "1,1",
+      "2,2",
+      "2,2"
+    ).mkString("\n")
+
+    TestBaseUtils.compareResultAsText(result.asJava, expected)
+  }
+
+  @Test
   def testTumbleWindowWithProperties(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
     val tEnv = TableEnvironment.getTableEnvironment(env, config)

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/batch/sql/AggregateITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/batch/sql/AggregateITCase.scala
@@ -368,7 +368,7 @@ class AggregateITCase(
   }
 
   @Test
-  def testUnnestMultisetFromTumbleWindowAggregateCollectResult(): Unit = {
+  def testTumbleWindowAggregateWithCollectUnnest(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
     val tEnv = TableEnvironment.getTableEnvironment(env, config)
 
@@ -385,7 +385,7 @@ class AggregateITCase(
     val view1 = tEnv.sqlQuery(sqlQuery)
     tEnv.registerTable("v1", view1)
 
-    val sqlQuery1 = "SELECT b, s FROM v1 t1, unnest(t1.`set`) AS A(s) where b < 3"
+    val sqlQuery1 = "SELECT b, s FROM v1, unnest(v1.`set`) AS A(s) where b < 3"
     val result = tEnv.sqlQuery(sqlQuery1).toDataSet[Row].collect()
 
     val expected = Seq(


### PR DESCRIPTION
## What is the purpose of the change
*This PR add support for UNNEST a MultiSet type field according to SQL standard UNNEST a collection value (collection value type includes  array and multiset value types)

## Brief change log
- *Add support for UNNEST a MultiSet type field
## Verifying this change
- *See added unit tests.

## Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with @Public(Evolving): no
- The serializers: no
- The runtime per-record code paths (performance sensitive): yes
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
- The S3 file system connector: no

## Documentation
- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? JavaDocs