### PR TITLE
[FLINK-9153] TaskManagerRunner should support rpc port range

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.GlobalConfiguration;
+import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.blob.BlobCacheService;
@@ -49,20 +50,23 @@ import org.apache.flink.runtime.util.LeaderRetrievalUtils;
 import org.apache.flink.runtime.util.SignalHandler;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.ExecutorUtils;
+import org.apache.flink.util.NetUtils;
 
 import akka.actor.ActorSystem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.net.BindException;
 import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.util.Iterator;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
-import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * This class is the executable entry point for the task manager in yarn or standalone mode.
@@ -355,13 +359,53 @@ public class TaskManagerRunner implements FatalErrorHandler {
 				taskManagerHostname, taskManagerAddress.getHostAddress());
 		}
 
-		final int rpcPort = configuration.getInteger(ConfigConstants.TASK_MANAGER_IPC_PORT_KEY, 0);
+		final String portRangeDefinition = configuration.getString(TaskManagerOptions.RPC_PORT, "0");
 
-		checkState(rpcPort >= 0 && rpcPort <= 65535, "Invalid value for " +
-				"'%s' (port for the TaskManager actor system) : %d - Leave config parameter empty or " +
-				"use 0 to let the system choose port automatically.",
-			ConfigConstants.TASK_MANAGER_IPC_PORT_KEY, rpcPort);
+		// parse port range definition and create port iterator
+		Iterator<Integer> portsIterator;
+		try {
+			portsIterator = NetUtils.getPortRangeFromString(portRangeDefinition);
+		} catch (Exception e) {
+			throw new IllegalArgumentException("Invalid port range definition: " + portRangeDefinition);
+		}
 
-		return AkkaRpcServiceUtils.createRpcService(taskManagerHostname, rpcPort, configuration);
+		while (portsIterator.hasNext()) {
+			// first, we check if the port is available by opening a socket
+			// if the actor system fails to start on the port, we try further
+			ServerSocket availableSocket = NetUtils.createSocketFromPorts(
+				portsIterator,
+				new NetUtils.SocketFactory() {
+					@Override
+					public ServerSocket createSocket(int port) throws IOException {
+						return new ServerSocket(port);
+					}
+				});
+
+			int port;
+			if (availableSocket == null) {
+				throw new BindException("Unable to allocate further port in port range: " + portRangeDefinition);
+			} else {
+				port = availableSocket.getLocalPort();
+				try {
+					availableSocket.close();
+				} catch (IOException ignored) {}
+			}
+
+			try {
+				return AkkaRpcServiceUtils.createRpcService(taskManagerHostname, port, configuration);
+			}
+			catch (Exception e) {
+				// we can continue to try if this contains a netty channel exception
+				Throwable cause = e.getCause();
+				if (!(cause instanceof org.jboss.netty.channel.ChannelException ||
+					cause instanceof java.net.BindException)) {
+					throw e;
+				} // else fall through the loop and try the next port
+			}
+		}
+
+		// if we come here, we have exhausted the port range
+		throw new BindException("Could not start actor system on any port in port range "
+			+ portRangeDefinition);
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

*This pull request makes `TaskManagerRunner` (FLIP-6) supports rpc port range*


## Brief change log

  - *Fixed a config item reading bug and let taskmanager runner support rpc port range *

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
