### PR TITLE
[FLINK-9304] Timer service shutdown should not stop if interrupted

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/ProcessingTimeService.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/ProcessingTimeService.java
@@ -96,6 +96,17 @@ public abstract class ProcessingTimeService {
 	public abstract void shutdownService();
 
 	/**
+	 * Shuts down and clean up the timer service provider hard and immediately. This does not wait
+	 * for any timer to complete. Any further call to {@link #registerTimer(long, ProcessingTimeCallback)}
+	 * will result in a hard exception. This call cannot be interrupted and will block until the shutdown is completed
+	 * or the timeout is exceeded.
+	 *
+	 * @param timeoutMs timeout for blocking on the service shutdown in milliseconds.
+	 * @return returns true iff the shutdown was completed.
+	 */
+	public abstract boolean shutdownServiceUninterruptible(long timeoutMs);
+
+	/**
 	 * Shuts down and clean up the timer service provider hard and immediately. This does wait
 	 * for all timers to complete or until the time limit is exceeded. Any call to
 	 * {@link #registerTimer(long, ProcessingTimeCallback)} will result in a hard exception after calling this method.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -347,9 +347,6 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 			// clean up everything we initialized
 			isRunning = false;
 
-			// clear the interrupted status so that we can wait for the following resource shutdowns to complete
-			Thread.interrupted();
-
 			// stop all timers and threads
 			tryShutdownTimerService();
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SystemProcessingTimeService.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SystemProcessingTimeService.java
@@ -18,10 +18,15 @@
 package org.apache.flink.streaming.runtime.tasks;
 
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.util.Preconditions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 
+import java.time.Duration;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.Delayed;
@@ -40,6 +45,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * {@link System#currentTimeMillis()} and registers timers using a {@link ScheduledThreadPoolExecutor}.
  */
 public class SystemProcessingTimeService extends ProcessingTimeService {
+
+	private static final Logger LOG = LoggerFactory.getLogger(SystemProcessingTimeService.class);
 
 	private static final int STATUS_ALIVE = 0;
 	private static final int STATUS_QUIESCED = 1;
@@ -195,6 +202,23 @@ public class SystemProcessingTimeService extends ProcessingTimeService {
 	public boolean shutdownAndAwaitPending(long time, TimeUnit timeUnit) throws InterruptedException {
 		shutdownService();
 		return timerService.awaitTermination(time, timeUnit);
+	}
+
+	@Override
+	public boolean shutdownServiceUninterruptible(long timeoutMs) {
+
+		final Deadline deadline = Deadline.fromNow(Duration.ofMillis(timeoutMs));
+
+		do {
+			try {
+				// wait for a reasonable time for all pending timer threads to finish
+				return shutdownAndAwaitPending(deadline.timeLeft().toMillis(), TimeUnit.MILLISECONDS);
+			} catch (InterruptedException iex) {
+				LOG.trace("Intercepted attempt to interrupt timer service shutdown.", iex);
+			}
+		} while (deadline.hasTimeLeft());
+
+		return false;
 	}
 
 	// safety net to destroy the thread pool

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TestProcessingTimeService.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TestProcessingTimeService.java
@@ -135,6 +135,12 @@ public class TestProcessingTimeService extends ProcessingTimeService {
 	}
 
 	@Override
+	public boolean shutdownServiceUninterruptible(long timeoutMs) {
+		shutdownService();
+		return true;
+	}
+
+	@Override
 	public boolean shutdownAndAwaitPending(long time, TimeUnit timeUnit) throws InterruptedException {
 		shutdownService();
 		return true;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SystemProcessingTimeServiceTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SystemProcessingTimeServiceTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.runtime.tasks;
 
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.streaming.runtime.operators.TestProcessingTimeServiceTest.ReferenceSettingExceptionHandler;
+import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Assert;
@@ -449,41 +450,11 @@ public class SystemProcessingTimeServiceTest extends TestLogger {
 	public void testShutdownAndWaitPending() {
 
 		final Object lock = new Object();
-		final OneShotLatch waitUntilTimerStarted = new OneShotLatch();
-		final OneShotLatch blockUntilTerminationInterrupts = new OneShotLatch();
 		final OneShotLatch blockUntilTriggered = new OneShotLatch();
-		final AtomicBoolean check = new AtomicBoolean(true);
+		final AtomicBoolean timerExecutionFinished = new AtomicBoolean(false);
 
-		final SystemProcessingTimeService timeService = new SystemProcessingTimeService(
-			(message, exception) -> {
-			},
-			lock);
-
-		timeService.scheduleAtFixedRate(
-			timestamp -> {
-
-				waitUntilTimerStarted.trigger();
-
-				try {
-					blockUntilTerminationInterrupts.await();
-					check.set(false);
-				} catch (InterruptedException ignore) {
-				}
-
-				try {
-					blockUntilTriggered.await();
-				} catch (InterruptedException ignore) {
-					check.set(false);
-				}
-			},
-			0L,
-			10L);
-
-		try {
-			waitUntilTimerStarted.await();
-		} catch (InterruptedException e) {
-			Assert.fail();
-		}
+		final SystemProcessingTimeService timeService =
+			createBlockingSystemProcessingTimeService(lock, blockUntilTriggered, timerExecutionFinished);
 
 		Assert.assertFalse(timeService.isTerminated());
 
@@ -504,7 +475,101 @@ public class SystemProcessingTimeServiceTest extends TestLogger {
 			Assert.fail("Unexpected interruption.");
 		}
 
-		Assert.assertTrue(check.get());
+		Assert.assertTrue(timerExecutionFinished.get());
 		Assert.assertTrue(timeService.isTerminated());
+	}
+
+	@Test
+	public void testShutdownServiceUninterruptible() {
+		final Object lock = new Object();
+		final OneShotLatch blockUntilTriggered = new OneShotLatch();
+		final AtomicBoolean timerFinished = new AtomicBoolean(false);
+
+		final SystemProcessingTimeService timeService =
+			createBlockingSystemProcessingTimeService(lock, blockUntilTriggered, timerFinished);
+
+		Assert.assertFalse(timeService.isTerminated());
+
+		final Thread interruptTarget = Thread.currentThread();
+		final AtomicBoolean runInterrupts = new AtomicBoolean(true);
+		final Thread interruptCallerThread = new Thread(() -> {
+			while (runInterrupts.get()) {
+				interruptTarget.interrupt();
+				try {
+					Thread.sleep(10);
+				} catch (InterruptedException ignore) {
+				}
+			}
+		});
+
+		interruptCallerThread.start();
+
+		final long timeoutMs = 1000L;
+		final long startTime = System.nanoTime();
+		Assert.assertFalse(timeService.isTerminated());
+		// check that termination did not succeed (because of blocking timer execution)
+		Assert.assertFalse(timeService.shutdownServiceUninterruptible(timeoutMs));
+		// check that termination flag was set.
+		Assert.assertTrue(timeService.isTerminated());
+		// check that the blocked timer is still in flight.
+		Assert.assertFalse(timerFinished.get());
+		// check that we waited until timeout
+		Assert.assertTrue((System.nanoTime() - startTime) >= (1_000_000L * timeoutMs));
+
+		runInterrupts.set(false);
+
+		do {
+			try {
+				interruptCallerThread.join();
+			} catch (InterruptedException ignore) {
+			}
+		} while (interruptCallerThread.isAlive());
+
+		blockUntilTriggered.trigger();
+		Assert.assertTrue(timeService.shutdownServiceUninterruptible(1000));
+		Assert.assertTrue(timerFinished.get());
+	}
+
+	private static SystemProcessingTimeService createBlockingSystemProcessingTimeService(
+		final Object lock,
+		final OneShotLatch blockUntilTriggered,
+		final AtomicBoolean check) {
+
+		final OneShotLatch waitUntilTimerStarted = new OneShotLatch();
+
+		Preconditions.checkState(!check.get());
+
+		final SystemProcessingTimeService timeService = new SystemProcessingTimeService(
+			(message, exception) -> {
+			},
+			lock);
+
+		timeService.scheduleAtFixedRate(
+			timestamp -> {
+
+				waitUntilTimerStarted.trigger();
+
+				boolean unblocked = false;
+
+				while (!unblocked) {
+					try {
+						blockUntilTriggered.await();
+						unblocked = true;
+					} catch (InterruptedException ignore) {
+					}
+				}
+
+				check.set(true);
+			},
+			0L,
+			10L);
+
+		try {
+			waitUntilTimerStarted.await();
+		} catch (InterruptedException e) {
+			Assert.fail("Problem while starting up service.");
+		}
+
+		return timeService;
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SystemProcessingTimeServiceTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SystemProcessingTimeServiceTest.java
@@ -496,7 +496,7 @@ public class SystemProcessingTimeServiceTest extends TestLogger {
 			while (runInterrupts.get()) {
 				interruptTarget.interrupt();
 				try {
-					Thread.sleep(10);
+					Thread.sleep(1);
 				} catch (InterruptedException ignore) {
 				}
 			}
@@ -504,7 +504,7 @@ public class SystemProcessingTimeServiceTest extends TestLogger {
 
 		interruptCallerThread.start();
 
-		final long timeoutMs = 1000L;
+		final long timeoutMs = 50L;
 		final long startTime = System.nanoTime();
 		Assert.assertFalse(timeService.isTerminated());
 		// check that termination did not succeed (because of blocking timer execution)
@@ -526,7 +526,7 @@ public class SystemProcessingTimeServiceTest extends TestLogger {
 		} while (interruptCallerThread.isAlive());
 
 		blockUntilTriggered.trigger();
-		Assert.assertTrue(timeService.shutdownServiceUninterruptible(1000));
+		Assert.assertTrue(timeService.shutdownServiceUninterruptible(timeoutMs));
 		Assert.assertTrue(timerFinished.get());
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

This PR prevents that interruption prematurely stops the shutdown of the timer service.


## Brief change log

We catch `InterruptedException` around the shutdown call and repeat the attempt while there is still time left w.r.t. to the shutdown grace period.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
