### PR TITLE
 [FLINK-8896][kafka08] fix Kafka08Fetcher trying to look up topic "n/a" on partiton "-1"

### DIFF
--- a/flink-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/Kafka08Fetcher.java
+++ b/flink-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/Kafka08Fetcher.java
@@ -189,7 +189,8 @@ public class Kafka08Fetcher<T> extends AbstractFetcher<T, TopicAndPartition> {
 				// special marker into the queue
 				List<KafkaTopicPartitionState<TopicAndPartition>> partitionsToAssign =
 						unassignedPartitionsQueue.getBatchBlocking(5000);
-				partitionsToAssign.remove(MARKER);
+				// note: if there are more markers, remove them all
+				partitionsToAssign.removeIf(MARKER::equals);
 
 				if (!partitionsToAssign.isEmpty()) {
 					LOG.info("Assigning {} partitions to broker threads", partitionsToAssign.size());

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBase.java
@@ -709,7 +709,10 @@ public abstract class FlinkKafkaConsumerBase<T> extends RichParallelSourceFuncti
 						discoveryLoopErrorRef.set(e);
 					} finally {
 						// calling cancel will also let the fetcher loop escape
-						cancel();
+						// (if not running, cancel() was already called)
+						if (running) {
+							cancel();
+						}
 					}
 				}
 			});


### PR DESCRIPTION
## What is the purpose of the change

`Kafka08Fetcher` uses a `MARKER` to make sure the main thread wakes up when cancelling. While looking up partition leaders, this marker is removed only once from the list of partitions to look up and there is a code path that leads to two markers being present in which case the lookup will throw an exception:
- `FlinkKafkaConsumerBase#cancel()` is called in one thread, stopped right after setting `running` to false, and then
-  `FlinkKafkaConsumerBase`'s partition discovery loop thread drops out before the first thread was able to call `Kafka08Fetcher#cancel`.

## Brief change log

- remove all markers in the list, not just one
- make `FlinkKafkaConsumerBase`'s partition discovery loop not call `cancel()` if already cancelled

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **JavaDocs**
