### PR TITLE
[FLINK-8843][flip6] Decouple bind REST address from advertised address

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/RestOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/RestOptions.java
@@ -29,12 +29,21 @@ import static org.apache.flink.configuration.ConfigOptions.key;
 public class RestOptions {
 
 	/**
-	 * The address that the server binds itself to / the client connects to.
+	 * The address that the server binds itself to.
+	 */
+	public static final ConfigOption<String> REST_BIND_ADDRESS =
+		key("rest.bind-address")
+			.noDefaultValue()
+			.withDescription("The address that the server binds itself.");
+
+	/**
+	 * The address that should be used by clients to connect to the server.
 	 */
 	public static final ConfigOption<String> REST_ADDRESS =
 		key("rest.address")
-			.defaultValue("localhost")
-			.withDescription("The address that the server binds itself to / the client connects to.");
+			.noDefaultValue()
+			.withDeprecatedKeys(JobManagerOptions.ADDRESS.key())
+			.withDescription("The address that should be used by clients to connect to the server.");
 
 	/**
 	 * The port that the server listens on / the client connects to.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -325,7 +325,7 @@ public abstract class ClusterEntrypoint implements FatalErrorHandler {
 				metricRegistry,
 				this,
 				clusterInformation,
-				webMonitorEndpoint.getRestAddress());
+				webMonitorEndpoint.getRestBaseUrl());
 
 			dispatcher = createDispatcher(
 				configuration,
@@ -337,7 +337,7 @@ public abstract class ClusterEntrypoint implements FatalErrorHandler {
 				metricRegistry,
 				archivedExecutionGraphStore,
 				this,
-				webMonitorEndpoint.getRestAddress());
+				webMonitorEndpoint.getRestBaseUrl());
 
 			LOG.debug("Starting ResourceManager.");
 			resourceManager.start();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServicesUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServicesUtils.java
@@ -39,6 +39,8 @@ import org.apache.flink.util.ConfigurationException;
 
 import java.util.concurrent.Executor;
 
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
 /**
  * Utils class to instantiate {@link HighAvailabilityServices} implementations.
  */
@@ -97,7 +99,9 @@ public class HighAvailabilityServicesUtils {
 					addressResolution,
 					configuration);
 
-				final String address = configuration.getString(RestOptions.REST_ADDRESS);
+				final String address = checkNotNull(configuration.getString(RestOptions.REST_ADDRESS),
+					"%s must be set",
+					RestOptions.REST_ADDRESS.key());
 				final int port = configuration.getInteger(RestOptions.REST_PORT);
 				final boolean enableSSL = configuration.getBoolean(SecurityOptions.SSL_ENABLED);
 				final String protocol = enableSSL ? "https://" : "http://";

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -336,7 +336,7 @@ public class MiniCluster implements JobExecutorService, AutoCloseableAsync {
 
 				dispatcherRestEndpoint.start();
 
-				restAddressURI = new URI(dispatcherRestEndpoint.getRestAddress());
+				restAddressURI = new URI(dispatcherRestEndpoint.getRestBaseUrl());
 
 				// bring up the dispatcher that launches JobManagers when jobs submitted
 				LOG.info("Starting job dispatcher(s) for JobManger");
@@ -353,7 +353,7 @@ public class MiniCluster implements JobExecutorService, AutoCloseableAsync {
 					new MemoryArchivedExecutionGraphStore(),
 					Dispatcher.DefaultJobManagerRunnerFactory.INSTANCE,
 					new ShutDownFatalErrorHandler(),
-					dispatcherRestEndpoint.getRestAddress());
+					dispatcherRestEndpoint.getRestBaseUrl());
 
 				dispatcher.start();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -212,9 +212,6 @@ public class MiniCluster implements JobExecutorService, AutoCloseableAsync {
 			LOG.info("Starting Flink Mini Cluster");
 			LOG.debug("Using configuration {}", miniClusterConfiguration);
 
-			// create a new termination future
-			terminationFuture = new CompletableFuture<>();
-
 			final Configuration configuration = miniClusterConfiguration.getConfiguration();
 			final Time rpcTimeout = miniClusterConfiguration.getRpcTimeout();
 			final int numTaskManagers = miniClusterConfiguration.getNumTaskManagers();
@@ -375,6 +372,9 @@ public class MiniCluster implements JobExecutorService, AutoCloseableAsync {
 				}
 				throw e;
 			}
+
+			// create a new termination future
+			terminationFuture = new CompletableFuture<>();
 
 			// now officially mark this as running
 			running = true;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniClusterConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniClusterConfiguration.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.configuration.UnmodifiableConfiguration;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.util.Preconditions;
@@ -167,6 +168,9 @@ public class MiniClusterConfiguration {
 		public MiniClusterConfiguration build() {
 			final Configuration modifiedConfiguration = new Configuration(configuration);
 			modifiedConfiguration.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, numSlotsPerTaskManager);
+			modifiedConfiguration.setString(
+				RestOptions.REST_ADDRESS,
+				modifiedConfiguration.getString(RestOptions.REST_ADDRESS, "localhost"));
 
 			return new MiniClusterConfiguration(
 				modifiedConfiguration,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
@@ -666,18 +666,18 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
 
 	@Override
 	public void grantLeadership(final UUID leaderSessionID) {
-		log.info("{} was granted leadership with leaderSessionID={}", getRestAddress(), leaderSessionID);
+		log.info("{} was granted leadership with leaderSessionID={}", getRestBaseUrl(), leaderSessionID);
 		leaderElectionService.confirmLeaderSessionID(leaderSessionID);
 	}
 
 	@Override
 	public void revokeLeadership() {
-		log.info("{} lost leadership", getRestAddress());
+		log.info("{} lost leadership", getRestBaseUrl());
 	}
 
 	@Override
 	public String getAddress() {
-		return getRestAddress();
+		return getRestBaseUrl();
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointITCase.java
@@ -115,6 +115,7 @@ public class RestServerEndpointITCase extends TestLogger {
 	public void setup() throws Exception {
 		Configuration config = new Configuration();
 		config.setInteger(RestOptions.REST_PORT, 0);
+		config.setString(RestOptions.REST_ADDRESS, "localhost");
 		config.setString(WebOptions.UPLOAD_DIR, temporaryFolder.newFolder().getCanonicalPath());
 		config.setInteger(RestOptions.REST_SERVER_MAX_CONTENT_LENGTH, TEST_REST_MAX_CONTENT_LENGTH);
 		config.setInteger(RestOptions.REST_CLIENT_MAX_CONTENT_LENGTH, TEST_REST_MAX_CONTENT_LENGTH);
@@ -335,7 +336,7 @@ public class RestServerEndpointITCase extends TestLogger {
 
 	private HttpURLConnection openHttpConnectionForUpload(final String boundary) throws IOException {
 		final HttpURLConnection connection =
-			(HttpURLConnection) new URL(serverEndpoint.getRestAddress() + "/upload").openConnection();
+			(HttpURLConnection) new URL(serverEndpoint.getRestBaseUrl() + "/upload").openConnection();
 		connection.setDoOutput(true);
 		connection.setRequestProperty("Content-Type", "multipart/form-data; boundary=" + boundary);
 		return connection;


### PR DESCRIPTION
## What is the purpose of the change

*The `RestServerEndpoint` is currently bound to the same address which is also advertised to the client, namely `RestOptions#REST_ADDRESS`. It would be better to start the `RestServerEndpoint` listening on all address by binding to `0.0.0.0` by default.*


## Brief change log

  - *By default bind REST server on wildcard address.*
  - *Rename `RestServerEndpoint#getRestAddress` to `getRestBaseUrl`.*


## Verifying this change

This change is already covered by existing tests, such as `RestServerEndpointITCase.java`.
This change added tests and can be verified as follows:

  - *Manually deployed Flink Cluster on YARN & Standalone mode.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
