### PR TITLE
[FLINK-8134] add method getDescription() to MessageHeaders

### DIFF
--- a/docs/_includes/generated/rest_dispatcher.html
+++ b/docs/_includes/generated/rest_dispatcher.html
@@ -8,7 +8,7 @@
       <td class="text-left">Response code: <code>200 OK</code></td>
     </tr>
     <tr>
-      <td colspan="2">description</td>
+      <td colspan="2">Query the port of blob server.</td>
     </tr>
     <tr>
       <td colspan="2">
@@ -45,6 +45,42 @@
 <table class="table table-bordered">
   <tbody>
     <tr>
+      <td class="text-left" colspan="2"><strong>/cluster</strong></td>
+    </tr>
+    <tr>
+      <td class="text-left" style="width: 20%">Verb: <code>DELETE</code></td>
+      <td class="text-left">Response code: <code>200 OK</code></td>
+    </tr>
+    <tr>
+      <td colspan="2">Shutdown the cluster</td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#-1674237828">Request</button>
+        <div id="-1674237828" class="collapse">
+          <pre>
+            <code>
+{}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#-1489255004">Response</button>
+        <div id="-1489255004" class="collapse">
+          <pre>
+            <code>
+{}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<table class="table table-bordered">
+  <tbody>
+    <tr>
       <td class="text-left" colspan="2"><strong>/config</strong></td>
     </tr>
     <tr>
@@ -52,7 +88,7 @@
       <td class="text-left">Response code: <code>200 OK</code></td>
     </tr>
     <tr>
-      <td colspan="2">description</td>
+      <td colspan="2">Some information about the monitoring API and the server setup.</td>
     </tr>
     <tr>
       <td colspan="2">
@@ -108,7 +144,7 @@
       <td class="text-left">Response code: <code>200 OK</code></td>
     </tr>
     <tr>
-      <td colspan="2">description</td>
+      <td colspan="2">List uploaded jars.</td>
     </tr>
     <tr>
       <td colspan="2">
@@ -185,7 +221,7 @@
       <td class="text-left">Response code: <code>200 OK</code></td>
     </tr>
     <tr>
-      <td colspan="2">description</td>
+      <td colspan="2">Send a POST request to /jars/upload with your jar file sent as multi-part data under the jarfile file. Also make sure that the multi-part data includes the Content-Type of the file itself, some http libraries do not add the header by default.</td>
     </tr>
     <tr>
       <td colspan="2">
@@ -241,7 +277,7 @@
       <td class="text-left">Response code: <code>200 OK</code></td>
     </tr>
     <tr>
-      <td colspan="2">description</td>
+      <td colspan="2">Delete an uploaded jar.</td>
     </tr>
     <tr>
       <td colspan="2">Path parameters</td>
@@ -287,7 +323,7 @@
       <td class="text-left">Response code: <code>200 OK</code></td>
     </tr>
     <tr>
-      <td colspan="2">description</td>
+      <td colspan="2">Fetch the plan for a jar.</td>
     </tr>
     <tr>
       <td colspan="2">Path parameters</td>
@@ -347,7 +383,9 @@
       <td class="text-left">Response code: <code>200 OK</code></td>
     </tr>
     <tr>
-      <td colspan="2">description</td>
+      <td colspan="2">Send a POST request to /jars/:jarid/run. The jarid parameter is the file name of the program JAR in the configured web frontend upload directory (configuration key jobmanager.web.upload.dir).
+
+If the call succeeds, you will get a response with the ID of the submitted job.</td>
     </tr>
     <tr>
       <td colspan="2">Path parameters</td>
@@ -415,7 +453,7 @@
       <td class="text-left">Response code: <code>200 OK</code></td>
     </tr>
     <tr>
-      <td colspan="2">description</td>
+      <td colspan="2">Get cluster configuration.</td>
     </tr>
     <tr>
       <td colspan="2">
@@ -465,7 +503,7 @@
       <td class="text-left">Response code: <code>200 OK</code></td>
     </tr>
     <tr>
-      <td colspan="2">description</td>
+      <td colspan="2">The metrics for a job manager.</td>
     </tr>
     <tr>
       <td colspan="2">Query parameters</td>
@@ -513,7 +551,7 @@
       <td class="text-left">Response code: <code>200 OK</code></td>
     </tr>
     <tr>
-      <td colspan="2">description</td>
+      <td colspan="2">An overview of how many jobs are in which status.</td>
     </tr>
     <tr>
       <td colspan="2">
@@ -570,7 +608,7 @@
       <td class="text-left">Response code: <code>202 Accepted</code></td>
     </tr>
     <tr>
-      <td colspan="2">description</td>
+      <td colspan="2">Submit a job to a flink cluster.</td>
     </tr>
     <tr>
       <td colspan="2">
@@ -625,7 +663,7 @@
       <td class="text-left">Response code: <code>200 OK</code></td>
     </tr>
     <tr>
-      <td colspan="2">description</td>
+      <td colspan="2">The aggregated metrics for a job.</td>
     </tr>
     <tr>
       <td colspan="2">Query parameters</td>
@@ -675,7 +713,7 @@
       <td class="text-left">Response code: <code>200 OK</code></td>
     </tr>
     <tr>
-      <td colspan="2">description</td>
+      <td colspan="2">Jobs, grouped by status, each with a small summary of its status.</td>
     </tr>
     <tr>
       <td colspan="2">
