### PR TITLE
[FLINK-7450] [types] Fix type extraction of bounded generic POJO fields

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
@@ -1924,7 +1924,16 @@ public class TypeExtractor {
 				pojoFields.add(new PojoField(field, ti));
 			} catch (InvalidTypesException e) {
 				Class<?> genericClass = Object.class;
-				if(isClassType(fieldType)) {
+				// use information about bounds if available
+				if (fieldType instanceof TypeVariable) {
+					TypeVariable<?> typeVar = (TypeVariable<?>) fieldType;
+					// we take the first bound (usually the class), everything is better than Object
+					if (typeVar.getBounds().length > 0 && isClassType(typeVar.getBounds()[0])) {
+						genericClass = typeToClass(typeVar.getBounds()[0]);
+					}
+				}
+				// use raw type
+				else if (isClassType(fieldType)) {
 					genericClass = typeToClass(fieldType);
 				}
 				pojoFields.add(new PojoField(field, new GenericTypeInfo<OUT>((Class<OUT>) genericClass)));

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/PojoTypeExtractionTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/PojoTypeExtractionTest.java
@@ -35,6 +35,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -877,4 +878,57 @@ public class PojoTypeExtractionTest {
 		Assert.assertEquals(GenericTypeInfo.class, ((PojoTypeInfo) pti).getPojoFieldAt(0).getTypeInformation().getClass());
 	}
 
+	/**
+	 * POJO with a bounded generic parameter.
+	 *
+	 * @param <T> generic parameter bounded by one type
+	 */
+	public static class BoundedPojo<T extends Tuple2<Integer, String>> {
+
+		public T someKey;
+
+		public BoundedPojo() {}
+
+		public BoundedPojo(T someKey) {
+			this.someKey = someKey;
+		}
+	}
+
+	@Test
+	public void testBoundedPojos() {
+		TypeInformation<?> ti = TypeExtractor.createTypeInfo(BoundedPojo.class);
+		Assert.assertTrue(ti instanceof PojoTypeInfo);
+		PojoTypeInfo<?> pti = (PojoTypeInfo<?>) ti;
+		Assert.assertEquals(BoundedPojo.class, pti.getTypeClass());
+		Assert.assertTrue(pti.getPojoFieldAt(0).getTypeInformation() instanceof GenericTypeInfo);
+		TypeInformation<?> fti = pti.getPojoFieldAt(0).getTypeInformation();
+		Assert.assertEquals(Tuple2.class, fti.getTypeClass());
+	}
+
+	/**
+	 * POJO with a bounded generic parameter.
+	 *
+	 * @param <T> generic parameter bounded by two types
+	 */
+	public static class MultiBoundedPojo<T extends Tuple2<Integer, String> & Serializable> {
+
+		public T someKey;
+
+		public MultiBoundedPojo() {}
+
+		public MultiBoundedPojo(T someKey) {
+			this.someKey = someKey;
+		}
+	}
+
+	@Test
+	public void testMultiBoundedPojos() {
+		TypeInformation<?> ti = TypeExtractor.createTypeInfo(MultiBoundedPojo.class);
+		Assert.assertTrue(ti instanceof PojoTypeInfo);
+		PojoTypeInfo<?> pti = (PojoTypeInfo<?>) ti;
+		Assert.assertEquals(MultiBoundedPojo.class, pti.getTypeClass());
+		Assert.assertTrue(pti.getPojoFieldAt(0).getTypeInformation() instanceof GenericTypeInfo);
+		TypeInformation<?> fti = pti.getPojoFieldAt(0).getTypeInformation();
+		Assert.assertEquals(Tuple2.class, fti.getTypeClass());
+	}
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes the type extraction of POJO fields with bounded generics. Before those fields were treated as unknown fields with `Object` type in Kryo. This PR breaks backwards compatibility for jobs with such special cases. We need to discuss if we want to do that.

## Brief change log

- Use generic bounds of type variables during POJO extraction


## Verifying this change

- Two unit tests have been added

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: yes
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? JavaDocs
