### PR TITLE
[FLINK-8887][flip-6] ClusterClient.getJobStatus can throw FencingTokenException

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -412,6 +412,10 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 			}
 		}
 
+		if (log.isDebugEnabled()) {
+			log.debug("Try to get job status from archived execution graph store for job {}.", jobId);
+		}
+
 		final JobDetails jobDetails = archivedExecutionGraphStore.getAvailableJobDetails(jobId);
 
 		if (jobDetails != null) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -407,7 +407,7 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 			try {
 				return jobManagerRunner.getJobManagerGateway().requestJobStatus(timeout);
 			} catch (Exception e) {
-				log.error("Request job status from job master : {} occurs exception : {}",
+				log.error("Request job status from remote job master : {} occurs exception : {}",
 					jobManagerRunner.getAddress(), e);
 			}
 		}


### PR DESCRIPTION
## What is the purpose of the change

*This pull request fixed ClusterClient.getJobStatus throw FencingTokenException issue*


## Brief change log

  - *try-catch request job status from job master gateway if catch a exception then goto : request job status  from archived execution graph store*

## Verifying this change

This change is already covered by existing tests, such as *DispatcherTest.testCacheJobExecutionResult*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
