### PR TITLE
Avro deserializer2

### DIFF
--- a/flink-formats/flink-avro-confluent-registry/pom.xml
+++ b/flink-formats/flink-avro-confluent-registry/pom.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<parent>
+		<artifactId>flink-formats</artifactId>
+		<groupId>org.apache.flink</groupId>
+		<version>1.6-SNAPSHOT</version>
+	</parent>
+	<modelVersion>4.0.0</modelVersion>
+
+	<artifactId>flink-avro-confluent-registry</artifactId>
+
+	<repositories>
+		<repository>
+			<id>confluent</id>
+			<url>http://packages.confluent.io/maven/</url>
+		</repository>
+	</repositories>
+
+	<dependencies>
+		<dependency>
+			<groupId>io.confluent</groupId>
+			<artifactId>kafka-schema-registry-client</artifactId>
+			<version>3.3.1</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.avro</groupId>
+					<artifactId>avro</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-log4j12</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-core</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-avro</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>shade-flink</id>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<relocations combine.children="append">
+								<relocation>
+									<pattern>com.fasterxml.jackson.core</pattern>
+									<shadedPattern>org.apache.flink.shaded.com.fasterxml.jackson.core</shadedPattern>
+								</relocation>
+							</relocations>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/ConfluentRegistryAvroDeserializationSchema.java
+++ b/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/ConfluentRegistryAvroDeserializationSchema.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.avro.registry.confluent;
+
+import org.apache.flink.formats.avro.AvroDeserializationSchema;
+import org.apache.flink.formats.avro.RegistryAvroDeserializationSchema;
+import org.apache.flink.formats.avro.SchemaCoder;
+
+import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.specific.SpecificRecord;
+
+import javax.annotation.Nullable;
+
+/**
+ * Deserialization schema that deserializes from Avro binary format using {@link SchemaCoder} that uses
+ * Confluent Schema Registry.
+ *
+ * @param <T> type of record it produces
+ */
+public class ConfluentRegistryAvroDeserializationSchema<T>
+	extends RegistryAvroDeserializationSchema<T> {
+
+	private static final int DEFAULT_IDENTITY_MAP_CAPACITY = 1000;
+
+	/**
+	 * Creates a Avro deserialization schema.
+	 *
+	 * @param recordClazz         class to which deserialize. Should be either
+	 *                            {@link SpecificRecord} or {@link GenericRecord}.
+	 * @param reader              reader's Avro schema. Should be provided if recordClazz is
+	 *                            {@link GenericRecord}
+	 * @param schemaCoderProvider provider for schema coder that reads writer schema from Confluent Schema Registry
+	 */
+	private ConfluentRegistryAvroDeserializationSchema(
+		Class<T> recordClazz,
+		@Nullable Schema reader,
+		SchemaCoder.SchemaCoderProvider schemaCoderProvider) {
+		super(recordClazz, reader, schemaCoderProvider);
+	}
+
+	/**
+	 * Creates {@link ConfluentRegistryAvroDeserializationSchema} that produces {@link GenericRecord}
+	 * using provided reader schema and looks up writer schema in Confluent Schema Registry.
+	 *
+	 * @param schema schema of produced records
+	 * @param url    url of schema registry to connect
+	 * @return deserialized record in form of {@link GenericRecord}
+	 */
+	public static ConfluentRegistryAvroDeserializationSchema<GenericRecord> forGeneric(
+		Schema schema, String url) {
+		return forGeneric(schema, url, DEFAULT_IDENTITY_MAP_CAPACITY);
+	}
+
+	/**
+	 * Creates {@link ConfluentRegistryAvroDeserializationSchema} that produces {@link GenericRecord}
+	 * using provided reader schema and looks up writer schema in Confluent Schema Registry.
+	 *
+	 * @param schema              schema of produced records
+	 * @param url                 url of schema registry to connect
+	 * @param identityMapCapacity maximum number of cached schema versions (default: 1000)
+	 * @return deserialized record in form of {@link GenericRecord}
+	 */
+	public static ConfluentRegistryAvroDeserializationSchema<GenericRecord> forGeneric(
+		Schema schema, String url, int identityMapCapacity) {
+		return new ConfluentRegistryAvroDeserializationSchema<>(
+			GenericRecord.class,
+			schema,
+			new CachedSchemaCoderProvider(url, identityMapCapacity));
+	}
+
+	/**
+	 * Creates {@link AvroDeserializationSchema} that produces classes that were generated from avro
+	 * schema and looks up writer schema in Confluent Schema Registry.
+	 *
+	 * @param tClass class of record to be produced
+	 * @param url    url of schema registry to connect
+	 * @return deserialized record
+	 */
+	public static <T extends SpecificRecord> ConfluentRegistryAvroDeserializationSchema<T> forSpecific(
+		Class<T> tClass, String url) {
+		return forSpecific(tClass, url, DEFAULT_IDENTITY_MAP_CAPACITY);
+	}
+
+	/**
+	 * Creates {@link AvroDeserializationSchema} that produces classes that were generated from avro
+	 * schema and looks up writer schema in Confluent Schema Registry.
+	 *
+	 * @param tClass              class of record to be produced
+	 * @param url                 url of schema registry to connect
+	 * @param identityMapCapacity maximum number of cached schema versions (default: 1000)
+	 * @return deserialized record
+	 */
+	public static <T extends SpecificRecord> ConfluentRegistryAvroDeserializationSchema<T> forSpecific(
+		Class<T> tClass, String url, int identityMapCapacity) {
+		return new ConfluentRegistryAvroDeserializationSchema<>(
+			tClass,
+			null,
+			new CachedSchemaCoderProvider(url, identityMapCapacity)
+		);
+	}
+
+	private static class CachedSchemaCoderProvider implements SchemaCoder.SchemaCoderProvider {
+
+		private final String url;
+		private final int identityMapCapacity;
+
+		private CachedSchemaCoderProvider(String url, int identityMapCapacity) {
+			this.url = url;
+			this.identityMapCapacity = identityMapCapacity;
+		}
+
+		@Override
+		public SchemaCoder get() {
+			return new ConfluentSchemaRegistryCoder(new CachedSchemaRegistryClient(
+				url,
+				identityMapCapacity));
+		}
+	}
+}

