### PR TITLE
[FLINK-8857] [Hbase] Avoid HBase connector read example throwing exception at the end

### DIFF
--- a/flink-connectors/flink-hbase/src/test/java/org/apache/flink/addons/hbase/example/HBaseReadExample.java
+++ b/flink-connectors/flink-hbase/src/test/java/org/apache/flink/addons/hbase/example/HBaseReadExample.java
@@ -86,8 +86,8 @@ public class HBaseReadExample {
 
 		hbaseDs.print();
 
-		// kick off execution.
-		env.execute();
+		// kick off execution is not needed.
+		// env.execute();
 
 	}
 

--- a/flink-connectors/flink-hbase/src/test/java/org/apache/flink/addons/hbase/example/HBaseReadExample.java
+++ b/flink-connectors/flink-hbase/src/test/java/org/apache/flink/addons/hbase/example/HBaseReadExample.java
@@ -86,9 +86,6 @@ public class HBaseReadExample {
 
 		hbaseDs.print();
 
-		// kick off execution is not needed.
-		// env.execute();
-
 	}
 
 }


### PR DESCRIPTION
## What is the purpose of the change

*This pull request fixes problem of HBase read example throwing exception at the end of the program execution.*


## Brief change log

  - *Update example `flink-hbase/src/test/java/org/apache/flink/addons/hbase/example/HBaseReadExample.java` by removing the part causing the problem.*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)