### PR TITLE
[FLINK-8933] Avoid calling Class#newInstance(part 2)

### DIFF
--- a/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSink.java
+++ b/flink-connectors/flink-connector-filesystem/src/main/java/org/apache/flink/streaming/connectors/fs/bucketing/BucketingSink.java
@@ -1297,7 +1297,7 @@ public class BucketingSink<T>
 			final Class<? extends FileSystem> fsClass = FileSystem.getFileSystemClass(fsUri.getScheme(), finalConf);
 			final FileSystem fs;
 			try {
-				fs = fsClass.newInstance();
+				fs = fsClass.getDeclaredConstructor().newInstance();
 			}
 			catch (Exception e) {
 				throw new IOException("Cannot instantiate the Hadoop file system", e);

--- a/flink-connectors/flink-hadoop-compatibility/src/main/java/org/apache/flink/api/java/hadoop/mapred/HadoopInputFormatBase.java
+++ b/flink-connectors/flink-hadoop-compatibility/src/main/java/org/apache/flink/api/java/hadoop/mapred/HadoopInputFormatBase.java
@@ -277,7 +277,7 @@ public abstract class HadoopInputFormatBase<K, V, T> extends HadoopInputFormatCo
 		}
 		jobConf.readFields(in);
 		try {
-			this.mapredInputFormat = (org.apache.hadoop.mapred.InputFormat<K, V>) Class.forName(hadoopInputFormatClassName, true, Thread.currentThread().getContextClassLoader()).newInstance();
+			this.mapredInputFormat = (org.apache.hadoop.mapred.InputFormat<K, V>) Class.forName(hadoopInputFormatClassName, true, Thread.currentThread().getContextClassLoader()).getDeclaredConstructor().newInstance();
 		} catch (Exception e) {
 			throw new RuntimeException("Unable to instantiate the hadoop input format", e);
 		}

--- a/flink-connectors/flink-hadoop-compatibility/src/main/java/org/apache/flink/api/java/hadoop/mapred/HadoopOutputFormatBase.java
+++ b/flink-connectors/flink-hadoop-compatibility/src/main/java/org/apache/flink/api/java/hadoop/mapred/HadoopOutputFormatBase.java
@@ -190,7 +190,7 @@ public abstract class HadoopOutputFormatBase<K, V, T> extends HadoopOutputFormat
 		}
 		jobConf.readFields(in);
 		try {
-			this.mapredOutputFormat = (org.apache.hadoop.mapred.OutputFormat<K, V>) Class.forName(hadoopOutputFormatName, true, Thread.currentThread().getContextClassLoader()).newInstance();
+			this.mapredOutputFormat = (org.apache.hadoop.mapred.OutputFormat<K, V>) Class.forName(hadoopOutputFormatName, true, Thread.currentThread().getContextClassLoader()).getDeclaredConstructor().newInstance();
 		} catch (Exception e) {
 			throw new RuntimeException("Unable to instantiate the hadoop output format", e);
 		}

--- a/flink-connectors/flink-hadoop-compatibility/src/main/java/org/apache/flink/api/java/hadoop/mapreduce/HadoopInputFormatBase.java
+++ b/flink-connectors/flink-hadoop-compatibility/src/main/java/org/apache/flink/api/java/hadoop/mapreduce/HadoopInputFormatBase.java
@@ -302,7 +302,7 @@ public abstract class HadoopInputFormatBase<K, V, T> extends HadoopInputFormatCo
 		}
 
 		try {
-			this.mapreduceInputFormat = (org.apache.hadoop.mapreduce.InputFormat<K, V>) Class.forName(hadoopInputFormatClassName, true, Thread.currentThread().getContextClassLoader()).newInstance();
+			this.mapreduceInputFormat = (org.apache.hadoop.mapreduce.InputFormat<K, V>) Class.forName(hadoopInputFormatClassName, true, Thread.currentThread().getContextClassLoader()).getDeclaredConstructor().newInstance();
 		} catch (Exception e) {
 			throw new RuntimeException("Unable to instantiate the hadoop input format", e);
 		}

--- a/flink-connectors/flink-hadoop-compatibility/src/main/java/org/apache/flink/api/java/hadoop/mapreduce/HadoopOutputFormatBase.java
+++ b/flink-connectors/flink-hadoop-compatibility/src/main/java/org/apache/flink/api/java/hadoop/mapreduce/HadoopOutputFormatBase.java
@@ -240,7 +240,7 @@ public abstract class HadoopOutputFormatBase<K, V, T> extends HadoopOutputFormat
 		}
 
 		try {
-			this.mapreduceOutputFormat = (org.apache.hadoop.mapreduce.OutputFormat<K, V>) Class.forName(hadoopOutputFormatClassName, true, Thread.currentThread().getContextClassLoader()).newInstance();
+			this.mapreduceOutputFormat = (org.apache.hadoop.mapreduce.OutputFormat<K, V>) Class.forName(hadoopOutputFormatClassName, true, Thread.currentThread().getContextClassLoader()).getDeclaredConstructor().newInstance();
 		} catch (Exception e) {
 			throw new RuntimeException("Unable to instantiate the hadoop output format", e);
 		}

--- a/flink-contrib/flink-storm/src/main/java/org/apache/flink/storm/api/FlinkOutputFieldsDeclarer.java
+++ b/flink-contrib/flink-storm/src/main/java/org/apache/flink/storm/api/FlinkOutputFieldsDeclarer.java
@@ -25,6 +25,7 @@ import org.apache.storm.topology.OutputFieldsDeclarer;
 import org.apache.storm.tuple.Fields;
 import org.apache.storm.utils.Utils;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.List;
 
