### PR TITLE
[FLINK-9282][doc] Synchronize Quickstart with the latest SNAPSHOT

### DIFF
--- a/docs/quickstart/setup_quickstart.md
+++ b/docs/quickstart/setup_quickstart.md
@@ -94,9 +94,9 @@ $ cd build-target               # this is where Flink is installed to
 $ ./bin/start-cluster.sh  # Start Flink
 {% endhighlight %}
 
-Check the __JobManager's web frontend__ at [http://localhost:8081](http://localhost:8081) and make sure everything is up and running. The web frontend should report a single available TaskManager instance.
+Check the __Dispatcher's web frontend__ at [http://localhost:8081](http://localhost:8081) and make sure everything is up and running. The web frontend should report a single available TaskManager instance.
 
-<a href="{{ site.baseurl }}/page/img/quickstart-setup/jobmanager-1.png" ><img class="img-responsive" src="{{ site.baseurl }}/page/img/quickstart-setup/jobmanager-1.png" alt="JobManager: Overview"/></a>
+<a href="{{ site.baseurl }}/page/img/quickstart-setup/jobmanager-1.png" ><img class="img-responsive" src="{{ site.baseurl }}/page/img/quickstart-setup/jobmanager-1.png" alt="Dispatcher: Overview"/></a>
 
 You can also verify that the system is running by checking the log files in the `logs` directory:
 
@@ -255,10 +255,10 @@ Starting execution of program
 
   <div class="row">
     <div class="col-sm-6">
-      <a href="{{ site.baseurl }}/page/img/quickstart-setup/jobmanager-2.png" ><img class="img-responsive" src="{{ site.baseurl }}/page/img/quickstart-setup/jobmanager-2.png" alt="JobManager: Overview (cont'd)"/></a>
+      <a href="{{ site.baseurl }}/page/img/quickstart-setup/jobmanager-2.png" ><img class="img-responsive" src="{{ site.baseurl }}/page/img/quickstart-setup/jobmanager-2.png" alt="Dispatcher: Overview (cont'd)"/></a>
     </div>
     <div class="col-sm-6">
-      <a href="{{ site.baseurl }}/page/img/quickstart-setup/jobmanager-3.png" ><img class="img-responsive" src="{{ site.baseurl }}/page/img/quickstart-setup/jobmanager-3.png" alt="JobManager: Running Jobs"/></a>
+      <a href="{{ site.baseurl }}/page/img/quickstart-setup/jobmanager-3.png" ><img class="img-responsive" src="{{ site.baseurl }}/page/img/quickstart-setup/jobmanager-3.png" alt="Dispatcher: Running Jobs"/></a>
     </div>
   </div>
 

--- a/docs/quickstart/setup_quickstart.md
+++ b/docs/quickstart/setup_quickstart.md
@@ -101,11 +101,17 @@ Check the __JobManager's web frontend__ at [http://localhost:8081](http://localh
 You can also verify that the system is running by checking the log files in the `logs` directory:
 
 {% highlight bash %}
