### PR TITLE
[FLINK-9266][flink-connector-kinesis]Updates Kinesis connector to use newer version of kcl to limit describe streams calls

### DIFF
--- a/flink-connectors/flink-connector-kinesis/pom.xml
+++ b/flink-connectors/flink-connector-kinesis/pom.xml
@@ -33,9 +33,9 @@ under the License.
 	<artifactId>flink-connector-kinesis_${scala.binary.version}</artifactId>
 	<name>flink-connector-kinesis</name>
 	<properties>
-		<aws.sdk.version>1.11.272</aws.sdk.version>
-		<aws.kinesis-kcl.version>1.8.1</aws.kinesis-kcl.version>
-		<aws.kinesis-kpl.version>0.12.6</aws.kinesis-kpl.version>
+		<aws.sdk.version>1.11.319</aws.sdk.version>
+		<aws.kinesis-kcl.version>1.9.0</aws.kinesis-kcl.version>
+		<aws.kinesis-kpl.version>0.12.9</aws.kinesis-kpl.version>
 	</properties>
 
 	<packaging>jar</packaging>


### PR DESCRIPTION
## What is the purpose of the change

Updates Kinesis Connector to use newest version of AWS Kinesis Client Library (KCL). The new version of the KCL removes the usage of Kinesis Describe Stream calls to alleviate account wide limits.


## Brief change log

*Flink-Kinesis-Connector*
  - *Upgrades KCL version to 1.9.0*
  - *Upgrades KPL version to 0.12.9*
  - *Upgrades AWS SDK version to 1.11.319*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (don't know)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
