### PR TITLE
[FLINK-9354][travis] Print execution times for nightly E2E tests

### DIFF
--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -42,154 +42,78 @@ EXIT_CODE=0
 # Template for adding a test:
 
 # if [ $EXIT_CODE == 0 ]; then
-#     printf "\n==============================================================================\n"
-#     printf "Running my fancy nightly end-to-end test\n"
-#     printf "==============================================================================\n"
-#     start_timer
-#     $END_TO_END_DIR/test-scripts/test_something_very_fancy.sh
-#     EXIT_CODE=$?
-#     end_timer
+#    run_test "<description>" "$END_TO_END_DIR/test-scripts/<script_name>"
+#    EXIT_CODE=$?
 # fi
 
-
 if [ $EXIT_CODE == 0 ]; then
-    printf "\n==============================================================================\n"
-    printf "Running HA end-to-end test\n"
-    printf "==============================================================================\n"
-    start_timer
-    $END_TO_END_DIR/test-scripts/test_ha.sh
+    run_test "HA end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha.sh"
     EXIT_CODE=$?
-    end_timer
 fi
 
 if [ $EXIT_CODE == 0 ]; then
-  printf "\n==============================================================================\n"
-  printf "Running Resuming Savepoint (file, async, no parallelism change) end-to-end test\n"
-  printf "==============================================================================\n"
-  start_timer
-  STATE_BACKEND_TYPE=file STATE_BACKEND_FILE_ASYNC=true $END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 2 2
-  EXIT_CODE=$?
-  end_timer
+    run_test "Resuming Savepoint (file, async, no parallelism change) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 2 2 file true"
+    EXIT_CODE=$?
 fi
 
 if [ $EXIT_CODE == 0 ]; then
-  printf "\n==============================================================================\n"
-  printf "Running Resuming Savepoint (file, sync, no parallelism change) end-to-end test\n"
-  printf "==============================================================================\n"
-  start_timer
-  STATE_BACKEND_TYPE=file STATE_BACKEND_FILE_ASYNC=false $END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 2 2
-  EXIT_CODE=$?
-  end_timer
+    run_test "Resuming Savepoint (file, sync, no parallelism change) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 2 2 file false"
+    EXIT_CODE=$?
 fi
 
 if [ $EXIT_CODE == 0 ]; then
-  printf "\n==============================================================================\n"
-  printf "Running Resuming Savepoint (file, async, scale up) end-to-end test\n"
-  printf "==============================================================================\n"
-  start_timer
-  STATE_BACKEND_TYPE=file STATE_BACKEND_FILE_ASYNC=true $END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 2 4
-  EXIT_CODE=$?
-  end_timer
+    run_test "Resuming Savepoint (file, async, scale up) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 2 4 file true"
+    EXIT_CODE=$?
 fi
 
 if [ $EXIT_CODE == 0 ]; then
-  printf "\n==============================================================================\n"
-  printf "Running Resuming Savepoint (file, sync, scale up) end-to-end test\n"
-  printf "==============================================================================\n"
-  start_timer
-  STATE_BACKEND_TYPE=file STATE_BACKEND_FILE_ASYNC=false $END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 2 4
-  EXIT_CODE=$?
-  end_timer
+    run_test "Resuming Savepoint (file, sync, scale up) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 2 4 file false"
+    EXIT_CODE=$?
 fi
 
 if [ $EXIT_CODE == 0 ]; then
-  printf "\n==============================================================================\n"
-  printf "Running Resuming Savepoint (file, async, scale down) end-to-end test\n"
-  printf "==============================================================================\n"
-  start_timer
-  STATE_BACKEND_TYPE=file STATE_BACKEND_FILE_ASYNC=true $END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 4 2
-  EXIT_CODE=$?
-  end_timer
+    run_test "Resuming Savepoint (file, async, scale down) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 4 2 file true"
+    EXIT_CODE=$?
 fi
 
 if [ $EXIT_CODE == 0 ]; then
