### PR TITLE
[FLINK-9257][E2E Tests] Fix wrong "All tests pass" message

### DIFF
--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -77,6 +77,5 @@ run_test "Elasticsearch (v5.1.2) sink end-to-end test" "$END_TO_END_DIR/test-scr
 run_test "Quickstarts Java nightly end-to-end test" "$END_TO_END_DIR/test-scripts/test_quickstarts.sh java"
 run_test "Quickstarts Scala nightly end-to-end test" "$END_TO_END_DIR/test-scripts/test_quickstarts.sh scala"
 
-# Exit code for Travis build success/failure
-exit $EXIT_CODE
+printf "\n[PASS] All tests passed\n"
 exit 0

--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -25,12 +25,14 @@ if [ -z "$END_TO_END_DIR" ] ; then
     exit 1  # fail
 fi
 
+export END_TO_END_DIR
+
 if [ -z "$FLINK_DIR" ] ; then
     echo "You have to export the Flink distribution directory as FLINK_DIR"
     exit 1
 fi
 
-source "$(dirname "$0")"/test-scripts/test-runner-common.sh
+source "${END_TO_END_DIR}/test-scripts/test-runner-common.sh"
 
 FLINK_DIR="`( cd \"$FLINK_DIR\" && pwd )`" # absolutized and normalized
 
@@ -75,8 +77,6 @@ run_test "Local recovery and sticky scheduling end-to-end test" "$END_TO_END_DIR
 run_test "Local recovery and sticky scheduling end-to-end test" "$END_TO_END_DIR/test-scripts/test_local_recovery_and_scheduling.sh 4 10 rocks true false"
 run_test "Local recovery and sticky scheduling end-to-end test" "$END_TO_END_DIR/test-scripts/test_local_recovery_and_scheduling.sh 4 10 rocks false true"
 run_test "Local recovery and sticky scheduling end-to-end test" "$END_TO_END_DIR/test-scripts/test_local_recovery_and_scheduling.sh 4 10 rocks true true"
-
-run_test "Quickstarts nightly end-to-end test" "$END_TO_END_DIR/test-scripts/test_quickstarts.sh"
 
 run_test "Elasticsearch (v1.7.1) sink end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_elasticsearch.sh 1 https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.7.1.tar.gz"
 run_test "Elasticsearch (v2.3.5) sink end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_elasticsearch.sh 2 https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.3.5/elasticsearch-2.3.5.tar.gz"

--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -37,13 +37,9 @@ FLINK_DIR="`( cd \"$FLINK_DIR\" && pwd )`" # absolutized and normalized
 echo "flink-end-to-end-test directory: $END_TO_END_DIR"
 echo "Flink distribution directory: $FLINK_DIR"
 
-EXIT_CODE=0
-
 # Template for adding a test:
 
 # run_test "<description>" "$END_TO_END_DIR/test-scripts/<script_name>"
-
-run_test "Failing" "$END_TO_END_DIR/test-scripts/failing.sh"
 
 run_test "Running HA (file, async) end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha.sh file true false"
 run_test "Running HA (file, sync) end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha.sh file false false"
@@ -83,3 +79,4 @@ run_test "Quickstarts Scala nightly end-to-end test" "$END_TO_END_DIR/test-scrip
 
 # Exit code for Travis build success/failure
 exit $EXIT_CODE
+exit 0

--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -67,7 +67,7 @@ run_test "Resuming Externalized Checkpoint after terminal failure (rocks) end-to
 run_test "DataSet allround end-to-end test" "$END_TO_END_DIR/test-scripts/test_batch_allround.sh"
 run_test "Streaming SQL end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_sql.sh"
 run_test "Streaming bucketing end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_bucketing.sh"
-run_test "stateful stream job upgrade end-to-end test" "$END_TO_END_DIR/test-scripts/test_stateful_stream_job_upgrade.sh 2 4"
+run_test "Stateful stream job upgrade end-to-end test" "$END_TO_END_DIR/test-scripts/test_stateful_stream_job_upgrade.sh 2 4"
 run_test "Local recovery and sticky scheduling end-to-end test" "$END_TO_END_DIR/test-scripts/test_local_recovery_and_scheduling.sh"
 
 run_test "Elasticsearch (v1.7.1) sink end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_elasticsearch.sh 1 https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.7.1.tar.gz"

--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -68,7 +68,15 @@ run_test "DataSet allround end-to-end test" "$END_TO_END_DIR/test-scripts/test_b
 run_test "Streaming SQL end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_sql.sh"
 run_test "Streaming bucketing end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_bucketing.sh"
 run_test "Stateful stream job upgrade end-to-end test" "$END_TO_END_DIR/test-scripts/test_stateful_stream_job_upgrade.sh 2 4"
-run_test "Local recovery and sticky scheduling end-to-end test" "$END_TO_END_DIR/test-scripts/test_local_recovery_and_scheduling.sh"
+
+run_test "Local recovery and sticky scheduling end-to-end test" "$END_TO_END_DIR/test-scripts/test_local_recovery_and_scheduling.sh 4 3 file false false"
+run_test "Local recovery and sticky scheduling end-to-end test" "$END_TO_END_DIR/test-scripts/test_local_recovery_and_scheduling.sh 4 3 file false true"
+run_test "Local recovery and sticky scheduling end-to-end test" "$END_TO_END_DIR/test-scripts/test_local_recovery_and_scheduling.sh 4 10 rocks false false"
+run_test "Local recovery and sticky scheduling end-to-end test" "$END_TO_END_DIR/test-scripts/test_local_recovery_and_scheduling.sh 4 10 rocks true false"
+run_test "Local recovery and sticky scheduling end-to-end test" "$END_TO_END_DIR/test-scripts/test_local_recovery_and_scheduling.sh 4 10 rocks false true"
+run_test "Local recovery and sticky scheduling end-to-end test" "$END_TO_END_DIR/test-scripts/test_local_recovery_and_scheduling.sh 4 10 rocks true true"
+
+run_test "Quickstarts nightly end-to-end test" "$END_TO_END_DIR/test-scripts/test_quickstarts.sh"
 
 run_test "Elasticsearch (v1.7.1) sink end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_elasticsearch.sh 1 https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.7.1.tar.gz"
 run_test "Elasticsearch (v2.3.5) sink end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_elasticsearch.sh 2 https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.3.5/elasticsearch-2.3.5.tar.gz"

--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -25,14 +25,12 @@ if [ -z "$END_TO_END_DIR" ] ; then
     exit 1  # fail
 fi
 
-export END_TO_END_DIR="${END_TO_END_DIR}"
-
 if [ -z "$FLINK_DIR" ] ; then
     echo "You have to export the Flink distribution directory as FLINK_DIR"
     exit 1
 fi
 
-source "$(dirname "$0")"/test-scripts/common.sh
+source "$(dirname "$0")"/test-scripts/test-runner-common.sh
 
 FLINK_DIR="`( cd \"$FLINK_DIR\" && pwd )`" # absolutized and normalized
 
@@ -43,162 +41,45 @@ EXIT_CODE=0
 
 # Template for adding a test:
 
-# if [ $EXIT_CODE == 0 ]; then
-#    run_test "<description>" "$END_TO_END_DIR/test-scripts/<script_name>"
-#    EXIT_CODE=$?
-# fi
+# run_test "<description>" "$END_TO_END_DIR/test-scripts/<script_name>"
 
+run_test "Failing" "$END_TO_END_DIR/test-scripts/failing.sh"
 
