### PR TITLE
[FLINK-9041] Refactor StreamTaskTest to not use scala and akka

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -452,7 +452,7 @@ under the License.
 			<dependency>
 				<groupId>org.javassist</groupId>
 				<artifactId>javassist</artifactId>
-				<version>3.18.2-GA</version>
+				<version>3.19.0-GA</version>
 			</dependency>
 
 			<!-- joda time is pulled in different versions by different transitive dependencies-->


### PR DESCRIPTION
## What is the purpose of the change

Get rid of scala/akka dependency in StreamTaskTest

## Brief change log

`StreamTaskTest.testEarlyCanceling()` and `StreamTaskTest.TestingExecutionStateListener` are refactored to use java 8 `CompletableFuture` instead of scala `Promise`

## Verifying this change

This change is already covered by existing tests, as it just refactors them.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes: javassist 3.18.2-GA to 3.19.0-GA - [reason](https://github.com/powermock/powermock/issues/729))
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