-  printf "\n==============================================================================\n"
-  printf "Running Resuming Savepoint (file, sync, scale down) end-to-end test\n"
-  printf "==============================================================================\n"
-  start_timer
-  STATE_BACKEND_TYPE=file STATE_BACKEND_FILE_ASYNC=false $END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 4 2
-  EXIT_CODE=$?
-  end_timer
+    run_test "Resuming Savepoint (file, sync, scale down) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 4 2 file false"
+    EXIT_CODE=$?
 fi
 
 if [ $EXIT_CODE == 0 ]; then
-  printf "\n==============================================================================\n"
-  printf "Running Resuming Savepoint (rocks, no parallelism change) end-to-end test\n"
-  printf "==============================================================================\n"
-  start_timer
-  STATE_BACKEND_TYPE=rocks $END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 2 2
-  EXIT_CODE=$?
-  end_timer
+    run_test "Resuming Savepoint (rocks, no parallelism change) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 2 2 rocks"
+    EXIT_CODE=$?
 fi
 
 if [ $EXIT_CODE == 0 ]; then
-  printf "\n==============================================================================\n"
-  printf "Running Resuming Savepoint (rocks, scale up) end-to-end test\n"
-  printf "==============================================================================\n"
-  start_timer
-  STATE_BACKEND_TYPE=rocks $END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 2 4
-  EXIT_CODE=$?
-  end_timer
+    run_test "Resuming Savepoint (rocks, scale up) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 2 4 rocks"
+    EXIT_CODE=$?
 fi
 
 if [ $EXIT_CODE == 0 ]; then
-  printf "\n==============================================================================\n"
-  printf "Running Resuming Savepoint (rocks, scale down) end-to-end test\n"
-  printf "==============================================================================\n"
-  start_timer
-  STATE_BACKEND_TYPE=rocks $END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 4 2
-  EXIT_CODE=$?
-  end_timer
+    run_test "Resuming Savepoint (rocks, scale down) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 4 2 rocks"
+    EXIT_CODE=$?
 fi
 
 if [ $EXIT_CODE == 0 ]; then
-  printf "\n==============================================================================\n"
-  printf "Running DataSet allround nightly end-to-end test\n"
-  printf "==============================================================================\n"
-  start_timer
-  $END_TO_END_DIR/test-scripts/test_batch_allround.sh
-  EXIT_CODE=$?
-  end_timer
+    run_test "DataSet allround end-to-end test" "$END_TO_END_DIR/test-scripts/test_batch_allround.sh"
+    EXIT_CODE=$?
 fi
 
 if [ $EXIT_CODE == 0 ]; then
-  printf "\n==============================================================================\n"
-  printf "Running Streaming SQL nightly end-to-end test\n"
-  printf "==============================================================================\n"
-  start_timer
-  $END_TO_END_DIR/test-scripts/test_streaming_sql.sh
-  EXIT_CODE=$?
-  end_timer
+    run_test "Streaming SQL end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_sql.sh"
+    EXIT_CODE=$?
 fi
 
 if [ $EXIT_CODE == 0 ]; then
-  printf "\n==============================================================================\n"
-  printf "Running Streaming bucketing nightly end-to-end test\n"
-  printf "==============================================================================\n"
-  start_timer
-  $END_TO_END_DIR/test-scripts/test_streaming_bucketing.sh
-  EXIT_CODE=$?
-  end_timer
+    run_test "Streaming bucketing end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_bucketing.sh"
+    EXIT_CODE=$?
 fi
 
 if [ $EXIT_CODE == 0 ]; then
-  printf "\n==============================================================================\n"
-  printf "Running stateful stream job upgrade nightly end-to-end test\n"
-  printf "==============================================================================\n"
-  start_timer
-  $END_TO_END_DIR/test-scripts/test_stateful_stream_job_upgrade.sh 2 4
-  EXIT_CODE=$?
-  end_timer
+    run_test "stateful stream job upgrade end-to-end test" "$END_TO_END_DIR/test-scripts/test_stateful_stream_job_upgrade.sh 2 4"
+    EXIT_CODE=$?
 fi
 
 # Exit code for Travis build success/failure

