### PR TITLE
[FLINK-9420][TableAPI & SQL] Add tests for SQL IN sub-query operator in streaming

### DIFF
--- a/docs/dev/table/sql.md
+++ b/docs/dev/table/sql.md
@@ -551,7 +551,7 @@ FROM (
     <tr>
       <td>
         <strong>In</strong><br>
-        <span class="label label-primary">Batch</span>
+        <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span>
       </td>
       <td>
       Returns true if an expression exists in a given table sub-query. The sub-query table must consist of one column. This column must have the same data type as the expression.
@@ -1093,7 +1093,7 @@ value IN (sub-query)
 {% endhighlight %}
       </td>
       <td>
-        <p>Returns TRUE if <i>value</i> is equal to a row returned by sub-query. This operation is not supported in a streaming environment yet.</p>
+        <p>Returns TRUE if <i>value</i> is equal to a row returned by sub-query.</p>
       </td>
     </tr>
 
@@ -1104,7 +1104,7 @@ value NOT IN (sub-query)
 {% endhighlight %}
       </td>
       <td>
-        <p>Returns TRUE if <i>value</i> is not equal to every row returned by sub-query. This operation is not supported in a streaming environment yet.</p>
+        <p>Returns TRUE if <i>value</i> is not equal to every row returned by sub-query.</p>
       </td>
     </tr>
 

--- a/docs/dev/table/tableApi.md
+++ b/docs/dev/table/tableApi.md
@@ -817,7 +817,7 @@ Table result = left.minusAll(right);
     <tr>
       <td>
         <strong>In</strong><br>
-        <span class="label label-primary">Batch</span>
+        <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span>
       </td>
       <td>
         <p>Similar to a SQL IN clause. In returns true if an expression exists in a given table sub-query. The sub-query table must consist of one column. This column must have the same data type as the expression.</p>
@@ -1793,7 +1793,7 @@ ANY.in(TABLE)
 {% endhighlight %}
       </td>
       <td>
-        <p>Returns true if an expression exists in a given table sub-query. The sub-query table must consist of one column. This column must have the same data type as the expression. Note: This operation is not supported in a streaming environment yet.</p>
+        <p>Returns true if an expression exists in a given table sub-query. The sub-query table must consist of one column. This column must have the same data type as the expression.</p>
       </td>
     </tr>
 

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/subquery.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/expressions/subquery.scala
@@ -54,10 +54,6 @@ case class In(expression: Expression, elements: Seq[Expression]) extends Express
         if (elements.length != 1) {
           return ValidationFailure("IN operator supports only one table reference.")
         }
-        if (table.tableEnv.isInstanceOf[StreamTableEnvironment]) {
-          return ValidationFailure(
-            "Sub-query IN operator on stream tables is currently not supported.")
-        }
         val tableOutput = table.logicalPlan.output
         if (tableOutput.length > 1) {
           return ValidationFailure(

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/SubQueryTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/sql/SubQueryTest.scala
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.api.stream.sql
+
+import org.apache.flink.api.scala._
+import org.apache.flink.table.api.scala._
+import org.apache.flink.table.utils.TableTestUtil._
+import org.apache.flink.table.utils.TableTestBase
+import org.junit.Test
+
+class SubQueryTest extends TableTestBase {
+
+  @Test
+  def testInUncorrelated(): Unit = {
+    val streamUtil = streamTestUtil()
+    streamUtil.addTable[(Int, Long, String)]("tableA", 'a, 'b, 'c)
+    streamUtil.addTable[(Int, String)]("tableB", 'x, 'y)
+
+    val sqlQuery =
+      s"""
+         |SELECT * FROM tableA
+         |WHERE a IN (SELECT x FROM tableB)
+       """.stripMargin
+
+    val expected =
+      unaryNode(
+        "DataStreamCalc",
+        binaryNode(
+          "DataStreamJoin",
+          streamTableNode(0),
+          unaryNode(
+            "DataStreamGroupAggregate",
+            unaryNode(
+              "DataStreamCalc",
+              streamTableNode(1),
+              term("select", "x")
+            ),
+            term("groupBy", "x"),
+            term("select", "x")
+          ),
+          term("where", "=(a, x)"),
+          term("join", "a", "b", "c", "x"),
+          term("joinType", "InnerJoin")
+        ),
+        term("select", "a", "b", "c")
+      )
+
+    streamUtil.verifySql(sqlQuery, expected)
+
+  }
+
+  @Test
+  def testInUncorrelatedWithConditionAndAgg(): Unit = {
+    val streamUtil = streamTestUtil()
+    streamUtil.addTable[(Int, Long, String)]("tableA", 'a, 'b, 'c)
+    streamUtil.addTable[(Int, String)]("tableB", 'x, 'y)
+
+    val sqlQuery =
+      s"""
+         |SELECT * FROM tableA
+         |WHERE a IN (SELECT SUM(x) FROM tableB GROUP BY y HAVING y LIKE '%Hanoi%')
+       """.stripMargin
+
+    val expected =
+      unaryNode(
+        "DataStreamCalc",
+        binaryNode(
+          "DataStreamJoin",
+          streamTableNode(0),
+          unaryNode(
+            "DataStreamGroupAggregate",
+            unaryNode(
+              "DataStreamCalc",
+              unaryNode(
+                "DataStreamGroupAggregate",
+                unaryNode(
+                  "DataStreamCalc",
+                  streamTableNode(1),
+                  term("select", "x", "y"),
+                  term("where", "LIKE(y, '%Hanoi%')")
+                ),
+                term("groupBy", "y"),
+                term("select", "y, SUM(x) AS EXPR$0")
+              ),
+              term("select", "EXPR$0")
+            ),
+            term("groupBy", "EXPR$0"),
+            term("select", "EXPR$0")
+          ),
+          term("where", "=(a, EXPR$0)"),
+          term("join", "a", "b", "c", "EXPR$0"),
+          term("joinType", "InnerJoin")
+        ),
+        term("select", "a", "b", "c")
+      )
+
+    streamUtil.verifySql(sqlQuery, expected)
+  }
+
+  @Test
+  def testInWithMultiUncorrelatedCondition(): Unit = {
+    val streamUtil = streamTestUtil()
+    streamUtil.addTable[(Int, Long, String)]("tableA", 'a, 'b, 'c)
+    streamUtil.addTable[(Int, String)]("tableB", 'x, 'y)
+    streamUtil.addTable[(Long, Int)]("tableC", 'w, 'z)
+
+    val sqlQuery =
+      s"""
+         |SELECT * FROM tableA
+         |WHERE a IN (SELECT x FROM tableB)
+         |AND b IN (SELECT w FROM tableC)
+       """.stripMargin
+
+    val expected =
+      unaryNode(
+        "DataStreamCalc",
+        binaryNode(
+          "DataStreamJoin",
+          unaryNode(
+            "DataStreamCalc",
+            binaryNode(
+              "DataStreamJoin",
+              streamTableNode(0),
+              unaryNode(
+                "DataStreamGroupAggregate",
+                unaryNode(
+                  "DataStreamCalc",
+                  streamTableNode(1),
+                  term("select", "x")
+                ),
+                term("groupBy", "x"),
+                term("select", "x")
+              ),
+              term("where", "=(a, x)"),
+              term("join", "a", "b", "c", "x"),
+              term("joinType", "InnerJoin")
+            ),
+            term("select", "a", "b", "c")
+          ),
+          unaryNode(
+            "DataStreamGroupAggregate",
+            unaryNode(
+              "DataStreamCalc",
+              streamTableNode(2),
+              term("select", "w")
+            ),
+            term("groupBy", "w"),
+            term("select", "w")
+          ),
+          term("where", "=(b, w)"),
+          term("join", "a", "b", "c", "w"),
+          term("joinType", "InnerJoin")
+      ),
+        term("select", "a", "b", "c")
+      )
+
+    streamUtil.verifySql(sqlQuery, expected)
+  }
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/SubQueryTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/SubQueryTest.scala
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api.stream.table
+
+import org.apache.flink.api.scala._
+import org.apache.flink.table.api.scala._
+import org.apache.flink.table.utils.TableTestUtil._
+import org.apache.flink.table.utils.TableTestBase
+import org.junit.Test
+
+class SubQueryTest extends TableTestBase {
+
+  @Test
+  def testInUncorrelated(): Unit = {
+    val streamUtil = streamTestUtil()
+    val tableA = streamUtil.addTable[(Int, Long, String)]('a, 'b, 'c)
+    val tableB = streamUtil.addTable[(Int, String)]('x, 'y)
+
+    val result = tableA.where('a.in(tableB.select('x)))
+
+    val expected =
+      unaryNode(
+        "DataStreamCalc",
+        binaryNode(
+          "DataStreamJoin",
+          streamTableNode(0),
+          unaryNode(
+            "DataStreamGroupAggregate",
+            unaryNode(
+              "DataStreamCalc",
+              streamTableNode(1),
+              term("select", "x")
+            ),
+            term("groupBy", "x"),
+            term("select", "x")
+          ),
+          term("where", "=(a, x)"),
+          term("join", "a", "b", "c", "x"),
+          term("joinType", "InnerJoin")
+        ),
+        term("select", "a", "b", "c")
+      )
+
+    streamUtil.verifyTable(result, expected)
+
+  }
+
+  @Test
+  def testInUncorrelatedWithConditionAndAgg(): Unit = {
+    val streamUtil = streamTestUtil()
+    val tableA = streamUtil.addTable[(Int, Long, String)]("tableA", 'a, 'b, 'c)
+    val tableB = streamUtil.addTable[(Int, String)]("tableB", 'x, 'y)
+
+    val result = tableA
+      .where('a.in(tableB.where('y.like("%Hanoi%")).groupBy('y).select('x.sum)))
+
+    val expected =
+      unaryNode(
+        "DataStreamCalc",
+        binaryNode(
+          "DataStreamJoin",
+          streamTableNode(0),
+          unaryNode(
+            "DataStreamGroupAggregate",
+            unaryNode(
+              "DataStreamCalc",
+              unaryNode(
+                "DataStreamGroupAggregate",
+                unaryNode(
+                  "DataStreamCalc",
+                  streamTableNode(1),
+                  term("select", "x", "y"),
+                  term("where", "LIKE(y, '%Hanoi%')")
+                ),
+                term("groupBy", "y"),
+                term("select", "y, SUM(x) AS TMP_0")
+              ),
+              term("select", "TMP_0")
+            ),
+            term("groupBy", "TMP_0"),
+            term("select", "TMP_0")
+          ),
+          term("where", "=(a, TMP_0)"),
+          term("join", "a", "b", "c", "TMP_0"),
+          term("joinType", "InnerJoin")
+        ),
+        term("select", "a", "b", "c")
+      )
+
+    streamUtil.verifyTable(result, expected)
+  }
+
+  @Test
+  def testInWithMultiUncorrelatedCondition(): Unit = {
+    val streamUtil = streamTestUtil()
+    val tableA = streamUtil.addTable[(Int, Long, String)]("tableA", 'a, 'b, 'c)
+    val tableB = streamUtil.addTable[(Int, String)]("tableB", 'x, 'y)
+    val tableC = streamUtil.addTable[(Long, Int)]("tableC", 'w, 'z)
+
+    val result = tableA
+      .where(('a.in(tableB.select('x)) && ('b.in(tableC.select('w)))))
+
+    val expected =
+      unaryNode(
+        "DataStreamCalc",
+        binaryNode(
+          "DataStreamJoin",
+          unaryNode(
+            "DataStreamCalc",
+            binaryNode(
+              "DataStreamJoin",
+              streamTableNode(0),
+              unaryNode(
+                "DataStreamGroupAggregate",
+                unaryNode(
+                  "DataStreamCalc",
+                  streamTableNode(1),
+                  term("select", "x")
+                ),
+                term("groupBy", "x"),
+                term("select", "x")
+              ),
+              term("where", "=(a, x)"),
+              term("join", "a", "b", "c", "x"),
+              term("joinType", "InnerJoin")
+            ),
+            term("select", "a", "b", "c")
+          ),
+          unaryNode(
+            "DataStreamGroupAggregate",
+            unaryNode(
+              "DataStreamCalc",
+              streamTableNode(2),
+              term("select", "w")
+            ),
+            term("groupBy", "w"),
+            term("select", "w")
+          ),
+          term("where", "=(b, w)"),
+          term("join", "a", "b", "c", "w"),
+          term("joinType", "InnerJoin")
+        ),
+        term("select", "a", "b", "c")
+      )
+
+    streamUtil.verifyTable(result, expected)
+  }
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/validation/UnsupportedOpsValidationTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/api/stream/table/validation/UnsupportedOpsValidationTest.scala
@@ -104,11 +104,4 @@ class UnsupportedOpsValidationTest extends AbstractTestBase {
     t1.fetch(5)
   }
 
-  @Test(expected = classOf[ValidationException])
-  def testIn(): Unit = {
-    val env = StreamExecutionEnvironment.getExecutionEnvironment
-    val tEnv = TableEnvironment.getTableEnvironment(env)
-    val t1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv)
-    t1.select(0.in(t1.select('_1)))
-  }
 }

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/sql/SubQueryITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/sql/SubQueryITCase.scala
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.stream.sql
+
+import org.apache.flink.api.scala._
+import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
+import org.apache.flink.table.api.TableEnvironment
+import org.apache.flink.table.api.scala._
+import org.apache.flink.table.runtime.utils.{StreamITCase, StreamingWithStateTestBase}
+import org.apache.flink.types.Row
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SubQueryITCase extends StreamingWithStateTestBase {
+
+  @Test
+  def testInUncorrelated(): Unit = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env)
+    StreamITCase.clear
+
+    val sqlQuery =
+      s"""
+         |SELECT * FROM tableA
+         |WHERE a IN (SELECT x FROM tableB)
+       """.stripMargin
+
+    val dataA = Seq(
+      (1, 1L, "Hello"),
+      (2, 2L, "Hello"),
+      (3, 3L, "Hello World"),
+      (4, 4L, "Hello")
+    )
+
+    val dataB = Seq(
+      (1, "hello"),
+      (2, "co-hello"),
+      (4, "hello")
+    )
+
+    tEnv.registerTable("tableA",
+      env.fromCollection(dataA).toTable(tEnv).as('a, 'b, 'c))
+
+    tEnv.registerTable("tableB",
+      env.fromCollection(dataB).toTable(tEnv).as('x, 'y))
+
+    val results = tEnv.sqlQuery(sqlQuery).toRetractStream[Row]
+    results.addSink(new StreamITCase.RetractingSink)
+    env.execute()
+
+    val expected = Seq(
+      "1,1,Hello", "2,2,Hello", "4,4,Hello"
+    )
+
+    assertEquals(expected.sorted, StreamITCase.retractedResults.sorted)
+  }
+
+  @Test
+  def testInUncorrelatedWithConditionAndAgg: Unit = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env)
+    StreamITCase.clear
+
+    val sqlQuery =
+      s"""
+         |SELECT * FROM tableA
+         |WHERE a IN (SELECT SUM(x) FROM tableB GROUP BY y HAVING y LIKE '%Hanoi%')
+       """.stripMargin
+
+    val dataA = Seq(
+      (1, 1L, "Hello"),
+      (2, 2L, "Hello"),
+      (3, 3L, "Hello World"),
+      (4, 4L, "Hello")
+    )
+
+    val dataB = Seq(
+      (1, "hello"),
+      (1, "Hanoi"),
+      (1, "Hanoi"),
+      (2, "Hanoi-1"),
+      (2, "Hanoi-1"),
+      (-1, "Hanoi-1")
+    )
+
+    tEnv.registerTable("tableA",
+      env.fromCollection(dataA).toTable(tEnv).as('a, 'b, 'c))
+
+    tEnv.registerTable("tableB",
+      env.fromCollection(dataB).toTable(tEnv).as('x, 'y))
+
+    val results = tEnv.sqlQuery(sqlQuery).toRetractStream[Row]
+    results.addSink(new StreamITCase.RetractingSink)
+    env.execute()
+
+    val expected = Seq(
+      "2,2,Hello", "3,3,Hello World"
+    )
+
+    assertEquals(expected.sorted, StreamITCase.retractedResults.sorted)
+  }
+
+  @Test
+  def testInWithMultiUncorrelatedCondition: Unit = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env)
+    StreamITCase.clear
+
+    val sqlQuery =
+      s"""
+         |SELECT * FROM tableA
+         |WHERE a IN (SELECT x FROM tableB)
+         |AND b IN (SELECT w FROM tableC)
+       """.stripMargin
+
+    val dataA = Seq(
+      (1, 1L, "Hello"),
+      (2, 2L, "Hello"),
+      (3, 3L, "Hello World"),
+      (4, 4L, "Hello")
+    )
+
+    val dataB = Seq(
+      (1, "hello"),
+      (2, "co-hello"),
+      (4, "hello")
+    )
+
+    val dataC = Seq(
+      (1L, "Joker"),
+      (1L, "Sanity"),
+      (2L, "Cool")
+    )
+
+    tEnv.registerTable("tableA",
+      env.fromCollection(dataA).toTable(tEnv).as('a, 'b, 'c))
+
+    tEnv.registerTable("tableB",
+      env.fromCollection(dataB).toTable(tEnv).as('x, 'y))
+
+    tEnv.registerTable("tableC",
+      env.fromCollection(dataC).toTable(tEnv).as('w, 'z))
+
+    val results = tEnv.sqlQuery(sqlQuery).toRetractStream[Row]
+    results.addSink(new StreamITCase.RetractingSink)
+    env.execute()
+
+    val expected = Seq(
+      "1,1,Hello", "2,2,Hello"
+    )
+
+    assertEquals(expected.sorted, StreamITCase.retractedResults.sorted)
+  }
+
+}

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/SubQueryITCase.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/runtime/stream/table/SubQueryITCase.scala
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.stream.table
+
+import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
+import org.apache.flink.table.api.TableEnvironment
+import org.apache.flink.table.runtime.utils.{StreamITCase, StreamingWithStateTestBase}
+import org.apache.flink.types.Row
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.apache.flink.api.scala._
+import org.apache.flink.table.api.scala._
+
+class SubQueryITCase extends StreamingWithStateTestBase {
+
+  @Test
+  def testInUncorrelated(): Unit = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env)
+    StreamITCase.clear
+
+    val dataA = Seq(
+      (1, 1L, "Hello"),
+      (2, 2L, "Hello"),
+      (3, 3L, "Hello World"),
+      (4, 4L, "Hello")
+    )
+
+    val dataB = Seq(
+      (1, "hello"),
+      (2, "co-hello"),
+      (4, "hello")
+    )
+
+    val tableA = env.fromCollection(dataA).toTable(tEnv, 'a, 'b, 'c)
+
+    val tableB = env.fromCollection(dataB).toTable(tEnv, 'x, 'y)
+
+    val result = tableA.where('a.in(tableB.select('x)))
+
+    val results = result.toRetractStream[Row]
+    results.addSink(new StreamITCase.RetractingSink)
+    env.execute()
+
+    val expected = Seq(
+      "1,1,Hello", "2,2,Hello", "4,4,Hello"
+    )
+
+    assertEquals(expected.sorted, StreamITCase.retractedResults.sorted)
+  }
+
+  @Test
+  def testInUncorrelatedWithConditionAndAgg: Unit = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env)
+    StreamITCase.clear
+
+    val dataA = Seq(
+      (1, 1L, "Hello"),
+      (2, 2L, "Hello"),
+      (3, 3L, "Hello World"),
+      (4, 4L, "Hello")
+    )
+
+    val dataB = Seq(
+      (1, "hello"),
+      (1, "Hanoi"),
+      (1, "Hanoi"),
+      (2, "Hanoi-1"),
+      (2, "Hanoi-1"),
+      (-1, "Hanoi-1")
+    )
+
+    val tableA = env.fromCollection(dataA).toTable(tEnv,'a, 'b, 'c)
+
+    val tableB = env.fromCollection(dataB).toTable(tEnv,'x, 'y)
+
+    val result = tableA
+      .where('a.in(tableB.where('y.like("%Hanoi%")).groupBy('y).select('x.sum)))
+
+    val results = result.toRetractStream[Row]
+    results.addSink(new StreamITCase.RetractingSink)
+    env.execute()
+
+    val expected = Seq(
+      "2,2,Hello", "3,3,Hello World"
+    )
+
+    assertEquals(expected.sorted, StreamITCase.retractedResults.sorted)
+  }
+
+  @Test
+  def testInWithMultiUncorrelatedCondition: Unit = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    val tEnv = TableEnvironment.getTableEnvironment(env)
+    StreamITCase.clear
+
+    val dataA = Seq(
+      (1, 1L, "Hello"),
+      (2, 2L, "Hello"),
+      (3, 3L, "Hello World"),
+      (4, 4L, "Hello")
+    )
+
+    val dataB = Seq(
+      (1, "hello"),
+      (2, "co-hello"),
+      (4, "hello")
+    )
+
+    val dataC = Seq(
+      (1L, "Joker"),
+      (1L, "Sanity"),
+      (2L, "Cool")
+    )
+
+    val tableA = env.fromCollection(dataA).toTable(tEnv,'a, 'b, 'c)
+
+    val tableB = env.fromCollection(dataB).toTable(tEnv,'x, 'y)
+
+    val tableC = env.fromCollection(dataC).toTable(tEnv,'w, 'z)
+
+    val result = tableA
+      .where(('a.in(tableB.select('x)) && ('b.in(tableC.select('w)))))
+
+    val results = result.toRetractStream[Row]
+    results.addSink(new StreamITCase.RetractingSink)
+    env.execute()
+
+    val expected = Seq(
+      "1,1,Hello", "2,2,Hello"
+    )
+
+    assertEquals(expected.sorted, StreamITCase.retractedResults.sorted)
+  }
+
+}


### PR DESCRIPTION

## What is the purpose of the change
Add tests for SQL IN sub-query operator in streaming


## Brief change log
add tests and disable some validation.


## Verifying this change

This change added tests and can be verified as follows:
unit tests: SubQueryTest
it tests: SubQueryITCase

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers:  no
  - The runtime per-record code paths (performance sensitive):  no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper:  no
  - The S3 file system connector:  no

## Documentation

  - Does this pull request introduce a new feature?  no
  - If yes, how is the feature documented? not documented
