### PR TITLE
[FLINK-8948][runtime] Fix IllegalStateException when closing StreamTask

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferBuilder.java
@@ -99,10 +99,11 @@ public class BufferBuilder {
 	 * Mark this {@link BufferBuilder} and associated {@link BufferConsumer} as finished - no new data writes will be
 	 * allowed.
 	 *
+	 * <p>This method should be idempotent to handle failures and task interruptions. Check FLINK-8948 for more details.
+	 *
 	 * @return number of written bytes.
 	 */
 	public int finish() {
-		checkState(!isFinished());
 		positionMarker.markFinished();
 		commit();
 		return getWrittenBytes();
@@ -125,7 +126,7 @@ public class BufferBuilder {
 		return memorySegment.size();
 	}
 
-	public int getWrittenBytes() {
+	private int getWrittenBytes() {
 		return positionMarker.getCached();
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/BufferBuilderAndConsumerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/BufferBuilderAndConsumerTest.java
@@ -202,22 +202,30 @@ public class BufferBuilderAndConsumerTest {
 		for (int i = 0; i < writes; i++) {
 			assertEquals(Integer.BYTES, bufferBuilder.appendAndCommit(toByteBuffer(42)));
 		}
+		int expectedWrittenBytes = writes * Integer.BYTES;
 
 		assertFalse(bufferBuilder.isFinished());
 		assertFalse(bufferConsumer.isFinished());
+		assertEquals(0, bufferConsumer.getWrittenBytes());
 
 		bufferConsumer.build();
-
 		assertFalse(bufferBuilder.isFinished());
 		assertFalse(bufferConsumer.isFinished());
+		assertEquals(expectedWrittenBytes, bufferConsumer.getWrittenBytes());
 
-		bufferBuilder.finish();
-
+		int actualWrittenBytes = bufferBuilder.finish();
+		assertEquals(expectedWrittenBytes, actualWrittenBytes);
 		assertTrue(bufferBuilder.isFinished());
 		assertFalse(bufferConsumer.isFinished());
+		assertEquals(expectedWrittenBytes, bufferConsumer.getWrittenBytes());
 
-		bufferConsumer.build();
+		actualWrittenBytes = bufferBuilder.finish();
+		assertEquals(expectedWrittenBytes, actualWrittenBytes);
+		assertTrue(bufferBuilder.isFinished());
+		assertFalse(bufferConsumer.isFinished());
+		assertEquals(expectedWrittenBytes, bufferConsumer.getWrittenBytes());
 
+		assertEquals(0, bufferConsumer.build().getSize());
 		assertTrue(bufferConsumer.isFinished());
 	}
 


### PR DESCRIPTION
All methods in org.apache.flink.streaming.runtime.tasks.OperatorChain#releaseOutputs shouldn't
throw any exceptions and should be able to release resources after interruption of the task's
thread.

## Verifying this change

No tests, this is a rare concurrent bug that requires ~30s sleep/freeze during task cancellation :( RescalingITCase could from time to time trigger this bug as reported in the jira ticket.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
