### PR TITLE
[FLINK-8946] TaskManager stop sending metrics after JobManager failover

### DIFF
--- a/flink-mesos/src/main/scala/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManager.scala
+++ b/flink-mesos/src/main/scala/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManager.scala
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.highavailability.HighAvailabilityServices
 import org.apache.flink.runtime.io.disk.iomanager.IOManager
 import org.apache.flink.runtime.io.network.NetworkEnvironment
 import org.apache.flink.runtime.memory.MemoryManager
+import org.apache.flink.runtime.metrics.MetricRegistry
 import org.apache.flink.runtime.metrics.groups.TaskManagerMetricGroup
 import org.apache.flink.runtime.state.TaskExecutorLocalStateStoresManager
 import org.apache.flink.runtime.taskexecutor.TaskManagerConfiguration
@@ -41,7 +42,7 @@ class MesosTaskManager(
     taskManagerLocalStateStoresManager: TaskExecutorLocalStateStoresManager,
     numberOfSlots: Int,
     highAvailabilityServices: HighAvailabilityServices,
-    taskManagerMetricGroup : TaskManagerMetricGroup)
+    metricRegistry: MetricRegistry)
   extends TaskManager(
     config,
     resourceID,
@@ -52,7 +53,7 @@ class MesosTaskManager(
     taskManagerLocalStateStoresManager,
     numberOfSlots,
     highAvailabilityServices,
-    taskManagerMetricGroup) {
+    metricRegistry) {
 
   override def handleMessage: Receive = {
     super.handleMessage

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/minicluster/LocalFlinkMiniCluster.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/minicluster/LocalFlinkMiniCluster.scala
@@ -46,6 +46,7 @@ import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService
 import org.apache.flink.runtime.memory.MemoryManager
 import org.apache.flink.runtime.messages.JobManagerMessages
 import org.apache.flink.runtime.messages.JobManagerMessages.{RunningJobsStatus, StoppingFailure, StoppingResponse}
+import org.apache.flink.runtime.metrics.MetricRegistry
 import org.apache.flink.runtime.metrics.groups.{JobManagerMetricGroup, TaskManagerMetricGroup}
 import org.apache.flink.runtime.metrics.util.MetricUtils
 import org.apache.flink.runtime.state.TaskExecutorLocalStateStoresManager
@@ -243,11 +244,6 @@ class LocalFlinkMiniCluster(
       EnvironmentInformation.getSizeOfFreeHeapMemoryWithDefrag,
       EnvironmentInformation.getMaxJvmHeapMemory)
 
-    val taskManagerMetricGroup = MetricUtils.instantiateTaskManagerMetricGroup(
-      metricRegistryOpt.get,
-      taskManagerServices.getTaskManagerLocation(),
-      taskManagerServices.getNetworkEnvironment())
-
     val props = getTaskManagerProps(
       taskManagerClass,
       taskManagerConfiguration,
@@ -257,7 +253,7 @@ class LocalFlinkMiniCluster(
       taskManagerServices.getIOManager(),
       taskManagerServices.getNetworkEnvironment,
       taskManagerServices.getTaskManagerStateStore,
-      taskManagerMetricGroup)
+      metricRegistryOpt.get)
 
     system.actorOf(props, taskManagerActorName)
   }
@@ -322,7 +318,7 @@ class LocalFlinkMiniCluster(
     ioManager: IOManager,
     networkEnvironment: NetworkEnvironment,
     taskManagerLocalStateStoresManager: TaskExecutorLocalStateStoresManager,
-    taskManagerMetricGroup: TaskManagerMetricGroup): Props = {
+    metricRegistry: MetricRegistry): Props = {
 
     TaskManager.getTaskManagerProps(
       taskManagerClass,
@@ -334,7 +330,7 @@ class LocalFlinkMiniCluster(
       networkEnvironment,
       taskManagerLocalStateStoresManager,
       highAvailabilityServices,
-      taskManagerMetricGroup)
+      metricRegistry)
   }
 
   def getResourceManagerProps(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/TaskManagerMetricsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/TaskManagerMetricsTest.java
@@ -27,8 +27,6 @@ import org.apache.flink.runtime.highavailability.nonha.embedded.EmbeddedHaServic
 import org.apache.flink.runtime.jobmanager.JobManager;
 import org.apache.flink.runtime.jobmanager.MemoryArchivist;
 import org.apache.flink.runtime.messages.TaskManagerMessages;
-import org.apache.flink.runtime.metrics.groups.TaskManagerMetricGroup;
-import org.apache.flink.runtime.metrics.util.MetricUtils;
 import org.apache.flink.runtime.taskexecutor.TaskManagerConfiguration;
 import org.apache.flink.runtime.taskexecutor.TaskManagerServices;
 import org.apache.flink.runtime.taskexecutor.TaskManagerServicesConfiguration;
@@ -103,11 +101,6 @@ public class TaskManagerMetricsTest extends TestLogger {
 				EnvironmentInformation.getSizeOfFreeHeapMemoryWithDefrag(),
 				EnvironmentInformation.getMaxJvmHeapMemory());
 
-			TaskManagerMetricGroup taskManagerMetricGroup = MetricUtils.instantiateTaskManagerMetricGroup(
-				metricRegistry,
-				taskManagerServices.getTaskManagerLocation(),
-				taskManagerServices.getNetworkEnvironment());
-
 			// create the task manager
 			final Props tmProps = TaskManager.getTaskManagerProps(
 				TaskManager.class,
@@ -119,7 +112,7 @@ public class TaskManagerMetricsTest extends TestLogger {
 				taskManagerServices.getNetworkEnvironment(),
 				taskManagerServices.getTaskManagerStateStore(),
 				highAvailabilityServices,
-				taskManagerMetricGroup);
+				metricRegistry);
 
 			final ActorRef taskManager = actorSystem.actorOf(tmProps);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerComponentsStartupShutdownTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskManagerComponentsStartupShutdownTest.java
@@ -44,7 +44,6 @@ import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.messages.TaskManagerMessages;
 import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
 import org.apache.flink.runtime.metrics.NoOpMetricRegistry;
-import org.apache.flink.runtime.metrics.groups.TaskManagerMetricGroup;
 import org.apache.flink.runtime.query.KvStateRegistry;
 import org.apache.flink.runtime.state.LocalRecoveryConfig;
 import org.apache.flink.runtime.state.TaskExecutorLocalStateStoresManager;
@@ -180,7 +179,7 @@ public class TaskManagerComponentsStartupShutdownTest extends TestLogger {
 				storesManager,
 				numberOfSlots,
 				highAvailabilityServices,
-				new TaskManagerMetricGroup(NoOpMetricRegistry.INSTANCE, connectionInfo.getHostname(), connectionInfo.getResourceID().getResourceIdString()));
+				NoOpMetricRegistry.INSTANCE);
 
 			taskManager = actorSystem.actorOf(tmProps);
 

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingTaskManager.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingTaskManager.scala
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.highavailability.HighAvailabilityServices
 import org.apache.flink.runtime.io.disk.iomanager.IOManager
 import org.apache.flink.runtime.io.network.NetworkEnvironment
 import org.apache.flink.runtime.memory.MemoryManager
+import org.apache.flink.runtime.metrics.MetricRegistry
 import org.apache.flink.runtime.metrics.groups.TaskManagerMetricGroup
 import org.apache.flink.runtime.state.TaskExecutorLocalStateStoresManager
 import org.apache.flink.runtime.taskexecutor.TaskManagerConfiguration
@@ -42,7 +43,7 @@ class TestingTaskManager(
     taskManagerStateStore: TaskExecutorLocalStateStoresManager,
     numberOfSlots: Int,
     highAvailabilityServices: HighAvailabilityServices,
-    taskManagerMetricGroup : TaskManagerMetricGroup)
+    metricRegistry: MetricRegistry)
   extends TaskManager(
     config,
     resourceID,
@@ -53,7 +54,7 @@ class TestingTaskManager(
     taskManagerStateStore,
     numberOfSlots,
     highAvailabilityServices,
-    taskManagerMetricGroup)
+    metricRegistry)
   with TestingTaskManagerLike {
 
   def this(
@@ -65,7 +66,7 @@ class TestingTaskManager(
     taskManagerLocalStateStoresManager: TaskExecutorLocalStateStoresManager,
     numberOfSlots: Int,
     highAvailabilityServices: HighAvailabilityServices,
-    taskManagerMetricGroup : TaskManagerMetricGroup) {
+    metricRegistry: MetricRegistry) {
     this(
       config,
       ResourceID.generate(),
@@ -76,6 +77,6 @@ class TestingTaskManager(
       taskManagerLocalStateStoresManager,
       numberOfSlots,
       highAvailabilityServices,
-      taskManagerMetricGroup)
+      metricRegistry)
   }
 }

--- a/flink-yarn-tests/src/test/scala/org/apache/flink/yarn/TestingYarnTaskManager.scala
+++ b/flink-yarn-tests/src/test/scala/org/apache/flink/yarn/TestingYarnTaskManager.scala
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.highavailability.HighAvailabilityServices
 import org.apache.flink.runtime.io.disk.iomanager.IOManager
 import org.apache.flink.runtime.io.network.NetworkEnvironment
 import org.apache.flink.runtime.memory.MemoryManager
+import org.apache.flink.runtime.metrics.MetricRegistry
 import org.apache.flink.runtime.metrics.groups.TaskManagerMetricGroup
 import org.apache.flink.runtime.security.SecurityUtils
 import org.apache.flink.runtime.state.TaskExecutorLocalStateStoresManager
@@ -56,7 +57,7 @@ class TestingYarnTaskManager(
     taskManagerLocalStateStoresManager: TaskExecutorLocalStateStoresManager,
     numberOfSlots: Int,
     highAvailabilityServices: HighAvailabilityServices,
-    taskManagerMetricGroup : TaskManagerMetricGroup)
+    metricRegistry: MetricRegistry)
   extends YarnTaskManager(
     config,
     resourceID,
@@ -67,7 +68,7 @@ class TestingYarnTaskManager(
     taskManagerLocalStateStoresManager,
     numberOfSlots,
     highAvailabilityServices,
-    taskManagerMetricGroup)
+    metricRegistry)
   with TestingTaskManagerLike {
 
   object YarnTaskManager {

--- a/flink-yarn/src/main/scala/org/apache/flink/yarn/YarnTaskManager.scala
+++ b/flink-yarn/src/main/scala/org/apache/flink/yarn/YarnTaskManager.scala
@@ -23,12 +23,11 @@ import org.apache.flink.runtime.highavailability.HighAvailabilityServices
 import org.apache.flink.runtime.io.disk.iomanager.IOManager
 import org.apache.flink.runtime.io.network.NetworkEnvironment
 import org.apache.flink.runtime.memory.MemoryManager
-import org.apache.flink.runtime.metrics.groups.TaskManagerMetricGroup
+import org.apache.flink.runtime.metrics.MetricRegistry
 import org.apache.flink.runtime.security.SecurityUtils
 import org.apache.flink.runtime.state.TaskExecutorLocalStateStoresManager
 import org.apache.flink.runtime.taskexecutor.TaskManagerConfiguration
 import org.apache.flink.runtime.taskmanager.{TaskManager, TaskManagerLocation}
-
 import grizzled.slf4j.Logger
 
 /** An extension of the TaskManager that listens for additional YARN related
@@ -44,7 +43,7 @@ class YarnTaskManager(
     taskManagerLocalStateStoresManager: TaskExecutorLocalStateStoresManager,
     numberOfSlots: Int,
     highAvailabilityServices: HighAvailabilityServices,
-    taskManagerMetricGroup: TaskManagerMetricGroup)
+    metricRegistry: MetricRegistry)
   extends TaskManager(
     config,
     resourceID,
@@ -55,7 +54,7 @@ class YarnTaskManager(
     taskManagerLocalStateStoresManager,
     numberOfSlots,
     highAvailabilityServices,
-    taskManagerMetricGroup) {
+    metricRegistry) {
 
   override def handleMessage: Receive = {
     super.handleMessage


### PR DESCRIPTION
## What is the purpose of the change

*This pull request fixed taskManager stop sending metrics after JobManager failover*

## Brief change log

  - *Initialize `TaskManagerMetricGroup`'s instance when invoking `handleJobManagerLeaderAddress`*
  - *Close `TaskManagerMetricGroup` when invoking `handleJobManagerDisconnect`*

## Verifying this change

This change is already covered by existing tests, such as *TaskManagerStartupTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
