### PR TITLE
[FLINK-8850] [sql-client] Add support for event-time in SQL Client

### DIFF
--- a/flink-libraries/flink-sql-client/conf/sql-client-defaults.yaml
+++ b/flink-libraries/flink-sql-client/conf/sql-client-defaults.yaml
@@ -41,12 +41,20 @@ sources: [] # empty list
 # Execution properties allow for changing the behavior of a table program.
 
 execution:
-  type: streaming              # 'batch' or 'streaming' execution
-  result-mode: changelog       # 'changelog' or 'table' presentation of results
-  parallelism: 1               # parallelism of the program
-  max-parallelism: 128         # maximum parallelism
-  min-idle-state-retention: 0  # minimum idle state retention in ms
-  max-idle-state-retention: 0  # maximum idle state retention in ms
+  # 'batch' or 'streaming' execution
+  type: streaming
+  # allow 'event-time', 'ingestion-time', or only 'processing-time' in sources
+  time-characteristic: event-time
+  # 'changelog' or 'table' presentation of results
+  result-mode: changelog
+  # parallelism of the program
+  parallelism: 1
+  # maximum parallelism
+  max-parallelism: 128
+  # minimum idle state retention in ms
+  min-idle-state-retention: 0
+  # maximum idle state retention in ms
+  max-idle-state-retention: 0
 
 #==============================================================================
 # Deployment properties
@@ -56,9 +64,13 @@ execution:
 # programs are submitted to.
 
 deployment:
-  type: standalone             # only the 'standalone' deployment is supported
-  response-timeout: 5000       # general cluster communication timeout in ms
-  gateway-address: ""          # (optional) address from cluster to gateway
-  gateway-port: 0              # (optional) port from cluster to gateway
+  # only the 'standalone' deployment is supported
+  type: standalone
+  # general cluster communication timeout in ms
+  response-timeout: 5000
+  # (optional) address from cluster to gateway
+  gateway-address: ""
+  # (optional) port from cluster to gateway
+  gateway-port: 0
 
 

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/config/Execution.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/config/Execution.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.table.client.config;
 
