### PR TITLE
[FLINK-9174][datastream]Fix the type of state created in ProccessWindowFunction.proccess() is inconsistency

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultKeyedStateStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultKeyedStateStore.java
@@ -44,8 +44,8 @@ import static java.util.Objects.requireNonNull;
  */
 public class DefaultKeyedStateStore implements KeyedStateStore {
 
-	private final KeyedStateBackend<?> keyedStateBackend;
-	private final ExecutionConfig executionConfig;
+	protected final KeyedStateBackend<?> keyedStateBackend;
+	protected final ExecutionConfig executionConfig;
 
 	public DefaultKeyedStateStore(KeyedStateBackend<?> keyedStateBackend, ExecutionConfig executionConfig) {
 		this.keyedStateBackend = Preconditions.checkNotNull(keyedStateBackend);
@@ -120,7 +120,7 @@ public class DefaultKeyedStateStore implements KeyedStateStore {
 		}
 	}
 
-	private <S extends State> S getPartitionedState(StateDescriptor<S, ?> stateDescriptor) throws Exception {
+	protected  <S extends State> S getPartitionedState(StateDescriptor<S, ?> stateDescriptor) throws Exception {
 		return keyedStateBackend.getPartitionedState(
 				VoidNamespace.INSTANCE,
 				VoidNamespaceSerializer.INSTANCE,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.runtime.operators.windowing;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.state.AggregatingState;
 import org.apache.flink.api.common.state.AggregatingStateDescriptor;
 import org.apache.flink.api.common.state.AppendingState;
@@ -45,6 +46,8 @@ import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.api.java.typeutils.runtime.TupleSerializer;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.state.DefaultKeyedStateStore;
+import org.apache.flink.runtime.state.KeyedStateBackend;
 import org.apache.flink.runtime.state.VoidNamespace;
 import org.apache.flink.runtime.state.VoidNamespaceSerializer;
 import org.apache.flink.runtime.state.internal.InternalAppendingState;
@@ -163,7 +166,7 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 
 	protected transient Context triggerContext = new Context(null, null);
 
-	protected transient WindowContext processContext = new WindowContext(null);
+	protected transient WindowContext processContext;
 
 	protected transient WindowAssigner.WindowAssignerContext windowAssignerContext;
 
@@ -654,17 +657,26 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 	 * Base class for per-window {@link KeyedStateStore KeyedStateStores}. Used to allow per-window
 	 * state access for {@link org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction}.
 	 */
-	public abstract class AbstractPerWindowStateStore implements KeyedStateStore {
+	public abstract class AbstractPerWindowStateStore extends DefaultKeyedStateStore {
 
 		// we have this in the base class even though it's not used in MergingKeyStore so that
 		// we can always set it and ignore what actual implementation we have
 		protected W window;
+
+		public AbstractPerWindowStateStore(KeyedStateBackend<?> keyedStateBackend, ExecutionConfig executionConfig) {
+			super(keyedStateBackend, executionConfig);
+		}
 	}
 
 	/**
 	 * Special {@link AbstractPerWindowStateStore} that doesn't allow access to per-window state.
 	 */
 	public class MergingWindowStateStore extends AbstractPerWindowStateStore {
+
+		public MergingWindowStateStore(KeyedStateBackend<?> keyedStateBackend, ExecutionConfig executionConfig) {
+			super(keyedStateBackend, executionConfig);
+		}
+
 		@Override
 		public <T> ValueState<T> getState(ValueStateDescriptor<T> stateProperties) {
 			throw new UnsupportedOperationException("Per-window state is not allowed when using merging windows.");
@@ -701,58 +713,17 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 	 * {@link org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction}.
 	 */
 	public class PerWindowStateStore extends AbstractPerWindowStateStore {
-		@Override
-		public <T> ValueState<T> getState(ValueStateDescriptor<T> stateProperties) {
-			try {
-				return WindowOperator.this.getPartitionedState(window, windowSerializer, stateProperties);
-			} catch (Exception e) {
-				throw new RuntimeException("Could not retrieve state", e);
-			}
+
+		public PerWindowStateStore(KeyedStateBackend<?> keyedStateBackend, ExecutionConfig executionConfig) {
+			super(keyedStateBackend, executionConfig);
 		}
 
 		@Override
-		public <T> ListState<T> getListState(ListStateDescriptor<T> stateProperties) {
-			try {
-				return WindowOperator.this.getPartitionedState(window, windowSerializer, stateProperties);
-			} catch (Exception e) {
-				throw new RuntimeException("Could not retrieve state", e);
-			}
-		}
-
-		@Override
-		public <T> ReducingState<T> getReducingState(ReducingStateDescriptor<T> stateProperties) {
-			try {
-				return WindowOperator.this.getPartitionedState(window, windowSerializer, stateProperties);
-			} catch (Exception e) {
-				throw new RuntimeException("Could not retrieve state", e);
-			}
-		}
-
-		@Override
-		public <IN, ACC, OUT> AggregatingState<IN, OUT> getAggregatingState(AggregatingStateDescriptor<IN, ACC, OUT> stateProperties) {
-			try {
-				return WindowOperator.this.getPartitionedState(window, windowSerializer, stateProperties);
-			} catch (Exception e) {
-				throw new RuntimeException("Could not retrieve state", e);
-			}
-		}
-
-		@Override
-		public <T, ACC> FoldingState<T, ACC> getFoldingState(FoldingStateDescriptor<T, ACC> stateProperties) {
-			try {
-				return WindowOperator.this.getPartitionedState(window, windowSerializer, stateProperties);
-			} catch (Exception e) {
-				throw new RuntimeException("Could not retrieve state", e);
-			}
-		}
-
-		@Override
-		public <UK, UV> MapState<UK, UV> getMapState(MapStateDescriptor<UK, UV> stateProperties) {
-			try {
-				return WindowOperator.this.getPartitionedState(window, windowSerializer, stateProperties);
-			} catch (Exception e) {
-				throw new RuntimeException("Could not retrieve state", e);
-			}
+		protected  <S extends State> S getPartitionedState(StateDescriptor<S, ?> stateDescriptor) throws Exception {
+			return keyedStateBackend.getPartitionedState(
+				window,
+				windowSerializer,
+				stateDescriptor);
 		}
 	}
 
@@ -768,7 +739,9 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 
 		public WindowContext(W window) {
 			this.window = window;
-			this.windowState = windowAssigner instanceof MergingWindowAssigner ?  new MergingWindowStateStore() : new PerWindowStateStore();
+			this.windowState = windowAssigner instanceof MergingWindowAssigner ?
+				new MergingWindowStateStore(getKeyedStateBackend(), getExecutionConfig()) :
+				new PerWindowStateStore(getKeyedStateBackend(), getExecutionConfig());
 		}
 
 		@Override


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes the type of state created in ```ProccessWindowFunction.proccess()``` is inconsistency.

Problem detail,

```java
context.windowState().getListState(); // return type is HeapListState or RocksDBListState
context.globalState().getListState(); // return type is UserFacingListState
````

This cause the problem in the following code,
```java
Iterable<T> iterableState = listState.get();
 if (terableState.iterator().hasNext()) {
   for (T value : iterableState) {
     value.setRetracting(true);
     collector.collect(value);
   }
   state.clear();
}
```
If the listState is created from context.globalState() then it's fine, but when it created from context.windowState() this will cause NPE. I met this in 1.3.2 but I found it also affect 1.5.0.

## Brief change log

  - modify ```WindowOperator#PerWindowStateStore``` to ensure the type of state created from `context.windowState().createXXXState()` is consistency with the state created from `context.globalState().createXXXState()`


## Verifying this change

- add a unit test in ``` WindowOperatorTest#testStateTypeIsConsistencyCreatedFromWindowStateAndGlobalState()``` to guard this change.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
