### PR TITLE
[FLINK-9087] [runtime] change the method signature of RecordWriter.broadcastEvent() from BufferConsumer to void

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/RecordWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/RecordWriter.java
@@ -150,7 +150,7 @@ public class RecordWriter<T extends IOReadableWritable> {
 		}
 	}
 
-	public BufferConsumer broadcastEvent(AbstractEvent event) throws IOException {
+	public void broadcastEvent(AbstractEvent event) throws IOException {
 		try (BufferConsumer eventBufferConsumer = EventSerializer.toBufferConsumer(event)) {
 			for (int targetChannel = 0; targetChannel < numChannels; targetChannel++) {
 				RecordSerializer<T> serializer = serializers[targetChannel];
@@ -164,7 +164,6 @@ public class RecordWriter<T extends IOReadableWritable> {
 			if (flushAlways) {
 				flushAll();
 			}
-			return eventBufferConsumer;
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/RecordWriterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/RecordWriterTest.java
@@ -299,18 +299,23 @@ public class RecordWriterTest {
 			new CollectingPartitionWriter(queues, new TestPooledBufferProvider(Integer.MAX_VALUE));
 		RecordWriter<?> writer = new RecordWriter<>(partition);
 
-		BufferConsumer bufferConsumer = writer.broadcastEvent(EndOfPartitionEvent.INSTANCE);
+		writer.broadcastEvent(EndOfPartitionEvent.INSTANCE);
 
 		// Verify added to all queues
 		assertEquals(1, queues[0].size());
 		assertEquals(1, queues[1].size());
+
+		// get references to buffer consumers (copies from the original event buffer consumer)
+		BufferConsumer bufferConsumer1 = queues[0].getFirst();
+		BufferConsumer bufferConsumer2 = queues[1].getFirst();
 
 		// process all collected events (recycles the buffer)
 		for (int i = 0; i < queues.length; i++) {
 			assertTrue(parseBuffer(queues[i].remove(), i).isEvent());
 		}
 
-		assertTrue(bufferConsumer.isRecycled());
+		assertTrue(bufferConsumer1.isRecycled());
+		assertTrue(bufferConsumer2.isRecycled());
 	}
 
 	/**


### PR DESCRIPTION
## What is the purpose of the change

RecordWriter.broadcastEvent() return value never used, so change the method signature from   BufferConsumer to void


## Brief change log

RecordWriter.broadcastEvent()  is called in StreamTask., RecordWriterOutput ,IterationIntermediateTask and IterationHeadTaskbroadcastEvent, also notice that no one make use of the BufferConsumer returned by broadcastEvent(), change  the method signature from   BufferConsumer to void.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
