### PR TITLE
[FLINK-9400] normalize import statement style for flink-scala

### DIFF
--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/CoGroupDataSet.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/CoGroupDataSet.scala
@@ -23,9 +23,9 @@ import org.apache.flink.annotation.{Internal, Public}
 import org.apache.flink.api.common.InvalidProgramException
 import org.apache.flink.api.common.functions.{CoGroupFunction, Partitioner, RichCoGroupFunction}
 import org.apache.flink.api.common.operators.{Keys, Order}
+import org.apache.flink.api.common.operators.Keys.ExpressionKeys
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.common.typeutils.CompositeType
-import Keys.ExpressionKeys
 import org.apache.flink.api.java.operators._
 import org.apache.flink.util.Collector
 

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/DataSet.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/DataSet.scala
@@ -23,7 +23,8 @@ import org.apache.flink.api.common.accumulators.SerializedListAccumulator
 import org.apache.flink.api.common.aggregators.Aggregator
 import org.apache.flink.api.common.functions._
 import org.apache.flink.api.common.io.{FileOutputFormat, OutputFormat}
-import org.apache.flink.api.common.operators.{Keys, Order, ResourceSpec}
+import org.apache.flink.api.common.operators.{Order, ResourceSpec}
+import org.apache.flink.api.common.operators.Keys.{ExpressionKeys, SelectorFunctionKeys}
 import org.apache.flink.api.common.operators.base.JoinOperatorBase.JoinHint
 import org.apache.flink.api.common.operators.base.CrossOperatorBase.CrossHint
 import org.apache.flink.api.common.operators.base.PartitionOperatorBase.PartitionMethod
@@ -32,7 +33,6 @@ import org.apache.flink.api.java.Utils.CountHelper
 import org.apache.flink.api.java.aggregation.Aggregations
 import org.apache.flink.api.java.functions.{FirstReducer, KeySelector}
 import org.apache.flink.api.java.io.{PrintingOutputFormat, TextOutputFormat}
-import Keys.ExpressionKeys
 import org.apache.flink.api.java.operators._
 import org.apache.flink.api.java.operators.join.JoinType
 import org.apache.flink.api.java.typeutils.TupleTypeInfoBase
@@ -837,7 +837,7 @@ class DataSet[T: ClassTag](set: JavaDataSet[T]) {
     }
     wrap(new DistinctOperator[T](
       javaSet,
-      new Keys.SelectorFunctionKeys[T, K](
+      new SelectorFunctionKeys[T, K](
         keyExtractor, javaSet.getType, implicitly[TypeInformation[K]]),
         getCallLocationName()))
   }
