### PR TITLE
[FLINK-9100][FLINK-8793][REST] hidden key containing secret words in web interface and log

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/GlobalConfiguration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/GlobalConfiguration.java
@@ -19,6 +19,7 @@
 package org.apache.flink.configuration;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.util.Preconditions;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,6 +43,11 @@ public final class GlobalConfiguration {
 
 	public static final String FLINK_CONF_FILENAME = "flink-conf.yaml";
 
+	// the keys to be hidden
+	private static final String[] KEYS_TO_HIDDEN = new String[] {"password", "secret"};
+
+	// the hidden content to be displayed
+	public static final String HIDDEN_CONTENT = "******";
 
 	// --------------------------------------------------------------------------------------------
 
@@ -183,7 +189,7 @@ public final class GlobalConfiguration {
 						continue;
 					}
 
-					LOG.info("Loading configuration property: {}, {}", key, value);
+					LOG.info("Loading configuration property: {}, {}", key, isHiddenKey(key) ? HIDDEN_CONTENT : value);
 					config.setString(key, value);
 				}
 			}
@@ -194,4 +200,20 @@ public final class GlobalConfiguration {
 		return config;
 	}
 
+	/**
+	 * Check whether the key is a hidden key.
+	 *
+	 * @param key the config key
+	 */
+	public static boolean isHiddenKey(String key) {
+		Preconditions.checkNotNull(key, "key is null");
+		final String keyInLower = key.toLowerCase();
+		for (String hideKey : KEYS_TO_HIDDEN) {
+			if (keyInLower.length() >= hideKey.length()
+				&& keyInLower.contains(hideKey)) {
+				return true;
+			}
+		}
+		return false;
+	}
 }

--- a/flink-core/src/test/java/org/apache/flink/configuration/GlobalConfigurationTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/GlobalConfigurationTest.java
@@ -31,7 +31,9 @@ import java.io.PrintWriter;
 import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * This class contains tests for the global configuration (parsing configuration directory information).
@@ -120,4 +122,12 @@ public class GlobalConfigurationTest extends TestLogger {
 		assertNotNull(GlobalConfiguration.loadConfiguration(tempFolder.getRoot().getAbsolutePath()));
 	}
 
+	@Test
+	public void testHiddenKey() {
+		assertTrue(GlobalConfiguration.isHiddenKey("password123"));
+		assertTrue(GlobalConfiguration.isHiddenKey("123pasSword"));
+		assertTrue(GlobalConfiguration.isHiddenKey("PasSword"));
+		assertTrue(GlobalConfiguration.isHiddenKey("Secret"));
+		assertFalse(GlobalConfiguration.isHiddenKey("Hello"));
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/ClusterConfigHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/ClusterConfigHandler.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.rest.handler.legacy;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.runtime.jobmaster.JobManagerGateway;
 import org.apache.flink.runtime.rest.messages.ClusterConfigurationInfoEntry;
 import org.apache.flink.runtime.rest.messages.ClusterConfigurationInfoHeaders;
@@ -74,8 +75,8 @@ public class ClusterConfigHandler extends AbstractJsonRequestHandler {
 
 				String value = config.getString(key, null);
 				// Mask key values which contain sensitive information
-				if (value != null && key.toLowerCase().contains("password")) {
-					value = "******";
+				if (value != null && GlobalConfiguration.isHiddenKey(key)) {
+					value = GlobalConfiguration.HIDDEN_CONTENT;
 				}
 				gen.writeStringField(ClusterConfigurationInfoEntry.FIELD_NAME_CONFIG_VALUE, value);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/ClusterConfigurationInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/ClusterConfigurationInfo.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.rest.messages;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.runtime.rest.handler.legacy.ClusterConfigHandler;
 
 import java.util.ArrayList;
@@ -45,8 +46,8 @@ public class ClusterConfigurationInfo extends ArrayList<ClusterConfigurationInfo
 			String value = config.getString(key, null);
 
 			// Mask key values which contain sensitive information
-			if (value != null && key.toLowerCase().contains("password")) {
-				value = "******";
+			if (value != null && GlobalConfiguration.isHiddenKey(key)) {
+				value = GlobalConfiguration.HIDDEN_CONTENT;
 			}
 
 			clusterConfig.add(new ClusterConfigurationInfoEntry(key, value));


### PR DESCRIPTION
## What is the purpose of the change

Currently, we going in /jobmanager/config on the web interface, the value of the key containing "password" are replaced by "****" 

When using s3 for checkpoint/savepoint configuration on an infrastructure which is not on AWS (where IAM is not possible), the s3.secret-key is revealed from the interface. 

I propose the same behaviour as key with "password" for key with "secret"

## Brief change log

  - *introduce `KEYS_TO_HIDDEN` in `ClusterConfigurationInfoTest` to define the keys need to be hidden, currently they are `"password"`, `"secret"`*

## Verifying this change

  - *Added unit tests ClusterConfigurationInfoTest#testHiddenKey()*
  
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

no