### PR TITLE
[FLINK-9398][Client] Fix CLI list running job returns all except scheduled jobs

### DIFF
--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -104,6 +104,10 @@ The command line can be used to
 
         ./bin/flink list -r
 
+-   List all existing jobs (including their JobIDs):
+
+        ./bin/flink list -a
+
 -   List running Flink jobs inside Flink YARN session:
 
         ./bin/flink list -m yarn-cluster -yid <yarnApplicationID> -r

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
@@ -94,6 +94,9 @@ public class CliFrontendParser {
 	static final Option SCHEDULED_OPTION = new Option("s", "scheduled", false,
 			"Show only scheduled programs and their JobIDs");
 
+	static final Option ALL_OPTION = new Option("a", "all", false,
+		"Show all programs and their JobIDs");
+
 	static final Option ZOOKEEPER_NAMESPACE_OPTION = new Option("z", "zookeeperNamespace", true,
 			"Namespace to create the Zookeeper sub-paths for high availability mode");
 
@@ -193,6 +196,7 @@ public class CliFrontendParser {
 
 	static Options getListCommandOptions() {
 		Options options = buildGeneralOptions(new Options());
+		options.addOption(ALL_OPTION);
 		options.addOption(RUNNING_OPTION);
 		return options.addOption(SCHEDULED_OPTION);
 	}

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/ListOptions.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/ListOptions.java
@@ -20,6 +20,7 @@ package org.apache.flink.client.cli;
 
 import org.apache.commons.cli.CommandLine;
 
+import static org.apache.flink.client.cli.CliFrontendParser.ALL_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.RUNNING_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.SCHEDULED_OPTION;
 
@@ -30,11 +31,13 @@ public class ListOptions extends CommandLineOptions {
 
 	private final boolean running;
 	private final boolean scheduled;
+	private final boolean other;
 
 	public ListOptions(CommandLine line) {
 		super(line);
-		this.running = line.hasOption(RUNNING_OPTION.getOpt());
-		this.scheduled = line.hasOption(SCHEDULED_OPTION.getOpt());
+		this.other = line.hasOption(ALL_OPTION.getOpt());
+		this.running = line.hasOption(RUNNING_OPTION.getOpt()) || this.other;
+		this.scheduled = line.hasOption(SCHEDULED_OPTION.getOpt()) || this.other;
 	}
 
 	public boolean getRunning() {
@@ -43,5 +46,9 @@ public class ListOptions extends CommandLineOptions {
 
 	public boolean getScheduled() {
 		return scheduled;
+	}
+
+	public boolean getOther() {
+		return other;
 	}
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/ListOptions.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/ListOptions.java
@@ -36,8 +36,8 @@ public class ListOptions extends CommandLineOptions {
 	public ListOptions(CommandLine line) {
 		super(line);
 		this.showAll = line.hasOption(ALL_OPTION.getOpt());
-		this.showRunning = line.hasOption(RUNNING_OPTION.getOpt()) || this.showAll;
-		this.showScheduled = line.hasOption(SCHEDULED_OPTION.getOpt()) || this.showAll;
+		this.showRunning = line.hasOption(RUNNING_OPTION.getOpt());
+		this.showScheduled = line.hasOption(SCHEDULED_OPTION.getOpt());
 	}
 
 	public boolean showRunning() {

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/ListOptions.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/ListOptions.java
@@ -29,26 +29,26 @@ import static org.apache.flink.client.cli.CliFrontendParser.SCHEDULED_OPTION;
  */
 public class ListOptions extends CommandLineOptions {
 
-	private final boolean running;
-	private final boolean scheduled;
-	private final boolean other;
+	private final boolean showRunning;
+	private final boolean showScheduled;
+	private final boolean showAll;
 
 	public ListOptions(CommandLine line) {
 		super(line);
-		this.other = line.hasOption(ALL_OPTION.getOpt());
-		this.running = line.hasOption(RUNNING_OPTION.getOpt()) || this.other;
-		this.scheduled = line.hasOption(SCHEDULED_OPTION.getOpt()) || this.other;
+		this.showAll = line.hasOption(ALL_OPTION.getOpt());
+		this.showRunning = line.hasOption(RUNNING_OPTION.getOpt()) || this.showAll;
+		this.showScheduled = line.hasOption(SCHEDULED_OPTION.getOpt()) || this.showAll;
 	}
 
-	public boolean getRunning() {
-		return running;
+	public boolean showRunning() {
+		return showRunning;
 	}
 
-	public boolean getScheduled() {
-		return scheduled;
+	public boolean showScheduled() {
+		return showScheduled;
 	}
 
-	public boolean getOther() {
-		return other;
+	public boolean showAll() {
+		return showAll;
 	}
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendListTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendListTest.java
@@ -30,6 +30,8 @@ import org.mockito.Mockito;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
@@ -53,12 +55,42 @@ public class CliFrontendListTest extends CliFrontendTestBase {
 	public void testList() throws Exception {
 		// test list properly
 		{
-			String[] parameters = {"-r", "-s"};
+			String[] parameters = {"-r", "-s", "-a"};
 			ClusterClient<String> clusterClient = createClusterClient();
 			MockedCliFrontend testFrontend = new MockedCliFrontend(clusterClient);
 			testFrontend.list(parameters);
 			Mockito.verify(clusterClient, times(1))
 				.listJobs();
+		}
+
+		// test configure all job
+		{
+			String[] parameters = {"-a"};
+			ListOptions options = new ListOptions(CliFrontendParser.parse(
+				CliFrontendParser.getListCommandOptions(), parameters, true));
+			assertTrue(options.getOther());
+			assertTrue(options.getRunning());
+			assertTrue(options.getScheduled());
+		}
+
+		// test configure running job
+		{
+			String[] parameters = {"-r"};
+			ListOptions options = new ListOptions(CliFrontendParser.parse(
+				CliFrontendParser.getListCommandOptions(), parameters, true));
+			assertFalse(options.getOther());
+			assertTrue(options.getRunning());
+			assertFalse(options.getScheduled());
+		}
+
+		// test configure scheduled job
+		{
+			String[] parameters = {"-s"};
+			ListOptions options = new ListOptions(CliFrontendParser.parse(
+				CliFrontendParser.getListCommandOptions(), parameters, true));
+			assertFalse(options.getOther());
+			assertFalse(options.getRunning());
+			assertTrue(options.getScheduled());
 		}
 	}
 

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendListTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendListTest.java
@@ -68,9 +68,9 @@ public class CliFrontendListTest extends CliFrontendTestBase {
 			String[] parameters = {"-a"};
 			ListOptions options = new ListOptions(CliFrontendParser.parse(
 				CliFrontendParser.getListCommandOptions(), parameters, true));
-			assertTrue(options.getOther());
-			assertTrue(options.getRunning());
-			assertTrue(options.getScheduled());
+			assertTrue(options.showAll());
+			assertTrue(options.showRunning());
+			assertTrue(options.showScheduled());
 		}
 
 		// test configure running job
@@ -78,9 +78,9 @@ public class CliFrontendListTest extends CliFrontendTestBase {
 			String[] parameters = {"-r"};
 			ListOptions options = new ListOptions(CliFrontendParser.parse(
 				CliFrontendParser.getListCommandOptions(), parameters, true));
-			assertFalse(options.getOther());
-			assertTrue(options.getRunning());
-			assertFalse(options.getScheduled());
+			assertFalse(options.showAll());
+			assertTrue(options.showRunning());
+			assertFalse(options.showScheduled());
 		}
 
 		// test configure scheduled job
@@ -88,9 +88,9 @@ public class CliFrontendListTest extends CliFrontendTestBase {
 			String[] parameters = {"-s"};
 			ListOptions options = new ListOptions(CliFrontendParser.parse(
 				CliFrontendParser.getListCommandOptions(), parameters, true));
-			assertFalse(options.getOther());
-			assertFalse(options.getRunning());
-			assertTrue(options.getScheduled());
+			assertFalse(options.showAll());
+			assertFalse(options.showRunning());
+			assertTrue(options.showScheduled());
 		}
 	}
 


### PR DESCRIPTION


## What is the purpose of the change

This PR fixes CLI command `bin/flink list -r` returning all except scheduled jobs.


## Brief change log

Change the behavior of `bin/flink list` to
  - Adding in a `-a` option to list all jobs. Including `CREATED`, `RUNNING` & `RESTARTING`
  - Fixing `-r` option to list only `RUNNING` and `RESTARTING`.
  - Internally map `-a` with `other` job type so it won't affect the behavior of explicit listing options when adding other options to `list` command.


## Verifying this change

This change added tests and can be verified as follows:

  - Added unit-test to verify `-a` options.
  - Added `ListOptions` unit-test suite which never existed before.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? documented in `cli.md`
