### PR TITLE
[FLINK-8973] [E2E] HA end-to-end test with StateMachineExample.

### DIFF
--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -47,6 +47,15 @@ EXIT_CODE=0
 #     EXIT_CODE=$?
 # fi
 
+
+if [ $EXIT_CODE == 0 ]; then
+    printf "\n==============================================================================\n"
+    printf "Running HA end-to-end test\n"
+    printf "==============================================================================\n"
+    $END_TO_END_DIR/test-scripts/test_ha.sh
+    EXIT_CODE=$?
+fi
+
 if [ $EXIT_CODE == 0 ]; then
   printf "\n==============================================================================\n"
   printf "Running DataSet allround nightly end-to-end test\n"

--- a/flink-end-to-end-tests/run-pre-commit-tests.sh
+++ b/flink-end-to-end-tests/run-pre-commit-tests.sh
@@ -117,13 +117,6 @@ if [ $EXIT_CODE == 0 ]; then
     EXIT_CODE=$?
 fi
 
-#if [ $EXIT_CODE == 0 ]; then
-#    printf "\n==============================================================================\n"
-#    printf "Running HA end-to-end test\n"
-#    printf "==============================================================================\n"
-#    $END_TO_END_DIR/test-scripts/test_ha.sh
-#    EXIT_CODE=$?
-#fi
 
 # Exit code for Travis build success/failure
 exit $EXIT_CODE

--- a/flink-end-to-end-tests/run-pre-commit-tests.sh
+++ b/flink-end-to-end-tests/run-pre-commit-tests.sh
@@ -117,6 +117,13 @@ if [ $EXIT_CODE == 0 ]; then
     EXIT_CODE=$?
 fi
 
+#if [ $EXIT_CODE == 0 ]; then
+#    printf "\n==============================================================================\n"
+#    printf "Running HA end-to-end test\n"
+#    printf "==============================================================================\n"
+#    $END_TO_END_DIR/test-scripts/test_ha.sh
+#    EXIT_CODE=$?
+#fi
 
 # Exit code for Travis build success/failure
 exit $EXIT_CODE

--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -40,39 +40,38 @@ export TEST_DATA_DIR=$TEST_INFRA_DIR/temp-test-directory-$(date +%S%N)
 echo "TEST_DATA_DIR: $TEST_DATA_DIR"
 
 function revert_default_config() {
-    sed 's/^    //g' > ${FLINK_DIR}/conf/flink-conf.yaml << EOL
-    #==============================================================================
-    # Common
-    #==============================================================================
 
-    jobmanager.rpc.address: localhost
-    jobmanager.rpc.port: 6123
-    jobmanager.heap.mb: 1024
-    taskmanager.heap.mb: 1024
-    taskmanager.numberOfTaskSlots: 1
-    parallelism.default: 1
+    # revert our modifications to the masters file
+    if [ -f $FLINK_DIR/conf/masters.bak ]; then
+        rm $FLINK_DIR/conf/masters
+        mv $FLINK_DIR/conf/masters.bak $FLINK_DIR/conf/masters
+    fi
 
-    #==============================================================================
-    # Web Frontend
-    #==============================================================================
-
-    web.port: 8081
-EOL
+    # revert our modifications to the Flink conf yaml
+    if [ -f $FLINK_DIR/conf/flink-conf.yaml.bak ]; then
+        rm $FLINK_DIR/conf/flink-conf.yaml
+        mv $FLINK_DIR/conf/flink-conf.yaml.bak $FLINK_DIR/conf/flink-conf.yaml
+    fi
 }
 