-if [ $EXIT_CODE == 0 ]; then
-  run_test "Running HA (file, async) end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha.sh file true false"
-  EXIT_CODE=$?
-fi
+run_test "Running HA (file, async) end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha.sh file true false"
+run_test "Running HA (file, sync) end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha.sh file false false"
+run_test "Running HA (rocks, non-incremental) end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha.sh rocks true false"
+run_test "Running HA (rocks, incremental) end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha.sh rocks true true"
 
-if [ $EXIT_CODE == 0 ]; then
-  run_test "Running HA (file, sync) end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha.sh file false false"
-  EXIT_CODE=$?
-fi
+run_test "Resuming Savepoint (file, async, no parallelism change) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 2 2 file true"
+run_test "Resuming Savepoint (file, sync, no parallelism change) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 2 2 file false"
+run_test "Resuming Savepoint (file, async, scale up) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 2 4 file true"
+run_test "Resuming Savepoint (file, sync, scale up) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 2 4 file false"
+run_test "Resuming Savepoint (file, async, scale down) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 4 2 file true"
+run_test "Resuming Savepoint (file, sync, scale down) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 4 2 file false"
+run_test "Resuming Savepoint (rocks, no parallelism change) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 2 2 rocks"
+run_test "Resuming Savepoint (rocks, scale up) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 2 4 rocks"
+run_test "Resuming Savepoint (rocks, scale down) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 4 2 rocks"
 
-if [ $EXIT_CODE == 0 ]; then
-  run_test "Running HA (rocks, non-incremental) end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha.sh rocks true false"
-  EXIT_CODE=$?
-fi
+run_test "Resuming Externalized Checkpoint (file, async) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_externalized_checkpoints.sh file true"
+run_test "Resuming Externalized Checkpoint (file, sync) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_externalized_checkpoints.sh file false"
+run_test "Resuming Externalized Checkpoint (rocks) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_externalized_checkpoints.sh rocks"
 
-if [ $EXIT_CODE == 0 ]; then
-  run_test "Running HA (rocks, incremental) end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha.sh rocks true true"
-  EXIT_CODE=$?
-fi
+run_test "Resuming Externalized Checkpoint after terminal failure (file, async) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_externalized_checkpoints.sh file true true"
+run_test "Resuming Externalized Checkpoint after terminal failure (file, sync) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_externalized_checkpoints.sh file false true"
+run_test "Resuming Externalized Checkpoint after terminal failure (rocks) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_externalized_checkpoints.sh rocks true"
 
-if [ $EXIT_CODE == 0 ]; then
-  run_test "Resuming Savepoint (file, async, no parallelism change) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 2 2 file true"
-  EXIT_CODE=$?
-fi
+run_test "DataSet allround end-to-end test" "$END_TO_END_DIR/test-scripts/test_batch_allround.sh"
+run_test "Streaming SQL end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_sql.sh"
+run_test "Streaming bucketing end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_bucketing.sh"
+run_test "stateful stream job upgrade end-to-end test" "$END_TO_END_DIR/test-scripts/test_stateful_stream_job_upgrade.sh 2 4"
+run_test "Local recovery and sticky scheduling end-to-end test" "$END_TO_END_DIR/test-scripts/test_local_recovery_and_scheduling.sh"
 
-if [ $EXIT_CODE == 0 ]; then
-  run_test "Resuming Savepoint (file, sync, no parallelism change) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 2 2 file false"
-  EXIT_CODE=$?
-fi
+run_test "Elasticsearch (v1.7.1) sink end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_elasticsearch.sh 1 https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.7.1.tar.gz"
+run_test "Elasticsearch (v2.3.5) sink end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_elasticsearch.sh 2 https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.3.5/elasticsearch-2.3.5.tar.gz"
+run_test "Elasticsearch (v5.1.2) sink end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_elasticsearch.sh 5 https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.1.2.tar.gz"
 
-if [ $EXIT_CODE == 0 ]; then
-  run_test "Resuming Savepoint (file, async, scale up) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 2 4 file true"
-  EXIT_CODE=$?
-fi
-
-if [ $EXIT_CODE == 0 ]; then
-  run_test "Resuming Savepoint (file, sync, scale up) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 2 4 file false"
-  EXIT_CODE=$?
-fi
-
-if [ $EXIT_CODE == 0 ]; then
-  run_test "Resuming Savepoint (file, async, scale down) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 4 2 file true"
-  EXIT_CODE=$?
-fi
-
-if [ $EXIT_CODE == 0 ]; then
-  run_test "Resuming Savepoint (file, sync, scale down) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 4 2 file false"
-  EXIT_CODE=$?
-fi
-
-if [ $EXIT_CODE == 0 ]; then
-  run_test "Resuming Savepoint (rocks, no parallelism change) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 2 2 rocks"
-  EXIT_CODE=$?
-fi
-
-if [ $EXIT_CODE == 0 ]; then
-  run_test "Resuming Savepoint (rocks, scale up) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 2 4 rocks"
-  EXIT_CODE=$?
-fi
-
-if [ $EXIT_CODE == 0 ]; then
-  run_test "Resuming Savepoint (rocks, scale down) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_savepoint.sh 4 2 rocks"
-  EXIT_CODE=$?
-fi
-
-if [ $EXIT_CODE == 0 ]; then
-  run_test "Resuming Externalized Checkpoint (file, async) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_externalized_checkpoints.sh file true false"
-  EXIT_CODE=$?
-fi
-
-if [ $EXIT_CODE == 0 ]; then
-  run_test "Resuming Externalized Checkpoint (file, sync) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_externalized_checkpoints.sh file false false"
-  EXIT_CODE=$?
-fi
-
-if [ $EXIT_CODE == 0 ]; then
-  run_test "Resuming Externalized Checkpoint (rocks) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_externalized_checkpoints.sh rocks false"
-  EXIT_CODE=$?
-fi
-
-if [ $EXIT_CODE == 0 ]; then
-  run_test "Resuming Externalized Checkpoint after terminal failure (file, async) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_externalized_checkpoints.sh file true true"
-  EXIT_CODE=$?
-fi
-
-if [ $EXIT_CODE == 0 ]; then
-  run_test "Resuming Externalized Checkpoint after terminal failure (file, sync) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_externalized_checkpoints.sh file false true"
-  EXIT_CODE=$?
-fi
-
-if [ $EXIT_CODE == 0 ]; then
-  run_test "Resuming Externalized Checkpoint after terminal failure (rocks) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_externalized_checkpoints.sh rocks true"
-  EXIT_CODE=$?
-fi
-
-if [ $EXIT_CODE == 0 ]; then
-  run_test "DataSet allround end-to-end test" "$END_TO_END_DIR/test-scripts/test_batch_allround.sh"
-  EXIT_CODE=$?
-fi
-
-if [ $EXIT_CODE == 0 ]; then
-  run_test "Streaming SQL end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_sql.sh"
-  EXIT_CODE=$?
-fi
-
-if [ $EXIT_CODE == 0 ]; then
-  run_test "Streaming bucketing end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_bucketing.sh"
-  EXIT_CODE=$?
-fi
-
-if [ $EXIT_CODE == 0 ]; then
-  run_test "Stateful stream job upgrade end-to-end test" "$END_TO_END_DIR/test-scripts/test_stateful_stream_job_upgrade.sh 2 4"
-  EXIT_CODE=$?
-fi
-
-if [ $EXIT_CODE == 0 ]; then
-  run_test \
-    "Elasticsearch (v1.7.1) sink end-to-end test" \
-    "$END_TO_END_DIR/test-scripts/test_streaming_elasticsearch.sh 1 https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.7.1.tar.gz"
-  EXIT_CODE=$?
-fi
-
-if [ $EXIT_CODE == 0 ]; then
-  run_test \
-    "Elasticsearch (v2.3.5) sink end-to-end test" \
-    "$END_TO_END_DIR/test-scripts/test_streaming_elasticsearch.sh 2 https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.3.5/elasticsearch-2.3.5.tar.gz"
-  EXIT_CODE=$?
-fi
-
-if [ $EXIT_CODE == 0 ]; then
-  run_test \
-    "Elasticsearch (v5.1.2) sink end-to-end test" \
-    "$END_TO_END_DIR/test-scripts/test_streaming_elasticsearch.sh 5 https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.1.2.tar.gz"
-  EXIT_CODE=$?
-fi
-
-if [ $EXIT_CODE == 0 ]; then
-  run_test "Local recovery and sticky scheduling nightly end-to-end test" "$END_TO_END_DIR/test-scripts/test_local_recovery_and_scheduling.sh"
-  EXIT_CODE=$?
-fi
-
-if [ $EXIT_CODE == 0 ]; then
-  run_test "Quickstarts Java nightly end-to-end test" "$END_TO_END_DIR/test-scripts/test_quickstarts.sh java"
-  EXIT_CODE=$?
-fi
-
-if [ $EXIT_CODE == 0 ]; then
-  run_test "Quickstarts Scala nightly end-to-end test" "$END_TO_END_DIR/test-scripts/test_quickstarts.sh scala"
-  EXIT_CODE=$?
-fi
+run_test "Quickstarts Java nightly end-to-end test" "$END_TO_END_DIR/test-scripts/test_quickstarts.sh java"
+run_test "Quickstarts Scala nightly end-to-end test" "$END_TO_END_DIR/test-scripts/test_quickstarts.sh scala"
 
 # Exit code for Travis build success/failure
 exit $EXIT_CODE

