### PR TITLE
[FLINK-9147] [metrics] Include shaded Prometheus dependencies in jar

### DIFF
--- a/flink-metrics/flink-metrics-prometheus/pom.xml
+++ b/flink-metrics/flink-metrics-prometheus/pom.xml
@@ -111,6 +111,11 @@ under the License.
 							<goal>shade</goal>
 						</goals>
 						<configuration>
+							<artifactSet>
+								<includes>
+									<include>io.prometheus:*</include>
+								</includes>
+							</artifactSet>
 							<relocations combine.children="append">
 								<relocation>
 									<pattern>io.prometheus.client</pattern>


### PR DESCRIPTION
## What is the purpose of the change

The Prometheus metrics reporter does not include the shaded Prometheus dependencies
in its jar. This commit changes this.

## Verifying this change

- Verified manually 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
