### PR TITLE
[FLINK-9426][test] Harden RocksDBWriteBatchPerformanceTest.benchMark()

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/benchmark/RocksDBWriteBatchPerformanceTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/benchmark/RocksDBWriteBatchPerformanceTest.java
@@ -24,7 +24,6 @@ import org.apache.flink.contrib.streaming.state.RocksDBWriteBatchWrapper;
 import org.apache.flink.testutils.junit.RetryOnFailure;
 import org.apache.flink.util.TestLogger;
 
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -94,8 +93,6 @@ public class RocksDBWriteBatchPerformanceTest extends TestLogger {
 		log.info("Single Put with disableWAL is false for {} records costs {}" , num, t1);
 		log.info("WriteBatch with disableWAL is false for {} records costs {}" , num, t2);
 
-		Assert.assertTrue(t2 < t1);
-
 		log.info("--------------> put VS WriteBatch with disableWAL=true <--------------");
 
 		t1 = benchMarkHelper(data, true, WRITETYPE.PUT);
@@ -103,8 +100,6 @@ public class RocksDBWriteBatchPerformanceTest extends TestLogger {
 
 		log.info("Single Put with disableWAL is true for {} records costs {}" , num, t1);
 		log.info("WriteBatch with disableWAL is true for {} records costs {}" , num, t2);
-
-		Assert.assertTrue(t2 < t1);
 	}
 
 	private enum WRITETYPE {PUT, WRITE_BATCH}


### PR DESCRIPTION
## What is the purpose of the change

We use the assert to check the performance of WriteBatch is better than Put(), this should be true in general, but in sometimes this could also be false. We may need to follow the other tests under the `org.apache.flink.contrib.streaming.state.benchmark.*`, only use the timeout property to guard the tests.

## Brief change log

  - remove asserts from RocksDBWriteBatchPerformanceTest.benchMark()

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

No