### PR TITLE
[FLINK-9373][state] Fix potential data losing for RocksDBBackend

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
@@ -99,7 +99,6 @@ import org.rocksdb.DBOptions;
 import org.rocksdb.ReadOptions;
 import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
-import org.rocksdb.RocksIterator;
 import org.rocksdb.Snapshot;
 import org.rocksdb.WriteOptions;
 import org.slf4j.Logger;
@@ -322,7 +321,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 			throw new FlinkRuntimeException("Failed to get keys from RocksDB state backend.", ex);
 		}
 
-		RocksIterator iterator = db.newIterator(columnInfo.f0);
+		RocksIteratorWrapper iterator = getRocksIterator(db, columnInfo.f0);
 		iterator.seekToFirst();
 
 		final RocksIteratorForKeysWrapper<K> iteratorWrapper = new RocksIteratorForKeysWrapper<>(iterator, state, keySerializer, keyGroupPrefixBytes,
@@ -734,7 +733,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 					restoreInstance((IncrementalLocalKeyedStateHandle) rawStateHandle);
 				} else {
 					throw new IllegalStateException("Unexpected state handle type, " +
-						"expected " + IncrementalKeyedStateHandle.class +
+						"expected " + IncrementalKeyedStateHandle.class + " or " + IncrementalLocalKeyedStateHandle.class +
 						", but found " + rawStateHandle.getClass());
 				}
 			}
@@ -1079,7 +1078,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 
 						ColumnFamilyHandle targetColumnFamilyHandle = registeredStateMetaInfoEntry.f0;
 
