### PR TITLE
[FLINK-8943] [ha] Fail Dispatcher if jobs cannot be recovered from HA store

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/function/BiFunctionWithException.java
+++ b/flink-core/src/main/java/org/apache/flink/util/function/BiFunctionWithException.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.util.function;
+
+import org.apache.flink.util.ExceptionUtils;
+
+import java.util.function.BiFunction;
+
+/**
+ * {@link BiFunction} interface which can throw exceptions.
+ *
+ * @param <T> type of the first parameter
+ * @param <U> type of the second parameter
+ * @param <R> type of the return type
+ * @param <E> type of the exception which can be thrown
+ */
+@FunctionalInterface
+public interface BiFunctionWithException<T, U, R, E extends Throwable> extends BiFunction<T, U, R> {
+
+	/**
+	 * Apply the given values t and u to obtain the resulting value. The operation can
+	 * throw an exception.
+	 *
+	 * @param t first parameter
+	 * @param u second parameter
+	 * @return result value
+	 * @throws E if the operation fails
+	 */
+	R applyWithException(T t, U u) throws E;
+
+	default R apply(T t, U u) {
+		try {
+			return applyWithException(t, u);
+		} catch (Throwable e) {
+			ExceptionUtils.rethrow(e);
+			// we have to return a value to please the compiler
+			// but we will never reach the code here
+			return null;
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -570,7 +570,7 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 				try {
 					jobIds = submittedJobGraphStore.getJobIds();
 				} catch (Exception e) {
-					log.error("Could not recover job ids from the submitted job graph store. Aborting recovery.", e);
+					onFatalError(new FlinkException("Could not recover job ids from the submitted job graph store. Aborting recovery.", e));
 					return;
 				}
 
@@ -580,7 +580,7 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 
 						runAsync(() -> submitJob(submittedJobGraph.getJobGraph(), RpcUtils.INF_TIMEOUT));
 					} catch (Exception e) {
-						log.error("Could not recover the job graph for " + jobId + '.', e);
+						onFatalError(new FlinkException("Could not recover the job graph for " + jobId + '.', e));
 					}
 				}
 			});

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/ZooKeeperSubmittedJobGraphStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/ZooKeeperSubmittedJobGraphStore.java
@@ -18,16 +18,17 @@
 
 package org.apache.flink.runtime.jobmanager;
 
-import org.apache.curator.framework.CuratorFramework;
-import org.apache.curator.framework.recipes.cache.PathChildrenCache;
-import org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent;
-import org.apache.curator.framework.recipes.cache.PathChildrenCacheListener;
-import org.apache.curator.utils.ZKPaths;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.state.RetrievableStateHandle;
 import org.apache.flink.runtime.zookeeper.RetrievableStateStorageHelper;
 import org.apache.flink.runtime.zookeeper.ZooKeeperStateHandleStore;
 import org.apache.flink.util.FlinkException;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.recipes.cache.PathChildrenCache;
+import org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent;
+import org.apache.curator.framework.recipes.cache.PathChildrenCacheListener;
+import org.apache.curator.utils.ZKPaths;
 import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -177,7 +178,7 @@ public class ZooKeeperSubmittedJobGraphStore implements SubmittedJobGraphStore {
 					success = true;
 					return null;
 				} catch (Exception e) {
-					throw new Exception("Could not retrieve the submitted job graph state handle " +
+					throw new FlinkException("Could not retrieve the submitted job graph state handle " +
 						"for " + path + "from the submitted job graph store.", e);
 				}
 				SubmittedJobGraph jobGraph;

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -40,10 +40,10 @@ import org.apache.flink.runtime.akka.{AkkaUtils, ListeningBehaviour}
 import org.apache.flink.runtime.blob.{BlobServer, BlobStore}
 import org.apache.flink.runtime.checkpoint._
 import org.apache.flink.runtime.client._
-import org.apache.flink.runtime.clusterframework.{BootstrapTools, FlinkResourceManager}
 import org.apache.flink.runtime.clusterframework.messages._
 import org.apache.flink.runtime.clusterframework.standalone.StandaloneResourceManager
 import org.apache.flink.runtime.clusterframework.types.ResourceID
+import org.apache.flink.runtime.clusterframework.{BootstrapTools, FlinkResourceManager}
 import org.apache.flink.runtime.concurrent.{FutureUtils, ScheduledExecutorServiceAdapter}
 import org.apache.flink.runtime.execution.SuppressRestartsException
 import org.apache.flink.runtime.execution.librarycache.FlinkUserCodeClassLoaders.ResolveOrder
@@ -501,7 +501,11 @@ class JobManager(
             }
           }
         } catch {
-          case t: Throwable => log.warn(s"Failed to recover job $jobId.", t)
+          case t: Throwable => {
+            log.error(s"Failed to recover job $jobId.", t)
+            // stop one self in order to be restarted and trying to recover the jobs again
+            context.stop(self)
+          }
         }
       }(context.dispatcher)
 