--- a/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/ConfluentSchemaRegistryCoder.java
+++ b/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/ConfluentSchemaRegistryCoder.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.avro.registry.confluent;
+
+import org.apache.flink.formats.avro.SchemaCoder;
+
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import org.apache.avro.Schema;
+
+import java.io.DataInputStream;
+import java.io.InputStream;
+
+/**
+ * Reads schema using Confluent Schema Registry protocol.
+ */
+public class ConfluentSchemaRegistryCoder implements SchemaCoder {
+
+	private final SchemaRegistryClient schemaRegistryClient;
+
+	/**
+	 * Creates {@link SchemaCoder} that uses provided {@link SchemaRegistryClient} to connect to
+	 * schema registry.
+	 *
+	 * @param schemaRegistryClient client to connect schema registry
+	 */
+	public ConfluentSchemaRegistryCoder(SchemaRegistryClient schemaRegistryClient) {
+		this.schemaRegistryClient = schemaRegistryClient;
+	}
+
+	@Override
+	public Schema readSchema(InputStream in) throws Exception {
+		DataInputStream dataInputStream = new DataInputStream(in);
+
+		if (dataInputStream.readByte() != 0) {
+			throw new RuntimeException("Unknown data format. Magic number does not match");
+		} else {
+			int schemaId = dataInputStream.readInt();
+
+			return schemaRegistryClient.getById(schemaId);
+		}
+	}
+
+}

