### PR TITLE
[FLINK-9182]async checkpoints for timer service

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PrioritizedOperatorSubtaskState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PrioritizedOperatorSubtaskState.java
@@ -58,12 +58,16 @@ public class PrioritizedOperatorSubtaskState {
 	/** List of prioritized snapshot alternatives for raw keyed state. */
 	private final List<StateObjectCollection<KeyedStateHandle>> prioritizedRawKeyedState;
 
+	/** List of prioritized snapshot alternatives for raw keyed state meta. */
+	private final List<StateObjectCollection<OperatorStateHandle>> prioritizedRawKeyedStateMeta;
+
 	/** Signal flag if this represents state for a restored operator. */
 	private final boolean restored;
 
 	PrioritizedOperatorSubtaskState(
 		@Nonnull List<StateObjectCollection<KeyedStateHandle>> prioritizedManagedKeyedState,
 		@Nonnull List<StateObjectCollection<KeyedStateHandle>> prioritizedRawKeyedState,
+		@Nonnull List<StateObjectCollection<OperatorStateHandle>> prioritizedRawKeyedStateMeta,
 		@Nonnull List<StateObjectCollection<OperatorStateHandle>> prioritizedManagedOperatorState,
 		@Nonnull List<StateObjectCollection<OperatorStateHandle>> prioritizedRawOperatorState,
 		boolean restored) {
@@ -72,6 +76,7 @@ public class PrioritizedOperatorSubtaskState {
 		this.prioritizedRawOperatorState = prioritizedRawOperatorState;
 		this.prioritizedManagedKeyedState = prioritizedManagedKeyedState;
 		this.prioritizedRawKeyedState = prioritizedRawKeyedState;
+		this.prioritizedRawKeyedStateMeta = prioritizedRawKeyedStateMeta;
 		this.restored = restored;
 	}
 
@@ -113,6 +118,11 @@ public class PrioritizedOperatorSubtaskState {
 		return prioritizedRawKeyedState;
 	}
 
+	@Nonnull
+	public List<StateObjectCollection<OperatorStateHandle>> getPrioritizedRawKeyedStateMeta() {
+		return prioritizedRawKeyedStateMeta;
+	}
+
 	// -----------------------------------------------------------------------------------------------------------------
 
 	/**
@@ -149,6 +159,11 @@ public class PrioritizedOperatorSubtaskState {
 	@Nonnull
 	public StateObjectCollection<KeyedStateHandle> getJobManagerRawKeyedState() {
 		return lastElement(prioritizedRawKeyedState);
+	}
+
+	@Nonnull
+	public StateObjectCollection<OperatorStateHandle> getJobManagerRawKeyedStateMeta() {
+		return lastElement(prioritizedRawKeyedStateMeta);
 	}
 
 	// -----------------------------------------------------------------------------------------------------------------
@@ -209,12 +224,14 @@ public class PrioritizedOperatorSubtaskState {
 			List<StateObjectCollection<KeyedStateHandle>> managedKeyedAlternatives = new ArrayList<>(size);
 			List<StateObjectCollection<OperatorStateHandle>> rawOperatorAlternatives = new ArrayList<>(size);
 			List<StateObjectCollection<KeyedStateHandle>> rawKeyedAlternatives = new ArrayList<>(size);
+			List<StateObjectCollection<OperatorStateHandle>> rawKeyedMetaAlternatives = new ArrayList<>(size);
 
 			for (OperatorSubtaskState subtaskState : alternativesByPriority) {
 
 				if (subtaskState != null) {
 					managedKeyedAlternatives.add(subtaskState.getManagedKeyedState());
 					rawKeyedAlternatives.add(subtaskState.getRawKeyedState());
+					rawKeyedMetaAlternatives.add(subtaskState.getRawKeyedStateMeta());
 					managedOperatorAlternatives.add(subtaskState.getManagedOperatorState());
 					rawOperatorAlternatives.add(subtaskState.getRawOperatorState());
 				}
@@ -237,6 +254,11 @@ public class PrioritizedOperatorSubtaskState {
 					jobManagerState.getRawKeyedState(),
 					rawKeyedAlternatives,
 					keyedStateApprover),
+				resolvePrioritizedAlternatives(
+					jobManagerState.getRawKeyedStateMeta(),
+					rawKeyedMetaAlternatives,
+					operatorStateApprover
+				),
 				resolvePrioritizedAlternatives(
 					jobManagerState.getManagedOperatorState(),
 					managedOperatorAlternatives,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointV2Serializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/savepoint/SavepointV2Serializer.java
@@ -282,6 +282,13 @@ class SavepointV2Serializer implements SavepointSerializer<SavepointV2> {
 
 		KeyedStateHandle keyedStateStream = extractSingleton(subtaskState.getRawKeyedState());
 		serializeKeyedStateHandle(keyedStateStream, dos);
+
+		OperatorStateHandle keyedStateMetaStream = extractSingleton(subtaskState.getRawKeyedStateMeta());
+		len = keyedStateMetaStream != null ? 1 : 0;
+		dos.writeInt(len);
+		if(len == 1) {
+			serializeOperatorStateHandle(keyedStateMetaStream, dos);
+		}
 	}
 
 	private static OperatorSubtaskState deserializeSubtaskState(DataInputStream dis) throws IOException {
@@ -313,11 +320,15 @@ class SavepointV2Serializer implements SavepointSerializer<SavepointV2> {
 
 		KeyedStateHandle keyedStateStream = deserializeKeyedStateHandle(dis);
 
+		len = dis.readInt();
+		OperatorStateHandle keyedStateMetaStream = len == 0 ? null : deserializeOperatorStateHandle(dis);
+
 		return new OperatorSubtaskState(
 				operatorStateBackend,
 				operatorStateStream,
 				keyedStateBackend,
-				keyedStateStream);
+				keyedStateStream,
+				keyedStateMetaStream);
 	}
 
 	private static void serializeKeyedStateHandle(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateSnapshotContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateSnapshotContext.java
@@ -33,6 +33,11 @@ public interface StateSnapshotContext extends FunctionSnapshotContext {
 	KeyedStateCheckpointOutputStream getRawKeyedOperatorStateOutput() throws Exception;
 
 	/**
+	 * Returns an output stream for keyed state meta
+     */
+	OperatorStateCheckpointOutputStream getRawKeyedOperatorStateMetaOutput() throws Exception;
+
+	/**
 	 * Returns an output stream for operator state
 	 */
 	OperatorStateCheckpointOutputStream getRawOperatorStateOutput() throws Exception;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorFailureTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorFailureTest.java
@@ -97,11 +97,13 @@ public class CheckpointCoordinatorFailureTest extends TestLogger {
 		OperatorStateHandle managedOpHandle = mock(OperatorStreamStateHandle.class);
 		OperatorStateHandle rawOpHandle = mock(OperatorStreamStateHandle.class);
 
+		//TODO:
 		final OperatorSubtaskState operatorSubtaskState = spy(new OperatorSubtaskState(
 			managedOpHandle,
 			rawOpHandle,
 			managedKeyedHandle,
-			rawKeyedHandle));
+			rawKeyedHandle,
+			null));
 
 		TaskStateSnapshot subtaskState = spy(new TaskStateSnapshot());
 		subtaskState.putSubtaskStateByOperatorID(new OperatorID(), operatorSubtaskState);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
@@ -2136,7 +2136,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 
 		for (int index = 0; index < jobVertex1.getParallelism(); index++) {
 			KeyGroupsStateHandle keyGroupState = generateKeyGroupState(jobVertexID1, keyGroupPartitions1.get(index), false);
-			OperatorSubtaskState operatorSubtaskState = new OperatorSubtaskState(null, null, keyGroupState, null);
+			OperatorSubtaskState operatorSubtaskState = new OperatorSubtaskState(null, null, keyGroupState, null, null);
 			TaskStateSnapshot taskOperatorSubtaskStates = new TaskStateSnapshot();
 			taskOperatorSubtaskStates.putSubtaskStateByOperatorID(OperatorID.fromJobVertexID(jobVertexID1), operatorSubtaskState);
 			AcknowledgeCheckpoint acknowledgeCheckpoint = new AcknowledgeCheckpoint(
@@ -2152,7 +2152,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 
 		for (int index = 0; index < jobVertex2.getParallelism(); index++) {
 			KeyGroupsStateHandle keyGroupState = generateKeyGroupState(jobVertexID2, keyGroupPartitions2.get(index), false);
-			OperatorSubtaskState operatorSubtaskState = new OperatorSubtaskState(null, null, keyGroupState, null);
+			OperatorSubtaskState operatorSubtaskState = new OperatorSubtaskState(null, null, keyGroupState, null, null);
 			TaskStateSnapshot taskOperatorSubtaskStates = new TaskStateSnapshot();
 			taskOperatorSubtaskStates.putSubtaskStateByOperatorID(OperatorID.fromJobVertexID(jobVertexID2), operatorSubtaskState);
 			AcknowledgeCheckpoint acknowledgeCheckpoint = new AcknowledgeCheckpoint(
@@ -2288,7 +2288,8 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			OperatorStateHandle opStateBackend = generatePartitionableStateHandle(jobVertexID1, index, 2, 8, false);
 			KeyGroupsStateHandle keyedStateBackend = generateKeyGroupState(jobVertexID1, keyGroupPartitions1.get(index), false);
 			KeyGroupsStateHandle keyedStateRaw = generateKeyGroupState(jobVertexID1, keyGroupPartitions1.get(index), true);
-			OperatorSubtaskState operatorSubtaskState = new OperatorSubtaskState(opStateBackend, null, keyedStateBackend, keyedStateRaw);
+			//TODO
+			OperatorSubtaskState operatorSubtaskState = new OperatorSubtaskState(opStateBackend, null, keyedStateBackend, keyedStateRaw, null);
 			TaskStateSnapshot taskOperatorSubtaskStates = new TaskStateSnapshot();
 			taskOperatorSubtaskStates.putSubtaskStateByOperatorID(OperatorID.fromJobVertexID(jobVertexID1), operatorSubtaskState);
 
@@ -2313,7 +2314,8 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			expectedOpStatesBackend.add(new ChainedStateHandle<>(Collections.singletonList(opStateBackend)));
 			expectedOpStatesRaw.add(new ChainedStateHandle<>(Collections.singletonList(opStateRaw)));
 
-			OperatorSubtaskState operatorSubtaskState = new OperatorSubtaskState(opStateBackend, opStateRaw, keyedStateBackend, keyedStateRaw);
+			//TODO:
+			OperatorSubtaskState operatorSubtaskState = new OperatorSubtaskState(opStateBackend, opStateRaw, keyedStateBackend, keyedStateRaw, null);
 			TaskStateSnapshot taskOperatorSubtaskStates = new TaskStateSnapshot();
 			taskOperatorSubtaskStates.putSubtaskStateByOperatorID(OperatorID.fromJobVertexID(jobVertexID2), operatorSubtaskState);
 
@@ -2446,6 +2448,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 					subManagedOperatorState,
 					subRawOperatorState,
 					null,
+					null,
 					null);
 				taskState.putState(index, subtaskState);
 			}
@@ -2479,11 +2482,13 @@ public class CheckpointCoordinatorTest extends TestLogger {
 				expectedManagedOperatorState.add(ChainedStateHandle.wrapSingleHandle(subManagedOperatorState));
 				expectedRawOperatorState.add(ChainedStateHandle.wrapSingleHandle(subRawOperatorState));
 
+				//TODO:
 				OperatorSubtaskState subtaskState = new OperatorSubtaskState(
 					subManagedOperatorState,
 					subRawOperatorState,
 					subManagedKeyedState,
-					subRawKeyedState);
+					subRawKeyedState,
+					null);
 				operatorState.putState(index, subtaskState);
 			}
 		}
@@ -3043,7 +3048,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 
 		TaskStateSnapshot subtaskStates = spy(new TaskStateSnapshot());
 		OperatorSubtaskState subtaskState = spy(new OperatorSubtaskState(
-			partitionableState, null, partitionedKeyGroupState, null)
+			partitionableState, null, partitionedKeyGroupState, null, null)
 		);
 
 		subtaskStates.putSubtaskStateByOperatorID(OperatorID.fromJobVertexID(jobVertexID), subtaskState);
