### PR TITLE
[FLINK-9344] [table] Support INTERSECT and INTERSECT ALL for streaming

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/logical/operators.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/logical/operators.scala
@@ -341,10 +341,6 @@ case class Intersect(left: LogicalNode, right: LogicalNode, all: Boolean) extend
   }
 
   override def validate(tableEnv: TableEnvironment): LogicalNode = {
-    if (tableEnv.isInstanceOf[StreamTableEnvironment]) {
-      failValidation(s"Intersect on stream tables is currently not supported.")
-    }
-
     val resolvedIntersect = super.validate(tableEnv).asInstanceOf[Intersect]
     if (left.output.length != right.output.length) {
       failValidation(s"Intersect two tables of different column sizes:" +

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamIntersect.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamIntersect.scala
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.nodes.datastream
+
+import org.apache.calcite.plan.{RelOptCluster, RelOptCost, RelOptPlanner, RelTraitSet}
+import org.apache.calcite.rel.{BiRel, RelNode, RelWriter}
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.metadata.RelMetadataQuery
+import org.apache.flink.api.java.typeutils.RowTypeInfo
+import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.table.api.{StreamQueryConfig, StreamTableEnvironment}
+import org.apache.flink.table.plan.schema.RowSchema
+import org.apache.flink.table.runtime.CRowKeySelector
+import org.apache.flink.table.runtime.setop.NonWindowIntersect
+import org.apache.flink.table.runtime.types.{CRow, CRowTypeInfo}
+
+import scala.collection.JavaConverters._
+
+/**
+  * RelNode for non-window stream intersect
+  */
+class DataStreamIntersect(
+  cluster: RelOptCluster,
+  traitSet: RelTraitSet,
+  leftNode: RelNode,
+  rightNode: RelNode,
+  rowRelDataType: RelDataType,
+  all: Boolean)
+  extends BiRel(cluster, traitSet, leftNode, rightNode)
+    with DataStreamRel {
+
+  private lazy val intersectType = if (all) {
+    "IntersectAll"
+  } else {
+    "Intersect"
+  }
+
+  override def needsUpdatesAsRetraction: Boolean = true
+
+  override def deriveRowType() = rowRelDataType
+
+  override def copy(traitSet: RelTraitSet, inputs: java.util.List[RelNode]): RelNode = {
+    new DataStreamIntersect(
+      cluster,
+      traitSet,
+      inputs.get(0),
+      inputs.get(1),
+      getRowType,
+      all
+    )
+  }
+
+  override def toString: String = {
+    s"$intersectType($intersectSelectionToString)"
+  }
+
+  override def explainTerms(pw: RelWriter): RelWriter = {
+    super.explainTerms(pw).item(s"$intersectType", intersectSelectionToString)
+  }
+
+  override def computeSelfCost (planner: RelOptPlanner, metadata: RelMetadataQuery): RelOptCost = {
+    val children = this.getInputs
+    children.asScala.foldLeft(planner.getCostFactory.makeCost(0, 0, 0)) { (cost, child) =>
+      val rowCnt = metadata.getRowCount(child)
+      val rowSize = this.estimateRowSize(child.getRowType)
+      cost.plus(planner.getCostFactory.makeCost(rowCnt, rowCnt, rowCnt * rowSize))
+    }
+  }
+
+  override def translateToPlan(
+    tableEnv: StreamTableEnvironment,
+    queryConfig: StreamQueryConfig): DataStream[CRow] = {
+
+    val leftDataStream = left.asInstanceOf[DataStreamRel].translateToPlan(tableEnv, queryConfig)
+    val rightDataStream = right.asInstanceOf[DataStreamRel].translateToPlan(tableEnv, queryConfig)
+
+    // key by all fields
+    val keys = leftNode.getRowType.getFieldList.asScala.indices.toArray
+
+    val rowSchema = new RowSchema(rowRelDataType).projectedTypeInfo(keys)
+
+    val coFunc = new NonWindowIntersect(
+      rowSchema.asInstanceOf[RowTypeInfo],
+      queryConfig,
+      this.all
+    )
+
+    val opName = this.toString
+
+    leftDataStream
+      .connect(rightDataStream)
+      .keyBy(
+        new CRowKeySelector(keys, rowSchema),
+        new CRowKeySelector(keys, rowSchema))
+      .process(coFunc)
+      .name(opName)
+      .returns(new CRowTypeInfo(rowSchema.asInstanceOf[RowTypeInfo]))
+  }
+
+  private def intersectSelectionToString: String = {
+    getRowType.getFieldNames.asScala.mkString(", ")
+  }
+
+}

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/FlinkRuleSets.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/FlinkRuleSets.scala
@@ -211,6 +211,7 @@ object FlinkRuleSets {
     DataStreamCorrelateRule.INSTANCE,
     DataStreamWindowJoinRule.INSTANCE,
     DataStreamJoinRule.INSTANCE,
+    DataStreamIntersectRule.INSTANCE,
     StreamTableSourceScanRule.INSTANCE
   )
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/datastream/DataStreamIntersectRule.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/rules/datastream/DataStreamIntersectRule.scala
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.rules.datastream
+
+import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall, RelTraitSet}
+import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rel.convert.ConverterRule
+import org.apache.flink.table.calcite.FlinkTypeFactory
+import org.apache.flink.table.plan.nodes.FlinkConventions
+import org.apache.flink.table.plan.nodes.datastream.DataStreamIntersect
+import org.apache.flink.table.plan.nodes.logical.FlinkLogicalIntersect
+
+import scala.collection.JavaConverters._
+
+class DataStreamIntersectRule
+  extends ConverterRule(
+    classOf[FlinkLogicalIntersect],
+    FlinkConventions.LOGICAL,
+    FlinkConventions.DATASTREAM,
+    "DataStreamIntersectRule"){
+
+  override def convert(rel: RelNode): RelNode = {
+    val intersect: FlinkLogicalIntersect = rel.asInstanceOf[FlinkLogicalIntersect]
+    val traitSet: RelTraitSet = rel.getTraitSet.replace(FlinkConventions.DATASTREAM)
+    val convLeft: RelNode = RelOptRule.convert(intersect.getInput(0), FlinkConventions.DATASTREAM)
+    val convRight: RelNode = RelOptRule.convert(intersect.getInput(1), FlinkConventions.DATASTREAM)
+
+    new DataStreamIntersect(
+      rel.getCluster,
+      traitSet,
+      convLeft,
+      convRight,
+      rel.getRowType,
+      intersect.all)
+  }
+
+  override def matches(call: RelOptRuleCall): Boolean = {
+    val intersect = call.rel[FlinkLogicalIntersect](0)
+    // Check that no event-time attributes are in the input
+    // because non-window intersect is unbounded
+    // and we don't know how much to hold back watermarks.
+    val hasRowtimeFields = intersect.getRowType.getFieldList.asScala
+      .exists(f => FlinkTypeFactory.isRowtimeIndicatorType(f.getType))
+    !hasRowtimeFields
+  }
+}
+
+object DataStreamIntersectRule {
+  val INSTANCE: RelOptRule = new DataStreamIntersectRule
+}
+

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/setop/NonWindowIntersect.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/setop/NonWindowIntersect.scala
@@ -1,0 +1,242 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.runtime.setop
+
+import org.apache.flink.api.common.state.{ValueState, ValueStateDescriptor}
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.tuple.{Tuple2 => JTuple2}
+import org.apache.flink.api.java.typeutils.TupleTypeInfo
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.streaming.api.functions.co.CoProcessFunction
+import org.apache.flink.table.api.{StreamQueryConfig, Types}
+import org.apache.flink.table.runtime.join.CRowWrappingMultiOutputCollector
+import org.apache.flink.table.runtime.types.CRow
+import org.apache.flink.table.typeutils.TypeCheckUtils.validateEqualsHashCode
+import org.apache.flink.table.util.Logging
+import org.apache.flink.types.Row
+import org.apache.flink.util.Collector
+
+/**
+  * This function connect left stream and right stream, only used for non-window stream intersect.
+  * @param resultType  the output type of intersect
+  * @param queryConfig the configuration for the query to generate
+  * @param all         indicates an intersect or intersect all
+  */
+class NonWindowIntersect(
+  resultType: TypeInformation[Row],
+  queryConfig: StreamQueryConfig,
+  all: Boolean)
+  extends CoProcessFunction[CRow, CRow, CRow]
+  with Logging {
+
+  validateEqualsHashCode("intersect", resultType)
+
+  // state to keep track of the left row
+  private var leftState: ValueState[JTuple2[Int, Long]] = _
+  // state to keep track of the right row
+  private var rightState: ValueState[JTuple2[Int, Long]] = _
+
+  private val minRetentionTime: Long = queryConfig.getMinIdleStateRetentionTime
+  private val maxRetentionTime: Long = queryConfig.getMaxIdleStateRetentionTime
+  private val stateCleaningEnabled: Boolean = minRetentionTime > 1
+
+  // state to record last timer of left stream, 0 means no timer
+  private var leftTimer: ValueState[Long] = _
+  // state to record last timer of right stream, 0 means no timer
+  private var rightTimer: ValueState[Long] = _
+
+  private var cRowWrapper: CRowWrappingMultiOutputCollector = _
+
+  override def open(parameters: Configuration): Unit = {
+    LOG.debug("Instantiating StreamIntersectCoProcessFunction.")
+    // initialize left and right state, the first element of tuple2 indicates how many rows of
+    // this row, while the second element represents the expired time of this row.
+    val tupleTypeInfo = new TupleTypeInfo[JTuple2[Int, Long]](Types.INT, Types.LONG)
+    val leftStateDescriptor = new ValueStateDescriptor[JTuple2[Int, Long]](
+      "left", tupleTypeInfo)
+    val rightStateDescriptor = new ValueStateDescriptor[JTuple2[Int, Long]](
+      "right", tupleTypeInfo)
+    leftState = getRuntimeContext.getState(leftStateDescriptor)
+    rightState = getRuntimeContext.getState(rightStateDescriptor)
+
+    // initialize timer state
+    val valueStateDescriptor1 = new ValueStateDescriptor[Long]("leftTimer", classOf[Long])
+    leftTimer = getRuntimeContext.getState(valueStateDescriptor1)
+    val valueStateDescriptor2 = new ValueStateDescriptor[Long]("rightTimer", classOf[Long])
+    rightTimer = getRuntimeContext.getState(valueStateDescriptor2)
+
+    cRowWrapper = new CRowWrappingMultiOutputCollector()
+    //we emit one record per process at most
+    cRowWrapper.setTimes(1)
+  }
+
+  override def processElement1(
+    value: CRow,
+    ctx: CoProcessFunction[CRow, CRow, CRow]#Context,
+    out: Collector[CRow]): Unit = {
+
+    processElement(value, ctx, out, leftState, leftTimer, rightState)
+  }
+
+  override def processElement2(
+    value: CRow,
+    ctx: CoProcessFunction[CRow, CRow, CRow]#Context,
+    out: Collector[CRow]): Unit = {
+
+    processElement(value, ctx, out, rightState, rightTimer, leftState)
+  }
+
+  private def processElement(
+    value: CRow,
+    ctx: CoProcessFunction[CRow, CRow, CRow]#Context,
+    out: Collector[CRow],
+    currentSideState: ValueState[JTuple2[Int, Long]],
+    currentSideTimer: ValueState[Long],
+    otherSideState: ValueState[JTuple2[Int, Long]]): Unit = {
+
+    val inputRow = value.row
+    cRowWrapper.setChange(value.change)
+    cRowWrapper.setCollector(out)
+
+    val cntAndExpiredTime = updateState(value, ctx, currentSideState, currentSideTimer)
+
+    val otherSideValue = otherSideState.value()
+    if (otherSideValue != null) {
+      if (all) {
+        if (value.change && cntAndExpiredTime.f0 <= otherSideValue.f0) {
+          cRowWrapper.collect(inputRow)
+        } else if (!value.change && cntAndExpiredTime.f0 < otherSideValue.f0) {
+          cRowWrapper.collect(inputRow)
+        }
+      } else {
+        if (value.change && cntAndExpiredTime.f0 == 1) {
+          cRowWrapper.collect(inputRow)
+        } else if (!value.change && cntAndExpiredTime.f0 == 0) {
+          cRowWrapper.collect(inputRow)
+        }
+      }
+    }
+  }
+
+  /**
+    * update valueState and TimerState and return the current state
+    * @param value
+    * @param ctx
+    * @param state
+    * @param timerState
+    * @return
+    */
+  private def updateState(
+    value: CRow,
+    ctx: CoProcessFunction[CRow, CRow, CRow]#Context,
+    state: ValueState[JTuple2[Int, Long]],
+    timerState: ValueState[Long]): JTuple2[Int, Long] = {
+
+    val curProcessTime = ctx.timerService.currentProcessingTime
+    val oldCntAndExpiredTime = state.value()
+    val cntAndExpiredTime = if (null == oldCntAndExpiredTime) {
+      JTuple2.of(0, -1L)
+    } else {
+      oldCntAndExpiredTime
+    }
+
+    cntAndExpiredTime.f1 = getNewExpiredTime(curProcessTime, cntAndExpiredTime.f1)
+    if (stateCleaningEnabled && timerState.value() == 0) {
+      timerState.update(cntAndExpiredTime.f1)
+      ctx.timerService().registerProcessingTimeTimer(cntAndExpiredTime.f1)
+    }
+
+    if (!value.change) {
+      cntAndExpiredTime.f0 = cntAndExpiredTime.f0 - 1
+      if (cntAndExpiredTime.f0 <= 0) {
+        state.clear()
+      } else {
+        state.update(cntAndExpiredTime)
+      }
+    } else {
+      cntAndExpiredTime.f0 = cntAndExpiredTime.f0 + 1
+      state.update(cntAndExpiredTime)
+    }
+    cntAndExpiredTime
+
+  }
+
+  def getNewExpiredTime(
+   curProcessTime: Long,
+   oldExpiredTime: Long): Long = {
+    if (stateCleaningEnabled && curProcessTime + minRetentionTime > oldExpiredTime) {
+      curProcessTime + maxRetentionTime
+    } else {
+      oldExpiredTime
+    }
+  }
+
+  override def onTimer(
+    timestamp: Long,
+    ctx: CoProcessFunction[CRow, CRow, CRow]#OnTimerContext,
+    out: Collector[CRow]): Unit = {
+
+    if (stateCleaningEnabled && leftTimer.value == timestamp) {
+      expireOutTimeRow(
+        timestamp,
+        leftState,
+        leftTimer,
+        ctx
+      )
+    }
+
+    if (stateCleaningEnabled && rightTimer.value == timestamp) {
+      expireOutTimeRow(
+        timestamp,
+        rightState,
+        rightTimer,
+        ctx
+      )
+    }
+  }
+
+  private def expireOutTimeRow(
+    curTime: Long,
+    rowState: ValueState[JTuple2[Int, Long]],
+    timerState: ValueState[Long],
+    ctx: CoProcessFunction[CRow, CRow, CRow]#OnTimerContext): Unit = {
+
+    var validTimestamp: Boolean = false
+    val rowValue = rowState.value()
+    if (rowValue != null) {
+      val recordExpiredTime = rowValue.f1
+      if (recordExpiredTime <= curTime) {
+        rowState.clear()
+      } else {
+        // we found a timestamp that is still valid
+        validTimestamp = true
+      }
+    }
+
+    // If the state has non-expired timestamps, register a new timer.
+    // Otherwise clean the complete state for this input.
+    if (validTimestamp) {
+      val cleanupTime = curTime + maxRetentionTime
+      ctx.timerService.registerProcessingTimeTimer(cleanupTime)
+      timerState.update(cleanupTime)
+    } else {
+      timerState.clear()
+      rowState.clear()
+    }
+  }
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/SetOperatorsTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/SetOperatorsTest.scala
@@ -228,4 +228,85 @@ class SetOperatorsTest extends TableTestBase {
 
     streamUtil.verifyTable(result, expected)
   }
+
+  @Test
+  def testFilterIntersectTranspose(): Unit = {
+    val util = streamTestUtil()
+    val left = util.addTable[(Int, Long, String)]("left", 'a, 'b, 'c)
+    val right = util.addTable[(Int, Long, String)]("right", 'a, 'b, 'c)
+
+    val result = left.intersect(right)
+      .where('a > 0)
+      .groupBy('b)
+      .select('a.sum as 'a, 'b as 'b, 'c.count as 'c)
+
+    val expected = unaryNode(
+      "DataStreamCalc",
+      unaryNode(
+        "DataStreamGroupAggregate",
+        binaryNode(
+          "DataStreamIntersect",
+          unaryNode(
+            "DataStreamCalc",
+            streamTableNode(0),
+            term("select", "a", "b", "c"),
+            term("where", ">(a, 0)")
+          ),
+          unaryNode(
+            "DataStreamCalc",
+            streamTableNode(1),
+            term("select", "a", "b", "c"),
+            term("where", ">(a, 0)")
+          ),
+          term("Intersect", "a", "b", "c")
+        ),
+        term("groupBy", "b"),
+        term("select", "b", "SUM(a) AS TMP_0", "COUNT(c) AS TMP_1")
+      ),
+      term("select", "TMP_0 AS a", "b", "TMP_1 AS c")
+    )
+
+    util.verifyTable(result, expected)
+  }
+
+  @Test
+  def testFilterIntersectAllTranspose(): Unit = {
+    val util = streamTestUtil()
+    val left = util.addTable[(Int, Long, String)]("left", 'a, 'b, 'c)
+    val right = util.addTable[(Int, Long, String)]("right", 'a, 'b, 'c)
+
+    val result = left.intersectAll(right)
+      .where('a > 0)
+      .groupBy('b)
+      .select('a.sum as 'a, 'b as 'b, 'c.count as 'c)
+
+    val expected = unaryNode(
+      "DataStreamCalc",
+      unaryNode(
+        "DataStreamGroupAggregate",
+        binaryNode(
+          "DataStreamIntersect",
+          unaryNode(
+            "DataStreamCalc",
+            streamTableNode(0),
+            term("select", "a", "b", "c"),
+            term("where", ">(a, 0)")
+          ),
+          unaryNode(
+            "DataStreamCalc",
+            streamTableNode(1),
+            term("select", "a", "b", "c"),
+            term("where", ">(a, 0)")
+          ),
+          term("IntersectAll", "a", "b", "c")
+        ),
+        term("groupBy", "b"),
+        term("select", "b", "SUM(a) AS TMP_0", "COUNT(c) AS TMP_1")
+      ),
+      term("select", "TMP_0 AS a", "b", "TMP_1 AS c")
+    )
+
+    util.verifyTable(result, expected)
+  }
+
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/stringexpr/SetOperatorsStringExpressionTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/stringexpr/SetOperatorsStringExpressionTest.scala
@@ -46,4 +46,26 @@ class SetOperatorsStringExpressionTest extends TableTestBase {
     val resJava = t1.unionAll(t2.select("int, long, string")).filter("int < 2").select("int")
     verifyTableEquals(resJava, resScala)
   }
+
+  @Test
+  def testIntersect(): Unit = {
+    val util = streamTestUtil()
+    val t1 = util.addTable[(Int, Long, String)]('int, 'long, 'string)
+    val t2 = util.addTable[(Int, Long, String)]('int, 'long, 'string)
+
+    val resScala = t1.intersect(t2).select('int)
+    val resJava = t1.intersect(t2).select("int")
+    verifyTableEquals(resJava, resScala)
+  }
+
+  @Test
+  def testIntersectAll(): Unit = {
+    val util = streamTestUtil()
+    val t1 = util.addTable[(Int, Long, String)]('int, 'long, 'string)
+    val t2 = util.addTable[(Int, Long, String)]('int, 'long, 'string)
+
+    val resScala = t1.intersectAll(t2).select('int)
+    val resJava = t1.intersectAll(t2).select("int")
+    verifyTableEquals(resJava, resScala)
+  }
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/validation/UnsupportedOpsValidationTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/validation/UnsupportedOpsValidationTest.scala
@@ -53,24 +53,6 @@ class UnsupportedOpsValidationTest extends AbstractTestBase {
   }
 
   @Test(expected = classOf[ValidationException])
-  def testIntersect(): Unit = {
-    val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
-    val t1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv)
-    val t2 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv)
-    t1.intersect(t2)
-  }
-
-  @Test(expected = classOf[ValidationException])
-  def testIntersectAll(): Unit = {
-    val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
-    val t1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv)
-    val t2 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv)
-    t1.intersectAll(t2)
-  }
-
-  @Test(expected = classOf[ValidationException])
   def testMinus(): Unit = {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     val tEnv = TableEnvironment.getTableEnvironment(env)

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/batch/sql/SetOperatorsITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/batch/sql/SetOperatorsITCase.scala
@@ -216,8 +216,6 @@ class SetOperatorsITCase(
   }
 
   @Test
-  @Ignore
-  // calcite sql parser doesn't support INTERSECT ALL
   def testIntersectAll(): Unit = {
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
     val tEnv = TableEnvironment.getTableEnvironment(env, config)

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/sql/SetOperatorsITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/sql/SetOperatorsITCase.scala
@@ -18,14 +18,17 @@
 
 package org.apache.flink.table.runtime.stream.sql
 
-import org.apache.flink.api.scala._
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.apache.flink.table.api.TableEnvironment
 import org.apache.flink.table.api.scala._
-import org.apache.flink.table.runtime.utils.{StreamITCase, StreamingWithStateTestBase}
+import org.apache.flink.api.scala._
+import org.apache.flink.table.runtime.utils.{StreamITCase, StreamTestData, StreamingWithStateTestBase}
 import org.apache.flink.types.Row
 import org.junit.Assert.assertEquals
 import org.junit.Test
+
+import scala.collection.mutable
+import scala.util.Random
 
 class SetOperatorsITCase extends StreamingWithStateTestBase {
 
@@ -164,6 +167,126 @@ class SetOperatorsITCase extends StreamingWithStateTestBase {
     val expected = Seq(
       "3,3,Hello World"
     )
+
+    assertEquals(expected.sorted, StreamITCase.retractedResults.sorted)
+  }
+
+  @Test
+  def testIntersect(): Unit = {
+    val env: StreamExecutionEnvironment = StreamExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env)
+
+    StreamITCase.clear
+    val sqlQuery = "SELECT c FROM t1 INTERSECT SELECT c FROM t2"
+
+    val ds1 = StreamTestData.getSmall3TupleDataStream(env)
+    val data = new mutable.MutableList[(Int, Long, String)]
+    data.+=((1, 1L, "Hi"))
+    data.+=((2, 2L, "Hello"))
+    data.+=((2, 2L, "Hello"))
+    data.+=((3, 2L, "Hello world!"))
+    val ds2 = env.fromCollection(Random.shuffle(data))
+
+    tEnv.registerTable("t1", ds1.toTable(tEnv, 'a, 'b, 'c))
+    tEnv.registerTable("t2", ds2.toTable(tEnv, 'a, 'b, 'c))
+
+    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    result.addSink(new StreamITCase.StringSink[Row])
+    env.execute()
+
+    val expected = List("Hi", "Hello")
+    assertEquals(expected.sorted, StreamITCase.testResults.sorted)
+  }
+
+  @Test
+  def testIntersectAll(): Unit = {
+    val env: StreamExecutionEnvironment = StreamExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env)
+
+    StreamITCase.clear
+    val sqlQuery = "SELECT c FROM t1 INTERSECT ALL SELECT c FROM t2"
+
+    val data1 = new mutable.MutableList[Int]
+    data1 += (1, 1, 1, 2, 2, 3, 3, 3, 4)
+    val data2 = new mutable.MutableList[Int]
+    data2 += (1, 2, 2, 3, 3, 3, 4, 4, 4, 4)
+    val ds1 = env.fromCollection(data1)
+    val ds2 = env.fromCollection(data2)
+
+    tEnv.registerTable("t1", ds1.toTable(tEnv, 'c))
+    tEnv.registerTable("t2", ds2.toTable(tEnv, 'c))
+
+    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    result.addSink(new StreamITCase.StringSink[Row])
+    env.execute()
+
+    val expected = List("1", "2", "2", "3", "3", "3", "4")
+
+    assertEquals(expected.sorted, StreamITCase.testResults.sorted)
+  }
+
+  @Test
+  def testIntersectWithFilter(): Unit = {
+    val env: StreamExecutionEnvironment = StreamExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env)
+
+    StreamITCase.clear
+
+    val sqlQuery = "SELECT c FROM ((SELECT * FROM t1) INTERSECT (SELECT * FROM t2)) WHERE a > 1"
+
+    val ds1 = StreamTestData.getSmall3TupleDataStream(env)
+    val ds2 = StreamTestData.get3TupleDataStream(env)
+
+    tEnv.registerTable("t1", ds1.toTable(tEnv, 'a, 'b, 'c))
+    tEnv.registerTable("t2", ds2.toTable(tEnv, 'a, 'b, 'c))
+
+    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    result.addSink(new StreamITCase.StringSink[Row])
+    env.execute()
+
+    val expected = List("Hello", "Hello world")
+
+    assertEquals(expected.sorted, StreamITCase.testResults.sorted)
+  }
+
+  @Test
+  def testIntersectWithRetraction(): Unit = {
+    val env: StreamExecutionEnvironment = StreamExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env)
+
+    StreamITCase.clear
+    val sqlQuery = "SELECT SUM(b) FROM t1 GROUP BY a INTERSECT SELECT SUM(b) FROM t2 GROUP BY a"
+
+    val data1 = List(
+      ("a", 1),
+      ("a", 2),
+      ("a", 3),
+      ("a", 4),
+      ("b", 10),
+      ("b", -6),
+      ("b", -1)
+    )
+    val data2 = List(
+      ("a", 3),
+      ("a", 3),
+      ("a", 3),
+      ("a", 1),
+      ("b", 1),
+      ("b", 1),
+      ("b", 1)
+    )
+
+    val ds1 = env.fromCollection(data1)
+    val ds2 = env.fromCollection(data2)
+
+    tEnv.registerTable("t1", ds1.toTable(tEnv, 'a, 'b))
+    tEnv.registerTable("t2", ds2.toTable(tEnv, 'a, 'b))
+
+    val result = tEnv.sqlQuery(sqlQuery).toRetractStream[Row]
+    result.addSink(new StreamITCase.RetractingSink)
+    env.execute()
+
+    val expected = List("10", "3")
 
     assertEquals(expected.sorted, StreamITCase.retractedResults.sorted)
   }


### PR DESCRIPTION
[FLINK-9344] [TableAPI & SQL] Support INTERSECT and INTERSECT ALL for streaming

## What is the purpose of the change
Support Intersect and Intersect All for Streaming SQL and TableAPI


## Brief change log
* implemented NonWindowIntersect


## Verifying this change

This change added tests and can be verified as follows:
cases of intersect operations in both ```org.apache.flink.table.runtime.stream.sql.SetOperatorsITCase```  and
```org.apache.flink.table.runtime.stream.table.SetOperatorsITCase```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers:  no
  - The runtime per-record code paths (performance sensitive):  no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper:  no
  - The S3 file system connector:  no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented?  not yet, but will be documented in next issue
