### PR TITLE
[FLINK-8906][flip6][tests] also test Flip6DefaultCLI in org.apache.flink.client.cli tests

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -86,6 +86,7 @@ import scala.concurrent.duration.FiniteDuration;
 
 import static org.apache.flink.client.cli.CliFrontendParser.HELP_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.MODIFY_PARALLELISM_OPTION;
+import static org.apache.flink.client.program.ClusterClient.MAX_SLOTS_UNKNOWN;
 
 /**
  * Implementation of a simple command line frontend for executing programs.
@@ -262,7 +263,7 @@ public class CliFrontend {
 
 					int userParallelism = runOptions.getParallelism();
 					LOG.debug("User parallelism is set to {}", userParallelism);
-					if (client.getMaxSlots() != -1 && userParallelism == -1) {
+					if (client.getMaxSlots() != MAX_SLOTS_UNKNOWN && userParallelism == -1) {
 						logAndSysout("Using the parallelism provided by the remote cluster ("
 							+ client.getMaxSlots() + "). "
 							+ "To use another parallelism, set it at the ./bin/flink client.");

--- a/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
@@ -133,6 +133,11 @@ public abstract class ClusterClient<T> {
 	/** Switch for blocking/detached job submission of the client. */
 	private boolean detachedJobSubmission = false;
 
+	/**
+	 * Value returned by {@link #getMaxSlots()} if the number of maximum slots is unknown.
+	 */
+	public static final int MAX_SLOTS_UNKNOWN = -1;
+
 	// ------------------------------------------------------------------------
 	//                            Construction
 	// ------------------------------------------------------------------------
