### PR TITLE
[FLINK-9253][network] make the maximum floating buffers count channel-type independent

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferPool.java
@@ -34,7 +34,7 @@ public interface BufferPool extends BufferProvider, BufferRecycler {
 	/**
 	 * Destroys this buffer pool.
 	 *
-	 * <p> If not all buffers are available, they are recycled lazily as soon as they are recycled.
+	 * <p>If not all buffers are available, they are recycled lazily as soon as they are recycled.
 	 */
 	void lazyDestroy();
 
@@ -50,7 +50,7 @@ public interface BufferPool extends BufferProvider, BufferRecycler {
 	int getNumberOfRequiredMemorySegments();
 
 	/**
-	 * Returns the maximum number of memory segments this buffer pool should use
+	 * Returns the maximum number of memory segments this buffer pool should use.
 	 *
 	 * @return maximum number of memory segments to use or <tt>-1</tt> if unlimited
 	 */
@@ -59,14 +59,14 @@ public interface BufferPool extends BufferProvider, BufferRecycler {
 	/**
 	 * Returns the current size of this buffer pool.
 	 *
-	 * <p> The size of the buffer pool can change dynamically at runtime.
+	 * <p>The size of the buffer pool can change dynamically at runtime.
 	 */
 	int getNumBuffers();
 
 	/**
 	 * Sets the current size of this buffer pool.
 	 *
-	 * <p> The size needs to be greater or equal to the guaranteed number of memory segments.
+	 * <p>The size needs to be greater or equal to the guaranteed number of memory segments.
 	 */
 	void setNumBuffers(int numBuffers) throws IOException;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferPool.java
@@ -18,7 +18,10 @@
 
 package org.apache.flink.runtime.io.network.buffer;
 
+import org.apache.flink.core.memory.MemorySegment;
+
 import java.io.IOException;
+import java.util.List;
 
 /**
  * A dynamically sized buffer pool.
@@ -79,4 +82,9 @@ public interface BufferPool extends BufferProvider, BufferRecycler {
 	 * Returns the number of used buffers of this buffer pool.
 	 */
 	int bestEffortGetNumOfUsedBuffers();
+
+	/**
+	 * Adds extra memory segments to the pool and increases the allowed maximum accordingly.
+	 */
+	void addExtraSegments(List<MemorySegment> segments);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
@@ -180,6 +180,12 @@ public class NetworkBufferPool implements BufferPoolFactory {
 		}
 	}
 
+	void decreaseTotalRequiredBuffers(int count) {
+		synchronized (factoryLock) {
+			numTotalRequiredBuffers -= count;
+		}
+	}
+
 	public void destroy() {
 		synchronized (factoryLock) {
 			isDestroyed = true;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannel.java
@@ -22,6 +22,7 @@ import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.event.TaskEvent;
 import org.apache.flink.runtime.execution.CancelTaskException;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultSubpartitionView;
 
@@ -124,6 +125,15 @@ public abstract class InputChannel {
 	// ------------------------------------------------------------------------
 	// Consume
 	// ------------------------------------------------------------------------
+
+	/**
+	 * Assigns exclusive buffers to this input channel, and this method should be called only once
+	 * after this input channel is created.
+	 *
+	 * @return number of assigned memory segments
+	 */
+	abstract int assignExclusiveSegments(NetworkBufferPool networkBufferPool, int networkBuffersPerChannel)
+		throws IOException;
 
 	/**
 	 * Requests the queue with the specified index of the source intermediate

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
@@ -57,7 +57,7 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
 	/** Task event dispatcher for backwards events. */
 	private final TaskEventDispatcher taskEventDispatcher;
 
-	/** The consumed subpartition */
+	/** The consumed subpartition. */
 	private volatile ResultSubpartitionView subpartitionView;
 
 	private volatile boolean isReleased;
@@ -244,7 +244,7 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
 	}
 
 	/**
-	 * Releases the partition reader
+	 * Releases the partition reader.
 	 */
 	@Override
 	void releaseAllResources() throws IOException {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.io.network.partition.consumer;
 import org.apache.flink.runtime.event.TaskEvent;
 import org.apache.flink.runtime.execution.CancelTaskException;
 import org.apache.flink.runtime.io.network.TaskEventDispatcher;
+import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
 import org.apache.flink.runtime.io.network.partition.BufferAvailabilityListener;
 import org.apache.flink.runtime.io.network.partition.PartitionNotFoundException;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
@@ -88,6 +89,12 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
 
 		this.partitionManager = checkNotNull(partitionManager);
 		this.taskEventDispatcher = checkNotNull(taskEventDispatcher);
+	}
+
+	@Override
+	int assignExclusiveSegments(NetworkBufferPool networkBufferPool, int networkBuffersPerChannel) {
+		// not needed for local channels
+		return 0;
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -62,10 +62,10 @@ import static org.apache.flink.util.Preconditions.checkState;
 /**
  * An input gate consumes one or more partitions of a single produced intermediate result.
  *
- * <p> Each intermediate result is partitioned over its producing parallel subtasks; each of these
+ * <p>Each intermediate result is partitioned over its producing parallel subtasks; each of these
  * partitions is furthermore partitioned into one or more subpartitions.
  *
- * <p> As an example, consider a map-reduce program, where the map operator produces data and the
+ * <p>As an example, consider a map-reduce program, where the map operator produces data and the
  * reduce operator consumes the produced data.
  *
  * <pre>{@code
@@ -74,7 +74,7 @@ import static org.apache.flink.util.Preconditions.checkState;
  * +-----+              +---------------------+              +--------+
  * }</pre>
  *
- * <p> When deploying such a program in parallel, the intermediate result will be partitioned over its
+ * <p>When deploying such a program in parallel, the intermediate result will be partitioned over its
  * producing parallel subtasks; each of these partitions is furthermore partitioned into one or more
  * subpartitions.
  *
@@ -95,7 +95,7 @@ import static org.apache.flink.util.Preconditions.checkState;
  *               +-----------------------------------------+
  * }</pre>
  *
- * <p> In the above example, two map subtasks produce the intermediate result in parallel, resulting
+ * <p>In the above example, two map subtasks produce the intermediate result in parallel, resulting
  * in two partitions (Partition 1 and 2). Each of these partitions is further partitioned into two
  * subpartitions -- one for each parallel reduce subtask.
  */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnknownInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnknownInputChannel.java
@@ -18,13 +18,13 @@
 
 package org.apache.flink.runtime.io.network.partition.consumer;
 
-import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
 import org.apache.flink.runtime.event.TaskEvent;
 import org.apache.flink.runtime.io.network.ConnectionID;
 import org.apache.flink.runtime.io.network.ConnectionManager;
 import org.apache.flink.runtime.io.network.TaskEventDispatcher;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionManager;
+import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
 
 import java.io.IOException;
 import java.util.Optional;
@@ -89,8 +89,8 @@ class UnknownInputChannel extends InputChannel {
 
 	/**
 	 * Returns <code>false</code>.
-	 * <p>
-	 * <strong>Important</strong>: It is important that the method correctly
+	 *
+	 * <p><strong>Important</strong>: It is important that the method correctly
 	 * always <code>false</code> for unknown input channels in order to not
 	 * finish the consumption of an intermediate result partition early.
 	 */

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NetworkEnvironmentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NetworkEnvironmentTest.java
@@ -136,8 +136,10 @@ public class NetworkEnvironmentTest {
 
 		assertEquals(Integer.MAX_VALUE, ig1.getBufferPool().getMaxNumberOfMemorySegments());
 		assertEquals(Integer.MAX_VALUE, ig2.getBufferPool().getMaxNumberOfMemorySegments());
-		assertEquals(enableCreditBasedFlowControl ? 8 : 2 * 2 + 8, ig3.getBufferPool().getMaxNumberOfMemorySegments());
-		assertEquals(enableCreditBasedFlowControl ? 8 : 8 * 2 + 8, ig4.getBufferPool().getMaxNumberOfMemorySegments());
+		// note: credit-based assigns exclusive buffers to (remote) channels but we did not set up
+		//       any channels, therefore, all buffers will be floating buffers
+		assertEquals(2 * 2 + 8, ig3.getBufferPool().getMaxNumberOfMemorySegments());
+		assertEquals(8 * 2 + 8, ig4.getBufferPool().getMaxNumberOfMemorySegments());
 
 		int invokations = enableCreditBasedFlowControl ? 1 : 0;
 		verify(ig1, times(invokations)).assignExclusiveSegments(network.getNetworkBufferPool(), 2);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannelTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.io.network.partition.consumer;
 
 import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.runtime.event.TaskEvent;
+import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.junit.Test;
 
@@ -121,6 +122,12 @@ public class InputChannelTest {
 			int maxBackoff) {
 
 			super(inputGate, channelIndex, partitionId, initialBackoff, maxBackoff, new SimpleCounter());
+		}
+
+		@Override
+		int assignExclusiveSegments(NetworkBufferPool networkBufferPool, int networkBuffersPerChannel)
+				throws IOException {
+			return 0;
 		}
 
 		@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
@@ -454,14 +454,15 @@ public class SingleInputGateTest {
 			NetworkBufferPool bufferPool = network.getNetworkBufferPool();
 
 			if (enableCreditBasedFlowControl) {
-				verify(bufferPool, times(0)).requestMemorySegments(buffersPerChannel);
+				verify(bufferPool, times(1)).requestMemorySegments(buffersPerChannel);
 
-				assertEquals(bufferPool.getTotalNumberOfMemorySegments(),
+				assertEquals(bufferPool.getTotalNumberOfMemorySegments() - buffersPerChannel,
 					bufferPool.getNumberOfAvailableMemorySegments());
 				// note: exclusive buffers are not handed out into LocalBufferPool and are thus not counted
 				assertEquals(extraNetworkBuffersPerGate, bufferPool.countBuffers());
 			} else {
-				assertEquals(buffersPerChannel + extraNetworkBuffersPerGate, bufferPool.countBuffers());
+				assertEquals(buffersPerChannel + extraNetworkBuffersPerGate,
+					bufferPool.countBuffers());
 			}
 
 			// Trigger updates to remote input channel from unknown input channel


### PR DESCRIPTION
## What is the purpose of the change

The credit-based flow control path assigns exclusive buffers only to remote channels (which makes sense since local channels don't use any own buffers). However, this is a bit intransparent with respect to how much data may be in buffers since this depends on the actual schedule of the job and not the job graph.

By adapting the floating buffers to use a maximum of `numberOfInputChannels * networkBuffersPerChannel + extraNetworkBuffersPerGate - #exclusiveBuffers`, we would be channel-type agnostic and keep the old behaviour of using at most `numberOfInputChannels * networkBuffersPerChannel + extraNetworkBuffersPerGate` buffers in total.

## Brief change log

- change the floating buffer pool to use the remaining number of buffers from a total maximum of `numberOfInputChannels * networkBuffersPerChannel + extraNetworkBuffersPerGate` per channel

## Verifying this change

This change is already covered by existing tests, such as `NetworkEnvironmentTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no** (well, kind of, but not per record)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
