### PR TITLE
[FLINK-8934] [flip6] Properly cancel slot requests of otherwisely fulfilled requests

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
@@ -691,7 +691,7 @@ public class SlotPool extends RpcEndpoint implements SlotPoolGateway, AllocatedS
 
 		pendingRequest.getAllocatedSlotFuture().whenComplete(
 			(AllocatedSlot allocatedSlot, Throwable throwable) -> {
-				if (throwable != null || allocationId.equals(allocatedSlot.getAllocationId())) {
+				if (throwable != null || !allocationId.equals(allocatedSlot.getAllocationId())) {
 					// cancel the slot request if there is a failure or if the pending request has
 					// been completed with another allocated slot
 					resourceManagerGateway.cancelSlotRequest(allocationId);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolTest.java
@@ -457,16 +457,21 @@ public class SlotPoolTest extends TestLogger {
 	 * Tests that unused offered slots are directly used to fulfill pending slot
 	 * requests.
 	 *
-	 * <p>See FLINK-8089
+	 * Moreover it tests that the old slot request is canceled
+	 *
+	 * <p>See FLINK-8089, FLINK-8934
 	 */
 	@Test
 	public void testFulfillingSlotRequestsWithUnusedOfferedSlots() throws Exception {
 		final SlotPool slotPool = new SlotPool(rpcService, jobId);
 
-		final CompletableFuture<AllocationID> allocationIdFuture = new CompletableFuture<>();
+		final ArrayBlockingQueue<AllocationID> allocationIds = new ArrayBlockingQueue<>(2);
 
 		resourceManagerGateway.setRequestSlotConsumer(
-			(SlotRequest slotRequest) -> allocationIdFuture.complete(slotRequest.getAllocationId()));
+			(SlotRequest slotRequest) -> allocationIds.offer(slotRequest.getAllocationId()));
+
+		final ArrayBlockingQueue<AllocationID> canceledSlotRequests = new ArrayBlockingQueue<>(2);
+		resourceManagerGateway.setCancelSlotConsumer(canceledSlotRequests::offer);
 
 		final SlotRequestId slotRequestId1 = new SlotRequestId();
 		final SlotRequestId slotRequestId2 = new SlotRequestId();
@@ -487,7 +492,7 @@ public class SlotPoolTest extends TestLogger {
 				timeout);
 
 			// wait for the first slot request
-			final AllocationID allocationId = allocationIdFuture.get();
+			final AllocationID allocationId1 = allocationIds.take();
 
 			CompletableFuture<LogicalSlot> slotFuture2 = slotPoolGateway.allocateSlot(
 				slotRequestId2,
@@ -495,6 +500,9 @@ public class SlotPoolTest extends TestLogger {
 				SlotProfile.noRequirements(),
 				true,
 				timeout);
+
+			// wait for the second slot request
+			final AllocationID allocationId2 = allocationIds.take();
 
 			slotPoolGateway.releaseSlot(slotRequestId1, null, null);
 
@@ -505,17 +513,21 @@ public class SlotPoolTest extends TestLogger {
 			} catch (ExecutionException ee) {
 				// expected
 				assertTrue(ExceptionUtils.stripExecutionException(ee) instanceof FlinkException);
-
 			}
 
-			final SlotOffer slotOffer = new SlotOffer(allocationId, 0, ResourceProfile.UNKNOWN);
+			assertEquals(allocationId1, canceledSlotRequests.take());
+
+			final SlotOffer slotOffer = new SlotOffer(allocationId1, 0, ResourceProfile.UNKNOWN);
 
 			slotPoolGateway.registerTaskManager(taskManagerLocation.getResourceID()).get();
 
 			assertTrue(slotPoolGateway.offerSlot(taskManagerLocation, taskManagerGateway, slotOffer).get());
 
 			// the slot offer should fulfill the second slot request
-			assertEquals(allocationId, slotFuture2.get().getAllocationId());
+			assertEquals(allocationId1, slotFuture2.get().getAllocationId());
+
+			// check that the second slot request has been canceled
+			assertEquals(allocationId2, canceledSlotRequests.take());
 		} finally {
 			RpcUtils.terminateRpcEndpoint(slotPool, timeout);
 		}


### PR DESCRIPTION
## What is the purpose of the change

Cancel slot requests at the ResourceManager if they have been completed with a different
allocation.

cc @zentol 

## Verifying this change

- Adapted `SlotPoolTest#testFulfillingSlotRequestsWithUnusedOfferedSlots` to check cancellation

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
