### PR TITLE
[FLINK-9102][FLIP6] disable queued scheduling for JobGraph in Flip6LocalStreamEnvironment

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/Flip6LocalStreamEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/Flip6LocalStreamEnvironment.java
@@ -75,7 +75,7 @@ public class Flip6LocalStreamEnvironment extends LocalStreamEnvironment {
 		streamGraph.setJobName(jobName);
 
 		JobGraph jobGraph = streamGraph.getJobGraph();
-		jobGraph.setAllowQueuedScheduling(true);
+		jobGraph.setAllowQueuedScheduling(false);
 
 		Configuration configuration = new Configuration();
 		configuration.addAll(jobGraph.getJobConfiguration());


### PR DESCRIPTION
## What is the purpose of the change

When we start cluster locally with fixed TMS and build stream job with Flip6LocalStreamEnvironment, we should disable queued scheduling for JobGraph.

## Brief change log

- disable queued scheduling for JobGraph in Flip6LocalStreamEnvironment

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

- no