@@ -3771,6 +3776,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 					StateObjectCollection.empty(),
 					StateObjectCollection.empty(),
 					StateObjectCollection.singleton(managedState),
+					StateObjectCollection.empty(),
 					StateObjectCollection.empty()));
 
 			Map<OperatorID, OperatorSubtaskState> opStates = new HashMap<>();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointMetadataLoadingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointMetadataLoadingTest.java
@@ -74,6 +74,7 @@ public class CheckpointMetadataLoadingTest {
 				new ByteStreamStateHandle("testHandler", new byte[0])),
 				null,
 				null,
+				null,
 				null);
 
 		OperatorState state = new OperatorState(operatorID, parallelism, parallelism);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStateRestoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStateRestoreTest.java
@@ -125,6 +125,7 @@ public class CheckpointStateRestoreTest {
 					StateObjectCollection.empty(),
 					StateObjectCollection.empty(),
 					StateObjectCollection.singleton(serializedKeyGroupStates),
+					StateObjectCollection.empty(),
 					StateObjectCollection.empty()));
 
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, statefulExec1.getAttemptId(), checkpointId, new CheckpointMetrics(), subtaskStates));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PrioritizedOperatorSubtaskStateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PrioritizedOperatorSubtaskStateTest.java
@@ -181,7 +181,8 @@ public class PrioritizedOperatorSubtaskStateTest extends TestLogger {
 							createNewKeyedStateHandle(keyGroupRange1),
 							createNewKeyedStateHandle(keyGroupRange2)));
 
