### PR TITLE
[FLINK-9243][tests] fix flaky SuccessAfterNetworkBuffersFailureITCase

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/misc/SuccessAfterNetworkBuffersFailureITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/misc/SuccessAfterNetworkBuffersFailureITCase.java
@@ -134,13 +134,17 @@ public class SuccessAfterNetworkBuffersFailureITCase extends TestLogger {
 		// set number of bulk iterations for KMeans algorithm
 		IterativeDataSet<KMeans.Centroid> loop = centroids.iterate(20);
 
+		// add some re-partitions to increase network buffer use
 		DataSet<KMeans.Centroid> newCentroids = points
+				.rebalance()
 				// compute closest centroid for each point
 				.map(new KMeans.SelectNearestCenter()).withBroadcastSet(loop, "centroids")
-						// count and sum point coordinates for each centroid
+				.rebalance()
+				// count and sum point coordinates for each centroid
 				.map(new KMeans.CountAppender())
 				.groupBy(0).reduce(new KMeans.CentroidAccumulator())
-						// compute new centroids from point counts and coordinate sums
+				// compute new centroids from point counts and coordinate sums
+				.rebalance()
 				.map(new KMeans.CentroidAverager());
 
 		// feed new centroids back into next iteration


### PR DESCRIPTION
this adds some `rebalance()` operations into `SuccessAfterNetworkBuffersFailureITCase#runKMeans` which should be set up to fail and at the same time allow `#runConnectedComponents()` to succeed. It appears, these two have been too close together regarding network buffer use before.

I ran the test 500 times locally and it always succeeded now.