### PR TITLE
[FLINK-8813][flip6] Disallow PARALLELISM_AUTO_MAX for flip6

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
@@ -69,6 +69,7 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 	 * The constant to use for the parallelism, if the system should use the number
 	 * of currently available slots.
 	 */
+	@Deprecated
 	public static final int PARALLELISM_AUTO_MAX = Integer.MAX_VALUE;
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -1135,7 +1135,6 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 			rpcTimeout,
 			restartStrategy,
 			currentJobManagerJobMetricGroup,
-			-1,
 			blobServer,
 			jobMasterConfiguration.getSlotRequestTimeout(),
 			log);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRescalingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRescalingTest.java
@@ -75,7 +75,6 @@ public class ExecutionGraphRescalingTest extends TestLogger {
 			AkkaUtils.getDefaultTimeout(),
 			new NoRestartStrategy(),
 			new UnregisteredMetricsGroup(),
-			-1,
 			VoidBlobWriter.getInstance(),
 			AkkaUtils.getDefaultTimeout(),
 			TEST_LOGGER);
@@ -105,7 +104,6 @@ public class ExecutionGraphRescalingTest extends TestLogger {
 			AkkaUtils.getDefaultTimeout(),
 			new NoRestartStrategy(),
 			new UnregisteredMetricsGroup(),
-			-1,
 			VoidBlobWriter.getInstance(),
 			AkkaUtils.getDefaultTimeout(),
 			TEST_LOGGER);
@@ -135,7 +133,6 @@ public class ExecutionGraphRescalingTest extends TestLogger {
 			AkkaUtils.getDefaultTimeout(),
 			new NoRestartStrategy(),
 			new UnregisteredMetricsGroup(),
-			-1,
 			VoidBlobWriter.getInstance(),
 			AkkaUtils.getDefaultTimeout(),
 			TEST_LOGGER);
@@ -178,7 +175,6 @@ public class ExecutionGraphRescalingTest extends TestLogger {
 				AkkaUtils.getDefaultTimeout(),
 				new NoRestartStrategy(),
 				new UnregisteredMetricsGroup(),
-				-1,
 				VoidBlobWriter.getInstance(),
 				AkkaUtils.getDefaultTimeout(),
 				TEST_LOGGER);

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/MiniClusterResource.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/MiniClusterResource.java
@@ -93,6 +93,10 @@ public class MiniClusterResource extends ExternalResource {
 		this.enableClusterClient = enableClusterClient;
 	}
 
+	public MiniClusterType getMiniClusterType() {
+		return miniClusterType;
+	}
+
 	public int getNumberSlots() {
 		return numberSlots;
 	}

--- a/flink-tests/src/test/java/org/apache/flink/test/misc/AutoParallelismITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/misc/AutoParallelismITCase.java
@@ -22,17 +22,19 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.RichMapPartitionFunction;
 import org.apache.flink.api.common.io.GenericInputFormat;
 import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.io.LocalCollectionOutputFormat;
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.io.GenericInputSplit;
-import org.apache.flink.runtime.minicluster.LocalFlinkMiniCluster;
-import org.apache.flink.test.util.TestEnvironment;
+import org.apache.flink.runtime.executiongraph.ExecutionGraphBuilder;
+import org.apache.flink.test.util.MiniClusterResource;
+import org.apache.flink.test.util.MiniClusterResource.MiniClusterResourceConfiguration;
+import org.apache.flink.test.util.MiniClusterResource.MiniClusterType;
 import org.apache.flink.util.Collector;
