### PR TITLE
[FLINK-8944] [Kinesis Connector] Use listShards instead of DescribeSt…

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/ConsumerConfigConstants.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/ConsumerConfigConstants.java
@@ -65,14 +65,14 @@ public class ConsumerConfigConstants extends AWSConfigConstants {
 	/** The date format of initial timestamp to start reading Kinesis stream from (when AT_TIMESTAMP is set for STREAM_INITIAL_POSITION). */
 	public static final String STREAM_TIMESTAMP_DATE_FORMAT = "flink.stream.initpos.timestamp.format";
 
-	/** The base backoff time between each describeStream attempt. */
-	public static final String SHARDS_LIST_BACKOFF_BASE = "flink.shards.list.backoff.base";
+	/** The base backoff time between each listShards attempt. */
+	public static final String SHARDS_LIST_BACKOFF_BASE = "flink.stream.describe.backoff.base";
 
-	/** The maximum backoff time between each describeStream attempt. */
-	public static final String SHARDS_LIST_BACKOFF_MAX = "flink.shards.list.backoff.max";
+	/** The maximum backoff time between each listShards attempt. */
+	public static final String SHARDS_LIST_BACKOFF_MAX = "flink.stream.describe.backoff.max";
 
-	/** The power constant for exponential backoff between each describeStream attempt. */
-	public static final String SHARDS_LIST_BACKOFF_EXPONENTIAL_CONSTANT = "flink.shards.list.backoff.expconst";
+	/** The power constant for exponential backoff between each listShards attempt. */
+	public static final String SHARDS_LIST_BACKOFF_EXPONENTIAL_CONSTANT = "flink.stream.describe.backoff.expconst";
 
 	/** The maximum number of records to try to get each time we fetch records from a AWS Kinesis shard. */
 	public static final String SHARD_GETRECORDS_MAX = "flink.shard.getrecords.maxrecordcount";

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/ConsumerConfigConstants.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/ConsumerConfigConstants.java
@@ -66,13 +66,13 @@ public class ConsumerConfigConstants extends AWSConfigConstants {
 	public static final String STREAM_TIMESTAMP_DATE_FORMAT = "flink.stream.initpos.timestamp.format";
 
 	/** The base backoff time between each describeStream attempt. */
-	public static final String STREAM_DESCRIBE_BACKOFF_BASE = "flink.stream.describe.backoff.base";
+	public static final String SHARDS_LIST_BACKOFF_BASE = "flink.shards.list.backoff.base";
 
 	/** The maximum backoff time between each describeStream attempt. */
-	public static final String STREAM_DESCRIBE_BACKOFF_MAX = "flink.stream.describe.backoff.max";
+	public static final String SHARDS_LIST_BACKOFF_MAX = "flink.shards.list.backoff.max";
 
 	/** The power constant for exponential backoff between each describeStream attempt. */
-	public static final String STREAM_DESCRIBE_BACKOFF_EXPONENTIAL_CONSTANT = "flink.stream.describe.backoff.expconst";
+	public static final String SHARDS_LIST_BACKOFF_EXPONENTIAL_CONSTANT = "flink.shards.list.backoff.expconst";
 
 	/** The maximum number of records to try to get each time we fetch records from a AWS Kinesis shard. */
 	public static final String SHARD_GETRECORDS_MAX = "flink.shard.getrecords.maxrecordcount";
@@ -115,11 +115,11 @@ public class ConsumerConfigConstants extends AWSConfigConstants {
 
 	public static final String DEFAULT_STREAM_TIMESTAMP_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
 
-	public static final long DEFAULT_STREAM_DESCRIBE_BACKOFF_BASE = 1000L;
+	public static final long DEFAULT_SHARDS_LIST_BACKOFF_BASE = 1000L;
 
-	public static final long DEFAULT_STREAM_DESCRIBE_BACKOFF_MAX = 5000L;
+	public static final long DEFAULT_SHARDS_LIST_BACKOFF_MAX = 5000L;
 
-	public static final double DEFAULT_STREAM_DESCRIBE_BACKOFF_EXPONENTIAL_CONSTANT = 1.5;
+	public static final double DEFAULT_SHARDS_LIST_BACKOFF_EXPONENTIAL_CONSTANT = 1.5;
 
 	public static final int DEFAULT_SHARD_GETRECORDS_MAX = 10000;
 

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/ConsumerConfigConstants.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/ConsumerConfigConstants.java
@@ -65,14 +65,41 @@ public class ConsumerConfigConstants extends AWSConfigConstants {
 	/** The date format of initial timestamp to start reading Kinesis stream from (when AT_TIMESTAMP is set for STREAM_INITIAL_POSITION). */
 	public static final String STREAM_TIMESTAMP_DATE_FORMAT = "flink.stream.initpos.timestamp.format";
 
+	/**
+	 * Deprecated key.
+	 *
+	 * @deprecated Use {@link ConsumerConfigConstants#LIST_SHARDS_BACKOFF_BASE} instead
+	 **/
+	@Deprecated
+	/** The base backoff time between each describeStream attempt. */
+	public static final String STREAM_DESCRIBE_BACKOFF_BASE = "flink.stream.describe.backoff.base";
+
+	/**
+	 * Deprecated key.
+	 *
+	 * @deprecated Use {@link ConsumerConfigConstants#LIST_SHARDS_BACKOFF_MAX} instead
+	 **/
+	@Deprecated
+	/** The maximum backoff time between each describeStream attempt. */
+	public static final String STREAM_DESCRIBE_BACKOFF_MAX = "flink.stream.describe.backoff.max";
+
+	/**
+	 * Deprecated key.
+	 *
+	 * @deprecated Use {@link ConsumerConfigConstants#LIST_SHARDS_BACKOFF_EXPONENTIAL_CONSTANT} instead
+	 **/
+	@Deprecated
+	/** The power constant for exponential backoff between each describeStream attempt. */
+	public static final String STREAM_DESCRIBE_BACKOFF_EXPONENTIAL_CONSTANT = "flink.stream.describe.backoff.expconst";
+
 	/** The base backoff time between each listShards attempt. */
-	public static final String DESCRIBE_STREAM_BACKOFF_BASE = "flink.stream.describe.backoff.base";
+	public static final String LIST_SHARDS_BACKOFF_BASE = "flink.list.shards.backoff.base";
 
 	/** The maximum backoff time between each listShards attempt. */
-	public static final String DESCRIBE_STREAM_BACKOFF_MAX = "flink.stream.describe.backoff.max";
+	public static final String LIST_SHARDS_BACKOFF_MAX = "flink.list.shards.backoff.max";
 
 	/** The power constant for exponential backoff between each listShards attempt. */
-	public static final String DESCRIBE_STREAM_BACKOFF_EXPONENTIAL_CONSTANT = "flink.stream.describe.backoff.expconst";
+	public static final String LIST_SHARDS_BACKOFF_EXPONENTIAL_CONSTANT = "flink.list.shards.backoff.expconst";
 
 	/** The maximum number of records to try to get each time we fetch records from a AWS Kinesis shard. */
 	public static final String SHARD_GETRECORDS_MAX = "flink.shard.getrecords.maxrecordcount";
@@ -115,11 +142,20 @@ public class ConsumerConfigConstants extends AWSConfigConstants {
 
 	public static final String DEFAULT_STREAM_TIMESTAMP_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
 
-	public static final long STREAM_DESCRIBE_BACKOFF_BASE = 1000L;
+	@Deprecated
+	public static final long DEFAULT_STREAM_DESCRIBE_BACKOFF_BASE = 1000L;
 
-	public static final long STREAM_DESCRIBE_BACKOFF_MAX = 5000L;
+	@Deprecated
+	public static final long DEFAULT_STREAM_DESCRIBE_BACKOFF_MAX = 5000L;
 
-	public static final double STREAM_DESCRIBE_BACKOFF_EXPONENTIAL_CONSTANT = 1.5;
+	@Deprecated
+	public static final double DEFAULT_STREAM_DESCRIBE_BACKOFF_EXPONENTIAL_CONSTANT = 1.5;
+
+	public static final long DEFAULT_LIST_SHARDS_BACKOFF_BASE = 1000L;
+
+	public static final long DEFAULT_LIST_SHARDS_BACKOFF_MAX = 5000L;
+
+	public static final double DEFAULT_LIST_SHARDS_BACKOFF_EXPONENTIAL_CONSTANT = 1.5;
 
 	public static final int DEFAULT_SHARD_GETRECORDS_MAX = 10000;
 

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/ConsumerConfigConstants.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/ConsumerConfigConstants.java
@@ -66,13 +66,13 @@ public class ConsumerConfigConstants extends AWSConfigConstants {
 	public static final String STREAM_TIMESTAMP_DATE_FORMAT = "flink.stream.initpos.timestamp.format";
 
 	/** The base backoff time between each listShards attempt. */
-	public static final String SHARDS_LIST_BACKOFF_BASE = "flink.stream.describe.backoff.base";
+	public static final String DESCRIBE_STREAM_BACKOFF_BASE = "flink.stream.describe.backoff.base";
 
 	/** The maximum backoff time between each listShards attempt. */
-	public static final String SHARDS_LIST_BACKOFF_MAX = "flink.stream.describe.backoff.max";
+	public static final String DESCRIBE_STREAM_BACKOFF_MAX = "flink.stream.describe.backoff.max";
 
 	/** The power constant for exponential backoff between each listShards attempt. */
-	public static final String SHARDS_LIST_BACKOFF_EXPONENTIAL_CONSTANT = "flink.stream.describe.backoff.expconst";
+	public static final String DESCRIBE_STREAM_BACKOFF_EXPONENTIAL_CONSTANT = "flink.stream.describe.backoff.expconst";
 
 	/** The maximum number of records to try to get each time we fetch records from a AWS Kinesis shard. */
 	public static final String SHARD_GETRECORDS_MAX = "flink.shard.getrecords.maxrecordcount";
@@ -115,11 +115,11 @@ public class ConsumerConfigConstants extends AWSConfigConstants {
 
 	public static final String DEFAULT_STREAM_TIMESTAMP_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
 
-	public static final long DEFAULT_SHARDS_LIST_BACKOFF_BASE = 1000L;
+	public static final long STREAM_DESCRIBE_BACKOFF_BASE = 1000L;
 
-	public static final long DEFAULT_SHARDS_LIST_BACKOFF_MAX = 5000L;
+	public static final long STREAM_DESCRIBE_BACKOFF_MAX = 5000L;
 
-	public static final double DEFAULT_SHARDS_LIST_BACKOFF_EXPONENTIAL_CONSTANT = 1.5;
+	public static final double STREAM_DESCRIBE_BACKOFF_EXPONENTIAL_CONSTANT = 1.5;
 
 	public static final int DEFAULT_SHARD_GETRECORDS_MAX = 10000;
 

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxy.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxy.java
@@ -27,18 +27,20 @@ import com.amazonaws.ClientConfiguration;
 import com.amazonaws.ClientConfigurationFactory;
 import com.amazonaws.SdkClientException;
 import com.amazonaws.services.kinesis.AmazonKinesis;
-import com.amazonaws.services.kinesis.model.DescribeStreamRequest;
-import com.amazonaws.services.kinesis.model.DescribeStreamResult;
+import com.amazonaws.services.kinesis.model.ExpiredNextTokenException;
 import com.amazonaws.services.kinesis.model.GetRecordsRequest;
 import com.amazonaws.services.kinesis.model.GetRecordsResult;
 import com.amazonaws.services.kinesis.model.GetShardIteratorRequest;
 import com.amazonaws.services.kinesis.model.GetShardIteratorResult;
+import com.amazonaws.services.kinesis.model.InvalidArgumentException;
 import com.amazonaws.services.kinesis.model.LimitExceededException;
+import com.amazonaws.services.kinesis.model.ListShardsRequest;
+import com.amazonaws.services.kinesis.model.ListShardsResult;
 import com.amazonaws.services.kinesis.model.ProvisionedThroughputExceededException;
+import com.amazonaws.services.kinesis.model.ResourceInUseException;
 import com.amazonaws.services.kinesis.model.ResourceNotFoundException;
 import com.amazonaws.services.kinesis.model.Shard;
 import com.amazonaws.services.kinesis.model.ShardIteratorType;
-import com.amazonaws.services.kinesis.model.StreamStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -80,13 +82,13 @@ public class KinesisProxy implements KinesisProxyInterface {
 	// ------------------------------------------------------------------------
 
 	/** Base backoff millis for the describe stream operation. */
-	private final long describeStreamBaseBackoffMillis;
+	private final long listShardsBaseBackoffMillis;
 
 	/** Maximum backoff millis for the describe stream operation. */
-	private final long describeStreamMaxBackoffMillis;
+	private final long listShardsMaxBackoffMillis;
 
 	/** Exponential backoff power constant for the describe stream operation. */
-	private final double describeStreamExpConstant;
+	private final double listShardsExpConstant;
 
 	// ------------------------------------------------------------------------
 	//  getRecords() related performance settings
@@ -130,18 +132,18 @@ public class KinesisProxy implements KinesisProxyInterface {
 
 		this.kinesisClient = createKinesisClient(configProps);
 
-		this.describeStreamBaseBackoffMillis = Long.valueOf(
+		this.listShardsBaseBackoffMillis = Long.valueOf(
 			configProps.getProperty(
-				ConsumerConfigConstants.STREAM_DESCRIBE_BACKOFF_BASE,
-				Long.toString(ConsumerConfigConstants.DEFAULT_STREAM_DESCRIBE_BACKOFF_BASE)));
-		this.describeStreamMaxBackoffMillis = Long.valueOf(
+				ConsumerConfigConstants.SHARDS_LIST_BACKOFF_BASE,
+				Long.toString(ConsumerConfigConstants.DEFAULT_SHARDS_LIST_BACKOFF_BASE)));
+		this.listShardsMaxBackoffMillis = Long.valueOf(
 			configProps.getProperty(
-				ConsumerConfigConstants.STREAM_DESCRIBE_BACKOFF_MAX,
-				Long.toString(ConsumerConfigConstants.DEFAULT_STREAM_DESCRIBE_BACKOFF_MAX)));
-		this.describeStreamExpConstant = Double.valueOf(
+				ConsumerConfigConstants.SHARDS_LIST_BACKOFF_MAX,
+				Long.toString(ConsumerConfigConstants.DEFAULT_SHARDS_LIST_BACKOFF_MAX)));
+		this.listShardsExpConstant = Double.valueOf(
 			configProps.getProperty(
-				ConsumerConfigConstants.STREAM_DESCRIBE_BACKOFF_EXPONENTIAL_CONSTANT,
-				Double.toString(ConsumerConfigConstants.DEFAULT_STREAM_DESCRIBE_BACKOFF_EXPONENTIAL_CONSTANT)));
+				ConsumerConfigConstants.SHARDS_LIST_BACKOFF_EXPONENTIAL_CONSTANT,
+				Double.toString(ConsumerConfigConstants.DEFAULT_SHARDS_LIST_BACKOFF_EXPONENTIAL_CONSTANT)));
 
 		this.getRecordsBaseBackoffMillis = Long.valueOf(
 			configProps.getProperty(
@@ -353,19 +355,21 @@ public class KinesisProxy implements KinesisProxyInterface {
 	private List<StreamShardHandle> getShardsOfStream(String streamName, @Nullable String lastSeenShardId) throws InterruptedException {
 		List<StreamShardHandle> shardsOfStream = new ArrayList<>();
 
-		DescribeStreamResult describeStreamResult;
+		// List Shards returns just the first 1000 shard entries. In order to read the entire stream,
+		// we need to use the returned nextToken to get additional shards.
+		ListShardsResult listShardsResult;
+		String startShardToken = null;
 		do {
-			describeStreamResult = describeStream(streamName, lastSeenShardId);
-
-			List<Shard> shards = describeStreamResult.getStreamDescription().getShards();
+			listShardsResult = listShards(streamName, lastSeenShardId, startShardToken);
+			if (listShardsResult == null) {
+				return shardsOfStream;
+			}
+			List<Shard> shards = listShardsResult.getShards();
 			for (Shard shard : shards) {
 				shardsOfStream.add(new StreamShardHandle(streamName, shard));
 			}
-
-			if (shards.size() != 0) {
-				lastSeenShardId = shards.get(shards.size() - 1).getShardId();
-			}
-		} while (describeStreamResult.getStreamDescription().isHasMoreShards());
+			startShardToken = listShardsResult.getNextToken();
+		} while (startShardToken != null);
 
 		return shardsOfStream;
 	}
@@ -382,50 +386,62 @@ public class KinesisProxy implements KinesisProxyInterface {
 	 * @param startShardId which shard to start with for this describe operation (earlier shard's infos will not appear in result)
 	 * @return the result of the describe stream operation
 	 */
-	private DescribeStreamResult describeStream(String streamName, @Nullable String startShardId) throws InterruptedException {
-		final DescribeStreamRequest describeStreamRequest = new DescribeStreamRequest();
-		describeStreamRequest.setStreamName(streamName);
-		describeStreamRequest.setExclusiveStartShardId(startShardId);
+	private ListShardsResult listShards(String streamName, @Nullable String startShardId,
+																			@Nullable String startNextToken)
+			throws InterruptedException {
+		final ListShardsRequest listShardsRequest = new ListShardsRequest();
+		if (startNextToken == null) {
+			listShardsRequest.setExclusiveStartShardId(startShardId);
+			listShardsRequest.setStreamName(streamName);
+		} else {
+			// Note the nextToken returned by AWS expires within 300 sec.
+			listShardsRequest.setNextToken(startNextToken);
+		}
 
-		DescribeStreamResult describeStreamResult = null;
+		ListShardsResult listShardsResults = null;
 
-		// Call DescribeStream, with full-jitter backoff (if we get LimitExceededException).
+		// Call ListShards, with full-jitter backoff (if we get LimitExceededException).
 		int attemptCount = 0;
-		while (describeStreamResult == null) { // retry until we get a result
+		// List Shards returns just the first 1000 shard entries. Make sure that all entries
+		// are taken up.
+		while (listShardsResults == null) { // retry until we get a result
 			try {
-				describeStreamResult = kinesisClient.describeStream(describeStreamRequest);
+				listShardsResults = kinesisClient.listShards(listShardsRequest);
 			} catch (LimitExceededException le) {
 				long backoffMillis = fullJitterBackoff(
-					describeStreamBaseBackoffMillis, describeStreamMaxBackoffMillis, describeStreamExpConstant, attemptCount++);
-				LOG.warn("Got LimitExceededException when describing stream " + streamName + ". Backing off for "
-					+ backoffMillis + " millis.");
+						listShardsBaseBackoffMillis, listShardsMaxBackoffMillis, listShardsExpConstant, attemptCount++);
+					LOG.warn("Got LimitExceededException when listing shards from stream " + streamName
+									+ ". Backing off for " + backoffMillis + " millis.");
 				Thread.sleep(backoffMillis);
-			} catch (ResourceNotFoundException re) {
-				throw new RuntimeException("Error while getting stream details", re);
+			} catch (ResourceInUseException reInUse) {
+				if (LOG.isWarnEnabled()) {
+					// List Shards will throw an exception if stream in not in active state. Will return
+					LOG.warn("The stream is currently not in active state. Reusing the older state "
+							+ "for the time being");
+					break;
+				}
+			} catch (ResourceNotFoundException reNotFound) {
+				throw new RuntimeException("Stream not found. Error while getting shard list.", reNotFound);
+			} catch (InvalidArgumentException inArg) {
+				throw new RuntimeException("Invalid Arguments to listShards.", inArg);
+			} catch (ExpiredNextTokenException expiredToken) {
+				LOG.warn("List Shards has an expired token. Reusing the previous state.");
+				break;
 			}
 		}
-
-		String streamStatus = describeStreamResult.getStreamDescription().getStreamStatus();
-		if (!(streamStatus.equals(StreamStatus.ACTIVE.toString()) || streamStatus.equals(StreamStatus.UPDATING.toString()))) {
-			if (LOG.isWarnEnabled()) {
-				LOG.warn("The status of stream " + streamName + " is " + streamStatus + "; result of the current " +
-					"describeStream operation will not contain any shard information.");
-			}
-		}
-
-		// Kinesalite (mock implementation of Kinesis) does not correctly exclude shards before the exclusive
-		// start shard id in the returned shards list; check if we need to remove these erroneously returned shards
-		if (startShardId != null) {
-			List<Shard> shards = describeStreamResult.getStreamDescription().getShards();
+    // Kinesalite (mock implementation of Kinesis) does not correctly exclude shards before
+		// the exclusive start shard id in the returned shards list; check if we need to remove
+		// these erroneously returned shards.
+		if (startShardId != null && listShardsResults != null) {
+			List<Shard> shards = listShardsResults.getShards();
 			Iterator<Shard> shardItr = shards.iterator();
-			while (shardItr.hasNext()) {
+			while (shardItr.hasNext()){
 				if (StreamShardHandle.compareShardIds(shardItr.next().getShardId(), startShardId) <= 0) {
 					shardItr.remove();
 				}
 			}
 		}
-
-		return describeStreamResult;
+		return listShardsResults;
 	}
 
 	protected static long fullJitterBackoff(long base, long max, double power, int attempt) {

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtil.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtil.java
@@ -142,13 +142,13 @@ public class KinesisConfigUtil {
 		validateOptionalPositiveLongProperty(config, ConsumerConfigConstants.SHARD_DISCOVERY_INTERVAL_MILLIS,
 			"Invalid value given for shard discovery sleep interval in milliseconds. Must be a valid non-negative long value.");
 
-		validateOptionalPositiveLongProperty(config, ConsumerConfigConstants.SHARDS_LIST_BACKOFF_BASE,
+		validateOptionalPositiveLongProperty(config, ConsumerConfigConstants.DESCRIBE_STREAM_BACKOFF_BASE,
 			"Invalid value given for list shards operation base backoff milliseconds. Must be a valid non-negative long value.");
 
-		validateOptionalPositiveLongProperty(config, ConsumerConfigConstants.SHARDS_LIST_BACKOFF_MAX,
+		validateOptionalPositiveLongProperty(config, ConsumerConfigConstants.DESCRIBE_STREAM_BACKOFF_MAX,
 			"Invalid value given for list shards operation max backoff milliseconds. Must be a valid non-negative long value.");
 
-		validateOptionalPositiveDoubleProperty(config, ConsumerConfigConstants.SHARDS_LIST_BACKOFF_EXPONENTIAL_CONSTANT,
+		validateOptionalPositiveDoubleProperty(config, ConsumerConfigConstants.DESCRIBE_STREAM_BACKOFF_EXPONENTIAL_CONSTANT,
 			"Invalid value given for list shards operation backoff exponential constant. Must be a valid non-negative double value.");
 
 		if (config.containsKey(ConsumerConfigConstants.SHARD_GETRECORDS_INTERVAL_MILLIS)) {

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtil.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtil.java
@@ -142,13 +142,13 @@ public class KinesisConfigUtil {
 		validateOptionalPositiveLongProperty(config, ConsumerConfigConstants.SHARD_DISCOVERY_INTERVAL_MILLIS,
 			"Invalid value given for shard discovery sleep interval in milliseconds. Must be a valid non-negative long value.");
 
-		validateOptionalPositiveLongProperty(config, ConsumerConfigConstants.DESCRIBE_STREAM_BACKOFF_BASE,
+		validateOptionalPositiveLongProperty(config, ConsumerConfigConstants.LIST_SHARDS_BACKOFF_BASE,
 			"Invalid value given for list shards operation base backoff milliseconds. Must be a valid non-negative long value.");
 
-		validateOptionalPositiveLongProperty(config, ConsumerConfigConstants.DESCRIBE_STREAM_BACKOFF_MAX,
+		validateOptionalPositiveLongProperty(config, ConsumerConfigConstants.LIST_SHARDS_BACKOFF_MAX,
 			"Invalid value given for list shards operation max backoff milliseconds. Must be a valid non-negative long value.");
 
-		validateOptionalPositiveDoubleProperty(config, ConsumerConfigConstants.DESCRIBE_STREAM_BACKOFF_EXPONENTIAL_CONSTANT,
+		validateOptionalPositiveDoubleProperty(config, ConsumerConfigConstants.LIST_SHARDS_BACKOFF_EXPONENTIAL_CONSTANT,
 			"Invalid value given for list shards operation backoff exponential constant. Must be a valid non-negative double value.");
 
 		if (config.containsKey(ConsumerConfigConstants.SHARD_GETRECORDS_INTERVAL_MILLIS)) {
@@ -177,6 +177,25 @@ public class KinesisConfigUtil {
 			configProps.setProperty(AGGREGATION_MAX_COUNT,
 					configProps.getProperty(ProducerConfigConstants.AGGREGATION_MAX_COUNT));
 			configProps.remove(ProducerConfigConstants.AGGREGATION_MAX_COUNT);
+		}
+		return configProps;
+	}
+
+	public static Properties replaceDeprecatedConsumerKeys(Properties configProps) {
+		if (configProps.containsKey(ConsumerConfigConstants.STREAM_DESCRIBE_BACKOFF_BASE)) {
+			configProps.setProperty(ConsumerConfigConstants.LIST_SHARDS_BACKOFF_BASE,
+							configProps.getProperty(ConsumerConfigConstants.STREAM_DESCRIBE_BACKOFF_BASE));
+			configProps.remove(ConsumerConfigConstants.STREAM_DESCRIBE_BACKOFF_BASE);
+		}
+		if (configProps.containsKey(ConsumerConfigConstants.STREAM_DESCRIBE_BACKOFF_MAX)) {
+			configProps.setProperty(ConsumerConfigConstants.LIST_SHARDS_BACKOFF_MAX,
+							configProps.getProperty(ConsumerConfigConstants.STREAM_DESCRIBE_BACKOFF_MAX));
+			configProps.remove(ConsumerConfigConstants.STREAM_DESCRIBE_BACKOFF_MAX);
+		}
+		if (configProps.containsKey(ConsumerConfigConstants.STREAM_DESCRIBE_BACKOFF_EXPONENTIAL_CONSTANT)) {
+			configProps.setProperty(ConsumerConfigConstants.LIST_SHARDS_BACKOFF_EXPONENTIAL_CONSTANT,
+							configProps.getProperty(ConsumerConfigConstants.STREAM_DESCRIBE_BACKOFF_EXPONENTIAL_CONSTANT));
+			configProps.remove(ConsumerConfigConstants.STREAM_DESCRIBE_BACKOFF_EXPONENTIAL_CONSTANT);
 		}
 		return configProps;
 	}

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtil.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtil.java
@@ -142,14 +142,14 @@ public class KinesisConfigUtil {
 		validateOptionalPositiveLongProperty(config, ConsumerConfigConstants.SHARD_DISCOVERY_INTERVAL_MILLIS,
 			"Invalid value given for shard discovery sleep interval in milliseconds. Must be a valid non-negative long value.");
 
-		validateOptionalPositiveLongProperty(config, ConsumerConfigConstants.STREAM_DESCRIBE_BACKOFF_BASE,
-			"Invalid value given for describe stream operation base backoff milliseconds. Must be a valid non-negative long value.");
+		validateOptionalPositiveLongProperty(config, ConsumerConfigConstants.SHARDS_LIST_BACKOFF_BASE,
+			"Invalid value given for list shards operation base backoff milliseconds. Must be a valid non-negative long value.");
 
-		validateOptionalPositiveLongProperty(config, ConsumerConfigConstants.STREAM_DESCRIBE_BACKOFF_MAX,
-			"Invalid value given for describe stream operation max backoff milliseconds. Must be a valid non-negative long value.");
+		validateOptionalPositiveLongProperty(config, ConsumerConfigConstants.SHARDS_LIST_BACKOFF_MAX,
+			"Invalid value given for list shards operation max backoff milliseconds. Must be a valid non-negative long value.");
 
-		validateOptionalPositiveDoubleProperty(config, ConsumerConfigConstants.STREAM_DESCRIBE_BACKOFF_EXPONENTIAL_CONSTANT,
-			"Invalid value given for describe stream operation backoff exponential constant. Must be a valid non-negative double value.");
+		validateOptionalPositiveDoubleProperty(config, ConsumerConfigConstants.SHARDS_LIST_BACKOFF_EXPONENTIAL_CONSTANT,
+			"Invalid value given for list shards operation backoff exponential constant. Must be a valid non-negative double value.");
 
 		if (config.containsKey(ConsumerConfigConstants.SHARD_GETRECORDS_INTERVAL_MILLIS)) {
 			checkArgument(

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxyTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxyTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.flink.streaming.connectors.kinesis.proxy;
 
-import com.amazonaws.ClientConfigurationFactory;
 import org.apache.flink.streaming.connectors.kinesis.config.AWSConfigConstants;
 import org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants;
 import org.apache.flink.streaming.connectors.kinesis.model.StreamShardHandle;
@@ -27,6 +26,7 @@ import org.apache.flink.streaming.connectors.kinesis.util.AWSUtil;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.AmazonServiceException.ErrorType;
 import com.amazonaws.ClientConfiguration;
+import com.amazonaws.ClientConfigurationFactory;
 import com.amazonaws.services.kinesis.AmazonKinesis;
 import com.amazonaws.services.kinesis.model.ExpiredIteratorException;
 import com.amazonaws.services.kinesis.model.ListShardsRequest;
@@ -157,7 +157,6 @@ public class KinesisProxyTest {
 		List<StreamShardHandle> actualShardList =
 				shardListResult.getRetrievedShardListOfStream(fakeStreamName);
 		List<StreamShardHandle> expectedStreamShard = new ArrayList<>();
-		System.out.println(actualShardList.toString());
 		assertThat(actualShardList, hasSize(4));
 		for (int i = 0; i < 4; i++) {
 			StreamShardHandle shardHandle =

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxyTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxyTest.java
@@ -18,28 +18,71 @@
 package org.apache.flink.streaming.connectors.kinesis.proxy;
 
 import org.apache.flink.streaming.connectors.kinesis.config.AWSConfigConstants;
+import org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants;
+import org.apache.flink.streaming.connectors.kinesis.model.StreamShardHandle;
+import org.apache.flink.streaming.connectors.kinesis.testutils.KinesisShardIdGenerator;
 import org.apache.flink.streaming.connectors.kinesis.util.AWSUtil;
 
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.AmazonServiceException.ErrorType;
 import com.amazonaws.ClientConfiguration;
-import com.amazonaws.ClientConfigurationFactory;
 import com.amazonaws.services.kinesis.AmazonKinesis;
 import com.amazonaws.services.kinesis.model.ExpiredIteratorException;
+import com.amazonaws.services.kinesis.model.ListShardsRequest;
+import com.amazonaws.services.kinesis.model.ListShardsResult;
 import com.amazonaws.services.kinesis.model.ProvisionedThroughputExceededException;
+import com.amazonaws.services.kinesis.model.Shard;
+import org.apache.commons.lang3.StringUtils;
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+import org.junit.Assert;
 import org.junit.Test;
 import org.powermock.reflect.Whitebox;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 
 /**
  * Test for methods in the {@link KinesisProxy} class.
  */
 public class KinesisProxyTest {
+	private static final String NEXT_TOKEN = "NextToken";
+	private static final String fakeStreamName = "fake-stream";
+	private Set<String> shardIdSet;
+	private List<Shard> shards;
+
+	protected static HashMap<String, String>
+	createInitialSubscribedStreamsToLastDiscoveredShardsState(List<String> streams) {
+		HashMap<String, String> initial = new HashMap<>();
+		for (String stream : streams) {
+			initial.put(stream, null);
+		}
+		return initial;
+	}
+
+	private static ListShardsRequestMatcher initialListShardsRequestMatcher() {
+		return new ListShardsRequestMatcher(null, null);
+	}
+
+	private static ListShardsRequestMatcher listShardsNextToken(final String nextToken) {
+		return new ListShardsRequestMatcher(null, nextToken);
+	}
 
 	@Test
 	public void testIsRecoverableExceptionWithProvisionedThroughputExceeded() {
@@ -70,20 +113,107 @@ public class KinesisProxyTest {
 	}
 
 	@Test
-	public void testCustomConfigurationOverride() {
-		Properties configProps = new Properties();
-		configProps.setProperty(AWSConfigConstants.AWS_REGION, "us-east-1");
-		KinesisProxy proxy = new KinesisProxy(configProps) {
-			@Override
-			protected AmazonKinesis createKinesisClient(Properties configProps) {
-				ClientConfiguration clientConfig = new ClientConfigurationFactory().getConfig();
-				clientConfig.setSocketTimeout(10000);
-				return AWSUtil.createKinesisClient(configProps, clientConfig);
+	public void testGetShardList() throws Exception {
+		List<String> shardIds =
+				Arrays.asList(
+						"shardId-000000000000",
+						"shardId-000000000001",
+						"shardId-000000000002",
+						"shardId-000000000003");
+		shardIdSet = new HashSet<>(shardIds);
+		shards =
+				shardIds
+						.stream()
+						.map(shardId -> new Shard().withShardId(shardId))
+						.collect(Collectors.toList());
+		Properties kinesisConsumerConfig = new Properties();
+		kinesisConsumerConfig.setProperty(ConsumerConfigConstants.AWS_REGION, "us-east-1");
+		kinesisConsumerConfig.setProperty(ConsumerConfigConstants.AWS_ACCESS_KEY_ID, "fake_accesskey");
+		kinesisConsumerConfig.setProperty(
+				ConsumerConfigConstants.AWS_SECRET_ACCESS_KEY, "fake_secretkey");
+		KinesisProxy kinesisProxy = new KinesisProxy(kinesisConsumerConfig);
+		AmazonKinesis mockClient = mock(AmazonKinesis.class);
+		Whitebox.setInternalState(kinesisProxy, "kinesisClient", mockClient);
+
+		ListShardsResult responseWithMoreData =
+				new ListShardsResult().withShards(shards.subList(0, 2)).withNextToken(NEXT_TOKEN);
+		ListShardsResult responseFinal =
+				new ListShardsResult().withShards(shards.subList(2, shards.size())).withNextToken(null);
+		doReturn(responseWithMoreData)
+				.when(mockClient)
+				.listShards(argThat(initialListShardsRequestMatcher()));
+		doReturn(responseFinal).when(mockClient).listShards(argThat(listShardsNextToken(NEXT_TOKEN)));
+		HashMap<String, String> streamHashMap =
+				createInitialSubscribedStreamsToLastDiscoveredShardsState(Arrays.asList(fakeStreamName));
+		GetShardListResult shardListResult = kinesisProxy.getShardList(streamHashMap);
+
+		Assert.assertEquals(shardListResult.hasRetrievedShards(), true);
+
+		Set<String> expectedStreams = new HashSet<>();
+		expectedStreams.add(fakeStreamName);
+		Assert.assertEquals(shardListResult.getStreamsWithRetrievedShards(), expectedStreams);
+		List<StreamShardHandle> actualShardList =
+				shardListResult.getRetrievedShardListOfStream(fakeStreamName);
+		List<StreamShardHandle> expectedStreamShard = new ArrayList<>();
+		System.out.println(actualShardList.toString());
+		assertThat(actualShardList, hasSize(4));
+		for (int i = 0; i < 4; i++) {
+			StreamShardHandle shardHandle =
+					new StreamShardHandle(
+							fakeStreamName,
+							new Shard().withShardId(KinesisShardIdGenerator.generateFromShardOrder(i)));
+			expectedStreamShard.add(shardHandle);
+		}
+
+		Assert.assertThat(
+				actualShardList,
+				containsInAnyOrder(
+						expectedStreamShard.toArray(new StreamShardHandle[actualShardList.size()])));
+	}
+
+	private static class ListShardsRequestMatcher extends TypeSafeDiagnosingMatcher<ListShardsRequest> {
+		private final String shardId;
+		private final String nextToken;
+
+		ListShardsRequestMatcher(String shardIdArg, String nextTokenArg) {
+			shardId = shardIdArg;
+			nextToken = nextTokenArg;
+		}
+
+		@Override
+		protected boolean matchesSafely(final ListShardsRequest listShardsRequest, final Description description) {
+			if (shardId == null) {
+				if (StringUtils.isNotEmpty(listShardsRequest.getExclusiveStartShardId())) {
+					return false;
+				}
+			} else {
+				if (!shardId.equals(listShardsRequest.getExclusiveStartShardId())) {
+					return false;
+				}
 			}
-		};
-		AmazonKinesis kinesisClient = Whitebox.getInternalState(proxy, "kinesisClient");
-		ClientConfiguration clientConfiguration = Whitebox.getInternalState(kinesisClient, "clientConfiguration");
-		assertEquals(10000, clientConfiguration.getSocketTimeout());
+
+			if (StringUtils.isNotEmpty(listShardsRequest.getNextToken())) {
+				if (StringUtils.isNotEmpty(listShardsRequest.getStreamName())
+								|| StringUtils.isNotEmpty(listShardsRequest.getExclusiveStartShardId())) {
+					return false;
+				}
+
+				if (!listShardsRequest.getNextToken().equals(nextToken)) {
+					return false;
+				}
+			} else {
+				return nextToken == null;
+			}
+			return true;
+		}
+
+		@Override
+		public void describeTo(final Description description) {
+			description
+							.appendText("A ListShardsRequest with a shardId: ")
+							.appendValue(shardId)
+							.appendText(" and empty nextToken");
+		}
 	}
 
 	@Test
@@ -97,8 +227,7 @@ public class KinesisProxyTest {
 
 		AmazonKinesis kinesisClient = Whitebox.getInternalState(proxy, "kinesisClient");
 		ClientConfiguration clientConfiguration = Whitebox.getInternalState(kinesisClient,
-			"clientConfiguration");
+						"clientConfiguration");
 		assertEquals(9999, clientConfiguration.getSocketTimeout());
 	}
-
 }

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxyTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxyTest.java
@@ -32,7 +32,6 @@ import com.amazonaws.services.kinesis.model.ListShardsRequest;
 import com.amazonaws.services.kinesis.model.ListShardsResult;
 import com.amazonaws.services.kinesis.model.ProvisionedThroughputExceededException;
 import com.amazonaws.services.kinesis.model.Shard;
-import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 import org.junit.Assert;
@@ -142,7 +141,9 @@ public class KinesisProxyTest {
 		doReturn(responseWithMoreData)
 				.when(mockClient)
 				.listShards(argThat(initialListShardsRequestMatcher()));
-		doReturn(responseFinal).when(mockClient).listShards(argThat(listShardsNextToken(NEXT_TOKEN)));
+		doReturn(responseFinal).
+						when(mockClient).
+						listShards(argThat(listShardsNextToken(NEXT_TOKEN)));
 		HashMap<String, String> streamHashMap =
 				createInitialSubscribedStreamsToLastDiscoveredShardsState(Arrays.asList(fakeStreamName));
 		GetShardListResult shardListResult = kinesisProxy.getShardList(streamHashMap);
@@ -183,7 +184,7 @@ public class KinesisProxyTest {
 		@Override
 		protected boolean matchesSafely(final ListShardsRequest listShardsRequest, final Description description) {
 			if (shardId == null) {
-				if (StringUtils.isNotEmpty(listShardsRequest.getExclusiveStartShardId())) {
+				if (listShardsRequest.getExclusiveStartShardId() != null) {
 					return false;
 				}
 			} else {
@@ -192,9 +193,9 @@ public class KinesisProxyTest {
 				}
 			}
 
-			if (StringUtils.isNotEmpty(listShardsRequest.getNextToken())) {
-				if (StringUtils.isNotEmpty(listShardsRequest.getStreamName())
-								|| StringUtils.isNotEmpty(listShardsRequest.getExclusiveStartShardId())) {
+			if (listShardsRequest.getNextToken() != null) {
+				if (!(listShardsRequest.getStreamName() == null
+								&& listShardsRequest.getExclusiveStartShardId() == null)) {
 					return false;
 				}
 

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtilTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtilTest.java
@@ -338,7 +338,7 @@ public class KinesisConfigUtilTest {
 		exception.expectMessage("Invalid value given for list shards operation base backoff milliseconds");
 
 		Properties testConfig = TestUtils.getStandardProperties();
-		testConfig.setProperty(ConsumerConfigConstants.SHARDS_LIST_BACKOFF_BASE, "unparsableLong");
+		testConfig.setProperty(ConsumerConfigConstants.DESCRIBE_STREAM_BACKOFF_BASE, "unparsableLong");
 
 		KinesisConfigUtil.validateConsumerConfiguration(testConfig);
 	}
@@ -349,7 +349,7 @@ public class KinesisConfigUtilTest {
 		exception.expectMessage("Invalid value given for list shards operation max backoff milliseconds");
 
 		Properties testConfig = TestUtils.getStandardProperties();
-		testConfig.setProperty(ConsumerConfigConstants.SHARDS_LIST_BACKOFF_MAX, "unparsableLong");
+		testConfig.setProperty(ConsumerConfigConstants.DESCRIBE_STREAM_BACKOFF_MAX, "unparsableLong");
 
 		KinesisConfigUtil.validateConsumerConfiguration(testConfig);
 	}
@@ -360,7 +360,7 @@ public class KinesisConfigUtilTest {
 		exception.expectMessage("Invalid value given for list shards operation backoff exponential constant");
 
 		Properties testConfig = TestUtils.getStandardProperties();
-		testConfig.setProperty(ConsumerConfigConstants.SHARDS_LIST_BACKOFF_EXPONENTIAL_CONSTANT, "unparsableDouble");
+		testConfig.setProperty(ConsumerConfigConstants.DESCRIBE_STREAM_BACKOFF_EXPONENTIAL_CONSTANT, "unparsableDouble");
 
 		KinesisConfigUtil.validateConsumerConfiguration(testConfig);
 	}

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtilTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtilTest.java
@@ -338,7 +338,7 @@ public class KinesisConfigUtilTest {
 		exception.expectMessage("Invalid value given for list shards operation base backoff milliseconds");
 
 		Properties testConfig = TestUtils.getStandardProperties();
-		testConfig.setProperty(ConsumerConfigConstants.DESCRIBE_STREAM_BACKOFF_BASE, "unparsableLong");
+		testConfig.setProperty(ConsumerConfigConstants.LIST_SHARDS_BACKOFF_BASE, "unparsableLong");
 
 		KinesisConfigUtil.validateConsumerConfiguration(testConfig);
 	}
@@ -349,7 +349,7 @@ public class KinesisConfigUtilTest {
 		exception.expectMessage("Invalid value given for list shards operation max backoff milliseconds");
 
 		Properties testConfig = TestUtils.getStandardProperties();
-		testConfig.setProperty(ConsumerConfigConstants.DESCRIBE_STREAM_BACKOFF_MAX, "unparsableLong");
+		testConfig.setProperty(ConsumerConfigConstants.LIST_SHARDS_BACKOFF_MAX, "unparsableLong");
 
 		KinesisConfigUtil.validateConsumerConfiguration(testConfig);
 	}
@@ -360,7 +360,7 @@ public class KinesisConfigUtilTest {
 		exception.expectMessage("Invalid value given for list shards operation backoff exponential constant");
 
 		Properties testConfig = TestUtils.getStandardProperties();
-		testConfig.setProperty(ConsumerConfigConstants.DESCRIBE_STREAM_BACKOFF_EXPONENTIAL_CONSTANT, "unparsableDouble");
+		testConfig.setProperty(ConsumerConfigConstants.LIST_SHARDS_BACKOFF_EXPONENTIAL_CONSTANT, "unparsableDouble");
 
 		KinesisConfigUtil.validateConsumerConfiguration(testConfig);
 	}

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtilTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtilTest.java
@@ -333,34 +333,34 @@ public class KinesisConfigUtilTest {
 	}
 
 	@Test
-	public void testUnparsableLongForDescribeStreamBackoffBaseMillisInConfig() {
+	public void testUnparsableLongForListShardsBackoffBaseMillisInConfig() {
 		exception.expect(IllegalArgumentException.class);
-		exception.expectMessage("Invalid value given for describe stream operation base backoff milliseconds");
+		exception.expectMessage("Invalid value given for list shards operation base backoff milliseconds");
 
 		Properties testConfig = TestUtils.getStandardProperties();
-		testConfig.setProperty(ConsumerConfigConstants.STREAM_DESCRIBE_BACKOFF_BASE, "unparsableLong");
+		testConfig.setProperty(ConsumerConfigConstants.SHARDS_LIST_BACKOFF_BASE, "unparsableLong");
 
 		KinesisConfigUtil.validateConsumerConfiguration(testConfig);
 	}
 
 	@Test
-	public void testUnparsableLongForDescribeStreamBackoffMaxMillisInConfig() {
+	public void testUnparsableLongForListShardsBackoffMaxMillisInConfig() {
 		exception.expect(IllegalArgumentException.class);
-		exception.expectMessage("Invalid value given for describe stream operation max backoff milliseconds");
+		exception.expectMessage("Invalid value given for list shards operation max backoff milliseconds");
 
 		Properties testConfig = TestUtils.getStandardProperties();
-		testConfig.setProperty(ConsumerConfigConstants.STREAM_DESCRIBE_BACKOFF_MAX, "unparsableLong");
+		testConfig.setProperty(ConsumerConfigConstants.SHARDS_LIST_BACKOFF_MAX, "unparsableLong");
 
 		KinesisConfigUtil.validateConsumerConfiguration(testConfig);
 	}
 
 	@Test
-	public void testUnparsableDoubleForDescribeStreamBackoffExponentialConstantInConfig() {
+	public void testUnparsableDoubleForListShardsBackoffExponentialConstantInConfig() {
 		exception.expect(IllegalArgumentException.class);
-		exception.expectMessage("Invalid value given for describe stream operation backoff exponential constant");
+		exception.expectMessage("Invalid value given for list shards operation backoff exponential constant");
 
 		Properties testConfig = TestUtils.getStandardProperties();
-		testConfig.setProperty(ConsumerConfigConstants.STREAM_DESCRIBE_BACKOFF_EXPONENTIAL_CONSTANT, "unparsableDouble");
+		testConfig.setProperty(ConsumerConfigConstants.SHARDS_LIST_BACKOFF_EXPONENTIAL_CONSTANT, "unparsableDouble");
 
 		KinesisConfigUtil.validateConsumerConfiguration(testConfig);
 	}


### PR DESCRIPTION
…ream for shard discovery as it offer higher rate limits

## What is the purpose of the change

List Shards provides high AWS rate limits unlike DescribeStreams (which is on AWS account level) allowing faster shard discovery when kinesis data source in case streams are changed(re-sharded)

## Brief change log
 - Change the kinesis connector to use listShards instead of DescribeStream for shard discovery.

## Verifying this change

This change added tests and can be verified as follows:
 - Added a unit test to check the code path mocking out the kinesis depenedencies
 - Tested by running a small flink job with this connector.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
