### PR TITLE
[FLINK-9361] [sql-client] Fix refresh interval in changelog mode

### DIFF
--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliChangelogResultView.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliChangelogResultView.java
@@ -89,6 +89,9 @@ public class CliChangelogResultView extends CliResultView<CliChangelogResultView
 	@Override
 	protected void display() {
 		// scroll down before displaying
+		if (scrolling > 0) {
+			selectedRow = NO_ROW_SELECTED;
+		}
 		scrollDown(scrolling);
 		scrolling = 0;
 
@@ -248,7 +251,7 @@ public class CliChangelogResultView extends CliResultView<CliChangelogResultView
 
 	@Override
 	protected List<AttributedString> computeFooterLines() {
-		return formatTwoLineHelpOptions(client.getWidth(), getHelpOptions());
+		return formatTwoLineHelpOptions(getWidth(), getHelpOptions());
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliView.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliView.java
@@ -57,7 +57,7 @@ public abstract class CliView<OP extends Enum<OP>, OUT> {
 
 	protected int offsetY;
 
-	private boolean isRunning;
+	private volatile boolean isRunning;
 
 	private Thread inputThread;
 


### PR DESCRIPTION
## What is the purpose of the change

This PR removes a InterruptedIOException when changing the refresh interval of the SQL Client CLI in changelog mode.


## Brief change log

- Do not use interrupts but a `wait`/`notify` pattern.
- Deselected row on refresh in changelog mode.

## Verifying this change

Manually verified.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
