### PR TITLE
[FLINK-8699][FLINK-8968][state]Fix native resource leak caused by ReadOptions

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
@@ -1952,14 +1952,15 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 			this.kvStateIterators = new ArrayList<>(kvStateInformationCopy.size());
 
 			int kvStateId = 0;
+
+			//retrieve iterator for this k/v states
+			readOptions = new ReadOptions();
+			readOptions.setSnapshot(snapshot);
+
 			for (Tuple2<ColumnFamilyHandle, RegisteredKeyedBackendStateMetaInfo<?, ?>> column :
 				kvStateInformationCopy) {
 
 				metaInfoSnapshots.add(column.f1.snapshot());
-
-				//retrieve iterator for this k/v states
-				readOptions = new ReadOptions();
-				readOptions.setSnapshot(snapshot);
 
 				kvStateIterators.add(
 					new Tuple2<>(stateBackend.db.newIterator(column.f0, readOptions), kvStateId));

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
@@ -1313,10 +1313,10 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 		private static final List<Comparator<MergeIterator>> COMPARATORS;
 
 		static {
-			int maxBytes = 4;
+			int maxBytes = 2;
 			COMPARATORS = new ArrayList<>(maxBytes);
 			for (int i = 0; i < maxBytes; ++i) {
-				final int currentBytes = i;
+				final int currentBytes = i + 1;
 				COMPARATORS.add(new Comparator<MergeIterator>() {
 					@Override
 					public int compare(MergeIterator o1, MergeIterator o2) {
@@ -1330,9 +1330,11 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 
 		RocksDBMergeIterator(List<Tuple2<RocksIterator, Integer>> kvStateIterators, final int keyGroupPrefixByteCount) {
 			Preconditions.checkNotNull(kvStateIterators);
+			Preconditions.checkArgument(keyGroupPrefixByteCount >= 1);
+
 			this.keyGroupPrefixByteCount = keyGroupPrefixByteCount;
 
-			Comparator<MergeIterator> iteratorComparator = COMPARATORS.get(keyGroupPrefixByteCount);
+			Comparator<MergeIterator> iteratorComparator = COMPARATORS.get(keyGroupPrefixByteCount - 1);
 
 			if (kvStateIterators.size() > 0) {
 				PriorityQueue<MergeIterator> iteratorPriorityQueue =
@@ -1837,10 +1839,14 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 		private Snapshot snapshot;
 		private ReadOptions readOptions;
 
-		/** The state meta data. */
+		/**
+		 * The state meta data.
+		 */
 		private List<RegisteredKeyedBackendStateMetaInfo.Snapshot<?, ?>> stateMetaInfoSnapshots;
 
-		/** The copied column handle. */
+		/**
+		 * The copied column handle.
+		 */
 		private List<ColumnFamilyHandle> copiedColumnFamilyHandles;
 
 		private List<Tuple2<RocksIterator, Integer>> kvStateIterators;

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
@@ -299,7 +299,9 @@ public class RocksDBStateBackendConfigTest {
 		});
 
 		assertNotNull(rocksDbBackend.getOptions());
-		assertEquals(CompactionStyle.FIFO, rocksDbBackend.getColumnOptions().compactionStyle());
+		try (ColumnFamilyOptions colCreated = rocksDbBackend.getColumnOptions()) {
+			assertEquals(CompactionStyle.FIFO, colCreated.compactionStyle());
+		}
 	}
 
 	@Test
@@ -324,7 +326,9 @@ public class RocksDBStateBackendConfigTest {
 
 		assertEquals(PredefinedOptions.SPINNING_DISK_OPTIMIZED, rocksDbBackend.getPredefinedOptions());
 		assertNotNull(rocksDbBackend.getOptions());
-		assertEquals(CompactionStyle.UNIVERSAL, rocksDbBackend.getColumnOptions().compactionStyle());
+		try (ColumnFamilyOptions colCreated = rocksDbBackend.getColumnOptions()) {
+			assertEquals(CompactionStyle.UNIVERSAL, colCreated.compactionStyle());
+		}
 	}
 
 	@Test


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes [FLINK-8968](https://issues.apache.org/jira/browse/FLINK-8968) Pull the creation of `ReadOptions` out of loop to avoid native resource leak in Full checkpoint.

## Brief change log

- pull the creation of `ReadOptions` out of loop in `RocksDBFullSnapshotOperation.writeKVStateMetaData()`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation
no