### PR TITLE
[FLINK-8135][REST][docs] Add description to MessageParameter

### DIFF
--- a/docs/_includes/generated/rest_dispatcher.html
+++ b/docs/_includes/generated/rest_dispatcher.html
@@ -581,7 +581,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=#pa
       <td class="text-left">Response code: <code>202 Accepted</code></td>
     </tr>
     <tr>
-      <td colspan="2">Submits a job. This call is primarily intended to be used by the Flink client. This call expects amultipart/form-data request that consists of file uploads for the serialized JobGraph, jars anddistributed cache artifacts and an attribute named "request"for the JSON payload.</td>
+      <td colspan="2">Submits a job. This call is primarily intended to be used by the Flink client. This call expects a multipart/form-data request that consists of file uploads for the serialized JobGraph, jars and distributed cache artifacts and an attribute named "request" for the JSON payload.</td>
     </tr>
     <tr>
       <td colspan="2">

--- a/docs/_includes/generated/rest_dispatcher.html
+++ b/docs/_includes/generated/rest_dispatcher.html
@@ -234,7 +234,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=#pa
     <tr>
       <td colspan="2">
         <ul>
-<li><code>jarid</code> - description</li>
+<li><code>jarid</code> - String value that identifies a jar. When uploading the jar a path is returned, where the filename is the ID. This value is equivalent to the `id` field in the list of uploaded jars (/jars).</li>
         </ul>
       </td>
     </tr>
@@ -280,7 +280,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=#pa
     <tr>
       <td colspan="2">
         <ul>
-<li><code>jarid</code> - description</li>
+<li><code>jarid</code> - String value that identifies a jar. When uploading the jar a path is returned, where the filename is the ID. This value is equivalent to the `id` field in the list of uploaded jars (/jars).</li>
         </ul>
       </td>
     </tr>
@@ -290,9 +290,9 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=#pa
     <tr>
       <td colspan="2">
         <ul>
-<li><code>entry-class</code> (optional): description</li>
-<li><code>parallelism</code> (optional): description</li>
-<li><code>program-args</code> (optional): description</li>
+<li><code>entry-class</code> (optional): String value that specifies the fully qualified name of the entry point class. Overrides the class defined in the jar file manifest.</li>
+<li><code>parallelism</code> (optional): Positive integer value that specifies the desired parallelism for the job.</li>
+<li><code>program-args</code> (optional): String value that specifies the arguments for the program or plan.</li>
         </ul>
       </td>
     </tr>
@@ -314,7 +314,13 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=#pa
           <pre>
             <code>
 {
-  "type" : "any"
+  "type" : "object",
+  "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:JobPlanInfo",
+  "properties" : {
+    "plan" : {
+      "type" : "any"
+    }
+  }
 }            </code>
           </pre>
          </div>
@@ -340,7 +346,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=#pa
     <tr>
       <td colspan="2">
         <ul>
-<li><code>jarid</code> - description</li>
+<li><code>jarid</code> - String value that identifies a jar. When uploading the jar a path is returned, where the filename is the ID. This value is equivalent to the `id` field in the list of uploaded jars (/jars).</li>
         </ul>
       </td>
     </tr>
@@ -350,11 +356,11 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=#pa
     <tr>
       <td colspan="2">
         <ul>
-<li><code>program-args</code> (optional): description</li>
-<li><code>entry-class</code> (optional): description</li>
-<li><code>parallelism</code> (optional): description</li>
-<li><code>allowNonRestoredState</code> (optional): description</li>
-<li><code>savepointPath</code> (optional): description</li>
+<li><code>program-args</code> (optional): String value that specifies the arguments for the program or plan.</li>
+<li><code>entry-class</code> (optional): String value that specifies the fully qualified name of the entry point class. Overrides the class defined in the jar file manifest.</li>
+<li><code>parallelism</code> (optional): Positive integer value that specifies the desired parallelism for the job.</li>
+<li><code>allowNonRestoredState</code> (optional): Boolean value that specifies whether the job submission should be rejected if the savepoint contains state that cannot be mapped back to the job.</li>
+<li><code>savepointPath</code> (optional): String value that specifies the path of the savepoint to restore the job from.</li>
         </ul>
       </td>
     </tr>
@@ -478,7 +484,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=#pa
     <tr>
       <td colspan="2">
         <ul>
-<li><code>get</code> (optional): description</li>
+<li><code>get</code> (optional): Comma-separated list of string values to select specific metrics.</li>
         </ul>
       </td>
     </tr>
@@ -656,9 +662,9 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=#pa
     <tr>
       <td colspan="2">
         <ul>
