### PR TITLE
[FLINK-7521][flip6] Remove the 10MB limit from the current REST implementation

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/RestOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/RestOptions.java
@@ -81,4 +81,19 @@ public class RestOptions {
 		key("rest.connection-timeout")
 			.defaultValue(15_000L)
 			.withDescription("The maximum time in ms for the client to establish a TCP connection.");
+
+	/**
+	 * The max content length that the server will handle.
+	 */
+	public static final ConfigOption<Integer> REST_SERVER_CONTENT_MAX_MB =
+		key("rest.server.content.max.mb")
+			.defaultValue(10);
+
+	/**
+	 * The max content length that the client will handle.
+	 */
+	public static final ConfigOption<Integer> REST_CLIENT_CONTENT_MAX_MB =
+		key("rest.client.content.max.mb")
+			.defaultValue(1);
+
 }

--- a/flink-core/src/main/java/org/apache/flink/configuration/RestOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/RestOptions.java
@@ -83,17 +83,19 @@ public class RestOptions {
 			.withDescription("The maximum time in ms for the client to establish a TCP connection.");
 
 	/**
-	 * The max content length that the server will handle.
+	 * The maximum content length that the server will handle.
 	 */
-	public static final ConfigOption<Integer> REST_SERVER_CONTENT_MAX_MB =
-		key("rest.server.content.max.mb")
-			.defaultValue(10);
+	public static final ConfigOption<Integer> REST_SERVER_MAX_CONTENT_LENGTH =
+		key("rest.server.max-content-length")
+			.defaultValue(104_857_600)
+			.withDescription("The maximum content length in bytes that the server will handle.");
 
 	/**
-	 * The max content length that the client will handle.
+	 * The maximum content length that the client will handle.
 	 */
-	public static final ConfigOption<Integer> REST_CLIENT_CONTENT_MAX_MB =
-		key("rest.client.content.max.mb")
-			.defaultValue(1);
+	public static final ConfigOption<Integer> REST_CLIENT_MAX_CONTENT_LENGTH =
+		key("rest.client.max-content-length")
+			.defaultValue(104_857_600)
+			.withDescription("The maximum content length in bytes that the client will handle.");
 
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherRestEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherRestEndpoint.java
@@ -44,7 +44,6 @@ import org.apache.flink.shaded.netty4.io.netty.channel.ChannelInboundHandler;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
@@ -92,7 +91,6 @@ public class DispatcherRestEndpoint extends WebMonitorEndpoint<DispatcherGateway
 		// Add the Dispatcher specific handlers
 
 		final Time timeout = restConfiguration.getTimeout();
-		final Map<String, String> responseHeaders = restConfiguration.getResponseHeaders();
 
 		BlobServerPortHandler blobServerPortHandler = new BlobServerPortHandler(
 			restAddressFuture,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/FlinkHttpObjectAggregator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/FlinkHttpObjectAggregator.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest;
+
+import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.runtime.rest.handler.util.HandlerUtils;
+import org.apache.flink.runtime.rest.messages.ErrorResponseBody;
+
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelHandlerContext;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.TooLongFrameException;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpObject;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Same as {@link org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpObjectDecoder}
+ * but returns HTTP 413 to the client if the payload exceeds {@link #maxContentLength}.
+ */
+public class FlinkHttpObjectAggregator extends org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpObjectAggregator {
+
+	private final Map<String, String> responseHeaders;
+
+	public FlinkHttpObjectAggregator(final int maxContentLength, final Map<String, String> responseHeaders) {
+		super(maxContentLength);
+		this.responseHeaders = responseHeaders;
+	}
+
+	@Override
+	protected void decode(
+			final ChannelHandlerContext ctx,
+			final HttpObject msg,
+			final List<Object> out) throws Exception {
+
+		try {
+			super.decode(ctx, msg, out);
+		} catch (final TooLongFrameException e) {
+			HandlerUtils.sendErrorResponse(
+				ctx,
+				false,
+				new ErrorResponseBody(String.format(
+					e.getMessage() + " Try to raise [%s]",
+					RestOptions.REST_SERVER_MAX_CONTENT_LENGTH.key())),
+				HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE,
+				responseHeaders);
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
@@ -20,7 +20,7 @@ package org.apache.flink.runtime.rest;
 
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.ConfigConstants;
-import org.apache.flink.runtime.rest.handler.PipelineErrorHandler;
+import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.runtime.rest.messages.ErrorResponseBody;
 import org.apache.flink.runtime.rest.messages.MessageHeaders;
 import org.apache.flink.runtime.rest.messages.MessageParameters;
@@ -50,6 +50,7 @@ import org.apache.flink.shaded.netty4.io.netty.channel.SimpleChannelInboundHandl
 import org.apache.flink.shaded.netty4.io.netty.channel.nio.NioEventLoopGroup;
 import org.apache.flink.shaded.netty4.io.netty.channel.socket.SocketChannel;
 import org.apache.flink.shaded.netty4.io.netty.channel.socket.nio.NioSocketChannel;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.TooLongFrameException;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.DefaultFullHttpRequest;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.FullHttpRequest;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.FullHttpResponse;
@@ -104,8 +105,7 @@ public class RestClient {
 				socketChannel.pipeline()
 					.addLast(new HttpClientCodec())
 					.addLast(new HttpObjectAggregator(configuration.getMaxContentLength()))
-					.addLast(new ClientHandler())
-					.addLast(new PipelineErrorHandler(LOG));
+					.addLast(new ClientHandler());
 			}
 		};
 		NioEventLoopGroup group = new NioEventLoopGroup(1, new DefaultThreadFactory("flink-rest-client-netty"));
@@ -269,8 +269,14 @@ public class RestClient {
 		}
 
 		@Override
-		public void exceptionCaught(final ChannelHandlerContext ctx, final Throwable cause) throws Exception {
-			jsonFuture.completeExceptionally(cause);
+		public void exceptionCaught(final ChannelHandlerContext ctx, final Throwable cause) {
+			if (cause instanceof TooLongFrameException) {
+				jsonFuture.completeExceptionally(new TooLongFrameException(String.format(
+					cause.getMessage() + " Try to raise [%s]",
+					RestOptions.REST_CLIENT_MAX_CONTENT_LENGTH.key())));
+			} else {
+				jsonFuture.completeExceptionally(cause);
+			}
 			ctx.close();
 		}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
@@ -103,7 +103,7 @@ public class RestClient {
 
 				socketChannel.pipeline()
 					.addLast(new HttpClientCodec())
-					.addLast(new HttpObjectAggregator(1024 * 1024))
+					.addLast(new HttpObjectAggregator(configuration.getMaxContentLength()))
 					.addLast(new ClientHandler())
 					.addLast(new PipelineErrorHandler(LOG));
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClientConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClientConfiguration.java
@@ -29,6 +29,8 @@ import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 
+import static org.apache.flink.util.Preconditions.checkArgument;
+
 /**
  * A configuration object for {@link RestClient}s.
  */
@@ -45,6 +47,7 @@ public final class RestClientConfiguration {
 			@Nullable final SSLEngine sslEngine,
 			final long connectionTimeout,
 			final int maxContentLength) {
+		checkArgument(maxContentLength > 0, "maxContentLength must be positive, was: %d", maxContentLength);
 		this.sslEngine = sslEngine;
 		this.connectionTimeout = connectionTimeout;
 		this.maxContentLength = maxContentLength;
@@ -104,10 +107,7 @@ public final class RestClientConfiguration {
 
 		final long connectionTimeout = config.getLong(RestOptions.CONNECTION_TIMEOUT);
 
-		int maxContentLength = config.getInteger(RestOptions.REST_CLIENT_CONTENT_MAX_MB) * 1024 * 1024;
-		if (maxContentLength <= 0) {
-			throw new ConfigurationException("Max content length for client must be a positive integer: " + maxContentLength);
-		}
+		int maxContentLength = config.getInteger(RestOptions.REST_CLIENT_MAX_CONTENT_LENGTH);
 
 		return new RestClientConfiguration(sslEngine, connectionTimeout, maxContentLength);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClientConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClientConfiguration.java
@@ -39,9 +39,15 @@ public final class RestClientConfiguration {
 
 	private final long connectionTimeout;
 
-	private RestClientConfiguration(@Nullable SSLEngine sslEngine, final long connectionTimeout) {
+	private final int maxContentLength;
+
+	private RestClientConfiguration(
+			@Nullable final SSLEngine sslEngine,
+			final long connectionTimeout,
+			final int maxContentLength) {
 		this.sslEngine = sslEngine;
 		this.connectionTimeout = connectionTimeout;
+		this.maxContentLength = maxContentLength;
 	}
 
 	/**
@@ -59,6 +65,15 @@ public final class RestClientConfiguration {
 	 */
 	public long getConnectionTimeout() {
 		return connectionTimeout;
+	}
+
+	/**
+	 * Returns the max content length that the REST client endpoint could handle.
+	 *
+	 * @return max content length that the REST client endpoint could handle
+	 */
+	public int getMaxContentLength() {
+		return maxContentLength;
 	}
 
 	/**
@@ -89,6 +104,11 @@ public final class RestClientConfiguration {
 
 		final long connectionTimeout = config.getLong(RestOptions.CONNECTION_TIMEOUT);
 
-		return new RestClientConfiguration(sslEngine, connectionTimeout);
+		int maxContentLength = config.getInteger(RestOptions.REST_CLIENT_CONTENT_MAX_MB) * 1024 * 1024;
+		if (maxContentLength <= 0) {
+			throw new ConfigurationException("Max content length for client must be a positive integer: " + maxContentLength);
+		}
+
+		return new RestClientConfiguration(sslEngine, connectionTimeout, maxContentLength);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
@@ -78,6 +78,7 @@ public abstract class RestServerEndpoint {
 	private final int configuredPort;
 	private final SSLEngine sslEngine;
 	private final Path uploadDir;
+	private final int maxContentLength;
 
 	private final CompletableFuture<Void> terminationFuture;
 
@@ -95,6 +96,8 @@ public abstract class RestServerEndpoint {
 
 		this.uploadDir = configuration.getUploadDir();
 		createUploadDir(uploadDir, log);
+
+		this.maxContentLength = configuration.getMaxContentLength();
 
 		terminationFuture = new CompletableFuture<>();
 
@@ -156,7 +159,7 @@ public abstract class RestServerEndpoint {
 					ch.pipeline()
 						.addLast(new HttpServerCodec())
 						.addLast(new FileUploadHandler(uploadDir))
-						.addLast(new HttpObjectAggregator(MAX_REQUEST_SIZE_BYTES))
+						.addLast(new HttpObjectAggregator(maxContentLength))
 						.addLast(handler.name(), handler)
 						.addLast(new PipelineErrorHandler(log));
 				}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
@@ -37,7 +37,6 @@ import org.apache.flink.shaded.netty4.io.netty.channel.ChannelInitializer;
 import org.apache.flink.shaded.netty4.io.netty.channel.nio.NioEventLoopGroup;
 import org.apache.flink.shaded.netty4.io.netty.channel.socket.SocketChannel;
 import org.apache.flink.shaded.netty4.io.netty.channel.socket.nio.NioServerSocketChannel;
-import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpObjectAggregator;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpServerCodec;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.router.Handler;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.router.Router;
@@ -59,6 +58,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
@@ -78,6 +78,7 @@ public abstract class RestServerEndpoint {
 	private final SSLEngine sslEngine;
 	private final Path uploadDir;
 	private final int maxContentLength;
+	protected final Map<String, String> responseHeaders;
 
 	private final CompletableFuture<Void> terminationFuture;
 
@@ -97,6 +98,7 @@ public abstract class RestServerEndpoint {
 		createUploadDir(uploadDir, log);
 
 		this.maxContentLength = configuration.getMaxContentLength();
+		this.responseHeaders = configuration.getResponseHeaders();
 
 		terminationFuture = new CompletableFuture<>();
 
@@ -148,7 +150,7 @@ public abstract class RestServerEndpoint {
 
 				@Override
 				protected void initChannel(SocketChannel ch) {
-					Handler handler = new RouterHandler(router);
+					Handler handler = new RouterHandler(router, responseHeaders);
 
 					// SSL should be the first handler in the pipeline
 					if (sslEngine != null) {
@@ -158,9 +160,9 @@ public abstract class RestServerEndpoint {
 					ch.pipeline()
 						.addLast(new HttpServerCodec())
 						.addLast(new FileUploadHandler(uploadDir))
-						.addLast(new HttpObjectAggregator(maxContentLength))
+						.addLast(new FlinkHttpObjectAggregator(maxContentLength, responseHeaders))
 						.addLast(handler.name(), handler)
-						.addLast(new PipelineErrorHandler(log));
+						.addLast(new PipelineErrorHandler(log, responseHeaders));
 				}
 			};
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
@@ -69,7 +69,6 @@ import java.util.concurrent.TimeoutException;
  */
 public abstract class RestServerEndpoint {
 
-	public static final int MAX_REQUEST_SIZE_BYTES = 1024 * 1024 * 10;
 	protected final Logger log = LoggerFactory.getLogger(getClass());
 
 	private final Object lock = new Object();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpointConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpointConfiguration.java
@@ -26,12 +26,16 @@ import org.apache.flink.runtime.net.SSLUtils;
 import org.apache.flink.util.ConfigurationException;
 import org.apache.flink.util.Preconditions;
 
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpHeaders;
+
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.Map;
 import java.util.UUID;
 
 import static java.util.Objects.requireNonNull;
@@ -53,20 +57,24 @@ public final class RestServerEndpointConfiguration {
 
 	private final int maxContentLength;
 
+	private final Map<String, String> responseHeaders;
+
 	private RestServerEndpointConfiguration(
 			@Nullable String restBindAddress,
 			int restBindPort,
 			@Nullable SSLEngine sslEngine,
 			final Path uploadDir,
-			final int maxContentLength) {
+			final int maxContentLength, final Map<String, String> responseHeaders) {
 
 		Preconditions.checkArgument(0 <= restBindPort && restBindPort < 65536, "The bing rest port " + restBindPort + " is out of range (0, 65536[");
+		Preconditions.checkArgument(maxContentLength > 0, "maxContentLength must be positive, was: %d", maxContentLength);
 
 		this.restBindAddress = restBindAddress;
 		this.restBindPort = restBindPort;
 		this.sslEngine = sslEngine;
 		this.uploadDir = requireNonNull(uploadDir);
 		this.maxContentLength = maxContentLength;
+		this.responseHeaders = requireNonNull(Collections.unmodifiableMap(responseHeaders));
 	}
 
 	/**
@@ -113,6 +121,13 @@ public final class RestServerEndpointConfiguration {
 	}
 
 	/**
+	 * Response headers that should be added to every HTTP response.
+	 */
+	public Map<String, String> getResponseHeaders() {
+		return responseHeaders;
+	}
+
+	/**
 	 * Creates and returns a new {@link RestServerEndpointConfiguration} from the given {@link Configuration}.
 	 *
 	 * @param config configuration from which the REST server endpoint configuration should be created from
@@ -144,11 +159,18 @@ public final class RestServerEndpointConfiguration {
 			config.getString(WebOptions.UPLOAD_DIR,	config.getString(WebOptions.TMP_DIR)),
 			"flink-web-upload-" + UUID.randomUUID());
 
-		int maxContentLength = config.getInteger(RestOptions.REST_SERVER_CONTENT_MAX_MB) * 1024 * 1024;
-		if (maxContentLength <= 0) {
-			throw new ConfigurationException("Max content length for server must be a positive integer: " + maxContentLength);
-		}
+		int maxContentLength = config.getInteger(RestOptions.REST_SERVER_MAX_CONTENT_LENGTH);
 
-		return new RestServerEndpointConfiguration(address, port, sslEngine, uploadDir, maxContentLength);
+		final Map<String, String> responseHeaders = Collections.singletonMap(
+			HttpHeaders.Names.ACCESS_CONTROL_ALLOW_ORIGIN,
+			config.getString(WebOptions.ACCESS_CONTROL_ALLOW_ORIGIN));
+
+		return new RestServerEndpointConfiguration(
+			address,
+			port,
+			sslEngine,
+			uploadDir,
+			maxContentLength,
+			responseHeaders);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/RestHandlerConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/RestHandlerConfiguration.java
@@ -23,11 +23,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.WebOptions;
 import org.apache.flink.util.Preconditions;
 
-import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpHeaders;
-
 import java.io.File;
-import java.util.Collections;
-import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -43,14 +39,11 @@ public class RestHandlerConfiguration {
 
 	private final File tmpDir;
 
-	private final Map<String, String> responseHeaders;
-
 	public RestHandlerConfiguration(
 			long refreshInterval,
 			int maxCheckpointStatisticCacheEntries,
 			Time timeout,
-			File tmpDir,
-			Map<String, String> responseHeaders) {
+			File tmpDir) {
 		Preconditions.checkArgument(refreshInterval > 0L, "The refresh interval (ms) should be larger than 0.");
 		this.refreshInterval = refreshInterval;
 
@@ -58,8 +51,6 @@ public class RestHandlerConfiguration {
 
 		this.timeout = Preconditions.checkNotNull(timeout);
 		this.tmpDir = Preconditions.checkNotNull(tmpDir);
-
-		this.responseHeaders = Preconditions.checkNotNull(responseHeaders);
 	}
 
 	public long getRefreshInterval() {
@@ -78,10 +69,6 @@ public class RestHandlerConfiguration {
 		return tmpDir;
 	}
 
-	public Map<String, String> getResponseHeaders() {
-		return Collections.unmodifiableMap(responseHeaders);
-	}
-
 	public static RestHandlerConfiguration fromConfiguration(Configuration configuration) {
 		final long refreshInterval = configuration.getLong(WebOptions.REFRESH_INTERVAL);
 
@@ -92,15 +79,10 @@ public class RestHandlerConfiguration {
 		final String rootDir = "flink-web-" + UUID.randomUUID();
 		final File tmpDir = new File(configuration.getString(WebOptions.TMP_DIR), rootDir);
 
-		final Map<String, String> responseHeaders = Collections.singletonMap(
-			HttpHeaders.Names.ACCESS_CONTROL_ALLOW_ORIGIN,
-			configuration.getString(WebOptions.ACCESS_CONTROL_ALLOW_ORIGIN));
-
 		return new RestHandlerConfiguration(
 			refreshInterval,
 			maxCheckpointStatisticCacheEntries,
 			timeout,
-			tmpDir,
-			responseHeaders);
+			tmpDir);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/RouterHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/RouterHandler.java
@@ -27,20 +27,21 @@ import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseSt
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.router.Handler;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.router.Router;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.Map;
 
-import java.util.Collections;
+import static java.util.Objects.requireNonNull;
 
 /**
  * This class is an extension of {@link Handler} that replaces the standard error response to be identical with those
  * sent by the {@link AbstractRestHandler}.
  */
 public class RouterHandler extends Handler {
-	private static final Logger LOG = LoggerFactory.getLogger(RouterHandler.class);
 
-	public RouterHandler(Router router) {
+	private final Map<String, String> responseHeaders;
+
+	public RouterHandler(Router router, final Map<String, String> responseHeaders) {
 		super(router);
+		this.responseHeaders = requireNonNull(responseHeaders);
 	}
 
 	@Override
@@ -50,6 +51,6 @@ public class RouterHandler extends Handler {
 			request,
 			new ErrorResponseBody("Not found."),
 			HttpResponseStatus.NOT_FOUND,
-			Collections.emptyMap());
+			responseHeaders);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobSubmitRequestBody.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobSubmitRequestBody.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.rest.messages.job;
 
 import org.apache.flink.runtime.jobgraph.JobGraph;
-import org.apache.flink.runtime.rest.RestServerEndpoint;
 import org.apache.flink.runtime.rest.messages.RequestBody;
 import org.apache.flink.util.Preconditions;
 
@@ -52,13 +51,7 @@ public final class JobSubmitRequestBody implements RequestBody {
 
 	@JsonCreator
 	public JobSubmitRequestBody(
-		@JsonProperty(FIELD_NAME_SERIALIZED_JOB_GRAPH) byte[] serializedJobGraph) {
-
-		// check that job graph can be read completely by the HttpObjectAggregator on the server
-		// we subtract 1024 bytes to account for http headers and such.
-		if (serializedJobGraph.length > RestServerEndpoint.MAX_REQUEST_SIZE_BYTES - 1024) {
-			throw new IllegalArgumentException("Serialized job graph exceeded max request size.");
-		}
+			@JsonProperty(FIELD_NAME_SERIALIZED_JOB_GRAPH) byte[] serializedJobGraph) {
 		this.serializedJobGraph = Preconditions.checkNotNull(serializedJobGraph);
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
@@ -129,7 +129,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -199,7 +198,6 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
 		ArrayList<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> handlers = new ArrayList<>(30);
 
 		final Time timeout = restConfiguration.getTimeout();
-		final Map<String, String> responseHeaders = restConfiguration.getResponseHeaders();
 
 		ClusterOverviewHandler clusterOverviewHandler = new ClusterOverviewHandler(
 			restAddressFuture,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskCurrentAttemptDetailsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskCurrentAttemptDetailsHandlerTest.java
@@ -126,7 +126,7 @@ public class SubtaskCurrentAttemptDetailsHandlerTest extends TestLogger {
 			CompletableFuture.completedFuture("127.0.0.1:9527"),
 			() -> null,
 			Time.milliseconds(100),
-			restHandlerConfiguration.getResponseHeaders(),
+			Collections.emptyMap(),
 			SubtaskCurrentAttemptDetailsHeaders.getInstance(),
 			new ExecutionGraphCache(
 				restHandlerConfiguration.getTimeout(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskExecutionAttemptAccumulatorsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskExecutionAttemptAccumulatorsHandlerTest.java
@@ -41,6 +41,7 @@ import org.apache.flink.util.TestLogger;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -62,7 +63,7 @@ public class SubtaskExecutionAttemptAccumulatorsHandlerTest extends TestLogger {
 			CompletableFuture.completedFuture("127.0.0.1:9527"),
 			() -> null,
 			Time.milliseconds(100L),
-			restHandlerConfiguration.getResponseHeaders(),
+			Collections.emptyMap(),
 			SubtaskExecutionAttemptAccumulatorsHeaders.getInstance(),
 			new ExecutionGraphCache(
 				restHandlerConfiguration.getTimeout(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskExecutionAttemptDetailsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskExecutionAttemptDetailsHandlerTest.java
@@ -129,7 +129,7 @@ public class SubtaskExecutionAttemptDetailsHandlerTest extends TestLogger {
 			CompletableFuture.completedFuture("127.0.0.1:9527"),
 			() -> null,
 			Time.milliseconds(100L),
-			restHandlerConfiguration.getResponseHeaders(),
+			Collections.emptyMap(),
 			SubtaskExecutionAttemptDetailsHeaders.getInstance(),
 			new ExecutionGraphCache(
 				restHandlerConfiguration.getTimeout(),


### PR DESCRIPTION
## What is the purpose of the change

*Make HTTP request and response limits configurable. A relatively high default value is chosen (100 mb) because Netty does not allocate the upper limit at once. Multipart form uploads should be used if the request body should be spilled to disk.*

cc: @tillrohrmann 


## Brief change log

  - *Make HTTP request and response limits configurable.*

## Verifying this change

This change added tests and can be verified as follows:
  - *Added tests to `RestServerEndpointITCase`*
  - *Manually verified that client and server limits are respected.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
