### PR TITLE
[FLINK-9270] Upgrade RocksDB to 5.11.3, and resolve concurrent test invocation problem of @RetryOnFailure

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/pom.xml
+++ b/flink-state-backends/flink-statebackend-rocksdb/pom.xml
@@ -57,7 +57,7 @@ under the License.
 		<dependency>
 			<groupId>org.rocksdb</groupId>
 			<artifactId>rocksdbjni</artifactId>
-			<version>5.7.5</version>
+			<version>5.11.3</version>
 		</dependency>
 
 		<!-- test dependencies -->

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/benchmark/RocksDBListStatePerformanceTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/benchmark/RocksDBListStatePerformanceTest.java
@@ -131,6 +131,8 @@ public class RocksDBListStatePerformanceTest extends TestLogger {
 			final long endInsert2 = System.nanoTime();
 
 			log.info("end update - duration: {} ns", (endInsert2 - beginInsert2));
+		} catch (Exception e) {
+			e.printStackTrace();
 		}
 	}
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/benchmark/RocksDBPerformanceTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/benchmark/RocksDBPerformanceTest.java
@@ -134,6 +134,8 @@ public class RocksDBPerformanceTest extends TestLogger {
 			final long endGet3 = System.nanoTime();
 
 			log.info("end get - duration: {} ms", (endGet3 - beginGet3) / 1_000_000);
+		} catch (Exception e) {
+			e.printStackTrace();
 		}
 	}
 
@@ -183,6 +185,8 @@ public class RocksDBPerformanceTest extends TestLogger {
 			final long endGet = System.nanoTime();
 
 			log.info("end get - duration: {} ms", (endGet - beginGet) / 1_000_000);
+		} catch (Exception e) {
+			e.printStackTrace();
 		}
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

- Upgrade RocksDB to 5.11.3 to take latest bug fixes
- Besides, I found that unit tests annotated with `@RetryOnFailure` will be run concurrently if there's only `try` clause without a `catch` following. For example, sometimes, `RocksDBPerformanceTest.testRocksDbMergePerformance()` will actually be running in 3 concurrent invocations, and multiple concurrent write to RocksDB result in errors. 

## Brief change log

- Upgrade RocksDB to 5.11.3
- For all RocksDB performance tests, add a `catch` clause to follow `try`

This change is already covered by existing tests

## Does this pull request potentially affect one of the following parts:

none

## Documentation

none