### PR TITLE
[FLINK-9425] Make release scripts compliant with ASF release policy

### DIFF
--- a/tools/releasing/create_binary_release.sh
+++ b/tools/releasing/create_binary_release.sh
@@ -40,10 +40,8 @@ fi
 
 if [ "$(uname)" == "Darwin" ]; then
     SHASUM="shasum -a 512"
-    MD5SUM="md5 -r"
 else
     SHASUM="sha512sum"
-    MD5SUM="md5sum"
 fi
 
 ###########################
@@ -70,12 +68,11 @@ make_binary_release() {
   cp flink-*.tgz ../../../
   cd ../../../
 
-  # Sign md5 and sha the tgz
+  # Sign sha the tgz
   if [ "$SKIP_GPG" == "false" ] ; then
     gpg --armor --detach-sig "${dir_name}.tgz"
   fi
-  $MD5SUM "${dir_name}.tgz" > "${dir_name}.tgz.md5"
-  $SHASUM "${dir_name}.tgz" > "${dir_name}.tgz.sha"
+  $SHASUM "${dir_name}.tgz" > "${dir_name}.tgz.sha512"
 }
 
 cd ..

--- a/tools/releasing/create_source_release.sh
+++ b/tools/releasing/create_source_release.sh
@@ -37,10 +37,8 @@ fi
 
 if [ "$(uname)" == "Darwin" ]; then
     SHASUM="shasum -a 512"
-    MD5SUM="md5 -r"
 else
     SHASUM="sha512sum"
-    MD5SUM="md5sum"
 fi
 
 ###########################
@@ -62,8 +60,7 @@ rsync -a \
 
 tar czf flink-${RELEASE_VERSION}-src.tgz flink-$RELEASE_VERSION
 gpg --armor --detach-sig flink-$RELEASE_VERSION-src.tgz
-$MD5SUM flink-$RELEASE_VERSION-src.tgz > flink-$RELEASE_VERSION-src.tgz.md5
-$SHASUM flink-$RELEASE_VERSION-src.tgz > flink-$RELEASE_VERSION-src.tgz.sha
+$SHASUM flink-$RELEASE_VERSION-src.tgz > flink-$RELEASE_VERSION-src.tgz.sha512
 
 mv flink-$RELEASE_VERSION-src.* ../
 cd ..


### PR DESCRIPTION
## What is the purpose of the change

Remove the generation of MD5 checksum files and create sha checksum
files with a sha512 file ending.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
