### PR TITLE
[FLINK-2435] User-defined types in CsvReader

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TupleTypeInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TupleTypeInfo.java
@@ -238,6 +238,37 @@ public final class TupleTypeInfo<T extends Tuple> extends TupleTypeInfoBase<T> {
 		return tupleInfo;
 	}
 
+	/**
+	 * Resolves a type information for each specified income type and forms an instance of a resulting {@link TupleTypeInfo} type.
+	 * @param incomeTypes tuple fields' types
+	 * @param <X> a resulting type of a tuple, e.g. Tuple1, Tuple2...
+	 * @return A tuple information type, built from the specified income types.
+	 */
+	@SuppressWarnings("unchecked")
+	@PublicEvolving
+	public static <X extends Tuple> TupleTypeInfo<X> getTupleTypeInfo(Class<?>... incomeTypes) {
+		if (incomeTypes == null || incomeTypes.length == 0) {
+			throw new IllegalArgumentException();
+		}
+
+		TypeInformation<?>[] infos = new TypeInformation<?>[incomeTypes.length];
+		for (int i = 0; i < infos.length; i++) {
+			Class<?> incomeType = incomeTypes[i];
+			if (incomeType == null) {
+				throw new IllegalArgumentException("Type at position " + i + " is null.");
+			}
+
+			TypeInformation<?> info = TypeExtractor.getForClass(incomeType);
+			if (!info.getTypeClass().equals(GenericTypeInfo.class)) {
+				infos[i] = info;
+			} else {
+				throw new IllegalArgumentException("Either a concrete type cannot be identified or this is a recursive type.");
+			}
+		}
+
+		return (TupleTypeInfo<X>) new TupleTypeInfo<>(infos);
+	}
+
 	@SuppressWarnings("unchecked")
 	@PublicEvolving
 	public static <X extends Tuple> TupleTypeInfo<X> getBasicAndBasicValueTupleTypeInfo(Class<?>... basicTypes) {

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
@@ -129,7 +129,7 @@ public class TypeExtractor {
 	//  TypeInfoFactory registry
 	// --------------------------------------------------------------------------------------------
 
-	private static Map<Type, Class<? extends TypeInfoFactory>> registeredTypeInfoFactories = new HashMap<>();
+	public static Map<Type, Class<? extends TypeInfoFactory>> registeredTypeInfoFactories = new HashMap<>();
 
 	/**
 	 * Registers a type information factory globally for a certain type. Every following type extraction

--- a/flink-core/src/main/java/org/apache/flink/types/parser/DefaultParserFactory.java
+++ b/flink-core/src/main/java/org/apache/flink/types/parser/DefaultParserFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.types.parser;
+
+import org.apache.flink.util.InstantiationUtil;
+import org.apache.flink.util.Preconditions;
+
+public class DefaultParserFactory<T> implements ParserFactory<T> {
+
+	private final Class<? extends FieldParser<T>> parserType;
+
+	public DefaultParserFactory(Class<? extends FieldParser<T>> parserType) {
+		Preconditions.checkNotNull(parserType, "Parser class must be not null.");
+		this.parserType = parserType;
+	}
+
+	@Override
+	public Class<? extends FieldParser<T>> getParserType() {
+		return parserType;
+	}
+
+	@Override
+	public FieldParser<T> create() {
+		return InstantiationUtil.instantiate(parserType, FieldParser.class);
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/types/parser/FieldParser.java
+++ b/flink-core/src/main/java/org/apache/flink/types/parser/FieldParser.java
@@ -28,6 +28,9 @@ import org.apache.flink.types.IntValue;
 import org.apache.flink.types.LongValue;
 import org.apache.flink.types.ShortValue;
 import org.apache.flink.types.StringValue;
+import org.apache.flink.util.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -47,7 +50,9 @@ import java.util.Map;
  */
 @PublicEvolving
 public abstract class FieldParser<T> {
-	
+
+	private static final Logger LOG = LoggerFactory.getLogger(FieldParser.class);
+
 	/**
 	 * An enumeration of different types of errors that may occur.
 	 */
@@ -89,14 +94,14 @@ public abstract class FieldParser<T> {
 	 * the state of this parser.
 	 * The start position within the byte array and the array's valid length is given.
 	 * The content of the value is delimited by a field delimiter.
-	 * 
+	 *
 	 * @param bytes The byte array that holds the value.
 	 * @param startPos The index where the field starts
 	 * @param limit The limit unto which the byte contents is valid for the parser. The limit is the
 	 *              position one after the last valid byte.
 	 * @param delim The field delimiter character
 	 * @param reuse An optional reusable field to hold the value
-	 * 
+	 *
 	 * @return The index of the next delimiter, if the field was parsed correctly. A value less than 0 otherwise.
 	 */
 	public int resetErrorStateAndParse(byte[] bytes, int startPos, int limit, byte[] delim, T reuse) {
@@ -122,27 +127,27 @@ public abstract class FieldParser<T> {
 	 * Gets the parsed field. This method returns the value parsed by the last successful invocation of
 	 * {@link #parseField(byte[], int, int, byte[], Object)}. It objects are mutable and reused, it will return
 	 * the object instance that was passed the parse function.
-	 * 
+	 *
 	 * @return The latest parsed field.
 	 */
 	public abstract T getLastResult();
-	
+
 	/**
 	 * Returns an instance of the parsed value type.
-	 * 
+	 *
 	 * @return An instance of the parsed value type. 
 	 */
 	public abstract T createValue();
-	
+
 	/**
 	 * Checks if the delimiter starts at the given start position of the byte array.
-	 * 
+	 *
 	 * Attention: This method assumes that enough characters follow the start position for the delimiter check!
-	 * 
+	 *
 	 * @param bytes The byte array that holds the value.
 	 * @param startPos The index of the byte array where the check for the delimiter starts.
 	 * @param delim The delimiter to check for.
-	 * 
+	 *
 	 * @return true if a delimiter starts at the given start position, false otherwise.
 	 */
 	public static final boolean delimiterNext(byte[] bytes, int startPos, byte[] delim) {
@@ -154,7 +159,7 @@ public abstract class FieldParser<T> {
 			}
 		}
 		return true;
-		
+
 	}
 
 	/**
@@ -177,21 +182,21 @@ public abstract class FieldParser<T> {
 		}
 		return true;
 	}
-	
+
 	/**
 	 * Sets the error state of the parser. Called by subclasses of the parser to set the type of error
 	 * when failing a parse.
-	 * 
+	 *
 	 * @param error The error state to set.
 	 */
 	protected void setErrorState(ParseErrorState error) {
 		this.errorState = error;
 	}
-	
+
 	/**
 	 * Gets the error state of the parser, as a value of the enumeration {@link ParseErrorState}.
 	 * If no error occurred, the error state will be {@link ParseErrorState#NONE}.
-	 * 
+	 *
 	 * @return The current error state of the parser.
 	 */
 	public ParseErrorState getErrorState() {
@@ -262,54 +267,115 @@ public abstract class FieldParser<T> {
 	// --------------------------------------------------------------------------------------------
 	//  Mapping from types to parsers
 	// --------------------------------------------------------------------------------------------
-	
+
 	/**
-	 * Gets the parser for the type specified by the given class. Returns null, if no parser for that class
+	 * Provides an instance of {@link FieldParser} that corresponds to the specified type.
+	 * @param type a field type for which a {@link FieldParser} is needed.
+	 * @return if there is a custom parser for the specified field type - it is returned; then, if there is a default parser
+	 * responsible for the specified type - it is returned; otherwise, {@code null} is returned.
+	 */
+	@SuppressWarnings("unchecked")
+	public static <T> FieldParser<T> getParserInstanceFor(Class<T> type) {
+		ParserFactory<T> parserFactory = (ParserFactory<T>) CUSTOM_PARSERS.get(type);
+		if (parserFactory == null) {
+			parserFactory = (ParserFactory<T>) DEFAULT_PARSERS.get(type);
+		}
+
+		if (parserFactory == null) {
+			return null;
+		}
+
+		return parserFactory.create();
+	}
+
+	/**
+	 * Gets the default parser for the type specified by the given class. Returns null, if no parser for that class
 	 * is known.
-	 * 
+	 *
 	 * @param type The class of the type to get the parser for.
 	 * @return The parser for the given type, or null, if no such parser exists.
 	 */
-	public static <T> Class<FieldParser<T>> getParserForType(Class<T> type) {
-		Class<? extends FieldParser<?>> parser = PARSERS.get(type);
-		if (parser == null) {
+	public static <T> Class<FieldParser<T>> getDefaultParserForType(Class<T> type) {
+		ParserFactory<?> parserFactory = DEFAULT_PARSERS.get(type);
+		if (parserFactory == null) {
 			return null;
 		} else {
 			@SuppressWarnings("unchecked")
-			Class<FieldParser<T>> typedParser = (Class<FieldParser<T>>) parser;
+			Class<FieldParser<T>> typedParser = (Class<FieldParser<T>>) parserFactory.getParserType();
 			return typedParser;
 		}
 	}
-	
-	private static final Map<Class<?>, Class<? extends FieldParser<?>>> PARSERS = 
-			new HashMap<Class<?>, Class<? extends FieldParser<?>>>();
-	
+
+	/**
+	 * Gets the custom parser for the type specified by the given class. Returns null, if no parser for that class
+	 * is known.
+	 *
+	 * @param type The class of the type to get the parser for.
+	 * @return The parser for the given type, or null, if no such parser exists.
+	 */
+	public static <T> Class<? extends FieldParser<T>> getCustomParserForType(Class<T> type) {
+		synchronized (CUSTOM_PARSERS) {
+			ParserFactory<T> parserFactory = (ParserFactory<T>) CUSTOM_PARSERS.get(type);
+			if (parserFactory == null) {
+				return null;
+			} else {
+				return parserFactory.getParserType();
+			}
+		}
+	}
+
+	private static final Map<Class<?>, ParserFactory<?>> DEFAULT_PARSERS = new HashMap<>();
+
 	static {
 		// basic types
-		PARSERS.put(Byte.class, ByteParser.class);
-		PARSERS.put(Short.class, ShortParser.class);
-		PARSERS.put(Integer.class, IntParser.class);
-		PARSERS.put(Long.class, LongParser.class);
-		PARSERS.put(String.class, StringParser.class);
-		PARSERS.put(Float.class, FloatParser.class);
-		PARSERS.put(Double.class, DoubleParser.class);
-		PARSERS.put(Boolean.class, BooleanParser.class);
-		PARSERS.put(BigDecimal.class, BigDecParser.class);
-		PARSERS.put(BigInteger.class, BigIntParser.class);
+		DEFAULT_PARSERS.put(Byte.class, new DefaultParserFactory<>(ByteParser.class));
+		DEFAULT_PARSERS.put(Short.class, new DefaultParserFactory<>(ShortParser.class));
+		DEFAULT_PARSERS.put(Integer.class, new DefaultParserFactory<>(IntParser.class));
+		DEFAULT_PARSERS.put(Long.class, new DefaultParserFactory<>(LongParser.class));
+		DEFAULT_PARSERS.put(String.class, new DefaultParserFactory<>(StringParser.class));
+		DEFAULT_PARSERS.put(Float.class, new DefaultParserFactory<>(FloatParser.class));
+		DEFAULT_PARSERS.put(Double.class, new DefaultParserFactory<>(DoubleParser.class));
+		DEFAULT_PARSERS.put(Boolean.class, new DefaultParserFactory<>(BooleanParser.class));
+		DEFAULT_PARSERS.put(BigDecimal.class, new DefaultParserFactory<>(BigDecParser.class));
+		DEFAULT_PARSERS.put(BigInteger.class, new DefaultParserFactory<>(BigIntParser.class));
 
 		// value types
-		PARSERS.put(ByteValue.class, ByteValueParser.class);
-		PARSERS.put(ShortValue.class, ShortValueParser.class);
-		PARSERS.put(IntValue.class, IntValueParser.class);
-		PARSERS.put(LongValue.class, LongValueParser.class);
-		PARSERS.put(StringValue.class, StringValueParser.class);
-		PARSERS.put(FloatValue.class, FloatValueParser.class);
-		PARSERS.put(DoubleValue.class, DoubleValueParser.class);
-		PARSERS.put(BooleanValue.class, BooleanValueParser.class);
+		DEFAULT_PARSERS.put(ByteValue.class, new DefaultParserFactory<>(ByteValueParser.class));
+		DEFAULT_PARSERS.put(ShortValue.class, new DefaultParserFactory<>(ShortValueParser.class));
+		DEFAULT_PARSERS.put(IntValue.class, new DefaultParserFactory<>(IntValueParser.class));
+		DEFAULT_PARSERS.put(LongValue.class, new DefaultParserFactory<>(LongValueParser.class));
+		DEFAULT_PARSERS.put(StringValue.class, new DefaultParserFactory<>(StringValueParser.class));
+		DEFAULT_PARSERS.put(FloatValue.class, new DefaultParserFactory<>(FloatValueParser.class));
+		DEFAULT_PARSERS.put(DoubleValue.class, new DefaultParserFactory<>(DoubleValueParser.class));
+		DEFAULT_PARSERS.put(BooleanValue.class, new DefaultParserFactory<>(BooleanValueParser.class));
 
 		// SQL date/time types
-		PARSERS.put(java.sql.Time.class, SqlTimeParser.class);
-		PARSERS.put(java.sql.Date.class, SqlDateParser.class);
-		PARSERS.put(java.sql.Timestamp.class, SqlTimestampParser.class);
+		DEFAULT_PARSERS.put(java.sql.Time.class, new DefaultParserFactory<>(SqlTimeParser.class));
+		DEFAULT_PARSERS.put(java.sql.Date.class, new DefaultParserFactory<>(SqlDateParser.class));
+		DEFAULT_PARSERS.put(java.sql.Timestamp.class, new DefaultParserFactory<>(SqlTimestampParser.class));
 	}
+
+	private static final Map<Class<?>, ParserFactory<?>> CUSTOM_PARSERS = new HashMap<>();
+
+	/**
+	 * Registers a user-defined (custom) type with a parser factory for it.
+	 * Custom type parsing precedes default one.
+	 * @param type a user-defined type
+	 * @param factory the type's parser factory.
+	 * @return the registration status: 1 - registration is successful, -1 - otherwise.
+	 */
+	public static <T> int registerCustomParser(Class<T> type, ParserFactory<T> factory) {
+		Preconditions.checkNotNull(type, "The type must be not null.");
+		Preconditions.checkNotNull(factory, "The factory must be not null.");
+
+		synchronized (CUSTOM_PARSERS) {
+			if (CUSTOM_PARSERS.containsKey(type)) {
+				LOG.warn("'{}' type is already registered with '{}' parser. Skipping.");
+				return -1;
+			}
+			CUSTOM_PARSERS.put(type, factory);
+			return 1;
+		}
+	}
+
 }

--- a/flink-core/src/main/java/org/apache/flink/types/parser/ParserFactory.java
+++ b/flink-core/src/main/java/org/apache/flink/types/parser/ParserFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.types.parser;
+
+/**
+ * Supertype for factories that supply instances of {@link FieldParser} class.
+ * @param <T> target type meant to be produced by the {@link FieldParser} instance.
+ */
+public interface ParserFactory<T> {
+
+	/**
+	 * Gives an insight of a {@link FieldParser} instance's type to be created by this factory.
+	 * @return a class of {@link FieldParser} instances provided by this factory.
+	 */
+	Class<? extends FieldParser<T>> getParserType();
+
+	/**
+	 * Creates a dedicated instance of {@link FieldParser}.
+	 * @return an instance of {@link FieldParser} covered by this factory.
+	 */
+	FieldParser<T> create();
+
+}

--- a/flink-java/pom.xml
+++ b/flink-java/pom.xml
@@ -65,6 +65,13 @@ under the License.
 			<artifactId>flink-test-utils-junit</artifactId>
 		</dependency>
 
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>2.6.3</version>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/flink-java/src/main/java/org/apache/flink/api/java/io/CsvReader.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/io/CsvReader.java
@@ -139,6 +139,7 @@ public class CsvReader {
 	 *
 	 * @param delimiter The delimiter that separates the fields in one row.
 	 * @return The CSV reader instance itself, to allow for fluent function chaining.
+	 *
 	 * @deprecated Please use {@link #fieldDelimiter(String)}.
 	 */
 	@Deprecated
@@ -223,7 +224,7 @@ public class CsvReader {
 	 * @param fields The array of flags that describes which fields are to be included and which not.
 	 * @return The CSV reader instance itself, to allow for fluent function chaining.
 	 */
-	public CsvReader includeFields(boolean... fields) {
+	public CsvReader includeFields(boolean ... fields) {
 		if (fields == null || fields.length == 0) {
 			throw new IllegalArgumentException("The set of included fields must not be null or empty.");
 		}
@@ -285,9 +286,9 @@ public class CsvReader {
 	 *
 	 * <p>Examples:
 	 * <ul>
-	 * <li>A mask of {@code 0x7} would include the first three fields.</li>
-	 * <li>A mask of {@code 0x26} (binary {@code 100110} would skip the first fields, include fields
-	 * two and three, skip fields four and five, and include field six.</li>
+	 *   <li>A mask of {@code 0x7} would include the first three fields.</li>
+	 *   <li>A mask of {@code 0x26} (binary {@code 100110} would skip the first fields, include fields
+	 *       two and three, skip fields four and five, and include field six.</li>
 	 * </ul>
 	 *
 	 * @param mask The bit mask defining which fields to include and which to skip.
@@ -329,7 +330,7 @@ public class CsvReader {
 	 *
 	 * @return The CSV reader instance itself, to allow for fluent function chaining.
 	 */
-	public CsvReader ignoreInvalidLines() {
+	public CsvReader ignoreInvalidLines(){
 		ignoreInvalidLines = true;
 		return this;
 	}
@@ -338,7 +339,7 @@ public class CsvReader {
 	 * Configures the reader to read the CSV data and parse it to the given type. The all fields of the type
 	 * must be public or able to set value. The type information for the fields is obtained from the type class.
 	 *
-	 * @param pojoType   The class of the target POJO.
+	 * @param pojoType The class of the target POJO.
 	 * @param pojoFields The fields of the POJO which are mapped to CSV fields.
 	 * @return The DataSet representing the parsed CSV data.
 	 */

--- a/flink-java/src/main/java/org/apache/flink/api/java/io/PrimitiveInputFormat.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/io/PrimitiveInputFormat.java
@@ -23,7 +23,6 @@ import org.apache.flink.api.common.io.DelimitedInputFormat;
 import org.apache.flink.core.fs.FileInputSplit;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.types.parser.FieldParser;
-import org.apache.flink.util.InstantiationUtil;
 
 import java.io.IOException;
 
@@ -58,11 +57,12 @@ public class PrimitiveInputFormat<OT> extends DelimitedInputFormat<OT> {
 	@Override
 	public void open(FileInputSplit split) throws IOException {
 		super.open(split);
-		Class<? extends FieldParser<OT>> parserType = FieldParser.getParserForType(primitiveClass);
-		if (parserType == null) {
+
+		FieldParser<OT> parserInstance = FieldParser.getParserInstanceFor(primitiveClass);
+		if (parserInstance == null) {
 			throw new IllegalArgumentException("The type '" + primitiveClass.getName() + "' is not supported for the primitive input format.");
 		}
-		parser = InstantiationUtil.instantiate(parserType, FieldParser.class);
+		parser = parserInstance;
 	}
 
 	@Override

--- a/flink-java/src/test/java/org/apache/flink/api/java/io/CSVReaderTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/io/CSVReaderTest.java
@@ -19,12 +19,24 @@
 package org.apache.flink.api.java.io;
 
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeHint;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.io.csv.custom.type.NestedCustomJsonType;
+import org.apache.flink.api.java.io.csv.custom.type.NestedCustomJsonTypeStringParser;
+import org.apache.flink.api.java.io.csv.custom.type.complex.GenericsAwareCustomJsonType;
+import org.apache.flink.api.java.io.csv.custom.type.complex.GenericsAwareCustomJsonTypeStringParser;
+import org.apache.flink.api.java.io.csv.custom.type.complex.Tuple3ContainerType;
+import org.apache.flink.api.java.io.csv.custom.type.simple.SimpleCustomJsonType;
+import org.apache.flink.api.java.io.csv.custom.type.simple.SimpleCustomJsonTypeStringParser;
+import org.apache.flink.api.java.io.csv.custom.type.simple.Tuple1ContainerType;
 import org.apache.flink.api.java.operators.DataSource;
+import org.apache.flink.api.java.tuple.Tuple1;
+import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.api.java.tuple.Tuple4;
 import org.apache.flink.api.java.tuple.Tuple5;
 import org.apache.flink.api.java.tuple.Tuple8;
+import org.apache.flink.api.java.typeutils.PojoTypeInfo;
 import org.apache.flink.api.java.typeutils.TupleTypeInfo;
 import org.apache.flink.api.java.typeutils.ValueTypeInfo;
 import org.apache.flink.core.memory.DataInputView;
@@ -36,18 +48,26 @@ import org.apache.flink.types.DoubleValue;
 import org.apache.flink.types.FloatValue;
 import org.apache.flink.types.IntValue;
 import org.apache.flink.types.LongValue;
+import org.apache.flink.types.Row;
 import org.apache.flink.types.ShortValue;
 import org.apache.flink.types.StringValue;
 import org.apache.flink.types.Value;
+import org.apache.flink.types.parser.FieldParser;
+import org.apache.flink.types.parser.ParserFactory;
 
-import org.junit.Assert;
+import com.fasterxml.jackson.core.type.TypeReference;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Map;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Tests for the CSV reader builder.
@@ -58,15 +78,15 @@ public class CSVReaderTest {
 	public void testIgnoreHeaderConfigure() {
 		CsvReader reader = getCsvReader();
 		reader.ignoreFirstLine();
-		Assert.assertTrue(reader.skipFirstLineAsHeader);
+		assertTrue(reader.skipFirstLineAsHeader);
 	}
 
 	@Test
 	public void testIgnoreInvalidLinesConfigure() {
 		CsvReader reader = getCsvReader();
-		Assert.assertFalse(reader.ignoreInvalidLines);
+		assertFalse(reader.ignoreInvalidLines);
 		reader.ignoreInvalidLines();
-		Assert.assertTrue(reader.ignoreInvalidLines);
+		assertTrue(reader.ignoreInvalidLines);
 	}
 
 	@Test
@@ -89,50 +109,50 @@ public class CSVReaderTest {
 	public void testIncludeFieldsDense() {
 		CsvReader reader = getCsvReader();
 		reader.includeFields(true, true, true);
-		Assert.assertTrue(Arrays.equals(new boolean[] {true,  true, true}, reader.includedMask));
+		assertTrue(Arrays.equals(new boolean[] {true,  true, true}, reader.includedMask));
 
 		reader = getCsvReader();
 		reader.includeFields("ttt");
-		Assert.assertTrue(Arrays.equals(new boolean[] {true,  true, true}, reader.includedMask));
+		assertTrue(Arrays.equals(new boolean[] {true,  true, true}, reader.includedMask));
 
 		reader = getCsvReader();
 		reader.includeFields("TTT");
-		Assert.assertTrue(Arrays.equals(new boolean[] {true,  true, true}, reader.includedMask));
+		assertTrue(Arrays.equals(new boolean[] {true,  true, true}, reader.includedMask));
 
 		reader = getCsvReader();
 		reader.includeFields("111");
-		Assert.assertTrue(Arrays.equals(new boolean[] {true,  true, true}, reader.includedMask));
+		assertTrue(Arrays.equals(new boolean[] {true,  true, true}, reader.includedMask));
 
 		reader = getCsvReader();
 		reader.includeFields(0x7L);
-		Assert.assertTrue(Arrays.equals(new boolean[] {true,  true, true}, reader.includedMask));
+		assertTrue(Arrays.equals(new boolean[] {true,  true, true}, reader.includedMask));
 	}
 
 	@Test
 	public void testIncludeFieldsSparse() {
 		CsvReader reader = getCsvReader();
 		reader.includeFields(false, true, true, false, false, true, false, false);
-		Assert.assertTrue(Arrays.equals(new boolean[] {false, true, true, false, false, true}, reader.includedMask));
+		assertTrue(Arrays.equals(new boolean[] {false, true, true, false, false, true}, reader.includedMask));
 
 		reader = getCsvReader();
 		reader.includeFields("fttfftff");
-		Assert.assertTrue(Arrays.equals(new boolean[] {false, true, true, false, false, true}, reader.includedMask));
+		assertTrue(Arrays.equals(new boolean[] {false, true, true, false, false, true}, reader.includedMask));
 
 		reader = getCsvReader();
 		reader.includeFields("FTTFFTFF");
-		Assert.assertTrue(Arrays.equals(new boolean[] {false, true, true, false, false, true}, reader.includedMask));
+		assertTrue(Arrays.equals(new boolean[] {false, true, true, false, false, true}, reader.includedMask));
 
 		reader = getCsvReader();
 		reader.includeFields("01100100");
-		Assert.assertTrue(Arrays.equals(new boolean[] {false, true, true, false, false, true}, reader.includedMask));
+		assertTrue(Arrays.equals(new boolean[] {false, true, true, false, false, true}, reader.includedMask));
 
 		reader = getCsvReader();
 		reader.includeFields("0t1f0TFF");
-		Assert.assertTrue(Arrays.equals(new boolean[] {false, true, true, false, false, true}, reader.includedMask));
+		assertTrue(Arrays.equals(new boolean[] {false, true, true, false, false, true}, reader.includedMask));
 
 		reader = getCsvReader();
 		reader.includeFields(0x26L);
-		Assert.assertTrue(Arrays.equals(new boolean[] {false, true, true, false, false, true}, reader.includedMask));
+		assertTrue(Arrays.equals(new boolean[] {false, true, true, false, false, true}, reader.includedMask));
 	}
 
 	@Test
@@ -141,7 +161,7 @@ public class CSVReaderTest {
 
 		try {
 			reader.includeFields("1t0Tfht");
-			Assert.fail("Reader accepted an invalid mask string");
+			fail("Reader accepted an invalid mask string");
 		}
 		catch (IllegalArgumentException e) {
 			// expected
@@ -154,7 +174,7 @@ public class CSVReaderTest {
 
 		try {
 			reader.includeFields(false, false, false, false, false, false);
-			Assert.fail("The reader accepted a fields configuration that excludes all fields.");
+			fail("The reader accepted a fields configuration that excludes all fields.");
 		}
 		catch (IllegalArgumentException e) {
 			// all good
@@ -162,7 +182,7 @@ public class CSVReaderTest {
 
 		try {
 			reader.includeFields(0);
-			Assert.fail("The reader accepted a fields configuration that excludes all fields.");
+			fail("The reader accepted a fields configuration that excludes all fields.");
 		}
 		catch (IllegalArgumentException e) {
 			// all good
@@ -170,7 +190,7 @@ public class CSVReaderTest {
 
 		try {
 			reader.includeFields("ffffffffffffff");
-			Assert.fail("The reader accepted a fields configuration that excludes all fields.");
+			fail("The reader accepted a fields configuration that excludes all fields.");
 		}
 		catch (IllegalArgumentException e) {
 			// all good
@@ -178,7 +198,7 @@ public class CSVReaderTest {
 
 		try {
 			reader.includeFields("00000000000000000");
-			Assert.fail("The reader accepted a fields configuration that excludes all fields.");
+			fail("The reader accepted a fields configuration that excludes all fields.");
 		}
 		catch (IllegalArgumentException e) {
 			// all good
@@ -189,7 +209,7 @@ public class CSVReaderTest {
 	public void testReturnType() throws Exception {
 		CsvReader reader = getCsvReader();
 		DataSource<Item> items = reader.tupleType(Item.class);
-		Assert.assertTrue(items.getType().getTypeClass() == Item.class);
+		assertTrue(items.getType().getTypeClass() == Item.class);
 	}
 
 	@Test
@@ -199,18 +219,18 @@ public class CSVReaderTest {
 
 		TypeInformation<?> info = items.getType();
 		if (!info.isTupleType()) {
-			Assert.fail();
+			fail();
 		} else {
 			TupleTypeInfo<?> tinfo = (TupleTypeInfo<?>) info;
-			Assert.assertEquals(BasicTypeInfo.INT_TYPE_INFO, tinfo.getTypeAt(0));
-			Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tinfo.getTypeAt(1));
-			Assert.assertEquals(BasicTypeInfo.DOUBLE_TYPE_INFO, tinfo.getTypeAt(2));
-			Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tinfo.getTypeAt(3));
+			assertEquals(BasicTypeInfo.INT_TYPE_INFO, tinfo.getTypeAt(0));
+			assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tinfo.getTypeAt(1));
+			assertEquals(BasicTypeInfo.DOUBLE_TYPE_INFO, tinfo.getTypeAt(2));
+			assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tinfo.getTypeAt(3));
 
 		}
 
 		CsvInputFormat<?> inputFormat = (CsvInputFormat<?>) items.getInputFormat();
-		Assert.assertArrayEquals(new Class<?>[]{Integer.class, String.class, Double.class, String.class}, inputFormat.getFieldTypes());
+		assertArrayEquals(new Class<?>[]{Integer.class, String.class, Double.class, String.class}, inputFormat.getFieldTypes());
 	}
 
 	@Test
@@ -219,19 +239,19 @@ public class CSVReaderTest {
 		DataSource<SubItem> sitems = reader.tupleType(SubItem.class);
 		TypeInformation<?> info = sitems.getType();
 
-		Assert.assertEquals(true, info.isTupleType());
-		Assert.assertEquals(SubItem.class, info.getTypeClass());
+		assertEquals(true, info.isTupleType());
+		assertEquals(SubItem.class, info.getTypeClass());
 
 		@SuppressWarnings("unchecked")
 		TupleTypeInfo<SubItem> tinfo = (TupleTypeInfo<SubItem>) info;
 
-		Assert.assertEquals(BasicTypeInfo.INT_TYPE_INFO, tinfo.getTypeAt(0));
-		Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tinfo.getTypeAt(1));
-		Assert.assertEquals(BasicTypeInfo.DOUBLE_TYPE_INFO, tinfo.getTypeAt(2));
-		Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tinfo.getTypeAt(3));
+		assertEquals(BasicTypeInfo.INT_TYPE_INFO, tinfo.getTypeAt(0));
+		assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tinfo.getTypeAt(1));
+		assertEquals(BasicTypeInfo.DOUBLE_TYPE_INFO, tinfo.getTypeAt(2));
+		assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tinfo.getTypeAt(3));
 
 		CsvInputFormat<?> inputFormat = (CsvInputFormat<?>) sitems.getInputFormat();
-		Assert.assertArrayEquals(new Class<?>[]{Integer.class, String.class, Double.class, String.class}, inputFormat.getFieldTypes());
+		assertArrayEquals(new Class<?>[]{Integer.class, String.class, Double.class, String.class}, inputFormat.getFieldTypes());
 	}
 
 	@Test
@@ -240,22 +260,22 @@ public class CSVReaderTest {
 		DataSource<FinalItem> sitems = reader.tupleType(FinalItem.class);
 		TypeInformation<?> info = sitems.getType();
 
-		Assert.assertEquals(true, info.isTupleType());
-		Assert.assertEquals(FinalItem.class, info.getTypeClass());
+		assertEquals(true, info.isTupleType());
+		assertEquals(FinalItem.class, info.getTypeClass());
 
 		@SuppressWarnings("unchecked")
 		TupleTypeInfo<SubItem> tinfo = (TupleTypeInfo<SubItem>) info;
 
-		Assert.assertEquals(BasicTypeInfo.INT_TYPE_INFO, tinfo.getTypeAt(0));
-		Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tinfo.getTypeAt(1));
-		Assert.assertEquals(BasicTypeInfo.DOUBLE_TYPE_INFO, tinfo.getTypeAt(2));
-		Assert.assertEquals(ValueTypeInfo.class, tinfo.getTypeAt(3).getClass());
-		Assert.assertEquals(ValueTypeInfo.class, tinfo.getTypeAt(4).getClass());
-		Assert.assertEquals(StringValue.class, ((ValueTypeInfo<?>) tinfo.getTypeAt(3)).getTypeClass());
-		Assert.assertEquals(LongValue.class, ((ValueTypeInfo<?>) tinfo.getTypeAt(4)).getTypeClass());
+		assertEquals(BasicTypeInfo.INT_TYPE_INFO, tinfo.getTypeAt(0));
+		assertEquals(BasicTypeInfo.STRING_TYPE_INFO, tinfo.getTypeAt(1));
+		assertEquals(BasicTypeInfo.DOUBLE_TYPE_INFO, tinfo.getTypeAt(2));
+		assertEquals(ValueTypeInfo.class, tinfo.getTypeAt(3).getClass());
+		assertEquals(ValueTypeInfo.class, tinfo.getTypeAt(4).getClass());
+		assertEquals(StringValue.class, ((ValueTypeInfo<?>) tinfo.getTypeAt(3)).getTypeClass());
+		assertEquals(LongValue.class, ((ValueTypeInfo<?>) tinfo.getTypeAt(4)).getTypeClass());
 
 		CsvInputFormat<?> inputFormat = (CsvInputFormat<?>) sitems.getInputFormat();
-		Assert.assertArrayEquals(new Class<?>[] {Integer.class, String.class, Double.class, StringValue.class, LongValue.class}, inputFormat.getFieldTypes());
+		assertArrayEquals(new Class<?>[] {Integer.class, String.class, Double.class, StringValue.class, LongValue.class}, inputFormat.getFieldTypes());
 	}
 
 	@Test
@@ -264,7 +284,7 @@ public class CSVReaderTest {
 
 		try {
 			reader.tupleType(PartialItem.class);
-			Assert.fail("tupleType() accepted an underspecified generic class.");
+			fail("tupleType() accepted an underspecified generic class.");
 		}
 		catch (Exception e) {
 			// okay.
@@ -278,8 +298,8 @@ public class CSVReaderTest {
 				reader.types(StringValue.class, BooleanValue.class, ByteValue.class, ShortValue.class, IntValue.class, LongValue.class, FloatValue.class, DoubleValue.class);
 		TypeInformation<?> info = items.getType();
 
-		Assert.assertEquals(true, info.isTupleType());
-		Assert.assertEquals(Tuple8.class, info.getTypeClass());
+		assertEquals(true, info.isTupleType());
+		assertEquals(Tuple8.class, info.getTypeClass());
 	}
 
 	@Test(expected = IllegalArgumentException.class)
@@ -294,6 +314,122 @@ public class CSVReaderTest {
 		CsvReader reader = getCsvReader();
 		// CsvReader doesn't support custom Value type
 		reader.types(ValueItem.class);
+	}
+
+	@Test
+	public void testWorkingWithSimpleCustomType() {
+		ParserFactory<SimpleCustomJsonType> factory = new ParserFactory<SimpleCustomJsonType>() {
+			@Override
+			public Class<? extends FieldParser<SimpleCustomJsonType>> getParserType() {
+				return SimpleCustomJsonTypeStringParser.class;
+			}
+
+			@Override
+			public FieldParser<SimpleCustomJsonType> create() {
+				return new SimpleCustomJsonTypeStringParser();
+			}
+		};
+		FieldParser.registerCustomParser(SimpleCustomJsonType.class, factory);
+
+		ParserFactory<NestedCustomJsonType> factory1 = new ParserFactory<NestedCustomJsonType>() {
+			@Override
+			public Class<? extends FieldParser<NestedCustomJsonType>> getParserType() {
+				return NestedCustomJsonTypeStringParser.class;
+			}
+
+			@Override
+			public FieldParser<NestedCustomJsonType> create() {
+				return new NestedCustomJsonTypeStringParser();
+			}
+		};
+		FieldParser.registerCustomParser(NestedCustomJsonType.class, factory1);
+
+		CsvReader reader = getCsvReader();
+		DataSource<?> simpleType = reader.preciseTypes(TypeInformation.of(SimpleCustomJsonType.class));
+		assertEquals(true, simpleType.getType().isTupleType());
+		assertEquals(Tuple1.class, simpleType.getType().getTypeClass());
+
+		DataSource<?> simpleType2 = reader.tupleType(Tuple1ContainerType.class);
+		assertEquals(true, simpleType2.getType().isTupleType());
+		assertTrue(Tuple1.class.isAssignableFrom(simpleType2.getType().getTypeClass()));
+
+		DataSource<?> simpleType3 = reader.pojoType(SimpleCustomJsonType.class);
+		assertTrue(SimpleCustomJsonType.class.isAssignableFrom(simpleType3.getType().getTypeClass()));
+	}
+
+	@Test
+	public void testWorkingWithComplexCustomType() {
+		ParserFactory<GenericsAwareCustomJsonType<NestedCustomJsonType>> factory = new ParserFactory<GenericsAwareCustomJsonType<NestedCustomJsonType>>() {
+			@Override
+			public Class<? extends FieldParser<GenericsAwareCustomJsonType<NestedCustomJsonType>>> getParserType() {
+				return (Class<FieldParser<GenericsAwareCustomJsonType<NestedCustomJsonType>>>) (Class<?>) GenericsAwareCustomJsonTypeStringParser.class;
+			}
+
+			@Override
+			public FieldParser<GenericsAwareCustomJsonType<NestedCustomJsonType>> create() {
+				return new GenericsAwareCustomJsonTypeStringParser<>(new TypeReference<GenericsAwareCustomJsonType<NestedCustomJsonType>>() {});
+			}
+		};
+
+		CsvReader reader = getCsvReader();
+
+		TypeHint<GenericsAwareCustomJsonType<NestedCustomJsonType>> typeHint = new TypeHint<GenericsAwareCustomJsonType<NestedCustomJsonType>>() {};
+		TypeInformation<GenericsAwareCustomJsonType<NestedCustomJsonType>> typeInfo = TypeInformation.of(typeHint);
+		FieldParser.registerCustomParser(typeInfo.getTypeClass(), factory);
+
+		DataSource<?> dataSource = reader.preciseTypes(
+			BasicTypeInfo.INT_TYPE_INFO,
+			BasicTypeInfo.STRING_TYPE_INFO,
+			typeInfo
+		);
+		verifyComplexCustomTypeDataSource(dataSource, Tuple3.class);
+
+		DataSource<Tuple3ContainerType> dataSource1 = reader.tupleType(Tuple3ContainerType.class);
+		verifyComplexCustomTypeDataSource(dataSource1, Tuple3ContainerType.class);
+
+		DataSource<GenericsAwareCustomJsonType<NestedCustomJsonType>> dataSource2 = reader.precisePojoType(typeInfo.getTypeClass(), new String[]{}, new TypeInformation[]{});
+		assertTrue(GenericsAwareCustomJsonType.class.isAssignableFrom(dataSource2.getType().getTypeClass()));
+	}
+
+	private void verifyComplexCustomTypeDataSource(DataSource<?> dataSource, Class targetType) {
+		assertEquals(true, dataSource.getType().isTupleType());
+		assertEquals(targetType, dataSource.getType().getTypeClass());
+
+		Map<String, TypeInformation<?>> genericParameters = dataSource.getType().getGenericParameters();
+		assertEquals(BasicTypeInfo.INT_TYPE_INFO, genericParameters.get("T0"));
+		assertEquals(BasicTypeInfo.STRING_TYPE_INFO, genericParameters.get("T1"));
+		assertTrue(genericParameters.get("T2") instanceof PojoTypeInfo);
+
+		PojoTypeInfo<?> pojoType = (PojoTypeInfo) genericParameters.get("T2");
+
+		assertTrue(String.class.isAssignableFrom(pojoType.getTypeAt(0).getTypeClass()));
+		assertTrue(NestedCustomJsonType.class.isAssignableFrom(pojoType.getTypeAt(1).getTypeClass()));
+		assertTrue(NestedCustomJsonType.class.isAssignableFrom(pojoType.getTypeAt(2).getTypeClass()));
+	}
+
+	@Test
+	public void testWithRowType() throws Exception {
+		CsvReader reader = getCsvReader();
+		DataSource<Row> items =
+			reader.rowType(StringValue.class);
+		TypeInformation<?> info = items.getType();
+
+		assertTrue(info.isTupleType());
+		assertEquals(Row.class, info.getTypeClass());
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testWithInvalidRowType() throws Exception {
+		CsvReader reader = getCsvReader();
+		// CsvReader doesn't support CharValue
+		reader.rowType(CharValue.class);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testWithInvalidRowType2() throws Exception {
+		CsvReader reader = getCsvReader();
+		// CsvReader doesn't support custom Value type
+		reader.rowType(ValueItem.class);
 	}
 
 	private static CsvReader getCsvReader() {

--- a/flink-java/src/test/java/org/apache/flink/api/java/io/csv/custom/type/NestedCustomJsonType.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/io/csv/custom/type/NestedCustomJsonType.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.io.csv.custom.type;
+
+/**
+ * A user-defined type with only Java primitives inside that is meant to be embedded into other user-defined types
+ * for hierarchical type information resolution tests.
+ */
+public class NestedCustomJsonType {
+
+	private String f21;
+
+	public String getF21() {
+		return f21;
+	}
+
+	public void setF21(String f21) {
+		this.f21 = f21;
+	}
+
+	@Override
+	public String toString() {
+		return "NestedCustomJsonType{" +
+			"f21='" + f21 + '\'' +
+			'}';
+	}
+}

--- a/flink-java/src/test/java/org/apache/flink/api/java/io/csv/custom/type/NestedCustomJsonTypeStringParser.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/io/csv/custom/type/NestedCustomJsonTypeStringParser.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.io.csv.custom.type;
+
+import org.apache.flink.types.parser.FieldParser;
+import org.apache.flink.types.parser.StringParser;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+
+/**
+ * A JSON parser for {@link NestedCustomJsonType} type, that is based on StringParser.
+ */
+public class NestedCustomJsonTypeStringParser extends FieldParser<NestedCustomJsonType> {
+
+	private final StringParser stringParser = new StringParser();
+
+	{
+		stringParser.enableQuotedStringParsing((byte) '\'');
+	}
+
+	private NestedCustomJsonType lastResult;
+
+	@Override
+	protected int parseField(byte[] bytes, int startPos, int limit, byte[] delim, NestedCustomJsonType reuse) {
+		int offset = stringParser.parseField(bytes, startPos, limit, delim, null);
+		String stringRepresentation = stringParser.getLastResult();
+
+		ObjectMapper mapper = new ObjectMapper();
+		try {
+			lastResult = mapper.readValue(stringRepresentation, NestedCustomJsonType.class);
+			return offset;
+		} catch (IOException e) {
+			e.printStackTrace();
+			return -1;
+		}
+	}
+
+	@Override
+	public NestedCustomJsonType getLastResult() {
+		return lastResult;
+	}
+
+	@Override
+	public NestedCustomJsonType createValue() {
+		return new NestedCustomJsonType();
+	}
+}

--- a/flink-java/src/test/java/org/apache/flink/api/java/io/csv/custom/type/complex/GenericsAwareCustomJsonType.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/io/csv/custom/type/complex/GenericsAwareCustomJsonType.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.io.csv.custom.type.complex;
+
+import org.apache.flink.api.java.io.csv.custom.type.NestedCustomJsonType;
+
+/**
+ * A user-defined type (with a Java Generic parameter inside) that is represented in one or several csv fields.
+ */
+public class GenericsAwareCustomJsonType<T> {
+
+	private String f1;
+	private NestedCustomJsonType f2;
+	private T f3;
+
+	public String getF1() {
+		return f1;
+	}
+
+	public void setF1(String f1) {
+		this.f1 = f1;
+	}
+
+	public NestedCustomJsonType getF2() {
+		return f2;
+	}
+
+	public void setF2(NestedCustomJsonType f2) {
+		this.f2 = f2;
+	}
+
+	public T getF3() {
+		return f3;
+	}
+
+	public void setF3(T f3) {
+		this.f3 = f3;
+	}
+
+	@Override
+	public String toString() {
+		return "GenericsAwareCustomJsonType{" +
+			"f1='" + f1 + '\'' +
+			", f2=" + f2 +
+			", f3=" + f3 +
+			'}';
+	}
+}

--- a/flink-java/src/test/java/org/apache/flink/api/java/io/csv/custom/type/complex/GenericsAwareCustomJsonTypeStringParser.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/io/csv/custom/type/complex/GenericsAwareCustomJsonTypeStringParser.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.io.csv.custom.type.complex;
+
+import org.apache.flink.types.parser.FieldParser;
+import org.apache.flink.types.parser.StringParser;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+
+/**
+ * A JSON parser for {@link GenericsAwareCustomJsonType} type, that is based on StringParser.
+ * @param <T> a generic type of the {@link GenericsAwareCustomJsonType} instance.
+ */
+public class GenericsAwareCustomJsonTypeStringParser<T> extends FieldParser<GenericsAwareCustomJsonType<T>> {
+
+	private final StringParser stringParser = new StringParser();
+
+	{
+		stringParser.enableQuotedStringParsing((byte) '\'');
+	}
+
+	private TypeReference<GenericsAwareCustomJsonType<T>> typeReference;
+	private GenericsAwareCustomJsonType<T> lastResult;
+
+	public GenericsAwareCustomJsonTypeStringParser(TypeReference<GenericsAwareCustomJsonType<T>> typeReference) {
+		this.typeReference = typeReference;
+	}
+
+	@Override
+	protected int parseField(byte[] bytes, int startPos, int limit, byte[] delim, GenericsAwareCustomJsonType<T> reuse) {
+		int offset = stringParser.parseField(bytes, startPos, limit, delim, null);
+		String stringRepresentation = stringParser.getLastResult();
+
+		ObjectMapper mapper = new ObjectMapper();
+		try {
+			lastResult = mapper.readValue(stringRepresentation, typeReference);
+			return offset;
+		} catch (IOException e) {
+			e.printStackTrace();
+			return -1;
+		}
+	}
+
+	@Override
+	public GenericsAwareCustomJsonType<T> getLastResult() {
+		return lastResult;
+	}
+
+	@Override
+	public GenericsAwareCustomJsonType<T> createValue() {
+		return new GenericsAwareCustomJsonType();
+	}
+}

--- a/flink-java/src/test/java/org/apache/flink/api/java/io/csv/custom/type/complex/Tuple3ContainerType.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/io/csv/custom/type/complex/Tuple3ContainerType.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.io.csv.custom.type.complex;
+
+import org.apache.flink.api.java.io.csv.custom.type.NestedCustomJsonType;
+import org.apache.flink.api.java.tuple.Tuple3;
+
+/**
+ * A container-type for {@link Tuple3}. Container types are required for {@code CsvReader.tupleType()} method -- pure Tuple classes
+ * cannot be used there.
+ */
+public class Tuple3ContainerType extends Tuple3<Integer, String, GenericsAwareCustomJsonType<NestedCustomJsonType>> {
+}

--- a/flink-java/src/test/java/org/apache/flink/api/java/io/csv/custom/type/simple/SimpleCustomJsonType.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/io/csv/custom/type/simple/SimpleCustomJsonType.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.io.csv.custom.type.simple;
+
+import org.apache.flink.api.java.io.csv.custom.type.NestedCustomJsonType;
+
+/**
+ * A user-defined type (without any Java Generics) that is represented in one or several csv fields.
+ */
+public class SimpleCustomJsonType {
+
+	private int f1;
+	private String f2;
+	private NestedCustomJsonType f3;
+
+	public int getF1() {
+		return f1;
+	}
+
+	public void setF1(int f1) {
+		this.f1 = f1;
+	}
+
+	public String getF2() {
+		return f2;
+	}
+
+	public void setF2(String f2) {
+		this.f2 = f2;
+	}
+
+	public NestedCustomJsonType getF3() {
+		return f3;
+	}
+
+	public void setF3(NestedCustomJsonType f3) {
+		this.f3 = f3;
+	}
+
+}

--- a/flink-java/src/test/java/org/apache/flink/api/java/io/csv/custom/type/simple/SimpleCustomJsonTypeStringParser.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/io/csv/custom/type/simple/SimpleCustomJsonTypeStringParser.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.io.csv.custom.type.simple;
+
+import org.apache.flink.types.parser.FieldParser;
+import org.apache.flink.types.parser.StringParser;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+
+/**
+ * A JSON parser for {@link SimpleCustomJsonType} type, that is based on StringParser.
+ */
+public class SimpleCustomJsonTypeStringParser extends FieldParser<SimpleCustomJsonType> {
+
+	private final StringParser stringParser = new StringParser();
+
+	{
+		stringParser.enableQuotedStringParsing((byte) '\'');
+	}
+
+	private SimpleCustomJsonType lastResult;
+
+	@Override
+	protected int parseField(byte[] bytes, int startPos, int limit, byte[] delim, SimpleCustomJsonType reuse) {
+		int offset = stringParser.parseField(bytes, startPos, limit, delim, null);
+		String stringRepresentation = stringParser.getLastResult();
+
+		ObjectMapper mapper = new ObjectMapper();
+		try {
+			lastResult = mapper.readValue(stringRepresentation, SimpleCustomJsonType.class);
+			return offset;
+		} catch (IOException e) {
+			e.printStackTrace();
+			return -1;
+		}
+	}
+
+	@Override
+	public SimpleCustomJsonType getLastResult() {
+		return lastResult;
+	}
+
+	@Override
+	public SimpleCustomJsonType createValue() {
+		return new SimpleCustomJsonType();
+	}
+}

--- a/flink-java/src/test/java/org/apache/flink/api/java/io/csv/custom/type/simple/Tuple1ContainerType.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/io/csv/custom/type/simple/Tuple1ContainerType.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.io.csv.custom.type.simple;
+
+import org.apache.flink.api.java.tuple.Tuple1;
+
+/**
+ * A container-type for {@link Tuple1}. Container types are required for {@code CsvReader.tupleType()} method -- pure Tuple classes
+ * cannot be used there.
+ */
+public class Tuple1ContainerType extends Tuple1<SimpleCustomJsonType> {
+}

--- a/flink-java/src/test/java/org/apache/flink/api/java/tuple/TupleGenerator.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/tuple/TupleGenerator.java
@@ -390,77 +390,138 @@ class TupleGenerator {
 		// generate code
 		StringBuilder sb = new StringBuilder(1000);
 		for (int numFields = FIRST; numFields <= LAST; numFields++) {
-
-			// method begin
-			sb.append("\n");
-
-			// java doc
-			sb.append("\t/**\n");
-			sb.append("\t * Specifies the types for the CSV fields. This method parses the CSV data to a ").append(numFields).append("-tuple\n");
-			sb.append("\t * which has fields of the specified types.\n");
-			sb.append("\t * This method is overloaded for each possible length of the tuples to support type safe\n");
-			sb.append("\t * creation of data sets through CSV parsing.\n");
-			sb.append("\t *\n");
-
-			for (int pos = 0; pos < numFields; pos++) {
-				sb.append("\t * @param type").append(pos);
-				sb.append(" The type of CSV field ").append(pos).append(" and the type of field ");
-				sb.append(pos).append(" in the returned tuple type.\n");
-			}
-			sb.append("\t * @return The {@link org.apache.flink.api.java.DataSet} representing the parsed CSV data.\n");
-			sb.append("\t */\n");
-
-			// method signature
-			sb.append("\tpublic <");
-			appendTupleTypeGenerics(sb, numFields);
-			sb.append("> DataSource<Tuple" + numFields + "<");
-			appendTupleTypeGenerics(sb, numFields);
-			sb.append(">> types(");
-			for (int i = 0; i < numFields; i++) {
-				if (i > 0) {
-					sb.append(", ");
-				}
-				sb.append("Class<");
-				sb.append(GEN_TYPE_PREFIX + i);
-				sb.append("> type" + i);
-			}
-			sb.append(") {\n");
-
-			// get TupleTypeInfo
-			sb.append("\t\tTupleTypeInfo<Tuple" + numFields + "<");
-			appendTupleTypeGenerics(sb, numFields);
-			sb.append(">> types = TupleTypeInfo.getBasicAndBasicValueTupleTypeInfo(");
-			for (int i = 0; i < numFields; i++) {
-				if (i > 0) {
-					sb.append(", ");
-				}
-				sb.append("type" + i);
-			}
-			sb.append(");\n");
-
-			// create csv input format
-			sb.append("\t\tCsvInputFormat<Tuple" + numFields + "<");
-			appendTupleTypeGenerics(sb, numFields);
-			sb.append(">> inputFormat = new TupleCsvInputFormat<Tuple" + numFields + "<");
-			appendTupleTypeGenerics(sb, numFields);
-			sb.append(">>(path, types, this.includedMask);\n");
-
-			// configure input format
-			sb.append("\t\tconfigureInputFormat(inputFormat);\n");
-
-			// return
-			sb.append("\t\treturn new DataSource<Tuple" + numFields + "<");
-			appendTupleTypeGenerics(sb, numFields);
-			sb.append(">>(executionContext, inputFormat, types, Utils.getCallLocationName());\n");
-
-			// end of method
-			sb.append("\t}\n");
+			generateTypesMethod(sb, numFields);
+			generatePreciseTypesMethod(sb, numFields);
 		}
 
 		// insert code into file
 		File dir = getPackage(root, CSV_READER_PACKAGE);
 		File csvReaderClass = new File(dir, CSV_READER_CLASSNAME + ".java");
 		insertCodeIntoFile(sb.toString(), csvReaderClass);
+	}
+
+	private static void generateTypesMethod(StringBuilder sb, int numFields) {
+		// method begin
+		sb.append("\n");
+
+		// java doc
+		sb.append("\t/**\n");
+		sb.append("\t * Specifies the types for the CSV fields. This method parses the CSV data to a ").append(numFields).append("-tuple\n");
+		sb.append("\t * which has fields of the specified types.\n");
+		sb.append("\t * This method is overloaded for each possible length of the tuples to support type safe\n");
+		sb.append("\t * creation of data sets through CSV parsing.\n");
+		sb.append("\t *\n");
+
+		for (int pos = 0; pos < numFields; pos++) {
+			sb.append("\t * @param type").append(pos);
+			sb.append(" The type of CSV field ").append(pos).append(" and the type of field ");
+			sb.append(pos).append(" in the returned tuple type.\n");
+		}
+		sb.append("\t * @return The {@link org.apache.flink.api.java.DataSet} representing the parsed CSV data.\n");
+		sb.append("\t */\n");
+
+		// method signature
+		sb.append("\tpublic <");
+		appendTupleTypeGenerics(sb, numFields);
+		sb.append("> DataSource<Tuple" + numFields + "<");
+		appendTupleTypeGenerics(sb, numFields);
+		sb.append(">> types(");
+		for (int i = 0; i < numFields; i++) {
+			if (i > 0) {
+				sb.append(", ");
+			}
+			sb.append("Class<");
+			sb.append(GEN_TYPE_PREFIX + i);
+			sb.append("> type" + i);
+		}
+		sb.append(") {\n");
+
+		// get TupleTypeInfo
+		sb.append("\t\tTupleTypeInfo<Tuple" + numFields + "<");
+		appendTupleTypeGenerics(sb, numFields);
+		sb.append(">> types = TupleTypeInfo.getTupleTypeInfo(");
+		for (int i = 0; i < numFields; i++) {
+			if (i > 0) {
+				sb.append(", ");
+			}
+			sb.append("type" + i);
+		}
+		sb.append(");\n");
+
+		// create csv input format
+		sb.append("\t\tCsvInputFormat<Tuple" + numFields + "<");
+		appendTupleTypeGenerics(sb, numFields);
+		sb.append(">> inputFormat = new TupleCsvInputFormat<Tuple" + numFields + "<");
+		appendTupleTypeGenerics(sb, numFields);
+		sb.append(">>(path, types, this.includedMask);\n");
+
+		// configure input format
+		sb.append("\t\tconfigureInputFormat(inputFormat);\n");
+
+		// return
+		sb.append("\t\treturn new DataSource<Tuple" + numFields + "<");
+		appendTupleTypeGenerics(sb, numFields);
+		sb.append(">>(executionContext, inputFormat, types, Utils.getCallLocationName());\n");
+
+		// end of method
+		sb.append("\t}\n");
+	}
+
+	private static void generatePreciseTypesMethod(StringBuilder sb, int numFields) {
+		// method begin
+		sb.append("\n");
+
+		// java doc
+		sb.append("\t/**\n");
+		sb.append("\t * Specifies the types for the CSV fields. This method parses the CSV data to a ").append(numFields).append("-tuple\n");
+		sb.append("\t * which has fields of the specified types.\n");
+		sb.append("\t * This method is created to overcome limitations of the types() method, which loose Generics information\n");
+		sb.append("\t * during runtime. With this method it is possible to use {@link TypeHint} power to instruct the engine about concrete\n");
+		sb.append("\t * field types.\n");
+		sb.append("\t * This method is overloaded for each possible length of the tuples to support type safe\n");
+		sb.append("\t * creation of data sets through CSV parsing.\n");
+		sb.append("\t *\n");
+
+		for (int pos = 0; pos < numFields; pos++) {
+			sb.append("\t * @param typeInfo").append(pos);
+			sb.append(" The type of CSV field ").append(pos).append(" and the type of field ");
+			sb.append(pos).append(" in the returned tuple type.\n");
+		}
+		sb.append("\t * @return The {@link org.apache.flink.api.java.DataSet} representing the parsed CSV data.\n");
+		sb.append("\t */\n");
+
+		// method signature
+		sb.append("\tpublic <");
+		appendTupleTypeGenerics(sb, numFields);
+		sb.append("> DataSource<Tuple" + numFields + "<");
+		appendTupleTypeGenerics(sb, numFields);
+		sb.append(">> preciseTypes(");
+		for (int i = 0; i < numFields; i++) {
+			if (i > 0) {
+				sb.append(", ");
+			}
+			sb.append("TypeInformation<");
+			sb.append(GEN_TYPE_PREFIX + i);
+			sb.append("> typeInfo" + i);
+		}
+		sb.append(") {\n");
+
+		// create DataSource
+		sb.append("\t\tDataSource<Tuple" + numFields + "<");
+		appendTupleTypeGenerics(sb, numFields);
+		sb.append(">> dataSource = commonPreciseTypes(");
+		for (int i = 0; i < numFields; i++) {
+			if (i > 0) {
+				sb.append(", ");
+			}
+			sb.append("typeInfo" + i);
+		}
+		sb.append(");\n");
+
+		sb.append("\t\treturn dataSource;\n");
+
+		// end of method
+		sb.append("\t}\n");
 	}
 
 	private static void appendTupleTypeGenerics(StringBuilder sb, int numFields) {
@@ -473,7 +534,7 @@ class TupleGenerator {
 	}
 
 	private static final String HEADER =
-			"/*\n"
+		"/*\n"
 			+ " * Licensed to the Apache Software Foundation (ASF) under one\n"
 			+ " * or more contributor license agreements.  See the NOTICE file\n"
 			+ " * distributed with this work for additional information\n"

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestBaseUtils.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestBaseUtils.java
@@ -41,6 +41,7 @@ import akka.util.Timeout;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
+import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -248,6 +249,13 @@ public class TestBaseUtils extends TestLogger {
 			Assert.assertEquals("Not all TCP connections were released.", 0, numActiveConnections);
 		}
 
+	}
+
+	public static String createInputData(TemporaryFolder tempFolder, String data) throws Exception {
+		File file = tempFolder.newFile("input");
+		org.apache.flink.util.FileUtils.writeFileUtf8(file, data);
+
+		return file.toURI().toString();
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-tests/pom.xml
+++ b/flink-tests/pom.xml
@@ -197,6 +197,13 @@ under the License.
 		</dependency>
 
 		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>2.6.3</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-shaded-guava</artifactId>
 		</dependency>

--- a/flink-tests/src/test/java/org/apache/flink/test/io/CsvReaderCustomGenericsAwareRowTupleIT.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/io/CsvReaderCustomGenericsAwareRowTupleIT.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.io;
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeHint;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.io.CsvReader;
+import org.apache.flink.test.io.csv.custom.type.NestedCustomJsonType;
+import org.apache.flink.test.io.csv.custom.type.complex.GenericsAwareCustomJsonType;
+import org.apache.flink.types.IntValue;
+import org.apache.flink.types.StringValue;
+import org.apache.flink.types.parser.FieldParser;
+import org.apache.flink.types.parser.ParserFactory;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.junit.Test;
+
+/**
+ * A collection of tests for checking different approaches of operating over user-defined Row types,
+ * utilizing newly introduced CsvReader methods.
+ * his class is aimed to verify use cases of classes with Java Generics.
+ */
+public class CsvReaderCustomGenericsAwareRowTupleIT extends CsvReaderCustomTypeTest {
+
+	public CsvReaderCustomGenericsAwareRowTupleIT(TestExecutionMode mode) {
+		super(mode);
+	}
+
+	@Test
+	public void testCustomGenericsAwareRowTypeViaRowTypeMethod() throws Exception {
+		givenCsvSourceData("1,'column2','{\"f1\":5, \"f2\": {\"f21\":\"nested_simple_f21\"}, \"f3\": {\"f21\":\"nested_generic_f31\"}}'\n");
+		givenCsvReaderConfigured();
+
+		whenCustomTypesAreRegisteredAlongWithTheirParsers();
+		whenDataSourceCreatedViaRowTypeMethod();
+		whenProcessingExecutedToCollectResultTuples();
+
+		thenResultingTupleHasExpectedHierarchyAndFieldValues();
+	}
+
+	@Test
+	public void testCustomGenericsAwareRowTypeViaPreciseRowTypeMethod() throws Exception {
+		givenCsvSourceData("1,'column2','{\"f1\":5, \"f2\": {\"f21\":\"nested_simple_f21\"}, \"f3\": {\"f21\":\"nested_generic_f31\"}}'\n");
+		givenCsvReaderConfigured();
+
+		whenCustomTypesAreRegisteredAlongWithTheirParsers();
+		whenDataSourceCreatedViaPreciseRowTypeMethod();
+		whenProcessingExecutedToCollectResultTuples();
+
+		thenResultingTupleHasExpectedHierarchyAndFieldValues();
+	}
+
+	private void givenCsvSourceData(String sourceData) {
+		context.sourceData = sourceData;
+	}
+
+	private void givenCsvReaderConfigured() throws Exception {
+		final String dataPath = createInputData(tempFolder, context.sourceData);
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		CsvReader reader = env.readCsvFile(dataPath);
+		reader.fieldDelimiter(",");
+		reader.parseQuotedStrings('\'');
+		context.reader = reader;
+	}
+
+	private void whenCustomTypesAreRegisteredAlongWithTheirParsers() {
+		ParserFactory<NestedCustomJsonType> factoryForNestedCustomType = new NestedCustomJsonParserFactory();
+		FieldParser.registerCustomParser(NestedCustomJsonType.class, factoryForNestedCustomType);
+
+		TypeHint<GenericsAwareCustomJsonType<NestedCustomJsonType>> typeHint = new TypeHint<GenericsAwareCustomJsonType<NestedCustomJsonType>>() {
+		};
+		TypeInformation<GenericsAwareCustomJsonType<NestedCustomJsonType>> typeInfo = TypeInformation.of(typeHint);
+		Class<GenericsAwareCustomJsonType<NestedCustomJsonType>> type = typeInfo.getTypeClass();
+
+		ParserFactory<GenericsAwareCustomJsonType<NestedCustomJsonType>> factoryForGenericType = new GenericsAwareCustomJsonParserFactory<>(
+			new TypeReference<GenericsAwareCustomJsonType<NestedCustomJsonType>>() {
+			}
+		);
+		FieldParser.registerCustomParser(type, factoryForGenericType);
+	}
+
+	private void whenDataSourceCreatedViaRowTypeMethod() {
+		context.dataSource = context.reader.rowType(IntValue.class, StringValue.class, GenericsAwareCustomJsonType.class);
+	}
+
+	private void whenDataSourceCreatedViaPreciseRowTypeMethod() {
+		context.dataSource = context.reader.preciseRowType(
+			BasicTypeInfo.INT_TYPE_INFO,
+			BasicTypeInfo.STRING_TYPE_INFO,
+			TypeInformation.of(new TypeHint<GenericsAwareCustomJsonType<NestedCustomJsonType>>() {
+			})
+		);
+	}
+
+	private void whenProcessingExecutedToCollectResultTuples() throws Exception {
+		context.result = context.dataSource.collect();
+	}
+
+	private void thenResultingTupleHasExpectedHierarchyAndFieldValues() {
+		compareResultAsText(
+			context.result,
+			"1,column2,GenericsAwareCustomJsonType{f1='5', f2=NestedCustomJsonType{f21='nested_simple_f21'}, f3=NestedCustomJsonType{f21='nested_generic_f31'}}"
+		);
+	}
+
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/io/CsvReaderCustomGenericsAwareTypePojoIT.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/io/CsvReaderCustomGenericsAwareTypePojoIT.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.io;
+
+import org.apache.flink.api.common.typeinfo.TypeHint;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.io.CsvReader;
+import org.apache.flink.test.io.csv.custom.type.NestedCustomJsonType;
+import org.apache.flink.test.io.csv.custom.type.complex.GenericsAwareCustomJsonType;
+import org.apache.flink.types.parser.FieldParser;
+import org.apache.flink.types.parser.ParserFactory;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * A collection of tests for checking different approaches of operating over user-defined POJO types,
+ * utilizing newly introduced CsvReader methods.
+ * This class is aimed to verify use cases of classes with Java Generics.
+ */
+public class CsvReaderCustomGenericsAwareTypePojoIT extends CsvReaderCustomTypeTest {
+
+	public CsvReaderCustomGenericsAwareTypePojoIT(TestExecutionMode mode) {
+		super(mode);
+	}
+
+	@Test
+	public void testGenericsAwareCustomPojoTypeViaPrecisePojoTypeMethod() throws Exception {
+		givenCsvSourceData("some_string,{\"f21\":\"nested_level1_f31\"},5\n");
+		givenCsvReaderConfigured();
+
+		whenCustomTypesAreRegisteredAlongWithTheirParsers();
+		whenDataSourceCreatedViaPrecisePojoTypeMethod();
+		whenProcessingExecutedToCollectResultTuples();
+
+		thenResultingPojoHasExpectedHierarchyAndFieldValues();
+	}
+
+	private void givenCsvSourceData(String sourceData) {
+		context.sourceData = sourceData;
+	}
+
+	private void givenCsvReaderConfigured() throws Exception {
+		final String dataPath = createInputData(tempFolder, context.sourceData);
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		CsvReader reader = env.readCsvFile(dataPath);
+		reader.fieldDelimiter(",");
+		reader.parseQuotedStrings('\'');
+		context.reader = reader;
+	}
+
+	private void whenCustomTypesAreRegisteredAlongWithTheirParsers() {
+		ParserFactory<NestedCustomJsonType> factoryForNestedCustomType = new NestedCustomJsonParserFactory();
+		FieldParser.registerCustomParser(NestedCustomJsonType.class, factoryForNestedCustomType);
+	}
+
+	private void whenDataSourceCreatedViaPrecisePojoTypeMethod() {
+		TypeHint<GenericsAwareCustomJsonType<Integer>> typeHint = new TypeHint<GenericsAwareCustomJsonType<Integer>>() {};
+		TypeInformation<GenericsAwareCustomJsonType<Integer>> typeInfo = TypeInformation.of(typeHint);
+		Class<GenericsAwareCustomJsonType<Integer>> type = typeInfo.getTypeClass();
+
+		context.dataSource = context.reader.precisePojoType(type,
+			new String[]{"f1", "f2", "f3"},
+			new TypeInformation[]{TypeInformation.of(String.class),
+				TypeInformation.of(NestedCustomJsonType.class),
+				TypeInformation.of(Integer.class)});
+	}
+
+	private void whenProcessingExecutedToCollectResultTuples() throws Exception {
+		context.result = context.dataSource.collect();
+	}
+
+	private void thenResultingPojoHasExpectedHierarchyAndFieldValues() {
+		assertEquals(1, context.result.size());
+		assertTrue(context.result.get(0) instanceof GenericsAwareCustomJsonType);
+		GenericsAwareCustomJsonType<Integer> genericsAwareCustomJsonType = (GenericsAwareCustomJsonType<Integer>) context.result.get(0);
+		assertEquals("some_string", genericsAwareCustomJsonType.getF1());
+		assertNotNull(genericsAwareCustomJsonType.getF2());
+		assertEquals("nested_level1_f31", genericsAwareCustomJsonType.getF2().getF21());
+		assertEquals(Integer.valueOf(5), genericsAwareCustomJsonType.getF3());
+		assertTrue(Integer.class.isAssignableFrom(genericsAwareCustomJsonType.getF3().getClass()));
+	}
+
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/io/CsvReaderCustomGenericsAwareTypeTupleIT.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/io/CsvReaderCustomGenericsAwareTypeTupleIT.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.io;
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeHint;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.io.CsvReader;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.test.io.csv.custom.type.NestedCustomJsonType;
+import org.apache.flink.test.io.csv.custom.type.complex.GenericsAwareCustomJsonType;
+import org.apache.flink.test.io.csv.custom.type.complex.Tuple3ContainerType;
+import org.apache.flink.types.parser.FieldParser;
+import org.apache.flink.types.parser.ParserFactory;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * A collection of tests for checking different approaches of operating over user-defined Tuple types,
+ * utilizing newly introduced CsvReader methods.
+ * This class is aimed to verify use cases of classes with Java Generics.
+ */
+public class CsvReaderCustomGenericsAwareTypeTupleIT extends CsvReaderCustomTypeTest {
+
+	public CsvReaderCustomGenericsAwareTypeTupleIT(TestExecutionMode mode) {
+		super(mode);
+	}
+
+	@Test
+	public void testGenericsAwareCustomTupleTypeViaTupleTypeMethod() throws Exception {
+		givenCsvSourceData("1,'column2','{\"f1\":\"f1_value\", \"f2\":{\"f21\":\"nested_level1_f21\"}, \"f3\":{\"f21\":\"nested_level2_f31\"}}'\n");
+		givenCsvReaderConfigured();
+
+		whenCustomTypesAreRegisteredAlongWithTheirParsers();
+		whenDataSourceCreatedViaTupleTypeMethod();
+		whenProcessingExecutedToCollectResultTuples();
+
+		thenResultingTupleContainerHasExpectedHierarchyAndFieldValues();
+	}
+
+	@Test
+	public void testGenericsAwareCustomTupleTypeViaPreciseTypesMethod() throws Exception {
+		givenCsvSourceData("1,'column2','{\"f1\":\"f1_value\", \"f2\":{\"f21\":\"nested_level1_f21\"}, \"f3\":{\"f21\":\"nested_level2_f31\"}}'\n");
+		givenCsvReaderConfigured();
+
+		whenCustomTypesAreRegisteredAlongWithTheirParsers();
+		whenDataSourceCreatedViaPreciseTypesMethod();
+		whenProcessingExecutedToCollectResultTuples();
+
+		thenResultingTupleHasExpectedHierarchyAndFieldValues();
+	}
+
+	private void givenCsvSourceData(String sourceData) {
+		context.sourceData = sourceData;
+	}
+
+	private void givenCsvReaderConfigured() throws Exception {
+		final String dataPath = createInputData(tempFolder, context.sourceData);
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		CsvReader reader = env.readCsvFile(dataPath);
+		reader.fieldDelimiter(",");
+		reader.parseQuotedStrings('\'');
+		context.reader = reader;
+	}
+
+	private void whenCustomTypesAreRegisteredAlongWithTheirParsers() {
+		ParserFactory<NestedCustomJsonType> factoryForNestedCustomType = new NestedCustomJsonParserFactory();
+		FieldParser.registerCustomParser(NestedCustomJsonType.class, factoryForNestedCustomType);
+
+		TypeHint<GenericsAwareCustomJsonType<NestedCustomJsonType>> typeHint = new TypeHint<GenericsAwareCustomJsonType<NestedCustomJsonType>>() {};
+		TypeInformation<GenericsAwareCustomJsonType<NestedCustomJsonType>> typeInfo = TypeInformation.of(typeHint);
+		Class<GenericsAwareCustomJsonType<NestedCustomJsonType>> type = typeInfo.getTypeClass();
+
+		ParserFactory<GenericsAwareCustomJsonType<NestedCustomJsonType>> factoryForGenericType = new GenericsAwareCustomJsonParserFactory<>(
+			new TypeReference<GenericsAwareCustomJsonType<NestedCustomJsonType>>() {}
+		);
+		FieldParser.registerCustomParser(type, factoryForGenericType);
+	}
+
+	private void whenDataSourceCreatedViaTupleTypeMethod() throws NoSuchFieldException {
+		context.dataSource = context.reader.tupleType(Tuple3ContainerType.class);
+	}
+
+	private void whenDataSourceCreatedViaPreciseTypesMethod() throws NoSuchFieldException {
+		context.dataSource = context.reader.preciseTypes(
+			BasicTypeInfo.INT_TYPE_INFO,
+			BasicTypeInfo.STRING_TYPE_INFO,
+			TypeInformation.of(new TypeHint<GenericsAwareCustomJsonType<NestedCustomJsonType>>() {})
+		);
+	}
+
+	private void whenProcessingExecutedToCollectResultTuples() throws Exception {
+		context.result = context.dataSource.collect();
+	}
+
+	private void thenResultingTupleContainerHasExpectedHierarchyAndFieldValues() {
+		assertEquals(1, context.result.size());
+		assertTrue(context.result.get(0) instanceof Tuple3ContainerType);
+		Tuple3ContainerType<NestedCustomJsonType> containerType = (Tuple3ContainerType<NestedCustomJsonType>) context.result.get(0);
+		assertEquals(1, containerType.f0.intValue());
+		assertEquals("column2", containerType.f1);
+		assertNotNull(containerType.f2);
+		assertEquals("f1_value", containerType.f2.getF1());
+		assertNotNull(containerType.f2.getF2());
+		assertEquals("nested_level1_f21", containerType.f2.getF2().getF21());
+		assertNotNull(containerType.f2.getF3());
+		assertEquals("nested_level2_f31", containerType.f2.getF3().getF21());
+	}
+
+	private void thenResultingTupleHasExpectedHierarchyAndFieldValues() {
+		assertEquals(1, context.result.size());
+		assertTrue(context.result.get(0) instanceof Tuple3);
+		Tuple3<Integer, String, GenericsAwareCustomJsonType<NestedCustomJsonType>> tuple =
+			(Tuple3<Integer, String, GenericsAwareCustomJsonType<NestedCustomJsonType>>) context.result.get(0);
+		assertEquals(1, tuple.f0.intValue());
+		assertEquals("column2", tuple.f1);
+		assertNotNull(tuple.f2);
+		assertEquals("f1_value", tuple.f2.getF1());
+		assertNotNull(tuple.f2.getF2());
+		assertEquals("nested_level1_f21", tuple.f2.getF2().getF21());
+		assertNotNull(tuple.f2.getF3());
+		assertEquals("nested_level2_f31", tuple.f2.getF3().getF21());
+	}
+
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/io/CsvReaderCustomSimpleRowTupleIT.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/io/CsvReaderCustomSimpleRowTupleIT.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.io;
+
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.io.CsvReader;
+import org.apache.flink.test.io.csv.custom.type.simple.SimpleCustomJsonType;
+import org.apache.flink.types.IntValue;
+import org.apache.flink.types.StringValue;
+import org.apache.flink.types.parser.FieldParser;
+import org.apache.flink.types.parser.ParserFactory;
+
+import org.junit.Test;
+
+/**
+ * A collection of tests for checking different approaches of operating over user-defined Row types,
+ * utilizing newly introduced CsvReader methods.
+ */
+public class CsvReaderCustomSimpleRowTupleIT extends CsvReaderCustomTypeTest {
+
+	public CsvReaderCustomSimpleRowTupleIT(TestExecutionMode mode) {
+		super(mode);
+	}
+
+	@Test
+	public void testSimpleCustomRowTypeViaRowTypeMethod() throws Exception {
+		givenCsvSourceData("1,'column2','{\"f1\":5, \"f2\":\"some_string\", \"f3\": {\"f21\":\"nested_level1_f31\"}}'\n");
+		givenCsvReaderConfigured();
+
+		whenCustomSimpleTypeIsRegisteredAlongWithItsParser();
+		whenDataSourceCreatedViaRowTypeMethod();
+		whenProcessingExecutedToCollectResultTuples();
+
+		thenResultingTupleHasExpectedHierarchyAndFieldValues();
+	}
+
+	private void givenCsvSourceData(String sourceData) {
+		context.sourceData = sourceData;
+	}
+
+	private void givenCsvReaderConfigured() throws Exception {
+		final String dataPath = createInputData(tempFolder, context.sourceData);
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		CsvReader reader = env.readCsvFile(dataPath);
+		reader.fieldDelimiter(",");
+		reader.parseQuotedStrings('\'');
+		context.reader = reader;
+	}
+
+	private void whenCustomSimpleTypeIsRegisteredAlongWithItsParser() {
+		ParserFactory<SimpleCustomJsonType> factory = new SimpleCustomJsonParserFactory();
+		FieldParser.registerCustomParser(SimpleCustomJsonType.class, factory);
+	}
+
+	private void whenDataSourceCreatedViaRowTypeMethod() {
+		context.dataSource = context.reader.rowType(IntValue.class, StringValue.class, SimpleCustomJsonType.class);
+	}
+
+	private void whenProcessingExecutedToCollectResultTuples() throws Exception {
+		context.result = context.dataSource.collect();
+	}
+
+	private void thenResultingTupleHasExpectedHierarchyAndFieldValues() {
+		compareResultAsText(
+			context.result,
+			"1,column2,SimpleCustomJsonType{f1=5,f2='some_string',f3=NestedCustomJsonType{f21='nested_level1_f31'}}"
+		);
+	}
+
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/io/CsvReaderCustomSimpleTypePojoIT.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/io/CsvReaderCustomSimpleTypePojoIT.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.io;
+
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.io.CsvReader;
+import org.apache.flink.test.io.csv.custom.type.NestedCustomJsonType;
+import org.apache.flink.test.io.csv.custom.type.simple.SimpleCustomJsonType;
+import org.apache.flink.types.parser.FieldParser;
+import org.apache.flink.types.parser.ParserFactory;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * A collection of tests for checking different approaches of operating over user-defined POJO types,
+ * utilizing newly introduced CsvReader methods.
+ */
+public class CsvReaderCustomSimpleTypePojoIT extends CsvReaderCustomTypeTest {
+
+	public CsvReaderCustomSimpleTypePojoIT(TestExecutionMode mode) {
+		super(mode);
+	}
+
+	@Test
+	public void testSimpleCustomJsonTypeViaPojoTypeMethod() throws Exception {
+		givenCsvSourceData("5,some_string,{\"f21\":\"nested_level1_f31\"}\n");
+		givenCsvReaderConfigured();
+
+		whenCustomTypesAreRegisteredAlongWithTheirParsers();
+		whenDataSourceCreatedViaPojoTypeMethod();
+		whenProcessingExecutedToCollectResultTuples();
+
+		thenResultingTupleHasExpectedHierarchyAndFieldValues();
+	}
+
+	private void givenCsvSourceData(String sourceData) {
+		context.sourceData = sourceData;
+	}
+
+	private void givenCsvReaderConfigured() throws Exception {
+		final String dataPath = createInputData(tempFolder, context.sourceData);
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		CsvReader reader = env.readCsvFile(dataPath);
+		reader.fieldDelimiter(",");
+		reader.parseQuotedStrings('\'');
+		context.reader = reader;
+	}
+
+	private void whenCustomTypesAreRegisteredAlongWithTheirParsers() {
+		ParserFactory<NestedCustomJsonType> factoryForNestedCustomType = new NestedCustomJsonParserFactory();
+		FieldParser.registerCustomParser(NestedCustomJsonType.class, factoryForNestedCustomType);
+	}
+
+	private void whenDataSourceCreatedViaPojoTypeMethod() {
+		context.dataSource = context.reader.pojoType(SimpleCustomJsonType.class, "f1", "f2", "f3");
+	}
+
+	private void whenProcessingExecutedToCollectResultTuples() throws Exception {
+		context.result = context.dataSource.collect();
+	}
+
+	private void thenResultingTupleHasExpectedHierarchyAndFieldValues() {
+		assertEquals(1, context.result.size());
+		assertTrue(context.result.get(0) instanceof SimpleCustomJsonType);
+		SimpleCustomJsonType simpleCustomJsonType = (SimpleCustomJsonType) context.result.get(0);
+		assertEquals(5, simpleCustomJsonType.getF1());
+		assertEquals("some_string", simpleCustomJsonType.getF2());
+		assertEquals("nested_level1_f31", simpleCustomJsonType.getF3().getF21());
+	}
+
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/io/CsvReaderCustomSimpleTypeTupleIT.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/io/CsvReaderCustomSimpleTypeTupleIT.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.io;
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.io.CsvReader;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.test.io.csv.custom.type.simple.SimpleCustomJsonType;
+import org.apache.flink.test.io.csv.custom.type.simple.Tuple3ContainerType;
+import org.apache.flink.types.parser.FieldParser;
+import org.apache.flink.types.parser.ParserFactory;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * A collection of tests for checking different approaches of operating over user-defined Tuple types,
+ * utilizing newly introduced CsvReader methods.
+ */
+public class CsvReaderCustomSimpleTypeTupleIT extends CsvReaderCustomTypeTest {
+
+	public CsvReaderCustomSimpleTypeTupleIT(TestExecutionMode mode) {
+		super(mode);
+	}
+
+	@Test
+	public void testSimpleCustomJsonTypeViaPreciseTypeMethod() throws Exception {
+		givenCsvSourceData("1,'column2','{\"f1\":5, \"f2\":\"some_string\", \"f3\": {\"f21\":\"nested_level1_f31\"}}'\n");
+		givenCsvReaderConfigured();
+
+		whenCustomSimpleTypeIsRegisteredAlongWithItsParser();
+		whenDataSourceCreatedViaPreciseTypesMethod();
+		whenProcessingExecutedToCollectResultTuples();
+
+		thenResultingTupleHasExpectedHierarchyAndFieldValues();
+	}
+
+	@Test
+	public void testSimpleCustomJsonTypeViaTupleTypeMethod() throws Exception {
+		givenCsvSourceData("1,'column2','{\"f1\":5, \"f2\":\"some_string\", \"f3\": {\"f21\":\"nested_level1_f31\"}}'\n");
+		givenCsvReaderConfigured();
+
+		whenCustomSimpleTypeIsRegisteredAlongWithItsParser();
+		whenDataSourceCreatedViaTupleTypeMethod();
+		whenProcessingExecutedToCollectResultTuples();
+
+		thenResultingTupleHasExpectedHierarchyAndFieldValues();
+	}
+
+	private void givenCsvSourceData(String sourceData) {
+		context.sourceData = sourceData;
+	}
+
+	private void givenCsvReaderConfigured() throws Exception {
+		final String dataPath = createInputData(tempFolder, context.sourceData);
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		CsvReader reader = env.readCsvFile(dataPath);
+		reader.fieldDelimiter(",");
+		reader.parseQuotedStrings('\'');
+		context.reader = reader;
+	}
+
+	private void whenCustomSimpleTypeIsRegisteredAlongWithItsParser() {
+		ParserFactory<SimpleCustomJsonType> factory = new SimpleCustomJsonParserFactory();
+		FieldParser.registerCustomParser(SimpleCustomJsonType.class, factory);
+	}
+
+	private void whenDataSourceCreatedViaTupleTypeMethod() {
+		context.dataSource = context.reader.tupleType(Tuple3ContainerType.class);
+	}
+
+	private void whenDataSourceCreatedViaPreciseTypesMethod() {
+		context.dataSource = context.reader.preciseTypes(
+			BasicTypeInfo.INT_TYPE_INFO,
+			BasicTypeInfo.STRING_TYPE_INFO,
+			TypeInformation.of(SimpleCustomJsonType.class)
+		);
+	}
+
+	private void whenProcessingExecutedToCollectResultTuples() throws Exception {
+		context.result = context.dataSource.collect();
+	}
+
+	private void thenResultingTupleHasExpectedHierarchyAndFieldValues() {
+		List<?> result = context.result;
+		assertTrue(result.size() == 1);
+		assertTrue(result.get(0) instanceof Tuple3);
+		Tuple3<Integer, String, SimpleCustomJsonType> tuple = (Tuple3<Integer, String, SimpleCustomJsonType>) result.get(0);
+		assertEquals(1, tuple.f0.intValue());
+		assertEquals("column2", tuple.f1);
+		assertNotNull(tuple.f2);
+		assertEquals(5, tuple.f2.getF1());
+		assertEquals("some_string", tuple.f2.getF2());
+		assertNotNull(tuple.f2.getF3());
+		assertEquals("nested_level1_f31", tuple.f2.getF3().getF21());
+	}
+
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/io/CsvReaderCustomTypeTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/io/CsvReaderCustomTypeTest.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.io;
+
+import org.apache.flink.api.java.io.CsvReader;
+import org.apache.flink.api.java.operators.DataSource;
+import org.apache.flink.test.io.csv.custom.type.NestedCustomJsonType;
+import org.apache.flink.test.io.csv.custom.type.NestedCustomJsonTypeStringParser;
+import org.apache.flink.test.io.csv.custom.type.complex.GenericsAwareCustomJsonType;
+import org.apache.flink.test.io.csv.custom.type.complex.GenericsAwareCustomJsonTypeStringParser;
+import org.apache.flink.test.io.csv.custom.type.simple.SimpleCustomJsonType;
+import org.apache.flink.test.io.csv.custom.type.simple.SimpleCustomJsonTypeStringParser;
+import org.apache.flink.test.util.MultipleProgramsTestBase;
+import org.apache.flink.types.parser.FieldParser;
+import org.apache.flink.types.parser.ParserFactory;
+import org.apache.flink.util.Preconditions;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.List;
+
+/**
+ * A parent class for integration test container classes for CsvReader.
+ */
+@RunWith(Parameterized.class)
+public abstract class CsvReaderCustomTypeTest extends MultipleProgramsTestBase {
+
+	protected CsvReaderContext context;
+
+	@Rule
+	public TemporaryFolder tempFolder = new TemporaryFolder();
+
+	@Before
+	public void setUp() {
+		context = new CsvReaderContext();
+	}
+
+	@After
+	public void tearDown() {
+		context = null;
+	}
+
+	public CsvReaderCustomTypeTest(TestExecutionMode mode) {
+		super(mode);
+	}
+
+	/**
+	 * Execution context for the Given-When-Then paradigm.
+	 */
+	protected static class CsvReaderContext {
+
+		protected String sourceData;
+		protected CsvReader reader;
+		protected DataSource<?> dataSource;
+		protected List<?> result;
+
+	}
+
+	static final class NestedCustomJsonParserFactory implements ParserFactory<NestedCustomJsonType> {
+
+		@Override
+		public Class<? extends FieldParser<NestedCustomJsonType>> getParserType() {
+			return NestedCustomJsonTypeStringParser.class;
+		}
+
+		@Override
+		public FieldParser<NestedCustomJsonType> create() {
+			return new NestedCustomJsonTypeStringParser();
+		}
+	}
+
+	static final class SimpleCustomJsonParserFactory implements ParserFactory<SimpleCustomJsonType> {
+
+		@Override
+		public Class<? extends FieldParser<SimpleCustomJsonType>> getParserType() {
+			return SimpleCustomJsonTypeStringParser.class;
+		}
+
+		@Override
+		public FieldParser<SimpleCustomJsonType> create() {
+			return new SimpleCustomJsonTypeStringParser();
+		}
+	}
+
+	static final class GenericsAwareCustomJsonParserFactory<T> implements ParserFactory<GenericsAwareCustomJsonType<T>> {
+
+		private TypeReference<GenericsAwareCustomJsonType<T>> typeReference;
+
+		public GenericsAwareCustomJsonParserFactory(TypeReference<GenericsAwareCustomJsonType<T>> typeReference) {
+			Preconditions.checkNotNull(typeReference);
+			this.typeReference = typeReference;
+		}
+
+		@Override
+		public Class<? extends FieldParser<GenericsAwareCustomJsonType<T>>> getParserType() {
+			return (Class<FieldParser<GenericsAwareCustomJsonType<T>>>) (Class<?>) GenericsAwareCustomJsonTypeStringParser.class;
+		}
+
+		@Override
+		public FieldParser<GenericsAwareCustomJsonType<T>> create() {
+			return new GenericsAwareCustomJsonTypeStringParser<T>(typeReference);
+		}
+	}
+}
+
+

--- a/flink-tests/src/test/java/org/apache/flink/test/io/csv/custom/type/NestedCustomJsonType.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/io/csv/custom/type/NestedCustomJsonType.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.io.csv.custom.type;
+
+/**
+ * A user-defined type with only Java primitives inside that is meant to be embedded into other user-defined types
+ * for hierarchical type information resolution tests.
+ */
+public class NestedCustomJsonType {
+
+	private String f21;
+
+	public String getF21() {
+		return f21;
+	}
+
+	public void setF21(String f21) {
+		this.f21 = f21;
+	}
+
+	@Override
+	public String toString() {
+		return "NestedCustomJsonType{" +
+			"f21='" + f21 + '\'' +
+			'}';
+	}
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/io/csv/custom/type/NestedCustomJsonTypeStringParser.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/io/csv/custom/type/NestedCustomJsonTypeStringParser.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.io.csv.custom.type;
+
+import org.apache.flink.types.parser.FieldParser;
+import org.apache.flink.types.parser.StringParser;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+
+/**
+ * A JSON parser for {@link NestedCustomJsonType} type, that is based on StringParser.
+ */
+public class NestedCustomJsonTypeStringParser extends FieldParser<NestedCustomJsonType> {
+
+	private final StringParser stringParser = new StringParser();
+
+	{
+		stringParser.enableQuotedStringParsing((byte) '\'');
+	}
+
+	private NestedCustomJsonType lastResult;
+
+	@Override
+	protected int parseField(byte[] bytes, int startPos, int limit, byte[] delim, NestedCustomJsonType reuse) {
+		int offset = stringParser.parseField(bytes, startPos, limit, delim, null);
+		String stringRepresentation = stringParser.getLastResult();
+
+		ObjectMapper mapper = new ObjectMapper();
+		try {
+			lastResult = mapper.readValue(stringRepresentation, NestedCustomJsonType.class);
+			return offset;
+		} catch (IOException e) {
+			e.printStackTrace();
+			return -1;
+		}
+	}
+
+	@Override
+	public NestedCustomJsonType getLastResult() {
+		return lastResult;
+	}
+
+	@Override
+	public NestedCustomJsonType createValue() {
+		return new NestedCustomJsonType();
+	}
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/io/csv/custom/type/complex/GenericsAwareCustomJsonType.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/io/csv/custom/type/complex/GenericsAwareCustomJsonType.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.io.csv.custom.type.complex;
+
+import org.apache.flink.test.io.csv.custom.type.NestedCustomJsonType;
+
+/**
+ * A user-defined type (with a Java Generic parameter inside) that is represented in one or several csv fields.
+ */
+public class GenericsAwareCustomJsonType<T> {
+
+	private String f1;
+	private NestedCustomJsonType f2;
+	private T f3;
+
+	public String getF1() {
+		return f1;
+	}
+
+	public void setF1(String f1) {
+		this.f1 = f1;
+	}
+
+	public NestedCustomJsonType getF2() {
+		return f2;
+	}
+
+	public void setF2(NestedCustomJsonType f2) {
+		this.f2 = f2;
+	}
+
+	public T getF3() {
+		return f3;
+	}
+
+	public void setF3(T f3) {
+		this.f3 = f3;
+	}
+
+	@Override
+	public String toString() {
+		return "GenericsAwareCustomJsonType{" +
+			"f1='" + f1 + '\'' +
+			", f2=" + f2 +
+			", f3=" + f3 +
+			'}';
+	}
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/io/csv/custom/type/complex/GenericsAwareCustomJsonTypeStringParser.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/io/csv/custom/type/complex/GenericsAwareCustomJsonTypeStringParser.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.io.csv.custom.type.complex;
+
+import org.apache.flink.types.parser.FieldParser;
+import org.apache.flink.types.parser.StringParser;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+
+/**
+ * A JSON parser for {@link GenericsAwareCustomJsonType} type, that is based on StringParser.
+ * @param <T> a generic type of the {@link GenericsAwareCustomJsonType} instance.
+ */
+public class GenericsAwareCustomJsonTypeStringParser<T> extends FieldParser<GenericsAwareCustomJsonType<T>> {
+
+	private final StringParser stringParser = new StringParser();
+
+	{
+		stringParser.enableQuotedStringParsing((byte) '\'');
+	}
+
+	private TypeReference<GenericsAwareCustomJsonType<T>> typeReference;
+	private GenericsAwareCustomJsonType<T> lastResult;
+
+	public GenericsAwareCustomJsonTypeStringParser(TypeReference<GenericsAwareCustomJsonType<T>> typeReference) {
+		this.typeReference = typeReference;
+	}
+
+	@Override
+	protected int parseField(byte[] bytes, int startPos, int limit, byte[] delim, GenericsAwareCustomJsonType<T> reuse) {
+		int offset = stringParser.parseField(bytes, startPos, limit, delim, null);
+		String stringRepresentation = stringParser.getLastResult();
+
+		ObjectMapper mapper = new ObjectMapper();
+		try {
+			lastResult = mapper.readValue(stringRepresentation, typeReference);
+			return offset;
+		} catch (IOException e) {
+			e.printStackTrace();
+			return -1;
+		}
+	}
+
+	@Override
+	public GenericsAwareCustomJsonType<T> getLastResult() {
+		return lastResult;
+	}
+
+	@Override
+	public GenericsAwareCustomJsonType<T> createValue() {
+		return new GenericsAwareCustomJsonType();
+	}
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/io/csv/custom/type/complex/Tuple3ContainerType.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/io/csv/custom/type/complex/Tuple3ContainerType.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.io.csv.custom.type.complex;
+
+import org.apache.flink.api.java.tuple.Tuple3;
+
+/**
+ * A container-type for {@link Tuple3}. Container types are required for {@code CsvReader.tupleType()} method -- pure Tuple classes
+ * cannot be used there.
+ */
+public class Tuple3ContainerType<T> extends Tuple3<Integer, String, GenericsAwareCustomJsonType<T>> {
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/io/csv/custom/type/simple/SimpleCustomJsonType.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/io/csv/custom/type/simple/SimpleCustomJsonType.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.io.csv.custom.type.simple;
+
+import org.apache.flink.test.io.csv.custom.type.NestedCustomJsonType;
+
+/**
+ * A user-defined type (without any Java Generics) that is represented in one or several csv fields.
+ */
+public class SimpleCustomJsonType {
+
+	private int f1;
+	private String f2;
+	private NestedCustomJsonType f3;
+
+	public int getF1() {
+		return f1;
+	}
+
+	public void setF1(int f1) {
+		this.f1 = f1;
+	}
+
+	public String getF2() {
+		return f2;
+	}
+
+	public void setF2(String f2) {
+		this.f2 = f2;
+	}
+
+	public NestedCustomJsonType getF3() {
+		return f3;
+	}
+
+	public void setF3(NestedCustomJsonType f3) {
+		this.f3 = f3;
+	}
+
+	@Override
+	public String toString() {
+		return "SimpleCustomJsonType{" +
+			"f1=" + f1 +
+			",f2='" + f2 + "'" +
+			",f3=" + f3 +
+			'}';
+	}
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/io/csv/custom/type/simple/SimpleCustomJsonTypeStringParser.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/io/csv/custom/type/simple/SimpleCustomJsonTypeStringParser.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.io.csv.custom.type.simple;
+
+import org.apache.flink.types.parser.FieldParser;
+import org.apache.flink.types.parser.StringParser;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+
+/**
+ * A JSON parser for {@link SimpleCustomJsonType} type, that is based on StringParser.
+ */
+public class SimpleCustomJsonTypeStringParser extends FieldParser<SimpleCustomJsonType> {
+
+	private final StringParser stringParser = new StringParser();
+
+	{
+		stringParser.enableQuotedStringParsing((byte) '\'');
+	}
+
+	private SimpleCustomJsonType lastResult;
+
+	@Override
+	protected int parseField(byte[] bytes, int startPos, int limit, byte[] delim, SimpleCustomJsonType reuse) {
+		int offset = stringParser.parseField(bytes, startPos, limit, delim, null);
+		String stringRepresentation = stringParser.getLastResult();
+
+		ObjectMapper mapper = new ObjectMapper();
+		try {
+			lastResult = mapper.readValue(stringRepresentation, SimpleCustomJsonType.class);
+			return offset;
+		} catch (IOException e) {
+			e.printStackTrace();
+			return -1;
+		}
+	}
+
+	@Override
+	public SimpleCustomJsonType getLastResult() {
+		return lastResult;
+	}
+
+	@Override
+	public SimpleCustomJsonType createValue() {
+		return new SimpleCustomJsonType();
+	}
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/io/csv/custom/type/simple/Tuple3ContainerType.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/io/csv/custom/type/simple/Tuple3ContainerType.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.io.csv.custom.type.simple;
+
+import org.apache.flink.api.java.tuple.Tuple3;
+
+/**
+ * A container-type for {@link Tuple3}. Container types are required for {@code CsvReader.tupleType()} method -- pure Tuple classes
+ * cannot be used there.
+ */
+public class Tuple3ContainerType extends Tuple3<Integer, String, SimpleCustomJsonType> {
+}


### PR DESCRIPTION
[FLINK-2435] Provides the capability of specifying user-defined types in Tuple and Row 'containers' while reading from a csv file
