### PR TITLE
[FLINK-8917] [Job-Submission] FlinkMiniCluster default createHighAvailabilityServices is not same as ClusterClient

### DIFF
--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/minicluster/FlinkMiniCluster.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/minicluster/FlinkMiniCluster.scala
@@ -127,9 +127,9 @@ abstract class FlinkMiniCluster(
   def this(configuration: Configuration, useSingleActorSystem: Boolean) {
     this(
       configuration,
-      HighAvailabilityServicesUtils.createAvailableOrEmbeddedServices(
-        configuration,
-        ExecutionContext.global),
+      HighAvailabilityServicesUtils.createHighAvailabilityServices(configuration,
+        org.apache.flink.runtime.concurrent.Executors.directExecutor,
+        HighAvailabilityServicesUtils.AddressResolution.TRY_ADDRESS_RESOLUTION),
       useSingleActorSystem)
   }
 

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/minicluster/LocalFlinkMiniCluster.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/minicluster/LocalFlinkMiniCluster.scala
@@ -76,9 +76,10 @@ class LocalFlinkMiniCluster(
   def this(userConfiguration: Configuration, useSingleActorSystem: Boolean) = {
     this(
       userConfiguration,
-       HighAvailabilityServicesUtils.createAvailableOrEmbeddedServices(
+      HighAvailabilityServicesUtils.createHighAvailabilityServices(
          userConfiguration,
-         ExecutionContext.global),
+          org.apache.flink.runtime.concurrent.Executors.directExecutor,
+            HighAvailabilityServicesUtils.AddressResolution.NO_ADDRESS_RESOLUTION),
       useSingleActorSystem)
   }
 


### PR DESCRIPTION
## What is the purpose of the change

the FlinkMiniCluster used
HighAvailabilityServicesUtils.createAvailableOrEmbeddedServices to create highAvailabilityServices，so the FlinkMiniCluster's  highAvailabilityServices is EmbeddedHaServices when highAvailabilityMode is none; RemoteStreamEnvironment use b ClusterClient to submit a job, and ClusterClient used 
`ClusterClient client;
		try {
			client = new StandaloneClusterClient(configuration);
			client.setPrintStatusDuringExecution(getConfig().isSysoutLoggingEnabled());
		}
		catch (Exception e) {
			throw new ProgramInvocationException("Cannot establish connection to JobManager: " + e.getMessage(), e);
		}`
HighAvailabilityServicesUtils.createHighAvailabilityServices to create highAvailabilityServices，so the ClusterClient's highAvailabilityServices is StandaloneHaServices when the highAvailabilityMode is none;  The two highAvailabilityServicess are different, if you use the flink-1.4 in zeppelin，the zeppelin use FlinkMiniCluster to start jobmanager, use RemoteStreamEnvironment to submit stream job, so the job submission will be failed with the follow msg:

Discard message LeaderSessionMessage(00000000-0000-0000-0000-000000000000,SubmitJob(JobGraph(jobId: 33d8e7d74aa48f76a1622d4d8f78105e),EXECUTION_RESULT_AND_STATE_CHANGES)) because the expected leader session ID 87efb7ca-b761-4977-9696-d521bc178703 did not equal the received leader session ID 00000000-0000-0000-0000-000000000000.

so this pull request will to change the FlinkMiniCluster use HighAvailabilityServicesUtils.createHighAvailabilityServices to create StandaloneHaServices as same as the ClusterClient created
## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.

This change is already covered by existing tests, such as LocalFlinkMiniClusterITCase.

## Does this pull request potentially affect one of the following parts:

   - Dependencies (does it add or upgrade a dependency):no 
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers:  don't know
  - The runtime per-record code paths (performance sensitive):  don't know
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector:no

## Documentation
  - Does this pull request introduce a new feature? no