### PR TITLE
[FLINK-8854] [table] Fix schema mapping with time attributes

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sources/definedTimeAttributes.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sources/definedTimeAttributes.scala
@@ -19,6 +19,7 @@
 package org.apache.flink.table.sources
 
 import java.util
+import java.util.Objects
 
 import org.apache.flink.table.api.TableSchema
 import org.apache.flink.table.api.Types
@@ -65,9 +66,9 @@ trait DefinedRowtimeAttributes {
   * @param watermarkStrategy The watermark strategy associated with the attribute.
   */
 class RowtimeAttributeDescriptor(
-  attributeName: String,
-  timestampExtractor: TimestampExtractor,
-  watermarkStrategy: WatermarkStrategy) {
+  val attributeName: String,
+  val timestampExtractor: TimestampExtractor,
+  val watermarkStrategy: WatermarkStrategy) {
 
   /** Returns the name of the rowtime attribute. */
   def getAttributeName: String = attributeName
@@ -77,4 +78,16 @@ class RowtimeAttributeDescriptor(
 
   /** Returns the [[WatermarkStrategy]] for the attribute. */
   def getWatermarkStrategy: WatermarkStrategy = watermarkStrategy
+
+  override def equals(other: Any): Boolean = other match {
+    case that: RowtimeAttributeDescriptor =>
+        Objects.equals(attributeName, that.attributeName) &&
+        Objects.equals(timestampExtractor, that.timestampExtractor) &&
+        Objects.equals(watermarkStrategy, that.watermarkStrategy)
+    case _ => false
+  }
+
+  override def hashCode(): Int = {
+    Objects.hash(attributeName, timestampExtractor, watermarkStrategy)
+  }
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sources/tsextractors/ExistingField.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sources/tsextractors/ExistingField.scala
@@ -27,7 +27,7 @@ import org.apache.flink.table.expressions.{Cast, Expression, ResolvedFieldRefere
   *
   * @param field The field to convert into a rowtime attribute.
   */
-class ExistingField(field: String) extends TimestampExtractor {
+class ExistingField(val field: String) extends TimestampExtractor {
 
   override def getArgumentFields: Array[String] = Array(field)
 
@@ -65,4 +65,12 @@ class ExistingField(field: String) extends TimestampExtractor {
     }
   }
 
+  override def equals(other: Any): Boolean = other match {
+    case that: ExistingField => field == that.field
+    case _ => false
+  }
+
+  override def hashCode(): Int = {
+    field.hashCode
+  }
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sources/wmstrategies/BoundedOutOfOrderTimestamps.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/sources/wmstrategies/BoundedOutOfOrderTimestamps.scala
@@ -38,4 +38,14 @@ final class BoundedOutOfOrderTimestamps(val delay: Long) extends PeriodicWaterma
   }
 
   override def getWatermark: Watermark = new Watermark(maxTimestamp - delay)
+
+  override def equals(other: Any): Boolean = other match {
+    case that: BoundedOutOfOrderTimestamps =>
+      delay == that.delay
+    case _ => false
+  }
+
+  override def hashCode(): Int = {
+    delay.hashCode()
+  }
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes the invalid field mapping and improves the mapping of time attributes in general.

## Brief change log

- `SchemaValidator.deriveFieldMapping()` and `SchemaValidator.deriveFormatFields()`


## Verifying this change

- Existing tests extended

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? JavaDocs
