### PR TITLE
[FLINK-9097] Fail fatally if job submission fails when recovering jobs

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -267,7 +267,8 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 					heartbeatServices,
 					blobServer,
 					jobManagerSharedServices,
-					new DefaultJobManagerJobMetricGroupFactory(jobManagerMetricGroup));
+					new DefaultJobManagerJobMetricGroupFactory(jobManagerMetricGroup),
+					fatalErrorHandler);
 
 				jobManagerRunner.getResultFuture().whenCompleteAsync(
 					(ArchivedExecutionGraph archivedExecutionGraph, Throwable throwable) -> {
@@ -587,8 +588,6 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 	}
 
 	protected void onFatalError(Throwable throwable) {
-		log.error("Fatal error occurred in dispatcher {}.", getAddress(), throwable);
-
 		fatalErrorHandler.onFatalError(throwable);
 	}
 
@@ -790,7 +789,8 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 			HeartbeatServices heartbeatServices,
 			BlobServer blobServer,
 			JobManagerSharedServices jobManagerServices,
-			JobManagerJobMetricGroupFactory jobManagerJobMetricGroupFactory) throws Exception;
+			JobManagerJobMetricGroupFactory jobManagerJobMetricGroupFactory,
+			FatalErrorHandler fatalErrorHandler) throws Exception;
 	}
 
 	/**
@@ -809,7 +809,8 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 				HeartbeatServices heartbeatServices,
 				BlobServer blobServer,
 				JobManagerSharedServices jobManagerServices,
-				JobManagerJobMetricGroupFactory jobManagerJobMetricGroupFactory) throws Exception {
+				JobManagerJobMetricGroupFactory jobManagerJobMetricGroupFactory,
+				FatalErrorHandler fatalErrorHandler) throws Exception {
 			return new JobManagerRunner(
 				resourceId,
 				jobGraph,
@@ -819,7 +820,8 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 				heartbeatServices,
 				blobServer,
 				jobManagerServices,
-				jobManagerJobMetricGroupFactory);
+				jobManagerJobMetricGroupFactory,
+				fatalErrorHandler);
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/OnCompletionActions.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/OnCompletionActions.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.jobmanager;
 
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
+import org.apache.flink.runtime.jobmaster.JobMaster;
 
 /**
  * Interface for completion actions once a Flink job has reached
@@ -37,4 +38,9 @@ public interface OnCompletionActions {
 	 * Job was finished by another JobMaster.
 	 */
 	void jobFinishedByOther();
+
+	/**
+	 * The {@link JobMaster} failed while executing the job.
+	 */
+	void jobMasterFailed(Throwable cause);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/SubmittedJobGraphStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/SubmittedJobGraphStore.java
@@ -20,6 +20,8 @@ package org.apache.flink.runtime.jobmanager;
 
 import org.apache.flink.api.common.JobID;
 
+import javax.annotation.Nullable;
+
 import java.util.Collection;
 
 /**
@@ -38,10 +40,10 @@ public interface SubmittedJobGraphStore {
 	void stop() throws Exception;
 
 	/**
-	 * Returns the {@link SubmittedJobGraph} with the given {@link JobID}.
-	 *
-	 * <p>An Exception is thrown, if no job graph with the given ID exists.
+	 * Returns the {@link SubmittedJobGraph} with the given {@link JobID} or
+	 * {@code null} if no job was registered.
 	 */
+	@Nullable
 	SubmittedJobGraph recoverJobGraph(JobID jobId) throws Exception;
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/ZooKeeperSubmittedJobGraphStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/ZooKeeperSubmittedJobGraphStore.java
@@ -33,6 +33,8 @@ import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -158,6 +160,7 @@ public class ZooKeeperSubmittedJobGraphStore implements SubmittedJobGraphStore {
 	}
 
 	@Override
