### PR TITLE
[FLINK-8415] Unprotected access to recordsToSend in LongRecordWriterThread#shutdown()

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/LongRecordWriterThread.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/LongRecordWriterThread.java
@@ -47,7 +47,7 @@ public class LongRecordWriterThread extends CheckedThread {
 		this.recordWriter = checkNotNull(recordWriter);
 	}
 
-	public void shutdown() {
+	public synchronized void shutdown() {
 		running = false;
 		recordsToSend.complete(0L);
 	}


### PR DESCRIPTION
## What is the purpose of the change

*This pull request marked a method as `synchronized` keyword.*


## Brief change log

  - *marked method `LongRecordWriterThread#shutdown` as `synchronized`*


## Verifying this change

This change is already covered by existing tests, such as *(StreamNetworkThroughputBenchmark#tearDown)*.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
