### PR TITLE
[FLINK-8982][E2E Tests] Add test for known failure of queryable state

### DIFF
--- a/flink-end-to-end-tests/flink-queryable-state-test/pom.xml
+++ b/flink-end-to-end-tests/flink-queryable-state-test/pom.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+    -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<parent>
+		<artifactId>flink-end-to-end-tests</artifactId>
+		<groupId>org.apache.flink</groupId>
+		<version>1.6-SNAPSHOT</version>
+	</parent>
+	<modelVersion>4.0.0</modelVersion>
+
+	<artifactId>flink-queryable-state-test_${scala.binary.version}</artifactId>
+	<name>flink-queryable-state-test</name>
+
+	<packaging>jar</packaging>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-core</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-statebackend-rocksdb_2.11</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<version>2.4</version>
+
+				<executions>
+					<execution>
+						<id>QsStateProducer</id>
+						<phase>package</phase>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+						<configuration>
+							<classifier>QsStateProducer</classifier>
+							<archive>
+								<manifestEntries>
+									<program-class>
+										org.apache.flink.streaming.tests.queryablestate.QsStateProducer
+									</program-class>
+								</manifestEntries>
+							</archive>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+
+					<execution>
+						<id>QsStateClient</id>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<shadeTestJar>false</shadeTestJar>
+							<shadedArtifactAttached>false</shadedArtifactAttached>
+							<createDependencyReducedPom>false</createDependencyReducedPom>
+							<transformers>
+								<transformer
+									implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+									<mainClass>
+										org.apache.flink.streaming.tests.queryablestate.QsStateClient
+									</mainClass>
+								</transformer>
+							</transformers>
+							<finalName>QsStateClient</finalName>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
+			<!--simplify the name of the testing JARs for referring to them in the end-to-end test scripts-->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-antrun-plugin</artifactId>
+				<version>1.7</version>
+				<executions>
+					<execution>
+						<id>rename</id>
+						<phase>package</phase>
+						<goals>
+							<goal>run</goal>
+						</goals>
+						<configuration>
+							<target>
+								<copy
+									file="${project.basedir}/target/flink-queryable-state-test_${scala.binary.version}-${project.version}-QsStateProducer.jar"
+									tofile="${project.basedir}/target/QsStateProducer.jar"/>
+							</target>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/flink-end-to-end-tests/flink-queryable-state-test/src/main/java/org/apache/flink/streaming/tests/queryablestate/Email.java
+++ b/flink-end-to-end-tests/flink-queryable-state-test/src/main/java/org/apache/flink/streaming/tests/queryablestate/Email.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.tests.queryablestate;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Toy email resentation.
+ */
+public class Email {
+
+	private EmailId emailId;
+	private Instant timestamp;
+	private String foo;
+	private LabelSurrogate label;
+
+	public Email(EmailId emailId, Instant timestamp, String foo, LabelSurrogate label) {
+		this.emailId = emailId;
+		this.timestamp = timestamp;
+		this.foo = foo;
+		this.label = label;
+	}
+
+	public EmailId getEmailId() {
+		return emailId;
+	}
+
+	public void setEmailId(EmailId emailId) {
+		this.emailId = emailId;
+	}
+
+	public Instant getTimestamp() {
+		return timestamp;
+	}
+
+	public void setTimestamp(Instant timestamp) {
+		this.timestamp = timestamp;
+	}
+
+	public String getFoo() {
+		return foo;
+	}
+
+	public void setFoo(String foo) {
+		this.foo = foo;
+	}
+
+	public LabelSurrogate getLabel() {
+		return label;
+	}
+
+	public void setLabel(LabelSurrogate label) {
+		this.label = label;
+	}
+
+	public String getDate() {
+		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneId.of("UTC"));
+		return formatter.format(timestamp);
+	}
+}

