### PR TITLE
[FLINK-9158][Distributed Coordination] Set default FixedRestartDelayStrategy delay to 0s.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -72,7 +72,7 @@ public final class ConfigConstants {
 	 */
 	@PublicEvolving
 	public static final ConfigOption<String> RESTART_STRATEGY_FIXED_DELAY_DELAY =
-		key("restart-strategy.fixed-delay.delay").defaultValue("1 s");
+		key("restart-strategy.fixed-delay.delay").defaultValue("0 s");
 
 	/**
 	 * Maximum number of restarts in given time interval {@link #RESTART_STRATEGY_FAILURE_RATE_FAILURE_RATE_INTERVAL} before failing a job

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -85,7 +85,7 @@ public class StreamingJobGraphGenerator {
 	 * Restart delay used for the FixedDelayRestartStrategy in case checkpointing was enabled but
 	 * no restart strategy has been specified.
 	 */
-	private static final long DEFAULT_RESTART_DELAY = 10000L;
+	private static final long DEFAULT_RESTART_DELAY = 0L;
 
 	// ------------------------------------------------------------------------
 


### PR DESCRIPTION
## What is the purpose of the change

Set default FixedRestartDelayStrategy delay to 0s.

## Brief change log

- Set default FixedRestartDelayStrategy delay to 0s.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

no