@@ -722,7 +760,7 @@
       <td class="text-left">Response code: <code>200 OK</code></td>
     </tr>
     <tr>
-      <td colspan="2">description</td>
+      <td colspan="2">Summary of one job, listing dataflow plan, status, timestamps of state transitions, aggregate information for each vertex (operator).</td>
     </tr>
     <tr>
       <td colspan="2">Path parameters</td>
@@ -880,7 +918,7 @@
       <td class="text-left">Response code: <code>202 Accepted</code></td>
     </tr>
     <tr>
-      <td colspan="2">description</td>
+      <td colspan="2">Cancel the job.</td>
     </tr>
     <tr>
       <td colspan="2">Path parameters</td>
@@ -936,7 +974,7 @@
       <td class="text-left">Response code: <code>200 OK</code></td>
     </tr>
     <tr>
-      <td colspan="2">description</td>
+      <td colspan="2">Get the aggregated accumulators of a job.</td>
     </tr>
     <tr>
       <td colspan="2">Path parameters</td>
@@ -1027,7 +1065,7 @@
       <td class="text-left">Response code: <code>200 OK</code></td>
     </tr>
     <tr>
-      <td colspan="2">description</td>
+      <td colspan="2">Get checkpointing statistics for a given job.</td>
     </tr>
     <tr>
       <td colspan="2">Path parameters</td>
@@ -1330,7 +1368,7 @@
       <td class="text-left">Response code: <code>200 OK</code></td>
     </tr>
     <tr>
-      <td colspan="2">description</td>
+      <td colspan="2">Get checkpoint config.</td>
     </tr>
     <tr>
       <td colspan="2">Path parameters</td>
@@ -1408,7 +1446,7 @@
       <td class="text-left">Response code: <code>200 OK</code></td>
     </tr>
     <tr>
-      <td colspan="2">description</td>
+      <td colspan="2">Get checkpoint statistic details.</td>
     </tr>
     <tr>
       <td colspan="2">Path parameters</td>
@@ -1525,7 +1563,7 @@
       <td class="text-left">Response code: <code>200 OK</code></td>
     </tr>
     <tr>
-      <td colspan="2">description</td>
+      <td colspan="2">Task checkpoint statistics which also includes information about the sub task checkpoint statistics.</td>
     </tr>
     <tr>
       <td colspan="2">Path parameters</td>
@@ -1671,7 +1709,7 @@
       <td class="text-left">Response code: <code>200 OK</code></td>
     </tr>
     <tr>
-      <td colspan="2">description</td>
+      <td colspan="2">Get the configuration of a job.</td>
     </tr>
     <tr>
       <td colspan="2">Path parameters</td>
@@ -1719,7 +1757,7 @@
       <td class="text-left">Response code: <code>200 OK</code></td>
     </tr>
     <tr>
-      <td colspan="2">description</td>
+      <td colspan="2">The non-recoverable exceptions that have been observed by the job. The truncated flag defines whether more exceptions occurred, but are not listed, because the response would otherwise get too big.</td>
     </tr>
     <tr>
       <td colspan="2">Path parameters</td>
@@ -1800,7 +1838,7 @@
       <td class="text-left">Response code: <code>200 OK</code></td>
     </tr>
     <tr>
-      <td colspan="2">description</td>
+      <td colspan="2">The result of a job execution. Gives access to the execution time of the job, and to all accumulators created by this job.</td>
     </tr>
     <tr>
       <td colspan="2">Path parameters</td>
@@ -1866,7 +1904,7 @@
       <td class="text-left">Response code: <code>200 OK</code></td>
     </tr>
     <tr>
-      <td colspan="2">description</td>
+      <td colspan="2">The metrics for a specified job.</td>
     </tr>
     <tr>
       <td colspan="2">Path parameters</td>
@@ -1924,7 +1962,7 @@
       <td class="text-left">Response code: <code>200 OK</code></td>
     </tr>
     <tr>
-      <td colspan="2">description</td>
+      <td colspan="2">The dataflow plan of a job. The plan is also included in the job summary (/jobs/<jobid>).</td>
     </tr>
     <tr>
       <td colspan="2">Path parameters</td>
@@ -1972,7 +2010,7 @@
       <td class="text-left">Response code: <code>200 OK</code></td>
     </tr>
     <tr>
-      <td colspan="2">description</td>
+      <td colspan="2">Trigger the rescaling of a job.</td>
     </tr>
     <tr>
       <td colspan="2">Path parameters</td>
@@ -2036,7 +2074,7 @@
       <td class="text-left">Response code: <code>200 OK</code></td>
     </tr>
     <tr>
-      <td colspan="2">description</td>
+      <td colspan="2">Polling the status of an ongoing rescaling operation.</td>
     </tr>
     <tr>
       <td colspan="2">Path parameters</td>
@@ -2102,7 +2140,7 @@
       <td class="text-left">Response code: <code>202 Accepted</code></td>
     </tr>
     <tr>
-      <td colspan="2">description</td>
+      <td colspan="2">Trigger a savepoint.</td>
     </tr>
     <tr>
       <td colspan="2">Path parameters</td>
@@ -2167,7 +2205,7 @@
       <td class="text-left">Response code: <code>200 OK</code></td>
     </tr>
     <tr>
