### PR TITLE
[FLINK-9208][tests] fix naming of StreamNetworkThroughputBenchmarkTest

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkThroughputBenchmarkTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkThroughputBenchmarkTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 /**
  * Tests for various network benchmarks based on {@link StreamNetworkThroughputBenchmark}.
  */
-public class StreamNetworkThroughputBenchmarkTests {
+public class StreamNetworkThroughputBenchmarkTest {
 	@Test
 	public void pointToPointBenchmark() throws Exception {
 		StreamNetworkThroughputBenchmark benchmark = new StreamNetworkThroughputBenchmark();


### PR DESCRIPTION
This PR fixes the naming of `StreamNetworkThroughputBenchmarkTest` so that it gets included in the maven tests.
