### PR TITLE
[FLINK-8916] Checkpointing Mode is always shown to be "At Least Once" in Web UI

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/CheckpointConfigInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/CheckpointConfigInfo.java
@@ -152,34 +152,13 @@ public class CheckpointConfigInfo implements ResponseBody {
 	}
 
 	/**
-	 * JSON serializer for {@link ProcessingMode}.
+	 * Processing mode.
 	 */
 	@JsonSerialize(using = ProcessingModeSerializer.class)
 	@JsonDeserialize(using = ProcessingModeDeserializer.class)
 	public enum ProcessingMode {
-		AT_LEAST_ONCE("at_least_once"),
-		EXACTLY_ONCE("exactly_once");
-
-		private String value;
-
-		ProcessingMode(String value) {
-			this.value = value;
-		}
-
-		public String getValue() {
-			return value;
-		}
-
-		public static ProcessingMode fromString(String value) {
-			for (ProcessingMode mode : ProcessingMode.values()) {
-				if (mode.value.equalsIgnoreCase(value)) {
-					return mode;
-				}
-			}
-
-			throw new IllegalArgumentException("No constant with value " + value + " found");
-		}
-
+		AT_LEAST_ONCE,
+		EXACTLY_ONCE
 	}
 
 	/**
@@ -194,7 +173,7 @@ public class CheckpointConfigInfo implements ResponseBody {
 		@Override
 		public void serialize(ProcessingMode mode, JsonGenerator generator, SerializerProvider serializerProvider)
 			throws IOException {
-			generator.writeString(mode.getValue());
+			generator.writeString(mode.name().toLowerCase());
 		}
 	}
 
@@ -210,7 +189,7 @@ public class CheckpointConfigInfo implements ResponseBody {
 		@Override
 		public ProcessingMode deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
 			throws IOException {
-			return ProcessingMode.fromString(jsonParser.getValueAsString());
+			return ProcessingMode.valueOf(jsonParser.getValueAsString().toUpperCase());
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/CheckpointConfigInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/CheckpointConfigInfo.java
@@ -24,7 +24,12 @@ import org.apache.flink.util.Preconditions;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.SerializerProvider;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ser.std.StdSerializer;
 
+import java.io.IOException;
 import java.util.Objects;
 
 /**
@@ -145,8 +150,36 @@ public class CheckpointConfigInfo implements ResponseBody {
 	/**
 	 * Processing mode.
 	 */
+	@JsonSerialize(using = ProcessingModeSerializer.class)
 	public enum ProcessingMode {
-		AT_LEAST_ONCE,
-		EXACTLY_ONCE
+		AT_LEAST_ONCE("at_least_once"),
+		EXACTLY_ONCE("exactly_once");
+
+		private String value;
+
+		ProcessingMode(String value) {
+			this.value = value;
+		}
+
+		public String getValue() {
+			return value;
+		}
+	}
+
+	/**
+	 * processing mode serializer.
+	 */
+	public static class ProcessingModeSerializer extends StdSerializer<ProcessingMode> {
+
+		public ProcessingModeSerializer() {
+			super(ProcessingMode.class);
+		}
+
+		@Override
+		public void serialize(ProcessingMode mode, JsonGenerator generator, SerializerProvider serializerProvider)
+			throws IOException {
+			generator.writeFieldName("mode");
+			generator.writeString(mode.getValue());
+		}
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

*This pull request add a customized serializer for checkpoint processing mode to support the Web UI's Presentation. *


## Brief change log

  - *Add a customized serializer for checkpoint processing mode*

## Verifying this change

This change is already covered by existing tests*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
