### PR TITLE
[FLINK-8715] Remove usage of StateDescriptor in state handles

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/CompatibilityUtil.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/CompatibilityUtil.java
@@ -30,6 +30,8 @@ public class CompatibilityUtil {
 	/**
 	 * Resolves the final compatibility result of two serializers by taking into account compound information,
 	 * including the preceding serializer, the preceding serializer's configuration snapshot, and the new serializer.
+	 * This method has the side effect that the provided new serializer may have been reconfigured in order to
+	 * remain compatible.
 	 *
 	 * The final result is determined as follows:
 	 *   1. If there is no configuration snapshot of the preceding serializer,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
@@ -455,4 +455,5 @@ public abstract class AbstractKeyedStateBackend<K> implements
 	@VisibleForTesting
 	public abstract int numStateEntries();
 
+
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackend.java
@@ -757,16 +757,17 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 				(RegisteredOperatorBackendStateMetaInfo.Snapshot<S>) restoredOperatorStateMetaInfos.get(name);
 
 			// check compatibility to determine if state migration is required
+			TypeSerializer<S> newPartitionStateSerializer = partitionStateSerializer.duplicate();
 			CompatibilityResult<S> stateCompatibility = CompatibilityUtil.resolveCompatibilityResult(
 					restoredMetaInfo.getPartitionStateSerializer(),
 					UnloadableDummyTypeSerializer.class,
 					restoredMetaInfo.getPartitionStateSerializerConfigSnapshot(),
-					partitionStateSerializer);
+					newPartitionStateSerializer);
 
 			if (!stateCompatibility.isRequiresMigration()) {
 				// new serializer is compatible; use it to replace the old serializer
 				partitionableListState.setStateMetaInfo(
-					new RegisteredOperatorBackendStateMetaInfo<>(name, partitionStateSerializer, mode));
+					new RegisteredOperatorBackendStateMetaInfo<>(name, newPartitionStateSerializer, mode));
 			} else {
 				// TODO state migration currently isn't possible.
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredKeyedBackendStateMetaInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredKeyedBackendStateMetaInfo.java
@@ -19,9 +19,13 @@
 package org.apache.flink.runtime.state;
 
 import org.apache.flink.api.common.state.StateDescriptor;
+import org.apache.flink.api.common.typeutils.CompatibilityResult;
+import org.apache.flink.api.common.typeutils.CompatibilityUtil;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
+import org.apache.flink.api.common.typeutils.UnloadableDummyTypeSerializer;
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.StateMigrationException;
 
 import java.util.Objects;
 
@@ -238,6 +242,58 @@ public class RegisteredKeyedBackendStateMetaInfo<N, S> {
 			result = 31 * result + (getNamespaceSerializerConfigSnapshot() != null ? getNamespaceSerializerConfigSnapshot().hashCode() : 0);
 			result = 31 * result + (getStateSerializerConfigSnapshot() != null ? getStateSerializerConfigSnapshot().hashCode() : 0);
 			return result;
+		}
+	}
+
+	/**
+	 * Checks compatibility of a restored k/v state, with the new {@link StateDescriptor} provided to it.
+	 * This checks that the descriptor specifies identical names and state types, as well as
+	 * serializers that are compatible for the restored k/v state bytes.
+	 */
+	public static  <N, S> RegisteredKeyedBackendStateMetaInfo<N, S> resolveKvStateCompatibility(
+		RegisteredKeyedBackendStateMetaInfo.Snapshot<?, ?> restoredStateMetaInfoSnapshot,
+		TypeSerializer<N> newNamespaceSerializer,
+		StateDescriptor<?, S> newStateDescriptor) throws StateMigrationException {
+
+		Preconditions.checkState(
+			Objects.equals(newStateDescriptor.getName(), restoredStateMetaInfoSnapshot.getName()),
+			"Incompatible state names. " +
+				"Was [" + restoredStateMetaInfoSnapshot.getName() + "], " +
+				"registered with [" + newStateDescriptor.getName() + "].");
+
+		if (!Objects.equals(newStateDescriptor.getType(), StateDescriptor.Type.UNKNOWN)
+			&& !Objects.equals(restoredStateMetaInfoSnapshot.getStateType(), StateDescriptor.Type.UNKNOWN)) {
+
+			Preconditions.checkState(
+				newStateDescriptor.getType() == restoredStateMetaInfoSnapshot.getStateType(),
+				"Incompatible state types. " +
+					"Was [" + restoredStateMetaInfoSnapshot.getStateType() + "], " +
+					"registered with [" + newStateDescriptor.getType() + "].");
+		}
+
+		// check compatibility results to determine if state migration is required
+		CompatibilityResult<N> namespaceCompatibility = CompatibilityUtil.resolveCompatibilityResult(
+			restoredStateMetaInfoSnapshot.getNamespaceSerializer(),
+			null,
+			restoredStateMetaInfoSnapshot.getNamespaceSerializerConfigSnapshot(),
+			newNamespaceSerializer);
+
+		TypeSerializer<S> newStateSerializer = newStateDescriptor.getSerializer();
+		CompatibilityResult<S> stateCompatibility = CompatibilityUtil.resolveCompatibilityResult(
+			restoredStateMetaInfoSnapshot.getStateSerializer(),
+			UnloadableDummyTypeSerializer.class,
+			restoredStateMetaInfoSnapshot.getStateSerializerConfigSnapshot(),
+			newStateSerializer);
+
+		if (namespaceCompatibility.isRequiresMigration() || stateCompatibility.isRequiresMigration()) {
+			// TODO state migration currently isn't possible.
+			throw new StateMigrationException("State migration isn't supported, yet.");
+		} else {
+			return new RegisteredKeyedBackendStateMetaInfo<>(
+				newStateDescriptor.getType(),
+				newStateDescriptor.getName(),
+				newNamespaceSerializer,
+				newStateSerializer);
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/AbstractHeapMergingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/AbstractHeapMergingState.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.state.heap;
 
 import org.apache.flink.api.common.state.MergingState;
 import org.apache.flink.api.common.state.State;
-import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.state.StateTransformationFunction;
 import org.apache.flink.runtime.state.internal.InternalMergingState;
@@ -36,10 +35,9 @@ import java.util.Collection;
  * @param <SV> The type of the values in the state.
  * @param <OUT> The type of the output elements.
  * @param <S> The type of State
- * @param <SD> The type of StateDescriptor for the State S
  */
-public abstract class AbstractHeapMergingState<K, N, IN, SV, OUT, S extends State, SD extends StateDescriptor<S, SV>>
-		extends AbstractHeapState<K, N, SV, S, SD>
+public abstract class AbstractHeapMergingState<K, N, IN, SV, OUT, S extends State>
+		extends AbstractHeapState<K, N, SV, S>
 		implements InternalMergingState<K, N, IN, SV, OUT> {
 
 	/**
@@ -50,8 +48,11 @@ public abstract class AbstractHeapMergingState<K, N, IN, SV, OUT, S extends Stat
 	/**
 	 * Creates a new key/value state for the given hash map of key/value pairs.
 	 *
+	 * @param stateTable The state table for which this state is associated to.
+	 * @param keySerializer The serializer for the keys.
 	 * @param valueSerializer The serializer for the state.
-	 * @param stateTable The state tab;e to use in this kev/value state. May contain initial state.
+	 * @param namespaceSerializer The serializer for the namespace.
+	 * @param defaultValue The default value for the state.
 	 */
 	protected AbstractHeapMergingState(
 			StateTable<K, N, SV> stateTable,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/AbstractHeapMergingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/AbstractHeapMergingState.java
@@ -50,17 +50,17 @@ public abstract class AbstractHeapMergingState<K, N, IN, SV, OUT, S extends Stat
 	/**
 	 * Creates a new key/value state for the given hash map of key/value pairs.
 	 *
-	 * @param stateDesc The state identifier for the state. This contains name
-	 *                           and can create a default state value.
+	 * @param valueSerializer The serializer for the state.
 	 * @param stateTable The state tab;e to use in this kev/value state. May contain initial state.
 	 */
 	protected AbstractHeapMergingState(
-			SD stateDesc,
 			StateTable<K, N, SV> stateTable,
 			TypeSerializer<K> keySerializer,
-			TypeSerializer<N> namespaceSerializer) {
+			TypeSerializer<SV> valueSerializer,
+			TypeSerializer<N> namespaceSerializer,
+			SV defaultValue) {
 
-		super(stateDesc, stateTable, keySerializer, namespaceSerializer);
+		super(stateTable, keySerializer, valueSerializer, namespaceSerializer, defaultValue);
 		this.mergeTransformation = new MergeTransformation();
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/AbstractHeapState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/AbstractHeapState.java
@@ -42,33 +42,35 @@ public abstract class AbstractHeapState<K, N, SV, S extends State, SD extends St
 	/** Map containing the actual key/value pairs. */
 	protected final StateTable<K, N, SV> stateTable;
 
-	/** This holds the name of the state and can create an initial default value for the state. */
-	protected final SD stateDesc;
-
 	/** The current namespace, which the access methods will refer to. */
 	protected N currentNamespace;
 
 	protected final TypeSerializer<K> keySerializer;
 
+	protected final TypeSerializer<SV> valueSerializer;
+
 	protected final TypeSerializer<N> namespaceSerializer;
+
+	private final SV defaultValue;
 
 	/**
 	 * Creates a new key/value state for the given hash map of key/value pairs.
 	 *
-	 * @param stateDesc The state identifier for the state. This contains name
-	 *                           and can create a default state value.
+	 * @param valueSerializer The serializer for the state.
 	 * @param stateTable The state tab;e to use in this kev/value state. May contain initial state.
 	 */
 	protected AbstractHeapState(
-			SD stateDesc,
 			StateTable<K, N, SV> stateTable,
 			TypeSerializer<K> keySerializer,
-			TypeSerializer<N> namespaceSerializer) {
+			TypeSerializer<SV> valueSerializer,
+			TypeSerializer<N> namespaceSerializer,
+			SV defaultValue) {
 
-		this.stateDesc = stateDesc;
 		this.stateTable = Preconditions.checkNotNull(stateTable, "State table must not be null.");
 		this.keySerializer = keySerializer;
+		this.valueSerializer = valueSerializer;
 		this.namespaceSerializer = namespaceSerializer;
+		this.defaultValue = defaultValue;
 		this.currentNamespace = null;
 	}
 
@@ -113,5 +115,13 @@ public abstract class AbstractHeapState<K, N, SV, S extends State, SD extends St
 	@VisibleForTesting
 	public StateTable<K, N, SV> getStateTable() {
 		return stateTable;
+	}
+
+	protected SV getDefaultValue() {
+		if (defaultValue != null) {
+			return valueSerializer.copy(defaultValue);
+		} else {
+			return null;
+		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/AbstractHeapState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/AbstractHeapState.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.state.heap;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.state.State;
-import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.queryablestate.client.state.serialization.KvStateSerializer;
@@ -35,9 +34,8 @@ import org.apache.flink.util.Preconditions;
  * @param <N> The type of the namespace.
  * @param <SV> The type of the values in the state.
  * @param <S> The type of State
- * @param <SD> The type of StateDescriptor for the State S
  */
-public abstract class AbstractHeapState<K, N, SV, S extends State, SD extends StateDescriptor<S, ?>> implements InternalKvState<K, N, SV> {
+public abstract class AbstractHeapState<K, N, SV, S extends State> implements InternalKvState<K, N, SV> {
 
 	/** Map containing the actual key/value pairs. */
 	protected final StateTable<K, N, SV> stateTable;
@@ -56,8 +54,11 @@ public abstract class AbstractHeapState<K, N, SV, S extends State, SD extends St
 	/**
 	 * Creates a new key/value state for the given hash map of key/value pairs.
 	 *
+	 * @param stateTable The state table for which this state is associated to.
+	 * @param keySerializer The serializer for the keys.
 	 * @param valueSerializer The serializer for the state.
-	 * @param stateTable The state tab;e to use in this kev/value state. May contain initial state.
+	 * @param namespaceSerializer The serializer for the namespace.
+	 * @param defaultValue The default value for the state.
 	 */
 	protected AbstractHeapState(
 			StateTable<K, N, SV> stateTable,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapAggregatingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapAggregatingState.java
@@ -47,21 +47,23 @@ public class HeapAggregatingState<K, N, IN, ACC, OUT>
 	/**
 	 * Creates a new key/value state for the given hash map of key/value pairs.
 	 *
-	 * @param stateDesc
-	 *             The state identifier for the state. This contains name and can create a default state value.
+	 * @param valueSerializer
+	 *             The serializer for the state.
 	 * @param stateTable
 	 *             The state table to use in this kev/value state. May contain initial state.
 	 * @param namespaceSerializer
 	 *             The serializer for the type that indicates the namespace
 	 */
 	public HeapAggregatingState(
-			AggregatingStateDescriptor<IN, ACC, OUT> stateDesc,
 			StateTable<K, N, ACC> stateTable,
 			TypeSerializer<K> keySerializer,
-			TypeSerializer<N> namespaceSerializer) {
+			TypeSerializer<ACC> valueSerializer,
+			TypeSerializer<N> namespaceSerializer,
+			ACC defaultValue,
+			AggregateFunction<IN, ACC, OUT> aggregateFunction) {
 
-		super(stateDesc, stateTable, keySerializer, namespaceSerializer);
-		this.aggregateTransformation = new AggregateTransformation<>(stateDesc.getAggregateFunction());
+		super(stateTable, keySerializer, valueSerializer, namespaceSerializer, defaultValue);
+		this.aggregateTransformation = new AggregateTransformation<>(aggregateFunction);
 	}
 
 	@Override
@@ -76,7 +78,7 @@ public class HeapAggregatingState<K, N, IN, ACC, OUT>
 
 	@Override
 	public TypeSerializer<ACC> getValueSerializer() {
-		return stateDesc.getSerializer();
+		return valueSerializer;
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapAggregatingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapAggregatingState.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.state.heap;
 
 import org.apache.flink.api.common.functions.AggregateFunction;
 import org.apache.flink.api.common.state.AggregatingState;
-import org.apache.flink.api.common.state.AggregatingStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.state.StateTransformationFunction;
 import org.apache.flink.runtime.state.internal.InternalAggregatingState;
@@ -39,7 +38,7 @@ import java.io.IOException;
  * @param <OUT> The type of the value returned from the state.
  */
 public class HeapAggregatingState<K, N, IN, ACC, OUT>
-		extends AbstractHeapMergingState<K, N, IN, ACC, OUT, AggregatingState<IN, OUT>, AggregatingStateDescriptor<IN, ACC, OUT>>
+		extends AbstractHeapMergingState<K, N, IN, ACC, OUT, AggregatingState<IN, OUT>>
 		implements InternalAggregatingState<K, N, IN, ACC, OUT> {
 
 	private final AggregateTransformation<IN, ACC, OUT> aggregateTransformation;
@@ -47,12 +46,12 @@ public class HeapAggregatingState<K, N, IN, ACC, OUT>
 	/**
 	 * Creates a new key/value state for the given hash map of key/value pairs.
 	 *
-	 * @param valueSerializer
-	 *             The serializer for the state.
-	 * @param stateTable
-	 *             The state table to use in this kev/value state. May contain initial state.
-	 * @param namespaceSerializer
-	 *             The serializer for the type that indicates the namespace
+	 * @param stateTable The state table for which this state is associated to.
+	 * @param keySerializer The serializer for the keys.
+	 * @param valueSerializer The serializer for the state.
+	 * @param namespaceSerializer The serializer for the namespace.
+	 * @param defaultValue The default value for the state.
+	 * @param aggregateFunction The aggregating function used for aggregating state.
 	 */
 	public HeapAggregatingState(
 			StateTable<K, N, ACC> stateTable,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapFoldingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapFoldingState.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.state.heap;
 
 import org.apache.flink.api.common.functions.FoldFunction;
 import org.apache.flink.api.common.state.FoldingState;
-import org.apache.flink.api.common.state.FoldingStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.state.StateTransformationFunction;
 import org.apache.flink.runtime.state.internal.InternalFoldingState;
@@ -40,7 +39,7 @@ import java.io.IOException;
  */
 @Deprecated
 public class HeapFoldingState<K, N, T, ACC>
-		extends AbstractHeapState<K, N, ACC, FoldingState<T, ACC>, FoldingStateDescriptor<T, ACC>>
+		extends AbstractHeapState<K, N, ACC, FoldingState<T, ACC>>
 		implements InternalFoldingState<K, N, T, ACC> {
 
 	/** The function used to fold the state */
@@ -49,8 +48,12 @@ public class HeapFoldingState<K, N, T, ACC>
 	/**
 	 * Creates a new key/value state for the given hash map of key/value pairs.
 	 *
+	 * @param stateTable The state table for which this state is associated to.
+	 * @param keySerializer The serializer for the keys.
 	 * @param valueSerializer The serializer for the state.
-	 * @param stateTable The state tab;e to use in this kev/value state. May contain initial state.
+	 * @param namespaceSerializer The serializer for the namespace.
+	 * @param defaultValue The default value for the state.
+	 * @param foldFunction The fold function used for folding state.
 	 */
 	public HeapFoldingState(
 			StateTable<K, N, ACC> stateTable,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapFoldingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapFoldingState.java
@@ -43,7 +43,7 @@ public class HeapFoldingState<K, N, T, ACC>
 		implements InternalFoldingState<K, N, T, ACC> {
 
 	/** The function used to fold the state */
-	private final FoldTransformation<T, ACC> foldTransformation;
+	private final FoldTransformation foldTransformation;
 
 	/**
 	 * Creates a new key/value state for the given hash map of key/value pairs.
@@ -63,7 +63,7 @@ public class HeapFoldingState<K, N, T, ACC>
 			ACC defaultValue,
 			FoldFunction<T, ACC> foldFunction) {
 		super(stateTable, keySerializer, valueSerializer, namespaceSerializer, defaultValue);
-		this.foldTransformation = new FoldTransformation<>(foldFunction, this);
+		this.foldTransformation = new FoldTransformation(foldFunction);
 	}
 
 	@Override
@@ -105,19 +105,17 @@ public class HeapFoldingState<K, N, T, ACC>
 		}
 	}
 
-	private static final class FoldTransformation<T, ACC> implements StateTransformationFunction<ACC, T> {
+	private final class FoldTransformation implements StateTransformationFunction<ACC, T> {
 
-		private final HeapFoldingState<?, ?, T, ACC> stateRef;
 		private final FoldFunction<T, ACC> foldFunction;
 
-		FoldTransformation(FoldFunction<T, ACC> foldFunction, HeapFoldingState<?, ?, T, ACC> stateRef) {
-			this.stateRef = Preconditions.checkNotNull(stateRef);
+		FoldTransformation(FoldFunction<T, ACC> foldFunction) {
 			this.foldFunction = Preconditions.checkNotNull(foldFunction);
 		}
 
 		@Override
 		public ACC apply(ACC previousState, T value) throws Exception {
-			return foldFunction.fold((previousState != null) ? previousState : stateRef.getDefaultValue(), value);
+			return foldFunction.fold((previousState != null) ? previousState : getDefaultValue(), value);
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
@@ -250,7 +250,12 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 			ValueStateDescriptor<V> stateDesc) throws Exception {
 
 		StateTable<K, N, V> stateTable = tryRegisterStateTable(namespaceSerializer, stateDesc);
-		return new HeapValueState<>(stateDesc, stateTable, keySerializer, namespaceSerializer);
+		return new HeapValueState<>(
+				stateTable,
+				keySerializer,
+				stateTable.getStateSerializer(),
+				namespaceSerializer,
+				stateDesc.getDefaultValue());
 	}
 
 	@Override
@@ -259,7 +264,12 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 			ListStateDescriptor<T> stateDesc) throws Exception {
 
 		StateTable<K, N, List<T>> stateTable = tryRegisterStateTable(namespaceSerializer, stateDesc);
-		return new HeapListState<>(stateDesc, stateTable, keySerializer, namespaceSerializer);
+		return new HeapListState<>(
+				stateTable,
+				keySerializer,
+				stateTable.getStateSerializer(),
+				namespaceSerializer,
+				stateDesc.getDefaultValue());
 	}
 
 	@Override
@@ -268,7 +278,13 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 			ReducingStateDescriptor<T> stateDesc) throws Exception {
 
 		StateTable<K, N, T> stateTable = tryRegisterStateTable(namespaceSerializer, stateDesc);
-		return new HeapReducingState<>(stateDesc, stateTable, keySerializer, namespaceSerializer);
+		return new HeapReducingState<>(
+				stateTable,
+				keySerializer,
+				stateTable.getStateSerializer(),
+				namespaceSerializer,
+				stateDesc.getDefaultValue(),
+				stateDesc.getReduceFunction());
 	}
 
 	@Override
@@ -277,7 +293,13 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 			AggregatingStateDescriptor<T, ACC, R> stateDesc) throws Exception {
 
 		StateTable<K, N, ACC> stateTable = tryRegisterStateTable(namespaceSerializer, stateDesc);
-		return new HeapAggregatingState<>(stateDesc, stateTable, keySerializer, namespaceSerializer);
+		return new HeapAggregatingState<>(
+				stateTable,
+				keySerializer,
+				stateTable.getStateSerializer(),
+				namespaceSerializer,
+				stateDesc.getDefaultValue(),
+				stateDesc.getAggregateFunction());
 	}
 
 	@Override
@@ -286,7 +308,13 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 			FoldingStateDescriptor<T, ACC> stateDesc) throws Exception {
 
 		StateTable<K, N, ACC> stateTable = tryRegisterStateTable(namespaceSerializer, stateDesc);
-		return new HeapFoldingState<>(stateDesc, stateTable, keySerializer, namespaceSerializer);
+		return new HeapFoldingState<>(
+				stateTable,
+				keySerializer,
+				stateTable.getStateSerializer(),
+				namespaceSerializer,
+				stateDesc.getDefaultValue(),
+				stateDesc.getFoldFunction());
 	}
 
 	@Override
@@ -295,7 +323,13 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 			MapStateDescriptor<UK, UV> stateDesc) throws Exception {
 
 		StateTable<K, N, Map<UK, UV>> stateTable = tryRegisterStateTable(namespaceSerializer, stateDesc);
-		return new HeapMapState<>(stateDesc, stateTable, keySerializer, namespaceSerializer);
+
+		return new HeapMapState<>(
+				stateTable,
+				keySerializer,
+				stateTable.getStateSerializer(),
+				namespaceSerializer,
+				null);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapListState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapListState.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.state.heap;
 
 import org.apache.flink.api.common.state.ListState;
-import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.ListSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
@@ -40,14 +39,17 @@ import java.util.List;
  * @param <V> The type of the value.
  */
 public class HeapListState<K, N, V>
-		extends AbstractHeapMergingState<K, N, V, List<V>, Iterable<V>, ListState<V>, ListStateDescriptor<V>>
+		extends AbstractHeapMergingState<K, N, V, List<V>, Iterable<V>, ListState<V>>
 		implements InternalListState<K, N, V> {
 
 	/**
 	 * Creates a new key/value state for the given hash map of key/value pairs.
 	 *
+	 * @param stateTable The state table for which this state is associated to.
+	 * @param keySerializer The serializer for the keys.
 	 * @param valueSerializer The serializer for the state.
-	 * @param stateTable The state tab;e to use in this kev/value state. May contain initial state.
+	 * @param namespaceSerializer The serializer for the namespace.
+	 * @param defaultValue The default value for the state.
 	 */
 	public HeapListState(
 			StateTable<K, N, List<V>> stateTable,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapListState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapListState.java
@@ -46,16 +46,16 @@ public class HeapListState<K, N, V>
 	/**
 	 * Creates a new key/value state for the given hash map of key/value pairs.
 	 *
-	 * @param stateDesc The state identifier for the state. This contains name
-	 *                           and can create a default state value.
+	 * @param valueSerializer The serializer for the state.
 	 * @param stateTable The state tab;e to use in this kev/value state. May contain initial state.
 	 */
 	public HeapListState(
-			ListStateDescriptor<V> stateDesc,
 			StateTable<K, N, List<V>> stateTable,
 			TypeSerializer<K> keySerializer,
-			TypeSerializer<N> namespaceSerializer) {
-		super(stateDesc, stateTable, keySerializer, namespaceSerializer);
+			TypeSerializer<List<V>> valueSerializer,
+			TypeSerializer<N> namespaceSerializer,
+			List<V> defaultValue) {
+		super(stateTable, keySerializer, valueSerializer, namespaceSerializer, defaultValue);
 	}
 
 	@Override
@@ -70,7 +70,7 @@ public class HeapListState<K, N, V>
 
 	@Override
 	public TypeSerializer<List<V>> getValueSerializer() {
-		return stateDesc.getSerializer();
+		return valueSerializer;
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapMapState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapMapState.java
@@ -46,16 +46,18 @@ public class HeapMapState<K, N, UK, UV>
 	/**
 	 * Creates a new key/value state for the given hash map of key/value pairs.
 	 *
-	 * @param stateDesc  The state identifier for the state. This contains name
-	 *                   and can create a default state value.
+	 * @param valueSerializer  The serializer for the state.
 	 * @param stateTable The state tab;e to use in this kev/value state. May contain initial state.
 	 */
 	public HeapMapState(
-			MapStateDescriptor<UK, UV> stateDesc,
 			StateTable<K, N, Map<UK, UV>> stateTable,
 			TypeSerializer<K> keySerializer,
-			TypeSerializer<N> namespaceSerializer) {
-		super(stateDesc, stateTable, keySerializer, namespaceSerializer);
+			TypeSerializer<Map<UK, UV>> valueSerializer,
+			TypeSerializer<N> namespaceSerializer,
+			HashMap<UK, UV> defaultValue) {
+		super(stateTable, keySerializer, valueSerializer, namespaceSerializer, defaultValue);
+
+		Preconditions.checkState(valueSerializer instanceof MapSerializer, "Unexpected serializer type.");
 	}
 
 	@Override
@@ -70,10 +72,7 @@ public class HeapMapState<K, N, UK, UV>
 
 	@Override
 	public TypeSerializer<Map<UK, UV>> getValueSerializer() {
-		return new MapSerializer<>(
-				stateDesc.getKeySerializer(),
-				stateDesc.getValueSerializer()
-		);
+		return valueSerializer;
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapMapState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapMapState.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.state.heap;
 
 import org.apache.flink.api.common.state.MapState;
-import org.apache.flink.api.common.state.MapStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.MapSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
@@ -40,14 +39,17 @@ import java.util.Map;
  * @param <UV> The type of the values in the state.
  */
 public class HeapMapState<K, N, UK, UV>
-		extends AbstractHeapState<K, N, Map<UK, UV>, MapState<UK, UV>, MapStateDescriptor<UK, UV>>
+		extends AbstractHeapState<K, N, Map<UK, UV>, MapState<UK, UV>>
 		implements InternalMapState<K, N, UK, UV> {
 
 	/**
 	 * Creates a new key/value state for the given hash map of key/value pairs.
 	 *
-	 * @param valueSerializer  The serializer for the state.
-	 * @param stateTable The state tab;e to use in this kev/value state. May contain initial state.
+	 * @param stateTable The state table for which this state is associated to.
+	 * @param keySerializer The serializer for the keys.
+	 * @param valueSerializer The serializer for the state.
+	 * @param namespaceSerializer The serializer for the namespace.
+	 * @param defaultValue The default value for the state.
 	 */
 	public HeapMapState(
 			StateTable<K, N, Map<UK, UV>> stateTable,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapReducingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapReducingState.java
@@ -44,18 +44,19 @@ public class HeapReducingState<K, N, V>
 	/**
 	 * Creates a new key/value state for the given hash map of key/value pairs.
 	 *
-	 * @param stateDesc The state identifier for the state. This contains name
-	 *                           and can create a default state value.
+	 * @param valueSerializer The serializer for the state.
 	 * @param stateTable The state table to use in this kev/value state. May contain initial state.
 	 */
 	public HeapReducingState(
-			ReducingStateDescriptor<V> stateDesc,
 			StateTable<K, N, V> stateTable,
 			TypeSerializer<K> keySerializer,
-			TypeSerializer<N> namespaceSerializer) {
+			TypeSerializer<V> valueSerializer,
+			TypeSerializer<N> namespaceSerializer,
+			V defaultValue,
+			ReduceFunction<V> reduceFunction) {
 
-		super(stateDesc, stateTable, keySerializer, namespaceSerializer);
-		this.reduceTransformation = new ReduceTransformation<>(stateDesc.getReduceFunction());
+		super(stateTable, keySerializer, valueSerializer, namespaceSerializer, defaultValue);
+		this.reduceTransformation = new ReduceTransformation<>(reduceFunction);
 	}
 
 	@Override
@@ -70,7 +71,7 @@ public class HeapReducingState<K, N, V>
 
 	@Override
 	public TypeSerializer<V> getValueSerializer() {
-		return stateDesc.getSerializer();
+		return valueSerializer;
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapReducingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapReducingState.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.state.heap;
 
 import org.apache.flink.api.common.functions.ReduceFunction;
 import org.apache.flink.api.common.state.ReducingState;
-import org.apache.flink.api.common.state.ReducingStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.state.StateTransformationFunction;
 import org.apache.flink.runtime.state.internal.InternalReducingState;
@@ -36,7 +35,7 @@ import java.io.IOException;
  * @param <V> The type of the value.
  */
 public class HeapReducingState<K, N, V>
-		extends AbstractHeapMergingState<K, N, V, V, V, ReducingState<V>, ReducingStateDescriptor<V>>
+		extends AbstractHeapMergingState<K, N, V, V, V, ReducingState<V>>
 		implements InternalReducingState<K, N, V> {
 
 	private final ReduceTransformation<V> reduceTransformation;
@@ -44,8 +43,12 @@ public class HeapReducingState<K, N, V>
 	/**
 	 * Creates a new key/value state for the given hash map of key/value pairs.
 	 *
+	 * @param stateTable The state table for which this state is associated to.
+	 * @param keySerializer The serializer for the keys.
 	 * @param valueSerializer The serializer for the state.
-	 * @param stateTable The state table to use in this kev/value state. May contain initial state.
+	 * @param namespaceSerializer The serializer for the namespace.
+	 * @param defaultValue The default value for the state.
+	 * @param reduceFunction The reduce function used for reducing state.
 	 */
 	public HeapReducingState(
 			StateTable<K, N, V> stateTable,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapValueState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapValueState.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.state.heap;
 
 import org.apache.flink.api.common.state.ValueState;
-import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.state.internal.InternalValueState;
 
@@ -31,14 +30,17 @@ import org.apache.flink.runtime.state.internal.InternalValueState;
  * @param <V> The type of the value.
  */
 public class HeapValueState<K, N, V>
-		extends AbstractHeapState<K, N, V, ValueState<V>, ValueStateDescriptor<V>>
+		extends AbstractHeapState<K, N, V, ValueState<V>>
 		implements InternalValueState<K, N, V> {
 
 	/**
 	 * Creates a new key/value state for the given hash map of key/value pairs.
 	 *
+	 * @param stateTable The state table for which this state is associated to.
+	 * @param keySerializer The serializer for the keys.
 	 * @param valueSerializer The serializer for the state.
-	 * @param stateTable The state tab;e to use in this kev/value state. May contain initial state.
+	 * @param namespaceSerializer The serializer for the namespace.
+	 * @param defaultValue The default value for the state.
 	 */
 	public HeapValueState(
 			StateTable<K, N, V> stateTable,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapValueState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapValueState.java
@@ -37,16 +37,16 @@ public class HeapValueState<K, N, V>
 	/**
 	 * Creates a new key/value state for the given hash map of key/value pairs.
 	 *
-	 * @param stateDesc The state identifier for the state. This contains name
-	 *                           and can create a default state value.
+	 * @param valueSerializer The serializer for the state.
 	 * @param stateTable The state tab;e to use in this kev/value state. May contain initial state.
 	 */
 	public HeapValueState(
-			ValueStateDescriptor<V> stateDesc,
 			StateTable<K, N, V> stateTable,
 			TypeSerializer<K> keySerializer,
-			TypeSerializer<N> namespaceSerializer) {
-		super(stateDesc, stateTable, keySerializer, namespaceSerializer);
+			TypeSerializer<V> valueSerializer,
+			TypeSerializer<N> namespaceSerializer,
+			V defaultValue) {
+		super(stateTable, keySerializer, valueSerializer, namespaceSerializer, defaultValue);
 	}
 
 	@Override
@@ -61,7 +61,7 @@ public class HeapValueState<K, N, V>
 
 	@Override
 	public TypeSerializer<V> getValueSerializer() {
-		return stateDesc.getSerializer();
+		return valueSerializer;
 	}
 
 	@Override
@@ -69,7 +69,7 @@ public class HeapValueState<K, N, V>
 		final V result = stateTable.get(currentNamespace);
 
 		if (result == null) {
-			return stateDesc.getDefaultValue();
+			return getDefaultValue();
 		}
 
 		return result;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
@@ -3203,7 +3203,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 			backend.setCurrentKey(1);
 			state.update(121818273);
 
-			StateTable<?, ?, ?> stateTable = ((AbstractHeapState<?, ?,? ,?, ?>) kvState).getStateTable();
+			StateTable<?, ?, ?> stateTable = ((AbstractHeapState<?, ?, ? ,?>) kvState).getStateTable();
 			checkConcurrentStateTable(stateTable, numberOfKeyGroups);
 
 		}
@@ -3225,7 +3225,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 			backend.setCurrentKey(1);
 			state.add(121818273);
 
-			StateTable<?, ?, ?> stateTable = ((AbstractHeapState<?, ?,? ,?, ?>) kvState).getStateTable();
+			StateTable<?, ?, ?> stateTable = ((AbstractHeapState<?, ?, ? , ?>) kvState).getStateTable();
 			checkConcurrentStateTable(stateTable, numberOfKeyGroups);
 		}
 
@@ -3252,7 +3252,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 			backend.setCurrentKey(1);
 			state.add(121818273);
 
-			StateTable<?, ?, ?> stateTable = ((AbstractHeapState<?, ?,? ,?, ?>) kvState).getStateTable();
+			StateTable<?, ?, ?> stateTable = ((AbstractHeapState<?, ?, ? ,?>) kvState).getStateTable();
 			checkConcurrentStateTable(stateTable, numberOfKeyGroups);
 		}
 
@@ -3279,7 +3279,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 			backend.setCurrentKey(1);
 			state.add(121818273);
 
-			StateTable<?, ?, ?> stateTable = ((AbstractHeapState<?, ?,? ,?, ?>) kvState).getStateTable();
+			StateTable<?, ?, ?> stateTable = ((AbstractHeapState<?, ?, ? ,?>) kvState).getStateTable();
 			checkConcurrentStateTable(stateTable, numberOfKeyGroups);
 		}
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBState.java
@@ -18,7 +18,6 @@
 package org.apache.flink.contrib.streaming.state;
 
 import org.apache.flink.api.common.state.State;
-import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.memory.ByteArrayOutputStreamWithPos;
@@ -45,9 +44,8 @@ import java.io.IOException;
  * @param <N> The type of the namespace.
  * @param <V> The type of values kept internally in state.
  * @param <S> The type of {@link State}.
- * @param <SD> The type of {@link StateDescriptor}.
  */
-public abstract class AbstractRocksDBState<K, N, V, S extends State, SD extends StateDescriptor<S, V>> implements InternalKvState<K, N, V>, State {
+public abstract class AbstractRocksDBState<K, N, V, S extends State> implements InternalKvState<K, N, V>, State {
 
 	/** Serializer for the namespace. */
 	final TypeSerializer<N> namespaceSerializer;
@@ -76,7 +74,12 @@ public abstract class AbstractRocksDBState<K, N, V, S extends State, SD extends 
 
 	/**
 	 * Creates a new RocksDB backed state.
-	 *  @param namespaceSerializer The serializer for the namespace.
+	 *
+	 * @param columnFamily The RocksDB column family that this state is associated to.
+	 * @param namespaceSerializer The serializer for the namespace.
+	 * @param valueSerializer The serializer for the state.
+	 * @param defaultValue The default value for the state.
+	 * @param backend The backend for which this state is bind to.
 	 */
 	protected AbstractRocksDBState(
 			ColumnFamilyHandle columnFamily,

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBAggregatingState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBAggregatingState.java
@@ -20,7 +20,6 @@ package org.apache.flink.contrib.streaming.state;
 
 import org.apache.flink.api.common.functions.AggregateFunction;
 import org.apache.flink.api.common.state.AggregatingState;
-import org.apache.flink.api.common.state.AggregatingStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.ByteArrayInputStreamWithPos;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
@@ -43,7 +42,7 @@ import java.util.Collection;
  * @param <R> The type of the value returned from the state
  */
 public class RocksDBAggregatingState<K, N, T, ACC, R>
-		extends AbstractRocksDBState<K, N, ACC, AggregatingState<T, R>, AggregatingStateDescriptor<T, ACC, R>>
+		extends AbstractRocksDBState<K, N, ACC, AggregatingState<T, R>>
 		implements InternalAggregatingState<K, N, T, ACC, R> {
 
 	/** User-specified aggregation function. */
@@ -52,10 +51,12 @@ public class RocksDBAggregatingState<K, N, T, ACC, R>
 	/**
 	 * Creates a new {@code RocksDBAggregatingState}.
 	 *
-	 * @param namespaceSerializer
-	 *             The serializer for the namespace.
-	 * @param valueSerializer
-	 *             The serializer for the state.
+	 * @param columnFamily The RocksDB column family that this state is associated to.
+	 * @param namespaceSerializer The serializer for the namespace.
+	 * @param valueSerializer The serializer for the state.
+	 * @param defaultValue The default value for the state.
+	 * @param aggFunction The aggregate function used for aggregating state.
+	 * @param backend The backend for which this state is bind to.
 	 */
 	public RocksDBAggregatingState(
 			ColumnFamilyHandle columnFamily,

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBAggregatingState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBAggregatingState.java
@@ -46,9 +46,6 @@ public class RocksDBAggregatingState<K, N, T, ACC, R>
 		extends AbstractRocksDBState<K, N, ACC, AggregatingState<T, R>, AggregatingStateDescriptor<T, ACC, R>>
 		implements InternalAggregatingState<K, N, T, ACC, R> {
 
-	/** Serializer for the values. */
-	private final TypeSerializer<ACC> valueSerializer;
-
 	/** User-specified aggregation function. */
 	private final AggregateFunction<T, ACC, R> aggFunction;
 
@@ -57,19 +54,19 @@ public class RocksDBAggregatingState<K, N, T, ACC, R>
 	 *
 	 * @param namespaceSerializer
 	 *             The serializer for the namespace.
-	 * @param stateDesc
-	 *             The state identifier for the state. This contains the state name and aggregation function.
+	 * @param valueSerializer
+	 *             The serializer for the state.
 	 */
 	public RocksDBAggregatingState(
 			ColumnFamilyHandle columnFamily,
 			TypeSerializer<N> namespaceSerializer,
-			AggregatingStateDescriptor<T, ACC, R> stateDesc,
+			TypeSerializer<ACC> valueSerializer,
+			ACC defaultValue,
+			AggregateFunction<T, ACC, R> aggFunction,
 			RocksDBKeyedStateBackend<K> backend) {
 
-		super(columnFamily, namespaceSerializer, stateDesc, backend);
-
-		this.valueSerializer = stateDesc.getSerializer();
-		this.aggFunction = stateDesc.getAggregateFunction();
+		super(columnFamily, namespaceSerializer, valueSerializer, defaultValue, backend);
+		this.aggFunction = aggFunction;
 	}
 
 	@Override
@@ -84,7 +81,7 @@ public class RocksDBAggregatingState<K, N, T, ACC, R>
 
 	@Override
 	public TypeSerializer<ACC> getValueSerializer() {
-		return stateDesc.getSerializer();
+		return valueSerializer;
 	}
 
 	@Override

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBFoldingState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBFoldingState.java
@@ -47,9 +47,6 @@ public class RocksDBFoldingState<K, N, T, ACC>
 		extends AbstractRocksDBState<K, N, ACC, FoldingState<T, ACC>, FoldingStateDescriptor<T, ACC>>
 		implements InternalFoldingState<K, N, T, ACC> {
 
-	/** Serializer for the values. */
-	private final TypeSerializer<ACC> valueSerializer;
-
 	/** User-specified fold function. */
 	private final FoldFunction<T, ACC> foldFunction;
 
@@ -57,18 +54,18 @@ public class RocksDBFoldingState<K, N, T, ACC>
 	 * Creates a new {@code RocksDBFoldingState}.
 	 *
 	 * @param namespaceSerializer The serializer for the namespace.
-	 * @param stateDesc The state identifier for the state. This contains name
-	 *                     and can create a default state value.
+	 * @param valueSerializer The serializer for the state.
 	 */
 	public RocksDBFoldingState(ColumnFamilyHandle columnFamily,
 			TypeSerializer<N> namespaceSerializer,
-			FoldingStateDescriptor<T, ACC> stateDesc,
+			TypeSerializer<ACC> valueSerializer,
+			ACC defaultValue,
+			FoldFunction<T, ACC> foldFunction,
 			RocksDBKeyedStateBackend<K> backend) {
 
-		super(columnFamily, namespaceSerializer, stateDesc, backend);
+		super(columnFamily, namespaceSerializer, valueSerializer, defaultValue, backend);
 
-		this.valueSerializer = stateDesc.getSerializer();
-		this.foldFunction = stateDesc.getFoldFunction();
+		this.foldFunction = foldFunction;
 	}
 
 	@Override
@@ -83,7 +80,7 @@ public class RocksDBFoldingState<K, N, T, ACC>
 
 	@Override
 	public TypeSerializer<ACC> getValueSerializer() {
-		return stateDesc.getSerializer();
+		return valueSerializer;
 	}
 
 	@Override
@@ -110,7 +107,7 @@ public class RocksDBFoldingState<K, N, T, ACC>
 			DataOutputViewStreamWrapper out = new DataOutputViewStreamWrapper(keySerializationStream);
 			if (valueBytes == null) {
 				keySerializationStream.reset();
-				valueSerializer.serialize(foldFunction.fold(stateDesc.getDefaultValue(), value), out);
+				valueSerializer.serialize(foldFunction.fold(getDefaultValue(), value), out);
 				backend.db.put(columnFamily, writeOptions, key, keySerializationStream.toByteArray());
 			} else {
 				ACC oldValue = valueSerializer.deserialize(new DataInputViewStreamWrapper(new ByteArrayInputStreamWithPos(valueBytes)));

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBFoldingState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBFoldingState.java
@@ -20,7 +20,6 @@ package org.apache.flink.contrib.streaming.state;
 
 import org.apache.flink.api.common.functions.FoldFunction;
 import org.apache.flink.api.common.state.FoldingState;
-import org.apache.flink.api.common.state.FoldingStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.ByteArrayInputStreamWithPos;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
@@ -44,7 +43,7 @@ import java.io.IOException;
  */
 @Deprecated
 public class RocksDBFoldingState<K, N, T, ACC>
-		extends AbstractRocksDBState<K, N, ACC, FoldingState<T, ACC>, FoldingStateDescriptor<T, ACC>>
+		extends AbstractRocksDBState<K, N, ACC, FoldingState<T, ACC>>
 		implements InternalFoldingState<K, N, T, ACC> {
 
 	/** User-specified fold function. */
@@ -53,8 +52,12 @@ public class RocksDBFoldingState<K, N, T, ACC>
 	/**
 	 * Creates a new {@code RocksDBFoldingState}.
 	 *
+	 * @param columnFamily The RocksDB column family that this state is associated to.
 	 * @param namespaceSerializer The serializer for the namespace.
 	 * @param valueSerializer The serializer for the state.
+	 * @param defaultValue The default value for the state.
+	 * @param foldFunction The fold function used for folding state.
+	 * @param backend The backend for which this state is bind to.
 	 */
 	public RocksDBFoldingState(ColumnFamilyHandle columnFamily,
 			TypeSerializer<N> namespaceSerializer,

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBListState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBListState.java
@@ -19,7 +19,6 @@
 package org.apache.flink.contrib.streaming.state;
 
 import org.apache.flink.api.common.state.ListState;
-import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
@@ -47,7 +46,7 @@ import java.util.List;
  * @param <V> The type of the values in the list state.
  */
 public class RocksDBListState<K, N, V>
-		extends AbstractRocksDBState<K, N, List<V>, ListState<V>, ListStateDescriptor<V>>
+		extends AbstractRocksDBState<K, N, List<V>, ListState<V>>
 		implements InternalListState<K, N, V> {
 
 	/** Serializer for the values. */
@@ -61,10 +60,15 @@ public class RocksDBListState<K, N, V>
 	/**
 	 * Creates a new {@code RocksDBListState}.
 	 *
+	 * @param columnFamily The RocksDB column family that this state is associated to.
 	 * @param namespaceSerializer The serializer for the namespace.
 	 * @param valueSerializer The serializer for the state.
+	 * @param defaultValue The default value for the state.
+	 * @param elementSerializer The serializer for elements of the list state.
+	 * @param backend The backend for which this state is bind to.
 	 */
-	public RocksDBListState(ColumnFamilyHandle columnFamily,
+	public RocksDBListState(
+			ColumnFamilyHandle columnFamily,
 			TypeSerializer<N> namespaceSerializer,
 			TypeSerializer<List<V>> valueSerializer,
 			List<V> defaultValue,

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBMapState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBMapState.java
@@ -75,18 +75,22 @@ public class RocksDBMapState<K, N, UK, UV>
 	 * Creates a new {@code RocksDBMapState}.
 	 *
 	 * @param namespaceSerializer The serializer for the namespace.
-	 * @param stateDesc The state identifier for the state.
+	 * @param valueSerializer The serializer for the state.
 	 */
 	public RocksDBMapState(
 			ColumnFamilyHandle columnFamily,
 			TypeSerializer<N> namespaceSerializer,
-			MapStateDescriptor<UK, UV> stateDesc,
+			TypeSerializer<Map<UK, UV>> valueSerializer,
+			Map<UK, UV> defaultValue,
 			RocksDBKeyedStateBackend<K> backend) {
 
-		super(columnFamily, namespaceSerializer, stateDesc, backend);
+		super(columnFamily, namespaceSerializer, valueSerializer, defaultValue, backend);
 
-		this.userKeySerializer = stateDesc.getKeySerializer();
-		this.userValueSerializer = stateDesc.getValueSerializer();
+		Preconditions.checkState(valueSerializer instanceof MapSerializer, "Unexpected serializer type.");
+
+		MapSerializer<UK, UV> castedMapSerializer = (MapSerializer<UK, UV>) valueSerializer;
+		this.userKeySerializer = castedMapSerializer.getKeySerializer();
+		this.userValueSerializer = castedMapSerializer.getValueSerializer();
 	}
 
 	@Override
@@ -101,7 +105,7 @@ public class RocksDBMapState<K, N, UK, UV>
 
 	@Override
 	public TypeSerializer<Map<UK, UV>> getValueSerializer() {
-		return stateDesc.getSerializer();
+		return valueSerializer;
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBMapState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBMapState.java
@@ -19,7 +19,6 @@
 package org.apache.flink.contrib.streaming.state;
 
 import org.apache.flink.api.common.state.MapState;
-import org.apache.flink.api.common.state.MapStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.MapSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
@@ -59,7 +58,7 @@ import java.util.Map;
  * @param <UV> The type of the values in the map state.
  */
 public class RocksDBMapState<K, N, UK, UV>
-		extends AbstractRocksDBState<K, N, Map<UK, UV>, MapState<UK, UV>, MapStateDescriptor<UK, UV>>
+		extends AbstractRocksDBState<K, N, Map<UK, UV>, MapState<UK, UV>>
 		implements InternalMapState<K, N, UK, UV> {
 
 	private static final Logger LOG = LoggerFactory.getLogger(RocksDBMapState.class);
@@ -74,8 +73,11 @@ public class RocksDBMapState<K, N, UK, UV>
 	/**
 	 * Creates a new {@code RocksDBMapState}.
 	 *
+	 * @param columnFamily The RocksDB column family that this state is associated to.
 	 * @param namespaceSerializer The serializer for the namespace.
 	 * @param valueSerializer The serializer for the state.
+	 * @param defaultValue The default value for the state.
+	 * @param backend The backend for which this state is bind to.
 	 */
 	public RocksDBMapState(
 			ColumnFamilyHandle columnFamily,

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBReducingState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBReducingState.java
@@ -45,9 +45,6 @@ public class RocksDBReducingState<K, N, V>
 		extends AbstractRocksDBState<K, N, V, ReducingState<V>, ReducingStateDescriptor<V>>
 		implements InternalReducingState<K, N, V> {
 
-	/** Serializer for the values. */
-	private final TypeSerializer<V> valueSerializer;
-
 	/** User-specified reduce function. */
 	private final ReduceFunction<V> reduceFunction;
 
@@ -55,17 +52,17 @@ public class RocksDBReducingState<K, N, V>
 	 * Creates a new {@code RocksDBReducingState}.
 	 *
 	 * @param namespaceSerializer The serializer for the namespace.
-	 * @param stateDesc The state identifier for the state. This contains name
-	 *                     and can create a default state value.
+	 * @param valueSerializer The serializer for the state.
 	 */
 	public RocksDBReducingState(ColumnFamilyHandle columnFamily,
 			TypeSerializer<N> namespaceSerializer,
-			ReducingStateDescriptor<V> stateDesc,
+			TypeSerializer<V> valueSerializer,
+			V defaultValue,
+			ReduceFunction<V> reduceFunction,
 			RocksDBKeyedStateBackend<K> backend) {
 
-		super(columnFamily, namespaceSerializer, stateDesc, backend);
-		this.valueSerializer = stateDesc.getSerializer();
-		this.reduceFunction = stateDesc.getReduceFunction();
+		super(columnFamily, namespaceSerializer, valueSerializer, defaultValue, backend);
+		this.reduceFunction = reduceFunction;
 	}
 
 	@Override
@@ -80,7 +77,7 @@ public class RocksDBReducingState<K, N, V>
 
 	@Override
 	public TypeSerializer<V> getValueSerializer() {
-		return stateDesc.getSerializer();
+		return valueSerializer;
 	}
 
 	@Override

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBReducingState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBReducingState.java
@@ -20,7 +20,6 @@ package org.apache.flink.contrib.streaming.state;
 
 import org.apache.flink.api.common.functions.ReduceFunction;
 import org.apache.flink.api.common.state.ReducingState;
-import org.apache.flink.api.common.state.ReducingStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.ByteArrayInputStreamWithPos;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
@@ -42,7 +41,7 @@ import java.util.Collection;
  * @param <V> The type of value that the state state stores.
  */
 public class RocksDBReducingState<K, N, V>
-		extends AbstractRocksDBState<K, N, V, ReducingState<V>, ReducingStateDescriptor<V>>
+		extends AbstractRocksDBState<K, N, V, ReducingState<V>>
 		implements InternalReducingState<K, N, V> {
 
 	/** User-specified reduce function. */
@@ -51,8 +50,12 @@ public class RocksDBReducingState<K, N, V>
 	/**
 	 * Creates a new {@code RocksDBReducingState}.
 	 *
+	 * @param columnFamily The RocksDB column family that this state is associated to.
 	 * @param namespaceSerializer The serializer for the namespace.
 	 * @param valueSerializer The serializer for the state.
+	 * @param defaultValue The default value for the state.
+	 * @param reduceFunction The reduce function used for reducing state.
+	 * @param backend The backend for which this state is bind to.
 	 */
 	public RocksDBReducingState(ColumnFamilyHandle columnFamily,
 			TypeSerializer<N> namespaceSerializer,

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBValueState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBValueState.java
@@ -42,23 +42,19 @@ public class RocksDBValueState<K, N, V>
 		extends AbstractRocksDBState<K, N, V, ValueState<V>, ValueStateDescriptor<V>>
 		implements InternalValueState<K, N, V> {
 
-	/** Serializer for the values. */
-	private final TypeSerializer<V> valueSerializer;
-
 	/**
 	 * Creates a new {@code RocksDBValueState}.
 	 *
 	 * @param namespaceSerializer The serializer for the namespace.
-	 * @param stateDesc The state identifier for the state. This contains name
-	 *                           and can create a default state value.
+	 * @param valueSerializer The serializer for the state.
 	 */
 	public RocksDBValueState(ColumnFamilyHandle columnFamily,
 			TypeSerializer<N> namespaceSerializer,
-			ValueStateDescriptor<V> stateDesc,
+			TypeSerializer<V> valueSerializer,
+			V defaultValue,
 			RocksDBKeyedStateBackend<K> backend) {
 
-		super(columnFamily, namespaceSerializer, stateDesc, backend);
-		this.valueSerializer = stateDesc.getSerializer();
+		super(columnFamily, namespaceSerializer, valueSerializer, defaultValue, backend);
 	}
 
 	@Override
@@ -73,7 +69,7 @@ public class RocksDBValueState<K, N, V>
 
 	@Override
 	public TypeSerializer<V> getValueSerializer() {
-		return stateDesc.getSerializer();
+		return valueSerializer;
 	}
 
 	@Override
@@ -83,7 +79,7 @@ public class RocksDBValueState<K, N, V>
 			byte[] key = keySerializationStream.toByteArray();
 			byte[] valueBytes = backend.db.get(columnFamily, key);
 			if (valueBytes == null) {
-				return stateDesc.getDefaultValue();
+				return getDefaultValue();
 			}
 			return valueSerializer.deserialize(new DataInputViewStreamWrapper(new ByteArrayInputStream(valueBytes)));
 		} catch (IOException | RocksDBException e) {

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBValueState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBValueState.java
@@ -19,7 +19,6 @@
 package org.apache.flink.contrib.streaming.state;
 
 import org.apache.flink.api.common.state.ValueState;
-import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
@@ -39,16 +38,20 @@ import java.io.IOException;
  * @param <V> The type of value that the state state stores.
  */
 public class RocksDBValueState<K, N, V>
-		extends AbstractRocksDBState<K, N, V, ValueState<V>, ValueStateDescriptor<V>>
+		extends AbstractRocksDBState<K, N, V, ValueState<V>>
 		implements InternalValueState<K, N, V> {
 
 	/**
 	 * Creates a new {@code RocksDBValueState}.
 	 *
+	 * @param columnFamily The RocksDB column family that this state is associated to.
 	 * @param namespaceSerializer The serializer for the namespace.
 	 * @param valueSerializer The serializer for the state.
+	 * @param defaultValue The default value for the state.
+	 * @param backend The backend for which this state is bind to.
 	 */
-	public RocksDBValueState(ColumnFamilyHandle columnFamily,
+	public RocksDBValueState(
+			ColumnFamilyHandle columnFamily,
 			TypeSerializer<N> namespaceSerializer,
 			TypeSerializer<V> valueSerializer,
 			V defaultValue,


### PR DESCRIPTION
## What is the purpose of the change

This PR is WIP, and is still lacking test coverage.
It is opened now to collect some feedback for a proposed solution for FLINK-8715.

Previously, reconfigured state serializers on restore were not properly forwarded to the state handles. In the past, the `StateDescriptor` served as the holder for the reconfigured serializer.
However, since 88ffad27, `StateDescriptor#getSerializer()` started giving out duplicates of the serializer, which caused reconfigured serializers to be a completely different copy then what the state handles were using.

This fix corrects this by explicitly forwarding the serializer to the instantiated state handles after the state is registered at the state backend. It also eliminates the use of `StateDescriptor`s internally in the state handles, so that the behaviour is independent of the `StateDescriptor#getSerializer()` method's implementation.

The alternative to this approach is to have an internal `setSerializer` method on the `StateDescriptor`, which should be used after state serializers are reconfigured on registration.
Then, that assures that handed out serializers by the descriptor are always reconfigured, as soon as the descriptor is registered at the backend.

## Brief change log

- Remove `StateDescriptor`s from heap / RocksDB state handle classes
- Forwards state serializer and any other necessary information provided by the state descriptor (e.g. default value, user functions, nested serializers, etc.) when instantiating state handles.

## Verifying this change

This fix still lacks test coverage.
It has been opened to collect feedback for the approach.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / (**no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (**yes** / no / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
