### PR TITLE
[FLINK-8859][state backend] RocksDB backend should pass WriteOption to Rocks.put() when restoring

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
@@ -680,7 +680,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 							if (RocksDBFullSnapshotOperation.hasMetaDataFollowsFlag(key)) {
 								//clear the signal bit in the key to make it ready for insertion again
 								RocksDBFullSnapshotOperation.clearMetaDataFollowsFlag(key);
-								rocksDBKeyedStateBackend.db.put(handle, key, value);
+								rocksDBKeyedStateBackend.db.put(handle, rocksDBKeyedStateBackend.writeOptions, key, value);
 								//TODO this could be aware of keyGroupPrefixBytes and write only one byte if possible
 								kvStateId = RocksDBFullSnapshotOperation.END_OF_KEY_GROUP_MARK
 									& compressedKgInputView.readShort();
@@ -690,7 +690,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 									handle = currentStateHandleKVStateColumnFamilies.get(kvStateId);
 								}
 							} else {
-								rocksDBKeyedStateBackend.db.put(handle, key, value);
+								rocksDBKeyedStateBackend.db.put(handle, rocksDBKeyedStateBackend.writeOptions, key, value);
 							}
 						}
 					}
@@ -1091,6 +1091,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 
 								if (stateBackend.keyGroupRange.contains(keyGroup)) {
 									stateBackend.db.put(targetColumnFamilyHandle,
+										stateBackend.writeOptions,
 										iterator.key(), iterator.value());
 								}
 


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes [FLINK-8859](https://issues.apache.org/jira/browse/FLINK-8859). We should pass `WriteOption` to Rocks.put() when restoring from handle (Both in full & incremental checkpoint). Because of `WriteOption.setDisableWAL(true)`, the performance can be increased by about 2 times.

## Brief change log

  - pass WriteOption to Rocks.put() when restoring

## Verifying this change
The changes can be verified by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
