### PR TITLE
[FLINK-9258][metrics] Thread-safe initialization of variables map

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroup.java
@@ -113,11 +113,12 @@ public abstract class AbstractMetricGroup<A extends AbstractMetricGroup<?>> impl
 		if (variables == null) { // avoid synchronization for common case
 			synchronized (this) {
 				if (variables == null) {
-					variables = new HashMap<>();
-					putVariables(variables);
-					if (parent != null) { // not true for Job-/TaskManagerMetricGroup and mocks
-						variables.putAll(parent.getAllVariables());
+					Map<String, String> tmpVariables = new HashMap<>();
+					putVariables(tmpVariables);
+					if (parent != null) { // not true for Job-/TaskManagerMetricGroup
+						tmpVariables.putAll(parent.getAllVariables());
 					}
+					variables = tmpVariables;
 				}
 			}
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/ComponentMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/ComponentMetricGroup.java
@@ -21,9 +21,6 @@ package org.apache.flink.runtime.metrics.groups;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 
-import java.util.HashMap;
-import java.util.Map;
-
 /**
  * Abstract {@link org.apache.flink.metrics.MetricGroup} for system components (e.g.,
  * TaskManager, Job, Task, Operator).
@@ -51,30 +48,6 @@ public abstract class ComponentMetricGroup<P extends AbstractMetricGroup<?>> ext
 	public ComponentMetricGroup(MetricRegistry registry, String[] scope, P parent) {
 		super(registry, scope, parent);
 	}
-
-	@Override
-	public Map<String, String> getAllVariables() {
-		if (variables == null) { // avoid synchronization for common case
-			synchronized (this) {
-				if (variables == null) {
-					Map<String, String> tmpVariables = new HashMap<>();
-					putVariables(tmpVariables);
-					if (parent != null) { // not true for Job-/TaskManagerMetricGroup
-						tmpVariables.putAll(parent.getAllVariables());
-					}
-					variables = tmpVariables;
-				}
-			}
-		}
-		return variables;
-	}
-
-	/**
-	 * Enters all variables specific to this ComponentMetricGroup and their associated values into the map.
-	 *
-	 * @param variables map to enter variables and their values into
-     */
-	protected abstract void putVariables(Map<String, String> variables);
 
 	/**
 	 * Closes the component group by removing and closing all metrics and subgroups

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/ComponentMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/ComponentMetricGroup.java
@@ -57,11 +57,12 @@ public abstract class ComponentMetricGroup<P extends AbstractMetricGroup<?>> ext
 		if (variables == null) { // avoid synchronization for common case
 			synchronized (this) {
 				if (variables == null) {
-					variables = new HashMap<>();
-					putVariables(variables);
+					Map<String, String> tmpVariables = new HashMap<>();
+					putVariables(tmpVariables);
 					if (parent != null) { // not true for Job-/TaskManagerMetricGroup
-						variables.putAll(parent.getAllVariables());
+						tmpVariables.putAll(parent.getAllVariables());
 					}
+					variables = tmpVariables;
 				}
 			}
 		}


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes a thread-safety issue in `ComponentMetricGroup` where a map was assigned to the `variables` field in a synchronized block before it was populated.
This meant that a modification could be made to the map that is already visible to other threads, leading to `ConcurrentModificationExceptions`.