### PR TITLE
[FLINK-8925][tests] Enable flip6 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,27 +39,27 @@ matrix:
     - jdk: "oraclejdk8"
       env:
         - TEST="core"
-        - PROFILE="-Dhadoop.version=2.8.3"
+        - PROFILE="-Dhadoop.version=2.8.3 -Dflip6"
         - CACHE_NAME=JDK8_H280_CO
     - jdk: "oraclejdk8"
       env:
         - TEST="libraries"
-        - PROFILE="-Dhadoop.version=2.8.3"
+        - PROFILE="-Dhadoop.version=2.8.3 -Dflip6"
         - CACHE_NAME=JDK8_H280_L
     - jdk: "oraclejdk8"
       env:
         - TEST="connectors"
-        - PROFILE="-Dhadoop.version=2.8.3 -Pinclude-kinesis"
+        - PROFILE="-Dhadoop.version=2.8.3 -Dflip6 -Pinclude-kinesis"
         - CACHE_NAME=JDK8_H280_CN
     - jdk: "oraclejdk8"
       env:
         - TEST="tests"
-        - PROFILE="-Dhadoop.version=2.8.3"
+        - PROFILE="-Dhadoop.version=2.8.3 -Dflip6"
         - CACHE_NAME=JDK8_H280_T
     - jdk: "oraclejdk8"
       env:
         - TEST="misc"
-        - PROFILE="-Dhadoop.version=2.8.3 -Dinclude_hadoop_aws"
+        - PROFILE="-Dhadoop.version=2.8.3 -Dflip6 -Dinclude_hadoop_aws"
         - CACHE_NAME=JDK8_H280_M
     - jdk: "openjdk8"
       env:
@@ -86,16 +86,6 @@ matrix:
         - TEST="misc"
         - PROFILE="-Dhadoop.version=2.4.1"
         - CACHE_NAME=JDK8_H241_M
-    - jdk: "oraclejdk8"
-      env:
-        - TEST="core"
-        - PROFILE="-Dhadoop.version=2.8.0 -Pflip6"
-        - CACHE_NAME=JDK8_H280_F6_CO
-    - jdk: "oraclejdk8"
-      env:
-        - TEST="tests"
-        - PROFILE="-Dhadoop.version=2.8.0 -Pflip6"
-        - CACHE_NAME=JDK8_H280_F6_T
 
 git:
   depth: 100

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,6 @@ under the License.
 		<hamcrest.version>1.3</hamcrest.version>
 		<japicmp.skip>false</japicmp.skip>
 		<!-- run all groups except flip6 by default -->
-		<test.groups></test.groups>
 		<test.excludedGroups>org.apache.flink.testutils.category.Flip6</test.excludedGroups>
 		<codebase>old</codebase>
 		<!--
@@ -595,8 +594,12 @@ under the License.
 
 		<profile>
 			<id>flip6</id>
+			<activation>
+				<property>
+					<name>flip6</name>
+				</property>
+			</activation>
 			<properties>
-				<test.groups>org.apache.flink.testutils.category.Flip6, org.apache.flink.testutils.category.OldAndFlip6</test.groups>
 				<!-- clear the excluded groups list -->
 				<test.excludedGroups></test.excludedGroups>
 				<codebase>flip6</codebase>


### PR DESCRIPTION
Minimal version of #5714.

## What is the purpose of the change

This PR enables Flip6 for half of our travis profiles.

Note: The CI will most likely fail due to 2-3 tests failing on Flip6. For the time being we can just `@Ignore` them.
