### PR TITLE
[FLINK-7789][DataStream API] Add handler for Async IO operator timeouts

### DIFF
--- a/docs/dev/stream/operators/asyncio.md
+++ b/docs/dev/stream/operators/asyncio.md
@@ -190,6 +190,12 @@ The following two parameters control the asynchronous operations:
     is exhausted.
 
 
+### Timeout Handling
+
+When a async I/O request times out, an exception is thrown and job is restarted. 
+If you want to handle timeouts, please use `TimeoutAwareAsyncFunction` instead of `AsyncFunction`.
+
+
 ### Order of Results
 
 The concurrent requests issued by the `AsyncFunction` frequently complete in some undefined order, based on which request finished first.

--- a/docs/dev/stream/operators/asyncio.md
+++ b/docs/dev/stream/operators/asyncio.md
@@ -193,7 +193,8 @@ The following two parameters control the asynchronous operations:
 ### Timeout Handling
 
 When a async I/O request times out, an exception is thrown and job is restarted. 
-If you want to handle timeouts, please use `TimeoutAwareAsyncFunction` instead of `AsyncFunction`.
+If you want to handle timeouts, please use `TimeoutAwareAsyncFunction` instead of `AsyncFunction` for Java API,
+override `AsyncFunction#timeout` for Scala API.
 
 
 ### Order of Results

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/async/AsyncFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/async/AsyncFunction.java
@@ -71,8 +71,11 @@ import java.io.Serializable;
  *
  * @param <IN> The type of the input elements.
  * @param <OUT> The type of the returned elements.
+ *
+ * @deprecated please use {@link TimeoutAwareAsyncFunction} for timeout handling.
  */
 @PublicEvolving
