### PR TITLE
[hotfix][README.md] Update building prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,10 @@ counts.writeAsCsv(outputPath)
 
 Prerequisites for building Flink:
 
-* Unix-like environment (We use Linux, Mac OS X, Cygwin)
+* Unix-like environment (we use Linux, Mac OS X, Cygwin)
 * git
 * Maven (we recommend version 3.2.5)
-* Java 8
+* Java 8 (exactly 8, not 9 or 10)
 
 ```
 git clone https://github.com/apache/flink.git

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Prerequisites for building Flink:
 * Unix-like environment (we use Linux, Mac OS X, Cygwin)
 * git
 * Maven (we recommend version 3.2.5)
-* Java 8 (exactly 8, not 9 or 10)
+* Java 8 (Java 9 and 10 are not yet supported)
 
 ```
 git clone https://github.com/apache/flink.git


### PR DESCRIPTION
## What is the purpose of the change
Once I used Java 9 to build flink project and fail, so I think it might be helpful to emphasize Java version should be exactly 8.