### PR TITLE
[FLINK-6909] [types] Fix error message in CsvReader for wrong type class

### DIFF
--- a/flink-java/src/main/java/org/apache/flink/api/java/io/CsvReader.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/io/CsvReader.java
@@ -20,6 +20,7 @@ package org.apache.flink.api.java.io;
 
 import org.apache.flink.annotation.Public;
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.Utils;
 import org.apache.flink.api.java.operators.DataSource;
@@ -316,14 +317,18 @@ public class CsvReader {
 		Preconditions.checkNotNull(pojoType, "The POJO type class must not be null.");
 		Preconditions.checkNotNull(pojoFields, "POJO fields must be specified (not null) if output type is a POJO.");
 
-		@SuppressWarnings("unchecked")
-		PojoTypeInfo<T> typeInfo = (PojoTypeInfo<T>) TypeExtractor.createTypeInfo(pojoType);
+		final TypeInformation<T> ti = TypeExtractor.createTypeInfo(pojoType);
+		if (!(ti instanceof PojoTypeInfo)) {
+			throw new IllegalArgumentException(
+				"The specified class is not a POJO. The type class must meet the POJO requirements. Found: " + ti);
+		}
+		final PojoTypeInfo<T> pti = (PojoTypeInfo<T>) ti;
 
-		CsvInputFormat<T> inputFormat = new PojoCsvInputFormat<T>(path, this.lineDelimiter, this.fieldDelimiter, typeInfo, pojoFields, this.includedMask);
+		CsvInputFormat<T> inputFormat = new PojoCsvInputFormat<T>(path, this.lineDelimiter, this.fieldDelimiter, pti, pojoFields, this.includedMask);
 
 		configureInputFormat(inputFormat);
 
-		return new DataSource<T>(executionContext, inputFormat, typeInfo, Utils.getCallLocationName());
+		return new DataSource<T>(executionContext, inputFormat, pti, Utils.getCallLocationName());
 	}
 
 	/**


### PR DESCRIPTION
## What is the purpose of the change

Fixes a minor issue that was reported by a user. See FLINK-6909. 

## Brief change log

Check type before casting.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