--- a/flink-end-to-end-tests/flink-queryable-state-test/src/main/java/org/apache/flink/streaming/tests/queryablestate/EmailId.java
+++ b/flink-end-to-end-tests/flink-queryable-state-test/src/main/java/org/apache/flink/streaming/tests/queryablestate/EmailId.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.tests.queryablestate;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * POJO representing an EmailId.
+ */
+public class EmailId implements Serializable {
+
+	private static final long serialVersionUID = -5001464312464872467L;
+
+	private String emailId;
+
+	public EmailId() {
+
+	}
+
+	public EmailId(String emailId) {
+		this.emailId = Objects.requireNonNull(emailId);
+	}
+
+	public void setEmailId(String emailId) {
+		this.emailId = emailId;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+
+		EmailId emailId1 = (EmailId) o;
+
+		return Objects.equals(emailId, emailId1.emailId);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(emailId);
+	}
+
+	public String getEmailId() {
+		return emailId;
+	}
+
+	@Override
+	public String toString() {
+		return "EmailId{" +
+				"emailId='" + emailId + '\'' +
+				'}';
+	}
+}

--- a/flink-end-to-end-tests/flink-queryable-state-test/src/main/java/org/apache/flink/streaming/tests/queryablestate/EmailInformation.java
+++ b/flink-end-to-end-tests/flink-queryable-state-test/src/main/java/org/apache/flink/streaming/tests/queryablestate/EmailInformation.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.tests.queryablestate;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * POJO representing some information about an email.
+ */
+public class EmailInformation implements Serializable {
+
+	private static final long serialVersionUID = -8956979869800484909L;
+
+	public void setEmailId(EmailId emailId) {
+		this.emailId = emailId;
+	}
+
+	private EmailId emailId;
+
+	public void setStuff(List<String> stuff) {
+		this.stuff = stuff;
+	}
+
+	private List<String> stuff;
+
+	public void setAsdf(Long asdf) {
+		this.asdf = asdf;
+	}
+
+	private Long asdf = 0L;
+
+	private transient LabelSurrogate label;
+
+	public EmailInformation() {
+
+	}
+
+	public EmailInformation(Email email) {
+		emailId = email.getEmailId();
+		stuff = new ArrayList<>();
+		stuff.add("1");
+		stuff.add("2");
+		stuff.add("3");
+		label = email.getLabel();
+	}
+
+	public EmailId getEmailId() {
+		return emailId;
+	}
+
+	public List<String> getStuff() {
+		return stuff;
+	}
+
+	public Long getAsdf() {
+		return asdf;
+	}
+
+	public LabelSurrogate getLabel() {
+		return label;
+	}
+
+	public void setLabel(LabelSurrogate label) {
+		this.label = label;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		EmailInformation that = (EmailInformation) o;
+		return Objects.equals(emailId, that.emailId) &&
+				Objects.equals(stuff, that.stuff) &&
+				Objects.equals(asdf, that.asdf) &&
+				Objects.equals(label, that.label);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(emailId, stuff, asdf, label);
+	}
+
+	@Override
+	public String toString() {
+		return "EmailInformation{" +
+				"emailId=" + emailId +
+				", stuff=" + stuff +
+				", asdf=" + asdf +
+				", label=" + label +
+				'}';
+	}
+}

--- a/flink-end-to-end-tests/flink-queryable-state-test/src/main/java/org/apache/flink/streaming/tests/queryablestate/LabelSurrogate.java
+++ b/flink-end-to-end-tests/flink-queryable-state-test/src/main/java/org/apache/flink/streaming/tests/queryablestate/LabelSurrogate.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.tests.queryablestate;
+
+/**
+ * A label surrogate.
+ */
+public class LabelSurrogate {
+
+	private Type type;
+	private String foo;
+
+	public LabelSurrogate(Type type, String foo) {
+		this.type = type;
+		this.foo = foo;
+	}
+
+	public Type getType() {
+		return type;
+	}
+
+	public void setType(Type type) {
+		this.type = type;
+	}
+
+	public String getFoo() {
+		return foo;
+	}
+
+	public void setFoo(String foo) {
+		this.foo = foo;
+	}
+
+	@Override
+	public String toString() {
+		return "LabelSurrogate{" +
+				"type=" + type +
+				", foo='" + foo + '\'' +
+				'}';
+	}
+
+	/**
+	 * An exemplary enum.
+	 */
+	public enum Type {
+		FOO,
+		BAR,
+		BAZ
+	}
+}

