### PR TITLE
[FLINK-8783] [tests] Harden SlotPoolRpcTest

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolRpcTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolRpcTest.java
@@ -195,6 +195,9 @@ public class SlotPoolRpcTest extends TestLogger {
 			pool.start(JobMasterId.generate(), "foobar");
 			SlotPoolGateway slotPoolGateway = pool.getSelfGateway(SlotPoolGateway.class);
 
+			final CompletableFuture<SlotRequestId> slotRequestTimeoutFuture = new CompletableFuture<>();
+			pool.setTimeoutPendingSlotRequestConsumer(slotRequestTimeoutFuture::complete);
+
 			ResourceManagerGateway resourceManagerGateway = new TestingResourceManagerGateway();
 			pool.connectToResourceManager(resourceManagerGateway);
 
@@ -212,6 +215,9 @@ public class SlotPoolRpcTest extends TestLogger {
 			} catch (ExecutionException e) {
 				assertTrue(ExceptionUtils.stripExecutionException(e) instanceof TimeoutException);
 			}
+
+			// wait until we have timed out the slot request
+			slotRequestTimeoutFuture.get();
 
 			assertEquals(0L, (long) pool.getNumberOfPendingRequests().get());
 		} finally {
@@ -243,6 +249,9 @@ public class SlotPoolRpcTest extends TestLogger {
 			resourceManagerGateway.setRequestSlotConsumer(
 				(SlotRequest slotRequest) -> allocationIdFuture.complete(slotRequest.getAllocationId()));
 
+			final CompletableFuture<SlotRequestId> slotRequestTimeoutFuture = new CompletableFuture<>();
+			pool.setTimeoutPendingSlotRequestConsumer(slotRequestTimeoutFuture::complete);
+
 			pool.connectToResourceManager(resourceManagerGateway);
 
 			SlotRequestId requestId = new SlotRequestId();
@@ -259,6 +268,9 @@ public class SlotPoolRpcTest extends TestLogger {
 			} catch (ExecutionException e) {
 				assertTrue(ExceptionUtils.stripExecutionException(e) instanceof TimeoutException);
 			}
+
+			// wait until we have timed out the slot request
+			slotRequestTimeoutFuture.get();
 
 			assertEquals(0L, (long) pool.getNumberOfPendingRequests().get());
 


### PR DESCRIPTION
## What is the purpose of the change

Wait for releasing of timed out pending slot requests before checking the
number of pending slots requests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