--- a/flink-end-to-end-tests/run-pre-commit-tests.sh
+++ b/flink-end-to-end-tests/run-pre-commit-tests.sh
@@ -25,6 +25,8 @@ if [ -z "$END_TO_END_DIR" ] ; then
     exit 1  # fail
 fi
 
+export END_TO_END_DIR
+
 if [ -z "$FLINK_DIR" ] ; then
     echo "You have to export the Flink distribution directory as FLINK_DIR"
     exit 1

--- a/flink-end-to-end-tests/run-pre-commit-tests.sh
+++ b/flink-end-to-end-tests/run-pre-commit-tests.sh
@@ -25,14 +25,13 @@ if [ -z "$END_TO_END_DIR" ] ; then
     exit 1  # fail
 fi
 
-export END_TO_END_DIR="${END_TO_END_DIR}"
-
 if [ -z "$FLINK_DIR" ] ; then
     echo "You have to export the Flink distribution directory as FLINK_DIR"
     exit 1
 fi
 
 source "$(dirname "$0")"/test-scripts/common.sh
+source "$(dirname "$0")"/test-scripts/test-runner-common.sh
 
 FLINK_DIR="`( cd \"$FLINK_DIR\" && pwd )`" # absolutized and normalized
 
@@ -42,57 +41,17 @@ echo "Flink distribution directory: $FLINK_DIR"
 EXIT_CODE=0
 
 # Template for adding a test:
+# run_test "<description>" "$END_TO_END_DIR/test-scripts/<script_name>"
 
-# if [ $EXIT_CODE == 0 ]; then
-#    run_test "<description>" "$END_TO_END_DIR/test-scripts/<script_name>"
-#    EXIT_CODE=$?
-# fi
-
-if [ $EXIT_CODE == 0 ]; then
-    run_test "Batch Python Wordcount end-to-end test" "$END_TO_END_DIR/test-scripts/test_batch_python_wordcount.sh"
-    EXIT_CODE=$?
-fi
-
-if [ $EXIT_CODE == 0 ]; then
-    run_test "Streaming Python Wordcount end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_python_wordcount.sh"
-    EXIT_CODE=$?
-fi
-
-if [ $EXIT_CODE == 0 ]; then
-    run_test "Wordcount end-to-end test" "$END_TO_END_DIR/test-scripts/test_batch_wordcount.sh"
-    EXIT_CODE=$?
-fi
-
-if [ $EXIT_CODE == 0 ]; then
-    run_test "Kafka end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_kafka010.sh"
-    EXIT_CODE=$?
-fi
-
-if [ $EXIT_CODE == 0 ]; then
-    run_test "class loading end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_classloader.sh"
-    EXIT_CODE=$?
-fi
-
-if [ $EXIT_CODE == 0 ]; then
-    run_test "Shaded Hadoop S3A end-to-end test" "$END_TO_END_DIR/test-scripts/test_shaded_hadoop_s3a.sh"
-    EXIT_CODE=$?
-fi
-
-if [ $EXIT_CODE == 0 ]; then
-    run_test "Shaded Presto S3 end-to-end test" "$END_TO_END_DIR/test-scripts/test_shaded_presto_s3.sh"
-    EXIT_CODE=$?
-fi
-
-if [ $EXIT_CODE == 0 ]; then
-    run_test "Hadoop-free Wordcount end-to-end test" "$END_TO_END_DIR/test-scripts/test_hadoop_free.sh"
-    EXIT_CODE=$?
-fi
-
-if [ $EXIT_CODE == 0 ]; then
-    run_test "Distributed cache end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_distributed_cache_via_blob.sh"
-    EXIT_CODE=$?
-fi
-
+run_test "Batch Python Wordcount end-to-end test" "$END_TO_END_DIR/test-scripts/test_batch_python_wordcount.sh"
+run_test "Streaming Python Wordcount end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_python_wordcount.sh"
+run_test "Wordcount end-to-end test" "$END_TO_END_DIR/test-scripts/test_batch_wordcount.sh"
+run_test "Kafka end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_kafka010.sh"
+run_test "class loading end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_classloader.sh"
+run_test "Shaded Hadoop S3A end-to-end test" "$END_TO_END_DIR/test-scripts/test_shaded_hadoop_s3a.sh"
+run_test "Shaded Presto S3 end-to-end test" "$END_TO_END_DIR/test-scripts/test_shaded_presto_s3.sh"
+run_test "Hadoop-free Wordcount end-to-end test" "$END_TO_END_DIR/test-scripts/test_hadoop_free.sh"
+run_test "Distributed cache end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_distributed_cache_via_blob.sh"
 
 # Exit code for Travis build success/failure
-exit $EXIT_CODE
+exit ${EXIT_CODE}

--- a/flink-end-to-end-tests/run-pre-commit-tests.sh
+++ b/flink-end-to-end-tests/run-pre-commit-tests.sh
@@ -51,4 +51,5 @@ run_test "Shaded Presto S3 end-to-end test" "$END_TO_END_DIR/test-scripts/test_s
 run_test "Hadoop-free Wordcount end-to-end test" "$END_TO_END_DIR/test-scripts/test_hadoop_free.sh"
 run_test "Distributed cache end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_distributed_cache_via_blob.sh"
 
+printf "\n[PASS] All tests passed\n"
 exit 0

