### PR TITLE
[FLINK-9113] [connectors] Use raw local file system for bucketing sink to prevent data loss

### DIFF
--- a/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/RollingSink.java
+++ b/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/RollingSink.java
@@ -699,9 +699,9 @@ public class RollingSink<T> extends RichSinkFunction<T>
 					}
 
 				} else {
-					LOG.debug("Writing valid-length file for {} to specify valid length {}", partPath, bucketState.currentFileValidLength);
 					Path validLengthFilePath = getValidLengthPathFor(partPath);
 					if (!fs.exists(validLengthFilePath) && fs.exists(partPath)) {
+						LOG.debug("Writing valid-length file for {} to specify valid length {}", partPath, bucketState.currentFileValidLength);
 						FSDataOutputStream lengthFileOut = fs.create(validLengthFilePath);
 						lengthFileOut.writeUTF(Long.toString(bucketState.currentFileValidLength));
 						lengthFileOut.close();

--- a/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSink.java
+++ b/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSink.java
@@ -44,6 +44,7 @@ import org.apache.flink.util.Preconditions;
 import org.apache.commons.lang3.time.StopWatch;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.LocalFileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.slf4j.Logger;
@@ -843,9 +844,9 @@ public class BucketingSink<T>
 						}
 					}
 				} else {
-					LOG.debug("Writing valid-length file for {} to specify valid length {}", partPath, validLength);
 					Path validLengthFilePath = getValidLengthPathFor(partPath);
 					if (!fs.exists(validLengthFilePath) && fs.exists(partPath)) {
+						LOG.debug("Writing valid-length file for {} to specify valid length {}", partPath, validLength);
 						FSDataOutputStream lengthFileOut = fs.create(validLengthFilePath);
 						lengthFileOut.writeUTF(Long.toString(validLength));
 						lengthFileOut.close();
@@ -1245,6 +1246,12 @@ public class BucketingSink<T>
 			}
 
 			fs.initialize(fsUri, finalConf);
+
+			// By default we don't perform checksums on Hadoop's local filesystem and use the raw filesystem.
+			// Otherwise buffers are not flushed entirely during checkpointing which results in data loss.
+			if (fs instanceof LocalFileSystem) {
+				return ((LocalFileSystem) fs).getRaw();
+			}
 			return fs;
 		}
 	}

--- a/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/RollingSinkFaultToleranceITCase.java
+++ b/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/RollingSinkFaultToleranceITCase.java
@@ -51,6 +51,8 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static org.apache.flink.streaming.connectors.fs.bucketing.BucketingSinkTestUtils.IN_PROGRESS_SUFFIX;
+import static org.apache.flink.streaming.connectors.fs.bucketing.BucketingSinkTestUtils.PENDING_SUFFIX;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -74,9 +76,6 @@ public class RollingSinkFaultToleranceITCase extends StreamFaultToleranceTestBas
 	private static org.apache.hadoop.fs.FileSystem dfs;
 
 	private static String outPath;
