### PR TITLE
[FLINK-9059][Table API & SQL] add table type attribute; replace "sources" with "tables" in environm…

### DIFF
--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/config/Environment.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/config/Environment.java
@@ -113,9 +113,9 @@ public class Environment {
 		final Environment mergedEnv = new Environment();
 
 		// merge tables
-		final Map<String, TableDescriptor> sources = new HashMap<>(env1.getTables());
+		final Map<String, TableDescriptor> tables = new HashMap<>(env1.getTables());
 		mergedEnv.getTables().putAll(env2.getTables());
-		mergedEnv.tables = sources;
+		mergedEnv.tables = tables;
 
 		// merge execution properties
 		mergedEnv.execution = Execution.merge(env1.getExecution(), env2.getExecution());

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/config/Environment.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/config/Environment.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.client.config;
 
 import org.apache.flink.table.client.SqlClientException;
+import org.apache.flink.table.descriptors.TableDescriptor;
 
 import java.io.IOException;
 import java.net.URL;
@@ -29,7 +30,7 @@ import java.util.Map;
 
 /**
  * Environment configuration that represents the content of an environment file. Environment files
- * define sources, execution, and deployment behavior. An environment might be defined by default or
+ * define tables, execution, and deployment behavior. An environment might be defined by default or
  * as part of a session. Environments can be merged or enriched with properties (e.g. from CLI command).
  *
  * <p>In future versions, we might restrict the merging or enrichment of deployment properties to not
@@ -37,30 +38,39 @@ import java.util.Map;
  */
 public class Environment {
 
-	private Map<String, Source> sources;
+	private Map<String, TableDescriptor> tables;
 
 	private Execution execution;
 
 	private Deployment deployment;
 
 	public Environment() {
-		this.sources = Collections.emptyMap();
+		this.tables = Collections.emptyMap();
 		this.execution = new Execution();
 		this.deployment = new Deployment();
 	}
 
-	public Map<String, Source> getSources() {
-		return sources;
+	public Map<String, TableDescriptor> getTables() {
+		return tables;
 	}
 
-	public void setSources(List<Map<String, Object>> sources) {
-		this.sources = new HashMap<>(sources.size());
-		sources.forEach(config -> {
-			final Source s = Source.create(config);
-			if (this.sources.containsKey(s.getName())) {
-				throw new SqlClientException("Duplicate source name '" + s + "'.");
+	public void setTables(List<Map<String, Object>> tables) {
+		this.tables = new HashMap<>(tables.size());
+		tables.forEach(config -> {
+			if (!config.containsKey(TableDescriptor.TABLE_TYPE())) {
+				throw new SqlClientException("The 'type' attribute of a table is missing.");
 			}
-			this.sources.put(s.getName(), s);
+			if (config.get(TableDescriptor.TABLE_TYPE()).equals(TableDescriptor.TABLE_TYPE_SOURCE())) {
+				config.remove(TableDescriptor.TABLE_TYPE());
+				final Source s = Source.create(config);
+				if (this.tables.containsKey(s.getName())) {
+					throw new SqlClientException("Duplicate source name '" + s + "'.");
+				}
+				this.tables.put(s.getName(), s);
+			} else {
+				throw new SqlClientException(
+						"Invalid table 'type' attribute value, only 'source' is supported");
+			}
 		});
 	}
 
@@ -102,10 +112,10 @@ public class Environment {
 	public static Environment merge(Environment env1, Environment env2) {
 		final Environment mergedEnv = new Environment();
 
-		// merge sources
-		final Map<String, Source> sources = new HashMap<>(env1.getSources());
-		mergedEnv.getSources().putAll(env2.getSources());
-		mergedEnv.sources = sources;
+		// merge tables
+		final Map<String, TableDescriptor> sources = new HashMap<>(env1.getTables());
+		mergedEnv.getTables().putAll(env2.getTables());
+		mergedEnv.tables = sources;
 
 		// merge execution properties
 		mergedEnv.execution = Execution.merge(env1.getExecution(), env2.getExecution());
@@ -119,8 +129,8 @@ public class Environment {
 	public static Environment enrich(Environment env, Map<String, String> properties) {
 		final Environment enrichedEnv = new Environment();
 
-		// merge sources
-		enrichedEnv.sources = new HashMap<>(env.getSources());
+		// merge tables
+		enrichedEnv.tables = new HashMap<>(env.getTables());
 
 		// enrich execution properties
 		enrichedEnv.execution = Execution.enrich(env.execution, properties);

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
@@ -45,6 +45,7 @@ import org.apache.flink.table.client.config.Deployment;
 import org.apache.flink.table.client.config.Environment;
 import org.apache.flink.table.client.gateway.SessionContext;
 import org.apache.flink.table.client.gateway.SqlExecutionException;
+import org.apache.flink.table.descriptors.TableSourceDescriptor;
 import org.apache.flink.table.sources.TableSource;
 import org.apache.flink.table.sources.TableSourceFactoryService;
 import org.apache.flink.util.FlinkException;
@@ -92,9 +93,12 @@ public class ExecutionContext<T> {
 
 		// create table sources
 		tableSources = new HashMap<>();
-		mergedEnv.getSources().forEach((name, source) -> {
-			final TableSource<?> tableSource = TableSourceFactoryService.findAndCreateTableSource(source, classLoader);
-			tableSources.put(name, tableSource);
+		mergedEnv.getTables().forEach((name, descriptor) -> {
+			if (descriptor instanceof TableSourceDescriptor) {
+				TableSource<?> tableSource = TableSourceFactoryService.findAndCreateTableSource(
+						(TableSourceDescriptor) descriptor, classLoader);
+				tableSources.put(name, tableSource);
+			}
 		});
 
 		// convert deployment options into command line options that describe a cluster

--- a/flink-libraries/flink-sql-client/src/test/resources/test-sql-client-defaults.yaml
+++ b/flink-libraries/flink-sql-client/src/test/resources/test-sql-client-defaults.yaml
@@ -23,8 +23,9 @@
 
 # this file has variables that can be filled with content by replacing $VAR_XXX
 
-sources:
+tables:
   - name: TableNumber1
+    type: source
     schema:
       - name: IntegerField1
         type: INT
@@ -43,6 +44,7 @@ sources:
       line-delimiter: "\n"
       comment-prefix: "#"
   - name: TableNumber2
+    type: source
     schema:
       - name: IntegerField2
         type: INT

--- a/flink-libraries/flink-sql-client/src/test/resources/test-sql-client-factory.yaml
+++ b/flink-libraries/flink-sql-client/src/test/resources/test-sql-client-factory.yaml
@@ -23,8 +23,9 @@
 
 # this file has variables that can be filled with content by replacing $VAR_XXX
 
-sources:
+tables:
   - name: TableNumber1
+    type: source
     schema:
       - name: IntegerField1
         type: INT

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/descriptors/TableDescriptor.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/descriptors/TableDescriptor.scala
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.descriptors
+
+import org.apache.flink.table.descriptors.DescriptorProperties.toScala
+import org.apache.flink.table.descriptors.StatisticsValidator.{STATISTICS_COLUMNS, STATISTICS_ROW_COUNT, readColumnStats}
+import org.apache.flink.table.plan.stats.TableStats
+
+import scala.collection.JavaConverters._
+
+/**
+  * Common class for all descriptors describing table sources and sinks.
+  */
+abstract class TableDescriptor extends Descriptor {
+
+  protected var connectorDescriptor: Option[ConnectorDescriptor] = None
+  protected var formatDescriptor: Option[FormatDescriptor] = None
+  protected var schemaDescriptor: Option[Schema] = None
+  protected var statisticsDescriptor: Option[Statistics] = None
+  protected var metaDescriptor: Option[Metadata] = None
+
+  /**
+    * Internal method for properties conversion.
+    */
+  override private[flink] def addProperties(properties: DescriptorProperties): Unit = {
+    connectorDescriptor.foreach(_.addProperties(properties))
+    formatDescriptor.foreach(_.addProperties(properties))
+    schemaDescriptor.foreach(_.addProperties(properties))
+    metaDescriptor.foreach(_.addProperties(properties))
+  }
+
+  /**
+    * Reads table statistics from the descriptors properties.
+    */
+  protected def getTableStats: Option[TableStats] = {
+    val normalizedProps = new DescriptorProperties()
+    addProperties(normalizedProps)
+    val rowCount = toScala(normalizedProps.getOptionalLong(STATISTICS_ROW_COUNT))
+    rowCount match {
+      case Some(cnt) =>
+        val columnStats = readColumnStats(normalizedProps, STATISTICS_COLUMNS)
+        Some(TableStats(cnt, columnStats.asJava))
+      case None =>
+        None
+    }
+  }
+}
+
+object TableDescriptor {
+  /**
+    * Key for describing the type of this table, valid values are ('source').
+    */
+  val TABLE_TYPE = "type"
+
+  /**
+    * Valid TABLE_TYPE value.
+    */
+  val TABLE_TYPE_SOURCE = "source"
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/descriptors/TableSourceDescriptor.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/descriptors/TableSourceDescriptor.scala
@@ -18,46 +18,8 @@
 
 package org.apache.flink.table.descriptors
 
-import org.apache.flink.table.descriptors.DescriptorProperties.toScala
-import org.apache.flink.table.descriptors.StatisticsValidator.{STATISTICS_COLUMNS, STATISTICS_ROW_COUNT, readColumnStats}
-import org.apache.flink.table.plan.stats.TableStats
-
-import scala.collection.JavaConverters._
-
 /**
   * Common class for all descriptors describing a table source.
   */
-abstract class TableSourceDescriptor extends Descriptor {
-
-  protected var connectorDescriptor: Option[ConnectorDescriptor] = None
-  protected var formatDescriptor: Option[FormatDescriptor] = None
-  protected var schemaDescriptor: Option[Schema] = None
-  protected var statisticsDescriptor: Option[Statistics] = None
-  protected var metaDescriptor: Option[Metadata] = None
-
-  /**
-    * Internal method for properties conversion.
-    */
-  override private[flink] def addProperties(properties: DescriptorProperties): Unit = {
-    connectorDescriptor.foreach(_.addProperties(properties))
-    formatDescriptor.foreach(_.addProperties(properties))
-    schemaDescriptor.foreach(_.addProperties(properties))
-    metaDescriptor.foreach(_.addProperties(properties))
-  }
-
-  /**
-    * Reads table statistics from the descriptors properties.
-    */
-  protected def getTableStats: Option[TableStats] = {
-      val normalizedProps = new DescriptorProperties()
-      addProperties(normalizedProps)
-      val rowCount = toScala(normalizedProps.getOptionalLong(STATISTICS_ROW_COUNT))
-      rowCount match {
-        case Some(cnt) =>
-          val columnStats = readColumnStats(normalizedProps, STATISTICS_COLUMNS)
-          Some(TableStats(cnt, columnStats.asJava))
-        case None =>
-          None
-      }
-    }
+abstract class TableSourceDescriptor extends TableDescriptor {
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/sources/TableSourceFactoryServiceTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/sources/TableSourceFactoryServiceTest.scala
@@ -19,8 +19,9 @@
 package org.apache.flink.table.sources
 
 import org.apache.flink.table.api.{NoMatchingTableSourceException, TableException, ValidationException}
-import org.apache.flink.table.descriptors.ConnectorDescriptorValidator.{CONNECTOR_TYPE, CONNECTOR_PROPERTY_VERSION}
-import org.apache.flink.table.descriptors.FormatDescriptorValidator.{FORMAT_TYPE, FORMAT_PROPERTY_VERSION}
+import org.apache.flink.table.descriptors.ConnectorDescriptorValidator.{CONNECTOR_PROPERTY_VERSION, CONNECTOR_TYPE}
+import org.apache.flink.table.descriptors.FormatDescriptorValidator.{FORMAT_PROPERTY_VERSION, FORMAT_TYPE}
+import org.apache.flink.table.descriptors.TableDescriptor
 import org.junit.Assert.assertTrue
 import org.junit.Test
 

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/sources/TestTableSourceFactory.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/sources/TestTableSourceFactory.scala
@@ -22,8 +22,8 @@ import java.util
 
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.table.api.TableSchema
-import org.apache.flink.table.descriptors.ConnectorDescriptorValidator.{CONNECTOR_TYPE, CONNECTOR_PROPERTY_VERSION}
-import org.apache.flink.table.descriptors.FormatDescriptorValidator.{FORMAT_TYPE, FORMAT_PROPERTY_VERSION}
+import org.apache.flink.table.descriptors.ConnectorDescriptorValidator.{CONNECTOR_PROPERTY_VERSION, CONNECTOR_TYPE}
+import org.apache.flink.table.descriptors.FormatDescriptorValidator.{FORMAT_PROPERTY_VERSION, FORMAT_TYPE}
 import org.apache.flink.types.Row
 
 class TestTableSourceFactory extends TableSourceFactory[Row] {


### PR DESCRIPTION
## What is the purpose of the change

Add support for unified table source and sink declaration in environment file definition.
This change prepares for FLINK-9049 (Create unified interfaces to configure and instatiate TableSink) We want to get this change in before 1.5 so it wont break the API in next flink release.


## Brief change log

  - Refactor sql client environment file definition to replace "sources" with "tables" 
  - Add "type" property to distinguish between table source and sink.

## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
