### PR TITLE
[FLINK-9234] [table] Fix missing dependencies for external catalogs

### DIFF
--- a/flink-libraries/flink-table/pom.xml
+++ b/flink-libraries/flink-table/pom.xml
@@ -89,6 +89,11 @@ under the License.
 			<groupId>commons-configuration</groupId>
 			<artifactId>commons-configuration</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>jcl-over-slf4j</artifactId>
+			<version>${slf4j.version}</version>
+		</dependency>
 
 		<!-- Used for base64 encoding of UDFs -->
 		<dependency>
@@ -312,8 +317,10 @@ under the License.
 
 									<!-- flink-table dependencies -->
 									<include>commons-configuration:*</include>
+									<include>org.slf4j:jcl-over-slf4j</include>
 									<include>commons-lang:*</include>
 									<include>commons-codec:*</include>
+									<include>commons-collections:*</include>
 									<include>org.apache.commons:commons-lang3</include>
 									<include>org.codehaus.janino:*</include>
 									<include>org.reflections:*</include>


### PR DESCRIPTION
## What is the purpose of the change

This PR adds the required dependencies `commons-logging` (via `slf4j`) and `commons-collections` to `flink-table`. They are required for the deprecated external catalog discovery.

## Brief change log

Modified `pom.xml`.


## Verifying this change

Manually verified.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
