### PR TITLE
[FLINK-9188] [kinesis] Generic mechanism to set ClientConfiguration properties.

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxy.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxy.java
@@ -186,7 +186,10 @@ public class KinesisProxy implements KinesisProxyInterface {
 	 * @return
 	 */
 	protected AmazonKinesis createKinesisClient(Properties configProps) {
-		return AWSUtil.createKinesisClient(configProps, new ClientConfigurationFactory().getConfig());
+
+		ClientConfiguration awsClientConfig = new ClientConfigurationFactory().getConfig();
+		AWSUtil.setAwsClientConfigProperties(awsClientConfig, configProps);
+		return AWSUtil.createKinesisClient(configProps, awsClientConfig);
 	}
 
 	/**

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/BeanDeserializerModifierForIgnorables.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/BeanDeserializerModifierForIgnorables.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kinesis.util;
+
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.DeserializationConfig;
+import com.fasterxml.jackson.databind.deser.BeanDeserializerBuilder;
+import com.fasterxml.jackson.databind.deser.BeanDeserializerModifier;
+import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Jackson bean deserializer utility that allows skipping of properties, for example because they
+ * cannot be handled by the default serializer or should be ignored for other reason.
+ *
+ * <p>Original source:
+ * https://stackoverflow.com/questions/12305438/jackson-dynamic-filtering-of-properties-during-deserialization
+ */
+public class BeanDeserializerModifierForIgnorables extends BeanDeserializerModifier {
+
+	private Class<?> type;
+	private List<String> ignorables;
+
+	public BeanDeserializerModifierForIgnorables(Class clazz, String... properties) {
+		ignorables = new ArrayList<>();
+		for (String property : properties) {
+			ignorables.add(property);
+		}
+		this.type = clazz;
+	}
+
+	@Override
+	public BeanDeserializerBuilder updateBuilder(
+		DeserializationConfig config, BeanDescription beanDesc,
+		BeanDeserializerBuilder builder) {
+		if (!type.equals(beanDesc.getBeanClass())) {
+			return builder;
+		}
+
+		for (String ignorable : ignorables) {
+			builder.addIgnorable(ignorable);
+		}
+		return builder;
+	}
+
+	@Override
+	public List<BeanPropertyDefinition> updateProperties(
+		DeserializationConfig config, BeanDescription beanDesc,
+		List<BeanPropertyDefinition> propDefs) {
+		if (!type.equals(beanDesc.getBeanClass())) {
+			return propDefs;
+		}
+
+		List<BeanPropertyDefinition> newPropDefs = new ArrayList<>();
+		for (BeanPropertyDefinition propDef : propDefs) {
+			if (!ignorables.contains(propDef.getName())) {
+				newPropDefs.add(propDef);
+			}
+		}
+		return newPropDefs;
+	}
+}

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxyTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxyTest.java
@@ -86,4 +86,19 @@ public class KinesisProxyTest {
 		assertEquals(10000, clientConfiguration.getSocketTimeout());
 	}
 
+	@Test
+	public void testClientConfigOverride() {
+
+		Properties configProps = new Properties();
+		configProps.setProperty(AWSConfigConstants.AWS_REGION, "us-east-1");
+		configProps.setProperty(AWSUtil.AWS_CLIENT_CONFIG_PREFIX + "socketTimeout", "9999");
+
+		KinesisProxyInterface proxy = KinesisProxy.create(configProps);
+
+		AmazonKinesis kinesisClient = Whitebox.getInternalState(proxy, "kinesisClient");
+		ClientConfiguration clientConfiguration = Whitebox.getInternalState(kinesisClient,
+			"clientConfiguration");
+		assertEquals(9999, clientConfiguration.getSocketTimeout());
+	}
+
 }


### PR DESCRIPTION
## What is the purpose of the change

This pull request enables setting properties on the AWS ClientConfiguration from user supplied properties with a specific prefix.

## Brief change log
- use Jackson to set properties in a generic way so that we don't need to assume knowledge of the AWS properties in the Flink connector code.

## Verifying this change

This change added tests and can be verified as follows:

Added test to verify the configuration mechanism.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
