### PR TITLE
[FLINK-9022][state] fix resource release in StreamTaskStateInitializerImpl.streamOperatorStateContext()

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
@@ -1620,7 +1620,6 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 			CheckpointOptions checkpointOptions) throws Exception {
 
 			long startTime = System.currentTimeMillis();
-			final CloseableRegistry snapshotCloseableRegistry = new CloseableRegistry();
 
 			if (kvStateInformation.isEmpty()) {
 				if (LOG.isDebugEnabled()) {
@@ -1646,6 +1645,8 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 					() -> CheckpointStreamWithResultProvider.createSimpleStream(
 						CheckpointedStateScope.EXCLUSIVE,
 						primaryStreamFactory);
+
+			final CloseableRegistry snapshotCloseableRegistry = new CloseableRegistry();
 
 			final RocksDBFullSnapshotOperation<K> snapshotOperation =
 				new RocksDBFullSnapshotOperation<>(

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
@@ -248,8 +248,8 @@ public abstract class AbstractStreamOperator<OUT>
 				context.isRestored(), // information whether we restore or start for the first time
 				operatorStateBackend, // access to operator state backend
 				keyedStateStore, // access to keyed state backend
-				keyedStateInputs, // access to operator state stream
-				operatorStateInputs); // access to keyed state stream
+				keyedStateInputs, // access to keyed state stream
+				operatorStateInputs); // access to operator state stream
 
 			initializeState(initializationContext);
 		} finally {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImpl.java
@@ -167,18 +167,17 @@ public class StreamTaskStateInitializerImpl implements StreamTaskStateInitialize
 			// cleanup if something went wrong before results got published.
 			if (streamTaskCloseableRegistry.unregisterCloseable(keyedStatedBackend)) {
 				IOUtils.closeQuietly(keyedStatedBackend);
+				// release resource (e.g native resource)
+				keyedStatedBackend.dispose();
 			}
 
 			if (streamTaskCloseableRegistry.unregisterCloseable(operatorStateBackend)) {
-				IOUtils.closeQuietly(keyedStatedBackend);
+				IOUtils.closeQuietly(operatorStateBackend);
+				operatorStateBackend.dispose();
 			}
 
 			if (streamTaskCloseableRegistry.unregisterCloseable(rawKeyedStateInputs)) {
 				IOUtils.closeQuietly(rawKeyedStateInputs);
-			}
-
-			if (streamTaskCloseableRegistry.unregisterCloseable(rawOperatorStateInputs)) {
-				IOUtils.closeQuietly(rawOperatorStateInputs);
 			}
 
 			if (streamTaskCloseableRegistry.unregisterCloseable(rawOperatorStateInputs)) {


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes the bug in `StreamTaskStateInitializerImpl.streamOperatorStateContext()` related to resource releasing. Additional, this PR also covers a minor change for [FLINK-9018](https://issues.apache.org/jira/browse/FLINK-9018).

## Brief change log

- fix resource release in StreamTaskStateInitializerImpl.streamOperatorStateContext()

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
