### PR TITLE
[FLINK-8999] [e2e] Ensure the job has an operator with operator state

### DIFF
--- a/flink-end-to-end-tests/flink-operator-state-test/pom.xml
+++ b/flink-end-to-end-tests/flink-operator-state-test/pom.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+    -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<parent>
+		<artifactId>flink-end-to-end-tests</artifactId>
+		<groupId>org.apache.flink</groupId>
+		<version>1.6-SNAPSHOT</version>
+		<relativePath>..</relativePath>
+	</parent>
+	<modelVersion>4.0.0</modelVersion>
+
+	<artifactId>flink-operator-state-test</artifactId>
+	<name>flink-operator-state-test</name>
+	<packaging>jar</packaging>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<version>3.0.0</version>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<finalName>OperatorStateTestProgram</finalName>
+							<artifactSet>
+								<excludes>
+									<exclude>com.google.code.findbugs:jsr305</exclude>
+								</excludes>
+							</artifactSet>
+							<filters>
+								<filter>
+									<artifact>*:*</artifact>
+									<excludes>
+										<exclude>META-INF/*.SF</exclude>
+										<exclude>META-INF/*.DSA</exclude>
+										<exclude>META-INF/*.RSA</exclude>
+									</excludes>
+								</filter>
+							</filters>
+							<transformers>
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+									<mainClass>org.apache.flink.streaming.test.OperatorStateTestProgram</mainClass>
+								</transformer>
+							</transformers>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/flink-end-to-end-tests/flink-operator-state-test/src/main/java/org/apache/flink/streaming/test/OperatorStateTestProgram.java
+++ b/flink-end-to-end-tests/flink-operator-state-test/src/main/java/org/apache/flink/streaming/test/OperatorStateTestProgram.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.test;
+
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.java.tuple.Tuple1;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.streaming.api.checkpoint.ListCheckpointed;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * End to end test for operator state in a job.
+ *
+ * <p>Program to test a operator state within an operator, to count the number to
+ * a new value is the old value + 1.
+ *
+ * <p>Program parameters:
+ * -outputPath Sets the path to where the result data is written.
+ */
+public class OperatorStateTestProgram {
+	public static void main(String[] args) throws Exception {
+		ParameterTool params = ParameterTool.fromArgs(args);
+		String outputPath = params.getRequired("outputPath");
+
+		StreamExecutionEnvironment sEnv = StreamExecutionEnvironment.getExecutionEnvironment();
+		sEnv.setParallelism(1);
+		sEnv
+			.addSource(new DataGenerator())
+			.map(new CountUpMap())
+			.writeAsText(outputPath, FileSystem.WriteMode.OVERWRITE);
+
+		sEnv.execute();
+	}
+
+	/**
+	 * The map operator that record the number by using operator state.
+	 */
+	public static class CountUpMap implements MapFunction<Tuple1<String>, Tuple2<String, Integer>>,
+		ListCheckpointed<Integer> {
+
+		private int count;
+
+		@Override
+		public Tuple2<String, Integer> map(Tuple1<String> value) throws Exception {
+			count++;
+			return new Tuple2<>(value.f0, count);
+		}
+
+		@Override
+		public List<Integer> snapshotState(long checkpointId, long timestamp) throws Exception {
+			return Collections.singletonList(count);
+		}
+
+		@Override
+		public void restoreState(List<Integer> state) throws Exception {
+			for (Integer i : state) {
+				count += i;
+			}
+		}
+	}
+
+	/**
+	 * Data-generating source function.
+	 */
+	public static class DataGenerator implements SourceFunction<Tuple1<String>> {
+
+		@Override
+		public void run(SourceContext<Tuple1<String>> ctx) throws Exception {
+			for (int i = 0; i < 1000; i++) {
+				synchronized (ctx.getCheckpointLock()) {
+					ctx.collect(Tuple1.of("Some payloads......"));
+				}
+			}
+		}
+
+		@Override
+		public void cancel() {
+
+		}
+	}
+}

--- a/flink-end-to-end-tests/pom.xml
+++ b/flink-end-to-end-tests/pom.xml
@@ -39,6 +39,7 @@ under the License.
 		<module>flink-dataset-allround-test</module>
 		<module>flink-stream-sql-test</module>
 		<module>flink-bucketing-sink-test</module>
+		<module>flink-operator-state-test</module>
 	</modules>
 
 </project>

--- a/flink-end-to-end-tests/run-pre-commit-tests.sh
+++ b/flink-end-to-end-tests/run-pre-commit-tests.sh
@@ -93,6 +93,13 @@ if [ $EXIT_CODE == 0 ]; then
     EXIT_CODE=$?
 fi
 
+if [ $EXIT_CODE == 0 ]; then
+    printf "\n==============================================================================\n"
+    printf "Running Streaming Operator State end-to-end test\n"
+    printf "==============================================================================\n"
+    $END_TO_END_DIR/test-scripts/test_streaming_operator_state.sh
+    EXIT_CODE=$?
+fi
 
 # Exit code for Travis build success/failure
 exit $EXIT_CODE

--- a/flink-end-to-end-tests/test-scripts/test_streaming_operator_state.sh
+++ b/flink-end-to-end-tests/test-scripts/test_streaming_operator_state.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+################################################################################
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+source "$(dirname "$0")"/common.sh
+
+TEST_PROGRAM_JAR=$TEST_INFRA_DIR/../../flink-end-to-end-tests/flink-operator-state-test/target/OperatorStateTestProgram.jar
+
+start_cluster
+
+$FLINK_DIR/bin/flink run -p 1 $TEST_PROGRAM_JAR \
+--outputPath $TEST_DATA_DIR/complete_result
+
+function operator_state_cleanup() {
+  stop_cluster
+
+  # make sure to run regular cleanup as well
+  cleanup
+}
+
+trap operator_state_cleanup INT
+trap operator_state_cleanup EXIT
+
+check_result_hash "Operator State" $TEST_DATA_DIR/complete_result "4a12dbf4937219c60e27b69aecc023d8"


### PR DESCRIPTION
## What is the purpose of the change
This commit that creates a job which contains an operator that use operator state. By using a map function using that state.

## Brief change log
Add a test job that ensure a job contains an operator state. 
Add a test script that verify the change.

## Verifying this change
Use the added script verify the change, or use run-pre-commit-tests.sh to trigger the test by Travis CI.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? ( not documented)
