### PR TITLE
[FLINK-8394] Lack of synchronization accessing expectedRecord in ReceiverThread#shutdown

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/ReceiverThread.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/ReceiverThread.java
@@ -89,7 +89,7 @@ public abstract class ReceiverThread extends CheckedThread {
 
 	protected abstract void readRecords(long lastExpectedRecord) throws Exception;
 
-	public void shutdown() {
+	public synchronized void shutdown() {
 		running = false;
 		interrupt();
 		expectedRecord.complete(0L);


### PR DESCRIPTION
## What is the purpose of the change

* This pull request fixed a Lack of synchronization accessing expectedRecord in ReceiverThread#shutdown.*


## Brief change log

  - *Wrapped the `shutdown` method with keyword `synchronized`*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
