### PR TITLE
[FLINK-9383][runtime] Test directories in DistributedCache E2E test 

### DIFF
--- a/flink-end-to-end-tests/run-pre-commit-tests.sh
+++ b/flink-end-to-end-tests/run-pre-commit-tests.sh
@@ -82,10 +82,7 @@ if [ $EXIT_CODE == 0 ]; then
 fi
 
 if [ $EXIT_CODE == 0 ]; then
-    printf "\n==============================================================================\n"
-    printf "Running Distributed cache end-to-end test\n"
-    printf "==============================================================================\n"
-    $END_TO_END_DIR/test-scripts/test_streaming_distributed_cache_via_blob.sh
+    run_test "Distributed cache end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_distributed_cache_via_blob.sh"
     EXIT_CODE=$?
 fi
 

--- a/flink-end-to-end-tests/run-pre-commit-tests.sh
+++ b/flink-end-to-end-tests/run-pre-commit-tests.sh
@@ -81,6 +81,14 @@ if [ $EXIT_CODE == 0 ]; then
     EXIT_CODE=$?
 fi
 
+if [ $EXIT_CODE == 0 ]; then
+    printf "\n==============================================================================\n"
+    printf "Running Distributed cache end-to-end test\n"
+    printf "==============================================================================\n"
+    $END_TO_END_DIR/test-scripts/test_streaming_distributed_cache_via_blob.sh
+    EXIT_CODE=$?
+fi
+
 
 # Exit code for Travis build success/failure
 exit $EXIT_CODE

--- a/flink-end-to-end-tests/test-scripts/test_streaming_distributed_cache_via_blob.sh
+++ b/flink-end-to-end-tests/test-scripts/test_streaming_distributed_cache_via_blob.sh
@@ -27,7 +27,7 @@ start_cluster
 
 mkdir -p $TEST_DATA_DIR
 
-$FLINK_DIR/bin/flink run -p 1 $TEST_PROGRAM_JAR --inputFile $TEST_INFRA_DIR/test-data/words --tempDir $TEST_DATA_DIR/ --output $TEST_DATA_DIR/out/cl_out_pf
+$FLINK_DIR/bin/flink run -p 1 $TEST_PROGRAM_JAR --inputFile $TEST_INFRA_DIR/test-data/words --inputDir $TEST_INFRA_DIR/test-data --tempDir $TEST_DATA_DIR/ --output $TEST_DATA_DIR/out/cl_out_pf
 
 OUTPUT=`cat $TEST_DATA_DIR/out/cl_out_pf`
 


### PR DESCRIPTION
## What is the purpose of the change

With this PR the distributed cache end-to-end test
* also covers the distributed of directories
* runs on every build.

## Brief change log

* add directory parameter to test class
  * verification works by looking for a file that the directory should contain
* activate distributed cache e2e test

Additionally, the test now verifies that the file size is identical, to ensure that the correct file was returned.
