### PR TITLE
[FLINK-9064] Add Scaladocs link to documentation

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -32,6 +32,7 @@ version: "1.6-SNAPSHOT"
 # release this should be the same as the regular version
 version_title: "1.6-SNAPSHOT"
 version_javadocs: "1.6-SNAPSHOT"
+version_scaladocs: "1.6-SNAPSHOT"
 
 # This suffix is appended to the Scala-dependent Maven artifact names
 scala_version_suffix: "_2.11"

--- a/docs/_includes/sidenav.html
+++ b/docs/_includes/sidenav.html
@@ -127,6 +127,7 @@ level is determined by 'nav-pos'.
 {% endfor %}
   <li class="divider"></li>
   <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-{{site.version_javadocs}}/api/java"><i class="fa fa-external-link title" aria-hidden="true"></i> Javadocs</a></li>
+  <li><a href="https://ci.apache.org/projects/flink/flink-docs-release-{{site.version_scaladocs}}/api/scala/index.html#org.apache.flink.api.scala.package"><i class="fa fa-external-link title" aria-hidden="true"></i> Scaladocs</a></li>
   <li><a href="http://flink.apache.org"><i class="fa fa-external-link title" aria-hidden="true"></i> Project Page</a></li>
 </ul>
 

--- a/tools/releasing/create_release_branch.sh
+++ b/tools/releasing/create_release_branch.sh
@@ -59,6 +59,7 @@ perl -pi -e "s#^version: .*#version: \"${NEW_VERSION}\"#" _config.yml
 VERSION_TITLE=$(echo $NEW_VERSION | sed 's/\.[^.]*$//')
 perl -pi -e "s#^version_title: .*#version_title: ${VERSION_TITLE}#" _config.yml
 perl -pi -e "s#^version_javadocs: .*#version_javadocs: ${VERSION_TITLE}#" _config.yml
+perl -pi -e "s#^version_scaladocs: .*#version_scaladocs: ${VERSION_TITLE}#" _config.yml
 cd ..
 
 git commit -am "Commit for release $NEW_VERSION"

--- a/tools/releasing/update_branch_version.sh
+++ b/tools/releasing/update_branch_version.sh
@@ -48,6 +48,7 @@ cd docs
 perl -pi -e "s#^version: .*#version: \"${NEW_VERSION}\"#" _config.yml
 perl -pi -e "s#^version_title: .*#version_title: \"${NEW_VERSION}\"#" _config.yml
 perl -pi -e "s#^version_javadocs: .*#version_javadocs: \"${NEW_VERSION}\"#" _config.yml
+perl -pi -e "s#^version_scaladocs: .*#version_scaladocs: \"${NEW_VERSION}\"#" _config.yml
 cd ..
 
 git commit -am "Update version to $NEW_VERSION"


### PR DESCRIPTION
## What is the purpose of the change

*This pull request adds Scaladocs link to documentation*


## Brief change log

  - *adds Scaladocs link to documentation*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
