### PR TITLE
[FLINK-8661] [table] Add support for batch queries in SQL Client

### DIFF
--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliTableResultView.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliTableResultView.java
@@ -124,6 +124,7 @@ public class CliTableResultView extends CliResultView<CliTableResultView.ResultT
 		keys.bind(ResultTableOperation.RIGHT, "d", "D", key(client.getTerminal(), Capability.key_right));
 		keys.bind(ResultTableOperation.OPEN, "o", "O", "\r");
 		keys.bind(ResultTableOperation.GOTO, "g", "G");
+		keys.bind(ResultTableOperation.FIRST, "f", "F");
 		keys.bind(ResultTableOperation.NEXT, "n", "N");
 		keys.bind(ResultTableOperation.PREV, "p", "P");
 		keys.bind(ResultTableOperation.LAST, "l", "L", key(client.getTerminal(), Capability.key_end));
@@ -158,6 +159,9 @@ public class CliTableResultView extends CliResultView<CliTableResultView.ResultT
 				break;
 			case PREV:
 				gotoPreviousPage();
+				break;
+			case FIRST:
+				gotoFirstPage();
 				break;
 			case LAST:
 				gotoLastPage();
@@ -289,6 +293,7 @@ public class CliTableResultView extends CliResultView<CliTableResultView.ResultT
 
 		options.add(Tuple2.of("G", CliStrings.RESULT_GOTO));
 		options.add(Tuple2.of("L", CliStrings.RESULT_LAST));
+		options.add(Tuple2.of("F", CliStrings.RESULT_FIRST));
 
 		options.add(Tuple2.of("N", CliStrings.RESULT_NEXT));
 		options.add(Tuple2.of("P", CliStrings.RESULT_PREV));
@@ -340,6 +345,11 @@ public class CliTableResultView extends CliResultView<CliTableResultView.ResultT
 		updatePage();
 	}
 
