### PR TITLE
[FLINK-9256][network] fix NPE in SingleInputGate#updateInputChannel() for non-credit based flow control

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkEnvironment.java
@@ -157,6 +157,10 @@ public class NetworkEnvironment {
 		return partitionRequestMaxBackoff;
 	}
 
+	public boolean isCreditBased() {
+		return enableCreditBased;
+	}
+
 	public KvStateRegistry getKvStateRegistry() {
 		return kvStateRegistry;
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NetworkEnvironmentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NetworkEnvironmentTest.java
@@ -329,7 +329,7 @@ public class NetworkEnvironmentTest {
 	 *
 	 * @return input gate with some fake settings
 	 */
-	private static SingleInputGate createSingleInputGate(
+	private SingleInputGate createSingleInputGate(
 			final ResultPartitionType partitionType, final int channels) {
 		return spy(new SingleInputGate(
 			"Test Task Name",
@@ -339,7 +339,8 @@ public class NetworkEnvironmentTest {
 			0,
 			channels,
 			mock(TaskActions.class),
-			UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup()));
+			UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup(),
+			enableCreditBasedFlowControl));
 	}
 
 	private static void createRemoteInputChannel(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientHandlerTest.java
@@ -221,7 +221,8 @@ public class PartitionRequestClientHandlerTest {
 			0,
 			1,
 			mock(TaskActions.class),
-			UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup());
+			UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup(),
+			true);
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputGateConcurrentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputGateConcurrentTest.java
@@ -66,7 +66,8 @@ public class InputGateConcurrentTest {
 				new IntermediateDataSetID(), ResultPartitionType.PIPELINED,
 				0, numChannels,
 				mock(TaskActions.class),
-				UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup());
+				UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup(),
+				true);
 
 		for (int i = 0; i < numChannels; i++) {
 			LocalInputChannel channel = new LocalInputChannel(gate, i, new ResultPartitionID(),
@@ -102,7 +103,8 @@ public class InputGateConcurrentTest {
 				0,
 				numChannels,
 				mock(TaskActions.class),
-				UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup());
+				UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup(),
+				true);
 
 		for (int i = 0; i < numChannels; i++) {
 			RemoteInputChannel channel = new RemoteInputChannel(
@@ -151,7 +153,8 @@ public class InputGateConcurrentTest {
 				0,
 				numChannels,
 				mock(TaskActions.class),
-				UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup());
+				UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup(),
+				true);
 
 		for (int i = 0, local = 0; i < numChannels; i++) {
 			if (localOrRemote.get(i)) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputGateFairnessTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputGateFairnessTest.java
@@ -93,7 +93,8 @@ public class InputGateFairnessTest {
 				new IntermediateDataSetID(),
 				0, numChannels,
 				mock(TaskActions.class),
-				UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup());
+				UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup(),
+				true);
 
 		for (int i = 0; i < numChannels; i++) {
 			LocalInputChannel channel = new LocalInputChannel(gate, i, new ResultPartitionID(),
@@ -146,7 +147,8 @@ public class InputGateFairnessTest {
 				new IntermediateDataSetID(),
 				0, numChannels,
 				mock(TaskActions.class),
-				UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup());
+				UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup(),
+				true);
 
 			for (int i = 0; i < numChannels; i++) {
 				LocalInputChannel channel = new LocalInputChannel(gate, i, new ResultPartitionID(),
@@ -196,7 +198,8 @@ public class InputGateFairnessTest {
 				new IntermediateDataSetID(),
 				0, numChannels,
 				mock(TaskActions.class),
-				UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup());
+				UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup(),
+				true);
 
 		final ConnectionManager connManager = createDummyConnectionManager();
 
@@ -251,7 +254,8 @@ public class InputGateFairnessTest {
 				new IntermediateDataSetID(),
 				0, numChannels,
 				mock(TaskActions.class),
-				UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup());
+				UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup(),
+				true);
 
 		final ConnectionManager connManager = createDummyConnectionManager();
 
@@ -349,11 +353,12 @@ public class InputGateFairnessTest {
 				int consumedSubpartitionIndex,
 				int numberOfInputChannels,
 				TaskActions taskActions,
-				TaskIOMetricGroup metrics) {
+				TaskIOMetricGroup metrics,
+				boolean isCreditBased) {
 
 			super(owningTaskName, jobId, consumedResultId, ResultPartitionType.PIPELINED,
 				consumedSubpartitionIndex,
-					numberOfInputChannels, taskActions, metrics);
+					numberOfInputChannels, taskActions, metrics, isCreditBased);
 
 			try {
 				Field f = SingleInputGate.class.getDeclaredField("inputChannelsWithData");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
@@ -293,7 +293,8 @@ public class LocalInputChannelTest {
 			0,
 			1,
 			mock(TaskActions.class),
-			UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup()
+			UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup(),
+			true
 		);
 
 		ResultPartitionManager partitionManager = mock(ResultPartitionManager.class);
@@ -490,7 +491,8 @@ public class LocalInputChannelTest {
 					subpartitionIndex,
 					numberOfInputChannels,
 					mock(TaskActions.class),
-					UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup());
+					UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup(),
+					true);
 
 			// Set buffer pool
 			inputGate.setBufferPool(bufferPool);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
@@ -889,7 +889,8 @@ public class RemoteInputChannelTest {
 			0,
 			1,
 			mock(TaskActions.class),
-			UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup());
+			UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup(),
+			true);
 	}
 
 	private RemoteInputChannel createRemoteInputChannel(SingleInputGate inputGate)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
@@ -19,13 +19,13 @@
 package org.apache.flink.runtime.io.network.partition.consumer;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.runtime.deployment.InputChannelDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.ResultPartitionLocation;
 import org.apache.flink.runtime.event.TaskEvent;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.network.ConnectionID;
 import org.apache.flink.runtime.io.network.ConnectionManager;
 import org.apache.flink.runtime.io.network.LocalConnectionManager;
@@ -45,30 +45,50 @@ import org.apache.flink.runtime.io.network.util.TestTaskEvent;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
+import org.apache.flink.runtime.query.KvStateRegistry;
 import org.apache.flink.runtime.taskmanager.TaskActions;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyListOf;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+/**
+ * Tests for {@link SingleInputGate}.
+ */
+@RunWith(Parameterized.class)
 public class SingleInputGateTest {
+
+	@Parameterized.Parameter
+	public boolean enableCreditBasedFlowControl;
+
+	@Parameterized.Parameters(name = "Credit-based = {0}")
+	public static List<Boolean> parameters() {
+		return Arrays.asList(Boolean.TRUE, Boolean.FALSE);
+	}
 
 	/**
 	 * Tests basic correctness of buffer-or-event interleaving and correct <code>null</code> return
@@ -324,12 +344,7 @@ public class SingleInputGateTest {
 		int initialBackoff = 137;
 		int maxBackoff = 1001;
 
-		NetworkEnvironment netEnv = mock(NetworkEnvironment.class);
-		when(netEnv.getResultPartitionManager()).thenReturn(new ResultPartitionManager());
-		when(netEnv.getTaskEventDispatcher()).thenReturn(new TaskEventDispatcher());
-		when(netEnv.getPartitionRequestInitialBackoff()).thenReturn(initialBackoff);
-		when(netEnv.getPartitionRequestMaxBackoff()).thenReturn(maxBackoff);
-		when(netEnv.getConnectionManager()).thenReturn(new LocalConnectionManager());
+		final NetworkEnvironment netEnv = createNetworkEnvironment(2, 8, initialBackoff, maxBackoff);
 
 		SingleInputGate gate = SingleInputGate.create(
 			"TestTask",
@@ -340,37 +355,43 @@ public class SingleInputGateTest {
 			mock(TaskActions.class),
 			UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup());
 
-		assertEquals(gateDesc.getConsumedPartitionType(), gate.getConsumedPartitionType());
+		try {
+			assertEquals(gateDesc.getConsumedPartitionType(), gate.getConsumedPartitionType());
 
-		Map<IntermediateResultPartitionID, InputChannel> channelMap = gate.getInputChannels();
+			Map<IntermediateResultPartitionID, InputChannel> channelMap = gate.getInputChannels();
 
-		assertEquals(3, channelMap.size());
-		InputChannel localChannel = channelMap.get(partitionIds[0].getPartitionId());
-		assertEquals(LocalInputChannel.class, localChannel.getClass());
+			assertEquals(3, channelMap.size());
+			InputChannel localChannel = channelMap.get(partitionIds[0].getPartitionId());
+			assertEquals(LocalInputChannel.class, localChannel.getClass());
 
-		InputChannel remoteChannel = channelMap.get(partitionIds[1].getPartitionId());
-		assertEquals(RemoteInputChannel.class, remoteChannel.getClass());
+			InputChannel remoteChannel = channelMap.get(partitionIds[1].getPartitionId());
+			assertEquals(RemoteInputChannel.class, remoteChannel.getClass());
 
-		InputChannel unknownChannel = channelMap.get(partitionIds[2].getPartitionId());
-		assertEquals(UnknownInputChannel.class, unknownChannel.getClass());
+			InputChannel unknownChannel = channelMap.get(partitionIds[2].getPartitionId());
+			assertEquals(UnknownInputChannel.class, unknownChannel.getClass());
 
-		InputChannel[] channels = new InputChannel[]{localChannel, remoteChannel, unknownChannel};
-		for (InputChannel ch : channels) {
-			assertEquals(0, ch.getCurrentBackoff());
+			InputChannel[] channels =
+				new InputChannel[] {localChannel, remoteChannel, unknownChannel};
+			for (InputChannel ch : channels) {
+				assertEquals(0, ch.getCurrentBackoff());
 
-			assertTrue(ch.increaseBackoff());
-			assertEquals(initialBackoff, ch.getCurrentBackoff());
+				assertTrue(ch.increaseBackoff());
+				assertEquals(initialBackoff, ch.getCurrentBackoff());
 
-			assertTrue(ch.increaseBackoff());
-			assertEquals(initialBackoff * 2, ch.getCurrentBackoff());
+				assertTrue(ch.increaseBackoff());
+				assertEquals(initialBackoff * 2, ch.getCurrentBackoff());
 
-			assertTrue(ch.increaseBackoff());
-			assertEquals(initialBackoff * 2 * 2, ch.getCurrentBackoff());
+				assertTrue(ch.increaseBackoff());
+				assertEquals(initialBackoff * 2 * 2, ch.getCurrentBackoff());
 
-			assertTrue(ch.increaseBackoff());
-			assertEquals(maxBackoff, ch.getCurrentBackoff());
+				assertTrue(ch.increaseBackoff());
+				assertEquals(maxBackoff, ch.getCurrentBackoff());
 
-			assertFalse(ch.increaseBackoff());
+				assertFalse(ch.increaseBackoff());
+			}
+		} finally {
+			gate.releaseAllResources();
+			netEnv.shutdown();
 		}
 	}
 
@@ -379,26 +400,39 @@ public class SingleInputGateTest {
 	 */
 	@Test
 	public void testRequestBuffersWithRemoteInputChannel() throws Exception {
-		final SingleInputGate inputGate = new SingleInputGate(
-			"t1",
-			new JobID(),
-			new IntermediateDataSetID(),
-			ResultPartitionType.PIPELINED_BOUNDED,
-			0,
-			1,
-			mock(TaskActions.class),
-			UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup());
+		final SingleInputGate inputGate = createInputGate(1, ResultPartitionType.PIPELINED_BOUNDED);
+		int buffersPerChannel = 2;
+		int extraNetworkBuffersPerGate = 8;
+		final NetworkEnvironment network = createNetworkEnvironment(buffersPerChannel,
+			extraNetworkBuffersPerGate, 0, 0);
 
-		RemoteInputChannel remote = mock(RemoteInputChannel.class);
-		inputGate.setInputChannel(new IntermediateResultPartitionID(), remote);
+		try {
+			final ResultPartitionID resultPartitionId = new ResultPartitionID();
+			final ConnectionID connectionId = new ConnectionID(new InetSocketAddress("localhost", 5000), 0);
+			addRemoteInputChannel(network, inputGate, connectionId, resultPartitionId, 0);
 
-		final int buffersPerChannel = 2;
-		NetworkBufferPool network = mock(NetworkBufferPool.class);
-		// Trigger requests of segments from global pool and assign buffers to remote input channel
-		inputGate.assignExclusiveSegments(network, buffersPerChannel);
+			network.setupInputGate(inputGate);
 
-		verify(network, times(1)).requestMemorySegments(buffersPerChannel);
-		verify(remote, times(1)).assignExclusiveSegments(anyListOf(MemorySegment.class));
+			NetworkBufferPool bufferPool = network.getNetworkBufferPool();
+			if (enableCreditBasedFlowControl) {
+				verify(bufferPool,
+					times(1)).requestMemorySegments(buffersPerChannel);
+				RemoteInputChannel remote = (RemoteInputChannel) inputGate.getInputChannels()
+					.get(resultPartitionId.getPartitionId());
+				// only the exclusive buffers should be assigned/available now
+				assertEquals(buffersPerChannel, remote.getNumberOfAvailableBuffers());
+
+				assertEquals(bufferPool.getTotalNumberOfMemorySegments() - buffersPerChannel,
+					bufferPool.getNumberOfAvailableMemorySegments());
+				// note: exclusive buffers are not handed out into LocalBufferPool and are thus not counted
+				assertEquals(extraNetworkBuffersPerGate, bufferPool.countBuffers());
+			} else {
+				assertEquals(buffersPerChannel + extraNetworkBuffersPerGate, bufferPool.countBuffers());
+			}
+		} finally {
+			inputGate.releaseAllResources();
+			network.shutdown();
+		}
 	}
 
 	/**
@@ -407,49 +441,193 @@ public class SingleInputGateTest {
 	 */
 	@Test
 	public void testRequestBuffersWithUnknownInputChannel() throws Exception {
-		final SingleInputGate inputGate = createInputGate(1);
+		final SingleInputGate inputGate = createInputGate(1, ResultPartitionType.PIPELINED_BOUNDED);
+		int buffersPerChannel = 2;
+		int extraNetworkBuffersPerGate = 8;
+		final NetworkEnvironment network = createNetworkEnvironment(buffersPerChannel, extraNetworkBuffersPerGate, 0, 0);
 
-		UnknownInputChannel unknown = mock(UnknownInputChannel.class);
-		final ResultPartitionID resultPartitionId = new ResultPartitionID();
-		inputGate.setInputChannel(resultPartitionId.getPartitionId(), unknown);
+		try {
+			final ResultPartitionID resultPartitionId = new ResultPartitionID();
+			addUnknownInputChannel(network, inputGate, resultPartitionId, 0);
 
-		RemoteInputChannel remote = mock(RemoteInputChannel.class);
-		final ConnectionID connectionId = new ConnectionID(new InetSocketAddress("localhost", 5000), 0);
-		when(unknown.toRemoteInputChannel(connectionId)).thenReturn(remote);
+			network.setupInputGate(inputGate);
+			NetworkBufferPool bufferPool = network.getNetworkBufferPool();
 
-		final int buffersPerChannel = 2;
-		NetworkBufferPool network = mock(NetworkBufferPool.class);
-		inputGate.assignExclusiveSegments(network, buffersPerChannel);
+			if (enableCreditBasedFlowControl) {
+				verify(bufferPool, times(0)).requestMemorySegments(buffersPerChannel);
 
-		// Trigger updates to remote input channel from unknown input channel
-		inputGate.updateInputChannel(new InputChannelDeploymentDescriptor(
-			resultPartitionId,
-			ResultPartitionLocation.createRemote(connectionId)));
+				assertEquals(bufferPool.getTotalNumberOfMemorySegments(),
+					bufferPool.getNumberOfAvailableMemorySegments());
+				// note: exclusive buffers are not handed out into LocalBufferPool and are thus not counted
+				assertEquals(extraNetworkBuffersPerGate, bufferPool.countBuffers());
+			} else {
+				assertEquals(buffersPerChannel + extraNetworkBuffersPerGate, bufferPool.countBuffers());
+			}
 
-		verify(network, times(1)).requestMemorySegments(buffersPerChannel);
-		verify(remote, times(1)).assignExclusiveSegments(anyListOf(MemorySegment.class));
+			// Trigger updates to remote input channel from unknown input channel
+			final ConnectionID connectionId = new ConnectionID(new InetSocketAddress("localhost", 5000), 0);
+			inputGate.updateInputChannel(new InputChannelDeploymentDescriptor(
+				resultPartitionId,
+				ResultPartitionLocation.createRemote(connectionId)));
+
+			if (enableCreditBasedFlowControl) {
+				verify(bufferPool,
+					times(1)).requestMemorySegments(buffersPerChannel);
+				RemoteInputChannel remote = (RemoteInputChannel) inputGate.getInputChannels()
+					.get(resultPartitionId.getPartitionId());
+				// only the exclusive buffers should be assigned/available now
+				assertEquals(buffersPerChannel, remote.getNumberOfAvailableBuffers());
+
+				assertEquals(bufferPool.getTotalNumberOfMemorySegments() - buffersPerChannel,
+					bufferPool.getNumberOfAvailableMemorySegments());
+				// note: exclusive buffers are not handed out into LocalBufferPool and are thus not counted
+				assertEquals(extraNetworkBuffersPerGate, bufferPool.countBuffers());
+			} else {
+				assertEquals(buffersPerChannel + extraNetworkBuffersPerGate, bufferPool.countBuffers());
+			}
+		} finally {
+			inputGate.releaseAllResources();
+			network.shutdown();
+		}
+	}
+
+	/**
+	 * Tests that input gate can successfully convert unknown input channels into local and remote
+	 * channels.
+	 */
+	@Test
+	public void testUpdateUnknownInputChannel() throws Exception {
+		final SingleInputGate inputGate = createInputGate(2);
+		int buffersPerChannel = 2;
+		final NetworkEnvironment network = createNetworkEnvironment(buffersPerChannel, 8, 0, 0);
+
+		try {
+			final ResultPartitionID localResultPartitionId = new ResultPartitionID();
+			addUnknownInputChannel(network, inputGate, localResultPartitionId, 0);
+
+			final ResultPartitionID remoteResultPartitionId = new ResultPartitionID();
+			addUnknownInputChannel(network, inputGate, remoteResultPartitionId, 1);
+
+			network.setupInputGate(inputGate);
+
+			assertThat(inputGate.getInputChannels().get(remoteResultPartitionId.getPartitionId()),
+				is(instanceOf((UnknownInputChannel.class))));
+			assertThat(inputGate.getInputChannels().get(localResultPartitionId.getPartitionId()),
+				is(instanceOf((UnknownInputChannel.class))));
+
+			// Trigger updates to remote input channel from unknown input channel
+			final ConnectionID remoteConnectionId = new ConnectionID(new InetSocketAddress("localhost", 5000), 0);
+			inputGate.updateInputChannel(new InputChannelDeploymentDescriptor(
+				remoteResultPartitionId,
+				ResultPartitionLocation.createRemote(remoteConnectionId)));
+
+			assertThat(inputGate.getInputChannels().get(remoteResultPartitionId.getPartitionId()),
+				is(instanceOf((RemoteInputChannel.class))));
+			assertThat(inputGate.getInputChannels().get(localResultPartitionId.getPartitionId()),
+				is(instanceOf((UnknownInputChannel.class))));
+
+			// Trigger updates to local input channel from unknown input channel
+			inputGate.updateInputChannel(new InputChannelDeploymentDescriptor(
+				localResultPartitionId,
+				ResultPartitionLocation.createLocal()));
+
+			assertThat(inputGate.getInputChannels().get(remoteResultPartitionId.getPartitionId()),
+				is(instanceOf((RemoteInputChannel.class))));
+			assertThat(inputGate.getInputChannels().get(localResultPartitionId.getPartitionId()),
+				is(instanceOf((LocalInputChannel.class))));
+		} finally {
+			inputGate.releaseAllResources();
+			network.shutdown();
+		}
 	}
 
 	// ---------------------------------------------------------------------------------------------
 
-	private static SingleInputGate createInputGate() {
+	private NetworkEnvironment createNetworkEnvironment(
+			int buffersPerChannel,
+			int extraNetworkBuffersPerGate,
+			int initialBackoff,
+			int maxBackoff) {
+		return new NetworkEnvironment(
+			spy(new NetworkBufferPool(100, 32)),
+			new LocalConnectionManager(),
+			new ResultPartitionManager(),
+			new TaskEventDispatcher(),
+			new KvStateRegistry(),
+			null,
+			null,
+			IOManager.IOMode.SYNC,
+			initialBackoff,
+			maxBackoff,
+			buffersPerChannel,
+			extraNetworkBuffersPerGate,
+			enableCreditBasedFlowControl);
+	}
+
+	private SingleInputGate createInputGate() {
 		return createInputGate(2);
 	}
 
-	private static SingleInputGate createInputGate(int numberOfInputChannels) {
+	private SingleInputGate createInputGate(int numberOfInputChannels) {
+		return createInputGate(numberOfInputChannels, ResultPartitionType.PIPELINED);
+	}
+
+	private SingleInputGate createInputGate(
+			int numberOfInputChannels, ResultPartitionType partitionType) {
 		SingleInputGate inputGate = new SingleInputGate(
 			"Test Task Name",
 			new JobID(),
 			new IntermediateDataSetID(),
-			ResultPartitionType.PIPELINED,
+			partitionType,
 			0,
 			numberOfInputChannels,
 			mock(TaskActions.class),
-			UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup());
+			UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup(),
+			enableCreditBasedFlowControl);
 
-		assertEquals(ResultPartitionType.PIPELINED, inputGate.getConsumedPartitionType());
+		assertEquals(partitionType, inputGate.getConsumedPartitionType());
 
 		return inputGate;
+	}
+
+	private void addUnknownInputChannel(
+			NetworkEnvironment network,
+			SingleInputGate inputGate,
+			ResultPartitionID partitionId,
+			int channelIndex) {
+		UnknownInputChannel unknown =
+			createUnknownInputChannel(network, inputGate, partitionId, channelIndex);
+		inputGate.setInputChannel(partitionId.getPartitionId(), unknown);
+	}
+
+	private UnknownInputChannel createUnknownInputChannel(
+			NetworkEnvironment network,
+			SingleInputGate inputGate,
+			ResultPartitionID partitionId,
+			int channelIndex) {
+		return new UnknownInputChannel(
+			inputGate,
+			channelIndex,
+			partitionId,
+			network.getResultPartitionManager(),
+			network.getTaskEventDispatcher(),
+			network.getConnectionManager(),
+			network.getPartitionRequestInitialBackoff(),
+			network.getPartitionRequestMaxBackoff(),
+			UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup()
+		);
+	}
+
+	private void addRemoteInputChannel(
+			NetworkEnvironment network,
+			SingleInputGate inputGate,
+			ConnectionID connectionId,
+			ResultPartitionID partitionId,
+			int channelIndex) {
+		RemoteInputChannel remote =
+			createUnknownInputChannel(network, inputGate, partitionId, channelIndex)
+				.toRemoteInputChannel(connectionId);
+		inputGate.setInputChannel(partitionId.getPartitionId(), remote);
 	}
 
 	static void verifyBufferOrEvent(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/TestSingleInputGate.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/TestSingleInputGate.java
@@ -60,7 +60,8 @@ public class TestSingleInputGate {
 			0,
 			numberOfInputChannels,
 			mock(TaskActions.class),
-			UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup());
+			UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup(),
+			true);
 
 		this.inputGate = spy(realGate);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGateTest.java
@@ -50,13 +50,15 @@ public class UnionInputGateTest {
 			new IntermediateDataSetID(), ResultPartitionType.PIPELINED,
 			0, 3,
 			mock(TaskActions.class),
-			UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup());
+			UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup(),
+			true);
 		final SingleInputGate ig2 = new SingleInputGate(
 			testTaskName, new JobID(),
 			new IntermediateDataSetID(), ResultPartitionType.PIPELINED,
 			0, 5,
 			mock(TaskActions.class),
-			UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup());
+			UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup(),
+			true);
 
 		final UnionInputGate union = new UnionInputGate(new SingleInputGate[]{ig1, ig2});
 


### PR DESCRIPTION
## What is the purpose of the change

`SingleInputGate#updateInputChannel()` fails to update an unknown into a remote partition without credit based flow control due to a `NullPointerException` resulting from `networkBufferPool == null`.

## Brief change log

- make `SingleInputGate` aware of credit-based flow control
- only try to assign exclusive buffers in `SingleInputGate` if credit-based
- replace some Mockito use in `SingleInputGateTest`

## Verifying this change

This change added tests and can be verified as follows:

- extend `SingleInputGateTest` with credit and non-credit based test variants
- add a test for `SingleInputGate#updateInputChannel()` in both modes

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
