### PR TITLE
[FLINK-8927][state] Eagerly release the checkpoint object created from RocksDB

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
@@ -2318,8 +2318,9 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 			}
 
 			// create hard links of living files in the snapshot path
-			Checkpoint checkpoint = Checkpoint.create(stateBackend.db);
-			checkpoint.createCheckpoint(localBackupDirectory.getDirectory().getPath());
+			try (Checkpoint checkpoint = Checkpoint.create(stateBackend.db)) {
+				checkpoint.createCheckpoint(localBackupDirectory.getDirectory().getPath());
+			}
 		}
 
 		@Nonnull


### PR DESCRIPTION
## What is the purpose of the change

This PR addresses [FLINK-8927](https://issues.apache.org/jira/browse/FLINK-8927), eagerly release the checkpoint object that is created from RocksDB

## Brief change log

  -  Use `try() {}` to release the checkpoint object eagerly

## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation
none