-$ tail log/flink-*-jobmanager-*.log
-INFO ... - Starting JobManager
-INFO ... - Starting JobManager web frontend
-INFO ... - Web frontend listening at 127.0.0.1:8081
-INFO ... - Registered TaskManager at 127.0.0.1 (akka://flink/user/taskmanager)
+$ tail log/flink-*-standalonesession-*.log
+INFO ... - Rest endpoint listening at localhost:8081
+INFO ... - http://localhost:8081 was granted leadership ...
+INFO ... - Web frontend listening at http://localhost:8081.
+INFO ... - Starting RPC endpoint for StandaloneResourceManager at akka://flink/user/resourcemanager .
+INFO ... - Starting RPC endpoint for StandaloneDispatcher at akka://flink/user/dispatcher .
+INFO ... - ResourceManager akka.tcp://flink@localhost:6123/user/resourcemanager was granted leadership ...
+INFO ... - Starting the SlotManager.
+INFO ... - Dispatcher akka.tcp://flink@localhost:6123/user/dispatcher was granted leadership ...
+INFO ... - Recovering all persisted jobs.
+INFO ... - Registering TaskManager ... under ... at the SlotManager.
 {% endhighlight %}
 
 ## Read the Code
@@ -233,29 +239,17 @@ window of processing time, as long as words are floating in.
 
 * First of all, we use **netcat** to start local server via
 
-  {% highlight bash %}
-  $ nc -l 9000
-  {% endhighlight %}
+{% highlight bash %}
+$ nc -l 9000
+{% endhighlight %}
 
 * Submit the Flink program:
 
-  {% highlight bash %}
-  $ ./bin/flink run examples/streaming/SocketWindowWordCount.jar --port 9000
+{% highlight bash %}
+$ ./bin/flink run examples/streaming/SocketWindowWordCount.jar --port 9000
+Starting execution of program
 
-  Cluster configuration: Standalone cluster with JobManager at /127.0.0.1:6123
-  Using address 127.0.0.1:6123 to connect to JobManager.
-  JobManager web interface address http://127.0.0.1:8081
-  Starting execution of program
-  Submitting job with JobID: 574a10c8debda3dccd0c78a3bde55e1b. Waiting for job completion.
-  Connected to JobManager at Actor[akka.tcp://flink@127.0.0.1:6123/user/jobmanager#297388688]
-  11/04/2016 14:04:50     Job execution switched to status RUNNING.
-  11/04/2016 14:04:50     Source: Socket Stream -> Flat Map(1/1) switched to SCHEDULED
-  11/04/2016 14:04:50     Source: Socket Stream -> Flat Map(1/1) switched to DEPLOYING
-  11/04/2016 14:04:50     Fast TumblingProcessingTimeWindows(5000) of WindowedStream.main(SocketWindowWordCount.java:79) -> Sink: Unnamed(1/1) switched to SCHEDULED
-  11/04/2016 14:04:51     Fast TumblingProcessingTimeWindows(5000) of WindowedStream.main(SocketWindowWordCount.java:79) -> Sink: Unnamed(1/1) switched to DEPLOYING
-  11/04/2016 14:04:51     Fast TumblingProcessingTimeWindows(5000) of WindowedStream.main(SocketWindowWordCount.java:79) -> Sink: Unnamed(1/1) switched to RUNNING
-  11/04/2016 14:04:51     Source: Socket Stream -> Flat Map(1/1) switched to RUNNING
-  {% endhighlight %}
+{% endhighlight %}
 
   The program connects to the socket and waits for input. You can check the web interface to verify that the job is running as expected:
 
@@ -273,28 +267,28 @@ window of processing time, as long as words are floating in.
   and write some text in `nc` (input is sent to Flink line by line after
   hitting <RETURN>):
 
-  {% highlight bash %}
-  $ nc -l 9000
-  lorem ipsum
-  ipsum ipsum ipsum
-  bye
-  {% endhighlight %}
+{% highlight bash %}
+$ nc -l 9000
+lorem ipsum
+ipsum ipsum ipsum
+bye
+{% endhighlight %}
 
   The `.out` file will print the counts at the end of each time window as long
   as words are floating in, e.g.:
 
-  {% highlight bash %}
-  $ tail -f log/flink-*-taskmanager-*.out
-  lorem : 1
-  bye : 1
-  ipsum : 4
-  {% endhighlight %}~
+{% highlight bash %}
+$ tail -f log/flink-*-taskexecutor-*.out
+lorem : 1
+bye : 1
+ipsum : 4
+{% endhighlight %}
 
   To **stop** Flink when you're done type:
 
-  {% highlight bash %}
-  $ ./bin/stop-local.sh
-  {% endhighlight %}
+{% highlight bash %}
+$ ./bin/stop-cluster.sh
+{% endhighlight %}
 
 ## Next Steps
 


### PR DESCRIPTION
## What is the purpose of the change

Our Quickstart page is a little out of date, this pull request is to keep it synchronized with the latest SNAPSHOT.

## Brief change log

- Modify print log command with new log filename.
- Remove leading whitespaces to trim them in highlight block.
- Correct the command to stop Flink