-<li><code>get</code> (optional): description</li>
-<li><code>agg</code> (optional): description</li>
-<li><code>jobs</code> (optional): description</li>
+<li><code>get</code> (optional): Comma-separated list of string values to select specific metrics.</li>
+<li><code>agg</code> (optional): Comma-separated list of aggregation modes which should be calculated. Available aggregations are: "min, max, sum, avg".</li>
+<li><code>jobs</code> (optional): Comma-separated list of 32-character hexadecimal strings to select specific jobs.</li>
         </ul>
       </td>
     </tr>
@@ -753,7 +759,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=#pa
     <tr>
       <td colspan="2">
         <ul>
-<li><code>jobid</code> - description</li>
+<li><code>jobid</code> - 32-character hexadecimal string value that identifies a job.</li>
         </ul>
       </td>
     </tr>
@@ -911,7 +917,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=#pa
     <tr>
       <td colspan="2">
         <ul>
-<li><code>jobid</code> - description</li>
+<li><code>jobid</code> - 32-character hexadecimal string value that identifies a job.</li>
         </ul>
       </td>
     </tr>
@@ -921,7 +927,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=#pa
     <tr>
       <td colspan="2">
         <ul>
-<li><code>mode</code> (optional): description</li>
+<li><code>mode</code> (optional): String value that specifies the termination mode. Supported values are: "cancel, stop".</li>
         </ul>
       </td>
     </tr>
@@ -967,7 +973,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=#pa
     <tr>
       <td colspan="2">
         <ul>
-<li><code>jobid</code> - description</li>
+<li><code>jobid</code> - 32-character hexadecimal string value that identifies a job.</li>
         </ul>
       </td>
     </tr>
@@ -977,7 +983,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=#pa
     <tr>
       <td colspan="2">
         <ul>
-<li><code>includeSerializedValue</code> (optional): description</li>
+<li><code>includeSerializedValue</code> (optional): Boolean value that specifies whether serialized user task accumulators should be included in the response.</li>
         </ul>
       </td>
     </tr>
@@ -1058,7 +1064,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=#pa
     <tr>
       <td colspan="2">
         <ul>
-<li><code>jobid</code> - description</li>
+<li><code>jobid</code> - 32-character hexadecimal string value that identifies a job.</li>
         </ul>
       </td>
     </tr>
@@ -1361,7 +1367,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=#pa
     <tr>
       <td colspan="2">
         <ul>
-<li><code>jobid</code> - description</li>
+<li><code>jobid</code> - 32-character hexadecimal string value that identifies a job.</li>
         </ul>
       </td>
     </tr>
@@ -1439,8 +1445,8 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=#pa
     <tr>
       <td colspan="2">
         <ul>
-<li><code>jobid</code> - description</li>
-<li><code>checkpointid</code> - description</li>
+<li><code>jobid</code> - 32-character hexadecimal string value that identifies a job.</li>
+<li><code>checkpointid</code> - Long value that identifies a checkpoint.</li>
         </ul>
       </td>
     </tr>
@@ -1556,9 +1562,9 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=#pa
     <tr>
       <td colspan="2">
         <ul>
-<li><code>jobid</code> - description</li>
-<li><code>checkpointid</code> - description</li>
-<li><code>vertexid</code> - description</li>
+<li><code>jobid</code> - 32-character hexadecimal string value that identifies a job.</li>
+<li><code>checkpointid</code> - Long value that identifies a checkpoint.</li>
+<li><code>vertexid</code> - 32-character hexadecimal string value that identifies a job vertex.</li>
         </ul>
       </td>
     </tr>
@@ -1702,7 +1708,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=#pa
     <tr>
       <td colspan="2">
         <ul>
-<li><code>jobid</code> - description</li>
+<li><code>jobid</code> - 32-character hexadecimal string value that identifies a job.</li>
         </ul>
       </td>
     </tr>
@@ -1750,7 +1756,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=#pa
     <tr>
       <td colspan="2">
         <ul>
-<li><code>jobid</code> - description</li>
+<li><code>jobid</code> - 32-character hexadecimal string value that identifies a job.</li>
         </ul>
       </td>
     </tr>
@@ -1831,7 +1837,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=#pa
     <tr>
       <td colspan="2">
         <ul>
-<li><code>jobid</code> - description</li>
+<li><code>jobid</code> - 32-character hexadecimal string value that identifies a job.</li>
         </ul>
       </td>
     </tr>
@@ -1897,7 +1903,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=#pa
     <tr>
       <td colspan="2">
         <ul>
