### PR TITLE
[FLINK-9319][docs] Move reflection dependencies into profile

### DIFF
--- a/flink-docs/pom.xml
+++ b/flink-docs/pom.xml
@@ -49,24 +49,9 @@ under the License.
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-		<dependency>
 			<!-- necessary for loading the web-submission extension -->
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-runtime-web_${scala.binary.version}</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-yarn_${scala.binary.version}</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-mesos_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 
@@ -184,6 +169,26 @@ under the License.
 					<name>generate-config-docs</name>
 				</property>
 			</activation>
+			<dependencies>
+				<dependency>
+					<!-- Required to load classes containing config options via reflection -->
+					<groupId>org.apache.flink</groupId>
+					<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+					<version>${project.version}</version>
+				</dependency>
+				<dependency>
+					<!-- Required to load classes containing config options via reflection -->
+					<groupId>org.apache.flink</groupId>
+					<artifactId>flink-yarn_${scala.binary.version}</artifactId>
+					<version>${project.version}</version>
+				</dependency>
+				<dependency>
+					<!-- Required to load classes containing config options via reflection -->
+					<groupId>org.apache.flink</groupId>
+					<artifactId>flink-mesos_${scala.binary.version}</artifactId>
+					<version>${project.version}</version>
+				</dependency>
+			</dependencies>
 			<build>
 				<plugins>
 					<plugin>


### PR DESCRIPTION
## What is the purpose of the change

This PR moves dependencies of `flink-docs` that are only accessed via reflection by the config docs generator into the `generate-config-docs` profile. This makes the generation of the rest docs faster/more convenient since we can skip a few modules.
