### PR TITLE
[FLINK-8459][flip6] Implement RestClusterClient.cancelWithSavepoint

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/MiniClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/MiniClusterClient.java
@@ -87,7 +87,7 @@ public class MiniClusterClient extends ClusterClient<MiniClusterClient.MiniClust
 
 	@Override
 	public String cancelWithSavepoint(JobID jobId, @Nullable String savepointDirectory) throws Exception {
-		throw new UnsupportedOperationException("MiniClusterClient does not yet support this operation.");
+		return miniCluster.triggerSavepoint(jobId, savepointDirectory, true).get();
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -487,11 +487,12 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 	public CompletableFuture<String> triggerSavepoint(
 			final JobID jobId,
 			final String targetDirectory,
+			final boolean cancelJob,
 			final Time timeout) {
 		if (jobManagerRunners.containsKey(jobId)) {
 			return jobManagerRunners.get(jobId)
 				.getJobManagerGateway()
-				.triggerSavepoint(targetDirectory, timeout);
+				.triggerSavepoint(targetDirectory, cancelJob, timeout);
 		} else {
 			return FutureUtils.completedExceptionally(new FlinkJobNotFoundException(jobId));
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -524,6 +524,7 @@ public class ExecutionGraph implements AccessExecutionGraph {
 		}
 	}
 
+	@Nullable
 	public CheckpointCoordinator getCheckpointCoordinator() {
 		return checkpointCoordinator;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
@@ -263,6 +263,7 @@ public interface JobMasterGateway extends
 	 */
 	CompletableFuture<String> triggerSavepoint(
 		@Nullable final String targetDirectory,
+		final boolean cancelJob,
 		final Time timeout);
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -483,6 +483,17 @@ public class MiniCluster implements JobExecutorService, AutoCloseableAsync {
 		}
 	}
 
+	public CompletableFuture<String> triggerSavepoint(JobID jobId, String targetDirectory, boolean cancelJob) {
+		try {
+			return getDispatcherGateway().triggerSavepoint(jobId, targetDirectory, cancelJob, rpcTimeout);
+		} catch (LeaderRetrievalException | InterruptedException e) {
+			return FutureUtils.completedExceptionally(
+				new FlinkException(
+					String.format("Could not cancel job %s.", jobId),
+					e));
+		}
+	}
+
 	// ------------------------------------------------------------------------
 	//  running jobs
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointHandlers.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointHandlers.java
@@ -127,8 +127,9 @@ public class SavepointHandlers extends AbstractAsynchronousOperationHandlers<Asy
 						HttpResponseStatus.BAD_REQUEST);
 			}
 
+			final boolean cancelJob = request.getRequestBody().isCancelJob();
 			final String targetDirectory = requestedTargetDirectory != null ? requestedTargetDirectory : defaultSavepointDir;
-			return gateway.triggerSavepoint(jobId, targetDirectory, RpcUtils.INF_TIMEOUT);
+			return gateway.triggerSavepoint(jobId, targetDirectory, cancelJob, RpcUtils.INF_TIMEOUT);
 		}
 
 		@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointTriggerRequestBody.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointTriggerRequestBody.java
