### PR TITLE
[FLINK-8984][network] Drop taskmanager.exactly-once.blocking.data.enabled config option

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -326,18 +326,6 @@ public class TaskManagerOptions {
 			.defaultValue(true)
 			.withDescription("Boolean flag to enable/disable network credit-based flow control.");
 
-	/**
-	 * Config parameter defining whether to spill data for channels with barrier or not in exactly-once
-	 * mode based on credit-based flow control.
-	 *
-	 * @deprecated Will be removed for Flink 1.6 when the old code will be dropped in favour of
-	 * credit-based flow control.
-	 */
-	@Deprecated
-	public static final ConfigOption<Boolean> EXACTLY_ONCE_BLOCKING_DATA_ENABLED =
-			key("taskmanager.exactly-once.blocking.data.enabled")
-			.defaultValue(true);
-
 	// ------------------------------------------------------------------------
 	//  Task Options
 	// ------------------------------------------------------------------------

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/InputProcessorUtil.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/InputProcessorUtil.java
@@ -51,7 +51,7 @@ public class InputProcessorUtil {
 					+ " must be positive or -1 (infinite)");
 			}
 
-			if (taskManagerConfig.getBoolean(TaskManagerOptions.EXACTLY_ONCE_BLOCKING_DATA_ENABLED)) {
+			if (taskManagerConfig.getBoolean(TaskManagerOptions.NETWORK_CREDIT_BASED_FLOW_CONTROL_ENABLED)) {
 				barrierHandler = new BarrierBuffer(inputGate, new CachedBufferBlocker(inputGate.getPageSize()), maxAlign);
 			} else {
 				barrierHandler = new BarrierBuffer(inputGate, new BufferSpiller(ioManager, inputGate.getPageSize()), maxAlign);


### PR DESCRIPTION
Previously there were twe options:

taskmanager.network.credit-based-flow-control.enabled

and

taskmanager.exactly-once.blocking.data.enabled

If we disabled first one, but keept default value for the second one deadlocks will occur.

By dropping taskmanager.exactly-once.blocking.data.enabled we can always use:
 - blocking BarrierBuffer for credit based flow control
 - spilling BarrierBuffer for non credit based flow control.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
