### PR TITLE
[FLINK-8887] Wait for JobMaster leader election in Dispatcher

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -42,6 +42,8 @@ import org.apache.flink.runtime.jobmaster.JobManagerSharedServices;
 import org.apache.flink.runtime.jobmaster.JobNotFinishedException;
 import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.runtime.jobmaster.RescalingBehaviour;
+import org.apache.flink.runtime.jobmaster.factories.DefaultJobManagerJobMetricGroupFactory;
+import org.apache.flink.runtime.jobmaster.factories.JobManagerJobMetricGroupFactory;
 import org.apache.flink.runtime.leaderelection.LeaderContender;
 import org.apache.flink.runtime.leaderelection.LeaderElectionService;
 import org.apache.flink.runtime.messages.Acknowledge;
@@ -50,7 +52,6 @@ import org.apache.flink.runtime.messages.webmonitor.ClusterOverview;
 import org.apache.flink.runtime.messages.webmonitor.JobDetails;
 import org.apache.flink.runtime.messages.webmonitor.JobsOverview;
 import org.apache.flink.runtime.messages.webmonitor.MultipleJobsDetails;
-import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
 import org.apache.flink.runtime.metrics.groups.JobManagerMetricGroup;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.resourcemanager.ResourceOverview;
@@ -262,7 +263,7 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 					heartbeatServices,
 					blobServer,
 					jobManagerSharedServices,
-					jobManagerMetricGroup.addJob(jobGraph),
+					new DefaultJobManagerJobMetricGroupFactory(jobManagerMetricGroup),
 					metricQueryServicePath,
 					restAddress);
 
@@ -756,7 +757,7 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 			HeartbeatServices heartbeatServices,
 			BlobServer blobServer,
 			JobManagerSharedServices jobManagerServices,
-			JobManagerJobMetricGroup jobManagerJobMetricGroup,
+			JobManagerJobMetricGroupFactory jobManagerJobMetricGroupFactory,
 			@Nullable String metricQueryServicePath,
 			@Nullable String restAddress) throws Exception;
 	}
@@ -777,7 +778,7 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 				HeartbeatServices heartbeatServices,
 				BlobServer blobServer,
 				JobManagerSharedServices jobManagerServices,
-				JobManagerJobMetricGroup jobManagerJobMetricGroup,
+				JobManagerJobMetricGroupFactory jobManagerJobMetricGroupFactory,
 				@Nullable String metricQueryServicePath,
 				@Nullable String restAddress) throws Exception {
 			return new JobManagerRunner(
@@ -789,7 +790,7 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 				heartbeatServices,
 				blobServer,
 				jobManagerServices,
-				jobManagerJobMetricGroup,
+				jobManagerJobMetricGroupFactory,
 				metricQueryServicePath,
 				restAddress);
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -39,6 +39,7 @@ import org.apache.flink.runtime.jobmanager.SubmittedJobGraph;
 import org.apache.flink.runtime.jobmanager.SubmittedJobGraphStore;
 import org.apache.flink.runtime.jobmaster.JobManagerRunner;
 import org.apache.flink.runtime.jobmaster.JobManagerSharedServices;
+import org.apache.flink.runtime.jobmaster.JobMasterGateway;
 import org.apache.flink.runtime.jobmaster.JobNotFinishedException;
 import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.runtime.jobmaster.RescalingBehaviour;
@@ -64,6 +65,7 @@ import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.Preconditions;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
@@ -75,9 +77,11 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
@@ -341,35 +345,25 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 
 	@Override
 	public CompletableFuture<Acknowledge> cancelJob(JobID jobId, Time timeout) {
-		JobManagerRunner jobManagerRunner = jobManagerRunners.get(jobId);
+		final CompletableFuture<JobMasterGateway> jobMasterGatewayFuture = getJobMasterGatewayFuture(jobId);
 
-		if (jobManagerRunner == null) {
-			return FutureUtils.completedExceptionally(new FlinkJobNotFoundException(jobId));
-		} else {
-			return jobManagerRunner.getJobManagerGateway().cancel(timeout);
-		}
+		return jobMasterGatewayFuture.thenCompose((JobMasterGateway jobMasterGateway) -> jobMasterGateway.cancel(timeout));
 	}
 
 	@Override
 	public CompletableFuture<Acknowledge> stopJob(JobID jobId, Time timeout) {
-		JobManagerRunner jobManagerRunner = jobManagerRunners.get(jobId);
+		final CompletableFuture<JobMasterGateway> jobMasterGatewayFuture = getJobMasterGatewayFuture(jobId);
 
-		if (jobManagerRunner == null) {
-			return FutureUtils.completedExceptionally(new FlinkJobNotFoundException(jobId));
-		} else {
-			return jobManagerRunner.getJobManagerGateway().stop(timeout);
-		}
+		return jobMasterGatewayFuture.thenCompose((JobMasterGateway jobMasterGateway) -> jobMasterGateway.stop(timeout));
 	}
 
 	@Override
 	public CompletableFuture<Acknowledge> rescaleJob(JobID jobId, int newParallelism, RescalingBehaviour rescalingBehaviour, Time timeout) {
-		JobManagerRunner jobManagerRunner = jobManagerRunners.get(jobId);
+		final CompletableFuture<JobMasterGateway> jobMasterGatewayFuture = getJobMasterGatewayFuture(jobId);
 
-		if (jobManagerRunner == null) {
-			return FutureUtils.completedExceptionally(new FlinkJobNotFoundException(jobId));
-		} else {
-			return jobManagerRunner.getJobManagerGateway().rescaleJob(newParallelism, rescalingBehaviour, timeout);
-		}
+		return jobMasterGatewayFuture.thenCompose(
+			(JobMasterGateway jobMasterGateway) ->
+				jobMasterGateway.rescaleJob(newParallelism, rescalingBehaviour, timeout));
 	}
 
 	@Override
@@ -385,15 +379,12 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 	public CompletableFuture<ClusterOverview> requestClusterOverview(Time timeout) {
 		CompletableFuture<ResourceOverview> taskManagerOverviewFuture = resourceManagerGateway.requestResourceOverview(timeout);
 
-		ArrayList<CompletableFuture<JobStatus>> jobStatus = new ArrayList<>(jobManagerRunners.size());
+		final List<CompletableFuture<Optional<JobStatus>>> optionalJobInformation = queryJobMastersForInformation(
+			(JobMasterGateway jobMasterGateway) -> jobMasterGateway.requestJobStatus(timeout));
 
-		for (Map.Entry<JobID, JobManagerRunner> jobManagerRunnerEntry : jobManagerRunners.entrySet()) {
-			CompletableFuture<JobStatus> jobStatusFuture = jobManagerRunnerEntry.getValue().getJobManagerGateway().requestJobStatus(timeout);
+		CompletableFuture<Collection<Optional<JobStatus>>> allOptionalJobsFuture = FutureUtils.combineAll(optionalJobInformation);
 
-			jobStatus.add(jobStatusFuture);
-		}
-
-		CompletableFuture<Collection<JobStatus>> allJobsFuture = FutureUtils.combineAll(jobStatus);
+		CompletableFuture<Collection<JobStatus>> allJobsFuture = allOptionalJobsFuture.thenApply(this::flattenOptionalCollection);
 
 		final JobsOverview completedJobsOverview = archivedExecutionGraphStore.getStoredJobsOverview();
 
@@ -403,76 +394,79 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 				final JobsOverview allJobsOverview = JobsOverview.create(runningJobsStatus).combine(completedJobsOverview);
 				return new ClusterOverview(resourceOverview, allJobsOverview);
 			});
