### PR TITLE
 [FLINK-8964][tests] Port JobSubmissionFailsITCase to flip6 

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/ExceptionUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/ExceptionUtils.java
@@ -35,6 +35,7 @@ import java.io.StringWriter;
 import java.util.Optional;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
+import java.util.function.Predicate;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -317,6 +318,30 @@ public final class ExceptionUtils {
 		while (t != null) {
 			if (searchType.isAssignableFrom(t.getClass())) {
 				return Optional.of(searchType.cast(t));
+			} else {
+				t = t.getCause();
+			}
+		}
+
+		return Optional.empty();
+	}
+
+	/**
+	 * Checks whether a throwable chain contains an exception matching a predicate and returns it.
+	 *
+	 * @param throwable the throwable chain to check.
+	 * @param predicate the predicate of the exception to search for in the chain.
+	 * @return Optional throwable of the requested type if available, otherwise empty
+	 */
+	public static Optional<Throwable> findThrowable(Throwable throwable, Predicate<Throwable> predicate) {
+		if (throwable == null || predicate == null) {
+			return Optional.empty();
+		}
+
+		Throwable t = throwable;
+		while (t != null) {
+			if (predicate.test(t)) {
+				return Optional.of(t);
 			} else {
 				t = t.getCause();
 			}

--- a/flink-tests/src/test/java/org/apache/flink/test/example/failing/JobSubmissionFailsITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/example/failing/JobSubmissionFailsITCase.java
@@ -19,30 +19,25 @@
 
 package org.apache.flink.test.example.failing;
 
-import org.apache.flink.api.common.JobExecutionResult;
-import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.TaskManagerOptions;
-import org.apache.flink.runtime.client.JobExecutionException;
-import org.apache.flink.runtime.client.JobSubmissionException;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
-import org.apache.flink.runtime.minicluster.LocalFlinkMiniCluster;
-import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
+import org.apache.flink.test.util.MiniClusterResource;
+import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.TestLogger;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Optional;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
@@ -51,47 +46,32 @@ import static org.junit.Assert.fail;
 @RunWith(Parameterized.class)
 public class JobSubmissionFailsITCase extends TestLogger {
 
+	private static final int NUM_TM = 2;
 	private static final int NUM_SLOTS = 20;
 
-	private static LocalFlinkMiniCluster cluster;
-	private static JobGraph workingJobGraph;
+	@ClassRule
+	public static final MiniClusterResource MINI_CLUSTER_RESOURCE = new MiniClusterResource(
+		new MiniClusterResource.MiniClusterResourceConfiguration(
+			getConfiguration(),
+			NUM_TM,
+			NUM_SLOTS / NUM_TM),
+		true);
 
-	@BeforeClass
-	public static void setup() {
-		try {
-			Configuration config = new Configuration();
-			config.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, 4L);
-			config.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, 2);
-			config.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, NUM_SLOTS / 2);
-
-			cluster = new LocalFlinkMiniCluster(config);
-
-			cluster.start();
-
-			final JobVertex jobVertex = new JobVertex("Working job vertex.");
-			jobVertex.setInvokableClass(NoOpInvokable.class);
-			workingJobGraph = new JobGraph("Working testing job", jobVertex);
-		}
-		catch (Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
-		}
+	private static Configuration getConfiguration() {
+		Configuration config = new Configuration();
+		config.setLong(TaskManagerOptions.MANAGED_MEMORY_SIZE, 4L);
+		return config;
 	}
 
-	@AfterClass
-	public static void teardown() {
-		try {
-			cluster.stop();
-		}
-		catch (Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
-		}
+	private static JobGraph getWorkingJobGraph() {
+		final JobVertex jobVertex = new JobVertex("Working job vertex.");
+		jobVertex.setInvokableClass(NoOpInvokable.class);
+		return new JobGraph("Working testing job", jobVertex);
 	}
 
 	// --------------------------------------------------------------------------------------------
 
-	private boolean detached;
+	private final boolean detached;
 
 	public JobSubmissionFailsITCase(boolean detached) {
 		this.detached = detached;
@@ -105,90 +85,51 @@ public class JobSubmissionFailsITCase extends TestLogger {
 
 	// --------------------------------------------------------------------------------------------
 
-	private JobExecutionResult submitJob(JobGraph jobGraph) throws Exception {
-		if (detached) {
-			cluster.submitJobDetached(jobGraph);
-			return null;
+	@Test
+	public void testExceptionInInitializeOnMaster() throws Exception {
+		final JobVertex failingJobVertex = new FailingJobVertex("Failing job vertex");
+		failingJobVertex.setInvokableClass(NoOpInvokable.class);
+
+		final JobGraph failingJobGraph = new JobGraph("Failing testing job", failingJobVertex);
+
+		ClusterClient<?> client = MINI_CLUSTER_RESOURCE.getClusterClient();
+		client.setDetached(detached);
+
+		try {
+			client.submitJob(failingJobGraph, JobSubmissionFailsITCase.class.getClassLoader());
+			fail("Job submission should have thrown an exception.");
+		} catch (Exception e) {
+			Optional<Throwable> expectedCause = ExceptionUtils.findThrowable(e,
+				candidate -> candidate.getMessage() != null && candidate.getMessage().equals("Test exception."));
+			if (!expectedCause.isPresent()) {
+				throw e;
+			}
 		}
-		else {
-			return cluster.submitJobAndWait(jobGraph, false, TestingUtils.TESTING_DURATION());
-		}
+
+		client.setDetached(false);
+		client.submitJob(getWorkingJobGraph(), JobSubmissionFailsITCase.class.getClassLoader());
 	}
 
 	@Test
-	public void testExceptionInInitializeOnMaster() {
+	public void testSubmitEmptyJobGraph() throws Exception {
+		final JobGraph jobGraph = new JobGraph("Testing job");
+
+		ClusterClient<?> client = MINI_CLUSTER_RESOURCE.getClusterClient();
+		client.setDetached(detached);
+
 		try {
-			final JobVertex failingJobVertex = new FailingJobVertex("Failing job vertex");
-			failingJobVertex.setInvokableClass(NoOpInvokable.class);
-
-			final JobGraph failingJobGraph = new JobGraph("Failing testing job", failingJobVertex);
-
-			try {
-				submitJob(failingJobGraph);
-				fail("Expected JobExecutionException.");
+			client.submitJob(jobGraph, JobSubmissionFailsITCase.class.getClassLoader());
+			fail("Job submission should have thrown an exception.");
+		} catch (Exception e) {
+			Optional<Throwable> expectedCause = ExceptionUtils.findThrowable(e,
+				throwable -> throwable.getMessage() != null && throwable.getMessage().contains("empty"));
+			if (!expectedCause.isPresent()) {
+				throw e;
 			}
-			catch (JobExecutionException e) {
-				assertEquals("Test exception.", e.getCause().getMessage());
-			}
-			catch (Throwable t) {
-				t.printStackTrace();
-				fail("Caught wrong exception of type " + t.getClass() + ".");
-			}
-
-			cluster.submitJobAndWait(workingJobGraph, false);
 		}
-		catch (Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
-		}
-	}
 
-	@Test
-	public void testSubmitEmptyJobGraph() {
-		try {
-			final JobGraph jobGraph = new JobGraph("Testing job");
-
-			try {
-				submitJob(jobGraph);
-				fail("Expected JobSubmissionException.");
-			}
-			catch (JobSubmissionException e) {
-				assertTrue(e.getMessage() != null && e.getMessage().contains("empty"));
-			}
-			catch (Throwable t) {
-				t.printStackTrace();
-				fail("Caught wrong exception of type " + t.getClass() + ".");
-			}
-
-			cluster.submitJobAndWait(workingJobGraph, false);
-		}
-		catch (Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
-		}
-	}
-
-	@Test
-	public void testSubmitNullJobGraph() {
-		try {
-			try {
-				submitJob(null);
-				fail("Expected JobSubmissionException.");
-			}
-			catch (NullPointerException e) {
-				// yo!
-			}
-			catch (Throwable t) {
-				t.printStackTrace();
-				fail("Caught wrong exception of type " + t.getClass() + ".");
-			}
-
-			cluster.submitJobAndWait(workingJobGraph, false);
-		}
-		catch (Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
-		}
+		client.setDetached(false);
+		client.submitJob(getWorkingJobGraph(), JobSubmissionFailsITCase.class.getClassLoader());
 	}
 
 	// --------------------------------------------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change

Ports the `JobSubmissionFailsITCase` to use `MiniClusterResource`.

## Brief change log

* add utility method to `ExceptionUtils` for finding a `Throwable` matching a `Predicate`
* remove `testSubmitNullJobGraph`; the test wasn't testing any runtime code
* replace static working JobGraph with a factory method, as submitting the same JobGraph twice doesn't work on Flip6
* introduce `MiniClusterResource`

## Verifying this change

Run `JobSubmissionFailsITCase` with `flip6` profile enabled/disabled.
