### PR TITLE
[FLINK-7343][kafka-tests] Fix test at-least-once test instability

### DIFF
--- a/flink-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka09ProducerITCase.java
+++ b/flink-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka09ProducerITCase.java
@@ -32,15 +32,4 @@ public class Kafka09ProducerITCase extends KafkaProducerTestBase {
 	public void testExactlyOnceCustomOperator() throws Exception {
 		// Kafka09 does not support exactly once semantic
 	}
-
-	@Override
-	public void testOneToOneAtLeastOnceRegularSink() throws Exception {
-		// For some reasons this test is sometimes failing in Kafka09 while the same code works in Kafka010. Disabling
-		// this test because everything indicates those failures might be caused by unfixed bugs in Kafka 0.9 branch
-	}
-
-	@Override
-	public void testOneToOneAtLeastOnceCustomOperator() throws Exception {
-		// Disable this test since FlinkKafka09Producer doesn't support custom operator mode
-	}
 }

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaProducerTestBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaProducerTestBase.java
@@ -292,7 +292,7 @@ public abstract class KafkaProducerTestBase extends KafkaTestBase {
 				properties,
 				topic,
 				partition,
-				Collections.unmodifiableSet(new HashSet<>(getIntegersSequence(BrokerRestartingMapper.numElementsBeforeSnapshot))),
+				Collections.unmodifiableSet(new HashSet<>(getIntegersSequence(BrokerRestartingMapper.lastSnapshotedElementBeforeShutdown))),
 				KAFKA_READ_TIMEOUT);
 
 		deleteTestTopic(topic);
@@ -483,7 +483,7 @@ public abstract class KafkaProducerTestBase extends KafkaTestBase {
 		private static final long serialVersionUID = 6334389850158707313L;
 
 		public static volatile boolean triggeredShutdown;
-		public static volatile int numElementsBeforeSnapshot;
+		public static volatile int lastSnapshotedElementBeforeShutdown;
 		public static volatile Runnable shutdownAction;
 
 		private final int failCount;
@@ -493,7 +493,7 @@ public abstract class KafkaProducerTestBase extends KafkaTestBase {
 
 		public static void resetState(Runnable shutdownAction) {
 			triggeredShutdown = false;
-			numElementsBeforeSnapshot = 0;
+			lastSnapshotedElementBeforeShutdown = 0;
 			BrokerRestartingMapper.shutdownAction = shutdownAction;
 		}
 
@@ -509,15 +509,12 @@ public abstract class KafkaProducerTestBase extends KafkaTestBase {
 		@Override
 		public T map(T value) throws Exception {
 			numElementsTotal++;
+			Thread.sleep(10);
 
-			if (!triggeredShutdown) {
-				Thread.sleep(10);
-
-				if (failer && numElementsTotal >= failCount) {
-					// shut down a Kafka broker
-					triggeredShutdown = true;
-					shutdownAction.run();
-				}
+			if (!triggeredShutdown && failer && numElementsTotal >= failCount) {
+				// shut down a Kafka broker
+				triggeredShutdown = true;
+				shutdownAction.run();
 			}
 			return value;
 		}
@@ -528,7 +525,9 @@ public abstract class KafkaProducerTestBase extends KafkaTestBase {
 
 		@Override
 		public void snapshotState(FunctionSnapshotContext context) throws Exception {
-			numElementsBeforeSnapshot = numElementsTotal;
+			if (!triggeredShutdown) {
+				lastSnapshotedElementBeforeShutdown = numElementsTotal;
+			}
 		}
 
 		@Override


### PR DESCRIPTION
This pr fixes instabilities in both Kafka 0.10 and Kafka 0.9.

Previously we could set numElementsBeforeSnapshot to some value during checkpointing
AFTER executing shutdown, while at the same time FlinkKafkaProducerXXX snapshot for this
value would fail. This lead to incorrectly cacluated expected set of values to be present
in the test kafka topic.

Fix is to remember lastSnapshotedElementBeforeShutdown - last snapshot that we expect
to succeed without failure.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
