### PR TITLE
[hotfix][docs][minor] fix typo in documentation

### DIFF
--- a/docs/dev/batch/index.md
+++ b/docs/dev/batch/index.md
@@ -288,7 +288,7 @@ result = input1.join(input2)
         describe whether the join happens through partitioning or broadcasting, and whether it uses
         a sort-based or a hash-based algorithm. Please refer to the
         <a href="dataset_transformations.html#join-algorithm-hints">Transformations Guide</a> for
-        a list of possible hints and an example.</br>
+        a list of possible hints and an example.<br>
         If no hint is specified, the system will try to make an estimate of the input sizes and
         pick the best strategy according to those estimates.
 {% highlight java %}

--- a/docs/dev/datastream_api.md
+++ b/docs/dev/datastream_api.md
@@ -192,7 +192,7 @@ Collection-based:
 
 Custom:
 
-- `addSource` - Attache a new source function. For example, to read from Apache Kafka you can use
+- `addSource` - Attach a new source function. For example, to read from Apache Kafka you can use
     `addSource(new FlinkKafkaConsumer08<>(...))`. See [connectors]({{ site.baseurl }}/dev/connectors/index.html) for more details.
 
 </div>


### PR DESCRIPTION
## Brief change log

  - Fix typo in DataSet API and DataStream API documentation

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

