### PR TITLE
[FLINK-8286][Security] Fix kerberos security configuration for YarnTaskExecutor

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
@@ -477,7 +477,7 @@ public class YarnResourceManager extends ResourceManager<YarnWorkerNode> impleme
 			taskManagerParameters,
 			flinkConfig,
 			currDir,
-			YarnTaskExecutorRunner.class,
+			YarnTaskExecutorRunnerFactory.class,
 			log);
 
 		// set a special environment variable to uniquely identify this container

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnTaskExecutorRunner.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnTaskExecutorRunner.java
@@ -128,6 +128,11 @@ public class YarnTaskExecutorRunner {
 			LOG.info("YARN daemon is running as: {} Yarn client user obtainer: {}",
 					currentUser.getShortUserName(), yarnClientUsername);
 
+			if (keytabPath != null && remoteKeytabPrincipal != null) {
+				configuration.setString(SecurityOptions.KERBEROS_LOGIN_KEYTAB, keytabPath);
+				configuration.setString(SecurityOptions.KERBEROS_LOGIN_PRINCIPAL, remoteKeytabPrincipal);
+			}
+
 			SecurityConfiguration sc;
 
 			//To support Yarn Secure Integration Test Scenario
@@ -144,11 +149,6 @@ public class YarnTaskExecutorRunner {
 
 			} else {
 				sc = new SecurityConfiguration(configuration);
-			}
-
-			if (keytabPath != null && remoteKeytabPrincipal != null) {
-				configuration.setString(SecurityOptions.KERBEROS_LOGIN_KEYTAB, keytabPath);
-				configuration.setString(SecurityOptions.KERBEROS_LOGIN_PRINCIPAL, remoteKeytabPrincipal);
 			}
 
 			final String containerId = ENV.get(YarnFlinkResourceManager.ENV_FLINK_CONTAINER_ID);

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnTaskExecutorRunnerFactory.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnTaskExecutorRunnerFactory.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.yarn;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.AkkaOptions;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
@@ -42,6 +43,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -49,15 +51,46 @@ import java.util.concurrent.Callable;
 /**
  * This class is the executable entry point for running a TaskExecutor in a YARN container.
  */
-public class YarnTaskExecutorRunner {
+public class YarnTaskExecutorRunnerFactory {
 
-	protected static final Logger LOG = LoggerFactory.getLogger(YarnTaskExecutorRunner.class);
-
-	/** The process environment variables. */
-	private static final Map<String, String> ENV = System.getenv();
+	protected static final Logger LOG = LoggerFactory.getLogger(YarnTaskExecutorRunnerFactory.class);
 
 	/** The exit code returned if the initialization of the yarn task executor runner failed. */
 	private static final int INIT_ERROR_EXIT_CODE = 31;
+
+	/**
+	 * Runner for the {@link TaskManagerRunner}.
+	 */
+	public static class Runner implements Callable<Object> {
+		private final Configuration configuration;
+		private final ResourceID resourceId;
+
+		Runner(Configuration configuration, ResourceID resourceId) {
+			this.configuration = Preconditions.checkNotNull(configuration);
+			this.resourceId = Preconditions.checkNotNull(resourceId);
+		}
+
+		@Override
+		public Object call() throws Exception {
+			try {
+				TaskManagerRunner.runTaskManager(configuration, resourceId);
+			} catch (Throwable t) {
+				LOG.error("Error while starting the TaskManager", t);
+				System.exit(INIT_ERROR_EXIT_CODE);
+			}
+			return null;
+		}
+
+		@VisibleForTesting
+		Configuration getConfiguration() {
+			return configuration;
+		}
+
+		@VisibleForTesting
+		ResourceID getResourceId() {
+			return resourceId;
+		}
+	}
 
 	// ------------------------------------------------------------------------
 	//  Program entry point
@@ -73,63 +106,59 @@ public class YarnTaskExecutorRunner {
 		SignalHandler.register(LOG);
 		JvmShutdownSafeguard.installAsShutdownHook(LOG);
 
-		run(args);
+		try {
+			SecurityUtils.getInstalledContext().runSecured(
+					YarnTaskExecutorRunnerFactory.create(System.getenv()));
+		} catch (Exception e) {
+			LOG.error("Exception occurred while launching Task Executor runner", e);
+			throw new RuntimeException(e);
+		}
 	}
 
 	/**
-	 * The instance entry point for the YARN task executor. Obtains user group information and calls
-	 * the main work method {@link TaskManagerRunner#runTaskManager(Configuration, ResourceID)}  as a
-	 * privileged action.
+	 * Creates a {@link YarnTaskExecutorRunnerFactory.Runner}.
 	 *
-	 * @param args The command line arguments.
+	 * @param envs environment variables.
 	 */
-	private static void run(String[] args) {
+	@VisibleForTesting
+	protected static Runner create(Map<String, String> envs) throws IOException {
+		LOG.debug("All environment variables: {}", envs);
+
+		final String yarnClientUsername = envs.get(YarnConfigKeys.ENV_HADOOP_USER_NAME);
+		final String localDirs = envs.get(Environment.LOCAL_DIRS.key());
+		LOG.info("Current working/local Directory: {}", localDirs);
+
+		final String currDir = envs.get(Environment.PWD.key());
+		LOG.info("Current working Directory: {}", currDir);
+
+		final String remoteKeytabPrincipal = envs.get(YarnConfigKeys.KEYTAB_PRINCIPAL);
+		LOG.info("TM: remote keytab principal obtained {}", remoteKeytabPrincipal);
+
+		final Configuration configuration = GlobalConfiguration.loadConfiguration(currDir);
+		FileSystem.initialize(configuration);
+
+		// configure local directory
+		if (configuration.contains(CoreOptions.TMP_DIRS)) {
+			LOG.info("Overriding YARN's temporary file directories with those " +
+				"specified in the Flink config: " + configuration.getValue(CoreOptions.TMP_DIRS));
+		}
+		else {
+			LOG.info("Setting directories for temporary files to: {}", localDirs);
+			configuration.setString(CoreOptions.TMP_DIRS, localDirs);
+		}
+
+		// tell akka to die in case of an error
+		configuration.setBoolean(AkkaOptions.JVM_EXIT_ON_FATAL_ERROR, true);
+
 		try {
-			LOG.debug("All environment variables: {}", ENV);
-
-			final String yarnClientUsername = ENV.get(YarnConfigKeys.ENV_HADOOP_USER_NAME);
-			final String localDirs = ENV.get(Environment.LOCAL_DIRS.key());
-			LOG.info("Current working/local Directory: {}", localDirs);
-
-			final String currDir = ENV.get(Environment.PWD.key());
-			LOG.info("Current working Directory: {}", currDir);
-
-			final String remoteKeytabPath = ENV.get(YarnConfigKeys.KEYTAB_PATH);
-			LOG.info("TM: remote keytab path obtained {}", remoteKeytabPath);
-
-			final String remoteKeytabPrincipal = ENV.get(YarnConfigKeys.KEYTAB_PRINCIPAL);
-			LOG.info("TM: remote keytab principal obtained {}", remoteKeytabPrincipal);
-
-			final Configuration configuration = GlobalConfiguration.loadConfiguration(currDir);
-			FileSystem.initialize(configuration);
-
-			// configure local directory
-			if (configuration.contains(CoreOptions.TMP_DIRS)) {
-				LOG.info("Overriding YARN's temporary file directories with those " +
-					"specified in the Flink config: " + configuration.getValue(CoreOptions.TMP_DIRS));
-			}
-			else {
-				LOG.info("Setting directories for temporary files to: {}", localDirs);
-				configuration.setString(CoreOptions.TMP_DIRS, localDirs);
-			}
-
-			// tell akka to die in case of an error
-			configuration.setBoolean(AkkaOptions.JVM_EXIT_ON_FATAL_ERROR, true);
-
-			String keytabPath = null;
-			if (remoteKeytabPath != null) {
-				File f = new File(currDir, Utils.KEYTAB_FILE_NAME);
-				keytabPath = f.getAbsolutePath();
-				LOG.info("keytab path: {}", keytabPath);
-			}
-
 			UserGroupInformation currentUser = UserGroupInformation.getCurrentUser();
 
 			LOG.info("YARN daemon is running as: {} Yarn client user obtainer: {}",
 					currentUser.getShortUserName(), yarnClientUsername);
 
-			if (keytabPath != null && remoteKeytabPrincipal != null) {
-				configuration.setString(SecurityOptions.KERBEROS_LOGIN_KEYTAB, keytabPath);
+			File f = new File(currDir, Utils.KEYTAB_FILE_NAME);
+			if (f.exists() && remoteKeytabPrincipal != null) {
+				configuration.setString(SecurityOptions.KERBEROS_LOGIN_KEYTAB, f.getAbsolutePath());
 				configuration.setString(SecurityOptions.KERBEROS_LOGIN_PRINCIPAL, remoteKeytabPrincipal);
 			}
 
@@ -151,30 +180,23 @@ public class YarnTaskExecutorRunner {
 				sc = new SecurityConfiguration(configuration);
 			}
 
-			final String containerId = ENV.get(YarnFlinkResourceManager.ENV_FLINK_CONTAINER_ID);
+			final String containerId = envs.get(YarnFlinkResourceManager.ENV_FLINK_CONTAINER_ID);
 			Preconditions.checkArgument(containerId != null,
 				"ContainerId variable %s not set", YarnFlinkResourceManager.ENV_FLINK_CONTAINER_ID);
 
 			// use the hostname passed by job manager
-			final String taskExecutorHostname = ENV.get(YarnResourceManager.ENV_FLINK_NODE_ID);
+			final String taskExecutorHostname = envs.get(YarnResourceManager.ENV_FLINK_NODE_ID);
 			if (taskExecutorHostname != null) {
 				configuration.setString(ConfigConstants.TASK_MANAGER_HOSTNAME_KEY, taskExecutorHostname);
 			}
 
 			SecurityUtils.install(sc);
 
-			SecurityUtils.getInstalledContext().runSecured(new Callable<Void>() {
-				@Override
-				public Void call() throws Exception {
-					TaskManagerRunner.runTaskManager(configuration, new ResourceID(containerId));
-					return null;
-				}
-			});
-		}
-		catch (Throwable t) {
+			return new Runner(configuration, new ResourceID(containerId));
+		} catch (Throwable t) {
 			// make sure that everything whatever ends up in the log
 			LOG.error("YARN TaskManager initialization failed.", t);
-			System.exit(INIT_ERROR_EXIT_CODE);
+			throw new RuntimeException(t);
 		}
 	}
 }

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnTaskExecutorRunnerFactoryTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnTaskExecutorRunnerFactoryTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.yarn;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.SecurityOptions;
+import org.apache.flink.runtime.security.SecurityUtils;
+import org.apache.flink.runtime.security.modules.HadoopModule;
+import org.apache.flink.runtime.security.modules.SecurityModule;
+
+import org.apache.hadoop.yarn.api.ApplicationConstants;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for {@link YarnTaskExecutorRunnerFactory}.
+ */
+public class YarnTaskExecutorRunnerFactoryTest {
+	@Test
+	public void testKerberosKeytabConfiguration() throws IOException {
+		final String resourceDirPath =
+				Paths.get("src", "test", "resources").toAbsolutePath().toString();
+		final Map<String, String> envs = new HashMap<>();
+		envs.put(YarnFlinkResourceManager.ENV_FLINK_CONTAINER_ID, "test_container_00001");
+		envs.put(YarnConfigKeys.KEYTAB_PRINCIPAL, "testuser1@domain");
+		envs.put(ApplicationConstants.Environment.PWD.key(), resourceDirPath);
+
+		final YarnTaskExecutorRunnerFactory.Runner tmRunner = YarnTaskExecutorRunnerFactory.create(
+				envs);
+
+		final List<SecurityModule> modules = SecurityUtils.getInstalledModules();
+		Optional<SecurityModule> moduleOpt =
+				modules.stream().filter(s -> s instanceof HadoopModule).findFirst();
+		if (moduleOpt.isPresent()) {
+			HadoopModule hadoopModule = (HadoopModule) moduleOpt.get();
+			assertEquals("testuser1@domain", hadoopModule.getSecurityConfig().getPrincipal());
+			assertEquals(resourceDirPath + "/" + Utils.KEYTAB_FILE_NAME,
+					hadoopModule.getSecurityConfig().getKeytab());
+		} else {
+			fail("Can not find HadoopModule!");
+		}
+
+		final Configuration configuration = tmRunner.getConfiguration();
+		assertEquals(resourceDirPath + "/" + Utils.KEYTAB_FILE_NAME, configuration.getString(SecurityOptions.KERBEROS_LOGIN_KEYTAB));
+		assertEquals("testuser1@domain", configuration.getString(SecurityOptions.KERBEROS_LOGIN_PRINCIPAL));
+		assertEquals("test_container_00001", tmRunner.getResourceId().toString());
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

Fix broken YARN kerberos integration for flip-6.


## Brief change log

  - Fix kerberos onfigurations.
  - Refactor code.
  - Add unittest.

## Verifying this change

This change added tests and can be verified as follows:
  - *Added test that validates kerberos credentials are set correctly *

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no )
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