-      <td colspan="2">description</td>
+      <td colspan="2">Polling status for the triggered savepoint.</td>
     </tr>
     <tr>
       <td colspan="2">Path parameters</td>
@@ -2233,7 +2271,7 @@
       <td class="text-left">Response code: <code>200 OK</code></td>
     </tr>
     <tr>
-      <td colspan="2">description</td>
+      <td colspan="2">Information about one specific vertex, with a summary for each of its subtasks.</td>
     </tr>
     <tr>
       <td colspan="2">Path parameters</td>
@@ -2358,7 +2396,80 @@
       <td class="text-left">Response code: <code>200 OK</code></td>
     </tr>
     <tr>
-      <td colspan="2">description</td>
+      <td colspan="2">The aggregated user-defined accumulators, for a specific vertex.</td>
+    </tr>
+    <tr>
+      <td colspan="2">Path parameters</td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <ul>
+<li><code>jobid</code> - description</li>
+<li><code>vertexid</code> - description</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#485581006">Request</button>
+        <div id="485581006" class="collapse">
+          <pre>
+            <code>
+{}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#-1070353054">Response</button>
+        <div id="-1070353054" class="collapse">
+          <pre>
+            <code>
+{
+  "type" : "object",
+  "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:JobVertexAccumulatorsInfo",
+  "properties" : {
+    "id" : {
+      "type" : "string"
+    },
+    "user-accumulators" : {
+      "type" : "array",
+      "items" : {
+        "type" : "object",
+        "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:UserAccumulator",
+        "properties" : {
+          "name" : {
+            "type" : "string"
+          },
+          "type" : {
+            "type" : "string"
+          },
+          "value" : {
+            "type" : "string"
+          }
+        }
+      }
+    }
+  }
+}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<table class="table table-bordered">
+  <tbody>
+    <tr>
+      <td class="text-left" colspan="2"><strong>/jobs/:jobid/vertices/:vertexid/accumulators</strong></td>
+    </tr>
+    <tr>
+      <td class="text-left" style="width: 20%">Verb: <code>GET</code></td>
+      <td class="text-left">Response code: <code>200 OK</code></td>
+    </tr>
+    <tr>
+      <td colspan="2">The aggregated user-defined accumulators, for a specific vertex.</td>
     </tr>
     <tr>
       <td colspan="2">Path parameters</td>
@@ -2431,7 +2542,7 @@
       <td class="text-left">Response code: <code>200 OK</code></td>
     </tr>
     <tr>
-      <td colspan="2">description</td>
+      <td colspan="2">Get job request backpressure info.</td>
     </tr>
     <tr>
       <td colspan="2">Path parameters</td>
@@ -2513,7 +2624,7 @@
       <td class="text-left">Response code: <code>200 OK</code></td>
     </tr>
     <tr>
-      <td colspan="2">description</td>
+      <td colspan="2">The metrics for a specified job and job vertex.</td>
     </tr>
     <tr>
       <td colspan="2">Path parameters</td>
@@ -2572,7 +2683,7 @@
       <td class="text-left">Response code: <code>200 OK</code></td>
     </tr>
     <tr>
-      <td colspan="2">description</td>
+      <td colspan="2">The aggregated metrics for a vertex subtask.</td>
     </tr>
     <tr>
       <td colspan="2">Path parameters</td>
@@ -2633,7 +2744,7 @@
       <td class="text-left">Response code: <code>200 OK</code></td>
     </tr>
     <tr>
-      <td colspan="2">description</td>
+      <td colspan="2">Summary of the current or latest execution attempt of a specific subtask.</td>
     </tr>
     <tr>
       <td colspan="2">Path parameters</td>
@@ -2738,7 +2849,7 @@
       <td class="text-left">Response code: <code>200 OK</code></td>
     </tr>
     <tr>
-      <td colspan="2">description</td>
+      <td colspan="2">Summary of a specific execution attempt of a specific subtask. Multiple execution attempts happen in case of failure/recovery.</td>
     </tr>
     <tr>
       <td colspan="2">Path parameters</td>
@@ -2844,7 +2955,7 @@
       <td class="text-left">Response code: <code>200 OK</code></td>
     </tr>
     <tr>
-      <td colspan="2">description</td>
+      <td colspan="2">The accumulators collected for one specific subtask during one specific execution attempt (multiple attempts happen in case of failure/recovery).</td>
     </tr>
     <tr>
       <td colspan="2">Path parameters</td>
@@ -2925,7 +3036,7 @@
       <td class="text-left">Response code: <code>200 OK</code></td>
     </tr>
     <tr>
-      <td colspan="2">description</td>
+      <td colspan="2">Get metrics for a subtask.</td>
     </tr>
     <tr>
       <td colspan="2">Path parameters</td>
@@ -2985,7 +3096,7 @@
       <td class="text-left">Response code: <code>200 OK</code></td>
     </tr>
     <tr>
-      <td colspan="2">description</td>
+      <td colspan="2">Get times info for a subtask.</td>
     </tr>
     <tr>
       <td colspan="2">Path parameters</td>
@@ -3070,7 +3181,7 @@
       <td class="text-left">Response code: <code>200 OK</code></td>
     </tr>
     <tr>
-      <td colspan="2">description</td>
+      <td colspan="2">TaskManager statistics for one specific vertex. This is an aggregation of subtask statistics returned by /jobs/<jobid>/vertices/<vertexid>.</td>
     </tr>
     <tr>
       <td colspan="2">Path parameters</td>
