### PR TITLE
[FLINK-8704][tests] Port SlotCountExceedingParallelismTest

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/LegacySlotCountExceedingParallelismTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/LegacySlotCountExceedingParallelismTest.java
@@ -18,8 +18,6 @@
 
 package org.apache.flink.runtime.jobmanager;
 
-import org.apache.flink.configuration.AkkaOptions;
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.io.network.api.reader.RecordReader;
@@ -29,22 +27,18 @@ import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
-import org.apache.flink.runtime.minicluster.MiniCluster;
-import org.apache.flink.runtime.minicluster.MiniClusterConfiguration;
+import org.apache.flink.runtime.testingUtils.TestingCluster;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
-import org.apache.flink.testutils.category.Flip6;
 import org.apache.flink.types.IntValue;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 
 import java.util.BitSet;
 
-@Category(Flip6.class)
-public class SlotCountExceedingParallelismTest extends TestLogger {
+public class LegacySlotCountExceedingParallelismTest extends TestLogger {
 
 	// Test configuration
 	private static final int NUMBER_OF_TMS = 2;
@@ -53,28 +47,20 @@ public class SlotCountExceedingParallelismTest extends TestLogger {
 
 	public static final String JOB_NAME = "SlotCountExceedingParallelismTest (no slot sharing, blocking results)";
 
-	private static MiniCluster flink;
+	private static TestingCluster flink;
 
 	@BeforeClass
 	public static void setUp() throws Exception {
-		final Configuration config = new Configuration();
-		config.setString(AkkaOptions.ASK_TIMEOUT, TestingUtils.DEFAULT_AKKA_ASK_TIMEOUT());
-
-		final MiniClusterConfiguration miniClusterConfiguration = new MiniClusterConfiguration.Builder()
-			.setConfiguration(config)
-			.setNumTaskManagers(NUMBER_OF_TMS)
-			.setNumSlotsPerTaskManager(NUMBER_OF_SLOTS_PER_TM)
-			.build();
-
-		flink = new MiniCluster(miniClusterConfiguration);
-
-		flink.start();
+		flink = TestingUtils.startTestingCluster(
+				NUMBER_OF_SLOTS_PER_TM,
+				NUMBER_OF_TMS,
+				TestingUtils.DEFAULT_AKKA_ASK_TIMEOUT());
 	}
 
 	@AfterClass
 	public static void tearDown() throws Exception {
 		if (flink != null) {
-			flink.close();
+			flink.stop();
 		}
 	}
 
@@ -101,8 +87,8 @@ public class SlotCountExceedingParallelismTest extends TestLogger {
 
 	// ---------------------------------------------------------------------------------------------
 
-	private void submitJobGraphAndWait(final JobGraph jobGraph) throws JobExecutionException, InterruptedException {
-		flink.executeJobBlocking(jobGraph);
+	private void submitJobGraphAndWait(final JobGraph jobGraph) throws JobExecutionException {
+		flink.submitJobAndWait(jobGraph, false, TestingUtils.TESTING_DURATION());
 	}
 
 	private JobGraph createTestJobGraph(


### PR DESCRIPTION
## What is the purpose of the change

This PR ports the `SlotCountExceedingParallelismTest` to flip6. The existing test was renamed to `LegacySlotCountExceedingParallelismTest`, and a ported copy was added.
