### PR TITLE
[FLINK-8785][Job-Submission]Handle JobSubmissionExceptions

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -246,7 +246,7 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId> impleme
 				return CompletableFuture.completedFuture(Acknowledge.get());
 			}
 		} catch (Exception e) {
-			return FutureUtils.completedExceptionally(new FlinkException(String.format("Failed to submit job %s.", jobId), e));
+			return FutureUtils.completedExceptionally(new FlinkException(String.format("Failed to submit job %s. reason: %s", jobId, e.getMessage()), e));
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerRunner.java
@@ -166,7 +166,8 @@ public class JobManagerRunner implements LeaderContender, OnCompletionActions, A
 			terminationFuture.completeExceptionally(t);
 			resultFuture.completeExceptionally(t);
 
-			throw new JobExecutionException(jobGraph.getJobID(), "Could not set up JobManager", t);
+			throw new JobExecutionException(jobGraph.getJobID(), String.join(";",
+				t.getMessage(), "Could not set up JobManager"), t);
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/AbstractHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/AbstractHandler.java
@@ -176,7 +176,7 @@ public abstract class AbstractHandler<T extends RestfulGateway, R extends Reques
 			HandlerUtils.sendErrorResponse(
 				ctx,
 				httpRequest,
-				new ErrorResponseBody("Internal server error."),
+				new ErrorResponseBody("Internal server error." + e.getMessage() + "."),
 				HttpResponseStatus.INTERNAL_SERVER_ERROR,
 				responseHeaders);
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/AbstractRestHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/AbstractRestHandler.java
@@ -100,7 +100,7 @@ public abstract class AbstractRestHandler<T extends RestfulGateway, R extends Re
 					HandlerUtils.sendErrorResponse(
 						ctx,
 						httpRequest,
-						new ErrorResponseBody("Internal server error."),
+						new ErrorResponseBody("Internal server error." + error.getMessage() + "."),
 						HttpResponseStatus.INTERNAL_SERVER_ERROR,
 						responseHeaders);
 				}


### PR DESCRIPTION
## What is the purpose of the change

We will get an "Internal server error" exception if we submit a jobgraph with a restclusterclient. This PR helps us get more details and causes of the exception, such as "The jobgraph is empty" message.

## Brief change log
Add causes and details of an exception which happens in job submission.

## Verifying this change  

## Does this pull request potentially affect one of the following parts:  

## Documentation  
