### PR TITLE
[FLINK-9019] Unclosed closeableRegistry in StreamTaskStateInitializerImpl#rawOperatorStateInputs

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImpl.java
@@ -279,8 +279,6 @@ public class StreamTaskStateInitializerImpl implements StreamTaskStateInitialize
 
 		if (restoreStateAlternatives.hasNext()) {
 
-			final CloseableRegistry closeableRegistry = new CloseableRegistry();
-
 			Collection<OperatorStateHandle> rawOperatorState = restoreStateAlternatives.next();
 			// TODO currently this does not support local state recovery, so we expect there is only one handle.
 			Preconditions.checkState(
@@ -288,6 +286,7 @@ public class StreamTaskStateInitializerImpl implements StreamTaskStateInitialize
 				"Local recovery is currently not implemented for raw operator state, but found state alternative.");
 
 			if (rawOperatorState != null) {
+				final CloseableRegistry closeableRegistry = new CloseableRegistry();
 
 				return new CloseableIterable<StatePartitionStreamProvider>() {
 					@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImpl.java
@@ -286,9 +286,10 @@ public class StreamTaskStateInitializerImpl implements StreamTaskStateInitialize
 				"Local recovery is currently not implemented for raw operator state, but found state alternative.");
 
 			if (rawOperatorState != null) {
-				final CloseableRegistry closeableRegistry = new CloseableRegistry();
-
 				return new CloseableIterable<StatePartitionStreamProvider>() {
+
+					final CloseableRegistry closeableRegistry = new CloseableRegistry();
+
 					@Override
 					public void close() throws IOException {
 						closeableRegistry.close();


### PR DESCRIPTION
## What is the purpose of the change

*This pull request fixed a resource(CloseableRegistry) leak.*


## Brief change log

  - *create the `ClosableRegistry`'s instance if necessary*

## Verifying this change

This change is already covered by existing tests, such as *StreamTaskStateInitializerImplTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