--- a/flink-end-to-end-tests/flink-queryable-state-test/src/main/java/org/apache/flink/streaming/tests/queryablestate/QsConstants.java
+++ b/flink-end-to-end-tests/flink-queryable-state-test/src/main/java/org/apache/flink/streaming/tests/queryablestate/QsConstants.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.tests.queryablestate;
+
+/**
+ * A class containing the constants used in the end-to-end test.
+ */
+public class QsConstants {
+
+	public static final String QUERY_NAME = "state";
+	public static final String STATE_NAME = "state";
+
+	public static final String KEY = "";
+}

--- a/flink-end-to-end-tests/flink-queryable-state-test/src/main/java/org/apache/flink/streaming/tests/queryablestate/QsStateClient.java
+++ b/flink-end-to-end-tests/flink-queryable-state-test/src/main/java/org/apache/flink/streaming/tests/queryablestate/QsStateClient.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.tests.queryablestate;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.state.MapState;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeHint;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.queryablestate.client.QueryableStateClient;
+import org.apache.flink.queryablestate.exceptions.UnknownKeyOrNamespaceException;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * A simple implementation of a queryable state client.
+ * This client queries the state for a while (~2.5 mins) and prints
+ * out the values that it found in the map state
+ *
+ * <p>Usage: java -jar QsStateClient.jar --host HOST --port PORT --job-id JOB_ID
+ */
+public class QsStateClient {
+
+	private static final int BOOTSTRAP_RETRIES = 240;
+
+	public static void main(final String[] args) throws Exception {
+
+		ParameterTool parameters = ParameterTool.fromArgs(args);
+
+		// setup values
+		String jobId = parameters.getRequired("job-id");
+		String host = parameters.get("host", "localhost");
+		int port = parameters.getInt("port", 9069);
+		int numIterations = parameters.getInt("iterations", 1500);
+
+		QueryableStateClient client = new QueryableStateClient(host, port);
+		client.setExecutionConfig(new ExecutionConfig());
+
+		MapStateDescriptor<EmailId, EmailInformation> stateDescriptor =
+				new MapStateDescriptor<>(
+						QsConstants.STATE_NAME,
+						TypeInformation.of(new TypeHint<EmailId>() {
+
+						}),
+						TypeInformation.of(new TypeHint<EmailInformation>() {
+
+						})
+				);
+
+		// wait for state to exist
+		for (int i = 0; i < BOOTSTRAP_RETRIES; i++) { // ~120s
+			try {
+				getMapState(jobId, client, stateDescriptor);
+				break;
+			} catch (ExecutionException e) {
+				if (e.getCause() instanceof UnknownKeyOrNamespaceException) {
+					System.err.println("State does not exist yet; sleeping 500ms");
+					Thread.sleep(500L);
+				} else {
+					throw e;
+				}
+			}
+
+			if (i == (BOOTSTRAP_RETRIES - 1)) {
+				throw new RuntimeException("Timeout: state doesn't exist after 120s");
+			}
+		}
+
+		// query state
+		for (int iterations = 0; iterations < numIterations; iterations++) {
+
+			MapState<EmailId, EmailInformation> mapState =
+				getMapState(jobId, client, stateDescriptor);
+
+			int counter = 0;
+			for (Map.Entry<EmailId, EmailInformation> entry: mapState.entries()) {
+				// this is to force deserialization
+				entry.getKey();
+				entry.getValue();
+				counter++;
+			}
+			System.out.println("MapState has " + counter + " entries"); // we look for it in the test
+
+			Thread.sleep(100L);
+		}
+	}
+
+	private static MapState<EmailId, EmailInformation> getMapState(
+			String jobId,
+			QueryableStateClient client,
+			MapStateDescriptor<EmailId, EmailInformation> stateDescriptor) throws InterruptedException, ExecutionException {
+
+		CompletableFuture<MapState<EmailId, EmailInformation>> resultFuture =
+				client.getKvState(
+						JobID.fromHexString(jobId),
+						QsConstants.QUERY_NAME,
+						QsConstants.KEY, // which key of the keyed state to access
+						BasicTypeInfo.STRING_TYPE_INFO,
+						stateDescriptor);
+
+		return resultFuture.get();
+	}
+}

