### PR TITLE
[FLINK-9086] Use INTERNAL_HADOOP_CLASSPATHS as classpath for Yarn Session

### DIFF
--- a/flink-scala-shell/start-script/start-scala-shell.sh
+++ b/flink-scala-shell/start-script/start-scala-shell.sh
@@ -79,7 +79,7 @@ log_setting=""
 
 if [[ $1 = "yarn" ]]
 then
-FLINK_CLASSPATH=$FLINK_CLASSPATH:$HADOOP_CLASSPATH:$HADOOP_CONF_DIR:$YARN_CONF_DIR
+FLINK_CLASSPATH=$FLINK_CLASSPATH:$INTERNAL_HADOOP_CLASSPATHS:$HADOOP_CONF_DIR:$YARN_CONF_DIR
 log=$FLINK_LOG_DIR/flink-$FLINK_IDENT_STRING-scala-shell-yarn-$HOSTNAME.log
 log_setting="-Dlog.file="$log" -Dlog4j.configuration=file:"$FLINK_CONF_DIR"/log4j-yarn-session.properties -Dlogback.configurationFile=file:"$FLINK_CONF_DIR"/logback-yarn.xml"
 fi


### PR DESCRIPTION
## What is the purpose of the change

* This change improves user experience for Flink on some environments such as AWS, which don't have hadoop jars in `HADOOP_CLASSPATH` but has `hadoop classpath` result set in `INTERNAL_HADOOP_CLASSPATHS` by `config.sh`. With this commit, users don't have to set `HADOOP_CLASSPATH` manually.

## Brief change log
  - Change `HADOOP_CLASSPATH` with `INTERNAL_HADOOP_CLASSPATHS` in `start-scala-shell.sh`.

## Verifying this change

  - Test on AWS environment to start a Flink Yarn cluster for Scala Shell.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
