### PR TITLE
[FLINK-8091] [flink-dist] Support running historyserver in foreground

### DIFF
--- a/docs/monitoring/historyserver.md
+++ b/docs/monitoring/historyserver.md
@@ -37,7 +37,7 @@ After you have configured the HistoryServer *and* JobManager, you start and stop
 
 ```sh
 # Start or stop the HistoryServer
-bin/historyserver.sh (start|stop)
+bin/historyserver.sh (start|start-foreground|stop)
 ```
 
 By default, this server binds to `localhost` and listens at port `8082`.

--- a/flink-dist/src/main/flink-bin/bin/flink-console.sh
+++ b/flink-dist/src/main/flink-bin/bin/flink-console.sh
@@ -19,7 +19,7 @@
 
 # Start a Flink service as a console application. Must be stopped with Ctrl-C
 # or with SIGTERM by kill or the controlling process.
-USAGE="Usage: flink-console.sh (jobmanager|taskmanager|zookeeper) [args]"
+USAGE="Usage: flink-console.sh (jobmanager|taskmanager|historyserver|zookeeper) [args]"
 
 SERVICE=$1
 ARGS=("${@:2}") # get remaining arguments as array
@@ -40,6 +40,10 @@ case $SERVICE in
 
     (taskexecutor)
         CLASS_TO_RUN=org.apache.flink.runtime.taskexecutor.TaskManagerRunner
+    ;;
+
+    (historyserver)
+        CLASS_TO_RUN=org.apache.flink.runtime.webmonitor.history.HistoryServer
     ;;
 
     (zookeeper)

--- a/flink-dist/src/main/flink-bin/bin/historyserver.sh
+++ b/flink-dist/src/main/flink-bin/bin/historyserver.sh
@@ -18,7 +18,7 @@
 ################################################################################
 
 # Start/stop a Flink HistoryServer
-USAGE="Usage: historyserver.sh (start|stop)"
+USAGE="Usage: historyserver.sh (start|start-foreground|stop)"
 
 STARTSTOP=$1
 
@@ -27,8 +27,12 @@ bin=`cd "$bin"; pwd`
 
 . "$bin"/config.sh
 
-if [[ $STARTSTOP == "start" ]]; then
+if [[ $STARTSTOP == "start" ]] || [[ $STARTSTOP == "start-foreground" ]]; then
 	args=("--configDir" "${FLINK_CONF_DIR}")
 fi
 
-"${FLINK_BIN_DIR}"/flink-daemon.sh $STARTSTOP historyserver "${args[@]}"
+if [[ $STARTSTOP == "start-foreground" ]]; then
+    exec "${FLINK_BIN_DIR}"/flink-console.sh historyserver "${args[@]}"
+else
+    "${FLINK_BIN_DIR}"/flink-daemon.sh $STARTSTOP historyserver "${args[@]}"
+fi


### PR DESCRIPTION
## Brief change log

*Allow historyserver to run in foreground*
  - The scripts "flink-console.sh" and "historyserver.sh" were adjusted to handle the "start-foreground" flag
  - The documentation for historyserver was adjusted accordingly


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

We use this change in our production setup with flink 1.3 but as far as i can see the related scripts did not change between releases.

"mvn clean verify" succeeded.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no
## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
