### PR TITLE
[FLINK-9263][state] Fix concurrency problem in DefaultOperatorStateBackend.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackend.java
@@ -636,7 +636,7 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 
 		private PartitionableListState(PartitionableListState<S> toCopy) {
 
-			this(toCopy.stateMetaInfo, toCopy.internalListCopySerializer.copy(toCopy.internalList));
+			this(toCopy.stateMetaInfo.deepCopy(), toCopy.internalListCopySerializer.copy(toCopy.internalList));
 		}
 
 		public void setStateMetaInfo(RegisteredOperatorBackendStateMetaInfo<S> stateMetaInfo) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/HeapBroadcastState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/HeapBroadcastState.java
@@ -66,7 +66,7 @@ public class HeapBroadcastState<K, V> implements BackendWritableBroadcastState<K
 	}
 
 	private HeapBroadcastState(HeapBroadcastState<K, V> toCopy) {
-		this(toCopy.stateMetaInfo, toCopy.internalMapCopySerializer.copy(toCopy.backingMap));
+		this(toCopy.stateMetaInfo.deepCopy(), toCopy.internalMapCopySerializer.copy(toCopy.backingMap));
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredBroadcastBackendStateMetaInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredBroadcastBackendStateMetaInfo.java
@@ -52,6 +52,23 @@ public class RegisteredBroadcastBackendStateMetaInfo<K, V> {
 		this.valueSerializer = Preconditions.checkNotNull(valueSerializer);
 	}
 
+	public RegisteredBroadcastBackendStateMetaInfo(RegisteredBroadcastBackendStateMetaInfo copy) {
+
+		Preconditions.checkNotNull(copy);
+
+		this.name = copy.name;
+		this.assignmentMode = copy.assignmentMode;
+		this.keySerializer = copy.keySerializer.duplicate();
+		this.valueSerializer = copy.valueSerializer.duplicate();
+	}
+
+	/**
+	 * Creates a deep copy of the itself.
+	 */
+	public RegisteredBroadcastBackendStateMetaInfo deepCopy() {
+		return new RegisteredBroadcastBackendStateMetaInfo(this);
+	}
+
 	public String getName() {
 		return name;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredOperatorBackendStateMetaInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredOperatorBackendStateMetaInfo.java
@@ -57,6 +57,22 @@ public class RegisteredOperatorBackendStateMetaInfo<S> {
 		this.assignmentMode = Preconditions.checkNotNull(assignmentMode);
 	}
 
+	private RegisteredOperatorBackendStateMetaInfo(RegisteredOperatorBackendStateMetaInfo copy) {
+
+		Preconditions.checkNotNull(copy);
+
+		this.name = copy.name;
+		this.partitionStateSerializer = copy.partitionStateSerializer.duplicate();
+		this.assignmentMode = copy.assignmentMode;
+	}
+
+	/**
+	 * Creates a deep copy of the itself.
+	 */
+	public RegisteredOperatorBackendStateMetaInfo deepCopy() {
+		return new RegisteredOperatorBackendStateMetaInfo(this);
+	}
+
 	public String getName() {
 		return name;
 	}


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes the concurrency problem in `DefaultOperatorStateBackend`, the reason for this bug is that when performing checkpoint we didn't create a true `deepCopy` of the `registeredOperatorStates` and `registeredBroadcastStates`.

## Brief change log

  - *create a truly deep copy of `registeredBroadcastStates` and `registeredOperatorStates` when performing checkpoint*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

no