-
 	}
 
 	@Override
 	public CompletableFuture<MultipleJobsDetails> requestMultipleJobDetails(Time timeout) {
-		final int numberJobsRunning = jobManagerRunners.size();
+		List<CompletableFuture<Optional<JobDetails>>> individualOptionalJobDetails = queryJobMastersForInformation(
+			(JobMasterGateway jobMasterGateway) -> jobMasterGateway.requestJobDetails(timeout));
 
-		ArrayList<CompletableFuture<JobDetails>> individualJobDetails = new ArrayList<>(numberJobsRunning);
+		CompletableFuture<Collection<Optional<JobDetails>>> optionalCombinedJobDetails = FutureUtils.combineAll(
+			individualOptionalJobDetails);
 
-		for (JobManagerRunner jobManagerRunner : jobManagerRunners.values()) {
-			individualJobDetails.add(jobManagerRunner.getJobManagerGateway().requestJobDetails(timeout));
-		}
-
-		CompletableFuture<Collection<JobDetails>> combinedJobDetails = FutureUtils.combineAll(individualJobDetails);
+		CompletableFuture<Collection<JobDetails>> combinedJobDetails = optionalCombinedJobDetails.thenApply(this::flattenOptionalCollection);
 
 		final Collection<JobDetails> completedJobDetails = archivedExecutionGraphStore.getAvailableJobDetails();
 
 		return combinedJobDetails.thenApply(
 			(Collection<JobDetails> runningJobDetails) -> {
 				final Collection<JobDetails> allJobDetails = new ArrayList<>(completedJobDetails.size() + runningJobDetails.size());
+
 				allJobDetails.addAll(runningJobDetails);
 				allJobDetails.addAll(completedJobDetails);
+
 				return new MultipleJobsDetails(allJobDetails);
 			});
 	}
 
 	@Override
 	public CompletableFuture<JobStatus> requestJobStatus(JobID jobId, Time timeout) {
-		final JobManagerRunner jobManagerRunner = jobManagerRunners.get(jobId);
 
-		if (jobManagerRunner != null) {
-			return jobManagerRunner.getJobManagerGateway().requestJobStatus(timeout);
-		} else {
-			final JobDetails jobDetails = archivedExecutionGraphStore.getAvailableJobDetails(jobId);
+		final CompletableFuture<JobMasterGateway> jobMasterGatewayFuture = getJobMasterGatewayFuture(jobId);
 
-			if (jobDetails != null) {
-				return CompletableFuture.completedFuture(jobDetails.getStatus());
-			} else {
-				return FutureUtils.completedExceptionally(new FlinkJobNotFoundException(jobId));
-			}
-		}
+		final CompletableFuture<JobStatus> jobStatusFuture = jobMasterGatewayFuture.thenCompose(
+			(JobMasterGateway jobMasterGateway) -> jobMasterGateway.requestJobStatus(timeout));
+
+		return jobStatusFuture.exceptionally(
+			(Throwable throwable) -> {
+				final JobDetails jobDetails = archivedExecutionGraphStore.getAvailableJobDetails(jobId);
+
+				// check whether it is a completed job
+				if (jobDetails == null) {
+					throw new CompletionException(ExceptionUtils.stripCompletionException(throwable));
+				} else {
+					return jobDetails.getStatus();
+				}
+			});
 	}
 
 	@Override
 	public CompletableFuture<OperatorBackPressureStatsResponse> requestOperatorBackPressureStats(
-			final JobID jobId, final JobVertexID jobVertexId) {
-			final JobManagerRunner jobManagerRunner = jobManagerRunners.get(jobId);
-		if (jobManagerRunner == null) {
-			return FutureUtils.completedExceptionally(new FlinkJobNotFoundException(jobId));
-		} else {
-			return jobManagerRunner.getJobManagerGateway().requestOperatorBackPressureStats(jobVertexId);
-		}
+			final JobID jobId,
+			final JobVertexID jobVertexId) {
+		final CompletableFuture<JobMasterGateway> jobMasterGatewayFuture = getJobMasterGatewayFuture(jobId);
+
+		return jobMasterGatewayFuture.thenCompose((JobMasterGateway jobMasterGateway) -> jobMasterGateway.requestOperatorBackPressureStats(jobVertexId));
 	}
 
 	@Override
 	public CompletableFuture<ArchivedExecutionGraph> requestJob(JobID jobId, Time timeout) {
-		final JobManagerRunner jobManagerRunner = jobManagerRunners.get(jobId);
+		final CompletableFuture<JobMasterGateway> jobMasterGatewayFuture = getJobMasterGatewayFuture(jobId);
 
-		if (jobManagerRunner == null) {
-			final ArchivedExecutionGraph serializableExecutionGraph = archivedExecutionGraphStore.get(jobId);
+		final CompletableFuture<ArchivedExecutionGraph> archivedExecutionGraphFuture = jobMasterGatewayFuture.thenCompose(
+			(JobMasterGateway jobMasterGateway) -> jobMasterGateway.requestJob(timeout));
 
-			// check whether it is a completed job
-			if (serializableExecutionGraph == null) {
-				return FutureUtils.completedExceptionally(new FlinkJobNotFoundException(jobId));
-			} else {
-				return CompletableFuture.completedFuture(serializableExecutionGraph);
-			}
-		} else {
-			return jobManagerRunner.getJobManagerGateway().requestJob(timeout);
-		}
+		return archivedExecutionGraphFuture.exceptionally(
+			(Throwable throwable) -> {
+				final ArchivedExecutionGraph serializableExecutionGraph = archivedExecutionGraphStore.get(jobId);
+
+				// check whether it is a completed job
+				if (serializableExecutionGraph == null) {
+					throw new CompletionException(ExceptionUtils.stripCompletionException(throwable));
+				} else {
+					return serializableExecutionGraph;
+				}
+			});
 	}
 
 	@Override