-<li><code>jobid</code> - description</li>
+<li><code>jobid</code> - 32-character hexadecimal string value that identifies a job.</li>
         </ul>
       </td>
     </tr>
@@ -1907,7 +1913,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=#pa
     <tr>
       <td colspan="2">
         <ul>
-<li><code>get</code> (optional): description</li>
+<li><code>get</code> (optional): Comma-separated list of string values to select specific metrics.</li>
         </ul>
       </td>
     </tr>
@@ -1955,7 +1961,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=#pa
     <tr>
       <td colspan="2">
         <ul>
-<li><code>jobid</code> - description</li>
+<li><code>jobid</code> - 32-character hexadecimal string value that identifies a job.</li>
         </ul>
       </td>
     </tr>
@@ -1977,7 +1983,13 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=#pa
           <pre>
             <code>
 {
-  "type" : "any"
+  "type" : "object",
+  "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:JobPlanInfo",
+  "properties" : {
+    "plan" : {
+      "type" : "any"
+    }
+  }
 }            </code>
           </pre>
          </div>
@@ -2003,7 +2015,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=#pa
     <tr>
       <td colspan="2">
         <ul>
-<li><code>jobid</code> - description</li>
+<li><code>jobid</code> - 32-character hexadecimal string value that identifies a job.</li>
         </ul>
       </td>
     </tr>
@@ -2013,7 +2025,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=#pa
     <tr>
       <td colspan="2">
         <ul>
-<li><code>parallelism</code> (mandatory): description</li>
+<li><code>parallelism</code> (mandatory): Positive integer value that specifies the desired parallelism.</li>
         </ul>
       </td>
     </tr>
@@ -2067,8 +2079,8 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=#pa
     <tr>
       <td colspan="2">
         <ul>
-<li><code>jobid</code> - description</li>
-<li><code>triggerid</code> - description</li>
+<li><code>jobid</code> - 32-character hexadecimal string value that identifies a job.</li>
+<li><code>triggerid</code> - 32-character hexadecimal string that identifies an asynchronous operation trigger ID. The ID was returned then the operation was triggered.</li>
         </ul>
       </td>
     </tr>
@@ -2133,7 +2145,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=#pa
     <tr>
       <td colspan="2">
         <ul>
-<li><code>jobid</code> - description</li>
+<li><code>jobid</code> - 32-character hexadecimal string value that identifies a job.</li>
         </ul>
       </td>
     </tr>
@@ -2198,8 +2210,8 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=#pa
     <tr>
       <td colspan="2">
         <ul>
-<li><code>jobid</code> - description</li>
-<li><code>triggerid</code> - description</li>
+<li><code>jobid</code> - 32-character hexadecimal string value that identifies a job.</li>
+<li><code>triggerid</code> - 32-character hexadecimal string that identifies an asynchronous operation trigger ID. The ID was returned then the operation was triggered.</li>
         </ul>
       </td>
     </tr>
@@ -2264,8 +2276,8 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=#pa
     <tr>
       <td colspan="2">
         <ul>
-<li><code>jobid</code> - description</li>
-<li><code>vertexid</code> - description</li>
+<li><code>jobid</code> - 32-character hexadecimal string value that identifies a job.</li>
+<li><code>vertexid</code> - 32-character hexadecimal string value that identifies a job vertex.</li>
         </ul>
       </td>
     </tr>
@@ -2389,8 +2401,8 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=#pa
     <tr>
       <td colspan="2">
         <ul>
-<li><code>jobid</code> - description</li>
-<li><code>vertexid</code> - description</li>
+<li><code>jobid</code> - 32-character hexadecimal string value that identifies a job.</li>
+<li><code>vertexid</code> - 32-character hexadecimal string value that identifies a job vertex.</li>
         </ul>
       </td>
     </tr>
@@ -2462,8 +2474,8 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=#pa
     <tr>
       <td colspan="2">
         <ul>
-<li><code>jobid</code> - description</li>
-<li><code>vertexid</code> - description</li>
+<li><code>jobid</code> - 32-character hexadecimal string value that identifies a job.</li>
+<li><code>vertexid</code> - 32-character hexadecimal string value that identifies a job vertex.</li>
         </ul>
       </td>
     </tr>
@@ -2544,8 +2556,8 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=#pa
     <tr>
       <td colspan="2">
         <ul>
-<li><code>jobid</code> - description</li>
-<li><code>vertexid</code> - description</li>
+<li><code>jobid</code> - 32-character hexadecimal string value that identifies a job.</li>
+<li><code>vertexid</code> - 32-character hexadecimal string value that identifies a job vertex.</li>
         </ul>
       </td>
     </tr>
