### PR TITLE
[FLINK-8703][tests] Port SavepointMigrationTestBase to MiniClusterResource

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatListener.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatListener.java
@@ -57,7 +57,8 @@ public interface HeartbeatListener<I, O> {
 	 * Retrieves the payload value for the next heartbeat message. Since the operation can happen
 	 * asynchronously, the result is returned wrapped in a future.
 	 *
+	 * @param resourceID Resource ID identifying the receiver of the payload
 	 * @return Future containing the next payload for heartbeats
 	 */
-	CompletableFuture<O> retrievePayload();
+	CompletableFuture<O> retrievePayload(ResourceID resourceID);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerImpl.java
@@ -27,6 +27,7 @@ import org.slf4j.Logger;
 import javax.annotation.concurrent.ThreadSafe;
 
 import java.util.Collection;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
@@ -106,8 +107,8 @@ public class HeartbeatManagerImpl<I, O> implements HeartbeatManager<I, O> {
 		return heartbeatListener;
 	}
 
-	Collection<HeartbeatManagerImpl.HeartbeatMonitor<O>> getHeartbeatTargets() {
-		return heartbeatTargets.values();
+	Collection<Map.Entry<ResourceID, HeartbeatMonitor<O>>> getHeartbeatTargets() {
+		return heartbeatTargets.entrySet();
 	}
 
 	//----------------------------------------------------------------------------------------------
@@ -202,7 +203,7 @@ public class HeartbeatManagerImpl<I, O> implements HeartbeatManager<I, O> {
 					heartbeatListener.reportPayload(requestOrigin, heartbeatPayload);
 				}
 
-				CompletableFuture<O> futurePayload = heartbeatListener.retrievePayload();
+				CompletableFuture<O> futurePayload = heartbeatListener.retrievePayload(requestOrigin);
 
 				if (futurePayload != null) {
 					CompletableFuture<Void> sendHeartbeatFuture = futurePayload.thenAcceptAsync(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerSenderImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerSenderImpl.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 
 import org.slf4j.Logger;
 
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledFuture;
@@ -62,9 +63,9 @@ public class HeartbeatManagerSenderImpl<I, O> extends HeartbeatManagerImpl<I, O>
 	public void run() {
 		if (!stopped) {
 			log.debug("Trigger heartbeat request.");
-			for (HeartbeatMonitor<O> heartbeatMonitor : getHeartbeatTargets()) {
-				CompletableFuture<O> futurePayload = getHeartbeatListener().retrievePayload();
-				final HeartbeatTarget<O> heartbeatTarget = heartbeatMonitor.getHeartbeatTarget();
+			for (Map.Entry<ResourceID, HeartbeatMonitor<O>> heartbeatTargetEntry : getHeartbeatTargets()) {
+				CompletableFuture<O> futurePayload = getHeartbeatListener().retrievePayload(heartbeatTargetEntry.getKey());
+				final HeartbeatTarget<O> heartbeatTarget = heartbeatTargetEntry.getValue().getHeartbeatTarget();
 
 				if (futurePayload != null) {
 					CompletableFuture<Void> requestHeartbeatFuture = futurePayload.thenAcceptAsync(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -1527,7 +1527,7 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 		}
 
 		@Override
-		public CompletableFuture<Void> retrievePayload() {
+		public CompletableFuture<Void> retrievePayload(ResourceID resourceID) {
 			return CompletableFuture.completedFuture(null);
 		}
 	}
@@ -1551,7 +1551,7 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 		}
 
 		@Override
-		public CompletableFuture<Void> retrievePayload() {
+		public CompletableFuture<Void> retrievePayload(ResourceID resourceID) {
 			return CompletableFuture.completedFuture(null);
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -1525,7 +1525,7 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 
 		@Override
 		public void reportPayload(ResourceID resourceID, AccumulatorReport payload) {
-			for (AccumulatorSnapshot snapshot : payload) {
+			for (AccumulatorSnapshot snapshot : payload.getAccumulatorSnapshots()) {
 				executionGraph.updateAccumulators(snapshot);
 			}
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -27,6 +27,7 @@ import org.apache.flink.core.io.InputSplitAssigner;
 import org.apache.flink.queryablestate.KvStateID;
 import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.StoppingException;
+import org.apache.flink.runtime.accumulators.AccumulatorSnapshot;
 import org.apache.flink.runtime.blob.BlobServer;
 import org.apache.flink.runtime.checkpoint.CheckpointCoordinator;
 import org.apache.flink.runtime.checkpoint.CheckpointDeclineReason;
@@ -93,6 +94,7 @@ import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.RpcTimeout;
 import org.apache.flink.runtime.rpc.akka.AkkaRpcServiceUtils;
 import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.taskexecutor.AccumulatorReport;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
 import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
@@ -166,7 +168,7 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 	private final JobManagerJobMetricGroup jobMetricGroup;
 
 	/** The heartbeat manager with task managers. */
-	private final HeartbeatManager<Void, Void> taskManagerHeartbeatManager;
+	private final HeartbeatManager<AccumulatorReport, Void> taskManagerHeartbeatManager;
 
 	/** The heartbeat manager with resource manager. */
 	private final HeartbeatManager<Void, Void> resourceManagerHeartbeatManager;
@@ -938,8 +940,8 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 	}
 
 	@Override
-	public void heartbeatFromTaskManager(final ResourceID resourceID) {
-		taskManagerHeartbeatManager.receiveHeartbeat(resourceID, null);
+	public void heartbeatFromTaskManager(final ResourceID resourceID, AccumulatorReport accumulatorReport) {
+		taskManagerHeartbeatManager.receiveHeartbeat(resourceID, accumulatorReport);
 	}
 
 	@Override
@@ -1504,7 +1506,7 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 		}
 	}
 
-	private class TaskManagerHeartbeatListener implements HeartbeatListener<Void, Void> {
+	private class TaskManagerHeartbeatListener implements HeartbeatListener<AccumulatorReport, Void> {
 
 		private final JobMasterGateway jobMasterGateway;
 
@@ -1522,8 +1524,10 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 		}
 
 		@Override
-		public void reportPayload(ResourceID resourceID, Void payload) {
-			// nothing to do since there is no payload
+		public void reportPayload(ResourceID resourceID, AccumulatorReport payload) {
+			for (AccumulatorSnapshot snapshot : payload) {
+				executionGraph.updateAccumulators(snapshot);
+			}
 		}
 
 		@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
@@ -40,6 +40,7 @@ import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.OperatorBackPressureStatsResponse;
 import org.apache.flink.runtime.rpc.FencedRpcGateway;
 import org.apache.flink.runtime.rpc.RpcTimeout;
+import org.apache.flink.runtime.taskexecutor.AccumulatorReport;
 import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
@@ -219,8 +220,11 @@ public interface JobMasterGateway extends
 	 * Sends the heartbeat to job manager from task manager.
 	 *
 	 * @param resourceID unique id of the task manager
+	 * @param accumulatorReport report containing accumulator updates
 	 */
-	void heartbeatFromTaskManager(final ResourceID resourceID);
+	void heartbeatFromTaskManager(
+		final ResourceID resourceID,
+		final AccumulatorReport accumulatorReport);
 
 	/**
 	 * Sends heartbeat request from the resource manager.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -1076,7 +1076,7 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 		}
 
 		@Override
-		public CompletableFuture<Void> retrievePayload() {
+		public CompletableFuture<Void> retrievePayload(ResourceID resourceID) {
 			return CompletableFuture.completedFuture(null);
 		}
 	}
@@ -1109,7 +1109,7 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 		}
 
 		@Override
-		public CompletableFuture<Void> retrievePayload() {
+		public CompletableFuture<Void> retrievePayload(ResourceID resourceID) {
 			return CompletableFuture.completedFuture(null);
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/AccumulatorReport.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/AccumulatorReport.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskexecutor;
+
+import org.apache.flink.runtime.accumulators.AccumulatorSnapshot;
+
+import java.io.Serializable;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * A report about the current values of all accumulators of the TaskExecutor for a given job.
+ */
+public class AccumulatorReport implements Serializable, Iterable<AccumulatorSnapshot> {
+	private final List<AccumulatorSnapshot> accumulatorSnapshots;
+
+	public AccumulatorReport(List<AccumulatorSnapshot> accumulatorSnapshots) {
+		this.accumulatorSnapshots = accumulatorSnapshots;
+	}
+
+	@Override
+	public Iterator<AccumulatorSnapshot> iterator() {
+		return accumulatorSnapshots.iterator();
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/AccumulatorReport.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/AccumulatorReport.java
@@ -21,21 +21,20 @@ package org.apache.flink.runtime.taskexecutor;
 import org.apache.flink.runtime.accumulators.AccumulatorSnapshot;
 
 import java.io.Serializable;
-import java.util.Iterator;
+import java.util.Collection;
 import java.util.List;
 
 /**
  * A report about the current values of all accumulators of the TaskExecutor for a given job.
  */
-public class AccumulatorReport implements Serializable, Iterable<AccumulatorSnapshot> {
-	private final List<AccumulatorSnapshot> accumulatorSnapshots;
+public class AccumulatorReport implements Serializable {
+	private final Collection<AccumulatorSnapshot> accumulatorSnapshots;
 
 	public AccumulatorReport(List<AccumulatorSnapshot> accumulatorSnapshots) {
 		this.accumulatorSnapshots = accumulatorSnapshots;
 	}
 
-	@Override
-	public Iterator<AccumulatorSnapshot> iterator() {
-		return accumulatorSnapshots.iterator();
+	public Collection<AccumulatorSnapshot> getAccumulatorSnapshots() {
+		return accumulatorSnapshots;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -1515,7 +1515,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 		}
 
 		@Override
-		public CompletableFuture<Void> retrievePayload() {
+		public CompletableFuture<Void> retrievePayload(ResourceID resourceID) {
 			return CompletableFuture.completedFuture(null);
 		}
 	}
@@ -1544,7 +1544,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 		}
 
 		@Override
-		public CompletableFuture<SlotReport> retrievePayload() {
+		public CompletableFuture<SlotReport> retrievePayload(ResourceID resourceID) {
 			return callAsync(
 					() -> taskSlotTable.createSlotReport(getResourceID()),
 					taskManagerConfiguration.getTimeout());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -107,6 +107,7 @@ import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -138,7 +139,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 	private final TaskManagerConfiguration taskManagerConfiguration;
 
 	/** The heartbeat manager for job manager in the task manager. */
-	private final HeartbeatManager<Void, Void> jobManagerHeartbeatManager;
+	private final HeartbeatManager<Void, AccumulatorReport> jobManagerHeartbeatManager;
 
 	/** The heartbeat manager for resource manager in the task manager. */
 	private final HeartbeatManager<Void, SlotReport> resourceManagerHeartbeatManager;
@@ -1050,14 +1051,14 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 		jobManagerTable.put(jobId, newJobManagerConnection);
 
 		// monitor the job manager as heartbeat target
-		jobManagerHeartbeatManager.monitorTarget(jobManagerResourceID, new HeartbeatTarget<Void>() {
+		jobManagerHeartbeatManager.monitorTarget(jobManagerResourceID, new HeartbeatTarget<AccumulatorReport>() {
 			@Override
-			public void receiveHeartbeat(ResourceID resourceID, Void payload) {
-				jobMasterGateway.heartbeatFromTaskManager(resourceID);
+			public void receiveHeartbeat(ResourceID resourceID, AccumulatorReport payload) {
+				jobMasterGateway.heartbeatFromTaskManager(resourceID, payload);
 			}
 
 			@Override
-			public void requestHeartbeat(ResourceID resourceID, Void payload) {
+			public void requestHeartbeat(ResourceID resourceID, AccumulatorReport payload) {
 				// request heartbeat will never be called on the task manager side
 			}
 		});
@@ -1488,7 +1489,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 		}
 	}
 
-	private class JobManagerHeartbeatListener implements HeartbeatListener<Void, Void> {
+	private class JobManagerHeartbeatListener implements HeartbeatListener<Void, AccumulatorReport> {
 
 		@Override
 		public void notifyHeartbeatTimeout(final ResourceID resourceID) {
@@ -1515,8 +1516,22 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 		}
 
 		@Override
-		public CompletableFuture<Void> retrievePayload(ResourceID resourceID) {
-			return CompletableFuture.completedFuture(null);
+		public CompletableFuture<AccumulatorReport> retrievePayload(ResourceID resourceID) {
+			JobManagerConnection jobManagerConnection = jobManagerConnections.get(resourceID);
+			if (jobManagerConnection != null) {
+				JobID jobId = jobManagerConnection.getJobID();
+
+				List<AccumulatorSnapshot> accumulatorSnapshots = new ArrayList<>(16);
+				Iterator<Task> allTasks = taskSlotTable.getTasks(jobId);
+
+				while (allTasks.hasNext()) {
+					Task task = allTasks.next();
+					accumulatorSnapshots.add(task.getAccumulatorRegistry().getSnapshot());
+				}
+				return CompletableFuture.completedFuture(new AccumulatorReport(accumulatorSnapshots));
+			} else {
+				return CompletableFuture.completedFuture(new AccumulatorReport(Collections.emptyList()));
+			}
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -1517,6 +1517,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 
 		@Override
 		public CompletableFuture<AccumulatorReport> retrievePayload(ResourceID resourceID) {
+			validateRunsInMainThread();
 			JobManagerConnection jobManagerConnection = jobManagerConnections.get(resourceID);
 			if (jobManagerConnection != null) {
 				JobID jobId = jobManagerConnection.getJobID();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.heartbeat;
 
+import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.concurrent.Executors;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
@@ -75,7 +76,7 @@ public class HeartbeatManagerTest extends TestLogger {
 
 		Object expectedObject = new Object();
 
-		when(heartbeatListener.retrievePayload()).thenReturn(CompletableFuture.completedFuture(expectedObject));
+		when(heartbeatListener.retrievePayload(any(ResourceID.class))).thenReturn(CompletableFuture.completedFuture(expectedObject));
 
 		HeartbeatManagerImpl<Object, Object> heartbeatManager = new HeartbeatManagerImpl<>(
 			heartbeatTimeout,
@@ -93,7 +94,7 @@ public class HeartbeatManagerTest extends TestLogger {
 		heartbeatManager.requestHeartbeat(targetResourceID, expectedObject);
 
 		verify(heartbeatListener, times(1)).reportPayload(targetResourceID, expectedObject);
-		verify(heartbeatListener, times(1)).retrievePayload();
+		verify(heartbeatListener, times(1)).retrievePayload(any(ResourceID.class));
 		verify(heartbeatTarget, times(1)).receiveHeartbeat(ownResourceID, expectedObject);
 
 		heartbeatManager.receiveHeartbeat(targetResourceID, expectedObject);
@@ -118,7 +119,7 @@ public class HeartbeatManagerTest extends TestLogger {
 
 		Object expectedObject = new Object();
 
-		when(heartbeatListener.retrievePayload()).thenReturn(CompletableFuture.completedFuture(expectedObject));
+		when(heartbeatListener.retrievePayload(any(ResourceID.class))).thenReturn(CompletableFuture.completedFuture(expectedObject));
 
 		HeartbeatManagerImpl<Object, Object> heartbeatManager = new HeartbeatManagerImpl<>(
 			heartbeatTimeout,
@@ -207,7 +208,7 @@ public class HeartbeatManagerTest extends TestLogger {
 		@SuppressWarnings("unchecked")
 		HeartbeatListener<Object, Object> heartbeatListener = mock(HeartbeatListener.class);
 
-		when(heartbeatListener.retrievePayload()).thenReturn(CompletableFuture.completedFuture(object));
+		when(heartbeatListener.retrievePayload(any(ResourceID.class))).thenReturn(CompletableFuture.completedFuture(object));
 
 		TestingHeartbeatListener heartbeatListener2 = new TestingHeartbeatListener(object2);
 
@@ -347,6 +348,162 @@ public class HeartbeatManagerTest extends TestLogger {
 		}
 	}
 
+	/**
+	 * Tests that the heartbeat target {@link ResourceID} is properly passed to the {@link HeartbeatListener} by the
+	 * {@link HeartbeatManagerImpl}.
+	 */
+	@Test
+	public void testHeartbeatManagerTargetPayload() {
+		final long heartbeatTimeout = 100L;
+
+		final ResourceID someTargetId = ResourceID.generate();
+		final ResourceID specialTargetId = ResourceID.generate();
+		final TargetDependentHeartbeatReceiver someHeartbeatTarget = new TargetDependentHeartbeatReceiver();
+		final TargetDependentHeartbeatReceiver specialHeartbeatTarget = new TargetDependentHeartbeatReceiver();
+
+		final int defaultResponse = 0;
+		final int specialResponse = 1;
+
+		HeartbeatManager<?, Integer> heartbeatManager = new HeartbeatManagerImpl<>(
+			heartbeatTimeout,
+			ResourceID.generate(),
+			new TargetDependentHeartbeatSender(specialTargetId, specialResponse, defaultResponse),
+			Executors.directExecutor(),
+			mock(ScheduledExecutor.class),
+			LOG);
+
+		try {
+			heartbeatManager.monitorTarget(someTargetId, someHeartbeatTarget);
+			heartbeatManager.monitorTarget(specialTargetId, specialHeartbeatTarget);
+
+			heartbeatManager.requestHeartbeat(someTargetId, null);
+			assertEquals(defaultResponse, someHeartbeatTarget.getLastReceivedHeartbeatPayload());
+
+			heartbeatManager.requestHeartbeat(specialTargetId, null);
+			assertEquals(specialResponse, specialHeartbeatTarget.getLastReceivedHeartbeatPayload());
+		} finally {
+			heartbeatManager.stop();
+		}
+	}
+
+	/**
+	 * Tests that the heartbeat target {@link ResourceID} is properly passed to the {@link HeartbeatListener} by the
+	 * {@link HeartbeatManagerSenderImpl}.
+	 */
+	@Test
+	public void testHeartbeatManagerSenderTargetPayload() throws Exception {
+		final long heartbeatTimeout = 100L;
+		final long heartbeatPeriod = 2000L;
+
+		final ScheduledThreadPoolExecutor scheduledThreadPoolExecutor = new ScheduledThreadPoolExecutor(1);
+
+		final ResourceID someTargetId = ResourceID.generate();
+		final ResourceID specialTargetId = ResourceID.generate();
+
+		final OneShotLatch someTargetReceivedLatch = new OneShotLatch();
+		final OneShotLatch specialTargedReceivedLatch = new OneShotLatch();
+
+		final TargetDependentHeartbeatReceiver someHeartbeatTarget = new TargetDependentHeartbeatReceiver(someTargetReceivedLatch);
+		final TargetDependentHeartbeatReceiver specialHeartbeatTarget = new TargetDependentHeartbeatReceiver(specialTargedReceivedLatch);
+
+		final int defaultResponse = 0;
+		final int specialResponse = 1;
+
+		HeartbeatManager<?, Integer> heartbeatManager = new HeartbeatManagerSenderImpl<>(
+			heartbeatPeriod,
+			heartbeatTimeout,
+			ResourceID.generate(),
+			new TargetDependentHeartbeatSender(specialTargetId, specialResponse, defaultResponse),
+			Executors.directExecutor(),
+			new ScheduledExecutorServiceAdapter(scheduledThreadPoolExecutor),
+			LOG);
+
+		try {
+			heartbeatManager.monitorTarget(someTargetId, someHeartbeatTarget);
+			heartbeatManager.monitorTarget(specialTargetId, specialHeartbeatTarget);
+
+			someTargetReceivedLatch.await(5, TimeUnit.SECONDS);
+			specialTargedReceivedLatch.await(5, TimeUnit.SECONDS);
+
+			assertEquals(defaultResponse, someHeartbeatTarget.getLastRequestedHeartbeatPayload());
+			assertEquals(specialResponse, specialHeartbeatTarget.getLastRequestedHeartbeatPayload());
+		} finally {
+			heartbeatManager.stop();
+			scheduledThreadPoolExecutor.shutdown();
+		}
+	}
+
+	/**
+	 * Test {@link HeartbeatTarget} that exposes the last received payload.
+	 */
+	private static class TargetDependentHeartbeatReceiver implements HeartbeatTarget<Integer> {
+
+		private int lastReceivedHeartbeatPayload = -1;
+		private int lastRequestedHeartbeatPayload = -1;
+
+		private final OneShotLatch latch;
+
+		public TargetDependentHeartbeatReceiver() {
+			this(new OneShotLatch());
+		}
+
+		public TargetDependentHeartbeatReceiver(OneShotLatch latch) {
+			this.latch = latch;
+		}
+
+		@Override
+		public void receiveHeartbeat(ResourceID heartbeatOrigin, Integer heartbeatPayload) {
+			this.lastReceivedHeartbeatPayload = heartbeatPayload;
+			latch.trigger();
+		}
+
+		@Override
+		public void requestHeartbeat(ResourceID requestOrigin, Integer heartbeatPayload) {
+			this.lastRequestedHeartbeatPayload = heartbeatPayload;
+			latch.trigger();
+		}
+
+		public int getLastReceivedHeartbeatPayload() {
+			return lastReceivedHeartbeatPayload;
+		}
+
+		public int getLastRequestedHeartbeatPayload() {
+			return lastRequestedHeartbeatPayload;
+		}
+	}
+
+	/**
+	 * Test {@link HeartbeatListener} that returns different payloads based on the target {@link ResourceID}.
+	 */
+	private static class TargetDependentHeartbeatSender implements HeartbeatListener<Object, Integer>  {
+		private final ResourceID specialId;
+		private final int specialResponse;
+		private final int defaultResponse;
+
+		TargetDependentHeartbeatSender(ResourceID specialId, int specialResponse, int defaultResponse) {
+			this.specialId = specialId;
+			this.specialResponse = specialResponse;
+			this.defaultResponse = defaultResponse;
+		}
+
+		@Override
+		public void notifyHeartbeatTimeout(ResourceID resourceID) {
+		}
+
+		@Override
+		public void reportPayload(ResourceID resourceID, Object payload) {
+		}
+
+		@Override
+		public CompletableFuture<Integer> retrievePayload(ResourceID resourceID) {
+			if (resourceID.equals(specialId)) {
+				return CompletableFuture.completedFuture(specialResponse);
+			} else {
+				return CompletableFuture.completedFuture(defaultResponse);
+			}
+		}
+	}
+
 	static class TestingHeartbeatListener implements HeartbeatListener<Object, Object> {
 
 		private final CompletableFuture<ResourceID> future = new CompletableFuture<>();
@@ -378,7 +535,7 @@ public class HeartbeatManagerTest extends TestLogger {
 		}
 
 		@Override
-		public CompletableFuture<Object> retrievePayload() {
+		public CompletableFuture<Object> retrievePayload(ResourceID resourceID) {
 			return CompletableFuture.completedFuture(payload);
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGateway.java
@@ -44,6 +44,7 @@ import org.apache.flink.runtime.registration.RegistrationResponse;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.OperatorBackPressureStatsResponse;
 import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.taskexecutor.AccumulatorReport;
 import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
@@ -130,7 +131,7 @@ public class TestingJobMasterGateway implements JobMasterGateway {
 	}
 
 	@Override
-	public void heartbeatFromTaskManager(ResourceID resourceID) {
+	public void heartbeatFromTaskManager(ResourceID resourceID, AccumulatorReport accumulatorReport) {
 		throw new UnsupportedOperationException();
 	}
 

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/utils/LegacyStatefulJobSavepointMigrationITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/utils/LegacyStatefulJobSavepointMigrationITCase.java
@@ -89,7 +89,7 @@ public class LegacyStatefulJobSavepointMigrationITCase extends SavepointMigratio
 	private final MigrationVersion testMigrateVersion;
 	private final String testStateBackend;
 
-	public LegacyStatefulJobSavepointMigrationITCase(Tuple2<MigrationVersion, String> testMigrateVersionAndBackend) {
+	public LegacyStatefulJobSavepointMigrationITCase(Tuple2<MigrationVersion, String> testMigrateVersionAndBackend) throws Exception {
 		this.testMigrateVersion = testMigrateVersionAndBackend.f0;
 		this.testStateBackend = testMigrateVersionAndBackend.f1;
 	}

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/utils/SavepointMigrationTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/utils/SavepointMigrationTestBase.java
@@ -69,12 +69,7 @@ public abstract class SavepointMigrationTestBase extends TestBaseUtils {
 	public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
 
 	@Rule
-	public final MiniClusterResource miniClusterResource = new MiniClusterResource(
-		new MiniClusterResource.MiniClusterResourceConfiguration(
-			getConfigurationSafe(),
-			1,
-			DEFAULT_PARALLELISM),
-		true);
+	public final MiniClusterResource miniClusterResource;
 
 	private static final Logger LOG = LoggerFactory.getLogger(SavepointMigrationTestBase.class);
 	private static final Deadline DEADLINE = new FiniteDuration(5, TimeUnit.MINUTES).fromNow();
@@ -89,12 +84,13 @@ public abstract class SavepointMigrationTestBase extends TestBaseUtils {
 		return resource.getFile();
 	}
 
-	private Configuration getConfigurationSafe() {
-		try {
-			return getConfiguration();
-		} catch (Exception e) {
-			throw new AssertionError("Could not initialize test.", e);
-		}
+	protected SavepointMigrationTestBase() throws Exception {
+		miniClusterResource = new MiniClusterResource(
+			new MiniClusterResource.MiniClusterResourceConfiguration(
+				getConfiguration(),
+				1,
+				DEFAULT_PARALLELISM),
+			true);
 	}
 
 	private Configuration getConfiguration() throws Exception {

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/utils/SavepointMigrationTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/utils/SavepointMigrationTestBase.java
@@ -21,25 +21,21 @@ package org.apache.flink.test.checkpointing.utils;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobSubmissionResult;
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.client.program.StandaloneClusterClient;
+import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.checkpoint.savepoint.SavepointSerializers;
-import org.apache.flink.runtime.client.JobListeningContext;
-import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
-import org.apache.flink.runtime.messages.JobManagerMessages;
-import org.apache.flink.runtime.minicluster.LocalFlinkMiniCluster;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.test.util.MiniClusterResource;
 import org.apache.flink.test.util.TestBaseUtils;
 
 import org.apache.commons.io.FileUtils;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
@@ -49,34 +45,40 @@ import java.io.File;
 import java.net.URI;
 import java.net.URL;
 import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
-import scala.Option;
-import scala.concurrent.Await;
-import scala.concurrent.Future;
 import scala.concurrent.duration.Deadline;
-import scala.concurrent.duration.Duration;
 import scala.concurrent.duration.FiniteDuration;
 
 import static junit.framework.Assert.fail;
+import static org.junit.Assert.assertNotEquals;
 
 /**
  * Test savepoint migration.
  */
-public class SavepointMigrationTestBase extends TestBaseUtils {
+public abstract class SavepointMigrationTestBase extends TestBaseUtils {
 
 	@BeforeClass
 	public static void before() {
 		SavepointSerializers.setFailWhenLegacyStateDetected(false);
 	}
 
+	@ClassRule
+	public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
+
 	@Rule
-	public TemporaryFolder tempFolder = new TemporaryFolder();
+	public final MiniClusterResource miniClusterResource = new MiniClusterResource(
+		new MiniClusterResource.MiniClusterResourceConfiguration(
+			getConfigurationSafe(),
+			1,
+			DEFAULT_PARALLELISM),
+		true);
 
 	private static final Logger LOG = LoggerFactory.getLogger(SavepointMigrationTestBase.class);
 	private static final Deadline DEADLINE = new FiniteDuration(5, TimeUnit.MINUTES).fromNow();
 	protected static final int DEFAULT_PARALLELISM = 4;
-	protected LocalFlinkMiniCluster cluster = null;
 
 	protected static String getResourceFilename(String filename) {
 		ClassLoader cl = SavepointMigrationTestBase.class.getClassLoader();
@@ -87,17 +89,24 @@ public class SavepointMigrationTestBase extends TestBaseUtils {
 		return resource.getFile();
 	}
 
-	@Before
-	public void setup() throws Exception {
+	private Configuration getConfigurationSafe() {
+		try {
+			return getConfiguration();
+		} catch (Exception e) {
+			throw new AssertionError("Could not initialize test.", e);
+		}
+	}
 
+	private Configuration getConfiguration() throws Exception {
 		// Flink configuration
 		final Configuration config = new Configuration();
 
 		config.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, 1);
 		config.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, DEFAULT_PARALLELISM);
 
-		final File checkpointDir = tempFolder.newFolder("checkpoints").getAbsoluteFile();
-		final File savepointDir = tempFolder.newFolder("savepoints").getAbsoluteFile();
+		UUID id = UUID.randomUUID();
+		final File checkpointDir = TEMP_FOLDER.newFolder("checkpoints_" + id).getAbsoluteFile();
+		final File savepointDir = TEMP_FOLDER.newFolder("savepoints_" + id).getAbsoluteFile();
 
 		if (!checkpointDir.exists() || !savepointDir.exists()) {
 			throw new Exception("Test setup failed: failed to create (temporary) directories.");
@@ -111,12 +120,7 @@ public class SavepointMigrationTestBase extends TestBaseUtils {
 		config.setInteger(CheckpointingOptions.FS_SMALL_FILE_THRESHOLD, 0);
 		config.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir.toURI().toString());
 
-		cluster = TestBaseUtils.startCluster(config, false);
-	}
-
-	@After
-	public void teardown() throws Exception {
-		stopCluster(cluster, TestBaseUtils.DEFAULT_TIMEOUT);
+		return config;
 	}
 
 	@SafeVarargs
@@ -125,22 +129,20 @@ public class SavepointMigrationTestBase extends TestBaseUtils {
 			String savepointPath,
 			Tuple2<String, Integer>... expectedAccumulators) throws Exception {
 
-		// Retrieve the job manager
-		ActorGateway jobManager = Await.result(cluster.leaderGateway().future(), DEADLINE.timeLeft());
+		ClusterClient<?> client = miniClusterResource.getClusterClient();
+		client.setDetached(true);
 
 		// Submit the job
 		JobGraph jobGraph = env.getStreamGraph().getJobGraph();
 
-		JobSubmissionResult jobSubmissionResult = cluster.submitJobDetached(jobGraph);
+		JobSubmissionResult jobSubmissionResult = client.submitJob(jobGraph, SavepointMigrationTestBase.class.getClassLoader());
 
 		LOG.info("Submitted job {} and waiting...", jobSubmissionResult.getJobID());
-
-		StandaloneClusterClient clusterClient = new StandaloneClusterClient(cluster.configuration());
 
 		boolean done = false;
 		while (DEADLINE.hasTimeLeft()) {
 			Thread.sleep(100);
-			Map<String, Object> accumulators = clusterClient.getAccumulators(jobSubmissionResult.getJobID());
+			Map<String, Object> accumulators = client.getAccumulators(jobSubmissionResult.getJobID());
 
 			boolean allDone = true;
 			for (Tuple2<String, Integer> acc : expectedAccumulators) {
@@ -166,18 +168,9 @@ public class SavepointMigrationTestBase extends TestBaseUtils {
 
 		LOG.info("Triggering savepoint.");
 
-		final Future<Object> savepointResultFuture =
-				jobManager.ask(new JobManagerMessages.TriggerSavepoint(jobSubmissionResult.getJobID(), Option.<String>empty()), DEADLINE.timeLeft());
+		CompletableFuture<String> savepointPathFuture = client.triggerSavepoint(jobSubmissionResult.getJobID(), null);
 
-		Object savepointResult = Await.result(savepointResultFuture, DEADLINE.timeLeft());
-
-		if (savepointResult instanceof JobManagerMessages.TriggerSavepointFailure) {
-			fail("Error drawing savepoint: " + ((JobManagerMessages.TriggerSavepointFailure) savepointResult).cause());
-		}
-
-		// jobmanager will store savepoint in heap, we have to retrieve it
-		final String jobmanagerSavepointPath = ((JobManagerMessages.TriggerSavepointSuccess) savepointResult).savepointPath();
-		LOG.info("Saved savepoint: " + jobmanagerSavepointPath);
+		String jobmanagerSavepointPath = savepointPathFuture.get(DEADLINE.timeLeft().toMillis(), TimeUnit.MILLISECONDS);
 
 		File jobManagerSavepoint = new File(new URI(jobmanagerSavepointPath).getPath());
 		// savepoints were changed to be directories in Flink 1.3
@@ -194,18 +187,15 @@ public class SavepointMigrationTestBase extends TestBaseUtils {
 			String savepointPath,
 			Tuple2<String, Integer>... expectedAccumulators) throws Exception {
 
-		// Retrieve the job manager
-		Await.result(cluster.leaderGateway().future(), DEADLINE.timeLeft());
+		ClusterClient<?> client = miniClusterResource.getClusterClient();
+		client.setDetached(true);
 
 		// Submit the job
 		JobGraph jobGraph = env.getStreamGraph().getJobGraph();
 
 		jobGraph.setSavepointRestoreSettings(SavepointRestoreSettings.forPath(savepointPath));
 
-		JobSubmissionResult jobSubmissionResult = cluster.submitJobDetached(jobGraph);
-
-		StandaloneClusterClient clusterClient = new StandaloneClusterClient(cluster.configuration());
-		JobListeningContext jobListeningContext = clusterClient.connectToJob(jobSubmissionResult.getJobID());
+		JobSubmissionResult jobSubmissionResult = client.submitJob(jobGraph, SavepointMigrationTestBase.class.getClassLoader());
 
 		boolean done = false;
 		while (DEADLINE.hasTimeLeft()) {
@@ -213,30 +203,19 @@ public class SavepointMigrationTestBase extends TestBaseUtils {
 			// try and get a job result, this will fail if the job already failed. Use this
 			// to get out of this loop
 			JobID jobId = jobSubmissionResult.getJobID();
-			FiniteDuration timeout = FiniteDuration.apply(5, TimeUnit.SECONDS);
 
 			try {
+				CompletableFuture<JobStatus> jobStatusFuture = client.getJobStatus(jobSubmissionResult.getJobID());
 
-				Future<Object> future = clusterClient
-						.getJobManagerGateway()
-						.ask(JobManagerMessages.getRequestJobStatus(jobSubmissionResult.getJobID()), timeout);
+				JobStatus jobStatus = jobStatusFuture.get(5, TimeUnit.SECONDS);
 
-				Object result = Await.result(future, timeout);
-
-				if (result instanceof JobManagerMessages.CurrentJobStatus) {
-					if (((JobManagerMessages.CurrentJobStatus) result).status() == JobStatus.FAILED) {
-						Object jobResult = Await.result(
-								jobListeningContext.getJobResultFuture(),
-								Duration.apply(5, TimeUnit.SECONDS));
-						fail("Job failed: " + jobResult);
-					}
-				}
+				assertNotEquals(JobStatus.FAILED, jobStatus);
 			} catch (Exception e) {
 				fail("Could not connect to job: " + e);
 			}
 
 			Thread.sleep(100);
-			Map<String, Object> accumulators = clusterClient.getAccumulators(jobId);
+			Map<String, Object> accumulators = client.getAccumulators(jobId);
 
 			boolean allDone = true;
 			for (Tuple2<String, Integer> acc : expectedAccumulators) {

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/utils/StatefulJobSavepointMigrationITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/utils/StatefulJobSavepointMigrationITCase.java
@@ -95,7 +95,7 @@ public class StatefulJobSavepointMigrationITCase extends SavepointMigrationTestB
 	private final MigrationVersion testMigrateVersion;
 	private final String testStateBackend;
 
-	public StatefulJobSavepointMigrationITCase(Tuple2<MigrationVersion, String> testMigrateVersionAndBackend) {
+	public StatefulJobSavepointMigrationITCase(Tuple2<MigrationVersion, String> testMigrateVersionAndBackend) throws Exception {
 		this.testMigrateVersion = testMigrateVersionAndBackend.f0;
 		this.testStateBackend = testMigrateVersionAndBackend.f1;
 	}


### PR DESCRIPTION
Based on #5699.

## What is the purpose of the change

With this PR accumulator updates are sent via heartbeats from the TaskManager to JobManagers.
The SavepointMigrationTestBase was also ported to flip6, serving as preliminary verification until the other accumulator tests are ported.

## Verifying this change

*(Please pick either of the following options)*

This change added tests and can be verified as follows:

* run SavepointMigrationTestBase

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
