### PR TITLE
[FLINK-8742][docs] Move docs generator annotations to flink-annotations

### DIFF
--- a/flink-annotations/src/main/java/org/apache/flink/annotation/docs/ConfigGroup.java
+++ b/flink-annotations/src/main/java/org/apache/flink/annotation/docs/ConfigGroup.java
@@ -16,14 +16,14 @@
  * limitations under the License.
  */
 
-package org.apache.flink.configuration;
+package org.apache.flink.annotation.docs;
 
 import org.apache.flink.annotation.Internal;
 
 import java.lang.annotation.Target;
 
 /**
- * A class that specifies a group of {@link ConfigOption}. The name of the group will be used as the basis for the
+ * A class that specifies a group of config options. The name of the group will be used as the basis for the
  * filename of the generated html file, as defined in {@link ConfigOptionsDocGenerator}.
  *
  * @see ConfigGroups

--- a/flink-annotations/src/main/java/org/apache/flink/annotation/docs/ConfigGroups.java
+++ b/flink-annotations/src/main/java/org/apache/flink/annotation/docs/ConfigGroups.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.configuration;
+package org.apache.flink.annotation.docs;
 
 import org.apache.flink.annotation.Internal;
 
@@ -26,8 +26,8 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotation used on classes containing {@link ConfigOption}s that enables the separation of options into different
- * tables based on key prefixes. A {@link ConfigOption} is assigned to a {@link ConfigGroup} if the option key matches
+ * Annotation used on classes containing config optionss that enables the separation of options into different
+ * tables based on key prefixes. A config option is assigned to a {@link ConfigGroup} if the option key matches
  * the group prefix. If a key matches multiple prefixes the longest matching prefix takes priority. An option is never
  * assigned to multiple groups. Options that don't match any group are implicitly added to a default group.
  */

--- a/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
@@ -19,6 +19,8 @@
 package org.apache.flink.configuration;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.docs.ConfigGroup;
+import org.apache.flink.annotation.docs.ConfigGroups;
 
 import static org.apache.flink.configuration.ConfigOptions.key;
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/HighAvailabilityOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/HighAvailabilityOptions.java
@@ -19,6 +19,8 @@
 package org.apache.flink.configuration;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.docs.ConfigGroup;
+import org.apache.flink.annotation.docs.ConfigGroups;
 
 import static org.apache.flink.configuration.ConfigOptions.key;
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
@@ -19,6 +19,8 @@
 package org.apache.flink.configuration;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.docs.ConfigGroup;
+import org.apache.flink.annotation.docs.ConfigGroups;
 
 /**
  * The set of configuration options relating to the ResourceManager.

--- a/flink-core/src/main/java/org/apache/flink/configuration/SecurityOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/SecurityOptions.java
@@ -19,6 +19,8 @@
 package org.apache.flink.configuration;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.docs.ConfigGroup;
+import org.apache.flink.annotation.docs.ConfigGroups;
 
 import static org.apache.flink.configuration.ConfigOptions.key;
 

--- a/flink-docs/pom.xml
+++ b/flink-docs/pom.xml
@@ -35,6 +35,11 @@ under the License.
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-annotations</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-core</artifactId>
 			<version>${project.version}</version>
 		</dependency>

--- a/flink-docs/src/main/java/org/apache/flink/docs/configuration/ConfigOptionsDocGenerator.java
+++ b/flink-docs/src/main/java/org/apache/flink/docs/configuration/ConfigOptionsDocGenerator.java
@@ -19,9 +19,9 @@
 package org.apache.flink.docs.configuration;
 
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.annotation.docs.ConfigGroup;
+import org.apache.flink.annotation.docs.ConfigGroups;
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.configuration.ConfigGroup;
-import org.apache.flink.configuration.ConfigGroups;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.WebOptions;

--- a/flink-docs/src/test/java/org/apache/flink/docs/configuration/ConfigOptionsDocGeneratorTest.java
+++ b/flink-docs/src/test/java/org/apache/flink/docs/configuration/ConfigOptionsDocGeneratorTest.java
@@ -18,9 +18,9 @@
 
 package org.apache.flink.docs.configuration;
 
+import org.apache.flink.annotation.docs.ConfigGroup;
+import org.apache.flink.annotation.docs.ConfigGroups;
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.configuration.ConfigGroup;
-import org.apache.flink.configuration.ConfigGroups;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 


### PR DESCRIPTION
## What is the purpose of the change

This PR moves the docs generator annotations to flink-docs, for consolidation purposes.
