### PR TITLE
[FLINK-9283] Update cluster execution docs

### DIFF
--- a/docs/dev/cluster_execution.md
+++ b/docs/dev/cluster_execution.md
@@ -62,7 +62,7 @@ The following illustrates the use of the `RemoteEnvironment`:
 {% highlight java %}
 public static void main(String[] args) throws Exception {
     ExecutionEnvironment env = ExecutionEnvironment
-        .createRemoteEnvironment("flink-master", 6123, "/home/user/udfs.jar");
+        .createRemoteEnvironment("flink-master", 8081, "/home/user/udfs.jar");
 
     DataSet<String> data = env.readTextFile("hdfs://path/to/file");
 


### PR DESCRIPTION
## What is the purpose of the change

This pull request is to fix port error in example about using `RemoteStreamEnvironment`


## Brief change log

  - Change port from 6123 to 8081 in example

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