@@ -2555,7 +2567,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=#pa
     <tr>
       <td colspan="2">
         <ul>
-<li><code>get</code> (optional): description</li>
+<li><code>get</code> (optional): Comma-separated list of string values to select specific metrics.</li>
         </ul>
       </td>
     </tr>
@@ -2603,8 +2615,8 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=#pa
     <tr>
       <td colspan="2">
         <ul>
-<li><code>jobid</code> - description</li>
-<li><code>vertexid</code> - description</li>
+<li><code>jobid</code> - 32-character hexadecimal string value that identifies a job.</li>
+<li><code>vertexid</code> - 32-character hexadecimal string value that identifies a job vertex.</li>
         </ul>
       </td>
     </tr>
@@ -2697,8 +2709,8 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=#pa
     <tr>
       <td colspan="2">
         <ul>
-<li><code>jobid</code> - description</li>
-<li><code>vertexid</code> - description</li>
+<li><code>jobid</code> - 32-character hexadecimal string value that identifies a job.</li>
+<li><code>vertexid</code> - 32-character hexadecimal string value that identifies a job vertex.</li>
         </ul>
       </td>
     </tr>
@@ -2708,9 +2720,9 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=#pa
     <tr>
       <td colspan="2">
         <ul>
-<li><code>get</code> (optional): description</li>
-<li><code>agg</code> (optional): description</li>
-<li><code>subtasks</code> (optional): description</li>
+<li><code>get</code> (optional): Comma-separated list of string values to select specific metrics.</li>
+<li><code>agg</code> (optional): Comma-separated list of aggregation modes which should be calculated. Available aggregations are: "min, max, sum, avg".</li>
+<li><code>subtasks</code> (optional): Comma-separated list of integer ranges (e.g. "1,3,5-9") to select specific subtasks.</li>
         </ul>
       </td>
     </tr>
@@ -2758,9 +2770,9 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=#pa
     <tr>
       <td colspan="2">
         <ul>
-<li><code>jobid</code> - description</li>
-<li><code>vertexid</code> - description</li>
-<li><code>subtaskindex</code> - description</li>
+<li><code>jobid</code> - 32-character hexadecimal string value that identifies a job.</li>
+<li><code>vertexid</code> - 32-character hexadecimal string value that identifies a job vertex.</li>
+<li><code>subtaskindex</code> - Positive integer value that identifies a subtask.</li>
         </ul>
       </td>
     </tr>
@@ -2863,10 +2875,10 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=#pa
     <tr>
       <td colspan="2">
         <ul>
-<li><code>jobid</code> - description</li>
-<li><code>vertexid</code> - description</li>
-<li><code>subtaskindex</code> - description</li>
-<li><code>attempt</code> - description</li>
+<li><code>jobid</code> - 32-character hexadecimal string value that identifies a job.</li>
+<li><code>vertexid</code> - 32-character hexadecimal string value that identifies a job vertex.</li>
+<li><code>subtaskindex</code> - Positive integer value that identifies a subtask.</li>
+<li><code>attempt</code> - Positive integer value that identifies an execution attempt.</li>
         </ul>
       </td>
     </tr>
@@ -2969,10 +2981,10 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=#pa
     <tr>
       <td colspan="2">
         <ul>
-<li><code>jobid</code> - description</li>
-<li><code>vertexid</code> - description</li>
-<li><code>subtaskindex</code> - description</li>
-<li><code>attempt</code> - description</li>
+<li><code>jobid</code> - 32-character hexadecimal string value that identifies a job.</li>
+<li><code>vertexid</code> - 32-character hexadecimal string value that identifies a job vertex.</li>
+<li><code>subtaskindex</code> - Positive integer value that identifies a subtask.</li>
+<li><code>attempt</code> - Positive integer value that identifies an execution attempt.</li>
         </ul>
       </td>
     </tr>
@@ -3050,9 +3062,9 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=#pa
     <tr>
       <td colspan="2">
         <ul>
-<li><code>jobid</code> - description</li>
-<li><code>vertexid</code> - description</li>
-<li><code>subtaskindex</code> - description</li>
+<li><code>jobid</code> - 32-character hexadecimal string value that identifies a job.</li>
+<li><code>vertexid</code> - 32-character hexadecimal string value that identifies a job vertex.</li>
+<li><code>subtaskindex</code> - Positive integer value that identifies a subtask.</li>
         </ul>
       </td>
     </tr>
@@ -3062,7 +3074,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=#pa
     <tr>
       <td colspan="2">
         <ul>
