### PR TITLE
[FLINK-8959][tests] Port AccumulatorLiveITCase to flip6 

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatListener.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatListener.java
@@ -57,7 +57,8 @@ public interface HeartbeatListener<I, O> {
 	 * Retrieves the payload value for the next heartbeat message. Since the operation can happen
 	 * asynchronously, the result is returned wrapped in a future.
 	 *
+	 * @param resourceID Resource ID identifying the receiver of the payload
 	 * @return Future containing the next payload for heartbeats
 	 */
-	CompletableFuture<O> retrievePayload();
+	CompletableFuture<O> retrievePayload(ResourceID resourceID);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerImpl.java
@@ -27,6 +27,7 @@ import org.slf4j.Logger;
 import javax.annotation.concurrent.ThreadSafe;
 
 import java.util.Collection;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
@@ -106,8 +107,8 @@ public class HeartbeatManagerImpl<I, O> implements HeartbeatManager<I, O> {
 		return heartbeatListener;
 	}
 
-	Collection<HeartbeatManagerImpl.HeartbeatMonitor<O>> getHeartbeatTargets() {
-		return heartbeatTargets.values();
+	Collection<Map.Entry<ResourceID, HeartbeatMonitor<O>>> getHeartbeatTargets() {
+		return heartbeatTargets.entrySet();
 	}
 
 	//----------------------------------------------------------------------------------------------
@@ -202,7 +203,7 @@ public class HeartbeatManagerImpl<I, O> implements HeartbeatManager<I, O> {
 					heartbeatListener.reportPayload(requestOrigin, heartbeatPayload);
 				}
 
-				CompletableFuture<O> futurePayload = heartbeatListener.retrievePayload();
+				CompletableFuture<O> futurePayload = heartbeatListener.retrievePayload(requestOrigin);
 
 				if (futurePayload != null) {
 					CompletableFuture<Void> sendHeartbeatFuture = futurePayload.thenAcceptAsync(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerSenderImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerSenderImpl.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 
 import org.slf4j.Logger;
 
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledFuture;
@@ -62,9 +63,9 @@ public class HeartbeatManagerSenderImpl<I, O> extends HeartbeatManagerImpl<I, O>
 	public void run() {
 		if (!stopped) {
 			log.debug("Trigger heartbeat request.");
-			for (HeartbeatMonitor<O> heartbeatMonitor : getHeartbeatTargets()) {
-				CompletableFuture<O> futurePayload = getHeartbeatListener().retrievePayload();
-				final HeartbeatTarget<O> heartbeatTarget = heartbeatMonitor.getHeartbeatTarget();
+			for (Map.Entry<ResourceID, HeartbeatMonitor<O>> heartbeatTargetEntry : getHeartbeatTargets()) {
+				CompletableFuture<O> futurePayload = getHeartbeatListener().retrievePayload(heartbeatTargetEntry.getKey());
+				final HeartbeatTarget<O> heartbeatTarget = heartbeatTargetEntry.getValue().getHeartbeatTarget();
 
 				if (futurePayload != null) {
 					CompletableFuture<Void> requestHeartbeatFuture = futurePayload.thenAcceptAsync(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -1527,7 +1527,7 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 		}
 
 		@Override
-		public CompletableFuture<Void> retrievePayload() {
+		public CompletableFuture<Void> retrievePayload(ResourceID resourceID) {
 			return CompletableFuture.completedFuture(null);
 		}
 	}
@@ -1551,7 +1551,7 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 		}
 
 		@Override
-		public CompletableFuture<Void> retrievePayload() {
+		public CompletableFuture<Void> retrievePayload(ResourceID resourceID) {
 			return CompletableFuture.completedFuture(null);
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -27,6 +27,7 @@ import org.apache.flink.core.io.InputSplitAssigner;
 import org.apache.flink.queryablestate.KvStateID;
 import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.StoppingException;
+import org.apache.flink.runtime.accumulators.AccumulatorSnapshot;
 import org.apache.flink.runtime.blob.BlobServer;
 import org.apache.flink.runtime.checkpoint.CheckpointCoordinator;
 import org.apache.flink.runtime.checkpoint.CheckpointDeclineReason;
@@ -93,6 +94,7 @@ import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.RpcTimeout;
 import org.apache.flink.runtime.rpc.akka.AkkaRpcServiceUtils;
 import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.taskexecutor.AccumulatorReport;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
 import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
@@ -166,7 +168,7 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 	private final JobManagerJobMetricGroup jobMetricGroup;
 
 	/** The heartbeat manager with task managers. */
-	private final HeartbeatManager<Void, Void> taskManagerHeartbeatManager;
+	private final HeartbeatManager<AccumulatorReport, Void> taskManagerHeartbeatManager;
 
 	/** The heartbeat manager with resource manager. */
 	private final HeartbeatManager<Void, Void> resourceManagerHeartbeatManager;
@@ -938,8 +940,8 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 	}
 
 	@Override
-	public void heartbeatFromTaskManager(final ResourceID resourceID) {
-		taskManagerHeartbeatManager.receiveHeartbeat(resourceID, null);
+	public void heartbeatFromTaskManager(final ResourceID resourceID, AccumulatorReport accumulatorReport) {
+		taskManagerHeartbeatManager.receiveHeartbeat(resourceID, accumulatorReport);
 	}
 
 	@Override
@@ -1504,7 +1506,7 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 		}
 	}
 
-	private class TaskManagerHeartbeatListener implements HeartbeatListener<Void, Void> {
+	private class TaskManagerHeartbeatListener implements HeartbeatListener<AccumulatorReport, Void> {
 
 		private final JobMasterGateway jobMasterGateway;
 
@@ -1522,8 +1524,10 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 		}
 
 		@Override
-		public void reportPayload(ResourceID resourceID, Void payload) {
-			// nothing to do since there is no payload
+		public void reportPayload(ResourceID resourceID, AccumulatorReport payload) {
+			for (AccumulatorSnapshot snapshot : payload) {
+				executionGraph.updateAccumulators(snapshot);
+			}
 		}
 
 		@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
@@ -40,6 +40,7 @@ import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.OperatorBackPressureStatsResponse;
 import org.apache.flink.runtime.rpc.FencedRpcGateway;
 import org.apache.flink.runtime.rpc.RpcTimeout;
+import org.apache.flink.runtime.taskexecutor.AccumulatorReport;
 import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
@@ -219,8 +220,11 @@ public interface JobMasterGateway extends
 	 * Sends the heartbeat to job manager from task manager.
 	 *
 	 * @param resourceID unique id of the task manager
+	 * @param accumulatorReport report containing accumulator updates
 	 */
-	void heartbeatFromTaskManager(final ResourceID resourceID);
+	void heartbeatFromTaskManager(
+		final ResourceID resourceID,
+		final AccumulatorReport accumulatorReport);
 
 	/**
 	 * Sends heartbeat request from the resource manager.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -1076,7 +1076,7 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 		}
 
 		@Override
-		public CompletableFuture<Void> retrievePayload() {
+		public CompletableFuture<Void> retrievePayload(ResourceID resourceID) {
 			return CompletableFuture.completedFuture(null);
 		}
 	}
@@ -1109,7 +1109,7 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 		}
 
 		@Override
-		public CompletableFuture<Void> retrievePayload() {
+		public CompletableFuture<Void> retrievePayload(ResourceID resourceID) {
 			return CompletableFuture.completedFuture(null);
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/AccumulatorReport.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/AccumulatorReport.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskexecutor;
+
+import org.apache.flink.runtime.accumulators.AccumulatorSnapshot;
+
+import java.io.Serializable;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * A report about the current values of all accumulators of the TaskExecutor for a given job.
+ */
+public class AccumulatorReport implements Serializable, Iterable<AccumulatorSnapshot> {
+	private final List<AccumulatorSnapshot> accumulatorSnapshots;
+
+	public AccumulatorReport(List<AccumulatorSnapshot> accumulatorSnapshots) {
+		this.accumulatorSnapshots = accumulatorSnapshots;
+	}
+
+	@Override
+	public Iterator<AccumulatorSnapshot> iterator() {
+		return accumulatorSnapshots.iterator();
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -1515,7 +1515,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 		}
 
 		@Override
-		public CompletableFuture<Void> retrievePayload() {
+		public CompletableFuture<Void> retrievePayload(ResourceID resourceID) {
 			return CompletableFuture.completedFuture(null);
 		}
 	}
@@ -1544,7 +1544,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 		}
 
 		@Override
-		public CompletableFuture<SlotReport> retrievePayload() {
+		public CompletableFuture<SlotReport> retrievePayload(ResourceID resourceID) {
 			return callAsync(
 					() -> taskSlotTable.createSlotReport(getResourceID()),
 					taskManagerConfiguration.getTimeout());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -107,6 +107,7 @@ import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -138,7 +139,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 	private final TaskManagerConfiguration taskManagerConfiguration;
 
 	/** The heartbeat manager for job manager in the task manager. */
-	private final HeartbeatManager<Void, Void> jobManagerHeartbeatManager;
+	private final HeartbeatManager<Void, AccumulatorReport> jobManagerHeartbeatManager;
 
 	/** The heartbeat manager for resource manager in the task manager. */
 	private final HeartbeatManager<Void, SlotReport> resourceManagerHeartbeatManager;
@@ -1050,14 +1051,14 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 		jobManagerTable.put(jobId, newJobManagerConnection);
 
 		// monitor the job manager as heartbeat target
-		jobManagerHeartbeatManager.monitorTarget(jobManagerResourceID, new HeartbeatTarget<Void>() {
+		jobManagerHeartbeatManager.monitorTarget(jobManagerResourceID, new HeartbeatTarget<AccumulatorReport>() {
 			@Override
-			public void receiveHeartbeat(ResourceID resourceID, Void payload) {
-				jobMasterGateway.heartbeatFromTaskManager(resourceID);
+			public void receiveHeartbeat(ResourceID resourceID, AccumulatorReport payload) {
+				jobMasterGateway.heartbeatFromTaskManager(resourceID, payload);
 			}
 
 			@Override
-			public void requestHeartbeat(ResourceID resourceID, Void payload) {
+			public void requestHeartbeat(ResourceID resourceID, AccumulatorReport payload) {
 				// request heartbeat will never be called on the task manager side
 			}
 		});
@@ -1488,7 +1489,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 		}
 	}
 
-	private class JobManagerHeartbeatListener implements HeartbeatListener<Void, Void> {
+	private class JobManagerHeartbeatListener implements HeartbeatListener<Void, AccumulatorReport> {
 
 		@Override
 		public void notifyHeartbeatTimeout(final ResourceID resourceID) {
@@ -1515,8 +1516,22 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 		}
 
 		@Override
-		public CompletableFuture<Void> retrievePayload(ResourceID resourceID) {
-			return CompletableFuture.completedFuture(null);
+		public CompletableFuture<AccumulatorReport> retrievePayload(ResourceID resourceID) {
+			JobManagerConnection jobManagerConnection = jobManagerConnections.get(resourceID);
+			if (jobManagerConnection != null) {
+				JobID jobId = jobManagerConnection.getJobID();
+
+				List<AccumulatorSnapshot> accumulatorSnapshots = new ArrayList<>(16);
+				Iterator<Task> allTasks = taskSlotTable.getTasks(jobId);
+
+				while (allTasks.hasNext()) {
+					Task task = allTasks.next();
+					accumulatorSnapshots.add(task.getAccumulatorRegistry().getSnapshot());
+				}
+				return CompletableFuture.completedFuture(new AccumulatorReport(accumulatorSnapshots));
+			} else {
+				return CompletableFuture.completedFuture(new AccumulatorReport(Collections.emptyList()));
+			}
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.heartbeat;
 
+import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.concurrent.Executors;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
@@ -75,7 +76,7 @@ public class HeartbeatManagerTest extends TestLogger {
 
 		Object expectedObject = new Object();
 
-		when(heartbeatListener.retrievePayload()).thenReturn(CompletableFuture.completedFuture(expectedObject));
+		when(heartbeatListener.retrievePayload(any(ResourceID.class))).thenReturn(CompletableFuture.completedFuture(expectedObject));
 
 		HeartbeatManagerImpl<Object, Object> heartbeatManager = new HeartbeatManagerImpl<>(
 			heartbeatTimeout,
@@ -93,7 +94,7 @@ public class HeartbeatManagerTest extends TestLogger {
 		heartbeatManager.requestHeartbeat(targetResourceID, expectedObject);
 
 		verify(heartbeatListener, times(1)).reportPayload(targetResourceID, expectedObject);
-		verify(heartbeatListener, times(1)).retrievePayload();
+		verify(heartbeatListener, times(1)).retrievePayload(any(ResourceID.class));
 		verify(heartbeatTarget, times(1)).receiveHeartbeat(ownResourceID, expectedObject);
 
 		heartbeatManager.receiveHeartbeat(targetResourceID, expectedObject);
@@ -118,7 +119,7 @@ public class HeartbeatManagerTest extends TestLogger {
 
 		Object expectedObject = new Object();
 
-		when(heartbeatListener.retrievePayload()).thenReturn(CompletableFuture.completedFuture(expectedObject));
+		when(heartbeatListener.retrievePayload(any(ResourceID.class))).thenReturn(CompletableFuture.completedFuture(expectedObject));
 
 		HeartbeatManagerImpl<Object, Object> heartbeatManager = new HeartbeatManagerImpl<>(
 			heartbeatTimeout,
@@ -207,7 +208,7 @@ public class HeartbeatManagerTest extends TestLogger {
 		@SuppressWarnings("unchecked")
 		HeartbeatListener<Object, Object> heartbeatListener = mock(HeartbeatListener.class);
 
-		when(heartbeatListener.retrievePayload()).thenReturn(CompletableFuture.completedFuture(object));
+		when(heartbeatListener.retrievePayload(any(ResourceID.class))).thenReturn(CompletableFuture.completedFuture(object));
 
 		TestingHeartbeatListener heartbeatListener2 = new TestingHeartbeatListener(object2);
 
@@ -347,6 +348,162 @@ public class HeartbeatManagerTest extends TestLogger {
 		}
 	}
 
+	/**
+	 * Tests that the heartbeat target {@link ResourceID} is properly passed to the {@link HeartbeatListener} by the
+	 * {@link HeartbeatManagerImpl}.
+	 */
+	@Test
+	public void testHeartbeatManagerTargetPayload() {
+		final long heartbeatTimeout = 100L;
+
+		final ResourceID someTargetId = ResourceID.generate();
+		final ResourceID specialTargetId = ResourceID.generate();
+		final TargetDependentHeartbeatReceiver someHeartbeatTarget = new TargetDependentHeartbeatReceiver();
+		final TargetDependentHeartbeatReceiver specialHeartbeatTarget = new TargetDependentHeartbeatReceiver();
+
+		final int defaultResponse = 0;
+		final int specialResponse = 1;
+
+		HeartbeatManager<?, Integer> heartbeatManager = new HeartbeatManagerImpl<>(
+			heartbeatTimeout,
+			ResourceID.generate(),
+			new TargetDependentHeartbeatSender(specialTargetId, specialResponse, defaultResponse),
+			Executors.directExecutor(),
+			mock(ScheduledExecutor.class),
+			LOG);
+
+		try {
+			heartbeatManager.monitorTarget(someTargetId, someHeartbeatTarget);
+			heartbeatManager.monitorTarget(specialTargetId, specialHeartbeatTarget);
+
+			heartbeatManager.requestHeartbeat(someTargetId, null);
+			assertEquals(defaultResponse, someHeartbeatTarget.getLastReceivedHeartbeatPayload());
+
+			heartbeatManager.requestHeartbeat(specialTargetId, null);
+			assertEquals(specialResponse, specialHeartbeatTarget.getLastReceivedHeartbeatPayload());
+		} finally {
+			heartbeatManager.stop();
+		}
+	}
+
+	/**
+	 * Tests that the heartbeat target {@link ResourceID} is properly passed to the {@link HeartbeatListener} by the
+	 * {@link HeartbeatManagerSenderImpl}.
+	 */
+	@Test
+	public void testHeartbeatManagerSenderTargetPayload() throws Exception {
+		final long heartbeatTimeout = 100L;
+		final long heartbeatPeriod = 2000L;
+
+		final ScheduledThreadPoolExecutor scheduledThreadPoolExecutor = new ScheduledThreadPoolExecutor(1);
+
+		final ResourceID someTargetId = ResourceID.generate();
+		final ResourceID specialTargetId = ResourceID.generate();
+
+		final OneShotLatch someTargetReceivedLatch = new OneShotLatch();
+		final OneShotLatch specialTargedReceivedLatch = new OneShotLatch();
+
+		final TargetDependentHeartbeatReceiver someHeartbeatTarget = new TargetDependentHeartbeatReceiver(someTargetReceivedLatch);
+		final TargetDependentHeartbeatReceiver specialHeartbeatTarget = new TargetDependentHeartbeatReceiver(specialTargedReceivedLatch);
+
+		final int defaultResponse = 0;
+		final int specialResponse = 1;
+
+		HeartbeatManager<?, Integer> heartbeatManager = new HeartbeatManagerSenderImpl<>(
+			heartbeatPeriod,
+			heartbeatTimeout,
+			ResourceID.generate(),
+			new TargetDependentHeartbeatSender(specialTargetId, specialResponse, defaultResponse),
+			Executors.directExecutor(),
+			new ScheduledExecutorServiceAdapter(scheduledThreadPoolExecutor),
+			LOG);
+
+		try {
+			heartbeatManager.monitorTarget(someTargetId, someHeartbeatTarget);
+			heartbeatManager.monitorTarget(specialTargetId, specialHeartbeatTarget);
+
+			someTargetReceivedLatch.await(5, TimeUnit.SECONDS);
+			specialTargedReceivedLatch.await(5, TimeUnit.SECONDS);
+
+			assertEquals(defaultResponse, someHeartbeatTarget.getLastRequestedHeartbeatPayload());
+			assertEquals(specialResponse, specialHeartbeatTarget.getLastRequestedHeartbeatPayload());
+		} finally {
+			heartbeatManager.stop();
+			scheduledThreadPoolExecutor.shutdown();
+		}
+	}
+
+	/**
+	 * Test {@link HeartbeatTarget} that exposes the last received payload.
+	 */
+	private static class TargetDependentHeartbeatReceiver implements HeartbeatTarget<Integer> {
+
+		private int lastReceivedHeartbeatPayload = -1;
+		private int lastRequestedHeartbeatPayload = -1;
+
+		private final OneShotLatch latch;
+
+		public TargetDependentHeartbeatReceiver() {
+			this(new OneShotLatch());
+		}
+
+		public TargetDependentHeartbeatReceiver(OneShotLatch latch) {
+			this.latch = latch;
+		}
+
+		@Override
+		public void receiveHeartbeat(ResourceID heartbeatOrigin, Integer heartbeatPayload) {
+			this.lastReceivedHeartbeatPayload = heartbeatPayload;
+			latch.trigger();
+		}
+
+		@Override
+		public void requestHeartbeat(ResourceID requestOrigin, Integer heartbeatPayload) {
+			this.lastRequestedHeartbeatPayload = heartbeatPayload;
+			latch.trigger();
+		}
+
+		public int getLastReceivedHeartbeatPayload() {
+			return lastReceivedHeartbeatPayload;
+		}
+
+		public int getLastRequestedHeartbeatPayload() {
+			return lastRequestedHeartbeatPayload;
+		}
+	}
+
+	/**
+	 * Test {@link HeartbeatListener} that returns different payloads based on the target {@link ResourceID}.
+	 */
+	private static class TargetDependentHeartbeatSender implements HeartbeatListener<Object, Integer>  {
+		private final ResourceID specialId;
+		private final int specialResponse;
+		private final int defaultResponse;
+
+		TargetDependentHeartbeatSender(ResourceID specialId, int specialResponse, int defaultResponse) {
+			this.specialId = specialId;
+			this.specialResponse = specialResponse;
+			this.defaultResponse = defaultResponse;
+		}
+
+		@Override
+		public void notifyHeartbeatTimeout(ResourceID resourceID) {
+		}
+
+		@Override
+		public void reportPayload(ResourceID resourceID, Object payload) {
+		}
+
+		@Override
+		public CompletableFuture<Integer> retrievePayload(ResourceID resourceID) {
+			if (resourceID.equals(specialId)) {
+				return CompletableFuture.completedFuture(specialResponse);
+			} else {
+				return CompletableFuture.completedFuture(defaultResponse);
+			}
+		}
+	}
+
 	static class TestingHeartbeatListener implements HeartbeatListener<Object, Object> {
 
 		private final CompletableFuture<ResourceID> future = new CompletableFuture<>();
@@ -378,7 +535,7 @@ public class HeartbeatManagerTest extends TestLogger {
 		}
 
 		@Override
-		public CompletableFuture<Object> retrievePayload() {
+		public CompletableFuture<Object> retrievePayload(ResourceID resourceID) {
 			return CompletableFuture.completedFuture(payload);
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGateway.java
@@ -44,6 +44,7 @@ import org.apache.flink.runtime.registration.RegistrationResponse;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.OperatorBackPressureStatsResponse;
 import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.taskexecutor.AccumulatorReport;
 import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
@@ -130,7 +131,7 @@ public class TestingJobMasterGateway implements JobMasterGateway {
 	}
 
 	@Override
-	public void heartbeatFromTaskManager(ResourceID resourceID) {
+	public void heartbeatFromTaskManager(ResourceID resourceID, AccumulatorReport accumulatorReport) {
 		throw new UnsupportedOperationException();
 	}
 

--- a/flink-tests/src/test/java/org/apache/flink/test/accumulators/AccumulatorLiveITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/accumulators/AccumulatorLiveITCase.java
@@ -18,47 +18,34 @@
 
 package org.apache.flink.test.accumulators;
 
-import org.apache.flink.api.common.JobExecutionResult;
-import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.Plan;
-import org.apache.flink.api.common.accumulators.Accumulator;
 import org.apache.flink.api.common.accumulators.IntCounter;
 import org.apache.flink.api.common.functions.RichFlatMapFunction;
 import org.apache.flink.api.common.io.OutputFormat;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
-import org.apache.flink.api.java.LocalEnvironment;
+import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.AkkaOptions;
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.HeartbeatManagerOptions;
+import org.apache.flink.core.testutils.MultiShotLatch;
 import org.apache.flink.optimizer.DataStatistics;
 import org.apache.flink.optimizer.Optimizer;
 import org.apache.flink.optimizer.plan.OptimizedPlan;
 import org.apache.flink.optimizer.plantranslate.JobGraphGenerator;
-import org.apache.flink.runtime.akka.AkkaUtils;
-import org.apache.flink.runtime.akka.ListeningBehaviour;
-import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
-import org.apache.flink.runtime.instance.ActorGateway;
-import org.apache.flink.runtime.instance.AkkaActorGateway;
 import org.apache.flink.runtime.jobgraph.JobGraph;
-import org.apache.flink.runtime.messages.JobManagerMessages;
-import org.apache.flink.runtime.testingUtils.TestingCluster;
-import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages;
-import org.apache.flink.runtime.testingUtils.TestingTaskManagerMessages;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.test.util.MiniClusterResource;
+import org.apache.flink.testutils.category.Flip6;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.TestLogger;
 
-import akka.actor.ActorRef;
-import akka.actor.ActorSystem;
-import akka.pattern.Patterns;
-import akka.testkit.JavaTestKit;
-import akka.util.Timeout;
-import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,244 +53,153 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
-import scala.concurrent.Await;
-import scala.concurrent.Future;
-import scala.concurrent.duration.FiniteDuration;
-
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
- * Tests the availability of accumulator results during runtime. The test case tests a user-defined
- * accumulator and Flink's internal accumulators for two consecutive tasks.
- *
- * <p>CHAINED[Source -> Map] -> Sink
- *
- * <p>Checks are performed as the elements arrive at the operators. Checks consist of a message sent by
- * the task to the task manager which notifies the job manager and sends the current accumulators.
- * The task blocks until the test has been notified about the current accumulator values.
- *
- * <p>A barrier between the operators ensures that that pipelining is disabled for the streaming test.
- * The batch job reads the records one at a time. The streaming code buffers the records beforehand;
- * that's why exact guarantees about the number of records read are very hard to make. Thus, why we
- * check for an upper bound of the elements read.
+ * Tests the availability of accumulator results during runtime.
  */
+@Category(Flip6.class)
 public class AccumulatorLiveITCase extends TestLogger {
 
 	private static final Logger LOG = LoggerFactory.getLogger(AccumulatorLiveITCase.class);
 
-	private static ActorSystem system;
-	private static ActorGateway jobManagerGateway;
-	private static ActorRef taskManager;
-
-	private static JobID jobID;
-	private static JobGraph jobGraph;
-
 	// name of user accumulator
 	private static final String ACCUMULATOR_NAME = "test";
+
+	private static final long HEARTBEAT_INTERVAL = 50L;
 
 	// number of heartbeat intervals to check
 	private static final int NUM_ITERATIONS = 5;
 
-	private static List<String> inputData = new ArrayList<>(NUM_ITERATIONS);
+	private static final List<Integer> inputData = new ArrayList<>(NUM_ITERATIONS);
 
-	private static final FiniteDuration TIMEOUT = new FiniteDuration(10, TimeUnit.SECONDS);
-
-	@Before
-	public void before() throws Exception {
-		system = AkkaUtils.createLocalActorSystem(new Configuration());
-
-		Configuration config = new Configuration();
-		config.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, 1);
-		config.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, 1);
-		config.setString(AkkaOptions.ASK_TIMEOUT, TestingUtils.DEFAULT_AKKA_ASK_TIMEOUT());
-		TestingCluster testingCluster = new TestingCluster(config, false, true);
-		testingCluster.start();
-
-		jobManagerGateway = testingCluster.getLeaderGateway(TestingUtils.TESTING_DURATION());
-		taskManager = testingCluster.getTaskManagersAsJava().get(0);
-
+	static {
 		// generate test data
 		for (int i = 0; i < NUM_ITERATIONS; i++) {
-			inputData.add(i, String.valueOf(i + 1));
+			inputData.add(i);
 		}
-
-		NotifyingMapper.finished = false;
 	}
 
-	@After
-	public void after() throws Exception {
-		JavaTestKit.shutdownActorSystem(system);
-		inputData.clear();
+	@ClassRule
+	public static final MiniClusterResource MINI_CLUSTER_RESOURCE = new MiniClusterResource(
+		new MiniClusterResource.MiniClusterResourceConfiguration(
+			getConfiguration(),
+			1,
+			1),
+		true);
+
+	private static Configuration getConfiguration() {
+		Configuration config = new Configuration();
+		config.setString(AkkaOptions.ASK_TIMEOUT, TestingUtils.DEFAULT_AKKA_ASK_TIMEOUT());
+		config.setLong(HeartbeatManagerOptions.HEARTBEAT_INTERVAL, HEARTBEAT_INTERVAL);
+
+		return config;
+	}
+
+	@Before
+	public void resetLatches() throws InterruptedException {
+		NotifyingMapper.reset();
 	}
 
 	@Test
 	public void testBatch() throws Exception {
-
-		/** The program **/
-		ExecutionEnvironment env = new BatchPlanExtractor();
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 		env.setParallelism(1);
 
-		DataSet<String> input = env.fromCollection(inputData);
+		DataSet<Integer> input = env.fromCollection(inputData);
 		input
 				.flatMap(new NotifyingMapper())
-				.output(new NotifyingOutputFormat());
-
-		env.execute();
+				.output(new DummyOutputFormat());
 
 		// Extract job graph and set job id for the task to notify of accumulator changes.
-		jobGraph = getOptimizedPlan(((BatchPlanExtractor) env).plan);
-		jobID = jobGraph.getJobID();
+		JobGraph jobGraph = getJobGraph(env.createProgramPlan());
 
-		verifyResults();
+		submitJobAndVerifyResults(jobGraph);
 	}
 
 	@Test
 	public void testStreaming() throws Exception {
 
-		StreamExecutionEnvironment env = new DummyStreamExecutionEnvironment();
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 		env.setParallelism(1);
 
-		DataStream<String> input = env.fromCollection(inputData);
+		DataStream<Integer> input = env.fromCollection(inputData);
 		input
 				.flatMap(new NotifyingMapper())
-				.writeUsingOutputFormat(new NotifyingOutputFormat()).disableChaining();
+				.writeUsingOutputFormat(new DummyOutputFormat()).disableChaining();
 
-		jobGraph = env.getStreamGraph().getJobGraph();
-		jobID = jobGraph.getJobID();
+		JobGraph jobGraph = env.getStreamGraph().getJobGraph();
 
-		verifyResults();
+		submitJobAndVerifyResults(jobGraph);
 	}
 
-	private static void verifyResults() {
-		new JavaTestKit(system) {{
+	private static void submitJobAndVerifyResults(JobGraph jobGraph) throws Exception {
 
-			ActorGateway selfGateway = new AkkaActorGateway(getRef(), jobManagerGateway.leaderSessionID());
+		ClusterClient<?> client = MINI_CLUSTER_RESOURCE.getClusterClient();
 
-			// register for accumulator changes
-			jobManagerGateway.tell(new TestingJobManagerMessages.NotifyWhenAccumulatorChange(jobID), selfGateway);
-			expectMsgEquals(TIMEOUT, true);
+		client.setDetached(true);
+		client.submitJob(jobGraph, AccumulatorLiveITCase.class.getClassLoader());
 
-			// submit job
+		try {
+			NotifyingMapper.notifyLatch.await();
+			Thread.sleep(HEARTBEAT_INTERVAL * 4); // wait for heartbeat
 
-			jobManagerGateway.tell(
-					new JobManagerMessages.SubmitJob(
-							jobGraph,
-							ListeningBehaviour.EXECUTION_RESULT),
-					selfGateway);
-			expectMsgClass(TIMEOUT, JobManagerMessages.JobSubmitSuccess.class);
+			Map<String, Object> initialAccumulators = client.getAccumulators(jobGraph.getJobID());
+			assertEquals(1, initialAccumulators.size());
+			assertTrue(initialAccumulators.containsKey(ACCUMULATOR_NAME));
+			assertEquals(NUM_ITERATIONS, (int) initialAccumulators.get(ACCUMULATOR_NAME));
 
-			TestingJobManagerMessages.UpdatedAccumulators msg = (TestingJobManagerMessages.UpdatedAccumulators) receiveOne(TIMEOUT);
-			Map<String, Accumulator<?, ?>> userAccumulators = msg.userAccumulators();
-
-			ExecutionAttemptID mapperTaskID = null;
-
-			ExecutionAttemptID sinkTaskID = null;
-
-			/* Check for accumulator values */
-			if (checkUserAccumulators(0, userAccumulators)) {
-				LOG.info("Passed initial check for map task.");
-			} else {
-				fail("Wrong accumulator results when map task begins execution.");
-			}
-
-			int expectedAccVal = 0;
-
-			/* for mapper task */
-			for (int i = 1; i <= NUM_ITERATIONS; i++) {
-				expectedAccVal += i;
-
-				// receive message
-				msg = (TestingJobManagerMessages.UpdatedAccumulators) receiveOne(TIMEOUT);
-				userAccumulators = msg.userAccumulators();
-
-				LOG.info("{}", userAccumulators);
-
-				if (checkUserAccumulators(expectedAccVal, userAccumulators)) {
-					LOG.info("Passed round #" + i);
-				} else if (checkUserAccumulators(expectedAccVal, userAccumulators)) {
-					// we determined the wrong task id and need to switch the two here
-					ExecutionAttemptID temp = mapperTaskID;
-					mapperTaskID = sinkTaskID;
-					sinkTaskID = temp;
-					LOG.info("Passed round #" + i);
-				} else {
-					fail("Failed in round #" + i);
-				}
-			}
-
-			msg = (TestingJobManagerMessages.UpdatedAccumulators) receiveOne(TIMEOUT);
-			userAccumulators = msg.userAccumulators();
-
-			if (checkUserAccumulators(expectedAccVal, userAccumulators)) {
-				LOG.info("Passed initial check for sink task.");
-			} else {
-				fail("Wrong accumulator results when sink task begins execution.");
-			}
-
-			/* for sink task */
-			for (int i = 1; i <= NUM_ITERATIONS; i++) {
-
-				// receive message
-				msg = (TestingJobManagerMessages.UpdatedAccumulators) receiveOne(TIMEOUT);
-
-				userAccumulators = msg.userAccumulators();
-
-				LOG.info("{}", userAccumulators);
-
-				if (checkUserAccumulators(expectedAccVal, userAccumulators)) {
-					LOG.info("Passed round #" + i);
-				} else {
-					fail("Failed in round #" + i);
-				}
-			}
-
-			expectMsgClass(TIMEOUT, JobManagerMessages.JobResultSuccess.class);
-
-		}};
-	}
-
-	private static boolean checkUserAccumulators(int expected, Map<String, Accumulator<?, ?>> accumulatorMap) {
-		LOG.info("checking user accumulators");
-		return accumulatorMap.containsKey(ACCUMULATOR_NAME) && expected == ((IntCounter) accumulatorMap.get(ACCUMULATOR_NAME)).getLocalValue();
+			NotifyingMapper.shutdownLatch.trigger();
+		} finally {
+			NotifyingMapper.shutdownLatch.trigger();
+		}
 	}
 
 	/**
 	 * UDF that notifies when it changes the accumulator values.
 	 */
-	private static class NotifyingMapper extends RichFlatMapFunction<String, Integer> {
+	private static class NotifyingMapper extends RichFlatMapFunction<Integer, Integer> {
 		private static final long serialVersionUID = 1L;
 
-		private IntCounter counter = new IntCounter();
+		private static final MultiShotLatch notifyLatch = new MultiShotLatch();
+		private static final MultiShotLatch shutdownLatch = new MultiShotLatch();
 
-		private static boolean finished = false;
+		private final IntCounter counter = new IntCounter();
 
 		@Override
 		public void open(Configuration parameters) throws Exception {
 			getRuntimeContext().addAccumulator(ACCUMULATOR_NAME, counter);
-			notifyTaskManagerOfAccumulatorUpdate();
 		}
 
 		@Override
-		public void flatMap(String value, Collector<Integer> out) throws Exception {
-			int val = Integer.valueOf(value);
-			counter.add(val);
-			out.collect(val);
+		public void flatMap(Integer value, Collector<Integer> out) throws Exception {
+			counter.add(1);
+			out.collect(value);
 			LOG.debug("Emitting value {}.", value);
-			notifyTaskManagerOfAccumulatorUpdate();
+			if (counter.getLocalValuePrimitive() == 5) {
+				notifyLatch.trigger();
+			}
 		}
 
 		@Override
 		public void close() throws Exception {
-			finished = true;
+			shutdownLatch.await();
+		}
+
+		private static void reset() throws InterruptedException {
+			notifyLatch.trigger();
+			notifyLatch.await();
+			shutdownLatch.trigger();
+			shutdownLatch.await();
 		}
 	}
 
 	/**
-	 * Outputs format which notifies of accumulator changes and waits for the previous mapper.
+	 * Outputs format which waits for the previous mapper.
 	 */
-	private static class NotifyingOutputFormat implements OutputFormat<Integer> {
+	private static class DummyOutputFormat implements OutputFormat<Integer> {
 		private static final long serialVersionUID = 1L;
 
 		@Override
@@ -312,17 +208,10 @@ public class AccumulatorLiveITCase extends TestLogger {
 
 		@Override
 		public void open(int taskNumber, int numTasks) throws IOException {
-			while (!NotifyingMapper.finished) {
-				try {
-					Thread.sleep(1000);
-				} catch (InterruptedException e) {}
-			}
-			notifyTaskManagerOfAccumulatorUpdate();
 		}
 
 		@Override
 		public void writeRecord(Integer record) throws IOException {
-			notifyTaskManagerOfAccumulatorUpdate();
 		}
 
 		@Override
@@ -331,56 +220,12 @@ public class AccumulatorLiveITCase extends TestLogger {
 	}
 
 	/**
-	 * Notify task manager of accumulator update and wait until the Heartbeat containing the message
-	 * has been reported.
-	 */
-	public static void notifyTaskManagerOfAccumulatorUpdate() {
-		new JavaTestKit(system) {{
-			Timeout timeout = new Timeout(TIMEOUT);
-			Future<Object> ask = Patterns.ask(taskManager, new TestingTaskManagerMessages.AccumulatorsChanged(jobID), timeout);
-			try {
-				Await.result(ask, timeout.duration());
-			} catch (Exception e) {
-				fail("Failed to notify task manager of accumulator update.");
-			}
-		}};
-	}
-
-	/**
 	 * Helpers to generate the JobGraph.
 	 */
-	private static JobGraph getOptimizedPlan(Plan plan) {
+	private static JobGraph getJobGraph(Plan plan) {
 		Optimizer pc = new Optimizer(new DataStatistics(), new Configuration());
 		JobGraphGenerator jgg = new JobGraphGenerator();
 		OptimizedPlan op = pc.compile(plan);
 		return jgg.compileJobGraph(op);
-	}
-
-	private static class BatchPlanExtractor extends LocalEnvironment {
-
-		private Plan plan = null;
-
-		@Override
-		public JobExecutionResult execute(String jobName) throws Exception {
-			plan = createProgramPlan();
-			return new JobExecutionResult(new JobID(), -1, null);
-		}
-	}
-
-	/**
-	 * This is used to for creating the example topology. {@link #execute} is never called, we
-	 * only use this to call {@link #getStreamGraph()}.
-	 */
-	private static class DummyStreamExecutionEnvironment extends StreamExecutionEnvironment {
-
-		@Override
-		public JobExecutionResult execute() throws Exception {
-			return execute("default");
-		}
-
-		@Override
-		public JobExecutionResult execute(String jobName) throws Exception {
-			throw new RuntimeException("This should not be called.");
-		}
 	}
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/accumulators/LegacyAccumulatorLiveITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/accumulators/LegacyAccumulatorLiveITCase.java
@@ -1,0 +1,386 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.accumulators;
+
+import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.Plan;
+import org.apache.flink.api.common.accumulators.Accumulator;
+import org.apache.flink.api.common.accumulators.IntCounter;
+import org.apache.flink.api.common.functions.RichFlatMapFunction;
+import org.apache.flink.api.common.io.OutputFormat;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.LocalEnvironment;
+import org.apache.flink.configuration.AkkaOptions;
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.optimizer.DataStatistics;
+import org.apache.flink.optimizer.Optimizer;
+import org.apache.flink.optimizer.plan.OptimizedPlan;
+import org.apache.flink.optimizer.plantranslate.JobGraphGenerator;
+import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.akka.ListeningBehaviour;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.instance.ActorGateway;
+import org.apache.flink.runtime.instance.AkkaActorGateway;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.messages.JobManagerMessages;
+import org.apache.flink.runtime.testingUtils.TestingCluster;
+import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages;
+import org.apache.flink.runtime.testingUtils.TestingTaskManagerMessages;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.TestLogger;
+
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import akka.pattern.Patterns;
+import akka.testkit.JavaTestKit;
+import akka.util.Timeout;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import scala.concurrent.Await;
+import scala.concurrent.Future;
+import scala.concurrent.duration.FiniteDuration;
+
+import static org.junit.Assert.fail;
+
+/**
+ * Tests the availability of accumulator results during runtime. The test case tests a user-defined
+ * accumulator and Flink's internal accumulators for two consecutive tasks.
+ *
+ * <p>CHAINED[Source -> Map] -> Sink
+ *
+ * <p>Checks are performed as the elements arrive at the operators. Checks consist of a message sent by
+ * the task to the task manager which notifies the job manager and sends the current accumulators.
+ * The task blocks until the test has been notified about the current accumulator values.
+ *
+ * <p>A barrier between the operators ensures that that pipelining is disabled for the streaming test.
+ * The batch job reads the records one at a time. The streaming code buffers the records beforehand;
+ * that's why exact guarantees about the number of records read are very hard to make. Thus, why we
+ * check for an upper bound of the elements read.
+ */
+public class LegacyAccumulatorLiveITCase extends TestLogger {
+
+	private static final Logger LOG = LoggerFactory.getLogger(LegacyAccumulatorLiveITCase.class);
+
+	private static ActorSystem system;
+	private static ActorGateway jobManagerGateway;
+	private static ActorRef taskManager;
+
+	private static JobID jobID;
+	private static JobGraph jobGraph;
+
+	// name of user accumulator
+	private static final String ACCUMULATOR_NAME = "test";
+
+	// number of heartbeat intervals to check
+	private static final int NUM_ITERATIONS = 5;
+
+	private static List<String> inputData = new ArrayList<>(NUM_ITERATIONS);
+
+	private static final FiniteDuration TIMEOUT = new FiniteDuration(10, TimeUnit.SECONDS);
+
+	@Before
+	public void before() throws Exception {
+		system = AkkaUtils.createLocalActorSystem(new Configuration());
+
+		Configuration config = new Configuration();
+		config.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, 1);
+		config.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, 1);
+		config.setString(AkkaOptions.ASK_TIMEOUT, TestingUtils.DEFAULT_AKKA_ASK_TIMEOUT());
+		TestingCluster testingCluster = new TestingCluster(config, false, true);
+		testingCluster.start();
+
+		jobManagerGateway = testingCluster.getLeaderGateway(TestingUtils.TESTING_DURATION());
+		taskManager = testingCluster.getTaskManagersAsJava().get(0);
+
+		// generate test data
+		for (int i = 0; i < NUM_ITERATIONS; i++) {
+			inputData.add(i, String.valueOf(i + 1));
+		}
+
+		NotifyingMapper.finished = false;
+	}
+
+	@After
+	public void after() throws Exception {
+		JavaTestKit.shutdownActorSystem(system);
+		inputData.clear();
+	}
+
+	@Test
+	public void testBatch() throws Exception {
+
+		/** The program **/
+		ExecutionEnvironment env = new BatchPlanExtractor();
+		env.setParallelism(1);
+
+		DataSet<String> input = env.fromCollection(inputData);
+		input
+				.flatMap(new NotifyingMapper())
+				.output(new NotifyingOutputFormat());
+
+		env.execute();
+
+		// Extract job graph and set job id for the task to notify of accumulator changes.
+		jobGraph = getOptimizedPlan(((BatchPlanExtractor) env).plan);
+		jobID = jobGraph.getJobID();
+
+		verifyResults();
+	}
+
+	@Test
+	public void testStreaming() throws Exception {
+
+		StreamExecutionEnvironment env = new DummyStreamExecutionEnvironment();
+		env.setParallelism(1);
+
+		DataStream<String> input = env.fromCollection(inputData);
+		input
+				.flatMap(new NotifyingMapper())
+				.writeUsingOutputFormat(new NotifyingOutputFormat()).disableChaining();
+
+		jobGraph = env.getStreamGraph().getJobGraph();
+		jobID = jobGraph.getJobID();
+
+		verifyResults();
+	}
+
+	private static void verifyResults() {
+		new JavaTestKit(system) {{
+
+			ActorGateway selfGateway = new AkkaActorGateway(getRef(), jobManagerGateway.leaderSessionID());
+
+			// register for accumulator changes
+			jobManagerGateway.tell(new TestingJobManagerMessages.NotifyWhenAccumulatorChange(jobID), selfGateway);
+			expectMsgEquals(TIMEOUT, true);
+
+			// submit job
+
+			jobManagerGateway.tell(
+					new JobManagerMessages.SubmitJob(
+							jobGraph,
+							ListeningBehaviour.EXECUTION_RESULT),
+					selfGateway);
+			expectMsgClass(TIMEOUT, JobManagerMessages.JobSubmitSuccess.class);
+
+			TestingJobManagerMessages.UpdatedAccumulators msg = (TestingJobManagerMessages.UpdatedAccumulators) receiveOne(TIMEOUT);
+			Map<String, Accumulator<?, ?>> userAccumulators = msg.userAccumulators();
+
+			ExecutionAttemptID mapperTaskID = null;
+
+			ExecutionAttemptID sinkTaskID = null;
+
+			/* Check for accumulator values */
+			if (checkUserAccumulators(0, userAccumulators)) {
+				LOG.info("Passed initial check for map task.");
+			} else {
+				fail("Wrong accumulator results when map task begins execution.");
+			}
+
+			int expectedAccVal = 0;
+
+			/* for mapper task */
+			for (int i = 1; i <= NUM_ITERATIONS; i++) {
+				expectedAccVal += i;
+
+				// receive message
+				msg = (TestingJobManagerMessages.UpdatedAccumulators) receiveOne(TIMEOUT);
+				userAccumulators = msg.userAccumulators();
+
+				LOG.info("{}", userAccumulators);
+
+				if (checkUserAccumulators(expectedAccVal, userAccumulators)) {
+					LOG.info("Passed round #" + i);
+				} else if (checkUserAccumulators(expectedAccVal, userAccumulators)) {
+					// we determined the wrong task id and need to switch the two here
+					ExecutionAttemptID temp = mapperTaskID;
+					mapperTaskID = sinkTaskID;
+					sinkTaskID = temp;
+					LOG.info("Passed round #" + i);
+				} else {
+					fail("Failed in round #" + i);
+				}
+			}
+
+			msg = (TestingJobManagerMessages.UpdatedAccumulators) receiveOne(TIMEOUT);
+			userAccumulators = msg.userAccumulators();
+
+			if (checkUserAccumulators(expectedAccVal, userAccumulators)) {
+				LOG.info("Passed initial check for sink task.");
+			} else {
+				fail("Wrong accumulator results when sink task begins execution.");
+			}
+
+			/* for sink task */
+			for (int i = 1; i <= NUM_ITERATIONS; i++) {
+
+				// receive message
+				msg = (TestingJobManagerMessages.UpdatedAccumulators) receiveOne(TIMEOUT);
+
+				userAccumulators = msg.userAccumulators();
+
+				LOG.info("{}", userAccumulators);
+
+				if (checkUserAccumulators(expectedAccVal, userAccumulators)) {
+					LOG.info("Passed round #" + i);
+				} else {
+					fail("Failed in round #" + i);
+				}
+			}
+
+			expectMsgClass(TIMEOUT, JobManagerMessages.JobResultSuccess.class);
+
+		}};
+	}
+
+	private static boolean checkUserAccumulators(int expected, Map<String, Accumulator<?, ?>> accumulatorMap) {
+		LOG.info("checking user accumulators");
+		return accumulatorMap.containsKey(ACCUMULATOR_NAME) && expected == ((IntCounter) accumulatorMap.get(ACCUMULATOR_NAME)).getLocalValue();
+	}
+
+	/**
+	 * UDF that notifies when it changes the accumulator values.
+	 */
+	private static class NotifyingMapper extends RichFlatMapFunction<String, Integer> {
+		private static final long serialVersionUID = 1L;
+
+		private IntCounter counter = new IntCounter();
+
+		private static boolean finished = false;
+
+		@Override
+		public void open(Configuration parameters) throws Exception {
+			getRuntimeContext().addAccumulator(ACCUMULATOR_NAME, counter);
+			notifyTaskManagerOfAccumulatorUpdate();
+		}
+
+		@Override
+		public void flatMap(String value, Collector<Integer> out) throws Exception {
+			int val = Integer.valueOf(value);
+			counter.add(val);
+			out.collect(val);
+			LOG.debug("Emitting value {}.", value);
+			notifyTaskManagerOfAccumulatorUpdate();
+		}
+
+		@Override
+		public void close() throws Exception {
+			finished = true;
+		}
+	}
+
+	/**
+	 * Outputs format which notifies of accumulator changes and waits for the previous mapper.
+	 */
+	private static class NotifyingOutputFormat implements OutputFormat<Integer> {
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public void configure(Configuration parameters) {
+		}
+
+		@Override
+		public void open(int taskNumber, int numTasks) throws IOException {
+			while (!NotifyingMapper.finished) {
+				try {
+					Thread.sleep(1000);
+				} catch (InterruptedException e) {}
+			}
+			notifyTaskManagerOfAccumulatorUpdate();
+		}
+
+		@Override
+		public void writeRecord(Integer record) throws IOException {
+			notifyTaskManagerOfAccumulatorUpdate();
+		}
+
+		@Override
+		public void close() throws IOException {
+		}
+	}
+
+	/**
+	 * Notify task manager of accumulator update and wait until the Heartbeat containing the message
+	 * has been reported.
+	 */
+	public static void notifyTaskManagerOfAccumulatorUpdate() {
+		new JavaTestKit(system) {{
+			Timeout timeout = new Timeout(TIMEOUT);
+			Future<Object> ask = Patterns.ask(taskManager, new TestingTaskManagerMessages.AccumulatorsChanged(jobID), timeout);
+			try {
+				Await.result(ask, timeout.duration());
+			} catch (Exception e) {
+				fail("Failed to notify task manager of accumulator update.");
+			}
+		}};
+	}
+
+	/**
+	 * Helpers to generate the JobGraph.
+	 */
+	private static JobGraph getOptimizedPlan(Plan plan) {
+		Optimizer pc = new Optimizer(new DataStatistics(), new Configuration());
+		JobGraphGenerator jgg = new JobGraphGenerator();
+		OptimizedPlan op = pc.compile(plan);
+		return jgg.compileJobGraph(op);
+	}
+
+	private static class BatchPlanExtractor extends LocalEnvironment {
+
+		private Plan plan = null;
+
+		@Override
+		public JobExecutionResult execute(String jobName) throws Exception {
+			plan = createProgramPlan();
+			return new JobExecutionResult(new JobID(), -1, null);
+		}
+	}
+
+	/**
+	 * This is used to for creating the example topology. {@link #execute} is never called, we
+	 * only use this to call {@link #getStreamGraph()}.
+	 */
+	private static class DummyStreamExecutionEnvironment extends StreamExecutionEnvironment {
+
+		@Override
+		public JobExecutionResult execute() throws Exception {
+			return execute("default");
+		}
+
+		@Override
+		public JobExecutionResult execute(String jobName) throws Exception {
+			throw new RuntimeException("This should not be called.");
+		}
+	}
+}


### PR DESCRIPTION
Based on #5701.

## What is the purpose of the change

This PR ports the `AccumulatorLiveITCase` to flip6. The existing test was renamed to `LegacyAccumulatorLiveITCase`, and a ported copy was added.

The heartbeat interval is not configurable for legacy clusters and is hard-coded to 5 seconds. Porting this test (in a reliable fashion) without relying on internal/test APIs would've increased the test duration, so I decided to just leave it as it is.

