### PR TITLE
[FLINK-8940] [flip6] Add support for dispose savepoint

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -47,7 +47,6 @@ import org.apache.flink.optimizer.plan.StreamingPlan;
 import org.apache.flink.optimizer.plandump.PlanJSONDumpGenerator;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.client.JobStatusMessage;
-import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.messages.Acknowledge;
@@ -706,7 +705,7 @@ public class CliFrontend {
 
 		logAndSysout("Disposing savepoint '" + savepointPath + "'.");
 
-		final CompletableFuture<Acknowledge> disposeFuture = clusterClient.disposeSavepoint(savepointPath, FutureUtils.toTime(clientTimeout));
+		final CompletableFuture<Acknowledge> disposeFuture = clusterClient.disposeSavepoint(savepointPath);
 
 		logAndSysout("Waiting for response...");
 

--- a/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
@@ -726,14 +726,14 @@ public abstract class ClusterClient<T> {
 		});
 	}
 
-	public CompletableFuture<Acknowledge> disposeSavepoint(String savepointPath, Time timeout) throws FlinkException {
+	public CompletableFuture<Acknowledge> disposeSavepoint(String savepointPath) throws FlinkException {
 		final ActorGateway jobManager = getJobManagerGateway();
 
 		Object msg = new JobManagerMessages.DisposeSavepoint(savepointPath);
 		CompletableFuture<Object> responseFuture = FutureUtils.<Object>toJava(
 			jobManager.ask(
 				msg,
-				FutureUtils.toFiniteDuration(timeout)));
+				timeout));
 
 		return responseFuture.thenApply(
 			(Object response) -> {

--- a/flink-clients/src/main/java/org/apache/flink/client/program/MiniClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/MiniClusterClient.java
@@ -123,8 +123,8 @@ public class MiniClusterClient extends ClusterClient<MiniClusterClient.MiniClust
 	}
 
 	@Override
-	public CompletableFuture<Acknowledge> disposeSavepoint(String savepointPath, Time timeout) throws FlinkException {
-		throw new UnsupportedOperationException("MiniClusterClient does not yet support this operation.");
+	public CompletableFuture<Acknowledge> disposeSavepoint(String savepointPath) throws FlinkException {
+		return guardWithSingleRetry(() -> miniCluster.disposeSavepoint(savepointPath), scheduledExecutor);
 	}
 
 	@Override

--- a/flink-clients/src/test/java/org/apache/flink/client/program/ClusterClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/ClusterClientTest.java
@@ -181,7 +181,7 @@ public class ClusterClientTest extends TestLogger {
 
 		final TestClusterClient clusterClient = new TestClusterClient(configuration, jobManagerGateway);
 
-		CompletableFuture<Acknowledge> acknowledgeCompletableFuture = clusterClient.disposeSavepoint(savepointPath, timeout);
+		CompletableFuture<Acknowledge> acknowledgeCompletableFuture = clusterClient.disposeSavepoint(savepointPath);
 
 		try {
 			acknowledgeCompletableFuture.get();
@@ -203,7 +203,7 @@ public class ClusterClientTest extends TestLogger {
 
 		final TestClusterClient clusterClient = new TestClusterClient(configuration, jobManagerGateway);
 
-		CompletableFuture<Acknowledge> acknowledgeCompletableFuture = clusterClient.disposeSavepoint(savepointPath, timeout);
+		CompletableFuture<Acknowledge> acknowledgeCompletableFuture = clusterClient.disposeSavepoint(savepointPath);
 
 		try {
 			acknowledgeCompletableFuture.get();

--- a/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
@@ -472,6 +472,7 @@ public class RestClusterClientTest extends TestLogger {
 
 			try {
 				restClusterClient.triggerSavepoint(new JobID(), null).get();
+				fail("Expected exception not thrown.");
 			} catch (final ExecutionException e) {
 				assertTrue(
 					"RestClientException not in causal chain",

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/Checkpoints.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/Checkpoints.java
@@ -38,6 +38,7 @@ import org.apache.flink.util.FlinkException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.io.DataInputStream;
@@ -292,6 +293,13 @@ public class Checkpoints {
 		checkNotNull(configuration, "configuration");
 		checkNotNull(classLoader, "classLoader");
 
+		StateBackend backend = loadStateBackend(configuration, classLoader, logger);
+
+		disposeSavepoint(pointer, backend, classLoader);
+	}
+
+	@Nonnull
+	public static StateBackend loadStateBackend(Configuration configuration, ClassLoader classLoader, @Nullable Logger logger) {
 		if (logger != null) {
 			logger.info("Attempting to load configured state backend for savepoint disposal");
 		}
@@ -318,8 +326,7 @@ public class Checkpoints {
 			// FileSystem-based for metadata
 			backend = new MemoryStateBackend();
 		}
-
-		disposeSavepoint(pointer, backend, classLoader);
+		return backend;
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -534,6 +534,18 @@ public class MiniCluster implements JobExecutorService, AutoCloseableAsync {
 		}
 	}
 
+	public CompletableFuture<Acknowledge> disposeSavepoint(String savepointPath) {
+		try {
+			return getDispatcherGateway().disposeSavepoint(savepointPath, rpcTimeout);
+		} catch (LeaderRetrievalException | InterruptedException e) {
+			ExceptionUtils.checkInterrupted(e);
+			return FutureUtils.completedExceptionally(
+				new FlinkException(
+					String.format("Could not dispose savepoint %s.", savepointPath),
+					e));
+		}
+	}
+
 	public CompletableFuture<? extends AccessExecutionGraph> getExecutionGraph(JobID jobId) {
 		try {
 			return getDispatcherGateway().requestJob(jobId, rpcTimeout);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerRunner.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.resourcemanager;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
-import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
@@ -106,13 +105,7 @@ public class ResourceManagerRunner implements FatalErrorHandler, AutoCloseableAs
 		synchronized (lock) {
 			resourceManager.shutDown();
 
-			return FutureUtils.runAfterwards(
-				resourceManager.getTerminationFuture(),
-				() -> {
-					synchronized (lock) {
-						resourceManagerRuntimeServices.shutDown();
-					}
-				});
+			return resourceManager.getTerminationFuture();
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerRuntimeServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerRuntimeServices.java
@@ -45,12 +45,6 @@ public class ResourceManagerRuntimeServices {
 		return jobLeaderIdService;
 	}
 
-	// -------------------- Lifecycle methods -----------------------------------
-
-	public void shutDown() throws Exception {
-		jobLeaderIdService.stop();
-	}
-
 	// -------------------- Static methods --------------------------------------
 
 	public static ResourceManagerRuntimeServices fromConfiguration(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/async/OperationKey.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/async/OperationKey.java
@@ -27,11 +27,11 @@ import java.util.Objects;
  * Any operation key for the {@link AbstractAsynchronousOperationHandlers} must extend this class.
  * It is used to store the trigger id.
  */
-public abstract class OperationKey {
+public class OperationKey {
 
 	private final TriggerId triggerId;
 
-	protected OperationKey(TriggerId triggerId) {
+	public OperationKey(TriggerId triggerId) {
 		this.triggerId = Preconditions.checkNotNull(triggerId);
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/rescaling/RescalingHandlers.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/rescaling/RescalingHandlers.java
@@ -32,6 +32,7 @@ import org.apache.flink.runtime.rest.messages.JobIDPathParameter;
 import org.apache.flink.runtime.rest.messages.RescalingParallelismQueryParameter;
 import org.apache.flink.runtime.rest.messages.TriggerId;
 import org.apache.flink.runtime.rest.messages.TriggerIdPathParameter;
+import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.webmonitor.RestfulGateway;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
 import org.apache.flink.util.SerializedThrowable;
@@ -80,7 +81,7 @@ public class RescalingHandlers extends AbstractAsynchronousOperationHandlers<Asy
 				jobId,
 				newParallelism,
 				RescalingBehaviour.STRICT,
-				timeout);
+				RpcUtils.INF_TIMEOUT);
 
 			return rescalingFuture;
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointDisposalHandlers.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointDisposalHandlers.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.job.savepoints;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.async.AbstractAsynchronousOperationHandlers;
+import org.apache.flink.runtime.rest.handler.async.AsynchronousOperationInfo;
+import org.apache.flink.runtime.rest.handler.async.OperationKey;
+import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.TriggerId;
+import org.apache.flink.runtime.rest.messages.TriggerIdPathParameter;
+import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointDisposalRequest;
+import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointDisposalStatusHeaders;
+import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointDisposalStatusMessageParameters;
+import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointDisposalTriggerHeaders;
+import org.apache.flink.runtime.rpc.RpcUtils;
+import org.apache.flink.runtime.webmonitor.RestfulGateway;
+import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+import org.apache.flink.util.SerializedThrowable;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Handlers to trigger the disposal of a savepoint.
+ */
+public class SavepointDisposalHandlers extends AbstractAsynchronousOperationHandlers<OperationKey, Acknowledge> {
+
+	/**
+	 * {@link TriggerHandler} implementation for the savepoint disposal operation.
+	 */
+	public class SavepointDisposalTriggerHandler extends TriggerHandler<RestfulGateway, SavepointDisposalRequest, EmptyMessageParameters> {
+
+		public SavepointDisposalTriggerHandler(
+				CompletableFuture<String> localRestAddress,
+				GatewayRetriever<? extends RestfulGateway> leaderRetriever,
+				Time timeout,
+				Map<String, String> responseHeaders) {
+			super(
+				localRestAddress,
+				leaderRetriever,
+				timeout,
+				responseHeaders,
+				SavepointDisposalTriggerHeaders.getInstance());
+		}
+
+		@Override
+		protected CompletableFuture<Acknowledge> triggerOperation(HandlerRequest<SavepointDisposalRequest, EmptyMessageParameters> request, RestfulGateway gateway) {
+			final String savepointPath = request.getRequestBody().getSavepointPath();
+			return gateway.disposeSavepoint(savepointPath, RpcUtils.INF_TIMEOUT);
+		}
+
+		@Override
+		protected OperationKey createOperationKey(HandlerRequest<SavepointDisposalRequest, EmptyMessageParameters> request) {
+			return new OperationKey(new TriggerId());
+		}
+	}
+
+	/**
+	 * {@link StatusHandler} implementation for the savepoint disposal operation.
+	 */
+	public class SavepointDisposalStatusHandler extends StatusHandler<RestfulGateway, AsynchronousOperationInfo, SavepointDisposalStatusMessageParameters> {
+
+		public SavepointDisposalStatusHandler(
+				CompletableFuture<String> localRestAddress,
+				GatewayRetriever<? extends RestfulGateway> leaderRetriever,
+				Time timeout,
+				Map<String, String> responseHeaders) {
+			super(
+				localRestAddress,
+				leaderRetriever,
+				timeout,
+				responseHeaders,
+				SavepointDisposalStatusHeaders.getInstance());
+		}
+
+		@Override
+		protected OperationKey getOperationKey(HandlerRequest<EmptyRequestBody, SavepointDisposalStatusMessageParameters> request) {
+			final TriggerId triggerId = request.getPathParameter(TriggerIdPathParameter.class);
+			return new OperationKey(triggerId);
+		}
+
+		@Override
+		protected AsynchronousOperationInfo exceptionalOperationResultResponse(Throwable throwable) {
+			return AsynchronousOperationInfo.completeExceptional(new SerializedThrowable(throwable));
+		}
+
+		@Override
+		protected AsynchronousOperationInfo operationResultResponse(Acknowledge operationResult) {
+			return AsynchronousOperationInfo.complete();
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointDisposalRequest.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointDisposalRequest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.job.savepoints;
+
+import org.apache.flink.runtime.rest.messages.RequestBody;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Request body for a savepoint disposal call.
+ */
+public class SavepointDisposalRequest implements RequestBody {
+
+	private static final String FIELD_NAME_SAVEPOINT_PATH = "savepoint-path";
+
+	@JsonProperty(FIELD_NAME_SAVEPOINT_PATH)
+	private final String savepointPath;
+
+	@JsonCreator
+	public SavepointDisposalRequest(
+		@JsonProperty(FIELD_NAME_SAVEPOINT_PATH) @Nonnull String savepointPath) {
+		this.savepointPath = savepointPath;
+	}
+
+	@JsonIgnore
+	public String getSavepointPath() {
+		return savepointPath;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointDisposalStatusHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointDisposalStatusHeaders.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.job.savepoints;
+
+import org.apache.flink.runtime.rest.HttpMethodWrapper;
+import org.apache.flink.runtime.rest.handler.async.AsynchronousOperationInfo;
+import org.apache.flink.runtime.rest.handler.async.AsynchronousOperationStatusMessageHeaders;
+import org.apache.flink.runtime.rest.handler.async.AsynchronousOperationTriggerMessageHeaders;
+import org.apache.flink.runtime.rest.handler.job.savepoints.SavepointDisposalHandlers;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.TriggerIdPathParameter;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+/**
+ * {@link AsynchronousOperationTriggerMessageHeaders} implementation for the {@link SavepointDisposalHandlers.SavepointDisposalStatusHandler}.
+ */
+public class SavepointDisposalStatusHeaders extends AsynchronousOperationStatusMessageHeaders<AsynchronousOperationInfo, SavepointDisposalStatusMessageParameters> {
+
+	private static final SavepointDisposalStatusHeaders INSTANCE = new SavepointDisposalStatusHeaders();
+
+	private static final String URL = String.format("/savepoint-disposal/:%s", TriggerIdPathParameter.KEY);
+
+	private SavepointDisposalStatusHeaders() {}
+
+	@Override
+	public HttpResponseStatus getResponseStatusCode() {
+		return HttpResponseStatus.OK;
+	}
+
+	@Override
+	public Class<EmptyRequestBody> getRequestClass() {
+		return EmptyRequestBody.class;
+	}
+
+	@Override
+	public SavepointDisposalStatusMessageParameters getUnresolvedMessageParameters() {
+		return new SavepointDisposalStatusMessageParameters();
+	}
+
+	@Override
+	public HttpMethodWrapper getHttpMethod() {
+		return HttpMethodWrapper.GET;
+	}
+
+	@Override
+	public String getTargetRestEndpointURL() {
+		return URL;
+	}
+
+	public static SavepointDisposalStatusHeaders getInstance() {
+		return INSTANCE;
+	}
+
+	@Override
+	protected Class<AsynchronousOperationInfo> getValueClass() {
+		return AsynchronousOperationInfo.class;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointDisposalStatusMessageParameters.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointDisposalStatusMessageParameters.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.job.savepoints;
+
+import org.apache.flink.runtime.rest.handler.job.savepoints.SavepointDisposalHandlers;
+import org.apache.flink.runtime.rest.messages.MessageParameters;
+import org.apache.flink.runtime.rest.messages.MessagePathParameter;
+import org.apache.flink.runtime.rest.messages.MessageQueryParameter;
+import org.apache.flink.runtime.rest.messages.TriggerIdPathParameter;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * {@link MessageParameters} for the {@link SavepointDisposalHandlers.SavepointDisposalStatusHandler}.
+ */
+public class SavepointDisposalStatusMessageParameters extends MessageParameters {
+
+	public final TriggerIdPathParameter triggerIdPathParameter = new TriggerIdPathParameter();
+
+	@Override
+	public Collection<MessagePathParameter<?>> getPathParameters() {
+		return Collections.singleton(triggerIdPathParameter);
+	}
+
+	@Override
+	public Collection<MessageQueryParameter<?>> getQueryParameters() {
+		return Collections.emptyList();
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointDisposalTriggerHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointDisposalTriggerHeaders.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.job.savepoints;
+
+import org.apache.flink.runtime.rest.HttpMethodWrapper;
+import org.apache.flink.runtime.rest.handler.async.AsynchronousOperationTriggerMessageHeaders;
+import org.apache.flink.runtime.rest.handler.job.savepoints.SavepointDisposalHandlers;
+import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+/**
+ * {@link AsynchronousOperationTriggerMessageHeaders} for the {@link SavepointDisposalHandlers.SavepointDisposalTriggerHandler}.
+ */
+public class SavepointDisposalTriggerHeaders extends AsynchronousOperationTriggerMessageHeaders<SavepointDisposalRequest, EmptyMessageParameters> {
+
+	private static final SavepointDisposalTriggerHeaders INSTANCE = new SavepointDisposalTriggerHeaders();
+
+	private static final String URL = "/savepoint-disposal";
+
+	private SavepointDisposalTriggerHeaders() {}
+
+	@Override
+	public HttpResponseStatus getResponseStatusCode() {
+		return HttpResponseStatus.OK;
+	}
+
+	@Override
+	public Class<SavepointDisposalRequest> getRequestClass() {
+		return SavepointDisposalRequest.class;
+	}
+
+	@Override
+	public EmptyMessageParameters getUnresolvedMessageParameters() {
+		return EmptyMessageParameters.getInstance();
+	}
+
+	@Override
+	public HttpMethodWrapper getHttpMethod() {
+		return HttpMethodWrapper.POST;
+	}
+
+	@Override
+	public String getTargetRestEndpointURL() {
+		return URL;
+	}
+
+	public static SavepointDisposalTriggerHeaders getInstance() {
+		return INSTANCE;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActor.java
@@ -140,8 +140,8 @@ class AkkaRpcActor<T extends RpcEndpoint & RpcGateway> extends UntypedActor {
 				rpcEndpoint.getClass().getName(),
 				message.getClass().getName());
 
-			sendErrorIfSender(new AkkaRpcException("Discard message, because " +
-				"the rpc endpoint has not been started yet."));
+			sendErrorIfSender(new AkkaRpcException(
+				String.format("Discard message, because the rpc endpoint %s has not been started yet.", rpcEndpoint.getAddress())));
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/FencedAkkaRpcActor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/FencedAkkaRpcActor.java
@@ -55,7 +55,10 @@ public class FencedAkkaRpcActor<F extends Serializable, T extends FencedRpcEndpo
 
 				sendErrorIfSender(
 					new FencingTokenException(
-						"Fencing token not set: Ignoring message " + message + " because the fencing token is null."));
+						String.format(
+							"Fencing token not set: Ignoring message %s sent to %s because the fencing token is null.",
+							message,
+							rpcEndpoint.getAddress())));
 			} else {
 				@SuppressWarnings("unchecked")
 				FencedMessage<F, ?> fencedMessage = ((FencedMessage<F, ?>) message);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/RestfulGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/RestfulGateway.java
@@ -145,6 +145,19 @@ public interface RestfulGateway extends RpcGateway {
 	}
 
 	/**
+	 * Dispose the given savepoint.
+	 *
+	 * @param savepointPath identifying the savepoint to dispose
+	 * @param timeout RPC timeout
+	 * @return A future acknowledge if the disposal succeeded
+	 */
+	default CompletableFuture<Acknowledge> disposeSavepoint(
+			final String savepointPath,
+			@RpcTimeout final Time timeout) {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
 	 * Request the {@link JobStatus} of the given job.
 	 *
 	 * @param jobId identifying the job for which to retrieve the JobStatus

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
@@ -64,6 +64,7 @@ import org.apache.flink.runtime.rest.handler.job.metrics.TaskManagerMetricsHandl
 import org.apache.flink.runtime.rest.handler.job.rescaling.RescalingHandlers;
 import org.apache.flink.runtime.rest.handler.job.rescaling.RescalingStatusHeaders;
 import org.apache.flink.runtime.rest.handler.job.rescaling.RescalingTriggerHeaders;
+import org.apache.flink.runtime.rest.handler.job.savepoints.SavepointDisposalHandlers;
 import org.apache.flink.runtime.rest.handler.job.savepoints.SavepointHandlers;
 import org.apache.flink.runtime.rest.handler.legacy.ConstantTextHandler;
 import org.apache.flink.runtime.rest.handler.legacy.ExecutionGraphCache;
@@ -108,6 +109,8 @@ import org.apache.flink.runtime.rest.messages.job.metrics.JobMetricsHeaders;
 import org.apache.flink.runtime.rest.messages.job.metrics.JobVertexMetricsHeaders;
 import org.apache.flink.runtime.rest.messages.job.metrics.SubtaskMetricsHeaders;
 import org.apache.flink.runtime.rest.messages.job.metrics.TaskManagerMetricsHeaders;
+import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointDisposalStatusHeaders;
+import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointDisposalTriggerHeaders;
 import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointStatusHeaders;
 import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointTriggerHeaders;
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerDetailsHeaders;
@@ -499,6 +502,20 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
 			executor,
 			metricFetcher);
 
+		final SavepointDisposalHandlers savepointDisposalHandlers = new SavepointDisposalHandlers();
+
+		final SavepointDisposalHandlers.SavepointDisposalTriggerHandler savepointDisposalTriggerHandler = savepointDisposalHandlers.new SavepointDisposalTriggerHandler(
+			restAddressFuture,
+			leaderRetriever,
+			timeout,
+			responseHeaders);
+
+		final SavepointDisposalHandlers.SavepointDisposalStatusHandler savepointDisposalStatusHandler = savepointDisposalHandlers.new SavepointDisposalStatusHandler(
+			restAddressFuture,
+			leaderRetriever,
+			timeout,
+			responseHeaders);
+
 		final Path webUiDir = restConfiguration.getWebUiDir();
 
 		Optional<StaticFileServerHandler<T>> optWebContent;
@@ -549,6 +566,8 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
 		handlers.add(Tuple2.of(JobVertexDetailsHeaders.getInstance(), jobVertexDetailsHandler));
 		handlers.add(Tuple2.of(RescalingTriggerHeaders.getInstance(), rescalingTriggerHandler));
 		handlers.add(Tuple2.of(RescalingStatusHeaders.getInstance(), rescalingStatusHandler));
+		handlers.add(Tuple2.of(SavepointDisposalTriggerHeaders.getInstance(), savepointDisposalTriggerHandler));
+		handlers.add(Tuple2.of(SavepointDisposalStatusHeaders.getInstance(), savepointDisposalStatusHandler));
 
 		// TODO: Remove once the Yarn proxy can forward all REST verbs
 		handlers.add(Tuple2.of(YarnCancelJobTerminationHeaders.getInstance(), jobCancelTerminationHandler));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointDisposalRequestTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointDisposalRequestTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.job.savepoints;
+
+import org.apache.flink.runtime.rest.messages.RestRequestMarshallingTestBase;
+
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+
+import java.util.UUID;
+
+/**
+ * Tests the un/marshalling of the {@link SavepointDisposalRequest}.
+ */
+public class SavepointDisposalRequestTest extends RestRequestMarshallingTestBase<SavepointDisposalRequest> {
+
+	@Override
+	protected Class<SavepointDisposalRequest> getTestRequestClass() {
+		return SavepointDisposalRequest.class;
+	}
+
+	@Override
+	protected SavepointDisposalRequest getTestRequestInstance() {
+		return new SavepointDisposalRequest(UUID.randomUUID().toString());
+	}
+
+	@Override
+	protected void assertOriginalEqualsToUnmarshalled(SavepointDisposalRequest expected, SavepointDisposalRequest actual) {
+		Assert.assertThat(actual.getSavepointPath(), Matchers.is(Matchers.equalTo(expected.getSavepointPath())));
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerTest.java
@@ -1734,6 +1734,10 @@ public class TaskManagerTest extends TestLogger {
 
 			Await.result(submitResponse, timeout);
 
+			final Future<Object> taskRunning = taskManager.ask(new TestingTaskManagerMessages.NotifyWhenTaskIsRunning(executionAttemptId), timeout);
+
+			Await.result(taskRunning, timeout);
+
 			Future<Object> stopResponse = taskManager.ask(new StopTask(executionAttemptId), timeout);
 
 			try {

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
@@ -394,6 +394,7 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 		try {
 			return deployInternal(
 				clusterSpecification,
+				"Flink session cluster",
 				getYarnSessionClusterEntrypoint(),
 				null,
 				false);
@@ -437,12 +438,14 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 	 * This method will block until the ApplicationMaster/JobManager have been deployed on YARN.
 	 *
 	 * @param clusterSpecification Initial cluster specification for the Flink cluster to be deployed
+	 * @param applicationName name of the Yarn application to start
 	 * @param yarnClusterEntrypoint Class name of the Yarn cluster entry point.
 	 * @param jobGraph A job graph which is deployed with the Flink cluster, {@code null} if none
 	 * @param detached True if the cluster should be started in detached mode
 	 */
 	protected ClusterClient<ApplicationId> deployInternal(
 			ClusterSpecification clusterSpecification,
+			String applicationName,
 			String yarnClusterEntrypoint,
 			@Nullable JobGraph jobGraph,
 			boolean detached) throws Exception {
@@ -517,6 +520,7 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 
 		ApplicationReport report = startAppMaster(
 			flinkConfiguration,
+			applicationName,
 			yarnClusterEntrypoint,
 			jobGraph,
 			yarnClient,
@@ -670,6 +674,7 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 
 	public ApplicationReport startAppMaster(
 			Configuration configuration,
+			String applicationName,
 			String yarnClusterEntrypoint,
 			JobGraph jobGraph,
 			YarnClient yarnClient,
@@ -1005,17 +1010,9 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 		capability.setMemory(clusterSpecification.getMasterMemoryMB());
 		capability.setVirtualCores(1);
 
-		String name;
-		if (customName == null) {
-			name = "Flink session with " + clusterSpecification.getNumberTaskManagers() + " TaskManagers";
-			if (detached) {
-				name += " (detached)";
-			}
-		} else {
-			name = customName;
-		}
+		final String customApplicationName = customName != null ? customName : applicationName;
 
-		appContext.setApplicationName(name);
+		appContext.setApplicationName(customApplicationName);
 		appContext.setApplicationType("Apache Flink");
 		appContext.setAMContainerSpec(amContainer);
 		appContext.setResource(capability);

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/Flip6YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/Flip6YarnClusterDescriptor.java
@@ -75,6 +75,7 @@ public class Flip6YarnClusterDescriptor extends AbstractYarnClusterDescriptor {
 		try {
 			return deployInternal(
 				clusterSpecification,
+				"Flink per-job cluster",
 				getYarnJobClusterEntrypoint(),
 				jobGraph,
 				detached);

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
@@ -265,11 +265,10 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<ApplicationId
 	}
 
 	private AbstractYarnClusterDescriptor createDescriptor(
-		Configuration configuration,
-		YarnConfiguration yarnConfiguration,
-		String configurationDirectory,
-		String defaultApplicationName,
-		CommandLine cmd) {
+			Configuration configuration,
+			YarnConfiguration yarnConfiguration,
+			String configurationDirectory,
+			CommandLine cmd) {
 
 		AbstractYarnClusterDescriptor yarnClusterDescriptor = getClusterDescriptor(
 			configuration,
@@ -356,11 +355,6 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<ApplicationId
 
 		if (cmd.hasOption(name.getOpt())) {
 			yarnClusterDescriptor.setName(cmd.getOptionValue(name.getOpt()));
-		} else {
-			// set the default application name, if none is specified
-			if (defaultApplicationName != null) {
-				yarnClusterDescriptor.setName(defaultApplicationName);
-			}
 		}
 
 		if (cmd.hasOption(zookeeperNamespace.getOpt())) {
@@ -456,7 +450,6 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine<ApplicationId
 			effectiveConfiguration,
 			yarnConfiguration,
 			configurationDirectory,
-			null,
 			commandLine);
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

Adds an AsynchronousOperationHandler for disposing savepoints. The handler is registered
under '/savepoint-disposal' and requires a SavepointDisposalRequest JSON object containing
the path to the savepoint to be disposed. The RestClusterClient polls the status registered
under '/savepoint-disposal/:triggerId' until the operation has been completed.

cc @zentol 

## Brief change log

- Implemented `Dispatcher#disposeSavepoint`
- Added `SavepointDisposalHandlers`
- Implemented `RestClusterClient#disposeSavepoint`

## Verifying this change

- Added `RestClusterClientTest#testDisposeSavepoint`
- Added `DispatcherTest#testSavepointDisposal`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