@@ -865,7 +865,7 @@ class DataSet[T: ClassTag](set: JavaDataSet[T]) {
   def distinct(fields: Int*): DataSet[T] = {
     wrap(new DistinctOperator[T](
       javaSet,
-      new Keys.ExpressionKeys[T](fields.toArray, javaSet.getType),
+      new ExpressionKeys[T](fields.toArray, javaSet.getType),
       getCallLocationName()))
   }
 
@@ -888,7 +888,7 @@ class DataSet[T: ClassTag](set: JavaDataSet[T]) {
   def distinct(firstField: String, otherFields: String*): DataSet[T] = {
     wrap(new DistinctOperator[T](
       javaSet,
-      new Keys.ExpressionKeys[T](firstField +: otherFields.toArray, javaSet.getType),
+      new ExpressionKeys[T](firstField +: otherFields.toArray, javaSet.getType),
       getCallLocationName()))
   }
 
@@ -911,7 +911,7 @@ class DataSet[T: ClassTag](set: JavaDataSet[T]) {
       def getKey(in: T) = cleanFun(in)
     }
     new GroupedDataSet[T](this,
-      new Keys.SelectorFunctionKeys[T, K](keyExtractor, javaSet.getType, keyType))
+      new SelectorFunctionKeys[T, K](keyExtractor, javaSet.getType, keyType))
   }
 
   /**
@@ -926,7 +926,7 @@ class DataSet[T: ClassTag](set: JavaDataSet[T]) {
   def groupBy(fields: Int*): GroupedDataSet[T] = {
     new GroupedDataSet[T](
       this,
-      new Keys.ExpressionKeys[T](fields.toArray, javaSet.getType))
+      new ExpressionKeys[T](fields.toArray, javaSet.getType))
   }
 
   /**
@@ -940,11 +940,11 @@ class DataSet[T: ClassTag](set: JavaDataSet[T]) {
   def groupBy(firstField: String, otherFields: String*): GroupedDataSet[T] = {
     new GroupedDataSet[T](
       this,
-      new Keys.ExpressionKeys[T](firstField +: otherFields.toArray, javaSet.getType))
+      new ExpressionKeys[T](firstField +: otherFields.toArray, javaSet.getType))
   }
 
   //  public UnsortedGrouping<T> groupBy(String... fields) {
-  //    new UnsortedGrouping<T>(this, new Keys.ExpressionKeys<T>(fields, getType()));
+  //    new UnsortedGrouping<T>(this, new ExpressionKeys<T>(fields, getType()));
   //  }
 
   // --------------------------------------------------------------------------------------------
@@ -1420,7 +1420,7 @@ class DataSet[T: ClassTag](set: JavaDataSet[T]) {
     val op = new PartitionOperator[T](
       javaSet,
       PartitionMethod.HASH,
-      new Keys.ExpressionKeys[T](fields.toArray, javaSet.getType),
+      new ExpressionKeys[T](fields.toArray, javaSet.getType),
       getCallLocationName())
     wrap(op)
   }
@@ -1435,7 +1435,7 @@ class DataSet[T: ClassTag](set: JavaDataSet[T]) {
     val op = new PartitionOperator[T](
       javaSet,
       PartitionMethod.HASH,
-      new Keys.ExpressionKeys[T](firstField +: otherFields.toArray, javaSet.getType),
+      new ExpressionKeys[T](firstField +: otherFields.toArray, javaSet.getType),
       getCallLocationName())
     wrap(op)
   }
@@ -1454,7 +1454,7 @@ class DataSet[T: ClassTag](set: JavaDataSet[T]) {
     val op = new PartitionOperator[T](
       javaSet,
       PartitionMethod.HASH,
-      new Keys.SelectorFunctionKeys[T, K](
+      new SelectorFunctionKeys[T, K](
         keyExtractor,
         javaSet.getType,
         implicitly[TypeInformation[K]]),
@@ -1474,7 +1474,7 @@ class DataSet[T: ClassTag](set: JavaDataSet[T]) {
     val op = new PartitionOperator[T](
       javaSet,
       PartitionMethod.RANGE,
-      new Keys.ExpressionKeys[T](fields.toArray, javaSet.getType),
+      new ExpressionKeys[T](fields.toArray, javaSet.getType),
       getCallLocationName())
     wrap(op)
   }
@@ -1490,7 +1490,7 @@ class DataSet[T: ClassTag](set: JavaDataSet[T]) {
     val op = new PartitionOperator[T](
       javaSet,
       PartitionMethod.RANGE,
-      new Keys.ExpressionKeys[T](firstField +: otherFields.toArray, javaSet.getType),
+      new ExpressionKeys[T](firstField +: otherFields.toArray, javaSet.getType),
       getCallLocationName())
     wrap(op)
   }
@@ -1510,7 +1510,7 @@ class DataSet[T: ClassTag](set: JavaDataSet[T]) {
     val op = new PartitionOperator[T](
       javaSet,
       PartitionMethod.RANGE,
-      new Keys.SelectorFunctionKeys[T, K](
+      new SelectorFunctionKeys[T, K](
         keyExtractor,
         javaSet.getType,
         implicitly[TypeInformation[K]]),
@@ -1528,7 +1528,7 @@ class DataSet[T: ClassTag](set: JavaDataSet[T]) {
   def partitionCustom[K: TypeInformation](partitioner: Partitioner[K], field: Int) : DataSet[T] = {
     val op = new PartitionOperator[T](
       javaSet,
-      new Keys.ExpressionKeys[T](Array[Int](field), javaSet.getType),
+      new ExpressionKeys[T](Array[Int](field), javaSet.getType),
       partitioner,
       implicitly[TypeInformation[K]],
       getCallLocationName())
@@ -1547,7 +1547,7 @@ class DataSet[T: ClassTag](set: JavaDataSet[T]) {
     : DataSet[T] = {
     val op = new PartitionOperator[T](
       javaSet,
-      new Keys.ExpressionKeys[T](Array[String](field), javaSet.getType),
+      new ExpressionKeys[T](Array[String](field), javaSet.getType),
       partitioner,
       implicitly[TypeInformation[K]],
       getCallLocationName())
@@ -1574,7 +1574,7 @@ class DataSet[T: ClassTag](set: JavaDataSet[T]) {
 
     val op = new PartitionOperator[T](
       javaSet,
-      new Keys.SelectorFunctionKeys[T, K](
+      new SelectorFunctionKeys[T, K](
         keyExtractor,
         javaSet.getType,
         keyType),
@@ -1639,7 +1639,7 @@ class DataSet[T: ClassTag](set: JavaDataSet[T]) {
     val keyType = implicitly[TypeInformation[K]]
     new PartitionSortedDataSet[T](
       new SortPartitionOperator[T](javaSet,
-        new Keys.SelectorFunctionKeys[T, K](
+        new SelectorFunctionKeys[T, K](
           keyExtractor,
           javaSet.getType,
           keyType),

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/GroupedDataSet.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/GroupedDataSet.scala
@@ -22,10 +22,10 @@ import org.apache.flink.api.common.InvalidProgramException
 import org.apache.flink.api.common.functions.{GroupCombineFunction, GroupReduceFunction, Partitioner, ReduceFunction}
 import org.apache.flink.api.common.operators.base.ReduceOperatorBase.CombineHint
 import org.apache.flink.api.common.operators.{Keys, Order}
+import org.apache.flink.api.common.operators.Keys.{ExpressionKeys, SelectorFunctionKeys}
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.aggregation.Aggregations
 import org.apache.flink.api.java.functions.{FirstReducer, KeySelector}
-import Keys.ExpressionKeys
 import org.apache.flink.api.java.operators._
 import org.apache.flink.api.java.typeutils.TupleTypeInfoBase
 import org.apache.flink.api.scala.operators.ScalaAggregateOperator
@@ -54,7 +54,7 @@ class GroupedDataSet[T: ClassTag](
 
   private var partitioner : Partitioner[_] = _
 
-  private var groupSortKeySelector: Option[Keys.SelectorFunctionKeys[T, _]] = None
+  private var groupSortKeySelector: Option[SelectorFunctionKeys[T, _]] = None
 
   /**
    * Adds a secondary sort key to this [[GroupedDataSet]]. This will only have an effect if you
@@ -63,7 +63,7 @@ class GroupedDataSet[T: ClassTag](
    * This only works on Tuple DataSets.
    */
   def sortGroup(field: Int, order: Order): GroupedDataSet[T] = {
-    if (keys.isInstanceOf[Keys.SelectorFunctionKeys[_, _]]) {
+    if (keys.isInstanceOf[SelectorFunctionKeys[_, _]]) {
       throw new InvalidProgramException("KeySelector grouping keys and field index group-sorting " +
         "keys cannot be used together.")
     }
@@ -90,7 +90,7 @@ class GroupedDataSet[T: ClassTag](
       throw new InvalidProgramException("Chaining sortGroup with KeySelector sorting is not" +
         "supported.")
     }
-    if (keys.isInstanceOf[Keys.SelectorFunctionKeys[_, _]]) {
+    if (keys.isInstanceOf[SelectorFunctionKeys[_, _]]) {
       throw new InvalidProgramException("KeySelector grouping keys and field expression " +
         "group-sorting keys cannot be used together.")
     }
@@ -113,7 +113,7 @@ class GroupedDataSet[T: ClassTag](
       throw new InvalidProgramException("Chaining sortGroup with KeySelector sorting is not" +
         "supported.")
     }
-    if (!keys.isInstanceOf[Keys.SelectorFunctionKeys[_, _]]) {
+    if (!keys.isInstanceOf[SelectorFunctionKeys[_, _]]) {
       throw new InvalidProgramException("Sorting on KeySelector keys only works with KeySelector " +
         "grouping.")
     }
@@ -123,7 +123,7 @@ class GroupedDataSet[T: ClassTag](
     val keyExtractor = new KeySelector[T, K] {
       def getKey(in: T) = fun(in)
     }
-    groupSortKeySelector = Some(new Keys.SelectorFunctionKeys[T, K](
+    groupSortKeySelector = Some(new SelectorFunctionKeys[T, K](
       keyExtractor,
       set.javaSet.getType,
       keyType))

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/CaseClassTypeInfo.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/CaseClassTypeInfo.scala
@@ -23,11 +23,10 @@ import java.util.regex.{Matcher, Pattern}
 
 import org.apache.flink.annotation.{Public, PublicEvolving}
 import org.apache.flink.api.common.ExecutionConfig
-import org.apache.flink.api.common.operators.Keys
+import org.apache.flink.api.common.operators.Keys.ExpressionKeys
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.common.typeutils.CompositeType.{FlatFieldDescriptor, InvalidFieldReferenceException, TypeComparatorBuilder}
 import org.apache.flink.api.common.typeutils._
-import Keys.ExpressionKeys
 import org.apache.flink.api.java.typeutils.TupleTypeInfoBase
 
 import scala.collection.JavaConverters._

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/unfinishedKeyPairOperation.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/unfinishedKeyPairOperation.scala
@@ -21,9 +21,9 @@ package org.apache.flink.api.scala
 import org.apache.flink.annotation.Internal
 import org.apache.flink.api.common.InvalidProgramException
 import org.apache.flink.api.common.operators.Keys
+import org.apache.flink.api.common.operators.Keys.{ExpressionKeys, SelectorFunctionKeys}
 
 import org.apache.flink.api.java.functions.KeySelector
-import Keys.ExpressionKeys
 import org.apache.flink.api.common.typeinfo.TypeInformation
 
 /**
@@ -87,7 +87,7 @@ private[flink] abstract class UnfinishedKeyPairOperation[L, R, O](
       val cleanFun = leftInput.clean(fun)
       def getKey(in: L) = cleanFun(in)
     }
-    val leftKey = new Keys.SelectorFunctionKeys[L, K](keyExtractor, leftInput.getType, keyType)
+    val leftKey = new SelectorFunctionKeys[L, K](keyExtractor, leftInput.getType, keyType)
     new HalfUnfinishedKeyPairOperation[L, R, O](this, leftKey)
   }
 }
@@ -136,7 +136,7 @@ private[flink] class HalfUnfinishedKeyPairOperation[L, R, O](
       val cleanFun = unfinished.leftInput.clean(fun)
       def getKey(in: R) = cleanFun(in)
     }
-    val rightKey = new Keys.SelectorFunctionKeys[R, K](
+    val rightKey = new SelectorFunctionKeys[R, K](
       keyExtractor,
       unfinished.rightInput.getType,
       keyType)


### PR DESCRIPTION
**(The sections below can be removed for hotfixes of typos)**

## What is the purpose of the change

When I read `flink-scala` code, I found like the below code:

```scala
import org.apache.flink.api.common.operators.Keys
import Keys.ExpressionKeys
```

So, I want to fix it, use the follow code:

```scala
import org.apache.flink.api.common.operators.Keys.ExpressionKeys
```

And `new ExpressionKeys` instead of `new Keys.ExpressionKeys` at source file.

## Brief change log

- normalize import statement style for flink-scala

## Verifying this change

This change is already covered by existing tests, test pass.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (don't know)
  - The runtime per-record code paths (performance sensitive): (don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (don't know)
  - The S3 file system connector: (don't know)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
