### PR TITLE
[FLINK-9047] Fix slot recycling in case of failed release

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/TaskManagerSlot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/TaskManagerSlot.java
@@ -139,6 +139,16 @@ public class TaskManagerSlot {
 		return resourceProfile.isMatching(required);
 	}
 
+	@Override
+	public String toString() {
+		return "TaskManagerSlot{" +
+			"slotId=" + slotId +
+			", allocationId=" + allocationId +
+			", assignedSlotRequest=" + assignedSlotRequest +
+			", state=" + state +
+			'}';
+	}
+
 	/**
 	 * State of the {@link TaskManagerSlot}.
 	 */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -689,6 +689,8 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 
 	@Override
 	public CompletableFuture<Acknowledge> disconnectTaskManager(final ResourceID resourceID, final Exception cause) {
+		log.debug("Disconnect TaskExecutor {} because: {}", resourceID, cause.getMessage());
+
 		taskManagerHeartbeatManager.unmonitorTarget(resourceID);
 		CompletableFuture<Acknowledge> releaseFuture = slotPoolGateway.releaseTaskManager(resourceID);
 
@@ -1516,8 +1518,6 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 
 		@Override
 		public void notifyHeartbeatTimeout(ResourceID resourceID) {
-			log.info("Heartbeat of TaskManager with id {} timed out.", resourceID);
-
 			jobMasterGateway.disconnectTaskManager(
 				resourceID,
 				new TimeoutException("Heartbeat of TaskManager with id " + resourceID + " timed out."));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SingleLogicalSlot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SingleLogicalSlot.java
@@ -19,13 +19,13 @@
 package org.apache.flink.runtime.jobmaster.slotpool;
 
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.instance.SlotSharingGroupId;
+import org.apache.flink.runtime.jobmanager.scheduler.Locality;
+import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
 import org.apache.flink.runtime.jobmaster.LogicalSlot;
 import org.apache.flink.runtime.jobmaster.SlotContext;
 import org.apache.flink.runtime.jobmaster.SlotOwner;
 import org.apache.flink.runtime.jobmaster.SlotRequestId;
-import org.apache.flink.runtime.instance.SlotSharingGroupId;
-import org.apache.flink.runtime.jobmanager.scheduler.Locality;
-import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.util.Preconditions;
 
@@ -33,7 +33,6 @@ import javax.annotation.Nullable;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
-import java.util.function.Function;
 
 /**
  * Implementation of the {@link LogicalSlot} which is used by the {@link SlotPool}.
@@ -127,8 +126,7 @@ public class SingleLogicalSlot implements LogicalSlot, AllocatedSlot.Payload {
 
 		// Wait until the payload has been terminated. Only then, we return the slot to its rightful owner
 		return payload.getTerminalStateFuture()
-			.handle((Object ignored, Throwable throwable) -> slotOwner.returnAllocatedSlot(this))
-			.thenApply(Function.identity());
+			.whenComplete((Object ignored, Throwable throwable) -> slotOwner.returnAllocatedSlot(this));
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
@@ -322,7 +322,6 @@ public class SlotPool extends RpcEndpoint implements SlotPoolGateway, AllocatedS
 			SlotProfile slotProfile,
 			boolean allowQueuedScheduling,
 			Time allocationTimeout) {
-
 		final SlotSharingGroupId slotSharingGroupId = task.getSlotSharingGroupId();
 
 		if (slotSharingGroupId != null) {
@@ -955,7 +954,7 @@ public class SlotPool extends RpcEndpoint implements SlotPoolGateway, AllocatedS
 		}
 
 		final AllocatedSlot allocatedSlot = new AllocatedSlot(
-			slotOffer.getAllocationId(),
+			allocationID,
 			taskManagerLocation,
 			slotOffer.getSlotIndex(),
 			slotOffer.getResourceProfile(),
@@ -971,6 +970,8 @@ public class SlotPool extends RpcEndpoint implements SlotPoolGateway, AllocatedS
 				// we could not complete the pending slot future --> try to fulfill another pending request
 				allocatedSlots.remove(pendingRequest.getSlotRequestId());
 				tryFulfillSlotRequestOrMakeAvailable(allocatedSlot);
+			} else {
+				log.debug("Fulfilled slot request {} with allocated slot {}.", pendingRequest.getSlotRequestId(), allocationID);
 			}
 		}
 		else {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
@@ -69,7 +69,6 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -721,15 +720,6 @@ public class SlotPool extends RpcEndpoint implements SlotPoolGateway, AllocatedS
 			if (log.isDebugEnabled()) {
 				log.debug("Unregistered slot request {} failed.", slotRequestID, failure);
 			}
-		}
-	}
-
-	private void checkTimeoutSlotAllocation(SlotRequestId slotRequestID) {
-		PendingRequest request = pendingRequests.removeKeyA(slotRequestID);
-		if (request != null) {
-			failPendingRequest(
-				request,
-				new TimeoutException("Slot allocation request " + slotRequestID + " timed out"));
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -682,7 +682,7 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 		WorkerRegistration<WorkerType> oldRegistration = taskExecutors.remove(taskExecutorResourceId);
 		if (oldRegistration != null) {
 			// TODO :: suggest old taskExecutor to stop itself
-			log.info("Replacing old instance of worker for ResourceID {}", taskExecutorResourceId);
+			log.info("Replacing old registration of TaskExecutor {}.", taskExecutorResourceId);
 
 			// remove old task manager registration from slot manager
 			slotManager.unregisterTaskManager(oldRegistration.getInstanceID());
@@ -779,14 +779,14 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 		WorkerRegistration<WorkerType> workerRegistration = taskExecutors.remove(resourceID);
 
 		if (workerRegistration != null) {
-			log.info("Task manager {} failed because {}.", resourceID, cause.getMessage());
+			log.info("Closing TaskExecutor connection {} because: {}", resourceID, cause.getMessage());
 
 			// TODO :: suggest failed task executor to stop itself
 			slotManager.unregisterTaskManager(workerRegistration.getInstanceID());
 
 			workerRegistration.getTaskExecutorGateway().disconnectResourceManager(cause);
 		} else {
-			log.debug("Could not find a registered task manager with the process id {}.", resourceID);
+			log.debug("No open TaskExecutor connection {}. Ignoring close TaskExecutor connection.", resourceID);
 		}
 	}
 
@@ -816,7 +816,7 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 		}
 	}
 
-	protected void releaseResource(InstanceID instanceId) {
+	protected void releaseResource(InstanceID instanceId, Exception cause) {
 		WorkerType worker = null;
 
 		// TODO: Improve performance by having an index on the instanceId
@@ -829,10 +829,9 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 
 		if (worker != null) {
 			if (stopWorker(worker)) {
-				closeTaskManagerConnection(worker.getResourceID(),
-						new FlinkException("Worker was stopped."));
+				closeTaskManagerConnection(worker.getResourceID(), cause);
 			} else {
-				log.debug("Worker {} was not stopped.", worker.getResourceID());
+				log.debug("Worker {} could not be stopped.", worker.getResourceID());
 			}
 		} else {
 			// unregister in order to clean up potential left over state
@@ -990,10 +989,10 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 	private class ResourceActionsImpl implements ResourceActions {
 
 		@Override
-		public void releaseResource(InstanceID instanceId) {
+		public void releaseResource(InstanceID instanceId, Exception cause) {
 			validateRunsInMainThread();
 
-			ResourceManager.this.releaseResource(instanceId);
+			ResourceManager.this.releaseResource(instanceId, cause);
 		}
 
 		@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/PendingSlotRequest.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/PendingSlotRequest.java
@@ -78,4 +78,11 @@ public class PendingSlotRequest {
 	public CompletableFuture<Acknowledge> getRequestFuture() {
 		return requestFuture;
 	}
+
+	@Override
+	public String toString() {
+		return "PendingSlotRequest{" +
+			"slotRequest=" + slotRequest +
+			'}';
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/ResourceActions.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/ResourceActions.java
@@ -33,8 +33,9 @@ public interface ResourceActions {
 	 * Releases the resource with the given instance id.
 	 *
 	 * @param instanceId identifying which resource to release
+	 * @param cause why the resource is released
 	 */
-	void releaseResource(InstanceID instanceId);
+	void releaseResource(InstanceID instanceId, Exception cause);
 
 	/**
 	 * Requests to allocate a resource with the given {@link ResourceProfile}.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -1262,6 +1262,8 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 	private void freeSlotInternal(AllocationID allocationId, Throwable cause) {
 		checkNotNull(allocationId);
 
+		log.debug("Free slot with allocation id {} because: {}", allocationId, cause.getMessage());
+
 		try {
 			final JobID jobId = taskSlotTable.getOwningJob(allocationId);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotProfile;
+import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
 import org.apache.flink.runtime.instance.SlotSharingGroupId;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
@@ -38,6 +39,7 @@ import org.apache.flink.runtime.resourcemanager.utils.TestingResourceManagerGate
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.rpc.TestingRpcService;
+import org.apache.flink.runtime.taskexecutor.TaskExecutor;
 import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
 import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
@@ -58,6 +60,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -67,6 +70,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static org.apache.flink.runtime.jobmaster.slotpool.AvailableSlotsTest.DEFAULT_TESTING_PROFILE;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -559,9 +563,15 @@ public class SlotPoolTest extends TestLogger {
 
 			final ArrayBlockingQueue<AllocationID> freedSlotQueue = new ArrayBlockingQueue<>(numSlotOffers);
 
-			taskManagerGateway.setFreeSlotConsumer(tuple -> {
-				while(!freedSlotQueue.offer(tuple.f0)) {}
-			});
+			taskManagerGateway.setFreeSlotFunction(
+				(AllocationID allocationID, Throwable cause) -> {
+					try {
+						freedSlotQueue.put(allocationID);
+						return CompletableFuture.completedFuture(Acknowledge.get());
+					} catch (InterruptedException e) {
+						return FutureUtils.completedExceptionally(e);
+					}
+				});
 
 			final CompletableFuture<Collection<SlotOffer>> acceptedSlotOffersFuture = slotPoolGateway.offerSlots(taskManagerLocation, taskManagerGateway, slotOffers);
 
@@ -598,7 +608,16 @@ public class SlotPoolTest extends TestLogger {
 
 		try {
 			final BlockingQueue<AllocationID> freedSlots = new ArrayBlockingQueue<>(1);
-			taskManagerGateway.setFreeSlotConsumer((tuple) -> freedSlots.offer(tuple.f0));
+			taskManagerGateway.setFreeSlotFunction(
+				(AllocationID allocationId, Throwable cause) ->
+				{
+					try {
+						freedSlots.put(allocationId);
+						return CompletableFuture.completedFuture(Acknowledge.get());
+					} catch (InterruptedException e) {
+						return FutureUtils.completedExceptionally(e);
+					}
+				});
 
 			final SlotPoolGateway slotPoolGateway = setupSlotPool(slotPool, resourceManagerGateway);
 
@@ -629,6 +648,99 @@ public class SlotPoolTest extends TestLogger {
 
 			assertThat(freedSlot, Matchers.is(expiredSlotID));
 			assertThat(freedSlots.isEmpty(), Matchers.is(true));
+		} finally {
+			RpcUtils.terminateRpcEndpoint(slotPool, timeout);
+		}
+	}
+
+	/**
+	 * Tests that idle slots which cannot be released are only recycled if the owning {@link TaskExecutor}
+	 * is still registered at the {@link SlotPool}. See FLINK-9047.
+	 */
+	@Test
+	public void testReleasingIdleSlotFailed() throws Exception {
+		final ManualClock clock = new ManualClock();
+		final SlotPool slotPool = new SlotPool(
+			rpcService,
+			jobId,
+			clock,
+			TestingUtils.infiniteTime(),
+			timeout);
+
+		try {
+			final SlotPoolGateway slotPoolGateway = setupSlotPool(slotPool, resourceManagerGateway);
+
+			final AllocationID expiredAllocationId = new AllocationID();
+			final SlotOffer slotToExpire = new SlotOffer(expiredAllocationId, 0, ResourceProfile.UNKNOWN);
+
+			final ArrayDeque<CompletableFuture<Acknowledge>> responseQueue = new ArrayDeque<>(2);
+			taskManagerGateway.setFreeSlotFunction((AllocationID allocationId, Throwable cause) -> {
+				if (responseQueue.isEmpty()) {
+					return CompletableFuture.completedFuture(Acknowledge.get());
+				} else {
+					return responseQueue.pop();
+				}
+			});
+
+			responseQueue.add(FutureUtils.completedExceptionally(new FlinkException("Test failure")));
+
+			final CompletableFuture<Acknowledge> responseFuture = new CompletableFuture<>();
+			responseQueue.add(responseFuture);
+
+			assertThat(
+				slotPoolGateway.registerTaskManager(taskManagerLocation.getResourceID()).get(),
+				Matchers.is(Acknowledge.get()));
+
+			assertThat(
+				slotPoolGateway.offerSlot(taskManagerLocation, taskManagerGateway, slotToExpire).get(),
+				Matchers.is(true));
+
+			clock.advanceTime(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+
+			slotPool.triggerCheckIdleSlot();
+
+			CompletableFuture<LogicalSlot> allocatedSlotFuture = slotPoolGateway.allocateSlot(
+				new SlotRequestId(),
+				new DummyScheduledUnit(),
+				SlotProfile.noRequirements(),
+				true,
+				timeout);
+
+			// wait until the slot has been fulfilled with the previously idling slot
+			final LogicalSlot logicalSlot = allocatedSlotFuture.get();
+			assertThat(logicalSlot.getAllocationId(), Matchers.is(expiredAllocationId));
+
+			// return the slot
+			slotPool.getSlotOwner().returnAllocatedSlot(logicalSlot).get();
+
+			// advance the time so that the returned slot is now idling
+			clock.advanceTime(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+
+			slotPool.triggerCheckIdleSlot();
+
+			// request a new slot after the idling slot has been released
+			allocatedSlotFuture = slotPoolGateway.allocateSlot(
+				new SlotRequestId(),
+				new DummyScheduledUnit(),
+				SlotProfile.noRequirements(),
+				true,
+				timeout);
+
+			// release the TaskExecutor before we get a response from the slot releasing
+			slotPoolGateway.releaseTaskManager(taskManagerLocation.getResourceID()).get();
+
+			// let the slot releasing fail --> since there the owning TaskExecutor is no longer registered
+			// the slot should be discarded
+			responseFuture.completeExceptionally(new FlinkException("Second test exception"));
+
+			try {
+				// since the slot msut have been discarded, we cannot fulfill the slot request
+				allocatedSlotFuture.get(10L, TimeUnit.MILLISECONDS);
+				fail("Expected to fail with a timeout.");
+			} catch (TimeoutException ignored) {
+				// expected
+			}
+
 		} finally {
 			RpcUtils.terminateRpcEndpoint(slotPool, timeout);
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerTest.java
@@ -685,7 +685,7 @@ public class SlotManagerTest extends TestLogger {
 			});
 
 			verify(resourceManagerActions, timeout(100L * tmTimeout).times(1))
-				.releaseResource(eq(taskManagerConnection.getInstanceID()));
+				.releaseResource(eq(taskManagerConnection.getInstanceID()), any(Exception.class));
 		}
 	}
 
@@ -1027,13 +1027,13 @@ public class SlotManagerTest extends TestLogger {
 
 			assertTrue(idleFuture2.get());
 
-			verify(resourceManagerActions, timeout(verifyTimeout).times(1)).releaseResource(eq(taskManagerConnection.getInstanceID()));
+			verify(resourceManagerActions, timeout(verifyTimeout).times(1)).releaseResource(eq(taskManagerConnection.getInstanceID()), any(Exception.class));
 		}
 	}
 
 	/**
 	 * Tests that a task manager timeout does not remove the slots from the SlotManager.
-	 * A timeout should only trigger the {@link ResourceActions#releaseResource(InstanceID)}
+	 * A timeout should only trigger the {@link ResourceActions#releaseResource(InstanceID, Exception)}
 	 * callback. The receiver of the callback can then decide what to do with the TaskManager.
 	 *
 	 * FLINK-7793
@@ -1064,7 +1064,7 @@ public class SlotManagerTest extends TestLogger {
 			assertEquals(1, slotManager.getNumberRegisteredSlots());
 
 			// wait for the timeout call to happen
-			verify(resourceActions, timeout(taskManagerTimeout.toMilliseconds() * 20L).atLeast(1)).releaseResource(eq(taskExecutorConnection.getInstanceID()));
+			verify(resourceActions, timeout(taskManagerTimeout.toMilliseconds() * 20L).atLeast(1)).releaseResource(eq(taskExecutorConnection.getInstanceID()), any(Exception.class));
 
 			assertEquals(1, slotManager.getNumberRegisteredSlots());
 

--- a/flink-runtime/src/test/resources/log4j-test.properties
+++ b/flink-runtime/src/test/resources/log4j-test.properties
@@ -16,7 +16,7 @@
 # limitations under the License.
 ################################################################################
 
-log4j.rootLogger=OFF, console
+log4j.rootLogger=DEBUG, console
 
 # -----------------------------------------------------------------------------
 # Console (use 'console')


### PR DESCRIPTION
## What is the purpose of the change

In case that a slot cannot be released it will only recycled/reused if the owning
TaskExecutor is still registered at the SlotPool. If this is not the case then we
drop the slot from the SlotPool.

cc @GJL 

## Brief change log

- Only recycle slots which could not be released if owner is still registered

## Verifying this change

- Added `SlotPoolTest#testReleasingIdleSlotFailed`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
