### PR TITLE
[FLINK-8958][tests] Port TaskCancelAsyncProducerConsumerITCase to flip6

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/LegacyTaskCancelAsyncProducerConsumerITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/LegacyTaskCancelAsyncProducerConsumerITCase.java
@@ -18,12 +18,11 @@
 
 package org.apache.flink.runtime.taskmanager;
 
-import org.apache.flink.api.common.time.Deadline;
-import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.TaskManagerOptions;
-import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.instance.ActorGateway;
 import org.apache.flink.runtime.io.network.api.writer.RecordWriter;
 import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
@@ -34,27 +33,29 @@ import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
-import org.apache.flink.runtime.minicluster.MiniCluster;
-import org.apache.flink.runtime.minicluster.MiniClusterConfiguration;
-import org.apache.flink.runtime.testingUtils.TestingUtils;
-import org.apache.flink.testutils.category.Flip6;
+import org.apache.flink.runtime.messages.JobManagerMessages.CancelJob;
+import org.apache.flink.runtime.testingUtils.TestingCluster;
+import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages.NotifyWhenJobStatus;
+import org.apache.flink.runtime.testingUtils.TestingJobManagerMessages.WaitForAllVerticesToBeRunning;
 import org.apache.flink.types.LongValue;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
+
+import scala.concurrent.Await;
+import scala.concurrent.Future;
+import scala.concurrent.duration.Deadline;
+import scala.concurrent.duration.FiniteDuration;
 
 import static org.apache.flink.runtime.io.network.buffer.LocalBufferPoolDestroyTest.isInBlockingBufferRequest;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-@Category(Flip6.class)
-public class TaskCancelAsyncProducerConsumerITCase extends TestLogger {
+public class LegacyTaskCancelAsyncProducerConsumerITCase extends TestLogger {
 
 	// The Exceptions thrown by the producer/consumer Threads
 	private static volatile Exception ASYNC_PRODUCER_EXCEPTION;
@@ -74,20 +75,18 @@ public class TaskCancelAsyncProducerConsumerITCase extends TestLogger {
 	 */
 	@Test
 	public void testCancelAsyncProducerAndConsumer() throws Exception {
-		Deadline deadline = Deadline.now().plus(Duration.ofMinutes(2));
+		Deadline deadline = new FiniteDuration(2, TimeUnit.MINUTES).fromNow();
+		TestingCluster flink = null;
 
-		// Cluster
-		Configuration config = new Configuration();
-		config.setInteger(TaskManagerOptions.MEMORY_SEGMENT_SIZE, 4096);
-		config.setInteger(TaskManagerOptions.NETWORK_NUM_BUFFERS, 9);
+		try {
+			// Cluster
+			Configuration config = new Configuration();
+			config.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, 1);
+			config.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, 1);
+			config.setInteger(TaskManagerOptions.MEMORY_SEGMENT_SIZE, 4096);
+			config.setInteger(TaskManagerOptions.NETWORK_NUM_BUFFERS, 9);
 
-		MiniClusterConfiguration miniClusterConfiguration = new MiniClusterConfiguration.Builder()
-			.setConfiguration(config)
-			.setNumTaskManagers(1)
-			.setNumSlotsPerTaskManager(1)
-			.build();
-
-		try (MiniCluster flink = new MiniCluster(miniClusterConfiguration)) {
+			flink = new TestingCluster(config, true);
 			flink.start();
 
 			// Job with async producer and consumer
@@ -107,15 +106,16 @@ public class TaskCancelAsyncProducerConsumerITCase extends TestLogger {
 			JobGraph jobGraph = new JobGraph(producer, consumer);
 
 			// Submit job and wait until running
-			flink.runDetached(jobGraph);
+			ActorGateway jobManager = flink.getLeaderGateway(deadline.timeLeft());
+			flink.submitJobDetached(jobGraph);
 
-			FutureUtils.retrySuccesfulWithDelay(
-				() -> flink.getJobStatus(jobGraph.getJobID()),
-				Time.milliseconds(10),
-				deadline,
-				status -> status == JobStatus.RUNNING,
-				TestingUtils.defaultScheduledExecutor()
-			).get(deadline.timeLeft().toMillis(), TimeUnit.MILLISECONDS);
+			Object msg = new WaitForAllVerticesToBeRunning(jobGraph.getJobID());
+			Future<?> runningFuture = jobManager.ask(msg, deadline.timeLeft());
+			Await.ready(runningFuture, deadline.timeLeft());
+
+			// Wait for blocking requests, cancel and wait for cancellation
+			msg = new NotifyWhenJobStatus(jobGraph.getJobID(), JobStatus.CANCELED);
+			Future<?> cancelledFuture = jobManager.ask(msg, deadline.timeLeft());
 
 			boolean producerBlocked = false;
 			for (int i = 0; i < 50; i++) {
@@ -156,17 +156,11 @@ public class TaskCancelAsyncProducerConsumerITCase extends TestLogger {
 			// Verify that async consumer is in blocking request
 			assertTrue("Consumer thread is not blocked.", consumerWaiting);
 
-			flink.cancelJob(jobGraph.getJobID())
-				.get(deadline.timeLeft().toMillis(), TimeUnit.MILLISECONDS);
+			msg = new CancelJob(jobGraph.getJobID());
+			Future<?> cancelFuture = jobManager.ask(msg, deadline.timeLeft());
+			Await.ready(cancelFuture, deadline.timeLeft());
 
-			// wait until the job is canceled
-			FutureUtils.retrySuccesfulWithDelay(
-				() -> flink.getJobStatus(jobGraph.getJobID()),
-				Time.milliseconds(10),
-				deadline,
-				status -> status == JobStatus.CANCELED,
-				TestingUtils.defaultScheduledExecutor()
-			).get(deadline.timeLeft().toMillis(), TimeUnit.MILLISECONDS);
+			Await.ready(cancelledFuture, deadline.timeLeft());
 
 			// Verify the expected Exceptions
 			assertNotNull(ASYNC_PRODUCER_EXCEPTION);
@@ -174,6 +168,10 @@ public class TaskCancelAsyncProducerConsumerITCase extends TestLogger {
 
 			assertNotNull(ASYNC_CONSUMER_EXCEPTION);
 			assertEquals(IllegalStateException.class, ASYNC_CONSUMER_EXCEPTION.getClass());
+		} finally {
+			if (flink != null) {
+				flink.stop();
+			}
 		}
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

This PR ports the `TaskCancelAsyncProducerConsumerITCase` to flip6. The existing test was renamed to `TaskCancelAsyncProducerConsumerITCase`, and a ported copy was added.

