### PR TITLE
[FLINK-9074] [e2e] Add e2e for resuming from externalized checkpoints

### DIFF
--- a/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/DataStreamAllroundTestJobFactory.java
+++ b/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/DataStreamAllroundTestJobFactory.java
@@ -30,6 +30,7 @@ import org.apache.flink.contrib.streaming.state.RocksDBStateBackend;
 import org.apache.flink.runtime.state.filesystem.FsStateBackend;
 import org.apache.flink.streaming.api.CheckpointingMode;
 import org.apache.flink.streaming.api.TimeCharacteristic;
+import org.apache.flink.streaming.api.environment.CheckpointConfig;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.api.functions.timestamps.BoundedOutOfOrdernessTimestampExtractor;
@@ -53,6 +54,8 @@ import java.util.List;
  * <ul>
  *     <li>test.semantics (String, default - 'exactly-once'): This configures the semantics to test. Can be 'exactly-once' or 'at-least-once'.</li>
  *     <li>environment.checkpoint_interval (long, default - 1000): the checkpoint interval.</li>
+ *     <li>environment.externalize_checkpoint (boolean, default - false): whether or not checkpoints should be externalized.</li>
+ *     <li>environment.externalize_checkpoint.cleanup (String, default - 'retain'): Configures the cleanup mode for externalized checkpoints. Can be 'retain' or 'delete'.</li>
  *     <li>environment.parallelism (int, default - 1): parallelism to use for the job.</li>
  *     <li>environment.max_parallelism (int, default - 128): max parallelism to use for the job</li>
  *     <li>environment.restart_strategy.delay (long, default - 0): delay between restart attempts, in milliseconds.</li>