--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -30,6 +30,8 @@ if [ -z "$FLINK_DIR" ] ; then
     exit 1
 fi
 
+source "$(dirname "$0")"/test-scripts/common.sh
+
 FLINK_DIR="`( cd \"$FLINK_DIR\" && pwd )`" # absolutized and normalized
 
 echo "flink-end-to-end-test directory: $END_TO_END_DIR"

--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -43,8 +43,10 @@ EXIT_CODE=0
 #     printf "\n==============================================================================\n"
 #     printf "Running my fancy nightly end-to-end test\n"
 #     printf "==============================================================================\n"
+#     start_timer
 #     $END_TO_END_DIR/test-scripts/test_something_very_fancy.sh
 #     EXIT_CODE=$?
+#     end_timer
 # fi
 
 
@@ -52,112 +54,140 @@ if [ $EXIT_CODE == 0 ]; then
     printf "\n==============================================================================\n"
     printf "Running HA end-to-end test\n"
     printf "==============================================================================\n"
+    start_timer
     $END_TO_END_DIR/test-scripts/test_ha.sh
     EXIT_CODE=$?
+    end_timer
 fi
 
 if [ $EXIT_CODE == 0 ]; then
   printf "\n==============================================================================\n"
   printf "Running Resuming Savepoint (file, async, no parallelism change) end-to-end test\n"
   printf "==============================================================================\n"
+  start_timer
   STATE_BACKEND_TYPE=file STATE_BACKEND_FILE_ASYNC=true $END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 2 2
   EXIT_CODE=$?
+  end_timer
 fi
 
 if [ $EXIT_CODE == 0 ]; then
   printf "\n==============================================================================\n"
   printf "Running Resuming Savepoint (file, sync, no parallelism change) end-to-end test\n"
   printf "==============================================================================\n"
+  start_timer
   STATE_BACKEND_TYPE=file STATE_BACKEND_FILE_ASYNC=false $END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 2 2
   EXIT_CODE=$?
+  end_timer
 fi
 
 if [ $EXIT_CODE == 0 ]; then
   printf "\n==============================================================================\n"
   printf "Running Resuming Savepoint (file, async, scale up) end-to-end test\n"
   printf "==============================================================================\n"
+  start_timer
   STATE_BACKEND_TYPE=file STATE_BACKEND_FILE_ASYNC=true $END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 2 4
   EXIT_CODE=$?
+  end_timer
 fi
 
 if [ $EXIT_CODE == 0 ]; then
   printf "\n==============================================================================\n"
   printf "Running Resuming Savepoint (file, sync, scale up) end-to-end test\n"
   printf "==============================================================================\n"
+  start_timer
   STATE_BACKEND_TYPE=file STATE_BACKEND_FILE_ASYNC=false $END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 2 4
   EXIT_CODE=$?
+  end_timer
 fi
 
 if [ $EXIT_CODE == 0 ]; then
   printf "\n==============================================================================\n"
   printf "Running Resuming Savepoint (file, async, scale down) end-to-end test\n"
   printf "==============================================================================\n"
+  start_timer
   STATE_BACKEND_TYPE=file STATE_BACKEND_FILE_ASYNC=true $END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 4 2
   EXIT_CODE=$?
+  end_timer
 fi
 
 if [ $EXIT_CODE == 0 ]; then
   printf "\n==============================================================================\n"
   printf "Running Resuming Savepoint (file, sync, scale down) end-to-end test\n"
   printf "==============================================================================\n"
+  start_timer
   STATE_BACKEND_TYPE=file STATE_BACKEND_FILE_ASYNC=false $END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 4 2
   EXIT_CODE=$?
+  end_timer
 fi
 
 if [ $EXIT_CODE == 0 ]; then
   printf "\n==============================================================================\n"
   printf "Running Resuming Savepoint (rocks, no parallelism change) end-to-end test\n"
   printf "==============================================================================\n"