-<li><code>get</code> (optional): description</li>
+<li><code>get</code> (optional): Comma-separated list of string values to select specific metrics.</li>
         </ul>
       </td>
     </tr>
@@ -3110,8 +3122,8 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=#pa
     <tr>
       <td colspan="2">
         <ul>
-<li><code>jobid</code> - description</li>
-<li><code>vertexid</code> - description</li>
+<li><code>jobid</code> - 32-character hexadecimal string value that identifies a job.</li>
+<li><code>vertexid</code> - 32-character hexadecimal string value that identifies a job vertex.</li>
         </ul>
       </td>
     </tr>
@@ -3195,8 +3207,8 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=#pa
     <tr>
       <td colspan="2">
         <ul>
-<li><code>jobid</code> - description</li>
-<li><code>vertexid</code> - description</li>
+<li><code>jobid</code> - 32-character hexadecimal string value that identifies a job.</li>
+<li><code>vertexid</code> - 32-character hexadecimal string value that identifies a job vertex.</li>
         </ul>
       </td>
     </tr>
@@ -3437,7 +3449,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=#pa
     <tr>
       <td colspan="2">
         <ul>
-<li><code>triggerid</code> - description</li>
+<li><code>triggerid</code> - 32-character hexadecimal string that identifies an asynchronous operation trigger ID. The ID was returned then the operation was triggered.</li>
         </ul>
       </td>
     </tr>
@@ -3588,9 +3600,9 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=#pa
     <tr>
       <td colspan="2">
         <ul>
-<li><code>get</code> (optional): description</li>
-<li><code>agg</code> (optional): description</li>
-<li><code>taskmanagers</code> (optional): description</li>
+<li><code>get</code> (optional): Comma-separated list of string values to select specific metrics.</li>
+<li><code>agg</code> (optional): Comma-separated list of aggregation modes which should be calculated. Available aggregations are: "min, max, sum, avg".</li>
+<li><code>taskmanagers</code> (optional): Comma-separated list of 32-character hexadecimal strings to select specific task managers.</li>
         </ul>
       </td>
     </tr>
@@ -3638,7 +3650,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=#pa
     <tr>
       <td colspan="2">
         <ul>
-<li><code>taskmanagerid</code> - description</li>
+<li><code>taskmanagerid</code> - 32-character hexadecimal string that identifies a task manager.</li>
         </ul>
       </td>
     </tr>
@@ -3791,7 +3803,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=#pa
     <tr>
       <td colspan="2">
         <ul>
-<li><code>taskmanagerid</code> - description</li>
+<li><code>taskmanagerid</code> - 32-character hexadecimal string that identifies a task manager.</li>
         </ul>
       </td>
     </tr>
@@ -3801,7 +3813,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=#pa
     <tr>
       <td colspan="2">
         <ul>
-<li><code>get</code> (optional): description</li>
+<li><code>get</code> (optional): Comma-separated list of string values to select specific metrics.</li>
         </ul>
       </td>
     </tr>

--- a/flink-core/src/main/java/org/apache/flink/util/StringUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/StringUtils.java
@@ -28,7 +28,9 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.Random;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -346,6 +348,21 @@ public final class StringUtils {
 		else {
 			return s2;
 		}
+	}
+
+	/**
+	 * Generates a string containing a comma-separated list of values in double-quotes.
+	 * Uses lower-cased values returned from {@link Object#toString()} method for each element in the given array.
+	 * Null values are skipped.
+	 *
+	 * @param values array of elements for the list
+	 *
+	 * @return The string with quoted list of elements
+	 */
+	public static String toQuotedListString(Object[] values) {
+		return Arrays.stream(values).filter(Objects::nonNull)
+			.map(v -> v.toString().toLowerCase())
+			.collect(Collectors.joining(", ", "\"", "\""));
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-docs/src/main/java/org/apache/flink/docs/rest/RestAPIDocGenerator.java
+++ b/flink-docs/src/main/java/org/apache/flink/docs/rest/RestAPIDocGenerator.java
@@ -226,7 +226,7 @@ public class RestAPIDocGenerator {
 			pathParameterList.append(
 				String.format("<li><code>%s</code> - %s</li>\n",
 					messagePathParameter.getKey(),
-					"description")
+					messagePathParameter.getDescription())
 			));
 		return pathParameterList.toString();
 	}
