### PR TITLE
[FLINK-7775] Remove unreferenced method PermanentBlobCache#getNumberOfCachedJobs

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/PermanentBlobCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/PermanentBlobCache.java
@@ -177,10 +177,6 @@ public class PermanentBlobCache extends AbstractBlobCache implements PermanentBl
 		}
 	}
 
-	public int getNumberOfCachedJobs() {
-		return jobRefCounters.size();
-	}
-
 	/**
 	 * Returns the path to a local copy of the file associated with the provided job ID and blob
 	 * key.


### PR DESCRIPTION
## What is the purpose of the change

*This pull request remove unreferenced method PermanentBlobCache#getNumberOfCachedJobs*

## Brief change log

  - *Remove unreferenced method PermanentBlobCache#getNumberOfCachedJobs*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
