### PR TITLE
[hotfix] [docs] fix  typos in Table API & SQL

### DIFF
--- a/docs/dev/table/common.md
+++ b/docs/dev/table/common.md
@@ -775,8 +775,8 @@ DataSet<Row> dsRow = tableEnv.toDataSet(table, Row.class);
 TupleTypeInfo<Tuple2<String, Integer>> tupleType = new TupleTypeInfo<>(
   Types.STRING(),
   Types.INT());
-DataStream<Tuple2<String, Integer>> dsTuple = 
-  tableEnv.toAppendStream(table, tupleType);
+DataSet<Tuple2<String, Integer>> dsTuple = 
+  tableEnv.toDataSet(table, tupleType);
 {% endhighlight %}
 </div>
 

--- a/docs/dev/table/streaming.md
+++ b/docs/dev/table/streaming.md
@@ -362,7 +362,7 @@ In either case the event time timestamp field will hold the value of the `DataSt
 // Option 1:
 
 // extract timestamp and assign watermarks based on knowledge of the stream
-DataStream<Tuple3<String, String>> stream = inputStream.assignTimestampsAndWatermarks(...);
+DataStream<Tuple2<String, String>> stream = inputStream.assignTimestampsAndWatermarks(...);
 
 // declare an additional logical field as an event time attribute
 Table table = tEnv.fromDataStream(stream, "Username, Data, UserActionTime.rowtime");


### PR DESCRIPTION
## Brief change log

- fix  mistake about Sample code in Concepts & Common API

- fix typo in table stream docs

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:
none
## Documentation
none
