### PR TITLE
[FLINK-7814][TableAPI && SQL] Add BETWEEN  and NOT BETWEEN expression to Table API

### DIFF
--- a/docs/dev/table/tableApi.md
+++ b/docs/dev/table/tableApi.md
@@ -1885,6 +1885,32 @@ BOOLEAN.isNotFalse
       </td>
     </tr>
 
+    <tr>
+      <td>
+        {% highlight java %}
+    ANY.between(lowerBound, upperBound)
+    {% endhighlight %}
+      </td>
+      <td>
+        <p>Returns true if given expression is between lowerBound and upperBound, both included. False otherwise.
+               The given expression and lowerBound and upperBound must be all numeric type or identical comparable type.
+        </p>
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        {% highlight java %}
+      ANY.notBetween(lowerBound, upperBound)
+    {% endhighlight %}
+      </td>
+      <td>
+        <p>Returns true if given expression is not between lowerBound and upperBound, both included. False otherwise.
+               The given expression and lowerBound and upperBound must be all numeric type or identical comparable type.
+        </p>
+      </td>
+    </tr>
+
   </tbody>
 </table>
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/api/scala/expressionDsl.scala
@@ -809,6 +809,23 @@ trait ImplicitExpressionOperations {
     */
   def sha2(hashLength: Expression) = Sha2(expr, hashLength)
 
+  /**
+    * Returns the Between with lower bound included and upper bound included.
+    * @param lowerBound
+    * @param upperBound
+    * @return Returns the Between with lower bound included and upper bound included
+    */
+  def between(lowerBound: Expression, upperBound: Expression) =
+    Between(expr, lowerBound, upperBound)
+
+  /**
+    * Returns the not Between with lower bound included and upper bound included.
+    * @param lowerBound
+    * @param upperBound
+    * @return Returns the NotBetween with lower bound included and upper bound included
+    */
+  def notBetween(lowerBound: Expression, upperBound: Expression) =
+    NotBetween(expr, lowerBound, upperBound)
 }
 
 /**

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/comparison.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/comparison.scala
@@ -22,6 +22,7 @@ import org.apache.calcite.sql.SqlOperator
 import org.apache.calcite.sql.fun.SqlStdOperatorTable
 import org.apache.calcite.tools.RelBuilder
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo._
+import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
 import org.apache.flink.table.typeutils.TypeCheckUtils
 import org.apache.flink.table.typeutils.TypeCheckUtils.{isArray, isComparable, isNumeric}
 import org.apache.flink.table.validate._
@@ -162,4 +163,76 @@ case class IsNotFalse(child: Expression) extends UnaryExpression {
   }
 
   override private[flink] def resultType = BOOLEAN_TYPE_INFO
+}
+
+abstract class BetweenProperty(
+  expr: Expression,
+  lowerBound: Expression,
+  upperBound: Expression) extends Expression {
+
+  override private[flink] def resultType: TypeInformation[_] = BasicTypeInfo.BOOLEAN_TYPE_INFO
+
+  override private[flink] def children: Seq[Expression] = Seq(expr, lowerBound, upperBound)
+
+  override private[flink] def validateInput(): ValidationResult = {
+    (expr.resultType, lowerBound.resultType, upperBound.resultType) match {
+      case (exprType, lowerType, upperType)
+        if isNumeric(exprType) && isNumeric(lowerType) && isNumeric(upperType)
+      => ValidationSuccess
+      case (exprType, lowerType, upperType)
+        if isComparable(exprType) && exprType == lowerType && exprType == upperType
+      => ValidationSuccess
+      case (exprType, lowerType, upperType) =>
+        ValidationFailure(
+          s"Between is only supported for numeric types and " +
+            s"identical comparable types, but got $exprType, $lowerType and $upperType"
+        )
+    }
+  }
+}
+
+case class Between(
+  expr: Expression,
+  lowerBound: Expression,
+  upperBound: Expression) extends BetweenProperty(expr, lowerBound, upperBound) {
+
+  override def toString: String = s"$expr.between($lowerBound, $upperBound)"
+
+  override private[flink] def toRexNode(implicit relBuilder: RelBuilder): RexNode = {
+    relBuilder.and(
+      relBuilder.call(
+        SqlStdOperatorTable.GREATER_THAN_OR_EQUAL,
+        expr.toRexNode,
+        lowerBound.toRexNode
+      ),
+      relBuilder.call(
+        SqlStdOperatorTable.LESS_THAN_OR_EQUAL,
+        expr.toRexNode,
+        upperBound.toRexNode
+      )
+    )
+  }
+}
+
+case class NotBetween(
+  expr: Expression,
+  lowerBound: Expression,
+  upperBound: Expression) extends BetweenProperty(expr, lowerBound, upperBound) {
+
+  override def toString: String = s"$expr.notBetween($lowerBound, $upperBound)"
+
+  override private[flink] def toRexNode(implicit relBuilder: RelBuilder): RexNode = {
+    relBuilder.or(
+      relBuilder.call(
+        SqlStdOperatorTable.LESS_THAN,
+        expr.toRexNode,
+        lowerBound.toRexNode
+      ),
+      relBuilder.call(
+        SqlStdOperatorTable.GREATER_THAN,
+        expr.toRexNode,
+        upperBound.toRexNode
+      )
+    )
+  }
 }

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/validate/FunctionCatalog.scala
@@ -168,6 +168,8 @@ object FunctionCatalog {
     "isNotTrue" -> classOf[IsNotTrue],
     "isNotFalse" -> classOf[IsNotFalse],
     "if" -> classOf[If],
+    "between" -> classOf[Between],
+    "notBetween" -> classOf[NotBetween],
 
     // aggregate functions
     "avg" -> classOf[Avg],

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarOperatorsTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/ScalarOperatorsTest.scala
@@ -407,4 +407,33 @@ class ScalarOperatorsTest extends ScalarOperatorsTestBase {
       "trueX")
     testTableApi(12.isNull, "12.isNull", "false")
   }
+
+  @Test
+  def testBetweenExpressions(): Unit = {
+    // between
+    testTableApi(2.between(1, 3), "2.BETWEEN(1, 3)", "true")
+    testTableApi(2.between(2, 2), "2.BETWEEN(2, 2)", "true")
+    testTableApi(2.1.between(2.0, 3.0), "2.1.BETWEEN(2.0, 3.0)", "true")
+    testTableApi(2.1.between(2.1, 2.1), "2.1.BETWEEN(2.1, 2.1)", "true")
+    testTableApi("b".between("a", "c"), "'b'.BETWEEN('a', 'c')", "true")
+    testTableApi("b".between("b", "c"), "'b'.BETWEEN('b', 'c')", "true")
+    testTableApi(
+      "2018-05-05".toDate.between("2018-05-01".toDate, "2018-05-10".toDate),
+      "'2018-05-05'.toDate.between('2018-05-01'.toDate, '2018-05-10'.toDate)",
+      "true"
+    )
+
+    // not between
+    testTableApi(2.notBetween(1, 3), "2.notBetween(1, 3)", "false")
+    testTableApi(2.notBetween(2, 2), "2.notBetween(2, 2)", "false")
+    testTableApi(2.1.notBetween(2.0, 3.0), "2.1.notBetween(2.0, 3.0)", "false")
+    testTableApi(2.1.notBetween(2.1, 2.1), "2.1.notBetween(2.1, 2.1)", "false")
+    testTableApi("b".notBetween("a", "c"), "'b'.notBetween('a', 'c')", "false")
+    testTableApi("b".notBetween("b", "c"), "'b'.notBetween('b', 'c')", "false")
+    testTableApi(
+      "2018-05-05".toDate.notBetween("2018-05-01".toDate, "2018-05-10".toDate),
+      "'2018-05-05'.toDate.notBetween('2018-05-01'.toDate, '2018-05-10'.toDate)",
+      "false"
+    )
+  }
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/validation/ScalarOperatorsValidationTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/validation/ScalarOperatorsValidationTest.scala
@@ -66,4 +66,22 @@ class ScalarOperatorsValidationTest extends ScalarOperatorsTestBase {
       "FAIL"
     )
   }
+
+  @Test(expected = classOf[ValidationException])
+  def testBetweenWithDifferentOperandTypeScala(): Unit = {
+    testTableApi(
+      2.between(1, "a"),
+      "FAIL",
+      "FAIL"
+    )
+  }
+
+  @Test(expected = classOf[ValidationException])
+  def testBetweenWithDifferentOperandTypeJava(): Unit = {
+    testTableApi(
+      "FAIL",
+      "2.between(1, 'a')",
+      "FAIL"
+    )
+  }
 }


### PR DESCRIPTION


## What is the purpose of the change

Add BETWEEN expression to Table API


## Brief change log
* add 'between' and 'not between' to TableAPI

## Verifying this change

This change added tests and can be verified as follows:
```org.apache.flink.table.expressions.ScalarOperatorsTest```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers:  no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper:  no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature?  no
  - If yes, how is the feature documented? not documented
