### PR TITLE
[FLINK-9215][resoucemanager] Reduce noise in SlotPool's log to avoid confusing

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobVertex.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobgraph.tasks.StoppableTask;
 import org.apache.flink.runtime.jobmanager.scheduler.CoLocationGroup;
 import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
+import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
 import org.apache.flink.util.Preconditions;
 
 import java.util.ArrayList;
@@ -304,7 +305,8 @@ public class JobVertex implements java.io.Serializable {
 	/**
 	 * Sets the maximum parallelism for the task.
 	 *
-	 * @param maxParallelism The maximum parallelism to be set. must be between 1 and Short.MAX_VALUE.
+	 * @param maxParallelism The maximum parallelism to be set.
+	 *                       Must be between 1 and {@link KeyGroupRangeAssignment#UPPER_BOUND_MAX_PARALLELISM}.
 	 */
 	public void setMaxParallelism(int maxParallelism) {
 		this.maxParallelism = maxParallelism;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
@@ -734,7 +734,7 @@ public class SlotPool extends RpcEndpoint implements SlotPoolGateway, AllocatedS
 
 	@Override
 	public CompletableFuture<Acknowledge> releaseSlot(SlotRequestId slotRequestId, @Nullable SlotSharingGroupId slotSharingGroupId, Throwable cause) {
-		log.debug("Releasing slot with slot request id {}.", slotRequestId, cause);
+		log.debug("Releasing slot with slot request id {} because of {}.", slotRequestId, cause != null ? cause.getMessage() : "null");
 
 		if (slotSharingGroupId != null) {
 			final SlotSharingManager multiTaskSlotManager = slotSharingManagers.get(slotSharingGroupId);


### PR DESCRIPTION
## What is the purpose of the change

This PR fix the log in `SlotPool#releaseSlot()` to avoid confusing.

## Brief change log

  - *Only log the exception when the log level is TRACE in SlothPool#releaseSlot()*
  - *dd double check in ZooKeeperLeaderRetrievalService#start() to avoid race condition*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

no

## Documentation

no