+import org.apache.flink.streaming.api.TimeCharacteristic;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -52,6 +54,22 @@ public class Execution {
 		return Objects.equals(
 			properties.getOrDefault(PropertyStrings.EXECUTION_TYPE, PropertyStrings.EXECUTION_TYPE_VALUE_STREAMING),
 			PropertyStrings.EXECUTION_TYPE_VALUE_BATCH);
+	}
+
+	public TimeCharacteristic getTimeCharacteristic() {
+		final String s = properties.getOrDefault(
+			PropertyStrings.EXECUTION_TIME_CHARACTERISTIC,
+			PropertyStrings.EXECUTION_TIME_CHARACTERISTIC_VALUE_EVENT_TIME);
+		switch (s) {
+			case PropertyStrings.EXECUTION_TIME_CHARACTERISTIC_VALUE_EVENT_TIME:
+				return TimeCharacteristic.EventTime;
+			case PropertyStrings.EXECUTION_TIME_CHARACTERISTIC_VALUE_INGESTION_TIME:
+				return TimeCharacteristic.IngestionTime;
+			case PropertyStrings.EXECUTION_TIME_CHARACTERISTIC_VALUE_PROCESSING_TIME:
+				return TimeCharacteristic.ProcessingTime;
+			default:
+				return TimeCharacteristic.EventTime;
+		}
 	}
 
 	public long getMinStateRetention() {

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/config/PropertyStrings.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/config/PropertyStrings.java
@@ -35,6 +35,14 @@ public final class PropertyStrings {
 
 	public static final String EXECUTION_TYPE_VALUE_BATCH = "batch";
 
+	public static final String EXECUTION_TIME_CHARACTERISTIC = "time-characteristic";
+
+	public static final String EXECUTION_TIME_CHARACTERISTIC_VALUE_EVENT_TIME = "event-time";
+
+	public static final String EXECUTION_TIME_CHARACTERISTIC_VALUE_PROCESSING_TIME = "processing-time";
+
+	public static final String EXECUTION_TIME_CHARACTERISTIC_VALUE_INGESTION_TIME = "ingestion-time";
+
 	public static final String EXECUTION_MIN_STATE_RETENTION = "min-idle-state-retention";
 
 	public static final String EXECUTION_MAX_STATE_RETENTION = "max-idle-state-retention";

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
@@ -46,7 +46,8 @@ public interface Executor {
 	List<String> listTables(SessionContext session) throws SqlExecutionException;
 
 	/**
-	 * Returns the schema of a table. Throws an exception if the table could not be found.
+	 * Returns the schema of a table. Throws an exception if the table could not be found. The
+	 * schema might contain time attribute types for helping the user during debugging a query.
 	 */
 	TableSchema getTableSchema(SessionContext session, String name) throws SqlExecutionException;
 

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
@@ -149,6 +149,7 @@ public class ExecutionContext {
 		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 		env.setParallelism(mergedEnv.getExecution().getParallelism());
 		env.setMaxParallelism(mergedEnv.getExecution().getMaxParallelism());
+		env.setStreamTimeCharacteristic(mergedEnv.getExecution().getTimeCharacteristic());
 		return env;
 	}
 

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
@@ -228,6 +228,7 @@ public class LocalExecutor implements Executor {
 
 		// create table here to fail quickly for wrong queries
 		final Table table = createTable(context, query);
+		final TableSchema resultSchema = table.getSchema().withoutTimeAttributes();
 
 		// deployment
 		final ClusterClient<?> clusterClient = createDeployment(mergedEnv.getDeployment());
@@ -235,7 +236,7 @@ public class LocalExecutor implements Executor {
 		// initialize result
 		final DynamicResult result = resultStore.createResult(
 			mergedEnv,
-			table.getSchema(),
+			resultSchema,
 			context.getExecutionConfig());
 
 		// create job graph with jars
@@ -275,7 +276,7 @@ public class LocalExecutor implements Executor {
 		// start result retrieval
 		result.startRetrieval(program);
 
-		return new ResultDescriptor(resultId, table.getSchema(), result.isMaterialized());
+		return new ResultDescriptor(resultId, resultSchema, result.isMaterialized());
 	}
 
 	@Override

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ResultStore.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ResultStore.java
@@ -55,7 +55,7 @@ public class ResultStore {
 	}
 
 	/**
-	 * Creates a result. Might start thread or opens sockets so every creates result must be closed.
+	 * Creates a result. Might start threads or opens sockets so every created result must be closed.
 	 */
 	public DynamicResult createResult(Environment env, TableSchema schema, ExecutionConfig config) {
 		if (!env.getExecution().isStreamingExecution()) {

--- a/flink-libraries/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/DependencyTest.java
+++ b/flink-libraries/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/DependencyTest.java
@@ -65,6 +65,7 @@ public class DependencyTest {
 		final TableSchema expected = TableSchema.builder()
 			.field("IntegerField1", Types.INT())
 			.field("StringField1", Types.STRING())
+			.field("rowtimeField", Types.SQL_TIMESTAMP())
 			.build();
 
 		assertEquals(expected, result);

--- a/flink-libraries/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/utils/TestTableSourceFactory.java
+++ b/flink-libraries/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/utils/TestTableSourceFactory.java
@@ -25,6 +25,10 @@ import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.Types;
 import org.apache.flink.table.client.gateway.local.DependencyTest;
 import org.apache.flink.table.descriptors.DescriptorProperties;
+import org.apache.flink.table.descriptors.SchemaValidator;
+import org.apache.flink.table.sources.DefinedProctimeAttribute;
+import org.apache.flink.table.sources.DefinedRowtimeAttributes;
+import org.apache.flink.table.sources.RowtimeAttributeDescriptor;
 import org.apache.flink.table.sources.StreamTableSource;
 import org.apache.flink.table.sources.TableSource;
 import org.apache.flink.table.sources.TableSourceFactory;
@@ -34,8 +38,11 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_TYPE;
+import static org.apache.flink.table.descriptors.RowtimeValidator.ROWTIME_TIMESTAMPS_TYPE;
+import static org.apache.flink.table.descriptors.RowtimeValidator.ROWTIME_WATERMARKS_TYPE;
 import static org.apache.flink.table.descriptors.SchemaValidator.SCHEMA;
 import static org.apache.flink.table.descriptors.SchemaValidator.SCHEMA_NAME;
 import static org.apache.flink.table.descriptors.SchemaValidator.SCHEMA_TYPE;
@@ -58,6 +65,8 @@ public class TestTableSourceFactory implements TableSourceFactory<Row> {
 		properties.add("connector.test-property");
 		properties.add(SCHEMA() + ".#." + SCHEMA_TYPE());
 		properties.add(SCHEMA() + ".#." + SCHEMA_NAME());
+		properties.add(SCHEMA() + ".#." + ROWTIME_TIMESTAMPS_TYPE());
+		properties.add(SCHEMA() + ".#." + ROWTIME_WATERMARKS_TYPE());
 		return properties;
 	}
 
@@ -65,9 +74,13 @@ public class TestTableSourceFactory implements TableSourceFactory<Row> {
 	public TableSource<Row> create(Map<String, String> properties) {
 		final DescriptorProperties params = new DescriptorProperties(true);
 		params.putProperties(properties);
+		final Optional<String> proctime = SchemaValidator.deriveProctimeAttribute(params);
+		final List<RowtimeAttributeDescriptor> rowtime = SchemaValidator.deriveRowtimeAttributes(params);
 		return new TestTableSource(
 			params.getTableSchema(SCHEMA()),
-			properties.get("connector.test-property"));
+			properties.get("connector.test-property"),
+			proctime.orElse(null),
+			rowtime);
 	}
 
 	// --------------------------------------------------------------------------------------------
@@ -75,14 +88,19 @@ public class TestTableSourceFactory implements TableSourceFactory<Row> {
 	/**
 	 * Test table source.
 	 */
-	public static class TestTableSource implements StreamTableSource<Row> {
+	public static class TestTableSource implements StreamTableSource<Row>, DefinedRowtimeAttributes, DefinedProctimeAttribute {
 
 		private final TableSchema schema;
 		private final String property;
+		private final String proctime;
+		private final List<RowtimeAttributeDescriptor> rowtime;
 
-		public TestTableSource(TableSchema schema, String property) {
+
+		public TestTableSource(TableSchema schema, String property, String proctime, List<RowtimeAttributeDescriptor> rowtime) {
 			this.schema = schema;
 			this.property = property;
+			this.proctime = proctime;
+			this.rowtime = rowtime;
 		}
 
 		public String getProperty() {
@@ -107,6 +125,16 @@ public class TestTableSourceFactory implements TableSourceFactory<Row> {
 		@Override
 		public String explainSource() {
 			return "TestTableSource";
+		}
+
+		@Override
+		public List<RowtimeAttributeDescriptor> getRowtimeAttributeDescriptors() {
+			return rowtime;
+		}
+
+		@Override
+		public String getProctimeAttribute() {
+			return proctime;
 		}
 	}
 }

--- a/flink-libraries/flink-sql-client/src/test/resources/test-sql-client-defaults.yaml
+++ b/flink-libraries/flink-sql-client/src/test/resources/test-sql-client-defaults.yaml
@@ -63,6 +63,7 @@ sources:
 
 execution:
   type: streaming
+  time-characteristic: event-time
   parallelism: 1
   max-parallelism: 16
   min-idle-state-retention: 0

--- a/flink-libraries/flink-sql-client/src/test/resources/test-sql-client-factory.yaml
+++ b/flink-libraries/flink-sql-client/src/test/resources/test-sql-client-factory.yaml
@@ -30,6 +30,13 @@ sources:
         type: INT
       - name: StringField1
         type: VARCHAR
+      - name: rowtimeField
+        type: TIMESTAMP
+        rowtime:
+          timestamps:
+            type: from-source
+          watermarks:
+            type: from-source
     connector:
       type: "$VAR_0"
       $VAR_1: "$VAR_2"


### PR DESCRIPTION
## What is the purpose of the change

Adds support for event-time in SQL Client. A full end-to-end test should and will follow once we support event-time in the CSVTableSourceFactory.


## Brief change log

- Added `time-characteristic` property
- Fixed result de/serialization


## Verifying this change

- Existing `DependencyTest` extended

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
