### PR TITLE
[FLINK-9151] [Startup Shell Scripts] Export FLINK_CONF_DIR to job manager and task managers in standalone cluster mode (master)

### DIFF
--- a/flink-dist/src/main/flink-bin/bin/config.sh
+++ b/flink-dist/src/main/flink-bin/bin/config.sh
@@ -489,11 +489,11 @@ TMSlaves() {
         command -v pdsh >/dev/null 2>&1
         if [[ $? -ne 0 ]]; then
             for slave in ${SLAVES[@]}; do
-                ssh -n $FLINK_SSH_OPTS $slave -- "nohup /bin/bash -l \"${FLINK_BIN_DIR}/taskmanager.sh\" \"${CMD}\" &"
+                ssh -n $FLINK_SSH_OPTS $slave -- "export FLINK_CONF_DIR=\"${FLINK_CONF_DIR}\"; nohup /bin/bash -l \"${FLINK_BIN_DIR}/taskmanager.sh\" \"${CMD}\" &"
             done
         else
             PDSH_SSH_ARGS="" PDSH_SSH_ARGS_APPEND=$FLINK_SSH_OPTS pdsh -w $(IFS=, ; echo "${SLAVES[*]}") \
-                "nohup /bin/bash -l \"${FLINK_BIN_DIR}/taskmanager.sh\" \"${CMD}\""
+                "export FLINK_CONF_DIR=\"${FLINK_CONF_DIR}\"; nohup /bin/bash -l \"${FLINK_BIN_DIR}/taskmanager.sh\" \"${CMD}\""
         fi
     fi
 }

--- a/flink-dist/src/main/flink-bin/bin/start-cluster.sh
+++ b/flink-dist/src/main/flink-bin/bin/start-cluster.sh
@@ -37,7 +37,7 @@ if [[ $HIGH_AVAILABILITY == "zookeeper" ]]; then
         if [ ${MASTERS_ALL_LOCALHOST} = true ] ; then
             "${FLINK_BIN_DIR}"/jobmanager.sh start "${master}" "${webuiport}"
         else
-            ssh -n $FLINK_SSH_OPTS $master -- "nohup /bin/bash -l \"${FLINK_BIN_DIR}/jobmanager.sh\" start ${master} ${webuiport} &"
+            ssh -n $FLINK_SSH_OPTS $master -- "export FLINK_CONF_DIR=\"${FLINK_CONF_DIR}\"; nohup /bin/bash -l \"${FLINK_BIN_DIR}/jobmanager.sh\" start ${master} ${webuiport} &"
         fi
     done
 


### PR DESCRIPTION
## What is the purpose of the change

This pull request makes the standalone cluster scripts pass FLINK_CONF_DIR to the launched job managers and task managers, rather than relying on the default config dir on the target host.

## Brief change log

- Added export FLINK_CONF_DIR to `config.sh` and `start_cluser.sh`

## Verifying this change

- I've only manually verified the change on 1.4.x.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
