### PR TITLE
[FLINK-8830][YARN] YarnResourceManager throws NullPointerException

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
@@ -496,18 +496,20 @@ public final class Utils {
 			// NOTE: must read the tokens from the local file, not from the UGI context, because if UGI is login
 			// using Kerberos keytabs, there is no HDFS delegation token in the UGI context.
 			String fileLocation = System.getenv(UserGroupInformation.HADOOP_TOKEN_FILE_LOCATION);
-			Method readTokenStorageFileMethod = Credentials.class.getMethod(
-				"readTokenStorageFile", File.class, org.apache.hadoop.conf.Configuration.class);
+			if (fileLocation != null) {
+				Method readTokenStorageFileMethod = Credentials.class.getMethod(
+					"readTokenStorageFile", File.class, org.apache.hadoop.conf.Configuration.class);
 
-			Credentials cred =
-				(Credentials) readTokenStorageFileMethod.invoke(
-					null,
-					new File(fileLocation),
-					HadoopUtils.getHadoopConfiguration(flinkConfig));
+				Credentials cred =
+					(Credentials) readTokenStorageFileMethod.invoke(
+						null,
+						new File(fileLocation),
+						HadoopUtils.getHadoopConfiguration(flinkConfig));
 
-			cred.writeTokenStorageToStream(dob);
-			ByteBuffer securityTokens = ByteBuffer.wrap(dob.getData(), 0, dob.getLength());
-			ctx.setTokens(securityTokens);
+				cred.writeTokenStorageToStream(dob);
+				ByteBuffer securityTokens = ByteBuffer.wrap(dob.getData(), 0, dob.getLength());
+				ctx.setTokens(securityTokens);
+			}
 		}
 		catch (Throwable t) {
 			log.error("Getting current user info failed when trying to launch the container", t);


### PR DESCRIPTION
## What is the purpose of the change

*This pull request fixed a NullPointException issue which `YarnResourceManager` throws*


## Brief change log

  - *Add a `null` check for the file location*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
