### PR TITLE
[FLINK-9106] [rpc] Add UnfencedMainThreadExecutor to FencedRpcEndpoint

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/FencedRpcEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/FencedRpcEndpoint.java
@@ -19,13 +19,16 @@
 package org.apache.flink.runtime.rpc;
 
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.util.Preconditions;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.io.Serializable;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 
 /**
  * Base class for fenced {@link RpcEndpoint}. A fenced rpc endpoint expects all rpc messages
@@ -37,14 +40,21 @@ import java.util.concurrent.CompletableFuture;
  */
 public abstract class FencedRpcEndpoint<F extends Serializable> extends RpcEndpoint {
 
+	private final UnfencedMainThreadExecutor unfencedMainThreadExecutor;
 	private volatile F fencingToken;
 	private volatile MainThreadExecutor fencedMainThreadExecutor;
 
 	protected FencedRpcEndpoint(RpcService rpcService, String endpointId) {
 		super(rpcService, endpointId);
 
+		Preconditions.checkArgument(
+			rpcServer instanceof FencedMainThreadExecutable,
+			"The rpcServer must be of type %s.",
+			FencedMainThreadExecutable.class.getSimpleName());
+
 		// no fencing token == no leadership
 		this.fencingToken = null;
+		this.unfencedMainThreadExecutor = new UnfencedMainThreadExecutor((FencedMainThreadExecutable) rpcServer);
 		this.fencedMainThreadExecutor = new MainThreadExecutor(
 			getRpcService().fenceRpcServer(
 				rpcServer,
@@ -87,6 +97,17 @@ public abstract class FencedRpcEndpoint<F extends Serializable> extends RpcEndpo
 	}
 
 	/**
+	 * Returns a main thread executor which is not bound to the fencing token.
+	 * This means that {@link Runnable} which are executed with this executor will always
+	 * be executed.
+	 *
+	 * @return MainThreadExecutor which is not bound to the fencing token
+	 */
+	protected Executor getUnfencedMainThreadExecutor() {
+		return unfencedMainThreadExecutor;
+	}
+
+	/**
 	 * Run the given runnable in the main thread of the RpcEndpoint without checking the fencing
 	 * token. This allows to run operations outside of the fencing token scope.
 	 *
@@ -113,6 +134,27 @@ public abstract class FencedRpcEndpoint<F extends Serializable> extends RpcEndpo
 			return ((FencedMainThreadExecutable) rpcServer).callAsyncWithoutFencing(callable, timeout);
 		} else {
 			throw new RuntimeException("FencedRpcEndpoint has not been started with a FencedMainThreadExecutable RpcServer.");
+		}
+	}
+
+	// ------------------------------------------------------------------------
+	//  Utilities
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Executor which executes {@link Runnable} in the main thread context without fencing.
+	 */
+	private static class UnfencedMainThreadExecutor implements Executor {
+
+		private final FencedMainThreadExecutable gateway;
+
+		UnfencedMainThreadExecutor(FencedMainThreadExecutable gateway) {
+			this.gateway = Preconditions.checkNotNull(gateway);
+		}
+
+		@Override
+		public void execute(@Nonnull Runnable runnable) {
+			gateway.runAsyncWithoutFencing(runnable);
 		}
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

The UnfencedMainThreadExecutor executed Runnables in the main thread context without
checking the fencing token. This is important to set a new fencing token, for example.

## Verifying this change

- Added `AsyncCallsTest#testUnfencedMainThreadExecutor`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