-		return new OperatorSubtaskState(s1, s2, s3, s4);
+		//TODO:
+		return new OperatorSubtaskState(s1, s2, s3, s4, null);
 	}
 
 	/**
@@ -198,17 +199,20 @@ public class PrioritizedOperatorSubtaskStateTest extends TestLogger {
 					deepCopyFirstElement(primaryOriginal.getManagedOperatorState()),
 					deepCopyFirstElement(primaryOriginal.getRawOperatorState()),
 					deepCopyFirstElement(primaryOriginal.getManagedKeyedState()),
-					deepCopyFirstElement(primaryOriginal.getRawKeyedState()));
+					deepCopyFirstElement(primaryOriginal.getRawKeyedState()),
+					deepCopyFirstElement(primaryOriginal.getRawKeyedStateMeta()));
 			case 1:
 				return new OperatorSubtaskState();
 			case 2:
 				KeyGroupRange otherRange = new KeyGroupRange(8, 16);
 				int numNamedStates = 2;
+				//TODO:
 				return new OperatorSubtaskState(
 					createNewOperatorStateHandle(numNamedStates, random),
 					createNewOperatorStateHandle(numNamedStates, random),
 					createNewKeyedStateHandle(otherRange),
-					createNewKeyedStateHandle(otherRange));
+					createNewKeyedStateHandle(otherRange),
+					null);
 			default:
 				throw new IllegalArgumentException("Mode: " + mode);
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/TaskStateSnapshotTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/TaskStateSnapshotTest.java
@@ -67,6 +67,7 @@ public class TaskStateSnapshotTest extends TestLogger {
 			stateHandle,
 			null,
 			null,
+			null,
 			null
 		);
 
@@ -109,6 +110,7 @@ public class TaskStateSnapshotTest extends TestLogger {
 			stateHandle_1,
 			null,
 			null,
+			null,
 			null
 		);
 
@@ -116,6 +118,7 @@ public class TaskStateSnapshotTest extends TestLogger {
 		OperatorSubtaskState nonEmptyOperatorSubtaskState_2 = new OperatorSubtaskState(
 			null,
 			stateHandle_2,
+			null,
 			null,
 			null
 		);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/savepoint/CheckpointTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/savepoint/CheckpointTestUtils.java
@@ -122,11 +122,13 @@ public class CheckpointTestUtils {
 					keyedStateStream = createDummyKeyGroupStateHandle(random);
 				}
 
+				//TODO:
 				taskState.putState(subtaskIdx, new OperatorSubtaskState(
 						operatorStateHandleBackend,
 						operatorStateHandleStream,
 						keyedStateStream,
-						keyedStateBackend));
+						keyedStateBackend,
+						null));
 			}
 
 			taskStates.add(taskState);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerHARecoveryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/JobManagerHARecoveryTest.java
@@ -551,6 +551,7 @@ public class JobManagerHARecoveryTest extends TestLogger {
 					StateObjectCollection.singleton(operatorStateHandle),
 					StateObjectCollection.empty(),
 					StateObjectCollection.empty(),
+					StateObjectCollection.empty(),
 					StateObjectCollection.empty()));
 
 			getEnvironment().acknowledgeCheckpoint(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/messages/CheckpointMessagesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/messages/CheckpointMessagesTest.java
@@ -78,6 +78,7 @@ public class CheckpointMessagesTest {
 					CheckpointCoordinatorTest.generatePartitionableStateHandle(new JobVertexID(), 0, 2, 8, false),
 					null,
 					CheckpointCoordinatorTest.generateKeyGroupState(keyGroupRange, Collections.singletonList(new MyHandle())),
+					null,
 					null
 				)
 			);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskStateManagerImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskStateManagerImplTest.java
@@ -82,10 +82,10 @@ public class TaskStateManagerImplTest extends TestLogger {
 		KeyGroupRange keyGroupRange = new KeyGroupRange(0,1);
 		// Remote state of operator 1 has only managed keyed state.
 		OperatorSubtaskState jmOperatorSubtaskState_1 =
-			new OperatorSubtaskState(null, null, StateHandleDummyUtil.createNewKeyedStateHandle(keyGroupRange), null);
+			new OperatorSubtaskState(null, null, StateHandleDummyUtil.createNewKeyedStateHandle(keyGroupRange), null, null);
 		// Remote state of operator 1 has only raw keyed state.
 		OperatorSubtaskState jmOperatorSubtaskState_2 =
-			new OperatorSubtaskState(null, null, null, StateHandleDummyUtil.createNewKeyedStateHandle(keyGroupRange));
+			new OperatorSubtaskState(null, null, null, StateHandleDummyUtil.createNewKeyedStateHandle(keyGroupRange), null);
 
 		jmTaskStateSnapshot.putSubtaskStateByOperatorID(operatorID_1, jmOperatorSubtaskState_1);
 		jmTaskStateSnapshot.putSubtaskStateByOperatorID(operatorID_2, jmOperatorSubtaskState_2);
@@ -94,7 +94,7 @@ public class TaskStateManagerImplTest extends TestLogger {
 
 		// Only operator 1 has a local alternative for the managed keyed state.
 		OperatorSubtaskState tmOperatorSubtaskState_1 =
-			new OperatorSubtaskState(null, null, StateHandleDummyUtil.createNewKeyedStateHandle(keyGroupRange), null);
+			new OperatorSubtaskState(null, null, StateHandleDummyUtil.createNewKeyedStateHandle(keyGroupRange), null, null);
 
 		tmTaskStateSnapshot.putSubtaskStateByOperatorID(operatorID_1, tmOperatorSubtaskState_1);
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileReaderOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileReaderOperator.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.state.StateSnapshotContext;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.OperatorSnapshotFutures;
 import org.apache.flink.streaming.api.operators.OutputTypeConfigurable;
 import org.apache.flink.streaming.api.operators.StreamSourceContexts;
 import org.apache.flink.streaming.api.watermark.Watermark;
@@ -389,8 +390,8 @@ public class ContinuousFileReaderOperator<OUT> extends AbstractStreamOperator<OU
 	//	---------------------			Checkpointing			--------------------------
 
 	@Override
-	public void snapshotState(StateSnapshotContext context) throws Exception {
-		super.snapshotState(context);
+	public void snapshotState(StateSnapshotContext context, OperatorSnapshotFutures snapshotInProgress) throws Exception {
+		super.snapshotState(context, snapshotInProgress);
 
 		checkState(checkpointedState != null,
 			"The operator state has not been properly initialized.");

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperator.java
@@ -85,8 +85,8 @@ public abstract class AbstractUdfStreamOperator<OUT, F extends Function>
 	}
 
 	@Override
-	public void snapshotState(StateSnapshotContext context) throws Exception {
-		super.snapshotState(context);
+	public void snapshotState(StateSnapshotContext context, OperatorSnapshotFutures snapshotInProgress) throws Exception {
+		super.snapshotState(context, snapshotInProgress);
 		StreamingFunctionUtils.snapshotFunctionState(context, getOperatorStateBackend(), userFunction);
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimersSnapshot.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimersSnapshot.java
@@ -20,11 +20,12 @@ package org.apache.flink.streaming.api.operators;
 
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nullable;
 
-import java.util.Set;
+import java.util.Map;
 
 /**
  * A snapshot of internal timers, containing event and processing timers and
@@ -37,9 +38,12 @@ public class InternalTimersSnapshot<K, N> {
 	private TypeSerializer<N> namespaceSerializer;
 	private TypeSerializerConfigSnapshot namespaceSerializerConfigSnapshot;
 
-	private Set<InternalTimer<K, N>> eventTimeTimers;
-	private Set<InternalTimer<K, N>> processingTimeTimers;
+	private Map<String, InternalTimer<K, N>> eventTimeTimers;
+	private Map<String, InternalTimer<K, N>> processingTimeTimers;
 
+	private InternalTimeServiceManager<K, N> manager;
+	private int snapshotVersion;
+	private DataOutputViewStreamWrapper metaWrapper;
 	/** Empty constructor used when restoring the timers. */
 	public InternalTimersSnapshot() {}
 
