### PR TITLE
[FLINK-8900] [yarn] Set correct application status when job is finished

### DIFF
--- a/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosJobClusterEntrypoint.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosJobClusterEntrypoint.java
@@ -25,6 +25,7 @@ import org.apache.flink.mesos.runtime.clusterframework.MesosTaskManagerParameter
 import org.apache.flink.mesos.runtime.clusterframework.services.MesosServices;
 import org.apache.flink.mesos.runtime.clusterframework.services.MesosServicesUtils;
 import org.apache.flink.mesos.util.MesosConfiguration;
+import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.runtime.clusterframework.ContainerSpecification;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
@@ -179,6 +180,9 @@ public class MesosJobClusterEntrypoint extends JobClusterEntrypoint {
 				}
 			});
 	}
+
+	@Override
+	protected void registerShutdownActions(CompletableFuture<ApplicationStatus> terminationFuture) {}
 
 	public static void main(String[] args) {
 		// startup checks and logging

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/ApplicationStatus.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/ApplicationStatus.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.clusterframework;
 
+import org.apache.flink.runtime.jobgraph.JobStatus;
+
 /**
  * The status of an application.
  */
@@ -52,4 +54,27 @@ public enum ApplicationStatus {
 		return processExitCode;
 	}
 
+	/**
+	 * Derives the ApplicationStatus that should be used for a job that resulted in the given
+	 * job status. If the job is not yet in a globally terminal state, this method returns
+	 * {@link #UNKNOWN}.
+	 */
+	public static ApplicationStatus fromJobStatus(JobStatus jobStatus) {
+		if (jobStatus == null) {
+			return UNKNOWN;
+		}
+		else {
+			switch (jobStatus) {
+				case FAILED:
+					return FAILED;
+				case CANCELED:
+					return CANCELED;
+				case FINISHED:
+					return SUCCEEDED;
+
+				default:
+					return UNKNOWN;
+			}
+		}
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/MiniDispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/MiniDispatcher.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobServer;
+import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.entrypoint.ClusterEntrypoint;
 import org.apache.flink.runtime.entrypoint.JobClusterEntrypoint;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
@@ -40,6 +41,8 @@ import javax.annotation.Nullable;
 
 import java.util.concurrent.CompletableFuture;
 
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
 /**
  * Mini Dispatcher which is instantiated as the dispatcher component by the {@link JobClusterEntrypoint}.
  *
@@ -51,6 +54,8 @@ import java.util.concurrent.CompletableFuture;
 public class MiniDispatcher extends Dispatcher {
 
 	private final JobClusterEntrypoint.ExecutionMode executionMode;
+
+	private final CompletableFuture<ApplicationStatus> jobTerminationFuture;
 
 	public MiniDispatcher(
 			RpcService rpcService,
@@ -84,7 +89,12 @@ public class MiniDispatcher extends Dispatcher {
 			fatalErrorHandler,
 			restAddress);
 
-		this.executionMode = executionMode;
+		this.executionMode = checkNotNull(executionMode);
+		this.jobTerminationFuture = new CompletableFuture<>();
+	}
+
+	public CompletableFuture<ApplicationStatus> getJobTerminationFuture() {
+		return jobTerminationFuture;
 	}
 
 	@Override
@@ -109,7 +119,11 @@ public class MiniDispatcher extends Dispatcher {
 
 		if (executionMode == ClusterEntrypoint.ExecutionMode.NORMAL) {
 			// terminate the MiniDispatcher once we served the first JobResult successfully
-			jobResultFuture.whenComplete((JobResult ignored, Throwable throwable) -> shutDown());
+			jobResultFuture.whenComplete((JobResult result, Throwable throwable) -> {
+				ApplicationStatus status = result.getSerializedThrowable().isPresent() ?
+						ApplicationStatus.FAILED : ApplicationStatus.SUCCEEDED;
+				jobTerminationFuture.complete(status);
+			});
 		}
 
 		return jobResultFuture;
@@ -121,7 +135,7 @@ public class MiniDispatcher extends Dispatcher {
 
 		if (executionMode == ClusterEntrypoint.ExecutionMode.DETACHED) {
 			// shut down since we don't have to wait for the execution result retrieval
-			shutDown();
+			jobTerminationFuture.complete(ApplicationStatus.fromJobStatus(archivedExecutionGraph.getState()));
 		}
 	}
 
@@ -130,6 +144,6 @@ public class MiniDispatcher extends Dispatcher {
 		super.jobNotFinished(jobId);
 
 		// shut down since we have done our job
-		shutDown();
+		jobTerminationFuture.complete(ApplicationStatus.UNKNOWN);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -241,6 +241,8 @@ public abstract class ClusterEntrypoint implements FatalErrorHandler {
 						LOG.info("Could not properly terminate the Dispatcher.", throwable);
 					}
 
+					// This is the general shutdown path. If a separate more specific shutdown was
+					// already triggered, this will do nothing
 					shutDownAndTerminate(
 						SUCCESS_RETURN_CODE,
 						ApplicationStatus.SUCCEEDED,
@@ -578,7 +580,7 @@ public abstract class ClusterEntrypoint implements FatalErrorHandler {
 		return terminationFuture;
 	}
 
-	private void shutDownAndTerminate(
+	protected void shutDownAndTerminate(
 		int returnCode,
 		ApplicationStatus applicationStatus,
 		@Nullable String diagnostics,

--- a/flink-runtime/src/test/resources/log4j-test.properties
+++ b/flink-runtime/src/test/resources/log4j-test.properties
@@ -16,23 +16,15 @@
 # limitations under the License.
 ################################################################################
 
-log4j.rootLogger=OFF, console
+# Set root logger level to OFF to not flood build logs
+# set manually to INFO for debugging purposes
+log4j.rootLogger=OFF, testlogger
 
-# -----------------------------------------------------------------------------
-# Console (use 'console')
-# -----------------------------------------------------------------------------
-log4j.appender.console=org.apache.log4j.ConsoleAppender
-log4j.appender.console.layout=org.apache.log4j.PatternLayout
-log4j.appender.console.layout.ConversionPattern=%d{HH:mm:ss,SSS} %-5p %-60c %x - %m%n
+# testlogger is set to be a ConsoleAppender.
+log4j.appender.testlogger=org.apache.log4j.ConsoleAppender
+log4j.appender.testlogger.target=System.err
+log4j.appender.testlogger.layout=org.apache.log4j.PatternLayout
+log4j.appender.testlogger.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n
 
-# -----------------------------------------------------------------------------
-# File (use 'file')
-# -----------------------------------------------------------------------------
-log4j.appender.file=org.apache.log4j.FileAppender
-log4j.appender.file.file=${log.dir}/${mvn.forkNumber}.log
-log4j.appender.file.append=false
-log4j.appender.file.layout=org.apache.log4j.PatternLayout
-log4j.appender.file.layout.ConversionPattern=%d{HH:mm:ss,SSS} %-5p %-60c %x - %m%n
-
-# suppress the irrelevant (wrong) warnings from the netty channel handler
-log4j.logger.org.jboss.netty.channel.DefaultChannelPipeline=ERROR, console
+# Suppress the irrelevant (wrong) warnings from the Netty channel handler
+log4j.logger.org.apache.flink.shaded.akka.org.jboss.netty.channel.DefaultChannelPipeline=ERROR, testlogger

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnJobClusterEntrypoint.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnJobClusterEntrypoint.java
@@ -19,6 +19,7 @@
 package org.apache.flink.yarn.entrypoint;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
 import org.apache.flink.runtime.entrypoint.JobClusterEntrypoint;
@@ -51,6 +52,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * Entry point for Yarn per-job clusters.
@@ -130,6 +132,17 @@ public class YarnJobClusterEntrypoint extends JobClusterEntrypoint {
 			throw new FlinkException("Could not load the JobGraph from file.", e);
 		}
 	}
+
+	@Override
+	protected void registerShutdownActions(CompletableFuture<ApplicationStatus> terminationFuture) {
+		terminationFuture.whenComplete((status, throwable) ->
+			shutDownAndTerminate(status.processExitCode(), status, null, true));
+	}
+
+	// ------------------------------------------------------------------------
+	//  The executable entry point for the Yarn Application Master Process
+	//  for a single Flink job.
+	// ------------------------------------------------------------------------
 
 	public static void main(String[] args) {
 		// startup checks and logging


### PR DESCRIPTION
## What is the purpose of the change

When finite Flink applications (batch jobs) are sent to YARN in the detached mode, the final status is currently always the same, because the job's result is not passed to the logic that initiates the application shutdown.

This PR forwards the final job status via a future that is used to register the shutdown handlers.

## Brief change log

  - Introduce the `JobTerminationFuture` in the `MiniDispatcher`
  - 

## Verifying this change

```
bin/flink run -m yarn-cluster -yjm 2048 -ytm 2048  ./examples/streaming/WordCount.jar
```

  - Run the batch job as described above on YARN to succeed, check that the final application status is successful.

  - Run the batch job with a parameter to a non existing input file on YARN, check that the final application status is failed.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no)**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