+  start_timer
   STATE_BACKEND_TYPE=rocks $END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 2 2
   EXIT_CODE=$?
+  end_timer
 fi
 
 if [ $EXIT_CODE == 0 ]; then
   printf "\n==============================================================================\n"
   printf "Running Resuming Savepoint (rocks, scale up) end-to-end test\n"
   printf "==============================================================================\n"
+  start_timer
   STATE_BACKEND_TYPE=rocks $END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 2 4
   EXIT_CODE=$?
+  end_timer
 fi
 
 if [ $EXIT_CODE == 0 ]; then
   printf "\n==============================================================================\n"
   printf "Running Resuming Savepoint (rocks, scale down) end-to-end test\n"
   printf "==============================================================================\n"
+  start_timer
   STATE_BACKEND_TYPE=rocks $END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 4 2
   EXIT_CODE=$?
+  end_timer
 fi
 
 if [ $EXIT_CODE == 0 ]; then
   printf "\n==============================================================================\n"
   printf "Running DataSet allround nightly end-to-end test\n"
   printf "==============================================================================\n"
+  start_timer
   $END_TO_END_DIR/test-scripts/test_batch_allround.sh
   EXIT_CODE=$?
+  end_timer
 fi
 
 if [ $EXIT_CODE == 0 ]; then
   printf "\n==============================================================================\n"
   printf "Running Streaming SQL nightly end-to-end test\n"
   printf "==============================================================================\n"
+  start_timer
   $END_TO_END_DIR/test-scripts/test_streaming_sql.sh
   EXIT_CODE=$?
+  end_timer
 fi
 
 if [ $EXIT_CODE == 0 ]; then
   printf "\n==============================================================================\n"
   printf "Running Streaming bucketing nightly end-to-end test\n"
   printf "==============================================================================\n"
+  start_timer
   $END_TO_END_DIR/test-scripts/test_streaming_bucketing.sh
   EXIT_CODE=$?
+  end_timer
 fi
 
 if [ $EXIT_CODE == 0 ]; then
   printf "\n==============================================================================\n"
   printf "Running stateful stream job upgrade nightly end-to-end test\n"
   printf "==============================================================================\n"
+  start_timer
   $END_TO_END_DIR/test-scripts/test_stateful_stream_job_upgrade.sh 2 4
   EXIT_CODE=$?
+  end_timer
 fi
 
 # Exit code for Travis build success/failure

--- a/flink-end-to-end-tests/run-pre-commit-tests.sh
+++ b/flink-end-to-end-tests/run-pre-commit-tests.sh
@@ -41,56 +41,70 @@ if [ $EXIT_CODE == 0 ]; then
     printf "\n==============================================================================\n"
     printf "Running Wordcount end-to-end test\n"
     printf "==============================================================================\n"
+    start_timer
     $END_TO_END_DIR/test-scripts/test_batch_wordcount.sh
     EXIT_CODE=$?
+    end_timer
 fi
 
 if [ $EXIT_CODE == 0 ]; then
     printf "\n==============================================================================\n"
     printf "Running Kafka end-to-end test\n"
     printf "==============================================================================\n"
+    start_timer
     $END_TO_END_DIR/test-scripts/test_streaming_kafka010.sh
     EXIT_CODE=$?
+    end_timer
 fi
 
 if [ $EXIT_CODE == 0 ]; then
     printf "\n==============================================================================\n"
     printf "Running class loading end-to-end test\n"
     printf "==============================================================================\n"
+    start_timer
     $END_TO_END_DIR/test-scripts/test_streaming_classloader.sh
     EXIT_CODE=$?
+    end_timer
 fi
 
 if [ $EXIT_CODE == 0 ]; then
     printf "\n==============================================================================\n"
     printf "Running Shaded Hadoop S3A end-to-end test\n"
     printf "==============================================================================\n"
+    start_timer
     $END_TO_END_DIR/test-scripts/test_shaded_hadoop_s3a.sh
     EXIT_CODE=$?
