### PR TITLE
[hotfix][tests] remove redundant rebalance in SuccessAfterNetworkBuffersFailureITCase

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/misc/SuccessAfterNetworkBuffersFailureITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/misc/SuccessAfterNetworkBuffersFailureITCase.java
@@ -136,7 +136,6 @@ public class SuccessAfterNetworkBuffersFailureITCase extends TestLogger {
 
 		// add some re-partitions to increase network buffer use
 		DataSet<KMeans.Centroid> newCentroids = points
-				.rebalance()
 				// compute closest centroid for each point
 				.map(new KMeans.SelectNearestCenter()).withBroadcastSet(loop, "centroids")
 				.rebalance()


### PR DESCRIPTION
This removes a redundant `rebalance()` operation introduced by #5915.