### PR TITLE
[FLINK-8789] Throw IllegalStateException when calling Task#stopExecution on not running Task

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
@@ -1734,6 +1734,10 @@ public class TaskManagerTest extends TestLogger {
 
 			Await.result(submitResponse, timeout);
 
+			final Future<Object> taskRunning = taskManager.ask(new TestingTaskManagerMessages.NotifyWhenTaskIsRunning(executionAttemptId), timeout);
+
+			Await.result(taskRunning, timeout);
+
 			Future<Object> stopResponse = taskManager.ask(new StopTask(executionAttemptId), timeout);
 
 			try {


### PR DESCRIPTION
## What is the purpose of the change

Before we threw an UnsupportedOperationException when calling Task#stopExecution on a Task
where we did not set the invokable yet. This can be a bit misleading and, thus, this commit
throws an IllegalStateException with an respective message.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