--- a/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/ConfluentSchemaRegistryCoderTest.java
+++ b/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/ConfluentSchemaRegistryCoderTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.avro.registry.confluent;
+
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link ConfluentSchemaRegistryCoder}.
+ */
+public class ConfluentSchemaRegistryCoderTest {
+
+	@Test
+	public void testSpecificRecordWithConfluentSchemaRegistry() throws Exception {
+		MockSchemaRegistryClient client = new MockSchemaRegistryClient();
+
+		Schema schema = SchemaBuilder.record("testRecord")
+			.fields()
+			.optionalString("testField")
+			.endRecord();
+		int schemaId = client.register("testTopic", schema);
+
+		ConfluentSchemaRegistryCoder registryCoder = new ConfluentSchemaRegistryCoder(client);
+		ByteArrayOutputStream byteOutStream = new ByteArrayOutputStream();
+		DataOutputStream dataOutputStream = new DataOutputStream(byteOutStream);
+		dataOutputStream.writeByte(0);
+		dataOutputStream.writeInt(schemaId);
+		dataOutputStream.flush();
+
+		ByteArrayInputStream byteInStream = new ByteArrayInputStream(byteOutStream.toByteArray());
+		Schema readSchema = registryCoder.readSchema(byteInStream);
+
+		assertEquals(schema, readSchema);
+		assertEquals(0, byteInStream.available());
+
+	}
+
+}

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroDeserializationSchema.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroDeserializationSchema.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.avro;
+
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.formats.avro.typeutils.AvroTypeInfo;
+import org.apache.flink.formats.avro.typeutils.GenericRecordAvroTypeInfo;
+import org.apache.flink.formats.avro.utils.MutableByteArrayInputStream;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.reflect.ReflectData;
+import org.apache.avro.reflect.ReflectDatumReader;
+import org.apache.avro.specific.SpecificData;
+import org.apache.avro.specific.SpecificDatumReader;
+import org.apache.avro.specific.SpecificRecord;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+
+/**
+ * Deserialization schema that deserializes from Avro binary format.
+ *
+ * @param <T> type of record it produces
+ */
+public class AvroDeserializationSchema<T> implements DeserializationSchema<T> {
+
+	/**
+	 * Class to deserialize to.
+	 */
+	private Class<T> recordClazz;
+
+	private String schemaString = null;
+
+	/**
+	 * Reader that deserializes byte array into a record.
+	 */
+	private transient GenericDatumReader<T> datumReader;
+
+	/**
+	 * Input stream to read message from.
+	 */
+	private transient MutableByteArrayInputStream inputStream;
+
+	/**
+	 * Avro decoder that decodes binary data.
+	 */
+	private transient Decoder decoder;
+
+	/**
+	 * Avro schema for the reader.
+	 */
+	private transient Schema reader;
+
+	/**
+	 * Creates a Avro deserialization schema.
+	 *
+	 * @param recordClazz class to which deserialize. Should be one of:
+	 *                    {@link org.apache.avro.specific.SpecificRecord},
+	 *                    {@link org.apache.avro.generic.GenericRecord}.
+	 * @param reader      reader's Avro schema. Should be provided if recordClazz is
+	 *                    {@link GenericRecord}
+	 */
+	AvroDeserializationSchema(Class<T> recordClazz, @Nullable Schema reader) {
+		Preconditions.checkNotNull(recordClazz, "Avro record class must not be null.");
+		this.recordClazz = recordClazz;
+		this.inputStream = new MutableByteArrayInputStream();
+		this.decoder = DecoderFactory.get().binaryDecoder(inputStream, null);
+		this.reader = reader;
+		if (reader != null) {
+			this.schemaString = reader.toString();
+		}
+	}
+
+	/**
+	 * Creates {@link AvroDeserializationSchema} that produces {@link GenericRecord} using provided schema.
+	 *
+	 * @param schema schema of produced records
+	 * @return deserialized record in form of {@link GenericRecord}
+	 */
+	public static AvroDeserializationSchema<GenericRecord> forGeneric(Schema schema) {
+		return new AvroDeserializationSchema<>(GenericRecord.class, schema);
+	}
+
+	/**
+	 * Creates {@link AvroDeserializationSchema} that produces classes that were generated from avro schema.
+	 *
+	 * @param tClass class of record to be produced
+	 * @return deserialized record
+	 */
+	public static <T extends SpecificRecord> AvroDeserializationSchema<T> forSpecific(Class<T> tClass) {
+		return new AvroDeserializationSchema<>(tClass, null);
+	}
+
+	GenericDatumReader<T> getDatumReader() {
+		if (datumReader != null) {
+			return datumReader;
+		}
+
+		if (SpecificRecord.class.isAssignableFrom(recordClazz)) {
+			this.datumReader = new SpecificDatumReader<>();
+		} else if (GenericRecord.class.isAssignableFrom(recordClazz)) {
+			this.datumReader = new GenericDatumReader<>();
+		} else {
+			this.datumReader = new ReflectDatumReader<>();
+		}
+
+		return datumReader;
+	}
+
+	Schema getReaderSchema() {
+		if (reader != null) {
+			return reader;
+		}
+
+		if (SpecificRecord.class.isAssignableFrom(recordClazz)) {
+			this.reader = SpecificData.get().getSchema(recordClazz);
+		} else if (GenericRecord.class.isAssignableFrom(recordClazz)) {
+			throw new IllegalStateException(
+				"Cannot infer schema for generic record. Please pass explicit schema in the ctor.");
+		} else {
+			this.reader = ReflectData.get().getSchema(recordClazz);
+		}
+
+		return reader;
+	}
+
+	MutableByteArrayInputStream getInputStream() {
+		return inputStream;
+	}
+
+	Decoder getDecoder() {
+		return decoder;
+	}
+
+	@Override
+	public T deserialize(byte[] message) {
+		// read record
+		try {
+			inputStream.setBuffer(message);
+			Schema readerSchema = getReaderSchema();
+			GenericDatumReader<T> datumReader = getDatumReader();
+
+			datumReader.setSchema(readerSchema);
+
+			return datumReader.read(null, decoder);
+		} catch (Exception e) {
+			throw new RuntimeException("Failed to deserialize message.", e);
+		}
+	}
+
+	private void readObject(ObjectInputStream ois) throws ClassNotFoundException, IOException {
+		ois.defaultReadObject();
+		this.inputStream = new MutableByteArrayInputStream();
+		this.decoder = DecoderFactory.get().binaryDecoder(inputStream, null);
+		if (schemaString != null) {
+			this.reader = new Schema.Parser().parse(schemaString);
+		}
+	}
+
+	@Override
+	public boolean isEndOfStream(T nextElement) {
+		return false;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public TypeInformation<T> getProducedType() {
+		if (SpecificRecord.class.isAssignableFrom(recordClazz)) {
+			return new AvroTypeInfo(recordClazz, false);
+		} else {
+			return (TypeInformation<T>) new GenericRecordAvroTypeInfo(this.reader);
+		}
+	}
+}

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroRowDeserializationSchema.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroRowDeserializationSchema.java
@@ -18,6 +18,7 @@
 package org.apache.flink.formats.avro;
 
 import org.apache.flink.api.common.serialization.AbstractDeserializationSchema;
+import org.apache.flink.formats.avro.utils.MutableByteArrayInputStream;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.Preconditions;
 
@@ -31,7 +32,6 @@ import org.apache.avro.specific.SpecificDatumReader;
 import org.apache.avro.specific.SpecificRecord;
 import org.apache.avro.util.Utf8;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
@@ -153,27 +153,4 @@ public class AvroRowDeserializationSchema extends AbstractDeserializationSchema<
 		}
 	}
 