+    end_timer
 fi
 
 if [ $EXIT_CODE == 0 ]; then
     printf "\n==============================================================================\n"
     printf "Running Shaded Presto S3 end-to-end test\n"
     printf "==============================================================================\n"
+  start_timer
     $END_TO_END_DIR/test-scripts/test_shaded_presto_s3.sh
     EXIT_CODE=$?
+    end_timer
 fi
 
 if [ $EXIT_CODE == 0 ]; then
     printf "\n==============================================================================\n"
     printf "Running Hadoop-free Wordcount end-to-end test\n"
     printf "==============================================================================\n"
+    start_timer
     CLUSTER_MODE=cluster $END_TO_END_DIR/test-scripts/test_hadoop_free.sh
     EXIT_CODE=$?
+    end_timer
 fi
 
 if [ $EXIT_CODE == 0 ]; then
     printf "\n==============================================================================\n"
     printf "Running Streaming Python Wordcount end-to-end test\n"
     printf "==============================================================================\n"
+    start_timer
     $END_TO_END_DIR/test-scripts/test_streaming_python_wordcount.sh
     EXIT_CODE=$?
+    end_timer
 fi
 
 

--- a/flink-end-to-end-tests/run-pre-commit-tests.sh
+++ b/flink-end-to-end-tests/run-pre-commit-tests.sh
@@ -39,74 +39,46 @@ echo "Flink distribution directory: $FLINK_DIR"
 
 EXIT_CODE=0
 
+# Template for adding a test:
+
+# if [ $EXIT_CODE == 0 ]; then
+#    run_test "<description>" "$END_TO_END_DIR/test-scripts/<script_name>"
+#    EXIT_CODE=$?
+# fi
+
 if [ $EXIT_CODE == 0 ]; then
-    printf "\n==============================================================================\n"
-    printf "Running Wordcount end-to-end test\n"
-    printf "==============================================================================\n"
-    start_timer
-    $END_TO_END_DIR/test-scripts/test_batch_wordcount.sh
+    run_test "Streaming Python Wordcount end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_python_wordcount.sh"
     EXIT_CODE=$?
-    end_timer
 fi
 
 if [ $EXIT_CODE == 0 ]; then
-    printf "\n==============================================================================\n"
-    printf "Running Kafka end-to-end test\n"
-    printf "==============================================================================\n"
-    start_timer
-    $END_TO_END_DIR/test-scripts/test_streaming_kafka010.sh
+    run_test "Wordcount end-to-end test" "$END_TO_END_DIR/test-scripts/test_batch_wordcount.sh"
     EXIT_CODE=$?
-    end_timer
 fi
 
 if [ $EXIT_CODE == 0 ]; then
-    printf "\n==============================================================================\n"
-    printf "Running class loading end-to-end test\n"
-    printf "==============================================================================\n"
-    start_timer
-    $END_TO_END_DIR/test-scripts/test_streaming_classloader.sh
+    run_test "Kafka end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_kafka010.sh"
     EXIT_CODE=$?
-    end_timer
 fi
 
 if [ $EXIT_CODE == 0 ]; then
-    printf "\n==============================================================================\n"
-    printf "Running Shaded Hadoop S3A end-to-end test\n"
-    printf "==============================================================================\n"
-    start_timer
-    $END_TO_END_DIR/test-scripts/test_shaded_hadoop_s3a.sh
+    run_test "class loading end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_classloader.sh"
     EXIT_CODE=$?
-    end_timer
 fi
 
 if [ $EXIT_CODE == 0 ]; then
-    printf "\n==============================================================================\n"
-    printf "Running Shaded Presto S3 end-to-end test\n"
-    printf "==============================================================================\n"
-  start_timer
-    $END_TO_END_DIR/test-scripts/test_shaded_presto_s3.sh
+    run_test "Shaded Hadoop S3A end-to-end test" "$END_TO_END_DIR/test-scripts/test_shaded_hadoop_s3a.sh"
     EXIT_CODE=$?
