### PR TITLE
[FLINK-8915] CheckpointingStatisticsHandler fails to return PendingCheckpointStats

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/CheckpointStatistics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/CheckpointStatistics.java
@@ -51,7 +51,8 @@ import java.util.Objects;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "@class")
 @JsonSubTypes({
 	@JsonSubTypes.Type(value = CheckpointStatistics.CompletedCheckpointStatistics.class, name = "completed"),
-	@JsonSubTypes.Type(value = CheckpointStatistics.FailedCheckpointStatistics.class, name = "failed")})
+	@JsonSubTypes.Type(value = CheckpointStatistics.FailedCheckpointStatistics.class, name = "failed"),
+	@JsonSubTypes.Type(value = CheckpointStatistics.PendingCheckpointStatistics.class, name = "in_progress")})
 public class CheckpointStatistics implements ResponseBody {
 
 	public static final String FIELD_NAME_ID = "id";
@@ -273,7 +274,7 @@ public class CheckpointStatistics implements ResponseBody {
 				checkpointStatisticsPerTask,
 				failedCheckpointStats.getFailureTimestamp(),
 				failedCheckpointStats.getFailureMessage());
-		} else {
+		} else if (checkpointStats instanceof PendingCheckpointStats) {
 			final PendingCheckpointStats pendingCheckpointStats = ((PendingCheckpointStats) checkpointStats);
 
 			return new CheckpointStatistics.PendingCheckpointStatistics(
@@ -289,6 +290,9 @@ public class CheckpointStatistics implements ResponseBody {
 				pendingCheckpointStats.getNumberOfAcknowledgedSubtasks(),
 				checkpointStatisticsPerTask
 			);
+		} else {
+			throw new IllegalArgumentException("Given checkpoint stats object of type "
+				+ checkpointStats.getClass().getName() + " cannot be converted.");
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/checkpoints/CheckpointingStatisticsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/checkpoints/CheckpointingStatisticsTest.java
@@ -122,6 +122,20 @@ public class CheckpointingStatisticsTest extends RestResponseMarshallingTestBase
 			true,
 			"foobar");
 
+		CheckpointStatistics.PendingCheckpointStatistics pending = new CheckpointStatistics.PendingCheckpointStatistics(
+			5L,
+			CheckpointStatsStatus.IN_PROGRESS,
+			false,
+			42L,
+			41L,
+			1337L,
+			1L,
+			0L,
+			10,
+			10,
+			Collections.emptyMap()
+		);
+
 		final CheckpointingStatistics.LatestCheckpoints latestCheckpoints = new CheckpointingStatistics.LatestCheckpoints(
 			completed,
 			savepoint,
@@ -132,6 +146,6 @@ public class CheckpointingStatisticsTest extends RestResponseMarshallingTestBase
 			counts,
 			summary,
 			latestCheckpoints,
-			Arrays.asList(completed, savepoint, failed));
+			Arrays.asList(completed, savepoint, failed, pending));
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

*This pull request fixed a issue : CheckpointingStatisticsHandler fails to return PendingCheckpointStats*


## Brief change log

  - *defined a new static inner class named `PendingCheckpointStatistics`*
  - *replaced the pre-process logic (throw a exception ) by return the instance of `PendingCheckpointStatistics`*


## Verifying this change

This change is already covered by existing tests, such as *`CheckpointingStatisticsTest`*.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