+	@Nullable
 	public SubmittedJobGraph recoverJobGraph(JobID jobId) throws Exception {
 		checkNotNull(jobId, "Job ID");
 		final String path = getPathForJob(jobId);
@@ -179,7 +182,7 @@ public class ZooKeeperSubmittedJobGraphStore implements SubmittedJobGraphStore {
 					return null;
 				} catch (Exception e) {
 					throw new FlinkException("Could not retrieve the submitted job graph state handle " +
-						"for " + path + "from the submitted job graph store.", e);
+						"for " + path + " from the submitted job graph store.", e);
 				}
 				SubmittedJobGraph jobGraph;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/FencedRpcEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/FencedRpcEndpoint.java
@@ -19,13 +19,16 @@
 package org.apache.flink.runtime.rpc;
 
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.util.Preconditions;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.io.Serializable;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 
 /**
  * Base class for fenced {@link RpcEndpoint}. A fenced rpc endpoint expects all rpc messages
@@ -37,14 +40,21 @@ import java.util.concurrent.CompletableFuture;
  */
 public abstract class FencedRpcEndpoint<F extends Serializable> extends RpcEndpoint {
 
+	private final UnfencedMainThreadExecutor unfencedMainThreadExecutor;
 	private volatile F fencingToken;
 	private volatile MainThreadExecutor fencedMainThreadExecutor;
 
 	protected FencedRpcEndpoint(RpcService rpcService, String endpointId) {
 		super(rpcService, endpointId);
 
+		Preconditions.checkArgument(
+			rpcServer instanceof FencedMainThreadExecutable,
+			"The rpcServer must be of type %s.",
+			FencedMainThreadExecutable.class.getSimpleName());
+
 		// no fencing token == no leadership
 		this.fencingToken = null;
+		this.unfencedMainThreadExecutor = new UnfencedMainThreadExecutor((FencedMainThreadExecutable) rpcServer);
 		this.fencedMainThreadExecutor = new MainThreadExecutor(
 			getRpcService().fenceRpcServer(
 				rpcServer,
@@ -87,6 +97,17 @@ public abstract class FencedRpcEndpoint<F extends Serializable> extends RpcEndpo
 	}
 
 	/**
+	 * Returns a main thread executor which is not bound to the fencing token.
+	 * This means that {@link Runnable} which are executed with this executor will always
+	 * be executed.
+	 *
+	 * @return MainThreadExecutor which is not bound to the fencing token
+	 */
+	protected Executor getUnfencedMainThreadExecutor() {
+		return unfencedMainThreadExecutor;
+	}
+
+	/**
 	 * Run the given runnable in the main thread of the RpcEndpoint without checking the fencing
 	 * token. This allows to run operations outside of the fencing token scope.
 	 *
@@ -113,6 +134,27 @@ public abstract class FencedRpcEndpoint<F extends Serializable> extends RpcEndpo
 			return ((FencedMainThreadExecutable) rpcServer).callAsyncWithoutFencing(callable, timeout);
 		} else {
 			throw new RuntimeException("FencedRpcEndpoint has not been started with a FencedMainThreadExecutable RpcServer.");
+		}
+	}
+
+	// ------------------------------------------------------------------------
+	//  Utilities
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Executor which executes {@link Runnable} in the main thread context without fencing.
+	 */
+	private static class UnfencedMainThreadExecutor implements Executor {
+
+		private final FencedMainThreadExecutable gateway;
+
+		UnfencedMainThreadExecutor(FencedMainThreadExecutable gateway) {
+			this.gateway = Preconditions.checkNotNull(gateway);
+		}
+
+		@Override
+		public void execute(@Nonnull Runnable runnable) {
+			gateway.runAsyncWithoutFencing(runnable);
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherTest.java
@@ -585,7 +585,8 @@ public class DispatcherTest extends TestLogger {
 				HeartbeatServices heartbeatServices,
 				BlobServer blobServer,
 				JobManagerSharedServices jobManagerSharedServices,
-				JobManagerJobMetricGroupFactory jobManagerJobMetricGroupFactory) throws Exception {
+				JobManagerJobMetricGroupFactory jobManagerJobMetricGroupFactory,
+				FatalErrorHandler fatalErrorHandler) throws Exception {
 			assertEquals(expectedJobId, jobGraph.getJobID());
 
 			return Dispatcher.DefaultJobManagerRunnerFactory.INSTANCE.createJobManagerRunner(
@@ -597,7 +598,8 @@ public class DispatcherTest extends TestLogger {
 				heartbeatServices,
 				blobServer,
 				jobManagerSharedServices,
-				jobManagerJobMetricGroupFactory);
+				jobManagerJobMetricGroupFactory,
+				fatalErrorHandler);
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/MiniDispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/MiniDispatcherTest.java
@@ -39,6 +39,7 @@ import org.apache.flink.runtime.leaderelection.TestingLeaderElectionService;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.resourcemanager.utils.TestingResourceManagerGateway;
 import org.apache.flink.runtime.rest.handler.legacy.utils.ArchivedExecutionGraphBuilder;
+import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.rpc.TestingRpcService;
@@ -283,7 +284,8 @@ public class MiniDispatcherTest extends TestLogger {
 				HeartbeatServices heartbeatServices,
 				BlobServer blobServer,
 				JobManagerSharedServices jobManagerSharedServices,
-				JobManagerJobMetricGroupFactory jobManagerJobMetricGroupFactory) throws Exception {
+				JobManagerJobMetricGroupFactory jobManagerJobMetricGroupFactory,
+				FatalErrorHandler fatalErrorHandler) throws Exception {
 			jobGraphFuture.complete(jobGraph);
 
 			final JobManagerRunner mock = mock(JobManagerRunner.class);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobManagerRunnerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobManagerRunnerTest.java
@@ -36,6 +36,7 @@ import org.apache.flink.runtime.leaderretrieval.SettableLeaderRetrievalService;
 import org.apache.flink.runtime.rest.handler.legacy.utils.ArchivedExecutionGraphBuilder;
 import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
+import org.apache.flink.runtime.util.TestingFatalErrorHandler;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.TestLogger;
 
@@ -81,6 +82,8 @@ public class JobManagerRunnerTest extends TestLogger {
 
 	private TestingHighAvailabilityServices haServices;
 
+	private TestingFatalErrorHandler fatalErrorHandler;
+
 	@BeforeClass
 	public static void setupClass() throws Exception {
 		configuration = new Configuration();
@@ -110,11 +113,13 @@ public class JobManagerRunnerTest extends TestLogger {
 		haServices.setJobMasterLeaderElectionService(jobGraph.getJobID(), new TestingLeaderElectionService());
 		haServices.setResourceManagerLeaderRetriever(new SettableLeaderRetrievalService());
 		haServices.setCheckpointRecoveryFactory(new StandaloneCheckpointRecoveryFactory());
+
+		fatalErrorHandler = new TestingFatalErrorHandler();
 	}
 
 	@After
-	public void tearDown() {
-
+	public void tearDown() throws Exception {
+		fatalErrorHandler.rethrowError();
 	}
 
 	@AfterClass
@@ -210,6 +215,7 @@ public class JobManagerRunnerTest extends TestLogger {
 			heartbeatServices,
 			blobServer,
 			jobManagerSharedServices,
-			UnregisteredJobManagerJobMetricGroupFactory.INSTANCE);
+			UnregisteredJobManagerJobMetricGroupFactory.INSTANCE,
+			fatalErrorHandler);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -431,6 +431,11 @@ public class JobMasterTest extends TestLogger {
 		public void jobFinishedByOther() {
 
 		}
+
+		@Override
+		public void jobMasterFailed(Throwable cause) {
+
+		}
 	}
 
 	private static final class DummyCheckpointStorageLocation implements CompletedCheckpointStorageLocation {


### PR DESCRIPTION
## What is the purpose of the change

In order to not drop jobs, we have to fail fatally if a job submission fails when
recovering jobs. In HA mode, this will restart the Dispatcher and let it retry
to recover all jobs.

This PR is based on #5746.

cc @GJL 

## Brief change log

- Restructured `Dispatcher#submitJob` method
- Registered callback to listen to job submission result
- Fail `Dispatcher` if job submission result is a failure if recovering a job

## Verifying this change

- Added `DispatcherTest#testJobSubmissionErrorAfterJobRecovery`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
