### PR TITLE
[FLINK-9299] [Documents] ProcessWindowFunction documentation Java examples have error

### DIFF
--- a/docs/dev/stream/operators/windows.md
+++ b/docs/dev/stream/operators/windows.md
@@ -730,9 +730,9 @@ input
 
 /* ... */
 
-public class MyProcessWindowFunction implements ProcessWindowFunction<Tuple<String, Long>, String, String, TimeWindow> {
+public static class MyProcessWindowFunction extends ProcessWindowFunction<Tuple<String, Long>, String, String, TimeWindow> {
 
-  void process(String key, Context context, Iterable<Tuple<String, Long>> input, Collector<String> out) {
+  public void process(String key, Context context, Iterable<Tuple<String, Long>> input, Collector<String> out) {
     long count = 0;
     for (Tuple<String, Long> in: input) {
       count++;


### PR DESCRIPTION

## What is the purpose of the change

ProcessWindowFunction documentation Java examples have error

## Brief change log

ProcessWindowFunction is an abstract class and should extends instead of implements 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
