### PR TITLE
[hotfix][tests] Hide output from config.sh

### DIFF
--- a/flink-dist/src/test/bin/calcTMHeapSizeMB.sh
+++ b/flink-dist/src/test/bin/calcTMHeapSizeMB.sh
@@ -37,6 +37,6 @@ if [[ -z "${FLINK_TM_MEM_MANAGED_FRACTION}" ]]; then
 fi
 
 FLINK_CONF_DIR=${bin}/../../main/resources
-. ${bin}/../../main/flink-bin/bin/config.sh
+. ${bin}/../../main/flink-bin/bin/config.sh > /dev/null
 
 calculateTaskManagerHeapSizeMB

--- a/flink-dist/src/test/bin/calcTMNetBufMem.sh
+++ b/flink-dist/src/test/bin/calcTMNetBufMem.sh
@@ -34,6 +34,6 @@ if [[ -z "${FLINK_TM_NET_BUF_MAX}" ]]; then
 fi
 
 FLINK_CONF_DIR=${bin}/../../main/resources
-. ${bin}/../../main/flink-bin/bin/config.sh
+. ${bin}/../../main/flink-bin/bin/config.sh > /dev/null
 
 calculateNetworkBufferMemory


### PR DESCRIPTION
## What is the purpose of the change

The `TaskManagerHeapSizeCalculationJavaBashTest` calls the `calcTMHeapSizeMB.sh/calcTMNetBufMem.sh` scripts and expects the result to be printed to stdout. These scripts also all `config.sh` which may `echo` messages that would result in a test failure, like the one below on AWS.

```
compareHeapSizeShellScriptWithJava(org.apache.flink.dist.TaskManagerHeapSizeCalculationJavaBashTest)  Time elapsed: 0.486 sec  <<< FAILURE!
org.junit.ComparisonFailure: Different heap sizes with configuration: {taskmanager.network.memory.fraction=0.1, taskmanager.memory.off-heap=false, taskmanager.memory.fraction=0.7, taskmanager.memory.size=-1, taskmanager.network.memory.max=1073741824, taskmanager.heap.mb=1000, taskmanager.network.memory.min=67108864} expected:<[]900> but was:<[Setting HADOOP_CONF_DIR=/etc/hadoop/conf because no HADOOP_CONF_DIR was set.]900>
        at org.junit.Assert.assertEquals(Assert.java:115)
        at org.apache.flink.dist.TaskManagerHeapSizeCalculationJavaBashTest.compareHeapSizeJavaVsScript(TaskManagerHeapSizeCalculationJavaBashTest.java:275)
        at org.apache.flink.dist.TaskManagerHeapSizeCalculationJavaBashTest.compareHeapSizeShellScriptWithJava(TaskManagerHeapSizeCalculationJavaBashTest.java:110)
```

To prevent this from happening this PR suppresses the standard output from `config.sh`.


