### PR TITLE
[FLINK-9317] Async I/O API Example For Scala has Variable Name error

### DIFF
--- a/docs/dev/stream/operators/asyncio.md
+++ b/docs/dev/stream/operators/asyncio.md
@@ -154,11 +154,11 @@ class AsyncDatabaseRequest extends AsyncFunction[String, (String, String)] {
     override def asyncInvoke(str: String, resultFuture: ResultFuture[(String, String)]): Unit = {
 
         // issue the asynchronous request, receive a future for the result
-        val resultFuture: Future[String] = client.query(str)
+        val resultFutureRequested: Future[String] = client.query(str)
 
         // set the callback to be executed once the request by the client is complete
         // the callback simply forwards the result to the result future
-        resultFuture.onSuccess {
+        resultFutureRequested.onSuccess {
             case result: String => resultFuture.complete(Iterable((str, result)))
         }
     }


### PR DESCRIPTION
## What is the purpose of the change

Updating AsyncIO Scala Example with proper variable names

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
