### PR TITLE
[FLINK-9180] [conf] Remove REST_ prefix from rest options

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/LocalExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/LocalExecutor.java
@@ -126,7 +126,7 @@ public class LocalExecutor extends PlanExecutor {
 		final JobExecutorService newJobExecutorService;
 		if (CoreOptions.NEW_MODE.equals(configuration.getString(CoreOptions.MODE))) {
 
-			configuration.setInteger(RestOptions.REST_PORT, 0);
+			configuration.setInteger(RestOptions.PORT, 0);
 
 			final MiniClusterConfiguration miniClusterConfiguration = new MiniClusterConfiguration.Builder()
 				.setConfiguration(configuration)
@@ -143,7 +143,7 @@ public class LocalExecutor extends PlanExecutor {
 			final MiniCluster miniCluster = new MiniCluster(miniClusterConfiguration);
 			miniCluster.start();
 
-			configuration.setInteger(RestOptions.REST_PORT, miniCluster.getRestAddress().getPort());
+			configuration.setInteger(RestOptions.PORT, miniCluster.getRestAddress().getPort());
 
 			newJobExecutorService = miniCluster;
 		} else {

--- a/flink-clients/src/main/java/org/apache/flink/client/RemoteExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/RemoteExecutor.java
@@ -113,7 +113,7 @@ public class RemoteExecutor extends PlanExecutor {
 
 		clientConfiguration.setString(JobManagerOptions.ADDRESS, inet.getHostName());
 		clientConfiguration.setInteger(JobManagerOptions.PORT, inet.getPort());
-		clientConfiguration.setInteger(RestOptions.REST_PORT, inet.getPort());
+		clientConfiguration.setInteger(RestOptions.PORT, inet.getPort());
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -1142,8 +1142,8 @@ public class CliFrontend {
 	public static void setJobManagerAddressInConfig(Configuration config, InetSocketAddress address) {
 		config.setString(JobManagerOptions.ADDRESS, address.getHostString());
 		config.setInteger(JobManagerOptions.PORT, address.getPort());
-		config.setString(RestOptions.REST_ADDRESS, address.getHostString());
-		config.setInteger(RestOptions.REST_PORT, address.getPort());
+		config.setString(RestOptions.ADDRESS, address.getHostString());
+		config.setInteger(RestOptions.PORT, address.getPort());
 	}
 
 	public static List<CustomCommandLine<?>> loadCustomCommandLines(Configuration configuration, String configurationDirectory) {

--- a/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
@@ -692,8 +692,8 @@ public class RestClusterClientTest extends TestLogger {
 
 		configuration.setString(JobManagerOptions.ADDRESS, configuredHostname);
 		configuration.setInteger(JobManagerOptions.PORT, configuredPort);
-		configuration.setString(RestOptions.REST_ADDRESS, configuredHostname);
-		configuration.setInteger(RestOptions.REST_PORT, configuredPort);
+		configuration.setString(RestOptions.ADDRESS, configuredHostname);
+		configuration.setInteger(RestOptions.PORT, configuredPort);
 
 		final DefaultCLI defaultCLI = new DefaultCLI(configuration);
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/RestOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/RestOptions.java
@@ -31,7 +31,7 @@ public class RestOptions {
 	/**
 	 * The address that the server binds itself to.
 	 */
-	public static final ConfigOption<String> REST_BIND_ADDRESS =
+	public static final ConfigOption<String> BIND_ADDRESS =
 		key("rest.bind-address")
 			.noDefaultValue()
 			.withDescription("The address that the server binds itself.");
@@ -39,7 +39,7 @@ public class RestOptions {
 	/**
 	 * The address that should be used by clients to connect to the server.
 	 */
-	public static final ConfigOption<String> REST_ADDRESS =
+	public static final ConfigOption<String> ADDRESS =
 		key("rest.address")
 			.noDefaultValue()
 			.withDeprecatedKeys(JobManagerOptions.ADDRESS.key())
@@ -48,7 +48,7 @@ public class RestOptions {
 	/**
 	 * The port that the server listens on / the client connects to.
 	 */
-	public static final ConfigOption<Integer> REST_PORT =
+	public static final ConfigOption<Integer> PORT =
 		key("rest.port")
 			.defaultValue(8081)
 			.withDescription("The port that the server listens on / the client connects to.");
@@ -94,7 +94,7 @@ public class RestOptions {
 	/**
 	 * The maximum content length that the server will handle.
 	 */
-	public static final ConfigOption<Integer> REST_SERVER_MAX_CONTENT_LENGTH =
+	public static final ConfigOption<Integer> SERVER_MAX_CONTENT_LENGTH =
 		key("rest.server.max-content-length")
 			.defaultValue(104_857_600)
 			.withDescription("The maximum content length in bytes that the server will handle.");
@@ -102,7 +102,7 @@ public class RestOptions {
 	/**
 	 * The maximum content length that the client will handle.
 	 */
-	public static final ConfigOption<Integer> REST_CLIENT_MAX_CONTENT_LENGTH =
+	public static final ConfigOption<Integer> CLIENT_MAX_CONTENT_LENGTH =
 		key("rest.client.max-content-length")
 			.defaultValue(104_857_600)
 			.withDescription("The maximum content length in bytes that the client will handle.");

--- a/flink-docs/src/main/java/org/apache/flink/docs/rest/RestAPIDocGenerator.java
+++ b/flink-docs/src/main/java/org/apache/flink/docs/rest/RestAPIDocGenerator.java
@@ -313,7 +313,7 @@ public class RestAPIDocGenerator {
 
 		static {
 			config = new Configuration();
-			config.setString(RestOptions.REST_ADDRESS, "localhost");
+			config.setString(RestOptions.ADDRESS, "localhost");
 			try {
 				restConfig = RestServerEndpointConfiguration.fromConfiguration(config);
 			} catch (ConfigurationException e) {

--- a/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
@@ -1126,9 +1126,9 @@ public abstract class ExecutionEnvironment {
 
 		conf.setBoolean(ConfigConstants.LOCAL_START_WEBSERVER, true);
 
-		if (!conf.contains(RestOptions.REST_PORT)) {
+		if (!conf.contains(RestOptions.PORT)) {
 			// explicitly set this option so that it's not set to 0 later
-			conf.setInteger(RestOptions.REST_PORT, RestOptions.REST_PORT.defaultValue());
+			conf.setInteger(RestOptions.PORT, RestOptions.PORT.defaultValue());
 		}
 
 		return createLocalEnvironment(conf, -1);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -704,7 +704,7 @@ public abstract class ClusterEntrypoint implements FatalErrorHandler {
 		final int restPort = clusterConfiguration.getRestPort();
 
 		if (restPort >= 0) {
-			configuration.setInteger(RestOptions.REST_PORT, restPort);
+			configuration.setInteger(RestOptions.PORT, restPort);
 		}
 
 		return configuration;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServicesUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServicesUtils.java
@@ -99,10 +99,10 @@ public class HighAvailabilityServicesUtils {
 					addressResolution,
 					configuration);
 
-				final String address = checkNotNull(configuration.getString(RestOptions.REST_ADDRESS),
+				final String address = checkNotNull(configuration.getString(RestOptions.ADDRESS),
 					"%s must be set",
-					RestOptions.REST_ADDRESS.key());
-				final int port = configuration.getInteger(RestOptions.REST_PORT);
+					RestOptions.ADDRESS.key());
+				final int port = configuration.getInteger(RestOptions.PORT);
 				final boolean enableSSL = configuration.getBoolean(SecurityOptions.SSL_ENABLED);
 				final String protocol = enableSSL ? "https://" : "http://";
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniClusterConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniClusterConfiguration.java
@@ -169,8 +169,8 @@ public class MiniClusterConfiguration {
 			final Configuration modifiedConfiguration = new Configuration(configuration);
 			modifiedConfiguration.setInteger(ConfigConstants.TASK_MANAGER_NUM_TASK_SLOTS, numSlotsPerTaskManager);
 			modifiedConfiguration.setString(
-				RestOptions.REST_ADDRESS,
-				modifiedConfiguration.getString(RestOptions.REST_ADDRESS, "localhost"));
+				RestOptions.ADDRESS,
+				modifiedConfiguration.getString(RestOptions.ADDRESS, "localhost"));
 
 			return new MiniClusterConfiguration(
 				modifiedConfiguration,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/FlinkHttpObjectAggregator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/FlinkHttpObjectAggregator.java
@@ -59,7 +59,7 @@ public class FlinkHttpObjectAggregator extends org.apache.flink.shaded.netty4.io
 				false,
 				new ErrorResponseBody(String.format(
 					e.getMessage() + " Try to raise [%s]",
-					RestOptions.REST_SERVER_MAX_CONTENT_LENGTH.key())),
+					RestOptions.SERVER_MAX_CONTENT_LENGTH.key())),
 				HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE,
 				responseHeaders);
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
@@ -273,7 +273,7 @@ public class RestClient {
 			if (cause instanceof TooLongFrameException) {
 				jsonFuture.completeExceptionally(new TooLongFrameException(String.format(
 					cause.getMessage() + " Try to raise [%s]",
-					RestOptions.REST_CLIENT_MAX_CONTENT_LENGTH.key())));
+					RestOptions.CLIENT_MAX_CONTENT_LENGTH.key())));
 			} else {
 				jsonFuture.completeExceptionally(cause);
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClientConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClientConfiguration.java
@@ -107,7 +107,7 @@ public final class RestClientConfiguration {
 
 		final long connectionTimeout = config.getLong(RestOptions.CONNECTION_TIMEOUT);
 
-		int maxContentLength = config.getInteger(RestOptions.REST_CLIENT_MAX_CONTENT_LENGTH);
+		int maxContentLength = config.getInteger(RestOptions.CLIENT_MAX_CONTENT_LENGTH);
 
 		return new RestClientConfiguration(sslEngine, connectionTimeout, maxContentLength);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpointConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpointConfiguration.java
@@ -81,7 +81,7 @@ public final class RestServerEndpointConfiguration {
 	}
 
 	/**
-	 * @see RestOptions#REST_ADDRESS
+	 * @see RestOptions#ADDRESS
 	 */
 	public String getRestAddress() {
 		return restAddress;
@@ -147,12 +147,12 @@ public final class RestServerEndpointConfiguration {
 	public static RestServerEndpointConfiguration fromConfiguration(Configuration config) throws ConfigurationException {
 		Preconditions.checkNotNull(config);
 
-		final String restAddress = Preconditions.checkNotNull(config.getString(RestOptions.REST_ADDRESS),
+		final String restAddress = Preconditions.checkNotNull(config.getString(RestOptions.ADDRESS),
 			"%s must be set",
-			RestOptions.REST_ADDRESS.key());
+			RestOptions.ADDRESS.key());
 
-		final String restBindAddress = config.getString(RestOptions.REST_BIND_ADDRESS);
-		final int port = config.getInteger(RestOptions.REST_PORT);
+		final String restBindAddress = config.getString(RestOptions.BIND_ADDRESS);
+		final int port = config.getInteger(RestOptions.PORT);
 
 		SSLEngine sslEngine = null;
 		final boolean enableSSL = config.getBoolean(SecurityOptions.SSL_ENABLED);
@@ -173,7 +173,7 @@ public final class RestServerEndpointConfiguration {
 			config.getString(WebOptions.UPLOAD_DIR,	config.getString(WebOptions.TMP_DIR)),
 			"flink-web-upload");
 
-		final int maxContentLength = config.getInteger(RestOptions.REST_SERVER_MAX_CONTENT_LENGTH);
+		final int maxContentLength = config.getInteger(RestOptions.SERVER_MAX_CONTENT_LENGTH);
 
 		final Map<String, String> responseHeaders = Collections.singletonMap(
 			HttpHeaders.Names.ACCESS_CONTROL_ALLOW_ORIGIN,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointITCase.java
@@ -114,11 +114,11 @@ public class RestServerEndpointITCase extends TestLogger {
 	@Before
 	public void setup() throws Exception {
 		Configuration config = new Configuration();
-		config.setInteger(RestOptions.REST_PORT, 0);
-		config.setString(RestOptions.REST_ADDRESS, "localhost");
+		config.setInteger(RestOptions.PORT, 0);
+		config.setString(RestOptions.ADDRESS, "localhost");
 		config.setString(WebOptions.UPLOAD_DIR, temporaryFolder.newFolder().getCanonicalPath());
-		config.setInteger(RestOptions.REST_SERVER_MAX_CONTENT_LENGTH, TEST_REST_MAX_CONTENT_LENGTH);
-		config.setInteger(RestOptions.REST_CLIENT_MAX_CONTENT_LENGTH, TEST_REST_MAX_CONTENT_LENGTH);
+		config.setInteger(RestOptions.SERVER_MAX_CONTENT_LENGTH, TEST_REST_MAX_CONTENT_LENGTH);
+		config.setInteger(RestOptions.CLIENT_MAX_CONTENT_LENGTH, TEST_REST_MAX_CONTENT_LENGTH);
 
 		RestServerEndpointConfiguration serverConfig = RestServerEndpointConfiguration.fromConfiguration(config);
 		RestClientConfiguration clientConfig = RestClientConfiguration.fromConfiguration(config);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/LocalStreamEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/LocalStreamEnvironment.java
@@ -99,8 +99,8 @@ public class LocalStreamEnvironment extends StreamExecutionEnvironment {
 		// add (and override) the settings with what the user defined
 		configuration.addAll(this.configuration);
 
-		if (!configuration.contains(RestOptions.REST_PORT)) {
-			configuration.setInteger(RestOptions.REST_PORT, 0);
+		if (!configuration.contains(RestOptions.PORT)) {
+			configuration.setInteger(RestOptions.PORT, 0);
 		}
 
 		MiniClusterConfiguration cfg = new MiniClusterConfiguration.Builder()
@@ -116,7 +116,7 @@ public class LocalStreamEnvironment extends StreamExecutionEnvironment {
 
 		try {
 			miniCluster.start();
-			configuration.setInteger(RestOptions.REST_PORT, miniCluster.getRestAddress().getPort());
+			configuration.setInteger(RestOptions.PORT, miniCluster.getRestAddress().getPort());
 
 			return miniCluster.executeJobBlocking(jobGraph);
 		}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -1680,9 +1680,9 @@ public abstract class StreamExecutionEnvironment {
 
 		conf.setBoolean(ConfigConstants.LOCAL_START_WEBSERVER, true);
 
-		if (!conf.contains(RestOptions.REST_PORT)) {
+		if (!conf.contains(RestOptions.PORT)) {
 			// explicitly set this option so that it's not set to 0 later
-			conf.setInteger(RestOptions.REST_PORT, RestOptions.REST_PORT.defaultValue());
+			conf.setInteger(RestOptions.PORT, RestOptions.PORT.defaultValue());
 		}
 
 		return createLocalEnvironment(defaultLocalParallelism, conf);

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/MiniClusterResource.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/MiniClusterResource.java
@@ -221,7 +221,7 @@ public class MiniClusterResource extends ExternalResource {
 		}
 
 		// set rest port to 0 to avoid clashes with concurrent MiniClusters
-		configuration.setInteger(RestOptions.REST_PORT, 0);
+		configuration.setInteger(RestOptions.PORT, 0);
 
 		final MiniClusterConfiguration miniClusterConfiguration = new MiniClusterConfiguration.Builder()
 			.setConfiguration(configuration)
@@ -234,7 +234,7 @@ public class MiniClusterResource extends ExternalResource {
 		miniCluster.start();
 
 		// update the port of the rest endpoint
-		configuration.setInteger(RestOptions.REST_PORT, miniCluster.getRestAddress().getPort());
+		configuration.setInteger(RestOptions.PORT, miniCluster.getRestAddress().getPort());
 
 		jobExecutorService = miniCluster;
 		if (enableClusterClient) {
@@ -242,7 +242,7 @@ public class MiniClusterResource extends ExternalResource {
 		}
 		Configuration restClientConfig = new Configuration();
 		restClientConfig.setString(JobManagerOptions.ADDRESS, miniCluster.getRestAddress().getHost());
-		restClientConfig.setInteger(RestOptions.REST_PORT, miniCluster.getRestAddress().getPort());
+		restClientConfig.setInteger(RestOptions.PORT, miniCluster.getRestAddress().getPort());
 		this.restClusterClientConfig = new UnmodifiableConfiguration(restClientConfig);
 	}
 

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/BigUserProgramJobSubmitITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/BigUserProgramJobSubmitITCase.java
@@ -73,7 +73,7 @@ public class BigUserProgramJobSubmitITCase extends TestLogger {
 
 			final Configuration clientConfig = new Configuration();
 			clientConfig.setString(JobManagerOptions.ADDRESS, restAddress.getHost());
-			clientConfig.setInteger(RestOptions.REST_PORT, restAddress.getPort());
+			clientConfig.setInteger(RestOptions.PORT, restAddress.getPort());
 
 			CLIENT = new RestClusterClient<>(
 				clientConfig,

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/AbstractYarnClusterDescriptor.java
@@ -382,8 +382,8 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 			flinkConfiguration.setString(JobManagerOptions.ADDRESS, host);
 			flinkConfiguration.setInteger(JobManagerOptions.PORT, rpcPort);
 
-			flinkConfiguration.setString(RestOptions.REST_ADDRESS, host);
-			flinkConfiguration.setInteger(RestOptions.REST_PORT, rpcPort);
+			flinkConfiguration.setString(RestOptions.ADDRESS, host);
+			flinkConfiguration.setInteger(RestOptions.PORT, rpcPort);
 
 			return createYarnClusterClient(
 				this,
@@ -542,8 +542,8 @@ public abstract class AbstractYarnClusterDescriptor implements ClusterDescriptor
 		flinkConfiguration.setString(JobManagerOptions.ADDRESS, host);
 		flinkConfiguration.setInteger(JobManagerOptions.PORT, port);
 
-		flinkConfiguration.setString(RestOptions.REST_ADDRESS, host);
-		flinkConfiguration.setInteger(RestOptions.REST_PORT, port);
+		flinkConfiguration.setString(RestOptions.ADDRESS, host);
+		flinkConfiguration.setInteger(RestOptions.PORT, port);
 
 		// the Flink cluster is deployed in YARN. Represent cluster
 		return createYarnClusterClient(

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnEntrypointUtils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnEntrypointUtils.java
@@ -95,7 +95,7 @@ public class YarnEntrypointUtils {
 			ApplicationConstants.Environment.NM_HOST.key());
 
 		configuration.setString(JobManagerOptions.ADDRESS, hostname);
-		configuration.setString(RestOptions.REST_ADDRESS, hostname);
+		configuration.setString(RestOptions.ADDRESS, hostname);
 
 		// TODO: Support port ranges for the AM
 //		final String portRange = configuration.getString(
@@ -115,9 +115,9 @@ public class YarnEntrypointUtils {
 			configuration.setInteger(WebOptions.PORT, 0);
 		}
 
-		if (configuration.getInteger(RestOptions.REST_PORT) >= 0) {
+		if (configuration.getInteger(RestOptions.PORT) >= 0) {
 			// set the REST port to 0 to select it randomly
-			configuration.setInteger(RestOptions.REST_PORT, 0);
+			configuration.setInteger(RestOptions.PORT, 0);
 		}
 
 		// if the user has set the deprecated YARN-specific config keys, we add the


### PR DESCRIPTION
## What is the purpose of the change
Remove REST_ prefix from rest options

## Brief change log
Update ```RestOptions.java``` for removing prefix rest_

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
