### PR TITLE
[FLINK-9185] [runtime] Fix potential null dereference in PrioritizedO…

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PrioritizedOperatorSubtaskState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PrioritizedOperatorSubtaskState.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.checkpoint;
 
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.OperatorStateHandle;
@@ -282,7 +283,7 @@ public class PrioritizedOperatorSubtaskState {
 				if (alternative != null
 					&& alternative.hasState()
 					&& alternative.size() == 1
-					&& approveFun.apply(reference, alternative.iterator().next())) {
+					&& BooleanUtils.isTrue(approveFun.apply(reference, alternative.iterator().next()))) {
 
 					approved.add(alternative);
 				}


### PR DESCRIPTION
## What is the purpose of the change

Fix potential null dereference in PrioritizedOperatorSubtaskState#resolvePrioritizedAlternatives


## Brief change log

  - Add null check for the return value of  approve function in PrioritizedOperatorSubtaskState#resolvePrioritizedAlternatives


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
