### PR TITLE
[FLINK-8852] [sql-client] Add FLIP-6 support to SQL Client

### DIFF
--- a/flink-clients/pom.xml
+++ b/flink-clients/pom.xml
@@ -147,6 +147,18 @@ under the License.
 					</execution>
 				</executions>
 			</plugin>
+			<!-- Make test classes available to other modules. -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>test-jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 		
 		<pluginManagement>

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
@@ -420,7 +420,7 @@ public class CliFrontendParser {
 	 * @param optionsB options to merge, can be null if none
 	 * @return
 	 */
-	static Options mergeOptions(@Nullable Options optionsA, @Nullable Options optionsB) {
+	public static Options mergeOptions(@Nullable Options optionsA, @Nullable Options optionsB) {
 		final Options resultOptions = new Options();
 		if (optionsA != null) {
 			for (Option option : optionsA.getOptions()) {

--- a/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
@@ -460,7 +460,7 @@ public abstract class ClusterClient<T> {
 	public JobSubmissionResult run(FlinkPlan compiledPlan,
 			List<URL> libraries, List<URL> classpaths, ClassLoader classLoader, SavepointRestoreSettings savepointSettings)
 			throws ProgramInvocationException {
-		JobGraph job = getJobGraph(compiledPlan, libraries, classpaths, savepointSettings);
+		JobGraph job = getJobGraph(flinkConfig, compiledPlan, libraries, classpaths, savepointSettings);
 		return submitJob(job, classLoader);
 	}
 
@@ -882,17 +882,17 @@ public abstract class ClusterClient<T> {
 		return getOptimizedPlan(compiler, prog.getPlan(), parallelism);
 	}
 
-	public JobGraph getJobGraph(PackagedProgram prog, FlinkPlan optPlan, SavepointRestoreSettings savepointSettings) throws ProgramInvocationException {
-		return getJobGraph(optPlan, prog.getAllLibraries(), prog.getClasspaths(), savepointSettings);
+	public static JobGraph getJobGraph(Configuration flinkConfig, PackagedProgram prog, FlinkPlan optPlan, SavepointRestoreSettings savepointSettings) throws ProgramInvocationException {
+		return getJobGraph(flinkConfig, optPlan, prog.getAllLibraries(), prog.getClasspaths(), savepointSettings);
 	}
 
-	public JobGraph getJobGraph(FlinkPlan optPlan, List<URL> jarFiles, List<URL> classpaths, SavepointRestoreSettings savepointSettings) {
+	public static JobGraph getJobGraph(Configuration flinkConfig, FlinkPlan optPlan, List<URL> jarFiles, List<URL> classpaths, SavepointRestoreSettings savepointSettings) {
 		JobGraph job;
 		if (optPlan instanceof StreamingPlan) {
 			job = ((StreamingPlan) optPlan).getJobGraph();
 			job.setSavepointRestoreSettings(savepointSettings);
 		} else {
-			JobGraphGenerator gen = new JobGraphGenerator(this.flinkConfig);
+			JobGraphGenerator gen = new JobGraphGenerator(flinkConfig);
 			job = gen.compileJobGraph((OptimizedPlan) optPlan);
 		}
 

--- a/flink-libraries/flink-sql-client/conf/sql-client-defaults.yaml
+++ b/flink-libraries/flink-sql-client/conf/sql-client-defaults.yaml
@@ -64,8 +64,6 @@ execution:
 # programs are submitted to.
 
 deployment:
-  # only the 'standalone' deployment is supported
-  type: standalone
   # general cluster communication timeout in ms
   response-timeout: 5000
   # (optional) address from cluster to gateway

--- a/flink-libraries/flink-sql-client/pom.xml
+++ b/flink-libraries/flink-sql-client/pom.xml
@@ -129,6 +129,15 @@ under the License.
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<!-- use a dedicated Scala version to not depend on it -->
+			<artifactId>flink-clients_2.11</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/SqlClientException.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/SqlClientException.java
@@ -32,4 +32,8 @@ public class SqlClientException extends RuntimeException {
 	public SqlClientException(String message, Throwable e) {
 		super(message, e);
 	}
+
+	public SqlClientException(Throwable e) {
+		super(e);
+	}
 }

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ChangelogCollectStreamResult.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ChangelogCollectStreamResult.java
@@ -30,8 +30,10 @@ import java.util.List;
 
 /**
  * Collects results and returns them as a changelog.
+ *
+ * @param <C> cluster id to which this result belongs to
  */
-public class ChangelogCollectStreamResult extends CollectStreamResult implements ChangelogResult {
+public class ChangelogCollectStreamResult<C> extends CollectStreamResult<C> implements ChangelogResult<C> {
 
 	private List<Tuple2<Boolean, Row>> changeRecordBuffer;
 	private static final int CHANGE_RECORD_BUFFER_SIZE = 5_000;

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ChangelogResult.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ChangelogResult.java
@@ -26,8 +26,10 @@ import java.util.List;
 
 /**
  * A result that is represented as a changelog consisting of insert and delete records.
+ *
+ * @param <C> cluster id to which this result belongs to
  */
-public interface ChangelogResult extends DynamicResult {
+public interface ChangelogResult<C> extends DynamicResult<C> {
 
 	/**
 	 * Retrieves the available result records.

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/CollectStreamResult.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/CollectStreamResult.java
@@ -37,8 +37,10 @@ import java.net.InetAddress;
 
 /**
  * A result that works similarly to {@link DataStreamUtils#collect(DataStream)}.
+ *
+ * @param <C> cluster id to which this result belongs to
  */
-public abstract class CollectStreamResult implements DynamicResult {
+public abstract class CollectStreamResult<C> implements DynamicResult<C> {
 
 	private final TypeInformation<Row> outputType;
 	private final SocketStreamIterator<Tuple2<Boolean, Row>> iterator;
@@ -46,6 +48,7 @@ public abstract class CollectStreamResult implements DynamicResult {
 	private final ResultRetrievalThread retrievalThread;
 	private final JobMonitoringThread monitoringThread;
 	private Runnable program;
+	private C clusterId;
 
 	protected final Object resultLock;
 	protected SqlExecutionException executionException;
@@ -71,6 +74,14 @@ public abstract class CollectStreamResult implements DynamicResult {
 		collectTableSink = new CollectStreamTableSink(iterator.getBindAddress(), iterator.getPort(), serializer);
 		retrievalThread = new ResultRetrievalThread();
 		monitoringThread = new JobMonitoringThread();
+	}
+
+	@Override
+	public void setClusterId(C clusterId) {
+		if (this.clusterId != null) {
+			throw new IllegalStateException("Cluster id is already present.");
+		}
+		this.clusterId = clusterId;
 	}
 
 	@Override

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/DynamicResult.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/DynamicResult.java
@@ -26,8 +26,15 @@ import org.apache.flink.types.Row;
  * A result of a dynamic table program.
  *
  * <p>Note: Make sure to call close() after the result is not needed anymore.
+ *
+ * @param <C> cluster id to which this result belongs to
  */
-public interface DynamicResult {
+public interface DynamicResult<C> {
+
+	/**
+	 * Sets the cluster id of the cluster this result comes from. This method should only be called once.
+	 */
+	void setClusterId(C clusterId);
 
 	/**
 	 * Returns whether this result is materialized such that snapshots can be taken or results

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
@@ -22,6 +22,11 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.client.cli.CliArgsException;
+import org.apache.flink.client.cli.CustomCommandLine;
+import org.apache.flink.client.cli.RunOptions;
+import org.apache.flink.client.deployment.ClusterDescriptor;
+import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.optimizer.DataStatistics;
@@ -29,48 +34,56 @@ import org.apache.flink.optimizer.Optimizer;
 import org.apache.flink.optimizer.costs.DefaultCostEstimator;
 import org.apache.flink.optimizer.plan.FlinkPlan;
 import org.apache.flink.runtime.execution.librarycache.FlinkUserCodeClassLoaders;
+import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.graph.StreamGraph;
 import org.apache.flink.table.api.BatchQueryConfig;
 import org.apache.flink.table.api.QueryConfig;
 import org.apache.flink.table.api.StreamQueryConfig;
 import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.client.config.Deployment;
 import org.apache.flink.table.client.config.Environment;
 import org.apache.flink.table.client.gateway.SessionContext;
+import org.apache.flink.table.client.gateway.SqlExecutionException;
 import org.apache.flink.table.sources.TableSource;
 import org.apache.flink.table.sources.TableSourceFactoryService;
+import org.apache.flink.util.FlinkException;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Options;
 
 import java.net.URL;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
- * Context for executing table programs. It contains configured environments and environment
- * specific logic such as plan translation.
+ * Context for executing table programs. This class caches everything that can be cached across
+ * multiple queries as long as the session context does not change. This must be thread-safe as
+ * it might be reused across different query submission.
+ *
+ * @param <T> cluster id
  */
-public class ExecutionContext {
+public class ExecutionContext<T> {
 
 	private final SessionContext sessionContext;
 	private final Environment mergedEnv;
-	private final ExecutionEnvironment execEnv;
-	private final StreamExecutionEnvironment streamExecEnv;
-	private final TableEnvironment tableEnv;
+	private final List<URL> dependencies;
 	private final ClassLoader classLoader;
-	private final QueryConfig queryConfig;
+	private final Map<String, TableSource<?>> tableSources;
+	private final Configuration flinkConfig;
+	private final CommandLine commandLine;
+	private final CustomCommandLine<T> activeCommandLine;
+	private final RunOptions runOptions;
+	private final T clusterId;
+	private final ClusterSpecification clusterSpec;
 
-	public ExecutionContext(Environment defaultEnvironment, SessionContext sessionContext, List<URL> dependencies) {
+	public ExecutionContext(Environment defaultEnvironment, SessionContext sessionContext, List<URL> dependencies,
+			Configuration flinkConfig, Options commandLineOptions, List<CustomCommandLine<?>> availableCommandLines) {
 		this.sessionContext = sessionContext;
 		this.mergedEnv = Environment.merge(defaultEnvironment, sessionContext.getEnvironment());
-
-		// create environments
-		if (mergedEnv.getExecution().isStreamingExecution()) {
-			streamExecEnv = createStreamExecutionEnvironment();
-			execEnv = null;
-			tableEnv = TableEnvironment.getTableEnvironment(streamExecEnv);
-		} else {
-			streamExecEnv = null;
-			execEnv = createExecutionEnvironment();
-			tableEnv = TableEnvironment.getTableEnvironment(execEnv);
-		}
+		this.dependencies = dependencies;
+		this.flinkConfig = flinkConfig;
 
 		// create class loader
 		classLoader = FlinkUserCodeClassLoaders.parentFirst(
@@ -78,29 +91,22 @@ public class ExecutionContext {
 			this.getClass().getClassLoader());
 
 		// create table sources
+		tableSources = new HashMap<>();
 		mergedEnv.getSources().forEach((name, source) -> {
-			TableSource<?> tableSource = TableSourceFactoryService.findAndCreateTableSource(source, classLoader);
-			tableEnv.registerTableSource(name, tableSource);
+			final TableSource<?> tableSource = TableSourceFactoryService.findAndCreateTableSource(source, classLoader);
+			tableSources.put(name, tableSource);
 		});
 
-		// create query config
-		queryConfig = createQueryConfig();
+		// convert deployment options into command line options that describe a cluster
+		commandLine = createCommandLine(mergedEnv.getDeployment(), commandLineOptions);
+		activeCommandLine = findActiveCommandLine(availableCommandLines, commandLine);
+		runOptions = createRunOptions(commandLine);
+		clusterId = activeCommandLine.getClusterId(commandLine);
+		clusterSpec = createClusterSpecification(activeCommandLine, commandLine);
 	}
 
 	public SessionContext getSessionContext() {
 		return sessionContext;
-	}
-
-	public ExecutionEnvironment getExecutionEnvironment() {
-		return execEnv;
-	}
-
-	public StreamExecutionEnvironment getStreamExecutionEnvironment() {
-		return streamExecEnv;
-	}
-
-	public TableEnvironment getTableEnvironment() {
-		return tableEnv;
 	}
 
 	public ClassLoader getClassLoader() {
@@ -111,57 +117,163 @@ public class ExecutionContext {
 		return mergedEnv;
 	}
 
-	public QueryConfig getQueryConfig() {
-		return queryConfig;
+	public ClusterSpecification getClusterSpec() {
+		return clusterSpec;
 	}
 
-	public ExecutionConfig getExecutionConfig() {
-		if (streamExecEnv != null) {
-			return streamExecEnv.getConfig();
-		} else {
-			return execEnv.getConfig();
+	public T getClusterId() {
+		return clusterId;
+	}
+
+	public ClusterDescriptor<T> createClusterDescriptor() throws Exception {
+		return activeCommandLine.createClusterDescriptor(commandLine);
+	}
+
+	public EnvironmentInstance createEnvironmentInstance() {
+		return new EnvironmentInstance();
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	private static CommandLine createCommandLine(Deployment deployment, Options commandLineOptions) {
+		try {
+			return deployment.getCommandLine(commandLineOptions);
+		} catch (Exception e) {
+			throw new SqlExecutionException("Invalid deployment options.", e);
 		}
 	}
 
-	public FlinkPlan createPlan(String name, Configuration flinkConfig) {
-		if (streamExecEnv != null) {
-			final StreamGraph graph = streamExecEnv.getStreamGraph();
-			graph.setJobName(name);
-			return graph;
-		} else {
-			final int parallelism = execEnv.getParallelism();
-			final Plan unoptimizedPlan = execEnv.createProgramPlan();
-			unoptimizedPlan.setJobName(name);
-			final Optimizer compiler = new Optimizer(new DataStatistics(), new DefaultCostEstimator(), flinkConfig);
-			return ClusterClient.getOptimizedPlan(compiler, unoptimizedPlan, parallelism);
+	@SuppressWarnings("unchecked")
+	private static <T> CustomCommandLine<T> findActiveCommandLine(List<CustomCommandLine<?>> availableCommandLines, CommandLine commandLine) {
+		for (CustomCommandLine<?> cli : availableCommandLines) {
+			if (cli.isActive(commandLine)) {
+				return (CustomCommandLine<T>) cli;
+			}
+		}
+		throw new SqlExecutionException("Could not find a matching deployment.");
+	}
+
+	private static RunOptions createRunOptions(CommandLine commandLine) {
+		try {
+			return new RunOptions(commandLine);
+		} catch (CliArgsException e) {
+			throw new SqlExecutionException("Invalid deployment run options.", e);
+		}
+	}
+
+	private static ClusterSpecification createClusterSpecification(CustomCommandLine<?> activeCommandLine, CommandLine commandLine) {
+		try {
+			return activeCommandLine.getClusterSpecification(commandLine);
+		} catch (FlinkException e) {
+			throw new SqlExecutionException("Could not create cluster specification for the given deployment.", e);
 		}
 	}
 
 	// --------------------------------------------------------------------------------------------
 
-	private ExecutionEnvironment createExecutionEnvironment() {
-		final ExecutionEnvironment execEnv = ExecutionEnvironment.getExecutionEnvironment();
-		execEnv.setParallelism(mergedEnv.getExecution().getParallelism());
-		return execEnv;
-	}
+	/**
+	 * {@link ExecutionEnvironment} and {@link StreamExecutionEnvironment} cannot be reused
+	 * across multiple queries because they are stateful. This class abstracts execution
+	 * environments and table environments.
+	 */
+	public class EnvironmentInstance {
 
-	private StreamExecutionEnvironment createStreamExecutionEnvironment() {
-		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-		env.setParallelism(mergedEnv.getExecution().getParallelism());
-		env.setMaxParallelism(mergedEnv.getExecution().getMaxParallelism());
-		env.setStreamTimeCharacteristic(mergedEnv.getExecution().getTimeCharacteristic());
-		return env;
-	}
+		private final QueryConfig queryConfig;
+		private final ExecutionEnvironment execEnv;
+		private final StreamExecutionEnvironment streamExecEnv;
+		private final TableEnvironment tableEnv;
 
-	private QueryConfig createQueryConfig() {
-		if (streamExecEnv != null) {
-			final StreamQueryConfig config = new StreamQueryConfig();
-			final long minRetention = mergedEnv.getExecution().getMinStateRetention();
-			final long maxRetention = mergedEnv.getExecution().getMaxStateRetention();
-			config.withIdleStateRetentionTime(Time.milliseconds(minRetention), Time.milliseconds(maxRetention));
-			return config;
-		} else {
-			return new BatchQueryConfig();
+		private EnvironmentInstance() {
+			// create environments
+			if (mergedEnv.getExecution().isStreamingExecution()) {
+				streamExecEnv = createStreamExecutionEnvironment();
+				execEnv = null;
+				tableEnv = TableEnvironment.getTableEnvironment(streamExecEnv);
+			} else {
+				streamExecEnv = null;
+				execEnv = createExecutionEnvironment();
+				tableEnv = TableEnvironment.getTableEnvironment(execEnv);
+			}
+
+			// create query config
+			queryConfig = createQueryConfig();
+
+			// register table sources
+			tableSources.forEach(tableEnv::registerTableSource);
+		}
+
+		public QueryConfig getQueryConfig() {
+			return queryConfig;
+		}
+
+		public ExecutionEnvironment getExecutionEnvironment() {
+			return execEnv;
+		}
+
+		public StreamExecutionEnvironment getStreamExecutionEnvironment() {
+			return streamExecEnv;
+		}
+
+		public TableEnvironment getTableEnvironment() {
+			return tableEnv;
+		}
+
+		public ExecutionConfig getExecutionConfig() {
+			if (streamExecEnv != null) {
+				return streamExecEnv.getConfig();
+			} else {
+				return execEnv.getConfig();
+			}
+		}
+
+		public JobGraph createJobGraph(String name) {
+			final FlinkPlan plan = createPlan(name, flinkConfig);
+			return ClusterClient.getJobGraph(
+				flinkConfig,
+				plan,
+				dependencies,
+				runOptions.getClasspaths(),
+				runOptions.getSavepointRestoreSettings());
+		}
+
+		private FlinkPlan createPlan(String name, Configuration flinkConfig) {
+			if (streamExecEnv != null) {
+				final StreamGraph graph = streamExecEnv.getStreamGraph();
+				graph.setJobName(name);
+				return graph;
+			} else {
+				final int parallelism = execEnv.getParallelism();
+				final Plan unoptimizedPlan = execEnv.createProgramPlan();
+				unoptimizedPlan.setJobName(name);
+				final Optimizer compiler = new Optimizer(new DataStatistics(), new DefaultCostEstimator(), flinkConfig);
+				return ClusterClient.getOptimizedPlan(compiler, unoptimizedPlan, parallelism);
+			}
+		}
+
+		private ExecutionEnvironment createExecutionEnvironment() {
+			final ExecutionEnvironment execEnv = ExecutionEnvironment.getExecutionEnvironment();
+			execEnv.setParallelism(mergedEnv.getExecution().getParallelism());
+			return execEnv;
+		}
+
+		private StreamExecutionEnvironment createStreamExecutionEnvironment() {
+			final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+			env.setParallelism(mergedEnv.getExecution().getParallelism());
+			env.setMaxParallelism(mergedEnv.getExecution().getMaxParallelism());
+			env.setStreamTimeCharacteristic(mergedEnv.getExecution().getTimeCharacteristic());
+			return env;
+		}
+
+		private QueryConfig createQueryConfig() {
+			if (streamExecEnv != null) {
+				final StreamQueryConfig config = new StreamQueryConfig();
+				final long minRetention = mergedEnv.getExecution().getMinStateRetention();
+				final long maxRetention = mergedEnv.getExecution().getMaxStateRetention();
+				config.withIdleStateRetentionTime(Time.milliseconds(minRetention), Time.milliseconds(maxRetention));
+				return config;
+			} else {
+				return new BatchQueryConfig();
+			}
 		}
 	}
 }

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
@@ -21,34 +21,31 @@ package org.apache.flink.table.client.gateway.local;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.client.cli.CliFrontend;
+import org.apache.flink.client.cli.CliFrontendParser;
+import org.apache.flink.client.cli.CustomCommandLine;
 import org.apache.flink.client.deployment.ClusterDescriptor;
-import org.apache.flink.client.deployment.ClusterRetrieveException;
-import org.apache.flink.client.deployment.StandaloneClusterDescriptor;
-import org.apache.flink.client.deployment.StandaloneClusterId;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.client.program.JobWithJars;
-import org.apache.flink.client.program.ProgramInvocationException;
-import org.apache.flink.configuration.AkkaOptions;
+import org.apache.flink.client.program.rest.RestClusterClient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.GlobalConfiguration;
+import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
-import org.apache.flink.optimizer.plan.FlinkPlan;
 import org.apache.flink.runtime.jobgraph.JobGraph;
-import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.client.SqlClientException;
-import org.apache.flink.table.client.config.Deployment;
 import org.apache.flink.table.client.config.Environment;
 import org.apache.flink.table.client.gateway.Executor;
 import org.apache.flink.table.client.gateway.ResultDescriptor;
 import org.apache.flink.table.client.gateway.SessionContext;
 import org.apache.flink.table.client.gateway.SqlExecutionException;
 import org.apache.flink.table.client.gateway.TypedResult;
-import org.apache.flink.table.sinks.TableSink;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.StringUtils;
+
+import org.apache.commons.cli.Options;
 
 import java.io.File;
 import java.io.IOException;
@@ -69,16 +66,23 @@ public class LocalExecutor implements Executor {
 
 	private static final String DEFAULT_ENV_FILE = "sql-client-defaults.yaml";
 
+	// deployment
+
 	private final Environment defaultEnvironment;
 	private final List<URL> dependencies;
 	private final Configuration flinkConfig;
+	private final List<CustomCommandLine<?>> commandLines;
+	private final Options commandLineOptions;
+
+	// result maintenance
+
 	private final ResultStore resultStore;
 
 	/**
 	 * Cached execution context for unmodified sessions. Do not access this variable directly
 	 * but through {@link LocalExecutor#getOrCreateExecutionContext}.
 	 */
-	private ExecutionContext executionContext;
+	private ExecutionContext<?> executionContext;
 
 	/**
 	 * Creates a local executor for submitting table programs and retrieving results.
@@ -92,6 +96,18 @@ public class LocalExecutor implements Executor {
 
 			// load the global configuration
 			this.flinkConfig = GlobalConfiguration.loadConfiguration(flinkConfigDir);
+
+			// initialize default file system
+			try {
+				FileSystem.initialize(this.flinkConfig);
+			} catch (IOException e) {
+				throw new SqlClientException(
+					"Error while setting the default filesystem scheme from configuration.", e);
+			}
+
+			// load command lines for deployment
+			this.commandLines = CliFrontend.loadCustomCommandLines(flinkConfig, flinkConfigDir);
+			this.commandLineOptions = collectCommandLineOptions(commandLines);
 		} catch (Exception e) {
 			throw new SqlClientException("Could not load Flink configuration.", e);
 		}
@@ -107,7 +123,7 @@ public class LocalExecutor implements Executor {
 				try {
 					defaultEnv = Path.fromLocalFile(file).toUri().toURL();
 				} catch (MalformedURLException e) {
-					throw new RuntimeException(e);
+					throw new SqlClientException(e);
 				}
 			} else {
 				System.out.println("not found.");
@@ -127,7 +143,300 @@ public class LocalExecutor implements Executor {
 		}
 
 		// discover dependencies
-		dependencies = new ArrayList<>();
+		dependencies = discoverDependencies(jars, libraries);
+
+		// prepare result store
+		resultStore = new ResultStore(flinkConfig);
+	}
+
+	/**
+	 * Constructor for testing purposes.
+	 */
+	public LocalExecutor(Environment defaultEnvironment, List<URL> dependencies, Configuration flinkConfig, CustomCommandLine<?> commandLine) {
+		this.defaultEnvironment = defaultEnvironment;
+		this.dependencies = dependencies;
+		this.flinkConfig = flinkConfig;
+		this.commandLines = Collections.singletonList(commandLine);
+		this.commandLineOptions = collectCommandLineOptions(commandLines);
+
+		// prepare result store
+		resultStore = new ResultStore(flinkConfig);
+	}
+
+	@Override
+	public void start() {
+		// nothing to do yet
+	}
+
+	@Override
+	public Map<String, String> getSessionProperties(SessionContext session) throws SqlExecutionException {
+		final Environment env = getOrCreateExecutionContext(session)
+			.getMergedEnvironment();
+		final Map<String, String> properties = new HashMap<>();
+		properties.putAll(env.getExecution().toProperties());
+		properties.putAll(env.getDeployment().toProperties());
+		return properties;
+	}
+
+	@Override
+	public List<String> listTables(SessionContext session) throws SqlExecutionException {
+		final TableEnvironment tableEnv = getOrCreateExecutionContext(session)
+			.createEnvironmentInstance()
+			.getTableEnvironment();
+		return Arrays.asList(tableEnv.listTables());
+	}
+
+	@Override
+	public TableSchema getTableSchema(SessionContext session, String name) throws SqlExecutionException {
+		final TableEnvironment tableEnv = getOrCreateExecutionContext(session)
+			.createEnvironmentInstance()
+			.getTableEnvironment();
+		try {
+			return tableEnv.scan(name).getSchema();
+		} catch (Throwable t) {
+			// catch everything such that the query does not crash the executor
+			throw new SqlExecutionException("No table with this name could be found.", t);
+		}
+	}
+
+	@Override
+	public String explainStatement(SessionContext session, String statement) throws SqlExecutionException {
+		final TableEnvironment tableEnv = getOrCreateExecutionContext(session)
+			.createEnvironmentInstance()
+			.getTableEnvironment();
+
+		// translate
+		try {
+			final Table table = createTable(tableEnv, statement);
+			return tableEnv.explain(table);
+		} catch (Throwable t) {
+			// catch everything such that the query does not crash the executor
+			throw new SqlExecutionException("Invalid SQL statement.", t);
+		}
+	}
+
+	@Override
+	public ResultDescriptor executeQuery(SessionContext session, String query) throws SqlExecutionException {
+		final ExecutionContext<?> context = getOrCreateExecutionContext(session);
+		return executeQueryInternal(context, query);
+	}
+
+	@Override
+	public TypedResult<List<Tuple2<Boolean, Row>>> retrieveResultChanges(SessionContext session,
+			String resultId) throws SqlExecutionException {
+		final DynamicResult result = resultStore.getResult(resultId);
+		if (result == null) {
+			throw new SqlExecutionException("Could not find a result with result identifier '" + resultId + "'.");
+		}
+		if (result.isMaterialized()) {
+			throw new SqlExecutionException("Invalid result retrieval mode.");
+		}
+		return ((ChangelogResult<?>) result).retrieveChanges();
+	}
+
+	@Override
+	public TypedResult<Integer> snapshotResult(SessionContext session, String resultId, int pageSize) throws SqlExecutionException {
+		final DynamicResult result = resultStore.getResult(resultId);
+		if (result == null) {
+			throw new SqlExecutionException("Could not find a result with result identifier '" + resultId + "'.");
+		}
+		if (!result.isMaterialized()) {
+			throw new SqlExecutionException("Invalid result retrieval mode.");
+		}
+		return ((MaterializedResult<?>) result).snapshot(pageSize);
+	}
+
+	@Override
+	public List<Row> retrieveResultPage(String resultId, int page) throws SqlExecutionException {
+		final DynamicResult result = resultStore.getResult(resultId);
+		if (result == null) {
+			throw new SqlExecutionException("Could not find a result with result identifier '" + resultId + "'.");
+		}
+		if (!result.isMaterialized()) {
+			throw new SqlExecutionException("Invalid result retrieval mode.");
+		}
+		return ((MaterializedResult<?>) result).retrievePage(page);
+	}
+
+	@Override
+	public void cancelQuery(SessionContext session, String resultId) throws SqlExecutionException {
+		final ExecutionContext<?> context = getOrCreateExecutionContext(session);
+		cancelQueryInternal(context, resultId);
+	}
+
+	@Override
+	public void stop(SessionContext session) {
+		resultStore.getResults().forEach((resultId) -> {
+			try {
+				cancelQuery(session, resultId);
+			} catch (Throwable t) {
+				// ignore any throwable to keep the clean up running
+			}
+		});
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	private <T> void cancelQueryInternal(ExecutionContext<T> context, String resultId) {
+		final DynamicResult<T> result = resultStore.getResult(resultId);
+		if (result == null) {
+			throw new SqlExecutionException("Could not find a result with result identifier '" + resultId + "'.");
+		}
+
+		// stop retrieval and remove the result
+		result.close();
+		resultStore.removeResult(resultId);
+
+		// stop Flink job
+		try (final ClusterDescriptor<T> clusterDescriptor = context.createClusterDescriptor()) {
+			ClusterClient<T> clusterClient = null;
+			try {
+				// retrieve existing cluster
+				clusterClient = clusterDescriptor.retrieve(context.getClusterId());
+				try {
+					clusterClient.cancel(new JobID(StringUtils.hexStringToByte(resultId)));
+				} catch (Throwable t) {
+					// the job might has finished earlier
+				}
+			} catch (Exception e) {
+				throw new SqlExecutionException("Could not retrieve or create a cluster.", e);
+			} finally {
+				try {
+					if (clusterClient != null) {
+						clusterClient.shutdown();
+					}
+				} catch (Exception e) {
+					// ignore
+				}
+			}
+		} catch (SqlExecutionException e) {
+			throw e;
+		} catch (Exception e) {
+			throw new SqlExecutionException("Could not locate a cluster.", e);
+		}
+	}
+
+	private <T> ResultDescriptor executeQueryInternal(ExecutionContext<T> context, String query) {
+		final ExecutionContext.EnvironmentInstance envInst = context.createEnvironmentInstance();
+
+		// create table
+		final Table table = createTable(envInst.getTableEnvironment(), query);
+
+		// initialize result
+		final DynamicResult<T> result = resultStore.createResult(
+			context.getMergedEnvironment(),
+			table.getSchema().withoutTimeAttributes(),
+			envInst.getExecutionConfig());
+
+		// create job graph with dependencies
+		final String jobName = context.getSessionContext().getName() + ": " + query;
+		final JobGraph jobGraph;
+		try {
+			table.writeToSink(result.getTableSink(), envInst.getQueryConfig());
+			jobGraph = envInst.createJobGraph(jobName);
+		} catch (Throwable t) {
+			// the result needs to be closed as long as
+			// it not stored in the result store
+			result.close();
+			// catch everything such that the query does not crash the executor
+			throw new SqlExecutionException("Invalid SQL statement.", t);
+		}
+
+		// store the result with a unique id (the job id for now)
+		final String resultId = jobGraph.getJobID().toString();
+		resultStore.storeResult(resultId, result);
+
+		// create execution
+		final Runnable program = () -> deployJob(context, jobGraph, result);
+
+		// start result retrieval
+		result.startRetrieval(program);
+
+		return new ResultDescriptor(
+			resultId,
+			table.getSchema().withoutTimeAttributes(),
+			result.isMaterialized());
+	}
+
+	private Table createTable(TableEnvironment tableEnv, String query) {
+		// parse and validate query
+		try {
+			return tableEnv.sqlQuery(query);
+		} catch (Throwable t) {
+			// catch everything such that the query does not crash the executor
+			throw new SqlExecutionException("Invalid SQL statement.", t);
+		}
+	}
+
+	/**
+	 * Creates or reuses the execution context.
+	 */
+	private synchronized ExecutionContext<?> getOrCreateExecutionContext(SessionContext session) throws SqlExecutionException {
+		if (executionContext == null || !executionContext.getSessionContext().equals(session)) {
+			try {
+				executionContext = new ExecutionContext<>(defaultEnvironment, session, dependencies,
+					flinkConfig, commandLineOptions, commandLines);
+			} catch (Throwable t) {
+				// catch everything such that a configuration does not crash the executor
+				throw new SqlExecutionException("Could not create execution context.", t);
+			}
+		}
+		return executionContext;
+	}
+
+	/**
+	 * Deploys a job. Depending on the deployment create a new job cluster. It saves cluster id in
+	 * the result and blocks until job completion.
+	 */
+	private <T> void deployJob(ExecutionContext<T> context, JobGraph jobGraph, DynamicResult<T> result) {
+		// create or retrieve cluster and deploy job
+		try (final ClusterDescriptor<T> clusterDescriptor = context.createClusterDescriptor()) {
+			ClusterClient<T> clusterClient = null;
+			try {
+				// new cluster
+				if (context.getClusterId() == null) {
+					// deploy job cluster with job attached
+					clusterClient = clusterDescriptor.deployJobCluster(context.getClusterSpec(), jobGraph, false);
+					// save the new cluster id
+					result.setClusterId(clusterClient.getClusterId());
+					// we need to hard cast for now
+					((RestClusterClient<T>) clusterClient)
+						.requestJobResult(jobGraph.getJobID())
+						.get()
+						.toJobExecutionResult(context.getClassLoader()); // throws exception if job fails
+				}
+				// reuse existing cluster
+				else {
+					// retrieve existing cluster
+					clusterClient = clusterDescriptor.retrieve(context.getClusterId());
+					// save the cluster id
+					result.setClusterId(clusterClient.getClusterId());
+					// submit the job
+					clusterClient.setDetached(false);
+					clusterClient.submitJob(jobGraph, context.getClassLoader()); // throws exception if job fails
+				}
+			} catch (Exception e) {
+				throw new SqlExecutionException("Could not retrieve or create a cluster.", e);
+			} finally {
+				try {
+					if (clusterClient != null) {
+						clusterClient.shutdown();
+					}
+				} catch (Exception e) {
+					// ignore
+				}
+			}
+		} catch (SqlExecutionException e) {
+			throw e;
+		} catch (Exception e) {
+			throw new SqlExecutionException("Could not locate a cluster.", e);
+		}
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	private static List<URL> discoverDependencies(List<URL> jars, List<URL> libraries) {
+		final List<URL> dependencies = new ArrayList<>();
 		try {
 			// find jar files
 			for (URL url : jars) {
@@ -159,274 +468,16 @@ public class LocalExecutor implements Executor {
 		} catch (Exception e) {
 			throw new SqlClientException("Could not load all required JAR files.", e);
 		}
-
-		// prepare result store
-		resultStore = new ResultStore(flinkConfig);
+		return dependencies;
 	}
 
-	/**
-	 * Constructor for testing purposes.
-	 */
-	public LocalExecutor(Environment defaultEnvironment, List<URL> dependencies, Configuration flinkConfig) {
-		this.defaultEnvironment = defaultEnvironment;
-		this.dependencies = dependencies;
-		this.flinkConfig = flinkConfig;
-
-		// prepare result store
-		resultStore = new ResultStore(flinkConfig);
-	}
-
-	@Override
-	public void start() {
-		// nothing to do yet
-	}
-
-	@Override
-	public Map<String, String> getSessionProperties(SessionContext session) throws SqlExecutionException {
-		final Environment env = getOrCreateExecutionContext(session).getMergedEnvironment();
-		final Map<String, String> properties = new HashMap<>();
-		properties.putAll(env.getExecution().toProperties());
-		properties.putAll(env.getDeployment().toProperties());
-		return properties;
-	}
-
-	@Override
-	public List<String> listTables(SessionContext session) throws SqlExecutionException {
-		final TableEnvironment tableEnv = getOrCreateExecutionContext(session).getTableEnvironment();
-		return Arrays.asList(tableEnv.listTables());
-	}
-
-	@Override
-	public TableSchema getTableSchema(SessionContext session, String name) throws SqlExecutionException {
-		final TableEnvironment tableEnv = getOrCreateExecutionContext(session).getTableEnvironment();
-		try {
-			return tableEnv.scan(name).getSchema();
-		} catch (Throwable t) {
-			// catch everything such that the query does not crash the executor
-			throw new SqlExecutionException("No table with this name could be found.", t);
+	private static Options collectCommandLineOptions(List<CustomCommandLine<?>> commandLines) {
+		final Options customOptions = new Options();
+		for (CustomCommandLine<?> customCommandLine : commandLines) {
+			customCommandLine.addRunOptions(customOptions);
 		}
-	}
-
-	@Override
-	public String explainStatement(SessionContext session, String statement) throws SqlExecutionException {
-		final ExecutionContext context = getOrCreateExecutionContext(session);
-
-		// translate
-		try {
-			final Table table = createTable(context, statement);
-			return context.getTableEnvironment().explain(table);
-		} catch (Throwable t) {
-			// catch everything such that the query does not crash the executor
-			throw new SqlExecutionException("Invalid SQL statement.", t);
-		}
-	}
-
-	@Override
-	public ResultDescriptor executeQuery(SessionContext session, String query) throws SqlExecutionException {
-		final ExecutionContext context = getOrCreateExecutionContext(session);
-		final Environment mergedEnv = context.getMergedEnvironment();
-
-		// create table here to fail quickly for wrong queries
-		final Table table = createTable(context, query);
-		final TableSchema resultSchema = table.getSchema().withoutTimeAttributes();
-
-		// deployment
-		final ClusterClient<?> clusterClient = createDeployment(mergedEnv.getDeployment());
-
-		// initialize result
-		final DynamicResult result = resultStore.createResult(
-			mergedEnv,
-			resultSchema,
-			context.getExecutionConfig());
-
-		// create job graph with jars
-		final JobGraph jobGraph;
-		try {
-			jobGraph = createJobGraph(context, context.getSessionContext().getName() + ": " + query, table,
-				result.getTableSink(),
-				clusterClient);
-		} catch (Throwable t) {
-			// the result needs to be closed as long as
-			// it not stored in the result store
-			result.close();
-			throw t;
-		}
-
-		// store the result with a unique id (the job id for now)
-		final String resultId = jobGraph.getJobID().toString();
-		resultStore.storeResult(resultId, result);
-
-		// create execution
-		final Runnable program = () -> {
-			// we need to submit the job attached for now
-			// otherwise it is not possible to retrieve the reason why an execution failed
-			try {
-				clusterClient.run(jobGraph, context.getClassLoader());
-			} catch (ProgramInvocationException e) {
-				throw new SqlExecutionException("Could not execute table program.", e);
-			} finally {
-				try {
-					clusterClient.shutdown();
-				} catch (Exception e) {
-					// ignore
-				}
-			}
-		};
-
-		// start result retrieval
-		result.startRetrieval(program);
-
-		return new ResultDescriptor(resultId, resultSchema, result.isMaterialized());
-	}
-
-	@Override
-	public TypedResult<List<Tuple2<Boolean, Row>>> retrieveResultChanges(SessionContext session,
-			String resultId) throws SqlExecutionException {
-		final DynamicResult result = resultStore.getResult(resultId);
-		if (result == null) {
-			throw new SqlExecutionException("Could not find a result with result identifier '" + resultId + "'.");
-		}
-		if (result.isMaterialized()) {
-			throw new SqlExecutionException("Invalid result retrieval mode.");
-		}
-		return ((ChangelogResult) result).retrieveChanges();
-	}
-
-	@Override
-	public TypedResult<Integer> snapshotResult(SessionContext session, String resultId, int pageSize) throws SqlExecutionException {
-		final DynamicResult result = resultStore.getResult(resultId);
-		if (result == null) {
-			throw new SqlExecutionException("Could not find a result with result identifier '" + resultId + "'.");
-		}
-		if (!result.isMaterialized()) {
-			throw new SqlExecutionException("Invalid result retrieval mode.");
-		}
-		return ((MaterializedResult) result).snapshot(pageSize);
-	}
-
-	@Override
-	public List<Row> retrieveResultPage(String resultId, int page) throws SqlExecutionException {
-		final DynamicResult result = resultStore.getResult(resultId);
-		if (result == null) {
-			throw new SqlExecutionException("Could not find a result with result identifier '" + resultId + "'.");
-		}
-		if (!result.isMaterialized()) {
-			throw new SqlExecutionException("Invalid result retrieval mode.");
-		}
-		return ((MaterializedResult) result).retrievePage(page);
-	}
-
-	@Override
-	public void cancelQuery(SessionContext session, String resultId) throws SqlExecutionException {
-		final DynamicResult result = resultStore.getResult(resultId);
-		if (result == null) {
-			throw new SqlExecutionException("Could not find a result with result identifier '" + resultId + "'.");
-		}
-
-		// stop retrieval and remove the result
-		result.close();
-		resultStore.removeResult(resultId);
-
-		// stop Flink job
-		final Environment mergedEnv = getOrCreateExecutionContext(session).getMergedEnvironment();
-		final ClusterClient<?> clusterClient = createDeployment(mergedEnv.getDeployment());
-		try {
-			clusterClient.cancel(new JobID(StringUtils.hexStringToByte(resultId)));
-		} catch (Throwable t) {
-			// the job might has finished earlier
-		} finally {
-			try {
-				clusterClient.shutdown();
-			} catch (Throwable t) {
-				// ignore
-			}
-		}
-	}
-
-	@Override
-	public void stop(SessionContext session) {
-		resultStore.getResults().forEach((resultId) -> {
-			try {
-				cancelQuery(session, resultId);
-			} catch (Throwable t) {
-				// ignore any throwable to keep the clean up running
-			}
-		});
-	}
-
-	// --------------------------------------------------------------------------------------------
-
-	private Table createTable(ExecutionContext context, String query) {
-		// parse and validate query
-		try {
-			return context.getTableEnvironment().sqlQuery(query);
-		} catch (Throwable t) {
-			// catch everything such that the query does not crash the executor
-			throw new SqlExecutionException("Invalid SQL statement.", t);
-		}
-	}
-
-	private JobGraph createJobGraph(ExecutionContext context, String name, Table table,
-			TableSink<?> sink, ClusterClient<?> clusterClient) {
-
-		// translate
-		try {
-			table.writeToSink(sink, context.getQueryConfig());
-		} catch (Throwable t) {
-			// catch everything such that the query does not crash the executor
-			throw new SqlExecutionException("Invalid SQL statement.", t);
-		}
-
-		// extract plan
-		final FlinkPlan plan = context.createPlan(name, clusterClient.getFlinkConfiguration());
-
-		// create job graph
-		return clusterClient.getJobGraph(
-			plan,
-			dependencies,
-			Collections.emptyList(),
-			SavepointRestoreSettings.none());
-	}
-
-	private ClusterClient<?> createDeployment(Deployment deploy) {
-
-		// change some configuration options for being more responsive
-		flinkConfig.setString(AkkaOptions.LOOKUP_TIMEOUT, deploy.getResponseTimeout() + " ms");
-		flinkConfig.setString(AkkaOptions.CLIENT_TIMEOUT, deploy.getResponseTimeout() + " ms");
-
-		// get cluster client
-		final ClusterClient<?> clusterClient;
-		if (deploy.isStandaloneDeployment()) {
-			clusterClient = createStandaloneClusterClient(flinkConfig);
-			clusterClient.setPrintStatusDuringExecution(false);
-		} else {
-			throw new SqlExecutionException("Unsupported deployment.");
-		}
-
-		return clusterClient;
-	}
-
-	private ClusterClient<?> createStandaloneClusterClient(Configuration configuration) {
-		final ClusterDescriptor<StandaloneClusterId> descriptor = new StandaloneClusterDescriptor(configuration);
-		try {
-			return descriptor.retrieve(StandaloneClusterId.getInstance());
-		} catch (ClusterRetrieveException e) {
-			throw new SqlExecutionException("Could not retrievePage standalone cluster.", e);
-		}
-	}
-
-	/**
-	 * Creates or reuses the execution context.
-	 */
-	private synchronized ExecutionContext getOrCreateExecutionContext(SessionContext session) throws SqlExecutionException {
-		if (executionContext == null || !executionContext.getSessionContext().equals(session)) {
-			try {
-				executionContext = new ExecutionContext(defaultEnvironment, session, dependencies);
-			} catch (Throwable t) {
-				// catch everything such that a configuration does not crash the executor
-				throw new SqlExecutionException("Could not create execution context.", t);
-			}
-		}
-		return executionContext;
+		return CliFrontendParser.mergeOptions(
+			CliFrontendParser.getRunCommandOptions(),
+			customOptions);
 	}
 }

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/MaterializedCollectStreamResult.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/MaterializedCollectStreamResult.java
@@ -33,8 +33,10 @@ import java.util.Map;
 
 /**
  * Collects results and returns them as table snapshots.
+ *
+ * @param <C> cluster id to which this result belongs to
  */
-public class MaterializedCollectStreamResult extends CollectStreamResult implements MaterializedResult {
+public class MaterializedCollectStreamResult<C> extends CollectStreamResult<C> implements MaterializedResult<C> {
 
 	private final List<Row> materializedTable;
 	private final Map<Row, List<Integer>> rowPositions; // positions of rows in table for faster access

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/MaterializedResult.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/MaterializedResult.java
@@ -25,8 +25,10 @@ import java.util.List;
 
 /**
  * A result that is materialized and can be viewed by navigating through a snapshot.
+ *
+ * @param <C> cluster id to which this result belongs to
  */
-public interface MaterializedResult extends DynamicResult {
+public interface MaterializedResult<C> extends DynamicResult<C> {
 
 	/**
 	 * Takes a snapshot of the current table and returns the number of pages for navigating

--- a/flink-libraries/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/DependencyTest.java
+++ b/flink-libraries/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/DependencyTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.client.gateway.local;
 
+import org.apache.flink.client.cli.Flip6DefaultCLI;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.Types;
@@ -57,7 +58,8 @@ public class DependencyTest {
 		final LocalExecutor executor = new LocalExecutor(
 			env,
 			Collections.singletonList(dependency),
-			new Configuration());
+			new Configuration(),
+			new Flip6DefaultCLI(new Configuration()));
 
 		final SessionContext session = new SessionContext("test-session", new Environment());
 

--- a/flink-libraries/flink-sql-client/src/test/resources/test-sql-client-defaults.yaml
+++ b/flink-libraries/flink-sql-client/src/test/resources/test-sql-client-defaults.yaml
@@ -71,7 +71,6 @@ execution:
   result-mode: "$VAR_2"
 
 deployment:
-  type: standalone
   response-timeout: 5000
 
 

--- a/flink-libraries/flink-sql-client/src/test/resources/test-sql-client-factory.yaml
+++ b/flink-libraries/flink-sql-client/src/test/resources/test-sql-client-factory.yaml
@@ -46,7 +46,6 @@ execution:
   parallelism: 1
 
 deployment:
-  type: standalone
   response-timeout: 5000
 
 


### PR DESCRIPTION
## What is the purpose of the change

This PR adds support for the new FLIP-6 mode in the SQL Client. For now, we only test the standalone mode. But in theory the current design should work with any deployment.


## Brief change log

- Use new FLIP-6 classes similar to `CliFrontend`
- Make some methods visible in `flink-clients` for reducing duplicate code.


## Verifying this change

Updated the existing integration tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? JavaDocs