--- a/flink-end-to-end-tests/flink-queryable-state-test/src/main/java/org/apache/flink/streaming/tests/queryablestate/QsStateProducer.java
+++ b/flink-end-to-end-tests/flink-queryable-state-test/src/main/java/org/apache/flink/streaming/tests/queryablestate/QsStateProducer.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.tests.queryablestate;
+
+import org.apache.flink.api.common.functions.RichFlatMapFunction;
+import org.apache.flink.api.common.state.MapState;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.typeinfo.TypeHint;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.contrib.streaming.state.RocksDBStateBackend;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.runtime.state.filesystem.FsStateBackend;
+import org.apache.flink.runtime.state.memory.MemoryStateBackend;
+import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.source.RichSourceFunction;
+import org.apache.flink.util.Collector;
+
+import org.apache.flink.shaded.guava18.com.google.common.collect.Iterables;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Random;
+
+/**
+ * Streaming application that creates an {@link Email} pojo with random ids and increasing
+ * timestamps and passes it to a stateful {@link org.apache.flink.api.common.functions.FlatMapFunction},
+ * where it is exposed as queryable state.
+ */
+public class QsStateProducer {
+
+	public static void main(final String[] args) throws Exception {
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+		ParameterTool tool = ParameterTool.fromArgs(args);
+		String tmpPath = tool.getRequired("tmp-dir");
+		String stateBackendType = tool.getRequired("state-backend");
+
+		StateBackend stateBackend;
+		switch (stateBackendType) {
+			case "rocksdb":
+				stateBackend = new RocksDBStateBackend(tmpPath);
+				break;
+			case "fs":
+				stateBackend = new FsStateBackend(tmpPath);
+				break;
+			case "memory":
+				stateBackend = new MemoryStateBackend();
+				break;
+			default:
+				throw new RuntimeException("Unsupported state backend " + stateBackendType);
+		}
+
+		env.setStateBackend(stateBackend);
+		env.enableCheckpointing(1000L);
+		env.getCheckpointConfig().setMaxConcurrentCheckpoints(1);
+		env.getCheckpointConfig().setMinPauseBetweenCheckpoints(0);
+
+		env.addSource(new EmailSource())
+			.keyBy(new KeySelector<Email, String>() {
+
+				private static final long serialVersionUID = -1480525724620425363L;
+
+				@Override
+				public String getKey(Email value) throws Exception {
+					return QsConstants.KEY;
+				}
+			})
+			.flatMap(new TestFlatMap());
+
+		env.execute();
+	}
+
+	private static class EmailSource extends RichSourceFunction<Email> {
+
+		private static final long serialVersionUID = -7286937645300388040L;
+
+		private transient volatile boolean isRunning;
+
+		private transient Random random;
+
+		@Override
+		public void open(Configuration parameters) throws Exception {
+			super.open(parameters);
+			this.random = new Random();
+			this.isRunning = true;
+		}
+
+		@Override
+		public void run(SourceContext<Email> ctx) throws Exception {
+			// Sleep for 10 seconds on start to allow time to copy jobid
+			Thread.sleep(10000L);
+
+			int types = LabelSurrogate.Type.values().length;
+
+			while (isRunning) {
+				int r = random.nextInt(100);
+
+				final EmailId emailId = new EmailId(Integer.toString(random.nextInt()));
+				final Instant timestamp = Instant.now().minus(Duration.ofDays(1L));
+				final String foo = String.format("foo #%d", r);
+				final LabelSurrogate label = new LabelSurrogate(LabelSurrogate.Type.values()[r % types], "bar");
+
+				synchronized (ctx.getCheckpointLock()) {
+					ctx.collect(new Email(emailId, timestamp, foo, label));
+				}
+
+				Thread.sleep(30L);
+			}
+		}
+
+		@Override
+		public void cancel() {
+			isRunning = false;
+		}
+	}
+
+	private static class TestFlatMap extends RichFlatMapFunction<Email, Object> implements CheckpointedFunction {
+
+		private static final long serialVersionUID = 7821128115999005941L;
+
+		private transient MapState<EmailId, EmailInformation> state;
+		private transient int count;
+
+		@Override
+		public void open(Configuration parameters) {
+			MapStateDescriptor<EmailId, EmailInformation> stateDescriptor =
+					new MapStateDescriptor<>(
+							QsConstants.STATE_NAME,
+							TypeInformation.of(new TypeHint<EmailId>() {
+
+							}),
+							TypeInformation.of(new TypeHint<EmailInformation>() {
+
+							})
+					);
+			stateDescriptor.setQueryable(QsConstants.QUERY_NAME);
+			state = getRuntimeContext().getMapState(stateDescriptor);
+			count = -1;
+		}
+
+		@Override
+		public void flatMap(Email value, Collector<Object> out) throws Exception {
+			state.put(value.getEmailId(), new EmailInformation(value));
+			count = Iterables.size(state.keys());
+		}
+
+		@Override
+		public void snapshotState(FunctionSnapshotContext context) {
+			System.out.println("Count on snapshot: " + count); // we look for it in the test
+		}
+
+		@Override
+		public void initializeState(FunctionInitializationContext context) {
+
+		}
+	}
+}

