### PR TITLE
[FLINK-8402][s3][tests] fix hadoop/presto S3 IT cases for eventually-consistent operations

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/core/fs/FileSystemTestUtils.java
+++ b/flink-core/src/test/java/org/apache/flink/core/fs/FileSystemTestUtils.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.fs;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Various utility functions for testing {@link FileSystem} implementations.
+ */
+public class FileSystemTestUtils {
+
+	/**
+	 * Verifies that the given path eventually appears on / disappears from <tt>fs</tt> within
+	 * <tt>deadline</tt> nanoseconds.
+	 */
+	public static void checkPathEventualExistence(
+			FileSystem fs,
+			Path path,
+			boolean expectedExists,
+			long deadline) throws IOException, InterruptedException {
+		boolean dirExists;
+		while ((dirExists = fs.exists(path)) != expectedExists &&
+				System.nanoTime() < deadline) {
+			Thread.sleep(10);
+		}
+		assertEquals(expectedExists, dirExists);
+	}
+}

--- a/flink-filesystems/flink-s3-fs-hadoop/src/test/java/org/apache/flink/fs/s3hadoop/HadoopS3FileSystemITCase.java
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/test/java/org/apache/flink/fs/s3hadoop/HadoopS3FileSystemITCase.java
@@ -95,7 +95,7 @@ public class HadoopS3FileSystemITCase extends TestLogger {
 	@AfterClass
 	public static void cleanUp() throws IOException, InterruptedException {
 		if (!skipTest) {
-			final long deadline = System.currentTimeMillis() + 30_000L; // 30 secs
+			final long deadline = System.nanoTime() + 30_000_000_000L; // 30 secs
 			// initialize configuration with valid credentials
 			final Configuration conf = new Configuration();
 			conf.setString("s3.access.key", ACCESS_KEY);
@@ -171,7 +171,7 @@ public class HadoopS3FileSystemITCase extends TestLogger {
 
 	@Test
 	public void testSimpleFileWriteAndRead() throws Exception {
-		final long deadline = System.currentTimeMillis() + 30_000L; // 30 secs
+		final long deadline = System.nanoTime() + 30_000_000_000L; // 30 secs
 		final Configuration conf = new Configuration();
 		conf.setString("s3.access.key", ACCESS_KEY);
 		conf.setString("s3.secret.key", SECRET_KEY);
@@ -206,7 +206,7 @@ public class HadoopS3FileSystemITCase extends TestLogger {
 
 	@Test
 	public void testDirectoryListing() throws Exception {
-		final long deadline = System.currentTimeMillis() + 30_000L; // 30 secs
+		final long deadline = System.nanoTime() + 30_000_000_000L; // 30 secs
 		final Configuration conf = new Configuration();
 		conf.setString("s3.access.key", ACCESS_KEY);
 		conf.setString("s3.secret.key", SECRET_KEY);
@@ -268,7 +268,7 @@ public class HadoopS3FileSystemITCase extends TestLogger {
 			long deadline) throws IOException, InterruptedException {
 		boolean dirExists;
 		while ((dirExists = fs.exists(path)) != expectedExists &&
-				System.currentTimeMillis() < deadline) {
+				System.nanoTime() < deadline) {
 			Thread.sleep(10);
 		}
 		assertEquals(expectedExists, dirExists);

--- a/flink-filesystems/flink-s3-fs-presto/src/test/java/org/apache/flink/fs/s3presto/PrestoS3FileSystemITCase.java
+++ b/flink-filesystems/flink-s3-fs-presto/src/test/java/org/apache/flink/fs/s3presto/PrestoS3FileSystemITCase.java
@@ -70,7 +70,7 @@ public class PrestoS3FileSystemITCase extends TestLogger {
 
 	@Test
 	public void testSimpleFileWriteAndRead() throws Exception {
-		final long deadline = System.currentTimeMillis() + 30_000L; // 30 secs
+		final long deadline = System.nanoTime() + 30_000_000_000L; // 30 secs
 		final Configuration conf = new Configuration();
 		conf.setString("s3.access-key", ACCESS_KEY);
 		conf.setString("s3.secret-key", SECRET_KEY);
@@ -105,7 +105,7 @@ public class PrestoS3FileSystemITCase extends TestLogger {
 
 	@Test
 	public void testDirectoryListing() throws Exception {
-		final long deadline = System.currentTimeMillis() + 30_000L; // 30 secs
+		final long deadline = System.nanoTime() + 30_000_000_000L; // 30 secs
 		final Configuration conf = new Configuration();
 		conf.setString("s3.access-key", ACCESS_KEY);
 		conf.setString("s3.secret-key", SECRET_KEY);
@@ -162,13 +162,13 @@ public class PrestoS3FileSystemITCase extends TestLogger {
 	}
 
 	private static void checkPathExists(
-		FileSystem fs,
-		Path path,
-		boolean expectedExists,
-		long deadline) throws IOException, InterruptedException {
+			FileSystem fs,
+			Path path,
+			boolean expectedExists,
+			long deadline) throws IOException, InterruptedException {
 		boolean dirExists;
 		while ((dirExists = fs.exists(path)) != expectedExists &&
-			System.currentTimeMillis() < deadline) {
+			System.nanoTime() < deadline) {
 			Thread.sleep(10);
 		}
 		assertEquals(expectedExists, dirExists);


### PR DESCRIPTION
## What is the purpose of the change

`HadoopS3FileSystemITCase` and `PrestoS3FileSystemITCase` rely on consistent read-after-write and delete operations which S3 does not offer and which the `FileSystem` wrappers not always circumvent. Also see
https://docs.aws.amazon.com/AmazonS3/latest/dev/Introduction.html#ConsistencyModel

Please merge into `master` and `release-1.5` after accepting.

## Brief change log

- harden `HadoopS3FileSystemITCase` with respect to eventual-consistent operations by adding retries of existence checks with an overall deadline of 30s
- harden `PrestoS3FileSystemITCase` with respect to eventual-consistent operations by adding retries of existence checks with an overall deadline of 30s

## Verifying this change

This change is already covered by existing tests, such as `HadoopS3FileSystemITCase` and `PrestoS3FileSystemITCase` which occasionally failed.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **yes**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
