### PR TITLE
[FLINK-9332][TableAPI & SQL] Fix Codegen error of CallGenerator

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/CallGenerator.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/CallGenerator.scala
@@ -21,6 +21,7 @@ package org.apache.flink.table.codegen.calls
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.table.codegen.CodeGenUtils._
 import org.apache.flink.table.codegen.{CodeGenerator, GeneratedExpression}
+import org.apache.flink.table.typeutils.TypeCheckUtils
 
 trait CallGenerator {
 
@@ -64,17 +65,28 @@ object CallGenerator {
 
     val (auxiliaryStmt, result) = call(operands.map(_.resultTerm))
 
+    val nullTermCode = if (
+      nullCheck &&
+      isReference(returnType) &&
+      !TypeCheckUtils.isTemporal(returnType)) {
+      s"""
+         |if ($resultTerm == null) {
+         |  $nullTerm = true;
+         |}
+       """.stripMargin
+    } else {
+      ""
+    }
+
     val resultCode = if (nullCheck && operands.nonEmpty) {
       s"""
         |${operands.map(_.code).mkString("\n")}
         |boolean $nullTerm = ${operands.map(_.nullTerm).mkString(" || ")};
-        |$resultTypeTerm $resultTerm;
-        |if ($nullTerm) {
-        |  $resultTerm = $defaultValue;
-        |}
-        |else {
+        |$resultTypeTerm $resultTerm = $defaultValue;
+        |if (!$nullTerm) {
         |  ${auxiliaryStmt.getOrElse("")}
         |  $resultTerm = $result;
+        |  $nullTermCode
         |}
         |""".stripMargin
     } else if (nullCheck && operands.isEmpty) {
@@ -83,6 +95,7 @@ object CallGenerator {
         |boolean $nullTerm = false;
         |${auxiliaryStmt.getOrElse("")}
         |$resultTypeTerm $resultTerm = $result;
+        |$nullTermCode
         |""".stripMargin
     } else{
       s"""

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarFunctionsTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarFunctionsTest.scala
@@ -364,6 +364,8 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
     testSqlApi("LPAD('⎨⎨',1,'??')", "⎨")
     testSqlApi("LPAD('äääääääää',2,'??')", "ää")
     testSqlApi("LPAD('äääääääää',10,'??')", "?äääääääää")
+    testSqlApi("LPAD('Hello', -1, 'x') IS NULL", "true")
+    testSqlApi("LPAD('Hello', -1, 'x') IS NOT NULL", "false")
 
     testAllApis(
       "äää".lpad(13, "12345"),


### PR DESCRIPTION


## What is the purpose of the change

Fix bugs that nullTerm do not handle function call return value correctly.


## Brief change log
- check function call return value and reset nullTerm if necessary.


## Verifying this change

This change added tests and can be verified as follows:
org.apache.flink.table.runtime.stream.sql.SqlITCase#testNullableFunctionCall

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers:  no
  - The runtime per-record code paths (performance sensitive):  no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector:  no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no