### PR TITLE
[FLINK-8500] Get the timestamp of the Kafka message from kafka consumer

### DIFF
--- a/docs/dev/connectors/kafka.md
+++ b/docs/dev/connectors/kafka.md
@@ -145,15 +145,19 @@ stream = env
 ### The `DeserializationSchema`
 
 The Flink Kafka Consumer needs to know how to turn the binary data in Kafka into Java/Scala objects. The
-`DeserializationSchema` allows users to specify such a schema. The `T deserialize(byte[] message)`
-method gets called for each Kafka message, passing the value from Kafka.
+`DeserializationSchema` allows users to specify such a schema. The `T deserialize(...)`
+method gets called for each Kafka message, passing the value from Kafka. There are two variants of the `T deserialize(...)`
+ method, for backwards compatibility the `T deserialize(byte[] message)` still exists, and the
+ `T deserialize(ConsumerRecordMetaInfo consumerRecord)` method which hasbesides the message some more kafka meta information,
+  such as the key, topic, partition, offset and depending on the kafka version the timestamp. 
 
 It is usually helpful to start from the `AbstractDeserializationSchema`, which takes care of describing the
 produced Java/Scala type to Flink's type system. Users that implement a vanilla `DeserializationSchema` need
 to implement the `getProducedType(...)` method themselves.
 
-For accessing both the key and value of the Kafka message, the `KeyedDeserializationSchema` has
-the following deserialize method ` T deserialize(byte[] messageKey, byte[] message, String topic, int partition, long offset)`.
+For accessing the kafka meta information the `T deserialize(ConsumerRecordMetaInfo consumerRecord)` is preferred but the 
+`KeyedDeserializationSchema` with the following deserialize method
+ ` T deserialize(byte[] messageKey, byte[] message, String topic, int partition, long offset)` is still available for backwards compatibility reasons.
 
 For convenience, Flink provides the following schemas:
 

--- a/flink-connectors/flink-connector-kafka-0.10/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumer010.java
+++ b/flink-connectors/flink-connector-kafka-0.10/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumer010.java
@@ -31,7 +31,6 @@ import org.apache.flink.streaming.connectors.kafka.internals.AbstractPartitionDi
 import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartition;
 import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicsDescriptor;
 import org.apache.flink.streaming.util.serialization.KeyedDeserializationSchema;
