### PR TITLE
[FLINK-8945] [kinesis] Allow customization of KinesisProxy

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxy.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxy.java
@@ -122,7 +122,7 @@ public class KinesisProxy implements KinesisProxyInterface {
 	 *
 	 * @param configProps configuration properties containing AWS credential and AWS region info
 	 */
-	private KinesisProxy(Properties configProps) {
+	protected KinesisProxy(Properties configProps) {
 		checkNotNull(configProps);
 
 		this.kinesisClient = AWSUtil.createKinesisClient(configProps);


### PR DESCRIPTION
## What is the purpose of the change
Allow customization of KinesisProxy. In this case we want to override just the getShardList implementation to use ListShards instead of DescribeStreams.

## Brief change log
  - Changed the constructor from private to protected for KinesisProxy

## Verifying this change
This change is a trivial rework / code cleanup without any test coverage.
Also verified with mvn clean verify. 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
