### PR TITLE
[FLINK-9365] [rpc] Add handshake procedure to AkkaRpcService when connecting

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/FencedAkkaRpcActor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/FencedAkkaRpcActor.java
@@ -39,12 +39,12 @@ import java.util.concurrent.CompletableFuture;
  */
 public class FencedAkkaRpcActor<F extends Serializable, T extends FencedRpcEndpoint<F> & RpcGateway> extends AkkaRpcActor<T> {
 
-	public FencedAkkaRpcActor(T rpcEndpoint, CompletableFuture<Boolean> terminationFuture) {
-		super(rpcEndpoint, terminationFuture);
+	public FencedAkkaRpcActor(T rpcEndpoint, CompletableFuture<Boolean> terminationFuture, int version) {
+		super(rpcEndpoint, terminationFuture, version);
 	}
 
 	@Override
-	protected void handleMessage(Object message) {
+	protected void handleRpcMessage(Object message) {
 		if (message instanceof FencedMessage) {
 
 			final F expectedFencingToken = rpcEndpoint.getFencingToken();
@@ -67,7 +67,7 @@ public class FencedAkkaRpcActor<F extends Serializable, T extends FencedRpcEndpo
 				F fencingToken = fencedMessage.getFencingToken();
 
 				if (Objects.equals(expectedFencingToken, fencingToken)) {
-					super.handleMessage(fencedMessage.getPayload());
+					super.handleRpcMessage(fencedMessage.getPayload());
 				} else {
 					if (log.isDebugEnabled()) {
 						log.debug("Fencing token mismatch: Ignoring message {} because the fencing token {} did " +
@@ -81,7 +81,7 @@ public class FencedAkkaRpcActor<F extends Serializable, T extends FencedRpcEndpo
 				}
 			}
 		} else if (message instanceof UnfencedMessage) {
-			super.handleMessage(((UnfencedMessage<?>) message).getPayload());
+			super.handleRpcMessage(((UnfencedMessage<?>) message).getPayload());
 		} else {
 			if (log.isDebugEnabled()) {
 				log.debug("Unknown message type: Ignoring message {} because it is neither of type {} nor {}.",

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/exceptions/AkkaHandshakeException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/exceptions/AkkaHandshakeException.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rpc.akka.exceptions;
+
+import org.apache.flink.runtime.rpc.exceptions.HandshakeException;
+
+/**
+ * Exception which is thrown if the handshake fails.
+ */
+public class AkkaHandshakeException extends HandshakeException {
+	private static final long serialVersionUID = 7690464691855200936L;
+
+	public AkkaHandshakeException(String message) {
+		super(message);
+	}
+
+	public AkkaHandshakeException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public AkkaHandshakeException(Throwable cause) {
+		super(cause);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/exceptions/HandshakeException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/exceptions/HandshakeException.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rpc.exceptions;
+
+/**
+ * Exception which signals a handshake failure.
+ */
+public class HandshakeException extends RpcConnectionException {
+	private static final long serialVersionUID = -8176772204831111193L;
+
+	public HandshakeException(String message) {
+		super(message);
+	}
+
+	public HandshakeException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public HandshakeException(Throwable cause) {
+		super(cause);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/messages/HandshakeSuccessMessage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/messages/HandshakeSuccessMessage.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rpc.messages;
+
+/**
+ * Handshake success response.
+ */
+public enum HandshakeSuccessMessage {
+	INSTANCE
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/messages/RemoteHandshakeMessage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/messages/RemoteHandshakeMessage.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rpc.messages;
+
+import javax.annotation.Nonnull;
+
+import java.io.Serializable;
+
+/**
+ * Handshake message between rpc endpoints. This message can be used
+ * to verify compatibility between different endpoints.
+ */
+public class RemoteHandshakeMessage implements Serializable {
+
+	private static final long serialVersionUID = -7150082246232019027L;
+
+	@Nonnull
+	private final Class<?> rpcGateway;
+
+	@Nonnull
+	private final int version;
+
+	public RemoteHandshakeMessage(@Nonnull Class<?> rpcGateway, @Nonnull int version) {
+		this.rpcGateway = rpcGateway;
+		this.version = version;
+	}
+
+	@Nonnull
+	public Class<?> getRpcGateway() {
+		return rpcGateway;
+	}
+
+	@Nonnull
+	public int getVersion() {
+		return version;
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTest.java
@@ -32,7 +32,7 @@ import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.taskexecutor.SlotReport;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
-import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGateway;
+import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
 import org.apache.flink.testutils.category.New;
@@ -105,7 +105,7 @@ public class ResourceManagerTest extends TestLogger {
 		try {
 			final ResourceID taskManagerId = ResourceID.generate();
 			final ResourceManagerGateway resourceManagerGateway = resourceManager.getSelfGateway(ResourceManagerGateway.class);
-			final TaskExecutorGateway taskExecutorGateway = new TestingTaskExecutorGateway();
+			final TaskExecutorGateway taskExecutorGateway = new TestingTaskExecutorGatewayBuilder().createTestingTaskExecutorGateway();
 
 			// first make the ResourceManager the leader
 			resourceManagerLeaderElectionService.isLeader(UUID.randomUUID()).get();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerTest.java
@@ -37,6 +37,7 @@ import org.apache.flink.runtime.taskexecutor.SlotReport;
 import org.apache.flink.runtime.taskexecutor.SlotStatus;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
 import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGateway;
+import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
 import org.apache.flink.runtime.taskexecutor.exceptions.SlotAllocationException;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.testutils.category.New;
@@ -1091,7 +1092,7 @@ public class SlotManagerTest extends TestLogger {
 	public void testReportAllocatedSlot() throws Exception {
 		final ResourceID taskManagerId = ResourceID.generate();
 		final ResourceActions resourceActions = mock(ResourceActions.class);
-		final TestingTaskExecutorGateway taskExecutorGateway = new TestingTaskExecutorGateway();
+		final TestingTaskExecutorGateway taskExecutorGateway = new TestingTaskExecutorGatewayBuilder().createTestingTaskExecutorGateway();
 		final TaskExecutorConnection taskExecutorConnection = new TaskExecutorConnection(taskManagerId, taskExecutorGateway);
 
 		try (final SlotManager slotManager = new SlotManager(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/RpcConnectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/RpcConnectionTest.java
@@ -58,7 +58,7 @@ public class RpcConnectionTest extends TestLogger {
 		RpcService rpcService = null;
 		try {
 			actorSystem = AkkaUtils.createActorSystem(
-					new Configuration(), Option.apply(new Tuple2<String, Object>("localhost", 0)));
+					new Configuration(), Option.<Tuple2<String, Object>>apply(new Tuple2<>("localhost", 0)));
 
 			// we start the RPC service with a very long timeout to ensure that the test
 			// can only pass if the connection problem is not recognized merely via a timeout

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActorHandshakeTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActorHandshakeTest.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rpc.akka;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.rpc.RpcGateway;
+import org.apache.flink.runtime.rpc.RpcUtils;
+import org.apache.flink.runtime.rpc.exceptions.HandshakeException;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.TestLogger;
+
+import akka.actor.ActorSystem;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for the handshake between rpc endpoints.
+ */
+public class AkkaRpcActorHandshakeTest extends TestLogger {
+
+	private static final Time timeout = Time.seconds(10L);
+
+	private static AkkaRpcService akkaRpcService1;
+	private static AkkaRpcService akkaRpcService2;
+	private static WrongVersionAkkaRpcService wrongVersionAkkaRpcService;
+
+	@BeforeClass
+	public static void setupClass() {
+		final ActorSystem actorSystem1 = AkkaUtils.createDefaultActorSystem();
+		final ActorSystem actorSystem2 = AkkaUtils.createDefaultActorSystem();
+		final ActorSystem wrongVersionActorSystem = AkkaUtils.createDefaultActorSystem();
+
+		akkaRpcService1 = new AkkaRpcService(actorSystem1, timeout);
+		akkaRpcService2 = new AkkaRpcService(actorSystem2, timeout);
+		wrongVersionAkkaRpcService = new WrongVersionAkkaRpcService(wrongVersionActorSystem, timeout);
+	}
+
+	@AfterClass
+	public static void teardownClass() throws Exception {
+		final Collection<CompletableFuture<?>> terminationFutures = new ArrayList<>(3);
+
+		terminationFutures.add(akkaRpcService1.stopService());
+		terminationFutures.add(akkaRpcService2.stopService());
+		terminationFutures.add(wrongVersionAkkaRpcService.stopService());
+
+		FutureUtils.waitForAll(terminationFutures).get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+	}
+
+	@Test
+	public void testVersionMatchBetweenRpcComponents() throws Exception {
+		AkkaRpcActorTest.DummyRpcEndpoint rpcEndpoint = new AkkaRpcActorTest.DummyRpcEndpoint(akkaRpcService1);
+		final int value = 42;
+		rpcEndpoint.setFoobar(value);
+
+		rpcEndpoint.start();
+
+		try {
+			final AkkaRpcActorTest.DummyRpcGateway dummyRpcGateway = akkaRpcService2.connect(rpcEndpoint.getAddress(), AkkaRpcActorTest.DummyRpcGateway.class).get();
+
+			assertThat(dummyRpcGateway.foobar().get(), equalTo(value));
+		} finally {
+			RpcUtils.terminateRpcEndpoint(rpcEndpoint, timeout);
+		}
+	}
+
+	@Test
+	public void testVersionMismatchBetweenRpcComponents() throws Exception {
+		AkkaRpcActorTest.DummyRpcEndpoint rpcEndpoint = new AkkaRpcActorTest.DummyRpcEndpoint(akkaRpcService1);
+
+		rpcEndpoint.start();
+
+		try {
+			try {
+				wrongVersionAkkaRpcService.connect(rpcEndpoint.getAddress(), AkkaRpcActorTest.DummyRpcGateway.class).get();
+				fail("Expected HandshakeException.");
+			} catch (ExecutionException ee) {
+				assertThat(ExceptionUtils.stripExecutionException(ee), instanceOf(HandshakeException.class));
+			}
+		} finally {
+			RpcUtils.terminateRpcEndpoint(rpcEndpoint, timeout);
+		}
+	}
+
+	/**
+	 * Tests that we receive a HandshakeException when connecting to a rpc endpoint which
+	 * does not support the requested rpc gateway.
+	 */
+	@Test
+	public void testWrongGatewayEndpointConnection() throws Exception {
+		AkkaRpcActorTest.DummyRpcEndpoint rpcEndpoint = new AkkaRpcActorTest.DummyRpcEndpoint(akkaRpcService1);
+
+		rpcEndpoint.start();
+
+		CompletableFuture<WrongRpcGateway> futureGateway = akkaRpcService2.connect(rpcEndpoint.getAddress(), WrongRpcGateway.class);
+
+		try {
+			futureGateway.get(timeout.getSize(), timeout.getUnit());
+			fail("We expected a HandshakeException.");
+		} catch (ExecutionException executionException) {
+			assertThat(ExceptionUtils.stripExecutionException(executionException), instanceOf(HandshakeException.class));
+		} finally {
+			RpcUtils.terminateRpcEndpoint(rpcEndpoint, timeout);
+		}
+	}
+
+	private static class WrongVersionAkkaRpcService extends AkkaRpcService {
+
+		WrongVersionAkkaRpcService(ActorSystem actorSystem, Time timeout) {
+			super(actorSystem, timeout);
+		}
+
+		@Override
+		protected int getVersion() {
+			return -1;
+		}
+	}
+
+	private interface WrongRpcGateway extends RpcGateway {
+		CompletableFuture<Boolean> barfoo();
+		void tell(String message);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActorTest.java
@@ -146,35 +146,6 @@ public class AkkaRpcActorTest extends TestLogger {
 	}
 
 	/**
-	 * Tests that we receive a RpcConnectionException when calling a rpc method (with return type)
-	 * on a wrong rpc endpoint.
-	 *
-	 * @throws Exception
-	 */
-	@Test
-	public void testWrongGatewayEndpointConnection() throws Exception {
-		DummyRpcEndpoint rpcEndpoint = new DummyRpcEndpoint(akkaRpcService);
-
-		rpcEndpoint.start();
-
-		CompletableFuture<WrongRpcGateway> futureGateway = akkaRpcService.connect(rpcEndpoint.getAddress(), WrongRpcGateway.class);
-
-		WrongRpcGateway gateway = futureGateway.get(timeout.getSize(), timeout.getUnit());
-
-		// since it is a tell operation we won't receive a RpcConnectionException, it's only logged
-		gateway.tell("foobar");
-
-		CompletableFuture<Boolean> result = gateway.barfoo();
-
-		try {
-			result.get(timeout.getSize(), timeout.getUnit());
-			fail("We expected a RpcConnectionException.");
-		} catch (ExecutionException executionException) {
-			assertTrue(executionException.getCause() instanceof RpcConnectionException);
-		}
-	}
-
-	/**
 	 * Tests that we can wait for a RpcEndpoint to terminate.
 	 *
 	 * @throws ExecutionException
@@ -327,13 +298,8 @@ public class AkkaRpcActorTest extends TestLogger {
 	//  Test Actors and Interfaces
 	// ------------------------------------------------------------------------
 
-	private interface DummyRpcGateway extends RpcGateway {
+	interface DummyRpcGateway extends RpcGateway {
 		CompletableFuture<Integer> foobar();
-	}
-
-	private interface WrongRpcGateway extends RpcGateway {
-		CompletableFuture<Boolean> barfoo();
-		void tell(String message);
 	}
 
 	private static class TestRpcEndpoint extends RpcEndpoint {
@@ -348,7 +314,7 @@ public class AkkaRpcActorTest extends TestLogger {
 		}
 	}
 
-	private static class DummyRpcEndpoint extends TestRpcEndpoint implements DummyRpcGateway {
+	static class DummyRpcEndpoint extends TestRpcEndpoint implements DummyRpcGateway {
 
 		private volatile int _foobar = 42;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceTest.java
@@ -312,4 +312,8 @@ public class AkkaRpcServiceTest extends TestLogger {
 			// expected
 		}
 	}
+
+	@Test
+	public void testVersionIncompatibility() {
+	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGatewayBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGatewayBuilder.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskexecutor;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
+import org.apache.flink.runtime.jobmaster.JobMasterId;
+import org.apache.flink.runtime.messages.Acknowledge;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+
+/**
+ * Builder for a {@link TestingTaskExecutorGateway}.
+ */
+public class TestingTaskExecutorGatewayBuilder {
+
+	private static final Consumer<ResourceID> NOOP_HEARTBEAT_JOBMANAGER_CONSUMER = ignored -> {};
+	private static final BiConsumer<JobID, Throwable> NOOP_DISCONNECT_JOBMANAGER_CONSUMER = (ignoredA, ignoredB) -> {};
+	private static final BiFunction<TaskDeploymentDescriptor, JobMasterId, CompletableFuture<Acknowledge>> NOOP_SUBMIT_TASK_CONSUMER = (ignoredA, ignoredB) -> CompletableFuture.completedFuture(Acknowledge.get());
+
+	private String address = "foobar:1234";
+	private String hostname = "foobar";
+	private Consumer<ResourceID> heartbeatJobManagerConsumer = NOOP_HEARTBEAT_JOBMANAGER_CONSUMER;
+	private BiConsumer<JobID, Throwable> disconnectJobManagerConsumer = NOOP_DISCONNECT_JOBMANAGER_CONSUMER;
+	private BiFunction<TaskDeploymentDescriptor, JobMasterId, CompletableFuture<Acknowledge>> submitTaskConsumer = NOOP_SUBMIT_TASK_CONSUMER;
+
+	public TestingTaskExecutorGatewayBuilder setAddress(String address) {
+		this.address = address;
+		return this;
+	}
+
+	public TestingTaskExecutorGatewayBuilder setHostname(String hostname) {
+		this.hostname = hostname;
+		return this;
+	}
+
+	public TestingTaskExecutorGatewayBuilder setHeartbeatJobManagerConsumer(Consumer<ResourceID> heartbeatJobManagerConsumer) {
+		this.heartbeatJobManagerConsumer = heartbeatJobManagerConsumer;
+		return this;
+	}
+
+	public TestingTaskExecutorGatewayBuilder setDisconnectJobManagerConsumer(BiConsumer<JobID, Throwable> disconnectJobManagerConsumer) {
+		this.disconnectJobManagerConsumer = disconnectJobManagerConsumer;
+		return this;
+	}
+
+	public TestingTaskExecutorGatewayBuilder setSubmitTaskConsumer(BiFunction<TaskDeploymentDescriptor, JobMasterId, CompletableFuture<Acknowledge>> submitTaskConsumer) {
+		this.submitTaskConsumer = submitTaskConsumer;
+		return this;
+	}
+
+	public TestingTaskExecutorGateway createTestingTaskExecutorGateway() {
+		return new TestingTaskExecutorGateway(address, hostname, heartbeatJobManagerConsumer, disconnectJobManagerConsumer, submitTaskConsumer);
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

The handshake procedure sends the source version and the target rpc gateway type
to the rpc endpoint. This information is used to validate whether the version is
compatible and whether the rpc endpoint supports the target gateway type.

## Brief change log

- Introduce a `RemoteHandshakeMessage` which contains the version information as well as the target gateway type
- Send handshake message after obtaining the `ActorRef` of the `AkkaRpcActor`
- Verify compatibility (version and gateway type) on the `AkkaRpcActor` and confirm with `HandshakeSuccessMessage`

## Verifying this change

- Added `AkkaRpcActorHandshakeTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