-import org.apache.flink.streaming.util.serialization.KeyedDeserializationSchemaWrapper;
 import org.apache.flink.util.SerializedValue;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -40,7 +39,6 @@ import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
 import org.apache.kafka.common.TopicPartition;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -82,7 +80,7 @@ public class FlinkKafkaConsumer010<T> extends FlinkKafkaConsumer09<T> {
 	 *           The properties used to configure the Kafka consumer client, and the ZooKeeper client.
 	 */
 	public FlinkKafkaConsumer010(String topic, DeserializationSchema<T> valueDeserializer, Properties props) {
-		this(Collections.singletonList(topic), valueDeserializer, props);
+		super(topic, valueDeserializer, props);
 	}
 
 	/**
@@ -99,7 +97,7 @@ public class FlinkKafkaConsumer010<T> extends FlinkKafkaConsumer09<T> {
 	 *           The properties used to configure the Kafka consumer client, and the ZooKeeper client.
 	 */
 	public FlinkKafkaConsumer010(String topic, KeyedDeserializationSchema<T> deserializer, Properties props) {
-		this(Collections.singletonList(topic), deserializer, props);
+		super(topic, deserializer, props);
 	}
 
 	/**
@@ -115,7 +113,7 @@ public class FlinkKafkaConsumer010<T> extends FlinkKafkaConsumer09<T> {
 	 *           The properties that are used to configure both the fetcher and the offset handler.
 	 */
 	public FlinkKafkaConsumer010(List<String> topics, DeserializationSchema<T> deserializer, Properties props) {
-		this(topics, new KeyedDeserializationSchemaWrapper<>(deserializer), props);
+		super(topics, deserializer, props);
 	}
 
 	/**
@@ -151,7 +149,7 @@ public class FlinkKafkaConsumer010<T> extends FlinkKafkaConsumer09<T> {
 	 */
 	@PublicEvolving
 	public FlinkKafkaConsumer010(Pattern subscriptionPattern, DeserializationSchema<T> valueDeserializer, Properties props) {
-		this(subscriptionPattern, new KeyedDeserializationSchemaWrapper<>(valueDeserializer), props);
+		super(subscriptionPattern, valueDeserializer, props);
 	}
 
 	/**

--- a/flink-connectors/flink-connector-kafka-0.10/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/Kafka010Fetcher.java
+++ b/flink-connectors/flink-connector-kafka-0.10/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/Kafka010Fetcher.java
@@ -115,7 +115,7 @@ public class Kafka010Fetcher<T> extends Kafka09Fetcher<T> {
 
 		@Override
 		public long getTimestamp() {
-			return Long.MIN_VALUE;
+			return consumerRecord.timestamp();
 		}
 
 		@Override
@@ -124,13 +124,13 @@ public class Kafka010Fetcher<T> extends Kafka09Fetcher<T> {
 			ConsumerRecordMetaInfo.TimestampType localTimestampType;
 			switch(consumerRecord.timestampType()) {
 				case CREATE_TIME:
-					localTimestampType = TimestampType.CREATE_TIME;
+					localTimestampType = TimestampType.EVENT_TIME;
 					break;
 				case LOG_APPEND_TIME:
 					localTimestampType = TimestampType.INGEST_TIME;
 					break;
 				default:
-					localTimestampType = TimestampType.NO_TIMESTAMP_TYPE;
+					localTimestampType = TimestampType.NO_TIMESTAMP;
 					break;
 			}
 			return localTimestampType;

--- a/flink-connectors/flink-connector-kafka-0.10/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironmentImpl.java
+++ b/flink-connectors/flink-connector-kafka-0.10/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironmentImpl.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.streaming.connectors.kafka;
 
+import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.networking.NetworkFailuresProxy;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
@@ -121,6 +122,11 @@ public class KafkaTestEnvironmentImpl extends KafkaTestEnvironment {
 
 	@Override
 	public <T> FlinkKafkaConsumerBase<T> getConsumer(List<String> topics, KeyedDeserializationSchema<T> readSchema, Properties props) {
+		return new FlinkKafkaConsumer010<>(topics, readSchema, props);
+	}
+
+	@Override
+	public <T> FlinkKafkaConsumerBase<T> getConsumer(List<String> topics, DeserializationSchema<T> readSchema, Properties props) {
 		return new FlinkKafkaConsumer010<>(topics, readSchema, props);
 	}
 

--- a/flink-connectors/flink-connector-kafka-0.10/src/test/java/org/apache/flink/streaming/connectors/kafka/internal/Kafka010FetcherTest.java
+++ b/flink-connectors/flink-connector-kafka-0.10/src/test/java/org/apache/flink/streaming/connectors/kafka/internal/Kafka010FetcherTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.connectors.kafka.internal;
 
+import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.serialization.SimpleStringSchema;
 import org.apache.flink.core.testutils.MultiShotLatch;
 import org.apache.flink.core.testutils.OneShotLatch;
@@ -28,8 +29,6 @@ import org.apache.flink.streaming.connectors.kafka.internals.KafkaCommitCallback
 import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartition;
 import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartitionStateSentinel;
 import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
-import org.apache.flink.streaming.util.serialization.KeyedDeserializationSchema;
-import org.apache.flink.streaming.util.serialization.KeyedDeserializationSchemaWrapper;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -115,7 +114,7 @@ public class Kafka010FetcherTest {
 		SourceContext<String> sourceContext = mock(SourceContext.class);
 		Map<KafkaTopicPartition, Long> partitionsWithInitialOffsets =
 			Collections.singletonMap(new KafkaTopicPartition("test", 42), KafkaTopicPartitionStateSentinel.GROUP_OFFSET);
-		KeyedDeserializationSchema<String> schema = new KeyedDeserializationSchemaWrapper<>(new SimpleStringSchema());
+		DeserializationSchema<String> schema = new SimpleStringSchema();
 
 		final Kafka010Fetcher<String> fetcher = new Kafka010Fetcher<>(
 				sourceContext,
@@ -252,7 +251,7 @@ public class Kafka010FetcherTest {
 		SourceContext<String> sourceContext = mock(SourceContext.class);
 		Map<KafkaTopicPartition, Long> partitionsWithInitialOffsets =
 			Collections.singletonMap(new KafkaTopicPartition("test", 42), KafkaTopicPartitionStateSentinel.GROUP_OFFSET);
-		KeyedDeserializationSchema<String> schema = new KeyedDeserializationSchemaWrapper<>(new SimpleStringSchema());
+		DeserializationSchema<String> schema = new SimpleStringSchema();
 
 		final Kafka010Fetcher<String> fetcher = new Kafka010Fetcher<>(
 				sourceContext,
@@ -367,7 +366,7 @@ public class Kafka010FetcherTest {
 		BlockingSourceContext<String> sourceContext = new BlockingSourceContext<>();
 		Map<KafkaTopicPartition, Long> partitionsWithInitialOffsets =
 			Collections.singletonMap(new KafkaTopicPartition(topic, partition), KafkaTopicPartitionStateSentinel.GROUP_OFFSET);
-		KeyedDeserializationSchema<String> schema = new KeyedDeserializationSchemaWrapper<>(new SimpleStringSchema());
+		DeserializationSchema<String> schema = new SimpleStringSchema();
 
 		final Kafka010Fetcher<String> fetcher = new Kafka010Fetcher<>(
 				sourceContext,

--- a/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumer011.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumer011.java
@@ -20,9 +20,7 @@ package org.apache.flink.streaming.connectors.kafka;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.streaming.util.serialization.KeyedDeserializationSchema;
-import org.apache.flink.streaming.util.serialization.KeyedDeserializationSchemaWrapper;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 import java.util.regex.Pattern;
@@ -62,7 +60,7 @@ public class FlinkKafkaConsumer011<T> extends FlinkKafkaConsumer010<T> {
 	 *           The properties used to configure the Kafka consumer client, and the ZooKeeper client.
 	 */
 	public FlinkKafkaConsumer011(String topic, DeserializationSchema<T> valueDeserializer, Properties props) {
-		this(Collections.singletonList(topic), valueDeserializer, props);
+		super(topic, valueDeserializer, props);
 	}
 
 	/**
@@ -79,7 +77,7 @@ public class FlinkKafkaConsumer011<T> extends FlinkKafkaConsumer010<T> {
 	 *           The properties used to configure the Kafka consumer client, and the ZooKeeper client.
 	 */
 	public FlinkKafkaConsumer011(String topic, KeyedDeserializationSchema<T> deserializer, Properties props) {
-		this(Collections.singletonList(topic), deserializer, props);
+		super(topic, deserializer, props);
 	}
 
 	/**
@@ -95,7 +93,7 @@ public class FlinkKafkaConsumer011<T> extends FlinkKafkaConsumer010<T> {
 	 *           The properties that are used to configure both the fetcher and the offset handler.
 	 */
 	public FlinkKafkaConsumer011(List<String> topics, DeserializationSchema<T> deserializer, Properties props) {
-		this(topics, new KeyedDeserializationSchemaWrapper<>(deserializer), props);
+		super(topics, deserializer, props);
 	}
 
 	/**
@@ -131,7 +129,7 @@ public class FlinkKafkaConsumer011<T> extends FlinkKafkaConsumer010<T> {
 	 */
 	@PublicEvolving
 	public FlinkKafkaConsumer011(Pattern subscriptionPattern, DeserializationSchema<T> valueDeserializer, Properties props) {
-		this(subscriptionPattern, new KeyedDeserializationSchemaWrapper<>(valueDeserializer), props);
+		super(subscriptionPattern, valueDeserializer, props);
 	}
 
 	/**

--- a/flink-connectors/flink-connector-kafka-0.11/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironmentImpl.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironmentImpl.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.streaming.connectors.kafka;
 
+import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.networking.NetworkFailuresProxy;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
@@ -128,6 +129,11 @@ public class KafkaTestEnvironmentImpl extends KafkaTestEnvironment {
 
 	@Override
 	public <T> FlinkKafkaConsumerBase<T> getConsumer(List<String> topics, KeyedDeserializationSchema<T> readSchema, Properties props) {
+		return new FlinkKafkaConsumer011<>(topics, readSchema, props);
+	}
+
+	@Override
+	public <T> FlinkKafkaConsumerBase<T> getConsumer(List<String> topics, DeserializationSchema<T> readSchema, Properties props) {
 		return new FlinkKafkaConsumer011<>(topics, readSchema, props);
 	}
 

--- a/flink-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumer08.java
+++ b/flink-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumer08.java
@@ -130,7 +130,7 @@ public class FlinkKafkaConsumer08<T> extends FlinkKafkaConsumerBase<T> {
 	 *           The properties used to configure the Kafka consumer client, and the ZooKeeper client.
 	 */
 	public FlinkKafkaConsumer08(String topic, KeyedDeserializationSchema<T> deserializer, Properties props) {
-		this(Collections.singletonList(topic), deserializer, props);
+		this(Collections.singletonList(topic), new KeyedDeserializationSchemaWrapper<>(deserializer), props);
 	}
 
 	/**
@@ -146,7 +146,7 @@ public class FlinkKafkaConsumer08<T> extends FlinkKafkaConsumerBase<T> {
 	 *           The properties that are used to configure both the fetcher and the offset handler.
 	 */
 	public FlinkKafkaConsumer08(List<String> topics, DeserializationSchema<T> deserializer, Properties props) {
-		this(topics, new KeyedDeserializationSchemaWrapper<>(deserializer), props);
+		this(topics, null, deserializer, props);
 	}
 
 	/**
@@ -162,7 +162,7 @@ public class FlinkKafkaConsumer08<T> extends FlinkKafkaConsumerBase<T> {
 	 *           The properties that are used to configure both the fetcher and the offset handler.
 	 */
 	public FlinkKafkaConsumer08(List<String> topics, KeyedDeserializationSchema<T> deserializer, Properties props) {
-		this(topics, null, deserializer, props);
+		this(topics, null, new KeyedDeserializationSchemaWrapper<>(deserializer), props);
 	}
 
 	/**
@@ -182,7 +182,7 @@ public class FlinkKafkaConsumer08<T> extends FlinkKafkaConsumerBase<T> {
 	 */
 	@PublicEvolving
 	public FlinkKafkaConsumer08(Pattern subscriptionPattern, DeserializationSchema<T> valueDeserializer, Properties props) {
-		this(subscriptionPattern, new KeyedDeserializationSchemaWrapper<>(valueDeserializer), props);
+		this(null, subscriptionPattern, valueDeserializer, props);
 	}
 
 	/**
@@ -205,13 +205,13 @@ public class FlinkKafkaConsumer08<T> extends FlinkKafkaConsumerBase<T> {
 	 */
 	@PublicEvolving
 	public FlinkKafkaConsumer08(Pattern subscriptionPattern, KeyedDeserializationSchema<T> deserializer, Properties props) {
-		this(null, subscriptionPattern, deserializer, props);
+		this(null, subscriptionPattern, new KeyedDeserializationSchemaWrapper<>(deserializer), props);
 	}
 
 	private FlinkKafkaConsumer08(
 			List<String> topics,
 			Pattern subscriptionPattern,
-			KeyedDeserializationSchema<T> deserializer,
+			DeserializationSchema<T> deserializer,
 			Properties props) {
 
 		super(

--- a/flink-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/Kafka08Fetcher.java
+++ b/flink-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/Kafka08Fetcher.java
@@ -20,13 +20,13 @@ package org.apache.flink.streaming.connectors.kafka.internals;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
 import org.apache.flink.streaming.api.functions.AssignerWithPunctuatedWatermarks;
 import org.apache.flink.streaming.api.functions.source.SourceFunction.SourceContext;
 import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
 import org.apache.flink.streaming.connectors.kafka.config.StartupMode;
-import org.apache.flink.streaming.util.serialization.KeyedDeserializationSchema;
 import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.SerializedValue;
 
@@ -68,7 +68,7 @@ public class Kafka08Fetcher<T> extends AbstractFetcher<T, TopicAndPartition> {
 	// ------------------------------------------------------------------------
 
 	/** The schema to convert between Kafka's byte messages, and Flink's objects. */
-	private final KeyedDeserializationSchema<T> deserializer;
+	private final DeserializationSchema<T> deserializer;
 
 	/** The properties that configure the Kafka connection. */
 	private final Properties kafkaConfig;
@@ -94,7 +94,7 @@ public class Kafka08Fetcher<T> extends AbstractFetcher<T, TopicAndPartition> {
 			SerializedValue<AssignerWithPeriodicWatermarks<T>> watermarksPeriodic,
 			SerializedValue<AssignerWithPunctuatedWatermarks<T>> watermarksPunctuated,
 			StreamingRuntimeContext runtimeContext,
-			KeyedDeserializationSchema<T> deserializer,
+			DeserializationSchema<T> deserializer,
 			Properties kafkaProperties,
 			long autoCommitInterval,
 			MetricGroup consumerMetricGroup,
@@ -387,7 +387,7 @@ public class Kafka08Fetcher<T> extends AbstractFetcher<T, TopicAndPartition> {
 			ExceptionProxy errorHandler) throws IOException, ClassNotFoundException {
 		// each thread needs its own copy of the deserializer, because the deserializer is
 		// not necessarily thread safe
-		final KeyedDeserializationSchema<T> clonedDeserializer =
+		final DeserializationSchema<T> clonedDeserializer =
 				InstantiationUtil.clone(deserializer, runtimeContext.getUserCodeClassLoader());
 
 		// seed thread with list of fetch partitions (otherwise it would shut down immediately again

--- a/flink-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/SimpleConsumerThread.java
+++ b/flink-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/SimpleConsumerThread.java
@@ -587,7 +587,7 @@ class SimpleConsumerThread<T> extends Thread {
 
 		@Override
 		public TimestampType getTimestampType() {
-			return ConsumerRecordMetaInfo.TimestampType.NO_TIMESTAMP_TYPE;
+			return ConsumerRecordMetaInfo.TimestampType.NO_TIMESTAMP;
 		}
 	}
 }

--- a/flink-connectors/flink-connector-kafka-0.8/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironmentImpl.java
+++ b/flink-connectors/flink-connector-kafka-0.8/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironmentImpl.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.streaming.connectors.kafka;
 
+import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.networking.NetworkFailuresProxy;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
@@ -113,6 +114,11 @@ public class KafkaTestEnvironmentImpl extends KafkaTestEnvironment {
 
 	@Override
 	public <T> FlinkKafkaConsumerBase<T> getConsumer(List<String> topics, KeyedDeserializationSchema<T> readSchema, Properties props) {
+		return new FlinkKafkaConsumer08<>(topics, readSchema, props);
+	}
+
+	@Override
+	public <T> FlinkKafkaConsumerBase<T> getConsumer(List<String> topics, DeserializationSchema<T> readSchema, Properties props) {
 		return new FlinkKafkaConsumer08<>(topics, readSchema, props);
 	}
 

--- a/flink-connectors/flink-connector-kafka-0.9/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumer09.java
+++ b/flink-connectors/flink-connector-kafka-0.9/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumer09.java
@@ -137,7 +137,7 @@ public class FlinkKafkaConsumer09<T> extends FlinkKafkaConsumerBase<T> {
 	 *           The properties that are used to configure both the fetcher and the offset handler.
 	 */
 	public FlinkKafkaConsumer09(List<String> topics, DeserializationSchema<T> deserializer, Properties props) {
-		this(topics, new KeyedDeserializationSchemaWrapper<>(deserializer), props);
+		this(topics, null, deserializer, props);
 	}
 
 	/**
@@ -153,7 +153,7 @@ public class FlinkKafkaConsumer09<T> extends FlinkKafkaConsumerBase<T> {
 	 *           The properties that are used to configure both the fetcher and the offset handler.
 	 */
 	public FlinkKafkaConsumer09(List<String> topics, KeyedDeserializationSchema<T> deserializer, Properties props) {
-		this(topics, null, deserializer, props);
+		this(topics, null, new KeyedDeserializationSchemaWrapper<>(deserializer), props);
 	}
 
 	/**
@@ -173,7 +173,7 @@ public class FlinkKafkaConsumer09<T> extends FlinkKafkaConsumerBase<T> {
 	 */
 	@PublicEvolving
 	public FlinkKafkaConsumer09(Pattern subscriptionPattern, DeserializationSchema<T> valueDeserializer, Properties props) {
-		this(subscriptionPattern, new KeyedDeserializationSchemaWrapper<>(valueDeserializer), props);
+		this(null, subscriptionPattern, valueDeserializer, props);
 	}
 
 	/**
@@ -196,13 +196,13 @@ public class FlinkKafkaConsumer09<T> extends FlinkKafkaConsumerBase<T> {
 	 */
 	@PublicEvolving
 	public FlinkKafkaConsumer09(Pattern subscriptionPattern, KeyedDeserializationSchema<T> deserializer, Properties props) {
-		this(null, subscriptionPattern, deserializer, props);
+		this(null, subscriptionPattern, new KeyedDeserializationSchemaWrapper<>(deserializer), props);
 	}
 
 	private FlinkKafkaConsumer09(
 			List<String> topics,
 			Pattern subscriptionPattern,
-			KeyedDeserializationSchema<T> deserializer,
+			DeserializationSchema<T> deserializer,
 			Properties props) {
 
 		super(

--- a/flink-connectors/flink-connector-kafka-0.9/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/Kafka09Fetcher.java
+++ b/flink-connectors/flink-connector-kafka-0.9/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/Kafka09Fetcher.java
@@ -213,7 +213,7 @@ public class Kafka09Fetcher<T> extends AbstractFetcher<T, TopicPartition> {
 
 		@Override
 		public TimestampType getTimestampType() {
-			return ConsumerRecordMetaInfo.TimestampType.NO_TIMESTAMP_TYPE;
+			return ConsumerRecordMetaInfo.TimestampType.NO_TIMESTAMP;
 		}
 	}
 

--- a/flink-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironmentImpl.java
+++ b/flink-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironmentImpl.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.streaming.connectors.kafka;
 
+import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.networking.NetworkFailuresProxy;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
@@ -104,6 +105,11 @@ public class KafkaTestEnvironmentImpl extends KafkaTestEnvironment {
 
 	@Override
 	public <T> FlinkKafkaConsumerBase<T> getConsumer(List<String> topics, KeyedDeserializationSchema<T> readSchema, Properties props) {
+		return new FlinkKafkaConsumer09<>(topics, readSchema, props);
+	}
+
+	@Override
+	public <T> FlinkKafkaConsumerBase<T> getConsumer(List<String> topics, DeserializationSchema<T> readSchema, Properties props) {
 		return new FlinkKafkaConsumer09<>(topics, readSchema, props);
 	}
 

--- a/flink-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/internal/Kafka09FetcherTest.java
+++ b/flink-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/internal/Kafka09FetcherTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.connectors.kafka.internal;
 
+import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.serialization.SimpleStringSchema;
 import org.apache.flink.core.testutils.MultiShotLatch;
 import org.apache.flink.core.testutils.OneShotLatch;
@@ -28,8 +29,6 @@ import org.apache.flink.streaming.connectors.kafka.internals.KafkaCommitCallback
 import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartition;
 import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartitionStateSentinel;
 import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
-import org.apache.flink.streaming.util.serialization.KeyedDeserializationSchema;
-import org.apache.flink.streaming.util.serialization.KeyedDeserializationSchemaWrapper;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -115,7 +114,7 @@ public class Kafka09FetcherTest {
 		SourceContext<String> sourceContext = mock(SourceContext.class);
 		Map<KafkaTopicPartition, Long> partitionsWithInitialOffsets =
 			Collections.singletonMap(new KafkaTopicPartition("test", 42), KafkaTopicPartitionStateSentinel.GROUP_OFFSET);
-		KeyedDeserializationSchema<String> schema = new KeyedDeserializationSchemaWrapper<>(new SimpleStringSchema());
+		DeserializationSchema<String> schema = new SimpleStringSchema();
 
 		final Kafka09Fetcher<String> fetcher = new Kafka09Fetcher<>(
 				sourceContext,
@@ -251,7 +250,7 @@ public class Kafka09FetcherTest {
 		SourceContext<String> sourceContext = mock(SourceContext.class);
 		Map<KafkaTopicPartition, Long> partitionsWithInitialOffsets =
 			Collections.singletonMap(new KafkaTopicPartition("test", 42), KafkaTopicPartitionStateSentinel.GROUP_OFFSET);
-		KeyedDeserializationSchema<String> schema = new KeyedDeserializationSchemaWrapper<>(new SimpleStringSchema());
+		DeserializationSchema<String> schema = new SimpleStringSchema();
 
 		final Kafka09Fetcher<String> fetcher = new Kafka09Fetcher<>(
 				sourceContext,
@@ -366,7 +365,7 @@ public class Kafka09FetcherTest {
 		BlockingSourceContext<String> sourceContext = new BlockingSourceContext<>();
 		Map<KafkaTopicPartition, Long> partitionsWithInitialOffsets =
 			Collections.singletonMap(new KafkaTopicPartition(topic, partition), KafkaTopicPartitionStateSentinel.GROUP_OFFSET);
-		KeyedDeserializationSchema<String> schema = new KeyedDeserializationSchemaWrapper<>(new SimpleStringSchema());
+		DeserializationSchema<String> schema = new SimpleStringSchema();
 
 		final Kafka09Fetcher<String> fetcher = new Kafka09Fetcher<>(
 				sourceContext,

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBase.java
@@ -19,6 +19,7 @@ package org.apache.flink.streaming.connectors.kafka;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.state.OperatorStateStore;
@@ -49,7 +50,6 @@ import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartition
 import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartitionAssigner;
 import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartitionStateSentinel;
 import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicsDescriptor;
-import org.apache.flink.streaming.util.serialization.KeyedDeserializationSchema;
 import org.apache.flink.util.SerializedValue;
 
 import org.apache.commons.collections.map.LinkedMap;
@@ -116,7 +116,7 @@ public abstract class FlinkKafkaConsumerBase<T> extends RichParallelSourceFuncti
 	private final KafkaTopicsDescriptor topicsDescriptor;
 
 	/** The schema to convert between Kafka's byte messages, and Flink's objects. */
-	protected final KeyedDeserializationSchema<T> deserializer;
+	protected final DeserializationSchema<T> deserializer;
 
 	/** The set of topic partitions that the source will read, with their initial offsets to start reading from. */
 	private Map<KafkaTopicPartition, Long> subscribedPartitionsToStartOffsets;
@@ -233,7 +233,7 @@ public abstract class FlinkKafkaConsumerBase<T> extends RichParallelSourceFuncti
 	public FlinkKafkaConsumerBase(
 			List<String> topics,
 			Pattern topicPattern,
-			KeyedDeserializationSchema<T> deserializer,
+			DeserializationSchema<T> deserializer,
 			long discoveryIntervalMillis,
 			boolean useMetrics) {
 		this.topicsDescriptor = new KafkaTopicsDescriptor(topics, topicPattern);

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/util/serialization/KeyedDeserializationSchema.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/util/serialization/KeyedDeserializationSchema.java
@@ -30,6 +30,7 @@ import java.io.Serializable;
  *
  * @param <T> The type created by the keyed deserialization schema.
  */
+@Deprecated
 @PublicEvolving
 public interface KeyedDeserializationSchema<T> extends Serializable, ResultTypeQueryable<T> {
 

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBaseMigrationTest.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBaseMigrationTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.connectors.kafka;
 
+import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
@@ -38,7 +39,6 @@ import org.apache.flink.streaming.util.AbstractStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.OperatorSnapshotUtil;
 import org.apache.flink.streaming.util.migration.MigrationTestUtil;
 import org.apache.flink.streaming.util.migration.MigrationVersion;
-import org.apache.flink.streaming.util.serialization.KeyedDeserializationSchema;
 import org.apache.flink.util.SerializedValue;
 
 import org.junit.Assert;
@@ -372,7 +372,7 @@ public class FlinkKafkaConsumerBaseMigrationTest {
 			super(
 				Arrays.asList("dummy-topic"),
 				null,
-				(KeyedDeserializationSchema< T >) mock(KeyedDeserializationSchema.class),
+				(DeserializationSchema< T >) mock(DeserializationSchema.class),
 				discoveryInterval,
 				false);
 

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBaseTest.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBaseTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.connectors.kafka;
 
 import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.state.BroadcastState;
 import org.apache.flink.api.common.state.KeyedStateStore;
 import org.apache.flink.api.common.state.ListState;
@@ -54,7 +55,6 @@ import org.apache.flink.streaming.connectors.kafka.testutils.TestPartitionDiscov
 import org.apache.flink.streaming.connectors.kafka.testutils.TestSourceContext;
 import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
 import org.apache.flink.streaming.util.AbstractStreamOperatorTestHarness;
-import org.apache.flink.streaming.util.serialization.KeyedDeserializationSchema;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.SerializedValue;
 
@@ -642,7 +642,7 @@ public class FlinkKafkaConsumerBaseTest {
 			super(
 					Collections.singletonList("dummy-topic"),
 					null,
-					(KeyedDeserializationSchema < T >) mock(KeyedDeserializationSchema.class),
+					(DeserializationSchema< T >) mock(DeserializationSchema.class),
 					PARTITION_DISCOVERY_DISABLED,
 					false);
 

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
@@ -66,7 +66,6 @@ import org.apache.flink.streaming.connectors.kafka.testutils.ThrottledMapper;
 import org.apache.flink.streaming.connectors.kafka.testutils.Tuple2FlinkPartitioner;
 import org.apache.flink.streaming.connectors.kafka.testutils.ValidatingExactlyOnceSink;
 import org.apache.flink.streaming.util.serialization.KeyedDeserializationSchema;
-import org.apache.flink.streaming.util.serialization.KeyedDeserializationSchemaWrapper;
 import org.apache.flink.streaming.util.serialization.KeyedSerializationSchema;
 import org.apache.flink.streaming.util.serialization.KeyedSerializationSchemaWrapper;
 import org.apache.flink.streaming.util.serialization.TypeInformationKeyValueSerializationSchema;
@@ -424,9 +423,8 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBase {
 			new KeyedSerializationSchemaWrapper<>(
 				new TypeInformationSerializationSchema<>(resultType, new ExecutionConfig()));
 
-		final KeyedDeserializationSchema<Tuple2<Integer, Integer>> deserSchema =
-			new KeyedDeserializationSchemaWrapper<>(
-				new TypeInformationSerializationSchema<>(resultType, new ExecutionConfig()));
+		final DeserializationSchema<Tuple2<Integer, Integer>> deserSchema =
+				new TypeInformationSerializationSchema<>(resultType, new ExecutionConfig());
 
 		// setup and run the latest-consuming job
 		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
@@ -1868,9 +1866,8 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBase {
 				new KeyedSerializationSchemaWrapper<>(
 						new TypeInformationSerializationSchema<>(resultType, new ExecutionConfig()));
 
-		final KeyedDeserializationSchema<Tuple2<Integer, Integer>> deserSchema =
-				new KeyedDeserializationSchemaWrapper<>(
-						new TypeInformationSerializationSchema<>(resultType, new ExecutionConfig()));
+		final DeserializationSchema<Tuple2<Integer, Integer>> deserSchema =
+						new TypeInformationSerializationSchema<>(resultType, new ExecutionConfig());
 
 		final int maxNumAttempts = 10;
 
@@ -1966,9 +1963,8 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBase {
 			new KeyedSerializationSchemaWrapper<>(
 				new TypeInformationSerializationSchema<>(resultType, new ExecutionConfig()));
 
-		final KeyedDeserializationSchema<Tuple2<Integer, Integer>> deserSchema =
-			new KeyedDeserializationSchemaWrapper<>(
-				new TypeInformationSerializationSchema<>(resultType, new ExecutionConfig()));
+		final DeserializationSchema<Tuple2<Integer, Integer>> deserSchema =
+				new TypeInformationSerializationSchema<>(resultType, new ExecutionConfig());
 
 		// -------- Write the append sequence --------
 
@@ -2028,7 +2024,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBase {
 	private boolean validateSequence(
 			final String topic,
 			final int parallelism,
-			KeyedDeserializationSchema<Tuple2<Integer, Integer>> deserSchema,
+			DeserializationSchema<Tuple2<Integer, Integer>> deserSchema,
 			final int totalNumElements) throws Exception {
 
 		final StreamExecutionEnvironment readEnv = StreamExecutionEnvironment.getExecutionEnvironment();

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceTestBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceTestBase.java
@@ -62,6 +62,7 @@ public abstract class KafkaTableSourceTestBase {
 	private static final String TOPIC = "testTopic";
 	private static final TableSchema SCHEMA = new TableSchema(FIELD_NAMES, FIELD_TYPES);
 	private static final Properties PROPS = createSourceProperties();
+	private static final DeserializationSchema DESERIALIZER = mock(DeserializationSchema.class);
 
 	@Test
 	@SuppressWarnings("unchecked")
@@ -202,39 +203,39 @@ public abstract class KafkaTableSourceTestBase {
 
 		// test the default behavior
 		KafkaTableSource source = spy(b.build());
-		when(source.createKafkaConsumer(TOPIC, PROPS, null))
+		when(source.createKafkaConsumer(TOPIC, PROPS, DESERIALIZER))
 				.thenReturn(mock(getFlinkKafkaConsumer()));
 
-		verify(source.getKafkaConsumer(TOPIC, PROPS, null)).setStartFromGroupOffsets();
+		verify(source.getKafkaConsumer(TOPIC, PROPS, DESERIALIZER)).setStartFromGroupOffsets();
 
 		// test reading from earliest
 		b.fromEarliest();
 		source = spy(b.build());
-		when(source.createKafkaConsumer(TOPIC, PROPS, null))
+		when(source.createKafkaConsumer(TOPIC, PROPS, DESERIALIZER))
 				.thenReturn(mock(getFlinkKafkaConsumer()));
 
-		verify(source.getKafkaConsumer(TOPIC, PROPS, null)).setStartFromEarliest();
+		verify(source.getKafkaConsumer(TOPIC, PROPS, DESERIALIZER)).setStartFromEarliest();
 
 		// test reading from latest
 		b.fromLatest();
 		source = spy(b.build());
-		when(source.createKafkaConsumer(TOPIC, PROPS, null))
+		when(source.createKafkaConsumer(TOPIC, PROPS, DESERIALIZER))
 				.thenReturn(mock(getFlinkKafkaConsumer()));
-		verify(source.getKafkaConsumer(TOPIC, PROPS, null)).setStartFromLatest();
+		verify(source.getKafkaConsumer(TOPIC, PROPS, DESERIALIZER)).setStartFromLatest();
 
 		// test reading from group offsets
 		b.fromGroupOffsets();
 		source = spy(b.build());
-		when(source.createKafkaConsumer(TOPIC, PROPS, null))
+		when(source.createKafkaConsumer(TOPIC, PROPS, DESERIALIZER))
 				.thenReturn(mock(getFlinkKafkaConsumer()));
-		verify(source.getKafkaConsumer(TOPIC, PROPS, null)).setStartFromGroupOffsets();
+		verify(source.getKafkaConsumer(TOPIC, PROPS, DESERIALIZER)).setStartFromGroupOffsets();
 
 		// test reading from given offsets
 		b.fromSpecificOffsets(mock(Map.class));
 		source = spy(b.build());
-		when(source.createKafkaConsumer(TOPIC, PROPS, null))
+		when(source.createKafkaConsumer(TOPIC, PROPS, DESERIALIZER))
 				.thenReturn(mock(getFlinkKafkaConsumer()));
-		verify(source.getKafkaConsumer(TOPIC, PROPS, null)).setStartFromSpecificOffsets(any(Map.class));
+		verify(source.getKafkaConsumer(TOPIC, PROPS, DESERIALIZER)).setStartFromSpecificOffsets(any(Map.class));
 	}
 
 	protected abstract KafkaTableSource.Builder getBuilder();

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironment.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironment.java
@@ -127,19 +127,19 @@ public abstract class KafkaTestEnvironment {
 	public abstract List<KafkaServer> getBrokers();
 
 	// -- consumer / producer instances:
-	public <T> FlinkKafkaConsumerBase<T> getConsumer(List<String> topics, DeserializationSchema<T> deserializationSchema, Properties props) {
+	public <T> FlinkKafkaConsumerBase<T> getConsumer(List<String> topics, KeyedDeserializationSchema<T> deserializationSchema, Properties props) {
 		return getConsumer(topics, new KeyedDeserializationSchemaWrapper<T>(deserializationSchema), props);
 	}
 
 	public <T> FlinkKafkaConsumerBase<T> getConsumer(String topic, KeyedDeserializationSchema<T> readSchema, Properties props) {
-		return getConsumer(Collections.singletonList(topic), readSchema, props);
+		return getConsumer(Collections.singletonList(topic), new KeyedDeserializationSchemaWrapper<T>(readSchema), props);
 	}
 
 	public <T> FlinkKafkaConsumerBase<T> getConsumer(String topic, DeserializationSchema<T> deserializationSchema, Properties props) {
 		return getConsumer(Collections.singletonList(topic), deserializationSchema, props);
 	}
 
-	public abstract <T> FlinkKafkaConsumerBase<T> getConsumer(List<String> topics, KeyedDeserializationSchema<T> readSchema, Properties props);
+	public abstract <T> FlinkKafkaConsumerBase<T> getConsumer(List<String> topics, DeserializationSchema<T> readSchema, Properties props);
 
 	public abstract <K, V> Collection<ConsumerRecord<K, V>> getAllRecordsFromTopic(
 			Properties properties,

--- a/flink-core/src/main/java/org/apache/flink/api/common/serialization/ConsumerRecordMetaInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/serialization/ConsumerRecordMetaInfo.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.serialization;
+
+import org.apache.flink.annotation.Public;
+
+/**
+ * The consumer record meta info contains, besides the actual message, some meta information, such as
+ * key, topic, partition, offset and timestamp for Apache kafka
+ *
+ * <p><b>Note:</b>The timestamp is only valid for Kafka clients 0.10+, for older versions the value has the value `Long.MinValue` and
+ * the timestampType has the value `NO_TIMESTAMP_TYPE`.
+ */
+@Public
+public interface ConsumerRecordMetaInfo {
+	/**
+	 * The TimestampType is introduced in the kafka clients 0.10+. This interface is also used for the Kafka connector 0.9
+	 * so a local enumeration is needed.
+	 */
+	enum TimestampType {
+		NO_TIMESTAMP_TYPE, CREATE_TIME, INGEST_TIME
+	}
+
+	/**
+	 * @return the key as a byte array (null if no key has been set).
+	 */
+	byte[] getKey();
+
+	/**
+	 * @return The message, as a byte array (null if the message was empty or deleted).
+	 */
+	byte[] getMessage();
+
+	/**
+	 * @return The topic the message has originated from (for example the Kafka topic).
+	 */
+	String getTopic();
+
+	/**
+	 * @return The partition the message has originated from (for example the Kafka partition).
+	 */
+	int getPartition();
+
+	/**
+	 * @return the offset of the message in the original source (for example the Kafka offset).
+	 */
+	long getOffset();
+
+	/**
+	 * @return the timestamp of the consumer record
+	 */
+	long getTimestamp();
+
+	/**
+	 * @return The timestamp type, could be NO_TIMESTAMP_TYPE, CREATE_TIME or INGEST_TIME.
+	 */
+	TimestampType getTimestampType();
+}

--- a/flink-core/src/main/java/org/apache/flink/api/common/serialization/ConsumerRecordMetaInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/serialization/ConsumerRecordMetaInfo.java
@@ -24,7 +24,7 @@ import org.apache.flink.annotation.Public;
  * key, topic, partition, offset and timestamp for Apache kafka
  *
  * <p><b>Note:</b>The timestamp is only valid for Kafka clients 0.10+, for older versions the value has the value `Long.MinValue` and
- * the timestampType has the value `NO_TIMESTAMP_TYPE`.
+ * the timestampType has the value `NO_TIMESTAMP`.
  */
 @Public
 public interface ConsumerRecordMetaInfo {
@@ -33,7 +33,7 @@ public interface ConsumerRecordMetaInfo {
 	 * so a local enumeration is needed.
 	 */
 	enum TimestampType {
-		NO_TIMESTAMP_TYPE, CREATE_TIME, INGEST_TIME
+		NO_TIMESTAMP, EVENT_TIME, INGEST_TIME
 	}
 
 	/**
@@ -62,12 +62,14 @@ public interface ConsumerRecordMetaInfo {
 	long getOffset();
 
 	/**
-	 * @return the timestamp of the consumer record
+	 * @return the timestamp of the consumer record. When the consumer record doesn't support the timestamp (e.g. kafka 0.9-)
+	 * then a dummy value should be returned (like Long.MinValue) and the timestampType should return NO_TIMESTAMP.
 	 */
 	long getTimestamp();
 
 	/**
-	 * @return The timestamp type, could be NO_TIMESTAMP_TYPE, CREATE_TIME or INGEST_TIME.
+	 * @return The timestamp type, could be NO_TIMESTAMP, EVENT_TIME or INGEST_TIME. When the consumer record doesn't
+	 * support the timestamp (e.g. kafka 0.9-) then NO_TIMESTAMP should be returned.
 	 */
 	TimestampType getTimestampType();
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/serialization/DeserializationSchema.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/serialization/DeserializationSchema.java
@@ -43,13 +43,21 @@ import java.io.Serializable;
 public interface DeserializationSchema<T> extends Serializable, ResultTypeQueryable<T> {
 
 	/**
+	 * @deprecated Use {@link #deserialize(ConsumerRecordMetaInfo)} .
+	 */
+	@Deprecated
+	T deserialize(byte[] message) throws IOException;
+
+	/**
 	 * Deserializes the byte message.
 	 *
-	 * @param message The message, as a byte array.
+	 * @param consumerRecordMetaInfossage The message, as a {@link ConsumerRecordMetaInfo}.
 	 *
 	 * @return The deserialized message as an object (null if the message cannot be deserialized).
 	 */
-	T deserialize(byte[] message) throws IOException;
+	default T deserialize(ConsumerRecordMetaInfo consumerRecordMetaInfossage) throws IOException {
+		return deserialize(consumerRecordMetaInfossage.getMessage());
+	}
 
 	/**
 	 * Method to decide whether the element signals the end of the stream. If

--- a/flink-core/src/main/java/org/apache/flink/api/common/serialization/DeserializationSchema.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/serialization/DeserializationSchema.java
@@ -43,13 +43,16 @@ import java.io.Serializable;
 public interface DeserializationSchema<T> extends Serializable, ResultTypeQueryable<T> {
 
 	/**
-	 * @deprecated Use {@link #deserialize(ConsumerRecordMetaInfo)} .
+	 * @deprecated This method still exist so the Flink API isn't broken and will be called by the default
+	 * implementation of the {@link #deserialize(ConsumerRecordMetaInfo)} method. By implementing the
+	 * {@link #deserialize(ConsumerRecordMetaInfo)} method you have access to all meta information of the kafka message.
 	 */
 	@Deprecated
 	T deserialize(byte[] message) throws IOException;
 
 	/**
-	 * Deserializes the byte message.
+	 * Deserializes the message with access to the meta information of the kafka message, like key, value, topic,
+	 * partition, offset and timestamp.
 	 *
 	 * @param consumerRecordMetaInfossage The message, as a {@link ConsumerRecordMetaInfo}.
 	 *

--- a/flink-core/src/test/java/org/apache/flink/api/common/serialization/TypeInformationSerializationSchemaTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/serialization/TypeInformationSerializationSchemaTest.java
@@ -57,6 +57,9 @@ public class TypeInformationSerializationSchemaTest {
 				byte[] serialized = schema.serialize(val);
 				MyPOJO deser = schema.deserialize(serialized);
 				assertEquals(val, deser);
+
+				MyPOJO deserConsumerRecord = schema.deserialize(new MyConsumerRecordMetaInfo(serialized));
+				assertEquals(val, deserConsumerRecord);
 			}
 		}
 		catch (Exception e) {
@@ -84,6 +87,48 @@ public class TypeInformationSerializationSchemaTest {
 	// ------------------------------------------------------------------------
 	//  Test data types
 	// ------------------------------------------------------------------------
+	private class MyConsumerRecordMetaInfo implements ConsumerRecordMetaInfo {
+		private byte[] message;
+
+		public MyConsumerRecordMetaInfo(byte[] message) {
+			this.message = message;
+		}
+
+		@Override
+		public byte[] getKey() {
+			return null;
+		}
+
+		@Override
+		public byte[] getMessage() {
+			return message;
+		}
+
+		@Override
+		public String getTopic() {
+			return null;
+		}
+
+		@Override
+		public int getPartition() {
+			return 0;
+		}
+
+		@Override
+		public long getOffset() {
+			return 0;
+		}
+
+		@Override
+		public long getTimestamp() {
+			return Long.MIN_VALUE;
+		}
+
+		@Override
+		public TimestampType getTimestampType() {
+			return null;
+		}
+	}
 
 	private static class MyPOJO {
 


### PR DESCRIPTION
## What is the purpose of the change

This pull request make the Kafka timestamp and timestampType available in the message deserialisation so one can use it in the business logic processing.

## Brief change log

Introduced new interface `ConsumerRecordMetaInfo` with meta info of the kafka message
Extended the `DeserializationSchema` with the `T deserialize(ConsumerRecordMetaInfo consumerRecord)` method.
Adjusted the Kafka Connectors to support the new interface.
Added some documentation.

## Verifying this change

This change is already covered by existing tests, such as most of the Kafka Consumer tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (**yes** / no / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** / **JavaDocs** / not documented)
