### PR TITLE
[FLINK-9331] [mesos] Let MesosResourceManager request new tasks for failed ones

### DIFF
--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManager.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManager.java
@@ -616,6 +616,7 @@ public class MesosResourceManager extends ResourceManager<RegisteredMesosWorkerN
 			assert(launched != null);
 			LOG.info("Worker {} failed with status: {}, reason: {}, message: {}.",
 				id, status.getState(), status.getReason(), status.getMessage());
+			startNewWorker(launched.profile());
 		}
 
 		closeTaskManagerConnection(id, new Exception(status.getMessage()));

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
@@ -110,6 +110,7 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -683,6 +684,7 @@ public class MesosResourceManagerTest extends TestLogger {
 			MesosWorkerStore.Worker worker1launched = MesosWorkerStore.Worker.newWorker(task1).launchWorker(slave1, slave1host);
 			when(rmServices.workerStore.getFrameworkID()).thenReturn(Option.apply(framework1));
 			when(rmServices.workerStore.recoverWorkers()).thenReturn(singletonList(worker1launched));
+			when(rmServices.workerStore.newTaskID()).thenReturn(task2);
 			startResourceManager();
 
 			// tell the RM that a task failed
@@ -694,6 +696,7 @@ public class MesosResourceManagerTest extends TestLogger {
 			verify(rmServices.workerStore).removeWorker(task1);
 			assertThat(resourceManager.workersInLaunch.entrySet(), empty());
 			assertThat(resourceManager.workersBeingReturned.entrySet(), empty());
+			assertThat(resourceManager.workersInNew, hasKey(extractResourceID(task2)));
 
 			// verify that `closeTaskManagerConnection` was called
 			assertThat(resourceManager.closedTaskManagerConnections, hasItem(extractResourceID(task1)));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/AllocationID.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/AllocationID.java
@@ -21,11 +21,16 @@ package org.apache.flink.runtime.clusterframework.types;
 import org.apache.flink.util.AbstractID;
 
 /**
- * Unique identifier for a slot allocated by a JobManager from a TaskManager.
- * Also identifies a pending allocation request, and is constant across retries.
- * 
- * <p>This ID is used for all synchronization of the status of Slots from TaskManagers
- * that are not free (i.e., have been allocated by a job).
+ * Unique identifier for a physical slot allocated by a JobManager via the ResourceManager
+ * from a TaskManager. The ID is assigned once the JobManager (or its SlotPool) first
+ * requests the slot and is constant across retries.
+ *
+ * <p>This ID is used by the TaskManager and ResourceManager to track and synchronize which
+ * slots are allocated to which JobManager and which are free.
+ *
+ * <p>In contrast to this AllocationID, the {@link org.apache.flink.runtime.jobmaster.SlotRequestId}
+ * is used when a task requests a logical slot from the SlotPool. Multiple logical slot requests
+ * can map to one physical slot request (due to slot sharing).
  */
 public class AllocationID extends AbstractID {
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/SlotRequestId.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/SlotRequestId.java
@@ -23,15 +23,21 @@ import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.util.AbstractID;
 
 /**
- * Request id identifying slot requests made by the {@link SlotProvider} towards the
- * {@link SlotPool}.
+ * This ID identifies the request for a logical slot from the Execution to the {@link SlotPool}
+ * oe {@link SlotProvider}. The logical slot may be a physical slot or a sub-slot thereof, in
+ * the case of slot sharing.
+ *
+ * <p>This ID serves a different purpose than the
+ * {@link org.apache.flink.runtime.clusterframework.types.AllocationID AllocationID}, which identifies
+ * the request of a physical slot, issued from the SlotPool via the ResourceManager to the TaskManager.
  */
 public final class SlotRequestId extends AbstractID {
-    private static final long serialVersionUID = -6072105912250154283L;
 
-    public SlotRequestId(long lowerPart, long upperPart) {
-        super(lowerPart, upperPart);
-    }
+	private static final long serialVersionUID = -6072105912250154283L;
 
-    public SlotRequestId() {}
+	public SlotRequestId(long lowerPart, long upperPart) {
+		super(lowerPart, upperPart);
+	}
+
+	public SlotRequestId() {}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/AllocatedSlot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/AllocatedSlot.java
@@ -42,7 +42,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * an AllocatedSlot was allocated to the JobManager as soon as the TaskManager registered at the
  * JobManager. All slots had a default unknown resource profile. 
  */
-public class AllocatedSlot implements SlotContext {
+class AllocatedSlot implements SlotContext {
 
 	/** The ID under which the slot is allocated. Uniquely identifies the slot. */
 	private final AllocationID allocationId;
@@ -171,21 +171,13 @@ public class AllocatedSlot implements SlotContext {
 	 * then it is removed from the slot.
 	 *
 	 * @param cause of the release operation
-	 * @return true if the payload could be released and was removed from the slot, otherwise false
 	 */
-	public boolean releasePayload(Throwable cause) {
+	public void releasePayload(Throwable cause) {
 		final Payload payload = payloadReference.get();
 
 		if (payload != null) {
-			if (payload.release(cause)) {
-				payloadReference.set(null);
-
-				return true;
-			} else {
-				return false;
-			}
-		} else {
-			return true;
+			payload.release(cause);
+			payloadReference.set(null);
 		}
 	}
 
@@ -222,12 +214,10 @@ public class AllocatedSlot implements SlotContext {
 	interface Payload {
 
 		/**
-		 * Releases the payload. If the payload could be released, then it returns true,
-		 * otherwise false.
+		 * Releases the payload
 		 *
 		 * @param cause of the payload release
-		 * @return true if the payload could be released, otherwise false
 		 */
-		boolean release(Throwable cause);
+		void release(Throwable cause);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SingleLogicalSlot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SingleLogicalSlot.java
@@ -33,6 +33,7 @@ import javax.annotation.Nullable;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.function.Function;
 
 /**
  * Implementation of the {@link LogicalSlot} which is used by the {@link SlotPool}.
@@ -43,6 +44,11 @@ public class SingleLogicalSlot implements LogicalSlot, AllocatedSlot.Payload {
 		SingleLogicalSlot.class,
 		Payload.class,
 		"payload");
+
+	private static final AtomicReferenceFieldUpdater<SingleLogicalSlot, State> STATE_UPDATER = AtomicReferenceFieldUpdater.newUpdater(
+		SingleLogicalSlot.class,
+		State.class,
+		"state");
 
 	private final SlotRequestId slotRequestId;
 
@@ -58,6 +64,10 @@ public class SingleLogicalSlot implements LogicalSlot, AllocatedSlot.Payload {
 	// owner of this slot to which it is returned upon release
 	private final SlotOwner slotOwner;
 
+	private final CompletableFuture<Void> releaseFuture;
+
+	private volatile State state;
+
 	// LogicalSlot.Payload of this slot
 	private volatile Payload payload;
 
@@ -72,8 +82,10 @@ public class SingleLogicalSlot implements LogicalSlot, AllocatedSlot.Payload {
 		this.slotSharingGroupId = slotSharingGroupId;
 		this.locality = Preconditions.checkNotNull(locality);
 		this.slotOwner = Preconditions.checkNotNull(slotOwner);
+		this.releaseFuture = new CompletableFuture<>();
 
-		payload = null;
+		this.state = State.ALIVE;
+		this.payload = null;
 	}
 
 	@Override
@@ -93,20 +105,11 @@ public class SingleLogicalSlot implements LogicalSlot, AllocatedSlot.Payload {
 
 	@Override
 	public boolean isAlive() {
-		final Payload currentPayload = payload;
-
-		if (currentPayload != null) {
-			return !currentPayload.getTerminalStateFuture().isDone();
-		} else {
-			// We are always alive if there is no payload assigned yet.
-			// If this slot is released and no payload is assigned, then the TERMINATED_PAYLOAD is assigned
-			return true;
-		}
+		return state == State.ALIVE;
 	}
 
 	@Override
 	public boolean tryAssignPayload(Payload payload) {
-		Preconditions.checkNotNull(payload);
 		return PAYLOAD_UPDATER.compareAndSet(this, null, payload);
 	}
 
@@ -118,15 +121,12 @@ public class SingleLogicalSlot implements LogicalSlot, AllocatedSlot.Payload {
 
 	@Override
 	public CompletableFuture<?> releaseSlot(@Nullable Throwable cause) {
-		// set an already terminated payload if the payload of this slot is still empty
-		tryAssignPayload(TERMINATED_PAYLOAD);
+		if (STATE_UPDATER.compareAndSet(this, State.ALIVE, State.RELEASING)) {
+			final CompletableFuture<?> payloadTerminalStateFuture = signalPayloadRelease(cause);
+			returnSlotToOwner(payloadTerminalStateFuture);
+		}
 
-		// notify the payload that the slot will be released
-		payload.fail(cause);
-
-		// Wait until the payload has been terminated. Only then, we return the slot to its rightful owner
-		return payload.getTerminalStateFuture()
-			.whenComplete((Object ignored, Throwable throwable) -> slotOwner.returnAllocatedSlot(this));
+		return releaseFuture;
 	}
 
 	@Override
@@ -159,10 +159,55 @@ public class SingleLogicalSlot implements LogicalSlot, AllocatedSlot.Payload {
 	 * the logical slot.
 	 *
 	 * @param cause of the payload release
-	 * @return true if the logical slot's payload could be released, otherwise false
 	 */
 	@Override
-	public boolean release(Throwable cause) {
-		return releaseSlot(cause).isDone();
+	public void release(Throwable cause) {
+		if (STATE_UPDATER.compareAndSet(this, State.ALIVE, State.RELEASING)) {
+			signalPayloadRelease(cause);
+		}
+		markReleased();
+		releaseFuture.complete(null);
+	}
+
+	private CompletableFuture<?> signalPayloadRelease(Throwable cause) {
+		tryAssignPayload(TERMINATED_PAYLOAD);
+		payload.fail(cause);
+
+		return payload.getTerminalStateFuture();
+	}
+
+	private void returnSlotToOwner(CompletableFuture<?> terminalStateFuture) {
+		final CompletableFuture<Boolean> slotReturnFuture = terminalStateFuture.handle((Object ignored, Throwable throwable) -> {
+			if (state == State.RELEASING) {
+				return slotOwner.returnAllocatedSlot(this);
+			} else {
+				return CompletableFuture.completedFuture(true);
+			}
+		}).thenCompose(Function.identity());
+
+		slotReturnFuture.whenComplete(
+			(Object ignored, Throwable throwable) -> {
+				markReleased();
+
+				if (throwable != null) {
+					releaseFuture.completeExceptionally(throwable);
+				} else {
+					releaseFuture.complete(null);
+				}
+			});
+	}
+
+	private void markReleased() {
+		state = State.RELEASED;
+	}
+
+	// -------------------------------------------------------------------------
+	// Internal classes
+	// -------------------------------------------------------------------------
+
+	enum State {
+		ALIVE,
+		RELEASING,
+		RELEASED
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotAndLocality.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotAndLocality.java
@@ -16,10 +16,9 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.jobmanager.slots;
+package org.apache.flink.runtime.jobmaster.slotpool;
 
 import org.apache.flink.runtime.jobmanager.scheduler.Locality;
-import org.apache.flink.runtime.jobmaster.slotpool.AllocatedSlot;
 
 import javax.annotation.Nonnull;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
@@ -303,25 +303,11 @@ public class SlotPool extends RpcEndpoint implements SlotPoolGateway, AllocatedS
 	@Override
 	public CompletableFuture<LogicalSlot> allocateSlot(
 			SlotRequestId slotRequestId,
-			ScheduledUnit scheduledUnit,
-			SlotProfile slotProfile,
-			boolean allowQueuedScheduling,
-			Time timeout) {
-
-		return internalAllocateSlot(
-			slotRequestId,
-			scheduledUnit,
-			slotProfile,
-			allowQueuedScheduling,
-			timeout);
-	}
-
-	private CompletableFuture<LogicalSlot> internalAllocateSlot(
-			SlotRequestId slotRequestId,
 			ScheduledUnit task,
 			SlotProfile slotProfile,
 			boolean allowQueuedScheduling,
 			Time allocationTimeout) {
+
 		final SlotSharingGroupId slotSharingGroupId = task.getSlotSharingGroupId();
 
 		if (slotSharingGroupId != null) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
@@ -35,7 +35,6 @@ import org.apache.flink.runtime.jobmanager.scheduler.CoLocationConstraint;
 import org.apache.flink.runtime.jobmanager.scheduler.Locality;
 import org.apache.flink.runtime.jobmanager.scheduler.NoResourceAvailableException;
 import org.apache.flink.runtime.jobmanager.scheduler.ScheduledUnit;
-import org.apache.flink.runtime.jobmanager.slots.SlotAndLocality;
 import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
 import org.apache.flink.runtime.jobmaster.JobMasterId;
 import org.apache.flink.runtime.jobmaster.LogicalSlot;
@@ -764,10 +763,8 @@ public class SlotPool extends RpcEndpoint implements SlotPoolGateway, AllocatedS
 				final AllocatedSlot allocatedSlot = allocatedSlots.remove(slotRequestId);
 
 				if (allocatedSlot != null) {
-					// sanity check
-					if (allocatedSlot.releasePayload(cause)) {
-						tryFulfillSlotRequestOrMakeAvailable(allocatedSlot);
-					}
+					allocatedSlot.releasePayload(cause);
+					tryFulfillSlotRequestOrMakeAvailable(allocatedSlot);
 				} else {
 					log.debug("There is no allocated slot with slot request id {}. Ignoring the release slot request.", slotRequestId);
 				}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/AvailableSlotsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/AvailableSlotsTest.java
@@ -22,7 +22,6 @@ import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotProfile;
-import org.apache.flink.runtime.jobmanager.slots.SlotAndLocality;
 import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.testutils.category.New;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DummyPayload.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/DummyPayload.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.runtime.jobmaster.LogicalSlot;
+import org.apache.flink.util.Preconditions;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * {@link LogicalSlot.Payload} implementation for test purposes.
+ */
+final class DummyPayload implements LogicalSlot.Payload {
+
+    private final CompletableFuture<?> terminalStateFuture;
+
+    DummyPayload() {
+    	this(new CompletableFuture<>());
+	}
+
+    DummyPayload(CompletableFuture<?> terminalStateFuture) {
+        this.terminalStateFuture = Preconditions.checkNotNull(terminalStateFuture);
+    }
+
+    @Override
+    public void fail(Throwable cause) {
+        terminalStateFuture.complete(null);
+    }
+
+    @Override
+    public CompletableFuture<?> getTerminalStateFuture() {
+        return terminalStateFuture;
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SingleLogicalSlotTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SingleLogicalSlotTest.java
@@ -1,0 +1,323 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
+import org.apache.flink.runtime.jobmanager.scheduler.Locality;
+import org.apache.flink.runtime.jobmanager.slots.DummySlotOwner;
+import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
+import org.apache.flink.runtime.jobmaster.LogicalSlot;
+import org.apache.flink.runtime.jobmaster.SlotContext;
+import org.apache.flink.runtime.jobmaster.SlotOwner;
+import org.apache.flink.runtime.jobmaster.SlotRequestId;
+import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+
+/**
+ * Tests for the {@link SingleLogicalSlot} class.
+ */
+public class SingleLogicalSlotTest extends TestLogger {
+
+	@Test
+	public void testPayloadAssignment() {
+		final SingleLogicalSlot singleLogicalSlot = createSingleLogicalSlot();
+		final DummyPayload dummyPayload1 = new DummyPayload();
+		final DummyPayload dummyPayload2 = new DummyPayload();
+
+		assertThat(singleLogicalSlot.tryAssignPayload(dummyPayload1), is(true));
+		assertThat(singleLogicalSlot.tryAssignPayload(dummyPayload2), is(false));
+
+		assertThat(singleLogicalSlot.getPayload(), sameInstance(dummyPayload1));
+	}
+
+	private SingleLogicalSlot createSingleLogicalSlot() {
+		return createSingleLogicalSlot(new DummySlotOwner());
+	}
+
+	private SingleLogicalSlot createSingleLogicalSlot(SlotOwner slotOwner) {
+		return new SingleLogicalSlot(
+			new SlotRequestId(),
+			new DummySlotContext(),
+			null,
+			Locality.LOCAL,
+			slotOwner);
+	}
+
+	@Test
+	public void testAlive() throws Exception {
+		final SingleLogicalSlot singleLogicalSlot = createSingleLogicalSlot();
+		final DummyPayload dummyPayload = new DummyPayload();
+
+		assertThat(singleLogicalSlot.isAlive(), is(true));
+
+		assertThat(singleLogicalSlot.tryAssignPayload(dummyPayload), is(true));
+		assertThat(singleLogicalSlot.isAlive(), is(true));
+
+		final CompletableFuture<?> releaseFuture = singleLogicalSlot.releaseSlot(new FlinkException("Test exception"));
+
+		assertThat(singleLogicalSlot.isAlive(), is(false));
+
+		releaseFuture.get();
+
+		assertThat(singleLogicalSlot.isAlive(), is(false));
+	}
+
+	@Test
+	public void testPayloadAssignmentAfterRelease() {
+		final SingleLogicalSlot singleLogicalSlot = createSingleLogicalSlot();
+		final DummyPayload dummyPayload = new DummyPayload();
+
+		singleLogicalSlot.releaseSlot(new FlinkException("Test exception"));
+
+		assertThat(singleLogicalSlot.tryAssignPayload(dummyPayload), is(false));
+	}
+
+	/**
+	 * Tests that the {@link AllocatedSlot.Payload#release(Throwable)} does not wait
+	 * for the payload to reach a terminal state.
+	 */
+	@Test
+	public void testAllocatedSlotRelease() {
+		final CompletableFuture<LogicalSlot> returnSlotFuture = new CompletableFuture<>();
+		final WaitingSlotOwner waitingSlotOwner = new WaitingSlotOwner(returnSlotFuture, new CompletableFuture<>());
+		final SingleLogicalSlot singleLogicalSlot = createSingleLogicalSlot(waitingSlotOwner);
+
+		final CompletableFuture<?> terminalStateFuture = new CompletableFuture<>();
+		final CompletableFuture<?> failFuture = new CompletableFuture<>();
+		final ManualTestingPayload dummyPayload = new ManualTestingPayload(failFuture, terminalStateFuture);
+
+		assertThat(singleLogicalSlot.tryAssignPayload(dummyPayload), is(true));
+
+		singleLogicalSlot.release(new FlinkException("Test exception"));
+
+		assertThat(failFuture.isDone(), is(true));
+		// we don't require the logical slot to return to the owner because
+		// the release call should only come from the owner
+		assertThat(returnSlotFuture.isDone(), is(false));
+	}
+
+	/**
+	 * Tests that the slot release is only signaled after the owner has
+	 * taken it back.
+	 */
+	@Test
+	public void testSlotRelease() {
+		final CompletableFuture<LogicalSlot> returnedSlotFuture = new CompletableFuture<>();
+		final CompletableFuture<Boolean> returnSlotResponseFuture = new CompletableFuture<>();
+		final WaitingSlotOwner waitingSlotOwner = new WaitingSlotOwner(returnedSlotFuture, returnSlotResponseFuture);
+		final CompletableFuture<?> terminalStateFuture = new CompletableFuture<>();
+		final CompletableFuture<?> failFuture = new CompletableFuture<>();
+		final ManualTestingPayload dummyPayload = new ManualTestingPayload(failFuture, terminalStateFuture);
+
+		final SingleLogicalSlot singleLogicalSlot = createSingleLogicalSlot(waitingSlotOwner);
+
+		assertThat(singleLogicalSlot.tryAssignPayload(dummyPayload), is(true));
+
+		final CompletableFuture<?> releaseFuture = singleLogicalSlot.releaseSlot(new FlinkException("Test exception"));
+
+		assertThat(releaseFuture.isDone(), is(false));
+		assertThat(returnedSlotFuture.isDone(), is(false));
+		assertThat(failFuture.isDone(), is(true));
+
+		terminalStateFuture.complete(null);
+
+		assertThat(returnedSlotFuture.isDone(), is(true));
+
+		returnSlotResponseFuture.complete(true);
+
+		assertThat(releaseFuture.isDone(), is(true));
+	}
+
+	/**
+	 * Tests that concurrent release operations only trigger the failing of the payload and
+	 * the return of the slot once.
+	 */
+	@Test
+	public void testConcurrentReleaseOperations() throws Exception {
+		final CountingSlotOwner countingSlotOwner = new CountingSlotOwner();
+		final CountingFailPayload countingFailPayload = new CountingFailPayload();
+		final SingleLogicalSlot singleLogicalSlot = createSingleLogicalSlot(countingSlotOwner);
+
+		singleLogicalSlot.tryAssignPayload(countingFailPayload);
+
+		final ExecutorService executorService = Executors.newFixedThreadPool(4);
+
+		try {
+			final int numberConcurrentOperations = 10;
+			final Collection<CompletableFuture<?>> releaseOperationFutures = new ArrayList<>(numberConcurrentOperations);
+
+			for (int i = 0; i < numberConcurrentOperations; i++) {
+				final CompletableFuture<Void> releaseOperationFuture = CompletableFuture.runAsync(
+					() -> {
+						try {
+							singleLogicalSlot.releaseSlot(new FlinkException("Test exception")).get();
+						} catch (InterruptedException | ExecutionException e) {
+							ExceptionUtils.checkInterrupted(e);
+							throw new CompletionException(e);
+						}
+					});
+
+				releaseOperationFutures.add(releaseOperationFuture);
+			}
+
+			final FutureUtils.ConjunctFuture<Void> releaseOperationsFuture = FutureUtils.waitForAll(releaseOperationFutures);
+
+			releaseOperationsFuture.get();
+
+			assertThat(countingSlotOwner.getReleaseCount(), is(1));
+			assertThat(countingFailPayload.getFailCount(), is(1));
+		} finally {
+			executorService.shutdownNow();
+		}
+	}
+
+	private static final class CountingFailPayload implements LogicalSlot.Payload {
+
+		private final AtomicInteger failCounter = new AtomicInteger(0);
+
+		int getFailCount() {
+			return failCounter.get();
+		}
+
+		@Override
+		public void fail(Throwable cause) {
+			failCounter.incrementAndGet();
+		}
+
+		@Override
+		public CompletableFuture<?> getTerminalStateFuture() {
+			return CompletableFuture.completedFuture(null);
+		}
+	}
+
+	private static final class CountingSlotOwner implements SlotOwner {
+
+		private final AtomicInteger counter;
+
+		private CountingSlotOwner() {
+			this.counter = new AtomicInteger(0);
+		}
+
+		public int getReleaseCount() {
+			return counter.get();
+		}
+
+		@Override
+		public CompletableFuture<Boolean> returnAllocatedSlot(LogicalSlot logicalSlot) {
+			counter.incrementAndGet();
+			return CompletableFuture.completedFuture(true);
+		}
+	}
+
+	private static final class ManualTestingPayload implements LogicalSlot.Payload {
+
+		private final CompletableFuture<?> failFuture;
+
+		private final CompletableFuture<?> terminalStateFuture;
+
+		private ManualTestingPayload(CompletableFuture<?> failFuture, CompletableFuture<?> terminalStateFuture) {
+			this.failFuture = failFuture;
+			this.terminalStateFuture = terminalStateFuture;
+		}
+
+		@Override
+		public void fail(Throwable cause) {
+			failFuture.completeExceptionally(cause);
+		}
+
+		@Override
+		public CompletableFuture<?> getTerminalStateFuture() {
+			return terminalStateFuture;
+		}
+	}
+
+	private static final class WaitingSlotOwner implements SlotOwner {
+
+		private final CompletableFuture<LogicalSlot> returnAllocatedSlotFuture;
+
+		private final CompletableFuture<Boolean> returnAllocatedSlotResponse;
+
+		private WaitingSlotOwner(CompletableFuture<LogicalSlot> returnAllocatedSlotFuture, CompletableFuture<Boolean> returnAllocatedSlotResponse) {
+			this.returnAllocatedSlotFuture = Preconditions.checkNotNull(returnAllocatedSlotFuture);
+			this.returnAllocatedSlotResponse = Preconditions.checkNotNull(returnAllocatedSlotResponse);
+		}
+
+		@Override
+		public CompletableFuture<Boolean> returnAllocatedSlot(LogicalSlot logicalSlot) {
+			returnAllocatedSlotFuture.complete(logicalSlot);
+			return returnAllocatedSlotResponse;
+		}
+	}
+
+	private static final class DummySlotContext implements SlotContext {
+
+		private final AllocationID allocationId;
+
+		private final TaskManagerLocation taskManagerLocation;
+
+		private final TaskManagerGateway taskManagerGateway;
+
+		DummySlotContext() {
+			allocationId = new AllocationID();
+			taskManagerLocation = new LocalTaskManagerLocation();
+			taskManagerGateway = new SimpleAckingTaskManagerGateway();
+		}
+
+		@Override
+		public AllocationID getAllocationId() {
+			return allocationId;
+		}
+
+		@Override
+		public TaskManagerLocation getTaskManagerLocation() {
+			return taskManagerLocation;
+		}
+
+		@Override
+		public int getPhysicalSlotNumber() {
+			return 0;
+		}
+
+		@Override
+		public TaskManagerGateway getTaskManagerGateway() {
+			return taskManagerGateway;
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSharingManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSharingManagerTest.java
@@ -105,7 +105,7 @@ public class SlotSharingManagerTest extends TestLogger {
 
 		assertTrue(slotSharingManager.contains(slotRequestId));
 
-		assertTrue(rootSlot.release(new FlinkException("Test exception")));
+		rootSlot.release(new FlinkException("Test exception"));
 
 		// check that we return the allocated slot
 		assertEquals(allocatedSlotRequestId, slotReleasedFuture.get());
@@ -194,7 +194,7 @@ public class SlotSharingManagerTest extends TestLogger {
 		assertFalse(singleTaskSlotFuture.isDone());
 
 		FlinkException testException = new FlinkException("Test exception");
-		assertTrue(singleTaskSlot.release(testException));
+		singleTaskSlot.release(testException);
 
 		// check that we fail the single task slot future
 		assertTrue(singleTaskSlotFuture.isCompletedExceptionally());
@@ -203,7 +203,7 @@ public class SlotSharingManagerTest extends TestLogger {
 		// the root slot has still one child
 		assertTrue(slotSharingManager.contains(rootSlotRequestId));
 
-		assertTrue(multiTaskSlot.release(testException));
+		multiTaskSlot.release(testException);
 
 		assertEquals(allocatedSlotRequestId, releasedSlotFuture.get());
 		assertFalse(slotSharingManager.contains(rootSlotRequestId));

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
@@ -177,12 +177,8 @@ public class YARNSessionFIFOITCase extends YarnTestBase {
 		long startTime = System.nanoTime();
 		while (System.nanoTime() - startTime < TimeUnit.NANOSECONDS.convert(10, TimeUnit.SECONDS) &&
 			!(verifyStringsInNamedLogFiles(
-				new String[]{isNewMode ? "JobManager successfully registered at ResourceManager"
-					: "YARN Application Master started"}, "jobmanager.log") &&
-				verifyStringsInNamedLogFiles(
-					new String[]{isNewMode ? "Successful registration at job manager"
-						: "Starting TaskManager actor"}, "taskmanager.log"))) {
-			LOG.info("Still waiting for JM/TM to initialize...");
+				new String[]{"switched from state RUNNING to FINISHED"}, "jobmanager.log"))) {
+			LOG.info("Still waiting for cluster to finish job...");
 			sleep(500);
 		}
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
@@ -74,14 +74,14 @@ public class YarnResourceManager extends ResourceManager<YarnWorkerNode> impleme
 	private final Map<String, String> env;
 
 	/** YARN container map. Package private for unit test purposes. */
-	final ConcurrentMap<ResourceID, YarnWorkerNode> workerNodeMap;
+	private final ConcurrentMap<ResourceID, YarnWorkerNode> workerNodeMap;
 
 	/** The heartbeat interval while the resource master is waiting for containers. */
 	private static final int FAST_YARN_HEARTBEAT_INTERVAL_MS = 500;
 
 	/** Environment variable name of the final container id used by the YarnResourceManager.
 	 * Container ID generation may vary across Hadoop versions. */
-	static final String ENV_FLINK_CONTAINER_ID = "_FLINK_CONTAINER_ID";
+	private static final String ENV_FLINK_CONTAINER_ID = "_FLINK_CONTAINER_ID";
 
 	/** Environment variable name of the hostname given by the YARN.
 	 * In task executor we use the hostnames given by YARN consistently throughout akka */

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
@@ -295,21 +295,16 @@ public class YarnResourceManager extends ResourceManager<YarnWorkerNode> impleme
 	}
 
 	@Override
-	public boolean stopWorker(YarnWorkerNode workerNode) {
-		if (workerNode != null) {
-			Container container = workerNode.getContainer();
-			log.info("Stopping container {}.", container.getId());
-			// release the container on the node manager
-			try {
-				nodeManagerClient.stopContainer(container.getId(), container.getNodeId());
-			} catch (Throwable t) {
-				log.warn("Error while calling YARN Node Manager to stop container", t);
-			}
-			resourceManagerClient.releaseAssignedContainer(container.getId());
-			workerNodeMap.remove(workerNode.getResourceID());
-		} else {
-			log.error("Can not find container for null workerNode.");
+	public boolean stopWorker(final YarnWorkerNode workerNode) {
+		final Container container = workerNode.getContainer();
+		log.info("Stopping container {}.", container.getId());
+		try {
+			nodeManagerClient.stopContainer(container.getId(), container.getNodeId());
+		} catch (final Exception e) {
+			log.warn("Error while calling YARN Node Manager to stop container", e);
 		}
+		resourceManagerClient.releaseAssignedContainer(container.getId());
+		workerNodeMap.remove(workerNode.getResourceID());
 		return true;
 	}
 
@@ -329,14 +324,19 @@ public class YarnResourceManager extends ResourceManager<YarnWorkerNode> impleme
 	}
 
 	@Override
-	public void onContainersCompleted(List<ContainerStatus> list) {
+	public void onContainersCompleted(final List<ContainerStatus> list) {
 		runAsync(() -> {
-				for (ContainerStatus container : list) {
-					if (container.getExitStatus() < 0) {
-						closeTaskManagerConnection(new ResourceID(
-							container.getContainerId().toString()), new Exception(container.getDiagnostics()));
+				for (final ContainerStatus containerStatus : list) {
+
+					final ResourceID resourceId = new ResourceID(containerStatus.getContainerId().toString());
+					final YarnWorkerNode yarnWorkerNode = workerNodeMap.remove(resourceId);
+
+					if (yarnWorkerNode != null) {
+						// Container completed unexpectedly ~> start a new one
+						final Container container = yarnWorkerNode.getContainer();
+						requestYarnContainer(container.getResource(), yarnWorkerNode.getContainer().getPriority());
+						closeTaskManagerConnection(resourceId, new Exception(containerStatus.getDiagnostics()));
 					}
-					workerNodeMap.remove(new ResourceID(container.getContainerId().toString()));
 				}
 			}
 		);
@@ -355,8 +355,9 @@ public class YarnResourceManager extends ResourceManager<YarnWorkerNode> impleme
 					numPendingContainerRequests--;
 
 					final String containerIdStr = container.getId().toString();
+					final ResourceID resourceId = new ResourceID(containerIdStr);
 
-					workerNodeMap.put(new ResourceID(containerIdStr), new YarnWorkerNode(container));
+					workerNodeMap.put(resourceId, new YarnWorkerNode(container));
 
 					try {
 						// Context information used to start a TaskExecutor Java process
@@ -370,6 +371,7 @@ public class YarnResourceManager extends ResourceManager<YarnWorkerNode> impleme
 						log.error("Could not start TaskManager in container {}.", container.getId(), t);
 
 						// release the failed container
+						workerNodeMap.remove(resourceId);
 						resourceManagerClient.releaseAssignedContainer(container.getId());
 						// and ask for a new one
 						requestYarnContainer(container.getResource(), container.getPriority());


### PR DESCRIPTION
## What is the purpose of the change

In order to avoid the problem of not fulfilling allocation requests when a Mesos
tasks dies before it could register at the RM, this commit restarts all failed
Mesos tasks. The downside is that in some cases where the JM notices the failure
of a TM and would fail the job, we request tasks which are not directly needed.

## Brief change log

- Request a new Mesos task for all failed tasks

## Verifying this change

- Adapted `MesosResourceManagerTest#testWorkerFailed` to check for the new Mesos task request

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