@@ -32,22 +32,21 @@ public class SavepointTriggerRequestBody implements RequestBody {
 
 	public static final String FIELD_NAME_TARGET_DIRECTORY = "target-directory";
 
+	private static final String FIELD_NAME_CANCEL_JOB = "cancel-job";
+
 	@JsonProperty(FIELD_NAME_TARGET_DIRECTORY)
 	@Nullable
 	private final String targetDirectory;
 
+	@JsonProperty(FIELD_NAME_CANCEL_JOB)
 	private final boolean cancelJob;
 
 	@JsonCreator
 	public SavepointTriggerRequestBody(
 			@Nullable @JsonProperty(FIELD_NAME_TARGET_DIRECTORY) final String targetDirectory,
-			@JsonProperty(value = "cancel-job", defaultValue = "false") final boolean cancelJob) {
+			@JsonProperty(value = FIELD_NAME_CANCEL_JOB, defaultValue = "false") final boolean cancelJob) {
 		this.targetDirectory = targetDirectory;
 		this.cancelJob = cancelJob;
-	}
-
-	public SavepointTriggerRequestBody(@Nullable final String targetDirectory) {
-		this(targetDirectory, false);
 	}
 
 	@Nullable

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointTriggerRequestBody.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointTriggerRequestBody.java
@@ -36,10 +36,18 @@ public class SavepointTriggerRequestBody implements RequestBody {
 	@Nullable
 	private final String targetDirectory;
 
+	private final boolean cancelJob;
+
 	@JsonCreator
 	public SavepointTriggerRequestBody(
-			@Nullable @JsonProperty(FIELD_NAME_TARGET_DIRECTORY) final String targetDirectory) {
+			@Nullable @JsonProperty(FIELD_NAME_TARGET_DIRECTORY) final String targetDirectory,
+			@JsonProperty(value = "cancel-job", defaultValue = "false") final boolean cancelJob) {
 		this.targetDirectory = targetDirectory;
+		this.cancelJob = cancelJob;
+	}
+
+	public SavepointTriggerRequestBody(@Nullable final String targetDirectory) {
+		this(targetDirectory, false);
 	}
 
 	@Nullable
@@ -47,4 +55,7 @@ public class SavepointTriggerRequestBody implements RequestBody {
 		return targetDirectory;
 	}
 
+	public boolean isCancelJob() {
+		return cancelJob;
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/RestfulGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/RestfulGateway.java
@@ -139,6 +139,7 @@ public interface RestfulGateway extends RpcGateway {
 	default CompletableFuture<String> triggerSavepoint(
 			JobID jobId,
 			String targetDirectory,
+			boolean cancelJob,
 			@RpcTimeout Time timeout) {
 		throw new UnsupportedOperationException();
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGateway.java
@@ -48,6 +48,8 @@ import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 
+import javax.annotation.Nullable;
+
 import java.net.InetSocketAddress;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
@@ -153,7 +155,7 @@ public class TestingJobMasterGateway implements JobMasterGateway {
 	}
 
 	@Override
-	public CompletableFuture<String> triggerSavepoint(String targetDirectory, Time timeout) {
+	public CompletableFuture<String> triggerSavepoint(@Nullable final String targetDirectory, final boolean cancelJob, final Time timeout) {
 		throw new UnsupportedOperationException();
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/async/AbstractAsynchronousOperationHandlersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/async/AbstractAsynchronousOperationHandlersTest.java
@@ -305,7 +305,7 @@ public class AbstractAsynchronousOperationHandlersTest extends TestLogger {
 
 			@Override
 			protected CompletableFuture<String> triggerOperation(HandlerRequest<EmptyRequestBody, EmptyMessageParameters> request, RestfulGateway gateway) throws RestHandlerException {
-				return gateway.triggerSavepoint(new JobID(), null, timeout);
+				return gateway.triggerSavepoint(new JobID(), null, false, timeout);
 			}
 
 			@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointHandlersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointHandlersTest.java
@@ -200,7 +200,7 @@ public class SavepointHandlersTest extends TestLogger {
 			final String targetDirectory
 	) throws HandlerRequestException {
 		return new HandlerRequest<>(
-			new SavepointTriggerRequestBody(targetDirectory),
+			new SavepointTriggerRequestBody(targetDirectory, false),
 			new SavepointTriggerMessageParameters(),
 			Collections.singletonMap(JobIDPathParameter.KEY, JOB_ID.toString()),
 			Collections.emptyMap());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointTriggerRequestBodyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointTriggerRequestBodyTest.java
@@ -20,13 +20,34 @@ package org.apache.flink.runtime.rest.messages.job.savepoints;
 
 import org.apache.flink.runtime.rest.messages.RestRequestMarshallingTestBase;
 
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
 import static org.junit.Assert.assertEquals;
 
 /**
  * Tests for {@link SavepointTriggerRequestBody}.
  */
+@RunWith(Parameterized.class)
 public class SavepointTriggerRequestBodyTest
 		extends RestRequestMarshallingTestBase<SavepointTriggerRequestBody> {
+
+	private final SavepointTriggerRequestBody savepointTriggerRequestBody;
+
+	public SavepointTriggerRequestBodyTest(final SavepointTriggerRequestBody savepointTriggerRequestBody) {
+		this.savepointTriggerRequestBody = savepointTriggerRequestBody;
+	}
+
+	@Parameterized.Parameters
+	public static Collection<Object[]> data() {
+		return Arrays.asList(new Object[][]{
+			{new SavepointTriggerRequestBody("/tmp", true)},
+			{new SavepointTriggerRequestBody("/tmp", false)}
+		});
+	}
 
 	@Override
 	protected Class<SavepointTriggerRequestBody> getTestRequestClass() {
@@ -35,7 +56,7 @@ public class SavepointTriggerRequestBodyTest
 
 	@Override
 	protected SavepointTriggerRequestBody getTestRequestInstance() {
-		return new SavepointTriggerRequestBody("/tmp", true);
+		return savepointTriggerRequestBody;
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointTriggerRequestBodyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointTriggerRequestBodyTest.java
@@ -34,8 +34,8 @@ public class SavepointTriggerRequestBodyTest
 	}
 
 	@Override
-	protected SavepointTriggerRequestBody getTestRequestInstance() throws Exception {
-		return new SavepointTriggerRequestBody("/tmp");
+	protected SavepointTriggerRequestBody getTestRequestInstance() {
+		return new SavepointTriggerRequestBody("/tmp", true);
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/TestingRestfulGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/TestingRestfulGateway.java
@@ -190,7 +190,7 @@ public class TestingRestfulGateway implements RestfulGateway {
 	}
 
 	@Override
-	public CompletableFuture<String> triggerSavepoint(JobID jobId, String targetDirectory, Time timeout) {
+	public CompletableFuture<String> triggerSavepoint(JobID jobId, String targetDirectory, boolean cancelJob, Time timeout) {
 		return triggerSavepointFunction.apply(jobId, targetDirectory);
 	}
 

--- a/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTriggerSavepointIT.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTriggerSavepointIT.java
@@ -1,0 +1,219 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.client.program.MiniClusterClient;
+import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
+import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointRetentionPolicy;
+import org.apache.flink.runtime.checkpoint.CheckpointTriggerException;
+import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
+import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobStatus;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
+import org.apache.flink.runtime.jobgraph.tasks.JobCheckpointingSettings;
+import org.apache.flink.test.util.AbstractTestBase;
+import org.apache.flink.testutils.category.Flip6;
+import org.apache.flink.util.ExceptionUtils;
+
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.isOneOf;
+
+/**
+ * Tests for {@link org.apache.flink.runtime.jobmaster.JobMaster#triggerSavepoint(String, boolean, Time)}.
+ *
+ * @see org.apache.flink.runtime.jobmaster.JobMaster
+ */
+@Category(Flip6.class)
+public class JobMasterTriggerSavepointIT extends AbstractTestBase {
+
+	private static CountDownLatch invokeLatch;
+
+	private static volatile CountDownLatch triggerCheckpointLatch;
+
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	private Path savepointDirectory;
+	private MiniClusterClient clusterClient;
+	private JobGraph jobGraph;
+
+	@Before
+	public void setUp() throws Exception {
+		invokeLatch = new CountDownLatch(1);
+		triggerCheckpointLatch = new CountDownLatch(1);
+		savepointDirectory = temporaryFolder.newFolder().toPath();
+
+		Assume.assumeTrue(
+			"ClusterClient is not an instance of MiniClusterClient",
+			miniClusterResource.getClusterClient() instanceof MiniClusterClient);
+
+		clusterClient = (MiniClusterClient) miniClusterResource.getClusterClient();
+		clusterClient.setDetached(true);
+
+		jobGraph = new JobGraph();
+
+		final JobVertex vertex = new JobVertex("testVertex");
+		vertex.setInvokableClass(NoOpBlockingInvokable.class);
+		jobGraph.addVertex(vertex);
+
+		jobGraph.setSnapshotSettings(new JobCheckpointingSettings(
+			Collections.singletonList(vertex.getID()),
+			Collections.singletonList(vertex.getID()),
+			Collections.singletonList(vertex.getID()),
+			new CheckpointCoordinatorConfiguration(
+				10,
+				60_000,
+				10,
+				1,
+				CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION,
+				true),
+			null
+		));
+
+		clusterClient.submitJob(jobGraph, ClassLoader.getSystemClassLoader());
+		invokeLatch.await(60, TimeUnit.SECONDS);
+		waitForJob();
+	}
+
+	@Test
+	public void testStopJobAfterSavepoint() throws Exception {
+		final String savepointLocation = cancelWithSavepoint();
+		final JobStatus jobStatus = clusterClient.getJobStatus(jobGraph.getJobID()).get(60, TimeUnit.SECONDS);
+
+		assertThat(jobStatus, isOneOf(JobStatus.CANCELED, JobStatus.CANCELLING));
+
+		final List<Path> savepoints = Files.list(savepointDirectory).map(Path::getFileName).collect(Collectors.toList());
+		assertThat(savepoints, hasItem(Paths.get(savepointLocation).getFileName()));
+	}
+
+	@Test
+	public void testDoNotCancelJobIfSavepointFails() throws Exception {
+		try {
+			Files.setPosixFilePermissions(savepointDirectory, Collections.emptySet());
+		} catch (IOException e) {
+			Assume.assumeNoException(e);
+		}
+
+		try {
+			cancelWithSavepoint();
+		} catch (Exception e) {
+			assertThat(ExceptionUtils.findThrowable(e, CheckpointTriggerException.class).isPresent(), equalTo(true));
+		}
+
+		final JobStatus jobStatus = clusterClient.getJobStatus(jobGraph.getJobID()).get(60, TimeUnit.SECONDS);
+		assertThat(jobStatus, equalTo(JobStatus.RUNNING));
+
+		// assert that checkpoints are continued to be triggered
+		triggerCheckpointLatch = new CountDownLatch(1);
+		assertThat(triggerCheckpointLatch.await(60, TimeUnit.SECONDS), equalTo(true));
+	}
+
+	private void waitForJob() throws Exception {
+		for (int i = 0; i < 60; i++) {
+			try {
+				final JobStatus jobStatus = clusterClient.getJobStatus(jobGraph.getJobID()).get(60, TimeUnit.SECONDS);
+				assertThat(jobStatus.isGloballyTerminalState(), equalTo(false));
+				if (jobStatus == JobStatus.RUNNING) {
+					return;
+				}
+			} catch (ExecutionException ignored) {
+				// JobManagerRunner is not yet registered in Dispatcher
+			}
+			Thread.sleep(1000);
+		}
+		throw new AssertionError("Job did not become running within timeout.");
+	}
+
+	/**
+	 * Invokable which calls {@link CountDownLatch#countDown()} on
+	 * {@link JobMasterTriggerSavepointIT#invokeLatch}, and then blocks afterwards.
+	 */
+	public static class NoOpBlockingInvokable extends AbstractInvokable {
+
+		public NoOpBlockingInvokable(final Environment environment) {
+			super(environment);
+		}
+
+		@Override
+		public void invoke() {
+			invokeLatch.countDown();
+			try {
+				Thread.sleep(Long.MAX_VALUE);
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+			}
+		}
+
+		@Override
+		public boolean triggerCheckpoint(final CheckpointMetaData checkpointMetaData, final CheckpointOptions checkpointOptions) throws Exception {
+			final TaskStateSnapshot checkpointStateHandles = new TaskStateSnapshot();
+			checkpointStateHandles.putSubtaskStateByOperatorID(
+				OperatorID.fromJobVertexID(getEnvironment().getJobVertexId()),
+				new OperatorSubtaskState());
+
+			getEnvironment().acknowledgeCheckpoint(
+				checkpointMetaData.getCheckpointId(),
+				new CheckpointMetrics(),
+				checkpointStateHandles);
+
+			triggerCheckpointLatch.countDown();
+
+			return true;
+		}
+
+		@Override
+		public void notifyCheckpointComplete(final long checkpointId) throws Exception {
+		}
+	}
+
+	private String cancelWithSavepoint() throws Exception {
+		return clusterClient.cancelWithSavepoint(
+			jobGraph.getJobID(),
+			savepointDirectory.toAbsolutePath().toString());
+	}
+
+}


### PR DESCRIPTION
## What is the purpose of the change

*Introduce cancelJob flag to existing triggerSavepoint methods in Dispatcher and
JobMaster. Stop checkpoint scheduler before taking savepoint to make sure that
the savepoint created by this command is the last one.*

cc: @tillrohrmann 

## Brief change log

  - *Implement RestClusterClient.cancelWithSavepoint*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added `JobMasterTriggerSavepointIT`.*
  - *Manually tested.*
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