--- a/flink-end-to-end-tests/pom.xml
+++ b/flink-end-to-end-tests/pom.xml
@@ -43,6 +43,7 @@ under the License.
 		<module>flink-distributed-cache-via-blob-test</module>
 		<module>flink-high-parallelism-iterations-test</module>
 		<module>flink-stream-stateful-job-upgrade-test</module>
+		<module>flink-queryable-state-test</module>
 		<module>flink-local-recovery-and-allocation-test</module>
 		<module>flink-elasticsearch1-test</module>
 		<module>flink-elasticsearch2-test</module>

--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -43,6 +43,9 @@ echo "Flink distribution directory: $FLINK_DIR"
 
 # run_test "<description>" "$END_TO_END_DIR/test-scripts/<script_name>"
 
+run_test "Queryable state (rocksdb) end-to-end test" "$END_TO_END_DIR/test-scripts/test_queryable_state.sh rocksdb"
+run_test "Queryable state (rocksdb) with TM restart end-to-end test" "$END_TO_END_DIR/test-scripts/test_queryable_state_restart_tm.sh"
+
 run_test "Running HA (file, async) end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha.sh file true false"
 run_test "Running HA (file, sync) end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha.sh file false false"
 run_test "Running HA (rocks, non-incremental) end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha.sh rocks true false"

--- a/flink-end-to-end-tests/test-scripts/queryable_state_base.sh
+++ b/flink-end-to-end-tests/test-scripts/queryable_state_base.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+################################################################################
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+function link_queryable_state_lib {
+    echo "Moving flink-queryable-state-runtime from opt/ to lib/"
+    mv ${FLINK_DIR}/opt/flink-queryable-state-runtime* ${FLINK_DIR}/lib/
+    if [ $? != 0 ]; then
+        echo "Failed to move flink-queryable-state-runtime from opt/ to lib/. Exiting"
+        exit 1
+    fi
+}
+
+function unlink_queryable_state_lib {
+    echo "Moving flink-queryable-state-runtime from lib/ to opt/"
+    mv ${FLINK_DIR}/lib/flink-queryable-state-runtime* ${FLINK_DIR}/opt/
+    if [ $? != 0 ]; then
+        echo "Failed to move flink-queryable-state-runtime from lib/ to opt/. Exiting"
+        exit 1
+    fi
+}
+
+# Returns the ip address of the queryable state server
+function get_queryable_state_server_ip {
+    local ip=$(cat ${FLINK_DIR}/log/flink*taskexecutor*log \
+        | grep "Started Queryable State Server" \
+        | head -1 \
+        | awk '{split($11, a, "/"); split(a[2], b, ":"); print b[1]}')
+
+    printf "${ip} \n"
+}
+
+# Returns the ip address of the queryable state server
+function get_queryable_state_proxy_port {
+    local port=$(cat ${FLINK_DIR}/log/flink*taskexecutor*log \
+        | grep "Started Queryable State Proxy Server" \
+        | head -1 \
+        | awk '{split($12, a, "/"); split(a[2], b, ":"); split(b[2], c, "."); print c[1]}')
+
+    printf "${port} \n"
+}

