### PR TITLE
Fix kerberos security configuration for YarnTaskExecutor

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
@@ -477,7 +477,7 @@ public class YarnResourceManager extends ResourceManager<YarnWorkerNode> impleme
 			taskManagerParameters,
 			flinkConfig,
 			currDir,
-			YarnTaskExecutorRunner.class,
+			YarnTaskExecutorRunnerFactory.class,
 			log);
 
 		// set a special environment variable to uniquely identify this container

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnTaskExecutorRunnerFactoryTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnTaskExecutorRunnerFactoryTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.yarn;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.SecurityOptions;
+import org.apache.flink.runtime.security.SecurityUtils;
+import org.apache.flink.runtime.security.modules.HadoopModule;
+import org.apache.flink.runtime.security.modules.SecurityModule;
+
+import org.apache.hadoop.yarn.api.ApplicationConstants;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for {@link YarnTaskExecutorRunnerFactory}.
+ */
+public class YarnTaskExecutorRunnerFactoryTest {
+	@Test
+	public void testKerberosKeytabConfiguration() throws IOException {
+		final String resourceDirPath =
+				Paths.get("src", "test", "resources").toAbsolutePath().toString();
+		final Map<String, String> envs = new HashMap<>();
+		envs.put(YarnFlinkResourceManager.ENV_FLINK_CONTAINER_ID, "test_container_00001");
+		envs.put(YarnConfigKeys.KEYTAB_PRINCIPAL, "testuser1@domain");
+		envs.put(ApplicationConstants.Environment.PWD.key(), resourceDirPath);
+
+		final YarnTaskExecutorRunnerFactory.Runner tmRunner = YarnTaskExecutorRunnerFactory.create(
+				envs);
+
+		final List<SecurityModule> modules = SecurityUtils.getInstalledModules();
+		Optional<SecurityModule> moduleOpt =
+				modules.stream().filter(s -> s instanceof HadoopModule).findFirst();
+		if (moduleOpt.isPresent()) {
+			HadoopModule hadoopModule = (HadoopModule) moduleOpt.get();
+			assertEquals("testuser1@domain", hadoopModule.getSecurityConfig().getPrincipal());
+			assertEquals(resourceDirPath + "/" + Utils.KEYTAB_FILE_NAME,
+					hadoopModule.getSecurityConfig().getKeytab());
+		} else {
+			fail("Can not find HadoopModule!");
+		}
+
+		final Configuration configuration = tmRunner.getConfiguration();
+		assertEquals(resourceDirPath + "/" + Utils.KEYTAB_FILE_NAME, configuration.getString(SecurityOptions.KERBEROS_LOGIN_KEYTAB));
+		assertEquals("testuser1@domain", configuration.getString(SecurityOptions.KERBEROS_LOGIN_PRINCIPAL));
+		assertEquals("test_container_00001", tmRunner.getResourceId().toString());
+	}
+}


### PR DESCRIPTION

## What is the purpose of the change

Fix broken YARN kerberos integration for flip-6.


## Brief change log

  - Fix kerberos onfigurations.
  - Refactor code.
  - Add unittest.

## Verifying this change

This change added tests and can be verified as follows:
  - *Added test that validates kerberos credentials are set correctly *

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no )
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