@@ -107,10 +108,8 @@ final class FlinkOutputFieldsDeclarer implements OutputFieldsDeclarer {
 
 		if (numberOfAttributes <= 24) {
 			try {
-				t = Tuple.getTupleClass(numberOfAttributes + 1).newInstance();
-			} catch (final InstantiationException e) {
-				throw new RuntimeException(e);
-			} catch (final IllegalAccessException e) {
+				t = Tuple.getTupleClass(numberOfAttributes + 1).getDeclaredConstructor().newInstance();
+			} catch (final InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
 				throw new RuntimeException(e);
 			}
 		} else {

--- a/flink-contrib/flink-storm/src/main/java/org/apache/flink/storm/wrappers/AbstractStormCollector.java
+++ b/flink-contrib/flink-storm/src/main/java/org/apache/flink/storm/wrappers/AbstractStormCollector.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.java.tuple.Tuple0;
 import org.apache.flink.api.java.tuple.Tuple25;
 import org.apache.flink.storm.util.SplitStreamType;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map.Entry;
@@ -94,10 +95,9 @@ abstract class AbstractStormCollector<OUT> {
 				try {
 					this.outputTuple.put(outputStream.getKey(),
 							org.apache.flink.api.java.tuple.Tuple.getTupleClass(numAtt)
-							.newInstance());
-				} catch (final InstantiationException e) {
-					throw new RuntimeException(e);
-				} catch (final IllegalAccessException e) {
+							.getDeclaredConstructor().newInstance());
+				} catch (final InstantiationException | IllegalAccessException
+					| NoSuchMethodException | InvocationTargetException e) {
 					throw new RuntimeException(e);
 				}
 

--- a/flink-contrib/flink-storm/src/test/java/org/apache/flink/storm/wrappers/BoltCollectorTest.java
+++ b/flink-contrib/flink-storm/src/test/java/org/apache/flink/storm/wrappers/BoltCollectorTest.java
@@ -25,6 +25,7 @@ import org.apache.storm.tuple.Values;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -39,7 +40,7 @@ public class BoltCollectorTest extends AbstractTest {
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Test
-	public void testBoltStormCollector() throws InstantiationException, IllegalAccessException {
+	public void testBoltStormCollector() throws InstantiationException, IllegalAccessException, NoSuchMethodException, InvocationTargetException {
 		for (int numberOfAttributes = -1; numberOfAttributes < 26; ++numberOfAttributes) {
 			final Output flinkCollector = mock(Output.class);
 			Tuple flinkTuple = null;
@@ -57,7 +58,7 @@ public class BoltCollectorTest extends AbstractTest {
 
 			} else {
 				collector = new BoltCollector(attributes, -1, flinkCollector);
-				flinkTuple = Tuple.getTupleClass(numberOfAttributes).newInstance();
+				flinkTuple = Tuple.getTupleClass(numberOfAttributes).getDeclaredConstructor().newInstance();
 
 				for (int i = 0; i < numberOfAttributes; ++i) {
 					tuple.add(new Integer(this.r.nextInt()));
@@ -81,7 +82,7 @@ public class BoltCollectorTest extends AbstractTest {
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Test
-	public void testBoltStormCollectorWithTaskId() throws InstantiationException, IllegalAccessException {
+	public void testBoltStormCollectorWithTaskId() throws InstantiationException, IllegalAccessException, NoSuchMethodException, InvocationTargetException {
 		for (int numberOfAttributes = 0; numberOfAttributes < 25; ++numberOfAttributes) {
 			final Output flinkCollector = mock(Output.class);
 			final int taskId = 42;
@@ -93,7 +94,7 @@ public class BoltCollectorTest extends AbstractTest {
 			BoltCollector<?> collector = new BoltCollector(attributes, taskId, flinkCollector);
 
 			final Values tuple = new Values();
-			final Tuple flinkTuple = Tuple.getTupleClass(numberOfAttributes + 1).newInstance();
+			final Tuple flinkTuple = Tuple.getTupleClass(numberOfAttributes + 1).getDeclaredConstructor().newInstance();
 
 			for (int i = 0; i < numberOfAttributes; ++i) {
 				tuple.add(new Integer(this.r.nextInt()));

--- a/flink-contrib/flink-storm/src/test/java/org/apache/flink/storm/wrappers/BoltWrapperTest.java
+++ b/flink-contrib/flink-storm/src/test/java/org/apache/flink/storm/wrappers/BoltWrapperTest.java
@@ -127,7 +127,7 @@ public class BoltWrapperTest extends AbstractTest {
 		if (numberOfAttributes == -1) {
 			rawTuple = "test";
 		} else {
-			flinkTuple = Tuple.getTupleClass(numberOfAttributes).newInstance();
+			flinkTuple = Tuple.getTupleClass(numberOfAttributes).getDeclaredConstructor().newInstance();
 		}
 
 		final String[] schema;

--- a/flink-contrib/flink-storm/src/test/java/org/apache/flink/storm/wrappers/SpoutCollectorTest.java
+++ b/flink-contrib/flink-storm/src/test/java/org/apache/flink/storm/wrappers/SpoutCollectorTest.java
@@ -25,6 +25,7 @@ import org.apache.storm.tuple.Values;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.List;
 
@@ -38,7 +39,7 @@ public class SpoutCollectorTest extends AbstractTest {
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Test
-	public void testSpoutStormCollector() throws InstantiationException, IllegalAccessException {
+	public void testSpoutStormCollector() throws InstantiationException, IllegalAccessException, NoSuchMethodException, InvocationTargetException {
 		for (int numberOfAttributes = -1; numberOfAttributes < 26; ++numberOfAttributes) {
 			final SourceContext flinkCollector = mock(SourceContext.class);
 			Tuple flinkTuple = null;
@@ -55,7 +56,7 @@ public class SpoutCollectorTest extends AbstractTest {
 				tuple.add(new Integer(this.r.nextInt()));
 			} else {
 				collector = new SpoutCollector(attributes, -1, flinkCollector);
-				flinkTuple = Tuple.getTupleClass(numberOfAttributes).newInstance();
+				flinkTuple = Tuple.getTupleClass(numberOfAttributes).getDeclaredConstructor().newInstance();
 
 				for (int i = 0; i < numberOfAttributes; ++i) {
 					tuple.add(new Integer(this.r.nextInt()));
@@ -80,7 +81,7 @@ public class SpoutCollectorTest extends AbstractTest {
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Test
-	public void testSpoutStormCollectorWithTaskId() throws InstantiationException, IllegalAccessException {
+	public void testSpoutStormCollectorWithTaskId() throws InstantiationException, IllegalAccessException, NoSuchMethodException, InvocationTargetException {
 		for (int numberOfAttributes = 0; numberOfAttributes < 25; ++numberOfAttributes) {
 			final SourceContext flinkCollector = mock(SourceContext.class);
 			final int taskId = 42;
@@ -92,7 +93,7 @@ public class SpoutCollectorTest extends AbstractTest {
 			SpoutCollector<?> collector = new SpoutCollector(attributes, taskId, flinkCollector);
 
 			final Values tuple = new Values();
-			final Tuple flinkTuple = Tuple.getTupleClass(numberOfAttributes + 1).newInstance();
+			final Tuple flinkTuple = Tuple.getTupleClass(numberOfAttributes + 1).getDeclaredConstructor().newInstance();
 
 			for (int i = 0; i < numberOfAttributes; ++i) {
 				tuple.add(new Integer(this.r.nextInt()));

--- a/flink-contrib/flink-storm/src/test/java/org/apache/flink/storm/wrappers/StormTupleTest.java
+++ b/flink-contrib/flink-storm/src/test/java/org/apache/flink/storm/wrappers/StormTupleTest.java
@@ -30,6 +30,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -66,11 +67,11 @@ public class StormTupleTest extends AbstractTest {
 	}
 
 	@Test
-	public void tupleTest() throws InstantiationException, IllegalAccessException {
+	public void tupleTest() throws InstantiationException, IllegalAccessException, NoSuchMethodException, InvocationTargetException {
 		for (int numberOfAttributes = 0; numberOfAttributes < 26; ++numberOfAttributes) {
 			final Object[] data = new Object[numberOfAttributes];
 
-			final Tuple flinkTuple = Tuple.getTupleClass(numberOfAttributes).newInstance();
+			final Tuple flinkTuple = Tuple.getTupleClass(numberOfAttributes).getDeclaredConstructor().newInstance();
 			for (int i = 0; i < numberOfAttributes; ++i) {
 				data[i] = this.r.nextInt();
 				flinkTuple.setField(data[i], i);
@@ -90,11 +91,11 @@ public class StormTupleTest extends AbstractTest {
 	}
 
 	@Test
-	public void tupleTestWithTaskId() throws InstantiationException, IllegalAccessException {
+	public void tupleTestWithTaskId() throws InstantiationException, IllegalAccessException, NoSuchMethodException, InvocationTargetException {
 		for (int numberOfAttributes = 1; numberOfAttributes < 26; ++numberOfAttributes) {
 			final Object[] data = new Object[numberOfAttributes];
 
-			final Tuple flinkTuple = Tuple.getTupleClass(numberOfAttributes).newInstance();
+			final Tuple flinkTuple = Tuple.getTupleClass(numberOfAttributes).getDeclaredConstructor().newInstance();
 			for (int i = 0; i < numberOfAttributes - 1; ++i) {
 				data[i] = this.r.nextInt();
 				flinkTuple.setField(data[i], i);
@@ -322,7 +323,7 @@ public class StormTupleTest extends AbstractTest {
 	@Test
 	public void testContains() throws Exception {
 		Fields schema = new Fields("a1", "a2");
-		StormTuple<Object> tuple = new StormTuple<Object>(Tuple.getTupleClass(1).newInstance(),
+		StormTuple<Object> tuple = new StormTuple<Object>(Tuple.getTupleClass(1).getDeclaredConstructor().newInstance(),
 				schema, -1, null, null, null);
 
 		Assert.assertTrue(tuple.contains("a1"));
@@ -341,7 +342,7 @@ public class StormTupleTest extends AbstractTest {
 	@Test
 	public void testFieldIndex() throws Exception {
 		Fields schema = new Fields("a1", "a2");
-		StormTuple<Object> tuple = new StormTuple<Object>(Tuple.getTupleClass(1).newInstance(),
+		StormTuple<Object> tuple = new StormTuple<Object>(Tuple.getTupleClass(1).getDeclaredConstructor().newInstance(),
 				schema, -1, null, null, null);
 
 		Assert.assertEquals(0, tuple.fieldIndex("a1"));
@@ -350,7 +351,7 @@ public class StormTupleTest extends AbstractTest {
 
 	@Test
 	public void testSelect() throws Exception {
-		Tuple tuple = Tuple.getTupleClass(arity).newInstance();
+		Tuple tuple = Tuple.getTupleClass(arity).getDeclaredConstructor().newInstance();
 		Values values = new Values();
 
 		ArrayList<String> attributeNames = new ArrayList<String>(arity);
@@ -637,7 +638,7 @@ public class StormTupleTest extends AbstractTest {
 
 		assert (index < arity);
 
-		Tuple tuple = Tuple.getTupleClass(arity).newInstance();
+		Tuple tuple = Tuple.getTupleClass(arity).getDeclaredConstructor().newInstance();
 		tuple.setField(value, index);
 
 		ArrayList<String> attributeNames = new ArrayList<String>(arity);

--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/util/AbstractRuntimeUDFContext.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/util/AbstractRuntimeUDFContext.java
@@ -187,7 +187,7 @@ public abstract class AbstractRuntimeUDFContext implements RuntimeContext {
 		} else {
 			// Create new accumulator
 			try {
-				accumulator = accumulatorClass.newInstance();
+				accumulator = accumulatorClass.getDeclaredConstructor().newInstance();
 			}
 			catch (Exception e) {
 				throw new RuntimeException("Cannot create accumulator " + accumulatorClass.getName());

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/AvroUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/AvroUtils.java
@@ -45,7 +45,7 @@ public abstract class AvroUtils {
 		// try and load the special AvroUtils from the flink-avro package
 		try {
 			Class<?> clazz = Class.forName(AVRO_KRYO_UTILS, false, Thread.currentThread().getContextClassLoader());
-			return clazz.asSubclass(AvroUtils.class).getConstructor().newInstance();
+			return clazz.asSubclass(AvroUtils.class).getDeclaredConstructor().newInstance();
 		} catch (ClassNotFoundException e) {
 			// cannot find the utils, return the default implementation
 			return new DefaultAvroUtils();

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializer.java
@@ -193,7 +193,7 @@ public final class PojoSerializer<T> extends TypeSerializer<T> {
 			return null;
 		}
 		try {
-			T t = clazz.newInstance();
+			T t = clazz.getDeclaredConstructor().newInstance();
 			initializeFields(t);
 			return t;
 		}
@@ -225,7 +225,7 @@ public final class PojoSerializer<T> extends TypeSerializer<T> {
 		if (actualType == clazz) {
 			T target;
 			try {
-				target = (T) from.getClass().newInstance();
+				target = (T) from.getClass().getDeclaredConstructor().newInstance();
 			}
 			catch (Throwable t) {
 				throw new RuntimeException("Cannot instantiate class.", t);

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/TupleSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/TupleSerializer.java
@@ -59,7 +59,7 @@ public class TupleSerializer<T extends Tuple> extends TupleSerializerBase<T> {
 	@Override
 	public T createInstance() {
 		try {
-			T t = tupleClass.newInstance();
+			T t = tupleClass.getDeclaredConstructor().newInstance();
 		
 			for (int i = 0; i < arity; i++) {
 				t.setField(fieldSerializers[i].createInstance(), i);
@@ -76,7 +76,7 @@ public class TupleSerializer<T extends Tuple> extends TupleSerializerBase<T> {
 	public T createInstance(Object[] fields) {
 
 		try {
-			T t = tupleClass.newInstance();
+			T t = tupleClass.getDeclaredConstructor().newInstance();
 
 			for (int i = 0; i < arity; i++) {
 				t.setField(fields[i], i);
@@ -150,7 +150,7 @@ public class TupleSerializer<T extends Tuple> extends TupleSerializerBase<T> {
 	
 	private T instantiateRaw() {
 		try {
-			return tupleClass.newInstance();
+			return tupleClass.getDeclaredConstructor().newInstance();
 		}
 		catch (Exception e) {
 			throw new RuntimeException("Cannot instantiate tuple.", e);

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializer.java
@@ -402,7 +402,7 @@ public class KryoSerializer<T> extends TypeSerializer<T> {
 			// check if ScalaKryoInstantiator is in class path (coming from Twitter's Chill library).
 			// This will be true if Flink's Scala API is used.
 			Class<?> chillInstantiatorClazz = Class.forName("com.twitter.chill.ScalaKryoInstantiator");
-			Object chillInstantiator = chillInstantiatorClazz.newInstance();
+			Object chillInstantiator = chillInstantiatorClazz.getDeclaredConstructor().newInstance();
 
 			// obtain a Kryo instance through Twitter Chill
 			Method m = chillInstantiatorClazz.getMethod("newKryo");

--- a/flink-core/src/main/java/org/apache/flink/core/fs/FileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/FileSystem.java
@@ -1009,7 +1009,7 @@ public abstract class FileSystem {
 
 		// Create the factory.
 		try {
-			return factoryClass.newInstance();
+			return factoryClass.getDeclaredConstructor().newInstance();
 		}
 		catch (Exception | LinkageError e) {
 			LOG.warn("Flink's Hadoop file system factory could not be created", e);

--- a/flink-core/src/main/java/org/apache/flink/types/ListValue.java
+++ b/flink-core/src/main/java/org/apache/flink/types/ListValue.java
@@ -20,6 +20,7 @@
 package org.apache.flink.types;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -93,14 +94,12 @@ public abstract class ListValue<V extends Value> implements Value, List<V> {
 
 		try {
 			for (; size > 0; size--) {
-				final V val = this.valueClass.newInstance();
+				final V val = this.valueClass.getDeclaredConstructor().newInstance();
 				val.read(in);
 
 				this.list.add(val);
 			}
-		} catch (final InstantiationException e) {
-			throw new RuntimeException(e);
-		} catch (final IllegalAccessException e) {
+		} catch (final InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
 			throw new RuntimeException(e);
 		}
 	}

--- a/flink-core/src/main/java/org/apache/flink/types/MapValue.java
+++ b/flink-core/src/main/java/org/apache/flink/types/MapValue.java
@@ -20,6 +20,7 @@
 package org.apache.flink.types;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -83,13 +84,13 @@ public abstract class MapValue<K extends Value, V extends Value> implements Valu
 
 		try {
 			for (; size > 0; size--) {
-				final K key = this.keyClass.newInstance();
-				final V val = this.valueClass.newInstance();
+				final K key = this.keyClass.getDeclaredConstructor().newInstance();
+				final V val = this.valueClass.getDeclaredConstructor().newInstance();
 				key.read(in);
 				val.read(in);
 				this.map.put(key, val);
 			}
-		} catch (final InstantiationException | IllegalAccessException e) {
+		} catch (final InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
 			throw new RuntimeException(e);
 		}
 	}

--- a/flink-core/src/main/java/org/apache/flink/util/DynamicCodeLoadingException.java
+++ b/flink-core/src/main/java/org/apache/flink/util/DynamicCodeLoadingException.java
@@ -28,7 +28,7 @@ import org.apache.flink.annotation.Public;
  *
  * <pre>{@code
  * try {
- *     Class.forName(classname).asSubclass(TheType.class).newInstance();
+ *     Class.forName(classname).asSubclass(TheType.class).getDeclaredConstructor().newInstance();
  * }
  * catch (ClassNotFoundException | ClassCastException | InstantiationException | IllegalAccessException e) {
  *     throw new DynamicCodeLoadingException("Could not load and instantiate " + classname", e);

--- a/flink-core/src/main/java/org/apache/flink/util/InstantiationUtil.java
+++ b/flink-core/src/main/java/org/apache/flink/util/InstantiationUtil.java
@@ -316,7 +316,7 @@ public final class InstantiationUtil {
 
 		// try to instantiate the class
 		try {
-			return clazz.newInstance();
+			return clazz.getDeclaredConstructor().newInstance();
 		}
 		catch (InstantiationException | IllegalAccessException iex) {
 			// check for the common problem causes

--- a/flink-core/src/main/java/org/apache/flink/util/ReflectionUtil.java
+++ b/flink-core/src/main/java/org/apache/flink/util/ReflectionUtil.java
@@ -35,7 +35,7 @@ public final class ReflectionUtil {
 
 	public static <T> T newInstance(Class<T> clazz) {
 		try {
-			return clazz.newInstance();
+			return clazz.getDeclaredConstructor().newInstance();
 		} catch (Exception e) {
 			throw new RuntimeException(e);
 		}

--- a/flink-core/src/test/java/org/apache/flink/core/memory/DataInputOutputSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/DataInputOutputSerializerTest.java
@@ -108,7 +108,7 @@ public class DataInputOutputSerializerTest {
 
 		for (SerializationTestType expected : reference) {
 			try {
-				SerializationTestType actual = expected.getClass().newInstance();
+				SerializationTestType actual = expected.getClass().getDeclaredConstructor().newInstance();
 				actual.read(deserializer);
 
 				Assert.assertEquals(expected, actual);

--- a/flink-core/src/test/java/org/apache/flink/types/RecordTest.java
+++ b/flink-core/src/test/java/org/apache/flink/types/RecordTest.java
@@ -707,7 +707,7 @@ public class RecordTest {
 					Assert.fail("Value at position " + pos + " expected to be null in " + Arrays.toString(expected));
 				}
 			} else {
-				final Value retrieved = rec.getField(pos, e.getClass().newInstance());
+				final Value retrieved = rec.getField(pos, e.getClass().getDeclaredConstructor().newInstance());
 				if (!(e.equals(retrieved))) {
 					Assert.assertEquals("Wrong value at position " + pos + " in " + Arrays.toString(expected), e, retrieved);
 				}
@@ -724,7 +724,7 @@ public class RecordTest {
 					Assert.fail("Value at position " + pos + " expected to be null in " + Arrays.toString(expected));
 				}
 			} else {
-				final Value retrieved = e.getClass().newInstance();
+				final Value retrieved = e.getClass().getDeclaredConstructor().newInstance();
 				if (!rec.getFieldInto(pos, retrieved)) {
 					Assert.fail("Value at position " + pos + " expected to be not null in " + Arrays.toString(expected));
 				}

--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopFsFactory.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopFsFactory.java
@@ -109,7 +109,7 @@ public class HadoopFsFactory implements FileSystemFactory {
 
 			LOG.debug("Instantiating for file system scheme {} Hadoop File System {}", scheme, fsClass.getName());
 
-			final org.apache.hadoop.fs.FileSystem hadoopFs = fsClass.newInstance();
+			final org.apache.hadoop.fs.FileSystem hadoopFs = fsClass.getDeclaredConstructor().newInstance();
 
 			// -- (4) create the proper URI to initialize the file system
 

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroOutputFormat.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroOutputFormat.java
@@ -33,6 +33,7 @@ import org.apache.avro.specific.SpecificDatumWriter;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.lang.reflect.InvocationTargetException;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -131,8 +132,8 @@ public class AvroOutputFormat<E> extends FileOutputFormat<E> implements Serializ
 		if (org.apache.avro.specific.SpecificRecordBase.class.isAssignableFrom(avroValueType)) {
 			datumWriter = new SpecificDatumWriter<E>(avroValueType);
 			try {
-				schema = ((org.apache.avro.specific.SpecificRecordBase) avroValueType.newInstance()).getSchema();
-			} catch (InstantiationException | IllegalAccessException e) {
+				schema = ((org.apache.avro.specific.SpecificRecordBase) avroValueType.getDeclaredConstructor().newInstance()).getSchema();
+			} catch (InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
 				throw new RuntimeException(e.getMessage());
 			}
 		} else if (org.apache.avro.generic.GenericRecord.class.isAssignableFrom(avroValueType)) {

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroKryoClassloadingTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroKryoClassloadingTest.java
@@ -82,7 +82,7 @@ public class AvroKryoClassloadingTest {
 		final Method m = userLoadedAvroClass.getMethod("addAvroGenericDataArrayRegistration", LinkedHashMap.class);
 
 		final LinkedHashMap<String, ?> map = new LinkedHashMap<>();
-		m.invoke(userLoadedAvroClass.newInstance(), map);
+		m.invoke(userLoadedAvroClass.getDeclaredConstructor().newInstance(), map);
 
 		assertEquals(1, map.size());
 	}

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/EncoderDecoderTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/EncoderDecoderTest.java
@@ -326,7 +326,7 @@ public class EncoderDecoderTest {
 				X reuse = null;
 				try {
 					@SuppressWarnings("unchecked")
-					X test = (X) obj.getClass().newInstance();
+					X test = (X) obj.getClass().getDeclaredConstructor().newInstance();
 					reuse = test;
 				} catch (Throwable t) {}
 

--- a/flink-java/src/main/java/org/apache/flink/api/java/operators/translation/PlanProjectOperator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/operators/translation/PlanProjectOperator.java
@@ -57,7 +57,7 @@ public class PlanProjectOperator<T, R extends Tuple> extends MapOperatorBase<T, 
 		private MapProjector(int[] fields) {
 			this.fields = fields;
 			try {
-				this.outTuple = Tuple.getTupleClass(fields.length).newInstance();
+				this.outTuple = Tuple.getTupleClass(fields.length).getDeclaredConstructor().newInstance();
 			}
 			catch (Exception e) {
 				// this should never happen

--- a/flink-java/src/main/java/org/apache/flink/api/java/summarize/aggregation/TupleSummaryAggregator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/summarize/aggregation/TupleSummaryAggregator.java
@@ -21,6 +21,8 @@ package org.apache.flink.api.java.summarize.aggregation;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.java.tuple.Tuple;
 
+import java.lang.reflect.InvocationTargetException;
+
 /**
  * Aggregate tuples using an array of aggregators, one for each "column" or position within the Tuple.
  */
@@ -58,13 +60,13 @@ public class TupleSummaryAggregator<R extends Tuple> implements Aggregator<Tuple
 	public R result() {
 		try {
 			Class tupleClass = Tuple.getTupleClass(columnAggregators.length);
-			R tuple = (R) tupleClass.newInstance();
+			R tuple = (R) tupleClass.getDeclaredConstructor().newInstance();
 			for (int i = 0; i < columnAggregators.length; i++) {
 				tuple.setField(columnAggregators[i].result(), i);
 			}
 			return tuple;
 		}
-		catch (InstantiationException | IllegalAccessException e) {
+		catch (InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
 			throw new RuntimeException("Unexpected error instantiating Tuple class for aggregation results", e);
 
 		}

--- a/flink-java/src/test/java/org/apache/flink/api/java/summarize/aggregation/AggregateCombineHarness.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/summarize/aggregation/AggregateCombineHarness.java
@@ -100,7 +100,7 @@ public abstract class AggregateCombineHarness<T, R, A extends Aggregator<T, R>> 
 		try {
 			// Instantiate a generic type
 			// http://stackoverflow.com/questions/75175/create-instance-of-generic-type-in-java
-			return (A) ((Class) ((ParameterizedType) this.getClass().getGenericSuperclass()).getActualTypeArguments()[2]).newInstance();
+			return (A) ((Class) ((ParameterizedType) this.getClass().getGenericSuperclass()).getActualTypeArguments()[2]).getDeclaredConstructor().newInstance();
 		}
 		catch (Exception e) {
 			throw new RuntimeException("Could not initialize aggregator", e);

--- a/flink-libraries/flink-python/src/main/java/org/apache/flink/python/api/streaming/data/PythonReceiver.java
+++ b/flink-libraries/flink-python/src/main/java/org/apache/flink/python/api/streaming/data/PythonReceiver.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.io.Serializable;
+import java.lang.reflect.InvocationTargetException;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
 
@@ -130,8 +131,9 @@ public class PythonReceiver<OUT> implements Serializable {
 
 	public static Tuple createTuple(int size) {
 		try {
-			return Tuple.getTupleClass(size).newInstance();
-		} catch (InstantiationException | IllegalAccessException e) {
+			return Tuple.getTupleClass(size).getDeclaredConstructor().newInstance();
+		} catch (InstantiationException | IllegalAccessException
+			| NoSuchMethodException | InvocationTargetException e) {
 			throw new RuntimeException(e);
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/reader/RecordReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/reader/RecordReader.java
@@ -22,6 +22,7 @@ import org.apache.flink.core.io.IOReadableWritable;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 
 /**
  * Record oriented reader for immutable types.
@@ -84,9 +85,9 @@ public class RecordReader<T extends IOReadableWritable> extends AbstractRecordRe
 
 	private T instantiateRecordType() {
 		try {
-			return recordType.newInstance();
+			return recordType.getDeclaredConstructor().newInstance();
 		}
-		catch (InstantiationException | IllegalAccessException e) {
+		catch (InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
 			throw new RuntimeException("Cannot instantiate class " + recordType.getName(), e);
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricRegistryImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricRegistryImpl.java
@@ -142,7 +142,7 @@ public class MetricRegistryImpl implements MetricRegistry {
 					}
 
 					Class<?> reporterClass = Class.forName(className);
-					MetricReporter reporterInstance = (MetricReporter) reporterClass.newInstance();
+					MetricReporter reporterInstance = (MetricReporter) reporterClass.getDeclaredConstructor().newInstance();
 
 					MetricConfig metricConfig = new MetricConfig();
 					reporterConfig.addAllToProperties(metricConfig);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/BatchTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/BatchTask.java
@@ -1294,7 +1294,7 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable impleme
 				final ChainedDriver<?, ?> ct;
 				try {
 					Class<? extends ChainedDriver<?, ?>> ctc = config.getChainedTask(i);
-					ct = ctc.newInstance();
+					ct = ctc.getDeclaredConstructor().newInstance();
 				}
 				catch (Exception ex) {
 					throw new RuntimeException("Could not instantiate chained task driver.", ex);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackendLoader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackendLoader.java
@@ -35,6 +35,7 @@ import org.slf4j.Logger;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.util.UUID;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -142,13 +143,14 @@ public class StateBackendLoader {
 							Class.forName(factoryClassName, false, classLoader)
 									.asSubclass(StateBackendFactory.class);
 
-					factory = clazz.newInstance();
+					factory = clazz.getDeclaredConstructor().newInstance();
 				}
 				catch (ClassNotFoundException e) {
 					throw new DynamicCodeLoadingException(
 							"Cannot find configured state backend factory class: " + backendName, e);
 				}
-				catch (ClassCastException | InstantiationException | IllegalAccessException e) {
+				catch (ClassCastException | InstantiationException | IllegalAccessException
+					| NoSuchMethodException | InvocationTargetException e) {
 					throw new DynamicCodeLoadingException("The class configured under '" +
 							CheckpointingOptions.STATE_BACKEND.key() + "' is not a valid state backend factory (" +
 							backendName + ')', e);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/serialization/PagedViewsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/serialization/PagedViewsTest.java
@@ -354,7 +354,7 @@ public class PagedViewsTest {
 		TestInputView inView = new TestInputView(outView.segments);
 
 		for (SerializationTestType reference : elements) {
-			SerializationTestType result = reference.getClass().newInstance();
+			SerializationTestType result = reference.getClass().getDeclaredConstructor().newInstance();
 			result.read(inView);
 			assertEquals(reference, result);
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/serialization/SpanningRecordSerializationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/serialization/SpanningRecordSerializationTest.java
@@ -150,7 +150,7 @@ public class SpanningRecordSerializationTest extends TestLogger {
 
 				while (!serializedRecords.isEmpty()) {
 					SerializationTestType expected = serializedRecords.poll();
-					SerializationTestType actual = expected.getClass().newInstance();
+					SerializationTestType actual = expected.getClass().getDeclaredConstructor().newInstance();
 
 					if (deserializer.getNextRecord(actual).isFullRecord()) {
 						Assert.assertEquals(expected, actual);
@@ -175,7 +175,7 @@ public class SpanningRecordSerializationTest extends TestLogger {
 		while (!serializedRecords.isEmpty()) {
 			SerializationTestType expected = serializedRecords.poll();
 
-			SerializationTestType actual = expected.getClass().newInstance();
+			SerializationTestType actual = expected.getClass().getDeclaredConstructor().newInstance();
 			RecordDeserializer.DeserializationResult result = deserializer.getNextRecord(actual);
 
 			Assert.assertTrue(result.isFullRecord());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/iterative/event/EventWithAggregatorsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/iterative/event/EventWithAggregatorsTest.java
@@ -106,7 +106,7 @@ public class EventWithAggregatorsTest {
 			baos.close();
 
 			DataInputViewStreamWrapper in = new DataInputViewStreamWrapper(new ByteArrayInputStream(data));
-			IterationEventWithAggregators newEvent = event.getClass().newInstance();
+			IterationEventWithAggregators newEvent = event.getClass().getDeclaredConstructor().newInstance();
 			newEvent.read(in);
 			in.close();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/BinaryOperatorTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/BinaryOperatorTestBase.java
@@ -190,7 +190,7 @@ public abstract class BinaryOperatorTestBase<S extends Function, IN, OUT> extend
 		this.driver = driver;
 		driver.setup(this);
 		
-		this.stub = (S) stubClass.newInstance();
+		this.stub = (S) stubClass.getDeclaredConstructor().newInstance();
 		
 		// regular running logic
 		this.running = true;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DriverTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DriverTestBase.java
@@ -182,7 +182,7 @@ public abstract class DriverTestBase<S extends Function> extends TestLogger impl
 		this.driver = driver;
 		driver.setup(this);
 
-		this.stub = (S)stubClass.newInstance();
+		this.stub = (S)stubClass.getDeclaredConstructor().newInstance();
 
 		// regular running logic
 		boolean stubOpen = false;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/TaskTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/TaskTestBase.java
@@ -117,7 +117,7 @@ public abstract class TaskTestBase extends TestLogger {
 	{
 		DelimitedInputFormat<Record> format;
 		try {
-			format = stubClass.newInstance();
+			format = stubClass.getDeclaredConstructor().newInstance();
 		}
 		catch (Throwable t) {
 			throw new RuntimeException("Could not instantiate test input format.", t);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/UnaryOperatorTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/UnaryOperatorTestBase.java
@@ -185,7 +185,7 @@ public abstract class UnaryOperatorTestBase<S extends Function, IN, OUT> extends
 		this.driver = driver;
 		driver.setup(this);
 
-		this.stub = (S)stubClass.newInstance();
+		this.stub = (S)stubClass.getDeclaredConstructor().newInstance();
 
 		// regular running logic
 		this.running = true;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/recordutils/RecordComparator.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/recordutils/RecordComparator.java
@@ -165,8 +165,8 @@ public final class RecordComparator extends TypeComparator<Record> {
 		
 		try {
 			for (int i = 0; i < this.keyHolders.length; i++) {
-				this.keyHolders[i] = toCopy.keyHolders[i].getClass().newInstance();
-				this.transientKeyHolders[i] = toCopy.keyHolders[i].getClass().newInstance();
+				this.keyHolders[i] = toCopy.keyHolders[i].getClass().getDeclaredConstructor().newInstance();
+				this.transientKeyHolders[i] = toCopy.keyHolders[i].getClass().getDeclaredConstructor().newInstance();
 			}
 		} catch (Exception ex) {
 			// this should never happen, because the classes have been instantiated before. Report for debugging.
@@ -378,7 +378,7 @@ public final class RecordComparator extends TypeComparator<Record> {
 		try {
 			final Value[] keys = new Value[this.keyFields.length];
 			for (int i = 0; i < keys.length; i++) {
-				keys[i] = this.keyHolders[i].getClass().newInstance();
+				keys[i] = this.keyHolders[i].getClass().getDeclaredConstructor().newInstance();
 			}
 			if(!record.getFieldsInto(this.keyFields, keys)) {
 				throw new RuntimeException("Could not extract keys from record.");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/SerializedThrowableTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/SerializedThrowableTest.java
@@ -101,7 +101,7 @@ public class SerializedThrowableTest {
 					new ProtectionDomain(new CodeSource(null, (Certificate[]) null), new Permissions()));
 			
 			// create an instance of the exception (no message, no cause)
-			Exception userException = clazz.asSubclass(Exception.class).newInstance();
+			Exception userException = clazz.asSubclass(Exception.class).getDeclaredConstructor().newInstance();
 			
 			// check that we cannot simply copy the exception
 			try {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/keys/KeySelectorUtil.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/keys/KeySelectorUtil.java
@@ -181,7 +181,7 @@ public final class KeySelectorUtil {
 
 		@Override
 		public Tuple getKey(IN value) throws Exception {
-			Tuple key = Tuple.getTupleClass(keyLength).newInstance();
+			Tuple key = Tuple.getTupleClass(keyLength).getDeclaredConstructor().newInstance();
 			comparator.extractKeys(value, keyArray, 0);
 			for (int i = 0; i < keyLength; i++) {
 				key.setField(keyArray[i], i);
@@ -221,7 +221,7 @@ public final class KeySelectorUtil {
 
 		@Override
 		public Tuple getKey(IN value) throws Exception {
-			Tuple key = tupleClass.newInstance();
+			Tuple key = tupleClass.getDeclaredConstructor().newInstance();
 			for (int i = 0; i < fields.length; i++) {
 				key.setField(Array.get(value, fields[i]), i);
 			}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/windowing/delta/extractor/ArrayFromTupleTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/windowing/delta/extractor/ArrayFromTupleTest.java
@@ -47,6 +47,8 @@ import org.apache.flink.api.java.tuple.Tuple9;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.lang.reflect.InvocationTargetException;
+
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -65,9 +67,10 @@ public class ArrayFromTupleTest {
 	}
 
 	@Test
-	public void testConvertFromTupleToArray() throws InstantiationException, IllegalAccessException {
+	public void testConvertFromTupleToArray() throws InstantiationException, IllegalAccessException,
+		NoSuchMethodException, InvocationTargetException {
 		for (int i = 0; i < Tuple.MAX_ARITY; i++) {
-			Tuple currentTuple = (Tuple) CLASSES[i].newInstance();
+			Tuple currentTuple = (Tuple) CLASSES[i].getDeclaredConstructor().newInstance();
 			String[] currentArray = new String[i + 1];
 			for (int j = 0; j <= i; j++) {
 				currentTuple.setField(testStrings[j], j);
@@ -78,8 +81,9 @@ public class ArrayFromTupleTest {
 	}
 
 	@Test
-	public void testUserSpecifiedOrder() throws InstantiationException, IllegalAccessException {
-		Tuple currentTuple = (Tuple) CLASSES[Tuple.MAX_ARITY - 1].newInstance();
+	public void testUserSpecifiedOrder() throws InstantiationException, IllegalAccessException,
+		NoSuchMethodException, InvocationTargetException {
+		Tuple currentTuple = (Tuple) CLASSES[Tuple.MAX_ARITY - 1].getDeclaredConstructor().newInstance();
 		for (int i = 0; i < Tuple.MAX_ARITY; i++) {
 			currentTuple.setField(testStrings[i], i);
 		}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/windowing/delta/extractor/FieldFromTupleTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/windowing/delta/extractor/FieldFromTupleTest.java
@@ -47,6 +47,8 @@ import org.apache.flink.api.java.tuple.Tuple9;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.lang.reflect.InvocationTargetException;
+
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -65,10 +67,11 @@ public class FieldFromTupleTest {
 	}
 
 	@Test
-	public void testSingleFieldExtraction() throws InstantiationException, IllegalAccessException {
+	public void testSingleFieldExtraction() throws InstantiationException, IllegalAccessException,
+		NoSuchMethodException, InvocationTargetException {
 		// extract single fields
 		for (int i = 0; i < Tuple.MAX_ARITY; i++) {
-			Tuple current = (Tuple) CLASSES[i].newInstance();
+			Tuple current = (Tuple) CLASSES[i].getDeclaredConstructor().newInstance();
 			for (int j = 0; j < i; j++) {
 				current.setField(testStrings[j], j);
 			}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/windowing/delta/extractor/FieldsFromTupleTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/windowing/delta/extractor/FieldsFromTupleTest.java
@@ -47,6 +47,8 @@ import org.apache.flink.api.java.tuple.Tuple9;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.lang.reflect.InvocationTargetException;
+
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -65,8 +67,9 @@ public class FieldsFromTupleTest {
 	}
 
 	@Test
-	public void testUserSpecifiedOrder() throws InstantiationException, IllegalAccessException {
-		Tuple currentTuple = (Tuple) CLASSES[Tuple.MAX_ARITY - 1].newInstance();
+	public void testUserSpecifiedOrder() throws InstantiationException, IllegalAccessException,
+		NoSuchMethodException, InvocationTargetException {
+		Tuple currentTuple = (Tuple) CLASSES[Tuple.MAX_ARITY - 1].getDeclaredConstructor().newInstance();
 		for (int i = 0; i < Tuple.MAX_ARITY; i++) {
 			currentTuple.setField(testDouble[i], i);
 		}

--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/CommonTestUtils.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/CommonTestUtils.java
@@ -170,7 +170,7 @@ public class CommonTestUtils {
 	public static Serializable createObjectForClassNotInClassPath(ClassLoader targetClassLoader) {
 		try {
 			Class<? extends Serializable> clazz = createClassNotInClassPath(targetClassLoader);
-			return clazz.newInstance();
+			return clazz.getDeclaredConstructor().newInstance();
 		}
 		catch (Exception e) {
 			throw new AssertionError("test setup broken", e);

--- a/flink-tests/src/test/java/org/apache/flink/test/typeserializerupgrade/PojoSerializerUpgradeTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/typeserializerupgrade/PojoSerializerUpgradeTest.java
@@ -445,7 +445,7 @@ public class PojoSerializerUpgradeTest extends TestLogger {
 
 		@Override
 		public Long map(Long value) throws Exception {
-			Object pojo = pojoClass.newInstance();
+			Object pojo = pojoClass.getDeclaredConstructor().newInstance();
 
 			fieldA.set(pojo, value);
 


### PR DESCRIPTION
## What is the purpose of the change

*This pull request avoid calling Class#newInstance*

## Brief change log

  - *Replace `Class#newInstance` to `Class#getDeclaredConstructor#newInstance`*

## Verifying this change


This change is already covered by existing tests*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
