### PR TITLE
[FLINK-9128] [flip6] Add support for scheduleRunAsync for FencedRpcEndpoints

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActor.java
@@ -303,7 +303,9 @@ class AkkaRpcActor<T extends RpcEndpoint & RpcGateway> extends UntypedActor {
 				FiniteDuration delay = new FiniteDuration(delayNanos, TimeUnit.NANOSECONDS);
 				RunAsync message = new RunAsync(runAsync.getRunnable(), timeToRun);
 
-				getContext().system().scheduler().scheduleOnce(delay, getSelf(), message,
+				final Object envelopedSelfMessage = envelopeSelfMessage(message);
+
+				getContext().system().scheduler().scheduleOnce(delay, getSelf(), envelopedSelfMessage,
 						getContext().dispatcher(), ActorRef.noSender());
 			}
 		}
@@ -331,5 +333,15 @@ class AkkaRpcActor<T extends RpcEndpoint & RpcGateway> extends UntypedActor {
 		if (!getSender().equals(ActorRef.noSender())) {
 			getSender().tell(new Status.Failure(throwable), getSelf());
 		}
+	}
+
+	/**
+	 * Hook to envelope self messages.
+	 *
+	 * @param message to envelope
+	 * @return enveloped message
+	 */
+	protected Object envelopeSelfMessage(Object message) {
+		return message;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/FencedAkkaRpcActor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/FencedAkkaRpcActor.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.rpc.RpcGateway;
 import org.apache.flink.runtime.rpc.akka.exceptions.AkkaUnknownMessageException;
 import org.apache.flink.runtime.rpc.exceptions.FencingTokenException;
 import org.apache.flink.runtime.rpc.messages.FencedMessage;
+import org.apache.flink.runtime.rpc.messages.LocalFencedMessage;
 import org.apache.flink.runtime.rpc.messages.UnfencedMessage;
 
 import java.io.Serializable;
@@ -91,5 +92,12 @@ public class FencedAkkaRpcActor<F extends Serializable, T extends FencedRpcEndpo
 				" of type " + message.getClass().getSimpleName() + " because it is neither of type " +
 				FencedMessage.class.getSimpleName() + " nor " + UnfencedMessage.class.getSimpleName() + '.'));
 		}
+	}
+
+	@Override
+	protected Object envelopeSelfMessage(Object message) {
+		final F fencingToken = rpcEndpoint.getFencingToken();
+
+		return new LocalFencedMessage<>(fencingToken, message);
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

Wrap self messages in the FencedRpcEndpoints in a LocalFencedMessage to not drop them
due to a missing fencing token.

## Brief change log
 
- Add `AkkaRpcActor#envelopeSelfMessage` method which can be used to put an envelope around self messages

## Verifying this change

- Added `AsyncCallsTest#testFencedScheduleWithNoDelay` and `AsyncCallsTest#testFencedScheduleWithDelay`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