--- a/flink-end-to-end-tests/run-pre-commit-tests.sh
+++ b/flink-end-to-end-tests/run-pre-commit-tests.sh
@@ -38,8 +38,6 @@ FLINK_DIR="`( cd \"$FLINK_DIR\" && pwd )`" # absolutized and normalized
 echo "flink-end-to-end-test directory: $END_TO_END_DIR"
 echo "Flink distribution directory: $FLINK_DIR"
 
-EXIT_CODE=0
-
 # Template for adding a test:
 # run_test "<description>" "$END_TO_END_DIR/test-scripts/<script_name>"
 
@@ -53,5 +51,4 @@ run_test "Shaded Presto S3 end-to-end test" "$END_TO_END_DIR/test-scripts/test_s
 run_test "Hadoop-free Wordcount end-to-end test" "$END_TO_END_DIR/test-scripts/test_hadoop_free.sh"
 run_test "Distributed cache end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_distributed_cache_via_blob.sh"
 
-# Exit code for Travis build success/failure
-exit ${EXIT_CODE}
+exit 0

--- a/flink-end-to-end-tests/run-pre-commit-tests.sh
+++ b/flink-end-to-end-tests/run-pre-commit-tests.sh
@@ -30,8 +30,7 @@ if [ -z "$FLINK_DIR" ] ; then
     exit 1
 fi
 
-source "$(dirname "$0")"/test-scripts/common.sh
-source "$(dirname "$0")"/test-scripts/test-runner-common.sh
+source ${END_TO_END_DIR}/test-scripts/test-runner-common.sh
 
 FLINK_DIR="`( cd \"$FLINK_DIR\" && pwd )`" # absolutized and normalized
 

