### PR TITLE
[FLINK-8933] Avoid calling Class#newInstance(part 1)

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/ExpressionReducer.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/ExpressionReducer.scala
@@ -102,7 +102,7 @@ class ExpressionReducer(config: TableConfig)
       resultType)
 
     val clazz = compile(getClass.getClassLoader, generatedFunction.name, generatedFunction.code)
-    val function = clazz.newInstance()
+    val function = clazz.getDeclaredConstructor().newInstance()
 
     // execute
     val reduced = function.map(EMPTY_ROW)

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/CRowCorrelateProcessRunner.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/CRowCorrelateProcessRunner.scala
@@ -51,7 +51,7 @@ class CRowCorrelateProcessRunner(
     LOG.debug(s"Compiling TableFunctionCollector: $collectorName \n\n Code:\n$collectorCode")
     val clazz = compile(getRuntimeContext.getUserCodeClassLoader, collectorName, collectorCode)
     LOG.debug("Instantiating TableFunctionCollector.")
-    collector = clazz.newInstance().asInstanceOf[TableFunctionCollector[_]]
+    collector = clazz.getDeclaredConstructor().newInstance().asInstanceOf[TableFunctionCollector[_]]
     this.cRowWrapper = new CRowWrappingCollector()
 
     LOG.debug(s"Compiling ProcessFunction: $processName \n\n Code:\n$processCode")

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/CRowMapRunner.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/CRowMapRunner.scala
@@ -45,7 +45,7 @@ class CRowMapRunner[OUT](
     LOG.debug(s"Compiling MapFunction: $name \n\n Code:\n$code")
     val clazz = compile(getRuntimeContext.getUserCodeClassLoader, name, code)
     LOG.debug("Instantiating MapFunction.")
-    function = clazz.newInstance()
+    function = clazz.getDeclaredConstructor().newInstance()
   }
 
   override def map(in: CRow): OUT = {

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/CRowOutputProcessRunner.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/CRowOutputProcessRunner.scala
@@ -48,7 +48,7 @@ class CRowOutputProcessRunner(
     LOG.debug(s"Compiling ProcessFunction: $name \n\n Code:\n$code")
     val clazz = compile(getRuntimeContext.getUserCodeClassLoader, name, code)
     LOG.debug("Instantiating ProcessFunction.")
-    function = clazz.newInstance()
+    function = clazz.getDeclaredConstructor().newInstance()
 
     this.cRowWrapper = new CRowWrappingCollector()
     this.cRowWrapper.setChange(true)

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/CRowProcessRunner.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/CRowProcessRunner.scala
@@ -48,7 +48,7 @@ class CRowProcessRunner(
     LOG.debug(s"Compiling ProcessFunction: $name \n\n Code:\n$code")
     val clazz = compile(getRuntimeContext.getUserCodeClassLoader, name, code)
     LOG.debug("Instantiating ProcessFunction.")
-    function = clazz.newInstance()
+    function = clazz.getDeclaredConstructor().newInstance()
     FunctionUtils.setFunctionRuntimeContext(function, getRuntimeContext)
     FunctionUtils.openFunction(function, parameters)
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/CorrelateFlatMapRunner.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/CorrelateFlatMapRunner.scala
@@ -45,7 +45,7 @@ class CorrelateFlatMapRunner[IN, OUT](
     LOG.debug(s"Compiling TableFunctionCollector: $collectorName \n\n Code:\n$collectorCode")
     val clazz = compile(getRuntimeContext.getUserCodeClassLoader, collectorName, collectorCode)
     LOG.debug("Instantiating TableFunctionCollector.")
-    collector = clazz.newInstance().asInstanceOf[TableFunctionCollector[_]]
+    collector = clazz.getDeclaredConstructor().newInstance().asInstanceOf[TableFunctionCollector[_]]
 
     LOG.debug(s"Compiling FlatMapFunction: $flatMapName \n\n Code:\n$flatMapCode")
     val flatMapClazz = compile(getRuntimeContext.getUserCodeClassLoader, flatMapName, flatMapCode)

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/FlatJoinRunner.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/FlatJoinRunner.scala
@@ -41,7 +41,7 @@ class FlatJoinRunner[IN1, IN2, OUT](
     LOG.debug(s"Compiling FlatJoinFunction: $name \n\n Code:\n$code")
     val clazz = compile(getRuntimeContext.getUserCodeClassLoader, name, code)
     LOG.debug("Instantiating FlatJoinFunction.")
-    function = clazz.newInstance()
+    function = clazz.getDeclaredConstructor().newInstance()
   }
 
   override def join(first: IN1, second: IN2, out: Collector[OUT]): Unit =

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/FlatMapRunner.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/FlatMapRunner.scala
@@ -43,7 +43,7 @@ class FlatMapRunner(
     LOG.debug(s"Compiling FlatMapFunction: $name \n\n Code:\n$code")
     val clazz = compile(getRuntimeContext.getUserCodeClassLoader, name, code)
     LOG.debug("Instantiating FlatMapFunction.")
-    function = clazz.newInstance()
+    function = clazz.getDeclaredConstructor().newInstance()
     FunctionUtils.setFunctionRuntimeContext(function, getRuntimeContext)
     FunctionUtils.openFunction(function, parameters)
   }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/MapRunner.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/MapRunner.scala
@@ -40,7 +40,7 @@ class MapRunner[IN, OUT](
     LOG.debug(s"Compiling MapFunction: $name \n\n Code:\n$code")
     val clazz = compile(getRuntimeContext.getUserCodeClassLoader, name, code)
     LOG.debug("Instantiating MapFunction.")
-    function = clazz.newInstance()
+    function = clazz.getDeclaredConstructor().newInstance()
   }
 
   override def map(in: IN): OUT =

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/MapSideJoinRunner.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/MapSideJoinRunner.scala
@@ -42,7 +42,7 @@ abstract class MapSideJoinRunner[IN1, IN2, SINGLE_IN, MULTI_IN, OUT](
     LOG.debug(s"Compiling FlatJoinFunction: $name \n\n Code:\n$code")
     val clazz = compile(getRuntimeContext.getUserCodeClassLoader, name, code)
     LOG.debug("Instantiating FlatJoinFunction.")
-    function = clazz.newInstance()
+    function = clazz.getDeclaredConstructor().newInstance()
     broadcastSet = retrieveBroadcastSet
   }
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/AggregateAggFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/AggregateAggFunction.scala
@@ -74,6 +74,6 @@ class AggregateAggFunction(genAggregations: GeneratedAggregationsFunction)
       genAggregations.name,
       genAggregations.code)
     LOG.debug("Instantiating AggregateHelper.")
-    function = clazz.newInstance()
+    function = clazz.getDeclaredConstructor().newInstance()
   }
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/DataSetAggFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/DataSetAggFunction.scala
@@ -51,7 +51,7 @@ class DataSetAggFunction(
       genAggregations.name,
       genAggregations.code)
     LOG.debug("Instantiating AggregateHelper.")
-    function = clazz.newInstance()
+    function = clazz.getDeclaredConstructor().newInstance()
 
     output = function.createOutputRow()
     accumulators = function.createAccumulators()

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/DataSetFinalAggFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/DataSetFinalAggFunction.scala
@@ -51,7 +51,7 @@ class DataSetFinalAggFunction(
       genAggregations.name,
       genAggregations.code)
     LOG.debug("Instantiating AggregateHelper.")
-    function = clazz.newInstance()
+    function = clazz.getDeclaredConstructor().newInstance()
 
     output = function.createOutputRow()
     accumulators = function.createAccumulators()

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/DataSetPreAggFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/DataSetPreAggFunction.scala
@@ -52,7 +52,7 @@ class DataSetPreAggFunction(genAggregations: GeneratedAggregationsFunction)
       genAggregations.name,
       genAggregations.code)
     LOG.debug("Instantiating AggregateHelper.")
-    function = clazz.newInstance()
+    function = clazz.getDeclaredConstructor().newInstance()
 
     output = function.createOutputRow()
     accumulators = function.createAccumulators()

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/DataSetSessionWindowAggReduceGroupFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/DataSetSessionWindowAggReduceGroupFunction.scala
@@ -76,7 +76,7 @@ class DataSetSessionWindowAggReduceGroupFunction(
       genAggregations.name,
       genAggregations.code)
     LOG.debug("Instantiating AggregateHelper.")
-    function = clazz.newInstance()
+    function = clazz.getDeclaredConstructor().newInstance()
 
     output = function.createOutputRow()
     accumulators = function.createAccumulators()

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/DataSetSessionWindowAggregatePreProcessor.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/DataSetSessionWindowAggregatePreProcessor.scala
@@ -63,7 +63,7 @@ class DataSetSessionWindowAggregatePreProcessor(
       genAggregations.name,
       genAggregations.code)
     LOG.debug("Instantiating AggregateHelper.")
-    function = clazz.newInstance()
+    function = clazz.getDeclaredConstructor().newInstance()
 
     accumulators = function.createAccumulators()
     output = function.createOutputRow()

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/DataSetSlideTimeWindowAggReduceGroupFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/DataSetSlideTimeWindowAggReduceGroupFunction.scala
@@ -72,7 +72,7 @@ class DataSetSlideTimeWindowAggReduceGroupFunction(
       genAggregations.name,
       genAggregations.code)
     LOG.debug("Instantiating AggregateHelper.")
-    function = clazz.newInstance()
+    function = clazz.getDeclaredConstructor().newInstance()
 
     accumulators = function.createAccumulators()
     intermediateRow = function.createOutputRow()

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/DataSetSlideWindowAggReduceCombineFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/DataSetSlideWindowAggReduceCombineFunction.scala
@@ -71,7 +71,7 @@ class DataSetSlideWindowAggReduceCombineFunction(
       genPreAggregations.name,
       genPreAggregations.code)
     LOG.debug("Instantiating AggregateHelper.")
-    preAggfunction = clazz.newInstance()
+    preAggfunction = clazz.getDeclaredConstructor().newInstance()
   }
 
   override def combine(records: Iterable[Row]): Row = {

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/DataSetSlideWindowAggReduceGroupFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/DataSetSlideWindowAggReduceGroupFunction.scala
@@ -67,7 +67,7 @@ class DataSetSlideWindowAggReduceGroupFunction(
       genAggregations.name,
       genAggregations.code)
     LOG.debug("Instantiating AggregateHelper.")
-    function = clazz.newInstance()
+    function = clazz.getDeclaredConstructor().newInstance()
 
     output = function.createOutputRow()
     accumulators = function.createAccumulators()

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/DataSetTumbleCountWindowAggReduceGroupFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/DataSetTumbleCountWindowAggReduceGroupFunction.scala
@@ -54,7 +54,7 @@ class DataSetTumbleCountWindowAggReduceGroupFunction(
       genAggregations.name,
       genAggregations.code)
     LOG.debug("Instantiating AggregateHelper.")
-    function = clazz.newInstance()
+    function = clazz.getDeclaredConstructor().newInstance()
 
     output = function.createOutputRow()
     accumulators = function.createAccumulators()

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/DataSetTumbleTimeWindowAggReduceCombineFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/DataSetTumbleTimeWindowAggReduceCombineFunction.scala
@@ -70,7 +70,7 @@ class DataSetTumbleTimeWindowAggReduceCombineFunction(
       genPreAggregations.name,
       genPreAggregations.code)
     LOG.debug("Instantiating AggregateHelper.")
-    preAggfunction = clazz.newInstance()
+    preAggfunction = clazz.getDeclaredConstructor().newInstance()
   }
 
   /**

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/DataSetTumbleTimeWindowAggReduceGroupFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/DataSetTumbleTimeWindowAggReduceGroupFunction.scala
@@ -66,7 +66,7 @@ class DataSetTumbleTimeWindowAggReduceGroupFunction(
       genAggregations.name,
       genAggregations.code)
     LOG.debug("Instantiating AggregateHelper.")
-    function = clazz.newInstance()
+    function = clazz.getDeclaredConstructor().newInstance()
 
     output = function.createOutputRow()
     accumulators = function.createAccumulators()

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/DataSetWindowAggMapFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/DataSetWindowAggMapFunction.scala
@@ -60,7 +60,7 @@ class DataSetWindowAggMapFunction(
       genAggregations.name,
       genAggregations.code)
     LOG.debug("Instantiating AggregateHelper.")
-    function = clazz.newInstance()
+    function = clazz.getDeclaredConstructor().newInstance()
 
     accs = function.createAccumulators()
     output = function.createOutputRow()

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/GroupAggProcessFunction.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/GroupAggProcessFunction.scala
@@ -63,7 +63,7 @@ class GroupAggProcessFunction(
       genAggregations.name,
       genAggregations.code)
     LOG.debug("Instantiating AggregateHelper.")
-    function = clazz.newInstance()
+    function = clazz.getDeclaredConstructor().newInstance()
     function.open(getRuntimeContext)
 
     newRow = new CRow(function.createOutputRow(), true)

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/ProcTimeBoundedRangeOver.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/ProcTimeBoundedRangeOver.scala
@@ -67,7 +67,7 @@ class ProcTimeBoundedRangeOver(
       genAggregations.name,
       genAggregations.code)
     LOG.debug("Instantiating AggregateHelper.")
-    function = clazz.newInstance()
+    function = clazz.getDeclaredConstructor().newInstance()
     function.open(getRuntimeContext)
 
     output = new CRow(function.createOutputRow(), true)

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/ProcTimeBoundedRowsOver.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/ProcTimeBoundedRowsOver.scala
@@ -68,7 +68,7 @@ class ProcTimeBoundedRowsOver(
       genAggregations.name,
       genAggregations.code)
     LOG.debug("Instantiating AggregateHelper.")
-    function = clazz.newInstance()
+    function = clazz.getDeclaredConstructor().newInstance()
     function.open(getRuntimeContext)
 
     output = new CRow(function.createOutputRow(), true)

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/ProcTimeUnboundedOver.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/ProcTimeUnboundedOver.scala
@@ -54,7 +54,7 @@ class ProcTimeUnboundedOver(
       genAggregations.name,
       genAggregations.code)
     LOG.debug("Instantiating AggregateHelper.")
-    function = clazz.newInstance()
+    function = clazz.getDeclaredConstructor().newInstance()
     function.open(getRuntimeContext)
 
     output = new CRow(function.createOutputRow(), true)

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/RowTimeBoundedRangeOver.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/RowTimeBoundedRangeOver.scala
@@ -77,7 +77,7 @@ class RowTimeBoundedRangeOver(
       genAggregations.name,
       genAggregations.code)
     LOG.debug("Instantiating AggregateHelper.")
-    function = clazz.newInstance()
+    function = clazz.getDeclaredConstructor().newInstance()
     function.open(getRuntimeContext)
 
     output = new CRow(function.createOutputRow(), true)

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/RowTimeBoundedRowsOver.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/RowTimeBoundedRowsOver.scala
@@ -82,7 +82,7 @@ class RowTimeBoundedRowsOver(
       genAggregations.name,
       genAggregations.code)
     LOG.debug("Instantiating AggregateHelper.")
-    function = clazz.newInstance()
+    function = clazz.getDeclaredConstructor().newInstance()
     function.open(getRuntimeContext)
 
     output = new CRow(function.createOutputRow(), true)

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/RowTimeUnboundedOver.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/aggregate/RowTimeUnboundedOver.scala
@@ -69,7 +69,7 @@ abstract class RowTimeUnboundedOver(
       genAggregations.name,
       genAggregations.code)
     LOG.debug("Instantiating AggregateHelper.")
-    function = clazz.newInstance()
+    function = clazz.getDeclaredConstructor().newInstance()
     function.open(getRuntimeContext)
 
     output = new CRow(function.createOutputRow(), true)

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/conversion/CRowToJavaTupleMapRunner.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/conversion/CRowToJavaTupleMapRunner.scala
@@ -49,7 +49,7 @@ class CRowToJavaTupleMapRunner(
     LOG.debug(s"Compiling MapFunction: $name \n\n Code:\n$code")
     val clazz = compile(getRuntimeContext.getUserCodeClassLoader, name, code)
     LOG.debug("Instantiating MapFunction.")
-    function = clazz.newInstance()
+    function = clazz.getDeclaredConstructor().newInstance()
     tupleWrapper = new JTuple2[JBool, Any]()
   }
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/conversion/CRowToScalaTupleMapRunner.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/conversion/CRowToScalaTupleMapRunner.scala
@@ -45,7 +45,7 @@ class CRowToScalaTupleMapRunner(
     LOG.debug(s"Compiling MapFunction: $name \n\n Code:\n$code")
     val clazz = compile(getRuntimeContext.getUserCodeClassLoader, name, code)
     LOG.debug("Instantiating MapFunction.")
-    function = clazz.newInstance()
+    function = clazz.getDeclaredConstructor().newInstance()
   }
 
   override def map(in: CRow): (Boolean, Any) =

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/io/CRowValuesInputFormat.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/io/CRowValuesInputFormat.scala
@@ -43,7 +43,7 @@ class CRowValuesInputFormat(
     LOG.debug(s"Compiling GenericInputFormat: $name \n\n Code:\n$code")
     val clazz = compile(getRuntimeContext.getUserCodeClassLoader, name, code)
     LOG.debug("Instantiating GenericInputFormat.")
-    format = clazz.newInstance()
+    format = clazz.getDeclaredConstructor().newInstance()
   }
 
   override def reachedEnd(): Boolean = format.reachedEnd()

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/io/ValuesInputFormat.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/io/ValuesInputFormat.scala
@@ -42,7 +42,7 @@ class ValuesInputFormat(
     LOG.debug(s"Compiling GenericInputFormat: $name \n\n Code:\n$code")
     val clazz = compile(getRuntimeContext.getUserCodeClassLoader, name, code)
     LOG.debug("Instantiating GenericInputFormat.")
-    format = clazz.newInstance()
+    format = clazz.getDeclaredConstructor().newInstance()
   }
 
   override def reachedEnd(): Boolean = format.reachedEnd()

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/join/NonWindowInnerJoin.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/join/NonWindowInnerJoin.scala
@@ -88,7 +88,7 @@ class NonWindowInnerJoin(
       genJoinFuncName,
       genJoinFuncCode)
     LOG.debug("Instantiating JoinFunction.")
-    joinFunction = clazz.newInstance()
+    joinFunction = clazz.getDeclaredConstructor().newInstance()
 
     // initialize left and right state, the first element of tuple2 indicates how many rows of
     // this row, while the second element represents the expired time of this row.

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/join/TimeBoundedStreamJoin.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/join/TimeBoundedStreamJoin.scala
@@ -109,7 +109,7 @@ abstract class TimeBoundedStreamJoin(
       genJoinFuncName,
       genJoinFuncCode)
     LOG.debug("Instantiating JoinFunction.")
-    joinFunction = clazz.newInstance()
+    joinFunction = clazz.getDeclaredConstructor().newInstance()
 
     joinCollector = new EmitAwareCollector()
     joinCollector.setCRowChange(true)

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/outerJoinGroupReduceRunners.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/outerJoinGroupReduceRunners.scala
@@ -40,7 +40,7 @@ abstract class OuterJoinGroupReduceRunner(
     LOG.debug(s"Compiling JoinFunction: $name \n\n Code:\n$code")
     val clazz = compile(getRuntimeContext.getUserCodeClassLoader, name, code)
     LOG.debug("Instantiating JoinFunction.")
-    function = clazz.newInstance()
+    function = clazz.getDeclaredConstructor().newInstance()
   }
 }
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/outerJoinRunners.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/outerJoinRunners.scala
@@ -44,7 +44,7 @@ abstract class OuterJoinRunner(
     LOG.debug(s"Compiling FlatJoinFunction: $name \n\n Code:\n$code")
     val clazz = compile(getRuntimeContext.getUserCodeClassLoader, name, code)
     LOG.debug("Instantiating FlatJoinFunction.")
-    function = clazz.newInstance()
+    function = clazz.getDeclaredConstructor().newInstance()
   }
 
   override def getProducedType: TypeInformation[Row] = returnType

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/utils/ExpressionTestBase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/utils/ExpressionTestBase.scala
@@ -141,7 +141,7 @@ abstract class ExpressionTestBase {
 
     // compile and evaluate
     val clazz = new TestCompiler[MapFunction[Any, Row], Row]().compile(genFunc)
-    val mapper = clazz.newInstance()
+    val mapper = clazz.getDeclaredConstructor().newInstance()
 
     val isRichFunction = mapper.isInstanceOf[RichFunction]
 


### PR DESCRIPTION
## What is the purpose of the change

*This pull request avoid calling Class#newInstance*

## Brief change log

  - *replaced `Class#newInstance` to `Class#getDeclaredConstructor#newInstance()`*

## Verifying this change


This change is already covered by existing tests*.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / no / **don't know**)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
