### PR TITLE
[FLINK-9141][datastream] Fail early when using both split and side-outputs

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/SingleOutputStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/SingleOutputStreamOperator.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.operators.ResourceSpec;
 import org.apache.flink.api.common.typeinfo.TypeHint;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.typeutils.TypeInfoParser;
+import org.apache.flink.streaming.api.collector.selector.OutputSelector;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.transformations.SideOutputTransformation;
@@ -54,6 +55,8 @@ public class SingleOutputStreamOperator<T> extends DataStream<T> {
 	 * type because this would lead to problems at runtime.
 	 */
 	private Map<OutputTag<?>, TypeInformation> requestedSideOutputs = new HashMap<>();
+
+	private boolean wasSplitApplied = false;
 
 	protected SingleOutputStreamOperator(StreamExecutionEnvironment environment, StreamTransformation<T> transformation) {
 		super(environment, transformation);
@@ -421,6 +424,17 @@ public class SingleOutputStreamOperator<T> extends DataStream<T> {
 		return this;
 	}
 
+	@Override
+	public SplitStream<T> split(OutputSelector<T> outputSelector) {
+		if (requestedSideOutputs.isEmpty()) {
+			wasSplitApplied = true;
+			return super.split(outputSelector);
+		} else {
+			throw new UnsupportedOperationException("getSideOutput() and split() may not be called on the same DataStream. " +
+				"As a work-around, please add a no-op map function before the split() call.");
+		}
+	}
+
 	/**
 	 * Gets the {@link DataStream} that contains the elements that are emitted from an operation
 	 * into the side output with the given {@link OutputTag}.
@@ -428,6 +442,11 @@ public class SingleOutputStreamOperator<T> extends DataStream<T> {
 	 * @see org.apache.flink.streaming.api.functions.ProcessFunction.Context#output(OutputTag, Object)
 	 */
 	public <X> DataStream<X> getSideOutput(OutputTag<X> sideOutputTag) {
+		if (wasSplitApplied) {
+			throw new UnsupportedOperationException("getSideOutput() and split() may not be called on the same DataStream. " +
+				"As a work-around, please add a no-op map function before the split() call.");
+		}
+
 		sideOutputTag = clean(requireNonNull(sideOutputTag));
 
 		// make a defensive copy

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/datastream/SplitSideOutputTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/datastream/SplitSideOutputTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.datastream;
+
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.ProcessFunction;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.OutputTag;
+
+import org.junit.Test;
+
+import java.util.Collections;
+
+/**
+ * Tests that verify correct behavior when applying split/getSideOutput operations on one {@link DataStream}.
+ */
+public class SplitSideOutputTest {
+
+	private static final OutputTag<String> outputTag = new OutputTag<String>("outputTag") {};
+
+	@Test
+	public void testSideOutputAfterSelectIsForbidden() {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+		SingleOutputStreamOperator<String> processInput = env.fromElements("foo")
+			.process(new DummyProcessFunction());
+
+		processInput.split(Collections::singleton);
+
+		try {
+			processInput.getSideOutput(outputTag);
+		} catch (UnsupportedOperationException expected){
+			// expected
+		}
+	}
+
+	@Test
+	public void testSelectAfterSideOutputIsForbidden() {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+		SingleOutputStreamOperator<String> processInput = env.fromElements("foo")
+			.process(new DummyProcessFunction());
+
+		processInput.getSideOutput(outputTag);
+
+		try {
+			processInput.split(Collections::singleton);
+		} catch (UnsupportedOperationException expected){
+			// expected
+		}
+	}
+
+	private static final class DummyProcessFunction extends ProcessFunction<String, String> {
+
+		@Override
+		public void processElement(String value, Context ctx, Collector<String> out) throws Exception {
+		}
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/datastream/SplitSideOutputTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/datastream/SplitSideOutputTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.streaming.api.functions.ProcessFunction;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.OutputTag;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -45,6 +46,7 @@ public class SplitSideOutputTest {
 
 		try {
 			processInput.getSideOutput(outputTag);
+			Assert.fail("Should have failed early with an exception.");
 		} catch (UnsupportedOperationException expected){
 			// expected
 		}
@@ -61,6 +63,7 @@ public class SplitSideOutputTest {
 
 		try {
 			processInput.split(Collections::singleton);
+			Assert.fail("Should have failed early with an exception.");
 		} catch (UnsupportedOperationException expected){
 			// expected
 		}


### PR DESCRIPTION
## What is the purpose of the change

With this PR we fail early if a user attempts to use split() and side-outputs on a single DataStream. Previously this would lead to a NullPointerException at runtime.

## Brief change log

* keep track of split() calls in `SingleOutputStreamOperator` by overriding it and setting the `wasSplitApplied` flag
* add checks to split() and getSideOutput() that throw an exception if the other method was already called


## Verifying this change

This change added tests and can be verified as follows:
* run SplitSideOutputTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
