### PR TITLE
[FLINK-8807] Fix ZookeeperCompleted checkpoint store can get stuck in infinite loop

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpoint.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.java.tuple.Tuple4;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
@@ -37,7 +38,10 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -282,6 +286,37 @@ public class CompletedCheckpoint implements Serializable {
 	// ------------------------------------------------------------------------
 	//  Miscellaneous
 	// ------------------------------------------------------------------------
+
+	public static boolean checkpointsMatch(
+		Collection<CompletedCheckpoint> first,
+		Collection<CompletedCheckpoint> second) {
+
+		Set<Tuple4<Long, Long, CheckpointProperties, String>> firstInterestingFields =
+			new HashSet<>();
+
+		for (CompletedCheckpoint checkpoint : first) {
+			firstInterestingFields.add(
+				new Tuple4<>(
+					checkpoint.getCheckpointID(),
+					checkpoint.getTimestamp(),
+					checkpoint.getProperties(),
+					checkpoint.getExternalPointer()));
+		}
+
+		Set<Tuple4<Long, Long, CheckpointProperties, String>> secondInterestingFields =
+			new HashSet<>();
+
+		for (CompletedCheckpoint checkpoint : second) {
+			secondInterestingFields.add(
+				new Tuple4<>(
+					checkpoint.getCheckpointID(),
+					checkpoint.getTimestamp(),
+					checkpoint.getProperties(),
+					checkpoint.getExternalPointer()));
+		}
+
+		return firstInterestingFields.equals(secondInterestingFields);
+	}
 
 	/**
 	 * Sets the callback for tracking when this checkpoint is discarded.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStore.java
@@ -199,7 +199,7 @@ public class ZooKeeperCompletedCheckpointStore implements CompletedCheckpointSto
 			}
 
 		} while (retrievedCheckpoints.size() != numberOfInitialCheckpoints &&
-			!lastTryRetrievedCheckpoints.equals(retrievedCheckpoints));
+			!CompletedCheckpoint.checkpointsMatch(lastTryRetrievedCheckpoints, retrievedCheckpoints));
 
 		// Clear local handles in order to prevent duplicates on
 		// recovery. The local handles should reflect the state

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreTest.java
@@ -83,30 +83,14 @@ public class ZooKeeperCompletedCheckpointStoreTest extends TestLogger {
 	/**
 	 * Tests that the completed checkpoint store can retrieve all checkpoints stored in ZooKeeper
 	 * and ignores those which cannot be retrieved via their state handles.
+	 *
+	 * <p>We have a timeout in case the ZooKeeper store get's into a deadlock/livelock situation.
 	 */
-	@Test
+	@Test(timeout = 50000)
 	public void testCheckpointRecovery() throws Exception {
+		final long checkpoint1Id = 1L;
+		final long checkpoint2Id = 2;
 		final List<Tuple2<RetrievableStateHandle<CompletedCheckpoint>, String>> checkpointsInZooKeeper = new ArrayList<>(4);
-
-		final CompletedCheckpoint completedCheckpoint1 = new CompletedCheckpoint(
-			new JobID(),
-			1L,
-			1L,
-			1L,
-			new HashMap<>(),
-			null,
-			CheckpointProperties.forCheckpoint(CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION),
-			new TestCompletedCheckpointStorageLocation());
-
-		final CompletedCheckpoint completedCheckpoint2 = new CompletedCheckpoint(
-			new JobID(),
-			2L,
-			2L,
-			2L,
-			new HashMap<>(),
-			null,
-			CheckpointProperties.forCheckpoint(CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION),
-			new TestCompletedCheckpointStorageLocation());
 
 		final Collection<Long> expectedCheckpointIds = new HashSet<>(2);
 		expectedCheckpointIds.add(1L);
@@ -116,10 +100,28 @@ public class ZooKeeperCompletedCheckpointStoreTest extends TestLogger {
 		when(failingRetrievableStateHandle.retrieveState()).thenThrow(new IOException("Test exception"));
 
 		final RetrievableStateHandle<CompletedCheckpoint> retrievableStateHandle1 = mock(RetrievableStateHandle.class);
-		when(retrievableStateHandle1.retrieveState()).thenReturn(completedCheckpoint1);
+		when(retrievableStateHandle1.retrieveState()).then(
+			(invocation) -> new CompletedCheckpoint(
+				new JobID(),
+				checkpoint1Id,
+				1L,
+				1L,
+				new HashMap<>(),
+				null,
+				CheckpointProperties.forCheckpoint(CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION),
+				new TestCompletedCheckpointStorageLocation()));
 
 		final RetrievableStateHandle<CompletedCheckpoint> retrievableStateHandle2 = mock(RetrievableStateHandle.class);
-		when(retrievableStateHandle2.retrieveState()).thenReturn(completedCheckpoint2);
+		when(retrievableStateHandle2.retrieveState()).then(
+			(invocation -> new CompletedCheckpoint(
+				new JobID(),
+				checkpoint2Id,
+				2L,
+				2L,
+				new HashMap<>(),
+				null,
+				CheckpointProperties.forCheckpoint(CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION),
+				new TestCompletedCheckpointStorageLocation())));
 
 		checkpointsInZooKeeper.add(Tuple2.of(retrievableStateHandle1, "/foobar1"));
 		checkpointsInZooKeeper.add(Tuple2.of(failingRetrievableStateHandle, "/failing1"));
@@ -185,7 +187,7 @@ public class ZooKeeperCompletedCheckpointStoreTest extends TestLogger {
 
 		// check that we return the latest retrievable checkpoint
 		// this should remove the latest checkpoint because it is broken
-		assertEquals(completedCheckpoint2.getCheckpointID(), latestCompletedCheckpoint.getCheckpointID());
+		assertEquals(checkpoint2Id, latestCompletedCheckpoint.getCheckpointID());
 
 		// this should remove the second broken checkpoint because we're iterating over all checkpoints
 		List<CompletedCheckpoint> completedCheckpoints = zooKeeperCompletedCheckpointStore.getAllCheckpoints();


### PR DESCRIPTION
Before, CompletedCheckpoint did not have proper equals()/hashCode(),
which meant that the fixpoint condition in
ZooKeeperCompletedCheckpointStore would never hold if at least on
checkpoint became unreadable.

We now compare the interesting fields of the checkpoints manually and
extended the test to properly create new CompletedCheckpoints. Before,
we were reusing the same CompletedCheckpoint instances, meaning that
Objects.equals()/hashCode() would make the test succeed.