@@ -49,8 +53,11 @@ public class InternalTimersSnapshot<K, N> {
 			TypeSerializerConfigSnapshot keySerializerConfigSnapshot,
 			TypeSerializer<N> namespaceSerializer,
 			TypeSerializerConfigSnapshot namespaceSerializerConfigSnapshot,
-			@Nullable Set<InternalTimer<K, N>> eventTimeTimers,
-			@Nullable Set<InternalTimer<K, N>> processingTimeTimers) {
+			@Nullable Map<String, InternalTimer<K, N>> eventTimeTimers,
+			@Nullable Map<String, InternalTimer<K, N>> processingTimeTimers,
+			InternalTimeServiceManager<K, N> manager,
+			int snapshotVersion,
+			DataOutputViewStreamWrapper metaWrapper) {
 
 		this.keySerializer = Preconditions.checkNotNull(keySerializer);
 		this.keySerializerConfigSnapshot = Preconditions.checkNotNull(keySerializerConfigSnapshot);
@@ -58,6 +65,9 @@ public class InternalTimersSnapshot<K, N> {
 		this.namespaceSerializerConfigSnapshot = Preconditions.checkNotNull(namespaceSerializerConfigSnapshot);
 		this.eventTimeTimers = eventTimeTimers;
 		this.processingTimeTimers = processingTimeTimers;
+		this.manager = manager;
+		this.snapshotVersion = snapshotVersion;
+		this.metaWrapper = metaWrapper;
 	}
 
 	public TypeSerializer<K> getKeySerializer() {
@@ -92,19 +102,19 @@ public class InternalTimersSnapshot<K, N> {
 		this.namespaceSerializerConfigSnapshot = namespaceSerializerConfigSnapshot;
 	}
 
-	public Set<InternalTimer<K, N>> getEventTimeTimers() {
+	public Map<String, InternalTimer<K, N>> getEventTimeTimers() {
 		return eventTimeTimers;
 	}
 
-	public void setEventTimeTimers(Set<InternalTimer<K, N>> eventTimeTimers) {
+	public void setEventTimeTimers(Map<String, InternalTimer<K, N>> eventTimeTimers) {
 		this.eventTimeTimers = eventTimeTimers;
 	}
 
-	public Set<InternalTimer<K, N>> getProcessingTimeTimers() {
+	public Map<String, InternalTimer<K, N>> getProcessingTimeTimers() {
 		return processingTimeTimers;
 	}
 
-	public void setProcessingTimeTimers(Set<InternalTimer<K, N>> processingTimeTimers) {
+	public void setProcessingTimeTimers(Map<String, InternalTimer<K, N>> processingTimeTimers) {
 		this.processingTimeTimers = processingTimeTimers;
 	}
 
@@ -116,5 +126,17 @@ public class InternalTimersSnapshot<K, N> {
 	@Override
 	public int hashCode() {
 		return super.hashCode();
+	}
+
+	public InternalTimeServiceManager<K, N> getManager() {
+		return manager;
+	}
+
+	public int getSnapshotVersion() {
+		return snapshotVersion;
+	}
+
+	public DataOutputViewStreamWrapper getMetaWrapper() {
+		return metaWrapper;
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/OperatorSnapshotFinalizer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/OperatorSnapshotFinalizer.java
@@ -49,6 +49,9 @@ public class OperatorSnapshotFinalizer {
 		SnapshotResult<KeyedStateHandle> keyedRaw =
 			FutureUtil.runIfNotDoneAndGet(snapshotFutures.getKeyedStateRawFuture());
 
+		SnapshotResult<OperatorStateHandle> keyedMetaRaw =
+			FutureUtil.runIfNotDoneAndGet(snapshotFutures.getKeyedStateMetaRawFuture());
+
 		SnapshotResult<OperatorStateHandle> operatorManaged =
 			FutureUtil.runIfNotDoneAndGet(snapshotFutures.getOperatorStateManagedFuture());
 
@@ -59,14 +62,16 @@ public class OperatorSnapshotFinalizer {
 			operatorManaged.getJobManagerOwnedSnapshot(),
 			operatorRaw.getJobManagerOwnedSnapshot(),
 			keyedManaged.getJobManagerOwnedSnapshot(),
-			keyedRaw.getJobManagerOwnedSnapshot()
+			keyedRaw.getJobManagerOwnedSnapshot(),
+			keyedMetaRaw.getJobManagerOwnedSnapshot()
 		);
 
 		taskLocalState = new OperatorSubtaskState(
 			operatorManaged.getTaskLocalSnapshot(),
 			operatorRaw.getTaskLocalSnapshot(),
 			keyedManaged.getTaskLocalSnapshot(),
-			keyedRaw.getTaskLocalSnapshot()
+			keyedRaw.getTaskLocalSnapshot(),
+			keyedMetaRaw.getTaskLocalSnapshot()
 		);
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperator.java
@@ -32,6 +32,7 @@ import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.AbstractUdfStreamOperator;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.OperatorSnapshotFutures;
 import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.api.operators.async.queue.OrderedStreamElementQueue;
 import org.apache.flink.streaming.api.operators.async.queue.StreamElementQueue;
@@ -236,8 +237,8 @@ public class AsyncWaitOperator<IN, OUT>
 	}
 
 	@Override
-	public void snapshotState(StateSnapshotContext context) throws Exception {
-		super.snapshotState(context);
+	public void snapshotState(StateSnapshotContext context, OperatorSnapshotFutures snapshotInProgress) throws Exception {
+		super.snapshotState(context, snapshotInProgress);
 
 		ListState<StreamElement> partitionableState =
 			getOperatorStateBackend().getListState(new ListStateDescriptor<>(STATE_NAME, inStreamElementSerializer));

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/GenericWriteAheadSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/GenericWriteAheadSink.java
@@ -32,6 +32,7 @@ import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.util.ReusingMutableToRegularIteratorWrapper;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.OperatorSnapshotFutures;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.util.Preconditions;
 
@@ -155,8 +156,8 @@ public abstract class GenericWriteAheadSink<IN> extends AbstractStreamOperator<I
 	}
 
 	@Override
-	public void snapshotState(StateSnapshotContext context) throws Exception {
-		super.snapshotState(context);
+	public void snapshotState(StateSnapshotContext context, OperatorSnapshotFutures snapshotInProgress) throws Exception {
+		super.snapshotState(context, snapshotInProgress);
 
 		Preconditions.checkState(this.checkpointedState != null,
 			"The operator state has not been properly initialized.");

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -70,6 +70,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
@@ -854,6 +855,14 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 					OperatorID operatorID = entry.getKey();
 					OperatorSnapshotFutures snapshotInProgress = entry.getValue();
 
+					Boolean snapshotTimerSuccess = null;
+					Callable<Boolean> snapshotTimerCallable = snapshotInProgress.getSnapshotTimerCallable();
+					if (snapshotTimerCallable != null) {
+						snapshotTimerSuccess = snapshotTimerCallable.call();
+						if (!snapshotTimerSuccess) {
+							throw new Exception("snapshot timer failed");
+						}
+					}
 					// finalize the async part of all by executing all snapshot runnables
 					OperatorSnapshotFinalizer finalizedSnapshots =
 						new OperatorSnapshotFinalizer(snapshotInProgress);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorTest.java
@@ -529,6 +529,7 @@ public class AbstractStreamOperatorTest {
 		final CloseableRegistry closeableRegistry = new CloseableRegistry();
 
 		StateSnapshotContextSynchronousImpl context = mock(StateSnapshotContextSynchronousImpl.class);
+		OperatorSnapshotFutures snapshotInProgress = mock(OperatorSnapshotFutures.class);
 
 		whenNew(StateSnapshotContextSynchronousImpl.class).withAnyArguments().thenReturn(context);
 
@@ -540,7 +541,7 @@ public class AbstractStreamOperatorTest {
 		doReturn(containingTask).when(operator).getContainingTask();
 
 		// lets fail when calling the actual snapshotState method
-		doThrow(failingException).when(operator).snapshotState(eq(context));
+		doThrow(failingException).when(operator).snapshotState(eq(context), eq(snapshotInProgress));
 
 		try {
 			operator.snapshotState(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperatorLifecycleTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperatorLifecycleTest.java
@@ -257,9 +257,9 @@ public class AbstractUdfStreamOperatorLifecycleTest {
 		}
 
 		@Override
-		public void snapshotState(StateSnapshotContext context) throws Exception {
+		public void snapshotState(StateSnapshotContext context, OperatorSnapshotFutures snapshotInProgress) throws Exception {
 			ACTUAL_ORDER_TRACKING.add("OPERATOR::snapshotState");
-			super.snapshotState(context);
+			super.snapshotState(context, snapshotInProgress);
 		}
 
 		@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/OperatorSnapshotFinalizerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/OperatorSnapshotFinalizerTest.java
@@ -78,7 +78,9 @@ public class OperatorSnapshotFinalizerTest extends TestLogger {
 		Assert.assertFalse(managedOp.isDone());
 		Assert.assertFalse(rawOp.isDone());
 
-		OperatorSnapshotFutures futures = new OperatorSnapshotFutures(managedKeyed, rawKeyed, managedOp, rawOp);
+		//TODO:
+		DoneFuture<SnapshotResult<OperatorStateHandle>> rawKeyedMeta = null;
+		OperatorSnapshotFutures futures = new OperatorSnapshotFutures(managedKeyed, rawKeyed, rawKeyedMeta, managedOp, rawOp);
 		OperatorSnapshotFinalizer operatorSnapshotFinalizer = new OperatorSnapshotFinalizer(futures);
 
 		Assert.assertTrue(managedKeyed.isDone());

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/OperatorSnapshotFuturesTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/OperatorSnapshotFuturesTest.java
@@ -60,6 +60,12 @@ public class OperatorSnapshotFuturesTest extends TestLogger {
 		RunnableFuture<SnapshotResult<KeyedStateHandle>> keyedStateRawFuture =
 			spy(DoneFuture.of(keyedStateRawResult));
 
+		OperatorStateHandle keyedRawStateMetaHandle = mock(OperatorStreamStateHandle.class);
+		SnapshotResult<OperatorStateHandle> keyedStateMetaRawResult =
+			SnapshotResult.of(keyedRawStateMetaHandle);
+		RunnableFuture<SnapshotResult<OperatorStateHandle>> keyedStateMetaRawFuture =
+			spy(DoneFuture.of(keyedStateMetaRawResult));
+
 		OperatorStateHandle operatorManagedStateHandle = mock(OperatorStreamStateHandle.class);
 		SnapshotResult<OperatorStateHandle> operatorStateManagedResult =
 			SnapshotResult.of(operatorManagedStateHandle);
@@ -75,6 +81,7 @@ public class OperatorSnapshotFuturesTest extends TestLogger {
 		operatorSnapshotResult = new OperatorSnapshotFutures(
 			keyedStateManagedFuture,
 			keyedStateRawFuture,
+			keyedStateMetaRawFuture,
 			operatorStateManagedFuture,
 			operatorStateRawFuture);
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StateInitializationContextImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StateInitializationContextImplTest.java
@@ -140,11 +140,13 @@ public class StateInitializationContextImplTest {
 			operatorStateHandles.add(operatorStateHandle);
 		}
 
+		//TODO:
 		OperatorSubtaskState operatorSubtaskState = new OperatorSubtaskState(
 			StateObjectCollection.empty(),
 			new StateObjectCollection<>(operatorStateHandles),
 			StateObjectCollection.empty(),
-			new StateObjectCollection<>(keyedStateHandles));
+			new StateObjectCollection<>(keyedStateHandles),
+			StateObjectCollection.empty());
 
 		OperatorID operatorID = new OperatorID();
 		TaskStateSnapshot taskStateSnapshot = new TaskStateSnapshot();
@@ -177,7 +179,8 @@ public class StateInitializationContextImplTest {
 			protected <K> InternalTimeServiceManager<?, K> internalTimeServiceManager(
 				AbstractKeyedStateBackend<K> keyedStatedBackend,
 				KeyContext keyContext,
-				Iterable<KeyGroupStatePartitionStreamProvider> rawKeyedStates) throws Exception {
+				Iterable<KeyGroupStatePartitionStreamProvider> rawKeyedStates,
+				Iterable<StatePartitionStreamProvider> rawKeyedStateMetaInputs) throws Exception {
 
 				// We do not initialize a timer service manager here, because it would already consume the raw keyed
 				// state as part of initialization. For the purpose of this test, we want an unconsumed raw keyed

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamOperatorSnapshotRestoreTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamOperatorSnapshotRestoreTest.java
@@ -205,7 +205,8 @@ public class StreamOperatorSnapshotRestoreTest extends TestLogger {
 					protected <K> InternalTimeServiceManager<?, K> internalTimeServiceManager(
 						AbstractKeyedStateBackend<K> keyedStatedBackend,
 						KeyContext keyContext,
-						Iterable<KeyGroupStatePartitionStreamProvider> rawKeyedStates) throws Exception {
+						Iterable<KeyGroupStatePartitionStreamProvider> rawKeyedStates,
+						Iterable<StatePartitionStreamProvider> rawKeyedStateMetaInputs) throws Exception {
 
 						return null;
 					}
@@ -282,7 +283,7 @@ public class StreamOperatorSnapshotRestoreTest extends TestLogger {
 		}
 
 		@Override
-		public void snapshotState(StateSnapshotContext context) throws Exception {
+		public void snapshotState(StateSnapshotContext context, OperatorSnapshotFutures snapshotInProgress) throws Exception {
 
 			KeyedStateCheckpointOutputStream out = context.getRawKeyedOperatorStateOutput();
 			DataOutputView dov = new DataOutputViewStreamWrapper(out);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImplTest.java
@@ -154,6 +154,7 @@ public class StreamTaskStateInitializerImplTest {
 
 		Random random = new Random(0x42);
 
+		//TODO:
 		OperatorSubtaskState operatorSubtaskState = new OperatorSubtaskState(
 			new OperatorStreamStateHandle(
 				Collections.singletonMap(
@@ -170,7 +171,8 @@ public class StreamTaskStateInitializerImplTest {
 						OperatorStateHandle.Mode.SPLIT_DISTRIBUTE)),
 				CheckpointTestUtils.createDummyStreamStateHandle(random)),
 			CheckpointTestUtils.createDummyKeyGroupStateHandle(random),
-			CheckpointTestUtils.createDummyKeyGroupStateHandle(random));
+			CheckpointTestUtils.createDummyKeyGroupStateHandle(random),
+			null);
 
 		taskStateSnapshot.putSubtaskStateByOperatorID(operatorID, operatorSubtaskState);
 
@@ -274,7 +276,8 @@ public class StreamTaskStateInitializerImplTest {
 				protected <K> InternalTimeServiceManager<?, K> internalTimeServiceManager(
 					AbstractKeyedStateBackend<K> keyedStatedBackend,
 					KeyContext keyContext,
-					Iterable<KeyGroupStatePartitionStreamProvider> rawKeyedStates) throws Exception {
+					Iterable<KeyGroupStatePartitionStreamProvider> rawKeyedStates,
+					Iterable<StatePartitionStreamProvider> rawKeyedStateMetaInputs) throws Exception {
 					return null;
 				}
 			};

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/InterruptSensitiveRestoreTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/InterruptSensitiveRestoreTest.java
@@ -188,6 +188,7 @@ public class InterruptSensitiveRestoreTest {
 
 		Collection<KeyedStateHandle> keyedStateFromBackend = Collections.emptyList();
 		Collection<KeyedStateHandle> keyedStateFromStream = Collections.emptyList();
+		Collection<OperatorStateHandle> keyedStateMetaFromStream = Collections.emptyList();
 		Collection<OperatorStateHandle> operatorStateBackend = Collections.emptyList();
 		Collection<OperatorStateHandle> operatorStateStream = Collections.emptyList();
 
@@ -225,7 +226,8 @@ public class InterruptSensitiveRestoreTest {
 			new StateObjectCollection<>(operatorStateBackend),
 			new StateObjectCollection<>(operatorStateStream),
 			new StateObjectCollection<>(keyedStateFromBackend),
-			new StateObjectCollection<>(keyedStateFromStream));
+			new StateObjectCollection<>(keyedStateFromStream),
+			new StateObjectCollection<>(keyedStateMetaFromStream));
 
 		JobVertexID jobVertexID = new JobVertexID();
 		OperatorID operatorID = OperatorID.fromJobVertexID(jobVertexID);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTest.java
@@ -50,6 +50,7 @@ import org.apache.flink.streaming.api.graph.StreamEdge;
 import org.apache.flink.streaming.api.graph.StreamNode;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.OperatorSnapshotFutures;
 import org.apache.flink.streaming.api.operators.StreamMap;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
@@ -770,7 +771,7 @@ public class OneInputStreamTaskTest extends TestLogger {
 		public static int numberSnapshotCalls = 0;
 
 		@Override
-		public void snapshotState(StateSnapshotContext context) throws Exception {
+		public void snapshotState(StateSnapshotContext context, OperatorSnapshotFutures snapshotInProgress) throws Exception {
 			ListState<Integer> partitionableState =
 				getOperatorStateBackend().getListState(TEST_DESCRIPTOR);
 			partitionableState.clear();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/RestoreStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/RestoreStreamTaskTest.java
@@ -38,6 +38,7 @@ import org.apache.flink.runtime.state.StateSnapshotContext;
 import org.apache.flink.runtime.state.TestTaskStateManager;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.OperatorSnapshotFutures;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.TestHarnessUtil;
 import org.apache.flink.util.TestLogger;
@@ -167,7 +168,8 @@ public class RestoreStreamTaskTest extends TestLogger {
 			Collections.emptyMap(),
 			Collections.emptyMap(),
 			Collections.emptyMap(),
-			Collections.emptyMap());
+			Collections.emptyMap(),
+			Collections.emptyList());
 
 		stateHandles.putSubtaskStateByOperatorID(headOperatorID, emptyHeadOperatorState);
 
@@ -335,7 +337,7 @@ public class RestoreStreamTaskTest extends TestLogger {
 		}
 
 		@Override
-		public void snapshotState(StateSnapshotContext context) throws Exception {
+		public void snapshotState(StateSnapshotContext context, OperatorSnapshotFutures snapshotInProgress) throws Exception {
 			counterState.add(counter);
 		}
 	}
@@ -353,7 +355,7 @@ public class RestoreStreamTaskTest extends TestLogger {
 		}
 
 		@Override
-		public void snapshotState(StateSnapshotContext context) throws Exception {
+		public void snapshotState(StateSnapshotContext context, OperatorSnapshotFutures snapshotInProgress) throws Exception {
 		}
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -520,12 +520,14 @@ public class StreamTaskTest extends TestLogger {
 
 		KeyedStateHandle managedKeyedStateHandle = mock(KeyedStateHandle.class);
 		KeyedStateHandle rawKeyedStateHandle = mock(KeyedStateHandle.class);
+		OperatorStateHandle rawKeyedStateMetaHandle = mock(OperatorStreamStateHandle.class);
 		OperatorStateHandle managedOperatorStateHandle = mock(OperatorStreamStateHandle.class);
 		OperatorStateHandle rawOperatorStateHandle = mock(OperatorStreamStateHandle.class);
 
 		OperatorSnapshotFutures operatorSnapshotResult = new OperatorSnapshotFutures(
 			DoneFuture.of(SnapshotResult.of(managedKeyedStateHandle)),
 			DoneFuture.of(SnapshotResult.of(rawKeyedStateHandle)),
+			DoneFuture.of(SnapshotResult.of(rawKeyedStateMetaHandle)),
 			DoneFuture.of(SnapshotResult.of(managedOperatorStateHandle)),
 			DoneFuture.of(SnapshotResult.of(rawOperatorStateHandle)));
 
@@ -566,12 +568,14 @@ public class StreamTaskTest extends TestLogger {
 		// check that the subtask state contains the expected state handles
 		assertEquals(StateObjectCollection.singleton(managedKeyedStateHandle), subtaskState.getManagedKeyedState());
 		assertEquals(StateObjectCollection.singleton(rawKeyedStateHandle), subtaskState.getRawKeyedState());
+		assertEquals(StateObjectCollection.singleton(rawKeyedStateMetaHandle), subtaskState.getRawKeyedStateMeta());
 		assertEquals(StateObjectCollection.singleton(managedOperatorStateHandle), subtaskState.getManagedOperatorState());
 		assertEquals(StateObjectCollection.singleton(rawOperatorStateHandle), subtaskState.getRawOperatorState());
 
 		// check that the state handles have not been discarded
 		verify(managedKeyedStateHandle, never()).discardState();
 		verify(rawKeyedStateHandle, never()).discardState();
+		verify(rawKeyedStateMetaHandle, never()).discardState();
 		verify(managedOperatorStateHandle, never()).discardState();
 		verify(rawOperatorStateHandle, never()).discardState();
 
@@ -583,6 +587,7 @@ public class StreamTaskTest extends TestLogger {
 		// the state handles
 		verify(managedKeyedStateHandle, never()).discardState();
 		verify(rawKeyedStateHandle, never()).discardState();
+		verify(rawKeyedStateMetaHandle, never()).discardState();
 		verify(managedOperatorStateHandle, never()).discardState();
 		verify(rawOperatorStateHandle, never()).discardState();
 	}
@@ -624,12 +629,14 @@ public class StreamTaskTest extends TestLogger {
 
 		KeyedStateHandle managedKeyedStateHandle = mock(KeyedStateHandle.class);
 		KeyedStateHandle rawKeyedStateHandle = mock(KeyedStateHandle.class);
+		OperatorStateHandle rawKeyedStateMetaHandle = mock(OperatorStreamStateHandle.class);
 		OperatorStateHandle managedOperatorStateHandle = mock(OperatorStreamStateHandle.class);
 		OperatorStateHandle rawOperatorStateHandle = mock(OperatorStreamStateHandle.class);
 
 		OperatorSnapshotFutures operatorSnapshotResult = new OperatorSnapshotFutures(
 			DoneFuture.of(SnapshotResult.of(managedKeyedStateHandle)),
 			DoneFuture.of(SnapshotResult.of(rawKeyedStateHandle)),
+			DoneFuture.of(SnapshotResult.of(rawKeyedStateMetaHandle)),
 			DoneFuture.of(SnapshotResult.of(managedOperatorStateHandle)),
 			DoneFuture.of(SnapshotResult.of(rawOperatorStateHandle)));
 
@@ -674,6 +681,7 @@ public class StreamTaskTest extends TestLogger {
 		// check that the state handles have been discarded
 		verify(managedKeyedStateHandle).discardState();
 		verify(rawKeyedStateHandle).discardState();
+		verify(rawKeyedStateMetaHandle).discardState();
 		verify(managedOperatorStateHandle).discardState();
 		verify(rawOperatorStateHandle).discardState();
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TaskCheckpointingBehaviourTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TaskCheckpointingBehaviourTest.java
@@ -74,6 +74,7 @@ import org.apache.flink.runtime.taskmanager.TaskManagerActions;
 import org.apache.flink.runtime.util.EnvironmentInformation;
 import org.apache.flink.runtime.util.TestingTaskManagerRuntimeInfo;
 import org.apache.flink.streaming.api.graph.StreamConfig;
+import org.apache.flink.streaming.api.operators.OperatorSnapshotFutures;
 import org.apache.flink.streaming.api.operators.StreamFilter;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.util.SerializedValue;
@@ -434,7 +435,7 @@ public class TaskCheckpointingBehaviourTest extends TestLogger {
 		}
 
 		@Override
-		public void snapshotState(StateSnapshotContext context) throws Exception {
+		public void snapshotState(StateSnapshotContext context, OperatorSnapshotFutures snapshotInProgress) throws Exception {
 			OperatorStateCheckpointOutputStream outStream = context.getRawOperatorStateOutput();
 
 			IN_CHECKPOINT_LATCH.trigger();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/OperatorSnapshotUtil.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/OperatorSnapshotUtil.java
@@ -19,20 +19,15 @@
 package org.apache.flink.streaming.util;
 
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
-import org.apache.flink.runtime.checkpoint.StateObjectCollection;
 import org.apache.flink.runtime.checkpoint.savepoint.SavepointV1Serializer;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.OperatorStateHandle;
 
-import java.io.DataInputStream;
 import java.io.DataOutputStream;
-import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URL;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 
 /**
  * Util for writing/reading {@link OperatorSubtaskState},
@@ -106,64 +101,6 @@ public class OperatorSnapshotUtil {
 	}
 
 	public static OperatorSubtaskState readStateHandle(String path) throws IOException, ClassNotFoundException {
-		FileInputStream in = new FileInputStream(path);
-		try (DataInputStream dis = new DataInputStream(in)) {
-
-			// required for backwards compatibility.
-			dis.readInt();
-
-			// still required for compatibility to consume the bytes.
-			SavepointV1Serializer.deserializeStreamStateHandle(dis);
-
-			List<OperatorStateHandle> rawOperatorState = null;
-			int numRawOperatorStates = dis.readInt();
-			if (numRawOperatorStates >= 0) {
-				rawOperatorState = new ArrayList<>();
-				for (int i = 0; i < numRawOperatorStates; i++) {
-					OperatorStateHandle operatorState = SavepointV1Serializer.deserializeOperatorStateHandle(
-						dis);
-					rawOperatorState.add(operatorState);
-				}
-			}
-
-			List<OperatorStateHandle> managedOperatorState = null;
-			int numManagedOperatorStates = dis.readInt();
-			if (numManagedOperatorStates >= 0) {
-				managedOperatorState = new ArrayList<>();
-				for (int i = 0; i < numManagedOperatorStates; i++) {
-					OperatorStateHandle operatorState = SavepointV1Serializer.deserializeOperatorStateHandle(
-						dis);
-					managedOperatorState.add(operatorState);
-				}
-			}
-
-			List<KeyedStateHandle> rawKeyedState = null;
-			int numRawKeyedStates = dis.readInt();
-			if (numRawKeyedStates >= 0) {
-				rawKeyedState = new ArrayList<>();
-				for (int i = 0; i < numRawKeyedStates; i++) {
-					KeyedStateHandle keyedState = SavepointV1Serializer.deserializeKeyedStateHandle(
-						dis);
-					rawKeyedState.add(keyedState);
-				}
-			}
-
-			List<KeyedStateHandle> managedKeyedState = null;
-			int numManagedKeyedStates = dis.readInt();
-			if (numManagedKeyedStates >= 0) {
-				managedKeyedState = new ArrayList<>();
-				for (int i = 0; i < numManagedKeyedStates; i++) {
-					KeyedStateHandle keyedState = SavepointV1Serializer.deserializeKeyedStateHandle(
-						dis);
-					managedKeyedState.add(keyedState);
-				}
-			}
-
-			return new OperatorSubtaskState(
-				new StateObjectCollection<>(managedOperatorState),
-				new StateObjectCollection<>(rawOperatorState),
-				new StateObjectCollection<>(managedKeyedState),
-				new StateObjectCollection<>(rawKeyedState));
-		}
+		throw new RuntimeException("break change has made for state, no longer support older version");
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change
This PR is WIP, and is need finish unit tests which are marked as TODO.
It is opened to collect feedback for a proposed solution for FLINK-9182

## Brief change log
1. add one more state called rawkeyedstatemeta, which is help to store verion info of timerservice and tierm size
2. make timer state snapshot async

## Does this pull request potentially affect one of the following parts:
    Dependencies (does it add or upgrade a dependency): (yes / (### no)
    The public API, i.e., is any changed class annotated with @Public(Evolving): (yes / ### no)
    The serializers: (yes / ### no / don't know)
    The runtime per-record code paths (performance sensitive): (yes / ### no / don't know)
    Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (### yes / no / don't know)
    The S3 file system connector: (yes / ### no / don't know)

## Documentation
    Does this pull request introduce a new feature? (yes / ### no)
    If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)


