### PR TITLE
[FLINK-8837] [DataStream API] add @Experimental annotation and properly annotate some classes

### DIFF
--- a/flink-annotations/src/main/java/org/apache/flink/annotation/Experimental.java
+++ b/flink-annotations/src/main/java/org/apache/flink/annotation/Experimental.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.flink.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to mark classes for experimental use.
+ *
+ * <p>Classes with this annotation are neither battle-tested nor stable, and may be changed or removed
+ * in future versions.
+ *
+ * <p>This annotation also excludes classes with evolving interfaces / signatures
+ * annotated with {@link Public} and {@link PublicEvolving}.
+ *
+ */
+@Documented
+@Target(ElementType.TYPE)
+@Public
+public @interface Experimental {
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamUtils.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamUtils.java
@@ -17,7 +17,7 @@
 
 package org.apache.flink.streaming.api.datastream;
 
-import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.Experimental;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.functions.KeySelector;
@@ -39,11 +39,8 @@ import java.util.Iterator;
 
 /**
  * A collection of utilities for {@link DataStream DataStreams}.
- *
- * <p>This experimental class is relocated from flink-streaming-contrib. Please see package-info.java
- * for more information.
  */
-@PublicEvolving
+@Experimental
 public final class DataStreamUtils {
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/experimental/CollectSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/experimental/CollectSink.java
@@ -17,7 +17,7 @@
 
 package org.apache.flink.streaming.experimental;
 
-import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.Experimental;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
@@ -34,7 +34,7 @@ import java.net.Socket;
  * <p>This experimental class is relocated from flink-streaming-contrib. Please see package-info.java
  * for more information.
  */
-@Internal
+@Experimental
 public class CollectSink<IN> extends RichSinkFunction<IN> {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/experimental/SocketStreamIterator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/experimental/SocketStreamIterator.java
@@ -17,7 +17,7 @@
 
 package org.apache.flink.streaming.experimental;
 
-import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.Experimental;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 
@@ -41,7 +41,7 @@ import java.util.NoSuchElementException;
  *
  * @param <T> The type of elements returned from the iterator.
  */
-@PublicEvolving
+@Experimental
 public class SocketStreamIterator<T> implements Iterator<T> {
 
 	/** Server socket to listen at. */

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStreamUtils.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStreamUtils.scala
@@ -18,7 +18,7 @@
 
 package org.apache.flink.streaming.api.scala
 
-import org.apache.flink.annotation.PublicEvolving
+import org.apache.flink.annotation.Experimental
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.streaming.api.datastream.{DataStreamUtils => JavaStreamUtils}
 
@@ -33,7 +33,7 @@ import scala.reflect.ClassTag
   *
   * @param self DataStream
   */
-@PublicEvolving
+@Experimental
 class DataStreamUtils[T: TypeInformation : ClassTag](val self: DataStream[T]) {
 
   /**


### PR DESCRIPTION
## What is the purpose of the change

- add @Experimental annotation
- properly annotate some classes with @Experimental 

## Brief change log

- add @Experimental annotation
- properly annotate some classes with @Experimental 

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
