### PR TITLE
[FLINK-9088][nifi-connector][build] Bump nifi-site-to-site-client to 1.6.0

### DIFF
--- a/flink-connectors/flink-connector-nifi/pom.xml
+++ b/flink-connectors/flink-connector-nifi/pom.xml
@@ -37,7 +37,7 @@ under the License.
 
 	<!-- Allow users to pass custom connector versions -->
 	<properties>
-		<nifi.version>0.6.1</nifi.version>
+		<nifi.version>1.6.0</nifi.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
## What is the purpose of the change

*Currently dependency of nifi-site-to-site-client is 0.6.1
We should upgrade to 1.6.0*


## Brief change log

  - *Upgrade `nifi-site-to-site-client` from 0.6.1 to 1.6.0*

## Verifying this change

Running a nifi cluster in docker: `docker run -d -p 8080:8080  --name=local_nifi   apache/nifi:1.6.0`,
Successfully run `NiFiSinkTopologyExample` and `NiFiSourceTopologyExample`.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**yes** / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
