### PR TITLE
[FLINK-9063] Fix SpillableSubpartitionTest testSpillFinishedBufferConsumers

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SpillableSubpartitionTest.java
@@ -675,14 +675,12 @@ public class SpillableSubpartitionTest extends SubpartitionTestBase {
 		SpillableSubpartition partition = createSubpartition();
 		BufferBuilder bufferBuilder = createBufferBuilder(BUFFER_DATA_SIZE);
 
-		try (BufferConsumer buffer = bufferBuilder.createBufferConsumer()) {
-			partition.add(buffer);
-			assertEquals(0, partition.releaseMemory());
-			// finally fill the buffer with some bytes
-			bufferBuilder.appendAndCommit(ByteBuffer.allocate(BUFFER_DATA_SIZE));
-			bufferBuilder.finish(); // so that this buffer can be removed from the queue
-			assertEquals(BUFFER_DATA_SIZE, partition.spillFinishedBufferConsumers());
-		}
+		partition.add(bufferBuilder.createBufferConsumer());
+		assertEquals(0, partition.releaseMemory());
+		// finally fill the buffer with some bytes
+		bufferBuilder.appendAndCommit(ByteBuffer.allocate(BUFFER_DATA_SIZE));
+		bufferBuilder.finish(); // so that this buffer can be removed from the queue
+		assertEquals(BUFFER_DATA_SIZE, partition.spillFinishedBufferConsumers());
 	}
 
 	/**


### PR DESCRIPTION
testSpillFinishedBufferConsumers was incorrectly manually closing the BufferConsumer
after passing it's ownership to the ResultSubpartition. This was leading to a race
conditions with AsynchronousBufferFileWriter.

This is a change in tests that improves stability.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