-function create_ha_conf() {
+function create_ha_config() {
+
+    # back up the masters and flink-conf.yaml
+    cp $FLINK_DIR/conf/masters $FLINK_DIR/conf/masters.bak
+    cp $FLINK_DIR/conf/flink-conf.yaml $FLINK_DIR/conf/flink-conf.yaml.bak
+
+    # clean up the dir that will be used for zookeeper storage
+    # (see high-availability.zookeeper.storageDir below)
+    if [ -e $TEST_DATA_DIR/recovery ]; then
+       echo "File ${TEST_DATA_DIR}/recovery exists. Deleting it..."
+       rm -rf $TEST_DATA_DIR/recovery
+    fi
 
     # create the masters file (only one currently).
     # This must have all the masters to be used in HA.
     echo "localhost:8081" > ${FLINK_DIR}/conf/masters
 
     # then move on to create the flink-conf.yaml
-
-    if [ -e $TEST_DATA_DIR/recovery ]; then
-       echo "File ${TEST_DATA_DIR}/recovery exists. Deleting it..."
-       rm -rf $TEST_DATA_DIR/recovery
-    fi
-
     sed 's/^    //g' > ${FLINK_DIR}/conf/flink-conf.yaml << EOL
     #==============================================================================
     # Common
@@ -104,13 +103,17 @@ EOL
 }
 
 function start_ha_cluster {
-    echo "Setting up HA Cluster..."
-    create_ha_conf
+    create_ha_config
     start_local_zk
     start_cluster
 }
 
 function start_local_zk {
+    # Parses the zoo.cfg and starts locally zk.
+
+    # This is almost the same code as the
+    # /bin/start-zookeeper-quorum.sh without the SSH part and only running for localhost.
+
     while read server ; do
         server=$(echo -e "${server}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//') # trim
 
@@ -119,6 +122,11 @@ function start_local_zk {
             id=${BASH_REMATCH[1]}
             address=${BASH_REMATCH[2]}
 
+            if [ "${address}" != "localhost" ]; then
+                echo "[ERROR] Parse error. Only available for localhost."
+                PASS=""
+                exit 1
+            fi
             ${FLINK_DIR}/bin/zookeeper.sh start $id
         else
             echo "[WARN] Parse error. Skipping config entry '$server'."
@@ -146,59 +154,13 @@ function start_cluster {
   done
 }
 
-function jm_watchdog() {
-    expectedJms=$1
-    ipPort=$2
-
-    while true; do
-        runningJms=`jps | grep -o 'StandaloneSessionClusterEntrypoint' | wc -l`;
-        missingJms=$((expectedJms-runningJms))
-        for (( c=0; c<missingJms; c++ )); do
-            "$FLINK_DIR"/bin/jobmanager.sh start "localhost" $2
-        done
-        sleep 5;
-    done
-}
-
-function kill_jm {
-    idx=$1
-
-    jm_pids=`jps | grep 'StandaloneSessionClusterEntrypoint' | cut -d " " -f 1`
-    jm_pids=(${jm_pids[@]})
-
-    pid=${jm_pids[$idx]}
-
-    # kill the JM and wait for the completion of its termination
-    kill -9 ${pid}
-
-    echo "Killed JM @ ${pid}."
-}
-
-function stop_ha_cluster {
-    echo "Tearing down HA Cluster..."
-    stop_cluster
-    stop_local_zk
-    cleanup
-}
-
-function stop_local_zk {
-    while read server ; do
-        server=$(echo -e "${server}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//') # trim
-
-        # match server.id=address[:port[:port]]
-        if [[ $server =~ ^server\.([0-9]+)[[:space:]]*\=[[:space:]]*([^: \#]+) ]]; then
-            id=${BASH_REMATCH[1]}
-            server=${BASH_REMATCH[2]}
-
-            ${FLINK_DIR}/bin/zookeeper.sh stop
-        else
-            echo "[WARN] Parse error. Skipping config entry '$server'."
-        fi
-    done < <(grep "^server\." "${FLINK_DIR}/conf/zoo.cfg")
-}
-
 function stop_cluster {
   "$FLINK_DIR"/bin/stop-cluster.sh
+
+  # stop zookeeper only if there are processes running
+  if ! [ `jps | grep 'FlinkZooKeeperQuorumPeer' | wc -l` -eq 0 ]; then
+    "$FLINK_DIR"/bin/zookeeper.sh stop
+  fi
 
   if grep -rv "GroupCoordinatorNotAvailableException" $FLINK_DIR/log \
       | grep -v "RetriableCommitFailedException" \
@@ -338,7 +300,7 @@ function s3_delete {
 function cleanup {
   stop_cluster
   check_all_pass
-  rm -r $TEST_DATA_DIR
+  rm -rf $TEST_DATA_DIR
   rm $FLINK_DIR/log/*
   revert_default_config
 }

--- a/flink-end-to-end-tests/test-scripts/test_ha.sh
+++ b/flink-end-to-end-tests/test-scripts/test_ha.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+
+################################################################################
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+source "$(dirname "$0")"/common.sh
+
+#FLINK_DIR=/Users/kkloudas/repos/dataartisans/flink/build-target flink-end-to-end-tests/test-scripts/test_ha.sh
+TEST_PROGRAM_JAR=$TEST_INFRA_DIR/../../flink-examples/flink-examples-streaming/target/StateMachineExample.jar\ --error-rate\ 0.0\ --sleep\ 2
+
+stop_cluster_and_watchdog() {
+    kill ${watchdogPid} 2> /dev/null
+    wait ${watchdogPid} 2> /dev/null
+
+    stop_ha_cluster
+}
+
+verify_logs() {
+    expectedRetries=$1
+
+    # verify that we have no alerts
+    if ! [ `cat ${output} | wc -l` -eq 0 ]; then
+        echo "FAILURE: Alerts found at the StateMachineExample with 0.0 error rate."
+        PASS=""
+    fi
+
+    # checks that all apart from the first JM recover the failes jobgraph.
+    if ! [ `grep -r --include '*standalonesession*.log' Recovered SubmittedJobGraph "${FLINK_DIR}/log/" | cut -d ":" -f 1 | uniq | wc -l` -eq ${expectedRetries} ]; then
+        echo "FAILURE: A JM did not take over."
+        PASS=""
+    fi
+
+    # search the logs for JMs that log completed checkpoints
+    if ! [ `grep -r --include '*standalonesession*.log' Completed checkpoint "${FLINK_DIR}/log/" | cut -d ":" -f 1 | uniq | wc -l` -eq $((expectedRetries + 1)) ]; then
+        echo "FAILURE: A JM did not execute the job."
+        PASS=""
+    fi
+}
+
+run_ha_test() {
+    parallelism=$1
+    backend=$2
+    async=$3
+    incremental=$4
+    maxAttempts=$5
+    rstrtInterval=$6
+    output=$7
+
+    jmKillAndRetries=2
+    checkpointDir="${TEST_DATA_DIR}/checkpoints/"
+
+    # start the cluster on HA mode and
+    # verify that all JMs are running
+    start_ha_cluster
+
+    echo "Running on HA mode: parallelism=${parallelism}, backend=${backend}, asyncSnapshots=${async}, and incremSnapshots=${incremental}."
+
+    # submit a job in detached mode and let it run
+    $FLINK_DIR/bin/flink run -d -p ${parallelism} \
+     $TEST_PROGRAM_JAR \
+        --stateBackend ${backend} \
+        --checkpointDir "file://${checkpointDir}" \
+        --asyncCheckpoints ${async} \
+        --incrementalCheckpoints ${incremental} \
+        --restartAttempts ${maxAttempts} \
+        --restartDelay ${rstrtInterval} \
+        --output ${output} > /dev/null
+
+    # start the watchdog that keeps the number of JMs stable
+    jm_watchdog 1 "8081" &
+    watchdogPid=$!
+
+    # let the job run for a while to take some checkpoints
+    sleep 50
+
+    for (( c=0; c<${jmKillAndRetries}; c++ )); do
+        # kill the JM and wait for watchdog to
+        # create a new JM which will take over
+        kill_jm 0
+        sleep 50
+    done
+
+    verify_logs ${jmKillAndRetries}
+
+    # kill the cluster and zookeeper
+    stop_cluster_and_watchdog
+}
+
+run_ha_test 1 "file" "false" "false" 3 100 "${TEST_DATA_DIR}/output.txt"
+run_ha_test 1 "rocks" "false" "false" 3 100 "${TEST_DATA_DIR}/output.txt"
+run_ha_test 1 "file" "true" "false" 3 100 "${TEST_DATA_DIR}/output.txt"
+run_ha_test 1 "rocks" "false" "true" 3 100 "${TEST_DATA_DIR}/output.txt"
+trap stop_cluster_and_watchdog EXIT

--- a/flink-examples/flink-examples-streaming/pom.xml
+++ b/flink-examples/flink-examples-streaming/pom.xml
@@ -84,7 +84,13 @@ under the License.
 			<type>test-jar</type>
 		</dependency>
 
-	</dependencies>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-statebackend-rocksdb_${scala.binary.version}</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+    </dependencies>
 
 	<build>
 		<plugins>


### PR DESCRIPTION
Adds an end-to-end test that runs the StateMachineExample on a local cluster with HA enabled. There is a single JM which gets killed and re-created and we check if the new JM picks up the job execution and if at the end the StateMachine has no ALERTs printed.

## Verifying this change

It is a script that you can run independently.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable