### PR TITLE
[FLINK-9190][flip6,yarn] Request new container if container completed unexpectedly

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
@@ -74,14 +74,14 @@ public class YarnResourceManager extends ResourceManager<YarnWorkerNode> impleme
 	private final Map<String, String> env;
 
 	/** YARN container map. Package private for unit test purposes. */
-	final ConcurrentMap<ResourceID, YarnWorkerNode> workerNodeMap;
+	private final ConcurrentMap<ResourceID, YarnWorkerNode> workerNodeMap;
 
 	/** The heartbeat interval while the resource master is waiting for containers. */
 	private static final int FAST_YARN_HEARTBEAT_INTERVAL_MS = 500;
 
 	/** Environment variable name of the final container id used by the YarnResourceManager.
 	 * Container ID generation may vary across Hadoop versions. */
-	static final String ENV_FLINK_CONTAINER_ID = "_FLINK_CONTAINER_ID";
+	private static final String ENV_FLINK_CONTAINER_ID = "_FLINK_CONTAINER_ID";
 
 	/** Environment variable name of the hostname given by the YARN.
 	 * In task executor we use the hostnames given by YARN consistently throughout akka */


### PR DESCRIPTION
## What is the purpose of the change

*Request new YARN container if container completed unexpectedly.*

cc: @sihuazhou @StephanEwen @tillrohrmann 

## Brief change log

  - *Request new container if container completed unexpectedly.*
  - *Reduce visibility of some fields in `YarnResourceManager`.*


## Verifying this change

This change added tests and can be verified as follows:

  - *Manually verified the change by deploying a Flink cluster on YARN and killing `TaskExecutorRunner`s randomly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