-    end_timer
 fi
 
 if [ $EXIT_CODE == 0 ]; then
-    printf "\n==============================================================================\n"
-    printf "Running Hadoop-free Wordcount end-to-end test\n"
-    printf "==============================================================================\n"
-    start_timer
-    CLUSTER_MODE=cluster $END_TO_END_DIR/test-scripts/test_hadoop_free.sh
+    run_test "Shaded Presto S3 end-to-end test" "$END_TO_END_DIR/test-scripts/test_shaded_presto_s3.sh"
     EXIT_CODE=$?
-    end_timer
 fi
 
 if [ $EXIT_CODE == 0 ]; then
-    printf "\n==============================================================================\n"
-    printf "Running Streaming Python Wordcount end-to-end test\n"
-    printf "==============================================================================\n"
-    start_timer
-    $END_TO_END_DIR/test-scripts/test_streaming_python_wordcount.sh
+    run_test "Hadoop-free Wordcount end-to-end test" "$END_TO_END_DIR/test-scripts/test_hadoop_free.sh"
     EXIT_CODE=$?
-    end_timer
 fi
 
 

--- a/flink-end-to-end-tests/run-pre-commit-tests.sh
+++ b/flink-end-to-end-tests/run-pre-commit-tests.sh
@@ -30,6 +30,8 @@ if [ -z "$FLINK_DIR" ] ; then
     exit 1
 fi
 
+source "$(dirname "$0")"/test-scripts/common.sh
+
 FLINK_DIR="`( cd \"$FLINK_DIR\" && pwd )`" # absolutized and normalized
 
 echo "flink-end-to-end-test directory: $END_TO_END_DIR"

--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -380,6 +380,17 @@ function wait_oper_metric_num_in_records {
     done
 }
 
+# Starts the timer. Note that nested timers are not supported.
+function start_timer {
+    SECONDS=0
+}
+
+# prints the number of minutes and seconds that have elapsed since the last call to start_timer
+function end_timer {
+    duration=$SECONDS
+    echo "$(($duration / 60)) minutes and $(($duration % 60)) seconds elapsed."
+}
+
 # make sure to clean up even in case of failures
 function cleanup {
   stop_cluster

--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -391,6 +391,26 @@ function end_timer {
     echo "$(($duration / 60)) minutes and $(($duration % 60)) seconds elapsed."
 }
 
+#######################################
+# Prints the given description, runs the given test and prints how long the execution took.
+# Arguments:
+#   $1: description of the test
+#   $2: command to execute
+#######################################
+function run_test {
+    description="$1"
+    command="$2"
+
+    printf "\n==============================================================================\n"
+    printf "Running ${description}\n"
+    printf "==============================================================================\n"
+    start_timer
+    ${command}
+    exit_code="$?"
+    end_timer
+    return "${exit_code}"
+}
+
 # make sure to clean up even in case of failures
 function cleanup {
   stop_cluster

--- a/flink-end-to-end-tests/test-scripts/test_resume_savepoint.sh
+++ b/flink-end-to-end-tests/test-scripts/test_resume_savepoint.sh
@@ -33,8 +33,8 @@ else
   NUM_SLOTS=$NEW_DOP
 fi
 
-STATE_BACKEND_TYPE=${STATE_BACKEND_TYPE:-file}
-STATE_BACKEND_FILE_ASYNC=${STATE_BACKEND_FILE_ASYNC:-true}
+STATE_BACKEND_TYPE=${3:-file}
+STATE_BACKEND_FILE_ASYNC=${4:-true}
 
 backup_config
 change_conf "taskmanager.numberOfTaskSlots" "1" "${NUM_SLOTS}"


### PR DESCRIPTION
## What is the purpose of the change

With this PR we print the execution time for all end-to-end tests.

## Brief change log

* add `start_timer`/`end_timer` functions to `common.sh`
* cover all E2E invocations with timers


## Verifying this change

* observe travis output when execution e2e tests