@@ -240,7 +240,7 @@ public class RestAPIDocGenerator {
 					String.format("<li><code>%s</code> (%s): %s</li>\n",
 						parameter.getKey(),
 						parameter.isMandatory() ? "mandatory" : "optional",
-						"description")
+						parameter.getDescription())
 				));
 		return queryParameterList.toString();
 	}

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/AllowNonRestoredStateQueryParameter.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/AllowNonRestoredStateQueryParameter.java
@@ -42,4 +42,10 @@ public class AllowNonRestoredStateQueryParameter extends MessageQueryParameter<B
 	public String convertValueToString(final Boolean value) {
 		return value.toString();
 	}
+
+	@Override
+	public String getDescription() {
+		return "Boolean value that specifies whether the job submission should be rejected " +
+			"if the savepoint contains state that cannot be mapped back to the job.";
+	}
 }

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/EntryClassQueryParameter.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/EntryClassQueryParameter.java
@@ -28,4 +28,10 @@ public class EntryClassQueryParameter extends StringQueryParameter {
 	public EntryClassQueryParameter() {
 		super("entry-class", MessageParameterRequisiteness.OPTIONAL);
 	}
+
+	@Override
+	public String getDescription() {
+		return "String value that specifies the fully qualified name of the entry point class. " +
+			"Overrides the class defined in the jar file manifest.";
+	}
 }

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarIdPathParameter.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarIdPathParameter.java
@@ -48,4 +48,11 @@ public class JarIdPathParameter extends MessagePathParameter<String> {
 	protected String convertToString(final String value) {
 		return value;
 	}
+
+	@Override
+	public String getDescription() {
+		return "String value that identifies a jar. When uploading the jar a path is returned, where the filename " +
+			"is the ID. This value is equivalent to the `" + JarListInfo.JarFileInfo.JAR_FILE_FIELD_ID + "` field " +
+			"in the list of uploaded jars (" + JarListHeaders.URL + ").";
+	}
 }

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/ParallelismQueryParameter.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/ParallelismQueryParameter.java
@@ -41,4 +41,9 @@ public class ParallelismQueryParameter extends MessageQueryParameter<Integer> {
 	public String convertValueToString(final Integer value) {
 		return value.toString();
 	}
+
+	@Override
+	public String getDescription() {
+		return "Positive integer value that specifies the desired parallelism for the job.";
+	}
 }

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/ProgramArgsQueryParameter.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/ProgramArgsQueryParameter.java
@@ -30,4 +30,8 @@ public class ProgramArgsQueryParameter extends StringQueryParameter {
 		super("program-args", MessageParameterRequisiteness.OPTIONAL);
 	}
 
