### PR TITLE
[FLINK-3952][runtine] Upgrade to Netty 4.1

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/ExceptionUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/ExceptionUtils.java
@@ -364,7 +364,7 @@ public final class ExceptionUtils {
 
 		Throwable t = throwable;
 		while (t != null) {
-			if (t.getMessage().contains(searchMessage)) {
+			if (t.getMessage() != null && t.getMessage().contains(searchMessage)) {
 				return Optional.of(t);
 			} else {
 				t = t.getCause();

--- a/flink-queryable-state/flink-queryable-state-client-java/src/main/java/org/apache/flink/queryablestate/network/ChunkedByteBuf.java
+++ b/flink-queryable-state/flink-queryable-state-client-java/src/main/java/org/apache/flink/queryablestate/network/ChunkedByteBuf.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.util.Preconditions;
 
 import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
+import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBufAllocator;
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelHandlerContext;
 import org.apache.flink.shaded.netty4.io.netty.handler.stream.ChunkedInput;
 import org.apache.flink.shaded.netty4.io.netty.handler.stream.ChunkedWriteHandler;
@@ -73,6 +74,15 @@ public class ChunkedByteBuf implements ChunkedInput<ByteBuf> {
 
 	@Override
 	public ByteBuf readChunk(ChannelHandlerContext ctx) throws Exception {
+		return readChunk();
+	}
+
+	@Override
+	public ByteBuf readChunk(ByteBufAllocator byteBufAllocator) throws Exception {
+		return readChunk();
+	}
+
+	private ByteBuf readChunk() {
 		if (isClosed) {
 			return null;
 		} else if (buf.readableBytes() <= chunkSize) {
@@ -86,6 +96,16 @@ public class ChunkedByteBuf implements ChunkedInput<ByteBuf> {
 			// a reference here.
 			return buf.readSlice(chunkSize).retain();
 		}
+	}
+
+	@Override
+	public long length() {
+		return -1;
+	}
+
+	@Override
+	public long progress() {
+		return buf.readerIndex();
 	}
 
 	@Override

--- a/flink-queryable-state/flink-queryable-state-client-java/src/main/java/org/apache/flink/queryablestate/network/NettyBufferPool.java
+++ b/flink-queryable-state/flink-queryable-state-client-java/src/main/java/org/apache/flink/queryablestate/network/NettyBufferPool.java
@@ -168,4 +168,9 @@ public class NettyBufferPool implements ByteBufAllocator {
 	public boolean isDirectBufferPooled() {
 		return alloc.isDirectBufferPooled();
 	}
+
+	@Override
+	public int calculateNewCapacity(int minNewCapacity, int maxCapacity) {
+		return alloc.calculateNewCapacity(minNewCapacity, maxCapacity);
+	}
 }

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/HttpRequestHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/HttpRequestHandler.java
@@ -146,8 +146,6 @@ public class HttpRequestHandler extends SimpleChannelInboundHandler<HttpObject> 
 								currentRequest.setUri(encoder.toString());
 							}
 						}
-
-						data.release();
 					}
 				}
 				catch (EndOfDataDecoderException ignored) {}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/ReadOnlySlicedNetworkBuffer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/ReadOnlySlicedNetworkBuffer.java
@@ -75,12 +75,12 @@ public final class ReadOnlySlicedNetworkBuffer extends ReadOnlyByteBuf implement
 
 	@Override
 	public ByteBuf unwrap() {
-		return super.unwrap().unwrap();
+		return super.unwrap();
 	}
 
 	@Override
 	public boolean isBuffer() {
-		return ((Buffer) unwrap()).isBuffer();
+		return getBuffer().isBuffer();
 	}
 
 	@Override
@@ -98,7 +98,7 @@ public final class ReadOnlySlicedNetworkBuffer extends ReadOnlyByteBuf implement
 	 */
 	@Override
 	public MemorySegment getMemorySegment() {
-		return ((Buffer) unwrap()).getMemorySegment();
+		return getBuffer().getMemorySegment();
 	}
 
 	@Override
@@ -108,22 +108,22 @@ public final class ReadOnlySlicedNetworkBuffer extends ReadOnlyByteBuf implement
 
 	@Override
 	public BufferRecycler getRecycler() {
-		return ((Buffer) unwrap()).getRecycler();
+		return getBuffer().getRecycler();
 	}
 
 	@Override
 	public void recycleBuffer() {
-		((Buffer) unwrap()).recycleBuffer();
+		getBuffer().recycleBuffer();
 	}
 
 	@Override
 	public boolean isRecycled() {
-		return ((Buffer) unwrap()).isRecycled();
+		return getBuffer().isRecycled();
 	}
 
 	@Override
 	public ReadOnlySlicedNetworkBuffer retainBuffer() {
-		((Buffer) unwrap()).retainBuffer();
+		getBuffer().retainBuffer();
 		return this;
 	}
 
@@ -203,11 +203,15 @@ public final class ReadOnlySlicedNetworkBuffer extends ReadOnlyByteBuf implement
 
 	@Override
 	public void setAllocator(ByteBufAllocator allocator) {
-		((Buffer) unwrap()).setAllocator(allocator);
+		getBuffer().setAllocator(allocator);
 	}
 
 	@Override
 	public ByteBuf asByteBuf() {
 		return this;
+	}
+
+	private Buffer getBuffer() {
+		return ((Buffer) unwrap().unwrap());
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/AbstractHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/AbstractHandler.java
@@ -86,7 +86,7 @@ public abstract class AbstractHandler<T extends RestfulGateway, R extends Reques
 	protected void respondAsLeader(ChannelHandlerContext ctx, RoutedRequest routedRequest, T gateway) throws Exception {
 		HttpRequest httpRequest = routedRequest.getRequest();
 		if (log.isTraceEnabled()) {
-			log.trace("Received request " + httpRequest.getUri() + '.');
+			log.trace("Received request " + httpRequest.uri() + '.');
 		}
 
 		try {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/FileUploadHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/FileUploadHandler.java
@@ -100,7 +100,6 @@ public class FileUploadHandler extends SimpleChannelInboundHandler<HttpObject> {
 					fileUpload.renameTo(dest.toFile());
 					ctx.channel().attr(UPLOADED_FILE).set(dest);
 				}
-				data.release();
 			}
 
 			if (httpContent instanceof LastHttpContent) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/router/RoutedRequest.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/router/RoutedRequest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.rest.handler.router;
 
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpRequest;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.QueryStringDecoder;
+import org.apache.flink.shaded.netty4.io.netty.util.ReferenceCountUtil;
 import org.apache.flink.shaded.netty4.io.netty.util.ReferenceCounted;
 
 import java.util.Optional;
@@ -40,7 +41,7 @@ public class RoutedRequest<T> implements ReferenceCounted {
 		this.result = checkNotNull(result);
 		this.request = checkNotNull(request);
 		this.requestAsReferenceCounted = Optional.ofNullable((request instanceof ReferenceCounted) ? (ReferenceCounted) request : null);
-		this.queryStringDecoder = new QueryStringDecoder(request.getUri());
+		this.queryStringDecoder = new QueryStringDecoder(request.uri());
 	}
 
 	public RouteResult<T> getRouteResult() {
@@ -91,6 +92,22 @@ public class RoutedRequest<T> implements ReferenceCounted {
 	public ReferenceCounted retain(int arg0) {
 		if (requestAsReferenceCounted.isPresent()) {
 			requestAsReferenceCounted.get().retain(arg0);
+		}
+		return this;
+	}
+
+	@Override
+	public ReferenceCounted touch() {
+		if (requestAsReferenceCounted.isPresent()) {
+			ReferenceCountUtil.touch(requestAsReferenceCounted.get());
+		}
+		return this;
+	}
+
+	@Override
+	public ReferenceCounted touch(Object hint) {
+		if (requestAsReferenceCounted.isPresent()) {
+			ReferenceCountUtil.touch(requestAsReferenceCounted.get(), hint);
 		}
 		return this;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/router/RouterHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/router/RouterHandler.java
@@ -73,7 +73,7 @@ public class RouterHandler extends SimpleChannelInboundHandler<HttpRequest> {
 
 		// Route
 		HttpMethod method = httpRequest.getMethod();
-		QueryStringDecoder qsd = new QueryStringDecoder(httpRequest.getUri());
+		QueryStringDecoder qsd = new QueryStringDecoder(httpRequest.uri());
 		RouteResult<?> routeResult = router.route(method, qsd.path(), qsd.parameters());
 
 		if (routeResult == null) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/AbstractByteBufTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/AbstractByteBufTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2012 The Netty Project
- * Copy from netty 4.0.50.Final, changed to fit our use of netty 4.0.27.
+ * Copy from netty 4.1.24.Final
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -14,33 +14,39 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.flink.runtime.io.network.buffer;
 
+import org.apache.flink.util.TestLogger;
+
 import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
-import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBufProcessor;
 import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBufUtil;
+import org.apache.flink.shaded.netty4.io.netty.util.ByteProcessor;
 import org.apache.flink.shaded.netty4.io.netty.util.CharsetUtil;
 import org.apache.flink.shaded.netty4.io.netty.util.IllegalReferenceCountException;
-import org.apache.flink.shaded.netty4.io.netty.util.internal.ThreadLocalRandom;
+import org.apache.flink.shaded.netty4.io.netty.util.internal.PlatformDependent;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
+import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.ReadOnlyBufferException;
 import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
 import java.nio.channels.GatheringByteChannel;
 import java.nio.channels.ScatteringByteChannel;
 import java.nio.channels.WritableByteChannel;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
@@ -53,6 +59,7 @@ import static org.apache.flink.shaded.netty4.io.netty.buffer.Unpooled.LITTLE_END
 import static org.apache.flink.shaded.netty4.io.netty.buffer.Unpooled.buffer;
 import static org.apache.flink.shaded.netty4.io.netty.buffer.Unpooled.copiedBuffer;
 import static org.apache.flink.shaded.netty4.io.netty.buffer.Unpooled.directBuffer;
+import static org.apache.flink.shaded.netty4.io.netty.buffer.Unpooled.unreleasableBuffer;
 import static org.apache.flink.shaded.netty4.io.netty.buffer.Unpooled.wrappedBuffer;
 import static org.apache.flink.shaded.netty4.io.netty.util.internal.EmptyArrays.EMPTY_BYTES;
 import static org.hamcrest.CoreMatchers.is;
@@ -64,14 +71,15 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
 
 /**
  * An abstract test class for channel buffers.
  *
- * Copied from netty 4.0.50 with some changes to fit our netty version 4.0.27.
+ * Copy from netty 4.1.24.Final.
  */
-public abstract class AbstractByteBufTest {
+public abstract class AbstractByteBufTest extends TestLogger {
 
     private static final int CAPACITY = 4096; // Must be even
     private static final int BLOCK_SIZE = 128;
@@ -115,11 +123,13 @@ public abstract class AbstractByteBufTest {
 
     @Test
     public void comparableInterfaceNotViolated() {
+        assumeFalse(buffer.isReadOnly());
         buffer.writerIndex(buffer.readerIndex());
         assumeTrue(buffer.writableBytes() >= 4);
 
         buffer.writeLong(0);
         ByteBuf buffer2 = newBuffer(CAPACITY);
+        assumeFalse(buffer2.isReadOnly());
         buffer2.writerIndex(buffer2.readerIndex());
         // Write an unsigned integer that will cause buffer.getUnsignedInt() - buffer2.getUnsignedInt() to underflow the
         // int type and wrap around on the negative side.
@@ -434,15 +444,31 @@ public abstract class AbstractByteBufTest {
 
     @Test
     public void testRandomShortAccess() {
+        testRandomShortAccess(true);
+    }
+    @Test
+    public void testRandomShortLEAccess() {
+        testRandomShortAccess(false);
+    }
+
+    private void testRandomShortAccess(boolean testBigEndian) {
         for (int i = 0; i < buffer.capacity() - 1; i += 2) {
             short value = (short) random.nextInt();
-            buffer.setShort(i, value);
+            if (testBigEndian) {
+                buffer.setShort(i, value);
+            } else {
+                buffer.setShortLE(i, value);
+            }
         }
 
         random.setSeed(seed);
         for (int i = 0; i < buffer.capacity() - 1; i += 2) {
             short value = (short) random.nextInt();
-            assertEquals(value, buffer.getShort(i));
+            if (testBigEndian) {
+                assertEquals(value, buffer.getShort(i));
+            } else {
+                assertEquals(value, buffer.getShortLE(i));
+            }
         }
     }
 
@@ -466,57 +492,110 @@ public abstract class AbstractByteBufTest {
             javaBuffer.putShort(expected);
 
             final int bufferIndex = buffer.capacity() - 2;
-            if (!testBigEndian) {
-                buffer = buffer.order(ByteOrder.LITTLE_ENDIAN);
+            if (testBigEndian) {
+                buffer.setShort(bufferIndex, expected);
+            } else {
+                buffer.setShortLE(bufferIndex, expected);
             }
-            buffer.setShort(bufferIndex, expected);
             javaBuffer.flip();
 
             short javaActual = javaBuffer.getShort();
             assertEquals(expected, javaActual);
-            assertEquals(javaActual, buffer.getShort(bufferIndex));
+            assertEquals(javaActual, testBigEndian ? buffer.getShort(bufferIndex)
+                                                   : buffer.getShortLE(bufferIndex));
         }
     }
 
     @Test
     public void testRandomUnsignedShortAccess() {
+        testRandomUnsignedShortAccess(true);
+    }
+
+    @Test
+    public void testRandomUnsignedShortLEAccess() {
+        testRandomUnsignedShortAccess(false);
+    }
+
+    private void testRandomUnsignedShortAccess(boolean testBigEndian) {
         for (int i = 0; i < buffer.capacity() - 1; i += 2) {
             short value = (short) random.nextInt();
-            buffer.setShort(i, value);
+            if (testBigEndian) {
+                buffer.setShort(i, value);
+            } else {
+                buffer.setShortLE(i, value);
+            }
         }
 
         random.setSeed(seed);
         for (int i = 0; i < buffer.capacity() - 1; i += 2) {
             int value = random.nextInt() & 0xFFFF;
-            assertEquals(value, buffer.getUnsignedShort(i));
+            if (testBigEndian) {
+                assertEquals(value, buffer.getUnsignedShort(i));
+            } else {
+                assertEquals(value, buffer.getUnsignedShortLE(i));
+            }
         }
     }
 
     @Test
     public void testRandomMediumAccess() {
+        testRandomMediumAccess(true);
+    }
+
+    @Test
+    public void testRandomMediumLEAccess() {
+        testRandomMediumAccess(false);
+    }
+
+    private void testRandomMediumAccess(boolean testBigEndian) {
         for (int i = 0; i < buffer.capacity() - 2; i += 3) {
             int value = random.nextInt();
-            buffer.setMedium(i, value);
+            if (testBigEndian) {
+                buffer.setMedium(i, value);
+            } else {
+                buffer.setMediumLE(i, value);
+            }
         }
 
         random.setSeed(seed);
         for (int i = 0; i < buffer.capacity() - 2; i += 3) {
             int value = random.nextInt() << 8 >> 8;
-            assertEquals(value, buffer.getMedium(i));
+            if (testBigEndian) {
+                assertEquals(value, buffer.getMedium(i));
+            } else {
+                assertEquals(value, buffer.getMediumLE(i));
+            }
         }
     }
 
     @Test
     public void testRandomUnsignedMediumAccess() {
+        testRandomUnsignedMediumAccess(true);
+    }
+
+    @Test
+    public void testRandomUnsignedMediumLEAccess() {
+        testRandomUnsignedMediumAccess(false);
+    }
+
+    private void testRandomUnsignedMediumAccess(boolean testBigEndian) {
         for (int i = 0; i < buffer.capacity() - 2; i += 3) {
             int value = random.nextInt();
-            buffer.setMedium(i, value);
+            if (testBigEndian) {
+                buffer.setMedium(i, value);
+            } else {
+                buffer.setMediumLE(i, value);
+            }
         }
 
         random.setSeed(seed);
         for (int i = 0; i < buffer.capacity() - 2; i += 3) {
             int value = random.nextInt() & 0x00FFFFFF;
-            assertEquals(value, buffer.getUnsignedMedium(i));
+            if (testBigEndian) {
+                assertEquals(value, buffer.getUnsignedMedium(i));
+            } else {
+                assertEquals(value, buffer.getUnsignedMediumLE(i));
+            }
         }
     }
 
@@ -541,28 +620,47 @@ public abstract class AbstractByteBufTest {
 
             final int bufferIndex = buffer.capacity() - 3;
             if (testBigEndian) {
-                buffer = buffer.order(ByteOrder.LITTLE_ENDIAN);
+                buffer.setMedium(bufferIndex, expected);
+            } else {
+                buffer.setMediumLE(bufferIndex, expected);
             }
-            buffer.setMedium(bufferIndex, expected);
             javaBuffer.flip();
 
             int javaActual = javaBuffer.getInt();
             assertEquals(expected, javaActual);
-            assertEquals(javaActual, buffer.getUnsignedMedium(bufferIndex));
+            assertEquals(javaActual, testBigEndian ? buffer.getUnsignedMedium(bufferIndex)
+                                                   : buffer.getUnsignedMediumLE(bufferIndex));
         }
     }
 
     @Test
     public void testRandomIntAccess() {
+        testRandomIntAccess(true);
+    }
+
+    @Test
+    public void testRandomIntLEAccess() {
+        testRandomIntAccess(false);
+    }
+
+    private void testRandomIntAccess(boolean testBigEndian) {
         for (int i = 0; i < buffer.capacity() - 3; i += 4) {
             int value = random.nextInt();
-            buffer.setInt(i, value);
+            if (testBigEndian) {
+                buffer.setInt(i, value);
+            } else {
+                buffer.setIntLE(i, value);
+            }
         }
 
         random.setSeed(seed);
         for (int i = 0; i < buffer.capacity() - 3; i += 4) {
             int value = random.nextInt();
-            assertEquals(value, buffer.getInt(i));
+            if (testBigEndian) {
+                assertEquals(value, buffer.getInt(i));
+            } else {
+                assertEquals(value, buffer.getIntLE(i));
+            }
         }
     }
 
@@ -587,42 +685,168 @@ public abstract class AbstractByteBufTest {
 
             final int bufferIndex = buffer.capacity() - 4;
             if (testBigEndian) {
-                buffer = buffer.order(ByteOrder.LITTLE_ENDIAN);
+                buffer.setInt(bufferIndex, expected);
+            } else {
+                buffer.setIntLE(bufferIndex, expected);
             }
-            buffer.setInt(bufferIndex, expected);
             javaBuffer.flip();
 
             int javaActual = javaBuffer.getInt();
             assertEquals(expected, javaActual);
-            assertEquals(javaActual, buffer.getInt(bufferIndex));
+            assertEquals(javaActual, testBigEndian ? buffer.getInt(bufferIndex)
+                                                   : buffer.getIntLE(bufferIndex));
         }
     }
 
     @Test
     public void testRandomUnsignedIntAccess() {
+        testRandomUnsignedIntAccess(true);
+    }
+
+    @Test
+    public void testRandomUnsignedIntLEAccess() {
+        testRandomUnsignedIntAccess(false);
+    }
+
+    private void testRandomUnsignedIntAccess(boolean testBigEndian) {
         for (int i = 0; i < buffer.capacity() - 3; i += 4) {
             int value = random.nextInt();
-            buffer.setInt(i, value);
+            if (testBigEndian) {
+                buffer.setInt(i, value);
+            } else {
+                buffer.setIntLE(i, value);
+            }
         }
 
         random.setSeed(seed);
         for (int i = 0; i < buffer.capacity() - 3; i += 4) {
             long value = random.nextInt() & 0xFFFFFFFFL;
-            assertEquals(value, buffer.getUnsignedInt(i));
+            if (testBigEndian) {
+                assertEquals(value, buffer.getUnsignedInt(i));
+            } else {
+                assertEquals(value, buffer.getUnsignedIntLE(i));
+            }
         }
     }
 
     @Test
     public void testRandomLongAccess() {
+        testRandomLongAccess(true);
+    }
+
+    @Test
+    public void testRandomLongLEAccess() {
+        testRandomLongAccess(false);
+    }
+
+    private void testRandomLongAccess(boolean testBigEndian) {
         for (int i = 0; i < buffer.capacity() - 7; i += 8) {
             long value = random.nextLong();
-            buffer.setLong(i, value);
+            if (testBigEndian) {
+                buffer.setLong(i, value);
+            } else {
+                buffer.setLongLE(i, value);
+            }
         }
 
         random.setSeed(seed);
         for (int i = 0; i < buffer.capacity() - 7; i += 8) {
             long value = random.nextLong();
-            assertEquals(value, buffer.getLong(i));
+            if (testBigEndian) {
+                assertEquals(value, buffer.getLong(i));
+            } else {
+                assertEquals(value, buffer.getLongLE(i));
+            }
+        }
+    }
+
+    @Test
+    public void testLongConsistentWithByteBuffer() {
+        testLongConsistentWithByteBuffer(true, true);
+        testLongConsistentWithByteBuffer(true, false);
+        testLongConsistentWithByteBuffer(false, true);
+        testLongConsistentWithByteBuffer(false, false);
+    }
+
+    private void testLongConsistentWithByteBuffer(boolean direct, boolean testBigEndian) {
+        for (int i = 0; i < JAVA_BYTEBUFFER_CONSISTENCY_ITERATIONS; ++i) {
+            ByteBuffer javaBuffer = direct ? ByteBuffer.allocateDirect(buffer.capacity())
+                                           : ByteBuffer.allocate(buffer.capacity());
+            if (!testBigEndian) {
+                javaBuffer = javaBuffer.order(ByteOrder.LITTLE_ENDIAN);
+            }
+
+            long expected = random.nextLong();
+            javaBuffer.putLong(expected);
+
+            final int bufferIndex = buffer.capacity() - 8;
+            if (testBigEndian) {
+                buffer.setLong(bufferIndex, expected);
+            } else {
+                buffer.setLongLE(bufferIndex, expected);
+            }
+            javaBuffer.flip();
+
+            long javaActual = javaBuffer.getLong();
+            assertEquals(expected, javaActual);
+            assertEquals(javaActual, testBigEndian ? buffer.getLong(bufferIndex)
+                                                   : buffer.getLongLE(bufferIndex));
+        }
+    }
+
+    @Test
+    public void testRandomFloatAccess() {
+        testRandomFloatAccess(true);
+    }
+
+    @Test
+    public void testRandomFloatLEAccess() {
+        testRandomFloatAccess(false);
+    }
+
+    private void testRandomFloatAccess(boolean testBigEndian) {
+        for (int i = 0; i < buffer.capacity() - 7; i += 8) {
+            float value = random.nextFloat();
+            if (testBigEndian) {
+                buffer.setFloat(i, value);
+            } else {
+                buffer.setFloatLE(i, value);
+            }
+        }
+
+        random.setSeed(seed);
+        for (int i = 0; i < buffer.capacity() - 7; i += 8) {
+            float expected = random.nextFloat();
+            float actual = testBigEndian? buffer.getFloat(i) : buffer.getFloatLE(i);
+            assertEquals(expected, actual, 0.01);
+        }
+    }
+
+    @Test
+    public void testRandomDoubleAccess() {
+        testRandomDoubleAccess(true);
+    }
+
+    @Test
+    public void testRandomDoubleLEAccess() {
+        testRandomDoubleAccess(false);
+    }
+
+    private void testRandomDoubleAccess(boolean testBigEndian) {
+        for (int i = 0; i < buffer.capacity() - 7; i += 8) {
+            double value = random.nextDouble();
+            if (testBigEndian) {
+                buffer.setDouble(i, value);
+            } else {
+                buffer.setDoubleLE(i, value);
+            }
+        }
+
+        random.setSeed(seed);
+        for (int i = 0; i < buffer.capacity() - 7; i += 8) {
+            double expected = random.nextDouble();
+            double actual = testBigEndian? buffer.getDouble(i) : buffer.getDoubleLE(i);
+            assertEquals(expected, actual, 0.01);
         }
     }
 
@@ -702,12 +926,25 @@ public abstract class AbstractByteBufTest {
 
     @Test
     public void testSequentialShortAccess() {
+        testSequentialShortAccess(true);
+    }
+
+    @Test
+    public void testSequentialShortLEAccess() {
+        testSequentialShortAccess(false);
+    }
+
+    private void testSequentialShortAccess(boolean testBigEndian) {
         buffer.writerIndex(0);
         for (int i = 0; i < buffer.capacity(); i += 2) {
             short value = (short) random.nextInt();
             assertEquals(i, buffer.writerIndex());
             assertTrue(buffer.isWritable());
-            buffer.writeShort(value);
+            if (testBigEndian) {
+                buffer.writeShort(value);
+            } else {
+                buffer.writeShortLE(value);
+            }
         }
 
         assertEquals(0, buffer.readerIndex());
@@ -719,7 +956,11 @@ public abstract class AbstractByteBufTest {
             short value = (short) random.nextInt();
             assertEquals(i, buffer.readerIndex());
             assertTrue(buffer.isReadable());
-            assertEquals(value, buffer.readShort());
+            if (testBigEndian) {
+                assertEquals(value, buffer.readShort());
+            } else {
+                assertEquals(value, buffer.readShortLE());
+            }
         }
 
         assertEquals(buffer.capacity(), buffer.readerIndex());
@@ -730,12 +971,25 @@ public abstract class AbstractByteBufTest {
 
     @Test
     public void testSequentialUnsignedShortAccess() {
+        testSequentialUnsignedShortAccess(true);
+    }
+
+    @Test
+    public void testSequentialUnsignedShortLEAccess() {
+        testSequentialUnsignedShortAccess(true);
+    }
+
+    private void testSequentialUnsignedShortAccess(boolean testBigEndian) {
         buffer.writerIndex(0);
         for (int i = 0; i < buffer.capacity(); i += 2) {
             short value = (short) random.nextInt();
             assertEquals(i, buffer.writerIndex());
             assertTrue(buffer.isWritable());
-            buffer.writeShort(value);
+            if (testBigEndian) {
+                buffer.writeShort(value);
+            } else {
+                buffer.writeShortLE(value);
+            }
         }
 
         assertEquals(0, buffer.readerIndex());
@@ -747,7 +1001,11 @@ public abstract class AbstractByteBufTest {
             int value = random.nextInt() & 0xFFFF;
             assertEquals(i, buffer.readerIndex());
             assertTrue(buffer.isReadable());
-            assertEquals(value, buffer.readUnsignedShort());
+            if (testBigEndian) {
+                assertEquals(value, buffer.readUnsignedShort());
+            } else {
+                assertEquals(value, buffer.readUnsignedShortLE());
+            }
         }
 
         assertEquals(buffer.capacity(), buffer.readerIndex());
@@ -758,12 +1016,24 @@ public abstract class AbstractByteBufTest {
 
     @Test
     public void testSequentialMediumAccess() {
+        testSequentialMediumAccess(true);
+    }
+    @Test
+    public void testSequentialMediumLEAccess() {
+        testSequentialMediumAccess(false);
+    }
+
+    private void testSequentialMediumAccess(boolean testBigEndian) {
         buffer.writerIndex(0);
         for (int i = 0; i < buffer.capacity() / 3 * 3; i += 3) {
             int value = random.nextInt();
             assertEquals(i, buffer.writerIndex());
             assertTrue(buffer.isWritable());
-            buffer.writeMedium(value);
+            if (testBigEndian) {
+                buffer.writeMedium(value);
+            } else {
+                buffer.writeMediumLE(value);
+            }
         }
 
         assertEquals(0, buffer.readerIndex());
@@ -775,7 +1045,11 @@ public abstract class AbstractByteBufTest {
             int value = random.nextInt() << 8 >> 8;
             assertEquals(i, buffer.readerIndex());
             assertTrue(buffer.isReadable());
-            assertEquals(value, buffer.readMedium());
+            if (testBigEndian) {
+                assertEquals(value, buffer.readMedium());
+            } else {
+                assertEquals(value, buffer.readMediumLE());
+            }
         }
 
         assertEquals(buffer.capacity() / 3 * 3, buffer.readerIndex());
@@ -786,12 +1060,25 @@ public abstract class AbstractByteBufTest {
 
     @Test
     public void testSequentialUnsignedMediumAccess() {
+        testSequentialUnsignedMediumAccess(true);
+    }
+
+    @Test
+    public void testSequentialUnsignedMediumLEAccess() {
+        testSequentialUnsignedMediumAccess(false);
+    }
+
+    private void testSequentialUnsignedMediumAccess(boolean testBigEndian) {
         buffer.writerIndex(0);
         for (int i = 0; i < buffer.capacity() / 3 * 3; i += 3) {
             int value = random.nextInt() & 0x00FFFFFF;
             assertEquals(i, buffer.writerIndex());
             assertTrue(buffer.isWritable());
-            buffer.writeMedium(value);
+            if (testBigEndian) {
+                buffer.writeMedium(value);
+            } else {
+                buffer.writeMediumLE(value);
+            }
         }
 
         assertEquals(0, buffer.readerIndex());
@@ -803,7 +1090,11 @@ public abstract class AbstractByteBufTest {
             int value = random.nextInt() & 0x00FFFFFF;
             assertEquals(i, buffer.readerIndex());
             assertTrue(buffer.isReadable());
-            assertEquals(value, buffer.readUnsignedMedium());
+            if (testBigEndian) {
+                assertEquals(value, buffer.readUnsignedMedium());
+            } else {
+                assertEquals(value, buffer.readUnsignedMediumLE());
+            }
         }
 
         assertEquals(buffer.capacity() / 3 * 3, buffer.readerIndex());
@@ -814,12 +1105,25 @@ public abstract class AbstractByteBufTest {
 
     @Test
     public void testSequentialIntAccess() {
+        testSequentialIntAccess(true);
+    }
+
+    @Test
+    public void testSequentialIntLEAccess() {
+        testSequentialIntAccess(false);
+    }
+
+    private void testSequentialIntAccess(boolean testBigEndian) {
         buffer.writerIndex(0);
         for (int i = 0; i < buffer.capacity(); i += 4) {
             int value = random.nextInt();
             assertEquals(i, buffer.writerIndex());
             assertTrue(buffer.isWritable());
-            buffer.writeInt(value);
+            if (testBigEndian) {
+                buffer.writeInt(value);
+            } else {
+                buffer.writeIntLE(value);
+            }
         }
 
         assertEquals(0, buffer.readerIndex());
@@ -831,7 +1135,11 @@ public abstract class AbstractByteBufTest {
             int value = random.nextInt();
             assertEquals(i, buffer.readerIndex());
             assertTrue(buffer.isReadable());
-            assertEquals(value, buffer.readInt());
+            if (testBigEndian) {
+                assertEquals(value, buffer.readInt());
+            } else {
+                assertEquals(value, buffer.readIntLE());
+            }
         }
 
         assertEquals(buffer.capacity(), buffer.readerIndex());
@@ -842,12 +1150,25 @@ public abstract class AbstractByteBufTest {
 
     @Test
     public void testSequentialUnsignedIntAccess() {
+        testSequentialUnsignedIntAccess(true);
+    }
+
+    @Test
+    public void testSequentialUnsignedIntLEAccess() {
+        testSequentialUnsignedIntAccess(false);
+    }
+
+    private void testSequentialUnsignedIntAccess(boolean testBigEndian) {
         buffer.writerIndex(0);
         for (int i = 0; i < buffer.capacity(); i += 4) {
             int value = random.nextInt();
             assertEquals(i, buffer.writerIndex());
             assertTrue(buffer.isWritable());
-            buffer.writeInt(value);
+            if (testBigEndian) {
+                buffer.writeInt(value);
+            } else {
+                buffer.writeIntLE(value);
+            }
         }
 
         assertEquals(0, buffer.readerIndex());
@@ -859,7 +1180,11 @@ public abstract class AbstractByteBufTest {
             long value = random.nextInt() & 0xFFFFFFFFL;
             assertEquals(i, buffer.readerIndex());
             assertTrue(buffer.isReadable());
-            assertEquals(value, buffer.readUnsignedInt());
+            if (testBigEndian) {
+                assertEquals(value, buffer.readUnsignedInt());
+            } else {
+                assertEquals(value, buffer.readUnsignedIntLE());
+            }
         }
 
         assertEquals(buffer.capacity(), buffer.readerIndex());
@@ -870,12 +1195,25 @@ public abstract class AbstractByteBufTest {
 
     @Test
     public void testSequentialLongAccess() {
+        testSequentialLongAccess(true);
+    }
+
+    @Test
+    public void testSequentialLongLEAccess() {
+        testSequentialLongAccess(false);
+    }
+
+    private void testSequentialLongAccess(boolean testBigEndian) {
         buffer.writerIndex(0);
         for (int i = 0; i < buffer.capacity(); i += 8) {
             long value = random.nextLong();
             assertEquals(i, buffer.writerIndex());
             assertTrue(buffer.isWritable());
-            buffer.writeLong(value);
+            if (testBigEndian) {
+                buffer.writeLong(value);
+            } else {
+                buffer.writeLongLE(value);
+            }
         }
 
         assertEquals(0, buffer.readerIndex());
@@ -887,7 +1225,11 @@ public abstract class AbstractByteBufTest {
             long value = random.nextLong();
             assertEquals(i, buffer.readerIndex());
             assertTrue(buffer.isReadable());
-            assertEquals(value, buffer.readLong());
+            if (testBigEndian) {
+                assertEquals(value, buffer.readLong());
+            } else {
+                assertEquals(value, buffer.readLongLE());
+            }
         }
 
         assertEquals(buffer.capacity(), buffer.readerIndex());
@@ -1619,6 +1961,41 @@ public abstract class AbstractByteBufTest {
     }
 
     @Test
+    public void testRetainedSliceIndex() throws Exception {
+        ByteBuf retainedSlice = buffer.retainedSlice(0, buffer.capacity());
+        assertEquals(0, retainedSlice.readerIndex());
+        retainedSlice.release();
+
+        retainedSlice = buffer.retainedSlice(0, buffer.capacity() - 1);
+        assertEquals(0, retainedSlice.readerIndex());
+        retainedSlice.release();
+
+        retainedSlice = buffer.retainedSlice(1, buffer.capacity() - 1);
+        assertEquals(0, retainedSlice.readerIndex());
+        retainedSlice.release();
+
+        retainedSlice = buffer.retainedSlice(1, buffer.capacity() - 2);
+        assertEquals(0, retainedSlice.readerIndex());
+        retainedSlice.release();
+
+        retainedSlice = buffer.retainedSlice(0, buffer.capacity());
+        assertEquals(buffer.capacity(), retainedSlice.writerIndex());
+        retainedSlice.release();
+
+        retainedSlice = buffer.retainedSlice(0, buffer.capacity() - 1);
+        assertEquals(buffer.capacity() - 1, retainedSlice.writerIndex());
+        retainedSlice.release();
+
+        retainedSlice = buffer.retainedSlice(1, buffer.capacity() - 1);
+        assertEquals(buffer.capacity() - 1, retainedSlice.writerIndex());
+        retainedSlice.release();
+
+        retainedSlice = buffer.retainedSlice(1, buffer.capacity() - 2);
+        assertEquals(buffer.capacity() - 2, retainedSlice.writerIndex());
+        retainedSlice.release();
+    }
+
+    @Test
     @SuppressWarnings("ObjectEqualsNull")
     public void testEquals() {
         assertFalse(buffer.equals(null));
@@ -1651,9 +2028,9 @@ public abstract class AbstractByteBufTest {
         random.nextBytes(value);
         // Prevent overflow / underflow
         if (value[0] == 0) {
-            value[0]++;
+            value[0] ++;
         } else if (value[0] == -1) {
-            value[0]--;
+            value[0] --;
         }
 
         buffer.setIndex(0, value.length);
@@ -1662,22 +2039,29 @@ public abstract class AbstractByteBufTest {
         assertEquals(0, buffer.compareTo(wrappedBuffer(value)));
         assertEquals(0, buffer.compareTo(wrappedBuffer(value).order(LITTLE_ENDIAN)));
 
-        value[0]++;
+        value[0] ++;
         assertTrue(buffer.compareTo(wrappedBuffer(value)) < 0);
         assertTrue(buffer.compareTo(wrappedBuffer(value).order(LITTLE_ENDIAN)) < 0);
         value[0] -= 2;
         assertTrue(buffer.compareTo(wrappedBuffer(value)) > 0);
         assertTrue(buffer.compareTo(wrappedBuffer(value).order(LITTLE_ENDIAN)) > 0);
-        value[0]++;
+        value[0] ++;
 
         assertTrue(buffer.compareTo(wrappedBuffer(value, 0, 31)) > 0);
         assertTrue(buffer.compareTo(wrappedBuffer(value, 0, 31).order(LITTLE_ENDIAN)) > 0);
         assertTrue(buffer.slice(0, 31).compareTo(wrappedBuffer(value)) < 0);
         assertTrue(buffer.slice(0, 31).compareTo(wrappedBuffer(value).order(LITTLE_ENDIAN)) < 0);
+
+        ByteBuf retainedSlice = buffer.retainedSlice(0, 31);
+        assertTrue(retainedSlice.compareTo(wrappedBuffer(value)) < 0);
+        retainedSlice.release();
+
+        retainedSlice = buffer.retainedSlice(0, 31);
+        assertTrue(retainedSlice.compareTo(wrappedBuffer(value).order(LITTLE_ENDIAN)) < 0);
+        retainedSlice.release();
     }
 
     @Test
-    @Ignore("Behaviour was changed after 4.0.27, this test is newer but we should keep the old behaviour to be consistent with the netty version we use.")
     public void testCompareTo2() {
         byte[] bytes = {1, 2, 3, 4};
         byte[] bytesReversed = {4, 3, 2, 1};
@@ -1706,6 +2090,43 @@ public abstract class AbstractByteBufTest {
         buffer.writeBytes(copied);
         assertEquals("Hello, World!", buffer.toString(CharsetUtil.ISO_8859_1));
         copied.release();
+    }
+
+    @Test(timeout = 10000)
+    public void testToStringMultipleThreads() throws Throwable {
+        buffer.clear();
+        buffer.writeBytes("Hello, World!".getBytes(CharsetUtil.ISO_8859_1));
+
+        final AtomicInteger counter = new AtomicInteger(30000);
+        final AtomicReference<Throwable> errorRef = new AtomicReference<Throwable>();
+        List<Thread> threads = new ArrayList<Thread>();
+        for (int i = 0; i < 10; i++) {
+            Thread thread = new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        while (errorRef.get() == null && counter.decrementAndGet() > 0) {
+                            assertEquals("Hello, World!", buffer.toString(CharsetUtil.ISO_8859_1));
+                        }
+                    } catch (Throwable cause) {
+                        errorRef.compareAndSet(null, cause);
+                    }
+                }
+            });
+            threads.add(thread);
+        }
+        for (Thread thread : threads) {
+            thread.start();
+        }
+
+        for (Thread thread : threads) {
+            thread.join();
+        }
+
+        Throwable error = errorRef.get();
+        if (error != null) {
+            throw error;
+        }
     }
 
     @Test
@@ -1839,7 +2260,7 @@ public abstract class AbstractByteBufTest {
 
         final AtomicInteger lastIndex = new AtomicInteger();
         buffer.setIndex(CAPACITY / 4, CAPACITY * 3 / 4);
-        assertThat(buffer.forEachByte(new ByteBufProcessor() {
+        assertThat(buffer.forEachByte(new ByteProcessor() {
             int i = CAPACITY / 4;
 
             @Override
@@ -1862,7 +2283,7 @@ public abstract class AbstractByteBufTest {
         }
 
         final int stop = CAPACITY / 2;
-        assertThat(buffer.forEachByte(CAPACITY / 3, CAPACITY / 3, new ByteBufProcessor() {
+        assertThat(buffer.forEachByte(CAPACITY / 3, CAPACITY / 3, new ByteProcessor() {
             int i = CAPACITY / 3;
 
             @Override
@@ -1886,7 +2307,7 @@ public abstract class AbstractByteBufTest {
         }
 
         final AtomicInteger lastIndex = new AtomicInteger();
-        assertThat(buffer.forEachByteDesc(CAPACITY / 4, CAPACITY * 2 / 4, new ByteBufProcessor() {
+        assertThat(buffer.forEachByteDesc(CAPACITY / 4, CAPACITY * 2 / 4, new ByteProcessor() {
             int i = CAPACITY * 3 / 4 - 1;
 
             @Override
@@ -1917,7 +2338,7 @@ public abstract class AbstractByteBufTest {
         assertEquals(1, buf.remaining());
 
         byte[] data = new byte[a];
-        ThreadLocalRandom.current().nextBytes(data);
+        PlatformDependent.threadLocalRandom().nextBytes(data);
         buffer.writeBytes(data);
 
         buf = buffer.internalNioBuffer(buffer.readerIndex(), a);
@@ -2156,10 +2577,10 @@ public abstract class AbstractByteBufTest {
 
     private ByteBuf releasedBuffer() {
         ByteBuf buffer = newBuffer(8);
+
         // Clear the buffer so we are sure the reader and writer indices are 0.
         // This is important as we may return a slice from newBuffer(...).
         buffer.clear();
-
         assertTrue(buffer.release());
         return buffer;
     }
@@ -2200,13 +2621,28 @@ public abstract class AbstractByteBufTest {
     }
 
     @Test(expected = IllegalReferenceCountException.class)
+    public void testGetShortLEAfterRelease() {
+        releasedBuffer().getShortLE(0);
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
     public void testGetUnsignedShortAfterRelease() {
         releasedBuffer().getUnsignedShort(0);
     }
 
     @Test(expected = IllegalReferenceCountException.class)
+    public void testGetUnsignedShortLEAfterRelease() {
+        releasedBuffer().getUnsignedShortLE(0);
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
     public void testGetMediumAfterRelease() {
         releasedBuffer().getMedium(0);
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
+    public void testGetMediumLEAfterRelease() {
+        releasedBuffer().getMediumLE(0);
     }
 
     @Test(expected = IllegalReferenceCountException.class)
@@ -2220,13 +2656,28 @@ public abstract class AbstractByteBufTest {
     }
 
     @Test(expected = IllegalReferenceCountException.class)
+    public void testGetIntLEAfterRelease() {
+        releasedBuffer().getIntLE(0);
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
     public void testGetUnsignedIntAfterRelease() {
         releasedBuffer().getUnsignedInt(0);
     }
 
     @Test(expected = IllegalReferenceCountException.class)
+    public void testGetUnsignedIntLEAfterRelease() {
+        releasedBuffer().getUnsignedIntLE(0);
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
     public void testGetLongAfterRelease() {
         releasedBuffer().getLong(0);
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
+    public void testGetLongLEAfterRelease() {
+        releasedBuffer().getLongLE(0);
     }
 
     @Test(expected = IllegalReferenceCountException.class)
@@ -2240,8 +2691,18 @@ public abstract class AbstractByteBufTest {
     }
 
     @Test(expected = IllegalReferenceCountException.class)
+    public void testGetFloatLEAfterRelease() {
+        releasedBuffer().getFloatLE(0);
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
     public void testGetDoubleAfterRelease() {
         releasedBuffer().getDouble(0);
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
+    public void testGetDoubleLEAfterRelease() {
+        releasedBuffer().getDoubleLE(0);
     }
 
     @Test(expected = IllegalReferenceCountException.class)
@@ -2315,8 +2776,18 @@ public abstract class AbstractByteBufTest {
     }
 
     @Test(expected = IllegalReferenceCountException.class)
+    public void testSetShortLEAfterRelease() {
+        releasedBuffer().setShortLE(0, 1);
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
     public void testSetMediumAfterRelease() {
         releasedBuffer().setMedium(0, 1);
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
+    public void testSetMediumLEAfterRelease() {
+        releasedBuffer().setMediumLE(0, 1);
     }
 
     @Test(expected = IllegalReferenceCountException.class)
@@ -2325,8 +2796,18 @@ public abstract class AbstractByteBufTest {
     }
 
     @Test(expected = IllegalReferenceCountException.class)
+    public void testSetIntLEAfterRelease() {
+        releasedBuffer().setIntLE(0, 1);
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
     public void testSetLongAfterRelease() {
         releasedBuffer().setLong(0, 1);
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
+    public void testSetLongLEAfterRelease() {
+        releasedBuffer().setLongLE(0, 1);
     }
 
     @Test(expected = IllegalReferenceCountException.class)
@@ -2372,6 +2853,30 @@ public abstract class AbstractByteBufTest {
         } finally {
             buffer.release();
         }
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
+    public void testSetUsAsciiCharSequenceAfterRelease() {
+        testSetCharSequenceAfterRelease0(CharsetUtil.US_ASCII);
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
+    public void testSetIso88591CharSequenceAfterRelease() {
+        testSetCharSequenceAfterRelease0(CharsetUtil.ISO_8859_1);
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
+    public void testSetUtf8CharSequenceAfterRelease() {
+        testSetCharSequenceAfterRelease0(CharsetUtil.UTF_8);
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
+    public void testSetUtf16CharSequenceAfterRelease() {
+        testSetCharSequenceAfterRelease0(CharsetUtil.UTF_16);
+    }
+
+    private void testSetCharSequenceAfterRelease0(Charset charset) {
+        releasedBuffer().setCharSequence(0, "x", charset);
     }
 
     @Test(expected = IllegalReferenceCountException.class)
@@ -2425,8 +2930,18 @@ public abstract class AbstractByteBufTest {
     }
 
     @Test(expected = IllegalReferenceCountException.class)
+    public void testReadShortLEAfterRelease() {
+        releasedBuffer().readShortLE();
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
     public void testReadUnsignedShortAfterRelease() {
         releasedBuffer().readUnsignedShort();
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
+    public void testReadUnsignedShortLEAfterRelease() {
+        releasedBuffer().readUnsignedShortLE();
     }
 
     @Test(expected = IllegalReferenceCountException.class)
@@ -2435,8 +2950,18 @@ public abstract class AbstractByteBufTest {
     }
 
     @Test(expected = IllegalReferenceCountException.class)
+    public void testReadMediumLEAfterRelease() {
+        releasedBuffer().readMediumLE();
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
     public void testReadUnsignedMediumAfterRelease() {
         releasedBuffer().readUnsignedMedium();
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
+    public void testReadUnsignedMediumLEAfterRelease() {
+        releasedBuffer().readUnsignedMediumLE();
     }
 
     @Test(expected = IllegalReferenceCountException.class)
@@ -2445,13 +2970,28 @@ public abstract class AbstractByteBufTest {
     }
 
     @Test(expected = IllegalReferenceCountException.class)
+    public void testReadIntLEAfterRelease() {
+        releasedBuffer().readIntLE();
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
     public void testReadUnsignedIntAfterRelease() {
         releasedBuffer().readUnsignedInt();
     }
 
     @Test(expected = IllegalReferenceCountException.class)
+    public void testReadUnsignedIntLEAfterRelease() {
+        releasedBuffer().readUnsignedIntLE();
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
     public void testReadLongAfterRelease() {
         releasedBuffer().readLong();
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
+    public void testReadLongLEAfterRelease() {
+        releasedBuffer().readLongLE();
     }
 
     @Test(expected = IllegalReferenceCountException.class)
@@ -2465,8 +3005,18 @@ public abstract class AbstractByteBufTest {
     }
 
     @Test(expected = IllegalReferenceCountException.class)
+    public void testReadFloatLEAfterRelease() {
+        releasedBuffer().readFloatLE();
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
     public void testReadDoubleAfterRelease() {
         releasedBuffer().readDouble();
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
+    public void testReadDoubleLEAfterRelease() {
+        releasedBuffer().readDoubleLE();
     }
 
     @Test(expected = IllegalReferenceCountException.class)
@@ -2550,8 +3100,18 @@ public abstract class AbstractByteBufTest {
     }
 
     @Test(expected = IllegalReferenceCountException.class)
+    public void testWriteShortLEAfterRelease() {
+        releasedBuffer().writeShortLE(1);
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
     public void testWriteMediumAfterRelease() {
         releasedBuffer().writeMedium(1);
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
+    public void testWriteMediumLEAfterRelease() {
+        releasedBuffer().writeMediumLE(1);
     }
 
     @Test(expected = IllegalReferenceCountException.class)
@@ -2560,8 +3120,18 @@ public abstract class AbstractByteBufTest {
     }
 
     @Test(expected = IllegalReferenceCountException.class)
+    public void testWriteIntLEAfterRelease() {
+        releasedBuffer().writeIntLE(1);
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
     public void testWriteLongAfterRelease() {
         releasedBuffer().writeLong(1);
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
+    public void testWriteLongLEAfterRelease() {
+        releasedBuffer().writeLongLE(1);
     }
 
     @Test(expected = IllegalReferenceCountException.class)
@@ -2575,8 +3145,18 @@ public abstract class AbstractByteBufTest {
     }
 
     @Test(expected = IllegalReferenceCountException.class)
+    public void testWriteFloatLEAfterRelease() {
+        releasedBuffer().writeFloatLE(1);
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
     public void testWriteDoubleAfterRelease() {
         releasedBuffer().writeDouble(1);
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
+    public void testWriteDoubleLEAfterRelease() {
+        releasedBuffer().writeDoubleLE(1);
     }
 
     @Test(expected = IllegalReferenceCountException.class)
@@ -2640,23 +3220,47 @@ public abstract class AbstractByteBufTest {
     }
 
     @Test(expected = IllegalReferenceCountException.class)
+    public void testWriteUsAsciiCharSequenceAfterRelease() {
+        testWriteCharSequenceAfterRelease0(CharsetUtil.US_ASCII);
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
+    public void testWriteIso88591CharSequenceAfterRelease() {
+        testWriteCharSequenceAfterRelease0(CharsetUtil.ISO_8859_1);
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
+    public void testWriteUtf8CharSequenceAfterRelease() {
+        testWriteCharSequenceAfterRelease0(CharsetUtil.UTF_8);
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
+    public void testWriteUtf16CharSequenceAfterRelease() {
+        testWriteCharSequenceAfterRelease0(CharsetUtil.UTF_16);
+    }
+
+    private void testWriteCharSequenceAfterRelease0(Charset charset) {
+        releasedBuffer().writeCharSequence("x", charset);
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
     public void testForEachByteAfterRelease() {
-        releasedBuffer().forEachByte(new TestByteBufProcessor());
+        releasedBuffer().forEachByte(new TestByteProcessor());
     }
 
     @Test(expected = IllegalReferenceCountException.class)
     public void testForEachByteAfterRelease1() {
-        releasedBuffer().forEachByte(0, 1, new TestByteBufProcessor());
+        releasedBuffer().forEachByte(0, 1, new TestByteProcessor());
     }
 
     @Test(expected = IllegalReferenceCountException.class)
     public void testForEachByteDescAfterRelease() {
-        releasedBuffer().forEachByteDesc(new TestByteBufProcessor());
+        releasedBuffer().forEachByteDesc(new TestByteProcessor());
     }
 
     @Test(expected = IllegalReferenceCountException.class)
     public void testForEachByteDescAfterRelease1() {
-        releasedBuffer().forEachByteDesc(0, 1, new TestByteBufProcessor());
+        releasedBuffer().forEachByteDesc(0, 1, new TestByteProcessor());
     }
 
     @Test(expected = IllegalReferenceCountException.class)
@@ -2721,12 +3325,1097 @@ public abstract class AbstractByteBufTest {
         }
     }
 
+    @Test(expected = IllegalReferenceCountException.class)
+    public void testSliceAfterRelease() {
+        releasedBuffer().slice();
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
+    public void testSliceAfterRelease2() {
+        releasedBuffer().slice(0, 1);
+    }
+
+    private static void assertSliceFailAfterRelease(ByteBuf... bufs) {
+        for (ByteBuf buf : bufs) {
+            if (buf.refCnt() > 0) {
+                buf.release();
+            }
+        }
+        for (ByteBuf buf : bufs) {
+            try {
+                assertEquals(0, buf.refCnt());
+                buf.slice();
+                fail();
+            } catch (IllegalReferenceCountException ignored) {
+                // as expected
+            }
+        }
+    }
+
+    @Test
+    public void testSliceAfterReleaseRetainedSlice() {
+        ByteBuf buf = newBuffer(1);
+        ByteBuf buf2 = buf.retainedSlice(0, 1);
+        assertSliceFailAfterRelease(buf, buf2);
+    }
+
+    @Test
+    public void testSliceAfterReleaseRetainedSliceDuplicate() {
+        ByteBuf buf = newBuffer(1);
+        ByteBuf buf2 = buf.retainedSlice(0, 1);
+        ByteBuf buf3 = buf2.duplicate();
+        assertSliceFailAfterRelease(buf, buf2, buf3);
+    }
+
+    @Test
+    public void testSliceAfterReleaseRetainedSliceRetainedDuplicate() {
+        ByteBuf buf = newBuffer(1);
+        ByteBuf buf2 = buf.retainedSlice(0, 1);
+        ByteBuf buf3 = buf2.retainedDuplicate();
+        assertSliceFailAfterRelease(buf, buf2, buf3);
+    }
+
+    @Test
+    public void testSliceAfterReleaseRetainedDuplicate() {
+        ByteBuf buf = newBuffer(1);
+        ByteBuf buf2 = buf.retainedDuplicate();
+        assertSliceFailAfterRelease(buf, buf2);
+    }
+
+    @Test
+    public void testSliceAfterReleaseRetainedDuplicateSlice() {
+        ByteBuf buf = newBuffer(1);
+        ByteBuf buf2 = buf.retainedDuplicate();
+        ByteBuf buf3 = buf2.slice(0, 1);
+        assertSliceFailAfterRelease(buf, buf2, buf3);
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
+    public void testRetainedSliceAfterRelease() {
+        releasedBuffer().retainedSlice();
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
+    public void testRetainedSliceAfterRelease2() {
+        releasedBuffer().retainedSlice(0, 1);
+    }
+
+    private static void assertRetainedSliceFailAfterRelease(ByteBuf... bufs) {
+        for (ByteBuf buf : bufs) {
+            if (buf.refCnt() > 0) {
+                buf.release();
+            }
+        }
+        for (ByteBuf buf : bufs) {
+            try {
+                assertEquals(0, buf.refCnt());
+                buf.retainedSlice();
+                fail();
+            } catch (IllegalReferenceCountException ignored) {
+                // as expected
+            }
+        }
+    }
+
+    @Test
+    public void testRetainedSliceAfterReleaseRetainedSlice() {
+        ByteBuf buf = newBuffer(1);
+        ByteBuf buf2 = buf.retainedSlice(0, 1);
+        assertRetainedSliceFailAfterRelease(buf, buf2);
+    }
+
+    @Test
+    public void testRetainedSliceAfterReleaseRetainedSliceDuplicate() {
+        ByteBuf buf = newBuffer(1);
+        ByteBuf buf2 = buf.retainedSlice(0, 1);
+        ByteBuf buf3 = buf2.duplicate();
+        assertRetainedSliceFailAfterRelease(buf, buf2, buf3);
+    }
+
+    @Test
+    public void testRetainedSliceAfterReleaseRetainedSliceRetainedDuplicate() {
+        ByteBuf buf = newBuffer(1);
+        ByteBuf buf2 = buf.retainedSlice(0, 1);
+        ByteBuf buf3 = buf2.retainedDuplicate();
+        assertRetainedSliceFailAfterRelease(buf, buf2, buf3);
+    }
+
+    @Test
+    public void testRetainedSliceAfterReleaseRetainedDuplicate() {
+        ByteBuf buf = newBuffer(1);
+        ByteBuf buf2 = buf.retainedDuplicate();
+        assertRetainedSliceFailAfterRelease(buf, buf2);
+    }
+
+    @Test
+    public void testRetainedSliceAfterReleaseRetainedDuplicateSlice() {
+        ByteBuf buf = newBuffer(1);
+        ByteBuf buf2 = buf.retainedDuplicate();
+        ByteBuf buf3 = buf2.slice(0, 1);
+        assertRetainedSliceFailAfterRelease(buf, buf2, buf3);
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
+    public void testDuplicateAfterRelease() {
+        releasedBuffer().duplicate();
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
+    public void testRetainedDuplicateAfterRelease() {
+        releasedBuffer().retainedDuplicate();
+    }
+
+    private static void assertDuplicateFailAfterRelease(ByteBuf... bufs) {
+        for (ByteBuf buf : bufs) {
+            if (buf.refCnt() > 0) {
+                buf.release();
+            }
+        }
+        for (ByteBuf buf : bufs) {
+            try {
+                assertEquals(0, buf.refCnt());
+                buf.duplicate();
+                fail();
+            } catch (IllegalReferenceCountException ignored) {
+                // as expected
+            }
+        }
+    }
+
+    @Test
+    public void testDuplicateAfterReleaseRetainedSliceDuplicate() {
+        ByteBuf buf = newBuffer(1);
+        ByteBuf buf2 = buf.retainedSlice(0, 1);
+        ByteBuf buf3 = buf2.duplicate();
+        assertDuplicateFailAfterRelease(buf, buf2, buf3);
+    }
+
+    @Test
+    public void testDuplicateAfterReleaseRetainedDuplicate() {
+        ByteBuf buf = newBuffer(1);
+        ByteBuf buf2 = buf.retainedDuplicate();
+        assertDuplicateFailAfterRelease(buf, buf2);
+    }
+
+    @Test
+    public void testDuplicateAfterReleaseRetainedDuplicateSlice() {
+        ByteBuf buf = newBuffer(1);
+        ByteBuf buf2 = buf.retainedDuplicate();
+        ByteBuf buf3 = buf2.slice(0, 1);
+        assertDuplicateFailAfterRelease(buf, buf2, buf3);
+    }
+
+    private static void assertRetainedDuplicateFailAfterRelease(ByteBuf... bufs) {
+        for (ByteBuf buf : bufs) {
+            if (buf.refCnt() > 0) {
+                buf.release();
+            }
+        }
+        for (ByteBuf buf : bufs) {
+            try {
+                assertEquals(0, buf.refCnt());
+                buf.retainedDuplicate();
+                fail();
+            } catch (IllegalReferenceCountException ignored) {
+                // as expected
+            }
+        }
+    }
+
+    @Test
+    public void testRetainedDuplicateAfterReleaseRetainedDuplicate() {
+        ByteBuf buf = newBuffer(1);
+        ByteBuf buf2 = buf.retainedDuplicate();
+        assertRetainedDuplicateFailAfterRelease(buf, buf2);
+    }
+
+    @Test
+    public void testRetainedDuplicateAfterReleaseDuplicate() {
+        ByteBuf buf = newBuffer(1);
+        ByteBuf buf2 = buf.duplicate();
+        assertRetainedDuplicateFailAfterRelease(buf, buf2);
+    }
+
+    @Test
+    public void testRetainedDuplicateAfterReleaseRetainedSlice() {
+        ByteBuf buf = newBuffer(1);
+        ByteBuf buf2 = buf.retainedSlice(0, 1);
+        assertRetainedDuplicateFailAfterRelease(buf, buf2);
+    }
+
     @Test
     public void testSliceRelease() {
         ByteBuf buf = newBuffer(8);
         assertEquals(1, buf.refCnt());
         assertTrue(buf.slice().release());
         assertEquals(0, buf.refCnt());
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void testReadSliceOutOfBounds() {
+        testReadSliceOutOfBounds(false);
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void testReadRetainedSliceOutOfBounds() {
+        testReadSliceOutOfBounds(true);
+    }
+
+    private void testReadSliceOutOfBounds(boolean retainedSlice) {
+        ByteBuf buf = newBuffer(100);
+        try {
+            buf.writeZero(50);
+            if (retainedSlice) {
+                buf.readRetainedSlice(51);
+            } else {
+                buf.readSlice(51);
+            }
+            fail();
+        } finally {
+            buf.release();
+        }
+    }
+
+    @Test
+    public void testWriteUsAsciiCharSequenceExpand() {
+        testWriteCharSequenceExpand(CharsetUtil.US_ASCII);
+    }
+
+    @Test
+    public void testWriteUtf8CharSequenceExpand() {
+        testWriteCharSequenceExpand(CharsetUtil.UTF_8);
+    }
+
+    @Test
+    public void testWriteIso88591CharSequenceExpand() {
+        testWriteCharSequenceExpand(CharsetUtil.ISO_8859_1);
+    }
+    @Test
+    public void testWriteUtf16CharSequenceExpand() {
+        testWriteCharSequenceExpand(CharsetUtil.UTF_16);
+    }
+
+    private void testWriteCharSequenceExpand(Charset charset) {
+        ByteBuf buf = newBuffer(1);
+        try {
+            int writerIndex = buf.capacity() - 1;
+            buf.writerIndex(writerIndex);
+            int written = buf.writeCharSequence("AB", charset);
+            assertEquals(writerIndex, buf.writerIndex() - written);
+        } finally {
+            buf.release();
+        }
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void testSetUsAsciiCharSequenceNoExpand() {
+        testSetCharSequenceNoExpand(CharsetUtil.US_ASCII);
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void testSetUtf8CharSequenceNoExpand() {
+        testSetCharSequenceNoExpand(CharsetUtil.UTF_8);
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void testSetIso88591CharSequenceNoExpand() {
+        testSetCharSequenceNoExpand(CharsetUtil.ISO_8859_1);
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void testSetUtf16CharSequenceNoExpand() {
+        testSetCharSequenceNoExpand(CharsetUtil.UTF_16);
+    }
+
+    private void testSetCharSequenceNoExpand(Charset charset) {
+        ByteBuf buf = newBuffer(1);
+        try {
+            buf.setCharSequence(0, "AB", charset);
+        } finally {
+            buf.release();
+        }
+    }
+
+    @Test
+    public void testSetUsAsciiCharSequence() {
+        testSetGetCharSequence(CharsetUtil.US_ASCII);
+    }
+
+    @Test
+    public void testSetUtf8CharSequence() {
+        testSetGetCharSequence(CharsetUtil.UTF_8);
+    }
+
+    @Test
+    public void testSetIso88591CharSequence() {
+        testSetGetCharSequence(CharsetUtil.ISO_8859_1);
+    }
+
+    @Test
+    public void testSetUtf16CharSequence() {
+        testSetGetCharSequence(CharsetUtil.UTF_16);
+    }
+
+    private void testSetGetCharSequence(Charset charset) {
+        ByteBuf buf = newBuffer(16);
+        String sequence = "AB";
+        int bytes = buf.setCharSequence(1, sequence, charset);
+        assertEquals(sequence, buf.getCharSequence(1, bytes, charset));
+        buf.release();
+    }
+
+    @Test
+    public void testWriteReadUsAsciiCharSequence() {
+        testWriteReadCharSequence(CharsetUtil.US_ASCII);
+    }
+
+    @Test
+    public void testWriteReadUtf8CharSequence() {
+        testWriteReadCharSequence(CharsetUtil.UTF_8);
+    }
+
+    @Test
+    public void testWriteReadIso88591CharSequence() {
+        testWriteReadCharSequence(CharsetUtil.ISO_8859_1);
+    }
+
+    @Test
+    public void testWriteReadUtf16CharSequence() {
+        testWriteReadCharSequence(CharsetUtil.UTF_16);
+    }
+
+    private void testWriteReadCharSequence(Charset charset) {
+        ByteBuf buf = newBuffer(16);
+        String sequence = "AB";
+        buf.writerIndex(1);
+        int bytes = buf.writeCharSequence(sequence, charset);
+        buf.readerIndex(1);
+        assertEquals(sequence, buf.readCharSequence(bytes, charset));
+        buf.release();
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void testRetainedSliceIndexOutOfBounds() {
+        testSliceOutOfBounds(true, true, true);
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void testRetainedSliceLengthOutOfBounds() {
+        testSliceOutOfBounds(true, true, false);
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void testMixedSliceAIndexOutOfBounds() {
+        testSliceOutOfBounds(true, false, true);
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void testMixedSliceALengthOutOfBounds() {
+        testSliceOutOfBounds(true, false, false);
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void testMixedSliceBIndexOutOfBounds() {
+        testSliceOutOfBounds(false, true, true);
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void testMixedSliceBLengthOutOfBounds() {
+        testSliceOutOfBounds(false, true, false);
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void testSliceIndexOutOfBounds() {
+        testSliceOutOfBounds(false, false, true);
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void testSliceLengthOutOfBounds() {
+        testSliceOutOfBounds(false, false, false);
+    }
+
+    @Test
+    public void testRetainedSliceAndRetainedDuplicateContentIsExpected() {
+        ByteBuf buf = newBuffer(8).resetWriterIndex();
+        ByteBuf expected1 = newBuffer(6).resetWriterIndex();
+        ByteBuf expected2 = newBuffer(5).resetWriterIndex();
+        ByteBuf expected3 = newBuffer(4).resetWriterIndex();
+        ByteBuf expected4 = newBuffer(3).resetWriterIndex();
+        buf.writeBytes(new byte[] {1, 2, 3, 4, 5, 6, 7, 8});
+        expected1.writeBytes(new byte[] {2, 3, 4, 5, 6, 7});
+        expected2.writeBytes(new byte[] {3, 4, 5, 6, 7});
+        expected3.writeBytes(new byte[] {4, 5, 6, 7});
+        expected4.writeBytes(new byte[] {5, 6, 7});
+
+        ByteBuf slice1 = buf.retainedSlice(buf.readerIndex() + 1, 6);
+        assertEquals(0, slice1.compareTo(expected1));
+        assertEquals(0, slice1.compareTo(buf.slice(buf.readerIndex() + 1, 6)));
+        // Simulate a handler that releases the original buffer, and propagates a slice.
+        buf.release();
+
+        // Advance the reader index on the slice.
+        slice1.readByte();
+
+        ByteBuf dup1 = slice1.retainedDuplicate();
+        assertEquals(0, dup1.compareTo(expected2));
+        assertEquals(0, dup1.compareTo(slice1.duplicate()));
+
+        // Advance the reader index on dup1.
+        dup1.readByte();
+
+        ByteBuf dup2 = dup1.duplicate();
+        assertEquals(0, dup2.compareTo(expected3));
+
+        // Advance the reader index on dup2.
+        dup2.readByte();
+
+        ByteBuf slice2 = dup2.retainedSlice(dup2.readerIndex(), 3);
+        assertEquals(0, slice2.compareTo(expected4));
+        assertEquals(0, slice2.compareTo(dup2.slice(dup2.readerIndex(), 3)));
+
+        // Cleanup the expected buffers used for testing.
+        assertTrue(expected1.release());
+        assertTrue(expected2.release());
+        assertTrue(expected3.release());
+        assertTrue(expected4.release());
+
+        slice2.release();
+        dup2.release();
+
+        assertEquals(slice2.refCnt(), dup2.refCnt());
+        assertEquals(dup2.refCnt(), dup1.refCnt());
+
+        // The handler is now done with the original slice
+        assertTrue(slice1.release());
+
+        // Reference counting may be shared, or may be independently tracked, but at this point all buffers should
+        // be deallocated and have a reference count of 0.
+        assertEquals(0, buf.refCnt());
+        assertEquals(0, slice1.refCnt());
+        assertEquals(0, slice2.refCnt());
+        assertEquals(0, dup1.refCnt());
+        assertEquals(0, dup2.refCnt());
+    }
+
+    @Test
+    public void testRetainedDuplicateAndRetainedSliceContentIsExpected() {
+        ByteBuf buf = newBuffer(8).resetWriterIndex();
+        ByteBuf expected1 = newBuffer(6).resetWriterIndex();
+        ByteBuf expected2 = newBuffer(5).resetWriterIndex();
+        ByteBuf expected3 = newBuffer(4).resetWriterIndex();
+        buf.writeBytes(new byte[] {1, 2, 3, 4, 5, 6, 7, 8});
+        expected1.writeBytes(new byte[] {2, 3, 4, 5, 6, 7});
+        expected2.writeBytes(new byte[] {3, 4, 5, 6, 7});
+        expected3.writeBytes(new byte[] {5, 6, 7});
+
+        ByteBuf dup1 = buf.retainedDuplicate();
+        assertEquals(0, dup1.compareTo(buf));
+        assertEquals(0, dup1.compareTo(buf.slice()));
+        // Simulate a handler that releases the original buffer, and propagates a slice.
+        buf.release();
+
+        // Advance the reader index on the dup.
+        dup1.readByte();
+
+        ByteBuf slice1 = dup1.retainedSlice(dup1.readerIndex(), 6);
+        assertEquals(0, slice1.compareTo(expected1));
+        assertEquals(0, slice1.compareTo(slice1.duplicate()));
+
+        // Advance the reader index on slice1.
+        slice1.readByte();
+
+        ByteBuf dup2 = slice1.duplicate();
+        assertEquals(0, dup2.compareTo(slice1));
+
+        // Advance the reader index on dup2.
+        dup2.readByte();
+
+        ByteBuf slice2 = dup2.retainedSlice(dup2.readerIndex() + 1, 3);
+        assertEquals(0, slice2.compareTo(expected3));
+        assertEquals(0, slice2.compareTo(dup2.slice(dup2.readerIndex() + 1, 3)));
+
+        // Cleanup the expected buffers used for testing.
+        assertTrue(expected1.release());
+        assertTrue(expected2.release());
+        assertTrue(expected3.release());
+
+        slice2.release();
+        slice1.release();
+
+        assertEquals(slice2.refCnt(), dup2.refCnt());
+        assertEquals(dup2.refCnt(), slice1.refCnt());
+
+        // The handler is now done with the original slice
+        assertTrue(dup1.release());
+
+        // Reference counting may be shared, or may be independently tracked, but at this point all buffers should
+        // be deallocated and have a reference count of 0.
+        assertEquals(0, buf.refCnt());
+        assertEquals(0, slice1.refCnt());
+        assertEquals(0, slice2.refCnt());
+        assertEquals(0, dup1.refCnt());
+        assertEquals(0, dup2.refCnt());
+    }
+
+    @Test
+    public void testRetainedSliceContents() {
+        testSliceContents(true);
+    }
+
+    @Test
+    public void testMultipleLevelRetainedSlice1() {
+        testMultipleLevelRetainedSliceWithNonRetained(true, true);
+    }
+
+    @Test
+    public void testMultipleLevelRetainedSlice2() {
+        testMultipleLevelRetainedSliceWithNonRetained(true, false);
+    }
+
+    @Test
+    public void testMultipleLevelRetainedSlice3() {
+        testMultipleLevelRetainedSliceWithNonRetained(false, true);
+    }
+
+    @Test
+    public void testMultipleLevelRetainedSlice4() {
+        testMultipleLevelRetainedSliceWithNonRetained(false, false);
+    }
+
+    @Test
+    public void testRetainedSliceReleaseOriginal1() {
+        testSliceReleaseOriginal(true, true);
+    }
+
+    @Test
+    public void testRetainedSliceReleaseOriginal2() {
+        testSliceReleaseOriginal(true, false);
+    }
+
+    @Test
+    public void testRetainedSliceReleaseOriginal3() {
+        testSliceReleaseOriginal(false, true);
+    }
+
+    @Test
+    public void testRetainedSliceReleaseOriginal4() {
+        testSliceReleaseOriginal(false, false);
+    }
+
+    @Test
+    public void testRetainedDuplicateReleaseOriginal1() {
+        testDuplicateReleaseOriginal(true, true);
+    }
+
+    @Test
+    public void testRetainedDuplicateReleaseOriginal2() {
+        testDuplicateReleaseOriginal(true, false);
+    }
+
+    @Test
+    public void testRetainedDuplicateReleaseOriginal3() {
+        testDuplicateReleaseOriginal(false, true);
+    }
+
+    @Test
+    public void testRetainedDuplicateReleaseOriginal4() {
+        testDuplicateReleaseOriginal(false, false);
+    }
+
+    @Test
+    public void testMultipleRetainedSliceReleaseOriginal1() {
+        testMultipleRetainedSliceReleaseOriginal(true, true);
+    }
+
+    @Test
+    public void testMultipleRetainedSliceReleaseOriginal2() {
+        testMultipleRetainedSliceReleaseOriginal(true, false);
+    }
+
+    @Test
+    public void testMultipleRetainedSliceReleaseOriginal3() {
+        testMultipleRetainedSliceReleaseOriginal(false, true);
+    }
+
+    @Test
+    public void testMultipleRetainedSliceReleaseOriginal4() {
+        testMultipleRetainedSliceReleaseOriginal(false, false);
+    }
+
+    @Test
+    public void testMultipleRetainedDuplicateReleaseOriginal1() {
+        testMultipleRetainedDuplicateReleaseOriginal(true, true);
+    }
+
+    @Test
+    public void testMultipleRetainedDuplicateReleaseOriginal2() {
+        testMultipleRetainedDuplicateReleaseOriginal(true, false);
+    }
+
+    @Test
+    public void testMultipleRetainedDuplicateReleaseOriginal3() {
+        testMultipleRetainedDuplicateReleaseOriginal(false, true);
+    }
+
+    @Test
+    public void testMultipleRetainedDuplicateReleaseOriginal4() {
+        testMultipleRetainedDuplicateReleaseOriginal(false, false);
+    }
+
+    @Test
+    public void testSliceContents() {
+        testSliceContents(false);
+    }
+
+    @Test
+    public void testRetainedDuplicateContents() {
+        testDuplicateContents(true);
+    }
+
+    @Test
+    public void testDuplicateContents() {
+        testDuplicateContents(false);
+    }
+
+    @Test
+    public void testDuplicateCapacityChange() {
+        testDuplicateCapacityChange(false);
+    }
+
+    @Test
+    public void testRetainedDuplicateCapacityChange() {
+        testDuplicateCapacityChange(true);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testSliceCapacityChange() {
+        testSliceCapacityChange(false);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testRetainedSliceCapacityChange() {
+        testSliceCapacityChange(true);
+    }
+
+    @Test
+    public void testRetainedSliceUnreleasable1() {
+        testRetainedSliceUnreleasable(true, true);
+    }
+
+    @Test
+    public void testRetainedSliceUnreleasable2() {
+        testRetainedSliceUnreleasable(true, false);
+    }
+
+    @Test
+    public void testRetainedSliceUnreleasable3() {
+        testRetainedSliceUnreleasable(false, true);
+    }
+
+    @Test
+    public void testRetainedSliceUnreleasable4() {
+        testRetainedSliceUnreleasable(false, false);
+    }
+
+    @Test
+    public void testReadRetainedSliceUnreleasable1() {
+        testReadRetainedSliceUnreleasable(true, true);
+    }
+
+    @Test
+    public void testReadRetainedSliceUnreleasable2() {
+        testReadRetainedSliceUnreleasable(true, false);
+    }
+
+    @Test
+    public void testReadRetainedSliceUnreleasable3() {
+        testReadRetainedSliceUnreleasable(false, true);
+    }
+
+    @Test
+    public void testReadRetainedSliceUnreleasable4() {
+        testReadRetainedSliceUnreleasable(false, false);
+    }
+
+    @Test
+    public void testRetainedDuplicateUnreleasable1() {
+        testRetainedDuplicateUnreleasable(true, true);
+    }
+
+    @Test
+    public void testRetainedDuplicateUnreleasable2() {
+        testRetainedDuplicateUnreleasable(true, false);
+    }
+
+    @Test
+    public void testRetainedDuplicateUnreleasable3() {
+        testRetainedDuplicateUnreleasable(false, true);
+    }
+
+    @Test
+    public void testRetainedDuplicateUnreleasable4() {
+        testRetainedDuplicateUnreleasable(false, false);
+    }
+
+    private void testRetainedSliceUnreleasable(boolean initRetainedSlice, boolean finalRetainedSlice) {
+        ByteBuf buf = newBuffer(8);
+        ByteBuf buf1 = initRetainedSlice ? buf.retainedSlice() : buf.slice().retain();
+        ByteBuf buf2 = unreleasableBuffer(buf1);
+        ByteBuf buf3 = finalRetainedSlice ? buf2.retainedSlice() : buf2.slice().retain();
+        assertFalse(buf3.release());
+        assertFalse(buf2.release());
+        buf1.release();
+        assertTrue(buf.release());
+        assertEquals(0, buf1.refCnt());
+        assertEquals(0, buf.refCnt());
+    }
+
+    private void testReadRetainedSliceUnreleasable(boolean initRetainedSlice, boolean finalRetainedSlice) {
+        ByteBuf buf = newBuffer(8);
+        ByteBuf buf1 = initRetainedSlice ? buf.retainedSlice() : buf.slice().retain();
+        ByteBuf buf2 = unreleasableBuffer(buf1);
+        ByteBuf buf3 = finalRetainedSlice ? buf2.readRetainedSlice(buf2.readableBytes())
+                                          : buf2.readSlice(buf2.readableBytes()).retain();
+        assertFalse(buf3.release());
+        assertFalse(buf2.release());
+        buf1.release();
+        assertTrue(buf.release());
+        assertEquals(0, buf1.refCnt());
+        assertEquals(0, buf.refCnt());
+    }
+
+    private void testRetainedDuplicateUnreleasable(boolean initRetainedDuplicate, boolean finalRetainedDuplicate) {
+        ByteBuf buf = newBuffer(8);
+        ByteBuf buf1 = initRetainedDuplicate ? buf.retainedDuplicate() : buf.duplicate().retain();
+        ByteBuf buf2 = unreleasableBuffer(buf1);
+        ByteBuf buf3 = finalRetainedDuplicate ? buf2.retainedDuplicate() : buf2.duplicate().retain();
+        assertFalse(buf3.release());
+        assertFalse(buf2.release());
+        buf1.release();
+        assertTrue(buf.release());
+        assertEquals(0, buf1.refCnt());
+        assertEquals(0, buf.refCnt());
+    }
+
+    private void testDuplicateCapacityChange(boolean retainedDuplicate) {
+        ByteBuf buf = newBuffer(8);
+        ByteBuf dup = retainedDuplicate ? buf.retainedDuplicate() : buf.duplicate();
+        try {
+            dup.capacity(10);
+            assertEquals(buf.capacity(), dup.capacity());
+            dup.capacity(5);
+            assertEquals(buf.capacity(), dup.capacity());
+        } finally {
+            if (retainedDuplicate) {
+                dup.release();
+            }
+            buf.release();
+        }
+    }
+
+    private void testSliceCapacityChange(boolean retainedSlice) {
+        ByteBuf buf = newBuffer(8);
+        ByteBuf slice = retainedSlice ? buf.retainedSlice(buf.readerIndex() + 1, 3)
+                                      : buf.slice(buf.readerIndex() + 1, 3);
+        try {
+            slice.capacity(10);
+        } finally {
+            if (retainedSlice) {
+                slice.release();
+            }
+            buf.release();
+        }
+    }
+
+    private void testSliceOutOfBounds(boolean initRetainedSlice, boolean finalRetainedSlice, boolean indexOutOfBounds) {
+        ByteBuf buf = newBuffer(8);
+        ByteBuf slice = initRetainedSlice ? buf.retainedSlice(buf.readerIndex() + 1, 2)
+                                          : buf.slice(buf.readerIndex() + 1, 2);
+        try {
+            assertEquals(2, slice.capacity());
+            assertEquals(2, slice.maxCapacity());
+            final int index = indexOutOfBounds ? 3 : 0;
+            final int length = indexOutOfBounds ? 0 : 3;
+            if (finalRetainedSlice) {
+                // This is expected to fail ... so no need to release.
+                slice.retainedSlice(index, length);
+            } else {
+                slice.slice(index, length);
+            }
+        } finally {
+            if (initRetainedSlice) {
+                slice.release();
+            }
+            buf.release();
+        }
+    }
+
+    private void testSliceContents(boolean retainedSlice) {
+        ByteBuf buf = newBuffer(8).resetWriterIndex();
+        ByteBuf expected = newBuffer(3).resetWriterIndex();
+        buf.writeBytes(new byte[] {1, 2, 3, 4, 5, 6, 7, 8});
+        expected.writeBytes(new byte[] {4, 5, 6});
+        ByteBuf slice = retainedSlice ? buf.retainedSlice(buf.readerIndex() + 3, 3)
+                                      : buf.slice(buf.readerIndex() + 3, 3);
+        try {
+            assertEquals(0, slice.compareTo(expected));
+            assertEquals(0, slice.compareTo(slice.duplicate()));
+            ByteBuf b = slice.retainedDuplicate();
+            assertEquals(0, slice.compareTo(b));
+            b.release();
+            assertEquals(0, slice.compareTo(slice.slice(0, slice.capacity())));
+        } finally {
+            if (retainedSlice) {
+                slice.release();
+            }
+            buf.release();
+            expected.release();
+        }
+    }
+
+    private void testSliceReleaseOriginal(boolean retainedSlice1, boolean retainedSlice2) {
+        ByteBuf buf = newBuffer(8).resetWriterIndex();
+        ByteBuf expected1 = newBuffer(3).resetWriterIndex();
+        ByteBuf expected2 = newBuffer(2).resetWriterIndex();
+        buf.writeBytes(new byte[] {1, 2, 3, 4, 5, 6, 7, 8});
+        expected1.writeBytes(new byte[] {6, 7, 8});
+        expected2.writeBytes(new byte[] {7, 8});
+        ByteBuf slice1 = retainedSlice1 ? buf.retainedSlice(buf.readerIndex() + 5, 3)
+                                        : buf.slice(buf.readerIndex() + 5, 3).retain();
+        assertEquals(0, slice1.compareTo(expected1));
+        // Simulate a handler that releases the original buffer, and propagates a slice.
+        buf.release();
+
+        ByteBuf slice2 = retainedSlice2 ? slice1.retainedSlice(slice1.readerIndex() + 1, 2)
+                                        : slice1.slice(slice1.readerIndex() + 1, 2).retain();
+        assertEquals(0, slice2.compareTo(expected2));
+
+        // Cleanup the expected buffers used for testing.
+        assertTrue(expected1.release());
+        assertTrue(expected2.release());
+
+        // The handler created a slice of the slice and is now done with it.
+        slice2.release();
+
+        // The handler is now done with the original slice
+        assertTrue(slice1.release());
+
+        // Reference counting may be shared, or may be independently tracked, but at this point all buffers should
+        // be deallocated and have a reference count of 0.
+        assertEquals(0, buf.refCnt());
+        assertEquals(0, slice1.refCnt());
+        assertEquals(0, slice2.refCnt());
+    }
+
+    private void testMultipleLevelRetainedSliceWithNonRetained(boolean doSlice1, boolean doSlice2) {
+        ByteBuf buf = newBuffer(8).resetWriterIndex();
+        ByteBuf expected1 = newBuffer(6).resetWriterIndex();
+        ByteBuf expected2 = newBuffer(4).resetWriterIndex();
+        ByteBuf expected3 = newBuffer(2).resetWriterIndex();
+        ByteBuf expected4SliceSlice = newBuffer(1).resetWriterIndex();
+        ByteBuf expected4DupSlice = newBuffer(1).resetWriterIndex();
+        buf.writeBytes(new byte[] {1, 2, 3, 4, 5, 6, 7, 8});
+        expected1.writeBytes(new byte[] {2, 3, 4, 5, 6, 7});
+        expected2.writeBytes(new byte[] {3, 4, 5, 6});
+        expected3.writeBytes(new byte[] {4, 5});
+        expected4SliceSlice.writeBytes(new byte[] {5});
+        expected4DupSlice.writeBytes(new byte[] {4});
+
+        ByteBuf slice1 = buf.retainedSlice(buf.readerIndex() + 1, 6);
+        assertEquals(0, slice1.compareTo(expected1));
+        // Simulate a handler that releases the original buffer, and propagates a slice.
+        buf.release();
+
+        ByteBuf slice2 = slice1.retainedSlice(slice1.readerIndex() + 1, 4);
+        assertEquals(0, slice2.compareTo(expected2));
+        assertEquals(0, slice2.compareTo(slice2.duplicate()));
+        assertEquals(0, slice2.compareTo(slice2.slice()));
+
+        ByteBuf tmpBuf = slice2.retainedDuplicate();
+        assertEquals(0, slice2.compareTo(tmpBuf));
+        tmpBuf.release();
+        tmpBuf = slice2.retainedSlice();
+        assertEquals(0, slice2.compareTo(tmpBuf));
+        tmpBuf.release();
+
+        ByteBuf slice3 = doSlice1 ? slice2.slice(slice2.readerIndex() + 1, 2) : slice2.duplicate();
+        if (doSlice1) {
+            assertEquals(0, slice3.compareTo(expected3));
+        } else {
+            assertEquals(0, slice3.compareTo(expected2));
+        }
+
+        ByteBuf slice4 = doSlice2 ? slice3.slice(slice3.readerIndex() + 1, 1) : slice3.duplicate();
+        if (doSlice1 && doSlice2) {
+            assertEquals(0, slice4.compareTo(expected4SliceSlice));
+        } else if (doSlice2) {
+            assertEquals(0, slice4.compareTo(expected4DupSlice));
+        } else {
+            assertEquals(0, slice3.compareTo(slice4));
+        }
+
+        // Cleanup the expected buffers used for testing.
+        assertTrue(expected1.release());
+        assertTrue(expected2.release());
+        assertTrue(expected3.release());
+        assertTrue(expected4SliceSlice.release());
+        assertTrue(expected4DupSlice.release());
+
+        // Slice 4, 3, and 2 should effectively "share" a reference count.
+        slice4.release();
+        assertEquals(slice3.refCnt(), slice2.refCnt());
+        assertEquals(slice3.refCnt(), slice4.refCnt());
+
+        // Slice 1 should also release the original underlying buffer without throwing exceptions
+        assertTrue(slice1.release());
+
+        // Reference counting may be shared, or may be independently tracked, but at this point all buffers should
+        // be deallocated and have a reference count of 0.
+        assertEquals(0, buf.refCnt());
+        assertEquals(0, slice1.refCnt());
+        assertEquals(0, slice2.refCnt());
+        assertEquals(0, slice3.refCnt());
+    }
+
+    private void testDuplicateReleaseOriginal(boolean retainedDuplicate1, boolean retainedDuplicate2) {
+        ByteBuf buf = newBuffer(8).resetWriterIndex();
+        ByteBuf expected = newBuffer(8).resetWriterIndex();
+        buf.writeBytes(new byte[] {1, 2, 3, 4, 5, 6, 7, 8});
+        expected.writeBytes(buf, buf.readerIndex(), buf.readableBytes());
+        ByteBuf dup1 = retainedDuplicate1 ? buf.retainedDuplicate()
+                                          : buf.duplicate().retain();
+        assertEquals(0, dup1.compareTo(expected));
+        // Simulate a handler that releases the original buffer, and propagates a slice.
+        buf.release();
+
+        ByteBuf dup2 = retainedDuplicate2 ? dup1.retainedDuplicate()
+                                          : dup1.duplicate().retain();
+        assertEquals(0, dup2.compareTo(expected));
+
+        // Cleanup the expected buffers used for testing.
+        assertTrue(expected.release());
+
+        // The handler created a slice of the slice and is now done with it.
+        dup2.release();
+
+        // The handler is now done with the original slice
+        assertTrue(dup1.release());
+
+        // Reference counting may be shared, or may be independently tracked, but at this point all buffers should
+        // be deallocated and have a reference count of 0.
+        assertEquals(0, buf.refCnt());
+        assertEquals(0, dup1.refCnt());
+        assertEquals(0, dup2.refCnt());
+    }
+
+    private void testMultipleRetainedSliceReleaseOriginal(boolean retainedSlice1, boolean retainedSlice2) {
+        ByteBuf buf = newBuffer(8).resetWriterIndex();
+        ByteBuf expected1 = newBuffer(3).resetWriterIndex();
+        ByteBuf expected2 = newBuffer(2).resetWriterIndex();
+        ByteBuf expected3 = newBuffer(2).resetWriterIndex();
+        buf.writeBytes(new byte[] {1, 2, 3, 4, 5, 6, 7, 8});
+        expected1.writeBytes(new byte[] {6, 7, 8});
+        expected2.writeBytes(new byte[] {7, 8});
+        expected3.writeBytes(new byte[] {6, 7});
+        ByteBuf slice1 = retainedSlice1 ? buf.retainedSlice(buf.readerIndex() + 5, 3)
+                                        : buf.slice(buf.readerIndex() + 5, 3).retain();
+        assertEquals(0, slice1.compareTo(expected1));
+        // Simulate a handler that releases the original buffer, and propagates a slice.
+        buf.release();
+
+        ByteBuf slice2 = retainedSlice2 ? slice1.retainedSlice(slice1.readerIndex() + 1, 2)
+                                        : slice1.slice(slice1.readerIndex() + 1, 2).retain();
+        assertEquals(0, slice2.compareTo(expected2));
+
+        // The handler created a slice of the slice and is now done with it.
+        slice2.release();
+
+        ByteBuf slice3 = slice1.retainedSlice(slice1.readerIndex(), 2);
+        assertEquals(0, slice3.compareTo(expected3));
+
+        // The handler created another slice of the slice and is now done with it.
+        slice3.release();
+
+        // The handler is now done with the original slice
+        assertTrue(slice1.release());
+
+        // Cleanup the expected buffers used for testing.
+        assertTrue(expected1.release());
+        assertTrue(expected2.release());
+        assertTrue(expected3.release());
+
+        // Reference counting may be shared, or may be independently tracked, but at this point all buffers should
+        // be deallocated and have a reference count of 0.
+        assertEquals(0, buf.refCnt());
+        assertEquals(0, slice1.refCnt());
+        assertEquals(0, slice2.refCnt());
+        assertEquals(0, slice3.refCnt());
+    }
+
+    private void testMultipleRetainedDuplicateReleaseOriginal(boolean retainedDuplicate1, boolean retainedDuplicate2) {
+        ByteBuf buf = newBuffer(8).resetWriterIndex();
+        ByteBuf expected = newBuffer(8).resetWriterIndex();
+        buf.writeBytes(new byte[] {1, 2, 3, 4, 5, 6, 7, 8});
+        expected.writeBytes(buf, buf.readerIndex(), buf.readableBytes());
+        ByteBuf dup1 = retainedDuplicate1 ? buf.retainedDuplicate()
+                                          : buf.duplicate().retain();
+        assertEquals(0, dup1.compareTo(expected));
+        // Simulate a handler that releases the original buffer, and propagates a slice.
+        buf.release();
+
+        ByteBuf dup2 = retainedDuplicate2 ? dup1.retainedDuplicate()
+                                          : dup1.duplicate().retain();
+        assertEquals(0, dup2.compareTo(expected));
+        assertEquals(0, dup2.compareTo(dup2.duplicate()));
+        assertEquals(0, dup2.compareTo(dup2.slice()));
+
+        ByteBuf tmpBuf = dup2.retainedDuplicate();
+        assertEquals(0, dup2.compareTo(tmpBuf));
+        tmpBuf.release();
+        tmpBuf = dup2.retainedSlice();
+        assertEquals(0, dup2.compareTo(tmpBuf));
+        tmpBuf.release();
+
+        // The handler created a slice of the slice and is now done with it.
+        dup2.release();
+
+        ByteBuf dup3 = dup1.retainedDuplicate();
+        assertEquals(0, dup3.compareTo(expected));
+
+        // The handler created another slice of the slice and is now done with it.
+        dup3.release();
+
+        // The handler is now done with the original slice
+        assertTrue(dup1.release());
+
+        // Cleanup the expected buffers used for testing.
+        assertTrue(expected.release());
+
+        // Reference counting may be shared, or may be independently tracked, but at this point all buffers should
+        // be deallocated and have a reference count of 0.
+        assertEquals(0, buf.refCnt());
+        assertEquals(0, dup1.refCnt());
+        assertEquals(0, dup2.refCnt());
+        assertEquals(0, dup3.refCnt());
+    }
+
+    private void testDuplicateContents(boolean retainedDuplicate) {
+        ByteBuf buf = newBuffer(8).resetWriterIndex();
+        buf.writeBytes(new byte[] {1, 2, 3, 4, 5, 6, 7, 8});
+        ByteBuf dup = retainedDuplicate ? buf.retainedDuplicate() : buf.duplicate();
+        try {
+            assertEquals(0, dup.compareTo(buf));
+            assertEquals(0, dup.compareTo(dup.duplicate()));
+            ByteBuf b = dup.retainedDuplicate();
+            assertEquals(0, dup.compareTo(b));
+            b.release();
+            assertEquals(0, dup.compareTo(dup.slice(dup.readerIndex(), dup.readableBytes())));
+        } finally {
+            if (retainedDuplicate) {
+                dup.release();
+            }
+            buf.release();
+        }
     }
 
     @Test
@@ -2791,6 +4480,94 @@ public abstract class AbstractByteBufTest {
     }
 
     @Test
+    public void testReadBytesAndWriteBytesWithFileChannel() throws IOException {
+        File file = File.createTempFile("file-channel", ".tmp");
+        RandomAccessFile randomAccessFile = null;
+        try {
+            randomAccessFile = new RandomAccessFile(file, "rw");
+            FileChannel channel = randomAccessFile.getChannel();
+            // channelPosition should never be changed
+            long channelPosition = channel.position();
+
+            byte[] bytes = {'a', 'b', 'c', 'd'};
+            int len = bytes.length;
+            ByteBuf buffer = newBuffer(len);
+            buffer.resetReaderIndex();
+            buffer.resetWriterIndex();
+            buffer.writeBytes(bytes);
+
+            int oldReaderIndex = buffer.readerIndex();
+            assertEquals(len, buffer.readBytes(channel, 10, len));
+            assertEquals(oldReaderIndex + len, buffer.readerIndex());
+            assertEquals(channelPosition, channel.position());
+
+            ByteBuf buffer2 = newBuffer(len);
+            buffer2.resetReaderIndex();
+            buffer2.resetWriterIndex();
+            int oldWriterIndex = buffer2.writerIndex();
+            assertEquals(len, buffer2.writeBytes(channel, 10, len));
+            assertEquals(channelPosition, channel.position());
+            assertEquals(oldWriterIndex + len, buffer2.writerIndex());
+            assertEquals('a', buffer2.getByte(0));
+            assertEquals('b', buffer2.getByte(1));
+            assertEquals('c', buffer2.getByte(2));
+            assertEquals('d', buffer2.getByte(3));
+            buffer.release();
+            buffer2.release();
+        } finally {
+            if (randomAccessFile != null) {
+                randomAccessFile.close();
+            }
+            file.delete();
+        }
+    }
+
+    @Test
+    public void testGetBytesAndSetBytesWithFileChannel() throws IOException {
+        File file = File.createTempFile("file-channel", ".tmp");
+        RandomAccessFile randomAccessFile = null;
+        try {
+            randomAccessFile = new RandomAccessFile(file, "rw");
+            FileChannel channel = randomAccessFile.getChannel();
+            // channelPosition should never be changed
+            long channelPosition = channel.position();
+
+            byte[] bytes = {'a', 'b', 'c', 'd'};
+            int len = bytes.length;
+            ByteBuf buffer = newBuffer(len);
+            buffer.resetReaderIndex();
+            buffer.resetWriterIndex();
+            buffer.writeBytes(bytes);
+
+            int oldReaderIndex = buffer.readerIndex();
+            assertEquals(len, buffer.getBytes(oldReaderIndex, channel, 10, len));
+            assertEquals(oldReaderIndex, buffer.readerIndex());
+            assertEquals(channelPosition, channel.position());
+
+            ByteBuf buffer2 = newBuffer(len);
+            buffer2.resetReaderIndex();
+            buffer2.resetWriterIndex();
+            int oldWriterIndex = buffer2.writerIndex();
+            assertEquals(buffer2.setBytes(oldWriterIndex, channel, 10, len), len);
+            assertEquals(channelPosition, channel.position());
+
+            assertEquals(oldWriterIndex, buffer2.writerIndex());
+            assertEquals('a', buffer2.getByte(oldWriterIndex));
+            assertEquals('b', buffer2.getByte(oldWriterIndex + 1));
+            assertEquals('c', buffer2.getByte(oldWriterIndex + 2));
+            assertEquals('d', buffer2.getByte(oldWriterIndex + 3));
+
+            buffer.release();
+            buffer2.release();
+        } finally {
+            if (randomAccessFile != null) {
+                randomAccessFile.close();
+            }
+            file.delete();
+        }
+    }
+
+    @Test
     public void testReadBytes() {
         ByteBuf buffer = newBuffer(8);
         byte[] bytes = new byte[8];
@@ -2812,7 +4589,7 @@ public abstract class AbstractByteBufTest {
         try {
             buf.writeBytes(expected);
             final byte[] bytes = new byte[expected.length];
-            int i = buf.forEachByteDesc(new ByteBufProcessor() {
+            int i = buf.forEachByteDesc(new ByteProcessor() {
                 private int index = bytes.length - 1;
 
                 @Override
@@ -2835,7 +4612,7 @@ public abstract class AbstractByteBufTest {
         try {
             buf.writeBytes(expected);
             final byte[] bytes = new byte[expected.length];
-            int i = buf.forEachByte(new ByteBufProcessor() {
+            int i = buf.forEachByte(new ByteProcessor() {
                 private int index;
 
                 @Override
@@ -3016,7 +4793,7 @@ public abstract class AbstractByteBufTest {
         }
     }
 
-    private static final class TestByteBufProcessor implements ByteBufProcessor {
+    private static final class TestByteProcessor implements ByteProcessor {
         @Override
         public boolean process(byte value) throws Exception {
             return true;
@@ -3070,6 +4847,27 @@ public abstract class AbstractByteBufTest {
             buffer.capacity(4);
             assertEquals(4, buffer.capacity());
             assertEquals(13, buffer.maxCapacity());
+        } finally {
+            buffer.release();
+        }
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void testReaderIndexLargerThanWriterIndex() {
+        String content1 = "hello";
+        String content2 = "world";
+        int length = content1.length() + content2.length();
+        ByteBuf buffer = newBuffer(length);
+        buffer.setIndex(0, 0);
+        buffer.writeCharSequence(content1, CharsetUtil.US_ASCII);
+        buffer.markWriterIndex();
+        buffer.skipBytes(content1.length());
+        buffer.writeCharSequence(content2, CharsetUtil.US_ASCII);
+        buffer.skipBytes(content2.length());
+        assertTrue(buffer.readerIndex() <= buffer.writerIndex());
+
+        try {
+            buffer.resetWriterIndex();
         } finally {
             buffer.release();
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/BufferTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/BufferTest.java
@@ -217,7 +217,7 @@ public class BufferTest extends AbstractByteBufTest {
 		assertEquals(0, slice.getReaderIndex());
 		assertEquals(10, slice.getSize());
 		assertEquals(10, slice.getSizeUnsafe());
-		assertSame(buffer, slice.unwrap());
+		assertSame(buffer, slice.unwrap().unwrap());
 
 		// slice indices should be independent:
 		buffer.setSize(8);
@@ -245,7 +245,7 @@ public class BufferTest extends AbstractByteBufTest {
 		assertEquals(0, slice.getReaderIndex());
 		assertEquals(10, slice.getSize());
 		assertEquals(10, slice.getSizeUnsafe());
-		assertSame(buffer, slice.unwrap());
+		assertSame(buffer, slice.unwrap().unwrap());
 
 		// slice indices should be independent:
 		buffer.setSize(8);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferTest.java
@@ -35,9 +35,9 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 /**
- * Tests for the {@link Buffer} class.
+ * Tests for the {@link NetworkBuffer} class.
  */
-public class BufferTest extends AbstractByteBufTest {
+public class NetworkBufferTest extends AbstractByteBufTest {
 
 	/**
 	 * Upper limit for the max size that is sufficient for all the tests.

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/ReadOnlySlicedBufferTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/ReadOnlySlicedBufferTest.java
@@ -144,8 +144,7 @@ public class ReadOnlySlicedBufferTest {
 		ReadOnlySlicedNetworkBuffer slice1 = buffer.readOnlySlice();
 		buffer.readByte(); // should not influence the second slice at all
 		ReadOnlySlicedNetworkBuffer slice2 = slice1.readOnlySlice();
-		ByteBuf unwrap = slice2.unwrap();
-		assertSame(buffer, unwrap);
+		assertSame(buffer, slice2.unwrap().unwrap());
 		assertSame(slice1.getMemorySegment(), slice2.getMemorySegment());
 		assertEquals(1, slice1.getMemorySegmentOffset());
 		assertEquals(slice1.getMemorySegmentOffset(), slice2.getMemorySegmentOffset());
@@ -160,8 +159,7 @@ public class ReadOnlySlicedBufferTest {
 		ReadOnlySlicedNetworkBuffer slice1 = buffer.readOnlySlice();
 		buffer.readByte(); // should not influence the second slice at all
 		ReadOnlySlicedNetworkBuffer slice2 = slice1.readOnlySlice(1, 2);
-		ByteBuf unwrap = slice2.unwrap();
-		assertSame(buffer, unwrap);
+		assertSame(buffer, slice2.unwrap().unwrap());
 		assertSame(slice1.getMemorySegment(), slice2.getMemorySegment());
 		assertEquals(1, slice1.getMemorySegmentOffset());
 		assertEquals(2, slice2.getMemorySegmentOffset());
@@ -175,8 +173,7 @@ public class ReadOnlySlicedBufferTest {
 		ReadOnlySlicedNetworkBuffer slice1 = buffer.readOnlySlice(1, 2);
 		buffer.readByte(); // should not influence the second slice at all
 		ReadOnlySlicedNetworkBuffer slice2 = slice1.readOnlySlice();
-		ByteBuf unwrap = slice2.unwrap();
-		assertSame(buffer, unwrap);
+		assertSame(buffer, slice2.unwrap().unwrap());
 		assertSame(slice1.getMemorySegment(), slice2.getMemorySegment());
 		assertEquals(1, slice1.getMemorySegmentOffset());
 		assertEquals(1, slice2.getMemorySegmentOffset());
@@ -190,8 +187,7 @@ public class ReadOnlySlicedBufferTest {
 		ReadOnlySlicedNetworkBuffer slice1 = buffer.readOnlySlice(1, 5);
 		buffer.readByte(); // should not influence the second slice at all
 		ReadOnlySlicedNetworkBuffer slice2 = slice1.readOnlySlice(1, 2);
-		ByteBuf unwrap = slice2.unwrap();
-		assertSame(buffer, unwrap);
+		assertSame(buffer, slice2.unwrap().unwrap());
 		assertSame(slice1.getMemorySegment(), slice2.getMemorySegment());
 		assertEquals(1, slice1.getMemorySegmentOffset());
 		assertEquals(2, slice2.getMemorySegmentOffset());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/ReadOnlySlicedBufferTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/ReadOnlySlicedBufferTest.java
@@ -322,22 +322,22 @@ public class ReadOnlySlicedBufferTest {
 
 	@Test
 	public void testGetNioBufferReadableThreadSafe1() {
-		BufferTest.testGetNioBufferReadableThreadSafe(buffer.readOnlySlice());
+		NetworkBufferTest.testGetNioBufferReadableThreadSafe(buffer.readOnlySlice());
 	}
 
 	@Test
 	public void testGetNioBufferReadableThreadSafe2() {
-		BufferTest.testGetNioBufferReadableThreadSafe(buffer.readOnlySlice(1, 2));
+		NetworkBufferTest.testGetNioBufferReadableThreadSafe(buffer.readOnlySlice(1, 2));
 	}
 
 	@Test
 	public void testGetNioBufferThreadSafe1() {
-		BufferTest.testGetNioBufferThreadSafe(buffer.readOnlySlice(), DATA_SIZE);
+		NetworkBufferTest.testGetNioBufferThreadSafe(buffer.readOnlySlice(), DATA_SIZE);
 	}
 
 	@Test
 	public void testGetNioBufferThreadSafe2() {
-		BufferTest.testGetNioBufferThreadSafe(buffer.readOnlySlice(1, 2), 2);
+		NetworkBufferTest.testGetNioBufferThreadSafe(buffer.readOnlySlice(1, 2), 2);
 	}
 
 	@Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyMessageSerializationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyMessageSerializationTest.java
@@ -36,6 +36,7 @@ import org.junit.Test;
 import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -151,9 +152,10 @@ public class NettyMessageSerializationTest {
 			testBuffer, random.nextInt(), new InputChannelID(), random.nextInt());
 		NettyMessage.BufferResponse actual = encodeAndDecode(expected);
 
-		// Verify recycle has been called on buffer instance (LengthFieldBasedFrameDecoder creates a new one)
-		assertTrue(buffer.isRecycled());
-		assertTrue(testBuffer.isRecycled());
+		// Netty 4.1 is not copying the messages, but retaining slices of them. BufferResponse actual is in this case
+		// holding a reference to the buffer. Buffer will be recycled only once "actual" will be released.
+		assertFalse(buffer.isRecycled());
+		assertFalse(testBuffer.isRecycled());
 
 		final ByteBuf retainedSlice = actual.getNettyBuffer();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/taskmanager/AbstractTaskManagerFileHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/taskmanager/AbstractTaskManagerFileHandlerTest.java
@@ -54,6 +54,7 @@ import org.apache.flink.shaded.netty4.io.netty.channel.ChannelProgressivePromise
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelPromise;
 import org.apache.flink.shaded.netty4.io.netty.channel.DefaultChannelPromise;
 import org.apache.flink.shaded.netty4.io.netty.channel.DefaultFileRegion;
+import org.apache.flink.shaded.netty4.io.netty.channel.embedded.EmbeddedChannel;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.DefaultFullHttpRequest;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpMethod;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpVersion;
@@ -320,7 +321,7 @@ public class AbstractTaskManagerFileHandlerTest extends TestLogger {
 				}
 			}
 
-			return new DefaultChannelPromise(null);
+			return new DefaultChannelPromise(new EmbeddedChannel());
 		}
 
 		@Override
@@ -522,6 +523,11 @@ public class AbstractTaskManagerFileHandlerTest extends TestLogger {
 		@Override
 		public <T> Attribute<T> attr(AttributeKey<T> key) {
 			return null;
+		}
+
+		@Override
+		public <T> boolean hasAttr(AttributeKey<T> attributeKey) {
+			return false;
 		}
 	}
 

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/NettyEpollITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/NettyEpollITCase.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.runtime;
+
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.test.util.MiniClusterResource;
+import org.apache.flink.test.util.MiniClusterResource.MiniClusterResourceConfiguration;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.AssumptionViolatedException;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.apache.flink.runtime.io.network.netty.NettyConfig.TRANSPORT_TYPE;
+import static org.apache.flink.util.ExceptionUtils.findThrowableWithMessage;
+
+/**
+ * Test network stack with taskmanager.network.netty.transport set to epoll. This test can only run
+ * on linux. On other platforms it's basically a NO-OP. See
+ * https://github.com/apache/flink-shaded/issues/30
+ */
+public class NettyEpollITCase extends TestLogger {
+
+	private static final Logger LOG = LoggerFactory.getLogger(NettyEpollITCase.class);
+
+	private static final int NUM_TASK_MANAGERS = 2;
+
+	@Test
+	public void testNettyEpoll() throws Exception {
+		MiniClusterResource cluster = trySetUpCluster();
+		try {
+			StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+			env.setParallelism(NUM_TASK_MANAGERS);
+			env.getConfig().disableSysoutLogging();
+
+			DataStream<Integer> input = env.fromElements(1, 2, 3, 4, 1, 2, 3, 42);
+			input.keyBy(new KeySelector<Integer, Integer>() {
+					@Override
+					public Integer getKey(Integer value) throws Exception {
+						return value;
+					}
+				})
+				.sum(0)
+				.print();
+
+			env.execute();
+		}
+		finally {
+			cluster.after();
+		}
+	}
+
+	private MiniClusterResource trySetUpCluster() throws Exception {
+		try {
+			Configuration config = new Configuration();
+			config.setString(TRANSPORT_TYPE, "epoll");
+			MiniClusterResource cluster = new MiniClusterResource(
+				new MiniClusterResourceConfiguration(
+					config,
+					NUM_TASK_MANAGERS,
+					1),
+				true);
+			cluster.before();
+			return cluster;
+		}
+		catch (UnsatisfiedLinkError ex) {
+			// If we failed to init netty because we are not on Linux platform, abort the test.
+			if (findThrowableWithMessage(ex, "Only supported on Linux").isPresent()) {
+				throw new AssumptionViolatedException("This test is only supported on linux");
+			}
+			throw ex;
+		}
+	}
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/minicluster/LocalFlinkMiniClusterITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/minicluster/LocalFlinkMiniClusterITCase.java
@@ -54,7 +54,11 @@ public class LocalFlinkMiniClusterITCase extends TestLogger {
 		// This is a daemon thread spawned by netty's ThreadLocalRandom class if no
 		// initialSeedUniquifier is set yet and it is sometimes spawned before this test and
 		// sometimes during this test.
-		"initialSeedUniquifierGenerator"
+		"initialSeedUniquifierGenerator",
+		// This thread quits only on JVM because of static field
+		// io.netty.buffer.PooledByteBufAllocator.DEFAULT
+		// https://github.com/netty/netty/issues/7759
+		"ObjectCleanerThread"
 	};
 
 	@Test

--- a/pom.xml
+++ b/pom.xml
@@ -259,15 +259,7 @@ under the License.
 			<dependency>
 				<groupId>org.apache.flink</groupId>
 				<artifactId>flink-shaded-netty</artifactId>
-				<!-- Don't upgrade for now. Netty versions >= 4.0.28.Final
-				contain an improvement by Netty, which slices a Netty buffer
-				instead of doing a memory copy [1] in the
-				LengthFieldBasedFrameDecoder. In some situations, this
-				interacts badly with our Netty pipeline leading to OutOfMemory
-				errors.
-
-				[1] https://github.com/netty/netty/issues/3704 -->
-				<version>4.0.27.Final-2.0</version>
+				<version>4.1.24.Final-${flink.shaded.version}</version>
 			</dependency>
 
 			<!-- This manages the 'javax.annotation' annotations (JSR305) -->


### PR DESCRIPTION
This PR bases on https://github.com/apache/flink/pull/6031 and first two commits should be ignored here.

This PR adjusts our code to work with Netty 4.1. It also includes possible bug fix to file uploading cleanup in FileUploadHandler and HttpRequestHandler. For mor information look here:

https://github.com/netty/netty/issues/7611

`Embed flink-shaded-netty-4` commit is only for having green travis and will be dropped once new `flink-shadded-netty` will be released.

## Verifying this change

This change is covered by variety of pre existing tests. Furthermore I have manually verified that issue mentioned by @uce in the commit message here: https://github.com/apache/flink/commit/d92e422ec7089376583a8f57043274d236c340a4
doesn't happen: 
- I have reproduced this issue on a test cluster with Flink 1.0-XXX
- I have verified that the same job passes without any problems after upgrading to Netty 4.1

I have also run our network benchmark suite and verified that there are no performance changes after this change.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**yes** / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
