### PR TITLE
[FLINK-8931] TASK_KILLING is not covered by match in TaskMonitor#whenUnhandled

### DIFF
--- a/flink-mesos/src/main/scala/org/apache/flink/mesos/scheduler/TaskMonitor.scala
+++ b/flink-mesos/src/main/scala/org/apache/flink/mesos/scheduler/TaskMonitor.scala
@@ -159,10 +159,11 @@ class TaskMonitor(
         case TASK_RUNNING =>
           LOG.info(s"Mesos task ${goal.taskID.getValue} is running.")
           goto(Running)
-        case TASK_FINISHED | TASK_LOST | TASK_FAILED | TASK_KILLED | TASK_KILLING | TASK_ERROR =>
+        case TASK_FINISHED | TASK_LOST | TASK_FAILED | TASK_KILLED | TASK_ERROR =>
           LOG.warn(s"Mesos task ${goal.taskID.getValue} failed unexpectedly.")
           context.parent ! TaskTerminated(goal.taskID, msg.status())
           stop()
+        case TASK_KILLING => stay()
       }
 
     case Event(msg: StatusUpdate, StateData(goal: Released)) =>
@@ -171,10 +172,11 @@ class TaskMonitor(
         case TASK_STAGING | TASK_STARTING | TASK_RUNNING =>
           LOG.info(s"Mesos task ${goal.taskID.getValue} is running unexpectedly; killing.")
           goto(Killing)
-        case TASK_FINISHED | TASK_LOST | TASK_FAILED | TASK_KILLED | TASK_KILLING | TASK_ERROR =>
+        case TASK_FINISHED | TASK_LOST | TASK_FAILED | TASK_KILLED | TASK_ERROR =>
           LOG.info(s"Mesos task ${goal.taskID.getValue} exited as planned.")
           context.parent ! TaskTerminated(goal.taskID, msg.status())
           stop()
+        case TASK_KILLING => stay()
       }
   }
 

--- a/flink-mesos/src/main/scala/org/apache/flink/mesos/scheduler/TaskMonitor.scala
+++ b/flink-mesos/src/main/scala/org/apache/flink/mesos/scheduler/TaskMonitor.scala
@@ -159,7 +159,7 @@ class TaskMonitor(
         case TASK_RUNNING =>
           LOG.info(s"Mesos task ${goal.taskID.getValue} is running.")
           goto(Running)
-        case TASK_FINISHED | TASK_LOST | TASK_FAILED | TASK_KILLED | TASK_ERROR =>
+        case TASK_FINISHED | TASK_LOST | TASK_FAILED | TASK_KILLED | TASK_KILLING | TASK_ERROR =>
           LOG.warn(s"Mesos task ${goal.taskID.getValue} failed unexpectedly.")
           context.parent ! TaskTerminated(goal.taskID, msg.status())
           stop()
@@ -171,7 +171,7 @@ class TaskMonitor(
         case TASK_STAGING | TASK_STARTING | TASK_RUNNING =>
           LOG.info(s"Mesos task ${goal.taskID.getValue} is running unexpectedly; killing.")
           goto(Killing)
-        case TASK_FINISHED | TASK_LOST | TASK_FAILED | TASK_KILLED | TASK_ERROR =>
+        case TASK_FINISHED | TASK_LOST | TASK_FAILED | TASK_KILLED | TASK_KILLING | TASK_ERROR =>
           LOG.info(s"Mesos task ${goal.taskID.getValue} exited as planned.")
           context.parent ! TaskTerminated(goal.taskID, msg.status())
           stop()


### PR DESCRIPTION
## What is the purpose of the change

*This pull request makes _TASK_KILLING_  covered by match in `TaskMonitor#whenUnhandled`*


## Brief change log

  - *Added **TASK_KILLING** in last case *


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
