### PR TITLE
 [FLINK-9027] [web] Clean up web UI resources by installing shut down hook

### DIFF
--- a/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
@@ -666,11 +666,6 @@ public class RestClusterClientTest extends TestLogger {
 
 		@Override
 		protected void startInternal() throws Exception {}
-
-		@Override
-		public void close() throws Exception {
-			shutDownAsync().get();
-		}
 	}
 
 	@FunctionalInterface

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherRestEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DispatcherRestEndpoint.java
@@ -42,7 +42,6 @@ import org.apache.flink.util.FlinkException;
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelInboundHandler;
 
 import java.io.IOException;
-import java.nio.file.Path;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -51,8 +50,6 @@ import java.util.concurrent.Executor;
  * REST endpoint for the {@link Dispatcher} component.
  */
 public class DispatcherRestEndpoint extends WebMonitorEndpoint<DispatcherGateway> {
-
-	private final Path uploadDir;
 
 	private WebMonitorExtension webSubmissionExtension;
 
@@ -80,7 +77,6 @@ public class DispatcherRestEndpoint extends WebMonitorEndpoint<DispatcherGateway
 			leaderElectionService,
 			fatalErrorHandler);
 
-		uploadDir = endpointConfiguration.getUploadDir();
 		webSubmissionExtension = WebMonitorExtension.empty();
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -758,7 +758,7 @@ public class MiniCluster implements JobExecutorService, AutoCloseableAsync {
 		}
 
 		if (dispatcherRestEndpoint != null) {
-			terminationFutures.add(dispatcherRestEndpoint.shutDownAsync());
+			terminationFutures.add(dispatcherRestEndpoint.closeAsync());
 
 			dispatcherRestEndpoint = null;
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
@@ -25,8 +25,8 @@ import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.rest.handler.PipelineErrorHandler;
 import org.apache.flink.runtime.rest.handler.RestHandlerSpecification;
 import org.apache.flink.runtime.rest.handler.RouterHandler;
+import org.apache.flink.util.AutoCloseableAsync;
 import org.apache.flink.util.ExceptionUtils;
-import org.apache.flink.util.FileUtils;
 import org.apache.flink.util.Preconditions;
 
 import org.apache.flink.shaded.netty4.io.netty.bootstrap.ServerBootstrap;
@@ -67,7 +67,7 @@ import java.util.concurrent.TimeoutException;
 /**
  * An abstract class for netty-based REST server endpoints.
  */
-public abstract class RestServerEndpoint {
+public abstract class RestServerEndpoint implements AutoCloseableAsync {
 
 	protected final Logger log = LoggerFactory.getLogger(getClass());
 
@@ -256,7 +256,8 @@ public abstract class RestServerEndpoint {
 		}
 	}
 
-	public final CompletableFuture<Void> shutDownAsync() {
+	@Override
+	public CompletableFuture<Void> closeAsync() {
 		synchronized (lock) {
 			log.info("Shutting down rest endpoint.");
 
@@ -370,12 +371,7 @@ public abstract class RestServerEndpoint {
 						});
 			});
 
-			return FutureUtils.runAfterwards(
-				channelTerminationFuture,
-				() -> {
-					log.info("Cleaning upload directory {}", uploadDir);
-					FileUtils.cleanDirectory(uploadDir.toFile());
-				});
+			return channelTerminationFuture;
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpoint.java
@@ -77,8 +77,9 @@ public abstract class RestServerEndpoint {
 	private final String restBindAddress;
 	private final int restBindPort;
 	private final SSLEngine sslEngine;
-	private final Path uploadDir;
 	private final int maxContentLength;
+
+	protected final Path uploadDir;
 	protected final Map<String, String> responseHeaders;
 
 	private final CompletableFuture<Void> terminationFuture;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpointConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpointConfiguration.java
@@ -36,7 +36,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.Map;
-import java.util.UUID;
 
 import static java.util.Objects.requireNonNull;
 
@@ -172,7 +171,7 @@ public final class RestServerEndpointConfiguration {
 
 		final Path uploadDir = Paths.get(
 			config.getString(WebOptions.UPLOAD_DIR,	config.getString(WebOptions.TMP_DIR)),
-			"flink-web-upload-" + UUID.randomUUID());
+			"flink-web-upload");
 
 		final int maxContentLength = config.getInteger(RestOptions.REST_SERVER_MAX_CONTENT_LENGTH);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/RestHandlerConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/RestHandlerConfiguration.java
@@ -23,8 +23,8 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.WebOptions;
 import org.apache.flink.util.Preconditions;
 
-import java.io.File;
-import java.util.UUID;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 /**
  * Configuration object containing values for the rest handler configuration.
@@ -37,20 +37,20 @@ public class RestHandlerConfiguration {
 
 	private final Time timeout;
 
-	private final File tmpDir;
+	private final Path webUiDir;
 
 	public RestHandlerConfiguration(
 			long refreshInterval,
 			int maxCheckpointStatisticCacheEntries,
 			Time timeout,
-			File tmpDir) {
+			Path webUiDir) {
 		Preconditions.checkArgument(refreshInterval > 0L, "The refresh interval (ms) should be larger than 0.");
 		this.refreshInterval = refreshInterval;
 
 		this.maxCheckpointStatisticCacheEntries = maxCheckpointStatisticCacheEntries;
 
 		this.timeout = Preconditions.checkNotNull(timeout);
-		this.tmpDir = Preconditions.checkNotNull(tmpDir);
+		this.webUiDir = Preconditions.checkNotNull(webUiDir);
 	}
 
 	public long getRefreshInterval() {
@@ -65,8 +65,8 @@ public class RestHandlerConfiguration {
 		return timeout;
 	}
 
-	public File getTmpDir() {
-		return tmpDir;
+	public Path getWebUiDir() {
+		return webUiDir;
 	}
 
 	public static RestHandlerConfiguration fromConfiguration(Configuration configuration) {
@@ -76,13 +76,13 @@ public class RestHandlerConfiguration {
 
 		final Time timeout = Time.milliseconds(configuration.getLong(WebOptions.TIMEOUT));
 
-		final String rootDir = "flink-web-" + UUID.randomUUID();
-		final File tmpDir = new File(configuration.getString(WebOptions.TMP_DIR), rootDir);
+		final String rootDir = "flink-web-ui";
+		final Path webUiDir = Paths.get(configuration.getString(WebOptions.TMP_DIR), rootDir);
 
 		return new RestHandlerConfiguration(
 			refreshInterval,
 			maxCheckpointStatisticCacheEntries,
 			timeout,
-			tmpDir);
+			webUiDir);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
@@ -127,6 +127,7 @@ import javax.annotation.Nonnull;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -498,7 +499,7 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
 			executor,
 			metricFetcher);
 
-		final File tmpDir = restConfiguration.getTmpDir();
+		final Path webUiDir = restConfiguration.getWebUiDir();
 
 		Optional<StaticFileServerHandler<T>> optWebContent;
 
@@ -507,7 +508,7 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
 				leaderRetriever,
 				restAddressFuture,
 				timeout,
-				tmpDir);
+				webUiDir.toFile());
 		} catch (IOException e) {
 			log.warn("Could not load web content handler.", e);
 			optWebContent = Optional.empty();
@@ -635,15 +636,15 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
 
 		final CompletableFuture<Void> shutdownFuture = super.shutDownInternal();
 
-		final File tmpDir = restConfiguration.getTmpDir();
+		final Path webUiDir = restConfiguration.getWebUiDir();
 
 		return FutureUtils.runAfterwardsAsync(
 			shutdownFuture,
 			() -> {
 				Exception exception = null;
 				try {
-					log.info("Removing cache directory {}", tmpDir);
-					FileUtils.deleteDirectory(tmpDir);
+					log.info("Removing cache directory {}", webUiDir);
+					FileUtils.deleteDirectory(webUiDir.toFile());
 				} catch (Exception e) {
 					exception = e;
 				}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointITCase.java
@@ -154,7 +154,7 @@ public class RestServerEndpointITCase extends TestLogger {
 		}
 
 		if (serverEndpoint != null) {
-			serverEndpoint.shutDownAsync().get();
+			serverEndpoint.close();
 			serverEndpoint = null;
 		}
 	}


### PR DESCRIPTION
## What is the purpose of the change

The RestServerEndpoint creates temp directories to upload files and store the web ui.
In case of a hard shut down, as it happens with bin/stop-cluster.sh we should still
delete these files. We do this by installing a shut down hook.

## Verifying this change

- Manually tested

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
