### PR TITLE
[FLINK-8861] [table] Add support for batch queries in SQL Client

### DIFF
--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/config/Execution.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/config/Execution.java
@@ -46,14 +46,8 @@ public class Execution {
 
 	public boolean isStreamingExecution() {
 		return Objects.equals(
-			properties.getOrDefault(PropertyStrings.EXECUTION_TYPE, PropertyStrings.EXECUTION_TYPE_VALUE_STREAMING),
+			properties.getOrDefault(PropertyStrings.EXECUTION_TYPE, ""),
 			PropertyStrings.EXECUTION_TYPE_VALUE_STREAMING);
-	}
-
-	public boolean isBatchExecution() {
-		return Objects.equals(
-			properties.getOrDefault(PropertyStrings.EXECUTION_TYPE, PropertyStrings.EXECUTION_TYPE_VALUE_STREAMING),
-			PropertyStrings.EXECUTION_TYPE_VALUE_BATCH);
 	}
 
 	public TimeCharacteristic getTimeCharacteristic() {
@@ -88,8 +82,14 @@ public class Execution {
 
 	public boolean isChangelogMode() {
 		return Objects.equals(
-			properties.getOrDefault(PropertyStrings.EXECUTION_RESULT_MODE, PropertyStrings.EXECUTION_RESULT_MODE_VALUE_CHANGELOG),
+			properties.getOrDefault(PropertyStrings.EXECUTION_RESULT_MODE, ""),
 			PropertyStrings.EXECUTION_RESULT_MODE_VALUE_CHANGELOG);
+	}
+
+	public boolean isTableMode() {
+		return Objects.equals(
+				properties.getOrDefault(PropertyStrings.EXECUTION_RESULT_MODE, ""),
+				PropertyStrings.EXECUTION_RESULT_MODE_VALUE_TABLE);
 	}
 
 	public Map<String, String> toProperties() {

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/CollectBatchTableSink.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/CollectBatchTableSink.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.client.gateway.local;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.Utils;
+import org.apache.flink.table.sinks.BatchTableSink;
+import org.apache.flink.table.sinks.TableSink;
+import org.apache.flink.types.Row;
+
+/**
+ * Table sink for collecting the results locally all at once.
+ */
+public class CollectBatchTableSink implements BatchTableSink<Row> {
+
+	private String[] fieldNames;
+	private TypeInformation<?>[] fieldTypes;
+	private String accumulatorName;
+	private TypeSerializer<Row> serializer;
+
+	public CollectBatchTableSink(String accumulatorName) {
+		this.accumulatorName = accumulatorName;
+	}
+
+	@Override
+	public TypeInformation<Row> getOutputType() {
+		return Types.ROW_NAMED(fieldNames, fieldTypes);
+	}
+
+	@Override
+	public String[] getFieldNames() {
+		return fieldNames;
+	}
+
+	@Override
+	public TypeInformation<?>[] getFieldTypes() {
+		return fieldTypes;
+	}
+
+	@Override
+	public TableSink<Row> configure(String[] fieldNames, TypeInformation<?>[] fieldTypes) {
+		this.fieldNames = fieldNames;
+		this.fieldTypes = fieldTypes;
+		return this;
+	}
+
+	@Override
+	public void emitDataSet(DataSet<Row> dataSet) {
+		serializer = dataSet.getType().createSerializer(dataSet.getExecutionEnvironment().getConfig());
+		dataSet.output(new Utils.CollectHelper<>(accumulatorName, serializer)).name("SQL Client Batch Collect Sink");
+	}
+
+	/**
+	 * Returns the serializer for deserializing the collected result.
+	 */
+	public TypeSerializer<Row> getSerializer() {
+		return serializer;
+	}
+}

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/CollectStreamResult.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/CollectStreamResult.java
@@ -90,7 +90,7 @@ public abstract class CollectStreamResult<C> implements DynamicResult<C> {
 	}
 
 	@Override
-	public void startRetrieval(Runnable program) {
+	public void startRetrieval(ProgramDeployer<C> program) {
 		// start listener thread
 		retrievalThread.start();
 

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/DynamicResult.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/DynamicResult.java
@@ -27,7 +27,7 @@ import org.apache.flink.types.Row;
  *
  * <p>Note: Make sure to call close() after the result is not needed anymore.
  *
- * @param <C> cluster id to which this result belongs to
+ * @param <C> type of the cluster id to which this result belongs to
  */
 public interface DynamicResult<C> {
 
@@ -50,7 +50,7 @@ public interface DynamicResult<C> {
 	/**
 	 * Starts the table program using the given runnable and monitors it's execution.
 	 */
-	void startRetrieval(Runnable program);
+	void startRetrieval(ProgramDeployer<C> program);
 
 	/**
 	 * Returns the table sink required by this result type.

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
@@ -26,7 +26,6 @@ import org.apache.flink.client.cli.CustomCommandLine;
 import org.apache.flink.client.deployment.ClusterDescriptor;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.client.program.JobWithJars;
-import org.apache.flink.client.program.rest.RestClusterClient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.core.fs.FileSystem;
@@ -353,17 +352,11 @@ public class LocalExecutor implements Executor {
 		resultStore.storeResult(resultId, result);
 
 		// create execution
-		final Runnable program = () -> {
-			LOG.info("Submitting job {} for query {}`", jobGraph.getJobID(), jobName);
-			if (LOG.isDebugEnabled()) {
-				LOG.debug("Submitting job {} with the following environment: \n{}",
-					jobGraph.getJobID(), context.getMergedEnvironment());
-			}
-			deployJob(context, jobGraph, result);
-		};
+		final ProgramDeployer<T> deployer = new ProgramDeployer<>(context, jobName, jobGraph,
+				result);
 
 		// start result retrieval
-		result.startRetrieval(program);
+		result.startRetrieval(deployer);
 
 		return new ResultDescriptor(
 			resultId,
@@ -395,55 +388,6 @@ public class LocalExecutor implements Executor {
 			}
 		}
 		return executionContext;
-	}
-
-	/**
-	 * Deploys a job. Depending on the deployment create a new job cluster. It saves cluster id in
-	 * the result and blocks until job completion.
-	 */
-	private <T> void deployJob(ExecutionContext<T> context, JobGraph jobGraph, DynamicResult<T> result) {
-		// create or retrieve cluster and deploy job
-		try (final ClusterDescriptor<T> clusterDescriptor = context.createClusterDescriptor()) {
-			ClusterClient<T> clusterClient = null;
-			try {
-				// new cluster
-				if (context.getClusterId() == null) {
-					// deploy job cluster with job attached
-					clusterClient = clusterDescriptor.deployJobCluster(context.getClusterSpec(), jobGraph, false);
-					// save the new cluster id
-					result.setClusterId(clusterClient.getClusterId());
-					// we need to hard cast for now
-					((RestClusterClient<T>) clusterClient)
-						.requestJobResult(jobGraph.getJobID())
-						.get()
-						.toJobExecutionResult(context.getClassLoader()); // throws exception if job fails
-				}
-				// reuse existing cluster
-				else {
-					// retrieve existing cluster
-					clusterClient = clusterDescriptor.retrieve(context.getClusterId());
-					// save the cluster id
-					result.setClusterId(clusterClient.getClusterId());
-					// submit the job
-					clusterClient.setDetached(false);
-					clusterClient.submitJob(jobGraph, context.getClassLoader()); // throws exception if job fails
-				}
-			} catch (Exception e) {
-				throw new SqlExecutionException("Could not retrieve or create a cluster.", e);
-			} finally {
-				try {
-					if (clusterClient != null) {
-						clusterClient.shutdown();
-					}
-				} catch (Exception e) {
-					// ignore
-				}
-			}
-		} catch (SqlExecutionException e) {
-			throw e;
-		} catch (Exception e) {
-			throw new SqlExecutionException("Could not locate a cluster.", e);
-		}
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/MaterializedCollectBatchResult.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/MaterializedCollectBatchResult.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.client.gateway.local;
+
+import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.api.common.accumulators.SerializedListAccumulator;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.table.client.gateway.SqlExecutionException;
+import org.apache.flink.table.client.gateway.TypedResult;
+import org.apache.flink.table.sinks.TableSink;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.AbstractID;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Result for batch queries.
+ */
+public class MaterializedCollectBatchResult<C> implements MaterializedResult<C> {
+
+	private String accumulatorName;
+	private CollectBatchTableSink tableSink;
+	private int pageSize;
+	private int pageCount;
+
+	private List<Row> resultTable = null;
+	private final TypeInformation<Row> outputType;
+	private final Object resultLock;
+	private Thread retrievingThread;
+	private ProgramDeployer<C> deployer;
+
+	private C clusterId;
+
+	private volatile boolean snapshotted = false;
+
+	public MaterializedCollectBatchResult(TypeInformation<Row> outputType) {
+		this.outputType = outputType;
+
+		accumulatorName = new AbstractID().toString();
+		tableSink = new CollectBatchTableSink(accumulatorName);
+		resultLock = new Object();
+		pageCount = 0;
+		retrievingThread = new Thread(() -> {
+			deployer.run();
+			JobExecutionResult result = deployer.fetchExecutionResult();
+			ArrayList<byte[]> accResult = result.getAccumulatorResult(getAccumulatorName());
+			if (accResult != null) {
+				try {
+					List<Row> resultTable = SerializedListAccumulator.deserializeList(accResult, getSerializer());
+					setResultTable(resultTable);
+				} catch (ClassNotFoundException e) {
+					throw new SqlExecutionException("Cannot find type class of collected data type.", e);
+				} catch (IOException e) {
+					throw new SqlExecutionException("Serialization error while deserializing collected data", e);
+				}
+			} else {
+				throw new SqlExecutionException("The call to collect() could not retrieve the DataSet.");
+			}
+		});
+	}
+
+	/**
+	 * Sets the result table all at once.
+	 */
+	private void setResultTable(List<Row> resultTable) {
+		synchronized (resultLock) {
+			this.resultTable = resultTable;
+		}
+	}
+
+	@Override
+	public void setClusterId(C clusterId) {
+		if (this.clusterId != null) {
+			throw new IllegalStateException("Cluster id is already present.");
+		}
+		this.clusterId = clusterId;
+	}
+
+	@Override
+	public boolean isMaterialized() {
+		return true;
+	}
+
+	@Override
+	public TypeInformation<Row> getOutputType() {
+		return outputType;
+	}
+
+	@Override
+	public void startRetrieval(ProgramDeployer<C> program) {
+		this.deployer = program;
+		retrievingThread.start();
+	}
+
+	@Override
+	public TableSink<?> getTableSink() {
+		return tableSink;
+	}
+
+	@Override
+	public void close() {
+		retrievingThread.interrupt();
+	}
+
+	@Override
+	public List<Row> retrievePage(int page) {
+		synchronized (resultLock) {
+			if (page <= 0 || page > pageCount) {
+				throw new SqlExecutionException("Invalid page '" + page + "'.");
+			}
+			return resultTable.subList(pageSize * (page - 1), Math.min(resultTable.size(), page * pageSize));
+		}
+	}
+
+	@Override
+	public TypedResult<Integer> snapshot(int pageSize) {
+		synchronized (resultLock) {
+			// We return a payload result the first time and EoS for the rest of times as if the results
+			// are retrieved dynamically.
+			if (null == resultTable) {
+				return TypedResult.empty();
+			} else if (!snapshotted) {
+				snapshotted = true;
+				this.pageSize = pageSize;
+				pageCount = Math.max(1, (int) Math.ceil(((double) resultTable.size() / pageSize)));
+				return TypedResult.payload(pageCount);
+			} else {
+				return TypedResult.endOfStream();
+			}
+		}
+	}
+
+	/**
+	 * Returns the accumulator name for retrieving the results.
+	 */
+	public String getAccumulatorName() {
+		return accumulatorName;
+	}
+
+	/**
+	 * Returns the serializer for deserializing the collected result.
+	 */
+	public TypeSerializer<Row> getSerializer() {
+		return tableSink.getSerializer();
+	}
+}

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ProgramDeployer.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ProgramDeployer.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.client.gateway.local;
+
+import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.client.deployment.ClusterDescriptor;
+import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.client.program.rest.RestClusterClient;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.table.client.gateway.SqlExecutionException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingDeque;
+
+/**
+ * The helper class to deploy a program on the cluster.
+ */
+public class ProgramDeployer<C> implements Runnable {
+	private static final Logger LOG = LoggerFactory.getLogger(ProgramDeployer.class);
+
+	private final ExecutionContext<C> context;
+	private final JobGraph jobGraph;
+	private final String jobName;
+	private final DynamicResult<C> result;
+	private final BlockingQueue<JobExecutionResult> executionResultBucket;
+
+	public ProgramDeployer(
+			ExecutionContext<C> context,
+			String jobName,
+			JobGraph jobGraph,
+			DynamicResult<C> result) {
+		this.context = context;
+		this.jobGraph = jobGraph;
+		this.jobName = jobName;
+		this.result = result;
+		executionResultBucket = new LinkedBlockingDeque<>(1);
+	}
+
+	@Override
+	public void run() {
+		LOG.info("Submitting job {} for query {}`", jobGraph.getJobID(), jobName);
+		if (LOG.isDebugEnabled()) {
+			LOG.debug("Submitting job {} with the following environment: \n{}",
+					jobGraph.getJobID(), context.getMergedEnvironment());
+		}
+		executionResultBucket.add(deployJob(context, jobGraph, result));
+	}
+
+	public JobExecutionResult fetchExecutionResult() {
+		return executionResultBucket.poll();
+	}
+
+	/**
+	 * Deploys a job. Depending on the deployment create a new job cluster. It saves cluster id in
+	 * the result and blocks until job completion.
+	 */
+	private <T> JobExecutionResult deployJob(ExecutionContext<T> context, JobGraph jobGraph, DynamicResult<T> result) {
+		// create or retrieve cluster and deploy job
+		try (final ClusterDescriptor<T> clusterDescriptor = context.createClusterDescriptor()) {
+			ClusterClient<T> clusterClient = null;
+			try {
+				// new cluster
+				if (context.getClusterId() == null) {
+					// deploy job cluster with job attached
+					clusterClient = clusterDescriptor.deployJobCluster(context.getClusterSpec(), jobGraph, false);
+					// save the new cluster id
+					result.setClusterId(clusterClient.getClusterId());
+					// we need to hard cast for now
+					return ((RestClusterClient<T>) clusterClient)
+							.requestJobResult(jobGraph.getJobID())
+							.get()
+							.toJobExecutionResult(context.getClassLoader()); // throws exception if job fails
+				}
+				// reuse existing cluster
+				else {
+					// retrieve existing cluster
+					clusterClient = clusterDescriptor.retrieve(context.getClusterId());
+					// save the cluster id
+					result.setClusterId(clusterClient.getClusterId());
+					// submit the job
+					clusterClient.setDetached(false);
+					return clusterClient.submitJob(jobGraph, context.getClassLoader()).getJobExecutionResult();
+					// throws exception if job fails
+				}
+			} catch (Exception e) {
+				throw new SqlExecutionException("Could not retrieve or create a cluster.", e);
+			} finally {
+				try {
+					if (clusterClient != null) {
+						clusterClient.shutdown();
+					}
+				} catch (Exception e) {
+					// ignore
+				}
+			}
+		} catch (SqlExecutionException e) {
+			throw e;
+		} catch (Exception e) {
+			throw new SqlExecutionException("Could not locate a cluster.", e);
+		}
+	}
+
+}
+

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ResultStore.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ResultStore.java
@@ -58,19 +58,26 @@ public class ResultStore {
 	 * Creates a result. Might start threads or opens sockets so every created result must be closed.
 	 */
 	public <T> DynamicResult<T> createResult(Environment env, TableSchema schema, ExecutionConfig config) {
-		if (!env.getExecution().isStreamingExecution()) {
-			throw new SqlExecutionException("Emission is only supported in streaming environments yet.");
-		}
 
 		final TypeInformation<Row> outputType = Types.ROW_NAMED(schema.getColumnNames(), schema.getTypes());
-		// determine gateway address (and port if possible)
-		final InetAddress gatewayAddress = getGatewayAddress(env.getDeployment());
-		final int gatewayPort = getGatewayPort(env.getDeployment());
 
-		if (env.getExecution().isChangelogMode()) {
-			return new ChangelogCollectStreamResult<>(outputType, config, gatewayAddress, gatewayPort);
+		if (env.getExecution().isStreamingExecution()) {
+			// determine gateway address (and port if possible)
+			final InetAddress gatewayAddress = getGatewayAddress(env.getDeployment());
+			final int gatewayPort = getGatewayPort(env.getDeployment());
+
+			if (env.getExecution().isChangelogMode()) {
+				return new ChangelogCollectStreamResult<>(outputType, config, gatewayAddress, gatewayPort);
+			} else {
+				return new MaterializedCollectStreamResult<>(outputType, config, gatewayAddress, gatewayPort);
+			}
+
 		} else {
-			return new MaterializedCollectStreamResult<>(outputType, config, gatewayAddress, gatewayPort);
+			// Batch Execution
+			if (!env.getExecution().isTableMode()) {
+				throw new SqlExecutionException("Batch queries can only work on table mode");
+			}
+			return new MaterializedCollectBatchResult<>(outputType);
 		}
 	}
 

--- a/flink-libraries/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
+++ b/flink-libraries/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
@@ -114,6 +114,7 @@ public class LocalExecutorITCase extends TestLogger {
 		executor.getSessionProperties(session);
 
 		// modify defaults
+		session.setSessionProperty("execution.type", "streaming");
 		session.setSessionProperty("execution.result-mode", "table");
 
 		final Map<String, String> actualProperties = executor.getSessionProperties(session);
@@ -146,13 +147,14 @@ public class LocalExecutorITCase extends TestLogger {
 	}
 
 	@Test(timeout = 30_000L)
-	public void testQueryExecutionChangelog() throws Exception {
+	public void testStreamQueryExecutionChangelog() throws Exception {
 		final URL url = getClass().getClassLoader().getResource("test-data.csv");
 		Objects.requireNonNull(url);
 		final Map<String, String> replaceVars = new HashMap<>();
 		replaceVars.put("$VAR_0", url.getPath());
 		replaceVars.put("$VAR_1", "/");
-		replaceVars.put("$VAR_2", "changelog");
+		replaceVars.put("$VAR_2", "streaming");
+		replaceVars.put("$VAR_3", "changelog");
 
 		final Executor executor = createModifiedExecutor(clusterClient, replaceVars);
 		final SessionContext session = new SessionContext("test-session", new Environment());
@@ -193,13 +195,14 @@ public class LocalExecutorITCase extends TestLogger {
 	}
 
 	@Test(timeout = 30_000L)
-	public void testQueryExecutionTable() throws Exception {
+	public void testStreamQueryExecutionTable() throws Exception {
 		final URL url = getClass().getClassLoader().getResource("test-data.csv");
 		Objects.requireNonNull(url);
 		final Map<String, String> replaceVars = new HashMap<>();
 		replaceVars.put("$VAR_0", url.getPath());
 		replaceVars.put("$VAR_1", "/");
-		replaceVars.put("$VAR_2", "table");
+		replaceVars.put("$VAR_2", "streaming");
+		replaceVars.put("$VAR_3", "table");
 
 		final Executor executor = createModifiedExecutor(clusterClient, replaceVars);
 		final SessionContext session = new SessionContext("test-session", new Environment());
@@ -210,22 +213,43 @@ public class LocalExecutorITCase extends TestLogger {
 
 			assertTrue(desc.isMaterialized());
 
-			final List<String> actualResults = new ArrayList<>();
+			final List<String> actualResults =
+					retrieveTableResult(executor, session, desc.getResultId());
 
-			while (true) {
-				Thread.sleep(50); // slow the processing down
-				final TypedResult<Integer> result = executor.snapshotResult(session, desc.getResultId(), 2);
-				if (result.getType() == TypedResult.ResultType.PAYLOAD) {
-					actualResults.clear();
-					IntStream.rangeClosed(1, result.getPayload()).forEach((page) -> {
-						for (Row row : executor.retrieveResultPage(desc.getResultId(), page)) {
-							actualResults.add(row.toString());
-						}
-					});
-				} else if (result.getType() == TypedResult.ResultType.EOS) {
-					break;
-				}
-			}
+			final List<String> expectedResults = new ArrayList<>();
+			expectedResults.add("42");
+			expectedResults.add("22");
+			expectedResults.add("32");
+			expectedResults.add("32");
+			expectedResults.add("42");
+			expectedResults.add("52");
+
+			TestBaseUtils.compareResultCollections(expectedResults, actualResults, Comparator.naturalOrder());
+		} finally {
+			executor.stop(session);
+		}
+	}
+
+	@Test(timeout = 30_000L)
+	public void testBatchQueryExecution() throws Exception {
+		final URL url = getClass().getClassLoader().getResource("test-data.csv");
+		Objects.requireNonNull(url);
+		final Map<String, String> replaceVars = new HashMap<>();
+		replaceVars.put("$VAR_0", url.getPath());
+		replaceVars.put("$VAR_1", "/");
+		replaceVars.put("$VAR_2", "batch");
+		replaceVars.put("$VAR_3", "table");
+
+		final Executor executor = createModifiedExecutor(clusterClient, replaceVars);
+		final SessionContext session = new SessionContext("test-session", new Environment());
+
+		try {
+			final ResultDescriptor desc = executor.executeQuery(session, "SELECT IntegerField1 FROM TableNumber1");
+
+			assertTrue(desc.isMaterialized());
+
+			final List<String> actualResults =
+					retrieveTableResult(executor, session, desc.getResultId());
 
 			final List<String> expectedResults = new ArrayList<>();
 			expectedResults.add("42");
@@ -255,5 +279,29 @@ public class LocalExecutorITCase extends TestLogger {
 			Collections.emptyList(),
 			clusterClient.getFlinkConfiguration(),
 			new DummyCustomCommandLine<T>(clusterClient));
+	}
+
+	private List<String> retrieveTableResult(
+			Executor executor,
+			SessionContext session,
+			String resultID) throws InterruptedException {
+
+		final List<String> actualResults = new ArrayList<>();
+		while (true) {
+			Thread.sleep(50); // slow the processing down
+			final TypedResult<Integer> result = executor.snapshotResult(session, resultID, 2);
+			if (result.getType() == TypedResult.ResultType.PAYLOAD) {
+				actualResults.clear();
+				IntStream.rangeClosed(1, result.getPayload()).forEach((page) -> {
+					for (Row row : executor.retrieveResultPage(resultID, page)) {
+						actualResults.add(row.toString());
+					}
+				});
+			} else if (result.getType() == TypedResult.ResultType.EOS) {
+				break;
+			}
+		}
+
+		return actualResults;
 	}
 }

--- a/flink-libraries/flink-sql-client/src/test/resources/test-sql-client-defaults.yaml
+++ b/flink-libraries/flink-sql-client/src/test/resources/test-sql-client-defaults.yaml
@@ -64,13 +64,13 @@ tables:
       comment-prefix: "#"
 
 execution:
-  type: streaming
+  type: "$VAR_2"
   time-characteristic: event-time
   parallelism: 1
   max-parallelism: 16
   min-idle-state-retention: 0
   max-idle-state-retention: 0
-  result-mode: "$VAR_2"
+  result-mode: "$VAR_3"
 
 deployment:
   response-timeout: 5000


### PR DESCRIPTION
## What is the purpose of the change

This PR added support for batch queries in SQL Client.

## Brief change log

 - Added a `BatchResult`, which also implemented `DynamicResult`, for the batch queries.
 - Added a program deployer for jobs since the results in batch mode are acquired by `JobExecutionResult`.
 - Added the logic for retrieving batch query results referring to `Dataset.collect()`.
 - Adapted the viewing logic for batch results to a "two-phase" (snapshotted or not) table result view.
 - Added a `retrieveTableResult()` method in `LocalExecutorITCase`.
 - Replaced some default values with `""` in `Execution.java`.

## Verifying this change

This change can be verified by the added test case `testBatchQueryExecution()`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)