### PR TITLE
[FLINK-9212][flip6] Port SubtasksAllAccumulatorsHandler to new REST endpoint

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/SubtasksAllAccumulatorsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/SubtasksAllAccumulatorsHandler.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.job;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.accumulators.StringifiedAccumulatorResult;
+import org.apache.flink.runtime.executiongraph.AccessExecutionJobVertex;
+import org.apache.flink.runtime.executiongraph.AccessExecutionVertex;
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.RestHandlerException;
+import org.apache.flink.runtime.rest.handler.legacy.ExecutionGraphCache;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.JobVertexMessageParameters;
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+import org.apache.flink.runtime.rest.messages.job.SubtasksAllAccumulatorsInfo;
+import org.apache.flink.runtime.rest.messages.job.UserAccumulator;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+import org.apache.flink.runtime.webmonitor.RestfulGateway;
+import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+/**
+ * Request handler for the subtasks all accumulators.
+ */
+public class SubtasksAllAccumulatorsHandler extends AbstractJobVertexHandler<SubtasksAllAccumulatorsInfo, JobVertexMessageParameters> {
+
+	/**
+	 * Instantiates a new subtasks all accumulators handler.
+	 *
+	 * @param localRestAddress    the local rest address
+	 * @param leaderRetriever     the leader retriever
+	 * @param timeout             the timeout
+	 * @param responseHeaders     the response headers
+	 * @param messageHeaders      the message headers
+	 * @param executionGraphCache the execution graph cache
+	 * @param executor            the executor
+	 */
+	public SubtasksAllAccumulatorsHandler(CompletableFuture<String> localRestAddress, GatewayRetriever<? extends RestfulGateway> leaderRetriever, Time timeout, Map<String, String> responseHeaders, MessageHeaders<EmptyRequestBody, SubtasksAllAccumulatorsInfo, JobVertexMessageParameters> messageHeaders, ExecutionGraphCache executionGraphCache, Executor executor) {
+		super(localRestAddress, leaderRetriever, timeout, responseHeaders, messageHeaders, executionGraphCache, executor);
+	}
+
+	@Override
+	protected SubtasksAllAccumulatorsInfo handleRequest(HandlerRequest<EmptyRequestBody, JobVertexMessageParameters> request, AccessExecutionJobVertex jobVertex) throws RestHandlerException {
+		String vertexId = jobVertex.getJobVertexId().toString();
+		int parallelism = jobVertex.getParallelism();
+
+		final List<SubtasksAllAccumulatorsInfo.SubtaskAccumulatorsInfo> subtaskAccumulatorsInfos = new ArrayList<>();
+
+		int index = 0;
+		for (AccessExecutionVertex vertex : jobVertex.getTaskVertices()) {
+			TaskManagerLocation location = vertex.getCurrentAssignedResourceLocation();
+			String locationString = location == null ? "(unassigned)" : location.getHostname();
+
+			StringifiedAccumulatorResult[] accs = vertex.getCurrentExecutionAttempt().getUserAccumulatorsStringified();
+			List<UserAccumulator> userAccumulators = new ArrayList<>(accs.length);
+			for (StringifiedAccumulatorResult acc : accs) {
+				userAccumulators.add(new UserAccumulator(acc.getName(), acc.getType(), acc.getValue()));
+			}
+
+			subtaskAccumulatorsInfos.add(
+				new SubtasksAllAccumulatorsInfo.SubtaskAccumulatorsInfo(
+					index++,
+					vertex.getCurrentExecutionAttempt().getAttemptNumber(),
+					locationString,
+					userAccumulators
+				));
+		}
+
+		return new SubtasksAllAccumulatorsInfo(vertexId, parallelism, subtaskAccumulatorsInfos);
+	}
+
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/SubtasksAllAccumulatorsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/SubtasksAllAccumulatorsHandler.java
@@ -97,7 +97,6 @@ public class SubtasksAllAccumulatorsHandler extends AbstractJobVertexRequestHand
 
 		gen.writeArrayFieldStart("subtasks");
 
-		int num = 0;
 		for (AccessExecutionVertex vertex : jobVertex.getTaskVertices()) {
 
 			TaskManagerLocation location = vertex.getCurrentAssignedResourceLocation();
@@ -105,7 +104,7 @@ public class SubtasksAllAccumulatorsHandler extends AbstractJobVertexRequestHand
 
 			gen.writeStartObject();
 
-			gen.writeNumberField("subtask", num++);
+			gen.writeNumberField("subtask", vertex.getCurrentExecutionAttempt().getParallelSubtaskIndex());
 			gen.writeNumberField("attempt", vertex.getCurrentExecutionAttempt().getAttemptNumber());
 			gen.writeStringField("host", locationString);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/SubtasksAllAccumulatorsHandlers.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/SubtasksAllAccumulatorsHandlers.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages;
+
+import org.apache.flink.runtime.rest.HttpMethodWrapper;
+import org.apache.flink.runtime.rest.handler.job.SubtasksAllAccumulatorsHandler;
+import org.apache.flink.runtime.rest.messages.job.SubtasksAllAccumulatorsInfo;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+/**
+ * Message headers for the {@link SubtasksAllAccumulatorsHandler}.
+ */
+public class SubtasksAllAccumulatorsHandlers implements MessageHeaders<EmptyRequestBody, SubtasksAllAccumulatorsInfo, JobVertexMessageParameters> {
+
+	private static final SubtasksAllAccumulatorsHandlers INSTANCE = new SubtasksAllAccumulatorsHandlers();
+
+	public static final String URL = "/jobs" +
+		"/:" + JobIDPathParameter.KEY +
+		"/vertices" +
+		"/:" + JobVertexIdPathParameter.KEY +
+		"/subtasks/accumulators";
+
+	private SubtasksAllAccumulatorsHandlers() {}
+
+	@Override
+	public Class<EmptyRequestBody> getRequestClass() {
+		return EmptyRequestBody.class;
+	}
+
+	@Override
+	public Class<SubtasksAllAccumulatorsInfo> getResponseClass() {
+		return SubtasksAllAccumulatorsInfo.class;
+	}
+
+	@Override
+	public HttpResponseStatus getResponseStatusCode() {
+		return HttpResponseStatus.OK;
+	}
+
+	@Override
+	public JobVertexMessageParameters getUnresolvedMessageParameters() {
+		return new JobVertexMessageParameters();
+	}
+
+	@Override
+	public HttpMethodWrapper getHttpMethod() {
+		return HttpMethodWrapper.GET;
+	}
+
+	@Override
+	public String getTargetRestEndpointURL() {
+		return URL;
+	}
+
+	public static SubtasksAllAccumulatorsHandlers getInstance() {
+		return INSTANCE;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/SubtasksAllAccumulatorsInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/SubtasksAllAccumulatorsInfo.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.job;
+
+import org.apache.flink.runtime.rest.handler.job.SubtasksAllAccumulatorsHandler;
+import org.apache.flink.runtime.rest.messages.ResponseBody;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Collection;
+import java.util.Objects;
+
+
+/**
+ * Response type of the {@link SubtasksAllAccumulatorsHandler}.
+ */
+public class SubtasksAllAccumulatorsInfo implements ResponseBody {
+
+	public static final String FIELD_NAME_ID = "id";
+	public static final String FIELD_NAME_PARALLELISM = "parallelism";
+	public static final String FILED_NMAE_SUBTASKS = "subtasks";
+
+	@JsonProperty(FIELD_NAME_ID)
+	private String id;
+
+	@JsonProperty(FIELD_NAME_PARALLELISM)
+	private int parallelism;
+
+	@JsonProperty(FILED_NMAE_SUBTASKS)
+	private Collection<SubtaskAccumulatorsInfo> subtaskAccumulatorsInfos;
+
+	@JsonCreator
+	public SubtasksAllAccumulatorsInfo(
+		@JsonProperty(FIELD_NAME_ID) String id,
+		@JsonProperty(FIELD_NAME_PARALLELISM) int parallelism,
+		@JsonProperty(FILED_NMAE_SUBTASKS) Collection<SubtaskAccumulatorsInfo> subtaskAccumulatorsInfos) {
+		this.id = Preconditions.checkNotNull(id);
+		this.parallelism = parallelism;
+		this.subtaskAccumulatorsInfos = Preconditions.checkNotNull(subtaskAccumulatorsInfos);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		SubtasksAllAccumulatorsInfo that = (SubtasksAllAccumulatorsInfo) o;
+		return Objects.equals(id, that.id) &&
+			parallelism == that.parallelism &&
+			Objects.equals(subtaskAccumulatorsInfos, that.subtaskAccumulatorsInfos);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(id, parallelism, subtaskAccumulatorsInfos);
+	}
+
+	// ---------------------------------------------------
+	// Static inner classes
+	// ---------------------------------------------------
+
+	/**
+	 * Detailed information about subtask accumulators.
+	 */
+	public static class SubtaskAccumulatorsInfo {
+		public static final String FIELD_NAME_SUBTASK_INDEX = "subtask";
+		public static final String FIELD_NAME_ATTEMPT_NUM = "attempt";
+		public static final String FIELD_NAME_HOST = "host";
+		public static final String FIELD_NAME_USER_ACCUMULATORS = "user-accumulators";
+
+
+		@JsonProperty(FIELD_NAME_SUBTASK_INDEX)
+		private final int subtaskIndex;
+
+		@JsonProperty(FIELD_NAME_ATTEMPT_NUM)
+		private final int attemptNum;
+
+		@JsonProperty(FIELD_NAME_HOST)
+		private final String host;
+
+		@JsonProperty(FIELD_NAME_USER_ACCUMULATORS)
+		private final Collection<UserAccumulator> userAccumulators;
+
+		@JsonCreator
+		public SubtaskAccumulatorsInfo(
+			@JsonProperty(FIELD_NAME_SUBTASK_INDEX) int subtaskIndex,
+			@JsonProperty(FIELD_NAME_ATTEMPT_NUM) int attemptNum,
+			@JsonProperty(FIELD_NAME_HOST) String host,
+			@JsonProperty(FIELD_NAME_USER_ACCUMULATORS) Collection<UserAccumulator> userAccumulators) {
+
+			this.subtaskIndex = subtaskIndex;
+			this.attemptNum = attemptNum;
+			this.host = Preconditions.checkNotNull(host);
+			this.userAccumulators = Preconditions.checkNotNull(userAccumulators);
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+			SubtaskAccumulatorsInfo that = (SubtaskAccumulatorsInfo) o;
+			return subtaskIndex == that.subtaskIndex &&
+				attemptNum == that.attemptNum &&
+				Objects.equals(host, that.host) &&
+				Objects.equals(userAccumulators, that.userAccumulators);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(subtaskIndex, attemptNum, host, userAccumulators);
+		}
+
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/SubtasksAllAccumulatorsInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/SubtasksAllAccumulatorsInfo.java
@@ -18,41 +18,46 @@
 
 package org.apache.flink.runtime.rest.messages.job;
 
+import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.rest.handler.job.SubtasksAllAccumulatorsHandler;
 import org.apache.flink.runtime.rest.messages.ResponseBody;
+import org.apache.flink.runtime.rest.messages.json.JobVertexIDDeserializer;
+import org.apache.flink.runtime.rest.messages.json.JobVertexIDSerializer;
 import org.apache.flink.util.Preconditions;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 import java.util.Collection;
 import java.util.Objects;
-
 
 /**
  * Response type of the {@link SubtasksAllAccumulatorsHandler}.
  */
 public class SubtasksAllAccumulatorsInfo implements ResponseBody {
 
-	public static final String FIELD_NAME_ID = "id";
+	public static final String FIELD_NAME_JOB_VERTEX_ID = "id";
 	public static final String FIELD_NAME_PARALLELISM = "parallelism";
-	public static final String FILED_NMAE_SUBTASKS = "subtasks";
+	public static final String FILED_NAME_SUBTASKS = "subtasks";
 
-	@JsonProperty(FIELD_NAME_ID)
-	private String id;
+	@JsonProperty(FIELD_NAME_JOB_VERTEX_ID)
+	@JsonSerialize(using = JobVertexIDSerializer.class)
+	private final JobVertexID jobVertexId;
 
 	@JsonProperty(FIELD_NAME_PARALLELISM)
-	private int parallelism;
+	private final int parallelism;
 
-	@JsonProperty(FILED_NMAE_SUBTASKS)
-	private Collection<SubtaskAccumulatorsInfo> subtaskAccumulatorsInfos;
+	@JsonProperty(FILED_NAME_SUBTASKS)
+	private final Collection<SubtaskAccumulatorsInfo> subtaskAccumulatorsInfos;
 
 	@JsonCreator
 	public SubtasksAllAccumulatorsInfo(
-		@JsonProperty(FIELD_NAME_ID) String id,
+		@JsonDeserialize(using = JobVertexIDDeserializer.class) @JsonProperty(FIELD_NAME_JOB_VERTEX_ID) JobVertexID jobVertexId,
 		@JsonProperty(FIELD_NAME_PARALLELISM) int parallelism,
-		@JsonProperty(FILED_NMAE_SUBTASKS) Collection<SubtaskAccumulatorsInfo> subtaskAccumulatorsInfos) {
-		this.id = Preconditions.checkNotNull(id);
+		@JsonProperty(FILED_NAME_SUBTASKS) Collection<SubtaskAccumulatorsInfo> subtaskAccumulatorsInfos) {
+		this.jobVertexId = Preconditions.checkNotNull(jobVertexId);
 		this.parallelism = parallelism;
 		this.subtaskAccumulatorsInfos = Preconditions.checkNotNull(subtaskAccumulatorsInfos);
 	}
@@ -66,14 +71,14 @@ public class SubtasksAllAccumulatorsInfo implements ResponseBody {
 			return false;
 		}
 		SubtasksAllAccumulatorsInfo that = (SubtasksAllAccumulatorsInfo) o;
-		return Objects.equals(id, that.id) &&
+		return Objects.equals(jobVertexId, that.jobVertexId) &&
 			parallelism == that.parallelism &&
 			Objects.equals(subtaskAccumulatorsInfos, that.subtaskAccumulatorsInfos);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(id, parallelism, subtaskAccumulatorsInfos);
+		return Objects.hash(jobVertexId, parallelism, subtaskAccumulatorsInfos);
 	}
 
 	// ---------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
@@ -50,6 +50,7 @@ import org.apache.flink.runtime.rest.handler.job.JobsOverviewHandler;
 import org.apache.flink.runtime.rest.handler.job.SubtaskCurrentAttemptDetailsHandler;
 import org.apache.flink.runtime.rest.handler.job.SubtaskExecutionAttemptAccumulatorsHandler;
 import org.apache.flink.runtime.rest.handler.job.SubtaskExecutionAttemptDetailsHandler;
+import org.apache.flink.runtime.rest.handler.job.SubtasksAllAccumulatorsHandler;
 import org.apache.flink.runtime.rest.handler.job.SubtasksTimesHandler;
 import org.apache.flink.runtime.rest.handler.job.checkpoints.CheckpointConfigHandler;
 import org.apache.flink.runtime.rest.handler.job.checkpoints.CheckpointStatisticDetailsHandler;
@@ -94,6 +95,7 @@ import org.apache.flink.runtime.rest.messages.JobVertexBackPressureHeaders;
 import org.apache.flink.runtime.rest.messages.JobVertexDetailsHeaders;
 import org.apache.flink.runtime.rest.messages.JobVertexTaskManagersHeaders;
 import org.apache.flink.runtime.rest.messages.JobsOverviewHeaders;
+import org.apache.flink.runtime.rest.messages.SubtasksAllAccumulatorsHandlers;
 import org.apache.flink.runtime.rest.messages.SubtasksTimesHeaders;
 import org.apache.flink.runtime.rest.messages.TerminationModeQueryParameter;
 import org.apache.flink.runtime.rest.messages.YarnCancelJobTerminationHeaders;
@@ -315,6 +317,15 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
 			timeout,
 			responseHeaders,
 			JobVertexAccumulatorsHeaders.getInstance(),
+			executionGraphCache,
+			executor);
+
+		SubtasksAllAccumulatorsHandler subtasksAllAccumulatorsHandler = new SubtasksAllAccumulatorsHandler(
+			restAddressFuture,
+			leaderRetriever,
+			timeout,
+			responseHeaders,
+			SubtasksAllAccumulatorsHandlers.getInstance(),
 			executionGraphCache,
 			executor);
 
@@ -575,6 +586,7 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
 		handlers.add(Tuple2.of(TaskCheckpointStatisticsHeaders.getInstance(), taskCheckpointStatisticDetailsHandler));
 		handlers.add(Tuple2.of(JobExceptionsHeaders.getInstance(), jobExceptionsHandler));
 		handlers.add(Tuple2.of(JobVertexAccumulatorsHeaders.getInstance(), jobVertexAccumulatorsHandler));
+		handlers.add(Tuple2.of(JobVertexAccumulatorsHeaders.getInstance(), subtasksAllAccumulatorsHandler));
 		handlers.add(Tuple2.of(JobDetailsHeaders.getInstance(), jobDetailsHandler));
 		handlers.add(Tuple2.of(JobAccumulatorsHeaders.getInstance(), jobAccumulatorsHandler));
 		handlers.add(Tuple2.of(TaskManagersHeaders.getInstance(), taskManagersHandler));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/SubtasksAllAccumulatorsInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/SubtasksAllAccumulatorsInfoTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.job;
+
+import org.apache.flink.runtime.rest.messages.RestResponseMarshallingTestBase;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Tests (un)marshalling of the {@link SubtasksAllAccumulatorsInfo}.
+ */
+public class SubtasksAllAccumulatorsInfoTest extends RestResponseMarshallingTestBase<SubtasksAllAccumulatorsInfo> {
+	@Override
+	protected Class<SubtasksAllAccumulatorsInfo> getTestResponseClass() {
+		return SubtasksAllAccumulatorsInfo.class;
+	}
+
+	@Override
+	protected SubtasksAllAccumulatorsInfo getTestResponseInstance() throws Exception {
+		List<SubtasksAllAccumulatorsInfo.SubtaskAccumulatorsInfo> subtaskAccumulatorsInfos = new ArrayList<>();
+
+		List<UserAccumulator> userAccumulators = new ArrayList<>(3);
+		userAccumulators.add(new UserAccumulator("test name1", "test type1", "test value1"));
+		userAccumulators.add(new UserAccumulator("test name2", "test type2", "test value2"));
+
+		for (int i = 0; i < 3; ++i) {
+			subtaskAccumulatorsInfos.add(
+				new SubtasksAllAccumulatorsInfo.SubtaskAccumulatorsInfo(
+					i,
+					i,
+					"host-" + String.valueOf(i),
+					userAccumulators
+				));
+
+		}
+		return new SubtasksAllAccumulatorsInfo("vertexId",
+			4,
+			subtaskAccumulatorsInfos);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/SubtasksAllAccumulatorsInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/SubtasksAllAccumulatorsInfoTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.rest.messages.job;
 
+import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.rest.messages.RestResponseMarshallingTestBase;
 
 import java.util.ArrayList;
@@ -34,9 +35,9 @@ public class SubtasksAllAccumulatorsInfoTest extends RestResponseMarshallingTest
 
 	@Override
 	protected SubtasksAllAccumulatorsInfo getTestResponseInstance() throws Exception {
-		List<SubtasksAllAccumulatorsInfo.SubtaskAccumulatorsInfo> subtaskAccumulatorsInfos = new ArrayList<>();
+		List<SubtasksAllAccumulatorsInfo.SubtaskAccumulatorsInfo> subtaskAccumulatorsInfos = new ArrayList<>(3);
 
-		List<UserAccumulator> userAccumulators = new ArrayList<>(3);
+		List<UserAccumulator> userAccumulators = new ArrayList<>(2);
 		userAccumulators.add(new UserAccumulator("test name1", "test type1", "test value1"));
 		userAccumulators.add(new UserAccumulator("test name2", "test type2", "test value2"));
 
@@ -50,7 +51,7 @@ public class SubtasksAllAccumulatorsInfoTest extends RestResponseMarshallingTest
 				));
 
 		}
-		return new SubtasksAllAccumulatorsInfo("vertexId",
+		return new SubtasksAllAccumulatorsInfo(new JobVertexID(),
 			4,
 			subtaskAccumulatorsInfos);
 	}


### PR DESCRIPTION

## What is the purpose of the change

*Port SubtasksAllAccumulatorsHandler to new REST endpoint*


## Brief change log

  - *Add SubtasksAllAccumulatorsHandler for WebMonitorEndpoint*
  - *Add SubtasksAllAccumulatorsHeaders/SubtasksAllAccumulatorsInfo for rest response*
  - *Add SubtasksAllAccumulatorsInfoTest*

## Verifying this change

*Added test case SubtasksAllAccumulatorsInfoTest to generate the json response*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
