### PR TITLE
[FLINK-8976] [test] Add end-to-end test for resuming savepoints with different parallelism

### DIFF
--- a/flink-end-to-end-tests/run-pre-commit-tests.sh
+++ b/flink-end-to-end-tests/run-pre-commit-tests.sh
@@ -55,9 +55,25 @@ fi
 
 if [ $EXIT_CODE == 0 ]; then
     printf "\n==============================================================================\n"
-    printf "Running Resuming Savepoint end-to-end test\n"
+    printf "Running Resuming Savepoint (no parallelism change) end-to-end test\n"
     printf "==============================================================================\n"
-    $END_TO_END_DIR/test-scripts/test_resume_savepoint.sh
+    $END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 2 2
+    EXIT_CODE=$?
+fi
+
+if [ $EXIT_CODE == 0 ]; then
+    printf "\n==============================================================================\n"
+    printf "Running Resuming Savepoint (scale up) end-to-end test\n"
+    printf "==============================================================================\n"
+    $END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 2 4
+    EXIT_CODE=$?
+fi
+
+if [ $EXIT_CODE == 0 ]; then
+    printf "\n==============================================================================\n"
+    printf "Running Resuming Savepoint (scale down) end-to-end test\n"
+    printf "==============================================================================\n"
+    $END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 4 2
     EXIT_CODE=$?
 fi
 

--- a/flink-end-to-end-tests/run-pre-commit-tests.sh
+++ b/flink-end-to-end-tests/run-pre-commit-tests.sh
@@ -55,6 +55,14 @@ fi
 
 if [ $EXIT_CODE == 0 ]; then
     printf "\n==============================================================================\n"
+    printf "Running Resuming Savepoint end-to-end test\n"
+    printf "==============================================================================\n"
+    $END_TO_END_DIR/test-scripts/test_resume_savepoint.sh
+    EXIT_CODE=$?
+fi
+
+if [ $EXIT_CODE == 0 ]; then
+    printf "\n==============================================================================\n"
     printf "Running class loading end-to-end test\n"
     printf "==============================================================================\n"
     $END_TO_END_DIR/test-scripts/test_streaming_classloader.sh