--- a/flink-end-to-end-tests/test-scripts/test_queryable_state.sh
+++ b/flink-end-to-end-tests/test-scripts/test_queryable_state.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+source "$(dirname "$0")"/common.sh
+source "$(dirname "$0")"/queryable_state_base.sh
+
+function run_test {
+    link_queryable_state_lib
+    start_cluster
+
+    QUERYABLE_STATE_PRODUCER_JAR=${TEST_INFRA_DIR}/../../flink-end-to-end-tests/flink-queryable-state-test/target/QsStateProducer.jar
+    QUERYABLE_STATE_CONSUMER_JAR=${TEST_INFRA_DIR}/../../flink-end-to-end-tests/flink-queryable-state-test/target/QsStateClient.jar
+
+    # start app with queryable state and wait for it to be available
+    JOB_ID=$(${FLINK_DIR}/bin/flink run \
+        -p 1 \
+        -d ${QUERYABLE_STATE_PRODUCER_JAR} \
+        --state-backend $1 \
+        --tmp-dir file://${TEST_DATA_DIR} \
+        | awk '{print $NF}' | tail -n 1)
+
+    wait_job_running ${JOB_ID}
+
+    # run the client and query state the first time
+    first_result=$(java -jar ${QUERYABLE_STATE_CONSUMER_JAR} \
+        --host $(get_queryable_state_server_ip) \
+        --port $(get_queryable_state_proxy_port) \
+        --job-id ${JOB_ID})
+
+    EXIT_CODE=$?
+
+    # Exit
+    exit ${EXIT_CODE}
+}
+
+function test_cleanup {
+    unlink_queryable_state_lib
+    clean_stdout_files
+}
+
+trap test_cleanup EXIT
+run_test $1

