### PR TITLE
[FLINK-8941][network][serializer] improve SpanningRecordSerializationTest and ensure unique spilling files

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/serialization/SpanningRecordSerializationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/serialization/SpanningRecordSerializationTest.java
@@ -27,9 +27,12 @@ import org.apache.flink.testutils.serialization.types.IntType;
 import org.apache.flink.testutils.serialization.types.SerializationTestType;
 import org.apache.flink.testutils.serialization.types.SerializationTestTypeFactory;
 import org.apache.flink.testutils.serialization.types.Util;
+import org.apache.flink.util.TestLogger;
 
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
 import java.util.ArrayDeque;
@@ -43,8 +46,11 @@ import static org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils.
 /**
  * Tests for the {@link SpillingAdaptiveSpanningRecordDeserializer}.
  */
-public class SpanningRecordSerializationTest {
+public class SpanningRecordSerializationTest extends TestLogger {
 	private static final Random RANDOM = new Random(42);
+
+	@Rule
+	public TemporaryFolder tempFolder = new TemporaryFolder();
 
 	@Test
 	public void testIntRecordsSpanningMultipleSegments() throws Exception {
@@ -100,11 +106,11 @@ public class SpanningRecordSerializationTest {
 
 	// -----------------------------------------------------------------------------------------------------------------
 
-	private static void testSerializationRoundTrip(Iterable<SerializationTestType> records, int segmentSize) throws Exception {
+	private void testSerializationRoundTrip(Iterable<SerializationTestType> records, int segmentSize) throws Exception {
 		RecordSerializer<SerializationTestType> serializer = new SpanningRecordSerializer<>();
 		RecordDeserializer<SerializationTestType> deserializer =
 			new SpillingAdaptiveSpanningRecordDeserializer<>(
-				new String[]{System.getProperty("java.io.tmpdir")});
+				new String[]{ tempFolder.getRoot().getAbsolutePath() });
 
 		testSerializationRoundTrip(records, segmentSize, serializer, deserializer);
 	}


### PR DESCRIPTION
## What is the purpose of the change

This PR contains two commits trying to tackle FLINK-8941 (which I could not reproduce).

## Brief change log

- let `SpanningRecordSerializationTest` extend from `TestLogger`
- use a `TemporaryFolder` in `SpanningRecordSerializationTest` for spilling files
- make sure `SpillingAdaptiveSpanningRecordDeserializer` does not work on an existing file, e.g. from another instance running on the same machine - allow 10 retries with 20 random bytes file names and fail otherwise

## Verifying this change

This change is already covered by existing tests, such as `SpanningRecordSerializationTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **yes** (well, partly - the code around the actual serializers)
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