@@ -523,9 +527,12 @@ class JobManager(
             }
           }
         } catch {
-          case e: Exception =>
-            log.warn("Failed to recover job ids from submitted job graph store. Aborting " +
-                       "recovery.", e)
+          case e: Exception => {
+            log.error("Failed to recover job ids from submitted job graph store. Aborting " +
+              "recovery.", e)
+            // stop one self in order to be restarted and trying to recover the jobs again
+            context.stop(self)
+          }
         }
       }(context.dispatcher)
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/TestingFatalErrorHandler.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/TestingFatalErrorHandler.java
@@ -19,10 +19,18 @@
 package org.apache.flink.runtime.util;
 
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.flink.util.Preconditions;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 
 /**
  * Testing fatal error handler which records the occurred exceptions during the execution of the
@@ -30,34 +38,62 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public class TestingFatalErrorHandler implements FatalErrorHandler {
 	private static final Logger LOG = LoggerFactory.getLogger(TestingFatalErrorHandler.class);
-	private final AtomicReference<Throwable> atomicThrowable;
+	private CompletableFuture<Throwable> errorFuture;
 
 	public TestingFatalErrorHandler() {
-		atomicThrowable = new AtomicReference<>(null);
+		errorFuture = new CompletableFuture<>();
 	}
 
-	public void rethrowError() throws TestingException {
-		Throwable throwable = atomicThrowable.get();
+	public synchronized void rethrowError() throws TestingException {
+		final Throwable throwable = getException();
 
 		if (throwable != null) {
-			throw new TestingException(throwable);
+            throw new TestingException(throwable);
+        }
+	}
+
+	public synchronized boolean hasExceptionOccurred() {
+		return errorFuture.isDone();
+	}
+
+	@Nullable
+	public synchronized Throwable getException() {
+		if (errorFuture.isDone()) {
+			Throwable throwable = null;
+
+			try {
+				throwable = errorFuture.get();
+			} catch (InterruptedException ie) {
+				Thread.interrupted();
+				throw new FlinkRuntimeException("This should never happen since the future was completed.");
+			} catch (ExecutionException e) {
+				throwable = ExceptionUtils.stripExecutionException(e);
+			}
+
+			return throwable;
+		} else {
+			return null;
 		}
 	}
 
-	public boolean hasExceptionOccurred() {
-		return atomicThrowable.get() != null;
+	public synchronized CompletableFuture<Throwable> getErrorFuture() {
+		return errorFuture;
 	}
 
-	public Throwable getException() {
-		return atomicThrowable.get();
+	public synchronized void clearError() {
+		errorFuture = new CompletableFuture<>();
 	}
 
 	@Override
-	public void onFatalError(Throwable exception) {
+	public synchronized void onFatalError(@Nonnull Throwable exception) {
 		LOG.error("OnFatalError:", exception);
 
-		if (!atomicThrowable.compareAndSet(null, exception)) {
-			atomicThrowable.get().addSuppressed(exception);
+		if (!errorFuture.complete(exception)) {
+			final Throwable throwable = getException();
+
+			Preconditions.checkNotNull(throwable);
+
+			throwable.addSuppressed(exception);
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/TestingFatalErrorHandler.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/TestingFatalErrorHandler.java
@@ -59,12 +59,12 @@ public class TestingFatalErrorHandler implements FatalErrorHandler {
 	@Nullable
 	public synchronized Throwable getException() {
 		if (errorFuture.isDone()) {
-			Throwable throwable = null;
+			Throwable throwable;
 
 			try {
 				throwable = errorFuture.get();
 			} catch (InterruptedException ie) {
-				Thread.interrupted();
+				ExceptionUtils.checkInterrupted(ie);
 				throw new FlinkRuntimeException("This should never happen since the future was completed.");
 			} catch (ExecutionException e) {
 				throwable = ExceptionUtils.stripExecutionException(e);

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/leaderelection/ZooKeeperLeaderElectionITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/leaderelection/ZooKeeperLeaderElectionITCase.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.configuration.AkkaOptions;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.client.JobClient;
 import org.apache.flink.runtime.instance.ActorGateway;
@@ -53,6 +54,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.util.UUID;
 
 import scala.concurrent.Await;
 import scala.concurrent.Future;
@@ -99,6 +101,7 @@ public class ZooKeeperLeaderElectionITCase extends TestLogger {
 		Configuration configuration = ZooKeeperTestUtils.createZooKeeperHAConfig(
 			zkServer.getConnectString(),
 			rootFolder.getPath());
+		configuration.setString(HighAvailabilityOptions.HA_CLUSTER_ID, UUID.randomUUID().toString());
 
 		int numJMs = 10;
 		int numTMs = 3;
@@ -150,6 +153,7 @@ public class ZooKeeperLeaderElectionITCase extends TestLogger {
 		Configuration configuration = ZooKeeperTestUtils.createZooKeeperHAConfig(
 			zkServer.getConnectString(),
 			rootFolder.getPath());
+		configuration.setString(HighAvailabilityOptions.HA_CLUSTER_ID, UUID.randomUUID().toString());
 
 		configuration.setInteger(ConfigConstants.LOCAL_NUMBER_JOB_MANAGER, numJMs);
 		configuration.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, numTMs);


### PR DESCRIPTION
## What is the purpose of the change

In HA mode, the Dispatcher should fail if it cannot recover the persisted jobs. The idea
is that another Dispatcher will be brought up and tries it again. This is better than
simply dropping the not recovered jobs.

cc @GJL 

## Brief change log

- Fail the `Dispatcher`/`JobManager` in case that we cannot recover a persisted job

## Verifying this change

- Added `DispatcherTest#testFatalErrorAfterJobIdRecoveryFailure` and `DispatcherTest#testFatalErrorAfterJobRecoveryFailure`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
