### PR TITLE
[FLINK-8255][DataSet API, DataStream API] key expressions on named row types do not work

### DIFF
--- a/flink-java/src/main/java/org/apache/flink/api/java/DataSet.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/DataSet.java
@@ -521,7 +521,7 @@ public abstract class DataSet<T> {
 	 */
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	public ReduceOperator<T> minBy(int... fields)  {
-		if (!getType().isTupleType()) {
+		if (!getType().isTupleType() || !(getType() instanceof TupleTypeInfo)) {
 			throw new InvalidProgramException("DataSet#minBy(int...) only works on Tuple types.");
 		}
 
@@ -557,7 +557,7 @@ public abstract class DataSet<T> {
 	 */
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	public ReduceOperator<T> maxBy(int... fields) {
-		if (!getType().isTupleType()) {
+		if (!getType().isTupleType() || !(getType() instanceof TupleTypeInfo)) {
 			throw new InvalidProgramException("DataSet#maxBy(int...) only works on Tuple types.");
 		}
 

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/UnsortedGrouping.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/UnsortedGrouping.java
@@ -221,7 +221,7 @@ public class UnsortedGrouping<T> extends Grouping<T> {
 	public ReduceOperator<T> minBy(int... fields)  {
 
 		// Check for using a tuple
-		if (!this.inputDataSet.getType().isTupleType()) {
+		if (!this.inputDataSet.getType().isTupleType() || !(this.inputDataSet.getType() instanceof TupleTypeInfo)) {
 			throw new InvalidProgramException("Method minBy(int) only works on tuples.");
 		}
 
@@ -243,7 +243,7 @@ public class UnsortedGrouping<T> extends Grouping<T> {
 	public ReduceOperator<T> maxBy(int... fields)  {
 
 		// Check for using a tuple
-		if (!this.inputDataSet.getType().isTupleType()) {
+		if (!this.inputDataSet.getType().isTupleType() || !(this.inputDataSet.getType() instanceof TupleTypeInfo)) {
 			throw new InvalidProgramException("Method maxBy(int) only works on tuples.");
 		}
 

--- a/flink-java/src/test/java/org/apache/flink/api/java/operator/MaxByOperatorTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/operator/MaxByOperatorTest.java
@@ -20,17 +20,22 @@ package org.apache.flink.api.java.operator;
 
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.operators.UnsortedGrouping;
 import org.apache.flink.api.java.tuple.Tuple5;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.api.java.typeutils.TupleTypeInfo;
+import org.apache.flink.types.Row;
 
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -228,6 +233,80 @@ public class MaxByOperatorTest {
 		public String toString() {
 			return myInt + "," + myLong + "," + myString;
 		}
+	}
+
+	/**
+	 * Validates that no ClassCastException happens
+	 * should not fail e.g. like in FLINK-8255.
+	 */
+	@Test(expected = InvalidProgramException.class)
+	public void testMinByRowTypeInfoKeyFieldsDataset() {
+
+		final ExecutionEnvironment env = ExecutionEnvironment
+			.getExecutionEnvironment();
+		TypeInformation[] types = new TypeInformation[] {Types.INT, Types.INT};
+
+		String[] fieldNames = new String[]{"id", "value"};
+		RowTypeInfo rowTypeInfo = new RowTypeInfo(types, fieldNames);
+		DataSet tupleDs = env
+			.fromCollection(Collections.singleton(new Row(2)), rowTypeInfo);
+
+		tupleDs.minBy(0);
+	}
+
+	/**
+	 * Validates that no ClassCastException happens
+	 * should not fail e.g. like in FLINK-8255.
+	 */
+	@Test(expected = InvalidProgramException.class)
+	public void testMaxByRowTypeInfoKeyFieldsDataset() {
+
+		final ExecutionEnvironment env = ExecutionEnvironment
+			.getExecutionEnvironment();
+		TypeInformation[] types = new TypeInformation[] {Types.INT, Types.INT};
+
+		String[] fieldNames = new String[]{"id", "value"};
+		RowTypeInfo rowTypeInfo = new RowTypeInfo(types, fieldNames);
+		DataSet tupleDs = env
+			.fromCollection(Collections.singleton(new Row(2)), rowTypeInfo);
+
+		tupleDs.maxBy(0);
+	}
+
+    /**
+     * Validates that no ClassCastException happens
+	 * should not fail e.g. like in FLINK-8255.
+	 */
+	@Test(expected = InvalidProgramException.class)
+	public void testMinByRowTypeInfoKeyFieldsForUnsortedGrouping() {
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+
+		TypeInformation[] types = new TypeInformation[]{Types.INT, Types.INT};
+
+		String[] fieldNames = new String[]{"id", "value"};
+		RowTypeInfo rowTypeInfo = new RowTypeInfo(types, fieldNames);
+
+		UnsortedGrouping groupDs = env.fromCollection(Collections.singleton(new Row(2)), rowTypeInfo).groupBy(0);
+
+		groupDs.minBy(1);
+	}
+
+	/**
+	 * Validates that no ClassCastException happens
+	 * should not fail e.g. like in FLINK-8255.
+	 */
+	@Test(expected = InvalidProgramException.class)
+	public void testMaxByRowTypeInfoKeyFieldsForUnsortedGrouping() {
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+
+		TypeInformation[] types = new TypeInformation[]{Types.INT, Types.INT};
+
+		String[] fieldNames = new String[]{"id", "value"};
+		RowTypeInfo rowTypeInfo = new RowTypeInfo(types, fieldNames);
+
+		UnsortedGrouping groupDs = env.fromCollection(Collections.singleton(new Row(2)), rowTypeInfo).groupBy(0);
+
+		groupDs.maxBy(1);
 	}
 
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/typeutils/FieldAccessorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/typeutils/FieldAccessorFactory.java
@@ -164,7 +164,7 @@ public class FieldAccessorFactory implements Serializable {
 			}
 
 		// In case of tuples
-		} else if (typeInfo.isTupleType()) {
+		} else if (typeInfo.isTupleType() && typeInfo instanceof TupleTypeInfo) {
 			TupleTypeInfo tupleTypeInfo = (TupleTypeInfo) typeInfo;
 			FieldExpression decomp = decomposeFieldExpression(field);
 			int fieldPos = tupleTypeInfo.getFieldIndex(decomp.head);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/typeutils/FieldAccessorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/typeutils/FieldAccessorTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.api.common.typeutils.CompositeType;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.api.java.typeutils.PojoTypeInfo;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.api.java.typeutils.TupleTypeInfo;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
 
@@ -368,4 +369,23 @@ public class FieldAccessorTest {
 
 		FieldAccessor<Long, Long> f = FieldAccessorFactory.getAccessor(tpeInfo, "foo", null);
 	}
+
+	/**
+	 * Validates that no ClassCastException happens
+	 * should not fail e.g. like in FLINK-8255.
+	 */
+	@Test(expected = CompositeType.InvalidFieldReferenceException.class)
+	public void testRowTypeInfo() {
+		TypeInformation<?>[] typeList = new TypeInformation<?>[]{
+			new RowTypeInfo(
+				BasicTypeInfo.SHORT_TYPE_INFO,
+				BasicTypeInfo.BIG_DEC_TYPE_INFO)
+		};
+
+		String[] fieldNames = new String[]{"row"};
+		RowTypeInfo rowTypeInfo = new RowTypeInfo(typeList, fieldNames);
+
+		FieldAccessor f = FieldAccessorFactory.getAccessor(rowTypeInfo, "row.0", null);
+	}
+
 }


### PR DESCRIPTION
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](http://flink.apache.org/contribute-code.html#best-practices).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**

## What is the purpose of the change
Fix issues related to ClassCastExceptions from Flink-8255 + add more tests

## Brief change log
- Usage of casting to TupleTypeInfoBase rather than to TupleTypeInfo as RowTypeInfo is a child of TupleTypeInfoBase but in a different branch in compare with TupleTypeInfo
- Add more tests which will fail with ClassCastException without changes from the previous item

## Verifying this change

*(Please pick either of the following options)*
This change added tests and can be verified as follows:
- Added tests that validates that ClassCastException related to Flink-8255 are not happen

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (don't know)
  - The runtime per-record code paths (performance sensitive): (don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