--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -111,12 +111,6 @@ function stop_cluster {
   rm $FLINK_DIR/log/*
 }
 
-function add_taskmanagers {
-  for i in {1..$1}; do
-    "$FLINK_DIR"/bin/taskmanager.sh start
-  done
-}
-
 function wait_job_running {
   for i in {1..10}; do
     JOB_LIST_RESULT=$("$FLINK_DIR"/bin/flink list | grep "$1")

--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -111,6 +111,34 @@ function stop_cluster {
   rm $FLINK_DIR/log/*
 }
 
+function add_taskmanagers {
+  for i in {1..$1}; do
+    "$FLINK_DIR"/bin/taskmanager.sh start
+  done
+}
+
+function wait_job_running {
+  for i in {1..10}; do
+    JOB_LIST_RESULT=$("$FLINK_DIR"/bin/flink list | grep "$1")
+
+    if [[ "$JOB_LIST_RESULT" == "" ]]; then
+      echo "Job ($1) is not yet running."
+    else
+      echo "Job ($1) is running."
+      break
+    fi
+    sleep 1
+  done
+}
+
+function take_savepoint {
+  "$FLINK_DIR"/bin/flink savepoint $1 $2
+}
+
+function cancel_job {
+  "$FLINK_DIR"/bin/flink cancel $1
+}
+
 function check_result_hash {
   local name=$1
   local outfile_prefix=$2

--- a/flink-end-to-end-tests/test-scripts/test_resume_savepoint.sh
+++ b/flink-end-to-end-tests/test-scripts/test_resume_savepoint.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+################################################################################
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+source "$(dirname "$0")"/common.sh
+
+start_cluster
+
+# this tests runs 2 streaming jobs; adding extra taskmanagers for more slots
+add_taskmanagers 1
+
+# get Kafka 0.10.0
+mkdir -p $TEST_DATA_DIR
+if [ -z "$3" ]; then
+  # need to download Kafka because no Kafka was specified on the invocation
+  KAFKA_URL="https://archive.apache.org/dist/kafka/0.10.2.0/kafka_2.11-0.10.2.0.tgz"
+  echo "Downloading Kafka from $KAFKA_URL"
+  curl "$KAFKA_URL" > $TEST_DATA_DIR/kafka.tgz
+else
+  echo "Using specified Kafka from $3"
+  cp $3 $TEST_DATA_DIR/kafka.tgz
+fi
+
+tar xzf $TEST_DATA_DIR/kafka.tgz -C $TEST_DATA_DIR/
+KAFKA_DIR=$TEST_DATA_DIR/kafka_2.11-0.10.2.0
+
+# fix kafka config
+sed -i -e "s+^\(dataDir\s*=\s*\).*$+\1$TEST_DATA_DIR/zookeeper+" $KAFKA_DIR/config/zookeeper.properties
+sed -i -e "s+^\(log\.dirs\s*=\s*\).*$+\1$TEST_DATA_DIR/kafka+" $KAFKA_DIR/config/server.properties
+$KAFKA_DIR/bin/zookeeper-server-start.sh -daemon $KAFKA_DIR/config/zookeeper.properties
+$KAFKA_DIR/bin/kafka-server-start.sh -daemon $KAFKA_DIR/config/server.properties
+
+# make sure to stop Kafka and ZooKeeper at the end
+
+function kafka_cleanup {
+  $KAFKA_DIR/bin/kafka-server-stop.sh
+  $KAFKA_DIR/bin/zookeeper-server-stop.sh
+
+  # make sure to run regular cleanup as well
+  cleanup
+}
+trap kafka_cleanup INT
+trap kafka_cleanup EXIT
+
+# zookeeper outputs the "Node does not exist" bit to stderr
+while [[ $($KAFKA_DIR/bin/zookeeper-shell.sh localhost:2181 get /brokers/ids/0 2>&1) =~ .*Node\ does\ not\ exist.* ]]; do
+  echo "Waiting for broker..."
+  sleep 1
+done
+
+# create the required topic
+$KAFKA_DIR/bin/kafka-topics.sh --create --zookeeper localhost:2181 --replication-factor 1 --partitions 1 --topic test-input
+
+# run the state machine example job
+STATE_MACHINE_JOB=$($FLINK_DIR/bin/flink run -d $FLINK_DIR/examples/streaming/StateMachineExample.jar \
+  --kafka-topic test-input \
+  | grep "Job has been submitted with JobID" | sed 's/.* //g')
+
+wait_job_running $STATE_MACHINE_JOB
+
+# then, run the events generator
+EVENTS_GEN_JOB=$($FLINK_DIR/bin/flink run -d -c org.apache.flink.streaming.examples.statemachine.KafkaEventsGeneratorJob $FLINK_DIR/examples/streaming/StateMachineExample.jar \
+  --kafka-topic test-input --sleep 200 \
+  | grep "Job has been submitted with JobID" | sed 's/.* //g')
+
+wait_job_running $EVENTS_GEN_JOB
+
+# wait a bit to have some events pass through the state machine
+sleep 15
+
+# take a savepoint of the state machine job
+SAVEPOINT_PATH=$(take_savepoint $STATE_MACHINE_JOB $TEST_DATA_DIR \
+  | grep "Savepoint completed. Path:" | sed 's/.* //g')
+
+cancel_job $STATE_MACHINE_JOB
+
+# resume state machine job with savepoint
+STATE_MACHINE_JOB=$($FLINK_DIR/bin/flink run -s $SAVEPOINT_PATH -d $FLINK_DIR/examples/streaming/StateMachineExample.jar \
+  --kafka-topic test-input \
+  | grep "Job has been submitted with JobID" | sed 's/.* //g')
+
+wait_job_running $STATE_MACHINE_JOB
+
+sleep 15
+
+# if state is errorneous and the state machine job produces alerting state transitions,
+# output would be non-empty and the test will not pass

--- a/flink-end-to-end-tests/test-scripts/test_resume_savepoint.sh
+++ b/flink-end-to-end-tests/test-scripts/test_resume_savepoint.sh
@@ -17,11 +17,25 @@
 # limitations under the License.
 ################################################################################
 
+if [ -z $1 ] || [ -z $2 ]; then
+  echo "Usage: ./test_resume_savepoint.sh <original_dop> <new_dop>"
+  exit 1
+fi
+
 source "$(dirname "$0")"/common.sh
 
-# modify configuration to have 2 slots
+ORIGINAL_DOP=$1
+NEW_DOP=$2
+
+if (( $ORIGINAL_DOP >= $NEW_DOP )); then
+  NUM_SLOTS=$(( $ORIGINAL_DOP + 1 ))
+else
+  NUM_SLOTS=$(( $NEW_DOP + 1 ))
+fi
+
+# modify configuration to have enough slots
 cp $FLINK_DIR/conf/flink-conf.yaml $FLINK_DIR/conf/flink-conf.yaml.bak
-sed -i -e 's/taskmanager.numberOfTaskSlots: 1/taskmanager.numberOfTaskSlots: 2/' $FLINK_DIR/conf/flink-conf.yaml
+sed -i -e "s/taskmanager.numberOfTaskSlots: 1/taskmanager.numberOfTaskSlots: $NUM_SLOTS/" $FLINK_DIR/conf/flink-conf.yaml
 
 # modify configuration to use SLF4J reporter; we will be using this to monitor the state machine progress
 cp $FLINK_DIR/opt/flink-metrics-slf4j-1.6-SNAPSHOT.jar $FLINK_DIR/lib/
@@ -77,7 +91,7 @@ done
 $KAFKA_DIR/bin/kafka-topics.sh --create --zookeeper localhost:2181 --replication-factor 1 --partitions 1 --topic test-input
 
 # run the state machine example job
-STATE_MACHINE_JOB=$($FLINK_DIR/bin/flink run -d $FLINK_DIR/examples/streaming/StateMachineExample.jar \
+STATE_MACHINE_JOB=$($FLINK_DIR/bin/flink run -d -p $ORIGINAL_DOP $FLINK_DIR/examples/streaming/StateMachineExample.jar \
   --kafka-topic test-input \
   | grep "Job has been submitted with JobID" | sed 's/.* //g')
 
@@ -126,7 +140,7 @@ cancel_job $STATE_MACHINE_JOB
 OLD_NUM_METRICS=$(get_num_metric_samples)
 
 # resume state machine job with savepoint
-STATE_MACHINE_JOB=$($FLINK_DIR/bin/flink run -s $SAVEPOINT_PATH -d $FLINK_DIR/examples/streaming/StateMachineExample.jar \
+STATE_MACHINE_JOB=$($FLINK_DIR/bin/flink run -s $SAVEPOINT_PATH -p $NEW_DOP -d $FLINK_DIR/examples/streaming/StateMachineExample.jar \
   --kafka-topic test-input \
   | grep "Job has been submitted with JobID" | sed 's/.* //g')
 

--- a/flink-end-to-end-tests/test-scripts/test_resume_savepoint.sh
+++ b/flink-end-to-end-tests/test-scripts/test_resume_savepoint.sh
@@ -19,10 +19,16 @@
 
 source "$(dirname "$0")"/common.sh
 
-start_cluster
+# modify configuration to have 2 slots
+cp $FLINK_DIR/conf/flink-conf.yaml $FLINK_DIR/conf/flink-conf.yaml.bak
+sed -i -e 's/taskmanager.numberOfTaskSlots: 1/taskmanager.numberOfTaskSlots: 2/' $FLINK_DIR/conf/flink-conf.yaml
 
-# this tests runs 2 streaming jobs; adding extra taskmanagers for more slots
-add_taskmanagers 1
+# modify configuration to use SLF4J reporter; we will be using this to monitor the state machine progress
+cp $FLINK_DIR/opt/flink-metrics-slf4j-1.6-SNAPSHOT.jar $FLINK_DIR/lib/
+echo "metrics.reporter.slf4j.class: org.apache.flink.metrics.slf4j.Slf4jReporter" >> $FLINK_DIR/conf/flink-conf.yaml
+echo "metrics.reporter.slf4j.interval: 5 SECONDS" >> $FLINK_DIR/conf/flink-conf.yaml
+
+start_cluster
 
 # get Kafka 0.10.0
 mkdir -p $TEST_DATA_DIR
@@ -45,17 +51,21 @@ sed -i -e "s+^\(log\.dirs\s*=\s*\).*$+\1$TEST_DATA_DIR/kafka+" $KAFKA_DIR/config
 $KAFKA_DIR/bin/zookeeper-server-start.sh -daemon $KAFKA_DIR/config/zookeeper.properties
 $KAFKA_DIR/bin/kafka-server-start.sh -daemon $KAFKA_DIR/config/server.properties
 
-# make sure to stop Kafka and ZooKeeper at the end
-
-function kafka_cleanup {
+# make sure to stop Kafka and ZooKeeper at the end, as well as cleaning up the Flink cluster and our moodifications
+function test_cleanup {
   $KAFKA_DIR/bin/kafka-server-stop.sh
   $KAFKA_DIR/bin/zookeeper-server-stop.sh
+
+  # revert our modifications to the Flink distribution
+  rm $FLINK_DIR/conf/flink-conf.yaml
+  mv $FLINK_DIR/conf/flink-conf.yaml.bak $FLINK_DIR/conf/flink-conf.yaml
+  rm $FLINK_DIR/lib/flink-metrics-slf4j-1.6-SNAPSHOT.jar
 
   # make sure to run regular cleanup as well
   cleanup
 }
-trap kafka_cleanup INT
-trap kafka_cleanup EXIT
+trap test_cleanup INT
+trap test_cleanup EXIT
 
 # zookeeper outputs the "Node does not exist" bit to stderr
 while [[ $($KAFKA_DIR/bin/zookeeper-shell.sh localhost:2181 get /brokers/ids/0 2>&1) =~ .*Node\ does\ not\ exist.* ]]; do
@@ -75,19 +85,45 @@ wait_job_running $STATE_MACHINE_JOB
 
 # then, run the events generator
 EVENTS_GEN_JOB=$($FLINK_DIR/bin/flink run -d -c org.apache.flink.streaming.examples.statemachine.KafkaEventsGeneratorJob $FLINK_DIR/examples/streaming/StateMachineExample.jar \
-  --kafka-topic test-input --sleep 200 \
+  --kafka-topic test-input --sleep 30 \
   | grep "Job has been submitted with JobID" | sed 's/.* //g')
 
 wait_job_running $EVENTS_GEN_JOB
 
-# wait a bit to have some events pass through the state machine
-sleep 15
+function get_metric_state_machine_processed_records {
+  grep ".State machine job.Flat Map -> Sink: Print to Std. Out.0.numRecordsIn:" $FLINK_DIR/log/*taskexecutor*.log | sed 's/.* //g' | tail -1
+}
+
+function get_num_metric_samples {
+  grep ".State machine job.Flat Map -> Sink: Print to Std. Out.0.numRecordsIn:" $FLINK_DIR/log/*taskexecutor*.log | wc -l
+}
+
+# monitor the numRecordsIn metric of the state machine operator;
+# only proceed to savepoint when the operator has processed 200 records
+while : ; do
+  NUM_RECORDS=$(get_metric_state_machine_processed_records)
+
+  if [ -z $NUM_RECORDS ]; then
+    NUM_RECORDS=0
+  fi
+
+  if (( $NUM_RECORDS < 200 )); then
+    echo "Waiting for state machine job to process up to 200 records, current progress: $NUM_RECORDS records ..."
+    sleep 5
+  else
+    break
+  fi
+done
 
 # take a savepoint of the state machine job
 SAVEPOINT_PATH=$(take_savepoint $STATE_MACHINE_JOB $TEST_DATA_DIR \
   | grep "Savepoint completed. Path:" | sed 's/.* //g')
 
 cancel_job $STATE_MACHINE_JOB
+
+# Since it is not possible to differentiate reporter output between the first and second exuection,
+# we remember the number of metrics sampled in the first execution so that they can be ignored in the following monitorings
+OLD_NUM_METRICS=$(get_num_metric_samples)
 
 # resume state machine job with savepoint
 STATE_MACHINE_JOB=$($FLINK_DIR/bin/flink run -s $SAVEPOINT_PATH -d $FLINK_DIR/examples/streaming/StateMachineExample.jar \
@@ -96,7 +132,24 @@ STATE_MACHINE_JOB=$($FLINK_DIR/bin/flink run -s $SAVEPOINT_PATH -d $FLINK_DIR/ex
 
 wait_job_running $STATE_MACHINE_JOB
 
-sleep 15
+# monitor the numRecordsIn metric of the state machine operator in the second execution
+# we let the test finish once the second restore execution has processed 200 records
+while : ; do
+  NUM_METRICS=$(get_num_metric_samples)
+  NUM_RECORDS=$(get_metric_state_machine_processed_records)
+
+  # only account for metrics that appeared in the second execution
+  if (( $OLD_NUM_METRICS >= $NUM_METRICS )) ; then
+    NUM_RECORDS=0
+  fi
+
+  if (( $NUM_RECORDS < 200 )); then
+    echo "Waiting for state machine job to process up to 200 records, current progress: $NUM_RECORDS records ..."
+    sleep 5
+  else
+    break
+  fi
+done
 
 # if state is errorneous and the state machine job produces alerting state transitions,
 # output would be non-empty and the test will not pass

--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/statemachine/KafkaEventsGeneratorJob.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/statemachine/KafkaEventsGeneratorJob.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.examples.statemachine;
+
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.connectors.kafka.FlinkKafkaProducer010;
+import org.apache.flink.streaming.examples.statemachine.generator.EventsGeneratorSource;
+import org.apache.flink.streaming.examples.statemachine.kafka.EventDeSerializer;
+
+/**
+ * Job to generate input events that are written to Kafka, for the {@link StateMachineExample} job.
+ */
+public class KafkaEventsGeneratorJob {
+
+	public static void main(String[] args) throws Exception {
+
+		final ParameterTool params = ParameterTool.fromArgs(args);
+
+		double errorRate = params.getDouble("error-rate", 0.0);
+		int sleep = params.getInt("sleep", 1);
+
+		String kafkaTopic = params.get("kafka-topic");
+		String brokers = params.get("brokers", "localhost:9092");
+
+		System.out.printf("Generating events to Kafka with standalone source with error rate %f and sleep delay %s millis\n", errorRate, sleep);
+		System.out.println();
+
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+		env
+			.addSource(new EventsGeneratorSource(errorRate, sleep))
+			.addSink(new FlinkKafkaProducer010<>(brokers, kafkaTopic, new EventDeSerializer()));
+
+		// trigger program execution
+		env.execute("State machine example Kafka events generator job");
+	}
+
+}

--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/statemachine/StateMachineExample.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/statemachine/StateMachineExample.java
@@ -108,7 +108,7 @@ public class StateMachineExample {
 		alerts.print();
 
 		// trigger program execution
-		env.execute();
+		env.execute("State machine job");
 	}
 
 	// ------------------------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change

This PR adds end-to-end tests for resuming a savepoint with different parallelisms.


## Brief change log

The changes are based on the new `test_resume_savepoint.sh` test script in #5733, so only the last commit is relevant.

That script has been modified to be able to specify parallelism of the state machine job, before and after the savepoint restore.

- Adapt `test_resume_savepoint.sh` to be able to use different parallelism after the savepoint restore.
- Add scale up / scale down tests to be executed by Travis.

## Verifying this change

This PR adds new tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
