### PR TITLE
[FLINK-9110][docs] fix local bundler installation

### DIFF
--- a/docs/build_docs.sh
+++ b/docs/build_docs.sh
@@ -27,16 +27,18 @@ DIR="`pwd`"
 
 # We need at least bundler to proceed
 if [ "`command -v bundle`" == "" ]; then
-	echo "WARN: Could not find bundle."
-    echo "Attempting to install locally. If this doesn't work, please install with 'gem install bundler'."
+	RUBYGEM_BINDIR=""
 
-    # Adjust the PATH to discover the locally installed Ruby gem
-    if which ${RUBY} >/dev/null && which gem >/dev/null; then
-        export PATH="$(${RUBY} -rubygems -e 'puts Gem.user_dir')/bin:$PATH"
-    fi
+	# Adjust the PATH to discover locally installed ruby gem binaries
+	export PATH="$(${RUBY} -e 'puts Gem.user_dir')/bin:$PATH"
 
-    # install bundler locally
-    ${GEM} install --user-install bundler
+	if [ "`command -v bundle`" == "" ]; then
+		echo "WARN: Could not find bundle."
+		echo "Attempting to install locally. If this doesn't work, please install with 'gem install bundler'."
+
+		# install bundler locally
+		${GEM} install --user-install --no-format-executable bundler
+	fi
 fi
 
 # Install Ruby dependencies locally

--- a/docs/build_docs.sh
+++ b/docs/build_docs.sh
@@ -59,7 +59,6 @@ while getopts "pi" opt; do
 		;;
 		i)
 		[[ `${RUBY} -v` =~ 'ruby 1' ]] && echo "Error: building the docs with the incremental option requires at least ruby 2.0" && exit 1
-		bundle install --path .rubydeps
 		JEKYLL_CMD="liveserve --baseurl= --watch --incremental"
 		;;
 	esac


### PR DESCRIPTION
## What is the purpose of the change

The fallback to installing `bundler` locally within `docs/build_docs.sh` did not work for several reasons:
- the `-rubygems` parameter to `ruby` is failing with Ruby 2.5:
```
> ruby -rubygems -e 'puts Gem.user_dir'
Traceback (most recent call last):
        1: from /usr/lib64/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
/usr/lib64/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require': cannot load such file -- ubygems (LoadError)
```
- the locally installed bundler formatted executables with the ruby version and was thus not available as `bundle`:
```
> find ~/.gem/ruby/2.*/bin
/home/nico/.gem/ruby/2.4.0/bin
/home/nico/.gem/ruby/2.4.0/bin/bundle.ruby2.4
/home/nico/.gem/ruby/2.4.0/bin/bundler.ruby2.4
/home/nico/.gem/ruby/2.5.0/bin
/home/nico/.gem/ruby/2.5.0/bin/bundle.ruby2.5
/home/nico/.gem/ruby/2.5.0/bin/bundler.ruby2.5
```

## Brief change log

- remove `-rubygems` parameter in `ruby` call
- do not echo a warning when a local `bundle` is found (adapt the `PATH` to look for that in a second step)
- install `bundler` locally with `--no-format-executable`

## Verifying this change

This change added tests and can be verified as follows:

- run `./docs/build_docs.sh` without globally installed `bundler`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
