### PR TITLE
[FLINK-8517] fix missing synchronization in TaskEventDispatcher

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/TaskEventDispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/TaskEventDispatcher.java
@@ -102,7 +102,10 @@ public class TaskEventDispatcher {
 		checkNotNull(eventListener);
 		checkNotNull(eventType);
 
-		TaskEventHandler taskEventHandler = registeredHandlers.get(partitionId);
+		TaskEventHandler taskEventHandler;
+		synchronized (registeredHandlers) {
+			taskEventHandler = registeredHandlers.get(partitionId);
+		}
 		if (taskEventHandler == null) {
 			throw new IllegalStateException(
 				"Partition " + partitionId + " not registered at task event dispatcher.");
@@ -123,7 +126,10 @@ public class TaskEventDispatcher {
 		checkNotNull(partitionId);
 		checkNotNull(event);
 
-		TaskEventHandler taskEventHandler = registeredHandlers.get(partitionId);
+		TaskEventHandler taskEventHandler;
+		synchronized (registeredHandlers) {
+			taskEventHandler = registeredHandlers.get(partitionId);
+		}
 
 		if (taskEventHandler != null) {
 			taskEventHandler.publish(event);


### PR DESCRIPTION
## What is the purpose of the change

The `TaskEventDispatcher` was missing synchronization accessing the `registeredHandlers` field for the new `subscribeToEvent()` and `publish()` methods. This was causing the `StaticlyNestedIterationsITCase.testJobWithoutObjectReuse()` test to sporadically fail (reproducible after running a couple of times).

Please merge into `master` and `release-1.5` after accepting.

## Brief change log

- add synchronization around `TaskEventDispatcher#subscribeToEvent()`'s access to `registeredHandlers`
- add synchronization around `TaskEventDispatcher#publish()`'s access to `registeredHandlers`

## Verifying this change

This change is already covered by existing tests (indirectly), such as `StaticlyNestedIterationsITCase.testJobWithoutObjectReuse()`. I ran it almost 24000 times and could not reproduce it anymore with the change

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
