### PR TITLE
[FLINK-8889][tests] Do not override cluster config values

### DIFF
--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/MiniClusterResource.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/MiniClusterResource.java
@@ -169,7 +169,9 @@ public class MiniClusterResource extends ExternalResource {
 
 		// we need to set this since a lot of test expect this because TestBaseUtils.startCluster()
 		// enabled this by default
-		configuration.setBoolean(CoreOptions.FILESYTEM_DEFAULT_OVERRIDE, true);
+		if (!configuration.contains(CoreOptions.FILESYTEM_DEFAULT_OVERRIDE)) {
+			configuration.setBoolean(CoreOptions.FILESYTEM_DEFAULT_OVERRIDE, true);
+		}
 
 		// set rest port to 0 to avoid clashes with concurrent MiniClusters
 		configuration.setInteger(RestOptions.REST_PORT, 0);

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestBaseUtils.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestBaseUtils.java
@@ -143,22 +143,41 @@ public class TestBaseUtils extends TestLogger {
 		Configuration config,
 		boolean singleActorSystem) throws Exception {
 
-		logDir = File.createTempFile("TestBaseUtils-logdir", null);
-		Assert.assertTrue("Unable to delete temp file", logDir.delete());
-		Assert.assertTrue("Unable to create temp directory", logDir.mkdir());
-		Path logFile = Files.createFile(new File(logDir, "jobmanager.log").toPath());
-		Files.createFile(new File(logDir, "jobmanager.out").toPath());
+		if (!config.contains(WebOptions.LOG_PATH) || !config.containsKey(ConfigConstants.TASK_MANAGER_LOG_PATH_KEY)) {
+			logDir = File.createTempFile("TestBaseUtils-logdir", null);
+			Assert.assertTrue("Unable to delete temp file", logDir.delete());
+			Assert.assertTrue("Unable to create temp directory", logDir.mkdir());
+			Path logFile = Files.createFile(new File(logDir, "jobmanager.log").toPath());
+			Files.createFile(new File(logDir, "jobmanager.out").toPath());
 
-		config.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, TASK_MANAGER_MEMORY_SIZE);
-		config.setBoolean(CoreOptions.FILESYTEM_DEFAULT_OVERRIDE, true);
+			if (!config.contains(WebOptions.LOG_PATH)) {
+				config.setString(WebOptions.LOG_PATH, logFile.toString());
+			}
 
-		config.setString(AkkaOptions.ASK_TIMEOUT, DEFAULT_AKKA_ASK_TIMEOUT + "s");
-		config.setString(AkkaOptions.STARTUP_TIMEOUT, DEFAULT_AKKA_STARTUP_TIMEOUT);
+			if (!config.containsKey(ConfigConstants.TASK_MANAGER_LOG_PATH_KEY)) {
+				config.setString(ConfigConstants.TASK_MANAGER_LOG_PATH_KEY, logFile.toString());
+			}
+		}
 
-		config.setInteger(WebOptions.PORT, 8081);
-		config.setString(WebOptions.LOG_PATH, logFile.toString());
+		if (!config.contains(WebOptions.PORT)) {
+			config.setInteger(WebOptions.PORT, 8081);
+		}
 
-		config.setString(ConfigConstants.TASK_MANAGER_LOG_PATH_KEY, logFile.toString());
+		if (!config.contains(AkkaOptions.ASK_TIMEOUT)) {
+			config.setString(AkkaOptions.ASK_TIMEOUT, DEFAULT_AKKA_ASK_TIMEOUT + "s");
+		}
+
+		if (!config.contains(AkkaOptions.STARTUP_TIMEOUT)) {
+			config.setString(AkkaOptions.STARTUP_TIMEOUT, DEFAULT_AKKA_STARTUP_TIMEOUT);
+		}
+
+		if (!config.contains(CoreOptions.FILESYTEM_DEFAULT_OVERRIDE)) {
+			config.setBoolean(CoreOptions.FILESYTEM_DEFAULT_OVERRIDE, true);
+		}
+
+		if (!config.contains(TaskManagerOptions.MANAGED_MEMORY_SIZE)) {
+			config.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, TASK_MANAGER_MEMORY_SIZE);
+		}
 
 		LocalFlinkMiniCluster cluster =  new LocalFlinkMiniCluster(config, singleActorSystem);
 


### PR DESCRIPTION
## What is the purpose of the change

This PR modifies the cluster configuration in `MiniClusterResource` and `TestBaseUtils` to not categorically override several options. They are now only set if they weren't previously configured (i.e. by the test itself). 

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
