### PR TITLE
[FLINK-9138][docs][tests] Make ConfigOptionsDocsCompletenessTest an IT case

### DIFF
--- a/flink-docs/src/test/java/org/apache/flink/docs/configuration/ConfigOptionsDocsCompletenessITCase.java
+++ b/flink-docs/src/test/java/org/apache/flink/docs/configuration/ConfigOptionsDocsCompletenessITCase.java
@@ -49,7 +49,7 @@ import static org.apache.flink.docs.configuration.ConfigOptionsDocGenerator.stri
  * the same key with different descriptions/default values), and that the documentation does not refer to non-existent
  * options.
  */
-public class ConfigOptionsDocsCompletenessTest {
+public class ConfigOptionsDocsCompletenessITCase {
 
 	@Test
 	public void testDocsCompleteness() throws IOException, ClassNotFoundException {


### PR DESCRIPTION
## What is the purpose of the change

This PR modifies the `ConfigOptionsDocsCompletenessTest` to be an IT case instead. You can now regenerate the docs without having to skip tests, since the docs are now generated _before_ the completeness check.