### PR TITLE
[FLINK-9325][checkpoint]generate the meta file for checkpoint only when the writing is truly successful

### DIFF
--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -146,6 +146,7 @@ under the License.
 							<exclude>org.apache.flink.core.fs.FileSystem#initialize(java.net.URI)</exclude>
 							<exclude>org.apache.flink.core.fs.FileSystem#isFlinkSupportedScheme(java.lang.String)</exclude>
 							<exclude>org.apache.flink.core.fs.FileSystem#setDefaultScheme(org.apache.flink.configuration.Configuration)</exclude>
+							<exclude>org.apache.flink.core.fs.FileSystem#createAtomically(org.apache.flink.core.fs.Path,org.apache.flink.core.fs.FileSystem$WriteMode)</exclude>
 							<exclude>org.apache.flink.api.java.typeutils.WritableTypeInfo</exclude>
 							<exclude>org.apache.flink.api.java.typeutils.AvroTypeInfo</exclude>
 							<!-- Breaking changes between 1.1 and 1.2.

--- a/flink-core/src/main/java/org/apache/flink/core/fs/AtomicCreatingFsDataOutputStream.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/AtomicCreatingFsDataOutputStream.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.fs;
+
+import java.io.IOException;
+
+/**
+ * The output stream to create a file atomically, the target file will be visible only
+ * when the writing is truly successful.
+ */
+public abstract class AtomicCreatingFsDataOutputStream extends FSDataOutputStream {
+
+	/**
+	 * This method means "close on success", after calling this the data that written
+	 * through this output stream will be published into the target file.
+	 */
+	public abstract void closeAndPublish() throws IOException;
+}

