### PR TITLE
[FLINK-9409][mvn] add missing assembly dependencies to flink-dist/pom…

### DIFF
--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -342,6 +342,20 @@ under the License.
 			<version>${project.version}</version>
 			<scope>provided</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-avro</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-json</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
 		<!-- end optional Flink libraries -->
 
 		<!-- test dependencies -->


### PR DESCRIPTION
## What is the purpose of the change

Building Flink via `mvn clean install -pl flink-dist -am` currently fails because `flink-json` is not defined as a dependency in `flink-dist/pom.xml` although being used in the assembly.

The same is true for `flink-avro` but this seems to be built due to some indirect dependency.

Please also merge to `master` after accepting.

## Brief change log

- add the following sub-projects to the optional Flink library dependencies in `flink-dist/pom.xml`:
  - `flink-json`
  - `flink-avro`

## Verifying this change

- build successfully with `mvn clean && mvn install -pl flink-dist -am`
- checked that `flink-dist_2.11-1.5-SNAPSHOT.jar` is the same as before

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no** (only internally)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
