### PR TITLE
[FLINK-9284] [doc] update the cli page,change rest port from 6123 to …

### DIFF
--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -71,7 +71,7 @@ The command line can be used to
 
 -   Run example program on a specific JobManager:
 
-        ./bin/flink run -m myJMHost:6123 \
+        ./bin/flink run -m myJMHost:8081 \
                                ./examples/batch/WordCount.jar \
                                --input file:///home/user/hamlet.txt --output file:///home/user/wordcount_out
 


### PR DESCRIPTION
## What is the purpose of the change

the flink 1.5 change the REST port from 6123 to 8081,so we need to change the  CLI page should be updated for 1.5.  here we change  -m option which be updated to use 8081.

## Brief change log

the  CLI page with -m option change REST port from 6123 to 8081

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