-
-	private static final String PENDING_SUFFIX = ".pending";
-	private static final String IN_PROGRESS_SUFFIX = ".in-progress";
 
 	@BeforeClass
 	public static void createHDFS() throws IOException {

--- a/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/RollingSinkITCase.java
+++ b/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/RollingSinkITCase.java
@@ -66,7 +66,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.BufferedReader;
+import java.io.DataInputStream;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.HashMap;
@@ -868,6 +870,13 @@ public class RollingSinkITCase extends TestLogger {
 			} else if (path.endsWith(PENDING_SUFFIX)) {
 				pend++;
 			} else if (path.endsWith(VALID_LENGTH_SUFFIX)) {
+				// check that content of length file is valid
+				try (FileInputStream fis = new FileInputStream(file)) {
+					final long validLength = Long.valueOf(new DataInputStream(fis).readUTF());
+					final String truncated = path.substring(0, path.length() - VALID_LENGTH_SUFFIX.length());
+					Assert.assertTrue("Mismatch between valid length and file size.",
+						FileUtils.sizeOf(new File(truncated)) >= validLength);
+				}
 				val++;
 			} else if (path.contains(PART_PREFIX)) {
 				compl++;

--- a/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/RollingSinkITCase.java
+++ b/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/RollingSinkITCase.java
@@ -45,7 +45,6 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericData.StringType;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.specific.SpecificDatumReader;
-import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
@@ -66,13 +65,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.BufferedReader;
-import java.io.DataInputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.HashMap;
 import java.util.Map;
+
+import static org.apache.flink.streaming.connectors.fs.bucketing.BucketingSinkTestUtils.checkLocalFs;
 
 /**
  * Tests for {@link RollingSink}. These
@@ -664,32 +663,32 @@ public class RollingSinkITCase extends TestLogger {
 
 		testHarness.processElement(new StreamRecord<>("test1", 1L));
 		testHarness.processElement(new StreamRecord<>("test2", 1L));
-		checkFs(outDir, 1, 1 , 0, 0);
+		checkLocalFs(outDir, 1, 1 , 0, 0);
 
 		testHarness.processElement(new StreamRecord<>("test3", 1L));
-		checkFs(outDir, 1, 2, 0, 0);
+		checkLocalFs(outDir, 1, 2, 0, 0);
 
 		testHarness.snapshot(0, 0);
-		checkFs(outDir, 1, 2, 0, 0);
+		checkLocalFs(outDir, 1, 2, 0, 0);
 
 		testHarness.notifyOfCompletedCheckpoint(0);
-		checkFs(outDir, 1, 0, 2, 0);
+		checkLocalFs(outDir, 1, 0, 2, 0);
 
 		OperatorSubtaskState snapshot = testHarness.snapshot(1, 0);
 
 		testHarness.close();
-		checkFs(outDir, 0, 1, 2, 0);
+		checkLocalFs(outDir, 0, 1, 2, 0);
 
 		testHarness = createRescalingTestSink(outDir, 1, 0);
 		testHarness.setup();
 		testHarness.initializeState(snapshot);
 		testHarness.open();
-		checkFs(outDir, 0, 0, 3, 1);
+		checkLocalFs(outDir, 0, 0, 3, 1);
 
 		snapshot = testHarness.snapshot(2, 0);
 
 		testHarness.processElement(new StreamRecord<>("test4", 10));
-		checkFs(outDir, 1, 0, 3, 1);
+		checkLocalFs(outDir, 1, 0, 3, 1);
 
 		testHarness = createRescalingTestSink(outDir, 1, 0);
 		testHarness.setup();
@@ -697,13 +696,13 @@ public class RollingSinkITCase extends TestLogger {
 		testHarness.open();
 
 		// the in-progress file remains as we do not clean up now
-		checkFs(outDir, 1, 0, 3, 1);
+		checkLocalFs(outDir, 1, 0, 3, 1);
 
 		testHarness.close();
 
 		// at close it is not moved to final because it is not part
 		// of the current task's state, it was just a not cleaned up leftover.
-		checkFs(outDir, 1, 0, 3, 1);
+		checkLocalFs(outDir, 1, 0, 3, 1);
 	}
 
 	@Test
@@ -723,18 +722,18 @@ public class RollingSinkITCase extends TestLogger {
 		testHarness3.open();
 
 		testHarness1.processElement(new StreamRecord<>("test1", 0L));
-		checkFs(outDir, 1, 0, 0, 0);
+		checkLocalFs(outDir, 1, 0, 0, 0);
 
 		testHarness2.processElement(new StreamRecord<>("test2", 0L));
 		testHarness2.processElement(new StreamRecord<>("test3", 0L));
 		testHarness2.processElement(new StreamRecord<>("test4", 0L));
 		testHarness2.processElement(new StreamRecord<>("test5", 0L));
 		testHarness2.processElement(new StreamRecord<>("test6", 0L));
-		checkFs(outDir, 2, 4, 0, 0);
+		checkLocalFs(outDir, 2, 4, 0, 0);
 
 		testHarness3.processElement(new StreamRecord<>("test7", 0L));
 		testHarness3.processElement(new StreamRecord<>("test8", 0L));
-		checkFs(outDir, 3, 5, 0, 0);
+		checkLocalFs(outDir, 3, 5, 0, 0);
 
 		// intentionally we snapshot them in a not ascending order so that the states are shuffled
 		OperatorSubtaskState mergedSnapshot = AbstractStreamOperatorTestHarness.repackageState(
@@ -754,14 +753,14 @@ public class RollingSinkITCase extends TestLogger {
 
 		// we do not have a length file for part-2-0 because bucket part-2-0
 		// was not "in-progress", but "pending" (its full content is valid).
-		checkFs(outDir, 1, 4, 3, 2);
+		checkLocalFs(outDir, 1, 4, 3, 2);
 
 		OneInputStreamOperatorTestHarness<String, Object> testHarness5 = createRescalingTestSink(outDir, 2, 1);
 		testHarness5.setup();
 		testHarness5.initializeState(mergedSnapshot);
 		testHarness5.open();
 
-		checkFs(outDir, 0, 0, 8, 3);
+		checkLocalFs(outDir, 0, 0, 8, 3);
 	}
 
 	@Test
@@ -779,13 +778,13 @@ public class RollingSinkITCase extends TestLogger {
 		testHarness1.processElement(new StreamRecord<>("test1", 0L));
 		testHarness1.processElement(new StreamRecord<>("test2", 0L));
 
-		checkFs(outDir, 1, 1, 0, 0);
+		checkLocalFs(outDir, 1, 1, 0, 0);
 
 		testHarness2.processElement(new StreamRecord<>("test3", 0L));
 		testHarness2.processElement(new StreamRecord<>("test4", 0L));
 		testHarness2.processElement(new StreamRecord<>("test5", 0L));
 
-		checkFs(outDir, 2, 3, 0, 0);
+		checkLocalFs(outDir, 2, 3, 0, 0);
 
 		// intentionally we snapshot them in the reverse order so that the states are shuffled
 		OperatorSubtaskState mergedSnapshot = AbstractStreamOperatorTestHarness.repackageState(
@@ -798,28 +797,28 @@ public class RollingSinkITCase extends TestLogger {
 		testHarness1.initializeState(mergedSnapshot);
 		testHarness1.open();
 
-		checkFs(outDir, 1, 1, 3, 1);
+		checkLocalFs(outDir, 1, 1, 3, 1);
 
 		testHarness2 = createRescalingTestSink(outDir, 3, 1);
 		testHarness2.setup();
 		testHarness2.initializeState(mergedSnapshot);
 		testHarness2.open();
 
-		checkFs(outDir, 0, 0, 5, 2);
+		checkLocalFs(outDir, 0, 0, 5, 2);
 
 		OneInputStreamOperatorTestHarness<String, Object> testHarness3 = createRescalingTestSink(outDir, 3, 2);
 		testHarness3.setup();
 		testHarness3.initializeState(mergedSnapshot);
 		testHarness3.open();
 
-		checkFs(outDir, 0, 0, 5, 2);
+		checkLocalFs(outDir, 0, 0, 5, 2);
 
 		testHarness1.processElement(new StreamRecord<>("test6", 0));
 		testHarness2.processElement(new StreamRecord<>("test6", 0));
 		testHarness3.processElement(new StreamRecord<>("test6", 0));
 
 		// 3 for the different tasks
-		checkFs(outDir, 3, 0, 5, 2);
+		checkLocalFs(outDir, 3, 0, 5, 2);
 
 		testHarness1.snapshot(1, 0);
 		testHarness2.snapshot(1, 0);
@@ -829,7 +828,7 @@ public class RollingSinkITCase extends TestLogger {
 		testHarness2.close();
 		testHarness3.close();
 
-		checkFs(outDir, 0, 3, 5, 2);
+		checkLocalFs(outDir, 0, 3, 5, 2);
 	}
 
 	private OneInputStreamOperatorTestHarness<String, Object> createRescalingTestSink(
@@ -852,41 +851,6 @@ public class RollingSinkITCase extends TestLogger {
 	private <T> OneInputStreamOperatorTestHarness<T, Object> createTestSink(
 		RollingSink<T> sink, int totalParallelism, int taskIdx) throws Exception {
 		return new OneInputStreamOperatorTestHarness<>(new StreamSink<>(sink), 10, totalParallelism, taskIdx);
-	}
-
-	private void checkFs(File outDir, int inprogress, int pending, int completed, int valid) throws IOException {
-		int inProg = 0;
-		int pend = 0;
-		int compl = 0;
-		int val = 0;
-
-		for (File file: FileUtils.listFiles(outDir, null, true)) {
-			if (file.getAbsolutePath().endsWith("crc")) {
-				continue;
-			}
-			String path = file.getPath();
-			if (path.endsWith(IN_PROGRESS_SUFFIX)) {
-				inProg++;
-			} else if (path.endsWith(PENDING_SUFFIX)) {
-				pend++;
-			} else if (path.endsWith(VALID_LENGTH_SUFFIX)) {
-				// check that content of length file is valid
-				try (FileInputStream fis = new FileInputStream(file)) {
-					final long validLength = Long.valueOf(new DataInputStream(fis).readUTF());
-					final String truncated = path.substring(0, path.length() - VALID_LENGTH_SUFFIX.length());
-					Assert.assertTrue("Mismatch between valid length and file size.",
-						FileUtils.sizeOf(new File(truncated)) >= validLength);
-				}
-				val++;
-			} else if (path.contains(PART_PREFIX)) {
-				compl++;
-			}
-		}
-
-		Assert.assertEquals(inprogress, inProg);
-		Assert.assertEquals(pending, pend);
-		Assert.assertEquals(completed, compl);
-		Assert.assertEquals(valid, val);
 	}
 
 	private static class TestSourceFunction implements SourceFunction<Tuple2<Integer, String>> {

--- a/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSinkFaultToleranceITCase.java
+++ b/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSinkFaultToleranceITCase.java
@@ -51,6 +51,8 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static org.apache.flink.streaming.connectors.fs.bucketing.BucketingSinkTestUtils.IN_PROGRESS_SUFFIX;
+import static org.apache.flink.streaming.connectors.fs.bucketing.BucketingSinkTestUtils.PENDING_SUFFIX;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -71,9 +73,6 @@ public class BucketingSinkFaultToleranceITCase extends StreamFaultToleranceTestB
 	private static org.apache.hadoop.fs.FileSystem dfs;
 
 	private static String outPath;
-
-	private static final String PENDING_SUFFIX = ".pending";
-	private static final String IN_PROGRESS_SUFFIX = ".in-progress";
 
 	@BeforeClass
 	public static void createHDFS() throws IOException {

--- a/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSinkMigrationTest.java
+++ b/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSinkMigrationTest.java
@@ -153,7 +153,8 @@ public class BucketingSinkMigrationTest {
 			.setValidLengthPrefix("")
 			.setInProgressSuffix(IN_PROGRESS_SUFFIX)
 			.setPendingSuffix(PENDING_SUFFIX)
-			.setValidLengthSuffix(VALID_LENGTH_SUFFIX);
+			.setValidLengthSuffix(VALID_LENGTH_SUFFIX)
+			.setUseTruncate(false); // don't use truncate because files do not exist
 
 		OneInputStreamOperatorTestHarness<String, Object> testHarness = new OneInputStreamOperatorTestHarness<>(
 			new StreamSink<>(sink), 10, 1, 0);

--- a/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSinkMigrationTest.java
+++ b/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSinkMigrationTest.java
@@ -32,7 +32,6 @@ import org.apache.flink.streaming.util.migration.MigrationTestUtil;
 import org.apache.flink.streaming.util.migration.MigrationVersion;
 import org.apache.flink.util.OperatingSystem;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.fs.Path;
 import org.junit.Assert;
 import org.junit.Assume;
@@ -45,12 +44,16 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.flink.streaming.connectors.fs.bucketing.BucketingSinkTestUtils.IN_PROGRESS_SUFFIX;
+import static org.apache.flink.streaming.connectors.fs.bucketing.BucketingSinkTestUtils.PART_PREFIX;
+import static org.apache.flink.streaming.connectors.fs.bucketing.BucketingSinkTestUtils.PENDING_SUFFIX;
+import static org.apache.flink.streaming.connectors.fs.bucketing.BucketingSinkTestUtils.VALID_LENGTH_SUFFIX;
+import static org.apache.flink.streaming.connectors.fs.bucketing.BucketingSinkTestUtils.checkLocalFs;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -71,11 +74,6 @@ public class BucketingSinkMigrationTest {
 
 	@ClassRule
 	public static TemporaryFolder tempFolder = new TemporaryFolder();
-
-	private static final String PART_PREFIX = "part";
-	private static final String PENDING_SUFFIX = ".pending";
-	private static final String IN_PROGRESS_SUFFIX = ".in-progress";
-	private static final String VALID_LENGTH_SUFFIX = ".valid";
 
 	@BeforeClass
 	public static void verifyOS() {
@@ -127,13 +125,13 @@ public class BucketingSinkMigrationTest {
 		testHarness.processElement(new StreamRecord<>("test1", 0L));
 		testHarness.processElement(new StreamRecord<>("test2", 0L));
 
-		checkFs(outDir, 1, 1, 0, 0);
+		checkLocalFs(outDir, 1, 1, 0, 0);
 
 		testHarness.processElement(new StreamRecord<>("test3", 0L));
 		testHarness.processElement(new StreamRecord<>("test4", 0L));
 		testHarness.processElement(new StreamRecord<>("test5", 0L));
 
-		checkFs(outDir, 1, 4, 0, 0);
+		checkLocalFs(outDir, 1, 4, 0, 0);
 
 		OperatorSubtaskState snapshot = testHarness.snapshot(0L, 0L);
 
@@ -174,37 +172,9 @@ public class BucketingSinkMigrationTest {
 		testHarness.processElement(new StreamRecord<>("test1", 0L));
 		testHarness.processElement(new StreamRecord<>("test2", 0L));
 
-		checkFs(outDir, 1, 1, 0, 0);
+		checkLocalFs(outDir, 1, 1, 0, 0);
 
 		testHarness.close();
-	}
-
-	private void checkFs(File outDir, int inprogress, int pending, int completed, int valid) throws IOException {
-		int inProg = 0;
-		int pend = 0;
-		int compl = 0;
-		int val = 0;
-
-		for (File file: FileUtils.listFiles(outDir, null, true)) {
-			if (file.getAbsolutePath().endsWith("crc")) {
-				continue;
-			}
-			String path = file.getPath();
-			if (path.endsWith(IN_PROGRESS_SUFFIX)) {
-				inProg++;
-			} else if (path.endsWith(PENDING_SUFFIX)) {
-				pend++;
-			} else if (path.endsWith(VALID_LENGTH_SUFFIX)) {
-				val++;
-			} else if (path.contains(PART_PREFIX)) {
-				compl++;
-			}
-		}
-
-		Assert.assertEquals(inprogress, inProg);
-		Assert.assertEquals(pending, pend);
-		Assert.assertEquals(completed, compl);
-		Assert.assertEquals(valid, val);
 	}
 
 	static class ValidatingBucketingSink<T> extends BucketingSink<T> {

--- a/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSinkTest.java
+++ b/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSinkTest.java
@@ -62,7 +62,9 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.BufferedReader;
+import java.io.DataInputStream;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.HashMap;
@@ -452,6 +454,13 @@ public class BucketingSinkTest extends TestLogger {
 			} else if (path.endsWith(PENDING_SUFFIX)) {
 				pend++;
 			} else if (path.endsWith(VALID_LENGTH_SUFFIX)) {
+				// check that content of length file is valid
+				try (DataInputStream dis = new DataInputStream(new FileInputStream(file))) {
+					final long validLength = Long.valueOf(dis.readUTF());
+					final String truncated = path.substring(0, path.length() - VALID_LENGTH_SUFFIX.length());
+					Assert.assertTrue("Mismatch between valid length and file size.",
+						FileUtils.sizeOf(new File(truncated)) >= validLength);
+				}
 				val++;
 			} else if (path.contains(PART_PREFIX)) {
 				compl++;

--- a/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSinkTest.java
+++ b/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSinkTest.java
@@ -62,13 +62,17 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.BufferedReader;
-import java.io.DataInputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.HashMap;
 import java.util.Map;
+
+import static org.apache.flink.streaming.connectors.fs.bucketing.BucketingSinkTestUtils.IN_PROGRESS_SUFFIX;
+import static org.apache.flink.streaming.connectors.fs.bucketing.BucketingSinkTestUtils.PART_PREFIX;
+import static org.apache.flink.streaming.connectors.fs.bucketing.BucketingSinkTestUtils.PENDING_SUFFIX;
+import static org.apache.flink.streaming.connectors.fs.bucketing.BucketingSinkTestUtils.VALID_LENGTH_SUFFIX;
+import static org.apache.flink.streaming.connectors.fs.bucketing.BucketingSinkTestUtils.checkLocalFs;
 
 /**
  * Tests for the {@link BucketingSink}.
@@ -80,11 +84,6 @@ public class BucketingSinkTest extends TestLogger {
 	private static MiniDFSCluster hdfsCluster;
 	private static org.apache.hadoop.fs.FileSystem dfs;
 	private static String hdfsURI;
-
-	private static final String PART_PREFIX = "part";
-	private static final String PENDING_SUFFIX = ".pending";
-	private static final String IN_PROGRESS_SUFFIX = ".in-progress";
-	private static final String VALID_LENGTH_SUFFIX = ".valid";
 
 	private OneInputStreamOperatorTestHarness<String, Object> createRescalingTestSink(
 		File outDir, int totalParallelism, int taskIdx, long inactivityInterval) throws Exception {
@@ -189,13 +188,13 @@ public class BucketingSinkTest extends TestLogger {
 
 		testHarness.processElement(new StreamRecord<>("test1", 1L));
 		testHarness.processElement(new StreamRecord<>("test2", 1L));
-		checkFs(outDir, 2, 0 , 0, 0);
+		checkLocalFs(outDir, 2, 0 , 0, 0);
 
 		testHarness.setProcessingTime(101L);	// put some in pending
-		checkFs(outDir, 0, 2, 0, 0);
+		checkLocalFs(outDir, 0, 2, 0, 0);
 
 		testHarness.snapshot(0, 0);				// put them in pending for 0
-		checkFs(outDir, 0, 2, 0, 0);
+		checkLocalFs(outDir, 0, 2, 0, 0);
 
 		testHarness.processElement(new StreamRecord<>("test3", 1L));
 		testHarness.processElement(new StreamRecord<>("test4", 1L));
@@ -203,13 +202,13 @@ public class BucketingSinkTest extends TestLogger {
 		testHarness.setProcessingTime(202L);	// put some in pending
 
 		testHarness.snapshot(1, 0);				// put them in pending for 1
-		checkFs(outDir, 0, 4, 0, 0);
+		checkLocalFs(outDir, 0, 4, 0, 0);
 
 		testHarness.notifyOfCompletedCheckpoint(0);	// put the pending for 0 to the "committed" state
-		checkFs(outDir, 0, 2, 2, 0);
+		checkLocalFs(outDir, 0, 2, 2, 0);
 
 		testHarness.notifyOfCompletedCheckpoint(1); // put the pending for 1 to the "committed" state
-		checkFs(outDir, 0, 0, 4, 0);
+		checkLocalFs(outDir, 0, 0, 4, 0);
 	}
 
 	@Test
@@ -224,36 +223,36 @@ public class BucketingSinkTest extends TestLogger {
 
 		testHarness.processElement(new StreamRecord<>("test1", 1L));
 		testHarness.processElement(new StreamRecord<>("test2", 1L));
-		checkFs(outDir, 2, 0 , 0, 0);
+		checkLocalFs(outDir, 2, 0 , 0, 0);
 
 		// this is to check the inactivity threshold
 		testHarness.setProcessingTime(101L);
-		checkFs(outDir, 0, 2, 0, 0);
+		checkLocalFs(outDir, 0, 2, 0, 0);
 
 		testHarness.processElement(new StreamRecord<>("test3", 1L));
-		checkFs(outDir, 1, 2, 0, 0);
+		checkLocalFs(outDir, 1, 2, 0, 0);
 
 		testHarness.snapshot(0, 0);
-		checkFs(outDir, 1, 2, 0, 0);
+		checkLocalFs(outDir, 1, 2, 0, 0);
 
 		testHarness.notifyOfCompletedCheckpoint(0);
-		checkFs(outDir, 1, 0, 2, 0);
+		checkLocalFs(outDir, 1, 0, 2, 0);
 
 		OperatorSubtaskState snapshot = testHarness.snapshot(1, 0);
 
 		testHarness.close();
-		checkFs(outDir, 0, 1, 2, 0);
+		checkLocalFs(outDir, 0, 1, 2, 0);
 
 		testHarness = createRescalingTestSink(outDir, 1, 0, 100);
 		testHarness.setup();
 		testHarness.initializeState(snapshot);
 		testHarness.open();
-		checkFs(outDir, 0, 0, 3, 1);
+		checkLocalFs(outDir, 0, 0, 3, 1);
 
 		snapshot = testHarness.snapshot(2, 0);
 
 		testHarness.processElement(new StreamRecord<>("test4", 10));
-		checkFs(outDir, 1, 0, 3, 1);
+		checkLocalFs(outDir, 1, 0, 3, 1);
 
 		testHarness = createRescalingTestSink(outDir, 1, 0, 100);
 		testHarness.setup();
@@ -261,13 +260,13 @@ public class BucketingSinkTest extends TestLogger {
 		testHarness.open();
 
 		// the in-progress file remains as we do not clean up now
-		checkFs(outDir, 1, 0, 3, 1);
+		checkLocalFs(outDir, 1, 0, 3, 1);
 
 		testHarness.close();
 
 		// at close it is not moved to final because it is not part
 		// of the current task's state, it was just a not cleaned up leftover.
-		checkFs(outDir, 1, 0, 3, 1);
+		checkLocalFs(outDir, 1, 0, 3, 1);
 	}
 
 	@Test
@@ -283,10 +282,10 @@ public class BucketingSinkTest extends TestLogger {
 		testHarness2.open();
 
 		testHarness1.processElement(new StreamRecord<>("test1", 0L));
-		checkFs(outDir, 1, 0, 0, 0);
+		checkLocalFs(outDir, 1, 0, 0, 0);
 
 		testHarness2.processElement(new StreamRecord<>("test2", 0L));
-		checkFs(outDir, 2, 0, 0, 0);
+		checkLocalFs(outDir, 2, 0, 0, 0);
 
 		// intentionally we snapshot them in the reverse order so that the states are shuffled
 		OperatorSubtaskState mergedSnapshot = AbstractStreamOperatorTestHarness.repackageState(
@@ -294,11 +293,11 @@ public class BucketingSinkTest extends TestLogger {
 			testHarness1.snapshot(0, 0)
 		);
 
-		checkFs(outDir, 2, 0, 0, 0);
+		checkLocalFs(outDir, 2, 0, 0, 0);
 
 		// this will not be included in any checkpoint so it can be cleaned up (although we do not)
 		testHarness2.processElement(new StreamRecord<>("test3", 0L));
-		checkFs(outDir, 3, 0, 0, 0);
+		checkLocalFs(outDir, 3, 0, 0, 0);
 
 		testHarness1 = createRescalingTestSink(outDir, 2, 0, 100);
 		testHarness1.setup();
@@ -307,20 +306,20 @@ public class BucketingSinkTest extends TestLogger {
 
 		// the one in-progress will be the one assigned to the next instance,
 		// the other is the test3 which is just not cleaned up
-		checkFs(outDir, 2, 0, 1, 1);
+		checkLocalFs(outDir, 2, 0, 1, 1);
 
 		testHarness2 = createRescalingTestSink(outDir, 2, 1, 100);
 		testHarness2.setup();
 		testHarness2.initializeState(mergedSnapshot);
 		testHarness2.open();
 
-		checkFs(outDir, 1, 0, 2, 2);
+		checkLocalFs(outDir, 1, 0, 2, 2);
 
 		testHarness1.close();
 		testHarness2.close();
 
 		// the 1 in-progress can be discarded.
-		checkFs(outDir, 1, 0, 2, 2);
+		checkLocalFs(outDir, 1, 0, 2, 2);
 	}
 
 	@Test
@@ -340,14 +339,14 @@ public class BucketingSinkTest extends TestLogger {
 		testHarness3.open();
 
 		testHarness1.processElement(new StreamRecord<>("test1", 0L));
-		checkFs(outDir, 1, 0, 0, 0);
+		checkLocalFs(outDir, 1, 0, 0, 0);
 
 		testHarness2.processElement(new StreamRecord<>("test2", 0L));
-		checkFs(outDir, 2, 0, 0, 0);
+		checkLocalFs(outDir, 2, 0, 0, 0);
 
 		testHarness3.processElement(new StreamRecord<>("test3", 0L));
 		testHarness3.processElement(new StreamRecord<>("test4", 0L));
-		checkFs(outDir, 4, 0, 0, 0);
+		checkLocalFs(outDir, 4, 0, 0, 0);
 
 		// intentionally we snapshot them in the reverse order so that the states are shuffled
 		OperatorSubtaskState mergedSnapshot = AbstractStreamOperatorTestHarness.repackageState(
@@ -361,14 +360,14 @@ public class BucketingSinkTest extends TestLogger {
 		testHarness1.initializeState(mergedSnapshot);
 		testHarness1.open();
 
-		checkFs(outDir, 1, 0, 3, 3);
+		checkLocalFs(outDir, 1, 0, 3, 3);
 
 		testHarness2 = createRescalingTestSink(outDir, 2, 1, 100);
 		testHarness2.setup();
 		testHarness2.initializeState(mergedSnapshot);
 		testHarness2.open();
 
-		checkFs(outDir, 0, 0, 4, 4);
+		checkLocalFs(outDir, 0, 0, 4, 4);
 	}
 
 	@Test
@@ -386,13 +385,13 @@ public class BucketingSinkTest extends TestLogger {
 		testHarness1.processElement(new StreamRecord<>("test1", 1L));
 		testHarness1.processElement(new StreamRecord<>("test2", 1L));
 
-		checkFs(outDir, 2, 0, 0, 0);
+		checkLocalFs(outDir, 2, 0, 0, 0);
 
 		testHarness2.processElement(new StreamRecord<>("test3", 1L));
 		testHarness2.processElement(new StreamRecord<>("test4", 1L));
 		testHarness2.processElement(new StreamRecord<>("test5", 1L));
 
-		checkFs(outDir, 5, 0, 0, 0);
+		checkLocalFs(outDir, 5, 0, 0, 0);
 
 		// intentionally we snapshot them in the reverse order so that the states are shuffled
 		OperatorSubtaskState mergedSnapshot = AbstractStreamOperatorTestHarness.repackageState(
@@ -405,27 +404,27 @@ public class BucketingSinkTest extends TestLogger {
 		testHarness1.initializeState(mergedSnapshot);
 		testHarness1.open();
 
-		checkFs(outDir, 2, 0, 3, 3);
+		checkLocalFs(outDir, 2, 0, 3, 3);
 
 		testHarness2 = createRescalingTestSink(outDir, 3, 1, 100);
 		testHarness2.setup();
 		testHarness2.initializeState(mergedSnapshot);
 		testHarness2.open();
 
-		checkFs(outDir, 0, 0, 5, 5);
+		checkLocalFs(outDir, 0, 0, 5, 5);
 
 		OneInputStreamOperatorTestHarness<String, Object> testHarness3 = createRescalingTestSink(outDir, 3, 2, 100);
 		testHarness3.setup();
 		testHarness3.initializeState(mergedSnapshot);
 		testHarness3.open();
 
-		checkFs(outDir, 0, 0, 5, 5);
+		checkLocalFs(outDir, 0, 0, 5, 5);
 
 		testHarness1.processElement(new StreamRecord<>("test6", 0));
 		testHarness2.processElement(new StreamRecord<>("test6", 0));
 		testHarness3.processElement(new StreamRecord<>("test6", 0));
 
-		checkFs(outDir, 3, 0, 5, 5);
+		checkLocalFs(outDir, 3, 0, 5, 5);
 
 		testHarness1.snapshot(1, 0);
 		testHarness2.snapshot(1, 0);
@@ -435,42 +434,7 @@ public class BucketingSinkTest extends TestLogger {
 		testHarness2.close();
 		testHarness3.close();
 
-		checkFs(outDir, 0, 3, 5, 5);
-	}
-
-	private void checkFs(File outDir, int inprogress, int pending, int completed, int valid) throws IOException {
-		int inProg = 0;
-		int pend = 0;
-		int compl = 0;
-		int val = 0;
-
-		for (File file: FileUtils.listFiles(outDir, null, true)) {
-			if (file.getAbsolutePath().endsWith("crc")) {
-				continue;
-			}
-			String path = file.getPath();
-			if (path.endsWith(IN_PROGRESS_SUFFIX)) {
-				inProg++;
-			} else if (path.endsWith(PENDING_SUFFIX)) {
-				pend++;
-			} else if (path.endsWith(VALID_LENGTH_SUFFIX)) {
-				// check that content of length file is valid
-				try (DataInputStream dis = new DataInputStream(new FileInputStream(file))) {
-					final long validLength = Long.valueOf(dis.readUTF());
-					final String truncated = path.substring(0, path.length() - VALID_LENGTH_SUFFIX.length());
-					Assert.assertTrue("Mismatch between valid length and file size.",
-						FileUtils.sizeOf(new File(truncated)) >= validLength);
-				}
-				val++;
-			} else if (path.contains(PART_PREFIX)) {
-				compl++;
-			}
-		}
-
-		Assert.assertEquals(inprogress, inProg);
-		Assert.assertEquals(pending, pend);
-		Assert.assertEquals(completed, compl);
-		Assert.assertEquals(valid, val);
+		checkLocalFs(outDir, 0, 3, 5, 5);
 	}
 
 	/**

--- a/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSinkTestUtils.java
+++ b/flink-connectors/flink-connector-filesystem/src/test/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSinkTestUtils.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.fs.bucketing;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.RawLocalFileSystem;
+import org.junit.Assert;
+
+import java.io.DataInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+
+/**
+ * Test utilities for bucketing sinks.
+ */
+public class BucketingSinkTestUtils {
+
+	public static final String PART_PREFIX = "part";
+	public static final String PENDING_SUFFIX = ".pending";
+	public static final String IN_PROGRESS_SUFFIX = ".in-progress";
+	public static final String VALID_LENGTH_SUFFIX = ".valid";
+
+	/**
+	 * Verifies the correct number of written files and reasonable length files.
+	 */
+	public static void checkLocalFs(File outDir, int inprogress, int pending, int completed, int valid) throws IOException {
+		int inProg = 0;
+		int pend = 0;
+		int compl = 0;
+		int val = 0;
+
+		for (File file: FileUtils.listFiles(outDir, null, true)) {
+			if (file.getAbsolutePath().endsWith("crc")) {
+				continue;
+			}
+			String path = file.getPath();
+			if (path.endsWith(IN_PROGRESS_SUFFIX)) {
+				inProg++;
+			} else if (path.endsWith(PENDING_SUFFIX)) {
+				pend++;
+			} else if (path.endsWith(VALID_LENGTH_SUFFIX)) {
+				// check that content of length file is valid
+				try (DataInputStream dis = new DataInputStream(new FileInputStream(file))) {
+					final long validLength = Long.valueOf(dis.readUTF());
+					final String truncated = path.substring(0, path.length() - VALID_LENGTH_SUFFIX.length());
+					Assert.assertTrue("Mismatch between valid length and file size.",
+						FileUtils.sizeOf(new File(truncated)) >= validLength);
+				}
+				val++;
+			} else if (path.contains(PART_PREFIX)) {
+				compl++;
+			}
+		}
+
+		Assert.assertEquals(inprogress, inProg);
+		Assert.assertEquals(pending, pend);
+		Assert.assertEquals(completed, compl);
+		// check length file in case truncating is not supported
+		try {
+			RawLocalFileSystem.class.getMethod("truncate", Path.class, long.class);
+		} catch (NoSuchMethodException e) {
+			Assert.assertEquals(valid, val);
+		}
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

This change replaces Hadoop's LocalFileSystem (which is a checksumming filesystem) with the RawFileSystem implementation. For performing checksums the default filesystem only flushes in 512 byte intervals which might lead to data loss during checkpointing. In order to guarantee exact results we skip the checksum computation and perform a raw flush.

Negative effect: Existing checksums are not maintained anymore and thus become invalid.

## Brief change log

- Replace local filesystem by raw filesystem


## Verifying this change

Added a check for verifying the file length and file size.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
