### PR TITLE
[FLINK-9193] Deprecate non-well-defined output methods on DataStream

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
@@ -968,8 +968,11 @@ public class DataStream<T> {
 	 *            The path pointing to the location the text file is written to.
 	 *
 	 * @return The closed DataStream.
+	 *
+	 * @deprecated Please use the {@code BucketingSink} for writing to files from a streaming program.
 	 */
 	@PublicEvolving
+	@Deprecated
 	public DataStreamSink<T> writeAsText(String path) {
 		return writeUsingOutputFormat(new TextOutputFormat<T>(new Path(path)));
 	}
@@ -987,8 +990,11 @@ public class DataStream<T> {
 	 *            NO_OVERWRITE and OVERWRITE.
 	 *
 	 * @return The closed DataStream.
+	 *
+	 * @deprecated Please use the {@code BucketingSink} for writing to files from a streaming program.
 	 */
 	@PublicEvolving
+	@Deprecated
 	public DataStreamSink<T> writeAsText(String path, WriteMode writeMode) {
 		TextOutputFormat<T> tof = new TextOutputFormat<>(new Path(path));
 		tof.setWriteMode(writeMode);
@@ -1006,8 +1012,11 @@ public class DataStream<T> {
 	 *            the path pointing to the location the text file is written to
 	 *
 	 * @return the closed DataStream
+	 *
+	 * @deprecated Please use the {@code BucketingSink} for writing to files from a streaming program.
 	 */
 	@PublicEvolving
+	@Deprecated
 	public DataStreamSink<T> writeAsCsv(String path) {
 		return writeAsCsv(path, null, CsvOutputFormat.DEFAULT_LINE_DELIMITER, CsvOutputFormat.DEFAULT_FIELD_DELIMITER);
 	}
@@ -1026,8 +1035,11 @@ public class DataStream<T> {
 	 *            NO_OVERWRITE and OVERWRITE.
 	 *
 	 * @return the closed DataStream
+	 *
+	 * @deprecated Please use the {@code BucketingSink} for writing to files from a streaming program.
 	 */
 	@PublicEvolving
+	@Deprecated
 	public DataStreamSink<T> writeAsCsv(String path, WriteMode writeMode) {
 		return writeAsCsv(path, writeMode, CsvOutputFormat.DEFAULT_LINE_DELIMITER, CsvOutputFormat.DEFAULT_FIELD_DELIMITER);
 	}
@@ -1050,9 +1062,12 @@ public class DataStream<T> {
 	 *            the delimiter for two fields
 	 *
 	 * @return the closed DataStream
+	 *
+	 * @deprecated Please use the {@code BucketingSink} for writing to files from a streaming program.
 	 */
 	@SuppressWarnings("unchecked")
 	@PublicEvolving
+	@Deprecated
 	public <X extends Tuple> DataStreamSink<T> writeAsCsv(
 			String path,
 			WriteMode writeMode,
@@ -1085,8 +1100,11 @@ public class DataStream<T> {
 	 * @param schema
 	 *            schema for serialization
 	 * @return the closed DataStream
+	 *
+	 * @deprecated Please use {@link #addSink(SinkFunction)} with {@link SocketClientSink}.
 	 */
 	@PublicEvolving
+	@Deprecated
 	public DataStreamSink<T> writeToSocket(String hostName, int port, SerializationSchema<T> schema) {
 		DataStreamSink<T> returnStream = addSink(new SocketClientSink<>(hostName, port, schema, 0));
 		returnStream.setParallelism(1); // It would not work if multiple instances would connect to the same port
@@ -1103,8 +1121,11 @@ public class DataStream<T> {
 	 *
 	 * @param format The output format
 	 * @return The closed DataStream
+	 *
+	 * @deprecated Please use the {@code BucketingSink} for writing to files from a streaming program.
 	 */
 	@PublicEvolving
+	@Deprecated
 	public DataStreamSink<T> writeUsingOutputFormat(OutputFormat<T> format) {
 		return addSink(new OutputFormatSinkFunction<>(format));
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/OutputFormatSinkFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/OutputFormatSinkFunction.java
@@ -37,8 +37,11 @@ import java.io.IOException;
  * OutputFormat format.
  *
  * @param <IN> Input type
+ *
+ * @deprecated Please use the {@code BucketingSink} for writing to files from a streaming program.
  */
 @PublicEvolving
+@Deprecated
 public class OutputFormatSinkFunction<IN> extends RichSinkFunction<IN> implements InputTypeConfigurable {
 
 	private static final long serialVersionUID = 1L;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/WriteFormat.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/WriteFormat.java
@@ -28,8 +28,11 @@ import java.util.ArrayList;
  *
  * @param <IN>
  *            Input tuple type
+ *
+ * @deprecated Please use the {@code BucketingSink} for writing to files from a streaming program.
  */
 @PublicEvolving
+@Deprecated
 public abstract class WriteFormat<IN> implements Serializable {
 	private static final long serialVersionUID = 1L;
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/WriteFormatAsCsv.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/WriteFormatAsCsv.java
@@ -30,8 +30,11 @@ import java.util.ArrayList;
  *
  * @param <IN>
  *            Input tuple type
+ *
+ * @deprecated Please use the {@code BucketingSink} for writing to files from a streaming program.
  */
 @PublicEvolving
+@Deprecated
 public class WriteFormatAsCsv<IN> extends WriteFormat<IN> {
 	private static final long serialVersionUID = 1L;
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/WriteFormatAsText.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/WriteFormatAsText.java
@@ -30,8 +30,11 @@ import java.util.ArrayList;
  *
  * @param <IN>
  *            Input tuple type
+ *
+ * @deprecated Please use the {@code BucketingSink} for writing to files from a streaming program.
  */
 @PublicEvolving
+@Deprecated
 public class WriteFormatAsText<IN> extends WriteFormat<IN> {
 	private static final long serialVersionUID = 1L;
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/WriteSinkFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/WriteSinkFunction.java
@@ -31,8 +31,11 @@ import java.util.ArrayList;
  *
  * @param <IN>
  *            Input tuple type
+ *
+ * @deprecated Please use the {@code BucketingSink} for writing to files from a streaming program.
  */
 @PublicEvolving
+@Deprecated
 public abstract class WriteSinkFunction<IN> implements SinkFunction<IN> {
 	private static final long serialVersionUID = 1L;
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/WriteSinkFunctionByMillis.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/WriteSinkFunctionByMillis.java
@@ -25,8 +25,11 @@ import org.apache.flink.annotation.PublicEvolving;
  *
  * @param <IN>
  *            Input tuple type
+ *
+ * @deprecated Please use the {@code BucketingSink} for writing to files from a streaming program.
  */
 @PublicEvolving
+@Deprecated
 public class WriteSinkFunctionByMillis<IN> extends WriteSinkFunction<IN> {
 	private static final long serialVersionUID = 1L;
 


### PR DESCRIPTION
Update of #5868 

@zentol 