+@Deprecated
 public interface AsyncFunction<IN, OUT> extends Function, Serializable {
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/async/RichAsyncFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/async/RichAsyncFunction.java
@@ -51,6 +51,7 @@ import org.apache.flink.util.Preconditions;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Rich variant of the {@link AsyncFunction}. As a {@link RichFunction}, it gives access to the
@@ -68,7 +69,7 @@ import java.util.Map;
  * @param <OUT> The type of the returned elements.
  */
 @PublicEvolving
-public abstract class RichAsyncFunction<IN, OUT> extends AbstractRichFunction implements AsyncFunction<IN, OUT> {
+public abstract class RichAsyncFunction<IN, OUT> extends AbstractRichFunction implements TimeoutAwareAsyncFunction<IN, OUT> {
 
 	private static final long serialVersionUID = 3858030061138121840L;
 
@@ -87,6 +88,13 @@ public abstract class RichAsyncFunction<IN, OUT> extends AbstractRichFunction im
 
 	@Override
 	public abstract void asyncInvoke(IN input, ResultFuture<OUT> resultFuture) throws Exception;
+
+	@Override
+	public void timeout(IN input, ResultFuture<OUT> resultFuture) throws Exception {
+		// By default, timeout handling should be compatible with AsyncFunction
+		resultFuture.completeExceptionally(
+			new TimeoutException("Async function call has timed out."));
+	}
 
 	// -----------------------------------------------------------------------------------------
 	// Wrapper classes

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/async/TimeoutAwareAsyncFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/async/TimeoutAwareAsyncFunction.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.functions.async;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+/**
+ * An enhanced {@link AsyncFunction} which can handle timeouts.
+ */
+@PublicEvolving
+public interface TimeoutAwareAsyncFunction<IN, OUT> extends AsyncFunction<IN, OUT> {
+
+	/**
+	 * asyncInvoke timeout occurred.
+	 * Here you can complete the result future exceptionally with timeout exception,
+	 * or complete with empty result. You can also retry to complete with the right results.
+	 *
+	 * @param input element coming from an upstream task
+	 * @param resultFuture to be completed with the result data
+	 * @exception Exception in case of a user code error. An exception will make the task fail and
+	 * trigger fail-over process.
+	 */
+	void timeout(IN input, ResultFuture<OUT> resultFuture) throws Exception;
+
+}

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/AsyncDataStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/AsyncDataStream.scala
@@ -21,8 +21,7 @@ package org.apache.flink.streaming.api.scala
 import org.apache.flink.annotation.PublicEvolving
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.streaming.api.datastream.{AsyncDataStream => JavaAsyncDataStream}
-import org.apache.flink.streaming.api.functions.async.{ResultFuture => JavaResultFuture}
-import org.apache.flink.streaming.api.functions.async.{AsyncFunction => JavaAsyncFunction}
+import org.apache.flink.streaming.api.functions.async.{TimeoutAwareAsyncFunction, AsyncFunction => JavaAsyncFunction, ResultFuture => JavaResultFuture}
 import org.apache.flink.streaming.api.scala.async.{AsyncFunction, JavaResultFutureWrapper, ResultFuture}
 import org.apache.flink.util.Preconditions
 
@@ -67,9 +66,12 @@ object AsyncDataStream {
       capacity: Int)
     : DataStream[OUT] = {
 
-    val javaAsyncFunction = new JavaAsyncFunction[IN, OUT] {
+    val javaAsyncFunction = new TimeoutAwareAsyncFunction[IN, OUT] {
       override def asyncInvoke(input: IN, resultFuture: JavaResultFuture[OUT]): Unit = {
         asyncFunction.asyncInvoke(input, new JavaResultFutureWrapper(resultFuture))
+      }
+      override def timeout(input: IN, resultFuture: JavaResultFuture[OUT]): Unit = {
+        asyncFunction.timeout(input, new JavaResultFutureWrapper(resultFuture))
       }
     }
 
@@ -120,6 +122,7 @@ object AsyncDataStream {
     * @tparam IN Type of the input record
     * @tparam OUT Type of the output record
     * @return the resulting stream containing the asynchronous results
+    * @deprecated please use [[AsyncFunction]] for timeout handling.
     */
   def unorderedWait[IN, OUT: TypeInformation](
       input: DataStream[IN],
@@ -162,6 +165,7 @@ object AsyncDataStream {
     * @tparam IN Type of the input record
     * @tparam OUT Type of the output record
     * @return the resulting stream containing the asynchronous results
+    * @deprecated please use [[AsyncFunction]] for timeout handling.
     */
   def unorderedWait[IN, OUT: TypeInformation](
     input: DataStream[IN],
@@ -194,9 +198,12 @@ object AsyncDataStream {
       capacity: Int)
     : DataStream[OUT] = {
 
-    val javaAsyncFunction = new JavaAsyncFunction[IN, OUT] {
+    val javaAsyncFunction = new TimeoutAwareAsyncFunction[IN, OUT] {
       override def asyncInvoke(input: IN, resultFuture: JavaResultFuture[OUT]): Unit = {
         asyncFunction.asyncInvoke(input, new JavaResultFutureWrapper[OUT](resultFuture))
+      }
+      override def timeout(input: IN, resultFuture: JavaResultFuture[OUT]): Unit = {
+        asyncFunction.timeout(input, new JavaResultFutureWrapper[OUT](resultFuture))
       }
     }
 
@@ -245,6 +252,7 @@ object AsyncDataStream {
     * @tparam IN Type of the input record
     * @tparam OUT Type of the output record
     * @return the resulting stream containing the asynchronous results
+    * @deprecated please use [[AsyncFunction]] for timeout handling.
     */
   def orderedWait[IN, OUT: TypeInformation](
     input: DataStream[IN],
@@ -285,6 +293,7 @@ object AsyncDataStream {
     * @tparam IN Type of the input record
     * @tparam OUT Type of the output record
     * @return the resulting stream containing the asynchronous results
+    * @deprecated please use [[AsyncFunction]] for timeout handling.
     */
   def orderedWait[IN, OUT: TypeInformation](
     input: DataStream[IN],

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/async/AsyncFunction.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/async/AsyncFunction.scala
@@ -21,6 +21,8 @@ package org.apache.flink.streaming.api.scala.async
 import org.apache.flink.annotation.PublicEvolving
 import org.apache.flink.api.common.functions.Function
 
+import java.util.concurrent.TimeoutException
+
 /**
   * A function to trigger async I/O operations.
   *
@@ -46,4 +48,18 @@ trait AsyncFunction[IN, OUT] extends Function {
     * @param resultFuture to be completed with the result data
     */
   def asyncInvoke(input: IN, resultFuture: ResultFuture[OUT]): Unit
+
+  /**
+    * asyncInvoke timeout occurred.
+    * By default, the result future is completed exceptionally with timeout exception.
+    * Override this method to complete with empty result, or retry to complete with the right
+    * results.
+    *
+    * @param input element coming from an upstream task
+    * @param resultFuture to be completed with the result data
+    */
+  def timeout(input: IN, resultFuture: ResultFuture[OUT]): Unit = {
+    resultFuture.completeExceptionally(new TimeoutException("Async function call has timed out."))
+  }
+
 }


### PR DESCRIPTION
## What is the purpose of the change

*Currently Async IO operator does not provide a mechanism to handle timeouts. This PR fixs the problem by adding an enhanced `AsyncFunction`, named `TimeoutAwareAsyncFunction`.*


## Brief change log

  - *Add a new interface, `TimeoutAwareAsyncFunction`, which extends the `AsyncFunction`*
  - *Change `RichAsyncFunction` to implement `TimeoutAwareAsyncFunction` instead of `AsyncFunction`*
  - *`AsyncWaitOperator` will invoke `TimeoutAwareAsyncFunction#timeout` when `asyncInvoke` times out*


## Verifying this change

  - *Add tests to `AsyncWaitOperatorTest`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no )
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( yes )
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): ( yes )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: ( no )
  - The S3 file system connector: ( no )

## Documentation

  - Does this pull request introduce a new feature? ( yes )
  - If yes, how is the feature documented? ( docs / JavaDocs )
