### PR TITLE
[FLINK-8845][state] Introduce RocksDBWriteBatchWrapper to improve performance for recovery in RocksDB backend

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBMapState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBMapState.java
@@ -134,8 +134,12 @@ public class RocksDBMapState<K, N, UK, UV>
 			return;
 		}
 
-		for (Map.Entry<UK, UV> entry : map.entrySet()) {
-			put(entry.getKey(), entry.getValue());
+		try (RocksDBWriteBatchWrapper writeBatchWrapper = new RocksDBWriteBatchWrapper(backend.db, writeOptions)) {
+			for (Map.Entry<UK, UV> entry : map.entrySet()) {
+				byte[] rawKeyBytes = serializeUserKeyWithCurrentKeyAndNamespace(entry.getKey());
+				byte[] rawValueBytes = serializeUserValue(entry.getValue());
+				writeBatchWrapper.put(columnFamily, rawKeyBytes, rawValueBytes);
+			}
 		}
 	}
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBWriteBatchWrapper.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBWriteBatchWrapper.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.state;
+
+import org.apache.flink.util.IOUtils;
+import org.apache.flink.util.Preconditions;
+
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.RocksDB;
+import org.rocksdb.RocksDBException;
+import org.rocksdb.WriteBatch;
+import org.rocksdb.WriteOptions;
+
+import javax.annotation.Nonnull;
+
+/**
+ * IMPORTANT: This class is not thread safe.
+ * It's a wrapper class to wrap {@link WriteBatch} for writing in bulk.
+ */
+public class RocksDBWriteBatchWrapper implements AutoCloseable {
+
+	private static final int MIN_CAPACITY = 100;
+	private static final int MAX_CAPACITY = 1000;
+	private static final int PER_RECORD_BYTES = 100;
+
+	private final RocksDB db;
+
+	private final WriteBatch batch;
+
+	private final WriteOptions options;
+
+	private final int capacity;
+
+	public RocksDBWriteBatchWrapper(@Nonnull RocksDB rocksDB) {
+		this(rocksDB, null, 500);
+	}
+
+	public RocksDBWriteBatchWrapper(@Nonnull RocksDB rocksDB, WriteOptions options) {
+		this(rocksDB, options, 500);
+	}
+
+	public RocksDBWriteBatchWrapper(@Nonnull RocksDB rocksDB, WriteOptions options, int capacity) {
+		Preconditions.checkArgument(capacity >= MIN_CAPACITY && capacity <= MAX_CAPACITY,
+			"capacity should be between " + MIN_CAPACITY + " and " + MAX_CAPACITY);
+
+		this.db = rocksDB;
+		this.options = options;
+		this.capacity = capacity;
+		this.batch = new WriteBatch(this.capacity * PER_RECORD_BYTES);
+	}
+
+	public void put(ColumnFamilyHandle handle, byte[] key, byte[] value) throws RocksDBException {
+
+		this.batch.put(handle, key, value);
+
+		if (this.batch.count() == capacity) {
+			flush();
+		}
+	}
+
+	public void flush() throws RocksDBException {
+		if (options != null) {
+			this.db.write(options, batch);
+		} else {
+			// use the default WriteOptions, if wasn't provided.
+			try (WriteOptions writeOptions = new WriteOptions()) {
+				this.db.write(writeOptions, batch);
+			}
+		}
+		batch.clear();
+	}
+
+	@Override
+	public void close() throws RocksDBException {
+		if (this.batch.count() != 0) {
+			flush();
+		}
+		IOUtils.closeQuietly(this.batch);
+	}
+}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBWriteBatchWrapperTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBWriteBatchWrapperTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.state;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.rocksdb.ColumnFamilyDescriptor;
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.RocksDB;
+import org.rocksdb.WriteOptions;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Tests to guard {@link RocksDBWriteBatchWrapper}.
+ */
+public class RocksDBWriteBatchWrapperTest {
+
+	@Rule
+	public TemporaryFolder folder = new TemporaryFolder();
+
+	@Test
+	public void basicTest() throws Exception {
+
+		List<Tuple2<byte[], byte[]>> data = new ArrayList<>(10000);
+		for (int i = 0; i < 10000; ++i) {
+			data.add(new Tuple2<>(("key:" + i).getBytes(), ("value:" + i).getBytes()));
+		}
+
+		try (RocksDB db = RocksDB.open(folder.newFolder().getAbsolutePath());
+			WriteOptions options = new WriteOptions().setDisableWAL(true);
+			ColumnFamilyHandle handle = db.createColumnFamily(new ColumnFamilyDescriptor("test".getBytes()));
+			RocksDBWriteBatchWrapper writeBatchWrapper = new RocksDBWriteBatchWrapper(db, options, 200)) {
+
+			// insert data
+			for (Tuple2<byte[], byte[]> item : data) {
+				writeBatchWrapper.put(handle, item.f0, item.f1);
+			}
+			writeBatchWrapper.flush();
+
+			// valid result
+			for (Tuple2<byte[], byte[]> item : data) {
+				Assert.assertArrayEquals(item.f1, db.get(handle, item.f0));
+			}
+		}
+	}
+}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/benchmark/RocksDBWriteBatchPerformanceTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/benchmark/RocksDBWriteBatchPerformanceTest.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.state.benchmark;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.contrib.streaming.state.RocksDBMapState;
+import org.apache.flink.contrib.streaming.state.RocksDBWriteBatchWrapper;
+import org.apache.flink.testutils.junit.RetryOnFailure;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.rocksdb.ColumnFamilyDescriptor;
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.NativeLibraryLoader;
+import org.rocksdb.RocksDB;
+import org.rocksdb.WriteOptions;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Test that validates that the performance of RocksDB's WriteBatch as expected.
+ *
+ * <p>Benchmarking:
+ * Computer: MacbookPro (Mid 2015), Flash Storage, Processor 2.5GHz Intel Core i5, Memory 16GB 1600MHz DDR3
+ *
+ * <p>With disableWAL is false
+ * Number of values added | time for Put		|  time for WriteBach | performance improvement of WriteBatch over Put
+ * 1000						10146397 ns			3546287 ns				2.86x
+ * 10000					118227077 ns		26040222 ns				4.54x
+ * 100000					1838593196 ns		375053755 ns			4.9x
+ * 1000000					8844612079 ns		2014077396 ns			4.39x
+ *
+ * <p>With disableWAL is true
+ * 1000						3955204 ns			2429725 ns				1.62x
+ * 10000					25618237 ns			16440113 ns				1.55x
+ * 100000					289153346 ns		183712685 ns			1.57x
+ * 1000000					2886298967 ns		1768688571 ns			1.63x
+ *
+ * <p>In summary:
+ *
+ * <p>WriteBatch gives users 2.5x-5x performance improvements when disableWAL is false(This is useful when
+ * restoring from savepoint, because we need to set disableWAL=true to avoid segfault bug, see FLINK-8859 for detail).
+ *
+ * <p>Write gives user 1.5x performance improvements when disableWAL is true, this is useful for batch writing scenario,
+ * e.g. {@link RocksDBMapState#putAll(Map)} & {@link RocksDBMapState#clear()}.
+ */
+public class RocksDBWriteBatchPerformanceTest extends TestLogger {
+
+	@Rule
+	public TemporaryFolder folder = new TemporaryFolder();
+
+	private final String KEY_PREFIX = "key";
+
+	private final String VALUE = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ7890654321";
+
+	@Test(timeout = 2000)
+	@RetryOnFailure(times = 3)
+	public void benchMark() throws Exception {
+
+		int num = 10000;
+
+		List<Tuple2<byte[], byte[]>> data = new ArrayList<>(num);
+		for (int i = 0; i < num; ++i) {
+			data.add(new Tuple2<>((KEY_PREFIX + i).getBytes(), VALUE.getBytes()));
+		}
+
+		log.info("--------------> put VS WriteBatch with disableWAL=false <--------------");
+
+		long t1 = benchMarkHelper(data, false, WRITE_TYPE.PUT);
+		long t2 = benchMarkHelper(data, false, WRITE_TYPE.WRITE_BATCH);
+
+		log.info("Single Put with disableWAL is false for {} records costs {}" , num, t1);
+		log.info("WriteBatch with disableWAL is false for {} records costs {}" , num, t2);
+
+		Assert.assertTrue(t2 < t1);
+
+		log.info("--------------> put VS WriteBatch with disableWAL=true <--------------");
+
+		t1 = benchMarkHelper(data, true, WRITE_TYPE.PUT);
+		t2 = benchMarkHelper(data, true, WRITE_TYPE.WRITE_BATCH);
+
+		log.info("Single Put with disableWAL is true for {} records costs {}" , num, t1);
+		log.info("WriteBatch with disableWAL is true for {} records costs {}" , num, t2);
+
+		Assert.assertTrue(t2 < t1);
+	}
+
+	private enum WRITE_TYPE {PUT, WRITE_BATCH}
+
+	private long benchMarkHelper(List<Tuple2<byte[], byte[]>> data, boolean disableWAL, WRITE_TYPE type) throws Exception {
+		final File rocksDir = folder.newFolder();
+
+		// ensure the RocksDB library is loaded to a distinct location each retry
+		NativeLibraryLoader.getInstance().loadLibrary(rocksDir.getAbsolutePath());
+
+		switch (type) {
+			case PUT:
+				try (RocksDB db = RocksDB.open(rocksDir.getAbsolutePath());
+					WriteOptions options = new WriteOptions().setDisableWAL(disableWAL);
+					ColumnFamilyHandle handle = db.createColumnFamily(new ColumnFamilyDescriptor("test".getBytes()))) {
+					long t1 = System.nanoTime();
+					for (Tuple2<byte[], byte[]> item : data) {
+						db.put(handle, options, item.f0, item.f1);
+					}
+					return System.nanoTime() - t1;
+				}
+			case WRITE_BATCH:
+				try (RocksDB db = RocksDB.open(rocksDir.getAbsolutePath());
+					WriteOptions options = new WriteOptions().setDisableWAL(disableWAL);
+					ColumnFamilyHandle handle = db.createColumnFamily(new ColumnFamilyDescriptor("test".getBytes()));
+					RocksDBWriteBatchWrapper writeBatchWrapper = new RocksDBWriteBatchWrapper(db, options)) {
+					long t1 = System.nanoTime();
+					for (Tuple2<byte[], byte[]> item : data) {
+						writeBatchWrapper.put(handle, item.f0, item.f1);
+					}
+					writeBatchWrapper.flush();
+					return System.nanoTime() - t1;
+				}
+			default:
+				throw new RuntimeException("Unknown benchmark type:" + type);
+		}
+	}
+}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/benchmark/RocksDBWriteBatchPerformanceTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/benchmark/RocksDBWriteBatchPerformanceTest.java
@@ -71,9 +71,9 @@ public class RocksDBWriteBatchPerformanceTest extends TestLogger {
 	@Rule
 	public TemporaryFolder folder = new TemporaryFolder();
 
-	private final String KEY_PREFIX = "key";
+	private static final String KEY_PREFIX = "key";
 
-	private final String VALUE = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ7890654321";
+	private static final String VALUE = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ7890654321";
 
 	@Test(timeout = 2000)
 	@RetryOnFailure(times = 3)
@@ -88,8 +88,8 @@ public class RocksDBWriteBatchPerformanceTest extends TestLogger {
 
 		log.info("--------------> put VS WriteBatch with disableWAL=false <--------------");
 
-		long t1 = benchMarkHelper(data, false, WRITE_TYPE.PUT);
-		long t2 = benchMarkHelper(data, false, WRITE_TYPE.WRITE_BATCH);
+		long t1 = benchMarkHelper(data, false, WRITETYPE.PUT);
+		long t2 = benchMarkHelper(data, false, WRITETYPE.WRITE_BATCH);
 
 		log.info("Single Put with disableWAL is false for {} records costs {}" , num, t1);
 		log.info("WriteBatch with disableWAL is false for {} records costs {}" , num, t2);
@@ -98,8 +98,8 @@ public class RocksDBWriteBatchPerformanceTest extends TestLogger {
 
 		log.info("--------------> put VS WriteBatch with disableWAL=true <--------------");
 
-		t1 = benchMarkHelper(data, true, WRITE_TYPE.PUT);
-		t2 = benchMarkHelper(data, true, WRITE_TYPE.WRITE_BATCH);
+		t1 = benchMarkHelper(data, true, WRITETYPE.PUT);
+		t2 = benchMarkHelper(data, true, WRITETYPE.WRITE_BATCH);
 
 		log.info("Single Put with disableWAL is true for {} records costs {}" , num, t1);
 		log.info("WriteBatch with disableWAL is true for {} records costs {}" , num, t2);
@@ -107,9 +107,9 @@ public class RocksDBWriteBatchPerformanceTest extends TestLogger {
 		Assert.assertTrue(t2 < t1);
 	}
 
-	private enum WRITE_TYPE {PUT, WRITE_BATCH}
+	private enum WRITETYPE {PUT, WRITE_BATCH}
 
-	private long benchMarkHelper(List<Tuple2<byte[], byte[]>> data, boolean disableWAL, WRITE_TYPE type) throws Exception {
+	private long benchMarkHelper(List<Tuple2<byte[], byte[]>> data, boolean disableWAL, WRITETYPE type) throws Exception {
 		final File rocksDir = folder.newFolder();
 
 		// ensure the RocksDB library is loaded to a distinct location each retry

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/resources/log4j-test.properties
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/resources/log4j-test.properties
@@ -17,7 +17,7 @@
 ################################################################################
 
 # Set root logger level to DEBUG and its only appender to A1.
-log4j.rootLogger=OFF, A1
+log4j.rootLogger=DEBUG, A1
 
 # A1 is set to be a ConsoleAppender.
 log4j.appender.A1=org.apache.log4j.ConsoleAppender

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/resources/log4j-test.properties
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/resources/log4j-test.properties
@@ -17,7 +17,7 @@
 ################################################################################
 
 # Set root logger level to DEBUG and its only appender to A1.
-log4j.rootLogger=DEBUG, A1
+log4j.rootLogger=OFF, A1
 
 # A1 is set to be a ConsoleAppender.
 log4j.appender.A1=org.apache.log4j.ConsoleAppender


### PR DESCRIPTION
## What is the purpose of the change

This PR addresses [FLINK-8845](https://issues.apache.org/jira/browse/FLINK-8845), which attempts to use `WriteBatch` to improve the performance for loading data into RocksDB. It's inspired by [RocksDB FAQ](https://github.com/facebook/rocksdb/wiki/RocksDB-FAQ).

## Brief change log

  - *Introduce `RocksDBWriteBatchWrapper` to load data into RocksDB in bulk*

## Verifying this change

- Introduce `RocksDBWriteBatchWrapperTest.java` to guard `RocksDBWriteBatchWrapper`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation
none