--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -288,9 +288,9 @@ function check_result_hash {
   if [[ "$actual" != "$expected" ]]
   then
     echo "FAIL $name: Output hash mismatch.  Got $actual, expected $expected."
-    PASS=""
     echo "head hexdump of actual:"
     head $outfile_prefix* | hexdump -c
+    exit 1
   else
     echo "pass $name"
     # Output files are left behind in /tmp

--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -456,5 +456,5 @@ function start_timer {
 # prints the number of minutes and seconds that have elapsed since the last call to start_timer
 function end_timer {
     duration=$SECONDS
-    echo "$(($duration / 60)) minutes and $(($duration % 60)) seconds elapsed."
+    echo "$(($duration / 60)) minutes and $(($duration % 60)) seconds"
 }

--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -24,7 +24,7 @@ if [[ -z $FLINK_DIR ]]; then
     exit 1
 fi
 
-export PASS=1
+export EXIT_CODE=0
 
 echo "Flink dist directory: $FLINK_DIR"
 
@@ -138,7 +138,6 @@ function start_local_zk {
 
             if [ "${address}" != "localhost" ]; then
                 echo "[ERROR] Parse error. Only available for localhost."
-                PASS=""
                 exit 1
             fi
             ${FLINK_DIR}/bin/zookeeper.sh start $id
@@ -186,7 +185,7 @@ function check_logs_for_errors {
       | grep -iq "error"; then
     echo "Found error in log files:"
     cat $FLINK_DIR/log/*
-    PASS=""
+    EXIT_CODE=1
   fi
 }
 
@@ -211,7 +210,7 @@ function check_logs_for_exceptions {
       | grep -iq "exception"; then
     echo "Found exception in log files:"
     cat $FLINK_DIR/log/*
-    PASS=""
+    EXIT_CODE=1
   fi
 }
 
@@ -219,7 +218,7 @@ function check_logs_for_non_empty_out_files {
   if grep -ri "." $FLINK_DIR/log/*.out > /dev/null; then
     echo "Found non-empty .out files:"
     cat $FLINK_DIR/log/*.out
-    PASS=""
+    EXIT_CODE=1
   fi
 }
 

--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -230,10 +230,6 @@ function stop_cluster {
   if ! [ "`jps | grep 'FlinkZooKeeperQuorumPeer' | wc -l`" = "0" ]; then
     "$FLINK_DIR"/bin/zookeeper.sh stop
   fi
-
-  check_logs_for_errors
-  check_logs_for_exceptions
-  check_logs_for_non_empty_out_files
 }
 
 function wait_job_running {
@@ -299,15 +295,6 @@ function check_result_hash {
     echo "pass $name"
     # Output files are left behind in /tmp
   fi
-}
-
-function check_all_pass {
-  if [[ ! "$PASS" ]]
-  then
-    echo "One or more tests FAILED."
-    exit 1
-  fi
-  echo "All tests PASS"
 }
 
 function s3_put {
@@ -471,35 +458,3 @@ function end_timer {
     duration=$SECONDS
     echo "$(($duration / 60)) minutes and $(($duration % 60)) seconds elapsed."
 }
-
-#######################################
-# Prints the given description, runs the given test and prints how long the execution took.
-# Arguments:
-#   $1: description of the test
-#   $2: command to execute
-#######################################
-function run_test {
-    description="$1"
-    command="$2"
-
-    printf "\n==============================================================================\n"
-    printf "Running ${description}\n"
-    printf "==============================================================================\n"
-    start_timer
-    ${command}
-    exit_code="$?"
-    end_timer
-    return "${exit_code}"
-}
-
-# Shuts down the cluster and cleans up all temporary folders and files. Make sure to clean up even in case of failures.
-function cleanup {
-  stop_cluster
-  tm_kill_all
-  jm_kill_all
-  rm -rf $TEST_DATA_DIR 2> /dev/null
-  revert_default_config
-  check_all_pass
-  rm -rf $FLINK_DIR/log/* 2> /dev/null
-}
-trap cleanup EXIT

--- a/flink-end-to-end-tests/test-scripts/elasticsearch-common.sh
+++ b/flink-end-to-end-tests/test-scripts/elasticsearch-common.sh
@@ -47,7 +47,6 @@ function verify_elasticsearch_process_exist {
     # make sure the elasticsearch node is actually running
     if [ "$elasticsearchProcess" != "Elasticsearch" ]; then
       echo "Elasticsearch node is not running."
-      PASS=""
       exit 1
     else
       echo "Elasticsearch node is running."

--- a/flink-end-to-end-tests/test-scripts/test-runner-common.sh
+++ b/flink-end-to-end-tests/test-scripts/test-runner-common.sh
@@ -44,14 +44,14 @@ function run_test {
     cleanup
 
     if [[ ${exit_code} == 0 ]]; then
-        if [[ ! "$PASS" ]]; then
+        if [[ ${EXIT_CODE} != 0 ]]; then
             printf "\n[FAIL] '${description}' failed after ${time_elapsed}! Test exited with exit code 0 but the logs contained errors, exceptions or non-empty .out files\n\n"
             exit_code=1
         else
             printf "\n[PASS] '${description}' passed after ${time_elapsed}! Test exited with exit code 0.\n\n"
         fi
     else
-        if [[ ! "$PASS" ]]; then
+        if [[ ${EXIT_CODE} != 0 ]]; then
             printf "\n[FAIL] '${description}' failed after ${time_elapsed}! Test exited with exit code ${exit_code} and the logs contained errors, exceptions or non-empty .out files\n\n"
         else
             printf "\n[FAIL] '${description}' failed after ${time_elapsed}! Test exited with exit code ${exit_code}\n\n"

--- a/flink-end-to-end-tests/test-scripts/test-runner-common.sh
+++ b/flink-end-to-end-tests/test-scripts/test-runner-common.sh
@@ -54,7 +54,7 @@ function run_test {
         if [[ ! "$PASS" ]]; then
             printf "\n[FAIL] '${description}' failed after ${time_elapsed}! Test exited with exit code ${exit_code} and the logs contained errors, exceptions or non-empty .out files\n\n"
         else
-            printf "\n[PASS] '${description}' failed after ${time_elapsed}! Test exited with exit code ${exit_code}\n\n"
+            printf "\n[FAIL] '${description}' failed after ${time_elapsed}! Test exited with exit code ${exit_code}\n\n"
         fi
     fi
 

--- a/flink-end-to-end-tests/test-scripts/test-runner-common.sh
+++ b/flink-end-to-end-tests/test-scripts/test-runner-common.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+################################################################################
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+source "$(pwd)"/test-scripts/common.sh
+
+#######################################
+# Prints the given description, runs the given test and prints how long the execution took.
+# Arguments:
+#   $1: description of the test
+#   $2: command to execute
+#######################################
+function run_test {
+    description="$1"
+    command="$2"
+
+    printf "\n==============================================================================\n"
+    printf "Running ${description}\n"
+    printf "==============================================================================\n"
+    start_timer
+    ${command}
+    exit_code="$?"
+    end_timer
+
+    check_logs_for_errors
+    check_logs_for_exceptions
+    check_logs_for_non_empty_out_files
+
+    if [[ ${exit_code} == 0 ]]; then
+        if [[ ! "$PASS" ]]; then
+            echo "FAIL: Test exited with exit code 0 but the logs contained errors, exceptions or non-empty .out files"
+            exit_code=1
+        else
+            echo "PASS: Test exited with exit code 0"
+        fi
+    else
+        if [[ ! "$PASS" ]]; then
+            echo "FAIL: Test exited with exit code ${exit_code} and the logs contained errors, exceptions or non-empty .out files"
+        else
+            echo "FAIL: Test exited with exit code ${exit_code}"
+        fi
+    fi
+
+    cleanup
+
+    if [[ ${exit_code} != 0 ]]; then
+        exit "${exit_code}"
+    fi
+}
+
+# Shuts down the cluster and cleans up all temporary folders and files. Make sure to clean up even in case of failures.
+function cleanup {
+  stop_cluster
+  tm_kill_all
+  jm_kill_all
+  rm -rf $TEST_DATA_DIR 2> /dev/null
+  revert_default_config
+  rm -rf $FLINK_DIR/log/* 2> /dev/null
+}
+
+trap cleanup EXIT

--- a/flink-end-to-end-tests/test-scripts/test-runner-common.sh
+++ b/flink-end-to-end-tests/test-scripts/test-runner-common.sh
@@ -17,7 +17,7 @@
 # limitations under the License.
 ################################################################################
 
-source "$(pwd)"/test-scripts/common.sh
+source "${END_TO_END_DIR}"/test-scripts/common.sh
 
 #######################################
 # Prints the given description, runs the given test and prints how long the execution took.

--- a/flink-end-to-end-tests/test-scripts/test-runner-common.sh
+++ b/flink-end-to-end-tests/test-scripts/test-runner-common.sh
@@ -30,33 +30,33 @@ function run_test {
     command="$2"
 
     printf "\n==============================================================================\n"
-    printf "Running ${description}\n"
+    printf "Running '${description}'\n"
     printf "==============================================================================\n"
     start_timer
     ${command}
     exit_code="$?"
-    end_timer
+    time_elapsed=$(end_timer)
 
     check_logs_for_errors
     check_logs_for_exceptions
     check_logs_for_non_empty_out_files
 
+    cleanup
+
     if [[ ${exit_code} == 0 ]]; then
         if [[ ! "$PASS" ]]; then
-            echo "FAIL: Test exited with exit code 0 but the logs contained errors, exceptions or non-empty .out files"
+            printf "\n[FAIL] '${description}' failed after ${time_elapsed}! Test exited with exit code 0 but the logs contained errors, exceptions or non-empty .out files\n\n"
             exit_code=1
         else
-            echo "PASS: Test exited with exit code 0"
+            printf "\n[PASS] '${description}' passed after ${time_elapsed}! Test exited with exit code 0.\n\n"
         fi
     else
         if [[ ! "$PASS" ]]; then
-            echo "FAIL: Test exited with exit code ${exit_code} and the logs contained errors, exceptions or non-empty .out files"
+            printf "\n[FAIL] '${description}' failed after ${time_elapsed}! Test exited with exit code ${exit_code} and the logs contained errors, exceptions or non-empty .out files\n\n"
         else
-            echo "FAIL: Test exited with exit code ${exit_code}"
+            printf "\n[PASS] '${description}' failed after ${time_elapsed}! Test exited with exit code ${exit_code}\n\n"
         fi
     fi
-
-    cleanup
 
     if [[ ${exit_code} != 0 ]]; then
         exit "${exit_code}"

--- a/flink-end-to-end-tests/test-scripts/test_batch_allround.sh
+++ b/flink-end-to-end-tests/test-scripts/test_batch_allround.sh
@@ -44,9 +44,6 @@ function test_cleanup {
 
   # revert our modifications to the Flink distribution
   mv -f $FLINK_DIR/conf/flink-conf.yaml.bak $FLINK_DIR/conf/flink-conf.yaml
-
-  # make sure to run regular cleanup as well
-  cleanup
 }
 trap test_cleanup INT
 trap test_cleanup EXIT

--- a/flink-end-to-end-tests/test-scripts/test_ha.sh
+++ b/flink-end-to-end-tests/test-scripts/test_ha.sh
@@ -49,26 +49,27 @@ function stop_cluster_and_watchdog() {
 function verify_logs() {
     local OUTPUT=$FLINK_DIR/log/*.out
     local JM_FAILURES=$1
+    local test_has_errors
 
     # verify that we have no alerts
     if ! [ `cat ${OUTPUT} | wc -l` -eq 0 ]; then
         echo "FAILURE: Alerts found at the general purpose DataStream job."
-        PASS=""
+        test_has_errors=""
     fi
 
     # checks that all apart from the first JM recover the failed jobgraph.
     if ! [ `grep -r --include '*standalonesession*.log' Recovered SubmittedJobGraph "${FLINK_DIR}/log/" | cut -d ":" -f 1 | uniq | wc -l` -eq ${JM_FAILURES} ]; then
         echo "FAILURE: A JM did not take over."
-        PASS=""
+        test_has_errors=""
     fi
 
     # search the logs for JMs that log completed checkpoints
     if ! [ `grep -r --include '*standalonesession*.log' Completed checkpoint "${FLINK_DIR}/log/" | cut -d ":" -f 1 | uniq | wc -l` -eq $((JM_FAILURES + 1)) ]; then
         echo "FAILURE: A JM did not execute the job."
-        PASS=""
+        test_has_errors=""
     fi
 
-    if [[ ! "$PASS" ]]; then
+    if [[ ! ${test_has_errors} ]]; then
         echo "One or more tests FAILED."
         exit 1
     fi

--- a/flink-end-to-end-tests/test-scripts/test_ha.sh
+++ b/flink-end-to-end-tests/test-scripts/test_ha.sh
@@ -42,7 +42,6 @@ function stop_cluster_and_watchdog() {
             wait ${TM_WATCHDOG_PID} 2> /dev/null
         fi
 
-        cleanup
         CLEARED=1
     fi
 }

--- a/flink-end-to-end-tests/test-scripts/test_ha.sh
+++ b/flink-end-to-end-tests/test-scripts/test_ha.sh
@@ -49,29 +49,29 @@ function stop_cluster_and_watchdog() {
 function verify_logs() {
     local OUTPUT=$FLINK_DIR/log/*.out
     local JM_FAILURES=$1
-    local test_has_errors=1
+    local EXIT_CODE=0
 
     # verify that we have no alerts
     if ! [ `cat ${OUTPUT} | wc -l` -eq 0 ]; then
         echo "FAILURE: Alerts found at the general purpose DataStream job."
-        test_has_errors=""
+        EXIT_CODE=1
     fi
 
     # checks that all apart from the first JM recover the failed jobgraph.
     if ! [ `grep -r --include '*standalonesession*.log' Recovered SubmittedJobGraph "${FLINK_DIR}/log/" | cut -d ":" -f 1 | uniq | wc -l` -eq ${JM_FAILURES} ]; then
         echo "FAILURE: A JM did not take over."
-        test_has_errors=""
+        EXIT_CODE=1
     fi
 
     # search the logs for JMs that log completed checkpoints
     if ! [ `grep -r --include '*standalonesession*.log' Completed checkpoint "${FLINK_DIR}/log/" | cut -d ":" -f 1 | uniq | wc -l` -eq $((JM_FAILURES + 1)) ]; then
         echo "FAILURE: A JM did not execute the job."
-        test_has_errors=""
+        EXIT_CODE=1
     fi
 
-    if [[ ! ${test_has_errors} ]]; then
+    if [[ $EXIT_CODE != 0 ]]; then
         echo "One or more tests FAILED."
-        exit 1
+        exit $EXIT_CODE
     fi
 }
 

--- a/flink-end-to-end-tests/test-scripts/test_ha.sh
+++ b/flink-end-to-end-tests/test-scripts/test_ha.sh
@@ -49,7 +49,7 @@ function stop_cluster_and_watchdog() {
 function verify_logs() {
     local OUTPUT=$FLINK_DIR/log/*.out
     local JM_FAILURES=$1
-    local test_has_errors
+    local test_has_errors=1
 
     # verify that we have no alerts
     if ! [ `cat ${OUTPUT} | wc -l` -eq 0 ]; then

--- a/flink-end-to-end-tests/test-scripts/test_high_parallelism_iterations.sh
+++ b/flink-end-to-end-tests/test-scripts/test_high_parallelism_iterations.sh
@@ -60,9 +60,6 @@ function test_cleanup {
 
   # revert our modifications to the Flink distribution
   mv -f $FLINK_DIR/conf/flink-conf.yaml.bak $FLINK_DIR/conf/flink-conf.yaml
-
-  # make sure to run regular cleanup as well
-  cleanup
 }
 trap test_cleanup INT
 trap test_cleanup EXIT

--- a/flink-end-to-end-tests/test-scripts/test_local_recovery_and_scheduling.sh
+++ b/flink-end-to-end-tests/test-scripts/test_local_recovery_and_scheduling.sh
@@ -69,8 +69,14 @@ function run_local_recovery_test {
     local incremental=$4
     local kill_jvm=$5
 
-    echo "Running local recovery test on ${backend} backend: incremental checkpoints = ${incremental}, kill JVM = ${kill_jvm}."
-    TEST_PROGRAM_JAR=${END_TO_END_DIR}/flink-local-recovery-and-allocation-test/target/StickyAllocationAndLocalRecoveryTestJob.jar
+    echo "Running local recovery test with configuration:
+        parallelism: ${parallelism}
+        max attempts: ${max_attempts}
+        backend: ${backend}
+        incremental checkpoints: ${incremental}
+        kill JVM: ${kill_jvm}"
+
+    TEST_PROGRAM_JAR=$TEST_INFRA_DIR/../../flink-end-to-end-tests/flink-local-recovery-and-allocation-test/target/StickyAllocationAndLocalRecoveryTestJob.jar
 
     # Backup conf and configure for HA
     backup_config
@@ -109,11 +115,6 @@ function run_local_recovery_test {
 
 ## MAIN
 trap cleanup_after_test_and_exit_fail EXIT
-run_local_recovery_test 4 3 "file" "false" "false"
-run_local_recovery_test 4 3 "file" "false" "true"
-run_local_recovery_test 4 10 "rocks" "false" "false"
-run_local_recovery_test 4 10 "rocks" "true" "false"
-run_local_recovery_test 4 10 "rocks" "false" "true"
-run_local_recovery_test 4 10 "rocks" "true" "true"
+run_local_recovery_test "$@"
 trap - EXIT
 exit 0

--- a/flink-end-to-end-tests/test-scripts/test_local_recovery_and_scheduling.sh
+++ b/flink-end-to-end-tests/test-scripts/test_local_recovery_and_scheduling.sh
@@ -34,14 +34,14 @@ function check_logs {
 
     if [ ${failed_local_recovery} -ne 0 ]
     then
-        PASS=""
         echo "FAILURE: Found ${failed_local_recovery} failed attempt(s) for local recovery of correctly scheduled task(s)."
+        exit 1
     fi
 
     if [ ${attempt_local_recovery} -eq 0 ]
     then
-        PASS=""
         echo "FAILURE: Found no attempt for local recovery. Configuration problem?"
+        exit 1
     fi
 }
 

--- a/flink-end-to-end-tests/test-scripts/test_local_recovery_and_scheduling.sh
+++ b/flink-end-to-end-tests/test-scripts/test_local_recovery_and_scheduling.sh
@@ -76,8 +76,7 @@ function run_local_recovery_test {
         incremental checkpoints: ${incremental}
         kill JVM: ${kill_jvm}"
 
-    TEST_PROGRAM_JAR=$TEST_INFRA_DIR/../../flink-end-to-end-tests/flink-local-recovery-and-allocation-test/target/StickyAllocationAndLocalRecoveryTestJob.jar
-
+    TEST_PROGRAM_JAR=${END_TO_END_DIR}/flink-local-recovery-and-allocation-test/target/StickyAllocationAndLocalRecoveryTestJob.jar
     # Backup conf and configure for HA
     backup_config
     create_ha_config

--- a/flink-end-to-end-tests/test-scripts/test_local_recovery_and_scheduling.sh
+++ b/flink-end-to-end-tests/test-scripts/test_local_recovery_and_scheduling.sh
@@ -53,8 +53,6 @@ function cleanup_after_test {
     #
     kill ${watchdog_pid} 2> /dev/null
     wait ${watchdog_pid} 2> /dev/null
-    #
-    cleanup
 }
 
 # Calls the cleanup step for this tests and exits with an error.

--- a/flink-end-to-end-tests/test-scripts/test_quickstarts.sh
+++ b/flink-end-to-end-tests/test-scripts/test_quickstarts.sh
@@ -81,7 +81,6 @@ if [[ `grep -c "org/apache/flink/api/java" contentsInJar.txt` -eq '0' && \
     echo "Success: There are no flink core classes are contained in the jar."
 else
     echo "Failure: There are flink core classes are contained in the jar."
-    PASS=""
     exit 1
 fi
 
@@ -90,7 +89,6 @@ if [[ `grep -c "org/apache/flink/quickstart/StreamingJob.class" contentsInJar.tx
       `grep -c "org/apache/flink/streaming/connectors/elasticsearch5" contentsInJar.txt` -eq '0' ]]; then
 
     echo "Failure: Since Elasticsearch5SinkExample.class and other user classes are not included in the jar. "
-    PASS=""
     exit 1
 else
     echo "Success: Elasticsearch5SinkExample.class and other user classes are included in the jar."

--- a/flink-end-to-end-tests/test-scripts/test_resume_externalized_checkpoints.sh
+++ b/flink-end-to-end-tests/test-scripts/test_resume_externalized_checkpoints.sh
@@ -88,14 +88,12 @@ CHECKPOINT_PATH=$(ls -d $CHECKPOINT_DIR/$DATASTREAM_JOB/chk-[1-9]*)
 
 if [ -z $CHECKPOINT_PATH ]; then
   echo "Expected an externalized checkpoint to be present, but none exists."
-  PASS=""
   exit 1
 fi
 
 NUM_CHECKPOINTS=$(echo $CHECKPOINT_PATH | wc -l | tr -d ' ')
 if (( $NUM_CHECKPOINTS > 1 )); then
   echo "Expected only exactly 1 externalized checkpoint to be present, but $NUM_CHECKPOINTS exists."
-  PASS=""
   exit 1
 fi
 

--- a/flink-end-to-end-tests/test-scripts/test_resume_externalized_checkpoints.sh
+++ b/flink-end-to-end-tests/test-scripts/test_resume_externalized_checkpoints.sh
@@ -34,9 +34,6 @@ function test_cleanup {
   trap "" EXIT
 
   rollback_flink_slf4j_metric_reporter
-
-  # make sure to run regular cleanup as well
-  cleanup
 }
 trap test_cleanup INT
 trap test_cleanup EXIT

--- a/flink-end-to-end-tests/test-scripts/test_resume_savepoint.sh
+++ b/flink-end-to-end-tests/test-scripts/test_resume_savepoint.sh
@@ -69,9 +69,6 @@ function test_cleanup {
 
   # revert our modifications to the Flink distribution
   rm ${FLINK_DIR}/lib/flink-metrics-slf4j-*.jar
-
-  # make sure to run regular cleanup as well
-  cleanup
 }
 trap test_cleanup INT
 trap test_cleanup EXIT

--- a/flink-end-to-end-tests/test-scripts/test_shaded_hadoop_s3a.sh
+++ b/flink-end-to-end-tests/test-scripts/test_shaded_hadoop_s3a.sh
@@ -37,9 +37,6 @@ function s3_cleanup {
   # remove any leftover settings
   sed -i -e 's/s3.access-key: .*//' "$FLINK_DIR/conf/flink-conf.yaml"
   sed -i -e 's/s3.secret-key: .*//' "$FLINK_DIR/conf/flink-conf.yaml"
-
-  # make sure to run regular cleanup as well
-  cleanup
 }
 trap s3_cleanup EXIT
 

--- a/flink-end-to-end-tests/test-scripts/test_shaded_presto_s3.sh
+++ b/flink-end-to-end-tests/test-scripts/test_shaded_presto_s3.sh
@@ -33,9 +33,6 @@ s3_put $TEST_INFRA_DIR/test-data/words $ARTIFACTS_AWS_BUCKET flink-end-to-end-te
 function s3_cleanup {
   s3_delete $ARTIFACTS_AWS_BUCKET flink-end-to-end-test-shaded-presto-s3
   rm $FLINK_DIR/lib/flink-s3-fs*.jar
-
-  # make sure to run regular cleanup as well
-  cleanup
 }
 trap s3_cleanup EXIT
 

--- a/flink-end-to-end-tests/test-scripts/test_stateful_stream_job_upgrade.sh
+++ b/flink-end-to-end-tests/test-scripts/test_stateful_stream_job_upgrade.sh
@@ -43,9 +43,6 @@ function test_cleanup {
 
   # revert our modifications to the Flink distribution
   rm ${FLINK_DIR}/lib/flink-metrics-slf4j-*.jar
-
-  # make sure to run regular cleanup as well
-  cleanup
 }
 trap test_cleanup INT
 trap test_cleanup EXIT

--- a/flink-end-to-end-tests/test-scripts/test_streaming_bucketing.sh
+++ b/flink-end-to-end-tests/test-scripts/test_streaming_bucketing.sh
@@ -36,9 +36,6 @@ function bucketing_cleanup() {
 
   # restore default logging level
   sed -i -e 's/log4j.logger.org.apache.flink=DEBUG/#log4j.logger.org.apache.flink=INFO/g' $FLINK_DIR/conf/log4j.properties
-
-  # make sure to run regular cleanup as well
-  cleanup
 }
 trap bucketing_cleanup INT
 trap bucketing_cleanup EXIT

--- a/flink-end-to-end-tests/test-scripts/test_streaming_classloader.sh
+++ b/flink-end-to-end-tests/test-scripts/test_streaming_classloader.sh
@@ -18,6 +18,7 @@
 ################################################################################
 
 source "$(dirname "$0")"/common.sh
+test_has_errors=1
 
 TEST_PROGRAM_JAR=${END_TO_END_DIR}/flink-parent-child-classloading-test/target/ClassLoaderTestProgram.jar
 

--- a/flink-end-to-end-tests/test-scripts/test_streaming_classloader.sh
+++ b/flink-end-to-end-tests/test-scripts/test_streaming_classloader.sh
@@ -51,7 +51,7 @@ if [[ "$OUTPUT" != "$EXPECTED" ]]; then
   echo "Output from Flink program does not match expected output."
   echo -e "EXPECTED: $EXPECTED"
   echo -e "ACTUAL: $OUTPUT"
-  PASS=""
+  test_has_errors=""
 fi
 
 # This verifies that Flink classes are still resolved from the parent because the default
@@ -81,7 +81,7 @@ if [[ "$OUTPUT" != "$EXPECTED" ]]; then
   echo "Output from Flink program does not match expected output."
   echo -e "EXPECTED: $EXPECTED"
   echo -e "ACTUAL: $OUTPUT"
-  PASS=""
+  test_has_errors=""
 fi
 
 echo "Testing child-first class loading"
@@ -110,5 +110,9 @@ if [[ "$OUTPUT" != "$EXPECTED" ]]; then
   echo "Output from Flink program does not match expected output."
   echo -e "EXPECTED: $EXPECTED"
   echo -e "ACTUAL: $OUTPUT"
-  PASS=""
+  test_has_errors=""
+fi
+
+if [[ ! ${test_has_errors} ]]; then
+    exit 1
 fi

--- a/flink-end-to-end-tests/test-scripts/test_streaming_classloader.sh
+++ b/flink-end-to-end-tests/test-scripts/test_streaming_classloader.sh
@@ -18,7 +18,7 @@
 ################################################################################
 
 source "$(dirname "$0")"/common.sh
-test_has_errors=1
+EXIT_CODE=0
 
 TEST_PROGRAM_JAR=${END_TO_END_DIR}/flink-parent-child-classloading-test/target/ClassLoaderTestProgram.jar
 
@@ -52,7 +52,7 @@ if [[ "$OUTPUT" != "$EXPECTED" ]]; then
   echo "Output from Flink program does not match expected output."
   echo -e "EXPECTED: $EXPECTED"
   echo -e "ACTUAL: $OUTPUT"
-  test_has_errors=""
+  EXIT_CODE=1
 fi
 
 # This verifies that Flink classes are still resolved from the parent because the default
@@ -82,7 +82,7 @@ if [[ "$OUTPUT" != "$EXPECTED" ]]; then
   echo "Output from Flink program does not match expected output."
   echo -e "EXPECTED: $EXPECTED"
   echo -e "ACTUAL: $OUTPUT"
-  test_has_errors=""
+  EXIT_CODE=1
 fi
 
 echo "Testing child-first class loading"
@@ -111,9 +111,9 @@ if [[ "$OUTPUT" != "$EXPECTED" ]]; then
   echo "Output from Flink program does not match expected output."
   echo -e "EXPECTED: $EXPECTED"
   echo -e "ACTUAL: $OUTPUT"
-  test_has_errors=""
+  EXIT_CODE=1
 fi
 
-if [[ ! ${test_has_errors} ]]; then
-    exit 1
+if [[ ${EXIT_CODE} != 0 ]]; then
+    exit ${EXIT_CODE}
 fi

--- a/flink-end-to-end-tests/test-scripts/test_streaming_distributed_cache_via_blob.sh
+++ b/flink-end-to-end-tests/test-scripts/test_streaming_distributed_cache_via_blob.sh
@@ -36,5 +36,5 @@ if [[ "$OUTPUT" != "$EXPECTED" ]]; then
   echo "Output from Flink program does not match expected output."
   echo -e "EXPECTED: $EXPECTED"
   echo -e "ACTUAL: $OUTPUT"
-  PASS=""
+  exit 1
 fi

--- a/flink-end-to-end-tests/test-scripts/test_streaming_kafka010.sh
+++ b/flink-end-to-end-tests/test-scripts/test_streaming_kafka010.sh
@@ -61,7 +61,6 @@ function verify_output {
     echo "Output from Flink program does not match expected output."
     echo -e "EXPECTED FOR KEY: --$expected--"
     echo -e "ACTUAL: --$2--"
-    PASS=""
     exit 1
   fi
 }
@@ -87,7 +86,6 @@ modify_num_partitions test-input 2
 
 if (( $(get_num_partitions test-input) != 2 )); then
   echo "Failed adding a partition to test-input topic."
-  PASS=""
   exit 1
 fi
 
@@ -98,7 +96,6 @@ send_messages_to_kafka "elephant,13,64213\ngiraffe,9,65555\nbee,5,65647\nsquirre
 # verify that our assumption that the new partition actually has written messages is correct
 if (( $(get_partition_end_offset test-input 1) == 0 )); then
   echo "The newly created partition does not have any new messages, and therefore partition discovery cannot be verified."
-  PASS=""
   exit 1
 fi
 

--- a/flink-end-to-end-tests/test-scripts/test_streaming_kafka010.sh
+++ b/flink-end-to-end-tests/test-scripts/test_streaming_kafka010.sh
@@ -39,9 +39,6 @@ function test_cleanup {
 
   # revert our modifications to the Flink distribution
   mv -f $FLINK_DIR/conf/flink-conf.yaml.bak $FLINK_DIR/conf/flink-conf.yaml
-
-  # make sure to run regular cleanup as well
-  cleanup
 }
 trap test_cleanup INT
 trap test_cleanup EXIT

--- a/flink-end-to-end-tests/test-scripts/test_streaming_sql.sh
+++ b/flink-end-to-end-tests/test-scripts/test_streaming_sql.sh
@@ -42,9 +42,6 @@ function sql_cleanup() {
 
   # remove flink-table from lib folder
   rm $FLINK_DIR/lib/flink-table*jar
-
-  # make sure to run regular cleanup as well
-  cleanup
 }
 trap sql_cleanup INT
 trap sql_cleanup EXIT


### PR DESCRIPTION
## What is the purpose of the change
Fix a wrongly printed "All tests PASS" message when they actually don't"

Previously the behaviour was like this:
>During the cleanup hook (trap cleanup EXIT in common.sh) it will be checked whether there are non-empty out files or log files with certain exceptions. If a tests fails with non-zero exit code, but does not have any exceptions or .out files, this will still print "All tests PASS" to stdout, even though they don't

With this PR the whole test-runner is restructured so that
1. The check for non-empty .out files, errors and exceptions in logs is triggered from the `run_test` method
2. The error message after each test is dependant on both the exit code of the test script as well as the result from checking the log files
3. cleanup is now triggered by the test runner, not by the individual tests anymore
4. tests that signaled their failure by modifying `PASS`  now do so by exiting with non-zero exit code
5. `check_result_hash` exits with 1 instead of modifying `PASS`

Additionally this PR
1. Reformats the output a little compared to previous tests
```
Flink dist directory: /Users/florianschmidt/dev/flink/flink-dist/target/flink-1.6-SNAPSHOT-bin/flink-1.6-SNAPSHOT
TEST_DATA_DIR: /Users/florianschmidt/dev/flink/flink-end-to-end-tests/temp-test-directory-00N
Flink dist directory: /Users/florianschmidt/dev/flink/flink-dist/target/flink-1.6-SNAPSHOT-bin/flink-1.6-SNAPSHOT
TEST_DATA_DIR: /Users/florianschmidt/dev/flink/flink-end-to-end-tests/temp-test-directory-00N
flink-end-to-end-test directory: /Users/florianschmidt/dev/flink/flink-end-to-end-tests
Flink distribution directory: /Users/florianschmidt/dev/flink/flink-dist/target/flink-1.6-SNAPSHOT-bin/flink-1.6-SNAPSHOT

==============================================================================
Running 'Streaming Python Wordcount end-to-end test'
==============================================================================
Flink dist directory: /Users/florianschmidt/dev/flink/flink-dist/target/flink-1.6-SNAPSHOT-bin/flink-1.6-SNAPSHOT
TEST_DATA_DIR: /Users/florianschmidt/dev/flink/flink-end-to-end-tests/test-scripts/temp-test-directory-00N
Starting cluster.
Starting standalonesession daemon on host Florians-MBP.fritz.box.
Starting taskexecutor daemon on host Florians-MBP.fritz.box.
Waiting for dispatcher REST endpoint to come up...
Waiting for dispatcher REST endpoint to come up...
Waiting for dispatcher REST endpoint to come up...
Waiting for dispatcher REST endpoint to come up...
Dispatcher REST endpoint is up.
Starting execution of program
Program execution finished
Job with JobID 436dfd1f2a81ab4f818fc7fb9c395f0c has finished.
Job Runtime: 7512 ms
pass StreamingPythonWordCount
Stopping taskexecutor daemon (pid: 9877) on host Florians-MBP.fritz.box.
Stopping standalonesession daemon (pid: 9585) on host Florians-MBP.fritz.box.
No zookeeper daemon to stop on host Florians-MBP.fritz.box.

[PASS] 'Streaming Python Wordcount end-to-end test' passed after 0 minutes and 22 seconds! Test exited with exit code 0.


==============================================================================
Running 'Wordcount end-to-end test'
==============================================================================
Flink dist directory: /Users/florianschmidt/dev/flink/flink-dist/target/flink-1.6-SNAPSHOT-bin/flink-1.6-SNAPSHOT
TEST_DATA_DIR: /Users/florianschmidt/dev/flink/flink-end-to-end-tests/test-scripts/temp-test-directory-24N
```

## Verifying this change
* I ran the test scripts manually and checked that they still behave as expected
* I used the following script as a sample e2e-test to trigger different failure / success behaviours
```
#!/usr/bin/env bash
source "$(dirname "$0")"/common.sh

# each of those can be used to cause a test to fail

# echo "This should cause the test to fail" > $FLINK_DIR/log/test.out
# check_result_hash "asf" "$FLINK_DIR/log/"
# exit 1

function test_cleanup {
    echo "Something"

    # Uncomment to see test fail in cleanup
    # exit 2
}

trap test_cleanup EXIT
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
