### PR TITLE
[FLINK-8429] Implement stream-stream non-window right outer join

### DIFF
--- a/docs/dev/table/sql.md
+++ b/docs/dev/table/sql.md
@@ -398,7 +398,7 @@ FROM Orders INNER JOIN Product ON Orders.productId = Product.id
         <span class="label label-info">Result Updating</span>
       </td>
       <td>
-        <p>Currently, only equi-joins are supported, i.e., joins that have at least one conjunctive condition with an equality predicate. Arbitrary cross or theta joins are not supported. Right and full joins are not supported in streaming yet.</p>
+        <p>Currently, only equi-joins are supported, i.e., joins that have at least one conjunctive condition with an equality predicate. Arbitrary cross or theta joins are not supported. Full join is not supported in streaming yet.</p>
         <p><b>Note:</b> The order of joins is not optimized. Tables are joined in the order in which they are specified in the FROM clause. Make sure to specify tables in an order that does not yield a cross join (Cartesian product) which are not supported and would cause a query to fail.</p>
 {% highlight sql %}
 SELECT *

--- a/docs/dev/table/tableApi.md
+++ b/docs/dev/table/tableApi.md
@@ -512,7 +512,7 @@ Table result = left.join(right).where("a = d").select("a, b, e");
         <span class="label label-info">Result Updating</span>
       </td>
       <td>
