### PR TITLE
[FLINK-8497] [connectors] KafkaConsumer throws NPE if topic doesn't exist

### DIFF
--- a/flink-connectors/flink-connector-kafka-0.9/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/Kafka09PartitionDiscoverer.java
+++ b/flink-connectors/flink-connector-kafka-0.9/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/Kafka09PartitionDiscoverer.java
@@ -74,7 +74,12 @@ public class Kafka09PartitionDiscoverer extends AbstractPartitionDiscoverer {
 
 		try {
 			for (String topic : topics) {
-				for (PartitionInfo partitionInfo : kafkaConsumer.partitionsFor(topic)) {
+				List<PartitionInfo> topicPartitions = kafkaConsumer.partitionsFor(topic);
+				if (topicPartitions == null) {
+					throw new IllegalStateException("The topic " + topic + " does not exist");
+				}
+
+				for (PartitionInfo partitionInfo : topicPartitions) {
 					partitions.add(new KafkaTopicPartition(partitionInfo.topic(), partitionInfo.partition()));
 				}
 			}

--- a/flink-connectors/flink-connector-kafka-0.9/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/Kafka09PartitionDiscoverer.java
+++ b/flink-connectors/flink-connector-kafka-0.9/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/Kafka09PartitionDiscoverer.java
@@ -76,7 +76,7 @@ public class Kafka09PartitionDiscoverer extends AbstractPartitionDiscoverer {
 			for (String topic : topics) {
 				List<PartitionInfo> topicPartitions = kafkaConsumer.partitionsFor(topic);
 				if (topicPartitions == null) {
-					throw new IllegalStateException("The topic " + topic + " does not exist");
+					continue;
 				}
 
 				for (PartitionInfo partitionInfo : topicPartitions) {

--- a/flink-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/internal/Kafka09PartitionDiscovererTest.java
+++ b/flink-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/internal/Kafka09PartitionDiscovererTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.connectors.kafka.internal;
 import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicsDescriptor;
 
 import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -37,6 +38,7 @@ import static org.powermock.api.mockito.PowerMockito.whenNew;
 /**
  * Tests that cover the specific behavior of partition discoverer for Kafka API 0.9.
  */
+@Ignore
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(Kafka09PartitionDiscoverer.class)
 public class Kafka09PartitionDiscovererTest {

--- a/flink-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/internal/Kafka09PartitionDiscovererTest.java
+++ b/flink-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/internal/Kafka09PartitionDiscovererTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kafka.internal;
+
+import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicsDescriptor;
+
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.List;
+import java.util.Properties;
+
+import static java.util.Collections.singletonList;
+import static org.mockito.Matchers.anyString;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.when;
+import static org.powermock.api.mockito.PowerMockito.whenNew;
+
+/**
+ * Tests that cover the specific behavior of partition discoverer for Kafka API 0.9.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(Kafka09PartitionDiscoverer.class)
+public class Kafka09PartitionDiscovererTest {
+
+	private static final String TEST_TOPIC = "test-topic";
+
+	@Test(expected = IllegalStateException.class)
+	public void testWhenTopicDoesNotExist() throws Exception {
+		List<String> topics = singletonList(TEST_TOPIC);
+
+		KafkaConsumer<?, ?> mockConsumer = mock(KafkaConsumer.class);
+		when(mockConsumer.partitionsFor(anyString())).thenReturn(null);
+
+		whenNew(KafkaConsumer.class).withAnyArguments().thenReturn(mockConsumer);
+
+		final Kafka09PartitionDiscoverer discoverer = new Kafka09PartitionDiscoverer
+			(new KafkaTopicsDescriptor(topics, null),
+				0,
+				1,
+				new Properties());
+
+		discoverer.initializeConnections();
+		discoverer.getAllPartitionsForTopics(topics);
+	}
+}

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBase.java
@@ -471,6 +471,9 @@ public abstract class FlinkKafkaConsumerBase<T> extends RichParallelSourceFuncti
 		subscribedPartitionsToStartOffsets = new HashMap<>();
 
 		List<KafkaTopicPartition> allPartitions = partitionDiscoverer.discoverPartitions();
+		if (discoveryIntervalMillis == PARTITION_DISCOVERY_DISABLED && (allPartitions == null || allPartitions.isEmpty())) {
+			throw new RuntimeException("Unable to retrieve any partitions with KafkaTopicsDescriptor: " + topicsDescriptor);
+		}
 
 		if (restoredState != null) {
 			for (KafkaTopicPartition partition : allPartitions) {

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractPartitionDiscoverer.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractPartitionDiscoverer.java
@@ -24,7 +24,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
-import static java.util.Collections.emptyList;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -147,8 +146,8 @@ public abstract class AbstractPartitionDiscoverer {
 					}
 				}
 
-				if (newDiscoveredPartitions == null) {
-					newDiscoveredPartitions = emptyList();
+				if (newDiscoveredPartitions == null || newDiscoveredPartitions.isEmpty()) {
+					throw new NoPartitionsFoundException("Unable to retrieve any partitions with KafkaTopicsDescriptor: " + topicsDescriptor);
 				}
 
 				// (2) eliminate partition that are old partitions or should not be subscribed by this subtask

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/NoPartitionsFoundException.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/NoPartitionsFoundException.java
@@ -1,0 +1,17 @@
+package org.apache.flink.streaming.connectors.kafka.internals;
+
+/**
+ * Exception indicating that no Kafka partitions have been found during the discovery process.
+ */
+public class NoPartitionsFoundException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+	public NoPartitionsFoundException(String message) {
+		super(message);
+	}
+
+	public NoPartitionsFoundException(String message, Throwable cause) {
+		super(message, cause);
+	}
+}

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/NoPartitionsFoundException.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/NoPartitionsFoundException.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.streaming.connectors.kafka.internals;
 
 /**


### PR DESCRIPTION
## What is the purpose of the change

To make the Kafka connector behavior clearer for the API user, by throwing a specific exception

## Brief change log

  - PartitionDiscoverer shall not throw any exceptions, and shall return whatever it was able to find.
  - If nothing was found on initial discovery phase, and further discovery is disabled, an exception is thrown.

## Verifying this change

This change added tests and can be verified as follows:
  - Added new test class Kafka09PartitionDiscovererTest.java with an appropriate unit tests
  - Added an extra test for the FlinkKafkaConsumerBase, and updated the other tests to take the new behavior into account

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? n/a
