### PR TITLE
[FLINK-9303] [kafka] Adding support for unassign dynamically partitions from kafka consumer when they become unavailable

### DIFF
--- a/flink-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumer08.java
+++ b/flink-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumer08.java
@@ -221,7 +221,8 @@ public class FlinkKafkaConsumer08<T> extends FlinkKafkaConsumerBase<T> {
 				getLong(
 					checkNotNull(props, "props"),
 					KEY_PARTITION_DISCOVERY_INTERVAL_MILLIS, PARTITION_DISCOVERY_DISABLED),
-				!getBoolean(props, KEY_DISABLE_METRICS, false));
+				!getBoolean(props, KEY_DISABLE_METRICS, false),
+				getBoolean(props, FLINK_CHECK_UNAVAILABLE_PARTITIONS, false));
 
 		this.kafkaProperties = props;
 

--- a/flink-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/Kafka08Fetcher.java
+++ b/flink-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/Kafka08Fetcher.java
@@ -47,6 +47,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -340,6 +341,11 @@ public class Kafka08Fetcher<T> extends AbstractFetcher<T, TopicAndPartition> {
 	@Override
 	protected TopicAndPartition createKafkaPartitionHandle(KafkaTopicPartition partition) {
 		return new TopicAndPartition(partition.getTopic(), partition.getPartition());
+	}
+
+	@Override
+	protected void addPartitionsToBeRemoved(Set<KafkaTopicPartition> partitionsToRemove) {
+		throw new UnsupportedOperationException();
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-connectors/flink-connector-kafka-0.9/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumer09.java
+++ b/flink-connectors/flink-connector-kafka-0.9/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumer09.java
@@ -212,7 +212,8 @@ public class FlinkKafkaConsumer09<T> extends FlinkKafkaConsumerBase<T> {
 				getLong(
 					checkNotNull(props, "props"),
 					KEY_PARTITION_DISCOVERY_INTERVAL_MILLIS, PARTITION_DISCOVERY_DISABLED),
-				!getBoolean(props, KEY_DISABLE_METRICS, false));
+				!getBoolean(props, KEY_DISABLE_METRICS, false),
+				getBoolean(props, FLINK_CHECK_UNAVAILABLE_PARTITIONS, false));
 
 		this.properties = props;
 		setDeserializer(this.properties);

--- a/flink-connectors/flink-connector-kafka-0.9/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/Kafka09Fetcher.java
+++ b/flink-connectors/flink-connector-kafka-0.9/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/Kafka09Fetcher.java
@@ -44,6 +44,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 
 import static org.apache.flink.util.Preconditions.checkState;
 
@@ -112,7 +113,8 @@ public class Kafka09Fetcher<T> extends AbstractFetcher<T, TopicPartition> {
 				pollTimeout,
 				useMetrics,
 				consumerMetricGroup,
-				subtaskMetricGroup);
+				subtaskMetricGroup,
+				partitionsToBeRemoved);
 	}
 
 	// ------------------------------------------------------------------------
@@ -213,6 +215,16 @@ public class Kafka09Fetcher<T> extends AbstractFetcher<T, TopicPartition> {
 	@Override
 	public TopicPartition createKafkaPartitionHandle(KafkaTopicPartition partition) {
 		return new TopicPartition(partition.getTopic(), partition.getPartition());
+	}
+
+	@Override
+	protected void addPartitionsToBeRemoved(Set<KafkaTopicPartition> partitionsToRemove) {
+		for (KafkaTopicPartition ptr : partitionsToRemove) {
+			TopicPartition partition = new TopicPartition(ptr.getTopic(), ptr.getPartition());
+			if (!partitionsToBeRemoved.contains(partition)) {
+				partitionsToBeRemoved.add(partition);
+			}
+		}
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/internal/KafkaConsumerThreadTest.java
+++ b/flink-connectors/flink-connector-kafka-0.9/src/test/java/org/apache/flink/streaming/connectors/kafka/internal/KafkaConsumerThreadTest.java
@@ -40,10 +40,12 @@ import org.slf4j.Logger;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -721,7 +723,8 @@ public class KafkaConsumerThreadTest {
 					0,
 					false,
 					new UnregisteredMetricsGroup(),
-					new UnregisteredMetricsGroup());
+					new UnregisteredMetricsGroup(),
+					new HashSet<>());
 
 			this.mockConsumer = mockConsumer;
 		}
