### PR TITLE
[FLINK-9301] [e2e test] Add back "not so mini cluster" test with reduced parallelism

### DIFF
--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -47,7 +47,6 @@ EXIT_CODE=0
 #     EXIT_CODE=$?
 # fi
 
-
 if [ $EXIT_CODE == 0 ]; then
     printf "\n==============================================================================\n"
     printf "Running HA end-to-end test\n"
@@ -173,6 +172,14 @@ if [ $EXIT_CODE == 0 ]; then
   printf "Running Streaming bucketing nightly end-to-end test\n"
   printf "==============================================================================\n"
   $END_TO_END_DIR/test-scripts/test_streaming_bucketing.sh
+  EXIT_CODE=$?
+fi
+
+if [ $EXIT_CODE == 0 ]; then
+  printf "\n==============================================================================\n"
+  printf "Running connected components iterations with high parallelism nightly end-to-end test\n"
+  printf "==============================================================================\n"
+  PARALLELISM=25 $END_TO_END_DIR/test-scripts/test_high_parallelism_iterations.sh
   EXIT_CODE=$?
 fi
 

--- a/flink-end-to-end-tests/test-scripts/test_high_parallelism_iterations.sh
+++ b/flink-end-to-end-tests/test-scripts/test_high_parallelism_iterations.sh
@@ -19,7 +19,7 @@
 
 source "$(dirname "$0")"/common.sh
 
-PARALLELISM="${PARALLELISM:-100}"
+PARALLELISM="${PARALLELISM:-25}"
 
 TEST=flink-high-parallelism-iterations-test
 TEST_PROGRAM_NAME=HighParallelismIterationsTestProgram
@@ -41,12 +41,15 @@ echo "taskmanager.network.netty.client.numThreads: 1" >> $FLINK_DIR/conf/flink-c
 
 echo "taskmanager.numberOfTaskSlots: 1" >> $FLINK_DIR/conf/flink-conf.yaml
 
+print_mem_use
 start_cluster
+print_mem_use
 
 let TMNUM=$PARALLELISM-1
 echo "Start $TMNUM more task managers"
 for i in `seq 1 $TMNUM`; do
     $FLINK_DIR/bin/taskmanager.sh start
+    print_mem_use
 done
 
 function test_cleanup {
@@ -56,7 +59,9 @@ function test_cleanup {
   trap "" EXIT
 
   stop_cluster
+  print_mem_use
   $FLINK_DIR/bin/taskmanager.sh stop-all
+  print_mem_use
 
   # revert our modifications to the Flink distribution
   mv -f $FLINK_DIR/conf/flink-conf.yaml.bak $FLINK_DIR/conf/flink-conf.yaml


### PR DESCRIPTION
## What is the purpose of the change

Add back "not so mini cluster" E2E nightly test with reduced to 25 parallelism and memory usage logging to address limitations of free Travis CI

## Brief change log

  - add `test_high_parallelism_iterations.sh` back to `run-nightly-tests.sh`
  - introduce memory logging in `common.sh` and use it in `test_high_parallelism_iterations.sh`


## Verifying this change

```bash
mvn clean -DskipTests package
FLINK_DIR=build-target ./flink-end-to-end-tests/test-scripts/test_high_parallelism_iterations.sh
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (n)o
  - The runtime per-record code paths (performance sensitive): (n)o
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (n)o
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