+import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.TestLogger;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -40,7 +42,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertTrue;
 
 /**
  * This test verifies that the auto parallelism is properly forwarded to the runtime.
@@ -52,55 +54,38 @@ public class AutoParallelismITCase extends TestLogger {
 	private static final int SLOTS_PER_TM = 7;
 	private static final int PARALLELISM = NUM_TM * SLOTS_PER_TM;
 
-	private static LocalFlinkMiniCluster cluster;
-
-	private static TestEnvironment env;
-
-	@BeforeClass
-	public static void setupCluster() {
-		Configuration config = new Configuration();
-		config.setInteger(ConfigConstants.LOCAL_NUMBER_TASK_MANAGER, NUM_TM);
-		config.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, SLOTS_PER_TM);
-		cluster = new LocalFlinkMiniCluster(config, false);
-
-		cluster.start();
-
-		env = new TestEnvironment(cluster, NUM_TM * SLOTS_PER_TM, false);
-	}
-
-	@AfterClass
-	public static void teardownCluster() {
-		try {
-			cluster.stop();
-		}
-		catch (Throwable t) {
-			System.err.println("Error stopping cluster on shutdown");
-			t.printStackTrace();
-			fail("ClusterClient shutdown caused an exception: " + t.getMessage());
-		}
-	}
+	@ClassRule
+	public static final MiniClusterResource MINI_CLUSTER_RESOURCE = new MiniClusterResource(
+		new MiniClusterResourceConfiguration(
+			new Configuration(),
+			NUM_TM,
+			SLOTS_PER_TM));
 
 	@Test
-	public void testProgramWithAutoParallelism() {
+	public void testProgramWithAutoParallelism() throws Exception {
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+
+		env.setParallelism(ExecutionConfig.PARALLELISM_AUTO_MAX);
+		env.getConfig().disableSysoutLogging();
+
+		DataSet<Integer> result = env
+				.createInput(new ParallelismDependentInputFormat())
+				.rebalance()
+				.mapPartition(new ParallelismDependentMapPartition());
+
+		List<Integer> resultCollection = new ArrayList<>();
+		result.output(new LocalCollectionOutputFormat<>(resultCollection));
+
 		try {
-			env.setParallelism(ExecutionConfig.PARALLELISM_AUTO_MAX);
-			env.getConfig().disableSysoutLogging();
-
-			DataSet<Integer> result = env
-					.createInput(new ParallelismDependentInputFormat())
-					.rebalance()
-					.mapPartition(new ParallelismDependentMapPartition());
-
-			List<Integer> resultCollection = new ArrayList<Integer>();
-			result.output(new LocalCollectionOutputFormat<Integer>(resultCollection));
-
 			env.execute();
-
 			assertEquals(PARALLELISM, resultCollection.size());
 		}
-		catch (Exception e) {
-			e.printStackTrace();
-			fail(e.getMessage());
+		catch (Exception ex) {
+			if (MINI_CLUSTER_RESOURCE.getMiniClusterType().equals(MiniClusterType.OLD)) {
+				throw ex;
+			}
+			assertTrue(
+				ExceptionUtils.findThrowableWithMessage(ex, ExecutionGraphBuilder.PARALLELISM_AUTO_MAX_ERROR_MESSAGE).isPresent());
 		}
 	}
 


### PR DESCRIPTION
This deprecates `org.apache.flink.api.common.ExecutionConfig#PARALLELISM_AUTO_MAX`. From now on, with flip6 mode user will be hit with following error message.

```
Caused by: org.apache.flink.runtime.client.JobSubmissionException: Could not start JobManager.
	at org.apache.flink.runtime.dispatcher.Dispatcher.submitJob(Dispatcher.java:299)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.flink.runtime.rpc.akka.AkkaRpcActor.handleRpcInvocation(AkkaRpcActor.java:210)
	at org.apache.flink.runtime.rpc.akka.AkkaRpcActor.handleMessage(AkkaRpcActor.java:154)
	at org.apache.flink.runtime.rpc.akka.FencedAkkaRpcActor.handleMessage(FencedAkkaRpcActor.java:66)
	at org.apache.flink.runtime.rpc.akka.AkkaRpcActor.lambda$onReceive$1(AkkaRpcActor.java:132)
	at akka.actor.ActorCell$$anonfun$become$1.applyOrElse(ActorCell.scala:544)
	at akka.actor.Actor$class.aroundReceive(Actor.scala:502)
	at akka.actor.UntypedActor.aroundReceive(UntypedActor.scala:95)
	at akka.actor.ActorCell.receiveMessage(ActorCell.scala:526)
	at akka.actor.ActorCell.invoke(ActorCell.scala:495)
	at akka.dispatch.Mailbox.processMailbox(Mailbox.scala:257)
	at akka.dispatch.Mailbox.run(Mailbox.scala:224)
	at akka.dispatch.Mailbox.exec(Mailbox.scala:234)
	at scala.concurrent.forkjoin.ForkJoinTask.doExec(ForkJoinTask.java:260)
	at scala.concurrent.forkjoin.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1339)
	at scala.concurrent.forkjoin.ForkJoinPool.runWorker(ForkJoinPool.java:1979)
	at scala.concurrent.forkjoin.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:107)
Caused by: org.apache.flink.runtime.client.JobExecutionException: Could not set up JobManager
	at org.apache.flink.runtime.jobmaster.JobManagerRunner.<init>(JobManagerRunner.java:167)
	at org.apache.flink.runtime.dispatcher.Dispatcher$DefaultJobManagerRunnerFactory.createJobManagerRunner(Dispatcher.java:762)
	at org.apache.flink.runtime.dispatcher.Dispatcher.submitJob(Dispatcher.java:254)
	... 20 more
Caused by: org.apache.flink.runtime.client.JobSubmissionException: PARALLELISM_AUTO_MAX is no longer supported. Please specify a concrete value for the parallelism.
	at org.apache.flink.runtime.executiongraph.ExecutionGraphBuilder.buildGraph(ExecutionGraphBuilder.java:206)
	at org.apache.flink.runtime.jobmaster.JobMaster.<init>(JobMaster.java:290)
	at org.apache.flink.runtime.jobmaster.JobManagerRunner.<init>(JobManagerRunner.java:147)
	... 22 more
```

Previously it was similar message but ending with: `Caused by: java.lang.IllegalArgumentException: The parallelism must be at least one.`

## What is the purpose of the change

Both flip6 and old modes are covered by `AutoParallelismITCase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no) - deprecates `org.apache.flink.api.common.ExecutionConfig#PARALLELISM_AUTO_MAX`
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
