### PR TITLE
[FLINK-9321] Rename SubtasksAllAccumulatorsHandlers

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/SubtasksAllAccumulatorsHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/SubtasksAllAccumulatorsHeaders.java
@@ -27,9 +27,9 @@ import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseSt
 /**
  * Message headers for the {@link SubtasksAllAccumulatorsHandler}.
  */
-public class SubtasksAllAccumulatorsHandlers implements MessageHeaders<EmptyRequestBody, SubtasksAllAccumulatorsInfo, JobVertexMessageParameters> {
+public class SubtasksAllAccumulatorsHeaders implements MessageHeaders<EmptyRequestBody, SubtasksAllAccumulatorsInfo, JobVertexMessageParameters> {
 
-	private static final SubtasksAllAccumulatorsHandlers INSTANCE = new SubtasksAllAccumulatorsHandlers();
+	private static final SubtasksAllAccumulatorsHeaders INSTANCE = new SubtasksAllAccumulatorsHeaders();
 
 	public static final String URL = "/jobs" +
 		"/:" + JobIDPathParameter.KEY +
@@ -37,7 +37,7 @@ public class SubtasksAllAccumulatorsHandlers implements MessageHeaders<EmptyRequ
 		"/:" + JobVertexIdPathParameter.KEY +
 		"/subtasks/accumulators";
 
-	private SubtasksAllAccumulatorsHandlers() {}
+	private SubtasksAllAccumulatorsHeaders() {}
 
 	@Override
 	public Class<EmptyRequestBody> getRequestClass() {
@@ -69,7 +69,7 @@ public class SubtasksAllAccumulatorsHandlers implements MessageHeaders<EmptyRequ
 		return URL;
 	}
 
-	public static SubtasksAllAccumulatorsHandlers getInstance() {
+	public static SubtasksAllAccumulatorsHeaders getInstance() {
 		return INSTANCE;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
@@ -96,7 +96,7 @@ import org.apache.flink.runtime.rest.messages.JobVertexBackPressureHeaders;
 import org.apache.flink.runtime.rest.messages.JobVertexDetailsHeaders;
 import org.apache.flink.runtime.rest.messages.JobVertexTaskManagersHeaders;
 import org.apache.flink.runtime.rest.messages.JobsOverviewHeaders;
-import org.apache.flink.runtime.rest.messages.SubtasksAllAccumulatorsHandlers;
+import org.apache.flink.runtime.rest.messages.SubtasksAllAccumulatorsHeaders;
 import org.apache.flink.runtime.rest.messages.SubtasksTimesHeaders;
 import org.apache.flink.runtime.rest.messages.TerminationModeQueryParameter;
 import org.apache.flink.runtime.rest.messages.YarnCancelJobTerminationHeaders;
@@ -327,7 +327,7 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
 			leaderRetriever,
 			timeout,
 			responseHeaders,
-			SubtasksAllAccumulatorsHandlers.getInstance(),
+			SubtasksAllAccumulatorsHeaders.getInstance(),
 			executionGraphCache,
 			executor);
 


### PR DESCRIPTION
## What is the purpose of the change

*This pull request renamed SubtasksAllAccumulatorsHandlers to SubtasksAllAccumulatorsHeaders*


## Brief change log

  - *renamed SubtasksAllAccumulatorsHandlers to SubtasksAllAccumulatorsHeaders*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