@@ -3192,7 +3303,7 @@
       <td class="text-left">Response code: <code>200 OK</code></td>
     </tr>
     <tr>
-      <td colspan="2">description</td>
+      <td colspan="2">Simple summary of the Flink cluster status.</td>
     </tr>
     <tr>
       <td colspan="2">
@@ -3260,7 +3371,7 @@
       <td class="text-left">Response code: <code>200 OK</code></td>
     </tr>
     <tr>
-      <td colspan="2">description</td>
+      <td colspan="2">Trigger the disposal of a savepoint.</td>
     </tr>
     <tr>
       <td colspan="2">
@@ -3312,7 +3423,7 @@
       <td class="text-left">Response code: <code>200 OK</code></td>
     </tr>
     <tr>
-      <td colspan="2">description</td>
+      <td colspan="2">Polling status for the savepoint disposal operation.</td>
     </tr>
     <tr>
       <td colspan="2">Path parameters</td>
@@ -3377,7 +3488,7 @@
       <td class="text-left">Response code: <code>200 OK</code></td>
     </tr>
     <tr>
-      <td colspan="2">description</td>
+      <td colspan="2">Get an overview over all taskmanagers or details for a single one.</td>
     </tr>
     <tr>
       <td colspan="2">
@@ -3463,7 +3574,7 @@
       <td class="text-left">Response code: <code>200 OK</code></td>
     </tr>
     <tr>
-      <td colspan="2">description</td>
+      <td colspan="2">The aggregated metrics for a task manager.</td>
     </tr>
     <tr>
       <td colspan="2">Query parameters</td>
@@ -3513,7 +3624,7 @@
       <td class="text-left">Response code: <code>200 OK</code></td>
     </tr>
     <tr>
-      <td colspan="2">description</td>
+      <td colspan="2">Get details for a TaskManager containing base information about executors and detailed metrics.</td>
     </tr>
     <tr>
       <td colspan="2">Path parameters</td>
@@ -3666,7 +3777,7 @@
       <td class="text-left">Response code: <code>200 OK</code></td>
     </tr>
     <tr>
-      <td colspan="2">description</td>
+      <td colspan="2">Get TaskManager metrics.</td>
     </tr>
     <tr>
       <td colspan="2">Path parameters</td>

--- a/flink-docs/src/main/java/org/apache/flink/docs/rest/RestAPIDocGenerator.java
+++ b/flink-docs/src/main/java/org/apache/flink/docs/rest/RestAPIDocGenerator.java
@@ -155,7 +155,7 @@ public class RestAPIDocGenerator {
 			sb.append("      <td class=\"text-left\">Response code: <code>" + spec.getResponseStatusCode() + "</code></td>\n");
 			sb.append("    </tr>\n");
 			sb.append("    <tr>\n");
-			sb.append("      <td colspan=\"2\">" + "description" + "</td>\n");
+			sb.append("      <td colspan=\"2\">" + spec.getDescription() + "</td>\n");
 			sb.append("    </tr>\n");
 		}
 		if (!pathParameterList.isEmpty()) {

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarDeleteHeaders.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarDeleteHeaders.java
@@ -66,4 +66,8 @@ public class JarDeleteHeaders implements MessageHeaders<EmptyRequestBody, EmptyR
 		return INSTANCE;
 	}
 
+	@Override
+	public String getDescription() {
+		return "Delete an uploaded jar.";
+	}
 }

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarListHeaders.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarListHeaders.java
@@ -69,4 +69,9 @@ public class JarListHeaders implements MessageHeaders<EmptyRequestBody, JarListI
 	public static JarListHeaders getInstance() {
 		return INSTANCE;
 	}
+
+	@Override
+	public String getDescription() {
+		return "List uploaded jars.";
+	}
 }

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarPlanHeaders.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarPlanHeaders.java
@@ -65,4 +65,9 @@ public class JarPlanHeaders implements MessageHeaders<EmptyRequestBody, JobPlanI
 	public static JarPlanHeaders getInstance() {
 		return INSTANCE;
 	}
+
+	@Override
+	public String getDescription() {
+		return "Fetch the plan for a jar.";
+	}
 }

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHeaders.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHeaders.java
@@ -66,4 +66,10 @@ public class JarRunHeaders implements MessageHeaders<EmptyRequestBody, JarRunRes
 	public static JarRunHeaders getInstance() {
 		return INSTANCE;
 	}
+
+	@Override
+	public String getDescription() {
+		return "Send a POST request to /jars/:jarid/run. The jarid parameter is the file name of the program JAR in the configured web frontend upload directory (configuration key jobmanager.web.upload.dir).\n\n" +
+			"If the call succeeds, you will get a response with the ID of the submitted job.";
+	}
 }

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarUploadHeaders.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarUploadHeaders.java
@@ -67,4 +67,9 @@ public final class JarUploadHeaders implements MessageHeaders<FileUpload, JarUpl
 	public static JarUploadHeaders getInstance() {
 		return INSTANCE;
 	}