@@ -517,13 +511,11 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 			final String targetDirectory,
 			final boolean cancelJob,
 			final Time timeout) {
-		if (jobManagerRunners.containsKey(jobId)) {
-			return jobManagerRunners.get(jobId)
-				.getJobManagerGateway()
-				.triggerSavepoint(targetDirectory, cancelJob, timeout);
-		} else {
-			return FutureUtils.completedExceptionally(new FlinkJobNotFoundException(jobId));
-		}
+		final CompletableFuture<JobMasterGateway> jobMasterGatewayFuture = getJobMasterGatewayFuture(jobId);
+
+		return jobMasterGatewayFuture.thenCompose(
+			(JobMasterGateway jobMasterGateway) ->
+				jobMasterGateway.triggerSavepoint(targetDirectory, cancelJob, timeout));
 	}
 
 	/**
@@ -642,6 +634,49 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 		orphanedJobManagerRunnersTerminationFuture = FutureUtils.completeAll(Arrays.asList(
 			orphanedJobManagerRunnersTerminationFuture,
 			jobManagerRunnerTerminationFuture));
+	}
+
+	private CompletableFuture<JobMasterGateway> getJobMasterGatewayFuture(JobID jobId) {
+		final JobManagerRunner jobManagerRunner = jobManagerRunners.get(jobId);
+
+		if (jobManagerRunner == null) {
+			return FutureUtils.completedExceptionally(new FlinkJobNotFoundException(jobId));
+		} else {
+			final CompletableFuture<JobMasterGateway> leaderGatewayFuture = jobManagerRunner.getLeaderGatewayFuture();
+			return leaderGatewayFuture.thenApplyAsync(
+				(JobMasterGateway jobMasterGateway) -> {
+					// check whether the retrieved JobMasterGateway belongs still to a running JobMaster
+					if (jobManagerRunners.containsKey(jobId)) {
+						return jobMasterGateway;
+					} else {
+						throw new CompletionException(new FlinkJobNotFoundException(jobId));
+					}
+				},
+				getMainThreadExecutor());
+		}
+	}
+
+	private <T> List<T> flattenOptionalCollection(Collection<Optional<T>> optionalCollection) {
+		return optionalCollection.stream().filter(Optional::isPresent).map(Optional::get).collect(Collectors.toList());
+	}
+
+	@Nonnull
+	private <T> List<CompletableFuture<Optional<T>>> queryJobMastersForInformation(Function<JobMasterGateway, CompletableFuture<T>> queryFunction) {
+		final int numberJobsRunning = jobManagerRunners.size();
+
+		ArrayList<CompletableFuture<Optional<T>>> optionalJobInformation = new ArrayList<>(
+			numberJobsRunning);
+
+		for (JobID jobId : jobManagerRunners.keySet()) {
+			final CompletableFuture<JobMasterGateway> jobMasterGatewayFuture = getJobMasterGatewayFuture(jobId);
+
+			final CompletableFuture<Optional<T>> optionalRequest = jobMasterGatewayFuture
+				.thenCompose(queryFunction::apply)
+				.handle((T value, Throwable throwable) -> Optional.ofNullable(value));
+
+			optionalJobInformation.add(optionalRequest);
+		}
+		return optionalJobInformation;
 	}
 
 	//------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -263,9 +263,7 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 					heartbeatServices,
 					blobServer,
 					jobManagerSharedServices,
-					new DefaultJobManagerJobMetricGroupFactory(jobManagerMetricGroup),
-					metricQueryServicePath,
-					restAddress);
+					new DefaultJobManagerJobMetricGroupFactory(jobManagerMetricGroup));
 
 				jobManagerRunner.getResultFuture().whenCompleteAsync(
 					(ArchivedExecutionGraph archivedExecutionGraph, Throwable throwable) -> {
@@ -757,9 +755,7 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 			HeartbeatServices heartbeatServices,
 			BlobServer blobServer,
 			JobManagerSharedServices jobManagerServices,
-			JobManagerJobMetricGroupFactory jobManagerJobMetricGroupFactory,
-			@Nullable String metricQueryServicePath,
-			@Nullable String restAddress) throws Exception;
+			JobManagerJobMetricGroupFactory jobManagerJobMetricGroupFactory) throws Exception;
 	}
 
 	/**
@@ -778,9 +774,7 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 				HeartbeatServices heartbeatServices,
 				BlobServer blobServer,
 				JobManagerSharedServices jobManagerServices,
-				JobManagerJobMetricGroupFactory jobManagerJobMetricGroupFactory,
-				@Nullable String metricQueryServicePath,
-				@Nullable String restAddress) throws Exception {
+				JobManagerJobMetricGroupFactory jobManagerJobMetricGroupFactory) throws Exception {
 			return new JobManagerRunner(
 				resourceId,
 				jobGraph,
@@ -790,9 +784,7 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 				heartbeatServices,
 				blobServer,
 				jobManagerServices,
-				jobManagerJobMetricGroupFactory,
-				metricQueryServicePath,
-				restAddress);
+				jobManagerJobMetricGroupFactory);
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerRunner.java
@@ -32,10 +32,10 @@ import org.apache.flink.runtime.highavailability.RunningJobsRegistry;
 import org.apache.flink.runtime.highavailability.RunningJobsRegistry.JobSchedulingStatus;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmanager.OnCompletionActions;
+import org.apache.flink.runtime.jobmaster.factories.JobManagerJobMetricGroupFactory;
 import org.apache.flink.runtime.leaderelection.LeaderContender;
 import org.apache.flink.runtime.leaderelection.LeaderElectionService;
 import org.apache.flink.runtime.messages.Acknowledge;
-import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.util.AutoCloseableAsync;
@@ -107,7 +107,7 @@ public class JobManagerRunner implements LeaderContender, OnCompletionActions, F
 			final HeartbeatServices heartbeatServices,
 			final BlobServer blobServer,
 			final JobManagerSharedServices jobManagerSharedServices,
-			final JobManagerJobMetricGroup jobManagerJobMetricGroup,
+			final JobManagerJobMetricGroupFactory jobManagerJobMetricGroupFactory,
 			@Nullable final String metricQueryServicePath,
 			@Nullable final String restAddress) throws Exception {
 
@@ -153,7 +153,7 @@ public class JobManagerRunner implements LeaderContender, OnCompletionActions, F
 				jobManagerSharedServices,
 				heartbeatServices,
 				blobServer,
-				jobManagerJobMetricGroup,
+				jobManagerJobMetricGroupFactory,
 				this,
 				this,
 				userCodeLoader,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerRunner.java
@@ -45,8 +45,6 @@ import org.apache.flink.util.FlinkException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
-
 import java.io.IOException;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -107,9 +105,7 @@ public class JobManagerRunner implements LeaderContender, OnCompletionActions, F
 			final HeartbeatServices heartbeatServices,
 			final BlobServer blobServer,
 			final JobManagerSharedServices jobManagerSharedServices,
-			final JobManagerJobMetricGroupFactory jobManagerJobMetricGroupFactory,
-			@Nullable final String metricQueryServicePath,
-			@Nullable final String restAddress) throws Exception {
+			final JobManagerJobMetricGroupFactory jobManagerJobMetricGroupFactory) throws Exception {
 
 		this.resultFuture = new CompletableFuture<>();
 		this.terminationFuture = new CompletableFuture<>();
@@ -156,9 +152,7 @@ public class JobManagerRunner implements LeaderContender, OnCompletionActions, F
 				jobManagerJobMetricGroupFactory,
 				this,
 				this,
-				userCodeLoader,
-				restAddress,
-				metricQueryServicePath);
+				userCodeLoader);
 		}
 		catch (Throwable t) {
 			terminationFuture.completeExceptionally(t);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -77,6 +77,7 @@ import org.apache.flink.runtime.messages.FlinkJobNotFoundException;
 import org.apache.flink.runtime.messages.checkpoint.AcknowledgeCheckpoint;
 import org.apache.flink.runtime.messages.checkpoint.DeclineCheckpoint;
 import org.apache.flink.runtime.messages.webmonitor.JobDetails;
+import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
 import org.apache.flink.runtime.query.KvStateLocation;
 import org.apache.flink.runtime.query.KvStateLocationRegistry;
 import org.apache.flink.runtime.query.UnknownKvStateLocation;
@@ -186,6 +187,8 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 
 	private final SlotPoolGateway slotPoolGateway;
 
+	private final RestartStrategy restartStrategy;
+
 	private final CompletableFuture<String> restAddressFuture;
 
 	private final String metricQueryServicePath;
@@ -210,6 +213,12 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 
 	/** The execution graph of this job. */
 	private ExecutionGraph executionGraph;
