### PR TITLE
[FLINK-8917] [Job-Submission] FlinkMiniCluster haService not same as ClusterClient

### DIFF
--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/minicluster/FlinkMiniCluster.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/minicluster/FlinkMiniCluster.scala
@@ -128,9 +128,9 @@ abstract class FlinkMiniCluster(
   def this(configuration: Configuration, useSingleActorSystem: Boolean) {
     this(
       configuration,
-      HighAvailabilityServicesUtils.createAvailableOrEmbeddedServices(
-        configuration,
-        ExecutionContext.global),
+      HighAvailabilityServicesUtils.createHighAvailabilityServices(configuration,
+        org.apache.flink.runtime.concurrent.Executors.directExecutor,
+        HighAvailabilityServicesUtils.AddressResolution.TRY_ADDRESS_RESOLUTION),
       useSingleActorSystem)
   }
 


### PR DESCRIPTION
FlinkMiniCluster default createHighAvailabilityServices is not same as ClusterClient，

the FlinkMiniCluster used 

`HighAvailabilityServicesUtils.createAvailableOrEmbeddedServices
`
but the ClusterClient used

`HighAvailabilityServicesUtils.createHighAvailabilityServices`，so if you use the flink-1.4 in zeppelin，the job submission will be failed with the follow msg: 

Discard message LeaderSessionMessage(00000000-0000-0000-0000-000000000000,SubmitJob(JobGraph(jobId: 33d8e7d74aa48f76a1622d4d8f78105e),EXECUTION_RESULT_AND_STATE_CHANGES)) because the expected leader session ID 87efb7ca-b761-4977-9696-d521bc178703 did not equal the received leader session ID 00000000-0000-0000-0000-000000000000.


## Verifying this change


This change is already covered by existing tests, such as `LocalFlinkMiniClusterITCase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):no 
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers:  don't know
  - The runtime per-record code paths (performance sensitive):  don't know
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector:no

## Documentation
  - Does this pull request introduce a new feature? no
