### PR TITLE
[FLINK-9305][s3] also register flink-s3-fs-hadoop's factory for the s3a:// scheme

### DIFF
--- a/docs/ops/deployment/aws.md
+++ b/docs/ops/deployment/aws.md
@@ -105,6 +105,8 @@ To use either `flink-s3-fs-hadoop` or `flink-s3-fs-presto`, copy the respective 
 cp ./opt/flink-s3-fs-presto-{{ site.version }}.jar ./lib/
 {% endhighlight %}
 
+Both `flink-s3-fs-hadoop` and `flink-s3-fs-presto` register default FileSystem wrappers for URIs with the `s3://` scheme, `flink-s3-fs-hadoop` also registers for `s3a://`.
+
 #### Configure Access Credentials
 
 After setting up the S3 FileSystem wrapper, you need to make sure that Flink is allowed to access your S3 buckets.

--- a/flink-filesystems/flink-s3-fs-hadoop/README.md
+++ b/flink-filesystems/flink-s3-fs-hadoop/README.md
@@ -30,7 +30,7 @@ steps are required to keep the shading correct:
 2. verify the shaded jar:
   - does not contain any unshaded classes except for `org.apache.flink.fs.s3hadoop.S3FileSystemFactory`
   - all other classes should be under `org.apache.flink.fs.s3hadoop.shaded`
-  - there should be a `META-INF/services/org.apache.flink.core.fs.FileSystemFactory` file pointing to the `org.apache.flink.fs.s3hadoop.S3FileSystemFactory` class
+  - there should be a `META-INF/services/org.apache.flink.core.fs.FileSystemFactory` file pointing to two classes: `org.apache.flink.fs.s3hadoop.S3FileSystemFactory` and `org.apache.flink.fs.s3hadoop.S3AFileSystemFactory`
   - other service files under `META-INF/services` should have their names and contents in the relocated `org.apache.flink.fs.s3hadoop.shaded` package
   - contains a `core-default-shaded.xml` file
   - does not contain a `core-default.xml` or `core-site.xml` file

--- a/flink-filesystems/flink-s3-fs-hadoop/README.md
+++ b/flink-filesystems/flink-s3-fs-hadoop/README.md
@@ -30,7 +30,7 @@ steps are required to keep the shading correct:
 2. verify the shaded jar:
   - does not contain any unshaded classes except for `org.apache.flink.fs.s3hadoop.S3FileSystemFactory`
   - all other classes should be under `org.apache.flink.fs.s3hadoop.shaded`
-  - there should be a `META-INF/services/org.apache.flink.fs.s3hadoop.S3FileSystemFactory` file pointing to the `org.apache.flink.fs.s3hadoop.S3FileSystemFactory` class
+  - there should be a `META-INF/services/org.apache.flink.core.fs.FileSystemFactory` file pointing to the `org.apache.flink.fs.s3hadoop.S3FileSystemFactory` class
   - other service files under `META-INF/services` should have their names and contents in the relocated `org.apache.flink.fs.s3hadoop.shaded` package
   - contains a `core-default-shaded.xml` file
   - does not contain a `core-default.xml` or `core-site.xml` file

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/java/org/apache/flink/fs/s3hadoop/S3AFileSystemFactory.java
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/java/org/apache/flink/fs/s3hadoop/S3AFileSystemFactory.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.s3hadoop;
+
+/**
+ * Simple factory for the S3 file system, registered for the <tt>s3a://</tt> scheme.
+ */
+public class S3AFileSystemFactory extends S3FileSystemFactory {
+	@Override
+	public String getScheme() {
+		return "s3a";
+	}
+}

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/services/org.apache.flink.core.fs.FileSystemFactory
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/services/org.apache.flink.core.fs.FileSystemFactory
@@ -14,3 +14,4 @@
 # limitations under the License.
 
 org.apache.flink.fs.s3hadoop.S3FileSystemFactory
+org.apache.flink.fs.s3hadoop.S3AFileSystemFactory

--- a/flink-filesystems/flink-s3-fs-presto/README.md
+++ b/flink-filesystems/flink-s3-fs-presto/README.md
@@ -31,7 +31,7 @@ steps are required to keep the shading correct:
 2. verify the shaded jar:
   - does not contain any unshaded classes except for `org.apache.flink.fs.s3presto.S3FileSystemFactory`
   - all other classes should be under `org.apache.flink.fs.s3presto.shaded`
-  - there should be a `META-INF/services/org.apache.flink.fs.s3presto.S3FileSystemFactory` file pointing to the `org.apache.flink.fs.s3presto.S3FileSystemFactory` class
+  - there should be a `META-INF/services/org.apache.flink.core.fs.FileSystemFactory` file pointing to the `org.apache.flink.fs.s3presto.S3FileSystemFactory` class
   - other service files under `META-INF/services` should have their names and contents in the relocated `org.apache.flink.fs.s3presto.shaded` package
   - contains a `core-default-shaded.xml` file
   - does not contain a `core-default.xml` or `core-site.xml` file

