### PR TITLE
[FLINK-6909] [types] Add tests for Lombok POJOs

### DIFF
--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -93,7 +93,7 @@ under the License.
 			<scope>test</scope>
 		</dependency>
 
-		<!-- Joda and jackson are used to test that serialization and type extraction
+		<!-- Joda, jackson, and lombok are used to test that serialization and type extraction
 			work with types from those libraries -->
 
 		<dependency>
@@ -111,6 +111,13 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-shaded-jackson</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<version>1.16.20</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/PojoTypeExtractionTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/PojoTypeExtractionTest.java
@@ -31,6 +31,9 @@ import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.types.Value;
 
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -877,4 +880,24 @@ public class PojoTypeExtractionTest {
 		Assert.assertEquals(GenericTypeInfo.class, ((PojoTypeInfo) pti).getPojoFieldAt(0).getTypeInformation().getClass());
 	}
 
+	/**
+	 * POJO generated using Lombok.
+	 */
+	@Getter
+	@Setter
+	@NoArgsConstructor
+	public static class TestLombok{
+		private int age = 10;
+		private String name;
+	}
+
+	@Test
+	public void testLombokPojo() {
+		TypeInformation<TestLombok> ti = TypeExtractor.getForClass(TestLombok.class);
+		Assert.assertTrue(ti instanceof PojoTypeInfo);
+
+		PojoTypeInfo<TestLombok> pti = (PojoTypeInfo<TestLombok>) ti;
+		Assert.assertEquals(BasicTypeInfo.INT_TYPE_INFO, pti.getTypeAt(0));
+		Assert.assertEquals(BasicTypeInfo.STRING_TYPE_INFO, pti.getTypeAt(1));
+	}
 }


### PR DESCRIPTION
## What is the purpose of the change

Add tests for POJOs generated with Lombok. We add these tests to notice incompatibilities when updating Java versions or type extraction in the future.

## Brief change log

- Unit test added

## Verifying this change

- Unit test added

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
