### PR TITLE
[FLINK-9312] [security] Add mutual authentication for RPC and data plane

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyClient.java
@@ -63,7 +63,7 @@ class NettyClient {
 
 		this.protocol = protocol;
 
-		long start = System.currentTimeMillis();
+		final long start = System.nanoTime();
 
 		bootstrap = new Bootstrap();
 
@@ -117,8 +117,8 @@ class NettyClient {
 			throw new IOException("Failed to initialize SSL Context for the Netty client", e);
 		}
 
-		long end = System.currentTimeMillis();
-		LOG.info("Successful initialization (took {} ms).", (end - start));
+		final long duration = (System.nanoTime() - start) / 1_000_000;
+		LOG.info("Successful initialization (took {} ms).", duration);
 	}
 
 	NettyConfig getConfig() {
@@ -130,7 +130,7 @@ class NettyClient {
 	}
 
 	void shutdown() {
-		long start = System.currentTimeMillis();
+		final long start = System.nanoTime();
 
 		if (bootstrap != null) {
 			if (bootstrap.group() != null) {
@@ -139,8 +139,8 @@ class NettyClient {
 			bootstrap = null;
 		}
 
-		long end = System.currentTimeMillis();
-		LOG.info("Successful shutdown (took {} ms).", (end - start));
+		final long duration = (System.nanoTime() - start) / 1_000_000;
+		LOG.info("Successful shutdown (took {} ms).", duration);
 	}
 
 	private void initNioBootstrap() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyClient.java
@@ -37,6 +37,7 @@ import org.slf4j.LoggerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLParameters;
+
 import java.io.IOException;
 import java.net.InetSocketAddress;
 
@@ -200,7 +201,7 @@ class NettyClient {
 			return bootstrap.connect(serverSocketAddress);
 		}
 		catch (ChannelException e) {
-			if ( (e.getCause() instanceof java.net.SocketException &&
+			if ((e.getCause() instanceof java.net.SocketException &&
 					e.getCause().getMessage().equals("Too many open files")) ||
 				(e.getCause() instanceof ChannelException &&
 						e.getCause().getCause() instanceof java.net.SocketException &&

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyServer.java
@@ -73,7 +73,7 @@ class NettyServer {
 	void init(final NettyProtocol protocol, NettyBufferPool nettyBufferPool) throws IOException {
 		checkState(bootstrap == null, "Netty server has already been initialized.");
 
-		long start = System.currentTimeMillis();
+		final long start = System.nanoTime();
 
 		bootstrap = new ServerBootstrap();
 
@@ -170,8 +170,8 @@ class NettyServer {
 
 		localAddress = (InetSocketAddress) bindFuture.channel().localAddress();
 
-		long end = System.currentTimeMillis();
-		LOG.info("Successful initialization (took {} ms). Listening on SocketAddress {}.", (end - start), bindFuture.channel().localAddress().toString());
+		final long duration = (System.nanoTime() - start) / 1_000_000;
+		LOG.info("Successful initialization (took {} ms). Listening on SocketAddress {}.", duration, localAddress);
 	}
 
 	NettyConfig getConfig() {
@@ -187,7 +187,7 @@ class NettyServer {
 	}
 
 	void shutdown() {
-		long start = System.currentTimeMillis();
+		final long start = System.nanoTime();
 		if (bindFuture != null) {
 			bindFuture.channel().close().awaitUninterruptibly();
 			bindFuture = null;
@@ -199,8 +199,8 @@ class NettyServer {
 			}
 			bootstrap = null;
 		}
-		long end = System.currentTimeMillis();
-		LOG.info("Successful shutdown (took {} ms).", (end - start));
+		final long duration = (System.nanoTime() - start) / 1_000_000;
+		LOG.info("Successful shutdown (took {} ms).", duration);
 	}
 
 	private void initNioBootstrap() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyServer.java
@@ -61,7 +61,7 @@ class NettyServer {
 
 	private ChannelFuture bindFuture;
 
-	private SSLContext serverSSLContext = null;
+	private SSLContext serverSSLContext;
 
 	private InetSocketAddress localAddress;
 
@@ -155,6 +155,7 @@ class NettyServer {
 					SSLEngine sslEngine = serverSSLContext.createSSLEngine();
 					config.setSSLVerAndCipherSuites(sslEngine);
 					sslEngine.setUseClientMode(false);
+					sslEngine.setNeedClientAuth(true);
 					channel.pipeline().addLast("ssl", new SslHandler(sslEngine));
 				}
 

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
@@ -443,6 +443,7 @@ object AkkaUtils {
          |          protocol = $akkaSSLProtocol
          |          enabled-algorithms = $akkaSSLAlgorithms
          |          random-number-generator = ""
+         |          require-mutual-authentication = on
          |        }
          |      }
          |    }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyTestUtil.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyTestUtil.java
@@ -21,7 +21,6 @@ package org.apache.flink.runtime.io.network.netty;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.NetUtils;
 
-import scala.Tuple2;
 import org.apache.flink.shaded.netty4.io.netty.channel.Channel;
 
 import java.net.InetAddress;
@@ -36,7 +35,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  */
 public class NettyTestUtil {
 
-	static int DEFAULT_SEGMENT_SIZE = 1024;
+	static final int DEFAULT_SEGMENT_SIZE = 1024;
 
 	// ---------------------------------------------------------------------------------------------
 	// NettyServer and NettyClient
@@ -145,32 +144,24 @@ public class NettyTestUtil {
 				config);
 	}
 
-	// ---------------------------------------------------------------------------------------------
+	// ------------------------------------------------------------------------
 
-	static class NettyServerAndClient extends Tuple2<NettyServer, NettyClient> {
+	static final class NettyServerAndClient {
 
-		private static final long serialVersionUID = 4440278728496341931L;
+		private final NettyServer server;
+		private final NettyClient client;
 
-		NettyServerAndClient(NettyServer _1, NettyClient _2) {
-			super(_1, _2);
+		NettyServerAndClient(NettyServer server, NettyClient client) {
+			this.server = checkNotNull(server);
+			this.client = checkNotNull(client);
 		}
 
 		NettyServer server() {
-			return _1();
+			return server;
 		}
 
 		NettyClient client() {
-			return _2();
-		}
-
-		@Override
-		public boolean canEqual(Object that) {
-			return false;
-		}
-
-		@Override
-		public boolean equals(Object that) {
-			return false;
+			return client;
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/net/SSLUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/net/SSLUtilsTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.net;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.SecurityOptions;
 
 import org.junit.Assert;
@@ -30,24 +31,32 @@ import javax.net.ssl.SSLServerSocket;
 
 import java.net.ServerSocket;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
 /**
  * Tests for the {@link SSLUtils}.
  */
 public class SSLUtilsTest {
+
+	private static final String TRUST_STORE_PATH = "src/test/resources/local127.truststore";
+	private static final String TRUST_STORE_PASSWORD = "password";
+	private static final String KEY_STORE_PATH = "src/test/resources/local127.keystore";
+	private static final String KEY_STORE_PASSWORD = "password";
+	private static final String KEY_PASSWORD = "password";
+
+	// ------------------------ client --------------------------
 
 	/**
 	 * Tests if SSL Client Context is created given a valid SSL configuration.
 	 */
 	@Test
 	public void testCreateSSLClientContext() throws Exception {
-
-		Configuration clientConfig = new Configuration();
-		clientConfig.setBoolean(SecurityOptions.SSL_ENABLED, true);
-		clientConfig.setString(SecurityOptions.SSL_TRUSTSTORE, "src/test/resources/local127.truststore");
-		clientConfig.setString(SecurityOptions.SSL_TRUSTSTORE_PASSWORD, "password");
+		Configuration clientConfig = createSslConfigWithTrustStore();
 
 		SSLContext clientContext = SSLUtils.createSSLClientContext(clientConfig);
-		Assert.assertNotNull(clientContext);
+		assertNotNull(clientContext);
 	}
 
 	/**
@@ -55,47 +64,76 @@ public class SSLUtilsTest {
 	 */
 	@Test
 	public void testCreateSSLClientContextWithSSLDisabled() throws Exception {
-
-		Configuration clientConfig = new Configuration();
+		Configuration clientConfig = createSslConfigWithTrustStore();
 		clientConfig.setBoolean(SecurityOptions.SSL_ENABLED, false);
 
 		SSLContext clientContext = SSLUtils.createSSLClientContext(clientConfig);
-		Assert.assertNull(clientContext);
+		assertNull(clientContext);
 	}
 
 	/**
 	 * Tests if SSL Client Context creation fails with bad SSL configuration.
 	 */
 	@Test
-	public void testCreateSSLClientContextMisconfiguration() {
+	public void testCreateSSLClientContextMissingTrustStore() throws Exception {
+		Configuration config = new Configuration();
+		config.setBoolean(SecurityOptions.SSL_ENABLED, true);
+		config.setString(SecurityOptions.SSL_TRUSTSTORE_PASSWORD, "some password");
 
-		Configuration clientConfig = new Configuration();
-		clientConfig.setBoolean(SecurityOptions.SSL_ENABLED, true);
-		clientConfig.setString(SecurityOptions.SSL_TRUSTSTORE, "src/test/resources/local127.truststore");
+		try {
+			SSLContext clientContext = SSLUtils.createSSLClientContext(config);
+			fail("exception expected");
+		}
+		catch (IllegalConfigurationException e) {
+			// expected
+		}
+	}
+
+	/**
+	 * Tests if SSL Client Context creation fails with bad SSL configuration.
+	 */
+	@Test
+	public void testCreateSSLClientContextMissingPassword() throws Exception {
+		Configuration config = new Configuration();
+		config.setBoolean(SecurityOptions.SSL_ENABLED, true);
+		config.setString(SecurityOptions.SSL_TRUSTSTORE, TRUST_STORE_PATH);
+
+		try {
+			SSLContext clientContext = SSLUtils.createSSLClientContext(config);
+			fail("exception expected");
+		}
+		catch (IllegalConfigurationException e) {
+			// expected
+		}
+	}
+
+	/**
+	 * Tests if SSL Client Context creation fails with bad SSL configuration.
+	 */
+	@Test
+	public void testCreateSSLClientContextWrongPassword() throws Exception {
+		Configuration clientConfig = createSslConfigWithTrustStore();
 		clientConfig.setString(SecurityOptions.SSL_TRUSTSTORE_PASSWORD, "badpassword");
 
 		try {
 			SSLContext clientContext = SSLUtils.createSSLClientContext(clientConfig);
-			Assert.fail("SSL client context created even with bad SSL configuration ");
+			fail("SSL client context created even with bad SSL configuration ");
 		} catch (Exception e) {
 			// Exception here is valid
 		}
 	}
+
+	// ------------------------ server --------------------------
 
 	/**
 	 * Tests if SSL Server Context is created given a valid SSL configuration.
 	 */
 	@Test
 	public void testCreateSSLServerContext() throws Exception {
-
-		Configuration serverConfig = new Configuration();
-		serverConfig.setBoolean(SecurityOptions.SSL_ENABLED, true);
-		serverConfig.setString(SecurityOptions.SSL_KEYSTORE, "src/test/resources/local127.keystore");
-		serverConfig.setString(SecurityOptions.SSL_KEYSTORE_PASSWORD, "password");
-		serverConfig.setString(SecurityOptions.SSL_KEY_PASSWORD, "password");
+		Configuration serverConfig = createSslConfigWithKeyStore();
 
 		SSLContext serverContext = SSLUtils.createSSLServerContext(serverConfig);
-		Assert.assertNotNull(serverContext);
+		assertNotNull(serverContext);
 	}
 
 	/**
@@ -103,29 +141,24 @@ public class SSLUtilsTest {
 	 */
 	@Test
 	public void testCreateSSLServerContextWithSSLDisabled() throws Exception {
-
-		Configuration serverConfig = new Configuration();
+		Configuration serverConfig = createSslConfigWithKeyStore();
 		serverConfig.setBoolean(SecurityOptions.SSL_ENABLED, false);
 
 		SSLContext serverContext = SSLUtils.createSSLServerContext(serverConfig);
-		Assert.assertNull(serverContext);
+		assertNull(serverContext);
 	}
 
 	/**
 	 * Tests if SSL Server Context creation fails with bad SSL configuration.
 	 */
 	@Test
-	public void testCreateSSLServerContextMisconfiguration() {
-
-		Configuration serverConfig = new Configuration();
-		serverConfig.setBoolean(SecurityOptions.SSL_ENABLED, true);
-		serverConfig.setString(SecurityOptions.SSL_KEYSTORE, "src/test/resources/local127.keystore");
+	public void testCreateSSLServerContextBadKeystorePassword() {
+		Configuration serverConfig = createSslConfigWithKeyStore();
 		serverConfig.setString(SecurityOptions.SSL_KEYSTORE_PASSWORD, "badpassword");
-		serverConfig.setString(SecurityOptions.SSL_KEY_PASSWORD, "badpassword");
 
 		try {
 			SSLContext serverContext = SSLUtils.createSSLServerContext(serverConfig);
-			Assert.fail("SSL server context created even with bad SSL configuration ");
+			fail("SSL server context created even with bad SSL configuration ");
 		} catch (Exception e) {
 			// Exception here is valid
 		}
@@ -135,18 +168,93 @@ public class SSLUtilsTest {
 	 * Tests if SSL Server Context creation fails with bad SSL configuration.
 	 */
 	@Test
-	public void testCreateSSLServerContextWithMultiProtocols() {
+	public void testCreateSSLServerContextBadKeyPassword() {
+		Configuration serverConfig = createSslConfigWithKeyStore();
+		serverConfig.setString(SecurityOptions.SSL_KEY_PASSWORD, "badpassword");
 
-		Configuration serverConfig = new Configuration();
-		serverConfig.setBoolean(SecurityOptions.SSL_ENABLED, true);
-		serverConfig.setString(SecurityOptions.SSL_KEYSTORE, "src/test/resources/local127.keystore");
-		serverConfig.setString(SecurityOptions.SSL_KEYSTORE_PASSWORD, "password");
-		serverConfig.setString(SecurityOptions.SSL_KEY_PASSWORD, "password");
+		try {
+			SSLContext serverContext = SSLUtils.createSSLServerContext(serverConfig);
+			fail("SSL server context created even with bad SSL configuration ");
+		} catch (Exception e) {
+			// Exception here is valid
+		}
+	}
+
+	// ----------------------- mutual auth contexts --------------------------
+
+	@Test
+	public void testCreateMutualAuthServerContext() throws Exception {
+		final Configuration config = createSslConfigWithKeyAndTrustStores();
+		assertNotNull(SSLUtils.createSSLServerContextIntraCluster(config));
+	}
+
+	@Test
+	public void testCreateMutualAuthClientContext() throws Exception {
+		final Configuration config = createSslConfigWithKeyAndTrustStores();
+		assertNotNull(SSLUtils.createSSLClientContextIntraCluster(config));
+	}
+
+	@Test
+	public void testCreateMutualAuthServerContextKeyStoreOnly() throws Exception {
+		final Configuration config = createSslConfigWithKeyStore();
+
+		try {
+			SSLContext serverContext = SSLUtils.createSSLServerContextIntraCluster(config);
+			fail("exception expected");
+		} catch (IllegalConfigurationException e) {
+			// expected
+		}
+	}
+
+	@Test
+	public void testCreateMutualAuthServerContextTrustStoreOnly() throws Exception {
+		final Configuration config = createSslConfigWithTrustStore();
+
+		try {
+			SSLContext serverContext = SSLUtils.createSSLServerContextIntraCluster(config);
+			fail("exception expected");
+		} catch (IllegalConfigurationException e) {
+			// expected
+		}
+	}
+
+	@Test
+	public void testCreateMutualAuthClientContextKeyStoreOnly() throws Exception {
+		final Configuration config = createSslConfigWithKeyStore();
+
+		try {
+			SSLContext serverContext = SSLUtils.createSSLClientContextIntraCluster(config);
+			fail("exception expected");
+		} catch (IllegalConfigurationException e) {
+			// expected
+		}
+	}
+
+	@Test
+	public void testCreateMutualAuthClientContextTrustStoreOnly() throws Exception {
+		final Configuration config = createSslConfigWithTrustStore();
+
+		try {
+			SSLContext serverContext = SSLUtils.createSSLClientContextIntraCluster(config);
+			fail("exception expected");
+		} catch (IllegalConfigurationException e) {
+			// expected
+		}
+	}
+
+	// -------------------- protocols and cipher suites -----------------------
+
+	/**
+	 * Tests if SSL Server Context creation fails with bad SSL configuration.
+	 */
+	@Test
+	public void testCreateSSLServerContextWithMultiProtocols() {
+		Configuration serverConfig = createSslConfigWithKeyStore();
 		serverConfig.setString(SecurityOptions.SSL_PROTOCOL, "TLSv1,TLSv1.2");
 
 		try {
 			SSLContext serverContext = SSLUtils.createSSLServerContext(serverConfig);
-			Assert.fail("SSL server context created even with multiple protocols set ");
+			fail("SSL server context should not be created with multiple protocols");
 		} catch (Exception e) {
 			// Exception here is valid
 		}
@@ -157,19 +265,13 @@ public class SSLUtilsTest {
 	 */
 	@Test
 	public void testSetSSLVersionAndCipherSuitesForSSLServerSocket() throws Exception {
-
-		Configuration serverConfig = new Configuration();
-		serverConfig.setBoolean(SecurityOptions.SSL_ENABLED, true);
-		serverConfig.setString(SecurityOptions.SSL_KEYSTORE, "src/test/resources/local127.keystore");
-		serverConfig.setString(SecurityOptions.SSL_KEYSTORE_PASSWORD, "password");
-		serverConfig.setString(SecurityOptions.SSL_KEY_PASSWORD, "password");
+		Configuration serverConfig = createSslConfigWithKeyStore();
 		serverConfig.setString(SecurityOptions.SSL_PROTOCOL, "TLSv1.1");
 		serverConfig.setString(SecurityOptions.SSL_ALGORITHMS, "TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_128_CBC_SHA256");
 
 		SSLContext serverContext = SSLUtils.createSSLServerContext(serverConfig);
-		ServerSocket socket = null;
-		try {
-			socket = serverContext.getServerSocketFactory().createServerSocket(0);
+
+		try (ServerSocket socket = serverContext.getServerSocketFactory().createServerSocket(0)) {
 
 			String[] protocols = ((SSLServerSocket) socket).getEnabledProtocols();
 			String[] algorithms = ((SSLServerSocket) socket).getEnabledCipherSuites();
@@ -186,10 +288,6 @@ public class SSLUtilsTest {
 			Assert.assertEquals(2, algorithms.length);
 			Assert.assertTrue(algorithms[0].equals("TLS_RSA_WITH_AES_128_CBC_SHA") || algorithms[0].equals("TLS_RSA_WITH_AES_128_CBC_SHA256"));
 			Assert.assertTrue(algorithms[1].equals("TLS_RSA_WITH_AES_128_CBC_SHA") || algorithms[1].equals("TLS_RSA_WITH_AES_128_CBC_SHA256"));
-		} finally {
-			if (socket != null) {
-				socket.close();
-			}
 		}
 	}
 
@@ -198,12 +296,7 @@ public class SSLUtilsTest {
 	 */
 	@Test
 	public void testSetSSLVersionAndCipherSuitesForSSLEngine() throws Exception {
-
-		Configuration serverConfig = new Configuration();
-		serverConfig.setBoolean(SecurityOptions.SSL_ENABLED, true);
-		serverConfig.setString(SecurityOptions.SSL_KEYSTORE, "src/test/resources/local127.keystore");
-		serverConfig.setString(SecurityOptions.SSL_KEYSTORE_PASSWORD, "password");
-		serverConfig.setString(SecurityOptions.SSL_KEY_PASSWORD, "password");
+		Configuration serverConfig = createSslConfigWithKeyStore();
 		serverConfig.setString(SecurityOptions.SSL_PROTOCOL, "TLSv1");
 		serverConfig.setString(SecurityOptions.SSL_ALGORITHMS, "TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA256");
 
@@ -227,4 +320,38 @@ public class SSLUtilsTest {
 		Assert.assertTrue(algorithms[1].equals("TLS_DHE_RSA_WITH_AES_128_CBC_SHA") || algorithms[1].equals("TLS_DHE_RSA_WITH_AES_128_CBC_SHA256"));
 	}
 
+	// ------------------------------- utils ----------------------------------
+
+	private static Configuration createSslConfigWithKeyStore() {
+		final Configuration config = new Configuration();
+		config.setBoolean(SecurityOptions.SSL_ENABLED, true);
+		addKeyStoreConfig(config);
+		return config;
+	}
+
+	private static Configuration createSslConfigWithTrustStore() {
+		final Configuration config = new Configuration();
+		config.setBoolean(SecurityOptions.SSL_ENABLED, true);
+		addTrustStoreConfig(config);
+		return config;
+	}
+
+	private static Configuration createSslConfigWithKeyAndTrustStores() {
+		final Configuration config = new Configuration();
+		config.setBoolean(SecurityOptions.SSL_ENABLED, true);
+		addKeyStoreConfig(config);
+		addTrustStoreConfig(config);
+		return config;
+	}
+
+	private static void addKeyStoreConfig(Configuration config) {
+		config.setString(SecurityOptions.SSL_KEYSTORE, KEY_STORE_PATH);
+		config.setString(SecurityOptions.SSL_KEYSTORE_PASSWORD, KEY_STORE_PASSWORD);
+		config.setString(SecurityOptions.SSL_KEY_PASSWORD, KEY_PASSWORD);
+	}
+
+	private static void addTrustStoreConfig(Configuration config) {
+		config.setString(SecurityOptions.SSL_TRUSTSTORE, TRUST_STORE_PATH);
+		config.setString(SecurityOptions.SSL_TRUSTSTORE_PASSWORD, TRUST_STORE_PASSWORD);
+	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/net/SSLUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/net/SSLUtilsTest.java
@@ -322,21 +322,21 @@ public class SSLUtilsTest {
 
 	// ------------------------------- utils ----------------------------------
 
-	private static Configuration createSslConfigWithKeyStore() {
+	public static Configuration createSslConfigWithKeyStore() {
 		final Configuration config = new Configuration();
 		config.setBoolean(SecurityOptions.SSL_ENABLED, true);
 		addKeyStoreConfig(config);
 		return config;
 	}
 
-	private static Configuration createSslConfigWithTrustStore() {
+	public static Configuration createSslConfigWithTrustStore() {
 		final Configuration config = new Configuration();
 		config.setBoolean(SecurityOptions.SSL_ENABLED, true);
 		addTrustStoreConfig(config);
 		return config;
 	}
 
-	private static Configuration createSslConfigWithKeyAndTrustStores() {
+	public static Configuration createSslConfigWithKeyAndTrustStores() {
 		final Configuration config = new Configuration();
 		config.setBoolean(SecurityOptions.SSL_ENABLED, true);
 		addKeyStoreConfig(config);


### PR DESCRIPTION
## What is the purpose of the change

Currently, the Flink processes encrypted connections via SSL:
  - Data exchange TM - TM
  - RPC JM - TM
  - Blob Service JM - TM

  - (Optionally to ZooKeeper and connectors, this is connector specific and not in scope of this change)

However, the server side always accepts any client to build up the connection, meaning the connections are not strongly authenticated. Activating SSL mutual authentication strengthens this significantly - only TaskManagers and JobManagers that have access to the same certificate can connect to each other.

## Brief change log

  - Activate mutual auth in akka (via akka config)
  - Activate mutual auth in Netty for data shuffles via `SSLContext` and `SSLEngine` parameters

## Verifying this change

  - Adds a test to the `NettyClientServerSslTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
