### PR TITLE
[FLINK-8894][REST] CurrentJobIdsHandler fails to serialize response

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/CurrentJobIdsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/CurrentJobIdsHandler.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.jobmaster.JobManagerGateway;
 import org.apache.flink.runtime.messages.webmonitor.JobIdsWithStatusOverview;
 import org.apache.flink.runtime.rest.messages.JobIdsWithStatusesOverviewHeaders;
+import org.apache.flink.runtime.rest.util.RestMapperUtils;
 import org.apache.flink.util.FlinkException;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator;
@@ -70,6 +71,7 @@ public class CurrentJobIdsHandler extends AbstractJsonRequestHandler {
 
 						StringWriter writer = new StringWriter();
 						JsonGenerator gen = JsonFactory.JACKSON_FACTORY.createGenerator(writer);
+						gen.setCodec(RestMapperUtils.getStrictObjectMapper());
 
 						gen.writeStartObject();
 						gen.writeArrayFieldStart(JobIdsWithStatusOverview.FIELD_NAME_JOBS);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/CurrentJobIdsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/CurrentJobIdsHandlerTest.java
@@ -18,21 +18,68 @@
 
 package org.apache.flink.runtime.rest.handler.legacy;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.concurrent.Executors;
+import org.apache.flink.runtime.jobgraph.JobStatus;
+import org.apache.flink.runtime.jobmaster.JobManagerGateway;
+import org.apache.flink.runtime.messages.webmonitor.JobIdsWithStatusOverview;
 
-import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
 
 /**
- * Tests for the CurrentJobIdsHandler.
+ * Tests for {@link CurrentJobIdsHandler}.
  */
 public class CurrentJobIdsHandlerTest {
+
+	private CurrentJobIdsHandler currentJobIdsHandler;
+
+	@Mock
+	private JobManagerGateway mockJobManagerGateway;
+
+	@Before
+	public void setUp() {
+		MockitoAnnotations.initMocks(this);
+		currentJobIdsHandler = new CurrentJobIdsHandler(Executors.directExecutor(), Time.seconds(0L));
+	}
+
 	@Test
 	public void testGetPaths() {
-		CurrentJobIdsHandler handler = new CurrentJobIdsHandler(Executors.directExecutor(), Time.seconds(0L));
-		String[] paths = handler.getPaths();
-		Assert.assertEquals(1, paths.length);
-		Assert.assertEquals("/jobs", paths[0]);
+		final String[] paths = currentJobIdsHandler.getPaths();
+		assertEquals(1, paths.length);
+		assertEquals("/jobs", paths[0]);
 	}
+
+	@Test
+	public void testHandleJsonRequest() throws Exception {
+		final JobID jobId = new JobID();
+		final JobStatus jobStatus = JobStatus.RUNNING;
+
+		when(mockJobManagerGateway.requestJobsOverview(any(Time.class))).thenReturn(
+			CompletableFuture.completedFuture(new JobIdsWithStatusOverview(Collections.singleton(
+				new JobIdsWithStatusOverview.JobIdWithStatus(jobId, jobStatus)))));
+
+		final CompletableFuture<String> jsonFuture = currentJobIdsHandler.handleJsonRequest(
+			Collections.emptyMap(),
+			Collections.emptyMap(),
+			mockJobManagerGateway);
+
+		final String json = jsonFuture.get();
+
+		assertThat(json, containsString(jobId.toString()));
+		assertThat(json, containsString(jobStatus.name()));
+	}
+
 }


### PR DESCRIPTION
## What is the purpose of the change

*This fixes a serialization error in `CurrentJobIdsHandler`.*

cc: @tillrohrmann 

## Brief change log

  - *Set object codec for `JsonGenerator` used in handler.*
  - *Add unit test.*


## Verifying this change

This change added tests and can be verified as follows:

  - *Added test to `CurrentJobIdsHandler`.*
  - *Manually verified the changes.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
