### PR TITLE
[FLINK-6719] [docs] Add details about fault-tolerance of timers to ProcessFunction docs

### DIFF
--- a/docs/dev/stream/operators/process_function.md
+++ b/docs/dev/stream/operators/process_function.md
@@ -286,8 +286,8 @@ this may put a significant burden on the Flink runtime.
 ### Fault Tolerance
 
 Timers registered within `ProcessFunction` are fault tolerant. They are synchronously checkpointed by Flink, regardless of
-configurations of state backends. (Therefore, a large number of timers can significantly increase checkpointing time. See optimizations
-section for advice to reduce the number of timers.)
+configurations of state backends. (Therefore, a large number of timers can significantly increase checkpointing time. See the optimizations
+section for advice on how to reduce the number of timers.)
 
 Upon restoring, timers that are checkpointed from the previous job will be restored on whatever new instance is responsible for that key.
 


### PR DESCRIPTION
## What is the purpose of the change

The fault-tolerance of timers is a frequently asked questions on the mailing lists. We should add details about the topic in the ProcessFunction docs.

## Brief change log

Added details about the topic in the ProcessFunction docs.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

none

## Documentation

none