### PR TITLE
[FLINK-9210] Removed unnecessary getValue calls in serializeGauge

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/dump/MetricDumpSerialization.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/dump/MetricDumpSerialization.java
@@ -40,6 +40,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.apache.flink.runtime.metrics.dump.QueryScopeInfo.INFO_CATEGORY_JM;
 import static org.apache.flink.runtime.metrics.dump.QueryScopeInfo.INFO_CATEGORY_JOB;
@@ -216,10 +217,8 @@ public class MetricDumpSerialization {
 	}
 
 	private static void serializeGauge(DataOutput out, QueryScopeInfo info, String name, Gauge<?> gauge) throws IOException {
-		Object value = gauge.getValue();
-		if (value == null) {
-			throw new NullPointerException("Value returned by gauge " + name + " was null.");
-		}
+		Object value = Optional.ofNullable(gauge.getValue()).orElseThrow(() -> new NullPointerException("Value returned by gauge " + name + " was "
+			+ "null."));
 		String stringValue = value.toString();
 		if (stringValue == null) {
 			throw new NullPointerException("toString() of the value returned by gauge " + name + " returned null.");


### PR DESCRIPTION
## What is the purpose of the change

* This pull request removes unnecessary gauge.getValue() call in MetricDumpSerialization.serializeGauge(). That way gauge value can reset inside getValue upon serialization. This allows gauge value to be reset at the time metric reporter prepares gauge value for the report.


## Brief change log

  - gauge.getValue() gets called only once in MetricDumpSerialization.serializeGauge()


## Verifying this change

This change is already covered by existing tests, such as MetricDumpSerializerTest.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers: no(changes live in the MetricDumpSerialization but it would not affect)
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
