### PR TITLE
[FLINK-9323][build] Properly organize checkstyle-plugin configuration

### DIFF
--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -123,7 +123,7 @@ under the License.
 				<artifactId>maven-checkstyle-plugin</artifactId>
 
 				<configuration>
-					<suppressionsLocation combine.self="override">/tools/maven/suppressions-runtime.xml</suppressionsLocation>
+					<suppressionsLocation combine.self="override">/tools/maven/suppressions-core.xml</suppressionsLocation>
 				</configuration>
 			</plugin>
 

--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -121,30 +121,9 @@ under the License.
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-checkstyle-plugin</artifactId>
-				<version>2.17</version>
-				<dependencies>
-					<dependency>
-						<groupId>com.puppycrawl.tools</groupId>
-						<artifactId>checkstyle</artifactId>
-						<version>8.4</version>
-					</dependency>
-				</dependencies>
-				<executions>
-					<execution>
-						<id>validate</id>
-						<phase>validate</phase>
-						<goals>
-							<goal>check</goal>
-						</goals>
-					</execution>
-				</executions>
 
 				<configuration>
-					<configLocation>/tools/maven/checkstyle.xml</configLocation>
-					<suppressionsLocation>/tools/maven/suppressions-core.xml</suppressionsLocation>
-					<includeTestSourceDirectory>true</includeTestSourceDirectory>
-					<logViolationsToConsole>true</logViolationsToConsole>
-					<failOnViolation>true</failOnViolation>
+					<suppressionsLocation combine.self="override">/tools/maven/suppressions-runtime.xml</suppressionsLocation>
 				</configuration>
 			</plugin>
 

--- a/flink-optimizer/pom.xml
+++ b/flink-optimizer/pom.xml
@@ -82,7 +82,7 @@ under the License.
 				<artifactId>maven-checkstyle-plugin</artifactId>
 
 				<configuration>
-					<suppressionsLocation combine.self="override">/tools/maven/suppressions-runtime.xml</suppressionsLocation>
+					<suppressionsLocation combine.self="override">/tools/maven/suppressions-optimizer.xml</suppressionsLocation>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/flink-optimizer/pom.xml
+++ b/flink-optimizer/pom.xml
@@ -80,30 +80,9 @@ under the License.
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-checkstyle-plugin</artifactId>
-				<version>2.17</version>
-				<dependencies>
-					<dependency>
-						<groupId>com.puppycrawl.tools</groupId>
-						<artifactId>checkstyle</artifactId>
-						<version>8.4</version>
-					</dependency>
-				</dependencies>
-				<executions>
-					<execution>
-						<id>validate</id>
-						<phase>validate</phase>
-						<goals>
-							<goal>check</goal>
-						</goals>
-					</execution>
-				</executions>
 
 				<configuration>
-					<configLocation>/tools/maven/checkstyle.xml</configLocation>
-					<suppressionsLocation>/tools/maven/suppressions-optimizer.xml</suppressionsLocation>
-					<includeTestSourceDirectory>true</includeTestSourceDirectory>
-					<logViolationsToConsole>true</logViolationsToConsole>
-					<failOnViolation>true</failOnViolation>
+					<suppressionsLocation combine.self="override">/tools/maven/suppressions-runtime.xml</suppressionsLocation>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -334,30 +334,9 @@ under the License.
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-checkstyle-plugin</artifactId>
-				<version>2.17</version>
-				<dependencies>
-					<dependency>
-						<groupId>com.puppycrawl.tools</groupId>
-						<artifactId>checkstyle</artifactId>
-						<version>8.4</version>
-					</dependency>
-				</dependencies>
-				<executions>
-					<execution>
-						<id>validate</id>
-						<phase>validate</phase>
-						<goals>
-							<goal>check</goal>
-						</goals>
-					</execution>
-				</executions>
 
 				<configuration>
-					<configLocation>/tools/maven/checkstyle.xml</configLocation>
-					<suppressionsLocation>/tools/maven/suppressions-runtime.xml</suppressionsLocation>
-					<includeTestSourceDirectory>true</includeTestSourceDirectory>
-					<logViolationsToConsole>true</logViolationsToConsole>
-					<failOnViolation>true</failOnViolation>
+					<suppressionsLocation combine.self="override">/tools/maven/suppressions-runtime.xml</suppressionsLocation>
 				</configuration>
 			</plugin>
 			<!-- Scala Compiler -->

--- a/pom.xml
+++ b/pom.xml
@@ -1164,31 +1164,6 @@ under the License.
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-checkstyle-plugin</artifactId>
-				<version>2.17</version>
-				<dependencies>
-					<dependency>
-						<groupId>com.puppycrawl.tools</groupId>
-						<artifactId>checkstyle</artifactId>
-						<!-- Note: match version with docs/internals/ide_setup.md -->
-						<version>8.4</version>
-					</dependency>
-				</dependencies>
-				<executions>
-					<execution>
-						<id>validate</id>
-						<phase>validate</phase>
-						<goals>
-							<goal>check</goal>
-						</goals>
-					</execution>
-				</executions>
-				<configuration>
-					<suppressionsLocation>/tools/maven/suppressions.xml</suppressionsLocation>
-					<includeTestSourceDirectory>true</includeTestSourceDirectory>
-					<configLocation>/tools/maven/checkstyle.xml</configLocation>
-					<logViolationsToConsole>true</logViolationsToConsole>
-					<failOnViolation>true</failOnViolation>
-				</configuration>
 			</plugin>
 			<plugin>
 				<!-- just define the Java version to be used for compiling and plugins -->
@@ -1393,6 +1368,36 @@ under the License.
 		<pluginManagement>
 			<plugins>
 
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-checkstyle-plugin</artifactId>
+					<version>2.17</version>
+					<dependencies>
+						<dependency>
+							<groupId>com.puppycrawl.tools</groupId>
+							<artifactId>checkstyle</artifactId>
+							<!-- Note: match version with docs/internals/ide_setup.md -->
+							<version>8.4</version>
+						</dependency>
+					</dependencies>
+					<executions>
+						<execution>
+							<id>validate</id>
+							<phase>validate</phase>
+							<goals>
+								<goal>check</goal>
+							</goals>
+						</execution>
+					</executions>
+					<configuration>
+						<suppressionsLocation>/tools/maven/suppressions.xml</suppressionsLocation>
+						<includeTestSourceDirectory>true</includeTestSourceDirectory>
+						<configLocation>/tools/maven/checkstyle.xml</configLocation>
+						<logViolationsToConsole>true</logViolationsToConsole>
+						<failOnViolation>true</failOnViolation>
+					</configuration>
+				</plugin>
+				
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-javadoc-plugin</artifactId>


### PR DESCRIPTION
## What is the purpose of the change

This PR reorganizes the checkstyle-plugin configuration to not be duplicated in 4 modules. Instead the configuration was moved into the root pluginManagement section. The child poms were adjusted to only override settings if required.

## Brief change log

* move checkstyle configuration into root pluginManagement section
* reduce child pom configuration to essential entry

## Verifying this change

* run `mvn help:effective-pom` to verify that the effective poms have not changed, and that the suppression file is properly overridden
