### PR TITLE
[FLINK-9069] Add checkstyle rule to detect multiple consecutive semicolons

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/HistoryServerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/HistoryServerOptions.java
@@ -34,7 +34,7 @@ public class HistoryServerOptions {
 	public static final ConfigOption<Long> HISTORY_SERVER_ARCHIVE_REFRESH_INTERVAL =
 		key("historyserver.archive.fs.refresh-interval")
 			.defaultValue(10000L)
-			.withDescription("Interval in milliseconds for refreshing the archived job directories.");;
+			.withDescription("Interval in milliseconds for refreshing the archived job directories.");
 
 	/**
 	 * Comma-separated list of directories which the HistoryServer polls for new archives.

--- a/flink-libraries/flink-table/src/main/java/org/apache/calcite/avatica/util/DateTimeUtils.java
+++ b/flink-libraries/flink-table/src/main/java/org/apache/calcite/avatica/util/DateTimeUtils.java
@@ -427,7 +427,7 @@ public class DateTimeUtils {
 	}
 
 	public static int digitCount(int v) {
-		for (int n = 1;; n++) {
+		for (int n = 1; true; n++) {
 			v /= 10;
 			if (v == 0) {
 				return n;
@@ -960,7 +960,7 @@ public class DateTimeUtils {
 		// Start with an estimate.
 		// Since no month has more than 31 days, the estimate is <= the true value.
 		int m = (date0 - date1) / 31;
-		for (;;) {
+		while (true) {
 			int date2 = addMonths(date1, m);
 			if (date2 >= date0) {
 				return m;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueueTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueueTest.java
@@ -165,7 +165,7 @@ public class PartitionRequestQueueTest {
 		private final AtomicInteger buffersInBacklog;
 
 		private DefaultBufferResultSubpartitionView(int buffersInBacklog) {
-			this.buffersInBacklog = new AtomicInteger(buffersInBacklog);;
+			this.buffersInBacklog = new AtomicInteger(buffersInBacklog);
 		}
 
 		@Nullable

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterClient.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterClient.java
@@ -244,7 +244,7 @@ public class YarnClusterClient extends ClusterClient<ApplicationId> {
 	public void waitForClusterToBeReady() {
 		logAndSysout("Waiting until all TaskManagers have connected");
 
-		for (GetClusterStatusResponse currentStatus, lastStatus = null;; lastStatus = currentStatus) {
+		for (GetClusterStatusResponse currentStatus, lastStatus = null; true; lastStatus = currentStatus) {
 			currentStatus = getClusterStatus();
 			if (currentStatus != null && !currentStatus.equals(lastStatus)) {
 				logAndSysout("TaskManager status (" + currentStatus.numRegisteredTaskManagers() + "/"

--- a/tools/maven/checkstyle.xml
+++ b/tools/maven/checkstyle.xml
@@ -462,6 +462,13 @@ This file is based on the checkstyle file of Apache Beam.
     <!-- Detects empty statements (standalone ";" semicolon). -->
     <module name="EmptyStatement"/>
 
+	<!-- Detect multiple consecutive semicolons (e.g. ";;"). -->
+	<module name="RegexpSinglelineJava">
+	  <property name="format" value=";{2,}"/>
+	  <property name="message" value="Use one semicolon"/>
+	  <property name="ignoreComments" value="true"/>
+	</module>
+
     <!--
 
     MODIFIERS CHECKS


### PR DESCRIPTION
## What is the purpose of the change

This pull request introduces a new checkstyle rule that detects multiple multiple consecutive semicolons like those at the end of a Java statement.

## Brief change log

  - Add new checkstyle rule.
  - Fix violations of new checkstyle rule.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
