### PR TITLE
[FLINK-9183] [Documentation] Kafka consumer docs to warn about idle partitions

### DIFF
--- a/docs/dev/connectors/kafka.md
+++ b/docs/dev/connectors/kafka.md
@@ -451,6 +451,15 @@ the `Watermark getCurrentWatermark()` (for periodic) or the
 `Watermark checkAndGetNextWatermark(T lastElement, long extractedTimestamp)` (for punctuated) is called to determine
 if a new watermark should be emitted and with which timestamp.
 
+If the watermark assigner depends on records read from Kafka, all topics and partitions need to
+have a continuous stream of records. Otherwise a windowed stream gets stalled, because watermark is
+not advancing. For example an idle kafka partition would cause this. A Flink improvement is planned
+to prevent this from happening
+([FLINK-5479: Per-partition watermarks in FlinkKafkaConsumer should consider idle partitions](
+https://issues.apache.org/jira/browse/FLINK-5479)).
+In the meanwhile, workaround is to send "heartbeat messages" to all consumed partitions, so that
+the watermark assigner can extract new timestamps normally also on partitions that would otherwise
+remain idle.
 
 ## Kafka Producer
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/FLINK-9183

Another sub-task was added as a reminder to remove this part of the docs when FLINK-5479 is resolved:
https://issues.apache.org/jira/browse/FLINK-9184

## What is the purpose of the change

Warn users of FLINK-9183 until it gets fixed.

## Brief change log

Added one paragraph.

## Verifying this change

Verified by running `./build_docs.sh -p` and checking the result in browser.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
