### PR TITLE
[Flink-8563][Table API & SQL] add unittest for consecutive dot access of composite array element in SQL

### DIFF
--- a/flink-libraries/flink-table/pom.xml
+++ b/flink-libraries/flink-table/pom.xml
@@ -68,7 +68,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.calcite</groupId>
 			<artifactId>calcite-core</artifactId>
-			<version>1.15.0</version>
+			<version>1.16.0</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.apache.calcite.avatica</groupId>

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/logical/rel/LogicalWindowAggregate.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/logical/rel/LogicalWindowAggregate.scala
@@ -23,7 +23,7 @@ import java.util
 import org.apache.calcite.plan.{Convention, RelOptCluster, RelTraitSet}
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.core.{Aggregate, AggregateCall}
-import org.apache.calcite.rel.{RelNode, RelShuttle}
+import org.apache.calcite.rel.{RelNode, RelShuttle, RelWriter}
 import org.apache.calcite.util.ImmutableBitSet
 import org.apache.flink.table.calcite.FlinkRelBuilder.NamedWindowProperty
 import org.apache.flink.table.calcite.FlinkTypeFactory
@@ -44,6 +44,14 @@ class LogicalWindowAggregate(
   def getWindow: LogicalWindow = window
 
   def getNamedProperties: Seq[NamedWindowProperty] = namedProperties
+
+  override def explainTerms(pw: RelWriter): RelWriter = {
+    super.explainTerms(pw)
+    for (property <- namedProperties) {
+      pw.item(property.name, property.property)
+    }
+    pw
+  }
 
   override def copy(
       traitSet: RelTraitSet,

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/CompositeAccessTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/CompositeAccessTest.scala
@@ -162,6 +162,13 @@ class CompositeAccessTest extends CompositeTypeTestBase {
       "f12[1].arrayField[1].stringField",
       "Alice"
     )
+
+    testAllApis(
+      'f13.at(1).get("objectField").get("stringField"),
+      "f13.at(1).get('objectField').get('stringField')",
+      "f13[1].objectField.stringField",
+      "Bob"
+    )
   }
 }
 

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/utils/CompositeTypeTestBase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/utils/CompositeTypeTestBase.scala
@@ -28,7 +28,7 @@ import org.apache.flink.types.Row
 class CompositeTypeTestBase extends ExpressionTestBase {
 
   def testData: Row = {
-    val testData = new Row(13)
+    val testData = new Row(14)
     testData.setField(0, MyCaseClass(42, "Bob", booleanField = true))
     testData.setField(1, MyCaseClass2(MyCaseClass(25, "Timo", booleanField = false)))
     testData.setField(2, ("a", "b"))
@@ -42,6 +42,7 @@ class CompositeTypeTestBase extends ExpressionTestBase {
     testData.setField(10, Array(MyCaseClass(42, "Bob", booleanField = true)))
     testData.setField(11, Array(new MyPojo()))
     testData.setField(12, Array(MyCaseClass3(Array(MyCaseClass(42, "Alice", booleanField = true)))))
+    testData.setField(13, Array(MyCaseClass2(MyCaseClass(42, "Bob", booleanField = true))))
     testData
   }
 
@@ -59,7 +60,8 @@ class CompositeTypeTestBase extends ExpressionTestBase {
       createTypeInformation[Array[Tuple1[Boolean]]],
       createTypeInformation[Array[MyCaseClass]],
       createTypeInformation[Array[MyPojo]],
-      createTypeInformation[Array[MyCaseClass3]]
+      createTypeInformation[Array[MyCaseClass3]],
+      createTypeInformation[Array[MyCaseClass2]]
       ).asInstanceOf[TypeInformation[Any]]
   }
 }


### PR DESCRIPTION
 ## What is the purpose of the change

    add unittest for consecutive dot access of composite array element in SQL. This depends on https://github.com/apache/flink/pull/5791.


    ## Brief change log

      -  add unittest


    ## Verifying this change

    This change is already covered by existing tests.

    ## Does this pull request potentially affect one of the following parts:

      - Dependencies (does it add or upgrade a dependency): (no)
      - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (y no)
      - The serializers: (no)
      - The runtime per-record code paths (performance sensitive): (no)
      - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
      - The S3 file system connector: (no)

    ## Documentation

      - Does this pull request introduce a new feature? (no)
      - If yes, how is the feature documented? (not applicable)