### PR TITLE
[FLINK-9293] [runtime] SlotPool should check slot id when accepting a slot offer with existing allocation id

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolTest.java
@@ -321,9 +321,20 @@ public class SlotPoolTest extends TestLogger {
 			assertTrue(slotPoolGateway.offerSlot(taskManagerLocation, taskManagerGateway, slotOffer).get());
 			assertTrue(slot.isAlive());
 
+			final SlotOffer anotherSlotOfferWithSameAllocationId = new SlotOffer(
+					slotRequest.getAllocationId(),
+					1,
+					DEFAULT_TESTING_PROFILE);
+			assertFalse(slotPoolGateway.offerSlot(taskManagerLocation, taskManagerGateway, anotherSlotOfferWithSameAllocationId).get());
+
+			TaskManagerLocation anotherTaskManagerLocation = new LocalTaskManagerLocation();
+			assertFalse(slotPoolGateway.offerSlot(anotherTaskManagerLocation, taskManagerGateway, slotOffer).get());
+
 			// duplicated offer with free slot
 			slot.releaseSlot();
 			assertTrue(slotPoolGateway.offerSlot(taskManagerLocation, taskManagerGateway, slotOffer).get());
+			assertFalse(slotPoolGateway.offerSlot(taskManagerLocation, taskManagerGateway, anotherSlotOfferWithSameAllocationId).get());
+			assertFalse(slotPoolGateway.offerSlot(anotherTaskManagerLocation, taskManagerGateway, slotOffer).get());
 		} finally {
 			slotPool.shutDown();
 		}


### PR DESCRIPTION

## What is the purpose of the change

*This pull request fix that job master will accept multi slot offers with same allocation id and make the later slots leak.*

## Verifying this change

This change added tests and can be verified as follows:

*(example:)*
  - *Run the SlotPoolTest*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
