### PR TITLE
[FLINK-9053][runtime] only release outputs under the checkpoint lock

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -399,7 +399,11 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 
 			// release the output resources. this method should never fail.
 			if (operatorChain != null) {
-				operatorChain.releaseOutputs();
+				// beware: without synchronization, #performCheckpoint() may run in
+				//         parallel and this call is not thread-safe
+				synchronized (lock) {
+					operatorChain.releaseOutputs();
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## What is the purpose of the change

Releasing an operator chain's outputs will call `RecordWriter#clearBuffers()` and this may not be run in parallel with `RecordWriter#broadcastEvent()` which the asynchronous checkpoint barrier trigger inside `Task` may run via `StreamTask#triggerCheckpoint()`. Now, during the cleanup of `StreamTask#invoke()`, `StreamTask`'s asynchronous services are shut down but not those of the `Task` and also `operatorChain.releaseOutputs()` is not put under the checkpoint lock. Therefore, the following may run in parallel:
- `Task`'s checkpoint trigger execution
- `operatorChain.releaseOutputs()`

We may guard `operatorChain.releaseOutputs()` with the checkpoint lock and should be safe to do so since we already closed all of `StreamTask`'s asynchronous executors and also disposed the operators. Hence nothing should be blocking the cleanup by holding the checkpoint lock.
@StephanEwen can you please have a look to verify the safety of this?

## Brief change log

- add the checkpoint lock in the cleanup of `StreamTask#invoke()` around  `operatorChain.releaseOutputs()`

## Verifying this change

This is a very rare race condition that was uncovered by the `RescalingITCase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **yes**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
