### PR TITLE
 [FLINK-8847][build] Prevent unnecessary recompilation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1094,6 +1094,8 @@ under the License.
 				<configuration>
 					<source>${java.version}</source>
 					<target>${java.version}</target>
+					<!-- The semantics of this option are reversed, see MCOMPILER-209. -->
+					<useIncrementalCompilation>false</useIncrementalCompilation>
 					<compilerArgs>
 						<!-- The output of Xlint is not shown by default, but we activate it for the QA bot
 						to be able to get more warnings -->

--- a/pom.xml
+++ b/pom.xml
@@ -1094,9 +1094,13 @@ under the License.
 				<configuration>
 					<source>${java.version}</source>
 					<target>${java.version}</target>
-					<!-- The output of Xlint is not shown by default, but we activate it for the QA bot
-					to be able to get more warnings -->
-					<compilerArgument>-Xlint:all</compilerArgument>
+					<compilerArgs>
+						<!-- The output of Xlint is not shown by default, but we activate it for the QA bot
+						to be able to get more warnings -->
+						<arg>-Xlint:all</arg>
+						<!-- Prevents recompilation due to missing package-info.class, see MCOMPILER-205 -->
+						<arg>-Xpkginfo:always</arg>
+					</compilerArgs>
 				</configuration>
 			</plugin>
 


### PR DESCRIPTION
## What is the purpose of the change

This PR contains 2 changes to prevent the `maven-compiler-plugin` from recompiling a module that doesn't require it.

The `maven-compiler-plugin` will now always create `.class` files for `package-info.java` files. Previously this was only done if the `.java` file contained annotations.

Having a `.java` file without a corresponding `.class` file throws of the `maven-compiler-plugin` stale source detection, as described in [MCOMPILER-205](https://issues.apache.org/jira/browse/MCOMPILER-205).

Additionally, `useIncrementalCompilation` is set to false which actually enables incremental compilation, as described in [MCOMPILER-209](https://issues.apache.org/jira/browse/MCOMPILER-209).

## Brief change log

* create `.class` files for all `package-info.java` files
* set `useIncrementalCompilation` to false which actually enables incremental compilation

## Verifying this change

Pick any module that contains a  `package-info.java` file (like `flink-optimizer`) and run `mvn package <speed options>` twice. The plugin should not recompile the module.