-	/**
-	 * An extension of the ByteArrayInputStream that allows to change a buffer that should be
-	 * read without creating a new ByteArrayInputStream instance. This allows to re-use the same
-	 * InputStream instance, copying message to process, and creation of Decoder on every new message.
-	 */
-	private static final class MutableByteArrayInputStream extends ByteArrayInputStream {
-
-		public MutableByteArrayInputStream() {
-			super(new byte[0]);
-		}
-
-		/**
-		 * Set buffer that can be read via the InputStream interface and reset the input stream.
-		 * This has the same effect as creating a new ByteArrayInputStream with a new buffer.
-		 *
-		 * @param buf the new buffer to read.
-		 */
-		public void setBuffer(byte[] buf) {
-			this.buf = buf;
-			this.pos = 0;
-			this.count = buf.length;
-		}
-	}
 }

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/RegistryAvroDeserializationSchema.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/RegistryAvroDeserializationSchema.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.avro;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.specific.SpecificRecord;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+
+/**
+ * Deserialization schema that deserializes from Avro binary format using {@link SchemaCoder}.
+ *
+ * @param <T> type of record it produces
+ */
+public class RegistryAvroDeserializationSchema<T> extends AvroDeserializationSchema<T> {
+	private final SchemaCoder.SchemaCoderProvider schemaCoderProvider;
+	private transient SchemaCoder schemaCoder;
+
+	/**
+	 * Creates Avro deserialization schema that reads schema from input stream using provided {@link SchemaCoder}.
+	 *
+	 * @param recordClazz         class to which deserialize. Should be either
+	 *                            {@link SpecificRecord} or {@link GenericRecord}.
+	 * @param reader              reader's Avro schema. Should be provided if recordClazz is
+	 *                            {@link GenericRecord}
+	 * @param schemaCoderProvider schema provider that allows instantiation of {@link SchemaCoder} that will be used for
+	 *                            schema reading
+	 */
+	protected RegistryAvroDeserializationSchema(
+		Class<T> recordClazz,
+		@Nullable Schema reader,
+		SchemaCoder.SchemaCoderProvider schemaCoderProvider) {
+		super(recordClazz, reader);
+		this.schemaCoderProvider = schemaCoderProvider;
+		this.schemaCoder = schemaCoderProvider.get();
+	}
+
+	@Override
+	public T deserialize(byte[] message) {
+		// read record
+		try {
+			getInputStream().setBuffer(message);
+			Schema writerSchema = schemaCoder.readSchema(getInputStream());
+			Schema readerSchema = getReaderSchema();
+
+			GenericDatumReader<T> datumReader = getDatumReader();
+
+			datumReader.setSchema(writerSchema);
+			datumReader.setExpected(readerSchema);
+
+			return datumReader.read(null, getDecoder());
+		} catch (Exception e) {
+			throw new RuntimeException("Failed to deserialize Row.", e);
+		}
+	}
+
+	private void readObject(ObjectInputStream ois) throws ClassNotFoundException, IOException {
+		ois.defaultReadObject();
+		this.schemaCoder = schemaCoderProvider.get();
+	}
+}

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/SchemaCoder.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/SchemaCoder.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.avro;
+
+import org.apache.avro.Schema;
+
+import java.io.InputStream;
+import java.io.Serializable;
+
+/**
+ * Schema coder that allows reading schema that is somehow embedded into serialized record.
+ * Used by {@link RegistryAvroDeserializationSchema}.
+ */
+public interface SchemaCoder {
+	Schema readSchema(InputStream in) throws Exception;
+
+	/**
+	 * Provider for {@link SchemaCoder}. It allows creating multiple instances of client in
+	 * parallel operators without serializing it.
+	 */
+	interface SchemaCoderProvider extends Serializable {
+
+		/**
+		 * Creates a new instance of {@link SchemaCoder}. Each time it should create a new
+		 * instance, as it will be called on multiple nodes.
+		 *
+		 * @return new instance {@link SchemaCoder}
+		 */
+		SchemaCoder get();
+	}
+}

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/typeutils/GenericRecordAvroTypeInfo.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/typeutils/GenericRecordAvroTypeInfo.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.avro.typeutils;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Objects;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * TypeInformation for {@link GenericRecord}.
+ */
+public class GenericRecordAvroTypeInfo extends TypeInformation<GenericRecord> {
+
+	private transient Schema schema;
+
+	public GenericRecordAvroTypeInfo(Schema schema) {
+		this.schema = checkNotNull(schema);
+	}
+
+	@Override
+	public boolean isBasicType() {
+		return false;
+	}
+
+	@Override
+	public boolean isTupleType() {
+		return false;
+	}
+
+	@Override
+	public int getArity() {
+		return 1;
+	}
+
+	@Override
+	public int getTotalFields() {
+		return 1;
+	}
+
+	@Override
+	public Class<GenericRecord> getTypeClass() {
+		return GenericRecord.class;
+	}
+
+	@Override
+	public boolean isKeyType() {
+		return false;
+	}
+
+	@Override
+	public TypeSerializer<GenericRecord> createSerializer(ExecutionConfig config) {
+		return new AvroSerializer<>(GenericRecord.class, schema);
+	}
+
+	@Override
+	public String toString() {
+		return String.format("GenericRecord(\"%s\")", schema.toString());
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (obj instanceof GenericRecordAvroTypeInfo) {
+			GenericRecordAvroTypeInfo avroTypeInfo = (GenericRecordAvroTypeInfo) obj;
+			return Objects.equals(avroTypeInfo.schema, schema);
+		} else {
+			return false;
+		}
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hashCode(schema);
+	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof GenericRecordAvroTypeInfo;
+	}
+
+	private void writeObject(ObjectOutputStream oos) throws IOException {
+		oos.writeUTF(schema.toString());
+	}
+
+	private void readObject(ObjectInputStream ois) throws ClassNotFoundException, IOException {
+		this.schema = new Schema.Parser().parse(ois.readUTF());
+	}
+}

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/utils/MutableByteArrayInputStream.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/utils/MutableByteArrayInputStream.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.avro.utils;
+
+import java.io.ByteArrayInputStream;
+
+/**
+ * An extension of the ByteArrayInputStream that allows to change a buffer that should be
+ * read without creating a new ByteArrayInputStream instance. This allows to re-use the same
+ * InputStream instance, copying message to process, and creation of Decoder on every new message.
+ */
+public final class MutableByteArrayInputStream extends ByteArrayInputStream {
+
+	public MutableByteArrayInputStream() {
+		super(new byte[0]);
+	}
+
+	/**
+	 * Set buffer that can be read via the InputStream interface and reset the input stream.
+	 * This has the same effect as creating a new ByteArrayInputStream with a new buffer.
+	 *
+	 * @param buf the new buffer to read.
+	 */
+	public void setBuffer(byte[] buf) {
+		this.buf = buf;
+		this.pos = 0;
+		this.count = buf.length;
+	}
+}

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroDeserializationSchemaTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroDeserializationSchemaTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.avro;
+
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.formats.avro.generated.Address;
+import org.apache.flink.formats.avro.utils.TestDataGenerator;
+
+import org.apache.avro.generic.GenericRecord;
+import org.junit.Test;
+
+import java.util.Random;
+
+import static org.apache.flink.formats.avro.utils.AvroTestUtils.writeRecord;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link AvroDeserializationSchema}.
+ */
+public class AvroDeserializationSchemaTest {
+
+	private static final Address address = TestDataGenerator.generateRandomAddress(new Random());
+
+	@Test
+	public void testGenericRecord() throws Exception {
+		DeserializationSchema<GenericRecord> deserializationSchema =
+			AvroDeserializationSchema.forGeneric(
+				address.getSchema()
+			);
+
+		byte[] encodedAddress = writeRecord(address, Address.getClassSchema());
+		GenericRecord genericRecord = deserializationSchema.deserialize(encodedAddress);
+		assertEquals(address.getCity(), genericRecord.get("city").toString());
+		assertEquals(address.getNum(), genericRecord.get("num"));
+		assertEquals(address.getState(), genericRecord.get("state").toString());
+	}
+
+	@Test
+	public void testSpecificRecordWithConfluentSchemaRegistry() throws Exception {
+		DeserializationSchema<Address> deserializer = AvroDeserializationSchema.forSpecific(Address.class);
+
+		byte[] encodedAddress = writeRecord(address, Address.getClassSchema());
+		Address deserializedAddress = deserializer.deserialize(encodedAddress);
+		assertEquals(address, deserializedAddress);
+	}
+}

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/RegistryAvroDeserializationSchemaTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/RegistryAvroDeserializationSchemaTest.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.avro;
+
+import org.apache.flink.formats.avro.generated.Address;
+import org.apache.flink.formats.avro.generated.SimpleRecord;
+import org.apache.flink.formats.avro.utils.TestDataGenerator;
+
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.GenericRecordBuilder;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Random;
+
+import static org.apache.flink.formats.avro.utils.AvroTestUtils.writeRecord;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Tests for {@link RegistryAvroDeserializationSchema}.
+ */
+public class RegistryAvroDeserializationSchemaTest {
+
+	private static final Address address = TestDataGenerator.generateRandomAddress(new Random());
+
+	@Test
+	public void testGenericRecordReadWithCompatibleSchema() throws IOException {
+		RegistryAvroDeserializationSchema<GenericRecord> deserializer = new RegistryAvroDeserializationSchema<>(
+			GenericRecord.class,
+			SchemaBuilder.record("Address")
+				.fields()
+				.requiredString("street")
+				.requiredInt("num")
+				.optionalString("country")
+				.endRecord(),
+			() -> new SchemaCoder() {
+				@Override
+				public Schema readSchema(InputStream in) {
+					return Address.getClassSchema();
+				}
+			}
+		);
+
+		GenericRecord genericRecord = deserializer.deserialize(writeRecord(
+			address,
+			Address.getClassSchema()));
+		assertEquals(address.getNum(), genericRecord.get("num"));
+		assertEquals(address.getStreet(), genericRecord.get("street").toString());
+		assertNull(genericRecord.get("city"));
+		assertNull(genericRecord.get("state"));
+		assertNull(genericRecord.get("zip"));
+		assertNull(genericRecord.get("country"));
+	}
+
+	@Test
+	public void testSpecificRecordReadMoreFieldsThanWereWritten() throws IOException {
+		Schema smallerUserSchema = new Schema.Parser().parse(
+			"{\"namespace\": \"org.apache.flink.formats.avro.generated\",\n" +
+				" \"type\": \"record\",\n" +
+				" \"name\": \"SimpleRecord\",\n" +
+				" \"fields\": [\n" +
+				"     {\"name\": \"name\", \"type\": \"string\"}" +
+				" ]\n" +
+				"}]");
+		RegistryAvroDeserializationSchema<SimpleRecord> deserializer = new RegistryAvroDeserializationSchema<>(
+			SimpleRecord.class,
+			null,
+			() -> in -> smallerUserSchema
+		);
+
+		GenericData.Record smallUser = new GenericRecordBuilder(smallerUserSchema)
+			.set("name", "someName")
+			.build();
+
+		SimpleRecord simpleRecord = deserializer.deserialize(writeRecord(
+			smallUser,
+			smallerUserSchema));
+
+		assertEquals("someName", simpleRecord.getName().toString());
+		assertNull(simpleRecord.getOptionalField());
+	}
+}

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/utils/AvroTestUtils.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/utils/AvroTestUtils.java
@@ -27,9 +27,15 @@ import org.apache.flink.types.Row;
 
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.BinaryEncoder;
+import org.apache.avro.io.EncoderFactory;
 import org.apache.avro.reflect.ReflectData;
 import org.apache.avro.specific.SpecificRecord;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -148,5 +154,20 @@ public final class AvroTestUtils {
 		t.f2 = rowUser;
 
 		return t;
+	}
+
+	/**
+	 * Writes given record using specified schema.
+	 * @param record record to serialize
+	 * @param schema schema to use for serialization
+	 * @return serialized record
+	 */
+	public static byte[] writeRecord(GenericRecord record, Schema schema) throws IOException {
+		ByteArrayOutputStream stream = new ByteArrayOutputStream();
+		BinaryEncoder encoder = EncoderFactory.get().binaryEncoder(stream, null);
+
+		new GenericDatumWriter<>(schema).write(record, encoder);
+		encoder.flush();
+		return stream.toByteArray();
 	}
 }

