### PR TITLE
[FLINK-8836] Fix duplicate method in KryoSerializer to perform deep c…

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializer.java
@@ -18,12 +18,6 @@
 
 package org.apache.flink.api.java.typeutils.runtime.kryo;
 
-import com.esotericsoftware.kryo.Kryo;
-import com.esotericsoftware.kryo.KryoException;
-import com.esotericsoftware.kryo.Serializer;
-import com.esotericsoftware.kryo.io.Input;
-import com.esotericsoftware.kryo.io.Output;
-
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.CompatibilityResult;
@@ -38,9 +32,15 @@ import org.apache.flink.api.java.typeutils.runtime.KryoUtils;
 import org.apache.flink.api.java.typeutils.runtime.NoFetchingInput;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.util.InstantiationUtil;
 
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.KryoException;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import org.apache.commons.lang3.exception.CloneFailedException;
 import org.objenesis.strategy.StdInstantiatorStrategy;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -140,14 +140,37 @@ public class KryoSerializer<T> extends TypeSerializer<T> {
 	 * Copy-constructor that does not copy transient fields. They will be initialized once required.
 	 */
 	protected KryoSerializer(KryoSerializer<T> toCopy) {
-		defaultSerializers = toCopy.defaultSerializers;
-		defaultSerializerClasses = toCopy.defaultSerializerClasses;
 
-		kryoRegistrations = toCopy.kryoRegistrations;
+		this.type = checkNotNull(toCopy.type, "Type class cannot be null.");
+		this.defaultSerializerClasses = toCopy.defaultSerializerClasses;
+		this.defaultSerializers = new LinkedHashMap<>(toCopy.defaultSerializers.size());
+		this.kryoRegistrations = new LinkedHashMap<>(toCopy.kryoRegistrations.size());
 
-		type = toCopy.type;
-		if(type == null){
-			throw new NullPointerException("Type class cannot be null.");
+		// deep copy the serializer instances in defaultSerializers
+		for (Map.Entry<Class<?>, ExecutionConfig.SerializableSerializer<?>> entry :
+			toCopy.defaultSerializers.entrySet()) {
+
+			this.defaultSerializers.put(entry.getKey(), deepCopySerializer(entry.getValue()));
+		}
+
+		// deep copy the serializer instances in kryoRegistrations
+		for (Map.Entry<String, KryoRegistration> entry : toCopy.kryoRegistrations.entrySet()) {
+
+			KryoRegistration kryoRegistration = entry.getValue();
+
+			if (kryoRegistration.getSerializerDefinitionType() == KryoRegistration.SerializerDefinitionType.INSTANCE) {
+
+				ExecutionConfig.SerializableSerializer<? extends Serializer<?>> serializerInstance =
+					kryoRegistration.getSerializableSerializerInstance();
+
+				if (serializerInstance != null) {
+					kryoRegistration = new KryoRegistration(
+						kryoRegistration.getRegisteredClass(),
+						deepCopySerializer(serializerInstance));
+				}
+			}
+
+			this.kryoRegistrations.put(entry.getKey(), kryoRegistration);
 		}
 	}
 
@@ -565,6 +588,17 @@ public class KryoSerializer<T> extends TypeSerializer<T> {
 					registeredTypes,
 					registeredTypesWithSerializerClasses,
 					registeredTypesWithSerializers);
+		}
+	}
+
+	private ExecutionConfig.SerializableSerializer<? extends Serializer<?>> deepCopySerializer(
+		ExecutionConfig.SerializableSerializer<? extends Serializer<?>> original) {
+		try {
+			return InstantiationUtil.clone(original, Thread.currentThread().getContextClassLoader());
+		} catch (IOException | ClassNotFoundException ex) {
+			throw new CloneFailedException(
+				"Could not clone serializer instance of class " + original.getClass(),
+				ex);
 		}
 	}
 

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializerConcurrencyTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializerConcurrencyTest.java
@@ -24,20 +24,70 @@ import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.core.testutils.BlockerSync;
 import org.apache.flink.core.testutils.CheckedThread;
 
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.io.Serializable;
 
 import static org.junit.Assert.fail;
 
 /**
  * This tests that the {@link KryoSerializer} properly fails when accessed by two threads
- * concurrently.
+ * concurrently and that Kryo serializers are properly duplicated to use them in different threads.
  *
  * <p><b>Important:</b> This test only works if assertions are activated (-ea) on the JVM
  * when running tests.
  */
 public class KryoSerializerConcurrencyTest {
+
+	@Test
+	public void testDuplicateSerializerWithDefaultSerializerClass() {
+		ExecutionConfig executionConfig = new ExecutionConfig();
+		executionConfig.addDefaultKryoSerializer(WrappedString.class, new TestSerializer());
+		runDuplicateSerializerTest(executionConfig);
+	}
+
+	@Test
+	public void testDuplicateSerializerWithDefaultSerializerInstance() {
+		ExecutionConfig executionConfig = new ExecutionConfig();
+		executionConfig.addDefaultKryoSerializer(WrappedString.class, TestSerializer.class);
+		runDuplicateSerializerTest(executionConfig);
+	}
+
+	@Test
+	public void testDuplicateSerializerWithRegisteredSerializerClass() {
+		ExecutionConfig executionConfig = new ExecutionConfig();
+		executionConfig.registerTypeWithKryoSerializer(WrappedString.class, TestSerializer.class);
+		runDuplicateSerializerTest(executionConfig);
+	}
+
+	@Test
+	public void testDuplicateSerializerWithRegisteredSerializerInstance() {
+		ExecutionConfig executionConfig = new ExecutionConfig();
+		executionConfig.registerTypeWithKryoSerializer(WrappedString.class, new TestSerializer());
+		runDuplicateSerializerTest(executionConfig);
+	}
+
+	private void runDuplicateSerializerTest(ExecutionConfig executionConfig) {
+		final KryoSerializer<WrappedString> original = new KryoSerializer<>(WrappedString.class, executionConfig);
+		final KryoSerializer<WrappedString> duplicate = original.duplicate();
+
+		WrappedString testString = new WrappedString("test");
+
+		String copyWithOriginal = original.copy(testString).content;
+		String copyWithDuplicate = duplicate.copy(testString).content;
+
+		Assert.assertTrue(copyWithOriginal.startsWith(testString.content));
+		Assert.assertTrue(copyWithDuplicate.startsWith(testString.content));
+
+		// check that both serializer instances have appended a different identity hash
+		Assert.assertNotEquals(copyWithOriginal, copyWithDuplicate);
+	}
 
 	@Test
 	public void testConcurrentUseOfSerializer() throws Exception {
@@ -90,6 +140,43 @@ public class KryoSerializerConcurrencyTest {
 		@Override
 		public void write(byte[] b, int off, int len) throws IOException {
 			blocker.blockNonInterruptible();
+		}
+	}
+
+	/**
+	 * A test class that wraps a string.
+	 */
+	public static class WrappedString {
+
+		private final String content;
+
+		WrappedString(String content) {
+			this.content = content;
+		}
+
+		@Override
+		public String toString() {
+			return "WrappedString{" +
+				"content='" + content + '\'' +
+				'}';
+		}
+	}
+
+	/**
+	 * A test serializer for {@link WrappedString} that appends its identity hash.
+	 */
+	public static class TestSerializer extends Serializer<WrappedString> implements Serializable {
+
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public void write(Kryo kryo, Output output, WrappedString object) {
+			output.writeString(object.content);
+		}
+
+		@Override
+		public WrappedString read(Kryo kryo, Input input, Class<WrappedString> type) {
+			return new WrappedString(input.readString() + " " + System.identityHashCode(this));
 		}
 	}
 }


### PR DESCRIPTION
…opy of default/registered serializer instances.

This method did create deep copies of registered or default serializer instances and
as a result those serializer instances can accidentally be shared across different threads.

## Brief change log

This PR fixes a problem with the `duplicate` method of `KryoSerializer`. We do now perform deep copies for default and registered serializer objects.

Otherwise, if we share duplicated `KryoSerializer` instances across different threads, some of their internal serializers might be a shared instance of a stateful object. 

## Verifying this change

This change added tests and can be verified by running `KryoSerializerConcurrencyTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (indirectly)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
