### PR TITLE
[FLINK-9423][state] Implement efficient deletes for heap-based timer …

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/HeapInternalTimerService.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/HeapInternalTimerService.java
@@ -288,10 +288,10 @@ public class HeapInternalTimerService<K, N> implements InternalTimerService<N>, 
 			"Key Group " + keyGroupIdx + " does not belong to the local range.");
 
 		// restore the event time timers
-		eventTimeTimersQueue.restoreTimers(restoredTimersSnapshot.getEventTimeTimers());
+		eventTimeTimersQueue.addRestoredTimers(restoredTimersSnapshot.getEventTimeTimers());
 
 		// restore the processing time timers
-		processingTimeTimersQueue.restoreTimers(restoredTimersSnapshot.getProcessingTimeTimers());
+		processingTimeTimersQueue.addRestoredTimers(restoredTimersSnapshot.getProcessingTimeTimers());
 	}
 
 	public int numProcessingTimeTimers() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimeServiceManager.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimeServiceManager.java
@@ -22,7 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.DataOutputView;
-import org.apache.flink.runtime.state.KeyGroupsList;
+import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.VoidNamespaceSerializer;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
@@ -47,7 +47,7 @@ import java.util.Map;
 public class InternalTimeServiceManager<K, N> {
 
 	private final int totalKeyGroups;
-	private final KeyGroupsList localKeyGroupRange;
+	private final KeyGroupRange localKeyGroupRange;
 	private final KeyContext keyContext;
 
 	private final ProcessingTimeService processingTimeService;
@@ -56,7 +56,7 @@ public class InternalTimeServiceManager<K, N> {
 
 	InternalTimeServiceManager(
 			int totalKeyGroups,
-			KeyGroupsList localKeyGroupRange,
+			KeyGroupRange localKeyGroupRange,
 			KeyContext keyContext,
 			ProcessingTimeService processingTimeService) {
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimer.java
@@ -23,8 +23,8 @@ import org.apache.flink.annotation.Internal;
 /**
  * Internal interface for in-flight timers.
  *
- * @param <K> type of the timer key.
- * @param <N> type of the timer namespace.
+ * @param <K> Type of the keys to which timers are scoped.
+ * @param <N> Type of the namespace to which timers are scoped.
  */
 @Internal
 public interface InternalTimer<K, N> {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimer.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,184 +19,28 @@
 package org.apache.flink.streaming.api.operators;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.common.typeutils.CompatibilityResult;
-import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
-import org.apache.flink.api.common.typeutils.base.LongSerializer;
-import org.apache.flink.core.memory.DataInputView;
-import org.apache.flink.core.memory.DataOutputView;
-
-import java.io.IOException;
 
 /**
- * Internal class for keeping track of in-flight timers.
+ * Internal interface for in-flight timers.
  *
- * @param <K> Type of the keys to which timers are scoped.
- * @param <N> Type of the namespace to which timers are scoped.
+ * @param <K> type of the timer key.
+ * @param <N> type of the timer namespace.
  */
 @Internal
-public class InternalTimer<K, N> implements Comparable<InternalTimer<K, N>> {
-	private final long timestamp;
-	private final K key;
-	private final N namespace;
-
-	public InternalTimer(long timestamp, K key, N namespace) {
-		this.timestamp = timestamp;
-		this.key = key;
-		this.namespace = namespace;
-	}
-
-	public long getTimestamp() {
-		return timestamp;
-	}
-
-	public K getKey() {
-		return key;
-	}
-
-	public N getNamespace() {
-		return namespace;
-	}
-
-	@Override
-	public int compareTo(InternalTimer<K, N> o) {
-		return Long.compare(this.timestamp, o.timestamp);
-	}
-
-	@Override
-	public boolean equals(Object o) {
-		if (this == o) {
-			return true;
-		}
-		if (o == null || getClass() != o.getClass()){
-			return false;
-		}
-
-		InternalTimer<?, ?> timer = (InternalTimer<?, ?>) o;
-
-		return timestamp == timer.timestamp
-				&& key.equals(timer.key)
-				&& namespace.equals(timer.namespace);
-
-	}
-
-	@Override
-	public int hashCode() {
-		int result = (int) (timestamp ^ (timestamp >>> 32));
-		result = 31 * result + key.hashCode();
-		result = 31 * result + namespace.hashCode();
-		return result;
-	}
-
-	@Override
-	public String toString() {
-		return "Timer{" +
-				"timestamp=" + timestamp +
-				", key=" + key +
-				", namespace=" + namespace +
-				'}';
-	}
+public interface InternalTimer<K, N> {
 
 	/**
-	 * A {@link TypeSerializer} used to serialize/deserialize a {@link InternalTimer}.
+	 * Returns the timestamp of the timer. This value determines the point in time when the timer will fire.
 	 */
-	public static class TimerSerializer<K, N> extends TypeSerializer<InternalTimer<K, N>> {
+	long getTimestamp();
 
-		private static final long serialVersionUID = 1119562170939152304L;
+	/**
+	 * Returns the key that is bound to this timer.
+	 */
+	K getKey();
 
-		private final TypeSerializer<K> keySerializer;
-
-		private final TypeSerializer<N> namespaceSerializer;
-
-		TimerSerializer(TypeSerializer<K> keySerializer, TypeSerializer<N> namespaceSerializer) {
-			this.keySerializer = keySerializer;
-			this.namespaceSerializer = namespaceSerializer;
-		}
-
-		@Override
-		public boolean isImmutableType() {
-			return false;
-		}
-
-		@Override
-		public TypeSerializer<InternalTimer<K, N>> duplicate() {
-			return this;
-		}
-
-		@Override
-		public InternalTimer<K, N> createInstance() {
-			return null;
-		}
-
-		@Override
-		public InternalTimer<K, N> copy(InternalTimer<K, N> from) {
-			return new InternalTimer<>(from.timestamp, from.key, from.namespace);
-		}
-
-		@Override
-		public InternalTimer<K, N> copy(InternalTimer<K, N> from, InternalTimer<K, N> reuse) {
-			return copy(from);
-		}
-
-		@Override
-		public int getLength() {
-			// we do not have fixed length
-			return -1;
-		}
-
-		@Override
-		public void serialize(InternalTimer<K, N> record, DataOutputView target) throws IOException {
-			keySerializer.serialize(record.key, target);
-			namespaceSerializer.serialize(record.namespace, target);
-			LongSerializer.INSTANCE.serialize(record.timestamp, target);
-		}
-
-		@Override
-		public InternalTimer<K, N> deserialize(DataInputView source) throws IOException {
-			K key = keySerializer.deserialize(source);
-			N namespace = namespaceSerializer.deserialize(source);
-			Long timestamp = LongSerializer.INSTANCE.deserialize(source);
-			return new InternalTimer<>(timestamp, key, namespace);
-		}
-
-		@Override
-		public InternalTimer<K, N> deserialize(InternalTimer<K, N> reuse, DataInputView source) throws IOException {
-			return deserialize(source);
-		}
-
-		@Override
-		public void copy(DataInputView source, DataOutputView target) throws IOException {
-			keySerializer.copy(source, target);
-			namespaceSerializer.copy(source, target);
-			LongSerializer.INSTANCE.copy(source, target);
-		}
-
-		@Override
-		public boolean equals(Object obj) {
-			return obj == this ||
-				(obj != null && obj.getClass() == getClass() &&
-					keySerializer.equals(((TimerSerializer) obj).keySerializer) &&
-					namespaceSerializer.equals(((TimerSerializer) obj).namespaceSerializer));
-		}
-
-		@Override
-		public boolean canEqual(Object obj) {
-			return true;
-		}
-
-		@Override
-		public int hashCode() {
-			return getClass().hashCode();
-		}
-
-		@Override
-		public TypeSerializerConfigSnapshot snapshotConfiguration() {
-			throw new UnsupportedOperationException("This serializer is not registered for managed state.");
-		}
-
-		@Override
-		public CompatibilityResult<InternalTimer<K, N>> ensureCompatibility(TypeSerializerConfigSnapshot configSnapshot) {
-			throw new UnsupportedOperationException("This serializer is not registered for managed state.");
-		}
-	}
+	/**
+	 * Returns the namespace that is bound to this timer.
+	 */
+	N getNamespace();
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimerHeap.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimerHeap.java
@@ -1,0 +1,504 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
+
+import javax.annotation.Nonnegative;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Queue;
+import java.util.Set;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/**
+ * A heap-based priority queue for internal timers. This heap is supported by hash sets for fast contains
+ * (de-duplication) and deletes. The heap implementation is a simple binary tree stored inside an array. Element indexes
+ * in the heap array start at 1 instead of 0 to make array index computations a bit simpler in the hot methods.
+ *
+ * <p>Possible future improvements:
+ * <ul>
+ *  <li>We could also implement shrinking for the heap and the deduplication maps.</li>
+ *  <li>We could replace the deduplication maps with more efficient custom implementations. In particular, a hash set
+ * would be enough if it could return existing elements on unsuccessful adding, etc..</li>
+ * </ul>
+ *
+ * @param <K> type of the key of the internal timers managed by this priority queue.
+ * @param <N> type of the namespace of the internal timers managed by this priority queue.
+ */
+public class InternalTimerHeap<K, N> implements Queue<TimerHeapInternalTimer<K, N>>, Set<TimerHeapInternalTimer<K, N>> {
+
+	/**
+	 * A safe maximum size for arrays in the JVM.
+	 */
+	private static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
+
+	/**
+	 * Comparator for {@link TimerHeapInternalTimer}, based on the timestamp in ascending order.
+	 */
+	private static final Comparator<TimerHeapInternalTimer<?, ?>> COMPARATOR =
+		(o1, o2) -> Long.compare(o1.getTimestamp(), o2.getTimestamp());
+
+	/**
+	 * This array contains one hash set per key-group. The sets are used for fast de-duplication and deletes of timers.
+	 */
+	private final HashMap<TimerHeapInternalTimer<K, N>, TimerHeapInternalTimer<K, N>>[] deduplicationMapsByKeyGroup;
+
+	/**
+	 * The array that represents the heap-organized priority queue.
+	 */
+	private TimerHeapInternalTimer<K, N>[] queue;
+
+	/**
+	 * The current size of the priority queue.
+	 */
+	private int size;
+
+	/**
+	 * The key-group range of timers that are managed by this queue.
+	 */
+	private final KeyGroupRange keyGroupRange;
+
+	/**
+	 * The total number of key-groups of the job.
+	 */
+	private final int totalNumberOfKeyGroups;
+
+
+	/**
+	 * Creates an empty {@link InternalTimerHeap} with the requested initial capacity.
+	 *
+	 * @param minimumCapacity the minimum and initial capacity of this priority queue.
+	 */
+	@SuppressWarnings("unchecked")
+	InternalTimerHeap(
+		@Nonnegative int minimumCapacity,
+		@Nonnull KeyGroupRange keyGroupRange,
+		@Nonnegative int totalNumberOfKeyGroups) {
+
+		this.totalNumberOfKeyGroups = totalNumberOfKeyGroups;
+		this.keyGroupRange = keyGroupRange;
+
+		final int keyGroupsInLocalRange = keyGroupRange.getNumberOfKeyGroups();
+		final int deduplicationSetSize = 1 + minimumCapacity / keyGroupsInLocalRange;
+		this.deduplicationMapsByKeyGroup = new HashMap[keyGroupsInLocalRange];
+		for (int i = 0; i < keyGroupsInLocalRange; ++i) {
+			deduplicationMapsByKeyGroup[i] = new HashMap<>(deduplicationSetSize);
+		}
+
+		this.queue = new TimerHeapInternalTimer[1 + minimumCapacity];
+	}
+
+	/**
+	 * @see Set#add(Object)
+	 */
+	@Override
+	public boolean add(@Nonnull TimerHeapInternalTimer<K, N> timer) {
+
+		if (getDedupMapForKeyGroup(timer).putIfAbsent(timer, timer) == null) {
+			final int newSize = ++this.size;
+			checkCapacity(newSize);
+			moveElementToIdx(timer, newSize);
+			siftUp(newSize);
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+	/**
+	 * This behaves like {@link #add(TimerHeapInternalTimer)}.
+	 */
+	@Override
+	public boolean offer(@Nonnull TimerHeapInternalTimer<K, N> k) {
+		return add(k);
+	}
+
+	@Nullable
+	@Override
+	public TimerHeapInternalTimer<K, N> poll() {
+		return size() > 0 ? removeElementAtIndex(1) : null;
+	}
+
+	@Nonnull
+	@Override
+	public TimerHeapInternalTimer<K, N> remove() {
+		TimerHeapInternalTimer<K, N> pollResult = poll();
+		if (pollResult != null) {
+			return pollResult;
+		} else {
+			throw new NoSuchElementException("InternalTimerPriorityQueue is empty.");
+		}
+	}
+
+	@Nullable
+	@Override
+	public TimerHeapInternalTimer<K, N> peek() {
+		return size() > 0 ? queue[1] : null;
+	}
+
+	@Nonnull
+	@Override
+	public TimerHeapInternalTimer<K, N> element() {
+		TimerHeapInternalTimer<K, N> peekResult = peek();
+		if (peekResult != null) {
+			return peekResult;
+		} else {
+			throw new NoSuchElementException("InternalTimerPriorityQueue is empty.");
+		}
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return size() == 0;
+	}
+
+	@Override
+	public boolean contains(@Nullable Object o) {
+		return (o instanceof TimerHeapInternalTimer)
+			&& getDedupMapForKeyGroup((TimerHeapInternalTimer<?, ?>) o).containsKey(o);
+	}
+
+	@Override
+	public boolean remove(@Nullable Object o) {
+		if (o instanceof TimerHeapInternalTimer) {
+			return removeInternal((TimerHeapInternalTimer<?, ?>) o);
+		}
+		return false;
+	}
+
+	@Override
+	public boolean addAll(@Nullable Collection<? extends TimerHeapInternalTimer<K, N>> timers) {
+
+		if (timers == null) {
+			return true;
+		}
+
+		if (timers.size() > queue.length) {
+			checkCapacity(timers.size());
+		}
+
+		for (TimerHeapInternalTimer<K, N> k : timers) {
+			add(k);
+		}
+
+		return true;
+	}
+
+	@Nonnull
+	@Override
+	public Object[] toArray() {
+		return Arrays.copyOfRange(queue, 1, size + 1);
+	}
+
+	@SuppressWarnings({"unchecked", "SuspiciousSystemArraycopy"})
+	@Nonnull
+	@Override
+	public <T> T[] toArray(@Nonnull T[] array) {
+		if (array.length >= size) {
+			System.arraycopy(queue, 1, array, 0, size);
+			return array;
+		}
+		return (T[]) Arrays.copyOfRange(queue, 1, size + 1, array.getClass());
+	}
+
+	@Override
+	public boolean removeAll(@Nullable Collection<?> toRemove) {
+
+		if (toRemove == null) {
+			return false;
+		}
+
+		int oldSize = size();
+		for (Object o : toRemove) {
+			remove(o);
+		}
+		return size() == oldSize;
+	}
+
+	/**
+	 * Returns an iterator over the elements in this queue. The iterator
+	 * does not return the elements in any particular order.
+	 *
+	 * @return an iterator over the elements in this queue.
+	 */
+	@Nonnull
+	@Override
+	public Iterator<TimerHeapInternalTimer<K, N>> iterator() {
+		return new InternalTimerPriorityQueueIterator();
+	}
+
+	@Override
+	public boolean containsAll(@Nullable Collection<?> toCheck) {
+
+		if (toCheck == null) {
+			return true;
+		}
+
+		for (Object o : toCheck) {
+			if (!contains(o)) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	@Nonnegative
+	@Override
+	public int size() {
+		return size;
+	}
+
+	@Override
+	public void clear() {
+
+		Arrays.fill(queue, null);
+		for (HashMap<TimerHeapInternalTimer<K, N>, TimerHeapInternalTimer<K, N>> timerHashMap :
+			deduplicationMapsByKeyGroup) {
+			timerHashMap.clear();
+		}
+		size = 0;
+	}
+
+	/**
+	 * This method is currently not implemented.
+	 */
+	@Override
+	public boolean retainAll(@Nullable Collection<?> toRetain) {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Adds a new timer with the given timestamp, key, and namespace to the heap, if an identical timer was not yet
+	 * registered.
+	 *
+	 * @param timestamp the timer timestamp.
+	 * @param key the timer key.
+	 * @param namespace the timer namespace.
+	 * @return true iff a new timer with given timestamp, key, and namespace was added to the heap.
+	 */
+	boolean scheduleTimer(long timestamp, K key, N namespace) {
+		return add(new TimerHeapInternalTimer<>(timestamp, key, namespace));
+	}
+
+	/**
+	 * Stops timer with the given timestamp, key, and namespace by removing it from the heap, if it exists on the heap.
+	 *
+	 * @param timestamp the timer timestamp.
+	 * @param key the timer key.
+	 * @param namespace the timer namespace.
+	 * @return true iff a timer with given timestamp, key, and namespace was found and removed from the heap.
+	 */
+	boolean stopTimer(long timestamp, K key, N namespace) {
+		return removeInternal(new TimerHeapInternalTimer<>(timestamp, key, namespace));
+	}
+
+	/**
+	 * This method adds all the given timers to the heap.
+	 */
+	void restoreTimers(Collection<? extends InternalTimer<K, N>> toAdd) {
+		if (toAdd == null) {
+			return;
+		}
+
+		if (toAdd.size() > queue.length) {
+			checkCapacity(toAdd.size());
+		}
+
+		for (InternalTimer<K, N> k : toAdd) {
+			if (k instanceof TimerHeapInternalTimer) {
+				add((TimerHeapInternalTimer<K, N>) k);
+			} else {
+				scheduleTimer(k.getTimestamp(), k.getKey(), k.getNamespace());
+			}
+		}
+	}
+
+	private boolean removeInternal(TimerHeapInternalTimer<?, ?> timerToRemove) {
+
+		TimerHeapInternalTimer<K, N> storedTimer = getDedupMapForKeyGroup(timerToRemove).remove(timerToRemove);
+
+		if (storedTimer != null) {
+			removeElementAtIndex(storedTimer.getTimerHeapIndex());
+			return true;
+		}
+
+		return false;
+	}
+
+	private TimerHeapInternalTimer<K, N> removeElementAtIndex(int removeIdx) {
+		TimerHeapInternalTimer<K, N>[] heap = this.queue;
+		TimerHeapInternalTimer<K, N> removedValue = heap[removeIdx];
+
+		assert removedValue.getTimerHeapIndex() == removeIdx;
+
+		final int oldSize = size;
+
+		if (removeIdx != oldSize) {
+			TimerHeapInternalTimer<K, N> timer = heap[oldSize];
+			moveElementToIdx(timer, removeIdx);
+			siftDown(removeIdx);
+			if (heap[removeIdx] == timer) {
+				siftUp(removeIdx);
+			}
+		}
+
+		heap[oldSize] = null;
+		getDedupMapForKeyGroup(removedValue).remove(removedValue);
+
+		--size;
+		return removedValue;
+	}
+
+	private void siftUp(int idx) {
+		final TimerHeapInternalTimer<K, N>[] heap = this.queue;
+		TimerHeapInternalTimer<K, N> currentTimer = heap[idx];
+		int parentIdx = idx >>> 1;
+
+		while (parentIdx > 0 && COMPARATOR.compare(currentTimer, heap[parentIdx]) < 0) {
+			moveElementToIdx(heap[parentIdx], idx);
+			idx = parentIdx;
+			parentIdx = parentIdx >>> 1;
+		}
+
+		moveElementToIdx(currentTimer, idx);
+	}
+
+	private void siftDown(int idx) {
+		final TimerHeapInternalTimer<K, N>[] heap = this.queue;
+		final int heapSize = this.size;
+
+		TimerHeapInternalTimer<K, N> currentTimer = heap[idx];
+		int firstChildIdx = idx << 1;
+		int secondChildIdx = firstChildIdx + 1;
+
+		if (secondChildIdx <= heapSize && COMPARATOR.compare(heap[secondChildIdx], heap[firstChildIdx]) < 0) {
+			firstChildIdx = secondChildIdx;
+		}
+
+		while (firstChildIdx <= heapSize && COMPARATOR.compare(heap[firstChildIdx], currentTimer) < 0) {
+			moveElementToIdx(heap[firstChildIdx], idx);
+			idx = firstChildIdx;
+			firstChildIdx = idx << 1;
+			secondChildIdx = firstChildIdx + 1;
+
+			if (secondChildIdx <= heapSize && COMPARATOR.compare(heap[secondChildIdx], heap[firstChildIdx]) < 0) {
+				firstChildIdx = secondChildIdx;
+			}
+		}
+
+		moveElementToIdx(currentTimer, idx);
+	}
+
+	/**
+	 * Returns an unmodifiable set of all timers in the given key-group.
+	 */
+	Set<InternalTimer<K, N>> getTimersForKeyGroup(@Nonnegative int keyGroupIdx) {
+		return Collections.unmodifiableSet(getDedupMapForKeyGroup(keyGroupIdx).keySet());
+	}
+
+	private HashMap<TimerHeapInternalTimer<K, N>, TimerHeapInternalTimer<K, N>> getDedupMapForKeyGroup(
+		@Nonnegative int keyGroupIdx) {
+		return deduplicationMapsByKeyGroup[globalKeyGroupToLocalIndex(keyGroupIdx)];
+	}
+
+	@VisibleForTesting
+	@SuppressWarnings("unchecked")
+	List<Set<InternalTimer<K, N>>> getTimersByKeyGroup() {
+		List<Set<InternalTimer<K, N>>> result = new ArrayList<>(deduplicationMapsByKeyGroup.length);
+		for (int i = 0; i < deduplicationMapsByKeyGroup.length; ++i) {
+			result.add(i, Collections.unmodifiableSet(deduplicationMapsByKeyGroup[i].keySet()));
+		}
+		return result;
+	}
+
+	private void moveElementToIdx(TimerHeapInternalTimer<K, N> element, int idx) {
+		queue[idx] = element;
+		element.setTimerHeapIndex(idx);
+	}
+
+	private HashMap<TimerHeapInternalTimer<K, N>, TimerHeapInternalTimer<K, N>> getDedupMapForKeyGroup(
+		TimerHeapInternalTimer<?, ?> timer) {
+		int keyGroup = KeyGroupRangeAssignment.assignToKeyGroup(timer.getKey(), totalNumberOfKeyGroups);
+		return getDedupMapForKeyGroup(keyGroup);
+	}
+
+	private int globalKeyGroupToLocalIndex(int keyGroup) {
+		checkArgument(keyGroupRange.contains(keyGroup));
+		return keyGroup - keyGroupRange.getStartKeyGroup();
+	}
+
+	private void checkCapacity(int requested) {
+		int oldArraySize = queue.length;
+
+		if (requested >= oldArraySize) {
+			final int grow = (oldArraySize < 64) ? oldArraySize + 2 : oldArraySize >> 1;
+			int newArraySize = oldArraySize + grow;
+			if (newArraySize - MAX_ARRAY_SIZE > 0) {
+				if (newArraySize < 0 || requested > MAX_ARRAY_SIZE) {
+					throw new OutOfMemoryError("Required timer heap exceeds maximum size!");
+				} else {
+					newArraySize = MAX_ARRAY_SIZE;
+				}
+			}
+			queue = Arrays.copyOf(queue, newArraySize);
+		}
+		// TODO implement shrinking as well?
+	}
+
+	/**
+	 * {@link Iterator} implementation for {@link InternalTimerPriorityQueueIterator}.
+	 * {@link Iterator#remove()} is not supported.
+	 */
+	private class InternalTimerPriorityQueueIterator implements Iterator<TimerHeapInternalTimer<K, N>> {
+
+		private int iterationIdx;
+
+		InternalTimerPriorityQueueIterator() {
+			this.iterationIdx = 0;
+		}
+
+		@Override
+		public boolean hasNext() {
+			return iterationIdx < size;
+		}
+
+		@Override
+		public TimerHeapInternalTimer<K, N> next() {
+			if (iterationIdx >= size) {
+				throw new NoSuchElementException("Iterator has no next element.");
+			}
+			return queue[++iterationIdx];
+		}
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimerServiceSerializationProxy.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimerServiceSerializationProxy.java
@@ -22,7 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.core.io.PostVersionedIOReadableWritable;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
-import org.apache.flink.runtime.state.KeyGroupsList;
+import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 
 import java.io.IOException;
@@ -47,7 +47,7 @@ public class InternalTimerServiceSerializationProxy<K, N> extends PostVersionedI
 	/** Properties of restored timer services. */
 	private int keyGroupIdx;
 	private int totalKeyGroups;
-	private KeyGroupsList localKeyGroupRange;
+	private KeyGroupRange localKeyGroupRange;
 	private KeyContext keyContext;
 	private ProcessingTimeService processingTimeService;
 
@@ -58,7 +58,7 @@ public class InternalTimerServiceSerializationProxy<K, N> extends PostVersionedI
 			Map<String, HeapInternalTimerService<K, N>> timerServicesMapToPopulate,
 			ClassLoader userCodeClassLoader,
 			int totalKeyGroups,
-			KeyGroupsList localKeyGroupRange,
+			KeyGroupRange localKeyGroupRange,
 			KeyContext keyContext,
 			ProcessingTimeService processingTimeService,
 			int keyGroupIdx) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimersSnapshotReaderWriters.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimersSnapshotReaderWriters.java
@@ -96,7 +96,7 @@ public class InternalTimersSnapshotReaderWriters {
 		public final void writeTimersSnapshot(DataOutputView out) throws IOException {
 			writeKeyAndNamespaceSerializers(out);
 
-			InternalTimer.TimerSerializer<K, N> timerSerializer = new InternalTimer.TimerSerializer<>(
+			TimerHeapInternalTimer.TimerSerializer<K, N> timerSerializer = new TimerHeapInternalTimer.TimerSerializer<>(
 				timersSnapshot.getKeySerializer(),
 				timersSnapshot.getNamespaceSerializer());
 
@@ -215,9 +215,10 @@ public class InternalTimersSnapshotReaderWriters {
 
 			restoreKeyAndNamespaceSerializers(restoredTimersSnapshot, in);
 
-			InternalTimer.TimerSerializer<K, N> timerSerializer = new InternalTimer.TimerSerializer<>(
-				restoredTimersSnapshot.getKeySerializer(),
-				restoredTimersSnapshot.getNamespaceSerializer());
+			TimerHeapInternalTimer.TimerSerializer<K, N> timerSerializer =
+				new TimerHeapInternalTimer.TimerSerializer<>(
+					restoredTimersSnapshot.getKeySerializer(),
+					restoredTimersSnapshot.getNamespaceSerializer());
 
 			// read the event time timers
 			int sizeOfEventTimeTimers = in.readInt();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/TimerHeapInternalTimer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/TimerHeapInternalTimer.java
@@ -1,0 +1,235 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeutils.CompatibilityResult;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
+import org.apache.flink.api.common.typeutils.base.LongSerializer;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+
+import java.io.IOException;
+
+/**
+ * Implementation of {@link InternalTimer} for the {@link InternalTimerHeap}.
+ *
+ * @param <K> Type of the keys to which timers are scoped.
+ * @param <N> Type of the namespace to which timers are scoped.
+ */
+@Internal
+public final class TimerHeapInternalTimer<K, N> implements InternalTimer<K, N> {
+
+	/** The index that indicates that a tracked internal timer is not tracked. */
+	private static final int NOT_MANAGED_BY_TIMER_QUEUE_INDEX = Integer.MIN_VALUE;
+
+	private final long timestamp;
+
+	private final K key;
+
+	private final N namespace;
+
+	/**
+	 * This field holds the current physical index if this timer when it is managed by a timer heap so that we can
+	 * support fast deletes.
+	 */
+	private transient int timerHeapIndex;
+
+	TimerHeapInternalTimer(long timestamp, K key, N namespace) {
+		this.timestamp = timestamp;
+		this.key = key;
+		this.namespace = namespace;
+		this.timerHeapIndex = NOT_MANAGED_BY_TIMER_QUEUE_INDEX;
+	}
+
+	@Override
+	public long getTimestamp() {
+		return timestamp;
+	}
+
+	@Override
+	public K getKey() {
+		return key;
+	}
+
+	@Override
+	public N getNamespace() {
+		return namespace;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+
+		if (o instanceof InternalTimer) {
+			InternalTimer<?, ?> timer = (InternalTimer<?, ?>) o;
+			return timestamp == timer.getTimestamp()
+				&& key.equals(timer.getKey())
+				&& namespace.equals(timer.getNamespace());
+		}
+
+		return false;
+	}
+
+	/**
+	 * Returns the current index of this timer in the owning timer heap.
+	 */
+	int getTimerHeapIndex() {
+		return timerHeapIndex;
+	}
+
+	/**
+	 * Sets the current index of this timer in the owning timer heap and should only be called by the managing heap.
+	 * @param timerHeapIndex the new index in the timer heap.
+	 */
+	void setTimerHeapIndex(int timerHeapIndex) {
+		this.timerHeapIndex = timerHeapIndex;
+	}
+
+	/**
+	 * This method can be called to indicate that the timer is no longer managed be a timer heap, e.g. because it as
+	 * removed.
+	 */
+	void removedFromTimerQueue() {
+		setTimerHeapIndex(NOT_MANAGED_BY_TIMER_QUEUE_INDEX);
+	}
+
+	@Override
+	public int hashCode() {
+		int result = (int) (timestamp ^ (timestamp >>> 32));
+		result = 31 * result + key.hashCode();
+		result = 31 * result + namespace.hashCode();
+		return result;
+	}
+
+	@Override
+	public String toString() {
+		return "Timer{" +
+				"timestamp=" + timestamp +
+				", key=" + key +
+				", namespace=" + namespace +
+				'}';
+	}
+
+	/**
+	 * A {@link TypeSerializer} used to serialize/deserialize a {@link TimerHeapInternalTimer}.
+	 */
+	public static class TimerSerializer<K, N> extends TypeSerializer<InternalTimer<K, N>> {
+
+		private static final long serialVersionUID = 1119562170939152304L;
+
+		private final TypeSerializer<K> keySerializer;
+
+		private final TypeSerializer<N> namespaceSerializer;
+
+		TimerSerializer(TypeSerializer<K> keySerializer, TypeSerializer<N> namespaceSerializer) {
+			this.keySerializer = keySerializer;
+			this.namespaceSerializer = namespaceSerializer;
+		}
+
+		@Override
+		public boolean isImmutableType() {
+			return false;
+		}
+
+		@Override
+		public TypeSerializer<InternalTimer<K, N>> duplicate() {
+			return this;
+		}
+
+		@Override
+		public TimerHeapInternalTimer<K, N> createInstance() {
+			return null;
+		}
+
+		@Override
+		public TimerHeapInternalTimer<K, N> copy(InternalTimer<K, N> from) {
+			return new TimerHeapInternalTimer<>(from.getTimestamp(), from.getKey(), from.getNamespace());
+		}
+
+		@Override
+		public TimerHeapInternalTimer<K, N> copy(InternalTimer<K, N> from, InternalTimer<K, N> reuse) {
+			return copy(from);
+		}
+
+		@Override
+		public int getLength() {
+			// we do not have fixed length
+			return -1;
+		}
+
+		@Override
+		public void serialize(InternalTimer<K, N> record, DataOutputView target) throws IOException {
+			keySerializer.serialize(record.getKey(), target);
+			namespaceSerializer.serialize(record.getNamespace(), target);
+			LongSerializer.INSTANCE.serialize(record.getTimestamp(), target);
+		}
+
+		@Override
+		public TimerHeapInternalTimer<K, N> deserialize(DataInputView source) throws IOException {
+			K key = keySerializer.deserialize(source);
+			N namespace = namespaceSerializer.deserialize(source);
+			Long timestamp = LongSerializer.INSTANCE.deserialize(source);
+			return new TimerHeapInternalTimer<>(timestamp, key, namespace);
+		}
+
+		@Override
+		public TimerHeapInternalTimer<K, N> deserialize(InternalTimer<K, N> reuse, DataInputView source) throws IOException {
+			return deserialize(source);
+		}
+
+		@Override
+		public void copy(DataInputView source, DataOutputView target) throws IOException {
+			keySerializer.copy(source, target);
+			namespaceSerializer.copy(source, target);
+			LongSerializer.INSTANCE.copy(source, target);
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			return obj == this ||
+				(obj != null && obj.getClass() == getClass() &&
+					keySerializer.equals(((TimerSerializer) obj).keySerializer) &&
+					namespaceSerializer.equals(((TimerSerializer) obj).namespaceSerializer));
+		}
+
+		@Override
+		public boolean canEqual(Object obj) {
+			return true;
+		}
+
+		@Override
+		public int hashCode() {
+			return getClass().hashCode();
+		}
+
+		@Override
+		public TypeSerializerConfigSnapshot snapshotConfiguration() {
+			throw new UnsupportedOperationException("This serializer is not registered for managed state.");
+		}
+
+		@Override
+		public CompatibilityResult<InternalTimer<K, N>> ensureCompatibility(TypeSerializerConfigSnapshot configSnapshot) {
+			throw new UnsupportedOperationException("This serializer is not registered for managed state.");
+		}
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/TimerHeapInternalTimer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/TimerHeapInternalTimer.java
@@ -47,7 +47,7 @@ public final class TimerHeapInternalTimer<K, N> implements InternalTimer<K, N> {
 	private final N namespace;
 
 	/**
-	 * This field holds the current physical index if this timer when it is managed by a timer heap so that we can
+	 * This field holds the current physical index of this timer when it is managed by a timer heap so that we can
 	 * support fast deletes.
 	 */
 	private transient int timerHeapIndex;
@@ -153,7 +153,18 @@ public final class TimerHeapInternalTimer<K, N> implements InternalTimer<K, N> {
 
 		@Override
 		public TypeSerializer<InternalTimer<K, N>> duplicate() {
-			return this;
+
+			final TypeSerializer<K> keySerializerDuplicate = keySerializer.duplicate();
+			final TypeSerializer<N> namespaceSerializerDuplicate = namespaceSerializer.duplicate();
+
+			if (keySerializerDuplicate == keySerializer &&
+				namespaceSerializerDuplicate == namespaceSerializer) {
+				// all delegate serializers seem stateless, so this is also stateless.
+				return this;
+			} else {
+				// at least one delegate serializer seems to be stateful, so we return a new instance.
+				return new TimerSerializer<>(keySerializerDuplicate, namespaceSerializerDuplicate);
+			}
 		}
 
 		@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/HeapInternalTimerServiceTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/HeapInternalTimerServiceTest.java
@@ -24,7 +24,6 @@ import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
-import org.apache.flink.runtime.state.KeyGroupsList;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
 
@@ -41,6 +40,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
@@ -79,7 +79,7 @@ public class HeapInternalTimerServiceTest {
 
 		int startKeyGroupIdx = 7;
 		int endKeyGroupIdx = 21;
-		KeyGroupsList testKeyGroupList = new KeyGroupRange(startKeyGroupIdx, endKeyGroupIdx);
+		KeyGroupRange testKeyGroupList = new KeyGroupRange(startKeyGroupIdx, endKeyGroupIdx);
 
 		TestKeyContext keyContext = new TestKeyContext();
 
@@ -119,7 +119,7 @@ public class HeapInternalTimerServiceTest {
 		for (int i = 0; i < totalNoOfTimers; i++) {
 
 			// create the timer to be registered
-			InternalTimer<Integer, String> timer = new InternalTimer<>(10 + i, i, "hello_world_" + i);
+			TimerHeapInternalTimer<Integer, String> timer = new TimerHeapInternalTimer<>(10 + i, i, "hello_world_" + i);
 			int keyGroupIdx =  KeyGroupRangeAssignment.assignToKeyGroup(timer.getKey(), totalNoOfKeyGroups);
 
 			// add it in the adequate expected set of timers per keygroup
@@ -136,21 +136,23 @@ public class HeapInternalTimerServiceTest {
 			timerService.registerProcessingTimeTimer(timer.getNamespace(), timer.getTimestamp());
 		}
 
-		Set<InternalTimer<Integer, String>>[] eventTimeTimers = timerService.getEventTimeTimersPerKeyGroup();
-		Set<InternalTimer<Integer, String>>[] processingTimeTimers = timerService.getProcessingTimeTimersPerKeyGroup();
+		List<Set<InternalTimer<Integer, String>>> eventTimeTimers =
+			timerService.getEventTimeTimersPerKeyGroup();
+		List<Set<InternalTimer<Integer, String>>> processingTimeTimers =
+			timerService.getProcessingTimeTimersPerKeyGroup();
 
 		// finally verify that the actual timers per key group sets are the expected ones.
 		for (int i = 0; i < expectedNonEmptyTimerSets.length; i++) {
 			Set<InternalTimer<Integer, String>> expected = expectedNonEmptyTimerSets[i];
-			Set<InternalTimer<Integer, String>> actualEvent = eventTimeTimers[i];
-			Set<InternalTimer<Integer, String>> actualProcessing = processingTimeTimers[i];
+			Set<InternalTimer<Integer, String>> actualEvent = eventTimeTimers.get(i);
+			Set<InternalTimer<Integer, String>> actualProcessing = processingTimeTimers.get(i);
 
 			if (expected == null) {
-				Assert.assertNull(actualEvent);
-				Assert.assertNull(actualProcessing);
+				Assert.assertTrue(actualEvent.isEmpty());
+				Assert.assertTrue(actualProcessing.isEmpty());
 			} else {
-				Assert.assertArrayEquals(expected.toArray(), actualEvent.toArray());
-				Assert.assertArrayEquals(expected.toArray(), actualProcessing.toArray());
+				Assert.assertEquals(expected, actualEvent);
+				Assert.assertEquals(expected, actualProcessing);
 			}
 		}
 	}
@@ -379,10 +381,10 @@ public class HeapInternalTimerServiceTest {
 		timerService.advanceWatermark(10);
 
 		verify(mockTriggerable, times(4)).onEventTime(anyInternalTimer());
-		verify(mockTriggerable, times(1)).onEventTime(eq(new InternalTimer<>(10, key1, "ciao")));
-		verify(mockTriggerable, times(1)).onEventTime(eq(new InternalTimer<>(10, key1, "hello")));
-		verify(mockTriggerable, times(1)).onEventTime(eq(new InternalTimer<>(10, key2, "ciao")));
-		verify(mockTriggerable, times(1)).onEventTime(eq(new InternalTimer<>(10, key2, "hello")));
+		verify(mockTriggerable, times(1)).onEventTime(eq(new TimerHeapInternalTimer<>(10, key1, "ciao")));
+		verify(mockTriggerable, times(1)).onEventTime(eq(new TimerHeapInternalTimer<>(10, key1, "hello")));
+		verify(mockTriggerable, times(1)).onEventTime(eq(new TimerHeapInternalTimer<>(10, key2, "ciao")));
+		verify(mockTriggerable, times(1)).onEventTime(eq(new TimerHeapInternalTimer<>(10, key2, "hello")));
 
 		assertEquals(0, timerService.numEventTimeTimers());
 	}
@@ -424,10 +426,10 @@ public class HeapInternalTimerServiceTest {
 		processingTimeService.setCurrentTime(10);
 
 		verify(mockTriggerable, times(4)).onProcessingTime(anyInternalTimer());
-		verify(mockTriggerable, times(1)).onProcessingTime(eq(new InternalTimer<>(10, key1, "ciao")));
-		verify(mockTriggerable, times(1)).onProcessingTime(eq(new InternalTimer<>(10, key1, "hello")));
-		verify(mockTriggerable, times(1)).onProcessingTime(eq(new InternalTimer<>(10, key2, "ciao")));
-		verify(mockTriggerable, times(1)).onProcessingTime(eq(new InternalTimer<>(10, key2, "hello")));
+		verify(mockTriggerable, times(1)).onProcessingTime(eq(new TimerHeapInternalTimer<>(10, key1, "ciao")));
+		verify(mockTriggerable, times(1)).onProcessingTime(eq(new TimerHeapInternalTimer<>(10, key1, "hello")));
+		verify(mockTriggerable, times(1)).onProcessingTime(eq(new TimerHeapInternalTimer<>(10, key2, "ciao")));
+		verify(mockTriggerable, times(1)).onProcessingTime(eq(new TimerHeapInternalTimer<>(10, key2, "hello")));
 
 		assertEquals(0, timerService.numProcessingTimeTimers());
 	}
@@ -481,10 +483,10 @@ public class HeapInternalTimerServiceTest {
 		timerService.advanceWatermark(10);
 
 		verify(mockTriggerable, times(2)).onEventTime(anyInternalTimer());
-		verify(mockTriggerable, times(1)).onEventTime(eq(new InternalTimer<>(10, key1, "ciao")));
-		verify(mockTriggerable, times(0)).onEventTime(eq(new InternalTimer<>(10, key1, "hello")));
-		verify(mockTriggerable, times(0)).onEventTime(eq(new InternalTimer<>(10, key2, "ciao")));
-		verify(mockTriggerable, times(1)).onEventTime(eq(new InternalTimer<>(10, key2, "hello")));
+		verify(mockTriggerable, times(1)).onEventTime(eq(new TimerHeapInternalTimer<>(10, key1, "ciao")));
+		verify(mockTriggerable, times(0)).onEventTime(eq(new TimerHeapInternalTimer<>(10, key1, "hello")));
+		verify(mockTriggerable, times(0)).onEventTime(eq(new TimerHeapInternalTimer<>(10, key2, "ciao")));
+		verify(mockTriggerable, times(1)).onEventTime(eq(new TimerHeapInternalTimer<>(10, key2, "hello")));
 
 		assertEquals(0, timerService.numEventTimeTimers());
 	}
@@ -538,10 +540,10 @@ public class HeapInternalTimerServiceTest {
 		processingTimeService.setCurrentTime(10);
 
 		verify(mockTriggerable, times(2)).onProcessingTime(anyInternalTimer());
-		verify(mockTriggerable, times(1)).onProcessingTime(eq(new InternalTimer<>(10, key1, "ciao")));
-		verify(mockTriggerable, times(0)).onProcessingTime(eq(new InternalTimer<>(10, key1, "hello")));
-		verify(mockTriggerable, times(0)).onProcessingTime(eq(new InternalTimer<>(10, key2, "ciao")));
-		verify(mockTriggerable, times(1)).onProcessingTime(eq(new InternalTimer<>(10, key2, "hello")));
+		verify(mockTriggerable, times(1)).onProcessingTime(eq(new TimerHeapInternalTimer<>(10, key1, "ciao")));
+		verify(mockTriggerable, times(0)).onProcessingTime(eq(new TimerHeapInternalTimer<>(10, key1, "hello")));
+		verify(mockTriggerable, times(0)).onProcessingTime(eq(new TimerHeapInternalTimer<>(10, key2, "ciao")));
+		verify(mockTriggerable, times(1)).onProcessingTime(eq(new TimerHeapInternalTimer<>(10, key2, "hello")));
 
 		assertEquals(0, timerService.numEventTimeTimers());
 	}
@@ -635,11 +637,11 @@ public class HeapInternalTimerServiceTest {
 		timerService.advanceWatermark(10);
 
 		verify(mockTriggerable2, times(2)).onProcessingTime(anyInternalTimer());
-		verify(mockTriggerable2, times(1)).onProcessingTime(eq(new InternalTimer<>(10, key1, "ciao")));
-		verify(mockTriggerable2, times(1)).onProcessingTime(eq(new InternalTimer<>(10, key2, "hello")));
+		verify(mockTriggerable2, times(1)).onProcessingTime(eq(new TimerHeapInternalTimer<>(10, key1, "ciao")));
+		verify(mockTriggerable2, times(1)).onProcessingTime(eq(new TimerHeapInternalTimer<>(10, key2, "hello")));
 		verify(mockTriggerable2, times(2)).onEventTime(anyInternalTimer());
-		verify(mockTriggerable2, times(1)).onEventTime(eq(new InternalTimer<>(10, key1, "hello")));
-		verify(mockTriggerable2, times(1)).onEventTime(eq(new InternalTimer<>(10, key2, "ciao")));
+		verify(mockTriggerable2, times(1)).onEventTime(eq(new TimerHeapInternalTimer<>(10, key1, "hello")));
+		verify(mockTriggerable2, times(1)).onEventTime(eq(new TimerHeapInternalTimer<>(10, key2, "ciao")));
 
 		assertEquals(0, timerService.numEventTimeTimers());
 	}
@@ -737,11 +739,11 @@ public class HeapInternalTimerServiceTest {
 		timerService1.advanceWatermark(10);
 
 		verify(mockTriggerable1, times(1)).onProcessingTime(anyInternalTimer());
-		verify(mockTriggerable1, times(1)).onProcessingTime(eq(new InternalTimer<>(10, key1, "ciao")));
-		verify(mockTriggerable1, never()).onProcessingTime(eq(new InternalTimer<>(10, key2, "hello")));
+		verify(mockTriggerable1, times(1)).onProcessingTime(eq(new TimerHeapInternalTimer<>(10, key1, "ciao")));
+		verify(mockTriggerable1, never()).onProcessingTime(eq(new TimerHeapInternalTimer<>(10, key2, "hello")));
 		verify(mockTriggerable1, times(1)).onEventTime(anyInternalTimer());
-		verify(mockTriggerable1, times(1)).onEventTime(eq(new InternalTimer<>(10, key1, "hello")));
-		verify(mockTriggerable1, never()).onEventTime(eq(new InternalTimer<>(10, key2, "ciao")));
+		verify(mockTriggerable1, times(1)).onEventTime(eq(new TimerHeapInternalTimer<>(10, key1, "hello")));
+		verify(mockTriggerable1, never()).onEventTime(eq(new TimerHeapInternalTimer<>(10, key2, "ciao")));
 
 		assertEquals(0, timerService1.numEventTimeTimers());
 
@@ -749,11 +751,11 @@ public class HeapInternalTimerServiceTest {
 		timerService2.advanceWatermark(10);
 
 		verify(mockTriggerable2, times(1)).onProcessingTime(anyInternalTimer());
-		verify(mockTriggerable2, never()).onProcessingTime(eq(new InternalTimer<>(10, key1, "ciao")));
-		verify(mockTriggerable2, times(1)).onProcessingTime(eq(new InternalTimer<>(10, key2, "hello")));
+		verify(mockTriggerable2, never()).onProcessingTime(eq(new TimerHeapInternalTimer<>(10, key1, "ciao")));
+		verify(mockTriggerable2, times(1)).onProcessingTime(eq(new TimerHeapInternalTimer<>(10, key2, "hello")));
 		verify(mockTriggerable2, times(1)).onEventTime(anyInternalTimer());
-		verify(mockTriggerable2, never()).onEventTime(eq(new InternalTimer<>(10, key1, "hello")));
-		verify(mockTriggerable2, times(1)).onEventTime(eq(new InternalTimer<>(10, key2, "ciao")));
+		verify(mockTriggerable2, never()).onEventTime(eq(new TimerHeapInternalTimer<>(10, key1, "hello")));
+		verify(mockTriggerable2, times(1)).onEventTime(eq(new TimerHeapInternalTimer<>(10, key2, "ciao")));
 
 		assertEquals(0, timerService2.numEventTimeTimers());
 	}
@@ -795,7 +797,7 @@ public class HeapInternalTimerServiceTest {
 			Triggerable<Integer, String> triggerable,
 			KeyContext keyContext,
 			ProcessingTimeService processingTimeService,
-			KeyGroupsList keyGroupList,
+			KeyGroupRange keyGroupList,
 			int maxParallelism) {
 		HeapInternalTimerService<Integer, String> service =
 			new HeapInternalTimerService<>(
@@ -814,7 +816,7 @@ public class HeapInternalTimerServiceTest {
 			Triggerable<Integer, String> triggerable,
 			KeyContext keyContext,
 			ProcessingTimeService processingTimeService,
-			KeyGroupsList keyGroupsList,
+			KeyGroupRange keyGroupsList,
 			int maxParallelism) throws Exception {
 
 		// create an empty service

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/InternalTimerHeapTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/InternalTimerHeapTest.java
@@ -1,0 +1,469 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators;
+
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.VoidNamespace;
+import org.apache.flink.util.Preconditions;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+/**
+ * Tests for {@link InternalTimerHeap}.
+ */
+public class InternalTimerHeapTest {
+
+	private static final KeyGroupRange KEY_GROUP_RANGE = new KeyGroupRange(0, 1);
+
+	private static void insertRandomTimers(
+		InternalTimerHeap<Integer, VoidNamespace> timerPriorityQueue,
+		int count) {
+		insertRandomTimers(timerPriorityQueue, null, count);
+	}
+
+	private static void insertRandomTimers(
+		InternalTimerHeap<Integer, VoidNamespace> timerPriorityQueue,
+		Set<TimerHeapInternalTimer<Integer, VoidNamespace>> checkSet,
+		int count) {
+
+		ThreadLocalRandom localRandom = ThreadLocalRandom.current();
+
+		for (int i = 0; i < count; ++i) {
+			TimerHeapInternalTimer<Integer, VoidNamespace> timer =
+				new TimerHeapInternalTimer<>(localRandom.nextLong(), i, VoidNamespace.INSTANCE);
+			if (checkSet != null) {
+				Preconditions.checkState(checkSet.add(timer));
+			}
+			Assert.assertTrue(timerPriorityQueue.add(timer));
+		}
+	}
+
+	private static InternalTimerHeap<Integer, VoidNamespace> newPriorityQueue(int initialCapacity) {
+		return new InternalTimerHeap<>(
+			initialCapacity,
+			KEY_GROUP_RANGE,
+			KEY_GROUP_RANGE.getNumberOfKeyGroups());
+	}
+
+	@Test
+	public void testCombined() {
+		final int initialCapacity = 4;
+		final int testSize = 1000;
+		InternalTimerHeap<Integer, VoidNamespace> timerPriorityQueue = newPriorityQueue(initialCapacity);
+		HashSet<TimerHeapInternalTimer<Integer, VoidNamespace>> checkSet = new HashSet<>(testSize);
+
+		insertRandomTimers(timerPriorityQueue, checkSet, testSize);
+
+		long lastTimestamp = Long.MIN_VALUE;
+		int lastSize = timerPriorityQueue.size();
+		Assert.assertEquals(testSize, lastSize);
+		TimerHeapInternalTimer<Integer, VoidNamespace> timer;
+		while ((timer = timerPriorityQueue.peek()) != null) {
+			Assert.assertFalse(timerPriorityQueue.isEmpty());
+			Assert.assertEquals(lastSize, timerPriorityQueue.size());
+			Assert.assertEquals(timer, timerPriorityQueue.poll());
+			Assert.assertTrue(checkSet.remove(timer));
+			Assert.assertTrue(timer.getTimestamp() >= lastTimestamp);
+			lastTimestamp = timer.getTimestamp();
+			--lastSize;
+		}
+
+		Assert.assertTrue(timerPriorityQueue.isEmpty());
+		Assert.assertEquals(0, timerPriorityQueue.size());
+		Assert.assertEquals(0, checkSet.size());
+	}
+
+	@Test
+	public void testAdd() {
+		testAddOfferCommon(InternalTimerHeap<Integer, VoidNamespace>::add);
+	}
+
+	@Test
+	public void testOffer() {
+		testAddOfferCommon(InternalTimerHeap<Integer, VoidNamespace>::offer);
+	}
+
+	@Test
+	public void testRemove() {
+		InternalTimerHeap<Integer, VoidNamespace> timerPriorityQueue = newPriorityQueue(3);
+
+		try {
+			timerPriorityQueue.remove();
+			Assert.fail();
+		} catch (NoSuchElementException ignore) {
+		}
+
+		testRemovePollCommon(timerPriorityQueue, InternalTimerHeap::remove);
+
+		try {
+			timerPriorityQueue.remove();
+			Assert.fail();
+		} catch (NoSuchElementException ignore) {
+		}
+	}
+
+	@Test
+	public void testPoll() {
+		InternalTimerHeap<Integer, VoidNamespace> timerPriorityQueue = newPriorityQueue(3);
+
+		Assert.assertNull(timerPriorityQueue.poll());
+
+		testRemovePollCommon(timerPriorityQueue, InternalTimerHeap::poll);
+
+		Assert.assertNull(timerPriorityQueue.poll());
+	}
+
+	@Test
+	public void testRemoveTimer() {
+
+		InternalTimerHeap<Integer, VoidNamespace> timerPriorityQueue = newPriorityQueue(3);
+
+		final int testSize = 345;
+		HashSet<TimerHeapInternalTimer<Integer, VoidNamespace>> checkSet = new HashSet<>(testSize);
+
+		insertRandomTimers(timerPriorityQueue, checkSet, testSize);
+
+		// check that the whole set is still in order
+		while (!checkSet.isEmpty()) {
+
+			Iterator<TimerHeapInternalTimer<Integer, VoidNamespace>> iterator = checkSet.iterator();
+			InternalTimer<Integer, VoidNamespace> timer = iterator.next();
+			iterator.remove();
+			Assert.assertTrue(timerPriorityQueue.remove(timer));
+			Assert.assertEquals(checkSet.size(), timerPriorityQueue.size());
+
+			long lastTimestamp = Long.MIN_VALUE;
+
+			while ((timer = timerPriorityQueue.poll()) != null) {
+				Assert.assertTrue(timer.getTimestamp() >= lastTimestamp);
+				lastTimestamp = timer.getTimestamp();
+			}
+
+			Assert.assertTrue(timerPriorityQueue.isEmpty());
+
+			timerPriorityQueue.addAll(checkSet);
+		}
+	}
+
+	@Test
+	public void testPeek() {
+		InternalTimerHeap<Integer, VoidNamespace> timerPriorityQueue =
+			newPriorityQueue(1);
+
+		Assert.assertNull(timerPriorityQueue.peek());
+
+		testPeekElementCommon(timerPriorityQueue, InternalTimerHeap::peek);
+	}
+
+	@Test
+	public void testElement() {
+		InternalTimerHeap<Integer, VoidNamespace> timerPriorityQueue =
+			newPriorityQueue(1);
+		try {
+			timerPriorityQueue.element();
+			Assert.fail();
+		} catch (NoSuchElementException ignore) {
+		}
+		testPeekElementCommon(timerPriorityQueue, InternalTimerHeap::element);
+	}
+
+	@Test
+	public void testIsEmpty() {
+		InternalTimerHeap<Integer, VoidNamespace> timerPriorityQueue =
+			newPriorityQueue(1);
+
+		Assert.assertTrue(timerPriorityQueue.isEmpty());
+
+		TimerHeapInternalTimer<Integer, VoidNamespace> timer =
+			new TimerHeapInternalTimer<>(42L, 4711, VoidNamespace.INSTANCE);
+
+		timerPriorityQueue.add(timer);
+		Assert.assertFalse(timerPriorityQueue.isEmpty());
+
+		timerPriorityQueue.poll();
+		Assert.assertTrue(timerPriorityQueue.isEmpty());
+	}
+
+	@Test
+	public void testContains() {
+		InternalTimerHeap<Integer, VoidNamespace> timerPriorityQueue =
+			newPriorityQueue(1);
+		TimerHeapInternalTimer<Integer, VoidNamespace> timer =
+			new TimerHeapInternalTimer<>(42L, 4711, VoidNamespace.INSTANCE);
+
+		Assert.assertFalse(timerPriorityQueue.contains(timer));
+
+		timerPriorityQueue.add(timer);
+		Assert.assertTrue(timerPriorityQueue.contains(timer));
+
+		timerPriorityQueue.remove(timer);
+		Assert.assertFalse(timerPriorityQueue.contains(timer));
+	}
+
+	@Test
+	public void testAddAll() {
+		final int testSize = 10;
+		HashSet<TimerHeapInternalTimer<Integer, VoidNamespace>> timerSet = new HashSet<>(testSize);
+		for (int i = 0; i < testSize; ++i) {
+			timerSet.add(new TimerHeapInternalTimer<>(i, i, VoidNamespace.INSTANCE));
+		}
+
+		List<TimerHeapInternalTimer<Integer, VoidNamespace>> twoTimesTimerSet = new ArrayList<>(timerSet.size() * 2);
+		twoTimesTimerSet.addAll(timerSet);
+		twoTimesTimerSet.addAll(timerSet);
+
+		InternalTimerHeap<Integer, VoidNamespace> timerPriorityQueue =
+			newPriorityQueue(1);
+
+		timerPriorityQueue.addAll(twoTimesTimerSet);
+
+		Assert.assertEquals(timerSet.size(), timerPriorityQueue.size());
+
+		for (TimerHeapInternalTimer<Integer, VoidNamespace> timer : timerPriorityQueue) {
+			Assert.assertTrue(timerSet.remove(timer));
+		}
+
+		Assert.assertTrue(timerSet.isEmpty());
+	}
+
+	@Test
+	public void testToArray() {
+		final int testSize = 10;
+		HashSet<TimerHeapInternalTimer<Integer, VoidNamespace>> checkSet = new HashSet<>(testSize);
+		InternalTimerHeap<Integer, VoidNamespace> timerPriorityQueue =
+			newPriorityQueue(1);
+
+		Assert.assertEquals(0, timerPriorityQueue.toArray().length);
+
+		insertRandomTimers(timerPriorityQueue, checkSet, testSize);
+
+		Object[] toArray = timerPriorityQueue.toArray();
+		Assert.assertEquals(timerPriorityQueue.size(), toArray.length);
+
+		for (Object o : toArray) {
+			if (o instanceof TimerHeapInternalTimer) {
+				Assert.assertTrue(checkSet.remove(o));
+			}
+		}
+
+		Assert.assertTrue(checkSet.isEmpty());
+	}
+
+	@Test
+	public void testToArrayGeneric() {
+		final int testSize = 10;
+		HashSet<TimerHeapInternalTimer<Integer, VoidNamespace>> checkSet = new HashSet<>(testSize);
+		InternalTimerHeap<Integer, VoidNamespace> timerPriorityQueue =
+			newPriorityQueue(1);
+
+		Assert.assertEquals(0, timerPriorityQueue.toArray().length);
+
+		insertRandomTimers(timerPriorityQueue, checkSet, testSize);
+
+		int[] arraySizes = new int[]{0, timerPriorityQueue.size(), timerPriorityQueue.size() + 2};
+
+		for (int arraySize : arraySizes) {
+			HashSet<TimerHeapInternalTimer<Integer, VoidNamespace>> checkSetCopy = new HashSet<>(checkSet);
+			TimerHeapInternalTimer[] toArray = timerPriorityQueue.toArray(new TimerHeapInternalTimer[arraySize]);
+			Assert.assertEquals(Math.max(timerPriorityQueue.size(), arraySize), toArray.length);
+
+			for (TimerHeapInternalTimer o : toArray) {
+				if (o != null) {
+					Assert.assertTrue(checkSetCopy.remove(o));
+				}
+			}
+			Assert.assertTrue(checkSetCopy.isEmpty());
+		}
+	}
+
+	@Test
+	public void testRemoveAll() {
+		final int testSize = 10;
+		InternalTimerHeap<Integer, VoidNamespace> timerPriorityQueue =
+			newPriorityQueue(1);
+		timerPriorityQueue.removeAll(Collections.<TimerHeapInternalTimer<Integer, VoidNamespace>>emptyList());
+		HashSet<TimerHeapInternalTimer<Integer, VoidNamespace>> checkSet = new HashSet<>(testSize);
+		insertRandomTimers(timerPriorityQueue, checkSet, testSize);
+
+	}
+
+	@Test
+	public void testRetainAll() {
+		InternalTimerHeap<Integer, VoidNamespace> timerPriorityQueue =
+			newPriorityQueue(1);
+		try {
+			timerPriorityQueue.retainAll(Collections.emptyList());
+			Assert.fail();
+		} catch (UnsupportedOperationException ignore) {
+		}
+	}
+
+	@Test
+	public void testIterator() {
+		InternalTimerHeap<Integer, VoidNamespace> timerPriorityQueue =
+			newPriorityQueue(1);
+
+		// test empty iterator
+		Iterator<TimerHeapInternalTimer<Integer, VoidNamespace>> iterator = timerPriorityQueue.iterator();
+		Assert.assertFalse(iterator.hasNext());
+		try {
+			iterator.next();
+			Assert.fail();
+		} catch (NoSuchElementException ignore) {
+		}
+
+		// iterate some data
+		final int testSize = 10;
+		HashSet<TimerHeapInternalTimer<Integer, VoidNamespace>> checkSet = new HashSet<>(testSize);
+		insertRandomTimers(timerPriorityQueue, checkSet, testSize);
+		iterator = timerPriorityQueue.iterator();
+		while (iterator.hasNext()) {
+			Assert.assertTrue(checkSet.remove(iterator.next()));
+		}
+		Assert.assertTrue(checkSet.isEmpty());
+
+		// test remove is not supported
+		try {
+			iterator.remove();
+			Assert.fail();
+		} catch (UnsupportedOperationException ignore) {
+		}
+	}
+
+	@Test
+	public void testClear() {
+		InternalTimerHeap<Integer, VoidNamespace> timerPriorityQueue =
+			newPriorityQueue(1);
+
+		int count = 10;
+		insertRandomTimers(timerPriorityQueue, count);
+		Assert.assertEquals(count, timerPriorityQueue.size());
+		timerPriorityQueue.clear();
+		Assert.assertEquals(0, timerPriorityQueue.size());
+	}
+
+	@Test
+	public void testScheduleTimer() {
+		InternalTimerHeap<Integer, VoidNamespace> timerPriorityQueue =
+			newPriorityQueue(1);
+
+		final long timestamp = 42L;
+		final Integer key = 4711;
+		Assert.assertTrue(timerPriorityQueue.scheduleTimer(timestamp, key, VoidNamespace.INSTANCE));
+		Assert.assertFalse(timerPriorityQueue.scheduleTimer(timestamp, key, VoidNamespace.INSTANCE));
+		Assert.assertEquals(1, timerPriorityQueue.size());
+		final InternalTimer<Integer, VoidNamespace> timer = timerPriorityQueue.remove();
+		Assert.assertEquals(timestamp, timer.getTimestamp());
+		Assert.assertEquals(key, timer.getKey());
+		Assert.assertEquals(VoidNamespace.INSTANCE, timer.getNamespace());
+	}
+
+	@Test
+	public void testStopTimer() {
+		InternalTimerHeap<Integer, VoidNamespace> timerPriorityQueue =
+			newPriorityQueue(1);
+
+		final long timestamp = 42L;
+		final Integer key = 4711;
+		Assert.assertFalse(timerPriorityQueue.stopTimer(timestamp, key, VoidNamespace.INSTANCE));
+		Assert.assertTrue(timerPriorityQueue.scheduleTimer(timestamp, key, VoidNamespace.INSTANCE));
+		Assert.assertTrue(timerPriorityQueue.stopTimer(timestamp, key, VoidNamespace.INSTANCE));
+		Assert.assertFalse(timerPriorityQueue.stopTimer(timestamp, key, VoidNamespace.INSTANCE));
+		Assert.assertTrue(timerPriorityQueue.isEmpty());
+	}
+
+	private void testAddOfferCommon(
+		BiFunction<InternalTimerHeap, TimerHeapInternalTimer<Integer, VoidNamespace>, Boolean> testMethod) {
+
+		InternalTimerHeap<Integer, VoidNamespace> timerPriorityQueue = newPriorityQueue(1);
+
+		Assert.assertTrue(timerPriorityQueue.isEmpty());
+
+		TimerHeapInternalTimer<Integer, VoidNamespace> timer1 =
+			new TimerHeapInternalTimer<>(42L, 4711, VoidNamespace.INSTANCE);
+		TimerHeapInternalTimer<Integer, VoidNamespace> timer2 =
+			new TimerHeapInternalTimer<>(43L, 4712, VoidNamespace.INSTANCE);
+
+		// add first timer
+		Assert.assertTrue(testMethod.apply(timerPriorityQueue, timer1));
+		Assert.assertEquals(1, timerPriorityQueue.size());
+
+		// add second timer
+		Assert.assertTrue(testMethod.apply(timerPriorityQueue, timer2));
+		Assert.assertEquals(2, timerPriorityQueue.size());
+
+		// check adding first timer again, duplicate should not be added
+		Assert.assertFalse(testMethod.apply(timerPriorityQueue, timer1));
+		Assert.assertEquals(2, timerPriorityQueue.size());
+	}
+
+	private void testPeekElementCommon(
+		InternalTimerHeap<Integer, VoidNamespace> timerPriorityQueue,
+		Function<InternalTimerHeap, TimerHeapInternalTimer<Integer, VoidNamespace>> testFun) {
+
+		TimerHeapInternalTimer<Integer, VoidNamespace> timer1 =
+			new TimerHeapInternalTimer<>(42L, 4711, VoidNamespace.INSTANCE);
+		timerPriorityQueue.add(timer1);
+
+		Assert.assertEquals(timer1, testFun.apply(timerPriorityQueue));
+
+		TimerHeapInternalTimer<Integer, VoidNamespace> timer2 =
+			new TimerHeapInternalTimer<>(43L, 4712, VoidNamespace.INSTANCE);
+		timerPriorityQueue.add(timer2);
+
+		Assert.assertEquals(timer1, testFun.apply(timerPriorityQueue));
+
+		TimerHeapInternalTimer<Integer, VoidNamespace> timer3 =
+			new TimerHeapInternalTimer<>(41L, 4712, VoidNamespace.INSTANCE);
+		timerPriorityQueue.add(timer3);
+
+		Assert.assertEquals(timer3, testFun.apply(timerPriorityQueue));
+		Assert.assertEquals(3, timerPriorityQueue.size());
+	}
+
+	private void testRemovePollCommon(
+		InternalTimerHeap<Integer, VoidNamespace> timerPriorityQueue,
+		Function<InternalTimerHeap<Integer, VoidNamespace>, TimerHeapInternalTimer<Integer, VoidNamespace>> fun) {
+
+		final int testSize = 345;
+		HashSet<TimerHeapInternalTimer<Integer, VoidNamespace>> checkSet = new HashSet<>(testSize);
+		insertRandomTimers(timerPriorityQueue, checkSet, testSize);
+
+		long lastTimestamp = Long.MIN_VALUE;
+		while (!timerPriorityQueue.isEmpty()) {
+			TimerHeapInternalTimer<Integer, VoidNamespace> removed = fun.apply(timerPriorityQueue);
+			Assert.assertTrue(checkSet.remove(removed));
+			Assert.assertTrue(removed.getTimestamp() >= lastTimestamp);
+			lastTimestamp = removed.getTimestamp();
+		}
+		Assert.assertTrue(checkSet.isEmpty());
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/InternalTimerHeapTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/InternalTimerHeapTest.java
@@ -243,7 +243,8 @@ public class InternalTimerHeapTest {
 		InternalTimerHeap<Integer, VoidNamespace> timerPriorityQueue =
 			newPriorityQueue(1);
 
-		timerPriorityQueue.addAll(twoTimesTimerSet);
+		Assert.assertTrue(timerPriorityQueue.addAll(twoTimesTimerSet));
+		Assert.assertFalse(timerPriorityQueue.addAll(twoTimesTimerSet));
 
 		Assert.assertEquals(timerSet.size(), timerPriorityQueue.size());
 


### PR DESCRIPTION
…service.

## What is the purpose of the change

This PR introduces `InternalTimerHeap`, as data structure of in-flight timers that are stored in memory. This structure is a combination of the previous `PriorityQueue` and `HashSet` that have previously been used by the `HeapInternalTimerService`, enhanced by a support for faster deletion of timers.


## Brief change log

- Made `InternalTimer` an interface, `TimerHeapInternalTimer` is currently the only implementation. The interface is in place to hide management methods like `setTimerHeapIndex(...)` from code that deals with the net information of timers.

- Introduced `InternalTimerHeap` structure and replaced PQ+set in `HeapInternalTimerService`.


## Verifying this change

Added the test `InternalTimerHeapTest` for `InternalTimerHeap`. Everything else is covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (yes)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
