### PR TITLE
[FLINK-8687] Make MaterializedCollectStreamResult#retrievePage to hav…

### DIFF
--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/MaterializedCollectStreamResult.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/MaterializedCollectStreamResult.java
@@ -86,11 +86,13 @@ public class MaterializedCollectStreamResult extends CollectStreamResult impleme
 
 	@Override
 	public List<Row> retrievePage(int page) {
-		if (page <= 0 || page > pageCount) {
-			throw new SqlExecutionException("Invalid page '" + page + "'.");
-		}
+		synchronized (resultLock) {
+			if (page <= 0 || page > pageCount) {
+				throw new SqlExecutionException("Invalid page '" + page + "'.");
+			}
 
-		return snapshot.subList(pageSize * (page - 1), Math.min(snapshot.size(), pageSize * page));
+			return snapshot.subList(pageSize * (page - 1), Math.min(snapshot.size(), pageSize * page));
+		}
 	}
 
 	// --------------------------------------------------------------------------------------------


### PR DESCRIPTION
…e resultLock

## What is the purpose of the change

Currently ```MaterializedCollectStreamResult#retrievePage``` checks page range and calls snapshot.subList() without holding resultLock. resultLock should be taken. If we do not lock, we might see the stale data.

## Brief change log
Add synchronized to protect it.