### PR TITLE
[FLINK-8839] [sql-client] Fix table source factory discovery

### DIFF
--- a/flink-libraries/flink-sql-client/pom.xml
+++ b/flink-libraries/flink-sql-client/pom.xml
@@ -133,6 +133,7 @@ under the License.
 
 	<build>
 		<plugins>
+			<!-- Build flink-sql-client jar -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
@@ -163,6 +164,28 @@ under the License.
 									</includes>
 								</filter>
 							</filters>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
+			<!-- Test dependency classloading -->
+			<plugin>
+				<artifactId>maven-assembly-plugin</artifactId>
+				<version>2.4</version>
+				<executions>
+					<execution>
+						<id>create-table-source-factory-jar</id>
+						<phase>process-test-classes</phase>
+						<goals>
+							<goal>single</goal>
+						</goals>
+						<configuration>
+							<finalName>table-source-factory</finalName>
+							<attach>false</attach>
+							<descriptors>
+								<descriptor>src/test/assembly/test-table-source-factory.xml</descriptor>
+							</descriptors>
 						</configuration>
 					</execution>
 				</executions>

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
@@ -38,38 +38,38 @@ public interface Executor {
 	/**
 	 * Lists all session properties that are defined by the executor and the session.
 	 */
-	Map<String, String> getSessionProperties(SessionContext context) throws SqlExecutionException;
+	Map<String, String> getSessionProperties(SessionContext session) throws SqlExecutionException;
 
 	/**
 	 * Lists all tables known to the executor.
 	 */
-	List<String> listTables(SessionContext context) throws SqlExecutionException;
+	List<String> listTables(SessionContext session) throws SqlExecutionException;
 
 	/**
 	 * Returns the schema of a table. Throws an exception if the table could not be found.
 	 */
-	TableSchema getTableSchema(SessionContext context, String name) throws SqlExecutionException;
+	TableSchema getTableSchema(SessionContext session, String name) throws SqlExecutionException;
 
 	/**
 	 * Returns a string-based explanation about AST and execution plan of the given statement.
 	 */
-	String explainStatement(SessionContext context, String statement) throws SqlExecutionException;
+	String explainStatement(SessionContext session, String statement) throws SqlExecutionException;
 
 	/**
 	 * Submits a Flink job (detached) and returns the result descriptor.
 	 */
-	ResultDescriptor executeQuery(SessionContext context, String query) throws SqlExecutionException;
+	ResultDescriptor executeQuery(SessionContext session, String query) throws SqlExecutionException;
 
 	/**
 	 * Asks for the next changelog results (non-blocking).
 	 */
-	TypedResult<List<Tuple2<Boolean, Row>>> retrieveResultChanges(SessionContext context, String resultId) throws SqlExecutionException;
+	TypedResult<List<Tuple2<Boolean, Row>>> retrieveResultChanges(SessionContext session, String resultId) throws SqlExecutionException;
 
 	/**
 	 * Creates an immutable result snapshot of the running Flink job. Throws an exception if no Flink job can be found.
 	 * Returns the number of pages.
 	 */
-	TypedResult<Integer> snapshotResult(SessionContext context, String resultId, int pageSize) throws SqlExecutionException;
+	TypedResult<Integer> snapshotResult(SessionContext session, String resultId, int pageSize) throws SqlExecutionException;
 
 	/**
 	 * Returns the rows that are part of the current page or throws an exception if the snapshot has been expired.
@@ -79,10 +79,10 @@ public interface Executor {
 	/**
 	 * Cancels a table program and stops the result retrieval.
 	 */
-	void cancelQuery(SessionContext context, String resultId) throws SqlExecutionException;
+	void cancelQuery(SessionContext session, String resultId) throws SqlExecutionException;
 
 	/**
 	 * Stops the executor.
 	 */
-	void stop(SessionContext context);
+	void stop(SessionContext session);
 }

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/SessionContext.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/SessionContext.java
@@ -22,6 +22,7 @@ import org.apache.flink.table.client.config.Environment;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Context describing a session.
@@ -53,5 +54,24 @@ public class SessionContext {
 	public Environment getEnvironment() {
 		// enrich with session properties
 		return Environment.enrich(defaultEnvironment, sessionProperties);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (!(o instanceof SessionContext)) {
+			return false;
+		}
+		SessionContext context = (SessionContext) o;
+		return Objects.equals(name, context.name) &&
+			Objects.equals(defaultEnvironment, context.defaultEnvironment) &&
+			Objects.equals(sessionProperties, context.sessionProperties);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(name, defaultEnvironment, sessionProperties);
 	}
 }

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.client.gateway.local;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.Plan;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.optimizer.DataStatistics;
+import org.apache.flink.optimizer.Optimizer;
+import org.apache.flink.optimizer.costs.DefaultCostEstimator;
+import org.apache.flink.optimizer.plan.FlinkPlan;
+import org.apache.flink.runtime.execution.librarycache.FlinkUserCodeClassLoaders;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.graph.StreamGraph;
+import org.apache.flink.table.api.BatchQueryConfig;
+import org.apache.flink.table.api.QueryConfig;
+import org.apache.flink.table.api.StreamQueryConfig;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.client.config.Environment;
+import org.apache.flink.table.client.gateway.SessionContext;
+import org.apache.flink.table.sources.TableSource;
+import org.apache.flink.table.sources.TableSourceFactoryService;
+
+import java.net.URL;
+import java.util.List;
+
+/**
+ * Context for executing table programs. It contains configured environments and environment
+ * specific logic such as plan translation.
+ */
+public class ExecutionContext {
+
+	private final SessionContext sessionContext;
+	private final Environment mergedEnv;
+	private final ExecutionEnvironment execEnv;
+	private final StreamExecutionEnvironment streamExecEnv;
+	private final TableEnvironment tableEnv;
+	private final ClassLoader classLoader;
+	private final QueryConfig queryConfig;
+
+	public ExecutionContext(Environment defaultEnvironment, SessionContext sessionContext, List<URL> dependencies) {
+		this.sessionContext = sessionContext;
+		this.mergedEnv = Environment.merge(defaultEnvironment, sessionContext.getEnvironment());
+
+		// create environments
+		if (mergedEnv.getExecution().isStreamingExecution()) {
+			streamExecEnv = createStreamExecutionEnvironment();
+			execEnv = null;
+			tableEnv = TableEnvironment.getTableEnvironment(streamExecEnv);
+		} else {
+			streamExecEnv = null;
+			execEnv = createExecutionEnvironment();
+			tableEnv = TableEnvironment.getTableEnvironment(execEnv);
+		}
+
+		// create class loader
+		classLoader = FlinkUserCodeClassLoaders.parentFirst(
+			dependencies.toArray(new URL[dependencies.size()]),
+			this.getClass().getClassLoader());
+
+		// create table sources
+		mergedEnv.getSources().forEach((name, source) -> {
+			TableSource<?> tableSource = TableSourceFactoryService.findAndCreateTableSource(source, classLoader);
+			tableEnv.registerTableSource(name, tableSource);
+		});
+
+		// create query config
+		queryConfig = createQueryConfig();
+	}
+
+	public SessionContext getSessionContext() {
+		return sessionContext;
+	}
+
+	public ExecutionEnvironment getExecutionEnvironment() {
+		return execEnv;
+	}
+
+	public StreamExecutionEnvironment getStreamExecutionEnvironment() {
+		return streamExecEnv;
+	}
+
+	public TableEnvironment getTableEnvironment() {
+		return tableEnv;
+	}
+
+	public ClassLoader getClassLoader() {
+		return classLoader;
+	}
+
+	public Environment getMergedEnvironment() {
+		return mergedEnv;
+	}
+
+	public QueryConfig getQueryConfig() {
+		return queryConfig;
+	}
+
+	public ExecutionConfig getExecutionConfig() {
+		if (streamExecEnv != null) {
+			return streamExecEnv.getConfig();
+		} else {
+			return execEnv.getConfig();
+		}
+	}
+
+	public FlinkPlan createPlan(String name, Configuration flinkConfig) {
+		if (streamExecEnv != null) {
+			final StreamGraph graph = streamExecEnv.getStreamGraph();
+			graph.setJobName(name);
+			return graph;
+		} else {
+			final int parallelism = execEnv.getParallelism();
+			final Plan unoptimizedPlan = execEnv.createProgramPlan();
+			unoptimizedPlan.setJobName(name);
+			final Optimizer compiler = new Optimizer(new DataStatistics(), new DefaultCostEstimator(), flinkConfig);
+			return ClusterClient.getOptimizedPlan(compiler, unoptimizedPlan, parallelism);
+		}
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	private ExecutionEnvironment createExecutionEnvironment() {
+		final ExecutionEnvironment execEnv = ExecutionEnvironment.getExecutionEnvironment();
+		execEnv.setParallelism(mergedEnv.getExecution().getParallelism());
+		return execEnv;
+	}
+
+	private StreamExecutionEnvironment createStreamExecutionEnvironment() {
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setParallelism(mergedEnv.getExecution().getParallelism());
+		env.setMaxParallelism(mergedEnv.getExecution().getMaxParallelism());
+		return env;
+	}
+
+	private QueryConfig createQueryConfig() {
+		if (streamExecEnv != null) {
+			final StreamQueryConfig config = new StreamQueryConfig();
+			final long minRetention = mergedEnv.getExecution().getMinStateRetention();
+			final long maxRetention = mergedEnv.getExecution().getMaxStateRetention();
+			config.withIdleStateRetentionTime(Time.milliseconds(minRetention), Time.milliseconds(maxRetention));
+			return config;
+		} else {
+			return new BatchQueryConfig();
+		}
+	}
+}

--- a/flink-libraries/flink-sql-client/src/test/assembly/test-table-source-factory.xml
+++ b/flink-libraries/flink-sql-client/src/test/assembly/test-table-source-factory.xml
@@ -1,0 +1,47 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+
+-->
+
+<assembly>
+	<id>test-jar</id>
+	<formats>
+		<format>jar</format>
+	</formats>
+	<includeBaseDirectory>false</includeBaseDirectory>
+	<fileSets>
+		<fileSet>
+			<directory>${project.build.testOutputDirectory}</directory>
+			<outputDirectory>/</outputDirectory>
+			<!-- modify/add include to match your package(s) -->
+			<includes>
+				<include>org/apache/flink/table/client/gateway/utils/TestTableSourceFactory.class</include>
+				<include>org/apache/flink/table/client/gateway/utils/TestTableSourceFactory$*.class</include>
+			</includes>
+		</fileSet>
+	</fileSets>
+	<files>
+		<!-- Create META-INF/services -->
+		<file>
+			<source>src/test/resources/test-factory-services-file</source>
+			<outputDirectory>META-INF/services</outputDirectory>
+			<destName>org.apache.flink.table.sources.TableSourceFactory</destName>
+			<fileMode>0755</fileMode>
+		</file>
+	</files>
+</assembly>

--- a/flink-libraries/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/DependencyTest.java
+++ b/flink-libraries/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/DependencyTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.client.gateway.local;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.api.Types;
+import org.apache.flink.table.client.config.Environment;
+import org.apache.flink.table.client.gateway.SessionContext;
+import org.apache.flink.table.client.gateway.utils.EnvironmentFileUtil;
+
+import org.junit.Test;
+
+import java.net.URL;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Dependency tests for {@link LocalExecutor}. Mainly for testing classloading of dependencies.
+ */
+public class DependencyTest {
+
+	private static final String FACTORY_ENVIRONMENT_FILE = "test-sql-client-factory.yaml";
+	private static final String TABLE_SOURCE_FACTORY_JAR_FILE = "table-source-factory-test-jar.jar";
+
+	@Test
+	public void testTableSourceFactoryDiscovery() throws Exception {
+		// create environment
+		final Map<String, String> replaceVars = new HashMap<>();
+		replaceVars.put("$VAR_0", "test-table-source-factory");
+		replaceVars.put("$VAR_1", "test-property");
+		replaceVars.put("$VAR_2", "test-value");
+		final Environment env = EnvironmentFileUtil.parseModified(FACTORY_ENVIRONMENT_FILE, replaceVars);
+
+		// create executor with dependencies
+		final URL dependency = Paths.get("target", TABLE_SOURCE_FACTORY_JAR_FILE).toUri().toURL();
+		final LocalExecutor executor = new LocalExecutor(
+			env,
+			Collections.singletonList(dependency),
+			new Configuration());
+
+		final SessionContext session = new SessionContext("test-session", new Environment());
+
+		final TableSchema result = executor.getTableSchema(session, "TableNumber1");
+		final TableSchema expected = TableSchema.builder()
+			.field("IntegerField1", Types.INT())
+			.field("StringField1", Types.STRING())
+			.build();
+
+		assertEquals(expected, result);
+	}
+}

--- a/flink-libraries/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/utils/EnvironmentFileUtil.java
+++ b/flink-libraries/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/utils/EnvironmentFileUtil.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.client.gateway.utils;
+
+import org.apache.flink.table.client.config.Environment;
+import org.apache.flink.util.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Utilities for reading an environment file.
+ */
+public final class EnvironmentFileUtil {
+
+	private EnvironmentFileUtil() {
+		// private
+	}
+
+	public static Environment parseUnmodified(String fileName) throws IOException {
+		final URL url = EnvironmentFileUtil.class.getClassLoader().getResource(fileName);
+		Objects.requireNonNull(url);
+		return Environment.parse(url);
+	}
+
+	public static Environment parseModified(String fileName, Map<String, String> replaceVars) throws IOException {
+		final URL url = EnvironmentFileUtil.class.getClassLoader().getResource(fileName);
+		Objects.requireNonNull(url);
+		String schema = FileUtils.readFileUtf8(new File(url.getFile()));
+
+		for (Map.Entry<String, String> replaceVar : replaceVars.entrySet()) {
+			schema = schema.replace(replaceVar.getKey(), replaceVar.getValue());
+		}
+
+		return Environment.parse(schema);
+	}
+}

--- a/flink-libraries/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/utils/TestTableSourceFactory.java
+++ b/flink-libraries/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/utils/TestTableSourceFactory.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.client.gateway.utils;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.api.Types;
+import org.apache.flink.table.client.gateway.local.DependencyTest;
+import org.apache.flink.table.descriptors.DescriptorProperties;
+import org.apache.flink.table.sources.StreamTableSource;
+import org.apache.flink.table.sources.TableSource;
+import org.apache.flink.table.sources.TableSourceFactory;
+import org.apache.flink.types.Row;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_TYPE;
+import static org.apache.flink.table.descriptors.SchemaValidator.SCHEMA;
+import static org.apache.flink.table.descriptors.SchemaValidator.SCHEMA_NAME;
+import static org.apache.flink.table.descriptors.SchemaValidator.SCHEMA_TYPE;
+
+/**
+ * Table source factory for testing the classloading in {@link DependencyTest}.
+ */
+public class TestTableSourceFactory implements TableSourceFactory<Row> {
+
+	@Override
+	public Map<String, String> requiredContext() {
+		final Map<String, String> context = new HashMap<>();
+		context.put(CONNECTOR_TYPE(), "test-table-source-factory");
+		return context;
+	}
+
+	@Override
+	public List<String> supportedProperties() {
+		final List<String> properties = new ArrayList<>();
+		properties.add("connector.test-property");
+		properties.add(SCHEMA() + ".#." + SCHEMA_TYPE());
+		properties.add(SCHEMA() + ".#." + SCHEMA_NAME());
+		return properties;
+	}
+
+	@Override
+	public TableSource<Row> create(Map<String, String> properties) {
+		final DescriptorProperties params = new DescriptorProperties(true);
+		params.putProperties(properties);
+		return new TestTableSource(
+			params.getTableSchema(SCHEMA()),
+			properties.get("connector.test-property"));
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	/**
+	 * Test table source.
+	 */
+	public static class TestTableSource implements StreamTableSource<Row> {
+
+		private final TableSchema schema;
+		private final String property;
+
+		public TestTableSource(TableSchema schema, String property) {
+			this.schema = schema;
+			this.property = property;
+		}
+
+		public String getProperty() {
+			return property;
+		}
+
+		@Override
+		public DataStream<Row> getDataStream(StreamExecutionEnvironment execEnv) {
+			return null;
+		}
+
+		@Override
+		public TypeInformation<Row> getReturnType() {
+			return Types.ROW(schema.getColumnNames(), schema.getTypes());
+		}
+
+		@Override
+		public TableSchema getTableSchema() {
+			return schema;
+		}
+
+		@Override
+		public String explainSource() {
+			return "TestTableSource";
+		}
+	}
+}

--- a/flink-libraries/flink-sql-client/src/test/resources/test-factory-services-file
+++ b/flink-libraries/flink-sql-client/src/test/resources/test-factory-services-file
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#==============================================================================
+# Test file for org.apache.flink.table.client.gateway.local.DependencyTest.
+#==============================================================================
+
+org.apache.flink.table.client.gateway.utils.TestTableSourceFactory

--- a/flink-libraries/flink-sql-client/src/test/resources/test-sql-client-factory.yaml
+++ b/flink-libraries/flink-sql-client/src/test/resources/test-sql-client-factory.yaml
@@ -18,7 +18,7 @@
 
 #==============================================================================
 # TEST ENVIRONMENT FILE
-# Intended for org.apache.flink.table.client.gateway.local.LocalExecutorITCase.
+# Intended for org.apache.flink.table.client.gateway.local.DependencyTest.
 #==============================================================================
 
 # this file has variables that can be filled with content by replacing $VAR_XXX
@@ -31,43 +31,12 @@ sources:
       - name: StringField1
         type: VARCHAR
     connector:
-      type: filesystem
-      path: "$VAR_0"
-    format:
-      type: csv
-      fields:
-        - name: IntegerField1
-          type: INT
-        - name: StringField1
-          type: VARCHAR
-      line-delimiter: "\n"
-      comment-prefix: "#"
-  - name: TableNumber2
-    schema:
-      - name: IntegerField2
-        type: INT
-      - name: StringField2
-        type: VARCHAR
-    connector:
-      type: filesystem
-      path: "$VAR_1"
-    format:
-      type: csv
-      fields:
-        - name: IntegerField2
-          type: INT
-        - name: StringField2
-          type: VARCHAR
-      line-delimiter: "\n"
-      comment-prefix: "#"
+      type: "$VAR_0"
+      $VAR_1: "$VAR_2"
 
 execution:
   type: streaming
   parallelism: 1
-  max-parallelism: 16
-  min-idle-state-retention: 0
-  max-idle-state-retention: 0
-  result-mode: "$VAR_2"
 
 deployment:
   type: standalone

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/descriptors/Rowtime.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/descriptors/Rowtime.scala
@@ -85,7 +85,7 @@ class Rowtime extends Descriptor {
     *
     * Emits watermarks which are the maximum observed timestamp minus the specified delay.
     */
-  def watermarksPeriodicBounding(delay: Long): Rowtime = {
+  def watermarksPeriodicBounded(delay: Long): Rowtime = {
     watermarkStrategy = Some(new BoundedOutOfOrderTimestamps(delay))
     this
   }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/descriptors/RowtimeTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/descriptors/RowtimeTest.scala
@@ -46,7 +46,7 @@ class RowtimeTest extends DescriptorTestBase {
   override def descriptors(): util.List[Descriptor] = {
     val desc1 = Rowtime()
       .timestampsFromField("otherField")
-      .watermarksPeriodicBounding(1000L)
+      .watermarksPeriodicBounded(1000L)
 
     val desc2 = Rowtime()
       .timestampsFromSource()


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes the table source factory discovery by adding dependencies to the classloader. It also implements an `ExecutionContext` that can be reused during the same session.


## Brief change log

- New `ExecutionContext` abstraction
- Possibility to pass a classloader to the Java service provider


## Verifying this change

- See `DependencyTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? JavaDocs
