### PR TITLE
[hotfix][tests] Do not use singleActorSystem in LocalFlinkMiniCluster

### DIFF
--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/MiniClusterResource.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/MiniClusterResource.java
@@ -62,6 +62,8 @@ public class MiniClusterResource extends ExternalResource {
 
 	private JobExecutorService jobExecutorService;
 
+	private final boolean enableClusterClient;
+
 	private ClusterClient<?> clusterClient;
 
 	private int numberSlots = -1;
@@ -69,16 +71,25 @@ public class MiniClusterResource extends ExternalResource {
 	private TestEnvironment executionEnvironment;
 
 	public MiniClusterResource(final MiniClusterResourceConfiguration miniClusterResourceConfiguration) {
-		this(
-			miniClusterResourceConfiguration,
-			Objects.equals(FLIP6_CODEBASE, System.getProperty(CODEBASE_KEY)) ? MiniClusterType.FLIP6 : MiniClusterType.OLD);
+		this(miniClusterResourceConfiguration, false);
 	}
 
 	public MiniClusterResource(
 			final MiniClusterResourceConfiguration miniClusterResourceConfiguration,
-			final MiniClusterType miniClusterType) {
+			final boolean enableClusterClient) {
+		this(
+			miniClusterResourceConfiguration,
+			Objects.equals(FLIP6_CODEBASE, System.getProperty(CODEBASE_KEY)) ? MiniClusterType.FLIP6 : MiniClusterType.OLD,
+			enableClusterClient);
+	}
+
+	private MiniClusterResource(
+			final MiniClusterResourceConfiguration miniClusterResourceConfiguration,
+			final MiniClusterType miniClusterType,
+			final boolean enableClusterClient) {
 		this.miniClusterResourceConfiguration = Preconditions.checkNotNull(miniClusterResourceConfiguration);
 		this.miniClusterType = Preconditions.checkNotNull(miniClusterType);
+		this.enableClusterClient = enableClusterClient;
 	}
 
 	public int getNumberSlots() {
@@ -86,6 +97,12 @@ public class MiniClusterResource extends ExternalResource {
 	}
 
 	public ClusterClient<?> getClusterClient() {
+		if (!enableClusterClient) {
+			// this check is technically only necessary for legacy clusters
+			// we still fail here for flip6 to keep the behaviors in sync
+			throw new IllegalStateException("To use the client you must enable it with the constructor.");
+		}
+
 		return clusterClient;
 	}
 
@@ -113,10 +130,12 @@ public class MiniClusterResource extends ExternalResource {
 
 		Exception exception = null;
 
-		try {
-			clusterClient.shutdown();
-		} catch (Exception e) {
-			exception = e;
+		if (clusterClient != null) {
+			try {
+				clusterClient.shutdown();
+			} catch (Exception e) {
+				exception = e;
+			}
 		}
 
 		clusterClient = null;
@@ -158,10 +177,12 @@ public class MiniClusterResource extends ExternalResource {
 
 		final LocalFlinkMiniCluster flinkMiniCluster = TestBaseUtils.startCluster(
 			configuration,
-			false);
+			!enableClusterClient); // the cluster client only works if separate actor systems are used
 
 		jobExecutorService = flinkMiniCluster;
-		clusterClient = new StandaloneClusterClient(configuration, flinkMiniCluster.highAvailabilityServices(), true);
+		if (enableClusterClient) {
+			clusterClient = new StandaloneClusterClient(configuration, flinkMiniCluster.highAvailabilityServices(), true);
+		}
 	}
 
 	private void startFlip6MiniCluster() throws Exception {
@@ -188,7 +209,9 @@ public class MiniClusterResource extends ExternalResource {
 		configuration.setInteger(RestOptions.REST_PORT, miniCluster.getRestAddress().getPort());
 
 		jobExecutorService = miniCluster;
-		clusterClient = new MiniClusterClient(configuration, miniCluster);
+		if (enableClusterClient) {
+			clusterClient = new MiniClusterClient(configuration, miniCluster);
+		}
 	}
 
 	/**

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/MiniClusterResource.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/MiniClusterResource.java
@@ -158,7 +158,7 @@ public class MiniClusterResource extends ExternalResource {
 
 		final LocalFlinkMiniCluster flinkMiniCluster = TestBaseUtils.startCluster(
 			configuration,
-			true);
+			false);
 
 		jobExecutorService = flinkMiniCluster;
 		clusterClient = new StandaloneClusterClient(configuration, flinkMiniCluster.highAvailabilityServices(), true);


### PR DESCRIPTION
## What is the purpose of the change

The legacy cluster started in {{MiniClusterResource}} used a single actor system, which rendered the returned {{ClusterClient}} unusable.

This change will unfortunately cause tests to take longer, but i don't know how to fix this in another way.

On every access you would get this exception below:
```
org.apache.flink.client.program.ProgramInvocationException: Failed to retrieve the JobManager gateway.

    at org.apache.flink.client.program.ClusterClient.runDetached(ClusterClient.java:513)

    at org.apache.flink.client.program.StandaloneClusterClient.submitJob(StandaloneClusterClient.java:113)

Caused by: org.apache.flink.util.FlinkException: Could not find out our own hostname by connecting to the leading JobManager. Please make sure that the Flink cluster has been started.

    at org.apache.flink.client.program.ClusterClient$LazyActorSystemLoader.get(ClusterClient.java:248)

    at org.apache.flink.client.program.ClusterClient.getJobManagerGateway(ClusterClient.java:923)

    at org.apache.flink.client.program.ClusterClient.runDetached(ClusterClient.java:511)

    ... 30 more

Caused by: org.apache.flink.runtime.leaderretrieval.LeaderRetrievalException: Could not find the connecting address by connecting to the current leader.

    at org.apache.flink.runtime.util.LeaderRetrievalUtils.findConnectingAddress(LeaderRetrievalUtils.java:164)

    at org.apache.flink.runtime.util.LeaderRetrievalUtils.findConnectingAddress(LeaderRetrievalUtils.java:145)

    at org.apache.flink.client.program.ClusterClient$LazyActorSystemLoader.get(ClusterClient.java:244)

    ... 32 more

Caused by: org.apache.flink.runtime.leaderretrieval.LeaderRetrievalException: Could not retrieve the connecting address to the current leader with the akka URL akka://flink/user/jobmanager_1.

    at org.apache.flink.runtime.net.ConnectionUtils$LeaderConnectingAddressListener.findConnectingAddress(ConnectionUtils.java:472)

    at org.apache.flink.runtime.net.ConnectionUtils$LeaderConnectingAddressListener.findConnectingAddress(ConnectionUtils.java:361)

    at org.apache.flink.runtime.util.LeaderRetrievalUtils.findConnectingAddress(LeaderRetrievalUtils.java:162)

    ... 34 more

Caused by: java.lang.Exception: Could not retrieve InetSocketAddress from Akka URL akka://flink/user/jobmanager_1

    at org.apache.flink.runtime.akka.AkkaUtils$.getInetSocketAddressFromAkkaURL(AkkaUtils.scala:709)

    at org.apache.flink.runtime.akka.AkkaUtils.getInetSocketAddressFromAkkaURL(AkkaUtils.scala)

    at org.apache.flink.runtime.net.ConnectionUtils$LeaderConnectingAddressListener.findConnectingAddress(ConnectionUtils.java:392)

    ... 36 more
```
