### PR TITLE
[FLINK-1044] Website: Offer a zip archive with a pre-setup user project

### DIFF
--- a/docs/quickstart/java_api_quickstart.md
+++ b/docs/quickstart/java_api_quickstart.md
@@ -40,33 +40,43 @@ Use one of the following commands to __create a project__:
 <ul class="nav nav-tabs" style="border-bottom: none;">
     <li class="active"><a href="#maven-archetype" data-toggle="tab">Use <strong>Maven archetypes</strong></a></li>
     <li><a href="#quickstart-script" data-toggle="tab">Run the <strong>quickstart script</strong></a></li>
+    <li><a href="#quickstart-compressed" data-toggle="tab">Download the <strong>compressed version</strong></a></li>
 </ul>
 <div class="tab-content">
     <div class="tab-pane active" id="maven-archetype">
-    {% highlight bash %}
-    $ mvn archetype:generate                               \
-      -DarchetypeGroupId=org.apache.flink              \
-      -DarchetypeArtifactId=flink-quickstart-java      \{% unless site.is_stable %}
-      -DarchetypeCatalog=https://repository.apache.org/content/repositories/snapshots/ \{% endunless %}
-      -DarchetypeVersion={{site.version}}
-    {% endhighlight %}
+        {% highlight bash %}
+        $ mvn archetype:generate                               \
+        -DarchetypeGroupId=org.apache.flink              \
+        -DarchetypeArtifactId=flink-quickstart-java      \{% unless site.is_stable %}
+        -DarchetypeCatalog=https://repository.apache.org/content/repositories/snapshots/ \{% endunless %}
+        -DarchetypeVersion={{site.version}}
+        {% endhighlight %}
         This allows you to <strong>name your newly created project</strong>. It will interactively ask you for the groupId, artifactId, and package name.
     </div>
     <div class="tab-pane" id="quickstart-script">
-    {% highlight bash %}
-{% if site.is_stable %}
-    $ curl https://flink.apache.org/q/quickstart.sh | bash
-{% else %}
-    $ curl https://flink.apache.org/q/quickstart-SNAPSHOT.sh | bash
-{% endif %}
-    {% endhighlight %}
-
+        {% highlight bash %}
+        {% if site.is_stable %}
+        $ curl https://flink.apache.org/q/quickstart.sh | bash
+        {% else %}
+        $ curl https://flink.apache.org/q/quickstart-SNAPSHOT.sh | bash
+        {% endif %}
+        {% endhighlight %}
+    </div>
+    <div class="tab-pane" id="quickstart-compressed">
+        <p style="border-radius: 5px; padding: 5px">
+        {% if site.is_stable %}
+            Download compressed version of QuickStart <a href="https://flink.apache.org/q/quickstart-java.zip">Here</a>
+            {% else %}
+            Download compressed version of QuickStart <a href="https://flink.apache.org/q/quickstart-java-SNAPSHOT.zip">Here</a>
+        {% endif %}
+        </p>
     </div>
     {% unless site.is_stable %}
     <p style="border-radius: 5px; padding: 5px" class="bg-danger">
         <b>Note</b>: For Maven 3.0 or higher, it is no longer possible to specify the repository (-DarchetypeCatalog) via the command line. If you wish to use the snapshot repository, you need to add a repository entry to your settings.xml. For details about this change, please refer to <a href="http://maven.apache.org/archetype/maven-archetype-plugin/archetype-repository.html">Maven official document</a>
     </p>
     {% endunless %}
+
 </div>
 
 ## Inspect Project

--- a/docs/quickstart/scala_api_quickstart.md
+++ b/docs/quickstart/scala_api_quickstart.md
@@ -46,6 +46,7 @@ You can scaffold a new project via either of the following two methods:
 <ul class="nav nav-tabs" style="border-bottom: none;">
     <li class="active"><a href="#sbt_template" data-toggle="tab">Use the <strong>sbt template</strong></a></li>
     <li><a href="#quickstart-script-sbt" data-toggle="tab">Run the <strong>quickstart script</strong></a></li>
