### PR TITLE
[FLINK-8887][tests] Add single retry in MiniClusterClient

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/MiniClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/MiniClusterClient.java
@@ -50,6 +50,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Supplier;
 
 /**
@@ -58,14 +59,19 @@ import java.util.function.Supplier;
 public class MiniClusterClient extends ClusterClient<MiniClusterClient.MiniClusterId> {
 
 	private final MiniCluster miniCluster;
-
-	private final ScheduledExecutor scheduledExecutor = new ScheduledExecutorServiceAdapter(
-		Executors.newScheduledThreadPool(4, new ExecutorThreadFactory("Flink-MiniClusterClient")));
+	private final ScheduledExecutorService scheduledExecutorService = Executors.newScheduledThreadPool(4, new ExecutorThreadFactory("Flink-MiniClusterClient"));
+	private final ScheduledExecutor scheduledExecutor = new ScheduledExecutorServiceAdapter(scheduledExecutorService);
 
 	public MiniClusterClient(@Nonnull Configuration configuration, @Nonnull MiniCluster miniCluster) throws Exception {
 		super(configuration, miniCluster.getHighAvailabilityServices(), true);
 
 		this.miniCluster = miniCluster;
+	}
+
+	@Override
+	public void shutdown() throws Exception {
+		super.shutdown();
+		scheduledExecutorService.shutdown();
 	}
 
 	@Override

--- a/flink-clients/src/main/java/org/apache/flink/client/program/MiniClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/MiniClusterClient.java
@@ -25,11 +25,17 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.runtime.clusterframework.messages.GetClusterStatusResponse;
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.concurrent.ScheduledExecutor;
+import org.apache.flink.runtime.concurrent.ScheduledExecutorServiceAdapter;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalException;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.minicluster.MiniCluster;
+import org.apache.flink.runtime.rpc.akka.exceptions.AkkaRpcException;
+import org.apache.flink.runtime.rpc.exceptions.FencingTokenException;
+import org.apache.flink.runtime.util.ExecutorThreadFactory;
 import org.apache.flink.runtime.util.LeaderConnectionInfo;
 import org.apache.flink.runtime.util.LeaderRetrievalUtils;
 import org.apache.flink.util.FlinkException;
@@ -43,6 +49,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.function.Supplier;
 
 /**
  * Client to interact with a {@link MiniCluster}.
@@ -50,6 +58,9 @@ import java.util.concurrent.CompletableFuture;
 public class MiniClusterClient extends ClusterClient<MiniClusterClient.MiniClusterId> {
 
 	private final MiniCluster miniCluster;
+
+	private final ScheduledExecutor scheduledExecutor = new ScheduledExecutorServiceAdapter(
+		Executors.newScheduledThreadPool(4, new ExecutorThreadFactory("Flink-MiniClusterClient")));
 
 	public MiniClusterClient(@Nonnull Configuration configuration, @Nonnull MiniCluster miniCluster) throws Exception {
 		super(configuration, miniCluster.getHighAvailabilityServices(), true);
@@ -82,12 +93,12 @@ public class MiniClusterClient extends ClusterClient<MiniClusterClient.MiniClust
 
 	@Override
 	public void cancel(JobID jobId) throws Exception {
-		miniCluster.cancelJob(jobId);
+		guardWithSingleRetry(() -> miniCluster.cancelJob(jobId), scheduledExecutor);
 	}
 
 	@Override
 	public String cancelWithSavepoint(JobID jobId, @Nullable String savepointDirectory) throws Exception {
-		return miniCluster.triggerSavepoint(jobId, savepointDirectory, true).get();
+		return guardWithSingleRetry(() -> miniCluster.triggerSavepoint(jobId, savepointDirectory, true), scheduledExecutor).get();
 	}
 
 	@Override
@@ -122,7 +133,7 @@ public class MiniClusterClient extends ClusterClient<MiniClusterClient.MiniClust
 
 	@Override
 	public CompletableFuture<JobStatus> getJobStatus(JobID jobId) {
-		return miniCluster.getJobStatus(jobId);
+		return guardWithSingleRetry(() -> miniCluster.getJobStatus(jobId), scheduledExecutor);
 	}
 
 	@Override
@@ -173,5 +184,14 @@ public class MiniClusterClient extends ClusterClient<MiniClusterClient.MiniClust
 
 	enum MiniClusterId {
 		INSTANCE
+	}
+
+	private static <X> CompletableFuture<X> guardWithSingleRetry(Supplier<CompletableFuture<X>> operation, ScheduledExecutor executor) {
+		return FutureUtils.retryWithDelay(
+			operation,
+			1,
+			Time.milliseconds(500),
+			throwable -> throwable instanceof FencingTokenException || throwable instanceof AkkaRpcException,
+			executor);
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR presents a test workaround for race-conditions in FLIP-6 (most notably FLINK-8887). Basically, every `MiniClusterClient` call is retried *once* after 500ms in case of certain exceptions.

**This is only a band-aid until a proper fix is in place** so we can finally continue merging more test ports.

## Brief change log

* add `guardWithSingleRetry` convenience method
* add `ScheduledExecutor` to `MiniClusterClient`
* guard all calls to the `MiniCluster`

## Verifying this change

The change can be verified by cherry-picking [this branch](https://github.com/zentol/flink/tree/8797) and running the `AbstractOperatorRestoreTestBase`. Before this change there was always 1-2 tests failing, whereas now none should fail.

/cc @aljoscha @GJL 