### PR TITLE
[FLINK-9060][state] Deleting state using KeyedStateBackend.getKeys() throws Exception

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
@@ -295,16 +295,16 @@ public abstract class AbstractKeyedStateBackend<K> implements
 			final KeyedStateFunction<K, S> function) throws Exception {
 
 		try (Stream<K> keyStream = getKeys(stateDescriptor.getName(), namespace)) {
+
+			final S state = getPartitionedState(
+				namespace,
+				namespaceSerializer,
+				stateDescriptor);
+
 			keyStream.forEach((K key) -> {
 				setCurrentKey(key);
 				try {
-					function.process(
-						key,
-						getPartitionedState(
-							namespace,
-							namespaceSerializer,
-							stateDescriptor)
-					);
+					function.process(key, state);
 				} catch (Throwable e) {
 					// we wrap the checked exception in an unchecked
 					// one and catch it (and re-throw it) later.


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes the problem when deleting state using `KeyedStateBackend.getKeys()` throws Exception.

## Brief change log

  - copy the result of `getKeys()` into `list` to avoid concurrency problem.

## Verifying this change

  - *add a unit test in `StateBackendTest#testConcurrentModificationWithGetKeys()` to verify this*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation
 no