+
+	@Nullable
+	private JobManagerJobStatusListener jobStatusListener;
+
+	@Nullable
+	private JobManagerJobMetricGroup jobManagerJobMetricGroup;
 
 	@Nullable
 	private String lastInternalSavepoint;
@@ -270,7 +279,7 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 						.deserializeValue(userCodeLoader)
 						.getRestartStrategy();
 
-		final RestartStrategy restartStrategy = (restartStrategyConfiguration != null) ?
+		this.restartStrategy = (restartStrategyConfiguration != null) ?
 				RestartStrategyFactory.createRestartStrategy(restartStrategyConfiguration) :
 				jobManagerSharedServices.getRestartStrategyFactory().createRestartStrategy();
 
@@ -287,40 +296,6 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 
 		this.slotPoolGateway = slotPool.getSelfGateway(SlotPoolGateway.class);
 
-		this.executionGraph = ExecutionGraphBuilder.buildGraph(
-			null,
-			jobGraph,
-			jobMasterConfiguration.getConfiguration(),
-			scheduledExecutorService,
-			scheduledExecutorService,
-			slotPool.getSlotProvider(),
-			userCodeLoader,
-			highAvailabilityServices.getCheckpointRecoveryFactory(),
-			rpcTimeout,
-			restartStrategy,
-			jobMetricGroupFactory.create(jobGraph),
-			-1,
-			blobServer,
-			jobMasterConfiguration.getSlotRequestTimeout(),
-			log);
-
-		final CheckpointCoordinator checkpointCoordinator = executionGraph.getCheckpointCoordinator();
-
-		if (checkpointCoordinator != null) {
-			// check whether we find a valid checkpoint
-			if (!checkpointCoordinator.restoreLatestCheckpointedState(
-				executionGraph.getAllVertices(),
-				false,
-				false)) {
-
-				// check whether we can restore from a savepoint
-				tryRestoreExecutionGraphFromSavepoint(executionGraph, jobGraph.getSavepointRestoreSettings());
-			}
-		}
-
-		// register self as job status change listener
-		executionGraph.registerJobStatusListener(new JobManagerJobStatusListener());
-
 		this.registeredTaskManagers = new HashMap<>(4);
 
 		this.restAddressFuture = Optional.ofNullable(restAddress)
@@ -330,6 +305,10 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 		this.metricQueryServicePath = metricQueryServicePath;
 		this.backPressureStatsTracker = checkNotNull(jobManagerSharedServices.getBackPressureStatsTracker());
 		this.lastInternalSavepoint = null;
+
+		this.jobManagerJobMetricGroup = jobMetricGroupFactory.create(jobGraph);
+		this.executionGraph = createAndRestoreExecutionGraph(jobManagerJobMetricGroup);
+		this.jobStatusListener = null;
 	}
 
 	//----------------------------------------------------------------------------------------------
@@ -474,32 +453,18 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 
 		final ExecutionGraph currentExecutionGraph = executionGraph;
 
+		final JobManagerJobMetricGroup newJobManagerJobMetricGroup = jobMetricGroupFactory.create(jobGraph);
 		final ExecutionGraph newExecutionGraph;
 
 		try {
-			newExecutionGraph = ExecutionGraphBuilder.buildGraph(
-				null,
-				jobGraph,
-				jobMasterConfiguration.getConfiguration(),
-				scheduledExecutorService,
-				scheduledExecutorService,
-				slotPool.getSlotProvider(),
-				userCodeLoader,
-				highAvailabilityServices.getCheckpointRecoveryFactory(),
-				rpcTimeout,
-				currentExecutionGraph.getRestartStrategy(),
-				jobMetricGroupFactory.create(jobGraph),
-				1,
-				blobServer,
-				jobMasterConfiguration.getSlotRequestTimeout(),
-				log);
+			newExecutionGraph = createExecutionGraph(newJobManagerJobMetricGroup);
 		} catch (JobExecutionException | JobException e) {
 			return FutureUtils.completedExceptionally(
 				new JobModificationException("Could not create rescaled ExecutionGraph.", e));
 		}
 
 		// 3. disable checkpoint coordinator to suppress subsequent checkpoints
-		final CheckpointCoordinator checkpointCoordinator = executionGraph.getCheckpointCoordinator();
+		final CheckpointCoordinator checkpointCoordinator = currentExecutionGraph.getCheckpointCoordinator();
 		checkpointCoordinator.stopCheckpointScheduler();
 
 		// 4. take a savepoint
@@ -527,7 +492,7 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 		// 5. suspend the current job
 		final CompletableFuture<JobStatus> terminationFuture = executionGraphFuture.thenComposeAsync(
 			(ExecutionGraph ignored) -> {
-				currentExecutionGraph.suspend(new FlinkException("Job is being rescaled."));
+				suspendExecutionGraph(new FlinkException("Job is being rescaled."));
 				return currentExecutionGraph.getTerminationFuture();
 			},
 			getMainThreadExecutor());
