### PR TITLE
[FLINK-8708] Unintended integer division in StandaloneThreadedGenerator

### DIFF
--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/statemachine/generator/StandaloneThreadedGenerator.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/statemachine/generator/StandaloneThreadedGenerator.java
@@ -235,7 +235,7 @@ public class StandaloneThreadedGenerator {
 					currCount += generator.currentCount();
 				}
 
-				double factor = (ts - lastTimeStamp) / 1000;
+				double factor = (ts - lastTimeStamp) / 1000.0;
 				double perSec = (currCount - lastCount) / factor;
 
 				lastTimeStamp = ts;


### PR DESCRIPTION
## What is the purpose of the change

*This pull request fixed unintended integer division in StandaloneThreadedGenerator*

## Brief change log

  - *Fixed unintended integer division in StandaloneThreadedGenerator*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
