### PR TITLE
[FLINK-9176] [build] Re-introduce category to surefire configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,8 @@ under the License.
 		<powermock.version>1.6.5</powermock.version>
 		<hamcrest.version>1.3</hamcrest.version>
 		<japicmp.skip>false</japicmp.skip>
+		<!-- run all groups except LegacyAndNew by default -->
+		<test.excludedGroups>org.apache.flink.testutils.category.LegacyAndNew</test.excludedGroups>
 		<codebase>new</codebase>
 		<!--
 			Keeping the MiniKDC version fixed instead of taking hadoop version dependency
@@ -644,7 +646,9 @@ under the License.
 				</property>
 			</activation>
 			<properties>
-				<codebase>legacy</codebase>
+				<!-- clear the excluded groups list -->
+				<test.excludedGroups></test.excludedGroups>
+				<codebase>legacyCode</codebase>
 			</properties>
 		</profile>
 
@@ -1160,6 +1164,7 @@ under the License.
 				<!-- Do NOT use a version >=2.19.X, as test cases may get stuck before execution. See SUREFIRE-1255 -->
 				<version>2.18.1</version>
 				<configuration>
+					<excludedGroups>${test.excludedGroups}</excludedGroups>
 					<forkCount>${flink.forkCount}</forkCount>
 					<reuseForks>${flink.reuseForks}</reuseForks>
 					<systemPropertyVariables>


### PR DESCRIPTION
 ## What is the purpose of the change

The LegacyAndNew and New annotations, that were previously used to disable tests based on whether the legacyCode profile is active, are effectively unused. So, I re-introduce category to surefire configuration to make them work.

## Brief change log
Update parent pom.xml file.

## Verifying this change
This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
