### PR TITLE
[FLINK-9286][docs] Update classloading docs

### DIFF
--- a/docs/monitoring/debugging_classloading.md
+++ b/docs/monitoring/debugging_classloading.md
@@ -69,9 +69,9 @@ cases. By default, Java ClassLoaders will first look for classes in the parent C
 the child ClassLoader for cases where we have a hierarchy of ClassLoaders. This is problematic if you
 have in your user jar a version of a library that conflicts with a version that comes with Flink. You can
 change this behaviour by configuring the ClassLoader resolution order via
-`classloader.resolve-order: child-first` in the Flink config. However, Flink classes will still
+[classloader.resolve-order](../ops/config.html#classloader-resolve-order) in the Flink config. However, Flink classes will still
 be resolved through the parent ClassLoader first, although you can also configure this via
-`classloader.parent-first-patterns` (see [config](../ops/config.html))
+[classloader.parent-first-patterns-default](../ops/config.html#classloader-parent-first-patterns-default).
 
 
 ## Avoiding Dynamic Classloading

--- a/docs/monitoring/debugging_classloading.md
+++ b/docs/monitoring/debugging_classloading.md
@@ -69,10 +69,10 @@ cases. By default, Java ClassLoaders will first look for classes in the parent C
 the child ClassLoader for cases where we have a hierarchy of ClassLoaders. This is problematic if you
 have in your user jar a version of a library that conflicts with a version that comes with Flink. You can
 change this behaviour by configuring the ClassLoader resolution order via
-[classloader.resolve-order](../ops/config.html#classloader-resolve-order) in the Flink config. However, Flink classes will still
-be resolved through the parent ClassLoader first, although you can also configure this via
-[classloader.parent-first-patterns-default](../ops/config.html#classloader-parent-first-patterns-default).
-
+[classloader.resolve-order](../ops/config.html#classloader-resolve-order) in the Flink config.
+Note that certain classes are always resolved through the parent ClassLoader first, which can be configured via
+[classloader.parent-first-patterns-default](../ops/config.html#classloader-parent-first-patterns-default) and
+[classloader.parent-first-patterns-additional](../ops/config.html#classloader-parent-first-patterns-additional).
 
 ## Avoiding Dynamic Classloading
 


### PR DESCRIPTION
## What is the purpose of the change

This PR updates the `Configuring ClassLoader Resolution Order` section of the `Debugging Classloading` page.

## Brief change log

* update `classloader.parent-first-pattern` key
* add links to key entries on the configuration page
