### PR TITLE
[doc] Remove missed CheckpointedRestoring

### DIFF
--- a/docs/dev/stream/state/state.md
+++ b/docs/dev/stream/state/state.md
@@ -386,8 +386,7 @@ public class BufferingSink
 {% highlight scala %}
 class BufferingSink(threshold: Int = 0)
   extends SinkFunction[(String, Int)]
-    with CheckpointedFunction
-    with CheckpointedRestoring[List[(String, Int)]] {
+    with CheckpointedFunction {
 
   @transient
   private var checkpointedState: ListState[(String, Int)] = _
@@ -426,9 +425,6 @@ class BufferingSink(threshold: Int = 0)
     }
   }
 
-  override def restoreState(state: List[(String, Int)]): Unit = {
-    bufferedElements ++= state
-  }
 }
 {% endhighlight %}
 </div>


### PR DESCRIPTION
## What is the purpose of the change

Pull request fixes one missed CheckpointedRestoring interface which was removed in Flink 1.4

## Brief change log

  - *Removed unused CheckpointedRestoring interface in streams docs. This interface was removed in Flink 1.4

## Verifying this change

PR is just a documentation change that can be verified in the diff very easily :)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? docs
