### PR TITLE
[FLINK-7804][flip6] YarnResourceManager does not execute AMRMClientAsync callbacks in main thread

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
@@ -389,13 +389,7 @@ public class YarnResourceManager extends ResourceManager<YarnWorkerNode> impleme
 
 	@Override
 	public void onShutdownRequest() {
-		runAsync(() -> {
-			try {
-				shutDown();
-			} catch (Exception e) {
-				log.warn("Fail to shutdown the YARN resource manager.", e);
-			}
-		});
+		shutDown();
 	}
 
 	@Override
@@ -405,7 +399,7 @@ public class YarnResourceManager extends ResourceManager<YarnWorkerNode> impleme
 
 	@Override
 	public void onError(Throwable error) {
-		runAsync(() -> onFatalError(error));
+		onFatalError(error);
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
@@ -316,7 +316,10 @@ public class YarnResourceManager extends ResourceManager<YarnWorkerNode> impleme
 		return workerNodeMap.get(resourceID);
 	}
 
-	// AMRMClientAsync CallbackHandler methods
+	// ------------------------------------------------------------------------
+	//  AMRMClientAsync CallbackHandler methods
+	// ------------------------------------------------------------------------
+
 	@Override
 	public float getProgress() {
 		// Temporarily need not record the total size of asked and allocated containers
@@ -325,67 +328,74 @@ public class YarnResourceManager extends ResourceManager<YarnWorkerNode> impleme
 
 	@Override
 	public void onContainersCompleted(List<ContainerStatus> list) {
-		for (ContainerStatus container : list) {
-			if (container.getExitStatus() < 0) {
-				closeTaskManagerConnection(new ResourceID(
-					container.getContainerId().toString()), new Exception(container.getDiagnostics()));
+		runAsync(() -> {
+				for (ContainerStatus container : list) {
+					if (container.getExitStatus() < 0) {
+						closeTaskManagerConnection(new ResourceID(
+							container.getContainerId().toString()), new Exception(container.getDiagnostics()));
+					}
+					workerNodeMap.remove(new ResourceID(container.getContainerId().toString()));
+				}
 			}
-			workerNodeMap.remove(new ResourceID(container.getContainerId().toString()));
-		}
+		);
 	}
 
 	@Override
 	public void onContainersAllocated(List<Container> containers) {
-		for (Container container : containers) {
-			log.info(
-				"Received new container: {} - Remaining pending container requests: {}",
-				container.getId(),
-				numPendingContainerRequests);
+		runAsync(() -> {
+			for (Container container : containers) {
+				log.info(
+					"Received new container: {} - Remaining pending container requests: {}",
+					container.getId(),
+					numPendingContainerRequests);
 
-			if (numPendingContainerRequests > 0) {
-				numPendingContainerRequests--;
+				if (numPendingContainerRequests > 0) {
+					numPendingContainerRequests--;
 
-				final String containerIdStr = container.getId().toString();
+					final String containerIdStr = container.getId().toString();
 
-				workerNodeMap.put(new ResourceID(containerIdStr), new YarnWorkerNode(container));
+					workerNodeMap.put(new ResourceID(containerIdStr), new YarnWorkerNode(container));
 
-				try {
-					// Context information used to start a TaskExecutor Java process
-					ContainerLaunchContext taskExecutorLaunchContext = createTaskExecutorLaunchContext(
-						container.getResource(),
-						containerIdStr,
-						container.getNodeId().getHost());
+					try {
+						// Context information used to start a TaskExecutor Java process
+						ContainerLaunchContext taskExecutorLaunchContext = createTaskExecutorLaunchContext(
+							container.getResource(),
+							containerIdStr,
+							container.getNodeId().getHost());
 
-					nodeManagerClient.startContainer(container, taskExecutorLaunchContext);
-				} catch (Throwable t) {
-					log.error("Could not start TaskManager in container {}.", container.getId(), t);
+						nodeManagerClient.startContainer(container, taskExecutorLaunchContext);
+					} catch (Throwable t) {
+						log.error("Could not start TaskManager in container {}.", container.getId(), t);
 
-					// release the failed container
+						// release the failed container
+						resourceManagerClient.releaseAssignedContainer(container.getId());
+						// and ask for a new one
+						requestYarnContainer(container.getResource(), container.getPriority());
+					}
+				} else {
+					// return the excessive containers
+					log.info("Returning excess container {}.", container.getId());
 					resourceManagerClient.releaseAssignedContainer(container.getId());
-					// and ask for a new one
-					requestYarnContainer(container.getResource(), container.getPriority());
 				}
-			} else {
-				// return the excessive containers
-				log.info("Returning excess container {}.", container.getId());
-				resourceManagerClient.releaseAssignedContainer(container.getId());
 			}
-		}
 
-		// if we are waiting for no further containers, we can go to the
-		// regular heartbeat interval
-		if (numPendingContainerRequests <= 0) {
-			resourceManagerClient.setHeartbeatInterval(yarnHeartbeatIntervalMillis);
-		}
+			// if we are waiting for no further containers, we can go to the
+			// regular heartbeat interval
+			if (numPendingContainerRequests <= 0) {
+				resourceManagerClient.setHeartbeatInterval(yarnHeartbeatIntervalMillis);
+			}
+		});
 	}
 
 	@Override
 	public void onShutdownRequest() {
-		try {
-			shutDown();
-		} catch (Exception e) {
-			log.warn("Fail to shutdown the YARN resource manager.", e);
-		}
+		runAsync(() -> {
+			try {
+				shutDown();
+			} catch (Exception e) {
+				log.warn("Fail to shutdown the YARN resource manager.", e);
+			}
+		});
 	}
 
 	@Override
@@ -395,10 +405,13 @@ public class YarnResourceManager extends ResourceManager<YarnWorkerNode> impleme
 
 	@Override
 	public void onError(Throwable error) {
-		onFatalError(error);
+		runAsync(() -> onFatalError(error));
 	}
 
-	//Utility methods
+	// ------------------------------------------------------------------------
+	//  Utility methods
+	// ------------------------------------------------------------------------
+
 	/**
 	 * Converts a Flink application status enum to a YARN application status enum.
 	 * @param status The Flink application status.

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
@@ -72,8 +72,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
@@ -105,13 +103,11 @@ import static org.mockito.Mockito.when;
  */
 public class YarnResourceManagerTest extends TestLogger {
 
-	private static final Logger LOG = LoggerFactory.getLogger(YarnResourceManagerTest.class);
+	private static final Time TIMEOUT = Time.seconds(10L);
 
 	private static Configuration flinkConfig = new Configuration();
 
 	private static Map<String, String> env = new HashMap<>();
-
-	private static final Time timeout = Time.seconds(10L);
 
 	@Rule
 	public TemporaryFolder folder = new TemporaryFolder();
@@ -178,7 +174,7 @@ public class YarnResourceManagerTest extends TestLogger {
 		}
 
 		public <T> CompletableFuture<T> runInMainThread(Callable<T> callable) {
-			return callAsync(callable, timeout);
+			return callAsync(callable, TIMEOUT);
 		}
 
 		public MainThreadExecutor getMainThreadExecutorForTesting() {
@@ -196,6 +192,11 @@ public class YarnResourceManagerTest extends TestLogger {
 		@Override
 		protected NMClient createAndStartNodeManagerClient(YarnConfiguration yarnConfiguration) {
 			return mockNMClient;
+		}
+
+		@Override
+		protected void runAsync(final Runnable runnable) {
+			runnable.run();
 		}
 	}
 
@@ -292,7 +293,7 @@ public class YarnResourceManagerTest extends TestLogger {
 
 			public void grantLeadership() throws Exception {
 				rmLeaderSessionId = UUID.randomUUID();
-				rmLeaderElectionService.isLeader(rmLeaderSessionId).get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+				rmLeaderElectionService.isLeader(rmLeaderSessionId).get(TIMEOUT.toMilliseconds(), TimeUnit.MILLISECONDS);
 			}
 		}
 


### PR DESCRIPTION
## What is the purpose of the change

*The `YarnResourceManager` registers callbacks at a `AMRMClientAsync` which it uses to react to Yarn container allocations. These callbacks, e.g., `onContainersAllocated`, modify the internal state of the YarnResourceManager. This can lead to race conditions with the `requestYarnContainer` method. To solve this problem we have to execute the state changing operations in the main thread of the `YarnResourceManager`.*


## Brief change log
  - *Run AMRMClientAsync callbacks in main thread*
  - *Fix `YarnResourceManagerTest`*


## Verifying this change

This change is already covered by existing tests, such as `YarnResourceManagerTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
