### PR TITLE
[FLINK-9409] [formats] Remove flink-avro and flink-json from /opt

### DIFF
--- a/flink-dist/src/main/assemblies/opt.xml
+++ b/flink-dist/src/main/assemblies/opt.xml
@@ -162,21 +162,6 @@
 			<fileMode>0644</fileMode>
 		</file>
 
-		<!-- Formats -->
-		<file>
-			<source>../flink-formats/flink-avro/target/flink-avro-${project.version}.jar</source>
-			<outputDirectory>opt/</outputDirectory>
-			<destName>flink-avro-${project.version}.jar</destName>
-			<fileMode>0644</fileMode>
-		</file>
-
-		<file>
-			<source>../flink-formats/flink-json/target/flink-json-${project.version}.jar</source>
-			<outputDirectory>opt/</outputDirectory>
-			<destName>flink-json-${project.version}.jar</destName>
-			<fileMode>0644</fileMode>
-		</file>
-
 		<!-- Streaming Python API -->
 		<file>
 			<source>../flink-libraries/flink-streaming-python/target/flink-streaming-python_${scala.binary.version}-${project.version}.jar</source>


### PR DESCRIPTION
## What is the purpose of the change

Both flink-json and flink-avro were added to the /opt directory in order to use them as jars for the SQL Client. However, they are not required anymore because we added dedicated SQL jars later that are distributed through Maven central (see FLINK-8831).

`mvn clean install -pl flink-dist -am` is working again

## Brief change log

Remove all formats from /opt

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