+    <li><a href="#quickstart-compressed" data-toggle="tab">Download the <strong>compressed version</strong></a></li>
 </ul>
 
 <div class="tab-content">
@@ -61,6 +62,15 @@ You can scaffold a new project via either of the following two methods:
     $ bash <(curl https://flink.apache.org/q/sbt-quickstart.sh)
     {% endhighlight %}
     This will create a Flink project in the <strong>specified</strong> project directory.
+    </div>
+        <div class="tab-pane" id="quickstart-compressed">
+            <p style="border-radius: 5px; padding: 5px">
+            {% if site.is_stable %}
+                Download compressed version of QuickStart <a href="https://flink.apache.org/q/quickstart-scala.zip">Here</a>
+                {% else %}
+                Download compressed version of QuickStart <a href="https://flink.apache.org/q/quickstart-scala-SNAPSHOT.zip">Here</a>
+            {% endif %}
+            </p>
     </div>
 </div>
 
@@ -124,6 +134,7 @@ Use one of the following commands to __create a project__:
 <ul class="nav nav-tabs" style="border-bottom: none;">
     <li class="active"><a href="#maven-archetype" data-toggle="tab">Use <strong>Maven archetypes</strong></a></li>
     <li><a href="#quickstart-script" data-toggle="tab">Run the <strong>quickstart script</strong></a></li>
+    <li><a href="#quickstart-compressed" data-toggle="tab">Download the <strong>compressed version</strong></a></li>
 </ul>
 
 <div class="tab-content">
@@ -138,13 +149,22 @@ Use one of the following commands to __create a project__:
     This allows you to <strong>name your newly created project</strong>. It will interactively ask you for the groupId, artifactId, and package name.
     </div>
     <div class="tab-pane" id="quickstart-script">
-{% highlight bash %}
-{% if site.is_stable %}
-    $ curl https://flink.apache.org/q/quickstart-scala.sh | bash
-{% else %}
-    $ curl https://flink.apache.org/q/quickstart-scala-SNAPSHOT.sh | bash
-{% endif %}
-{% endhighlight %}
+        {% highlight bash %}
+        {% if site.is_stable %}
+            $ curl https://flink.apache.org/q/quickstart-scala.sh | bash
+        {% else %}
+            $ curl https://flink.apache.org/q/quickstart-scala-SNAPSHOT.sh | bash
+        {% endif %}
+        {% endhighlight %}
+    </div>
+    <div class="tab-pane" id="quickstart-compressed">
+        <p style="border-radius: 5px; padding: 5px">
+        {% if site.is_stable %}
+            Download compressed version of QuickStart <a href="https://flink.apache.org/q/quickstart-scala.zip">Here</a>
+            {% else %}
+            Download compressed version of QuickStart <a href="https://flink.apache.org/q/quickstart-scala-SNAPSHOT.zip">Here</a>
+        {% endif %}
+        </p>
     </div>
     {% unless site.is_stable %}
     <p style="border-radius: 5px; padding: 5px" class="bg-danger">

--- a/flink-end-to-end-tests/run-pre-commit-tests.sh
+++ b/flink-end-to-end-tests/run-pre-commit-tests.sh
@@ -81,6 +81,15 @@ if [ $EXIT_CODE == 0 ]; then
     EXIT_CODE=$?
 fi
 
+if [ $EXIT_CODE == 0 ]; then
+    run_test "JAVA QuickStart package build test" "$END_TO_END_DIR/test-scripts/test_build_quickstart_java.sh"
+    EXIT_CODE=$?
+fi
+
+if [ $EXIT_CODE == 0 ]; then
+    run_test "SCALA QuickStart package build test" "$END_TO_END_DIR/test-scripts/test_build_quickstart_scala.sh"
+    EXIT_CODE=$?
+fi
 
 # Exit code for Travis build success/failure
 exit $EXIT_CODE

--- a/flink-end-to-end-tests/test-scripts/test_build_quickstart_java.sh
+++ b/flink-end-to-end-tests/test-scripts/test_build_quickstart_java.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+################################################################################
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+
+source "$(dirname "$0")"/common.sh
+
+projectVersion=`mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version | grep -E '^([0-9]+.[0-9]+(.[0-9]+)?(-[a-zA-Z0-9]+)?)$'`
+snapshotPrefix=`echo ${projectVersion} | grep -Eo "\-SNAPSHOT"`
+
+TEST_PROGRAM_JAR=$TEST_DATA_DIR/flink-quickstart/target/flink-quickstart-0.1${snapshotPrefix}.jar
+mkdir -p $TEST_DATA_DIR
+cd $TEST_DATA_DIR
+
+mvn archetype:generate                             \
+    -DarchetypeGroupId=org.apache.flink            \
+    -DarchetypeArtifactId=flink-quickstart-java    \
+    -DarchetypeVersion=${projectVersion}           \
+    -DgroupId=org.apache.flink.quickstart          \
+    -DartifactId=flink-quickstart                  \
+    -Dversion=0.1${snapshotPrefix}                 \
+    -Dpackage=org.apache.flink.quickstart          \
+    -DinteractiveMode=false
+
+cd flink-quickstart
+mvn clean package -nsu
+
+cd target
+jar tvf flink-quickstart-0.1${snapshotPrefix}.jar > contentsInJar.txt
+
+if [[ `grep -c "org/apache/flink/api/java" contentsInJar.txt` -eq '0' && \
+      `grep -c "org/apache/flink/streaming/api" contentsInJar.txt` -eq '0' && \
+      `grep -c "org/apache/flink/streaming/experimental" contentsInJar.txt` -eq '0' && \
+      `grep -c "org/apache/flink/streaming/runtime" contentsInJar.txt` -eq '0' && \
+      `grep -c "org/apache/flink/streaming/util" contentsInJar.txt` -eq '0' ]]; then
+
+    echo "Success: There are no flink core classes are contained in the jar."
+else
+    echo "Failure: There are flink core classes are contained in the jar."
+    PASS=""
+    exit 1
+fi
+
+
+if [[ `grep -c "org/apache/flink/quickstart/BatchJob.class" contentsInJar.txt` -eq '0' && \
+      `grep -c "org/apache/flink/quickstart/SocketTextStreamWordCount.class" contentsInJar.txt` -eq '0' && \
+      `grep -c "org/apache/flink/quickstart/WordCount.class" contentsInJar.txt` -eq '0' && \
+      `grep -c "org/apache/flink/quickstart/StreamingJob.class" contentsInJar.txt` -eq '0' ]]; then
+
+    echo "Failure: One of quickstart classes [ BatchJob or SocketTextStreamWordCount or WordCount or StreamingJob] are not included in the jar. "
+    PASS=""
+    exit 1
+else
+    echo "Success: All quickstart classes [ BatchJob and SocketTextStreamWordCount and WordCount and StreamingJob] are included in the jar."
+fi
+
+start_cluster
+
+$FLINK_DIR/bin/flink run -c org.apache.flink.quickstart.WordCount $TEST_PROGRAM_JAR > testResutls.txt
+
+
+if [[ `grep -e '\,\d' testResutls.txt | tr -d '\n'}` == '(against,1)(and,1)(arms,1)(arrows,1)(be,2)(is,1)(nobler,1)(not,1)(of,2)(outrageous,1)(sea,1)(the,3)(tis,1)(troubles,1)(whether,1)(a,1)(fortune,1)(in,1)(mind,1)(or,2)(question,1)(slings,1)(suffer,1)(take,1)(that,1)(to,4)' ]]; then
+    echo "Success: WordCount job test passed"
+els
+    echo "Failure: WordCount job test failed"
+        PASS=""
+    exit 1
+fi
+
+
+cd $TEST_DATA_DIR/flink-quickstart
+rm -rf target/
+tar -zcvf quickstart-java${snapshotPrefix}.zip .
+#[TODO]: ADD right command to upload the .zip file to flink repo
+#curl -F 'quickstart-java${snapshotPrefix}=@quickstart-java${snapshotPrefix}.zip' https://flink.apache.org/q/quickstart-java${snapshotPrefix}.zip

--- a/flink-end-to-end-tests/test-scripts/test_build_quickstart_java.sh
+++ b/flink-end-to-end-tests/test-scripts/test_build_quickstart_java.sh
@@ -48,7 +48,6 @@ if [[ `grep -c "org/apache/flink/api/java" contentsInJar.txt` -eq '0' && \
       `grep -c "org/apache/flink/streaming/experimental" contentsInJar.txt` -eq '0' && \
       `grep -c "org/apache/flink/streaming/runtime" contentsInJar.txt` -eq '0' && \
       `grep -c "org/apache/flink/streaming/util" contentsInJar.txt` -eq '0' ]]; then
-
     echo "Success: There are no flink core classes are contained in the jar."
 else
     echo "Failure: There are flink core classes are contained in the jar."
@@ -56,32 +55,14 @@ else
     exit 1
 fi
 
-
 if [[ `grep -c "org/apache/flink/quickstart/BatchJob.class" contentsInJar.txt` -eq '0' && \
-      `grep -c "org/apache/flink/quickstart/SocketTextStreamWordCount.class" contentsInJar.txt` -eq '0' && \
-      `grep -c "org/apache/flink/quickstart/WordCount.class" contentsInJar.txt` -eq '0' && \
       `grep -c "org/apache/flink/quickstart/StreamingJob.class" contentsInJar.txt` -eq '0' ]]; then
-
-    echo "Failure: One of quickstart classes [ BatchJob or SocketTextStreamWordCount or WordCount or StreamingJob] are not included in the jar. "
+    echo "Failure: One of quickstart classes [ BatchJob or StreamingJob] are not included in the jar. "
     PASS=""
     exit 1
 else
-    echo "Success: All quickstart classes [ BatchJob and SocketTextStreamWordCount and WordCount and StreamingJob] are included in the jar."
+    echo "Success: All quickstart classes [ BatchJob  and StreamingJob] are included in the jar."
 fi
-
-start_cluster
-
-$FLINK_DIR/bin/flink run -c org.apache.flink.quickstart.WordCount $TEST_PROGRAM_JAR > testResutls.txt
-
-
-if [[ `grep -e '\,\d' testResutls.txt | tr -d '\n'}` == '(against,1)(and,1)(arms,1)(arrows,1)(be,2)(is,1)(nobler,1)(not,1)(of,2)(outrageous,1)(sea,1)(the,3)(tis,1)(troubles,1)(whether,1)(a,1)(fortune,1)(in,1)(mind,1)(or,2)(question,1)(slings,1)(suffer,1)(take,1)(that,1)(to,4)' ]]; then
-    echo "Success: WordCount job test passed"
-els
-    echo "Failure: WordCount job test failed"
-        PASS=""
-    exit 1
-fi
-
 
 cd $TEST_DATA_DIR/flink-quickstart
 rm -rf target/

--- a/flink-end-to-end-tests/test-scripts/test_build_quickstart_scala.sh
+++ b/flink-end-to-end-tests/test-scripts/test_build_quickstart_scala.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+################################################################################
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+
+source "$(dirname "$0")"/common.sh
+
+projectVersion=`mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version | grep -E '^([0-9]+.[0-9]+(.[0-9]+)?(-[a-zA-Z0-9]+)?)$'`
+projectVersion=1.4.1
+snapshotPrefix=`echo ${projectVersion} | grep -Eo "\-SNAPSHOT"`
+
+TEST_PROGRAM_JAR=$TEST_DATA_DIR/flink-quickstart/target/flink-quickstart-0.1${snapshotPrefix}.jar
+mkdir -p $TEST_DATA_DIR
+cd $TEST_DATA_DIR
+
+mvn archetype:generate                             \
+    -DarchetypeGroupId=org.apache.flink            \
+    -DarchetypeArtifactId=flink-quickstart-scala   \
+    -DarchetypeVersion=${projectVersion}           \
+    -DgroupId=org.apache.flink.quickstart          \
+    -DartifactId=flink-quickstart                  \
+    -Dversion=0.1${snapshotPrefix}                 \
+    -Dpackage=org.apache.flink.quickstart          \
+    -DinteractiveMode=false
+
+cd flink-quickstart
+mvn clean package -nsu
+
+cd target
+jar tvf flink-quickstart-0.1${snapshotPrefix}.jar > contentsInJar.txt
+
+if [[ `grep -c "org/apache/flink/api/java" contentsInJar.txt` -eq '0' && \
+      `grep -c "org/apache/flink/streaming/api" contentsInJar.txt` -eq '0' && \
+      `grep -c "org/apache/flink/streaming/experimental" contentsInJar.txt` -eq '0' && \
+      `grep -c "org/apache/flink/streaming/runtime" contentsInJar.txt` -eq '0' && \
+      `grep -c "org/apache/flink/streaming/util" contentsInJar.txt` -eq '0' ]]; then
+
+    echo "Success: There are no flink core classes are contained in the jar."
+else
+    echo "Failure: There are flink core classes are contained in the jar."
+    PASS=""
+    exit 1
+fi
+
+
+if [[ `grep -c "org/apache/flink/quickstart/BatchJob.class" contentsInJar.txt` -eq '0' && \
+      `grep -c "org/apache/flink/quickstart/SocketTextStreamWordCount.class" contentsInJar.txt` -eq '0' && \
+      `grep -c "org/apache/flink/quickstart/WordCount.class" contentsInJar.txt` -eq '0' && \
+      `grep -c "org/apache/flink/quickstart/StreamingJob.class" contentsInJar.txt` -eq '0' ]]; then
+
+    echo "Failure: One of quickstart classes [ BatchJob or SocketTextStreamWordCount or WordCount or StreamingJob] are not included in the jar. "
+    PASS=""
+    exit 1
+else
+    echo "Success: All quickstart classes [ BatchJob and SocketTextStreamWordCount and WordCount and StreamingJob] are included in the jar."
+fi
+
+start_cluster
+
+$FLINK_DIR/bin/flink run -c org.apache.flink.quickstart.WordCount $TEST_PROGRAM_JAR > testResutls.txt
+
+
+if [[ `grep -e '\,\d' testResutls.txt | tr -d '\n'}` == '(against,1)(and,1)(arms,1)(arrows,1)(be,2)(is,1)(nobler,1)(not,1)(of,2)(outrageous,1)(sea,1)(the,3)(tis,1)(troubles,1)(whether,1)(a,1)(fortune,1)(in,1)(mind,1)(or,2)(question,1)(slings,1)(suffer,1)(take,1)(that,1)(to,4)' ]]; then
+    echo "Success"
+else
+    echo "Failure"
+        PASS=""
+    exit 1
+fi
+
+cd $TEST_DATA_DIR/flink-quickstart
+rm -rf target/
+tar -zcvf quickstart-scala${snapshotPrefix}.zip .
+#[TODO]: ADD right command to upload the .zip file to flink repo
+#curl -F 'quickstart-scala${snapshotPrefix}=@quickstart-scala${snapshotPrefix}.zip' https://flink.apache.org/q/quickstart-scala${snapshotPrefix}.zip
+
+
+

--- a/flink-end-to-end-tests/test-scripts/test_build_quickstart_scala.sh
+++ b/flink-end-to-end-tests/test-scripts/test_build_quickstart_scala.sh
@@ -21,7 +21,6 @@
 source "$(dirname "$0")"/common.sh
 
 projectVersion=`mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version | grep -E '^([0-9]+.[0-9]+(.[0-9]+)?(-[a-zA-Z0-9]+)?)$'`
-projectVersion=1.4.1
 snapshotPrefix=`echo ${projectVersion} | grep -Eo "\-SNAPSHOT"`
 
 TEST_PROGRAM_JAR=$TEST_DATA_DIR/flink-quickstart/target/flink-quickstart-0.1${snapshotPrefix}.jar
@@ -49,7 +48,6 @@ if [[ `grep -c "org/apache/flink/api/java" contentsInJar.txt` -eq '0' && \
       `grep -c "org/apache/flink/streaming/experimental" contentsInJar.txt` -eq '0' && \
       `grep -c "org/apache/flink/streaming/runtime" contentsInJar.txt` -eq '0' && \
       `grep -c "org/apache/flink/streaming/util" contentsInJar.txt` -eq '0' ]]; then
-
     echo "Success: There are no flink core classes are contained in the jar."
 else
     echo "Failure: There are flink core classes are contained in the jar."
@@ -57,30 +55,13 @@ else
     exit 1
 fi
 
-
 if [[ `grep -c "org/apache/flink/quickstart/BatchJob.class" contentsInJar.txt` -eq '0' && \
-      `grep -c "org/apache/flink/quickstart/SocketTextStreamWordCount.class" contentsInJar.txt` -eq '0' && \
-      `grep -c "org/apache/flink/quickstart/WordCount.class" contentsInJar.txt` -eq '0' && \
       `grep -c "org/apache/flink/quickstart/StreamingJob.class" contentsInJar.txt` -eq '0' ]]; then
-
-    echo "Failure: One of quickstart classes [ BatchJob or SocketTextStreamWordCount or WordCount or StreamingJob] are not included in the jar. "
+    echo "Failure: One of quickstart classes [ BatchJob or StreamingJob] are not included in the jar. "
     PASS=""
     exit 1
 else
-    echo "Success: All quickstart classes [ BatchJob and SocketTextStreamWordCount and WordCount and StreamingJob] are included in the jar."
-fi
-
-start_cluster
-
-$FLINK_DIR/bin/flink run -c org.apache.flink.quickstart.WordCount $TEST_PROGRAM_JAR > testResutls.txt
-
-
-if [[ `grep -e '\,\d' testResutls.txt | tr -d '\n'}` == '(against,1)(and,1)(arms,1)(arrows,1)(be,2)(is,1)(nobler,1)(not,1)(of,2)(outrageous,1)(sea,1)(the,3)(tis,1)(troubles,1)(whether,1)(a,1)(fortune,1)(in,1)(mind,1)(or,2)(question,1)(slings,1)(suffer,1)(take,1)(that,1)(to,4)' ]]; then
-    echo "Success"
-else
-    echo "Failure"
-        PASS=""
-    exit 1
+    echo "Success: All quickstart classes [ BatchJob and StreamingJob] are included in the jar."
 fi
 
 cd $TEST_DATA_DIR/flink-quickstart


### PR DESCRIPTION
## What is the purpose of the change

This PR will run two tests to build Java and Scala quickstart packages. After compiling and packaging  the jar files, it submit the wordcount class to a cluster and validate the output. At the very end it should upload the jar files to `https://flink.apache.org/q` server. Last part not working as I need more details to find out how to upload the .jar files to the flink server and I am looking for help from reviewers to point me to the right direction.


## Brief change log

  - *add two new e2e tests *
  - *Modify run-pre-commit-tests*


## Verifying this change

This change added tests and can be verified as follows:

Run test_build_quickstart_java.sh and test_build_quickstart_scala.sh to verify this change

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
