### PR TITLE
[FLINK-8938] [runtime] not remove job graph during job master failover

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -280,7 +280,9 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 				try {
 					// We should only remove a job from the submitted job graph store
 					// if the initial submission failed. Never in case of a recovery
-					submittedJobGraphStore.removeJobGraph(jobId);
+					if (!RunningJobsRegistry.JobSchedulingStatus.RUNNING.equals(jobSchedulingStatus)) {
+						submittedJobGraphStore.removeJobGraph(jobId);
+					}
 				} catch (Throwable t) {
 					log.warn("Cannot remove job graph from submitted job graph store.", t);
 					e.addSuppressed(t);


### PR DESCRIPTION

## What is the purpose of the change

*This pull request fix a bug that when job master failover, it may delete the job graph, so the next job master can not recover the job any more.*


## Verifying this change

*(Please pick either of the following options)*

This change is tested manually.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
