### PR TITLE
[hotfix] [DataStream API] [Scala] removed unused scala imports

### DIFF
--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/async/JavaResultFutureWrapper.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/async/JavaResultFutureWrapper.scala
@@ -20,7 +20,6 @@ package org.apache.flink.streaming.api.scala.async
 
 import org.apache.flink.annotation.Internal
 import org.apache.flink.streaming.api.functions.async
-import org.apache.flink.streaming.api.functions.async.ResultFuture
 
 import scala.collection.JavaConverters._
 

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/BroadcastStateITCase.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/BroadcastStateITCase.scala
@@ -28,7 +28,7 @@ import org.apache.flink.streaming.api.watermark.Watermark
 import org.apache.flink.test.util.AbstractTestBase
 import org.apache.flink.util.Collector
 import org.junit.Assert.assertEquals
-import org.junit.{Test}
+import org.junit.Test
 
 /**
   * ITCase for the [[org.apache.flink.api.common.state.BroadcastState]].

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/SlotAllocationTest.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/SlotAllocationTest.scala
@@ -18,7 +18,7 @@
 package org.apache.flink.streaming.api.scala
 
 import org.apache.flink.api.common.functions.FilterFunction
-import org.apache.flink.runtime.jobgraph.{JobVertex, JobGraph}
+import org.apache.flink.runtime.jobgraph.JobGraph
 import org.junit.Assert._
 import org.junit.Test
 

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/WindowFunctionITCase.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/WindowFunctionITCase.scala
@@ -32,7 +32,7 @@ import org.apache.flink.streaming.api.windowing.time.Time
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow
 import org.apache.flink.util.TestLogger
 import org.junit.Assert._
-import org.junit.{Ignore, Test}
+import org.junit.Test
 
 import scala.collection.mutable
 


### PR DESCRIPTION
## What is the purpose of the change

removed unused scala imports

## Brief change log

removed unused scala imports

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

none

## Documentation

none