### PR TITLE
[FLINK-9356] Improve error message for when queryable state not ready / reachable

### DIFF
--- a/flink-queryable-state/flink-queryable-state-runtime/src/main/java/org/apache/flink/queryablestate/client/proxy/KvStateClientProxyHandler.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/main/java/org/apache/flink/queryablestate/client/proxy/KvStateClientProxyHandler.java
@@ -226,8 +226,8 @@ public class KvStateClientProxyHandler extends AbstractServerHandler<KvStateRequ
 			return location;
 		} else {
 			return FutureUtils.completedExceptionally(
-				new UnknownLocationException("Could not contact the state location oracle to retrieve the state location for state="
-					+ queryableStateName + " of job=" + jobId + ", the caused reason maybe the state is not ready or there is no job exists."));
+				new UnknownLocationException("Could not retrieve the location for state="
+					+ queryableStateName + " of job=" + jobId + ". The reason can be that the state is not ready or that job does not exist."));
 		}
 	}
 

--- a/flink-queryable-state/flink-queryable-state-runtime/src/main/java/org/apache/flink/queryablestate/client/proxy/KvStateClientProxyHandler.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/main/java/org/apache/flink/queryablestate/client/proxy/KvStateClientProxyHandler.java
@@ -225,7 +225,9 @@ public class KvStateClientProxyHandler extends AbstractServerHandler<KvStateRequ
 
 			return location;
 		} else {
-			return FutureUtils.completedExceptionally(new UnknownLocationException("Could not contact the state location oracle to retrieve the state location."));
+			return FutureUtils.completedExceptionally(
+				new UnknownLocationException("Could not contact the state location oracle to retrieve the state location for state="
+					+ queryableStateName + " of job=" + jobId + ", the caused reason maybe the state is not ready or there is no job exists."));
 		}
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

*This pull request improve error message for when queryable state not ready / reachable*


## Brief change log

  - *Improve error message for when queryable state not ready / reachable*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