-						try (RocksIterator iterator = restoreDb.newIterator(columnFamilyHandle)) {
+						try (RocksIteratorWrapper iterator = getRocksIterator(restoreDb, columnFamilyHandle)) {
 
 							int startKeyGroup = stateBackend.getKeyGroupRange().getStartKeyGroup();
 							byte[] startKeyGroupPrefixBytes = new byte[stateBackend.keyGroupPrefixBytes];
@@ -1309,7 +1308,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 		int count = 0;
 
 		for (Tuple2<ColumnFamilyHandle, RegisteredKeyedBackendStateMetaInfo<?, ?>> column : kvStateInformation.values()) {
-			try (RocksIterator rocksIterator = db.newIterator(column.f0)) {
+			try (RocksIteratorWrapper rocksIterator = getRocksIterator(db, column.f0)) {
 				rocksIterator.seekToFirst();
 
 				while (rocksIterator.isValid()) {
@@ -1357,7 +1356,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 			}
 		}
 
-		RocksDBMergeIterator(List<Tuple2<RocksIterator, Integer>> kvStateIterators, final int keyGroupPrefixByteCount) {
+		RocksDBMergeIterator(List<Tuple2<RocksIteratorWrapper, Integer>> kvStateIterators, final int keyGroupPrefixByteCount) throws RocksDBException {
 			Preconditions.checkNotNull(kvStateIterators);
 			Preconditions.checkArgument(keyGroupPrefixByteCount >= 1);
 
@@ -1369,8 +1368,8 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 				PriorityQueue<MergeIterator> iteratorPriorityQueue =
 					new PriorityQueue<>(kvStateIterators.size(), iteratorComparator);
 
-				for (Tuple2<RocksIterator, Integer> rocksIteratorWithKVStateId : kvStateIterators) {
-					final RocksIterator rocksIterator = rocksIteratorWithKVStateId.f0;
+				for (Tuple2<RocksIteratorWrapper, Integer> rocksIteratorWithKVStateId : kvStateIterators) {
+					final RocksIteratorWrapper rocksIterator = rocksIteratorWithKVStateId.f0;
 					rocksIterator.seekToFirst();
 					if (rocksIterator.isValid()) {
 						iteratorPriorityQueue.offer(new MergeIterator(rocksIterator, rocksIteratorWithKVStateId.f1));
@@ -1398,15 +1397,16 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 		 * Advance the iterator. Should only be called if {@link #isValid()} returned true. Valid can only chance after
 		 * calls to {@link #next()}.
 		 */
-		public void next() {
+		public void next() throws RocksDBException {
 			newKeyGroup = false;
 			newKVState = false;
 
-			final RocksIterator rocksIterator = currentSubIterator.getIterator();
+			final RocksIteratorWrapper rocksIterator = currentSubIterator.getIterator();
 			rocksIterator.next();
 
 			byte[] oldKey = currentSubIterator.getCurrentKey();
 			if (rocksIterator.isValid()) {
+
 				currentSubIterator.currentKey = rocksIterator.key();
 
 				if (isDifferentKeyGroup(oldKey, currentSubIterator.getCurrentKey())) {
@@ -1523,13 +1523,13 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 		 * @param iterator  The #RocksIterator to wrap .
 		 * @param kvStateId Id of the K/V state to which this iterator belongs.
 		 */
-		MergeIterator(RocksIterator iterator, int kvStateId) {
+		MergeIterator(RocksIteratorWrapper iterator, int kvStateId) {
 			this.iterator = Preconditions.checkNotNull(iterator);
 			this.currentKey = iterator.key();
 			this.kvStateId = kvStateId;
 		}
 
-		private final RocksIterator iterator;
+		private final RocksIteratorWrapper iterator;
 		private byte[] currentKey;
 		private final int kvStateId;
 
@@ -1541,7 +1541,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 			this.currentKey = currentKey;
 		}
 
-		public RocksIterator getIterator() {
+		public RocksIteratorWrapper getIterator() {
 			return iterator;
 		}
 
@@ -1556,13 +1556,13 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 	}
 
 	/**
-	 * Adapter class to bridge between {@link RocksIterator} and {@link Iterator} to iterate over the keys. This class
+	 * Adapter class to bridge between {@link RocksIteratorWrapper} and {@link Iterator} to iterate over the keys. This class
 	 * is not thread safe.
 	 *
 	 * @param <K> the type of the iterated objects, which are keys in RocksDB.
 	 */
 	static class RocksIteratorForKeysWrapper<K> implements Iterator<K>, AutoCloseable {
-		private final RocksIterator iterator;
+		private final RocksIteratorWrapper iterator;
 		private final String state;
 		private final TypeSerializer<K> keySerializer;
 		private final int keyGroupPrefixBytes;
@@ -1571,7 +1571,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 		private K nextKey;
 
 		RocksIteratorForKeysWrapper(
-			RocksIterator iterator,
+			RocksIteratorWrapper iterator,
 			String state,
 			TypeSerializer<K> keySerializer,
 			int keyGroupPrefixBytes,
@@ -1588,8 +1588,9 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 
 		@Override
 		public boolean hasNext() {
-			while (nextKey == null && iterator.isValid()) {
-				try {
+			try {
+				while (nextKey == null && iterator.isValid()) {
+
 					byte[] key = iterator.key();
 					if (isMatchingNameSpace(key)) {
 						ByteArrayInputStreamWithPos inputStream =
@@ -1603,9 +1604,9 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 						nextKey = value;
 					}
 					iterator.next();
-				} catch (IOException e) {
-					throw new FlinkRuntimeException("Failed to access state [" + state + "]", e);
 				}
+			} catch (Exception e) {
+				throw new FlinkRuntimeException("Failed to access state [" + state + "]", e);
 			}
 			return nextKey != null;
 		}
@@ -1878,7 +1879,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 		 */
 		private List<ColumnFamilyHandle> copiedColumnFamilyHandles;
 
-		private List<Tuple2<RocksIterator, Integer>> kvStateIterators;
+		private List<Tuple2<RocksIteratorWrapper, Integer>> kvStateIterators;
 
 		private CheckpointStreamWithResultProvider checkpointStreamWithResultProvider;
 		private DataOutputView outputView;
@@ -1937,7 +1938,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 		 *
 		 * @throws IOException
 		 */
-		public void writeDBSnapshot() throws IOException, InterruptedException {
+		public void writeDBSnapshot() throws IOException, InterruptedException, RocksDBException {
 
 			if (null == snapshot) {
 				throw new IOException("No snapshot available. Might be released due to cancellation.");
@@ -1975,7 +1976,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 			checkpointStreamWithResultProvider = null;
 
 			if (null != kvStateIterators) {
-				for (Tuple2<RocksIterator, Integer> kvStateIterator : kvStateIterators) {
+				for (Tuple2<RocksIteratorWrapper, Integer> kvStateIterator : kvStateIterators) {
 					IOUtils.closeQuietly(kvStateIterator.f0);
 				}
 				kvStateIterators = null;
@@ -2010,7 +2011,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 			for (ColumnFamilyHandle columnFamilyHandle : copiedColumnFamilyHandles) {
 
 				kvStateIterators.add(
-					new Tuple2<>(stateBackend.db.newIterator(columnFamilyHandle, readOptions), kvStateId));
+					new Tuple2<>(getRocksIterator(stateBackend.db, columnFamilyHandle, readOptions), kvStateId));
 
 				++kvStateId;
 			}
@@ -2028,7 +2029,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 			serializationProxy.write(outputView);
 		}
 
-		private void writeKVStateData() throws IOException, InterruptedException {
+		private void writeKVStateData() throws IOException, InterruptedException, RocksDBException {
 
 			byte[] previousKey = null;
 			byte[] previousValue = null;
@@ -2527,5 +2528,22 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 				}
 			}
 		}
+	}
+
+	public static RocksIteratorWrapper getRocksIterator(RocksDB db) {
+		return new RocksIteratorWrapper(db.newIterator());
+	}
+
+	public static RocksIteratorWrapper getRocksIterator(
+		RocksDB db,
+		ColumnFamilyHandle columnFamilyHandle) {
+		return new RocksIteratorWrapper(db.newIterator(columnFamilyHandle));
+	}
+
+	public static RocksIteratorWrapper getRocksIterator(
+		RocksDB db,
+		ColumnFamilyHandle columnFamilyHandle,
+		ReadOptions readOptions) {
+		return new RocksIteratorWrapper(db.newIterator(columnFamilyHandle, readOptions));
 	}
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBMapState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBMapState.java
@@ -34,7 +34,6 @@ import org.apache.flink.util.Preconditions;
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
-import org.rocksdb.RocksIterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -548,7 +547,7 @@ public class RocksDBMapState<K, N, UK, UV>
 
 			// use try-with-resources to ensure RocksIterator can be release even some runtime exception
 			// occurred in the below code block.
-			try (RocksIterator iterator = db.newIterator(columnFamily)) {
+			try (RocksIteratorWrapper iterator = RocksDBKeyedStateBackend.getRocksIterator(db, columnFamily)) {
 
 				/*
 				 * The iteration starts from the prefix bytes at the first loading. The cache then is

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksIteratorWrapper.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksIteratorWrapper.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.state;
+
+import org.apache.flink.util.FlinkRuntimeException;
+import org.rocksdb.RocksDBException;
+import org.rocksdb.RocksIterator;
+import org.rocksdb.RocksIteratorInterface;
+
+import javax.annotation.Nonnull;
+import java.io.Closeable;
+
+/**
+ * This is a wrapper that wraps {@link RocksIterator} to check status there for all the methods mentioned
+ * in the wiki documentation: Seek(), Next(), SeekToFirst(), SeekToLast(), SeekForPrev(), and Prev() to be
+ * on the safe side, because the iterator may pass the blocks or files it had difficulties in reading (because
+ * of IO error, data corruption or other issues) and continue with the next available keys. status() may not OK,
+ * even if Valid()=true. more information can be found in https://github.com/facebook/rocksdb/wiki/Iterator#error-handling
+ */
+public class RocksIteratorWrapper implements RocksIteratorInterface, Closeable {
+
+	private RocksIterator iterator;
+
+	public RocksIteratorWrapper(@Nonnull RocksIterator iterator) {
+		this.iterator = iterator;
+	}
+
+	@Override
+	public boolean isValid() {
+		return this.iterator.isValid();
+	}
+
+	@Override
+	public void seekToFirst() {
+		iterator.seekToFirst();
+		status();
+	}
+
+	@Override
+	public void seekToLast() {
+		iterator.seekToFirst();
+		status();
+	}
+
+	@Override
+	public void seek(byte[] target) {
+		iterator.seek(target);
+		status();
+	}
+
+	@Override
+	public void next() {
+		iterator.next();
+		status();
+	}
+
+	@Override
+	public void prev() {
+		iterator.prev();
+		status();
+	}
+
+	@Override
+	public void status() {
+		try {
+			iterator.status();
+		} catch (RocksDBException ex) {
+			throw new FlinkRuntimeException("Internal exception found in RocksDB", ex);
+		}
+	}
+
+	public byte[] key() {
+		return iterator.key();
+	}
+
+	public byte[] value() {
+		return iterator.value();
+	}
+
+	@Override
+	public void close() {
+		iterator.close();
+	}
+}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBMergeIteratorTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBMergeIteratorTest.java
@@ -30,10 +30,8 @@ import org.junit.rules.TemporaryFolder;
 import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.RocksDB;
-import org.rocksdb.RocksIterator;
 
 import java.io.DataOutputStream;
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -52,7 +50,7 @@ public class RocksDBMergeIteratorTest {
 	public TemporaryFolder tempFolder = new TemporaryFolder();
 
 	@Test
-	public void testEmptyMergeIterator() throws IOException {
+	public void testEmptyMergeIterator() throws Exception {
 		RocksDBKeyedStateBackend.RocksDBMergeIterator emptyIterator =
 				new RocksDBKeyedStateBackend.RocksDBMergeIterator(Collections.emptyList(), 2);
 		Assert.assertFalse(emptyIterator.isValid());
@@ -76,7 +74,7 @@ public class RocksDBMergeIteratorTest {
 		Random random = new Random(1234);
 
 		try (RocksDB rocksDB = RocksDB.open(tempFolder.getRoot().getAbsolutePath())) {
-			List<Tuple2<RocksIterator, Integer>> rocksIteratorsWithKVStateId = new ArrayList<>();
+			List<Tuple2<RocksIteratorWrapper, Integer>> rocksIteratorsWithKVStateId = new ArrayList<>();
 			List<Tuple2<ColumnFamilyHandle, Integer>> columnFamilyHandlesWithKeyCount = new ArrayList<>();
 
 			int totalKeysExpected = 0;
@@ -109,7 +107,7 @@ public class RocksDBMergeIteratorTest {
 
 			int id = 0;
 			for (Tuple2<ColumnFamilyHandle, Integer> columnFamilyHandle : columnFamilyHandlesWithKeyCount) {
-				rocksIteratorsWithKVStateId.add(new Tuple2<>(rocksDB.newIterator(columnFamilyHandle.f0), id));
+				rocksIteratorsWithKVStateId.add(new Tuple2<>(RocksDBKeyedStateBackend.getRocksIterator(rocksDB, columnFamilyHandle.f0), id));
 				++id;
 			}
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBRocksIteratorForKeysWrapperTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBRocksIteratorForKeysWrapperTest.java
@@ -36,7 +36,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.rocksdb.ColumnFamilyHandle;
-import org.rocksdb.RocksIterator;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -48,7 +47,7 @@ import static org.mockito.Mockito.mock;
 /**
  * Tests for the RocksIteratorWrapper.
  */
-public class RocksDBRocksIteratorWrapperTest {
+public class RocksDBRocksIteratorForKeysWrapperTest {
 
 	@Rule
 	public final TemporaryFolder tmp = new TemporaryFolder();
@@ -119,7 +118,7 @@ public class RocksDBRocksIteratorWrapperTest {
 
 			try (
 				ColumnFamilyHandle handle = keyedStateBackend.getColumnFamilyHandle(testStateName);
-				RocksIterator iterator = keyedStateBackend.db.newIterator(handle);
+				RocksIteratorWrapper iterator = RocksDBKeyedStateBackend.getRocksIterator(keyedStateBackend.db, handle);
 				RocksDBKeyedStateBackend.RocksIteratorForKeysWrapper<K> iteratorWrapper =
 					new RocksDBKeyedStateBackend.RocksIteratorForKeysWrapper<>(
 						iterator,

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/benchmark/RocksDBPerformanceTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/benchmark/RocksDBPerformanceTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.contrib.streaming.state.benchmark;
 
 import org.apache.flink.contrib.streaming.state.RocksDBKeyedStateBackend;
+import org.apache.flink.contrib.streaming.state.RocksIteratorWrapper;
 import org.apache.flink.core.memory.MemoryUtils;
 import org.apache.flink.testutils.junit.RetryOnFailure;
 import org.apache.flink.testutils.junit.RetryRule;
@@ -33,7 +34,6 @@ import org.rocksdb.CompactionStyle;
 import org.rocksdb.NativeLibraryLoader;
 import org.rocksdb.Options;
 import org.rocksdb.RocksDB;
-import org.rocksdb.RocksIterator;
 import org.rocksdb.WriteOptions;
 import sun.misc.Unsafe;
 
@@ -166,7 +166,7 @@ public class RocksDBPerformanceTest extends TestLogger {
 
 			int pos = 0;
 
-			try (final RocksIterator iterator = rocksDB.newIterator()) {
+			try (final RocksIteratorWrapper iterator = RocksDBKeyedStateBackend.getRocksIterator(rocksDB)) {
 				// seek to start
 				unsafe.putInt(keyTemplate, offset, 0);
 				iterator.seek(keyTemplate);


### PR DESCRIPTION
## What is the purpose of the change

Currently, when using RocksIterator we only use the `iterator.isValid()` to check whether we have reached the end of the iterator. But that is not enough, if we refer to RocksDB's wiki https://github.com/facebook/rocksdb/wiki/Iterator#error-handling we should find that even if `iterator.isValid()=true`, there may also exist some internal errors. A safer way to use the `RocksIterator` is to always call the `iterator.status()` to check the internal error of RocksDB. There is one case from user email seems to lost data because of this http://apache-flink-user-mailing-list-archive.2336050.n4.nabble.com/Missing-MapState-when-Timer-fires-after-restored-state-td20134.html (I'm not so sure yet)

## Brief change log

  - *Always call RocksIterator.status() to check the internal error of RocksDB*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