-        <p>Similar to SQL LEFT/RIGHT/FULL OUTER JOIN clauses. Joins two tables. Both tables must have distinct field names and at least one equality join predicate must be defined. Right and full joins are not supported in streaming yet.</p>
+        <p>Similar to SQL LEFT/RIGHT/FULL OUTER JOIN clauses. Joins two tables. Both tables must have distinct field names and at least one equality join predicate must be defined. Full join is not supported in streaming yet.</p>
 {% highlight java %}
 Table left = tableEnv.fromDataSet(ds1, "a, b, c");
 Table right = tableEnv.fromDataSet(ds2, "d, e, f");

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamJoin.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamJoin.scala
@@ -139,16 +139,19 @@ class DataStreamJoin(
     val rightDataStream =
       right.asInstanceOf[DataStreamRel].translateToPlan(tableEnv, queryConfig)
 
-    val (connectOperator, nullCheck) = joinType match {
-      case JoinRelType.INNER | JoinRelType.LEFT => (leftDataStream.connect(rightDataStream), false)
+    val connectOperator = joinType match {
+      case JoinRelType.INNER | JoinRelType.LEFT | JoinRelType.RIGHT =>
+        leftDataStream.connect(rightDataStream)
       case _ =>
         throw TableException(s"Unsupported join type '$joinType'. Currently only " +
-          s"non-window inner/left joins with at least one equality predicate are supported")
+          s"non-window inner/left/right joins with at least one equality predicate are supported")
     }
 
+    // NullableInput will always be false, because the runtime join function will make sure
+    // the codegen function won't process null inputs
     val generator = new FunctionCodeGenerator(
       config,
-      nullCheck,
+      false,
       leftSchema.typeInfo,
       Some(rightSchema.typeInfo))
     val conversion = generator.generateConverterResultExpression(
@@ -188,7 +191,7 @@ class DataStreamJoin(
           genFunction.name,
           genFunction.code,
           queryConfig)
-      case JoinRelType.LEFT if joinInfo.isEqui =>
+      case JoinRelType.LEFT | JoinRelType.RIGHT if joinInfo.isEqui =>
         new NonWindowLeftRightJoin(
           leftSchema.typeInfo,
           rightSchema.typeInfo,
@@ -197,7 +200,7 @@ class DataStreamJoin(
           genFunction.code,
           joinType == JoinRelType.LEFT,
           queryConfig)
-      case JoinRelType.LEFT =>
+      case JoinRelType.LEFT | JoinRelType.RIGHT =>
         new NonWindowLeftRightJoinWithNonEquiPredicates(
           leftSchema.typeInfo,
           rightSchema.typeInfo,

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/JoinTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/JoinTest.scala
@@ -413,5 +413,188 @@ class JoinTest extends TableTestBase {
       )
     util.verifyTable(resultTable, expected)
   }
+  
+  @Test
+  def testLeftOuterJoinEquiPred(): Unit = {
+    val util = streamTestUtil()
+    val t = util.addTable[(Int, Long, String)]("T", 'a, 'b, 'c)
+    val s = util.addTable[(Long, String, Int)]("S", 'x, 'y, 'z)
 
+    val joined = t.leftOuterJoin(s, 'a === 'z).select('b, 'y)
+
+    val expected = unaryNode(
+      "DataStreamCalc",
+      binaryNode(
+        "DataStreamJoin",
+        unaryNode(
+          "DataStreamCalc",
+          streamTableNode(0),
+          term("select", "a", "b")
+        ),
+        unaryNode(
+          "DataStreamCalc",
+          streamTableNode(1),
+          term("select", "y", "z")
+        ),
+        term("where", "=(a, z)"),
+        term("join", "a", "b", "y", "z"),
+        term("joinType", "LeftOuterJoin")
+      ),
+      term("select", "b", "y")
+    )
+
+    util.verifyTable(joined, expected)
+  }
+
+  @Test
+  def testLeftOuterJoinEquiAndLocalPred(): Unit = {
+    val util = streamTestUtil()
+    val t = util.addTable[(Int, Long, String)]("T", 'a, 'b, 'c)
+    val s = util.addTable[(Long, String, Int)]("S", 'x, 'y, 'z)
+
+    val joined = t.leftOuterJoin(s, 'a === 'z && 'b < 2).select('b, 'y)
+
+    val expected = unaryNode(
+      "DataStreamCalc",
+      binaryNode(
+        "DataStreamJoin",
+        unaryNode(
+          "DataStreamCalc",
+          streamTableNode(0),
+          term("select", "a", "b")
+        ),
+        unaryNode(
+          "DataStreamCalc",
+          streamTableNode(1),
+          term("select", "y", "z")
+        ),
+        term("where", "AND(=(a, z), <(b, 2))"),
+        term("join", "a", "b", "y", "z"),
+        term("joinType", "LeftOuterJoin")
+      ),
+      term("select", "b", "y")
+    )
+
+    util.verifyTable(joined, expected)
+  }
+
+  @Test
+  def testLeftOuterJoinEquiAndNonEquiPred(): Unit = {
+    val util = streamTestUtil()
+    val t = util.addTable[(Int, Long, String)]("T", 'a, 'b, 'c)
+    val s = util.addTable[(Long, String, Int)]("S", 'x, 'y, 'z)
+
+    val joined = t.leftOuterJoin(s, 'a === 'z && 'b < 'x).select('b, 'y)
+
+    val expected = unaryNode(
+      "DataStreamCalc",
+      binaryNode(
+        "DataStreamJoin",
+        unaryNode(
+          "DataStreamCalc",
+          streamTableNode(0),
+          term("select", "a", "b")
+        ),
+        streamTableNode(1),
+        term("where", "AND(=(a, z), <(b, x))"),
+        term("join", "a", "b", "x", "y", "z"),
+        term("joinType", "LeftOuterJoin")
+      ),
+      term("select", "b", "y")
+    )
+
+    util.verifyTable(joined, expected)
+  }
+
+  @Test
+  def testRightOuterJoinEquiPred(): Unit = {
+    val util = streamTestUtil()
+    val t = util.addTable[(Int, Long, String)]("T", 'a, 'b, 'c)
+    val s = util.addTable[(Long, String, Int)]("S", 'x, 'y, 'z)
+
+    val joined = t.rightOuterJoin(s, 'a === 'z).select('b, 'y)
+
+    val expected = unaryNode(
+      "DataStreamCalc",
+      binaryNode(
+        "DataStreamJoin",
+        unaryNode(
+          "DataStreamCalc",
+          streamTableNode(0),
+          term("select", "a", "b")
+        ),
+        unaryNode(
+          "DataStreamCalc",
+          streamTableNode(1),
+          term("select", "y", "z")
+        ),
+        term("where", "=(a, z)"),
+        term("join", "a", "b", "y", "z"),
+        term("joinType", "RightOuterJoin")
+      ),
+      term("select", "b", "y")
+    )
+
+    util.verifyTable(joined, expected)
+  }
+
+  @Test
+  def testRightOuterJoinEquiAndLocalPred(): Unit = {
+    val util = streamTestUtil()
+    val t = util.addTable[(Int, Long, String)]("T", 'a, 'b, 'c)
+    val s = util.addTable[(Long, String, Int)]("S", 'x, 'y, 'z)
+
+    val joined = t.rightOuterJoin(s, 'a === 'z && 'x < 2).select('b, 'x)
+
+    val expected = unaryNode(
+      "DataStreamCalc",
+      binaryNode(
+        "DataStreamJoin",
+        unaryNode(
+          "DataStreamCalc",
+          streamTableNode(0),
+          term("select", "a", "b")
+        ),
+        unaryNode(
+          "DataStreamCalc",
+          streamTableNode(1),
+          term("select", "x", "z")
+        ),
+        term("where", "AND(=(a, z), <(x, 2))"),
+        term("join", "a", "b", "x", "z"),
+        term("joinType", "RightOuterJoin")
+      ),
+      term("select", "b", "x")
+    )
+
+    util.verifyTable(joined, expected)
+  }
+
+  @Test
+  def testRightOuterJoinEquiAndNonEquiPred(): Unit = {
+    val util = streamTestUtil()
+    val t = util.addTable[(Int, Long, String)]("T", 'a, 'b, 'c)
+    val s = util.addTable[(Long, String, Int)]("S", 'x, 'y, 'z)
+
+    val joined = t.rightOuterJoin(s, 'a === 'z && 'b < 'x).select('b, 'y)
+
+    val expected = unaryNode(
+      "DataStreamCalc",
+      binaryNode(
+        "DataStreamJoin",
+        unaryNode(
+          "DataStreamCalc",
+          streamTableNode(0),
+          term("select", "a", "b")
+        ),
+        streamTableNode(1),
+        term("where", "AND(=(a, z), <(b, x))"),
+        term("join", "a", "b", "x", "y", "z"),
+        term("joinType", "RightOuterJoin")
+      ),
+      term("select", "b", "y")
+    )
+
+    util.verifyTable(joined, expected)
+  }
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/JoinHarnessTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/harness/JoinHarnessTest.scala
@@ -114,6 +114,38 @@ class JoinHarnessTest extends HarnessTestBase {
       |}
     """.stripMargin
 
+  val funcCodeWithNonEqualPred2: String =
+    """
+      |public class TestJoinFunction
+      |          extends org.apache.flink.api.common.functions.RichFlatJoinFunction {
+      |  transient org.apache.flink.types.Row out =
+      |            new org.apache.flink.types.Row(4);
+      |  public TestJoinFunction() throws Exception {}
+      |
+      |  @Override
+      |  public void open(org.apache.flink.configuration.Configuration parameters)
+      |  throws Exception {}
+      |
+      |  @Override
+      |  public void join(Object _in1, Object _in2, org.apache.flink.util.Collector c)
+      |   throws Exception {
+      |   org.apache.flink.types.Row in1 = (org.apache.flink.types.Row) _in1;
+      |   org.apache.flink.types.Row in2 = (org.apache.flink.types.Row) _in2;
+      |
+      |   out.setField(0, in1.getField(0));
+      |   out.setField(1, in1.getField(1));
+      |   out.setField(2, in2.getField(0));
+      |   out.setField(3, in2.getField(1));
+      |   if(((java.lang.String)in1.getField(1)).compareTo((java.lang.String)in2.getField(1))<0) {
+      |      c.collect(out);
+      |   }
+      |  }
+      |
+      |  @Override
+      |  public void close() throws Exception {}
+      |}
+    """.stripMargin
+
   /** a.proctime >= b.proctime - 10 and a.proctime <= b.proctime + 20 **/
   @Test
   def testProcTimeInnerJoinWithCommonBounds() {
@@ -1269,6 +1301,262 @@ class JoinHarnessTest extends HarnessTestBase {
       CRow(Row.of(1: JInt, "bbb", 1: JInt, "Hi1"), change = false)))
     expectedOutput.add(new StreamRecord(
       CRow(Row.of(1: JInt, "bbb", null: JInt, null), change = true)))
+    verify(expectedOutput, result, new RowResultSortComparator())
+
+    testHarness.close()
+  }
+
+  @Test
+  def testNonWindowRightJoinWithoutNonEqualPred() {
+
+    val joinReturnType = CRowTypeInfo(new RowTypeInfo(
+      Array[TypeInformation[_]](
+        INT_TYPE_INFO,
+        STRING_TYPE_INFO,
+        INT_TYPE_INFO,
+        STRING_TYPE_INFO),
+      Array("a", "b", "c", "d")))
+
+    val joinProcessFunc = new NonWindowLeftRightJoin(
+      rowType,
+      rowType,
+      joinReturnType,
+      "TestJoinFunction",
+      funcCode,
+      false,
+      queryConfig)
+
+    val operator: KeyedCoProcessOperator[Integer, CRow, CRow, CRow] =
+      new KeyedCoProcessOperator[Integer, CRow, CRow, CRow](joinProcessFunc)
+    val testHarness: KeyedTwoInputStreamOperatorTestHarness[Integer, CRow, CRow, CRow] =
+      new KeyedTwoInputStreamOperatorTestHarness[Integer, CRow, CRow, CRow](
+        operator,
+        new TupleRowKeySelector[Integer](0),
+        new TupleRowKeySelector[Integer](0),
+        BasicTypeInfo.INT_TYPE_INFO,
+        1, 1, 0)
+
+    testHarness.open()
+
+    // right stream input
+    testHarness.setProcessingTime(1)
+    testHarness.processElement2(new StreamRecord(
+      CRow(Row.of(1: JInt, "aaa"), change = true)))
+    assertEquals(1, testHarness.numProcessingTimeTimers())
+    assertEquals(2, testHarness.numKeyedStateEntries())
+    testHarness.setProcessingTime(2)
+    testHarness.processElement2(new StreamRecord(
+      CRow(Row.of(1: JInt, "aaa"), change = true)))
+    testHarness.processElement2(new StreamRecord(
+      CRow(Row.of(2: JInt, "bbb"), change = true)))
+    assertEquals(2, testHarness.numProcessingTimeTimers())
+    assertEquals(4, testHarness.numKeyedStateEntries())
+    testHarness.setProcessingTime(3)
+    testHarness.processElement2(new StreamRecord(
+      CRow(Row.of(1: JInt, "aaa"), change = false)))
+    assertEquals(4, testHarness.numKeyedStateEntries())
+    assertEquals(2, testHarness.numProcessingTimeTimers())
+
+    // left stream input and output normally
+    testHarness.processElement1(new StreamRecord(
+      CRow(Row.of(1: JInt, "Hi1"), change = true)))
+    testHarness.processElement1(new StreamRecord(
+      CRow(Row.of(1: JInt, "Hi1"), change = false)))
+    assertEquals(5, testHarness.numKeyedStateEntries())
+    assertEquals(3, testHarness.numProcessingTimeTimers())
+    testHarness.setProcessingTime(4)
+    testHarness.processElement1(new StreamRecord(
+      CRow(Row.of(2: JInt, "Hello1"), change = true)))
+    assertEquals(7, testHarness.numKeyedStateEntries())
+    assertEquals(4, testHarness.numProcessingTimeTimers())
+
+    testHarness.processElement2(new StreamRecord(
+      CRow(Row.of(1: JInt, "aaa"), change = false)))
+    // expired right stream record with key value of 1
+    testHarness.setProcessingTime(5)
+    testHarness.processElement1(new StreamRecord(
+      CRow(Row.of(1: JInt, "Hi2"), change = true)))
+    testHarness.processElement1(new StreamRecord(
+      CRow(Row.of(1: JInt, "Hi2"), change = false)))
+    assertEquals(5, testHarness.numKeyedStateEntries())
+    assertEquals(3, testHarness.numProcessingTimeTimers())
+
+    // expired all right stream record
+    testHarness.setProcessingTime(6)
+    assertEquals(3, testHarness.numKeyedStateEntries())
+    assertEquals(2, testHarness.numProcessingTimeTimers())
+
+    // expired left stream record with key value of 2
+    testHarness.setProcessingTime(8)
+    assertEquals(0, testHarness.numKeyedStateEntries())
+    assertEquals(0, testHarness.numProcessingTimeTimers())
+
+    val result = testHarness.getOutput
+
+    val expectedOutput = new ConcurrentLinkedQueue[Object]()
+
+    expectedOutput.add(new StreamRecord(
+      CRow(Row.of(null: JInt, null, 1: JInt, "aaa"), change = true)))
+    expectedOutput.add(new StreamRecord(
+      CRow(Row.of(null: JInt, null, 1: JInt, "aaa"), change = true)))
+    expectedOutput.add(new StreamRecord(
+      CRow(Row.of(null: JInt, null, 2: JInt, "bbb"), change = true)))
+    expectedOutput.add(new StreamRecord(
+      CRow(Row.of(null: JInt, null, 1: JInt, "aaa"), change = false)))
+    expectedOutput.add(new StreamRecord(
+      CRow(Row.of(null: JInt, null, 1: JInt, "aaa"), change = false)))
+    expectedOutput.add(new StreamRecord(
+      CRow(Row.of(1: JInt, "Hi1", 1: JInt, "aaa"), change = true)))
+    expectedOutput.add(new StreamRecord(
+      CRow(Row.of(1: JInt, "Hi1", 1: JInt, "aaa"), change = false)))
+    expectedOutput.add(new StreamRecord(
+      CRow(Row.of(null: JInt, null, 1: JInt, "aaa"), change = true)))
+    expectedOutput.add(new StreamRecord(
+      CRow(Row.of(null: JInt, null, 2: JInt, "bbb"), change = false)))
+    expectedOutput.add(new StreamRecord(
+      CRow(Row.of(2: JInt, "Hello1", 2: JInt, "bbb"), change = true)))
+    expectedOutput.add(new StreamRecord(
+      CRow(Row.of(null: JInt, null, 1: JInt, "aaa"), change = false)))
+
+    verify(expectedOutput, result, new RowResultSortComparator())
+
+    testHarness.close()
+  }
+
+  @Test
+  def testNonWindowRightJoinWithNonEqualPred() {
+
+    val joinReturnType = CRowTypeInfo(new RowTypeInfo(
+      Array[TypeInformation[_]](
+        INT_TYPE_INFO,
+        STRING_TYPE_INFO,
+        INT_TYPE_INFO,
+        STRING_TYPE_INFO),
+      Array("a", "b", "c", "d")))
+
+    val joinProcessFunc = new NonWindowLeftRightJoinWithNonEquiPredicates(
+      rowType,
+      rowType,
+      joinReturnType,
+      "TestJoinFunction",
+      funcCodeWithNonEqualPred2,
+      false,
+      queryConfig)
+
+    val operator: KeyedCoProcessOperator[Integer, CRow, CRow, CRow] =
+      new KeyedCoProcessOperator[Integer, CRow, CRow, CRow](joinProcessFunc)
+    val testHarness: KeyedTwoInputStreamOperatorTestHarness[Integer, CRow, CRow, CRow] =
+      new KeyedTwoInputStreamOperatorTestHarness[Integer, CRow, CRow, CRow](
+        operator,
+        new TupleRowKeySelector[Integer](0),
+        new TupleRowKeySelector[Integer](0),
+        BasicTypeInfo.INT_TYPE_INFO,
+        1, 1, 0)
+
+    testHarness.open()
+
+    // right stream input
+    testHarness.setProcessingTime(1)
+    testHarness.processElement2(new StreamRecord(
+      CRow(Row.of(1: JInt, "aaa"), change = true)))
+    testHarness.processElement2(new StreamRecord(
+      CRow(Row.of(1: JInt, "aaa"), change = false)))
+    testHarness.processElement2(new StreamRecord(
+      CRow(Row.of(1: JInt, "bbb"), change = true)))
+    assertEquals(1, testHarness.numProcessingTimeTimers())
+    // 1 right timer(5), 1 right key(1), 1 join cnt
+    assertEquals(3, testHarness.numKeyedStateEntries())
+    testHarness.setProcessingTime(2)
+    testHarness.processElement2(new StreamRecord(
+      CRow(Row.of(1: JInt, "aaa"), change = true)))
+    testHarness.processElement2(new StreamRecord(
+      CRow(Row.of(2: JInt, "bbb"), change = true)))
+    assertEquals(2, testHarness.numProcessingTimeTimers())
+    // 2 right timer(5,6), 2 right key(1,2), 2 join cnt
+    assertEquals(6, testHarness.numKeyedStateEntries())
+    testHarness.setProcessingTime(3)
+
+    // left stream input and output normally
+    testHarness.processElement1(new StreamRecord(
+      CRow(Row.of(1: JInt, "Hi1"), change = true)))
+    testHarness.processElement1(new StreamRecord(
+      CRow(Row.of(1: JInt, "bbb"), change = false)))
+    // 2 right timer(5,6), 2 right keys(1,2), 2 join cnt, 1 left timer(7), 1 left key(1)
+    assertEquals(8, testHarness.numKeyedStateEntries())
+    assertEquals(3, testHarness.numProcessingTimeTimers())
+    testHarness.setProcessingTime(4)
+    testHarness.processElement1(new StreamRecord(
+      CRow(Row.of(2: JInt, "ccc"), change = true)))
+    testHarness.processElement1(new StreamRecord(
+      CRow(Row.of(2: JInt, "Hello"), change = true)))
+    // 2 right timer(5,6), 2 right keys(1,2), 2 join cnt, 2 left timer(7,8), 2 left key(1,2)
+    assertEquals(10, testHarness.numKeyedStateEntries())
+    assertEquals(4, testHarness.numProcessingTimeTimers())
+
+    testHarness.processElement2(new StreamRecord(
+      CRow(Row.of(1: JInt, "aaa"), change = false)))
+    testHarness.processElement1(new StreamRecord(
+      CRow(Row.of(1: JInt, "Hi2"), change = true)))
+    testHarness.processElement1(new StreamRecord(
+      CRow(Row.of(1: JInt, "Hi2"), change = false)))
+    testHarness.processElement1(new StreamRecord(
+      CRow(Row.of(1: JInt, "Hi1"), change = false)))
+    // expired right stream record with key value of 1
+    testHarness.setProcessingTime(5)
+    testHarness.processElement1(new StreamRecord(
+      CRow(Row.of(1: JInt, "Hi3"), change = true)))
+    testHarness.processElement1(new StreamRecord(
+      CRow(Row.of(1: JInt, "Hi3"), change = false)))
+    // 1 right timer(6), 1 right keys(2), 1 join cnt, 2 left timer(7,8), 1 left key(2)
+    assertEquals(6, testHarness.numKeyedStateEntries())
+    assertEquals(3, testHarness.numProcessingTimeTimers())
+
+    // expired all right stream record
+    testHarness.setProcessingTime(6)
+    assertEquals(3, testHarness.numKeyedStateEntries())
+    assertEquals(2, testHarness.numProcessingTimeTimers())
+
+    // expired left stream record with key value of 2
+    testHarness.setProcessingTime(8)
+    assertEquals(0, testHarness.numKeyedStateEntries())
+    assertEquals(0, testHarness.numProcessingTimeTimers())
+
+    val result = testHarness.getOutput
+
+    val expectedOutput = new ConcurrentLinkedQueue[Object]()
+
+    expectedOutput.add(new StreamRecord(
+      CRow(Row.of(null: JInt, null, 1: JInt, "aaa"), change = true)))
+    expectedOutput.add(new StreamRecord(
+      CRow(Row.of(null: JInt, null, 1: JInt, "aaa"), change = false)))
+    expectedOutput.add(new StreamRecord(
+      CRow(Row.of(null: JInt, null, 1: JInt, "bbb"), change = true)))
+    expectedOutput.add(new StreamRecord(
+      CRow(Row.of(null: JInt, null, 1: JInt, "aaa"), change = true)))
+    expectedOutput.add(new StreamRecord(
+      CRow(Row.of(null: JInt, null, 2: JInt, "bbb"), change = true)))
+    expectedOutput.add(new StreamRecord(
+      CRow(Row.of(null: JInt, null, 1: JInt, "bbb"), change = false)))
+    expectedOutput.add(new StreamRecord(
+      CRow(Row.of(null: JInt, null, 1: JInt, "aaa"), change = false)))
+    expectedOutput.add(new StreamRecord(
+      CRow(Row.of(1: JInt, "Hi1", 1: JInt, "aaa"), change = true)))
+    expectedOutput.add(new StreamRecord(
+      CRow(Row.of(1: JInt, "Hi1", 1: JInt, "bbb"), change = true)))
+    expectedOutput.add(new StreamRecord(
+      CRow(Row.of(null: JInt, null, 2: JInt, "bbb"), change = false)))
+    expectedOutput.add(new StreamRecord(
+      CRow(Row.of(2: JInt, "Hello", 2: JInt, "bbb"), change = true)))
+    expectedOutput.add(new StreamRecord(
+      CRow(Row.of(1: JInt, "Hi1", 1: JInt, "aaa"), change = false)))
+    expectedOutput.add(new StreamRecord(
+      CRow(Row.of(1: JInt, "Hi2", 1: JInt, "bbb"), change = true)))
+    expectedOutput.add(new StreamRecord(
+      CRow(Row.of(1: JInt, "Hi2", 1: JInt, "bbb"), change = false)))
+    expectedOutput.add(new StreamRecord(
+      CRow(Row.of(1: JInt, "Hi1", 1: JInt, "bbb"), change = false)))
+    expectedOutput.add(new StreamRecord(
+      CRow(Row.of(null: JInt, null, 1: JInt, "bbb"), change = true)))
     verify(expectedOutput, result, new RowResultSortComparator())
 
     testHarness.close()


### PR DESCRIPTION

## What is the purpose of the change

Implement stream-stream non-window right outer join. Most of the work has been done by [FLINK-8428](https://issues.apache.org/jira/browse/FLINK-8428), this pr mainly adds tests for right join.


## Brief change log

  - Add right join support during `translateToPlan`.
  - Add right join tests.
  - Update docs.


## Verifying this change

This change added tests and can be verified as follows:

  - Added IT/UT/harness tests for right join

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
