### PR TITLE
[FLINK-9026][Metrics] Close the TaskManagerMetricGroup when the TaskExecutor is shut down

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -292,6 +292,13 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 			throwable = ExceptionUtils.firstOrSuppressed(t, throwable);
 		}
 
+		try {
+			// it will call close() recursively from the parent to children
+			taskManagerMetricGroup.close();
+		} catch (Exception e) {
+			throwable = ExceptionUtils.firstOrSuppressed(e, throwable);
+		}
+
 		if (throwable != null) {
 			return FutureUtils.completedExceptionally(new FlinkException("Error while shutting the TaskExecutor down.", throwable));
 		} else {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -292,12 +292,8 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 			throwable = ExceptionUtils.firstOrSuppressed(t, throwable);
 		}
 
-		try {
-			// it will call close() recursively from the parent to children
-			taskManagerMetricGroup.close();
-		} catch (Exception e) {
-			throwable = ExceptionUtils.firstOrSuppressed(e, throwable);
-		}
+		// it will call close() recursively from the parent to children
+		taskManagerMetricGroup.close();
 
 		if (throwable != null) {
 			return FutureUtils.completedExceptionally(new FlinkException("Error while shutting the TaskExecutor down.", throwable));

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -265,7 +265,11 @@ class TaskManager(
       case t: Exception => log.error("FileCache did not shutdown properly.", t)
     }
 
-    taskManagerMetricGroup.close()
+    try {
+      taskManagerMetricGroup.close()
+    } catch {
+      case e: Exception => log.error("TaskManagerMetricGroup did not shutdown properly.", e)
+    }
 
     log.info(s"Task manager ${self.path} is completely shut down.")
   }

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/taskmanager/TaskManager.scala
@@ -265,11 +265,7 @@ class TaskManager(
       case t: Exception => log.error("FileCache did not shutdown properly.", t)
     }
 
-    try {
-      taskManagerMetricGroup.close()
-    } catch {
-      case e: Exception => log.error("TaskManagerMetricGroup did not shutdown properly.", e)
-    }
+    taskManagerMetricGroup.close()
 
     log.info(s"Task manager ${self.path} is completely shut down.")
   }


### PR DESCRIPTION
## What is the purpose of the change

We should close the `TaskManagerMetricGroup` when the `TaskExecutor` is shutdown.

## Brief change log

- close the `TaskManagerMetricGroup` when the `TaskExecutor` is shutdown.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