@@ -748,7 +751,7 @@ public class KafkaConsumerThreadTest {
 		}
 
 		@Override
-		void reassignPartitions(List<KafkaTopicPartitionState<TopicPartition>> newPartitions) throws Exception {
+		void reassignPartitions(List<KafkaTopicPartitionState<TopicPartition>> newPartitions, Set<TopicPartition> partitionsToBeRemoved) throws Exception {
 			// triggers blocking calls on waitPartitionReassignmentInvoked()
 			preReassignmentLatch.trigger();
 
@@ -756,7 +759,7 @@ public class KafkaConsumerThreadTest {
 			startReassignmentLatch.await();
 
 			try {
-				super.reassignPartitions(newPartitions);
+				super.reassignPartitions(newPartitions, partitionsToBeRemoved);
 			} finally {
 				// triggers blocking calls on waitPartitionReassignmentComplete()
 				reassignmentCompleteLatch.trigger();

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBaseMigrationTest.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBaseMigrationTest.java
@@ -374,6 +374,7 @@ public class FlinkKafkaConsumerBaseMigrationTest {
 				null,
 				(KeyedDeserializationSchema< T >) mock(KeyedDeserializationSchema.class),
 				discoveryInterval,
+				false,
 				false);
 
 			this.fetcher = fetcher;

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBaseTest.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBaseTest.java
@@ -644,6 +644,7 @@ public class FlinkKafkaConsumerBaseTest {
 					null,
 					(KeyedDeserializationSchema < T >) mock(KeyedDeserializationSchema.class),
 					PARTITION_DISCOVERY_DISABLED,
+					false,
 					false);
 
 			this.testFetcher = testFetcher;
@@ -781,6 +782,10 @@ public class FlinkKafkaConsumerBaseTest {
 			this.lastCommittedOffsets = offsets;
 			this.commitCount++;
 			commitCallback.onSuccess();
+		}
+
+		@Override
+		protected void addPartitionsToBeRemoved(Set<KafkaTopicPartition> partitionsToRemove) {
 		}
 
 		@Override

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractFetcherTest.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractFetcherTest.java
@@ -37,6 +37,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -414,6 +415,10 @@ public class AbstractFetcherTest {
 				TestFetcher.class.getClassLoader(),
 				new UnregisteredMetricsGroup(),
 				false);
+		}
+
+		@Override
+		protected void addPartitionsToBeRemoved(Set<KafkaTopicPartition> partitionsToRemove) {
 		}
 
 		@Override


### PR DESCRIPTION
## What is the purpose of the change

This pull request add an option on the kafka consumer to check for unavailable partitions and unassign them from the consumer. That way the consumer does not request for records on invalid partitions and prevent Logs noises.

## Brief change log

- Modify the partition discovery system to check not only new partitions, but also check partitions that are no longer available.
- Check for partitions no longer available recovered from state.
- Add option on kafka consumer to activate this checks

## Verifying this change

This change added tests and can be verified as follows:
*Manually verified as follows:*
- Create a job with a kafka consumer listening to a topic pattern and having partition discovery activated and the property introduced in this PR set to true.
- Configure Kafka to have set the following properties: 
   delete.topic.enable=true
   auto.create.topics.enable=false
- Create some topics matching the pattern.
- Run the job.
-  While running, remove some of the topics. 
- Verify the partitions are unassigned and the job continue running without Log noises.

*I guess this can be tested with e2e tests, but I'm not familiarised with the system in place* 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