--- a/tools/travis_mvn_watchdog.sh
+++ b/tools/travis_mvn_watchdog.sh
@@ -412,7 +412,7 @@ check_shaded_artifacts_s3_fs() {
 	UNSHADED_CLASSES=`cat allClasses | grep -v -e '^META-INF' -e '^assets' -e "^org/apache/flink/fs/s3${VARIANT}/" | grep '\.class$'`
 	if [ "$?" == "0" ]; then
 		echo "=============================================================================="
-		echo "Detected unshaded dependencies in fat jar:"
+		echo "${VARIANT}: Detected unshaded dependencies in fat jar:"
 		echo "${UNSHADED_CLASSES}"
 		echo "=============================================================================="
 		return 1
@@ -420,24 +420,33 @@ check_shaded_artifacts_s3_fs() {
 
 	if [ ! `cat allClasses | grep '^META-INF/services/org\.apache\.flink\.core\.fs\.FileSystemFactory$'` ]; then
 		echo "=============================================================================="
-		echo "File does not exist: services/org.apache.flink.core.fs.FileSystemFactory"
+		echo "${VARIANT}: File does not exist: services/org.apache.flink.core.fs.FileSystemFactory"
 		echo "=============================================================================="
+		return 1
 	fi
 
 	UNSHADED_SERVICES=`cat allClasses | grep '^META-INF/services/' | grep -v -e '^META-INF/services/org\.apache\.flink\.core\.fs\.FileSystemFactory$' -e "^META-INF/services/org\.apache\.flink\.fs\.s3${VARIANT}\.shaded" -e '^META-INF/services/'`
 	if [ "$?" == "0" ]; then
 		echo "=============================================================================="
-		echo "Detected unshaded service files in fat jar:"
+		echo "${VARIANT}: Detected unshaded service files in fat jar:"
 		echo "${UNSHADED_SERVICES}"
 		echo "=============================================================================="
 		return 1
 	fi
 
-	FS_SERVICE_FILE_CLASS=`unzip -q -c flink-filesystems/flink-s3-fs-${VARIANT}/target/flink-s3-fs-${VARIANT}*.jar META-INF/services/org.apache.flink.core.fs.FileSystemFactory | grep -v -e '^#' -e '^$'`
-	if [ "${FS_SERVICE_FILE_CLASS}" != "org.apache.flink.fs.s3${VARIANT}.S3FileSystemFactory" ]; then
+	FS_SERVICE_FILE_CLASSES=`unzip -q -c flink-filesystems/flink-s3-fs-${VARIANT}/target/flink-s3-fs-${VARIANT}*.jar META-INF/services/org.apache.flink.core.fs.FileSystemFactory | grep -v -e '^#' -e '^$'`
+	EXPECTED_FS_SERVICE_FILE_CLASSES="org.apache.flink.fs.s3${VARIANT}.S3FileSystemFactory"
+	if [ "${VARIANT}" == "hadoop" ]; then
+		read -r -d '' EXPECTED_FS_SERVICE_FILE_CLASSES <<EOF
+org.apache.flink.fs.s3${VARIANT}.S3FileSystemFactory
+org.apache.flink.fs.s3${VARIANT}.S3AFileSystemFactory
+EOF
+	fi
+
+	if [ "${FS_SERVICE_FILE_CLASSES}" != "${EXPECTED_FS_SERVICE_FILE_CLASSES}" ]; then
 		echo "=============================================================================="
-		echo "Detected wrong content in services/org.apache.flink.core.fs.FileSystemFactory:"
-		echo "${FS_SERVICE_FILE_CLASS}"
+		echo "${VARIANT}: Detected wrong content in services/org.apache.flink.core.fs.FileSystemFactory:"
+		echo "${FS_SERVICE_FILE_CLASSES}"
 		echo "=============================================================================="
 		return 1
 	fi


### PR DESCRIPTION
## What is the purpose of the change

For enhanced user experience, we should also register our Hadoop S3A-based shaded S3 file system implementation for the `s3a://` file system scheme, not just `s3://`(similar to supporting fall-back configuration options which are already supported). This way, the user can easily switch from the manual S3 integration to the shaded one.

Please merge into Flink 1.4+.

## Brief change log

- create a separate `S3AFileSystemFactory` deriving from `S3FileSystemFactory` with a different scheme onle
- add `S3AFileSystemFactory` to the service file

## Verifying this change

This change added tests and can be verified as follows:

- made existing tests parameterized for using both schemes: `s3://` and `s3a://` (except `HadoopS3FileSystemBehaviorITCase` which takes a lot of time and would just test the same implementation again without any difference)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **yes**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **docs**
