### PR TITLE
[FLINK-9343] [Example] Add Async Example with External Rest API call

### DIFF
--- a/flink-examples/flink-examples-streaming/src/main/scala/org/apache/flink/streaming/scala/examples/async/AsyncAPIExample.scala
+++ b/flink-examples/flink-examples-streaming/src/main/scala/org/apache/flink/streaming/scala/examples/async/AsyncAPIExample.scala
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.scala.examples.async
+
+
+import java.io.{BufferedReader, InputStreamReader}
+import java.util.concurrent.TimeUnit
+
+import org.apache.flink.runtime.concurrent.Executors
+import org.apache.flink.streaming.api.scala.{AsyncDataStream, DataStream, StreamExecutionEnvironment, _}
+import org.apache.flink.streaming.api.scala.async.{AsyncFunction, ResultFuture}
+import org.apache.http.client.methods.HttpGet
+import org.apache.http.impl.client.HttpClientBuilder
+
+import scala.concurrent.{ExecutionContext, Future}
+
+object AsyncAPIExample {
+
+  def main(args: Array[String]) {
+
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+
+    val input : DataStream[Int] = env.addSource(new SimpleSource())
+
+    val quoteStream: DataStream[(Int, String)] = AsyncDataStream.unorderedWait(
+      input,
+      new AsyncQuoteRequest,
+      1000,
+      TimeUnit.MILLISECONDS,
+      10)
+
+    quoteStream.print()
+
+    env.execute("Async API job")
+  }
+}
+
+class AsyncQuoteRequest extends AsyncFunction[Int, (Int, String)] {
+
+  /** The API specific client that can issue concurrent requests with callbacks */
+
+  /** The context used for the future callbacks */
+  implicit lazy val executor: ExecutionContext = ExecutionContext.global
+
+  lazy val client = new Quote()
+
+  override def asyncInvoke(input: Int, resultFuture: ResultFuture[(Int, String)]): Unit = {
+
+
+    // issue the asynchronous request, receive a future for the result
+    val resultFutureRequested: Future[String] = Future {
+      client.getQuote(input.toString)
+    }
+
+    // set the callback to be executed once the request by the client is complete
+    // the callback simply forwards the result to the result future
+    resultFutureRequested.onSuccess {
+      case result: String => {
+        resultFuture.complete(Iterable((input, result)))
+      }
+    }
+  }
+
+
+}
+
+class Quote {
+  @throws[Exception]
+  def getQuote(number: String) : String = {
+    val url = "http://gturnquist-quoters.cfapps.io/api/" + number
+    val client = HttpClientBuilder.create.build
+    val request = new HttpGet(url)
+    val response = client.execute(request)
+    val rd = new BufferedReader(new InputStreamReader(response.getEntity.getContent))
+    rd.readLine
+  }
+}

--- a/flink-examples/flink-examples-streaming/src/main/scala/org/apache/flink/streaming/scala/examples/async/SimpleSource.scala
+++ b/flink-examples/flink-examples-streaming/src/main/scala/org/apache/flink/streaming/scala/examples/async/SimpleSource.scala
@@ -18,32 +18,26 @@
 
 package org.apache.flink.streaming.scala.examples.async
 
+import org.apache.flink.streaming.api.functions.source.ParallelSourceFunction
+import org.apache.flink.streaming.api.functions.source.SourceFunction.SourceContext
 
-import java.util.concurrent.TimeUnit
+class SimpleSource extends ParallelSourceFunction[Int] {
+  var running = true
+  var counter = 0
 
-import org.apache.flink.streaming.api.scala._
-import org.apache.flink.streaming.api.scala.async.ResultFuture
+  override def run(ctx: SourceContext[Int]): Unit = {
+    while (running) {
+      ctx.getCheckpointLock.synchronized {
+        ctx.collect(counter)
+      }
+      counter += 1
 
-import scala.concurrent.{ExecutionContext, Future}
-
-object AsyncIOExample {
-
-  def main(args: Array[String]) {
-    val timeout = 10000L
-
-    val env = StreamExecutionEnvironment.getExecutionEnvironment
-
-    val input = env.addSource(new SimpleSource())
-
-    val asyncMapped = AsyncDataStream.orderedWait(input, timeout, TimeUnit.MILLISECONDS, 10) {
-      (input, collector: ResultFuture[Int]) =>
-        Future {
-          collector.complete(Seq(input))
-        } (ExecutionContext.global)
+      Thread.sleep(10L)
     }
+  }
 
-    asyncMapped.print()
-
-    env.execute("Async I/O job")
+  override def cancel(): Unit = {
+    running = false
   }
 }
+


### PR DESCRIPTION
## What is the purpose of the change

Example to simulate Async GET api call on an input stream.


## Brief change log

- Async I/O is a good way to call External resources such as REST API and enrich the stream with external data.

- Adding example to simulate Async GET api call on an input stream.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
