### PR TITLE
[FLINK-6160] Add reconnection attempts in case of heartbeat timeouts to JobMaster and TaskExecutor

### DIFF
--- a/docs/_includes/generated/task_manager_configuration.html
+++ b/docs/_includes/generated/task_manager_configuration.html
@@ -154,7 +154,7 @@
         </tr>
         <tr>
             <td><h5>taskmanager.registration.timeout</h5></td>
-            <td style="word-wrap: break-word;">"Inf"</td>
+            <td style="word-wrap: break-word;">"5 min"</td>
             <td>Defines the timeout for the TaskManager registration. If the duration is exceeded without a successful registration, then the TaskManager terminates.</td>
         </tr>
         <tr>

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -139,7 +139,7 @@ public class TaskManagerOptions {
 	 */
 	public static final ConfigOption<String> REGISTRATION_TIMEOUT =
 		key("taskmanager.registration.timeout")
-			.defaultValue("Inf")
+			.defaultValue("5 min")
 			.withDeprecatedKeys("taskmanager.maxRegistrationDuration")
 			.withDescription("Defines the timeout for the TaskManager registration. If the duration is" +
 				" exceeded without a successful registration, then the TaskManager terminates.");

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerConfiguration.java
@@ -50,8 +50,11 @@ public class TaskManagerConfiguration implements TaskManagerRuntimeInfo {
 	private final String[] tmpDirectories;
 
 	private final Time timeout;
+
 	// null indicates an infinite duration
+	@Nullable
 	private final Time maxRegistrationDuration;
+
 	private final Time initialRegistrationPause;
 	private final Time maxRegistrationPause;
 	private final Time refusedRegistrationPause;
@@ -74,7 +77,7 @@ public class TaskManagerConfiguration implements TaskManagerRuntimeInfo {
 		int numberSlots,
 		String[] tmpDirectories,
 		Time timeout,
-		Time maxRegistrationDuration,
+		@Nullable Time maxRegistrationDuration,
 		Time initialRegistrationPause,
 		Time maxRegistrationPause,
 		Time refusedRegistrationPause,
@@ -108,6 +111,7 @@ public class TaskManagerConfiguration implements TaskManagerRuntimeInfo {
 		return timeout;
 	}
 
+	@Nullable
 	public Time getMaxRegistrationDuration() {
 		return maxRegistrationDuration;
 	}
@@ -116,6 +120,7 @@ public class TaskManagerConfiguration implements TaskManagerRuntimeInfo {
 		return initialRegistrationPause;
 	}
 
+	@Nullable
 	public Time getMaxRegistrationPause() {
 		return maxRegistrationPause;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/exceptions/RegistrationTimeoutException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/exceptions/RegistrationTimeoutException.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskexecutor.exceptions;
+
+import org.apache.flink.runtime.taskexecutor.TaskExecutor;
+
+/**
+ * Exception which indicates that the {@link TaskExecutor} could not register at
+ * the master in time.
+ */
+public class RegistrationTimeoutException extends TaskManagerException {
+	private static final long serialVersionUID = -6377818046575001931L;
+
+	public RegistrationTimeoutException(String message) {
+		super(message);
+	}
+
+	public RegistrationTimeoutException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public RegistrationTimeoutException(Throwable cause) {
+		super(cause);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/utils/TestingResourceManagerGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/utils/TestingResourceManagerGateway.java
@@ -109,6 +109,10 @@ public class TestingResourceManagerGateway implements ResourceManagerGateway {
 		this.requestSlotConsumer = null;
 	}
 
+	public ResourceID getOwnResourceId() {
+		return ownResourceId;
+	}
+
 	public void setRequestSlotFuture(CompletableFuture<Acknowledge> slotFuture) {
 		this.slotFutureReference.set(slotFuture);
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -22,6 +22,8 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.blob.BlobCacheService;
 import org.apache.flink.runtime.blob.VoidBlobStore;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
@@ -76,6 +78,7 @@ import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.state.TaskExecutorLocalStateStoresManager;
+import org.apache.flink.runtime.taskexecutor.exceptions.RegistrationTimeoutException;
 import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
 import org.apache.flink.runtime.taskexecutor.slot.TaskSlotTable;
 import org.apache.flink.runtime.taskexecutor.slot.TimerService;
@@ -87,6 +90,7 @@ import org.apache.flink.runtime.taskmanager.TaskManagerActions;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
+import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.TestLogger;
@@ -113,12 +117,15 @@ import java.util.UUID;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -302,9 +309,11 @@ public class TaskExecutorTest extends TestLogger {
 			new ClusterInformation("localhost", 1234));
 
 		final CompletableFuture<ResourceID> taskExecutorRegistrationFuture = new CompletableFuture<>();
+		final CountDownLatch registrationAttempts = new CountDownLatch(2);
 		rmGateway.setRegisterTaskExecutorFunction(
 			registration -> {
 				taskExecutorRegistrationFuture.complete(registration.f1);
+				registrationAttempts.countDown();
 				return CompletableFuture.completedFuture(registrationResponse);
 			});
 
@@ -352,6 +361,9 @@ public class TaskExecutorTest extends TestLogger {
 
 			// heartbeat timeout should trigger disconnect TaskManager from ResourceManager
 			assertThat(taskExecutorDisconnectFuture.get(heartbeatTimeout * 50L, TimeUnit.MILLISECONDS), equalTo(taskManagerLocation.getResourceID()));
+
+			// the TaskExecutor should try to reconnect to the RM
+			registrationAttempts.await();
 
 		} finally {
 			RpcUtils.terminateRpcEndpoint(taskManager, timeout);
@@ -1382,6 +1394,90 @@ public class TaskExecutorTest extends TestLogger {
 			// wait that the job leader retrieval service for jobId stopped becaue it should get removed
 			stopFuture.get();
 			assertThat(jobLeaderService.containsJob(jobId), is(false));
+		} finally {
+			RpcUtils.terminateRpcEndpoint(taskExecutor, timeout);
+		}
+	}
+
+	@Test
+	public void testMaximumRegistrationDuration() throws Exception {
+		configuration.setString(TaskManagerOptions.REGISTRATION_TIMEOUT, "10 ms");
+
+		final TaskExecutor taskExecutor = new TaskExecutor(
+			rpc,
+			TaskManagerConfiguration.fromConfiguration(configuration),
+			haServices,
+			new TaskManagerServicesBuilder().build(),
+			new HeartbeatServices(1000L, 1000L),
+			UnregisteredMetricGroups.createUnregisteredTaskManagerMetricGroup(),
+			dummyBlobCacheService,
+			testingFatalErrorHandler);
+
+		taskExecutor.start();
+
+		try {
+			final Throwable error = testingFatalErrorHandler.getErrorFuture().get();
+			assertThat(error, is(notNullValue()));
+			assertThat(ExceptionUtils.stripExecutionException(error), instanceOf(RegistrationTimeoutException.class));
+
+			testingFatalErrorHandler.clearError();
+		} finally {
+			RpcUtils.terminateRpcEndpoint(taskExecutor, timeout);
+		}
+	}
+
+	@Test
+	public void testMaximumRegistrationDurationAfterConnectionLoss() throws Exception {
+		configuration.setString(TaskManagerOptions.REGISTRATION_TIMEOUT, "100 ms");
+		final TaskSlotTable taskSlotTable = new TaskSlotTable(Collections.singleton(ResourceProfile.UNKNOWN), timerService);
+
+		final long heartbeatInterval = 10L;
+		final TaskManagerServices taskManagerServices = new TaskManagerServicesBuilder().setTaskSlotTable(taskSlotTable).build();
+		final TaskExecutor taskExecutor = new TaskExecutor(
+			rpc,
+			TaskManagerConfiguration.fromConfiguration(configuration),
+			haServices,
+			taskManagerServices,
+			new HeartbeatServices(heartbeatInterval, 10L),
+			UnregisteredMetricGroups.createUnregisteredTaskManagerMetricGroup(),
+			dummyBlobCacheService,
+			testingFatalErrorHandler);
+
+		taskExecutor.start();
+
+		final CompletableFuture<ResourceID> registrationFuture = new CompletableFuture<>();
+		final OneShotLatch secondRegistration = new OneShotLatch();
+		try {
+			final TestingResourceManagerGateway testingResourceManagerGateway = new TestingResourceManagerGateway();
+			testingResourceManagerGateway.setRegisterTaskExecutorFunction(
+				tuple -> {
+					if (registrationFuture.complete(tuple.f1)) {
+						return CompletableFuture.completedFuture(new TaskExecutorRegistrationSuccess(
+							new InstanceID(),
+							testingResourceManagerGateway.getOwnResourceId(),
+							heartbeatInterval,
+							new ClusterInformation("localhost", 1234)));
+					} else {
+						secondRegistration.trigger();
+						return CompletableFuture.completedFuture(new RegistrationResponse.Decline("Only the first registration should succeed."));
+					}
+				}
+			);
+			rpc.registerGateway(testingResourceManagerGateway.getAddress(), testingResourceManagerGateway);
+
+			resourceManagerLeaderRetriever.notifyListener(testingResourceManagerGateway.getAddress(), UUID.randomUUID());
+
+			final ResourceID registrationResourceId = registrationFuture.get();
+
+			assertThat(registrationResourceId, equalTo(taskManagerServices.getTaskManagerLocation().getResourceID()));
+
+			secondRegistration.await();
+
+			final Throwable error = testingFatalErrorHandler.getErrorFuture().get();
+			assertThat(error, is(notNullValue()));
+			assertThat(ExceptionUtils.stripExecutionException(error), instanceOf(RegistrationTimeoutException.class));
+
+			testingFatalErrorHandler.clearError();
 		} finally {
 			RpcUtils.terminateRpcEndpoint(taskExecutor, timeout);
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskexecutor;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.net.ServerSocket;
+import java.util.concurrent.CompletableFuture;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for the {@link TaskManagerRunner}.
+ */
+public class TaskManagerRunnerTest extends TestLogger {
+
+	@Test
+	public void testTaskManagerRunnerShutdown() throws Exception {
+		final Configuration configuration = new Configuration();
+		final ResourceID taskManagerResourceId = ResourceID.generate();
+
+		final ServerSocket localhost = new ServerSocket(0);
+
+		configuration.setString(JobManagerOptions.ADDRESS, localhost.getInetAddress().getHostName());
+		configuration.setInteger(JobManagerOptions.PORT, localhost.getLocalPort());
+		configuration.setString(TaskManagerOptions.REGISTRATION_TIMEOUT, "10 ms");
+		final CompletableFuture<Void> jvmTerminationFuture = new CompletableFuture<>();
+		final TestingTaskManagerRunner taskManagerRunner = new TestingTaskManagerRunner(configuration, taskManagerResourceId, jvmTerminationFuture);
+
+		taskManagerRunner.start();
+
+		try {
+			// wait until we trigger the jvm termination
+			jvmTerminationFuture.get();
+
+			assertThat(taskManagerRunner.getTerminationFuture().isDone(), is(true));
+		} finally {
+			localhost.close();
+			taskManagerRunner.close();
+		}
+	}
+
+	private static class TestingTaskManagerRunner extends TaskManagerRunner {
+
+		private final CompletableFuture<Void> jvmTerminationFuture;
+
+		public TestingTaskManagerRunner(Configuration configuration, ResourceID resourceId, CompletableFuture<Void> jvmTerminationFuture) throws Exception {
+			super(configuration, resourceId);
+			this.jvmTerminationFuture = jvmTerminationFuture;
+		}
+
+		@Override
+		protected void terminateJVM() {
+			jvmTerminationFuture.complete(null);
+		}
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

If a timeout with the RM occurs on on the JobMaster and TaskExecutor, then they will both try to reconnect
to the last known RM address.

Additionally, we now respect the TaskManagerOption#REGISTRATION_TIMEOUT on the TaskExecutor. This means that
if the TaskExecutor could not register at a RM within the given registration timeout, it will fail with a
fatal exception. This allows to fail the TaskExecutor process in case that it cannot establish a connection
and ultimately frees the occupied resources.

The commit also changes the default value for TaskManagerOption#REGISTRATION_TIMEOUT from "Inf" to "5 min".

cc @GJL.

## Brief change log

- Retry connection to RM in case of heartbeat timeout on `JobMaster` and `TaskExecutor`
- Fail `TaskExecutor` if we could not connect to `RM` within `TaskManagerOptions#REGISTRATION_TIMEOUT`

## Verifying this change

- Adapted `JobMasterTest#testHeartbeatTimeoutWithResourceManager`
- Adapted `TaskExecutorTest#testHeartbeatTimeoutWithResourceManager`
- Added `TaskExecutorTest#testMaximumRegistrationDuration` and `TaskExecutorTest#testMaximumRegistrationDurationAfterConnectionLoss`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
