### PR TITLE
[FLINK-9127] [Core] Filesystem State Backend logged incorrectly

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackendLoader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackendLoader.java
@@ -120,7 +120,7 @@ public class StateBackendLoader {
 			case FS_STATE_BACKEND_NAME:
 				FsStateBackend fsBackend = new FsStateBackendFactory().createFromConfig(config);
 				if (logger != null) {
-					logger.info("State backend is set to heap memory (checkpoints to filesystem \"{}\")",
+					logger.info("State backend is set to filesystem (checkpoints to filesystem \"{}\")",
 							fsBackend.getCheckpointPath());
 				}
 				return fsBackend;


### PR DESCRIPTION
## What is the purpose of the change

This pull-request fixes a message logged when during startup of the Flink Task-Manager and Job-Manager when a filesystem backend is in use.

The old incorrect behavior produced a log message indicating that a heap-memory backend is use in.

## Brief change log

  - Fix the log message produced by the StateBackendLoader class in Core.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
