### PR TITLE
[FLINK-9274][kafka] add thread name for partition discovery

### DIFF
--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBase.java
@@ -715,7 +715,7 @@ public abstract class FlinkKafkaConsumerBase<T> extends RichParallelSourceFuncti
 						}
 					}
 				}
-			});
+			}, "Kafka Partition Discovery for " + getRuntimeContext().getTaskNameWithSubtasks());
 
 			discoveryLoopThread.start();
 			kafkaFetcher.runFetchLoop();


### PR DESCRIPTION
## What is the purpose of the change

For debugging, threads should have names to filter on and get a quick overview. The Kafka partition discovery thread(s) currently don't have any name assigned.

## Brief change log

- set "Kafka Partition Discovery for <taskName>" as the partition discovery thread's name

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage. It was tested locally with a stacktrace of the end-to-end test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