+	@Override
+	public String getDescription() {
+		return "String value that specifies the arguments for the program or plan.";
+	}
 }

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/SavepointPathQueryParameter.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/SavepointPathQueryParameter.java
@@ -28,4 +28,9 @@ public class SavepointPathQueryParameter  extends StringQueryParameter {
 	public SavepointPathQueryParameter() {
 		super(KEY, MessageParameterRequisiteness.OPTIONAL);
 	}
+
+	@Override
+	public String getDescription() {
+		return "String value that specifies the path of the savepoint to restore the job from.";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/AccumulatorsIncludeSerializedValueQueryParameter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/AccumulatorsIncludeSerializedValueQueryParameter.java
@@ -38,4 +38,9 @@ public class AccumulatorsIncludeSerializedValueQueryParameter extends MessageQue
 	public Boolean convertStringToValue(String value) {
 		return Boolean.valueOf(value);
 	}
+
+	@Override
+	public String getDescription() {
+		return "Boolean value that specifies whether serialized user task accumulators should be included in the response.";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobIDPathParameter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobIDPathParameter.java
@@ -40,4 +40,9 @@ public class JobIDPathParameter extends MessagePathParameter<JobID> {
 	protected String convertToString(JobID value) {
 		return value.toString();
 	}
+
+	@Override
+	public String getDescription() {
+		return "32-character hexadecimal string value that identifies a job.";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobVertexIdPathParameter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobVertexIdPathParameter.java
@@ -40,4 +40,9 @@ public class JobVertexIdPathParameter extends MessagePathParameter<JobVertexID> 
 	protected String convertToString(JobVertexID value) {
 		return value.toString();
 	}
+
+	@Override
+	public String getDescription() {
+		return "32-character hexadecimal string value that identifies a job vertex.";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/MessageParameter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/MessageParameter.java
@@ -137,4 +137,10 @@ public abstract class MessageParameter<X> {
 		MANDATORY,
 		OPTIONAL
 	}
+
+	/**
+	 * Returns a description for REST API HTML documentation.
+ 	 * @return escaped HTML string
+	 */
+	public abstract String getDescription();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/RescalingParallelismQueryParameter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/RescalingParallelismQueryParameter.java
@@ -38,4 +38,9 @@ public class RescalingParallelismQueryParameter extends MessageQueryParameter<In
 	public String convertValueToString(Integer value) {
 		return value.toString();
 	}
+
+	@Override
+	public String getDescription() {
+		return "Positive integer value that specifies the desired parallelism.";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/SubtaskIndexPathParameter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/SubtaskIndexPathParameter.java
@@ -44,4 +44,9 @@ public class SubtaskIndexPathParameter extends MessagePathParameter<Integer> {
 		return value.toString();
 	}
 
+	@Override
+	public String getDescription() {
+		return "Positive integer value that identifies a subtask.";
+	}
+
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/TerminationModeQueryParameter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/TerminationModeQueryParameter.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.rest.messages;
 
 import org.apache.flink.runtime.rest.handler.legacy.JobCancellationHandler;
+import org.apache.flink.util.StringUtils;
 
 /**
  * Termination mode for the {@link JobCancellationHandler}.
@@ -39,6 +40,12 @@ public class TerminationModeQueryParameter extends MessageQueryParameter<Termina
 	@Override
 	public String convertValueToString(TerminationMode value) {
 		return value.name().toLowerCase();
+	}
+
+	@Override
+	public String getDescription() {
+		return "String value that specifies the termination mode. Supported values are: " +
+			StringUtils.toQuotedListString(TerminationMode.values()) + '.';
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/TriggerIdPathParameter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/TriggerIdPathParameter.java
@@ -38,4 +38,10 @@ public class TriggerIdPathParameter extends MessagePathParameter<TriggerId> {
 	protected String convertToString(TriggerId value) {
 		return value.toString();
 	}
+
+	@Override
+	public String getDescription() {
+		return "32-character hexadecimal string that identifies an asynchronous operation trigger ID. " +
+			"The ID was returned then the operation was triggered.";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/CheckpointIdPathParameter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/CheckpointIdPathParameter.java
@@ -45,4 +45,9 @@ public class CheckpointIdPathParameter extends MessagePathParameter<Long> {
 	protected String convertToString(Long value) {
 		return value.toString();
 	}
+
+	@Override
+	public String getDescription() {
+		return "Long value that identifies a checkpoint.";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobSubmitHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobSubmitHeaders.java
@@ -72,9 +72,9 @@ public class JobSubmitHeaders implements MessageHeaders<JobSubmitRequestBody, Jo
 
 	@Override
 	public String getDescription() {
-		return "Submits a job. This call is primarily intended to be used by the Flink client. This call expects a" +
-			"multipart/form-data request that consists of file uploads for the serialized JobGraph, jars and" +
-			"distributed cache artifacts and an attribute named \"" + FileUploadHandler.HTTP_ATTRIBUTE_REQUEST + "\"for " +
+		return "Submits a job. This call is primarily intended to be used by the Flink client. This call expects a " +
+			"multipart/form-data request that consists of file uploads for the serialized JobGraph, jars and " +
+			"distributed cache artifacts and an attribute named \"" + FileUploadHandler.HTTP_ATTRIBUTE_REQUEST + "\" for " +
 			"the JSON payload.";
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/SubtaskAttemptPathParameter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/SubtaskAttemptPathParameter.java
@@ -50,4 +50,9 @@ public class SubtaskAttemptPathParameter extends MessagePathParameter<Integer> {
 	protected String convertToString(Integer value) {
 		return value.toString();
 	}
+
+	@Override
+	public String getDescription() {
+		return "Positive integer value that identifies an execution attempt.";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/JobsFilterQueryParameter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/JobsFilterQueryParameter.java
@@ -45,4 +45,9 @@ public class JobsFilterQueryParameter extends MessageQueryParameter<JobID> {
 	public String convertValueToString(JobID value) {
 		return value.toString();
 	}
+
+	@Override
+	public String getDescription() {
+		return "Comma-separated list of 32-character hexadecimal strings to select specific jobs.";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/MetricsAggregationParameter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/MetricsAggregationParameter.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.rest.messages.job.metrics;
 
 import org.apache.flink.runtime.rest.messages.ConversionException;
 import org.apache.flink.runtime.rest.messages.MessageQueryParameter;
+import org.apache.flink.util.StringUtils;
 
 import java.util.Locale;
 
@@ -44,6 +45,12 @@ public class MetricsAggregationParameter extends MessageQueryParameter<MetricsAg
 	@Override
 	public String convertValueToString(AggregationMode value) {
 		return value.name().toLowerCase();
+	}
+
+	@Override
+	public String getDescription() {
+		return "Comma-separated list of aggregation modes which should be calculated. " +
+			"Available aggregations are: " + StringUtils.toQuotedListString(AggregationMode.values()) + '.';
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/MetricsFilterParameter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/MetricsFilterParameter.java
@@ -45,4 +45,8 @@ public class MetricsFilterParameter extends MessageQueryParameter<String> {
 		return value;
 	}
 
+	@Override
+	public String getDescription() {
+		return "Comma-separated list of string values to select specific metrics.";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/SubtasksFilterQueryParameter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/SubtasksFilterQueryParameter.java
@@ -38,4 +38,9 @@ public class SubtasksFilterQueryParameter extends MessageQueryParameter<String> 
 	public String convertValueToString(String value) {
 		return value;
 	}
+
+	@Override
+	public String getDescription() {
+		return "Comma-separated list of integer ranges (e.g. \"1,3,5-9\") to select specific subtasks.";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/TaskManagersFilterQueryParameter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/TaskManagersFilterQueryParameter.java
@@ -39,4 +39,9 @@ public class TaskManagersFilterQueryParameter extends MessageQueryParameter<Reso
 	public String convertValueToString(ResourceID value) {
 		return value.getResourceIdString();
 	}
+
+	@Override
+	public String getDescription() {
+		return "Comma-separated list of 32-character hexadecimal strings to select specific task managers.";
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/taskmanager/TaskManagerIdPathParameter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/taskmanager/TaskManagerIdPathParameter.java
@@ -41,4 +41,9 @@ public class TaskManagerIdPathParameter extends MessagePathParameter<ResourceID>
 	protected String convertToString(ResourceID value) {
 		return value.getResourceIdString();
 	}
+
+	@Override
+	public String getDescription() {
+		return "32-character hexadecimal string that identifies a task manager.";
+	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointITCase.java
@@ -616,6 +616,11 @@ public class RestServerEndpointITCase extends TestLogger {
 		protected String convertToString(JobID value) {
 			return value.toString();
 		}
+
+		@Override
+		public String getDescription() {
+			return "correct JobID parameter";
+		}
 	}
 
 	static class FaultyJobIDPathParameter extends MessagePathParameter<JobID> {
@@ -633,6 +638,11 @@ public class RestServerEndpointITCase extends TestLogger {
 		protected String convertToString(JobID value) {
 			return "foobar";
 		}
+
+		@Override
+		public String getDescription() {
+			return "faulty JobID parameter";
+		}
 	}
 
 	static class JobIDQueryParameter extends MessageQueryParameter<JobID> {
@@ -648,6 +658,11 @@ public class RestServerEndpointITCase extends TestLogger {
 		@Override
 		public String convertValueToString(JobID value) {
 			return value.toString();
+		}
+
+		@Override
+		public String getDescription() {
+			return "query JobID parameter";
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/util/HandlerRequestUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/util/HandlerRequestUtilsTest.java
@@ -111,5 +111,10 @@ public class HandlerRequestUtilsTest extends TestLogger {
 		public String convertValueToString(final Boolean value) {
 			return value.toString();
 		}
+
+		@Override
+		public String getDescription() {
+			return "boolean query parameter";
+		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/MessageParametersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/MessageParametersTest.java
@@ -92,6 +92,11 @@ public class MessageParametersTest extends TestLogger {
 		protected String convertToString(JobID value) {
 			return value.toString();
 		}
+
+		@Override
+		public String getDescription() {
+			return "path parameter";
+		}
 	}
 
 	private static class TestQueryParameter extends MessageQueryParameter<JobID> {
@@ -108,6 +113,11 @@ public class MessageParametersTest extends TestLogger {
 		@Override
 		public String convertValueToString(JobID value) {
 			return value.toString();
+		}
+
+		@Override
+		public String getDescription() {
+			return "query parameter";
 		}
 	}
 }


### PR DESCRIPTION
## This pull request adds methods for auto-documenting REST API.

Introduced getDescription() method will generate path and query parameter description on 
[REST API documentation](https://ci.apache.org/projects/flink/flink-docs-master/monitoring/rest_api.html) page. 
 
## Brief change log

  - An abstract **getDescription()** method was added to the base **MessageParameter.java** class.
  - All extending classes overrides the method with brief parameter description.
  - The method is called in the **RestAPIDocGenerator.java** class for filling description sections in the output HTML file.

This change is a trivial documentation fix without any test coverage.

## This pull request potentially affect one of the following parts:

  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation
  - Does this pull request introduce a new feature? no
  - This pull request just adds documentation for an existed API