+
+	@Override
+	public String getDescription() {
+		return "Send a POST request to /jars/upload with your jar file sent as multi-part data under the jarfile file. Also make sure that the multi-part data includes the Content-Type of the file itself, some http libraries do not add the header by default.";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/rescaling/RescalingStatusHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/rescaling/RescalingStatusHeaders.java
@@ -75,4 +75,9 @@ public class RescalingStatusHeaders extends
 	public static RescalingStatusHeaders getInstance() {
 		return INSTANCE;
 	}
+
+	@Override
+	public String getDescription() {
+		return "Polling the status of an ongoing rescaling operation.";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/rescaling/RescalingTriggerHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/rescaling/RescalingTriggerHeaders.java
@@ -67,4 +67,9 @@ public class RescalingTriggerHeaders extends
 	public static RescalingTriggerHeaders getInstance() {
 		return INSTANCE;
 	}
+
+	@Override
+	public String getDescription() {
+		return "Trigger the rescaling of a job.";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/BlobServerPortHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/BlobServerPortHeaders.java
@@ -66,4 +66,9 @@ public class BlobServerPortHeaders implements MessageHeaders<EmptyRequestBody, B
 	public static BlobServerPortHeaders getInstance() {
 		return INSTANCE;
 	}
+
+	@Override
+	public String getDescription() {
+		return "Query the port of blob server.";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/ClusterConfigurationInfoHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/ClusterConfigurationInfoHeaders.java
@@ -69,4 +69,9 @@ public final class ClusterConfigurationInfoHeaders implements MessageHeaders<Emp
 	public static ClusterConfigurationInfoHeaders getInstance() {
 		return INSTANCE;
 	}
+
+	@Override
+	public String getDescription() {
+		return "Get cluster configuration.";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/ClusterOverviewHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/ClusterOverviewHeaders.java
@@ -69,4 +69,9 @@ public final class ClusterOverviewHeaders implements MessageHeaders<EmptyRequest
 	public static ClusterOverviewHeaders getInstance() {
 		return INSTANCE;
 	}
+
+	@Override
+	public String getDescription() {
+		return "Simple summary of the Flink cluster status.";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/DashboardConfigurationHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/DashboardConfigurationHeaders.java
@@ -66,4 +66,9 @@ public final class DashboardConfigurationHeaders implements MessageHeaders<Empty
 	public static DashboardConfigurationHeaders getInstance() {
 		return INSTANCE;
 	}
+
+	@Override
+	public String getDescription() {
+		return "Some information about the monitoring API and the server setup.";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobAccumulatorsHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobAccumulatorsHeaders.java
@@ -70,4 +70,9 @@ public class JobAccumulatorsHeaders implements MessageHeaders<EmptyRequestBody, 
 	public static JobAccumulatorsHeaders getInstance() {
 		return INSTANCE;
 	}
+
+	@Override
+	public String getDescription() {
+		return "Get the aggregated accumulators of a job.";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobConfigHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobConfigHeaders.java
@@ -67,4 +67,9 @@ public class JobConfigHeaders implements MessageHeaders<EmptyRequestBody, JobCon
 	public static JobConfigHeaders getInstance() {
 		return INSTANCE;
 	}
+
+	@Override
+	public String getDescription() {
+		return "Get the configuration of a job.";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobExceptionsHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobExceptionsHeaders.java
@@ -67,4 +67,10 @@ public class JobExceptionsHeaders implements MessageHeaders<EmptyRequestBody, Jo
 	public static JobExceptionsHeaders getInstance() {
 		return INSTANCE;
 	}
+
+	@Override
+	public String getDescription() {
+		return "The non-recoverable exceptions that have been observed by the job. The truncated flag defines " +
+			"whether more exceptions occurred, but are not listed, because the response would otherwise get too big.";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobIdsWithStatusesOverviewHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobIdsWithStatusesOverviewHeaders.java
@@ -67,4 +67,9 @@ public class JobIdsWithStatusesOverviewHeaders implements MessageHeaders<EmptyRe
 	public static JobIdsWithStatusesOverviewHeaders getInstance() {
 		return INSTANCE;
 	}
+
+	@Override
+	public String getDescription() {
+		return "An overview of how many jobs are in which status.";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobPlanHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobPlanHeaders.java
@@ -68,4 +68,9 @@ public class JobPlanHeaders implements MessageHeaders<EmptyRequestBody, JobPlanI
 	public static JobPlanHeaders getInstance() {
 		return INSTANCE;
 	}
+
+	@Override
+	public String getDescription() {
+		return "The dataflow plan of a job. The plan is also included in the job summary (/jobs/<jobid>).";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobTerminationHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobTerminationHeaders.java
@@ -67,4 +67,9 @@ public class JobTerminationHeaders implements MessageHeaders<EmptyRequestBody, E
 	public static JobTerminationHeaders getInstance() {
 		return INSTANCE;
 	}
+
+	@Override
+	public String getDescription() {
+		return "Cancel the job.";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobVertexAccumulatorsHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobVertexAccumulatorsHeaders.java
@@ -71,4 +71,9 @@ public class JobVertexAccumulatorsHeaders implements MessageHeaders<EmptyRequest
 	public static JobVertexAccumulatorsHeaders getInstance() {
 		return INSTANCE;
 	}
+
+	@Override
+	public String getDescription() {
+		return "The aggregated user-defined accumulators, for a specific vertex.";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobVertexBackPressureHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobVertexBackPressureHeaders.java
@@ -65,4 +65,9 @@ public class JobVertexBackPressureHeaders implements MessageHeaders<EmptyRequest
 	public static JobVertexBackPressureHeaders getInstance() {
 		return INSTANCE;
 	}
+
+	@Override
+	public String getDescription() {
+		return "Get job request backpressure info.";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobVertexDetailsHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobVertexDetailsHeaders.java
@@ -65,4 +65,9 @@ public class JobVertexDetailsHeaders implements MessageHeaders<EmptyRequestBody,
 	public static JobVertexDetailsHeaders getInstance() {
 		return INSTANCE;
 	}
+
+	@Override
+	public String getDescription() {
+		return "Information about one specific vertex, with a summary for each of its subtasks.";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobVertexTaskManagersHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobVertexTaskManagersHeaders.java
@@ -71,4 +71,10 @@ public class JobVertexTaskManagersHeaders implements MessageHeaders<EmptyRequest
 	public static JobVertexTaskManagersHeaders getInstance() {
 		return INSTANCE;
 	}
+
+	@Override
+	public String getDescription() {
+		return "TaskManager statistics for one specific vertex. This is an aggregation of subtask statistics " +
+			"returned by /jobs/<jobid>/vertices/<vertexid>.";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobsOverviewHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobsOverviewHeaders.java
@@ -69,4 +69,9 @@ public final class JobsOverviewHeaders implements MessageHeaders<EmptyRequestBod
 	public static JobsOverviewHeaders getInstance() {
 		return INSTANCE;
 	}
+
+	@Override
+	public String getDescription() {
+		return "Jobs, grouped by status, each with a small summary of its status.";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/MessageHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/MessageHeaders.java
@@ -56,4 +56,11 @@ public interface MessageHeaders<R extends RequestBody, P extends ResponseBody, M
 	default Collection<Class<?>> getResponseTypeParameters() {
 		return Collections.emptyList();
 	}
+
+	/**
+	 * Returns the description for the response type. The description must be valid HTML
+	 *
+	 * @return description for the response type
+	 */
+	String getDescription();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/SubtasksAllAccumulatorsHandlers.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/SubtasksAllAccumulatorsHandlers.java
@@ -72,4 +72,11 @@ public class SubtasksAllAccumulatorsHandlers implements MessageHeaders<EmptyRequ
 	public static SubtasksAllAccumulatorsHandlers getInstance() {
 		return INSTANCE;
 	}
+
+	@Override
+	public String getDescription() {
+		return "Gets all user-defined accumulators for all subtasks of a given vertex. These are the individual " +
+			"accumulators that are returned in aggregated form by the request " +
+			"/jobs/<jobid>/vertices/<vertexid>/accumulators.";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/SubtasksTimesHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/SubtasksTimesHeaders.java
@@ -66,4 +66,9 @@ public class SubtasksTimesHeaders implements MessageHeaders<EmptyRequestBody, Su
 	public static SubtasksTimesHeaders getInstance() {
 		return INSTANCE;
 	}
+
+	@Override
+	public String getDescription() {
+		return "Get times info for a subtask.";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/CheckpointConfigHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/CheckpointConfigHeaders.java
@@ -70,4 +70,9 @@ public class CheckpointConfigHeaders implements MessageHeaders<EmptyRequestBody,
 	public static CheckpointConfigHeaders getInstance() {
 		return INSTANCE;
 	}
+
+	@Override
+	public String getDescription() {
+		return "Get checkpoint config.";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/CheckpointStatisticDetailsHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/CheckpointStatisticDetailsHeaders.java
@@ -69,4 +69,9 @@ public class CheckpointStatisticDetailsHeaders implements MessageHeaders<EmptyRe
 	public static CheckpointStatisticDetailsHeaders getInstance() {
 		return INSTANCE;
 	}
+
+	@Override
+	public String getDescription() {
+		return "Get checkpoint statistic details.";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/CheckpointingStatisticsHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/CheckpointingStatisticsHeaders.java
@@ -68,4 +68,9 @@ public class CheckpointingStatisticsHeaders implements MessageHeaders<EmptyReque
 	public static CheckpointingStatisticsHeaders getInstance() {
 		return INSTANCE;
 	}
+
+	@Override
+	public String getDescription() {
+		return "Get checkpointing statistics for a given job.";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/TaskCheckpointStatisticsHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/TaskCheckpointStatisticsHeaders.java
@@ -69,4 +69,9 @@ public class TaskCheckpointStatisticsHeaders implements MessageHeaders<EmptyRequ
 	public static TaskCheckpointStatisticsHeaders getInstance() {
 		return INSTANCE;
 	}
+
+	@Override
+	public String getDescription() {
+		return "Task checkpoint statistics which also includes information about the sub task checkpoint statistics.";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/cluster/ShutdownHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/cluster/ShutdownHeaders.java
@@ -66,4 +66,9 @@ public class ShutdownHeaders implements MessageHeaders<EmptyRequestBody, EmptyRe
 	public static ShutdownHeaders getInstance() {
 		return INSTANCE;
 	}
+
+	@Override
+	public String getDescription() {
+		return "Shutdown the cluster";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobDetailsHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobDetailsHeaders.java
@@ -71,4 +71,10 @@ public class JobDetailsHeaders implements MessageHeaders<EmptyRequestBody, JobDe
 	public static JobDetailsHeaders getInstance() {
 		return INSTANCE;
 	}
+
+	@Override
+	public String getDescription() {
+		return "Summary of one job, listing dataflow plan, status, timestamps of state transitions, aggregate " +
+			"information for each vertex (operator).";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobExecutionResultHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobExecutionResultHeaders.java
@@ -68,4 +68,9 @@ public class JobExecutionResultHeaders
 		return INSTANCE;
 	}
 
+	@Override
+	public String getDescription() {
+		return "The result of a job execution. Gives access to the execution time of the job, " +
+			"and to all accumulators created by this job.";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobSubmitHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobSubmitHeaders.java
@@ -68,4 +68,9 @@ public class JobSubmitHeaders implements MessageHeaders<JobSubmitRequestBody, Jo
 	public static JobSubmitHeaders getInstance() {
 		return INSTANCE;
 	}
+
+	@Override
+	public String getDescription() {
+		return "Submit a job to a flink cluster.";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/SubtaskCurrentAttemptDetailsHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/SubtaskCurrentAttemptDetailsHeaders.java
@@ -74,4 +74,9 @@ public class SubtaskCurrentAttemptDetailsHeaders implements MessageHeaders<Empty
 	public static SubtaskCurrentAttemptDetailsHeaders getInstance() {
 		return INSTANCE;
 	}
+
+	@Override
+	public String getDescription() {
+		return "Summary of the current or latest execution attempt of a specific subtask.";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/SubtaskExecutionAttemptAccumulatorsHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/SubtaskExecutionAttemptAccumulatorsHeaders.java
@@ -75,4 +75,9 @@ public class SubtaskExecutionAttemptAccumulatorsHeaders implements MessageHeader
 	public static SubtaskExecutionAttemptAccumulatorsHeaders getInstance() {
 		return INSTANCE;
 	}
+
+	@Override
+	public String getDescription() {
+		return "The accumulators collected for one specific subtask during one specific execution attempt (multiple attempts happen in case of failure/recovery).";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/SubtaskExecutionAttemptDetailsHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/SubtaskExecutionAttemptDetailsHeaders.java
@@ -75,4 +75,9 @@ public class SubtaskExecutionAttemptDetailsHeaders implements MessageHeaders<Emp
 	public static SubtaskExecutionAttemptDetailsHeaders getInstance() {
 		return INSTANCE;
 	}
+
+	@Override
+	public String getDescription() {
+		return "Summary of a specific execution attempt of a specific subtask. Multiple execution attempts happen in case of failure/recovery.";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/AggregatedJobMetricsHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/AggregatedJobMetricsHeaders.java
@@ -41,4 +41,9 @@ public class AggregatedJobMetricsHeaders extends AbstractAggregatedMetricsHeader
 	public static AggregatedJobMetricsHeaders getInstance() {
 		return INSTANCE;
 	}
+
+	@Override
+	public String getDescription() {
+		return "The aggregated metrics for a job.";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/AggregatedSubtaskMetricsHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/AggregatedSubtaskMetricsHeaders.java
@@ -44,4 +44,9 @@ public class AggregatedSubtaskMetricsHeaders extends AbstractAggregatedMetricsHe
 	public static AggregatedSubtaskMetricsHeaders getInstance() {
 		return INSTANCE;
 	}
+
+	@Override
+	public String getDescription() {
+		return "The aggregated metrics for a vertex subtask.";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/AggregatedTaskManagerMetricsHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/AggregatedTaskManagerMetricsHeaders.java
@@ -41,4 +41,10 @@ public class AggregatedTaskManagerMetricsHeaders extends AbstractAggregatedMetri
 	public static AggregatedTaskManagerMetricsHeaders getInstance() {
 		return INSTANCE;
 	}
+
+	@Override
+	public String getDescription() {
+		return "The aggregated metrics for a task manager.";
+	}
+
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/JobManagerMetricsHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/JobManagerMetricsHeaders.java
@@ -46,4 +46,8 @@ public final class JobManagerMetricsHeaders extends
 		return INSTANCE;
 	}
 
+	@Override
+	public String getDescription() {
+		return "The metrics for a job manager.";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/JobMetricsHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/JobMetricsHeaders.java
@@ -46,4 +46,8 @@ public final class JobMetricsHeaders extends AbstractMetricsHeaders<JobMetricsMe
 		return INSTANCE;
 	}
 
+	@Override
+	public String getDescription() {
+		return "The metrics for a specified job.";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/JobVertexMetricsHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/JobVertexMetricsHeaders.java
@@ -49,4 +49,8 @@ public final class JobVertexMetricsHeaders extends
 		return INSTANCE;
 	}
 
+	@Override
+	public String getDescription() {
+		return "The metrics for a specified job and job vertex.";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/SubtaskMetricsHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/SubtaskMetricsHeaders.java
@@ -50,4 +50,8 @@ public final class SubtaskMetricsHeaders extends
 		return INSTANCE;
 	}
 
+	@Override
+	public String getDescription() {
+		return "Get metrics for a subtask.";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/TaskManagerMetricsHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/TaskManagerMetricsHeaders.java
@@ -47,4 +47,8 @@ public final class TaskManagerMetricsHeaders extends
 		return INSTANCE;
 	}
 
+	@Override
+	public String getDescription() {
+		return "Get TaskManager metrics.";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointDisposalStatusHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointDisposalStatusHeaders.java
@@ -72,4 +72,9 @@ public class SavepointDisposalStatusHeaders extends AsynchronousOperationStatusM
 	protected Class<AsynchronousOperationInfo> getValueClass() {
 		return AsynchronousOperationInfo.class;
 	}
+
+	@Override
+	public String getDescription() {
+		return "Polling status for the savepoint disposal operation.";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointDisposalTriggerHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointDisposalTriggerHeaders.java
@@ -64,4 +64,9 @@ public class SavepointDisposalTriggerHeaders extends AsynchronousOperationTrigge
 	public static SavepointDisposalTriggerHeaders getInstance() {
 		return INSTANCE;
 	}
+
+	@Override
+	public String getDescription() {
+		return "Trigger the disposal of a savepoint.";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointStatusHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointStatusHeaders.java
@@ -75,4 +75,9 @@ public class SavepointStatusHeaders
 	protected Class<SavepointInfo> getValueClass() {
 		return SavepointInfo.class;
 	}
+
+	@Override
+	public String getDescription() {
+		return "Polling status for the triggered savepoint.";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointTriggerHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointTriggerHeaders.java
@@ -76,4 +76,9 @@ public class SavepointTriggerHeaders
 	public static SavepointTriggerHeaders getInstance() {
 		return INSTANCE;
 	}
+
+	@Override
+	public String getDescription() {
+		return "Trigger a savepoint.";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/taskmanager/TaskManagerDetailsHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/taskmanager/TaskManagerDetailsHeaders.java
@@ -69,4 +69,9 @@ public class TaskManagerDetailsHeaders implements MessageHeaders<EmptyRequestBod
 	public static TaskManagerDetailsHeaders getInstance() {
 		return INSTANCE;
 	}
+
+	@Override
+	public String getDescription() {
+		return "Get details for a TaskManager containing base information about executors and detailed metrics.";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/taskmanager/TaskManagersHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/taskmanager/TaskManagersHeaders.java
@@ -70,4 +70,9 @@ public class TaskManagersHeaders implements MessageHeaders<EmptyRequestBody, Tas
 	public static TaskManagersHeaders getInstance() {
 		return INSTANCE;
 	}
+
+	@Override
+	public String getDescription() {
+		return "Get an overview over all taskmanagers or details for a single one.";
+	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestClientTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestClientTest.java
@@ -84,6 +84,11 @@ public class RestClientTest extends TestLogger {
 		}
 
 		@Override
+		public String getDescription() {
+			return "";
+		}
+
+		@Override
 		public EmptyMessageParameters getUnresolvedMessageParameters() {
 			return EmptyMessageParameters.getInstance();
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointITCase.java
@@ -494,9 +494,15 @@ public class RestServerEndpointITCase extends TestLogger {
 		}
 
 		@Override
+		public String getDescription() {
+			return "";
+		}
+
+		@Override
 		public TestParameters getUnresolvedMessageParameters() {
 			return new TestParameters();
 		}
+
 	}
 
 	private static class TestParameters extends MessageParameters {
@@ -625,6 +631,11 @@ public class RestServerEndpointITCase extends TestLogger {
 		@Override
 		public String getTargetRestEndpointURL() {
 			return "/upload";
+		}
+
+		@Override
+		public String getDescription() {
+			return "";
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/async/AbstractAsynchronousOperationHandlersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/async/AbstractAsynchronousOperationHandlersTest.java
@@ -238,6 +238,11 @@ public class AbstractAsynchronousOperationHandlersTest extends TestLogger {
 		}
 
 		@Override
+		public String getDescription() {
+			return "";
+		}
+
+		@Override
 		public Class<EmptyRequestBody> getRequestClass() {
 			return EmptyRequestBody.class;
 		}
@@ -292,6 +297,11 @@ public class AbstractAsynchronousOperationHandlersTest extends TestLogger {
 		@Override
 		public String getTargetRestEndpointURL() {
 			return "foobar";
+		}
+
+		@Override
+		public String getDescription() {
+			return "description";
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/metrics/AbstractMetricsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/metrics/AbstractMetricsHandlerTest.java
@@ -221,6 +221,11 @@ public class AbstractMetricsHandlerTest extends TestLogger {
 		public String getTargetRestEndpointURL() {
 			return "/";
 		}
+
+		@Override
+		public String getDescription() {
+			return "";
+		}
 	}
 
 	private static class TestMessageParameters extends MessageParameters {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/metrics/AbstractMetricsHeadersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/metrics/AbstractMetricsHeadersTest.java
@@ -53,6 +53,11 @@ public class AbstractMetricsHeadersTest extends TestLogger {
 			public String getTargetRestEndpointURL() {
 				return "/";
 			}
+
+			@Override
+			public String getDescription() {
+				return "description";
+			}
 		};
 	}
 


### PR DESCRIPTION
## What is the purpose of the change
* Add method getDescription() to MessageHeaders interface to provide meaningful REST endpoint description for generated documentation by implementing classes (see **_RestAPIDocGenerator_**). The resulting documentation is available at [flink-docs](https://ci.apache.org/projects/flink/flink-docs-master/monitoring/rest_api.html)


## Brief change log

  - *Added method **getDescription()** to **MessageHeaders** interface to provide meaningful REST endpoint description in generated documentation*
  - *Overridden this method in all implementing classes and added descriptions*
  - *Generated by **RestAPIDocGenerator** updated documentation file **rest_dispatcher.html** to be included in Flink documentation*


## Verifying this change

*This change is a documentation change and can be verified running `mvn package -Dgenerate-rest-docs` and check the description part for all REST endpoints is filled in documentation* 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: don't know
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
