### PR TITLE
[FLINK-9326] TaskManagerOptions.NUM_TASK_SLOTS does not work for local/embedded mode

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/LocalStreamEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/LocalStreamEnvironment.java
@@ -103,12 +103,7 @@ public class LocalStreamEnvironment extends StreamExecutionEnvironment {
 			configuration.setInteger(RestOptions.PORT, 0);
 		}
 
-		int numSlotsPerTaskManager;
-		if (configuration.contains(TaskManagerOptions.NUM_TASK_SLOTS)) {
-			numSlotsPerTaskManager = configuration.getInteger(TaskManagerOptions.NUM_TASK_SLOTS);
-		} else {
-			numSlotsPerTaskManager = jobGraph.getMaximumParallelism();
-		}
+		int numSlotsPerTaskManager = configuration.getInteger(TaskManagerOptions.NUM_TASK_SLOTS, jobGraph.getMaximumParallelism());
 
 		MiniClusterConfiguration cfg = new MiniClusterConfiguration.Builder()
 			.setConfiguration(configuration)

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/LocalStreamEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/LocalStreamEnvironment.java
@@ -103,9 +103,16 @@ public class LocalStreamEnvironment extends StreamExecutionEnvironment {
 			configuration.setInteger(RestOptions.PORT, 0);
 		}
 
+		int numSlotsPerTaskManager;
+		if (configuration.contains(TaskManagerOptions.NUM_TASK_SLOTS)) {
+			numSlotsPerTaskManager = configuration.getInteger(TaskManagerOptions.NUM_TASK_SLOTS);
+		} else {
+			numSlotsPerTaskManager = jobGraph.getMaximumParallelism();
+		}
+
 		MiniClusterConfiguration cfg = new MiniClusterConfiguration.Builder()
 			.setConfiguration(configuration)
-			.setNumSlotsPerTaskManager(jobGraph.getMaximumParallelism())
+			.setNumSlotsPerTaskManager(numSlotsPerTaskManager)
 			.build();
 
 		if (LOG.isInfoEnabled()) {


### PR DESCRIPTION
## What is the purpose of the change

*This pull request fixed the num slot config value override error.*

## Brief change log

  - *fixed the num slot config value override error.*

## Verifying this change

This change is already covered by existing tests*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
