### PR TITLE
[FLINK-7917] The return of taskInformationOrBlobKey should be placed inside synchronized in ExecutionJobVertex

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
@@ -395,9 +395,9 @@ public class ExecutionJobVertex implements AccessExecutionJobVertex, Archiveable
 					getJobId(),
 					blobWriter);
 			}
-		}
 
-		return taskInformationOrBlobKey;
+			return taskInformationOrBlobKey;
+		}
 	}
 
 	@Override


### PR DESCRIPTION
## What is the purpose of the change

*This pull request placed the  taskInformationOrBlobKey inside synchronized in ExecutionJobVertex*


## Brief change log

  - *Placed the  taskInformationOrBlobKey inside synchronized in ExecutionJobVertex*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
