### PR TITLE
[FLINK-9182]async checkpoints for timer service

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileReaderOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileReaderOperator.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.state.StateSnapshotContext;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.OperatorSnapshotFutures;
 import org.apache.flink.streaming.api.operators.OutputTypeConfigurable;
 import org.apache.flink.streaming.api.operators.StreamSourceContexts;
 import org.apache.flink.streaming.api.watermark.Watermark;
@@ -389,8 +390,8 @@ public class ContinuousFileReaderOperator<OUT> extends AbstractStreamOperator<OU
 	//	---------------------			Checkpointing			--------------------------
 
 	@Override
-	public void snapshotState(StateSnapshotContext context) throws Exception {
-		super.snapshotState(context);
+	public void snapshotState(StateSnapshotContext context, OperatorSnapshotFutures snapshotInProgress) throws Exception {
+		super.snapshotState(context, snapshotInProgress);
 
 		checkState(checkpointedState != null,
 			"The operator state has not been properly initialized.");

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperator.java
@@ -85,8 +85,8 @@ public abstract class AbstractUdfStreamOperator<OUT, F extends Function>
 	}
 
 	@Override
-	public void snapshotState(StateSnapshotContext context) throws Exception {
-		super.snapshotState(context);
+	public void snapshotState(StateSnapshotContext context, OperatorSnapshotFutures snapshotInProgress) throws Exception {
+		super.snapshotState(context, snapshotInProgress);
 		StreamingFunctionUtils.snapshotFunctionState(context, getOperatorStateBackend(), userFunction);
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/HeapInternalTimerService.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/HeapInternalTimerService.java
@@ -292,17 +292,16 @@ public class HeapInternalTimerService<K, N> implements InternalTimerService<N>, 
 	/**
 	 * Snapshots the timers (both processing and event time ones) for a given {@code keyGroupIdx}.
 	 *
-	 * @param keyGroupIdx the id of the key-group to be put in the snapshot.
 	 * @return a snapshot containing the timers for the given key-group, and the serializers for them
 	 */
-	public InternalTimersSnapshot<K, N> snapshotTimersForKeyGroup(int keyGroupIdx) {
+	public InternalTimersSnapshot<K, N> snapshotTimersForKeyGroup(Set<InternalTimer<K, N>> eventTimeTimers, Set<InternalTimer<K, N>> processingTimeTimers) {
 		return new InternalTimersSnapshot<>(
 				keySerializer,
 				keySerializer.snapshotConfiguration(),
 				namespaceSerializer,
 				namespaceSerializer.snapshotConfiguration(),
-				getEventTimeTimerSetForKeyGroup(keyGroupIdx),
-				getProcessingTimeTimerSetForKeyGroup(keyGroupIdx));
+				eventTimeTimers,
+				processingTimeTimers);
 	}
 
 	/**
@@ -358,7 +357,8 @@ public class HeapInternalTimerService<K, N> implements InternalTimerService<N>, 
 	 * @param keyGroupIdx the index of the key group we are interested in.
 	 * @return the set of registered timers for the key-group.
 	 */
-	private Set<InternalTimer<K, N>> getEventTimeTimerSetForKeyGroup(int keyGroupIdx) {
+	@VisibleForTesting
+	public Set<InternalTimer<K, N>> getEventTimeTimerSetForKeyGroup(int keyGroupIdx) {
 		int localIdx = getIndexForKeyGroup(keyGroupIdx);
 		Set<InternalTimer<K, N>> timers = eventTimeTimersByKeyGroup[localIdx];
 		if (timers == null) {
@@ -386,7 +386,8 @@ public class HeapInternalTimerService<K, N> implements InternalTimerService<N>, 
 	 * @param keyGroupIdx the index of the key group we are interested in.
 	 * @return the set of registered timers for the key-group.
 	 */
-	private Set<InternalTimer<K, N>> getProcessingTimeTimerSetForKeyGroup(int keyGroupIdx) {
+	@VisibleForTesting
+	public Set<InternalTimer<K, N>> getProcessingTimeTimerSetForKeyGroup(int keyGroupIdx) {
 		int localIdx = getIndexForKeyGroup(keyGroupIdx);
 		Set<InternalTimer<K, N>> timers = processingTimeTimersByKeyGroup[localIdx];
 		if (timers == null) {
@@ -444,6 +445,14 @@ public class HeapInternalTimerService<K, N> implements InternalTimerService<N>, 
 		return this.localKeyGroupRangeStartIdx;
 	}
 
+	public KeyGroupsList getLocalKeyGroupRange() {
+		return localKeyGroupRange;
+	}
+
+	public int getTotalKeyGroups() {
+		return totalKeyGroups;
+	}
+
 	@VisibleForTesting
 	public Set<InternalTimer<K, N>>[] getEventTimeTimersPerKeyGroup() {
 		return this.eventTimeTimersByKeyGroup;
@@ -452,5 +461,13 @@ public class HeapInternalTimerService<K, N> implements InternalTimerService<N>, 
 	@VisibleForTesting
 	public Set<InternalTimer<K, N>>[] getProcessingTimeTimersPerKeyGroup() {
 		return this.processingTimeTimersByKeyGroup;
+	}
+
+	public PriorityQueue<InternalTimer<K, N>> getProcessingTimeTimersQueue() {
+		return processingTimeTimersQueue;
+	}
+
+	public PriorityQueue<InternalTimer<K, N>> getEventTimeTimersQueue() {
+		return eventTimeTimersQueue;
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/OperatorSnapshotFutures.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/OperatorSnapshotFutures.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.streaming.api.operators;
 
-import org.apache.flink.runtime.state.DoneFuture;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.runtime.state.SnapshotResult;
@@ -27,6 +27,7 @@ import org.apache.flink.util.ExceptionUtils;
 
 import javax.annotation.Nonnull;
 
+import java.util.concurrent.Callable;
 import java.util.concurrent.RunnableFuture;
 
 /**
@@ -46,12 +47,10 @@ public class OperatorSnapshotFutures {
 	@Nonnull
 	private RunnableFuture<SnapshotResult<OperatorStateHandle>> operatorStateRawFuture;
 
+	private Callable<Tuple2<Boolean, Exception>> snapshotTimerCallable;
+
 	public OperatorSnapshotFutures() {
-		this(
-			DoneFuture.of(SnapshotResult.empty()),
-			DoneFuture.of(SnapshotResult.empty()),
-			DoneFuture.of(SnapshotResult.empty()),
-			DoneFuture.of(SnapshotResult.empty()));
+		this(null, null, null, null);
 	}
 
 	public OperatorSnapshotFutures(
@@ -141,5 +140,13 @@ public class OperatorSnapshotFutures {
 		if (exception != null) {
 			throw exception;
 		}
+	}
+
+	public Callable<Tuple2<Boolean, Exception>> getSnapshotTimerCallable() {
+		return snapshotTimerCallable;
+	}
+
+	public void setSnapshotTimerCallable(Callable<Tuple2<Boolean, Exception>> snapshotTimerCallable) {
+		this.snapshotTimerCallable = snapshotTimerCallable;
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperator.java
@@ -32,6 +32,7 @@ import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.AbstractUdfStreamOperator;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.OperatorSnapshotFutures;
 import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.api.operators.async.queue.OrderedStreamElementQueue;
 import org.apache.flink.streaming.api.operators.async.queue.StreamElementQueue;
@@ -236,8 +237,8 @@ public class AsyncWaitOperator<IN, OUT>
 	}
 
 	@Override
-	public void snapshotState(StateSnapshotContext context) throws Exception {
-		super.snapshotState(context);
+	public void snapshotState(StateSnapshotContext context, OperatorSnapshotFutures snapshotInProgress) throws Exception {
+		super.snapshotState(context, snapshotInProgress);
 
 		ListState<StreamElement> partitionableState =
 			getOperatorStateBackend().getListState(new ListStateDescriptor<>(STATE_NAME, inStreamElementSerializer));

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/GenericWriteAheadSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/GenericWriteAheadSink.java
@@ -32,6 +32,7 @@ import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.util.ReusingMutableToRegularIteratorWrapper;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.OperatorSnapshotFutures;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.util.Preconditions;
 
@@ -155,8 +156,8 @@ public abstract class GenericWriteAheadSink<IN> extends AbstractStreamOperator<I
 	}
 
 	@Override
-	public void snapshotState(StateSnapshotContext context) throws Exception {
-		super.snapshotState(context);
+	public void snapshotState(StateSnapshotContext context, OperatorSnapshotFutures snapshotInProgress) throws Exception {
+		super.snapshotState(context, snapshotInProgress);
 
 		Preconditions.checkState(this.checkpointedState != null,
 			"The operator state has not been properly initialized.");

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorTest.java
@@ -540,7 +540,8 @@ public class AbstractStreamOperatorTest {
 		doReturn(containingTask).when(operator).getContainingTask();
 
 		// lets fail when calling the actual snapshotState method
-		doThrow(failingException).when(operator).snapshotState(eq(context));
+		OperatorSnapshotFutures snapshotInProgress = new OperatorSnapshotFutures();
+		doThrow(failingException).when(operator).snapshotState(eq(context), snapshotInProgress);
 
 		try {
 			operator.snapshotState(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperatorLifecycleTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperatorLifecycleTest.java
@@ -257,9 +257,9 @@ public class AbstractUdfStreamOperatorLifecycleTest {
 		}
 
 		@Override
-		public void snapshotState(StateSnapshotContext context) throws Exception {
+		public void snapshotState(StateSnapshotContext context, OperatorSnapshotFutures snapshotInProgress) throws Exception {
 			ACTUAL_ORDER_TRACKING.add("OPERATOR::snapshotState");
-			super.snapshotState(context);
+			super.snapshotState(context, snapshotInProgress);
 		}
 
 		@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/HeapInternalTimerServiceTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/HeapInternalTimerServiceTest.java
@@ -606,7 +606,8 @@ public class HeapInternalTimerServiceTest {
 		Map<Integer, byte[]> snapshot = new HashMap<>();
 		for (Integer keyGroupIndex : testKeyGroupRange) {
 			try (ByteArrayOutputStream outStream = new ByteArrayOutputStream()) {
-				InternalTimersSnapshot<?, ?> timersSnapshot = timerService.snapshotTimersForKeyGroup(keyGroupIndex);
+				InternalTimersSnapshot<?, ?> timersSnapshot = timerService.snapshotTimersForKeyGroup(timerService.getEventTimeTimerSetForKeyGroup(keyGroupIndex),
+					timerService.getProcessingTimeTimerSetForKeyGroup(keyGroupIndex));
 
 				InternalTimersSnapshotReaderWriters
 					.getWriterForVersion(snapshotVersion, timersSnapshot)
@@ -686,7 +687,8 @@ public class HeapInternalTimerServiceTest {
 		Map<Integer, byte[]> snapshot2 = new HashMap<>();
 		for (Integer keyGroupIndex : testKeyGroupRange) {
 			try (ByteArrayOutputStream outStream = new ByteArrayOutputStream()) {
-				InternalTimersSnapshot<?, ?> timersSnapshot = timerService.snapshotTimersForKeyGroup(keyGroupIndex);
+				InternalTimersSnapshot<?, ?> timersSnapshot = timerService.snapshotTimersForKeyGroup(timerService.getEventTimeTimerSetForKeyGroup(keyGroupIndex),
+					timerService.getProcessingTimeTimerSetForKeyGroup(keyGroupIndex));
 
 				InternalTimersSnapshotReaderWriters
 					.getWriterForVersion(snapshotVersion, timersSnapshot)

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamOperatorSnapshotRestoreTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamOperatorSnapshotRestoreTest.java
@@ -280,7 +280,7 @@ public class StreamOperatorSnapshotRestoreTest extends TestLogger {
 		}
 
 		@Override
-		public void snapshotState(StateSnapshotContext context) throws Exception {
+		public void snapshotState(StateSnapshotContext context, OperatorSnapshotFutures snapshotInProgress) throws Exception {
 
 			KeyedStateCheckpointOutputStream out = context.getRawKeyedOperatorStateOutput();
 			DataOutputView dov = new DataOutputViewStreamWrapper(out);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTest.java
@@ -50,6 +50,7 @@ import org.apache.flink.streaming.api.graph.StreamEdge;
 import org.apache.flink.streaming.api.graph.StreamNode;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.OperatorSnapshotFutures;
 import org.apache.flink.streaming.api.operators.StreamMap;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
@@ -770,7 +771,7 @@ public class OneInputStreamTaskTest extends TestLogger {
 		public static int numberSnapshotCalls = 0;
 
 		@Override
-		public void snapshotState(StateSnapshotContext context) throws Exception {
+		public void snapshotState(StateSnapshotContext context, OperatorSnapshotFutures snapshotInProgress) throws Exception {
 			ListState<Integer> partitionableState =
 				getOperatorStateBackend().getListState(TEST_DESCRIPTOR);
 			partitionableState.clear();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/RestoreStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/RestoreStreamTaskTest.java
@@ -38,6 +38,7 @@ import org.apache.flink.runtime.state.StateSnapshotContext;
 import org.apache.flink.runtime.state.TestTaskStateManager;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.OperatorSnapshotFutures;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.TestHarnessUtil;
 import org.apache.flink.util.TestLogger;
@@ -335,7 +336,7 @@ public class RestoreStreamTaskTest extends TestLogger {
 		}
 
 		@Override
-		public void snapshotState(StateSnapshotContext context) throws Exception {
+		public void snapshotState(StateSnapshotContext context, OperatorSnapshotFutures snapshotInProgress) throws Exception {
 			counterState.add(counter);
 		}
 	}
@@ -353,7 +354,7 @@ public class RestoreStreamTaskTest extends TestLogger {
 		}
 
 		@Override
-		public void snapshotState(StateSnapshotContext context) throws Exception {
+		public void snapshotState(StateSnapshotContext context, OperatorSnapshotFutures snapshotInProgress) throws Exception {
 		}
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TaskCheckpointingBehaviourTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TaskCheckpointingBehaviourTest.java
@@ -74,6 +74,7 @@ import org.apache.flink.runtime.taskmanager.TaskManagerActions;
 import org.apache.flink.runtime.util.EnvironmentInformation;
 import org.apache.flink.runtime.util.TestingTaskManagerRuntimeInfo;
 import org.apache.flink.streaming.api.graph.StreamConfig;
+import org.apache.flink.streaming.api.operators.OperatorSnapshotFutures;
 import org.apache.flink.streaming.api.operators.StreamFilter;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.util.SerializedValue;
@@ -435,7 +436,7 @@ public class TaskCheckpointingBehaviourTest extends TestLogger {
 		}
 
 		@Override
-		public void snapshotState(StateSnapshotContext context) throws Exception {
+		public void snapshotState(StateSnapshotContext context, OperatorSnapshotFutures snapshotInProgress) throws Exception {
 			OperatorStateCheckpointOutputStream outStream = context.getRawOperatorStateOutput();
 
 			IN_CHECKPOINT_LATCH.trigger();


### PR DESCRIPTION
## What is the purpose of the change

it is for async checkpoints for timer service
the whole idea is based on discussion in previous PR for FLINK-9182 in this link:https://github.com/apache/flink/pull/5908

## Brief change log

in sync part flat copy of the internal array of the priority queue
in async part build key group and write timer key group

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
