### PR TITLE
[hotfix] [streaming API] update doc of InternalTimerService.registerEventTimeTimer()

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimerService.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimerService.java
@@ -49,7 +49,7 @@ public interface InternalTimerService<N> {
 	void deleteProcessingTimeTimer(N namespace, long time);
 
 	/**
-	 * Registers a timer to be fired when processing time passes the given time. The namespace
+	 * Registers a timer to be fired when event time watermark passes the given time. The namespace
 	 * you pass here will be provided when the timer fires.
 	 */
 	void registerEventTimeTimer(N namespace, long time);


### PR DESCRIPTION
## What is the purpose of the change

update doc of InternalTimerService.registerEventTimeTimer()

## Brief change log

update doc of InternalTimerService.registerEventTimeTimer()

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

none

## Documentation

none