### PR TITLE
[FLINK-9040][local runtime] check maxParallelism in JobVertex#setMaxParallelism()

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobVertex.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobgraph.tasks.StoppableTask;
 import org.apache.flink.runtime.jobmanager.scheduler.CoLocationGroup;
 import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
+import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
 import org.apache.flink.util.Preconditions;
 
 import java.util.ArrayList;
@@ -304,7 +305,7 @@ public class JobVertex implements java.io.Serializable {
 	/**
 	 * Sets the maximum parallelism for the task.
 	 *
-	 * @param maxParallelism The maximum parallelism to be set. must be between 1 and Short.MAX_VALUE.
+	 * @param maxParallelism The maximum parallelism to be set. must be between 1 and {@link KeyGroupRangeAssignment#UPPER_BOUND_MAX_PARALLELISM}.
 	 */
 	public void setMaxParallelism(int maxParallelism) {
 		this.maxParallelism = maxParallelism;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/StreamTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/StreamTransformation.java
@@ -31,6 +31,7 @@ import org.apache.flink.util.Preconditions;
 
 import java.util.Collection;
 
+import static org.apache.flink.runtime.executiongraph.ExecutionJobVertex.VALUE_NOT_SET;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -122,7 +123,7 @@ public abstract class StreamTransformation<T> {
 	 * The maximum parallelism for this stream transformation. It defines the upper limit for
 	 * dynamic scaling and the number of key groups used for partitioned state.
 	 */
-	private int maxParallelism = -1;
+	private int maxParallelism = VALUE_NOT_SET;
 
 	/**
 	 *  The minimum resources for this stream transformation. It defines the lower limit for


### PR DESCRIPTION
## What is the purpose of the change

fix javadoc for JobVertex#setMaxParallelism().

## Brief change log

  - fix javadoc for JobVertex#setMaxParallelism()

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation
no
