### PR TITLE
[FLINK-8919] [Table API & SQL] Add KeyedProcessFunctionWithCleanupState.

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/KeyedProcessFunctionWithCleanupState.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/KeyedProcessFunctionWithCleanupState.scala
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.aggregate
+
+import java.lang.{Long => JLong}
+import org.apache.flink.api.common.state.{State, ValueState, ValueStateDescriptor}
+import org.apache.flink.streaming.api.TimeDomain
+import org.apache.flink.streaming.api.functions.{KeyedProcessFunction, ProcessFunction}
+import org.apache.flink.table.api.{StreamQueryConfig, Types}
+
+abstract class KeyedProcessFunctionWithCleanupState[K, I, O](queryConfig: StreamQueryConfig)
+  extends KeyedProcessFunction[K, I, O] {
+  protected val minRetentionTime: Long = queryConfig.getMinIdleStateRetentionTime
+  protected val maxRetentionTime: Long = queryConfig.getMaxIdleStateRetentionTime
+  protected val stateCleaningEnabled: Boolean = minRetentionTime > 1
+
+  // holds the latest registered cleanup timer
+  private var cleanupTimeState: ValueState[JLong] = _
+
+  protected def initCleanupTimeState(stateName: String) {
+    if (stateCleaningEnabled) {
+      val inputCntDescriptor: ValueStateDescriptor[JLong] =
+        new ValueStateDescriptor[JLong](stateName, Types.LONG)
+      cleanupTimeState = getRuntimeContext.getState(inputCntDescriptor)
+    }
+  }
+
+  protected def registerProcessingCleanupTimer(
+    ctx: KeyedProcessFunction[K, I, O]#Context,
+    currentTime: Long): Unit = {
+    if (stateCleaningEnabled) {
+
+      // last registered timer
+      val curCleanupTime = cleanupTimeState.value()
+
+      // check if a cleanup timer is registered and
+      // that the current cleanup timer won't delete state we need to keep
+      if (curCleanupTime == null || (currentTime + minRetentionTime) > curCleanupTime) {
+        // we need to register a new (later) timer
+        val cleanupTime = currentTime + maxRetentionTime
+        // register timer and remember clean-up time
+        ctx.timerService().registerProcessingTimeTimer(cleanupTime)
+        cleanupTimeState.update(cleanupTime)
+      }
+    }
+  }
+
+  protected def isProcessingTimeTimer(ctx: OnTimerContext): Boolean = {
+    ctx.timeDomain() == TimeDomain.PROCESSING_TIME
+  }
+
+  protected def needToCleanupState(timestamp: Long): Boolean = {
+    if (stateCleaningEnabled) {
+      val cleanupTime = cleanupTimeState.value()
+      // check that the triggered timer is the last registered processing time timer.
+      null != cleanupTime && timestamp == cleanupTime
+    } else {
+      false
+    }
+  }
+
+  protected def cleanupState(states: State*): Unit = {
+    // clear all state
+    states.foreach(_.clear())
+    if (stateCleaningEnabled) {
+      this.cleanupTimeState.clear()
+    }
+  }
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/operators/KeyedProcessFunctionWithCleanupStateTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/operators/KeyedProcessFunctionWithCleanupStateTest.scala
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators
+
+import java.lang.{Boolean => JBool}
+import scala.collection.JavaConversions._
+import org.apache.flink.api.common.time.Time
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.streaming.api.functions.KeyedProcessFunction
+import org.apache.flink.streaming.api.operators.KeyedProcessOperator
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord
+import org.apache.flink.table.api.StreamQueryConfig
+import org.apache.flink.table.runtime.aggregate.KeyedProcessFunctionWithCleanupState
+import org.apache.flink.table.runtime.harness.HarnessTestBase
+import org.apache.flink.util.Collector
+import org.junit.Test
+import org.junit.Assert.assertArrayEquals
+
+class KeyedProcessFunctionWithCleanupStateTest extends HarnessTestBase {
+  @Test
+  def testNeedToCleanup(): Unit = {
+    val queryConfig = new StreamQueryConfig()
+      .withIdleStateRetentionTime(Time.milliseconds(5), Time.milliseconds(10))
+
+    val func = new MockedKeyedProcessFunction[String, String](queryConfig)
+    val operator = new KeyedProcessOperator(func)
+
+    val testHarness = createHarnessTester(operator,
+      new IdentityKeySelector[String],
+      TypeInformation.of(classOf[String]))
+
+    testHarness.open()
+
+    testHarness.setProcessingTime(2)
+    testHarness.processElement("a", 2)
+    testHarness.processElement("a", 8)
+    testHarness.setProcessingTime(18)
+    testHarness.processElement("a", 10)
+
+    val output: Array[Boolean] = testHarness.getOutput
+      .map(_.asInstanceOf[StreamRecord[JBool]].getValue.asInstanceOf[Boolean])
+      .toArray
+    val expected = Array(false, false, true)
+
+    assertArrayEquals(expected, output)
+
+    testHarness.close()
+  }
+}
+
+private class MockedKeyedProcessFunction[K, I](queryConfig: StreamQueryConfig)
+  extends KeyedProcessFunctionWithCleanupState[K, I, Boolean](queryConfig) {
+  override def open(parameters: Configuration): Unit = {
+    initCleanupTimeState("CleanUpState")
+  }
+
+
+  override def processElement(
+    value: I,
+    ctx: KeyedProcessFunction[K, I, Boolean]#Context,
+    out: Collector[Boolean]): Unit = {
+    val recordTime = ctx.timestamp()
+    registerProcessingCleanupTimer(ctx, recordTime)
+
+    val curTime = ctx.timerService().currentProcessingTime()
+    out.collect(needToCleanupState(curTime))
+  }
+}
+


### PR DESCRIPTION
## What is the purpose of the change

*Add ProcessFunctionWithCleanupState's counterpart for KeyedProcessFunction.*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
