### PR TITLE
[FLINK-9163[e2e-tests] harden signal traps and config restoration

### DIFF
--- a/flink-end-to-end-tests/test-scripts/test_resume_savepoint.sh
+++ b/flink-end-to-end-tests/test-scripts/test_resume_savepoint.sh
@@ -50,11 +50,15 @@ start_cluster
 
 # make sure to stop Kafka and ZooKeeper at the end, as well as cleaning up the Flink cluster and our moodifications
 function test_cleanup {
+  # don't call ourselves again for another signal interruption
+  trap "exit -1" INT
+  # don't call ourselves again for normal exit
+  trap "" EXIT
+
   stop_kafka_cluster
 
   # revert our modifications to the Flink distribution
-  rm $FLINK_DIR/conf/flink-conf.yaml
-  mv $FLINK_DIR/conf/flink-conf.yaml.bak $FLINK_DIR/conf/flink-conf.yaml
+  mv -f $FLINK_DIR/conf/flink-conf.yaml.bak $FLINK_DIR/conf/flink-conf.yaml
   rm $FLINK_DIR/lib/flink-metrics-slf4j-*.jar
 
   # make sure to run regular cleanup as well

--- a/flink-end-to-end-tests/test-scripts/test_streaming_kafka010.sh
+++ b/flink-end-to-end-tests/test-scripts/test_streaming_kafka010.sh
@@ -30,11 +30,15 @@ sed -i -e "s/taskmanager.numberOfTaskSlots: 1/taskmanager.numberOfTaskSlots: 3/"
 start_cluster
 
 function test_cleanup {
+  # don't call ourselves again for another signal interruption
+  trap "exit -1" INT
+  # don't call ourselves again for normal exit
+  trap "" EXIT
+
   stop_kafka_cluster
 
   # revert our modifications to the Flink distribution
-  rm $FLINK_DIR/conf/flink-conf.yaml
-  mv $FLINK_DIR/conf/flink-conf.yaml.bak $FLINK_DIR/conf/flink-conf.yaml
+  mv -f $FLINK_DIR/conf/flink-conf.yaml.bak $FLINK_DIR/conf/flink-conf.yaml
 
   # make sure to run regular cleanup as well
   cleanup

--- a/flink-end-to-end-tests/test-scripts/test_streaming_sql.sh
+++ b/flink-end-to-end-tests/test-scripts/test_streaming_sql.sh
@@ -32,6 +32,10 @@ $FLINK_DIR/bin/taskmanager.sh start
 $FLINK_DIR/bin/flink run -p 4 $TEST_PROGRAM_JAR -outputPath file://${TEST_DATA_DIR}/out/result
 
 function sql_cleanup() {
+  # don't call ourselves again for another signal interruption
+  trap "exit -1" INT
+  # don't call ourselves again for normal exit
+  trap "" EXIT
 
   stop_cluster
   $FLINK_DIR/bin/taskmanager.sh stop-all


### PR DESCRIPTION
## What is the purpose of the change

Signal traps on certain systems, e.g. Linux, may be called concurrently when the trap is caught during its own execution. In that case, our cleanup may just be wrong and may also overly eagerly delete `flink-conf.yaml`.

## Brief change log

- place pattern `rm <file>; mv <file.bak> <file>` with the more atomic `mv -f <file.bak> <file>`
- reduce unnecessary error messages in the output during early (manual) test aborts
- stop complaining about `md5sum` or `md5` not being available if the error is from something else
- stop complaining about not being able to delete non-existing log files
- disable signal traps while in signal handling (needs to be done in each e2e test that was using this pattern)

## Verifying this change

This change adapts the e2e tests and was tested with them also manually by aborting (CTRL-C) during different phases of the execution.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
