### PR TITLE
[FLINK-9231] [web] Enable SO_REUSEADDR on listen sockets for WebFront…

### DIFF
--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/utils/WebFrontendBootstrap.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/utils/WebFrontendBootstrap.java
@@ -29,6 +29,7 @@ import org.apache.flink.shaded.netty4.io.netty.bootstrap.ServerBootstrap;
 import org.apache.flink.shaded.netty4.io.netty.channel.Channel;
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelFuture;
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelInitializer;
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelOption;
 import org.apache.flink.shaded.netty4.io.netty.channel.nio.NioEventLoopGroup;
 import org.apache.flink.shaded.netty4.io.netty.channel.socket.SocketChannel;
 import org.apache.flink.shaded.netty4.io.netty.channel.socket.nio.NioServerSocketChannel;
@@ -103,7 +104,8 @@ public class WebFrontendBootstrap {
 		this.bootstrap
 			.group(bossGroup, workerGroup)
 			.channel(NioServerSocketChannel.class)
-			.childHandler(initializer);
+			.childHandler(initializer)
+			.option(ChannelOption.SO_REUSEADDR, true);
 
 		ChannelFuture ch;
 		if (configuredAddress == null) {


### PR DESCRIPTION
## What is the purpose of the change

Enable SO_REUSEADDR on listen sockets for WebFrontendBootstrap,This allows sockets to be bound even if there are sockets from a previous application that are still pending closure. so we can restart the application at once

## Brief change log

Enable SO_REUSEADDR on listen sockets for WebFrontendBootstrap, so we add option ChannelOption.SO_REUSEADDR, true for ServerBootstrap.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? ( not documented)
