### PR TITLE
[FLINK-8655] [Cassandra Connector] add keyspace in cassandra sink builder

### DIFF
--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraPojoSink.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraPojoSink.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.connectors.cassandra;
 import org.apache.flink.configuration.Configuration;
 
 import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.Session;
 import com.datastax.driver.mapping.Mapper;
 import com.datastax.driver.mapping.MappingManager;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -41,6 +42,7 @@ public class CassandraPojoSink<IN> extends CassandraSinkBase<IN, ResultSet> {
 
 	protected final Class<IN> clazz;
 	private final MapperOptions options;
+	private final String keyspace;
 	protected transient Mapper<IN> mapper;
 	protected transient MappingManager mappingManager;
 
@@ -50,13 +52,22 @@ public class CassandraPojoSink<IN> extends CassandraSinkBase<IN, ResultSet> {
 	 * @param clazz Class instance
 	 */
 	public CassandraPojoSink(Class<IN> clazz, ClusterBuilder builder) {
-		this(clazz, builder, null);
+		this(clazz, builder, null, null);
 	}
 
 	public CassandraPojoSink(Class<IN> clazz, ClusterBuilder builder, @Nullable MapperOptions options) {
+		this(clazz, builder, options, null);
+	}
+
+	public CassandraPojoSink(Class<IN> clazz, ClusterBuilder builder, String keyspace) {
+		this(clazz, builder, null, keyspace);
+	}
+
+	public CassandraPojoSink(Class<IN> clazz, ClusterBuilder builder, @Nullable MapperOptions options, String keyspace) {
 		super(builder);
 		this.clazz = clazz;
 		this.options = options;
+		this.keyspace = keyspace;
 	}
 
 	@Override
@@ -74,6 +85,11 @@ public class CassandraPojoSink<IN> extends CassandraSinkBase<IN, ResultSet> {
 		} catch (Exception e) {
 			throw new RuntimeException("Cannot create CassandraPojoSink with input: " + clazz.getSimpleName(), e);
 		}
+	}
+
+	@Override
+	protected Session createSession() {
+		return cluster.connect(keyspace);
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraSink.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraSink.java
@@ -236,6 +236,7 @@ public class CassandraSink<IN> {
 		protected final TypeSerializer<IN> serializer;
 		protected final TypeInformation<IN> typeInfo;
 		protected ClusterBuilder builder;
+		protected String keyspace;
 		protected MapperOptions mapperOptions;
 		protected String query;
 		protected CheckpointCommitter committer;
@@ -255,6 +256,17 @@ public class CassandraSink<IN> {
 		 */
 		public CassandraSinkBuilder<IN> setQuery(String query) {
 			this.query = query;
+			return this;
+		}
+
+		/**
+		 * Sets the keyspace to be used.
+		 *
+		 * @param keyspace keyspace to use
+		 * @return this builder
+		 */
+		public CassandraSinkBuilder<IN> setDefaultKeyspace(String keyspace) {
+			this.keyspace = keyspace;
 			return this;
 		}
 
@@ -381,6 +393,9 @@ public class CassandraSink<IN> {
 			if (query == null || query.length() == 0) {
 				throw new IllegalArgumentException("Query must not be null or empty.");
 			}
+			if (keyspace != null) {
+				throw new IllegalArgumentException("Specifying a default keyspace is only allowed when using a Pojo-Stream as input.");
+			}
 		}
 
 		@Override
@@ -409,6 +424,9 @@ public class CassandraSink<IN> {
 			super.sanityCheck();
 			if (query == null || query.length() == 0) {
 				throw new IllegalArgumentException("Query must not be null or empty.");
+			}
+			if (keyspace != null) {
+				throw new IllegalArgumentException("Specifying a default keyspace is only allowed when using a Pojo-Stream as input.");
 			}
 		}
 
@@ -445,7 +463,7 @@ public class CassandraSink<IN> {
 
 		@Override
 		public CassandraSink<IN> createSink() throws Exception {
-			return new CassandraSink<>(input.addSink(new CassandraPojoSink<>(typeInfo.getTypeClass(), builder, mapperOptions)).name("Cassandra Sink"));
+			return new CassandraSink<>(input.addSink(new CassandraPojoSink<>(typeInfo.getTypeClass(), builder, mapperOptions, keyspace)).name("Cassandra Sink"));
 		}
 
 		@Override
@@ -469,6 +487,9 @@ public class CassandraSink<IN> {
 			super.sanityCheck();
 			if (query == null || query.length() == 0) {
 				throw new IllegalArgumentException("Query must not be null or empty.");
+			}
+			if (keyspace != null) {
+				throw new IllegalArgumentException("Specifying a default keyspace is only allowed when using a Pojo-Stream as input.");
 			}
 		}
 

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraSinkBase.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraSinkBase.java
@@ -85,7 +85,11 @@ public abstract class CassandraSinkBase<IN, V> extends RichSinkFunction<IN> impl
 			}
 		};
 		this.cluster = builder.getCluster();
-		this.session = cluster.connect();
+		this.session = createSession();
+	}
+
+	protected Session createSession() {
+		return cluster.connect();
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraConnectorITCase.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraConnectorITCase.java
@@ -430,6 +430,25 @@ public class CassandraConnectorITCase extends WriteAheadSinkTestBase<Tuple3<Stri
 	}
 
 	@Test
+	public void testCassandraPojoNoAnnotatedKeyspaceAtLeastOnceSink() throws Exception {
+		session.execute(CREATE_TABLE_QUERY.replace(TABLE_NAME_VARIABLE, "testPojoNoAnnotatedKeyspace"));
+
+		CassandraPojoSink<PojoNoAnnotatedKeyspace> sink = new CassandraPojoSink<>(PojoNoAnnotatedKeyspace.class, builder, "flink");
+
+		Configuration configuration = new Configuration();
+		sink.open(configuration);
+
+		for (int x = 0; x < 20; x++) {
+			sink.send(new PojoNoAnnotatedKeyspace(UUID.randomUUID().toString(), x, 0));
+		}
+
+		sink.close();
+
+		ResultSet rs = session.execute(SELECT_DATA_QUERY.replace(TABLE_NAME_VARIABLE, "testPojoNoAnnotatedKeyspace"));
+		Assert.assertEquals(20, rs.all().size());
+	}
+
+	@Test
 	public void testCassandraTableSink() throws Exception {
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 		env.setParallelism(4);

--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/PojoNoAnnotatedKeyspace.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/PojoNoAnnotatedKeyspace.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.cassandra;
+
+import com.datastax.driver.mapping.annotations.Column;
+import com.datastax.driver.mapping.annotations.Table;
+
+import java.io.Serializable;
+
+/**
+ * Test Pojo with DataStax annotations used (no keyspace).
+ */
+@Table(name = "testPojoNoAnnotatedKeyspace")
+public class PojoNoAnnotatedKeyspace implements Serializable {
+
+	private static final long serialVersionUID = 1038054554690916991L;
+
+	@Column(name = "id")
+	private String id;
+	@Column(name = "counter")
+	private int counter;
+	@Column(name = "batch_id")
+	private int batchID;
+
+	public PojoNoAnnotatedKeyspace(String id, int counter, int batchID) {
+		this.id = id;
+		this.counter = counter;
+		this.batchID = batchID;
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public int getCounter() {
+		return counter;
+	}
+
+	public void setCounter(int counter) {
+		this.counter = counter;
+	}
+
+	public int getBatchID() {
+		return batchID;
+	}
+
+	public void setBatchID(int batchId) {
+		this.batchID = batchId;
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change
This PR is an alternative to https://github.com/apache/flink/pull/5538.

## Brief change log
A discussion started on https://github.com/apache/flink/pull/5538 that i'm quoting here:
> What about using the Configuration that is provided in RichFunction.open(Configuration parameters) for the CassandraSinkBase.open(Configuration configuration) {...} implementation ?
> 
> I saw in old docs that Configuration can be used in the open(...) method but today (1.4+) it might not be a good practice anymore.
> 
> What about adding keyspace attribute in CassandraPojoSink and CassandraSinkBuilder (throwing exception when not using a CassandraPojoSinkBuilder for the moment).
> And create a new Configuration() with this keyspace in CassandraPojoSink.
> And finally do a cluster.connect(keyspace);
> 
> I've done this here if you can have a look.
> I've updated CassandraConnectorITCase with a new test.
> I would like to run CassandraPojoSinkExample.main() to cover the CassandraSink.addSink() mechanism, but it doesn't work for me (even on flink master branch).
> 
> Can this be a candidate for a PR, I am new to flink so it might break the flink good practice principles...
> Let me know!

The reply from zentol (Chesnay) (**I will check this point**):

> We would have to pass the keyspace via the constructor as the Configuration approach doesn't work for streaming.
> 
> Generally speaking it isn't a problem to set the keyspace when creating the connection. But I would like to know what happens if a POJO comes along that explicitly sets the keyspace; is it ignored, respected or will it cause an exception?

## Verifying this change

This change added tests and can be verified as follows:
- `testCassandraPojoNoAnnotatedKeyspaceAtLeastOnceSink()` in `CassandraConnectorITCase.java`
- Need to run CassandraPojoSinkExample.main() to cover the CassandraSink.addSink() mechanism, but it doesn't work for me (even on flink master branch, **I will investigate**)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **don't know**
  - The runtime per-record code paths (performance sensitive): **don't know**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **yes**
  - If yes, how is the feature documented? **JavaDocs**