### PR TITLE
[FLINK-9043][CLI]Automatically search for the last successful checkpoint when recover the job from externalized checkpoint

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/AbstractCheckpointStateOutputStreamTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/AbstractCheckpointStateOutputStreamTestBase.java
@@ -147,10 +147,10 @@ public abstract class AbstractCheckpointStateOutputStreamTestBase extends TestLo
 			for (int i = 0; i < rnd.nextInt(1000); i++) {
 				stream.write(rnd.nextInt(100));
 			}
-			assertTrue(fs.exists(path));
+			assertTrue(fs.exists(getFlyingPath(path)));
 		}
 
-		assertFalse(fs.exists(path));
+		assertFalse(fs.exists(getTargetPath(path)));
 	}
 
 	/**
@@ -175,7 +175,7 @@ public abstract class AbstractCheckpointStateOutputStreamTestBase extends TestLo
 			// expected exception
 		}
 
-		verify(fs).delete(filePath, false);
+		verify(fs).delete(getFlyingPath(filePath), false);
 	}
 
 	/**
@@ -229,6 +229,16 @@ public abstract class AbstractCheckpointStateOutputStreamTestBase extends TestLo
 	 * Closes the stream successfully and returns a FileStateHandle to the result.
 	 */
 	protected abstract FileStateHandle closeAndGetResult(FSDataOutputStream stream) throws IOException;
+
+	/**
+	 * Return the temporary path of the FSDataOutputStream that is used for writing data.
+	 */
+	abstract Path getFlyingPath(Path path);
+
+	/**
+	 * Return the final target path of FSDataOutputStream.
+	 */
+	abstract Path getTargetPath(Path path);
 
 	// ------------------------------------------------------------------------
 	//  utilities

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/AbstractFileCheckpointStorageTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/AbstractFileCheckpointStorageTestBase.java
@@ -223,7 +223,7 @@ public abstract class AbstractFileCheckpointStorageTestBase {
 			loc.createMetadataOutputStream();
 			fail("this should fail with an exception");
 		}
-		catch (IOException ignored) {}
+		catch (Exception ignored) {}
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FileBasedStateOutputStreamTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FileBasedStateOutputStreamTest.java
@@ -38,4 +38,14 @@ public class FileBasedStateOutputStreamTest extends AbstractCheckpointStateOutpu
 	protected FileStateHandle closeAndGetResult(FSDataOutputStream stream) throws IOException {
 		return ((FileBasedStateOutputStream) stream).closeAndGetHandle();
 	}
+
+	@Override
+	Path getFlyingPath(Path path) {
+		return path;
+	}
+
+	@Override
+	Path getTargetPath(Path path) {
+		return path;
+	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsCheckpointMetadataOutputStreamTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsCheckpointMetadataOutputStreamTest.java
@@ -39,4 +39,14 @@ public class FsCheckpointMetadataOutputStreamTest extends AbstractCheckpointStat
 	protected FileStateHandle closeAndGetResult(FSDataOutputStream stream) throws IOException {
 		return ((FsCheckpointMetadataOutputStream) stream).closeAndFinalizeCheckpoint().getMetadataHandle();
 	}
+
+	@Override
+	Path getFlyingPath(Path path) {
+		return FsCheckpointMetadataOutputStream.getTempPath(path);
+	}
+
+	@Override
+	Path getTargetPath(Path path) {
+		return path;
+	}
 }


### PR DESCRIPTION
## What is the purpose of the change
*This PR base on [5982](https://github.com/apache/flink/pull/5982).*
*Automatically search for the last successful checkpoint from the given checkpoint pointer, this would be more friendly when user try to recover job from the externalized checkpoint.* 

## Brief change log

  - *Automatically search for the last successful checkpoint when recover the job from externalized checkpoint*

## Verifying this change

This change extended the `AbstractFileCheckpointStorageTestBase#testPointerPathResolution()`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - I will add the doc, once the reviews is almost complete.