--- a/flink-formats/flink-avro/src/test/resources/avro/user.avsc
+++ b/flink-formats/flink-avro/src/test/resources/avro/user.avsc
@@ -32,4 +32,12 @@
      {"name": "type_union", "type": ["null", "boolean", "long", "double"]},
      {"name": "type_nested", "type": ["null", "Address"]}
  ]
+},
+ {"namespace": "org.apache.flink.formats.avro.generated",
+  "type": "record",
+  "name": "SimpleRecord",
+  "fields": [
+      {"name": "name", "type": "string"},
+      {"name": "optionalField",  "type": ["null", "int"], "default": null}
+  ]
 }]

--- a/flink-formats/pom.xml
+++ b/flink-formats/pom.xml
@@ -38,6 +38,7 @@ under the License.
 	<modules>
 		<module>flink-avro</module>
 		<module>flink-json</module>
+		<module>flink-avro-confluent-registry</module>
 	</modules>
 
 	<!-- override these root dependencies as 'provided', so they don't end up


### PR DESCRIPTION
## What is the purpose of the change
Provides implementation of AvroDeserializationSchema that reads records serialized as avro and also provides version that uses Confluent Schema Registry to look up writer schema.


## Brief change log

  - Implemented AvroDeserializationSchema / RegistryAvroDeserializationSchema / ConfluentRegistryAvroDeserializationSchema
  - Extended AvroSerializer to handle GenericRecords
  - Added GenericRecordTypeInformation

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**yes** / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (**yes** / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
