### PR TITLE
[FLINK-5411] [flip6] Fix JobLeaderIdService shut down in ResourceManager

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerRunner.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.resourcemanager;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
-import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
@@ -106,13 +105,7 @@ public class ResourceManagerRunner implements FatalErrorHandler, AutoCloseableAs
 		synchronized (lock) {
 			resourceManager.shutDown();
 
-			return FutureUtils.runAfterwards(
-				resourceManager.getTerminationFuture(),
-				() -> {
-					synchronized (lock) {
-						resourceManagerRuntimeServices.shutDown();
-					}
-				});
+			return resourceManager.getTerminationFuture();
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerRuntimeServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerRuntimeServices.java
@@ -45,12 +45,6 @@ public class ResourceManagerRuntimeServices {
 		return jobLeaderIdService;
 	}
 
-	// -------------------- Lifecycle methods -----------------------------------
-
-	public void shutDown() throws Exception {
-		jobLeaderIdService.stop();
-	}
-
 	// -------------------- Static methods --------------------------------------
 
 	public static ResourceManagerRuntimeServices fromConfiguration(


### PR DESCRIPTION
## What is the purpose of the change

The JobLeaderIdService was formerly closed at two different locations. Once in the
ResourceManager and once in the ResourceManagerRuntimeServices. Since the JobLeaderIdService
is a RM specific component. It should also be closed in the scope of the RM.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
