### PR TITLE
[FLINK-8842] Change the Rest default port to 8081

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/RestOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/RestOptions.java
@@ -41,7 +41,7 @@ public class RestOptions {
 	 */
 	public static final ConfigOption<Integer> REST_PORT =
 		key("rest.port")
-			.defaultValue(9065)
+			.defaultValue(8081)
 			.withDescription("The port that the server listens on / the client connects to.");
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterConfiguration.java
@@ -27,11 +27,18 @@ import org.apache.flink.util.Preconditions;
 public class ClusterConfiguration {
 	private final String configDir;
 
-	public ClusterConfiguration(String configDir) {
+	private final int restPort;
+
+	public ClusterConfiguration(String configDir, int restPort) {
 		this.configDir = Preconditions.checkNotNull(configDir);
+		this.restPort = restPort;
 	}
 
 	public String getConfigDir() {
 		return configDir;
+	}
+
+	public int getRestPort() {
+		return restPort;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -24,6 +24,7 @@ import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.GlobalConfiguration;
+import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.configuration.WebOptions;
@@ -59,6 +60,7 @@ import org.apache.flink.runtime.rpc.akka.AkkaRpcService;
 import org.apache.flink.runtime.security.SecurityConfiguration;
 import org.apache.flink.runtime.security.SecurityContext;
 import org.apache.flink.runtime.security.SecurityUtils;
+import org.apache.flink.runtime.util.ZooKeeperUtils;
 import org.apache.flink.runtime.webmonitor.WebMonitorEndpoint;
 import org.apache.flink.runtime.webmonitor.retriever.LeaderGatewayRetriever;
 import org.apache.flink.runtime.webmonitor.retriever.MetricQueryServiceRetriever;
@@ -354,7 +356,11 @@ public abstract class ClusterEntrypoint implements FatalErrorHandler {
 	 * @return Port range for the common {@link RpcService}
 	 */
 	protected String getRPCPortRange(Configuration configuration) {
-		return String.valueOf(configuration.getInteger(JobManagerOptions.PORT));
+		if (ZooKeeperUtils.isZooKeeperRecoveryMode(configuration)) {
+			return configuration.getString(HighAvailabilityOptions.HA_JOB_MANAGER_PORT_RANGE);
+		} else {
+			return String.valueOf(configuration.getInteger(JobManagerOptions.PORT));
+		}
 	}
 
 	protected RpcService createRpcService(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -25,6 +25,7 @@ import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.configuration.WebOptions;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.runtime.akka.AkkaUtils;
@@ -594,11 +595,28 @@ public abstract class ClusterEntrypoint implements FatalErrorHandler {
 
 		final String configDir = parameterTool.get("configDir", "");
 
-		return new ClusterConfiguration(configDir);
+		final int restPort;
+
+		final String portKey = "webui-port";
+		if (parameterTool.has(portKey)) {
+			restPort = Integer.valueOf(parameterTool.get(portKey));
+		} else {
+			restPort = -1;
+		}
+
+		return new ClusterConfiguration(configDir, restPort);
 	}
 
 	protected static Configuration loadConfiguration(ClusterConfiguration clusterConfiguration) {
-		return GlobalConfiguration.loadConfiguration(clusterConfiguration.getConfigDir());
+		final Configuration configuration = GlobalConfiguration.loadConfiguration(clusterConfiguration.getConfigDir());
+
+		final int restPort = clusterConfiguration.getRestPort();
+
+		if (restPort >= 0) {
+			configuration.setInteger(RestOptions.REST_PORT, restPort);
+		}
+
+		return configuration;
 	}
 
 	/**


### PR DESCRIPTION
## What is the purpose of the change

Change the default REST port to `8081`.

## Verifying this change

Tested manually

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