+	private void gotoFirstPage() {
+		page = 1;
+		updatePage();
+	}
+
 	// --------------------------------------------------------------------------------------------
 
 	/**
@@ -354,6 +364,7 @@ public class CliTableResultView extends CliResultView<CliTableResultView.ResultT
 		GOTO, // enter table page number
 		NEXT, // next table page
 		PREV, // previous table page
+		FIRST, // first table page
 		LAST, // last table page
 		LEFT, // scroll left if row is large
 		RIGHT, // scroll right if row is large

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/config/Execution.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/config/Execution.java
@@ -44,13 +44,13 @@ public class Execution {
 
 	public boolean isStreamingExecution() {
 		return Objects.equals(
-			properties.getOrDefault(PropertyStrings.EXECUTION_TYPE, PropertyStrings.EXECUTION_TYPE_VALUE_STREAMING),
+			properties.getOrDefault(PropertyStrings.EXECUTION_TYPE, ""),
 			PropertyStrings.EXECUTION_TYPE_VALUE_STREAMING);
 	}
 
 	public boolean isBatchExecution() {
 		return Objects.equals(
-			properties.getOrDefault(PropertyStrings.EXECUTION_TYPE, PropertyStrings.EXECUTION_TYPE_VALUE_STREAMING),
+			properties.getOrDefault(PropertyStrings.EXECUTION_TYPE, ""),
 			PropertyStrings.EXECUTION_TYPE_VALUE_BATCH);
 	}
 
@@ -72,8 +72,14 @@ public class Execution {
 
 	public boolean isChangelogMode() {
 		return Objects.equals(
-			properties.getOrDefault(PropertyStrings.EXECUTION_RESULT_MODE, PropertyStrings.EXECUTION_RESULT_MODE_VALUE_CHANGELOG),
+			properties.getOrDefault(PropertyStrings.EXECUTION_RESULT_MODE, ""),
 			PropertyStrings.EXECUTION_RESULT_MODE_VALUE_CHANGELOG);
+	}
+
+	public boolean isTableMode() {
+		return Objects.equals(
+				properties.getOrDefault(PropertyStrings.EXECUTION_RESULT_MODE, ""),
+				PropertyStrings.EXECUTION_RESULT_MODE_VALUE_TABLE);
 	}
 
 	public Map<String, String> toProperties() {

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/BatchResult.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/BatchResult.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.client.gateway.local;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.table.client.gateway.SqlExecutionException;
+import org.apache.flink.table.client.gateway.TypedResult;
+import org.apache.flink.table.sinks.TableSink;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.AbstractID;
+
+import java.util.List;
+
+/**
+ * Result for batch queries.
+ */
+public class BatchResult implements StaticResult {
+
+	private String accumulatorName;
+	private CollectBatchTableSink tableSink;
+	private List<Row> resultTable;
+	private int pageSize;
+	private int pageCount;
+
+	private volatile boolean snapshotted = false;
+
+	public BatchResult() {
+		accumulatorName = new AbstractID().toString();
+		tableSink = new CollectBatchTableSink(accumulatorName);
+		pageCount = 0;
+	}
+
+	@Override
+	public TableSink<?> getTableSink() {
+		return tableSink;
+	}
+
+	@Override
+	public List<Row> retrievePage(int page) {
+		if (page <= 0 || page > pageCount) {
+			throw new SqlExecutionException("Invalid page '" + page + "'.");
+		}
+		return resultTable.subList(pageSize * (page - 1), Math.min(resultTable.size(), page * pageSize));
+	}
+
+	@Override
+	public void setResultTable(List<Row> resultTable) {
+		this.resultTable = resultTable;
+	}
+
+	@Override
+	public TypedResult<Integer> snapshot(int pageSize) {
+		// We return a payload result the first time and EoS for the rest of times as if the results
+		// are retrieved dynamically.
+		if (!snapshotted) {
+			snapshotted = true;
+			this.pageSize = pageSize;
+			pageCount = Math.max(1, (int) Math.ceil(((double) resultTable.size() / pageSize)));
+			return TypedResult.payload(pageCount);
+		} else {
+			return TypedResult.endOfStream();
+		}
+	}
+
+	/**
+	 * Returns the accumulator name for retrieving the results.
+	 */
+	public String getAccumulatorName() {
+		return accumulatorName;
+	}
+
+	/**
+	 * Returns the serializer for deserializing the collected result.
+	 */
+	public TypeSerializer<Row> getSerializer() {
+		return tableSink.getSerializer();
+	}
+}

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/CollectBatchTableSink.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/CollectBatchTableSink.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.client.gateway.local;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.Utils;
+import org.apache.flink.table.sinks.BatchTableSink;
+import org.apache.flink.table.sinks.TableSink;
+import org.apache.flink.types.Row;
+
+/**
+ * Table sink for collecting the results locally all at once.
+ */
+public class CollectBatchTableSink implements BatchTableSink<Row> {
+
+	private String[] fieldNames;
+	private TypeInformation<?>[] fieldTypes;
+
+	private String accumulatorName;
+	private TypeSerializer<Row> serializer;
+
+	public CollectBatchTableSink(String accumulatorName) {
+		this.accumulatorName = accumulatorName;
+	}
+
+	@Override
+	public TypeInformation<Row> getOutputType() {
+		return Types.ROW_NAMED(fieldNames, fieldTypes);
+	}
+
+	@Override
+	public String[] getFieldNames() {
+		return fieldNames;
+	}
+
+	@Override
+	public TypeInformation<?>[] getFieldTypes() {
+		return fieldTypes;
+	}
+
+	@Override
+	public TableSink<Row> configure(String[] fieldNames, TypeInformation<?>[] fieldTypes) {
+		this.fieldNames = fieldNames;
+		this.fieldTypes = fieldTypes;
+		return this;
+	}
+
+	@Override
+	public void emitDataSet(DataSet<Row> dataSet) {
+		serializer = dataSet.getType().createSerializer(dataSet.getExecutionEnvironment().getConfig());
+		dataSet.output(new Utils.CollectHelper<>(accumulatorName, serializer)).name("SQL Client Batch Collect Sink");
+	}
+
+	/**
+	 * Returns the serializer for deserializing the collected result.
+	 */
+	public TypeSerializer<Row> getSerializer() {
+		return serializer;
+	}
+}

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ResultStore.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ResultStore.java
@@ -46,18 +46,21 @@ public class ResultStore {
 
 	private Configuration flinkConfig;
 
-	private Map<String, DynamicResult> results;
+	private Map<String, DynamicResult> dynamicResults;
+
+	private Map<String, StaticResult> staticResults;
 
 	public ResultStore(Configuration flinkConfig) {
 		this.flinkConfig = flinkConfig;
 
-		results = new HashMap<>();
+		dynamicResults = new HashMap<>();
+		staticResults = new HashMap<>();
 	}
 
 	/**
-	 * Creates a result. Might start thread or opens sockets so every creates result must be closed.
+	 * Creates a dynamic result. Might start thread or opens sockets so every creates result must be closed.
 	 */
-	public DynamicResult createResult(Environment env, TableSchema schema, ExecutionConfig config) {
+	public DynamicResult createDynamicResult(Environment env, TableSchema schema, ExecutionConfig config) {
 		if (!env.getExecution().isStreamingExecution()) {
 			throw new SqlExecutionException("Emission is only supported in streaming environments yet.");
 		}
@@ -74,20 +77,36 @@ public class ResultStore {
 		}
 	}
 
-	public void storeResult(String resultId, DynamicResult result) {
-		results.put(resultId, result);
+	public void storeDynamicResult(String resultId, DynamicResult result) {
+		dynamicResults.put(resultId, result);
 	}
 
-	public DynamicResult getResult(String resultId) {
-		return results.get(resultId);
+	public void storeStaticResult(String resultId, StaticResult result) {
+		staticResults.put(resultId, result);
 	}
 
-	public void removeResult(String resultId) {
-		results.remove(resultId);
+	public DynamicResult getDynamicResult(String resultId) {
+		return dynamicResults.get(resultId);
 	}
 
-	public List<String> getResults() {
-		return new ArrayList<>(results.keySet());
+	public StaticResult getStaticResult(String resultId) {
+		return staticResults.get(resultId);
+	}
+
+	public void removeDynamicResult(String resultId) {
+		dynamicResults.remove(resultId);
+	}
+
+	public void removeStaticResult(String resultId) {
+		staticResults.remove(resultId);
+	}
+
+	public List<String> getDynamicResults() {
+		return new ArrayList<>(dynamicResults.keySet());
+	}
+
+	public boolean isStatic(String resultId) {
+		return staticResults.containsKey(resultId);
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/StaticResult.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/StaticResult.java
@@ -18,24 +18,22 @@
 
 package org.apache.flink.table.client.gateway.local;
 
-import org.apache.flink.table.client.gateway.TypedResult;
+import org.apache.flink.table.sinks.TableSink;
 import org.apache.flink.types.Row;
 
 import java.util.List;
 
 /**
- * A result that is materialized and can be viewed by navigating through a snapshot.
+ * A result of a static table program.
  */
-public interface MaterializedResult {
+public interface StaticResult extends MaterializedResult {
+	/**
+	 * Returns the table sink required by this result type.
+	 */
+	TableSink<?> getTableSink();
 
 	/**
-	 * Takes a snapshot of the current table and returns the number of pages for navigating
-	 * through the snapshot.
+	 * Sets the collected SQL result.
 	 */
-	TypedResult<Integer> snapshot(int pageSize);
-
-	/**
-	 * Retrieves a page of a snapshotted result.
-	 */
-	List<Row> retrievePage(int page);
+	void setResultTable(List<Row> resultTable);
 }

--- a/flink-libraries/flink-sql-client/src/test/resources/test-sql-client-defaults.yaml
+++ b/flink-libraries/flink-sql-client/src/test/resources/test-sql-client-defaults.yaml
@@ -61,12 +61,12 @@ sources:
       comment-prefix: "#"
 
 execution:
-  type: streaming
+  type: "$VAR_2"
   parallelism: 1
   max-parallelism: 16
   min-idle-state-retention: 0
   max-idle-state-retention: 0
-  result-mode: "$VAR_2"
+  result-mode: "$VAR_3"
 
 deployment:
   type: standalone


### PR DESCRIPTION
## What is the purpose of the change

This PR added support for batch queries in SQL Client.

## Brief change log

 - Added a `StaticResult` and a `BatchResult` for the batch query results.
 - Added related methods to `ResultStore` for static results and renamed the existing methods with a prefix "dynamic".
 - Added the logic for retrieving batch query results consulting to `Dataset.collect()`.
 - Adapted the viewing logic for static results to a "two-phase" table result view.
 - Added the first-page option to `CliTableResultView.java`.
 - Replaced some default values with `""` in `Execution.java`.

## Verifying this change

This change can be verified by the added test case `testBatchQueryExecution()`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