@@ -546,13 +511,9 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 			executionGraphFuture,
 			(Void ignored, ExecutionGraph restoredExecutionGraph) -> {
 				// check if the ExecutionGraph is still the same
-				//noinspection ObjectEquality
 				if (executionGraph == currentExecutionGraph) {
-					executionGraph = restoredExecutionGraph;
-
-					// register self as job status change listener
-					executionGraph.registerJobStatusListener(new JobManagerJobStatusListener());
-
+					clearExecutionGraphFields();
+					assignExecutionGraph(restoredExecutionGraph, newJobManagerJobMetricGroup);
 					scheduleExecutionGraph();
 
 					return Acknowledge.get();
@@ -1040,6 +1001,28 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 			return Acknowledge.get();
 		}
 
+		setNewFencingToken(newJobMasterId);
+
+		log.info("Starting execution of job {} ({})", jobGraph.getName(), jobGraph.getJobID());
+
+		startJobMasterServices();
+		resetAndScheduleExecutionGraph();
+
+		return Acknowledge.get();
+	}
+
+	private void startJobMasterServices() throws Exception {
+		// start the slot pool make sure the slot pool now accepts messages for this leader
+		slotPool.start(getFencingToken(), getAddress());
+
+		// job is ready to go, try to establish connection with resource manager
+		//   - activate leader retrieval for the resource manager
+		//   - on notification of the leader, the connection will be established and
+		//     the slot pool will start requesting slots
+		resourceManagerLeaderRetriever.start(new ResourceManagerLeaderListener());
+	}
+
+	private void setNewFencingToken(JobMasterId newJobMasterId) {
 		if (getFencingToken() != null) {
 			log.info("Restarting old job with JobMasterId {}. The new JobMasterId is {}.", getFencingToken(), newJobMasterId);
 
@@ -1050,30 +1033,6 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 
 		// set new leader id
 		setFencingToken(newJobMasterId);
-
-		log.info("Starting execution of job {} ({})", jobGraph.getName(), jobGraph.getJobID());
-
-		try {
-			// start the slot pool make sure the slot pool now accepts messages for this leader
-			log.debug("Staring SlotPool component");
-			slotPool.start(getFencingToken(), getAddress());
-
-			// job is ready to go, try to establish connection with resource manager
-			//   - activate leader retrieval for the resource manager
-			//   - on notification of the leader, the connection will be established and
-			//     the slot pool will start requesting slots
-			resourceManagerLeaderRetriever.start(new ResourceManagerLeaderListener());
-		}
-		catch (Throwable t) {
-			log.error("Failed to start job {} ({})", jobGraph.getName(), jobGraph.getJobID(), t);
-
-			throw new Exception("Could not start job execution: Failed to start JobMaster services.", t);
-		}
-
-		// start scheduling job in another thread
-		scheduledExecutorService.execute(this::scheduleExecutionGraph);
-
-		return Acknowledge.get();
 	}
 
 	/**
@@ -1102,8 +1061,7 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 			log.warn("Failed to stop resource manager leader retriever when suspending.", t);
 		}
 
-		// tell the execution graph (JobManager is still processing messages here)
-		executionGraph.suspend(cause);
+		suspendAndClearExecutionGraphFields(cause);
 
 		// the slot pool stops receiving messages and clears its pooled slots
 		slotPoolGateway.suspend();
@@ -1114,16 +1072,114 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 		return Acknowledge.get();
 	}
 
-	/**
-	 * Schedules the execution of the current {@link ExecutionGraph}.
-	 */
+	private void assignExecutionGraph(
+			ExecutionGraph newExecutionGraph,
+			JobManagerJobMetricGroup newJobManagerJobMetricGroup) {
+		validateRunsInMainThread();
+		Preconditions.checkState(executionGraph.getState().isTerminalState());
+		Preconditions.checkState(jobManagerJobMetricGroup == null);
+
+		executionGraph = newExecutionGraph;
+		jobManagerJobMetricGroup = newJobManagerJobMetricGroup;
+	}
+
+	private void resetAndScheduleExecutionGraph() throws Exception {
+		validateRunsInMainThread();
+
+		final CompletableFuture<Void> executionGraphAssignedFuture;
+
+		if (executionGraph.getState() == JobStatus.CREATED) {
+			executionGraphAssignedFuture = CompletableFuture.completedFuture(null);
+		} else {
+			suspendAndClearExecutionGraphFields(new FlinkException("ExecutionGraph is being reset in order to be rescheduled."));
+			final JobManagerJobMetricGroup newJobManagerJobMetricGroup = jobMetricGroupFactory.create(jobGraph);
+			final ExecutionGraph newExecutionGraph = createAndRestoreExecutionGraph(newJobManagerJobMetricGroup);
+
+			executionGraphAssignedFuture = executionGraph.getTerminationFuture().handleAsync(
+				(JobStatus ignored, Throwable throwable) -> {
+					assignExecutionGraph(newExecutionGraph, newJobManagerJobMetricGroup);
+					return null;
+				},
+				getMainThreadExecutor());
+		}
+
+		executionGraphAssignedFuture.thenRun(this::scheduleExecutionGraph);
+	}
+
 	private void scheduleExecutionGraph() {
+		Preconditions.checkState(jobStatusListener == null);
+		// register self as job status change listener
+		jobStatusListener = new JobManagerJobStatusListener();
+		executionGraph.registerJobStatusListener(jobStatusListener);
+
 		try {
 			executionGraph.scheduleForExecution();
 		}
 		catch (Throwable t) {
 			executionGraph.failGlobal(t);
 		}
+	}
+
+	private ExecutionGraph createAndRestoreExecutionGraph(JobManagerJobMetricGroup currentJobManagerJobMetricGroup) throws Exception {
+
+		ExecutionGraph newExecutionGraph = createExecutionGraph(currentJobManagerJobMetricGroup);
+
+		final CheckpointCoordinator checkpointCoordinator = newExecutionGraph.getCheckpointCoordinator();
+
+		if (checkpointCoordinator != null) {
+			// check whether we find a valid checkpoint
+			if (!checkpointCoordinator.restoreLatestCheckpointedState(
+				newExecutionGraph.getAllVertices(),
+				false,
+				false)) {
+
+				// check whether we can restore from a savepoint
+				tryRestoreExecutionGraphFromSavepoint(newExecutionGraph, jobGraph.getSavepointRestoreSettings());
+			}
+		}
+
+		return newExecutionGraph;
+	}
+
+	private ExecutionGraph createExecutionGraph(JobManagerJobMetricGroup currentJobManagerJobMetricGroup) throws JobExecutionException, JobException {
+		return ExecutionGraphBuilder.buildGraph(
+			null,
+			jobGraph,
+			jobMasterConfiguration.getConfiguration(),
+			scheduledExecutorService,
+			scheduledExecutorService,
+			slotPool.getSlotProvider(),
+			userCodeLoader,
+			highAvailabilityServices.getCheckpointRecoveryFactory(),
+			rpcTimeout,
+			restartStrategy,
+			currentJobManagerJobMetricGroup,
+			-1,
+			blobServer,
+			jobMasterConfiguration.getSlotRequestTimeout(),
+			log);
+	}
+
+	private void suspendAndClearExecutionGraphFields(Exception cause) {
+		suspendExecutionGraph(cause);
+		clearExecutionGraphFields();
+	}
+
+	private void suspendExecutionGraph(Exception cause) {
+		executionGraph.suspend(cause);
+
+		if (jobManagerJobMetricGroup != null) {
+			jobManagerJobMetricGroup.close();
+		}
+
+		if (jobStatusListener != null) {
+			jobStatusListener.stop();
+		}
+	}
+
+	private void clearExecutionGraphFields() {
+		jobManagerJobMetricGroup = null;
+		jobStatusListener = null;
 	}
 
 	/**
@@ -1496,6 +1552,8 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 
 	private class JobManagerJobStatusListener implements JobStatusListener {
 
+		private volatile boolean running = true;
+
 		@Override
 		public void jobStatusChanges(
 				final JobID jobId,
@@ -1503,8 +1561,14 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 				final long timestamp,
 				final Throwable error) {
 
-			// run in rpc thread to avoid concurrency
-			runAsync(() -> jobStatusChanged(newJobStatus, timestamp, error));
+			if (running) {
+				// run in rpc thread to avoid concurrency
+				runAsync(() -> jobStatusChanged(newJobStatus, timestamp, error));
+			}
+		}
+
+		private void stop() {
+			running = false;
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -189,10 +189,6 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 
 	private final RestartStrategy restartStrategy;
 
-	private final CompletableFuture<String> restAddressFuture;
-
-	private final String metricQueryServicePath;
-
 	// --------- BackPressure --------
 
 	private final BackPressureStatsTracker backPressureStatsTracker;
@@ -237,9 +233,7 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 			JobManagerJobMetricGroupFactory jobMetricGroupFactory,
 			OnCompletionActions jobCompletionActions,
 			FatalErrorHandler errorHandler,
-			ClassLoader userCodeLoader,
-			@Nullable String restAddress,
-			@Nullable String metricQueryServicePath) throws Exception {
+			ClassLoader userCodeLoader) throws Exception {
 
 		super(rpcService, AkkaRpcServiceUtils.createRandomName(JOB_MANAGER_NAME));
 
@@ -298,11 +292,6 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 
 		this.registeredTaskManagers = new HashMap<>(4);
 
-		this.restAddressFuture = Optional.ofNullable(restAddress)
-			.map(CompletableFuture::completedFuture)
-			.orElse(FutureUtils.completedExceptionally(new JobMasterException("The JobMaster has not been started with a REST endpoint.")));
-
-		this.metricQueryServicePath = metricQueryServicePath;
 		this.backPressureStatsTracker = checkNotNull(jobManagerSharedServices.getBackPressureStatsTracker());
 		this.lastInternalSavepoint = null;
 
@@ -993,7 +982,7 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 	private Acknowledge startJobExecution(JobMasterId newJobMasterId) throws Exception {
 		validateRunsInMainThread();
 
-		Preconditions.checkNotNull(newJobMasterId, "The new JobMasterId must not be null.");
+		checkNotNull(newJobMasterId, "The new JobMasterId must not be null.");
 
 		if (Objects.equals(getFencingToken(), newJobMasterId)) {
 			log.info("Already started the job execution with JobMasterId {}.", newJobMasterId);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -154,27 +154,20 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 
 	private final ResourceID resourceId;
 
-	/** Logical representation of the job. */
 	private final JobGraph jobGraph;
 
 	private final Time rpcTimeout;
 
-	/** Service to contend for and retrieve the leadership of JM and RM. */
 	private final HighAvailabilityServices highAvailabilityServices;
 
-	/** Blob server used across jobs. */
 	private final BlobServer blobServer;
 
-	/** The metrics for the job. */
 	private final JobManagerJobMetricGroupFactory jobMetricGroupFactory;
 
-	/** The heartbeat manager with task managers. */
 	private final HeartbeatManager<AccumulatorReport, Void> taskManagerHeartbeatManager;
 
-	/** The heartbeat manager with resource manager. */
 	private final HeartbeatManager<Void, Void> resourceManagerHeartbeatManager;
 
-	/** The execution context which is used to execute futures. */
 	private final ScheduledExecutorService scheduledExecutorService;
 
 	private final OnCompletionActions jobCompletionActions;
@@ -195,10 +188,9 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 
 	// --------- ResourceManager --------
 
-	/** Leader retriever service used to locate ResourceManager's address. */
 	private LeaderRetrievalService resourceManagerLeaderRetriever;
 
-	/** Connection with ResourceManager, null if not located address yet or we close it initiative. */
+	@Nullable
 	private ResourceManagerConnection resourceManagerConnection;
 
 	// --------- TaskManagers --------
@@ -207,7 +199,6 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 
 	// -------- Mutable fields ---------
 
-	/** The execution graph of this job. */
 	private ExecutionGraph executionGraph;
 
 	@Nullable

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -903,7 +903,8 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 
 	@Override
 	public CompletableFuture<JobDetails> requestJobDetails(@RpcTimeout Time timeout) {
-		return CompletableFuture.supplyAsync(() -> WebMonitorUtils.createDetailsForJob(executionGraph), scheduledExecutorService);
+		final ExecutionGraph currentExecutionGraph = executionGraph;
+		return CompletableFuture.supplyAsync(() -> WebMonitorUtils.createDetailsForJob(currentExecutionGraph), scheduledExecutorService);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/factories/DefaultJobManagerJobMetricGroupFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/factories/DefaultJobManagerJobMetricGroupFactory.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.factories;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
+import org.apache.flink.runtime.metrics.groups.JobManagerMetricGroup;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Implementation of {@link JobManagerJobMetricGroupFactory} which makes sure that there is always
+ * at most one {@link JobManagerJobMetricGroup} for a given {@link JobID} registered.
+ */
+public class DefaultJobManagerJobMetricGroupFactory implements JobManagerJobMetricGroupFactory {
+
+	private final JobManagerMetricGroup jobManagerMetricGroup;
+
+	public DefaultJobManagerJobMetricGroupFactory(@Nonnull JobManagerMetricGroup jobManagerMetricGroup) {
+		this.jobManagerMetricGroup = jobManagerMetricGroup;
+	}
+
+	@Override
+	public JobManagerJobMetricGroup create(@Nonnull JobGraph jobGraph) {
+		jobManagerMetricGroup.removeJob(jobGraph.getJobID());
+
+		return jobManagerMetricGroup.addJob(jobGraph);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/factories/DefaultJobManagerJobMetricGroupFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/factories/DefaultJobManagerJobMetricGroupFactory.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.jobmaster.factories;
 
-import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
 import org.apache.flink.runtime.metrics.groups.JobManagerMetricGroup;
@@ -26,8 +25,8 @@ import org.apache.flink.runtime.metrics.groups.JobManagerMetricGroup;
 import javax.annotation.Nonnull;
 
 /**
- * Implementation of {@link JobManagerJobMetricGroupFactory} which makes sure that there is always
- * at most one {@link JobManagerJobMetricGroup} for a given {@link JobID} registered.
+ * Default implementation of {@link JobManagerJobMetricGroupFactory} which creates for a given
+ * {@link JobGraph} a {@link JobManagerJobMetricGroup}.
  */
 public class DefaultJobManagerJobMetricGroupFactory implements JobManagerJobMetricGroupFactory {
 
@@ -39,8 +38,6 @@ public class DefaultJobManagerJobMetricGroupFactory implements JobManagerJobMetr
 
 	@Override
 	public JobManagerJobMetricGroup create(@Nonnull JobGraph jobGraph) {
-		jobManagerMetricGroup.removeJob(jobGraph.getJobID());
-
 		return jobManagerMetricGroup.addJob(jobGraph);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/factories/JobManagerJobMetricGroupFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/factories/JobManagerJobMetricGroupFactory.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.factories;
+
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Factory interface for {@link JobManagerJobMetricGroup}.
+ */
+public interface JobManagerJobMetricGroupFactory {
+
+	/**
+	 * Create a new {@link JobManagerJobMetricGroup}.
+	 *
+	 * @param jobGraph for which to create a new {@link JobManagerJobMetricGroup}.
+	 * @return {@link JobManagerJobMetricGroup}
+	 */
+	JobManagerJobMetricGroup create(@Nonnull JobGraph jobGraph);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/factories/UnregisteredJobManagerJobMetricGroupFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/factories/UnregisteredJobManagerJobMetricGroupFactory.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.factories;
+
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
+import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
+
+import javax.annotation.Nonnull;
+
+/**
+ * {@link JobManagerJobMetricGroupFactory} which returns an unregistered {@link JobManagerJobMetricGroup}.
+ */
+public enum UnregisteredJobManagerJobMetricGroupFactory implements JobManagerJobMetricGroupFactory {
+	INSTANCE {
+		@Override
+		public JobManagerJobMetricGroup create(@Nonnull JobGraph jobGraph) {
+			return UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup();
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
@@ -69,6 +69,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -659,7 +660,7 @@ public class SlotPool extends RpcEndpoint implements SlotPoolGateway, AllocatedS
 			.orTimeout(pendingRequest.getAllocatedSlotFuture(), allocationTimeout.toMilliseconds(), TimeUnit.MILLISECONDS)
 			.whenCompleteAsync(
 				(AllocatedSlot ignored, Throwable throwable) -> {
-					if (throwable != null) {
+					if (throwable instanceof TimeoutException) {
 						timeoutPendingSlotRequest(slotRequestId);
 					}
 				},

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -1769,6 +1769,7 @@ class JobManager(
     val futures = for ((jobID, (eg, jobInfo)) <- currentJobs) yield {
       future {
         eg.suspend(cause)
+        jobManagerMetricGroup.removeJob(eg.getJobID)
 
         jobInfo.notifyNonDetachedClients(
           decorateMessage(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -480,9 +480,7 @@ public class DispatcherTest extends TestLogger {
 				HeartbeatServices heartbeatServices,
 				BlobServer blobServer,
 				JobManagerSharedServices jobManagerSharedServices,
-				JobManagerJobMetricGroupFactory jobManagerJobMetricGroupFactory,
-				@Nullable String metricQueryServicePath,
-				@Nullable String restAddress) throws Exception {
+				JobManagerJobMetricGroupFactory jobManagerJobMetricGroupFactory) throws Exception {
 			assertEquals(expectedJobId, jobGraph.getJobID());
 
 			return Dispatcher.DefaultJobManagerRunnerFactory.INSTANCE.createJobManagerRunner(
@@ -494,9 +492,7 @@ public class DispatcherTest extends TestLogger {
 				heartbeatServices,
 				blobServer,
 				jobManagerSharedServices,
-				jobManagerJobMetricGroupFactory,
-				metricQueryServicePath,
-				restAddress);
+				jobManagerJobMetricGroupFactory);
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -96,6 +96,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.hamcrest.Matchers.contains;
@@ -103,11 +104,13 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -368,12 +371,12 @@ public class DispatcherTest extends TestLogger {
 	 */
 	@Test
 	public void testSavepointDisposal() throws Exception {
+		final URI externalPointer = createTestingSavepoint();
+		final Path savepointPath = Paths.get(externalPointer);
+
 		final DispatcherGateway dispatcherGateway = dispatcher.getSelfGateway(DispatcherGateway.class);
 
 		dispatcherLeaderElectionService.isLeader(UUID.randomUUID()).get();
-
-		final URI externalPointer = createTestingSavepoint();
-		final Path savepointPath = Paths.get(externalPointer);
 
 		assertThat(Files.exists(savepointPath), is(true));
 
@@ -397,6 +400,35 @@ public class DispatcherTest extends TestLogger {
 		final CompletedCheckpointStorageLocation completedCheckpointStorageLocation = metadataOutputStream.closeAndFinalizeCheckpoint();
 
 		return new URI(completedCheckpointStorageLocation.getExternalPointer());
+
+	}
+
+	/**
+	 * Tests that we wait until the JobMaster has gained leader ship before sending requests
+	 * to it. See FLINK-8887.
+	 */
+	@Test
+	public void testWaitingForJobMasterLeadership() throws ExecutionException, InterruptedException {
+		final DispatcherGateway dispatcherGateway = dispatcher.getSelfGateway(DispatcherGateway.class);
+
+		dispatcherLeaderElectionService.isLeader(UUID.randomUUID()).get();
+
+		dispatcherGateway.submitJob(jobGraph, TIMEOUT).get();
+
+		final CompletableFuture<JobStatus> jobStatusFuture = dispatcherGateway.requestJobStatus(jobGraph.getJobID(), TIMEOUT);
+
+		assertThat(jobStatusFuture.isDone(), is(false));
+
+		try {
+			jobStatusFuture.get(10, TimeUnit.MILLISECONDS);
+			fail("Should not complete.");
+		} catch (TimeoutException ignored) {
+			// ignored
+		}
+
+		jobMasterLeaderElectionService.isLeader(UUID.randomUUID()).get();
+
+		assertThat(jobStatusFuture.get(), notNullValue());
 	}
 
 	private static class TestingDispatcher extends Dispatcher {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -43,11 +43,11 @@ import org.apache.flink.runtime.jobmanager.SubmittedJobGraphStore;
 import org.apache.flink.runtime.jobmaster.JobManagerRunner;
 import org.apache.flink.runtime.jobmaster.JobManagerSharedServices;
 import org.apache.flink.runtime.jobmaster.JobResult;
+import org.apache.flink.runtime.jobmaster.factories.JobManagerJobMetricGroupFactory;
 import org.apache.flink.runtime.leaderelection.TestingLeaderElectionService;
 import org.apache.flink.runtime.leaderretrieval.SettableLeaderRetrievalService;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.messages.FlinkJobNotFoundException;
-import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
 import org.apache.flink.runtime.metrics.groups.JobManagerMetricGroup;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
@@ -480,7 +480,7 @@ public class DispatcherTest extends TestLogger {
 				HeartbeatServices heartbeatServices,
 				BlobServer blobServer,
 				JobManagerSharedServices jobManagerSharedServices,
-				JobManagerJobMetricGroup jobManagerJobMetricGroup,
+				JobManagerJobMetricGroupFactory jobManagerJobMetricGroupFactory,
 				@Nullable String metricQueryServicePath,
 				@Nullable String restAddress) throws Exception {
 			assertEquals(expectedJobId, jobGraph.getJobID());
@@ -494,7 +494,7 @@ public class DispatcherTest extends TestLogger {
 				heartbeatServices,
 				blobServer,
 				jobManagerSharedServices,
-				jobManagerJobMetricGroup,
+				jobManagerJobMetricGroupFactory,
 				metricQueryServicePath,
 				restAddress);
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/MiniDispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/MiniDispatcherTest.java
@@ -34,8 +34,8 @@ import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobmaster.JobManagerRunner;
 import org.apache.flink.runtime.jobmaster.JobManagerSharedServices;
 import org.apache.flink.runtime.jobmaster.JobResult;
+import org.apache.flink.runtime.jobmaster.factories.JobManagerJobMetricGroupFactory;
 import org.apache.flink.runtime.leaderelection.TestingLeaderElectionService;
-import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.resourcemanager.utils.TestingResourceManagerGateway;
 import org.apache.flink.runtime.rest.handler.legacy.utils.ArchivedExecutionGraphBuilder;
@@ -284,7 +284,7 @@ public class MiniDispatcherTest extends TestLogger {
 				HeartbeatServices heartbeatServices,
 				BlobServer blobServer,
 				JobManagerSharedServices jobManagerSharedServices,
-				JobManagerJobMetricGroup jobManagerJobMetricGroup,
+				JobManagerJobMetricGroupFactory jobManagerJobMetricGroupFactory,
 				@Nullable String metricQueryServicePath,
 				@Nullable String restAddress) throws Exception {
 			jobGraphFuture.complete(jobGraph);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/MiniDispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/MiniDispatcherTest.java
@@ -56,7 +56,6 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.UUID;
@@ -284,9 +283,7 @@ public class MiniDispatcherTest extends TestLogger {
 				HeartbeatServices heartbeatServices,
 				BlobServer blobServer,
 				JobManagerSharedServices jobManagerSharedServices,
-				JobManagerJobMetricGroupFactory jobManagerJobMetricGroupFactory,
-				@Nullable String metricQueryServicePath,
-				@Nullable String restAddress) throws Exception {
+				JobManagerJobMetricGroupFactory jobManagerJobMetricGroupFactory) throws Exception {
 			jobGraphFuture.complete(jobGraph);
 
 			final JobManagerRunner mock = mock(JobManagerRunner.class);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobManagerRunnerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobManagerRunnerTest.java
@@ -30,9 +30,9 @@ import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobmaster.factories.UnregisteredJobManagerJobMetricGroupFactory;
 import org.apache.flink.runtime.leaderelection.TestingLeaderElectionService;
 import org.apache.flink.runtime.leaderretrieval.SettableLeaderRetrievalService;
-import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.rest.handler.legacy.utils.ArchivedExecutionGraphBuilder;
 import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
@@ -210,7 +210,7 @@ public class JobManagerRunnerTest extends TestLogger {
 			heartbeatServices,
 			blobServer,
 			jobManagerSharedServices,
-			UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup(),
+			UnregisteredJobManagerJobMetricGroupFactory.INSTANCE,
 			null,
 			null);
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobManagerRunnerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobManagerRunnerTest.java
@@ -210,8 +210,6 @@ public class JobManagerRunnerTest extends TestLogger {
 			heartbeatServices,
 			blobServer,
 			jobManagerSharedServices,
-			UnregisteredJobManagerJobMetricGroupFactory.INSTANCE,
-			null,
-			null);
+			UnregisteredJobManagerJobMetricGroupFactory.INSTANCE);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -45,9 +45,9 @@ import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
 import org.apache.flink.runtime.jobgraph.tasks.JobCheckpointingSettings;
 import org.apache.flink.runtime.jobmanager.OnCompletionActions;
+import org.apache.flink.runtime.jobmaster.factories.UnregisteredJobManagerJobMetricGroupFactory;
 import org.apache.flink.runtime.leaderretrieval.SettableLeaderRetrievalService;
 import org.apache.flink.runtime.messages.Acknowledge;
-import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.registration.RegistrationResponse;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
 import org.apache.flink.runtime.resourcemanager.utils.TestingResourceManagerGateway;
@@ -299,6 +299,8 @@ public class JobMasterTest extends TestLogger {
 			haServices,
 			new TestingJobManagerSharedServicesBuilder().build());
 
+		jobMaster.start(JobMasterId.generate(), testingTimeout).get();
+
 		try {
 			// starting the JobMaster should have read the savepoint
 			final CompletedCheckpoint savepointCheckpoint = completedCheckpointStore.getLatestCheckpoint();
@@ -411,7 +413,7 @@ public class JobMasterTest extends TestLogger {
 			jobManagerSharedServices,
 			fastHeartbeatServices,
 			blobServer,
-			UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup(),
+			UnregisteredJobManagerJobMetricGroupFactory.INSTANCE,
 			new NoOpOnCompletionActions(),
 			testingFatalErrorHandler,
 			JobMasterTest.class.getClassLoader(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -299,8 +299,6 @@ public class JobMasterTest extends TestLogger {
 			haServices,
 			new TestingJobManagerSharedServicesBuilder().build());
 
-		jobMaster.start(JobMasterId.generate(), testingTimeout).get();
-
 		try {
 			// starting the JobMaster should have read the savepoint
 			final CompletedCheckpoint savepointCheckpoint = completedCheckpointStore.getLatestCheckpoint();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -414,9 +414,7 @@ public class JobMasterTest extends TestLogger {
 			UnregisteredJobManagerJobMetricGroupFactory.INSTANCE,
 			new NoOpOnCompletionActions(),
 			testingFatalErrorHandler,
-			JobMasterTest.class.getClassLoader(),
-			null,
-			null);
+			JobMasterTest.class.getClassLoader());
 	}
 
 	/**


### PR DESCRIPTION
## What is the purpose of the change

Before sending requests from the Dispatcher to the JobMasters, the Dispatcher must
wait until the respective JobMaster has gained leadership. Otherwise we might risk
that the messages are ignored because no fencing token was set.

This is solved by letting the JobManagerRunner expose a CompletableFuture<JobMasterGateway>
which is only completed after the JobMaster has gained leadership. The future is cleared
once the leadership is revoked.

cc @GJL 

## Brief change log

- confirm leader session after `JobMaster` is started by `JobManagerRunner`
- expose `JobMasterGateway` as a future in `JobManagerRunner`
- Wait for the `JobMasterGateway#getLeaderGatewayFuture` completion before sending messages from the `Dispatcher` to the `JobMaster`

## Verifying this change

- Added `DispatcherTest#testWaitingForJobMasterLeadership`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
