### PR TITLE
[FLINK-8904][cli][tests] always restore the previous sysout when changing it in the test

### DIFF
--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendCancelTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendCancelTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.TestLogger;
 
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -44,6 +45,11 @@ public class CliFrontendCancelTest extends TestLogger {
 	@BeforeClass
 	public static void init() {
 		CliFrontendTestUtils.pipeSystemOutToNull();
+	}
+
+	@AfterClass
+	public static void shutdown() {
+		CliFrontendTestUtils.restoreSystemOut();
 	}
 
 	@Test

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendListTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendListTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.TestLogger;
 
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -42,6 +43,11 @@ public class CliFrontendListTest extends TestLogger {
 	@BeforeClass
 	public static void init() {
 		CliFrontendTestUtils.pipeSystemOutToNull();
+	}
+
+	@AfterClass
+	public static void shutdown() {
+		CliFrontendTestUtils.restoreSystemOut();
 	}
 
 	@Test

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendPackageProgramTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendPackageProgramTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.optimizer.Optimizer;
 import org.apache.flink.optimizer.costs.DefaultCostEstimator;
 import org.apache.flink.util.TestLogger;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -40,7 +41,6 @@ import static org.apache.flink.client.cli.CliFrontendTestUtils.TEST_JAR_CLASSLOA
 import static org.apache.flink.client.cli.CliFrontendTestUtils.TEST_JAR_MAIN_CLASS;
 import static org.apache.flink.client.cli.CliFrontendTestUtils.getNonJarFilePath;
 import static org.apache.flink.client.cli.CliFrontendTestUtils.getTestJarPath;
-import static org.apache.flink.client.cli.CliFrontendTestUtils.pipeSystemOutToNull;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -58,7 +58,12 @@ public class CliFrontendPackageProgramTest extends TestLogger {
 
 	@BeforeClass
 	public static void init() {
-		pipeSystemOutToNull();
+		CliFrontendTestUtils.pipeSystemOutToNull();
+	}
+
+	@AfterClass
+	public static void shutdown() {
+		CliFrontendTestUtils.restoreSystemOut();
 	}
 
 	@Before

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendRunTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendRunTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.client.program.PackagedProgram;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
+import org.apache.flink.util.TestLogger;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -37,7 +38,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * Tests for the RUN command.
  */
-public class CliFrontendRunTest {
+public class CliFrontendRunTest extends TestLogger {
 
 	@BeforeClass
 	public static void init() {

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendRunTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendRunTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.util.TestLogger;
 
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -43,6 +44,11 @@ public class CliFrontendRunTest extends TestLogger {
 	@BeforeClass
 	public static void init() {
 		CliFrontendTestUtils.pipeSystemOutToNull();
+	}
+
+	@AfterClass
+	public static void shutdown() {
+		CliFrontendTestUtils.restoreSystemOut();
 	}
 
 	@Test

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendStopTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendStopTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
 
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -34,7 +35,6 @@ import javax.annotation.Nullable;
 
 import java.util.Collections;
 
-import static org.apache.flink.client.cli.CliFrontendTestUtils.pipeSystemOutToNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
@@ -49,7 +49,12 @@ public class CliFrontendStopTest extends TestLogger {
 
 	@BeforeClass
 	public static void setup() {
-		pipeSystemOutToNull();
+		CliFrontendTestUtils.pipeSystemOutToNull();
+	}
+
+	@AfterClass
+	public static void shutdown() {
+		CliFrontendTestUtils.restoreSystemOut();
 	}
 
 	@Test

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendTestUtils.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendTestUtils.java
@@ -41,6 +41,8 @@ public class CliFrontendTestUtils {
 
 	public static final int TEST_JOB_MANAGER_PORT = 55443;
 
+	public static PrintStream previousSysout = System.out;
+
 	public static String getTestJarPath() throws FileNotFoundException, MalformedURLException {
 		File f = new File("target/maven-test-jar.jar");
 		if (!f.exists()) {
@@ -65,7 +67,12 @@ public class CliFrontendTestUtils {
 	}
 
 	public static void pipeSystemOutToNull() {
+		previousSysout = System.out;
 		System.setOut(new PrintStream(new BlackholeOutputSteam()));
+	}
+
+	public static void restoreSystemOut() {
+		System.setOut(previousSysout);
 	}
 
 	private static final class BlackholeOutputSteam extends java.io.OutputStream {

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendTestUtils.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendTestUtils.java
@@ -41,7 +41,7 @@ public class CliFrontendTestUtils {
 
 	public static final int TEST_JOB_MANAGER_PORT = 55443;
 
-	public static PrintStream previousSysout = System.out;
+	private static final PrintStream previousSysout = System.out;
 
 	public static String getTestJarPath() throws FileNotFoundException, MalformedURLException {
 		File f = new File("target/maven-test-jar.jar");
@@ -67,7 +67,6 @@ public class CliFrontendTestUtils {
 	}
 
 	public static void pipeSystemOutToNull() {
-		previousSysout = System.out;
 		System.setOut(new PrintStream(new BlackholeOutputSteam()));
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

Several tests inside the `org.apache.flink.client.cli` package change `System.out` to point towards a black whole using `CliFrontendTestUtils.pipeSystemOutToNull()` but do not restore the default sysout after the test finishes.

## Brief change log

- add a proper restoration of the previous `System.out` by caching it during `pipeSystemOutToNull()`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
