### PR TITLE
[hotfix][doc] Clarify kinesis docs and fix debugging classloading docs

### DIFF
--- a/docs/dev/connectors/kinesis.md
+++ b/docs/dev/connectors/kinesis.md
@@ -286,6 +286,8 @@ producerConfig.put("RecordTtl", "30000");
 producerConfig.put("RequestTimeout", "6000");
 producerConfig.put("ThreadPoolSize", "15");
 
+// Disable Aggregation if it's not supported by a consumer
+// producerConfig.put("AggregationEnabled", "false");
 // Switch KinesisProducer's threading model
 // producerConfig.put("ThreadingModel", "PER_REQUEST");
 
@@ -312,6 +314,8 @@ producerConfig.put("RecordTtl", "30000")
 producerConfig.put("RequestTimeout", "6000")
 producerConfig.put("ThreadPoolSize", "15")
 
+// Disable Aggregation if it's not supported by a consumer
+// producerConfig.put("AggregationEnabled", "false")
 // Switch KinesisProducer's threading model
 // producerConfig.put("ThreadingModel", "PER_REQUEST")
 

--- a/docs/monitoring/debugging_classloading.md
+++ b/docs/monitoring/debugging_classloading.md
@@ -65,13 +65,11 @@ classes are loaded dynamically when the jobs are submitted.
 
 Flink uses a hierarchy of ClassLoaders for loading classes from the user-code jar(s). The user-code
 ClassLoader has a reference to the parent ClassLoader, which is the default Java ClassLoader in most
-cases. By default, Java ClassLoaders will first look for classes in the parent ClassLoader and then in
-the child ClassLoader for cases where we have a hierarchy of ClassLoaders. This is problematic if you
-have in your user jar a version of a library that conflicts with a version that comes with Flink. You can
-change this behaviour by configuring the ClassLoader resolution order via
-`classloader.resolve-order: child-first` in the Flink config. However, Flink classes will still
-be resolved through the parent ClassLoader first, although you can also configure this via
-`classloader.parent-first-patterns` (see [config](../ops/config.html))
+cases. In Flink by default, Java ClassLoaders will first look for classes in the child ClassLoader and then
+in the parent ClassLoader for cases where we have a hierarchy of ClassLoaders. You can change this behaviour
+by configuring the ClassLoader resolution order via `classloader.resolve-order: parent-first` in the Flink
+config. However, Flink classes are still resolved through the parent ClassLoader first, although you can also
+configure this via `classloader.parent-first-patterns` (see [config](../ops/config.html))
 
 
 ## Avoiding Dynamic Classloading


### PR DESCRIPTION
This change only clarifies the documentation 

1. Mention AggregationEnabled setting in kinesis docs

2. Fix the default settings of class loading order in the docs