### PR TITLE
[FLINK-7850] [build system] Give each maven profile an activation property

### DIFF
--- a/flink-connectors/flink-connector-kafka-0.11/pom.xml
+++ b/flink-connectors/flink-connector-kafka-0.11/pom.xml
@@ -215,6 +215,11 @@ under the License.
 		<profile>
 			<!-- Create SQL Client uber jars for releases -->
 			<id>release</id>
+			<activation>
+				<property>
+					<name>release</name>
+				</property>
+			</activation>
 			<build>
 				<plugins>
 					<plugin>

--- a/flink-connectors/flink-hbase/pom.xml
+++ b/flink-connectors/flink-hbase/pom.xml
@@ -272,6 +272,11 @@ under the License.
 	<profiles>
 		<profile>
 			<id>cdh5.1.3</id>
+			<activation>
+				<property>
+					<name>cdh5.1.3</name>
+				</property>
+			</activation>
 			<properties>
 				<hbase.version>0.98.1-cdh5.1.3</hbase.version>
 				<hadoop.version>2.3.0-cdh5.1.3</hadoop.version>

--- a/flink-connectors/pom.xml
+++ b/flink-connectors/pom.xml
@@ -89,6 +89,11 @@ under the License.
 		-->
 		<profile>
 			<id>include-kinesis</id>
+			<activation>
+				<property>
+					<name>include-kinesis</name>
+				</property>
+			</activation>
 			<modules>
 				<module>flink-connector-kinesis</module>
 			</modules>

--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -393,9 +393,6 @@ under the License.
 			<!-- Creates/Removes the 'build-target' symlink in the root directory (only Unix systems) -->
 			<id>symlink-build-target</id>
 			<activation>
-				<property>
-					<name>symlink-build-target</name>
-				</property>
 				<os>
 					<family>unix</family>
 				</os>

--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -393,6 +393,9 @@ under the License.
 			<!-- Creates/Removes the 'build-target' symlink in the root directory (only Unix systems) -->
 			<id>symlink-build-target</id>
 			<activation>
+				<property>
+					<name>symlink-build-target</name>
+				</property>
 				<os>
 					<family>unix</family>
 				</os>

--- a/flink-formats/flink-json/pom.xml
+++ b/flink-formats/flink-json/pom.xml
@@ -91,6 +91,11 @@ under the License.
 		<profile>
 			<!-- Create SQL Client uber jars for releases -->
 			<id>release</id>
+			<activation>
+				<property>
+					<name>release</name>
+				</property>
+			</activation>
 			<build>
 				<plugins>
 					<plugin>

--- a/flink-libraries/flink-ml/pom.xml
+++ b/flink-libraries/flink-ml/pom.xml
@@ -103,6 +103,9 @@
 		<profile>
 			<id>windows</id>
 			<activation>
+				<property>
+					<name>windows</name>
+				</property>
 				<os>
 					<family>windows</family>
 				</os>
@@ -116,6 +119,9 @@
 			<id>default</id>
 			<activation>
 				<activeByDefault>true</activeByDefault>
+				<property>
+					<name>default</name>
+				</property>
 			</activation>
 			<properties>
 				<suffix.test>(?&lt;!(IT|Integration))(Test|Suite|Case)</suffix.test>

--- a/flink-libraries/flink-python/pom.xml
+++ b/flink-libraries/flink-python/pom.xml
@@ -88,6 +88,11 @@ under the License.
 	<profiles>
 		<profile>
 			<id>generate-config-docs</id>
+			<activation>
+				<property>
+					<name>generate-config-docs</name>
+				</property>
+			</activation>
 
 			<build>
 				<plugins>

--- a/flink-shaded-hadoop/flink-shaded-hadoop2/pom.xml
+++ b/flink-shaded-hadoop/flink-shaded-hadoop2/pom.xml
@@ -668,6 +668,11 @@ under the License.
 		<profile>
 			<!-- MapR build profile -->
 			<id>mapr</id>
+			<activation>
+				<property>
+					<name>mapr</name>
+				</property>
+			</activation>
 			<dependencies>
 				<dependency>
 					<groupId>org.apache.hadoop</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -725,6 +725,11 @@ under the License.
 
 		<profile>
 			<id>vendor-repos</id>
+			<activation>
+				<property>
+					<name>vendor-repos</name>
+				</property>
+			</activation>
 			<!-- Add vendor maven repositories -->
 			<repositories>
 				<!-- Cloudera -->
@@ -769,6 +774,11 @@ under the License.
 				to be able to locate the MapR Hadoop / Zookeeper dependencies.
 			-->
 			<id>mapr</id>
+			<activation>
+				<property>
+					<name>mapr</name>
+				</property>
+			</activation>
 
 			<!--
 				use MapR Hadoop / Zookeeper dependencies appropriate for MapR 5.2.0;
@@ -809,6 +819,11 @@ under the License.
 		<profile>
 			<!-- used for SNAPSHOT and regular releases -->
 			<id>docs-and-source</id>
+			<activation>
+				<property>
+					<name>docs-and-source</name>
+				</property>
+			</activation>
 			<build>
 				<plugins>
 					<plugin>
@@ -861,6 +876,11 @@ under the License.
 
 		<profile>
 			<id>release</id>
+			<activation>
+				<property>
+					<name>release</name>
+				</property>
+			</activation>
 			<properties>
 				<java.version>1.8</java.version>
 			</properties>

--- a/tools/force-shading/pom.xml
+++ b/tools/force-shading/pom.xml
@@ -45,6 +45,11 @@ under the License.
 	<profiles>
 		<profile>
 			<id>release</id>
+			<activation>
+				<property>
+					<name>release</name>
+				</property>
+			</activation>
 			<build>
 				<plugins>
 					<plugin>


### PR DESCRIPTION
## What is the purpose of the change

This PR gives every maven profile an activation property so they can be activated with `-Dabcde`. This makes them a lot easier to work with in scripts that want to control profile activation, since you can just append `-D` switches.


## Brief change log

Maven profiles that were missing activation property got one with the name equal to profile's name


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no