### PR TITLE
[FLINK-9428] [checkpointing] Allow operators to flush data on checkpoint pre-barrier

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
@@ -347,6 +347,12 @@ public abstract class AbstractStreamOperator<OUT>
 	}
 
 	@Override
+	public void prepareSnapshotPreBarrier(long checkpointId) throws Exception {
+		// the default implementation does nothing and accepts the checkpoint
+		// this is purely for subclasses to override
+	}
+
+	@Override
 	public final OperatorSnapshotFutures snapshotState(long checkpointId, long timestamp, CheckpointOptions checkpointOptions,
 			CheckpointStreamFactory factory) throws Exception {
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperator.java
@@ -94,6 +94,20 @@ public interface StreamOperator<OUT> extends CheckpointListener, KeyContext, Dis
 	// ------------------------------------------------------------------------
 
 	/**
+	 * This method is called when the operator should do a snapshot, before it emits its
+	 * own checkpoint barrier. This method is intended not for any actual state persistence,
+	 * but only for emitting some data before emitting the checkpoint barrier.
+	 *
+	 * <p><b>Important:</b> This method should not be used for any actual state snapshot logic, because
+	 * it will inherently be within the synchronous part of the operator's checkpoint. If heavy work is done
+	 * withing this method, it will affect latency and downstream checkpoint alignments.
+	 *
+	 * @param checkpointId The ID of the checkpoint.
+	 * @throws Exception Throwing an exception here causes the operator to fail and go into recovery.
+	 */
+	void prepareSnapshotPreBarrier(long checkpointId) throws Exception;
+
+	/**
 	 * Called to draw a state snapshot from the operator.
 	 *
 	 * @return a runnable future to the state handle that points to the snapshotted state. For synchronous implementations,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
@@ -18,6 +18,7 @@
 package org.apache.flink.streaming.runtime.tasks;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.metrics.Counter;
@@ -54,12 +55,16 @@ import org.apache.flink.util.XORShiftRandom;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * The {@code OperatorChain} contains all operators that are executed as one chain within a single
@@ -158,7 +163,19 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>> implements Strea
 				}
 			}
 		}
+	}
 
+	@VisibleForTesting
+	OperatorChain(
+			StreamOperator<?>[] allOperators,
+			RecordWriterOutput<?>[] streamOutputs,
+			WatermarkGaugeExposingOutput<StreamRecord<OUT>> chainEntryPoint,
+			OP headOperator) {
+
+		this.allOperators = checkNotNull(allOperators);
+		this.streamOutputs = checkNotNull(streamOutputs);
+		this.chainEntryPoint = checkNotNull(chainEntryPoint);
+		this.headOperator = checkNotNull(headOperator);
 	}
 
 	@Override
@@ -189,6 +206,18 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>> implements Strea
 		CancelCheckpointMarker barrier = new CancelCheckpointMarker(id);
 		for (RecordWriterOutput<?> streamOutput : streamOutputs) {
 			streamOutput.broadcastEvent(barrier);
+		}
+	}
+
+	public void prepareSnapshotPreBarrier(long checkpointId) throws Exception {
+		// go forward through the operator chain and tell each operator
+		// to prepare the checkpoint
+		final StreamOperator<?>[] operators = this.allOperators;
+		for (int i = operators.length - 1; i >= 0; --i) {
+			final StreamOperator<?> op = operators[i];
+			if (op != null) {
+				op.prepareSnapshotPreBarrier(checkpointId);
+			}
 		}
 	}
 
@@ -392,7 +421,7 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>> implements Strea
 		Gauge<Long> getWatermarkGauge();
 	}
 
-	private static class ChainingOutput<T> implements WatermarkGaugeExposingOutput<StreamRecord<T>> {
+	static class ChainingOutput<T> implements WatermarkGaugeExposingOutput<StreamRecord<T>> {
 
 		protected final OneInputStreamOperator<T, ?> operator;
 		protected final Counter numRecordsIn;
@@ -400,12 +429,13 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>> implements Strea
 
 		protected final StreamStatusProvider streamStatusProvider;
 
+		@Nullable
 		protected final OutputTag<T> outputTag;
 
 		public ChainingOutput(
 				OneInputStreamOperator<T, ?> operator,
 				StreamStatusProvider streamStatusProvider,
-				OutputTag<T> outputTag) {
+				@Nullable OutputTag<T> outputTag) {
 			this.operator = operator;
 
 			{
@@ -502,7 +532,7 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>> implements Strea
 		}
 	}
 
-	private static final class CopyingChainingOutput<T> extends ChainingOutput<T> {
+	static final class CopyingChainingOutput<T> extends ChainingOutput<T> {
 
 		private final TypeSerializer<T> serializer;
 
@@ -570,7 +600,7 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>> implements Strea
 		}
 	}
 
-	private static class BroadcastingOutputCollector<T> implements WatermarkGaugeExposingOutput<StreamRecord<T>> {
+	static class BroadcastingOutputCollector<T> implements WatermarkGaugeExposingOutput<StreamRecord<T>> {
 
 		protected final Output<StreamRecord<T>>[] outputs;
 
@@ -640,7 +670,7 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>> implements Strea
 	 * Special version of {@link BroadcastingOutputCollector} that performs a shallow copy of the
 	 * {@link StreamRecord} to ensure that multi-chaining works correctly.
 	 */
-	private static final class CopyingBroadcastingOutputCollector<T> extends BroadcastingOutputCollector<T> {
+	static final class CopyingBroadcastingOutputCollector<T> extends BroadcastingOutputCollector<T> {
 
 		public CopyingBroadcastingOutputCollector(
 				Output<StreamRecord<T>>[] outputs,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperatorLifecycleTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperatorLifecycleTest.java
@@ -64,6 +64,7 @@ public class AbstractUdfStreamOperatorLifecycleTest {
 			"UDF::open",
 			"OPERATOR::run",
 			"UDF::run",
+			"OPERATOR::prepareSnapshotPreBarrier",
 			"OPERATOR::snapshotState",
 			"OPERATOR::close",
 			"UDF::close",
@@ -82,15 +83,22 @@ public class AbstractUdfStreamOperatorLifecycleTest {
 			"OPERATOR::dispose",
 			"UDF::close");
 
-	private static final String ALL_METHODS_STREAM_OPERATOR = "[close[], dispose[], getChainingStrategy[], " +
-			"getCurrentKey[], getMetricGroup[], getOperatorID[], initializeState[], " +
-			"notifyCheckpointComplete[long], open[], setChainingStrategy[class " +
-			"org.apache.flink.streaming.api.operators.ChainingStrategy], setCurrentKey[class java.lang.Object], " +
+	private static final String ALL_METHODS_STREAM_OPERATOR = "[" +
+			"close[], " +
+			"dispose[], " +
+			"getChainingStrategy[], " +
+			"getCurrentKey[], " +
+			"getMetricGroup[], " +
+			"getOperatorID[], " +
+			"initializeState[], " +
+			"notifyCheckpointComplete[long], " +
+			"open[], " +
+			"prepareSnapshotPreBarrier[long], " +
+			"setChainingStrategy[class org.apache.flink.streaming.api.operators.ChainingStrategy], " +
+			"setCurrentKey[class java.lang.Object], " +
 			"setKeyContextElement1[class org.apache.flink.streaming.runtime.streamrecord.StreamRecord], " +
 			"setKeyContextElement2[class org.apache.flink.streaming.runtime.streamrecord.StreamRecord], " +
-			"setup[class org.apache.flink.streaming.runtime.tasks.StreamTask, class " +
-			"org.apache.flink.streaming.api.graph.StreamConfig, interface " +
-			"org.apache.flink.streaming.api.operators.Output], " +
+			"setup[class org.apache.flink.streaming.runtime.tasks.StreamTask, class org.apache.flink.streaming.api.graph.StreamConfig, interface org.apache.flink.streaming.api.operators.Output], " +
 			"snapshotState[long, long, class org.apache.flink.runtime.checkpoint.CheckpointOptions, interface org.apache.flink.runtime.state.CheckpointStreamFactory]]";
 
 	private static final String ALL_METHODS_RICH_FUNCTION = "[close[], getIterationRuntimeContext[], getRuntimeContext[]" +
@@ -129,7 +137,7 @@ public class AbstractUdfStreamOperatorLifecycleTest {
 		StreamConfig cfg = new StreamConfig(new Configuration());
 		MockSourceFunction srcFun = new MockSourceFunction();
 
-		cfg.setStreamOperator(new LifecycleTrackingStreamSource(srcFun, true));
+		cfg.setStreamOperator(new LifecycleTrackingStreamSource<>(srcFun, true));
 		cfg.setOperatorID(new OperatorID());
 		cfg.setTimeCharacteristic(TimeCharacteristic.ProcessingTime);
 
@@ -152,7 +160,7 @@ public class AbstractUdfStreamOperatorLifecycleTest {
 		Configuration taskManagerConfig = new Configuration();
 		StreamConfig cfg = new StreamConfig(new Configuration());
 		MockSourceFunction srcFun = new MockSourceFunction();
-		cfg.setStreamOperator(new LifecycleTrackingStreamSource(srcFun, false));
+		cfg.setStreamOperator(new LifecycleTrackingStreamSource<>(srcFun, false));
 		cfg.setOperatorID(new OperatorID());
 		cfg.setTimeCharacteristic(TimeCharacteristic.ProcessingTime);
 
@@ -266,6 +274,12 @@ public class AbstractUdfStreamOperatorLifecycleTest {
 		public void initializeState(StateInitializationContext context) throws Exception {
 			ACTUAL_ORDER_TRACKING.add("OPERATOR::initializeState");
 			super.initializeState(context);
+		}
+
+		@Override
+		public void prepareSnapshotPreBarrier(long checkpointId) throws Exception {
+			ACTUAL_ORDER_TRACKING.add("OPERATOR::prepareSnapshotPreBarrier");
+			super.prepareSnapshotPreBarrier(checkpointId);
 		}
 
 		@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OperatorChainTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OperatorChainTest.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.operators.testutils.MockEnvironment;
+import org.apache.flink.streaming.api.graph.StreamConfig;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.runtime.io.RecordWriterOutput;
+import org.apache.flink.streaming.runtime.operators.StreamOperatorChainingTest;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.streamstatus.StreamStatusProvider;
+import org.apache.flink.streaming.runtime.tasks.OperatorChain.BroadcastingOutputCollector;
+import org.apache.flink.streaming.runtime.tasks.OperatorChain.ChainingOutput;
+import org.apache.flink.streaming.runtime.tasks.OperatorChain.WatermarkGaugeExposingOutput;
+
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+/**
+ * This class test the {@link OperatorChain}.
+ *
+ * <p>It takes a different (simpler) approach at testing the operator chain than
+ * {@link StreamOperatorChainingTest}.
+ */
+public class OperatorChainTest {
+
+	@Test
+	public void testPrepareCheckpointPreBarrier() throws Exception {
+		final AtomicInteger intRef = new AtomicInteger();
+
+		final OneInputStreamOperator<String, String> one = new ValidatingOperator(intRef, 0);
+		final OneInputStreamOperator<String, String> two = new ValidatingOperator(intRef, 1);
+		final OneInputStreamOperator<String, String> three = new ValidatingOperator(intRef, 2);
+
+		final OperatorChain<?, ?> chain = setupOperatorChain(one, two, three);
+		chain.prepareSnapshotPreBarrier(ValidatingOperator.CHECKPOINT_ID);
+
+		assertEquals(3, intRef.get());
+	}
+
+	// ------------------------------------------------------------------------
+	//  Operator Chain Setup Utils
+	// ------------------------------------------------------------------------
+
+	@SafeVarargs
+	private static <T, OP extends StreamOperator<T>> OperatorChain<T, OP> setupOperatorChain(
+			OneInputStreamOperator<T, T>... operators) {
+
+		checkNotNull(operators);
+		checkArgument(operators.length > 0);
+
+		try (MockEnvironment env = MockEnvironment.builder().build()) {
+
+		final StreamTask<?, ?> containingTask = new OneInputStreamTask<T, OneInputStreamOperator<T, T>>(env);
+
+			final StreamStatusProvider statusProvider = mock(StreamStatusProvider.class);
+			final StreamConfig cfg = new StreamConfig(new Configuration());
+
+			final StreamOperator<?>[] ops = new StreamOperator<?>[operators.length];
+
+			// initial output goes to nowhere
+			@SuppressWarnings({"unchecked", "rawtypes"})
+			WatermarkGaugeExposingOutput<StreamRecord<T>> lastWriter = new BroadcastingOutputCollector<>(
+					new Output[0], statusProvider);
+
+			// build the reverse operators array
+			for (int i = 0; i < ops.length; i++) {
+				OneInputStreamOperator<T, T> op = operators[ops.length - i - 1];
+				op.setup(containingTask, cfg, lastWriter);
+				lastWriter = new ChainingOutput<>(op, statusProvider, null);
+				ops[i] = op;
+			}
+
+			@SuppressWarnings("unchecked")
+			final OP head = (OP) operators[0];
+
+			return new OperatorChain<>(
+					ops,
+					new RecordWriterOutput<?>[0],
+					lastWriter,
+					head);
+		}
+	}
+
+	// ------------------------------------------------------------------------
+	//  Test Operator Implementations
+	// ------------------------------------------------------------------------
+
+	private static class ValidatingOperator
+			extends AbstractStreamOperator<String>
+			implements OneInputStreamOperator<String, String> {
+
+		private static final long serialVersionUID = 1L;
+
+		static final long CHECKPOINT_ID = 5765167L;
+
+		final AtomicInteger toUpdate;
+		final int expected;
+
+		public ValidatingOperator(AtomicInteger toUpdate, int expected) {
+			this.toUpdate = toUpdate;
+			this.expected = expected;
+		}
+
+		@Override
+		public void prepareSnapshotPreBarrier(long checkpointId) throws Exception {
+			assertEquals("wrong checkpointId", CHECKPOINT_ID, checkpointId);
+			assertEquals("wrong order", expected, toUpdate.getAndIncrement());
+		}
+
+		@Override
+		public void processElement(StreamRecord<String> element) throws Exception {
+			throw new UnsupportedOperationException();
+		}
+	}
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
@@ -314,24 +314,12 @@ public class SavepointITCase extends TestLogger {
 			env.setParallelism(parallelism);
 			env.addSource(new InfiniteTestSource())
 					.shuffle()
-					.map(new MapFunction<Integer, Integer>() {
-
-						@Override
-						public Integer map(Integer value) throws Exception {
-							return 4 * value;
-						}
-					})
+					.map(value -> 4 * value)
 					.shuffle()
 					.map(statefulCounter).uid("statefulCounter")
 					.shuffle()
-					.map(new MapFunction<Integer, Integer>() {
-
-						@Override
-						public Integer map(Integer value) throws Exception {
-							return 2 * value;
-						}
-					})
-					.addSink(new DiscardingSink<Integer>());
+					.map(value -> 2 * value)
+					.addSink(new DiscardingSink<>());
 
 			JobGraph originalJobGraph = env.getStreamGraph().getJobGraph();
 
@@ -375,14 +363,8 @@ public class SavepointITCase extends TestLogger {
 					.shuffle()
 					.map(new StatefulCounter()).uid("statefulCounter")
 					.shuffle()
-					.map(new MapFunction<Integer, Integer>() {
-
-						@Override
-						public Integer map(Integer value) throws Exception {
-							return value;
-						}
-					})
-					.addSink(new DiscardingSink<Integer>());
+					.map(value -> value)
+					.addSink(new DiscardingSink<>());
 
 			JobGraph modifiedJobGraph = env.getStreamGraph().getJobGraph();
 
@@ -428,7 +410,7 @@ public class SavepointITCase extends TestLogger {
 			.shuffle()
 			.map(new StatefulCounter());
 
-		stream.addSink(new DiscardingSink<Integer>());
+		stream.addSink(new DiscardingSink<>());
 
 		return env.getStreamGraph().getJobGraph();
 	}


### PR DESCRIPTION
## What is the purpose of the change

Some operators maintain some small transient state that may be inefficient to checkpoint, especially when it would need to be checkpointed also in a re-scalable way.
An example are opportunistic pre-aggregation operators, which have small the pre-aggregation state that is frequently flushed downstream.

Rather that persisting that state in a checkpoint, it can make sense to flush the data downstream upon a checkpoint, to let it be part of the downstream operator's state.

This feature is sensitive, because flushing state has a clean implication on the downstream operator's checkpoint alignment. However, used with care, and with the new back-pressure-based checkpoint alignment, this feature can be very useful.

Because it is sensitive, this PR makes this an internal feature (accessible to operators) and does NOT expose it in the public API.

## Brief change log

  - Adds the `prepareSnapshotPreBarrier(long checkpointId)` call to `(Abstract)StreamOperator`, with an empty default implementation.
  - Adds a call on `OperatorChain` to call this in front-to-back order on the operators.

## Verifying this change

  - This change does not yet alter any behavior, it adds only a plug point for future stream operators.
  - The `OperatorChainTest` Unit Test validates that the call happens, and that operators are called in the right order.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **yes**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