@@ -1000,7 +1005,7 @@ public abstract class ClusterClient<T> {
 
 	/**
 	 * The client may define an upper limit on the number of slots to use.
-	 * @return -1 if unknown
+	 * @return <tt>-1</tt> ({@link #MAX_SLOTS_UNKNOWN}) if unknown
 	 */
 	public abstract int getMaxSlots();
 

--- a/flink-clients/src/main/java/org/apache/flink/client/program/MiniClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/MiniClusterClient.java
@@ -181,7 +181,7 @@ public class MiniClusterClient extends ClusterClient<MiniClusterClient.MiniClust
 
 	@Override
 	public int getMaxSlots() {
-		return 0;
+		return MAX_SLOTS_UNKNOWN;
 	}
 
 	@Override

--- a/flink-clients/src/main/java/org/apache/flink/client/program/StandaloneClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/StandaloneClusterClient.java
@@ -98,7 +98,7 @@ public class StandaloneClusterClient extends ClusterClient<StandaloneClusterId> 
 
 	@Override
 	public int getMaxSlots() {
-		return -1;
+		return MAX_SLOTS_UNKNOWN;
 	}
 
 	@Override

--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
@@ -567,7 +567,7 @@ public class RestClusterClient<T> extends ClusterClient<T> {
 
 	@Override
 	public int getMaxSlots() {
-		return 0;
+		return -1;
 	}
 
 	//-------------------------------------------------------------------------

--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
@@ -567,7 +567,7 @@ public class RestClusterClient<T> extends ClusterClient<T> {
 
 	@Override
 	public int getMaxSlots() {
-		return -1;
+		return MAX_SLOTS_UNKNOWN;
 	}
 
 	//-------------------------------------------------------------------------

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendCancelTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendCancelTest.java
@@ -22,22 +22,14 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.client.cli.util.MockedCliFrontend;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.CoreOptions;
-import org.apache.flink.util.TestLogger;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 import org.mockito.Mockito;
 
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 
-import static org.apache.flink.client.cli.CliFrontendTestUtils.getCli;
-import static org.apache.flink.client.cli.CliFrontendTestUtils.getConfiguration;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.isNull;
 import static org.mockito.Matchers.notNull;
@@ -47,16 +39,7 @@ import static org.mockito.Mockito.times;
 /**
  * Tests for the CANCEL command.
  */
-@RunWith(Parameterized.class)
-public class CliFrontendCancelTest extends TestLogger {
-
-	@Parameterized.Parameters(name = "Mode = {0}")
-	public static List<String> parameters() {
-		return Arrays.asList(CoreOptions.OLD_MODE, CoreOptions.FLIP6_MODE);
-	}
-
-	@Parameterized.Parameter
-	public String mode;
+public class CliFrontendCancelTest extends CliFrontendTestBase {
 
 	@BeforeClass
 	public static void init() {
@@ -85,7 +68,7 @@ public class CliFrontendCancelTest extends TestLogger {
 	@Test(expected = CliArgsException.class)
 	public void testMissingJobId() throws Exception {
 		String[] parameters = {};
-		Configuration configuration = getConfiguration(mode);
+		Configuration configuration = getConfiguration();
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
 			Collections.singletonList(getCli(configuration)));
@@ -95,7 +78,7 @@ public class CliFrontendCancelTest extends TestLogger {
 	@Test(expected = CliArgsException.class)
 	public void testUnrecognizedOption() throws Exception {
 		String[] parameters = {"-v", "-l"};
-		Configuration configuration = getConfiguration(mode);
+		Configuration configuration = getConfiguration();
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
 			Collections.singletonList(getCli(configuration)));
@@ -138,7 +121,7 @@ public class CliFrontendCancelTest extends TestLogger {
 	public void testCancelWithSavepointWithoutJobId() throws Exception {
 		// Cancel with savepoint (with target directory), but no job ID
 		String[] parameters = { "-s", "targetDirectory" };
-		Configuration configuration = getConfiguration(mode);
+		Configuration configuration = getConfiguration();
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
 			Collections.singletonList(getCli(configuration)));
@@ -149,7 +132,7 @@ public class CliFrontendCancelTest extends TestLogger {
 	public void testCancelWithSavepointWithoutParameters() throws Exception {
 		// Cancel with savepoint (no target directory) and no job ID
 		String[] parameters = { "-s" };
-		Configuration configuration = getConfiguration(mode);
+		Configuration configuration = getConfiguration();
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
 			Collections.singletonList(getCli(configuration)));

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendCancelTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendCancelTest.java
@@ -22,15 +22,22 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.client.cli.util.MockedCliFrontend;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.mockito.Mockito;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
+import static org.apache.flink.client.cli.CliFrontendTestUtils.getCli;
+import static org.apache.flink.client.cli.CliFrontendTestUtils.getConfiguration;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.isNull;
 import static org.mockito.Matchers.notNull;
@@ -40,7 +47,16 @@ import static org.mockito.Mockito.times;
 /**
  * Tests for the CANCEL command.
  */
+@RunWith(Parameterized.class)
 public class CliFrontendCancelTest extends TestLogger {
+
+	@Parameterized.Parameters(name = "Mode = {0}")
+	public static List<String> parameters() {
+		return Arrays.asList(CoreOptions.OLD_MODE, CoreOptions.FLIP6_MODE);
+	}
+
+	@Parameterized.Parameter
+	public String mode;
 
 	@BeforeClass
 	public static void init() {
@@ -69,20 +85,20 @@ public class CliFrontendCancelTest extends TestLogger {
 	@Test(expected = CliArgsException.class)
 	public void testMissingJobId() throws Exception {
 		String[] parameters = {};
-		Configuration configuration = new Configuration();
+		Configuration configuration = getConfiguration(mode);
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
-			Collections.singletonList(new DefaultCLI(configuration)));
+			Collections.singletonList(getCli(configuration)));
 		testFrontend.cancel(parameters);
 	}
 
 	@Test(expected = CliArgsException.class)
 	public void testUnrecognizedOption() throws Exception {
 		String[] parameters = {"-v", "-l"};
-		Configuration configuration = new Configuration();
+		Configuration configuration = getConfiguration(mode);
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
-			Collections.singletonList(new DefaultCLI(configuration)));
+			Collections.singletonList(getCli(configuration)));
 		testFrontend.cancel(parameters);
 	}
 
@@ -122,10 +138,10 @@ public class CliFrontendCancelTest extends TestLogger {
 	public void testCancelWithSavepointWithoutJobId() throws Exception {
 		// Cancel with savepoint (with target directory), but no job ID
 		String[] parameters = { "-s", "targetDirectory" };
-		Configuration configuration = new Configuration();
+		Configuration configuration = getConfiguration(mode);
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
-			Collections.singletonList(new DefaultCLI(configuration)));
+			Collections.singletonList(getCli(configuration)));
 		testFrontend.cancel(parameters);
 	}
 
@@ -133,10 +149,10 @@ public class CliFrontendCancelTest extends TestLogger {
 	public void testCancelWithSavepointWithoutParameters() throws Exception {
 		// Cancel with savepoint (no target directory) and no job ID
 		String[] parameters = { "-s" };
-		Configuration configuration = new Configuration();
+		Configuration configuration = getConfiguration(mode);
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
-			Collections.singletonList(new DefaultCLI(configuration)));
+			Collections.singletonList(getCli(configuration)));
 		testFrontend.cancel(parameters);
 	}
 

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendInfoTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendInfoTest.java
@@ -19,21 +19,37 @@
 package org.apache.flink.client.cli;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
+import static org.apache.flink.client.cli.CliFrontendTestUtils.getCli;
+import static org.apache.flink.client.cli.CliFrontendTestUtils.getConfiguration;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
  * Tests for the "info" command.
  */
+@RunWith(Parameterized.class)
 public class CliFrontendInfoTest extends TestLogger {
+
+	@Parameterized.Parameters(name = "Mode = {0}")
+	public static List<String> parameters() {
+		return Arrays.asList(CoreOptions.OLD_MODE, CoreOptions.FLIP6_MODE);
+	}
+
+	@Parameterized.Parameter
+	public String mode;
 
 	private static PrintStream stdOut;
 	private static PrintStream capture;
@@ -42,20 +58,20 @@ public class CliFrontendInfoTest extends TestLogger {
 	@Test(expected = CliArgsException.class)
 	public void testMissingOption() throws Exception {
 		String[] parameters = {};
-		Configuration configuration = new Configuration();
+		Configuration configuration = getConfiguration(mode);
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
-			Collections.singletonList(new DefaultCLI(configuration)));
+			Collections.singletonList(getCli(configuration)));
 		testFrontend.cancel(parameters);
 	}
 
 	@Test(expected = CliArgsException.class)
 	public void testUnrecognizedOption() throws Exception {
 		String[] parameters = {"-v", "-l"};
-		Configuration configuration = new Configuration();
+		Configuration configuration = getConfiguration(mode);
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
-			Collections.singletonList(new DefaultCLI(configuration)));
+			Collections.singletonList(getCli(configuration)));
 		testFrontend.cancel(parameters);
 	}
 
@@ -65,10 +81,10 @@ public class CliFrontendInfoTest extends TestLogger {
 		try {
 
 			String[] parameters = new String[]{CliFrontendTestUtils.getTestJarPath(), "-f", "true"};
-			Configuration configuration = new Configuration();
+			Configuration configuration = getConfiguration(mode);
 			CliFrontend testFrontend = new CliFrontend(
 				configuration,
-				Collections.singletonList(new DefaultCLI(configuration)));
+				Collections.singletonList(getCli(configuration)));
 			testFrontend.info(parameters);
 			assertTrue(buffer.toString().contains("\"parallelism\": \"1\""));
 		}
@@ -82,10 +98,10 @@ public class CliFrontendInfoTest extends TestLogger {
 		replaceStdOut();
 		try {
 			String[] parameters = {"-p", "17", CliFrontendTestUtils.getTestJarPath()};
-			Configuration configuration = new Configuration();
+			Configuration configuration = getConfiguration(mode);
 			CliFrontend testFrontend = new CliFrontend(
 				configuration,
-				Collections.singletonList(new DefaultCLI(configuration)));
+				Collections.singletonList(getCli(configuration)));
 			testFrontend.info(parameters);
 			assertTrue(buffer.toString().contains("\"parallelism\": \"17\""));
 		}

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendInfoTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendInfoTest.java
@@ -19,37 +19,20 @@
 package org.apache.flink.client.cli;
 
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.CoreOptions;
-import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 
-import static org.apache.flink.client.cli.CliFrontendTestUtils.getCli;
-import static org.apache.flink.client.cli.CliFrontendTestUtils.getConfiguration;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
  * Tests for the "info" command.
  */
-@RunWith(Parameterized.class)
-public class CliFrontendInfoTest extends TestLogger {
-
-	@Parameterized.Parameters(name = "Mode = {0}")
-	public static List<String> parameters() {
-		return Arrays.asList(CoreOptions.OLD_MODE, CoreOptions.FLIP6_MODE);
-	}
-
-	@Parameterized.Parameter
-	public String mode;
+public class CliFrontendInfoTest extends CliFrontendTestBase {
 
 	private static PrintStream stdOut;
 	private static PrintStream capture;
@@ -58,7 +41,7 @@ public class CliFrontendInfoTest extends TestLogger {
 	@Test(expected = CliArgsException.class)
 	public void testMissingOption() throws Exception {
 		String[] parameters = {};
-		Configuration configuration = getConfiguration(mode);
+		Configuration configuration = getConfiguration();
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
 			Collections.singletonList(getCli(configuration)));
@@ -68,7 +51,7 @@ public class CliFrontendInfoTest extends TestLogger {
 	@Test(expected = CliArgsException.class)
 	public void testUnrecognizedOption() throws Exception {
 		String[] parameters = {"-v", "-l"};
-		Configuration configuration = getConfiguration(mode);
+		Configuration configuration = getConfiguration();
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
 			Collections.singletonList(getCli(configuration)));
@@ -81,7 +64,7 @@ public class CliFrontendInfoTest extends TestLogger {
 		try {
 
 			String[] parameters = new String[]{CliFrontendTestUtils.getTestJarPath(), "-f", "true"};
-			Configuration configuration = getConfiguration(mode);
+			Configuration configuration = getConfiguration();
 			CliFrontend testFrontend = new CliFrontend(
 				configuration,
 				Collections.singletonList(getCli(configuration)));
@@ -98,7 +81,7 @@ public class CliFrontendInfoTest extends TestLogger {
 		replaceStdOut();
 		try {
 			String[] parameters = {"-p", "17", CliFrontendTestUtils.getTestJarPath()};
-			Configuration configuration = getConfiguration(mode);
+			Configuration configuration = getConfiguration();
 			CliFrontend testFrontend = new CliFrontend(
 				configuration,
 				Collections.singletonList(getCli(configuration)));

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendListTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendListTest.java
@@ -21,23 +21,15 @@ package org.apache.flink.client.cli;
 import org.apache.flink.client.cli.util.MockedCliFrontend;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.CoreOptions;
-import org.apache.flink.util.TestLogger;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 import org.mockito.Mockito;
 
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
-import static org.apache.flink.client.cli.CliFrontendTestUtils.getCli;
-import static org.apache.flink.client.cli.CliFrontendTestUtils.getConfiguration;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
@@ -45,16 +37,7 @@ import static org.mockito.Mockito.when;
 /**
  * Tests for the LIST command.
  */
-@RunWith(Parameterized.class)
-public class CliFrontendListTest extends TestLogger {
-
-	@Parameterized.Parameters(name = "Mode = {0}")
-	public static List<String> parameters() {
-		return Arrays.asList(CoreOptions.OLD_MODE, CoreOptions.FLIP6_MODE);
-	}
-
-	@Parameterized.Parameter
-	public String mode;
+public class CliFrontendListTest extends CliFrontendTestBase {
 
 	@BeforeClass
 	public static void init() {
@@ -82,7 +65,7 @@ public class CliFrontendListTest extends TestLogger {
 	@Test(expected = CliArgsException.class)
 	public void testUnrecognizedOption() throws Exception {
 		String[] parameters = {"-v", "-k"};
-		Configuration configuration = getConfiguration(mode);
+		Configuration configuration = getConfiguration();
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
 			Collections.singletonList(getCli(configuration)));

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendListTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendListTest.java
@@ -21,16 +21,23 @@ package org.apache.flink.client.cli;
 import org.apache.flink.client.cli.util.MockedCliFrontend;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.mockito.Mockito;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
+import static org.apache.flink.client.cli.CliFrontendTestUtils.getCli;
+import static org.apache.flink.client.cli.CliFrontendTestUtils.getConfiguration;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
@@ -38,7 +45,16 @@ import static org.mockito.Mockito.when;
 /**
  * Tests for the LIST command.
  */
+@RunWith(Parameterized.class)
 public class CliFrontendListTest extends TestLogger {
+
+	@Parameterized.Parameters(name = "Mode = {0}")
+	public static List<String> parameters() {
+		return Arrays.asList(CoreOptions.OLD_MODE, CoreOptions.FLIP6_MODE);
+	}
+
+	@Parameterized.Parameter
+	public String mode;
 
 	@BeforeClass
 	public static void init() {
@@ -66,10 +82,10 @@ public class CliFrontendListTest extends TestLogger {
 	@Test(expected = CliArgsException.class)
 	public void testUnrecognizedOption() throws Exception {
 		String[] parameters = {"-v", "-k"};
-		Configuration configuration = new Configuration();
+		Configuration configuration = getConfiguration(mode);
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
-			Collections.singletonList(new DefaultCLI(configuration)));
+			Collections.singletonList(getCli(configuration)));
 		testFrontend.list(parameters);
 	}
 

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendModifyTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendModifyTest.java
@@ -22,37 +22,22 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.client.cli.util.MockedCliFrontend;
 import org.apache.flink.client.program.StandaloneClusterClient;
-import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
 import org.apache.flink.runtime.messages.Acknowledge;
-import org.apache.flink.util.TestLogger;
 
 import org.hamcrest.Matchers;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
-import java.util.Arrays;
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
-import static org.apache.flink.client.cli.CliFrontendTestUtils.getConfiguration;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 /**
  * Tests for the modify command.
  */
-@RunWith(Parameterized.class)
-public class CliFrontendModifyTest extends TestLogger {
-
-	@Parameterized.Parameters(name = "Mode = {0}")
-	public static List<String> parameters() {
-		return Arrays.asList(CoreOptions.OLD_MODE, CoreOptions.FLIP6_MODE);
-	}
-
-	@Parameterized.Parameter
-	public String mode;
+public class CliFrontendModifyTest extends CliFrontendTestBase {
 
 	@Test
 	public void testModifyJob() throws Exception {
@@ -120,7 +105,7 @@ public class CliFrontendModifyTest extends TestLogger {
 
 	private Tuple2<JobID, Integer> callModify(String[] args) throws Exception {
 		final CompletableFuture<Tuple2<JobID, Integer>> rescaleJobFuture = new CompletableFuture<>();
-		final TestingClusterClient clusterClient = new TestingClusterClient(rescaleJobFuture, mode);
+		final TestingClusterClient clusterClient = new TestingClusterClient(rescaleJobFuture, getConfiguration());
 		final MockedCliFrontend cliFrontend = new MockedCliFrontend(clusterClient);
 
 		cliFrontend.modify(args);
@@ -134,9 +119,9 @@ public class CliFrontendModifyTest extends TestLogger {
 
 		private final CompletableFuture<Tuple2<JobID, Integer>> rescaleJobFuture;
 
-		public TestingClusterClient(
-			CompletableFuture<Tuple2<JobID, Integer>> rescaleJobFuture, String mode) throws Exception {
-			super(getConfiguration(mode), new TestingHighAvailabilityServices(), false);
+		TestingClusterClient(
+			CompletableFuture<Tuple2<JobID, Integer>> rescaleJobFuture, Configuration configuration) {
+			super(configuration, new TestingHighAvailabilityServices(), false);
 
 			this.rescaleJobFuture = rescaleJobFuture;
 		}

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendRunTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendRunTest.java
@@ -21,22 +21,14 @@ package org.apache.flink.client.cli;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.client.program.PackagedProgram;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
-import org.apache.flink.util.TestLogger;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 
-import static org.apache.flink.client.cli.CliFrontendTestUtils.getCli;
-import static org.apache.flink.client.cli.CliFrontendTestUtils.getConfiguration;
 import static org.apache.flink.client.cli.CliFrontendTestUtils.getTestJarPath;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -45,16 +37,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * Tests for the RUN command.
  */
-@RunWith(Parameterized.class)
-public class CliFrontendRunTest extends TestLogger {
-
-	@Parameterized.Parameters(name = "Mode = {0}")
-	public static List<String> parameters() {
-		return Arrays.asList(CoreOptions.OLD_MODE, CoreOptions.FLIP6_MODE);
-	}
-
-	@Parameterized.Parameter
-	public String mode;
+public class CliFrontendRunTest extends CliFrontendTestBase {
 
 	@BeforeClass
 	public static void init() {
@@ -68,7 +51,7 @@ public class CliFrontendRunTest extends TestLogger {
 
 	@Test
 	public void testRun() throws Exception {
-		final Configuration configuration = getConfiguration(mode);
+		final Configuration configuration = getConfiguration();
 		// test without parallelism
 		{
 			String[] parameters = {"-v", getTestJarPath()};
@@ -130,7 +113,7 @@ public class CliFrontendRunTest extends TestLogger {
 	public void testUnrecognizedOption() throws Exception {
 		// test unrecognized option
 		String[] parameters = {"-v", "-l", "-a", "some", "program", "arguments"};
-		Configuration configuration = getConfiguration(mode);
+		Configuration configuration = getConfiguration();
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
 			Collections.singletonList(getCli(configuration)));
@@ -141,7 +124,7 @@ public class CliFrontendRunTest extends TestLogger {
 	public void testInvalidParallelismOption() throws Exception {
 		// test configure parallelism with non integer value
 		String[] parameters = {"-v", "-p", "text",  getTestJarPath()};
-		Configuration configuration = getConfiguration(mode);
+		Configuration configuration = getConfiguration();
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
 			Collections.singletonList(getCli(configuration)));

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendRunTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendRunTest.java
@@ -21,16 +21,22 @@ package org.apache.flink.client.cli;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.client.program.PackagedProgram;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.GlobalConfiguration;
+import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
+import static org.apache.flink.client.cli.CliFrontendTestUtils.getCli;
+import static org.apache.flink.client.cli.CliFrontendTestUtils.getConfiguration;
 import static org.apache.flink.client.cli.CliFrontendTestUtils.getTestJarPath;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -39,7 +45,16 @@ import static org.junit.Assert.assertTrue;
 /**
  * Tests for the RUN command.
  */
+@RunWith(Parameterized.class)
 public class CliFrontendRunTest extends TestLogger {
+
+	@Parameterized.Parameters(name = "Mode = {0}")
+	public static List<String> parameters() {
+		return Arrays.asList(CoreOptions.OLD_MODE, CoreOptions.FLIP6_MODE);
+	}
+
+	@Parameterized.Parameter
+	public String mode;
 
 	@BeforeClass
 	public static void init() {
@@ -53,33 +68,29 @@ public class CliFrontendRunTest extends TestLogger {
 
 	@Test
 	public void testRun() throws Exception {
-		final Configuration configuration = GlobalConfiguration.loadConfiguration(CliFrontendTestUtils.getConfigDir());
+		final Configuration configuration = getConfiguration(mode);
 		// test without parallelism
 		{
 			String[] parameters = {"-v", getTestJarPath()};
-			RunTestingCliFrontend testFrontend = new RunTestingCliFrontend(configuration, 1, true, false);
-			testFrontend.run(parameters);
+			verifyCliFrontend(getCli(configuration), parameters, 1, true, false);
 		}
 
 		// test configure parallelism
 		{
 			String[] parameters = {"-v", "-p", "42",  getTestJarPath()};
-			RunTestingCliFrontend testFrontend = new RunTestingCliFrontend(configuration, 42, true, false);
-			testFrontend.run(parameters);
+			verifyCliFrontend(getCli(configuration), parameters, 42, true, false);
 		}
 
 		// test configure sysout logging
 		{
 			String[] parameters = {"-p", "2", "-q", getTestJarPath()};
-			RunTestingCliFrontend testFrontend = new RunTestingCliFrontend(configuration, 2, false, false);
-			testFrontend.run(parameters);
+			verifyCliFrontend(getCli(configuration), parameters, 2, false, false);
 		}
 
 		// test detached mode
 		{
 			String[] parameters = {"-p", "2", "-d", getTestJarPath()};
-			RunTestingCliFrontend testFrontend = new RunTestingCliFrontend(configuration, 2, true, true);
-			testFrontend.run(parameters);
+			verifyCliFrontend(getCli(configuration), parameters, 2, true, true);
 		}
 
 		// test configure savepoint path (no ignore flag)
@@ -119,10 +130,10 @@ public class CliFrontendRunTest extends TestLogger {
 	public void testUnrecognizedOption() throws Exception {
 		// test unrecognized option
 		String[] parameters = {"-v", "-l", "-a", "some", "program", "arguments"};
-		Configuration configuration = new Configuration();
+		Configuration configuration = getConfiguration(mode);
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
-			Collections.singletonList(new DefaultCLI(configuration)));
+			Collections.singletonList(getCli(configuration)));
 		testFrontend.run(parameters);
 	}
 
@@ -130,10 +141,10 @@ public class CliFrontendRunTest extends TestLogger {
 	public void testInvalidParallelismOption() throws Exception {
 		// test configure parallelism with non integer value
 		String[] parameters = {"-v", "-p", "text",  getTestJarPath()};
-		Configuration configuration = new Configuration();
+		Configuration configuration = getConfiguration(mode);
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
-			Collections.singletonList(new DefaultCLI(configuration)));
+			Collections.singletonList(getCli(configuration)));
 		testFrontend.run(parameters);
 	}
 
@@ -144,11 +155,23 @@ public class CliFrontendRunTest extends TestLogger {
 		Configuration configuration = new Configuration();
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
-			Collections.singletonList(new DefaultCLI(configuration)));
+			Collections.singletonList(getCli(configuration)));
 		testFrontend.run(parameters);
 	}
 
 	// --------------------------------------------------------------------------------------------
+
+	private static void verifyCliFrontend(
+			AbstractCustomCommandLine<?> cli,
+			String[] parameters,
+			int expectedParallelism,
+			boolean logging,
+			boolean isDetached) throws Exception {
+		RunTestingCliFrontend testFrontend =
+			new RunTestingCliFrontend(cli, expectedParallelism, logging,
+				isDetached);
+		testFrontend.run(parameters); // verifies the expected values (see below)
+	}
 
 	private static final class RunTestingCliFrontend extends CliFrontend {
 
@@ -156,10 +179,14 @@ public class CliFrontendRunTest extends TestLogger {
 		private final boolean sysoutLogging;
 		private final boolean isDetached;
 
-		public RunTestingCliFrontend(Configuration configuration, int expectedParallelism, boolean logging, boolean isDetached) throws Exception {
+		private RunTestingCliFrontend(
+				AbstractCustomCommandLine<?> cli,
+				int expectedParallelism,
+				boolean logging,
+				boolean isDetached) throws Exception {
 			super(
-				configuration,
-				Collections.singletonList(new DefaultCLI(configuration)));
+				cli.getConfiguration(),
+				Collections.singletonList(cli));
 			this.expectedParallelism = expectedParallelism;
 			this.sysoutLogging = logging;
 			this.isDetached = isDetached;

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendStopTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendStopTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.client.cli.util.MockedCliFrontend;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
@@ -29,12 +30,18 @@ import org.apache.flink.util.TestLogger;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.mockito.Mockito;
 
 import javax.annotation.Nullable;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
+import static org.apache.flink.client.cli.CliFrontendTestUtils.getCli;
+import static org.apache.flink.client.cli.CliFrontendTestUtils.getConfiguration;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
@@ -45,7 +52,16 @@ import static org.powermock.api.mockito.PowerMockito.doThrow;
 /**
  * Tests for the STOP command.
  */
+@RunWith(Parameterized.class)
 public class CliFrontendStopTest extends TestLogger {
+
+	@Parameterized.Parameters(name = "Mode = {0}")
+	public static List<String> parameters() {
+		return Arrays.asList(CoreOptions.OLD_MODE, CoreOptions.FLIP6_MODE);
+	}
+
+	@Parameterized.Parameter
+	public String mode;
 
 	@BeforeClass
 	public static void setup() {
@@ -76,10 +92,10 @@ public class CliFrontendStopTest extends TestLogger {
 	public void testUnrecognizedOption() throws Exception {
 		// test unrecognized option
 		String[] parameters = { "-v", "-l" };
-		Configuration configuration = new Configuration();
+		Configuration configuration = getConfiguration(mode);
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
-			Collections.singletonList(new DefaultCLI(configuration)));
+			Collections.singletonList(getCli(configuration)));
 		testFrontend.stop(parameters);
 	}
 
@@ -87,10 +103,10 @@ public class CliFrontendStopTest extends TestLogger {
 	public void testMissingJobId() throws Exception {
 		// test missing job id
 		String[] parameters = {};
-		Configuration configuration = new Configuration();
+		Configuration configuration = getConfiguration(mode);
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
-			Collections.singletonList(new DefaultCLI(configuration)));
+			Collections.singletonList(getCli(configuration)));
 		testFrontend.stop(parameters);
 	}
 

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendStopTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendStopTest.java
@@ -22,26 +22,18 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.client.cli.util.MockedCliFrontend;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
-import org.apache.flink.util.TestLogger;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 import org.mockito.Mockito;
 
 import javax.annotation.Nullable;
 
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 
-import static org.apache.flink.client.cli.CliFrontendTestUtils.getCli;
-import static org.apache.flink.client.cli.CliFrontendTestUtils.getConfiguration;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
@@ -52,16 +44,7 @@ import static org.powermock.api.mockito.PowerMockito.doThrow;
 /**
  * Tests for the STOP command.
  */
-@RunWith(Parameterized.class)
-public class CliFrontendStopTest extends TestLogger {
-
-	@Parameterized.Parameters(name = "Mode = {0}")
-	public static List<String> parameters() {
-		return Arrays.asList(CoreOptions.OLD_MODE, CoreOptions.FLIP6_MODE);
-	}
-
-	@Parameterized.Parameter
-	public String mode;
+public class CliFrontendStopTest extends CliFrontendTestBase {
 
 	@BeforeClass
 	public static void setup() {
@@ -92,7 +75,7 @@ public class CliFrontendStopTest extends TestLogger {
 	public void testUnrecognizedOption() throws Exception {
 		// test unrecognized option
 		String[] parameters = { "-v", "-l" };
-		Configuration configuration = getConfiguration(mode);
+		Configuration configuration = getConfiguration();
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
 			Collections.singletonList(getCli(configuration)));
@@ -103,7 +86,7 @@ public class CliFrontendStopTest extends TestLogger {
 	public void testMissingJobId() throws Exception {
 		// test missing job id
 		String[] parameters = {};
-		Configuration configuration = getConfiguration(mode);
+		Configuration configuration = getConfiguration();
 		CliFrontend testFrontend = new CliFrontend(
 			configuration,
 			Collections.singletonList(getCli(configuration)));

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendTestBase.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendTestBase.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.cli;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.configuration.GlobalConfiguration;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Base test class for {@link CliFrontend} tests that wraps the Flip-6 vs. non-Flip-6 modes.
+ */
+@RunWith(Parameterized.class)
+public abstract class CliFrontendTestBase extends TestLogger {
+	@Parameterized.Parameter
+	public String mode;
+
+	@Parameterized.Parameters(name = "Mode = {0}")
+	public static List<String> parameters() {
+		return Arrays.asList(CoreOptions.OLD_MODE, CoreOptions.FLIP6_MODE);
+	}
+
+	protected Configuration getConfiguration() {
+		final Configuration configuration = GlobalConfiguration
+			.loadConfiguration(CliFrontendTestUtils.getConfigDir());
+		configuration.setString(CoreOptions.MODE, mode);
+		return configuration;
+	}
+
+	static AbstractCustomCommandLine<?> getCli(Configuration configuration) {
+		switch (configuration.getString(CoreOptions.MODE)) {
+			case CoreOptions.OLD_MODE:
+				return new DefaultCLI(configuration);
+			case CoreOptions.FLIP6_MODE:
+				return new Flip6DefaultCLI(configuration);
+		}
+		throw new IllegalStateException();
+	}
+}

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendTestUtils.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendTestUtils.java
@@ -19,6 +19,8 @@
 package org.apache.flink.client.cli;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.configuration.JobManagerOptions;
 
 import java.io.File;
@@ -64,6 +66,22 @@ public class CliFrontendTestUtils {
 	public static String getInvalidConfigDir() {
 		String confFile = CliFrontendRunTest.class.getResource("/invalidtestconfig/flink-conf.yaml").getFile();
 		return new File(confFile).getAbsoluteFile().getParent();
+	}
+
+	static Configuration getConfiguration(String mode) {
+		final Configuration configuration = GlobalConfiguration.loadConfiguration(getConfigDir());
+		configuration.setString(CoreOptions.MODE, mode);
+		return configuration;
+	}
+
+	static AbstractCustomCommandLine<?> getCli(Configuration configuration) {
+		switch (configuration.getString(CoreOptions.MODE)) {
+			case CoreOptions.OLD_MODE:
+				return new DefaultCLI(configuration);
+			case CoreOptions.FLIP6_MODE:
+				return new Flip6DefaultCLI(configuration);
+		}
+		throw new IllegalStateException();
 	}
 
 	public static void pipeSystemOutToNull() {

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendTestUtils.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendTestUtils.java
@@ -19,8 +19,6 @@
 package org.apache.flink.client.cli;
 
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.CoreOptions;
-import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.configuration.JobManagerOptions;
 
 import java.io.File;
@@ -66,22 +64,6 @@ public class CliFrontendTestUtils {
 	public static String getInvalidConfigDir() {
 		String confFile = CliFrontendRunTest.class.getResource("/invalidtestconfig/flink-conf.yaml").getFile();
 		return new File(confFile).getAbsoluteFile().getParent();
-	}
-
-	static Configuration getConfiguration(String mode) {
-		final Configuration configuration = GlobalConfiguration.loadConfiguration(getConfigDir());
-		configuration.setString(CoreOptions.MODE, mode);
-		return configuration;
-	}
-
-	static AbstractCustomCommandLine<?> getCli(Configuration configuration) {
-		switch (configuration.getString(CoreOptions.MODE)) {
-			case CoreOptions.OLD_MODE:
-				return new DefaultCLI(configuration);
-			case CoreOptions.FLIP6_MODE:
-				return new Flip6DefaultCLI(configuration);
-		}
-		throw new IllegalStateException();
 	}
 
 	public static void pipeSystemOutToNull() {

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/DefaultCLITest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/DefaultCLITest.java
@@ -18,9 +18,11 @@
 
 package org.apache.flink.client.cli;
 
-import org.apache.flink.client.deployment.StandaloneClusterDescriptor;
+import org.apache.flink.client.deployment.ClusterDescriptor;
+import org.apache.flink.client.deployment.StandaloneClusterId;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.runtime.util.LeaderConnectionInfo;
 import org.apache.flink.util.TestLogger;
@@ -30,13 +32,29 @@ import org.hamcrest.Matchers;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import java.util.Arrays;
+import java.util.List;
+
+import static org.apache.flink.client.cli.CliFrontendTestUtils.getCli;
+import static org.apache.flink.client.cli.CliFrontendTestUtils.getConfiguration;
 import static org.junit.Assert.assertThat;
 
 /**
  * Tests for the {@link DefaultCLI}.
  */
+@RunWith(Parameterized.class)
 public class DefaultCLITest extends TestLogger {
+
+	@Parameterized.Parameters(name = "Mode = {0}")
+	public static List<String> parameters() {
+		return Arrays.asList(CoreOptions.OLD_MODE, CoreOptions.FLIP6_MODE);
+	}
+
+	@Parameterized.Parameter
+	public String mode;
 
 	@Rule
 	public TemporaryFolder temporaryFolder = new TemporaryFolder();
@@ -47,7 +65,7 @@ public class DefaultCLITest extends TestLogger {
 	 */
 	@Test
 	public void testConfigurationPassing() throws Exception {
-		final Configuration configuration = new Configuration();
+		final Configuration configuration = getConfiguration(mode);
 
 		final String localhost = "localhost";
 		final int port = 1234;
@@ -55,13 +73,16 @@ public class DefaultCLITest extends TestLogger {
 		configuration.setString(JobManagerOptions.ADDRESS, localhost);
 		configuration.setInteger(JobManagerOptions.PORT, port);
 
-		final DefaultCLI defaultCLI = new DefaultCLI(configuration);
+		@SuppressWarnings("unchecked")
+		final AbstractCustomCommandLine<StandaloneClusterId> defaultCLI =
+			(AbstractCustomCommandLine<StandaloneClusterId>) getCli(configuration);
 
 		final String[] args = {};
 
 		CommandLine commandLine = defaultCLI.parseCommandLineOptions(args, false);
 
-		final StandaloneClusterDescriptor clusterDescriptor = defaultCLI.createClusterDescriptor(commandLine);
+		final ClusterDescriptor<StandaloneClusterId> clusterDescriptor =
+			defaultCLI.createClusterDescriptor(commandLine);
 
 		final ClusterClient<?> clusterClient = clusterDescriptor.retrieve(defaultCLI.getClusterId(commandLine));
 
@@ -78,12 +99,14 @@ public class DefaultCLITest extends TestLogger {
 	public void testManualConfigurationOverride() throws Exception {
 		final String localhost = "localhost";
 		final int port = 1234;
-		final Configuration configuration = new Configuration();
+		final Configuration configuration = getConfiguration(mode);
 
 		configuration.setString(JobManagerOptions.ADDRESS, localhost);
 		configuration.setInteger(JobManagerOptions.PORT, port);
 
-		final DefaultCLI defaultCLI = new DefaultCLI(configuration);
+		@SuppressWarnings("unchecked")
+		final AbstractCustomCommandLine<StandaloneClusterId> defaultCLI =
+			(AbstractCustomCommandLine<StandaloneClusterId>) getCli(configuration);
 
 		final String manualHostname = "123.123.123.123";
 		final int manualPort = 4321;
@@ -91,7 +114,8 @@ public class DefaultCLITest extends TestLogger {
 
 		CommandLine commandLine = defaultCLI.parseCommandLineOptions(args, false);
 
-		final StandaloneClusterDescriptor clusterDescriptor = defaultCLI.createClusterDescriptor(commandLine);
+		final ClusterDescriptor<StandaloneClusterId> clusterDescriptor =
+			defaultCLI.createClusterDescriptor(commandLine);
 
 		final ClusterClient<?> clusterClient = clusterDescriptor.retrieve(defaultCLI.getClusterId(commandLine));
 

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/DefaultCLITest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/DefaultCLITest.java
@@ -22,39 +22,21 @@ import org.apache.flink.client.deployment.ClusterDescriptor;
 import org.apache.flink.client.deployment.StandaloneClusterId;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.runtime.util.LeaderConnectionInfo;
-import org.apache.flink.util.TestLogger;
 
 import org.apache.commons.cli.CommandLine;
 import org.hamcrest.Matchers;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
-import java.util.Arrays;
-import java.util.List;
-
-import static org.apache.flink.client.cli.CliFrontendTestUtils.getCli;
-import static org.apache.flink.client.cli.CliFrontendTestUtils.getConfiguration;
 import static org.junit.Assert.assertThat;
 
 /**
  * Tests for the {@link DefaultCLI}.
  */
-@RunWith(Parameterized.class)
-public class DefaultCLITest extends TestLogger {
-
-	@Parameterized.Parameters(name = "Mode = {0}")
-	public static List<String> parameters() {
-		return Arrays.asList(CoreOptions.OLD_MODE, CoreOptions.FLIP6_MODE);
-	}
-
-	@Parameterized.Parameter
-	public String mode;
+public class DefaultCLITest extends CliFrontendTestBase {
 
 	@Rule
 	public TemporaryFolder temporaryFolder = new TemporaryFolder();
@@ -65,7 +47,7 @@ public class DefaultCLITest extends TestLogger {
 	 */
 	@Test
 	public void testConfigurationPassing() throws Exception {
-		final Configuration configuration = getConfiguration(mode);
+		final Configuration configuration = getConfiguration();
 
 		final String localhost = "localhost";
 		final int port = 1234;
@@ -99,7 +81,7 @@ public class DefaultCLITest extends TestLogger {
 	public void testManualConfigurationOverride() throws Exception {
 		final String localhost = "localhost";
 		final int port = 1234;
-		final Configuration configuration = getConfiguration(mode);
+		final Configuration configuration = getConfiguration();
 
 		configuration.setString(JobManagerOptions.ADDRESS, localhost);
 		configuration.setInteger(JobManagerOptions.PORT, port);

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterClient.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterClient.java
@@ -139,7 +139,7 @@ public class YarnClusterClient extends ClusterClient<ApplicationId> {
 	public int getMaxSlots() {
 		// TODO: this should be retrieved from the running Flink cluster
 		int maxSlots = numberTaskManagers * slotsPerTaskManager;
-		return maxSlots > 0 ? maxSlots : -1;
+		return maxSlots > 0 ? maxSlots : MAX_SLOTS_UNKNOWN;
 	}
 
 	@Override


### PR DESCRIPTION
## What is the purpose of the change

Various tests in `org.apache.flink.client.cli` only test with the `DefaultCLI` but should also test `Flip6DefaultCLI`.

Please note that this PR also includes [FLINK-8905](https://issues.apache.org/jira/browse/FLINK-8905) (RestClusterClient#getMaxSlots() returning `0` instead of `-1`) which was uncovered by these tests. It also includes #5670.

## Brief change log

- let `RestClusterClient#getMaxSlots()` return `-1` as expected for unknown slot counts
- make tests under `org.apache.flink.client.cli` parameterized with Flip-6 and old mode to test with `DefaultCLI` and `Flip6DefaultCLI`

## Verifying this change

This change added tests for FLIP-6 based on existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