@@ -89,6 +92,14 @@ class DataStreamAllroundTestJobFactory {
 	private static final ConfigOption<Integer> ENVIRONMENT_RESTART_DELAY = ConfigOptions
 		.key("environment.restart_strategy.delay")
 		.defaultValue(0);
+
+	private static final ConfigOption<Boolean> ENVIRONMENT_EXTERNALIZE_CHECKPOINT = ConfigOptions
+		.key("environment.externalize_checkpoint")
+		.defaultValue(false);
+
+	private static final ConfigOption<String> ENVIRONMENT_EXTERNALIZE_CHECKPOINT_CLEANUP = ConfigOptions
+		.key("environment.externalize_checkpoint.cleanup")
+		.defaultValue("retain");
 
 	private static final ConfigOption<String> STATE_BACKEND = ConfigOptions
 		.key("state_backend")
@@ -178,6 +189,30 @@ class DataStreamAllroundTestJobFactory {
 			env.setStateBackend(new RocksDBStateBackend(checkpointDir, incrementalCheckpoints));
 		} else {
 			throw new IllegalArgumentException("Unknown backend requested: " + stateBackend);
+		}
+
+		boolean enableExternalizedCheckpoints = pt.getBoolean(
+			ENVIRONMENT_EXTERNALIZE_CHECKPOINT.key(),
+			ENVIRONMENT_EXTERNALIZE_CHECKPOINT.defaultValue());
+
+		if (enableExternalizedCheckpoints) {
+			String cleanupModeConfig = pt.get(
+				ENVIRONMENT_EXTERNALIZE_CHECKPOINT_CLEANUP.key(),
+				ENVIRONMENT_EXTERNALIZE_CHECKPOINT_CLEANUP.defaultValue());
+
+			CheckpointConfig.ExternalizedCheckpointCleanup cleanupMode;
+			switch (cleanupModeConfig) {
+				case "retain":
+					cleanupMode = CheckpointConfig.ExternalizedCheckpointCleanup.RETAIN_ON_CANCELLATION;
+					break;
+				case "delete":
+					cleanupMode = CheckpointConfig.ExternalizedCheckpointCleanup.DELETE_ON_CANCELLATION;
+					break;
+				default:
+					throw new IllegalArgumentException("Unknown clean up mode for externalized checkpoints: " + cleanupModeConfig);
+			}
+
+			env.getCheckpointConfig().enableExternalizedCheckpoints(cleanupMode);
 		}
 
 		// make parameters available in the web interface

--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -130,6 +130,30 @@ fi
 
 if [ $EXIT_CODE == 0 ]; then
   printf "\n==============================================================================\n"
+  printf "Running Resuming Externalized Checkpoint (file, async) end-to-end test\n"
+  printf "==============================================================================\n"
+  STATE_BACKEND_TYPE=file STATE_BACKEND_FILE_ASYNC=true $END_TO_END_DIR/test-scripts/test_resume_externalized_checkpoints.sh
+  EXIT_CODE=$?
+fi
+
+if [ $EXIT_CODE == 0 ]; then
+  printf "\n==============================================================================\n"
+  printf "Running Resuming Externalized Checkpoint (file, sync) end-to-end test\n"
+  printf "==============================================================================\n"
+  STATE_BACKEND_TYPE=file STATE_BACKEND_FILE_ASYNC=false $END_TO_END_DIR/test-scripts/test_resume_externalized_checkpoints.sh
+  EXIT_CODE=$?
+fi
+
+if [ $EXIT_CODE == 0 ]; then
+  printf "\n==============================================================================\n"
+  printf "Running Resuming Externalized Checkpoint (rocks) end-to-end test\n"
+  printf "==============================================================================\n"
+  STATE_BACKEND_TYPE=rocks $END_TO_END_DIR/test-scripts/test_resume_externalized_checkpoints.sh
+  EXIT_CODE=$?
+fi
+
+if [ $EXIT_CODE == 0 ]; then
+  printf "\n==============================================================================\n"
   printf "Running DataSet allround nightly end-to-end test\n"
   printf "==============================================================================\n"
   $END_TO_END_DIR/test-scripts/test_batch_allround.sh

--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -380,6 +380,27 @@ function wait_oper_metric_num_in_records {
     done
 }
 
+function wait_num_checkpoints {
+    JOB=$1
+    NUM_CHECKPOINTS=$2
+
+    echo "Waiting for job ($JOB) to have at least $NUM_CHECKPOINTS completed checkpoints ..."
+
+    while : ; do
+      N=$(grep -o "Completed checkpoint [1-9]* for job $JOB" $FLINK_DIR/log/*standalonesession*.log | awk '{print $3}' | tail -1)
+
+      if [ -z $N ]; then
+        N=0
+      fi
+
+      if (( N < NUM_CHECKPOINTS )); then
+        sleep 1
+      else
+        break
+      fi
+    done
+}
+
 # make sure to clean up even in case of failures
 function cleanup {
   stop_cluster

--- a/flink-end-to-end-tests/test-scripts/test_resume_externalized_checkpoints.sh
+++ b/flink-end-to-end-tests/test-scripts/test_resume_externalized_checkpoints.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+################################################################################
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+source "$(dirname "$0")"/common.sh
+
+STATE_BACKEND_TYPE=${STATE_BACKEND_TYPE:-file}
+STATE_BACKEND_FILE_ASYNC=${STATE_BACKEND_FILE_ASYNC:-true}
+
+setup_flink_slf4j_metric_reporter
+start_cluster
+
+function test_cleanup {
+  # don't call ourselves again for another signal interruption
+  trap "exit -1" INT
+  # don't call ourselves again for normal exit
+  trap "" EXIT
+
+  rollback_flink_slf4j_metric_reporter
+
+  # make sure to run regular cleanup as well
+  cleanup
+}
+trap test_cleanup INT
+trap test_cleanup EXIT
+
+CHECKPOINT_DIR="$TEST_DATA_DIR/externalized-chckpt-e2e-backend-dir"
+CHECKPOINT_DIR_URI="file://$CHECKPOINT_DIR"
+
+# run the DataStream allroundjob
+TEST_PROGRAM_JAR=$TEST_INFRA_DIR/../../flink-end-to-end-tests/flink-datastream-allround-test/target/DataStreamAllroundTestProgram.jar
+DATASTREAM_JOB=$($FLINK_DIR/bin/flink run -d $TEST_PROGRAM_JAR \
+  --test.semantics exactly-once \
+  --environment.externalize_checkpoint true \
+  --environment.externalize_checkpoint.cleanup retain \
+  --state_backend $STATE_BACKEND_TYPE \
+  --state_backend.checkpoint_directory $CHECKPOINT_DIR_URI \
+  --state_backend.file.async $STATE_BACKEND_FILE_ASYNC \
+  --sequence_generator_source.sleep_time 15 \
+  --sequence_generator_source.sleep_after_elements 1 \
+  | grep "Job has been submitted with JobID" | sed 's/.* //g')
+
+wait_job_running $DATASTREAM_JOB
+
+wait_num_checkpoints $DATASTREAM_JOB 1
+wait_oper_metric_num_in_records ArtificalKeyedStateMapper.0 200
+
+cancel_job $DATASTREAM_JOB
+
+CHECKPOINT_PATH=$(ls -d $CHECKPOINT_DIR/$DATASTREAM_JOB/chk-[1-9]*)
+
+if [ -z $CHECKPOINT_PATH ]; then
+  echo "Expected an externalized checkpoint to be present, but none exists."
+  PASS=""
+  exit 1
+fi
+
+NUM_CHECKPOINTS=$(echo $CHECKPOINT_PATH | wc -l | tr -d ' ')
+if (( $NUM_CHECKPOINTS > 1 )); then
+  echo "Expected only exactly 1 externalized checkpoint to be present, but $NUM_CHECKPOINTS exists."
+  PASS=""
+  exit 1
+fi
+
+echo "Restoring job with externalized checkpoint at $CHECKPOINT_PATH ..."
+DATASTREAM_JOB=$($FLINK_DIR/bin/flink run -s $CHECKPOINT_PATH -d $TEST_PROGRAM_JAR \
+  --test.semantics exactly-once \
+  --environment.externalize_checkpoint true \
+  --environment.externalize_checkpoint.cleanup retain \
+  --state_backend $STATE_BACKEND_TYPE \
+  --state_backend.checkpoint_directory $CHECKPOINT_DIR_URI \
+  --state_backend.file.async $STATE_BACKEND_FILE_ASYNC \
+  --sequence_generator_source.sleep_time 15 \
+  --sequence_generator_source.sleep_after_elements 1 \
+  | grep "Job has been submitted with JobID" | sed 's/.* //g')
+
+wait_job_running $DATASTREAM_JOB
+
+wait_oper_metric_num_in_records ArtificalKeyedStateMapper.0 200
+
+# if state is errorneous and the general purpose DataStream job produces alerting messages,
+# output would be non-empty and the test will not pass


### PR DESCRIPTION
## What is the purpose of the change

This PR adds an end-to-end test for resuming from externalized, retained checkpoints.

The test does the following:
- Runs the general purpose DataStream job, with externalized checkpoints enabled
- Waits until the job has at least 1 completed checkpoints, AND has processed at least 200 records
- Cancel the job
- Make sure that there is exactly 1 externalized checkpoint available
- Restore from that, wait for another 200 records to be processed to verify that exactly-once isn't violated

## Brief change log

- Allow general purpose job to be configured for externalized checkpoints
- Add new e2e test script `test_resume_externalized_checkpoint.sh`

## Verifying this change

This PR adds a new test, `test_resume_externalized_checkpoint.sh`.

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