--- a/flink-core/src/main/java/org/apache/flink/core/fs/FileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/FileSystem.java
@@ -633,6 +633,24 @@ public abstract class FileSystem {
 	public abstract FSDataOutputStream create(Path f, WriteMode overwriteMode) throws IOException;
 
 	/**
+	 * Opens an FSDataOutputStream to a new file at the given path atomically, this means that
+	 * we create the target file only with the writing is truly successful.
+	 *
+	 * <p>If the file already exists, the behavior depends on the given {@code WriteMode}.
+	 * If the mode is set to {@link WriteMode#NO_OVERWRITE}, then this method fails with an
+	 * exception.
+	 *
+	 * @param f The file path to write to
+	 * @param overwriteMode The action to take if a file or directory already exists at the given path.
+	 * @return The stream to the new file at the target path.
+	 *
+	 * @throws IOException Thrown, if the stream could not be opened because of an I/O, or because
+	 *                     a file already exists at that path and the write mode indicates to not
+	 *                     overwrite the file.
+	 */
+	public abstract FSDataOutputStream createAtomically(Path f, WriteMode overwriteMode) throws IOException;
+
+	/**
 	 * Renames the file/directory src to dst.
 	 *
 	 * @param src

--- a/flink-core/src/main/java/org/apache/flink/core/fs/FileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/FileSystem.java
@@ -648,7 +648,7 @@ public abstract class FileSystem {
 	 *                     a file already exists at that path and the write mode indicates to not
 	 *                     overwrite the file.
 	 */
-	public abstract FSDataOutputStream createAtomically(Path f, WriteMode overwriteMode) throws IOException;
+	public abstract AtomicCreatingFsDataOutputStream createAtomically(Path f, WriteMode overwriteMode) throws IOException;
 
 	/**
 	 * Renames the file/directory src to dst.

--- a/flink-core/src/main/java/org/apache/flink/core/fs/LimitedConnectionsFileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/LimitedConnectionsFileSystem.java
@@ -273,6 +273,11 @@ public class LimitedConnectionsFileSystem extends FileSystem {
 	}
 
 	@Override
+	public FSDataOutputStream createAtomically(Path f, WriteMode overwriteMode) throws IOException {
+		throw new UnsupportedOperationException("createAtomically(...) is unsupported in LimitedConnectionsFileSystem yet.");
+	}
+
+	@Override
 	@Deprecated
 	@SuppressWarnings("deprecation")
 	public FSDataOutputStream create(

--- a/flink-core/src/main/java/org/apache/flink/core/fs/LimitedConnectionsFileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/LimitedConnectionsFileSystem.java
@@ -274,7 +274,7 @@ public class LimitedConnectionsFileSystem extends FileSystem {
 
 	@Override
 	public FSDataOutputStream createAtomically(Path f, WriteMode overwriteMode) throws IOException {
-		throw new UnsupportedOperationException("createAtomically(...) is unsupported in LimitedConnectionsFileSystem yet.");
+		return createOutputStream(() -> originalFs.createAtomically(f, overwriteMode));
 	}
 
 	@Override

--- a/flink-core/src/main/java/org/apache/flink/core/fs/SafetyNetWrapperFileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/SafetyNetWrapperFileSystem.java
@@ -123,6 +123,11 @@ public class SafetyNetWrapperFileSystem extends FileSystem implements WrappingPr
 	}
 
 	@Override
+	public FSDataOutputStream createAtomically(Path f, WriteMode overwriteMode) throws IOException {
+		throw new UnsupportedOperationException("createAtomically(...) is unsupported in SafetyNetWrapperFileSystem yet.");
+	}
+
+	@Override
 	public boolean rename(Path src, Path dst) throws IOException {
 		return unsafeFileSystem.rename(src, dst);
 	}

--- a/flink-core/src/main/java/org/apache/flink/core/fs/SafetyNetWrapperFileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/SafetyNetWrapperFileSystem.java
@@ -123,9 +123,9 @@ public class SafetyNetWrapperFileSystem extends FileSystem implements WrappingPr
 	}
 
 	@Override
-	public FSDataOutputStream createAtomically(Path f, WriteMode overwriteMode) throws IOException {
-		FSDataOutputStream innerStream = unsafeFileSystem.createAtomically(f, overwriteMode);
-		return ClosingFSDataOutputStream.wrapSafe(innerStream, registry, String.valueOf(f));
+	public AtomicCreatingFsDataOutputStream createAtomically(Path f, WriteMode overwriteMode) throws IOException {
+		AtomicCreatingFsDataOutputStream innerStream = unsafeFileSystem.createAtomically(f, overwriteMode);
+		return ClosingAtomicCreatingFSDataOutputStream.wrapSafe(innerStream, registry, String.valueOf(f));
 	}
 
 	@Override

--- a/flink-core/src/main/java/org/apache/flink/core/fs/SafetyNetWrapperFileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/SafetyNetWrapperFileSystem.java
@@ -124,7 +124,8 @@ public class SafetyNetWrapperFileSystem extends FileSystem implements WrappingPr
 
 	@Override
 	public FSDataOutputStream createAtomically(Path f, WriteMode overwriteMode) throws IOException {
-		throw new UnsupportedOperationException("createAtomically(...) is unsupported in SafetyNetWrapperFileSystem yet.");
+		FSDataOutputStream innerStream = unsafeFileSystem.createAtomically(f, overwriteMode);
+		return ClosingFSDataOutputStream.wrapSafe(innerStream, registry, String.valueOf(f));
 	}
 
 	@Override

--- a/flink-core/src/main/java/org/apache/flink/core/fs/TwoPhaseFSDataOutputStream.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/TwoPhaseFSDataOutputStream.java
@@ -27,15 +27,15 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 
 /**
- * Operates the output stream in two phrases, any exception during the operation of {@link TwoPhraseFSDataOutputStream} will
+ * Operates the output stream in two phrases, any exception during the operation of {@link TwoPhaseFSDataOutputStream} will
  * lead the {@link #targetFile} to be invisible.
- * PHRASE 1, write the data into the {@link #preparingFile}.
- * PHRASE 2, close the {@link #preparingFile} and rename it to the {@link #targetFile}.
+ * PHASE 1, write the data into the {@link #preparingFile}.
+ * PHASE 2, close the {@link #preparingFile} and rename it to the {@link #targetFile}.
  */
 @Internal
-public class TwoPhraseFSDataOutputStream extends FSDataOutputStream {
+public class TwoPhaseFSDataOutputStream extends FSDataOutputStream {
 
-	private static final Logger LOG = LoggerFactory.getLogger(TwoPhraseFSDataOutputStream.class);
+	private static final Logger LOG = LoggerFactory.getLogger(TwoPhaseFSDataOutputStream.class);
 
 	private static final String PREPARING_FILE_SUFFIX = "_tmp";
 
@@ -63,7 +63,7 @@ public class TwoPhraseFSDataOutputStream extends FSDataOutputStream {
 
 	private PhraseType currentPhrase;
 
-	public TwoPhraseFSDataOutputStream(FileSystem fs, Path f, FileSystem.WriteMode writeMode) throws IOException {
+	public TwoPhaseFSDataOutputStream(FileSystem fs, Path f, FileSystem.WriteMode writeMode) throws IOException {
 
 		this.fs = fs;
 		this.targetFile = f;

--- a/flink-core/src/main/java/org/apache/flink/core/fs/TwoPhaseFSDataOutputStream.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/TwoPhaseFSDataOutputStream.java
@@ -20,8 +20,8 @@ package org.apache.flink.core.fs;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
-
 import org.apache.flink.util.Preconditions;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,7 +36,7 @@ import java.util.UUID;
  * PHASE 2, close the {@link #preparingFile} and rename it to the {@link #targetFile}.
  */
 @Internal
-public class TwoPhaseFSDataOutputStream extends FSDataOutputStream {
+public class TwoPhaseFSDataOutputStream extends AtomicCreatingFsDataOutputStream {
 
 	private static final Logger LOG = LoggerFactory.getLogger(TwoPhaseFSDataOutputStream.class);
 
@@ -46,7 +46,7 @@ public class TwoPhaseFSDataOutputStream extends FSDataOutputStream {
 	private final FileSystem fs;
 
 	/**
-	 * the target file which the preparing file will be renamed to in the close().
+	 * the target file which the preparing file will be renamed to in the {@link #closeAndPublish()}.
 	 */
 	private final Path targetFile;
 

--- a/flink-core/src/main/java/org/apache/flink/core/fs/TwoPhraseFSDataOutputStream.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/TwoPhraseFSDataOutputStream.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.fs;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+/**
+ * Operates the output stream in two phrases, any exception during the operation of {@link TwoPhraseFSDataOutputStream} will
+ * lead the {@link #targetFile} to be invisible.
+ *
+ * <p>PHRASE 1, write the data into the {@link #preparingFile}.
+ * <p>PHRASE 2, close the {@link #preparingFile} and rename it to the {@link #targetFile}.
+ */
+@Internal
+public class TwoPhraseFSDataOutputStream extends FSDataOutputStream {
+
+	private static final Logger LOG = LoggerFactory.getLogger(TwoPhraseFSDataOutputStream.class);
+
+	private static final String PREPARING_FILE_SUFFIX = "_tmp";
+
+	/**
+	 * the target file system.
+	 */
+	private final FileSystem fs;
+
+	/**
+	 * the target file which the preparing file will be renamed to in the close().
+	 */
+	private final Path targetFile;
+
+	/**
+	 * the preparing file to store the on flying data.
+	 */
+	private final Path preparingFile;
+
+	/**
+	 * the output stream of the preparing file.
+	 */
+	private final FSDataOutputStream preparedOutputStream;
+
+	enum PhraseType {PREPARE, COMMIT}
+
+	private PhraseType currentPhrase;
+
+	public TwoPhraseFSDataOutputStream(FileSystem fs, Path f, FileSystem.WriteMode writeMode) throws IOException {
+
+		this.fs = fs;
+		this.targetFile = f;
+		this.preparingFile = new Path(f.getPath() + PREPARING_FILE_SUFFIX);
+		this.currentPhrase = PhraseType.PREPARE;
+
+		if (writeMode == FileSystem.WriteMode.NO_OVERWRITE && fs.exists(targetFile)) {
+			throw new IOException("Target file " + targetFile + " is already exists.");
+		}
+
+		this.preparedOutputStream = fs.create(this.preparingFile, writeMode);
+	}
+
+	@Override
+	public long getPos() throws IOException {
+		return this.preparedOutputStream.getPos();
+	}
+
+	@Override
+	public void write(int b) throws IOException {
+		checkPhrase(PhraseType.PREPARE);
+		this.preparedOutputStream.write(b);
+	}
+
+	@Override
+	public void flush() throws IOException {
+		checkPhrase(PhraseType.PREPARE);
+		this.preparedOutputStream.flush();
+	}
+
+	@Override
+	public void sync() throws IOException {
+		checkPhrase(PhraseType.PREPARE);
+		this.preparedOutputStream.sync();
+	}
+
+	@Override
+	public void close() throws IOException {
+		try {
+			checkPhrase(PhraseType.COMMIT);
+			this.preparedOutputStream.close();
+			this.fs.rename(preparingFile, targetFile);
+		} catch (Exception e) {
+			this.preparedOutputStream.close();
+			if (fs.exists(preparingFile)) {
+				try {
+					fs.delete(preparingFile, false);
+				} catch (Throwable ignored) {
+					LOG.warn("Failed to delete the preparing file {" + preparingFile + "}.", ignored);
+				}
+			}
+			throw e;
+		}
+	}
+
+	private void checkPhrase(PhraseType phrase) {
+		if (currentPhrase != phrase) {
+			throw new IllegalStateException("we are not in " + phrase + " phrase currently.");
+		}
+	}
+
+	public void commit() {
+		currentPhrase = PhraseType.COMMIT;
+	}
+
+	@VisibleForTesting
+	public Path getPreparingFile() {
+		return preparingFile;
+	}
+}

--- a/flink-core/src/main/java/org/apache/flink/core/fs/TwoPhraseFSDataOutputStream.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/TwoPhraseFSDataOutputStream.java
@@ -20,6 +20,7 @@ package org.apache.flink.core.fs;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,8 +30,8 @@ import java.io.IOException;
  * Operates the output stream in two phrases, any exception during the operation of {@link TwoPhraseFSDataOutputStream} will
  * lead the {@link #targetFile} to be invisible.
  *
- * <p>PHRASE 1, write the data into the {@link #preparingFile}.
- * <p>PHRASE 2, close the {@link #preparingFile} and rename it to the {@link #targetFile}.
+ * PHRASE 1, write the data into the {@link #preparingFile}.
+ * PHRASE 2, close the {@link #preparingFile} and rename it to the {@link #targetFile}.
  */
 @Internal
 public class TwoPhraseFSDataOutputStream extends FSDataOutputStream {

--- a/flink-core/src/main/java/org/apache/flink/core/fs/TwoPhraseFSDataOutputStream.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/TwoPhraseFSDataOutputStream.java
@@ -29,7 +29,6 @@ import java.io.IOException;
 /**
  * Operates the output stream in two phrases, any exception during the operation of {@link TwoPhraseFSDataOutputStream} will
  * lead the {@link #targetFile} to be invisible.
- *
  * PHRASE 1, write the data into the {@link #preparingFile}.
  * PHRASE 2, close the {@link #preparingFile} and rename it to the {@link #targetFile}.
  */

--- a/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalFileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalFileSystem.java
@@ -33,6 +33,7 @@ import org.apache.flink.core.fs.FileStatus;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.FileSystemKind;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.fs.TwoPhraseFSDataOutputStream;
 import org.apache.flink.util.OperatingSystem;
 
 import org.slf4j.Logger;
@@ -273,6 +274,11 @@ public class LocalFileSystem extends FileSystem {
 
 		final File file = pathToFile(filePath);
 		return new LocalDataOutputStream(file);
+	}
+
+	@Override
+	public FSDataOutputStream createAtomically(Path f, WriteMode overwriteMode) throws IOException {
+		return new TwoPhraseFSDataOutputStream(this, f, overwriteMode);
 	}
 
 	@Override

--- a/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalFileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalFileSystem.java
@@ -33,7 +33,7 @@ import org.apache.flink.core.fs.FileStatus;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.FileSystemKind;
 import org.apache.flink.core.fs.Path;
-import org.apache.flink.core.fs.TwoPhraseFSDataOutputStream;
+import org.apache.flink.core.fs.TwoPhaseFSDataOutputStream;
 import org.apache.flink.util.OperatingSystem;
 
 import org.slf4j.Logger;
@@ -278,7 +278,7 @@ public class LocalFileSystem extends FileSystem {
 
 	@Override
 	public FSDataOutputStream createAtomically(Path f, WriteMode overwriteMode) throws IOException {
-		return new TwoPhraseFSDataOutputStream(this, f, overwriteMode);
+		return new TwoPhaseFSDataOutputStream(this, f, overwriteMode);
 	}
 
 	@Override

--- a/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalFileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalFileSystem.java
@@ -26,6 +26,7 @@
 package org.apache.flink.core.fs.local;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.core.fs.AtomicCreatingFsDataOutputStream;
 import org.apache.flink.core.fs.BlockLocation;
 import org.apache.flink.core.fs.FSDataInputStream;
 import org.apache.flink.core.fs.FSDataOutputStream;
@@ -277,7 +278,7 @@ public class LocalFileSystem extends FileSystem {
 	}
 
 	@Override
-	public FSDataOutputStream createAtomically(Path f, WriteMode overwriteMode) throws IOException {
+	public AtomicCreatingFsDataOutputStream createAtomically(Path f, WriteMode overwriteMode) throws IOException {
 		return new TwoPhaseFSDataOutputStream(this, f, overwriteMode);
 	}
 

--- a/flink-core/src/test/java/org/apache/flink/core/fs/FileSystemBehaviorTestSuite.java
+++ b/flink-core/src/test/java/org/apache/flink/core/fs/FileSystemBehaviorTestSuite.java
@@ -231,30 +231,6 @@ public abstract class FileSystemBehaviorTestSuite {
 				assertFalse(fs.exists(file2));
 			}
 		}
-
-		// regenerate the expectedData to start a new round test
-		new Random().nextBytes(expectedData);
-
-		// valid the content is as expected after overwriting the file.
-		{
-			createFileAtomically(file, WriteMode.OVERWRITE, expectedData, false);
-			resultData = new byte[102400];
-			readFromFile(file, resultData);
-			assertArrayEquals(expectedData, resultData);
-		}
-
-		// test the atomic feature of the FileSystem#createAtomically(...) with mode WriteMode.OVERWRITE
-		{
-			try {
-				createFileAtomically(file, WriteMode.OVERWRITE, expectedData, true);
-				fail("should throw an exception on purpose.");
-			} catch (Exception ex) {
-				resultData = new byte[102400];
-				readFromFile(file, resultData);
-				// the writing(with mode WriteMode.OVERWRITE) failure shouldn't broke the content of the existing file.
-				assertArrayEquals(expectedData, resultData);
-			}
-		}
 	}
 
 	// ------------------------------------------------------------------------
@@ -287,7 +263,7 @@ public abstract class FileSystemBehaviorTestSuite {
 			if (throwException) {
 				throw new RuntimeException("throws exception on purpose.");
 			}
-			((TwoPhaseFSDataOutputStream) outputStream).commit();
+			((TwoPhaseFSDataOutputStream) outputStream).closeAndPublish();
 		}
 	}
 

--- a/flink-core/src/test/java/org/apache/flink/core/fs/TwoPhaseFSDataOutputStreamTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/fs/TwoPhaseFSDataOutputStreamTest.java
@@ -28,7 +28,7 @@ import java.util.Random;
 /**
  * Tests to guard {@link TwoPhaseFSDataOutputStream}.
  */
-public class TwoPhraseFSDataOutputStreamTest {
+public class TwoPhaseFSDataOutputStreamTest {
 
 	@Rule
 	public TemporaryFolder temporaryFolder = new TemporaryFolder();
@@ -36,7 +36,7 @@ public class TwoPhraseFSDataOutputStreamTest {
 	@Test
 	public void testWriteSuccessfully() throws Exception {
 
-		final String tmpPath = temporaryFolder.newFolder("testTwoPhraseFSDataOutputStream").getPath();
+		final String tmpPath = temporaryFolder.newFolder("testTwoPhaseFSDataOutputStream").getPath();
 		final Path targetFile = new Path(tmpPath, "target");
 		final FileSystem fileSystem = targetFile.getFileSystem();
 
@@ -64,7 +64,7 @@ public class TwoPhraseFSDataOutputStreamTest {
 	@Test
 	public void testWriteFailed() throws Exception {
 
-		final String tmpPath = temporaryFolder.newFolder("testTwoPhraseFSDataOutputStream").getPath();
+		final String tmpPath = temporaryFolder.newFolder("testTwoPhaseFSDataOutputStream").getPath();
 		final Path targetFile = new Path(tmpPath, "target");
 		final FileSystem fileSystem = targetFile.getFileSystem();
 

--- a/flink-core/src/test/java/org/apache/flink/core/fs/TwoPhraseFSDataOutputStreamTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/fs/TwoPhraseFSDataOutputStreamTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.flink.core.fs;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.util.Random;
+
+/**
+ * Tests to guard {@link TwoPhraseFSDataOutputStream}.
+ */
+public class TwoPhraseFSDataOutputStreamTest {
+
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	@Test
+	public void testWriteSuccessfully() throws Exception {
+
+		final String tmpPath = temporaryFolder.newFolder("testTwoPhraseFSDataOutputStream").getPath();
+		final Path targetFile = new Path(tmpPath, "target");
+		final FileSystem fileSystem = targetFile.getFileSystem();
+
+		byte[] expectedData = new byte[512];
+		new Random().nextBytes(expectedData);
+
+		testWriteData(false, expectedData, targetFile);
+
+		try {
+			testWriteData(false, expectedData, targetFile);
+			Assert.fail("Should fail because the target file is already exists, and we are using NO_OVERWRITE model");
+		} catch (Exception expected) {
+			// we expected it.
+		}
+
+		Assert.assertTrue(fileSystem.exists(targetFile));
+
+		try (FSDataInputStream inputStream = fileSystem.open(targetFile)) {
+			byte[] data = new byte[512];
+			Assert.assertEquals(512, inputStream.read(data));
+			Assert.assertArrayEquals(expectedData, data);
+		}
+	}
+
+	@Test
+	public void testWriteFailed() throws Exception {
+
+		final String tmpPath = temporaryFolder.newFolder("testTwoPhraseFSDataOutputStream").getPath();
+		final Path targetFile = new Path(tmpPath, "target");
+		final FileSystem fileSystem = targetFile.getFileSystem();
+
+		byte[] expectedData = new byte[512];
+		new Random().nextBytes(expectedData);
+
+		try {
+			testWriteData(true, expectedData, targetFile);
+			Assert.fail("Should fail because we have triggered an exception.");
+		} catch (Exception expected) {
+			Assert.assertFalse(fileSystem.exists(targetFile));
+		}
+	}
+
+	private void testWriteData(boolean triggerException, byte[] data, Path targetFile) throws Exception {
+
+		final FileSystem fileSystem = targetFile.getFileSystem();
+
+		try (TwoPhraseFSDataOutputStream outputStream = new TwoPhraseFSDataOutputStream(targetFile.getFileSystem(), targetFile, FileSystem.WriteMode.NO_OVERWRITE)) {
+
+			outputStream.write(data);
+
+			Assert.assertTrue(fileSystem.exists(outputStream.getPreparingFile()));
+			Assert.assertFalse(fileSystem.exists(targetFile));
+
+			if (triggerException) {
+				throw new Exception("Trigger exception on purpose.");
+			}
+
+			outputStream.commit();
+		}
+	}
+}

--- a/flink-core/src/test/java/org/apache/flink/core/fs/TwoPhraseFSDataOutputStreamTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/fs/TwoPhraseFSDataOutputStreamTest.java
@@ -16,7 +16,6 @@
  * limitations under the License.
  */
 
-
 package org.apache.flink.core.fs;
 
 import org.junit.Assert;

--- a/flink-core/src/test/java/org/apache/flink/core/fs/TwoPhraseFSDataOutputStreamTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/fs/TwoPhraseFSDataOutputStreamTest.java
@@ -26,7 +26,7 @@ import org.junit.rules.TemporaryFolder;
 import java.util.Random;
 
 /**
- * Tests to guard {@link TwoPhraseFSDataOutputStream}.
+ * Tests to guard {@link TwoPhaseFSDataOutputStream}.
  */
 public class TwoPhraseFSDataOutputStreamTest {
 
@@ -83,7 +83,7 @@ public class TwoPhraseFSDataOutputStreamTest {
 
 		final FileSystem fileSystem = targetFile.getFileSystem();
 
-		try (TwoPhraseFSDataOutputStream outputStream = new TwoPhraseFSDataOutputStream(targetFile.getFileSystem(), targetFile, FileSystem.WriteMode.NO_OVERWRITE)) {
+		try (TwoPhaseFSDataOutputStream outputStream = new TwoPhaseFSDataOutputStream(targetFile.getFileSystem(), targetFile, FileSystem.WriteMode.NO_OVERWRITE)) {
 
 			outputStream.write(data);
 

--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopFileSystem.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopFileSystem.java
@@ -24,7 +24,7 @@ import org.apache.flink.core.fs.FileStatus;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.FileSystemKind;
 import org.apache.flink.core.fs.Path;
-import org.apache.flink.core.fs.TwoPhraseFSDataOutputStream;
+import org.apache.flink.core.fs.TwoPhaseFSDataOutputStream;
 
 import java.io.IOException;
 import java.net.URI;
@@ -154,7 +154,7 @@ public class HadoopFileSystem extends FileSystem {
 		final String schema = this.fs.getScheme();
 
 		if (schema.equals("file") || schema.equals("hdfs")) {
-			return new TwoPhraseFSDataOutputStream(this, f, overwriteMode);
+			return new TwoPhaseFSDataOutputStream(this, f, overwriteMode);
 		} else if (schema.equals("s3")) {
 			return create(f, overwriteMode);
 		} else {

--- a/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopLocalFileSystemBehaviorTest.java
+++ b/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopLocalFileSystemBehaviorTest.java
@@ -19,56 +19,18 @@
 package org.apache.flink.runtime.fs.hdfs;
 
 import org.apache.flink.core.fs.FileSystem;
-import org.apache.flink.core.fs.FileSystemBehaviorTestSuite;
-import org.apache.flink.core.fs.FileSystemKind;
-import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.fs.local.LocalFileSystem;
-
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.RawLocalFileSystem;
-import org.apache.hadoop.util.VersionInfo;
-import org.junit.Assume;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
 
 /**
  * Behavior tests for HDFS.
  */
-public class HadoopLocalFileSystemBehaviorTest extends FileSystemBehaviorTestSuite {
-
-	@Rule
-	public final TemporaryFolder tmp = new TemporaryFolder();
+public class HadoopLocalFileSystemBehaviorTest extends HadoopRawLocalFileSystemBehaviorTest {
 
 	@Override
 	public FileSystem getFileSystem() throws Exception {
-		org.apache.hadoop.fs.FileSystem fs = new RawLocalFileSystem();
+		org.apache.hadoop.fs.FileSystem fs = new org.apache.hadoop.fs.LocalFileSystem();
 		fs.initialize(LocalFileSystem.getLocalFsURI(), new Configuration());
 		return new HadoopFileSystem(fs);
-	}
-
-	@Override
-	public Path getBasePath() throws Exception {
-		return new Path(tmp.newFolder().toURI());
-	}
-
-	@Override
-	public FileSystemKind getFileSystemKind() {
-		return FileSystemKind.FILE_SYSTEM;
-	}
-
-	// ------------------------------------------------------------------------
-
-	/**
-	 * This test needs to be skipped for earlier Hadoop versions because those
-	 * have a bug.
-	 */
-	@Override
-	public void testMkdirsFailsForExistingFile() throws Exception {
-		final String versionString = VersionInfo.getVersion();
-		final String prefix = versionString.substring(0, 3);
-		final float version = Float.parseFloat(prefix);
-		Assume.assumeTrue("Cannot execute this test on Hadoop prior to 2.8", version >= 2.8f);
-
-		super.testMkdirsFailsForExistingFile();
 	}
 }

--- a/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopLocalFileSystemBehaviorTest.java
+++ b/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopLocalFileSystemBehaviorTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.fs.hdfs;
 
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.local.LocalFileSystem;
+
 import org.apache.hadoop.conf.Configuration;
 
 /**

--- a/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopRawLocalFileSystemBehaviorTest.java
+++ b/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopRawLocalFileSystemBehaviorTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.fs.hdfs;
+
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.FileSystemBehaviorTestSuite;
+import org.apache.flink.core.fs.FileSystemKind;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.fs.local.LocalFileSystem;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.RawLocalFileSystem;
+import org.apache.hadoop.util.VersionInfo;
+import org.junit.Assume;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Behavior tests for HDFS.
+ */
+public class HadoopRawLocalFileSystemBehaviorTest extends FileSystemBehaviorTestSuite {
+
+	@Rule
+	public final TemporaryFolder tmp = new TemporaryFolder();
+
+	@Override
+	public FileSystem getFileSystem() throws Exception {
+		org.apache.hadoop.fs.FileSystem fs = new RawLocalFileSystem();
+		fs.initialize(LocalFileSystem.getLocalFsURI(), new Configuration());
+		return new HadoopFileSystem(fs);
+	}
+
+	@Override
+	public Path getBasePath() throws Exception {
+		return new Path(tmp.newFolder().toURI());
+	}
+
+	@Override
+	public FileSystemKind getFileSystemKind() {
+		return FileSystemKind.FILE_SYSTEM;
+	}
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * This test needs to be skipped for earlier Hadoop versions because those
+	 * have a bug.
+	 */
+	@Override
+	public void testMkdirsFailsForExistingFile() throws Exception {
+		final String versionString = VersionInfo.getVersion();
+		final String prefix = versionString.substring(0, 3);
+		final float version = Float.parseFloat(prefix);
+		Assume.assumeTrue("Cannot execute this test on Hadoop prior to 2.8", version >= 2.8f);
+
+		super.testMkdirsFailsForExistingFile();
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointMetadataOutputStream.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointMetadataOutputStream.java
@@ -142,7 +142,7 @@ public final class FsCheckpointMetadataOutputStream extends CheckpointMetadataOu
 					} catch (Exception ignored) {}
 
 					if (out instanceof TwoPhaseFSDataOutputStream) {
-						((TwoPhaseFSDataOutputStream) out).commit();
+						((TwoPhaseFSDataOutputStream) out).closeAndPublish();
 					}
 
 					out.close();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointMetadataOutputStream.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointMetadataOutputStream.java
@@ -19,11 +19,11 @@
 package org.apache.flink.runtime.state.filesystem;
 
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.core.fs.AtomicCreatingFsDataOutputStream;
 import org.apache.flink.core.fs.FSDataOutputStream;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.FileSystem.WriteMode;
 import org.apache.flink.core.fs.Path;
-import org.apache.flink.core.fs.TwoPhaseFSDataOutputStream;
 import org.apache.flink.runtime.state.CheckpointMetadataOutputStream;
 
 import org.slf4j.Logger;
@@ -141,11 +141,11 @@ public final class FsCheckpointMetadataOutputStream extends CheckpointMetadataOu
 						size = out.getPos();
 					} catch (Exception ignored) {}
 
-					if (out instanceof TwoPhaseFSDataOutputStream) {
-						((TwoPhaseFSDataOutputStream) out).closeAndPublish();
+					if (out instanceof AtomicCreatingFsDataOutputStream) {
+						((AtomicCreatingFsDataOutputStream) out).closeAndPublish();
+					} else {
+						out.close();
 					}
-
-					out.close();
 
 					FileStateHandle metaDataHandle = new FileStateHandle(metadataFilePath, size);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointMetadataOutputStream.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointMetadataOutputStream.java
@@ -23,7 +23,7 @@ import org.apache.flink.core.fs.FSDataOutputStream;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.FileSystem.WriteMode;
 import org.apache.flink.core.fs.Path;
-import org.apache.flink.core.fs.TwoPhraseFSDataOutputStream;
+import org.apache.flink.core.fs.TwoPhaseFSDataOutputStream;
 import org.apache.flink.runtime.state.CheckpointMetadataOutputStream;
 
 import org.slf4j.Logger;
@@ -141,8 +141,8 @@ public final class FsCheckpointMetadataOutputStream extends CheckpointMetadataOu
 						size = out.getPos();
 					} catch (Exception ignored) {}
 
-					if (out instanceof TwoPhraseFSDataOutputStream) {
-						((TwoPhraseFSDataOutputStream) out).commit();
+					if (out instanceof TwoPhaseFSDataOutputStream) {
+						((TwoPhaseFSDataOutputStream) out).commit();
 					}
 
 					out.close();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/AbstractCheckpointStateOutputStreamTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/AbstractCheckpointStateOutputStreamTestBase.java
@@ -22,6 +22,7 @@ import org.apache.flink.core.fs.FSDataInputStream;
 import org.apache.flink.core.fs.FSDataOutputStream;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.fs.TwoPhraseFSDataOutputStream;
 import org.apache.flink.core.fs.local.LocalDataOutputStream;
 import org.apache.flink.core.fs.local.LocalFileSystem;
 import org.apache.flink.core.testutils.CheckedThread;
@@ -147,7 +148,17 @@ public abstract class AbstractCheckpointStateOutputStreamTestBase extends TestLo
 			for (int i = 0; i < rnd.nextInt(1000); i++) {
 				stream.write(rnd.nextInt(100));
 			}
-			assertTrue(fs.exists(path));
+
+			if (stream instanceof FsCheckpointMetadataOutputStream) {
+				FSDataOutputStream outputStream = ((FsCheckpointMetadataOutputStream) stream).getOutputStream();
+				if (outputStream instanceof TwoPhraseFSDataOutputStream) {
+					assertTrue(fs.exists(((TwoPhraseFSDataOutputStream) outputStream).getPreparingFile()));
+				} else {
+					assertTrue(fs.exists(path));
+				}
+			} else {
+				assertTrue(fs.exists(path));
+			}
 		}
 
 		assertFalse(fs.exists(path));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/AbstractCheckpointStateOutputStreamTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/AbstractCheckpointStateOutputStreamTestBase.java
@@ -22,7 +22,7 @@ import org.apache.flink.core.fs.FSDataInputStream;
 import org.apache.flink.core.fs.FSDataOutputStream;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
-import org.apache.flink.core.fs.TwoPhraseFSDataOutputStream;
+import org.apache.flink.core.fs.TwoPhaseFSDataOutputStream;
 import org.apache.flink.core.fs.local.LocalDataOutputStream;
 import org.apache.flink.core.fs.local.LocalFileSystem;
 import org.apache.flink.core.testutils.CheckedThread;
@@ -151,8 +151,8 @@ public abstract class AbstractCheckpointStateOutputStreamTestBase extends TestLo
 
 			if (stream instanceof FsCheckpointMetadataOutputStream) {
 				FSDataOutputStream outputStream = ((FsCheckpointMetadataOutputStream) stream).getOutputStream();
-				if (outputStream instanceof TwoPhraseFSDataOutputStream) {
-					assertTrue(fs.exists(((TwoPhraseFSDataOutputStream) outputStream).getPreparingFile()));
+				if (outputStream instanceof TwoPhaseFSDataOutputStream) {
+					assertTrue(fs.exists(((TwoPhaseFSDataOutputStream) outputStream).getPreparingFile()));
 				} else {
 					assertTrue(fs.exists(path));
 				}


### PR DESCRIPTION
## What is the purpose of the change

*This PR in order to enhance the checkpoint's finalization a bit, write the metadata file first to a temp file and then atomically rename it (with an equivalent workaround for S3).*


## Brief change log

  - *write the metadata file first to a temp file and then atomically rename it*

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

no