--- a/flink-end-to-end-tests/test-scripts/test_queryable_state_restart_tm.sh
+++ b/flink-end-to-end-tests/test-scripts/test_queryable_state_restart_tm.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+source "$(dirname "$0")"/common.sh
+source "$(dirname "$0")"/queryable_state_base.sh
+
+QUERYABLE_STATE_SERVER_JAR=${TEST_INFRA_DIR}/../../flink-end-to-end-tests/flink-queryable-state-test/target/QsStateProducer.jar
+QUERYABLE_STATE_CLIENT_JAR=${TEST_INFRA_DIR}/../../flink-end-to-end-tests/flink-queryable-state-test/target/QsStateClient.jar
+
+#####################
+# Test that queryable state works as expected with HA mode when restarting a taskmanager
+#
+# The general outline is like this:
+# 1. start cluster in HA mode with 1 TM
+# 2. start a job that exposes queryable state from a mapstate with increasing num. of keys
+# 3. query the state with a queryable state client and expect no error to occur
+# 4. stop the TM
+# 5. check how many keys were in our mapstate at the time of the latest snapshot
+# 6. start a new TM
+# 7. query the state with a queryable state client and retrieve the number of elements
+#    in the mapstate
+# 8. expect the number of elements in the mapstate after restart of TM to be > number of elements
+#    at last snapshot
+#
+# Globals:
+#   QUERYABLE_STATE_SERVER_JAR
+#   QUERYABLE_STATE_CLIENT_JAR
+# Arguments:
+#   None
+# Returns:
+#   None
+#####################
+function run_test() {
+    local EXIT_CODE=0
+    local PARALLELISM=1 # parallelism of queryable state app
+    local PORT="9069" # port of queryable state server
+
+    # to ensure there are no files accidentally left behind by previous tests
+    clean_log_files
+    clean_stdout_files
+
+    link_queryable_state_lib
+    start_cluster
+
+    local JOB_ID=$(${FLINK_DIR}/bin/flink run \
+        -p ${PARALLELISM} \
+        -d ${QUERYABLE_STATE_SERVER_JAR} \
+        --state-backend "rocksdb" \
+        --tmp-dir file://${TEST_DATA_DIR} \
+        | awk '{print $NF}' | tail -n 1)
+
+    wait_job_running ${JOB_ID}
+    wait_for_number_of_checkpoints ${JOB_ID} 10 60
+
+    SERVER=$(get_queryable_state_server_ip)
+    PORT=$(get_queryable_state_proxy_port)
+
+    echo SERVER: ${SERVER}
+    echo PORT: ${PORT}
+
+    java -jar ${QUERYABLE_STATE_CLIENT_JAR} \
+        --host ${SERVER} \
+        --port ${PORT} \
+        --iterations 1 \
+        --job-id ${JOB_ID}
+
+    if [ $? != 0 ]; then
+        echo "An error occurred when executing queryable state client"
+        exit 1
+    fi
+
+    local current_num_checkpoints=current_num_checkpoints$(get_completed_number_of_checkpoints ${JOB_ID})
+
+    kill_random_taskmanager
+
+    latest_snapshot_count=$(cat $FLINK_DIR/log/*out* | grep "on snapshot" | tail -n 1 | awk '{print $4}')
+    echo "Latest snapshot count was ${latest_snapshot_count}"
+
+    sleep 65 # this is a little longer than the heartbeat timeout so that the TM is gone
+
+    start_and_wait_for_tm
+
+    # wait for some more checkpoint to have happened
+    ((current_num_checkpoints+=2))
+    wait_for_number_of_checkpoints ${JOB_ID} ${current_num_checkpoints} 60
+
+    local num_entries_in_map_state_after=$(java -jar ${QUERYABLE_STATE_CLIENT_JAR} \
+        --host ${SERVER} \
+        --port ${PORT} \
+        --iterations 1 \
+        --job-id ${JOB_ID} | grep "MapState has" | awk '{print $3}')
+
+    echo "after: $num_entries_in_map_state_after"
+
+    if ((latest_snapshot_count > num_entries_in_map_state_after)); then
+        echo "An error occurred"
+        EXIT_CODE=1
+    fi
+
+    exit ${EXIT_CODE}
+}
+
+###################################
+# Wait a specific number of successful checkpoints
+# to have happened
+#
+# Globals:
+#   None
+# Arguments:
+#   $1: the job id
+#   $2: the number of expected successful checkpoints
+#   $3: timeout in seconds
+# Returns:
+#   None
+###################################
+function wait_for_number_of_checkpoints {
+    local job_id=$1
+    local expected_num_checkpoints=$2
+    local timeout=$3
+    local count=0
+
+    echo "Starting to wait for checkpoints"
+    while (($(get_completed_number_of_checkpoints ${job_id}) < ${expected_num_checkpoints})); do
+
+        if [[ ${count} -gt ${timeout} ]]; then
+            echo "A timeout occurred waiting for successful checkpoints"
+            exit 1
+        else
+            ((count+=2))
+        fi
+
+        local current_num_checkpoints=$(get_completed_number_of_checkpoints ${job_id})
+        echo "${current_num_checkpoints}/${expected_num_checkpoints} completed checkpoints"
+        sleep 2
+    done
+}
+
+function get_completed_number_of_checkpoints {
+    local job_id=$1
+    local json_res=$(curl -s http://localhost:8081/jobs/${job_id}/checkpoints)
+
+    echo ${json_res}    | # {"counts":{"restored":0,"total":25,"in_progress":1,"completed":24,"failed":0} ...
+        cut -d ":" -f 6 | # 24,"failed"
+        sed 's/,.*//'     # 24
+}
+
+function test_cleanup {
+    unlink_queryable_state_lib
+
+    # this is needed b.c. otherwise we might have exceptions from when
+    # we kill the task manager left behind in the logs, which would cause
+    # our test to fail in the cleanup function
+    clean_log_files
+    clean_stdout_files
+}
+
+trap test_cleanup EXIT
+run_test


### PR DESCRIPTION
 ## What is the purpose of the change
Add an end-to-end test to verify that the changes that @kl0u introduced in https://github.com/apache/flink/pull/5691 fix a known issue with concurrent access to queryable state, by verifying that access to queryable state works as expected.

## Brief change log
- Add flink app with queryable state the continuously updates mapstate
- Add queryable state client that periodically queries map state
- Add end-to-end test that runs client against app and verifies that no unexpected exceptions occur
- Integrate end-to-end test in testsuite

## Verifying this change
This change added tests and can be verified as follows:
- Run `./run-pre-commit-tests.sh`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
