### PR TITLE
[hotfix] [docs] Add Release Notes for Flink 1.5.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -41,12 +41,11 @@ Apache Flink is an open source platform for distributed stream and batch data pr
 
 Before putting your Flink job into production, read the [Production Readiness Checklist](ops/production_ready.html).
 
-## Migration Guide
+## Release Notes
 
-For users of earlier versions of Apache Flink, we recommend the [API migration guide](dev/migration.html).
-While all parts of the API that were marked as public and stable are still supported (the public API is backwards compatible), we suggest migrating applications to the newer interfaces where applicable.
+Release notes cover important changes between Flink versions. Please carefully read these notes if you plan to upgrade your Flink setup to a later version. 
 
-For users that plan to upgrade a Flink system in production, we recommend reading the guide on [upgrading Apache Flink](ops/upgrading.html).
+* [Release notes for Flink 1.5](release-notes/flink-1.5.html).
 
 ## External Resources
 

--- a/docs/release-notes/flink-1.5.md
+++ b/docs/release-notes/flink-1.5.md
@@ -1,0 +1,84 @@
+---
+title: "Release Notes - Flink 1.5"
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+These release notes discuss important aspects, such as configuration, behavior, or dependencies, that changed between Flink 1.4 and Flink 1.5. Please read these notes carefully if you are planning to upgrade your Flink version to 1.5.
+
+### Update Configuration for Reworked Job Deployment
+
+Flink’s reworked cluster and job deployment component improves the integration with resource managers and enables dynamic resource allocation. One result of these changes is, that you no longer have to specify the number of containers when submitting applications to YARN and Mesos. Flink will automatically determine the number of containers from the parallelism of the application.
+
+Although the deployment logic was completely reworked, we aimed to not unnecessarily change the previous behavior to enable a smooth transition. Nonetheless, there are a few options that you should update in your `conf/flink-conf.yaml` or know about. 
+
+* The allocation of TaskManagers with multiple slots is not fully supported yet. Therefore, we recommend to configure TaskManagers with a single slot, i.e., set `taskmanager.numberOfTaskSlots: 1`
+* If you observed any problems with the new deployment mode, you can always switch back to the pre-1.5 behavior by configuring `mode: legacy`. 
+
+Please report any problems or possible improvements that you notice to the Flink community, either by posting to a mailing list or by opening a JIRA issue.
+
+*Note*: We plan to remove the legacy mode in the next release. 
+
+### Update Configuration for Reworked Network Stack
+
+The changes on the networking stack for credit-based flow control and improved latency affect the configuration of network buffers. In a nutshell, the networking stack can require more memory to run applications. Hence, you might need to adjust the network configuration of your Flink setup. 
+
+There are two ways to address problems of job submissions that fail due to lack of network buffers.
+
+* Reduce the number of buffers per channel, i.e., `taskmanager.network.memory.buffers-per-channel` or
+* Increase the amount of TaskManager memory that is used by the network stack, i.e., increase `taskmanager.network.memory.fraction` and/or `taskmanager.network.memory.max`.
+
+Please consult the section about [network buffer configuration]({{ site.baseurl }}/ops/config.html#configuring-the-network-buffers) in the Flink documentation for details. In case you experience issues with the new credit-based flow control mode, you can disable flow control by setting `taskmanager.network.credit-model: false`. 
+
+*Note*: We plan to remove the old model and this configuration in the next release.
+
+### Hadoop Classpath Discovery
+
+We removed the automatic Hadoop classpath discovery via the Hadoop binary. If you want Flink to pick up the Hadoop classpath you have to export `HADOOP_CLASSPATH`. On cloud environments and most Hadoop distributions you would do 
+
+```
+export HADOOP_CLASSPATH=`hadoop classpath`.
+```
+
+### Breaking Changes of the REST API
+
+In an effort to harmonize, extend, and improve the REST API, a few handlers and return values were changed.
+
+* The jobs overview handler is now registered under `/jobs/overview` (before `/joboverview`) and returns a list of job details instead of the pre-grouped view of running, finished, cancelled and failed jobs. 
+* The REST API to cancel a job was changed.
+* The REST API to cancel a job with savepoint was changed. 
+
+Please check the [REST API documentation]({{ site.baseurl }}/monitoring/rest_api.html#available-requests) for details.
+
+### Kafka Producer Flushes on Checkpoint by Default
+
+The Flink Kafka Producer now flushes on checkpoints by default. Prior to version 1.5, the behaviour was disabled by default and users had to explicitly call `setFlushOnCheckpoints(true)` on the producer to enable it.
+
+### Updated Kinesis Dependency
+
+The Kinesis dependencies of Flink’s Kinesis connector have been updated to the following versions.
+
+```
+<aws.sdk.version>1.11.319</aws.sdk.version>
+<aws.kinesis-kcl.version>1.9.0</aws.kinesis-kcl.version>
+<aws.kinesis-kpl.version>0.12.9</aws.kinesis-kcl.version>
+```
+
+
+{% top %}


### PR DESCRIPTION
## What is the purpose of the change

* Add release notes for Flink 1.5 to the documentation

## Brief change log

* Add page with release notes for Flink 1.5
* Add "Release Notes" section to index page and link to Flink 1.5 release notes
* Remove link to out-dated migration guide from index page

## Verifying this change

* Docs change only.