### PR TITLE
[FLINK-9436][state] Remove generic parameter namespace from InternalTimeServiceManager

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
@@ -151,7 +151,7 @@ public abstract class AbstractStreamOperator<OUT>
 
 	// ---------------- time handler ------------------
 
-	protected transient InternalTimeServiceManager<?, ?> timeServiceManager;
+	protected transient InternalTimeServiceManager<?> timeServiceManager;
 
 	// ---------------- two-input operator watermarks ------------------
 
@@ -725,7 +725,7 @@ public abstract class AbstractStreamOperator<OUT>
 
 		// the following casting is to overcome type restrictions.
 		TypeSerializer<K> keySerializer = (TypeSerializer<K>) getKeyedStateBackend().getKeySerializer();
-		InternalTimeServiceManager<K, N> keyedTimeServiceHandler = (InternalTimeServiceManager<K, N>) timeServiceManager;
+		InternalTimeServiceManager<K> keyedTimeServiceHandler = (InternalTimeServiceManager<K>) timeServiceManager;
 		return keyedTimeServiceHandler.getInternalTimerService(name, keySerializer, namespaceSerializer, triggerable);
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/HeapInternalTimerService.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/HeapInternalTimerService.java
@@ -22,15 +22,12 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.typeutils.CompatibilityResult;
 import org.apache.flink.api.common.typeutils.CompatibilityUtil;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
-import org.apache.flink.runtime.state.KeyGroupsList;
+import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeCallback;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.util.Preconditions;
 
-import java.io.IOException;
-import java.util.HashSet;
-import java.util.PriorityQueue;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ScheduledFuture;
 
@@ -49,20 +46,18 @@ public class HeapInternalTimerService<K, N> implements InternalTimerService<N>, 
 	/**
 	 * Processing time timers that are currently in-flight.
 	 */
-	private final Set<InternalTimer<K, N>>[] processingTimeTimersByKeyGroup;
-	private final PriorityQueue<InternalTimer<K, N>> processingTimeTimersQueue;
+	private final InternalTimerHeap<K, N> processingTimeTimersQueue;
 
 	/**
 	 * Event time timers that are currently in-flight.
 	 */
-	private final Set<InternalTimer<K, N>>[] eventTimeTimersByKeyGroup;
-	private final PriorityQueue<InternalTimer<K, N>> eventTimeTimersQueue;
+	private final InternalTimerHeap<K, N> eventTimeTimersQueue;
 
 	/**
 	 * Information concerning the local key-group range.
 	 */
-	private final KeyGroupsList localKeyGroupRange;
-	private final int totalKeyGroups;
+	private final KeyGroupRange localKeyGroupRange;
+
 	private final int localKeyGroupRangeStartIdx;
 
 	/**
@@ -94,16 +89,14 @@ public class HeapInternalTimerService<K, N> implements InternalTimerService<N>, 
 	/** The restored timers snapshot, if any. */
 	private InternalTimersSnapshot<K, N> restoredTimersSnapshot;
 
-	public HeapInternalTimerService(
+	HeapInternalTimerService(
 		int totalKeyGroups,
-		KeyGroupsList localKeyGroupRange,
+		KeyGroupRange localKeyGroupRange,
 		KeyContext keyContext,
 		ProcessingTimeService processingTimeService) {
 
 		this.keyContext = checkNotNull(keyContext);
 		this.processingTimeService = checkNotNull(processingTimeService);
-
-		this.totalKeyGroups = totalKeyGroups;
 		this.localKeyGroupRange = checkNotNull(localKeyGroupRange);
 
 		// find the starting index of the local key-group range
@@ -113,14 +106,8 @@ public class HeapInternalTimerService<K, N> implements InternalTimerService<N>, 
 		}
 		this.localKeyGroupRangeStartIdx = startIdx;
 
-		// the list of ids of the key-groups this task is responsible for
-		int localKeyGroups = this.localKeyGroupRange.getNumberOfKeyGroups();
-
-		this.eventTimeTimersQueue = new PriorityQueue<>(100);
-		this.eventTimeTimersByKeyGroup = new HashSet[localKeyGroups];
-
-		this.processingTimeTimersQueue = new PriorityQueue<>(100);
-		this.processingTimeTimersByKeyGroup = new HashSet[localKeyGroups];
+		this.eventTimeTimersQueue = new InternalTimerHeap<>(128, localKeyGroupRange, totalKeyGroups);
+		this.processingTimeTimersQueue = new InternalTimerHeap<>(128, localKeyGroupRange, totalKeyGroups);
 	}
 
 	/**
@@ -175,8 +162,9 @@ public class HeapInternalTimerService<K, N> implements InternalTimerService<N>, 
 			this.triggerTarget = Preconditions.checkNotNull(triggerTarget);
 
 			// re-register the restored timers (if any)
-			if (processingTimeTimersQueue.size() > 0) {
-				nextTimer = processingTimeService.registerTimer(processingTimeTimersQueue.peek().getTimestamp(), this);
+			final InternalTimer<K, N> headTimer = processingTimeTimersQueue.peek();
+			if (headTimer != null) {
+				nextTimer = processingTimeService.registerTimer(headTimer.getTimestamp(), this);
 			}
 			this.isInitialized = true;
 		} else {
@@ -199,17 +187,9 @@ public class HeapInternalTimerService<K, N> implements InternalTimerService<N>, 
 
 	@Override
 	public void registerProcessingTimeTimer(N namespace, long time) {
-		InternalTimer<K, N> timer = new InternalTimer<>(time, (K) keyContext.getCurrentKey(), namespace);
-
-		// make sure we only put one timer per key into the queue
-		Set<InternalTimer<K, N>> timerSet = getProcessingTimeTimerSetForTimer(timer);
-		if (timerSet.add(timer)) {
-
-			InternalTimer<K, N> oldHead = processingTimeTimersQueue.peek();
+		InternalTimer<K, N> oldHead = processingTimeTimersQueue.peek();
+		if (processingTimeTimersQueue.scheduleTimer(time, (K) keyContext.getCurrentKey(), namespace)) {
 			long nextTriggerTime = oldHead != null ? oldHead.getTimestamp() : Long.MAX_VALUE;
-
-			processingTimeTimersQueue.add(timer);
-
 			// check if we need to re-schedule our timer to earlier
 			if (time < nextTriggerTime) {
 				if (nextTimer != null) {
@@ -222,29 +202,17 @@ public class HeapInternalTimerService<K, N> implements InternalTimerService<N>, 
 
 	@Override
 	public void registerEventTimeTimer(N namespace, long time) {
-		InternalTimer<K, N> timer = new InternalTimer<>(time, (K) keyContext.getCurrentKey(), namespace);
-		Set<InternalTimer<K, N>> timerSet = getEventTimeTimerSetForTimer(timer);
-		if (timerSet.add(timer)) {
-			eventTimeTimersQueue.add(timer);
-		}
+		eventTimeTimersQueue.scheduleTimer(time, (K) keyContext.getCurrentKey(), namespace);
 	}
 
 	@Override
 	public void deleteProcessingTimeTimer(N namespace, long time) {
-		InternalTimer<K, N> timer = new InternalTimer<>(time, (K) keyContext.getCurrentKey(), namespace);
-		Set<InternalTimer<K, N>> timerSet = getProcessingTimeTimerSetForTimer(timer);
-		if (timerSet.remove(timer)) {
-			processingTimeTimersQueue.remove(timer);
-		}
+		processingTimeTimersQueue.stopTimer(time, (K) keyContext.getCurrentKey(), namespace);
 	}
 
 	@Override
 	public void deleteEventTimeTimer(N namespace, long time) {
-		InternalTimer<K, N> timer = new InternalTimer<>(time, (K) keyContext.getCurrentKey(), namespace);
-		Set<InternalTimer<K, N>> timerSet = getEventTimeTimerSetForTimer(timer);
-		if (timerSet.remove(timer)) {
-			eventTimeTimersQueue.remove(timer);
-		}
+		eventTimeTimersQueue.stopTimer(time, (K) keyContext.getCurrentKey(), namespace);
 	}
 
 	@Override
@@ -256,12 +224,7 @@ public class HeapInternalTimerService<K, N> implements InternalTimerService<N>, 
 		InternalTimer<K, N> timer;
 
 		while ((timer = processingTimeTimersQueue.peek()) != null && timer.getTimestamp() <= time) {
-
-			Set<InternalTimer<K, N>> timerSet = getProcessingTimeTimerSetForTimer(timer);
-
-			timerSet.remove(timer);
-			processingTimeTimersQueue.remove();
-
+			processingTimeTimersQueue.poll();
 			keyContext.setCurrentKey(timer.getKey());
 			triggerTarget.onProcessingTime(timer);
 		}
@@ -279,11 +242,7 @@ public class HeapInternalTimerService<K, N> implements InternalTimerService<N>, 
 		InternalTimer<K, N> timer;
 
 		while ((timer = eventTimeTimersQueue.peek()) != null && timer.getTimestamp() <= time) {
-
-			Set<InternalTimer<K, N>> timerSet = getEventTimeTimerSetForTimer(timer);
-			timerSet.remove(timer);
-			eventTimeTimersQueue.remove();
-
+			eventTimeTimersQueue.poll();
 			keyContext.setCurrentKey(timer.getKey());
 			triggerTarget.onEventTime(timer);
 		}
@@ -301,114 +260,37 @@ public class HeapInternalTimerService<K, N> implements InternalTimerService<N>, 
 				keySerializer.snapshotConfiguration(),
 				namespaceSerializer,
 				namespaceSerializer.snapshotConfiguration(),
-				getEventTimeTimerSetForKeyGroup(keyGroupIdx),
-				getProcessingTimeTimerSetForKeyGroup(keyGroupIdx));
+				eventTimeTimersQueue.getTimersForKeyGroup(keyGroupIdx),
+				processingTimeTimersQueue.getTimersForKeyGroup(keyGroupIdx));
 	}
 
 	/**
 	 * Restore the timers (both processing and event time ones) for a given {@code keyGroupIdx}.
 	 *
-	 * @param restoredTimersSnapshot the restored snapshot containing the key-group's timers,
+	 * @param restoredSnapshot the restored snapshot containing the key-group's timers,
 	 *                       and the serializers that were used to write them
 	 * @param keyGroupIdx the id of the key-group to be put in the snapshot.
 	 */
 	@SuppressWarnings("unchecked")
-	public void restoreTimersForKeyGroup(InternalTimersSnapshot<?, ?> restoredTimersSnapshot, int keyGroupIdx) throws IOException {
-		this.restoredTimersSnapshot = (InternalTimersSnapshot<K, N>) restoredTimersSnapshot;
+	public void restoreTimersForKeyGroup(InternalTimersSnapshot<?, ?> restoredSnapshot, int keyGroupIdx) {
+		this.restoredTimersSnapshot = (InternalTimersSnapshot<K, N>) restoredSnapshot;
 
-		if ((this.keyDeserializer != null && !this.keyDeserializer.equals(restoredTimersSnapshot.getKeySerializer())) ||
-			(this.namespaceDeserializer != null && !this.namespaceDeserializer.equals(restoredTimersSnapshot.getNamespaceSerializer()))) {
-
+		if (areSnapshotSerializersIncompatible(restoredSnapshot)) {
 			throw new IllegalArgumentException("Tried to restore timers " +
 				"for the same service with different serializers.");
 		}
 
-		this.keyDeserializer = this.restoredTimersSnapshot.getKeySerializer();
-		this.namespaceDeserializer = this.restoredTimersSnapshot.getNamespaceSerializer();
+		this.keyDeserializer = restoredTimersSnapshot.getKeySerializer();
+		this.namespaceDeserializer = restoredTimersSnapshot.getNamespaceSerializer();
 
 		checkArgument(localKeyGroupRange.contains(keyGroupIdx),
 			"Key Group " + keyGroupIdx + " does not belong to the local range.");
 
 		// restore the event time timers
-		Set<InternalTimer<K, N>> eventTimers = getEventTimeTimerSetForKeyGroup(keyGroupIdx);
-		eventTimers.addAll(this.restoredTimersSnapshot.getEventTimeTimers());
-		eventTimeTimersQueue.addAll(this.restoredTimersSnapshot.getEventTimeTimers());
+		eventTimeTimersQueue.bulkAddRestoredTimers(restoredTimersSnapshot.getEventTimeTimers());
 
 		// restore the processing time timers
-		Set<InternalTimer<K, N>> processingTimers = getProcessingTimeTimerSetForKeyGroup(keyGroupIdx);
-		processingTimers.addAll(this.restoredTimersSnapshot.getProcessingTimeTimers());
-		processingTimeTimersQueue.addAll(this.restoredTimersSnapshot.getProcessingTimeTimers());
-	}
-
-	/**
-	 * Retrieve the set of event time timers for the key-group this timer belongs to.
-	 *
-	 * @param timer the timer whose key-group we are searching.
-	 * @return the set of registered timers for the key-group.
-	 */
-	private Set<InternalTimer<K, N>> getEventTimeTimerSetForTimer(InternalTimer<K, N> timer) {
-		checkArgument(localKeyGroupRange != null, "The operator has not been initialized.");
-		int keyGroupIdx = KeyGroupRangeAssignment.assignToKeyGroup(timer.getKey(), this.totalKeyGroups);
-		return getEventTimeTimerSetForKeyGroup(keyGroupIdx);
-	}
-
-	/**
-	 * Retrieve the set of event time timers for the requested key-group.
-	 *
-	 * @param keyGroupIdx the index of the key group we are interested in.
-	 * @return the set of registered timers for the key-group.
-	 */
-	private Set<InternalTimer<K, N>> getEventTimeTimerSetForKeyGroup(int keyGroupIdx) {
-		int localIdx = getIndexForKeyGroup(keyGroupIdx);
-		Set<InternalTimer<K, N>> timers = eventTimeTimersByKeyGroup[localIdx];
-		if (timers == null) {
-			timers = new HashSet<>();
-			eventTimeTimersByKeyGroup[localIdx] = timers;
-		}
-		return timers;
-	}
-
-	/**
-	 * Retrieve the set of processing time timers for the key-group this timer belongs to.
-	 *
-	 * @param timer the timer whose key-group we are searching.
-	 * @return the set of registered timers for the key-group.
-	 */
-	private Set<InternalTimer<K, N>> getProcessingTimeTimerSetForTimer(InternalTimer<K, N> timer) {
-		checkArgument(localKeyGroupRange != null, "The operator has not been initialized.");
-		int keyGroupIdx = KeyGroupRangeAssignment.assignToKeyGroup(timer.getKey(), this.totalKeyGroups);
-		return getProcessingTimeTimerSetForKeyGroup(keyGroupIdx);
-	}
-
-	/**
-	 * Retrieve the set of processing time timers for the requested key-group.
-	 *
-	 * @param keyGroupIdx the index of the key group we are interested in.
-	 * @return the set of registered timers for the key-group.
-	 */
-	private Set<InternalTimer<K, N>> getProcessingTimeTimerSetForKeyGroup(int keyGroupIdx) {
-		int localIdx = getIndexForKeyGroup(keyGroupIdx);
-		Set<InternalTimer<K, N>> timers = processingTimeTimersByKeyGroup[localIdx];
-		if (timers == null) {
-			timers = new HashSet<>();
-			processingTimeTimersByKeyGroup[localIdx] = timers;
-		}
-		return timers;
-	}
-
-	/**
-	 * Computes the index of the requested key-group in the local datastructures.
-	 * <li/>
-	 * Currently we assume that each task is assigned a continuous range of key-groups,
-	 * e.g. 1,2,3,4, and not 1,3,5. We leverage this to keep the different states by
-	 * key-grouped in arrays instead of maps, where the offset for each key-group is
-	 * the key-group id (an int) minus the id of the first key-group in the local range.
-	 * This is for performance reasons.
-	 */
-	private int getIndexForKeyGroup(int keyGroupIdx) {
-		checkArgument(localKeyGroupRange.contains(keyGroupIdx),
-			"Key Group " + keyGroupIdx + " does not belong to the local range.");
-		return keyGroupIdx - this.localKeyGroupRangeStartIdx;
+		processingTimeTimersQueue.bulkAddRestoredTimers(restoredTimersSnapshot.getProcessingTimeTimers());
 	}
 
 	public int numProcessingTimeTimers() {
@@ -440,17 +322,22 @@ public class HeapInternalTimerService<K, N> implements InternalTimerService<N>, 
 	}
 
 	@VisibleForTesting
-	public int getLocalKeyGroupRangeStartIdx() {
+	int getLocalKeyGroupRangeStartIdx() {
 		return this.localKeyGroupRangeStartIdx;
 	}
 
 	@VisibleForTesting
-	public Set<InternalTimer<K, N>>[] getEventTimeTimersPerKeyGroup() {
-		return this.eventTimeTimersByKeyGroup;
+	List<Set<InternalTimer<K, N>>> getEventTimeTimersPerKeyGroup() {
+		return eventTimeTimersQueue.getTimersByKeyGroup();
 	}
 
 	@VisibleForTesting
-	public Set<InternalTimer<K, N>>[] getProcessingTimeTimersPerKeyGroup() {
-		return this.processingTimeTimersByKeyGroup;
+	List<Set<InternalTimer<K, N>>> getProcessingTimeTimersPerKeyGroup() {
+		return processingTimeTimersQueue.getTimersByKeyGroup();
+	}
+
+	private boolean areSnapshotSerializersIncompatible(InternalTimersSnapshot<?, ?> restoredSnapshot) {
+		return (this.keyDeserializer != null && !this.keyDeserializer.equals(restoredSnapshot.getKeySerializer())) ||
+			(this.namespaceDeserializer != null && !this.namespaceDeserializer.equals(restoredSnapshot.getNamespaceSerializer()));
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimeServiceManager.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimeServiceManager.java
@@ -22,7 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.DataOutputView;
-import org.apache.flink.runtime.state.KeyGroupsList;
+import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.VoidNamespaceSerializer;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
@@ -47,7 +47,7 @@ import java.util.Map;
 public class InternalTimeServiceManager<K, N> {
 
 	private final int totalKeyGroups;
-	private final KeyGroupsList localKeyGroupRange;
+	private final KeyGroupRange localKeyGroupRange;
 	private final KeyContext keyContext;
 
 	private final ProcessingTimeService processingTimeService;
@@ -56,7 +56,7 @@ public class InternalTimeServiceManager<K, N> {
 
 	InternalTimeServiceManager(
 			int totalKeyGroups,
-			KeyGroupsList localKeyGroupRange,
+			KeyGroupRange localKeyGroupRange,
 			KeyContext keyContext,
 			ProcessingTimeService processingTimeService) {
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimeServiceManager.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimeServiceManager.java
@@ -41,10 +41,9 @@ import java.util.Map;
  * <b>NOTE:</b> These services are only available to keyed operators.
  *
  * @param <K> The type of keys used for the timers and the registry.
- * @param <N> The type of namespace used for the timers.
  */
 @Internal
-public class InternalTimeServiceManager<K, N> {
+public class InternalTimeServiceManager<K> {
 
 	private final int totalKeyGroups;
 	private final KeyGroupRange localKeyGroupRange;
@@ -52,7 +51,7 @@ public class InternalTimeServiceManager<K, N> {
 
 	private final ProcessingTimeService processingTimeService;
 
-	private final Map<String, HeapInternalTimerService<K, N>> timerServices;
+	private final Map<String, HeapInternalTimerService<K, ?>> timerServices;
 
 	InternalTimeServiceManager(
 			int totalKeyGroups,
@@ -90,10 +89,11 @@ public class InternalTimeServiceManager<K, N> {
 	 * @param namespaceSerializer {@code TypeSerializer} for the timer namespace.
 	 * @param triggerable The {@link Triggerable} that should be invoked when timers fire
 	 */
-	public InternalTimerService<N> getInternalTimerService(String name, TypeSerializer<K> keySerializer,
+	@SuppressWarnings("unchecked")
+	public <N> InternalTimerService<N> getInternalTimerService(String name, TypeSerializer<K> keySerializer,
 														TypeSerializer<N> namespaceSerializer, Triggerable<K, N> triggerable) {
 
-		HeapInternalTimerService<K, N> timerService = timerServices.get(name);
+		HeapInternalTimerService<K, N> timerService = (HeapInternalTimerService<K, N>) timerServices.get(name);
 		if (timerService == null) {
 			timerService = new HeapInternalTimerService<>(totalKeyGroups,
 				localKeyGroupRange, keyContext, processingTimeService);
@@ -112,7 +112,7 @@ public class InternalTimeServiceManager<K, N> {
 	//////////////////				Fault Tolerance Methods				///////////////////
 
 	public void snapshotStateForKeyGroup(DataOutputView stream, int keyGroupIdx) throws IOException {
-		InternalTimerServiceSerializationProxy<K, N> serializationProxy =
+		InternalTimerServiceSerializationProxy<K> serializationProxy =
 			new InternalTimerServiceSerializationProxy<>(timerServices, keyGroupIdx);
 
 		serializationProxy.write(stream);
@@ -123,7 +123,7 @@ public class InternalTimeServiceManager<K, N> {
 			int keyGroupIdx,
 			ClassLoader userCodeClassLoader) throws IOException {
 
-		InternalTimerServiceSerializationProxy<K, N> serializationProxy =
+		InternalTimerServiceSerializationProxy<K> serializationProxy =
 			new InternalTimerServiceSerializationProxy<>(
 				timerServices,
 				userCodeClassLoader,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimer.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,184 +19,28 @@
 package org.apache.flink.streaming.api.operators;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.common.typeutils.CompatibilityResult;
-import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
-import org.apache.flink.api.common.typeutils.base.LongSerializer;
-import org.apache.flink.core.memory.DataInputView;
-import org.apache.flink.core.memory.DataOutputView;
-
-import java.io.IOException;
 
 /**
- * Internal class for keeping track of in-flight timers.
+ * Internal interface for in-flight timers.
  *
  * @param <K> Type of the keys to which timers are scoped.
  * @param <N> Type of the namespace to which timers are scoped.
  */
 @Internal
-public class InternalTimer<K, N> implements Comparable<InternalTimer<K, N>> {
-	private final long timestamp;
-	private final K key;
-	private final N namespace;
-
-	public InternalTimer(long timestamp, K key, N namespace) {
-		this.timestamp = timestamp;
-		this.key = key;
-		this.namespace = namespace;
-	}
-
-	public long getTimestamp() {
-		return timestamp;
-	}
-
-	public K getKey() {
-		return key;
-	}
-
-	public N getNamespace() {
-		return namespace;
-	}
-
-	@Override
-	public int compareTo(InternalTimer<K, N> o) {
-		return Long.compare(this.timestamp, o.timestamp);
-	}
-
-	@Override
-	public boolean equals(Object o) {
-		if (this == o) {
-			return true;
-		}
-		if (o == null || getClass() != o.getClass()){
-			return false;
-		}
-
-		InternalTimer<?, ?> timer = (InternalTimer<?, ?>) o;
-
-		return timestamp == timer.timestamp
-				&& key.equals(timer.key)
-				&& namespace.equals(timer.namespace);
-
-	}
-
-	@Override
-	public int hashCode() {
-		int result = (int) (timestamp ^ (timestamp >>> 32));
-		result = 31 * result + key.hashCode();
-		result = 31 * result + namespace.hashCode();
-		return result;
-	}
-
-	@Override
-	public String toString() {
-		return "Timer{" +
-				"timestamp=" + timestamp +
-				", key=" + key +
-				", namespace=" + namespace +
-				'}';
-	}
+public interface InternalTimer<K, N> {
 
 	/**
-	 * A {@link TypeSerializer} used to serialize/deserialize a {@link InternalTimer}.
+	 * Returns the timestamp of the timer. This value determines the point in time when the timer will fire.
 	 */
-	public static class TimerSerializer<K, N> extends TypeSerializer<InternalTimer<K, N>> {
+	long getTimestamp();
 
-		private static final long serialVersionUID = 1119562170939152304L;
+	/**
+	 * Returns the key that is bound to this timer.
+	 */
+	K getKey();
 
-		private final TypeSerializer<K> keySerializer;
-
-		private final TypeSerializer<N> namespaceSerializer;
-
-		TimerSerializer(TypeSerializer<K> keySerializer, TypeSerializer<N> namespaceSerializer) {
-			this.keySerializer = keySerializer;
-			this.namespaceSerializer = namespaceSerializer;
-		}
-
-		@Override
-		public boolean isImmutableType() {
-			return false;
-		}
-
-		@Override
-		public TypeSerializer<InternalTimer<K, N>> duplicate() {
-			return this;
-		}
-
-		@Override
-		public InternalTimer<K, N> createInstance() {
-			return null;
-		}
-
-		@Override
-		public InternalTimer<K, N> copy(InternalTimer<K, N> from) {
-			return new InternalTimer<>(from.timestamp, from.key, from.namespace);
-		}
-
-		@Override
-		public InternalTimer<K, N> copy(InternalTimer<K, N> from, InternalTimer<K, N> reuse) {
-			return copy(from);
-		}
-
-		@Override
-		public int getLength() {
-			// we do not have fixed length
-			return -1;
-		}
-
-		@Override
-		public void serialize(InternalTimer<K, N> record, DataOutputView target) throws IOException {
-			keySerializer.serialize(record.key, target);
-			namespaceSerializer.serialize(record.namespace, target);
-			LongSerializer.INSTANCE.serialize(record.timestamp, target);
-		}
-
-		@Override
-		public InternalTimer<K, N> deserialize(DataInputView source) throws IOException {
-			K key = keySerializer.deserialize(source);
-			N namespace = namespaceSerializer.deserialize(source);
-			Long timestamp = LongSerializer.INSTANCE.deserialize(source);
-			return new InternalTimer<>(timestamp, key, namespace);
-		}
-
-		@Override
-		public InternalTimer<K, N> deserialize(InternalTimer<K, N> reuse, DataInputView source) throws IOException {
-			return deserialize(source);
-		}
-
-		@Override
-		public void copy(DataInputView source, DataOutputView target) throws IOException {
-			keySerializer.copy(source, target);
-			namespaceSerializer.copy(source, target);
-			LongSerializer.INSTANCE.copy(source, target);
-		}
-
-		@Override
-		public boolean equals(Object obj) {
-			return obj == this ||
-				(obj != null && obj.getClass() == getClass() &&
-					keySerializer.equals(((TimerSerializer) obj).keySerializer) &&
-					namespaceSerializer.equals(((TimerSerializer) obj).namespaceSerializer));
-		}
-
-		@Override
-		public boolean canEqual(Object obj) {
-			return true;
-		}
-
-		@Override
-		public int hashCode() {
-			return getClass().hashCode();
-		}
-
-		@Override
-		public TypeSerializerConfigSnapshot snapshotConfiguration() {
-			throw new UnsupportedOperationException("This serializer is not registered for managed state.");
-		}
-
-		@Override
-		public CompatibilityResult<InternalTimer<K, N>> ensureCompatibility(TypeSerializerConfigSnapshot configSnapshot) {
-			throw new UnsupportedOperationException("This serializer is not registered for managed state.");
-		}
-	}
+	/**
+	 * Returns the namespace that is bound to this timer.
+	 */
+	N getNamespace();
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimerHeap.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimerHeap.java
@@ -1,0 +1,405 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
+
+import javax.annotation.Nonnegative;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/**
+ * A heap-based priority queue for internal timers. This heap is supported by hash sets for fast contains
+ * (de-duplication) and deletes. The heap implementation is a simple binary tree stored inside an array. Element indexes
+ * in the heap array start at 1 instead of 0 to make array index computations a bit simpler in the hot methods.
+ *
+ * <p>Possible future improvements:
+ * <ul>
+ *  <li>We could also implement shrinking for the heap and the deduplication maps.</li>
+ *  <li>We could replace the deduplication maps with more efficient custom implementations. In particular, a hash set
+ * would be enough if it could return existing elements on unsuccessful adding, etc..</li>
+ * </ul>
+ *
+ * @param <K> type of the key of the internal timers managed by this priority queue.
+ * @param <N> type of the namespace of the internal timers managed by this priority queue.
+ */
+public class InternalTimerHeap<K, N> implements Iterable<InternalTimer<K, N>> {//implements Queue<TimerHeapInternalTimer<K, N>>, Set<TimerHeapInternalTimer<K, N>> {
+
+	/**
+	 * A safe maximum size for arrays in the JVM.
+	 */
+	private static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
+
+	/**
+	 * Comparator for {@link TimerHeapInternalTimer}, based on the timestamp in ascending order.
+	 */
+	private static final Comparator<TimerHeapInternalTimer<?, ?>> COMPARATOR =
+		(o1, o2) -> Long.compare(o1.getTimestamp(), o2.getTimestamp());
+
+	/**
+	 * This array contains one hash set per key-group. The sets are used for fast de-duplication and deletes of timers.
+	 */
+	private final HashMap<TimerHeapInternalTimer<K, N>, TimerHeapInternalTimer<K, N>>[] deduplicationMapsByKeyGroup;
+
+	/**
+	 * The array that represents the heap-organized priority queue.
+	 */
+	private TimerHeapInternalTimer<K, N>[] queue;
+
+	/**
+	 * The current size of the priority queue.
+	 */
+	private int size;
+
+	/**
+	 * The key-group range of timers that are managed by this queue.
+	 */
+	private final KeyGroupRange keyGroupRange;
+
+	/**
+	 * The total number of key-groups of the job.
+	 */
+	private final int totalNumberOfKeyGroups;
+
+
+	/**
+	 * Creates an empty {@link InternalTimerHeap} with the requested initial capacity.
+	 *
+	 * @param minimumCapacity the minimum and initial capacity of this priority queue.
+	 */
+	@SuppressWarnings("unchecked")
+	InternalTimerHeap(
+		@Nonnegative int minimumCapacity,
+		@Nonnull KeyGroupRange keyGroupRange,
+		@Nonnegative int totalNumberOfKeyGroups) {
+
+		this.totalNumberOfKeyGroups = totalNumberOfKeyGroups;
+		this.keyGroupRange = keyGroupRange;
+
+		final int keyGroupsInLocalRange = keyGroupRange.getNumberOfKeyGroups();
+		final int deduplicationSetSize = 1 + minimumCapacity / keyGroupsInLocalRange;
+		this.deduplicationMapsByKeyGroup = new HashMap[keyGroupsInLocalRange];
+		for (int i = 0; i < keyGroupsInLocalRange; ++i) {
+			deduplicationMapsByKeyGroup[i] = new HashMap<>(deduplicationSetSize);
+		}
+
+		this.queue = new TimerHeapInternalTimer[1 + minimumCapacity];
+	}
+
+	@Nullable
+	public InternalTimer<K, N> poll() {
+		return size() > 0 ? removeElementAtIndex(1) : null;
+	}
+
+	@Nullable
+	public InternalTimer<K, N> peek() {
+		return size() > 0 ? queue[1] : null;
+	}
+
+	/**
+	 * Adds a new timer with the given timestamp, key, and namespace to the heap, if an identical timer was not yet
+	 * registered.
+	 *
+	 * @param timestamp the timer timestamp.
+	 * @param key the timer key.
+	 * @param namespace the timer namespace.
+	 * @return true iff a new timer with given timestamp, key, and namespace was added to the heap.
+	 */
+	public boolean scheduleTimer(long timestamp, K key, N namespace) {
+		return addInternal(new TimerHeapInternalTimer<>(timestamp, key, namespace));
+	}
+
+	/**
+	 * Stops timer with the given timestamp, key, and namespace by removing it from the heap, if it exists on the heap.
+	 *
+	 * @param timestamp the timer timestamp.
+	 * @param key the timer key.
+	 * @param namespace the timer namespace.
+	 * @return true iff a timer with given timestamp, key, and namespace was found and removed from the heap.
+	 */
+	public boolean stopTimer(long timestamp, K key, N namespace) {
+		return removeInternal(new TimerHeapInternalTimer<>(timestamp, key, namespace));
+	}
+
+	public boolean isEmpty() {
+		return size() == 0;
+	}
+
+	@Nonnegative
+	public int size() {
+		return size;
+	}
+
+	public void clear() {
+		Arrays.fill(queue, null);
+		for (HashMap<TimerHeapInternalTimer<K, N>, TimerHeapInternalTimer<K, N>> timerHashMap :
+			deduplicationMapsByKeyGroup) {
+			timerHashMap.clear();
+		}
+		size = 0;
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Nonnull
+	public InternalTimer<K, N>[] toArray() {
+		return (InternalTimer<K, N>[]) Arrays.copyOfRange(queue, 1, size + 1, queue.getClass());
+	}
+
+	/**
+	 * Returns an iterator over the elements in this queue. The iterator
+	 * does not return the elements in any particular order.
+	 *
+	 * @return an iterator over the elements in this queue.
+	 */
+	@Nonnull
+	public Iterator<InternalTimer<K, N>> iterator() {
+		return new InternalTimerPriorityQueueIterator();
+	}
+
+	/**
+	 * This method adds all the given timers to the heap.
+	 */
+	void bulkAddRestoredTimers(Collection<? extends InternalTimer<K, N>> restoredTimers) {
+
+		if (restoredTimers == null) {
+			return;
+		}
+
+		resizeForBulkLoad(restoredTimers.size());
+
+		for (InternalTimer<K, N> timer : restoredTimers) {
+			if (timer instanceof TimerHeapInternalTimer) {
+				addInternal((TimerHeapInternalTimer<K, N>) timer);
+			} else {
+				scheduleTimer(timer.getTimestamp(), timer.getKey(), timer.getNamespace());
+			}
+		}
+	}
+
+	/**
+	 * Returns an unmodifiable set of all timers in the given key-group.
+	 */
+	Set<InternalTimer<K, N>> getTimersForKeyGroup(@Nonnegative int keyGroupIdx) {
+		return Collections.unmodifiableSet(getDedupMapForKeyGroup(keyGroupIdx).keySet());
+	}
+
+	@VisibleForTesting
+	@SuppressWarnings("unchecked")
+	List<Set<InternalTimer<K, N>>> getTimersByKeyGroup() {
+		List<Set<InternalTimer<K, N>>> result = new ArrayList<>(deduplicationMapsByKeyGroup.length);
+		for (int i = 0; i < deduplicationMapsByKeyGroup.length; ++i) {
+			result.add(i, Collections.unmodifiableSet(deduplicationMapsByKeyGroup[i].keySet()));
+		}
+		return result;
+	}
+
+	private boolean addInternal(TimerHeapInternalTimer<K, N> timer) {
+
+		if (getDedupMapForTimer(timer).putIfAbsent(timer, timer) == null) {
+			final int newSize = increaseSizeByOne();
+			moveElementToIdx(timer, newSize);
+			siftUp(newSize);
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+	private boolean removeInternal(TimerHeapInternalTimer<K, N> timerToRemove) {
+
+		TimerHeapInternalTimer<K, N> storedTimer = getDedupMapForTimer(timerToRemove).remove(timerToRemove);
+
+		if (storedTimer != null) {
+			removeElementAtIndex(storedTimer.getTimerHeapIndex());
+			return true;
+		}
+
+		return false;
+	}
+
+	private TimerHeapInternalTimer<K, N> removeElementAtIndex(int removeIdx) {
+		TimerHeapInternalTimer<K, N>[] heap = this.queue;
+		TimerHeapInternalTimer<K, N> removedValue = heap[removeIdx];
+
+		assert removedValue.getTimerHeapIndex() == removeIdx;
+
+		final int oldSize = size;
+
+		if (removeIdx != oldSize) {
+			TimerHeapInternalTimer<K, N> timer = heap[oldSize];
+			moveElementToIdx(timer, removeIdx);
+			siftDown(removeIdx);
+			if (heap[removeIdx] == timer) {
+				siftUp(removeIdx);
+			}
+		}
+
+		heap[oldSize] = null;
+		getDedupMapForTimer(removedValue).remove(removedValue);
+
+		--size;
+		return removedValue;
+	}
+
+	private void siftUp(int idx) {
+		final TimerHeapInternalTimer<K, N>[] heap = this.queue;
+		final TimerHeapInternalTimer<K, N> currentTimer = heap[idx];
+		int parentIdx = idx >>> 1;
+
+		while (parentIdx > 0 && isTimerLessThen(currentTimer, heap[parentIdx])) {
+			moveElementToIdx(heap[parentIdx], idx);
+			idx = parentIdx;
+			parentIdx >>>= 1;
+		}
+
+		moveElementToIdx(currentTimer, idx);
+	}
+
+	private void siftDown(int idx) {
+		final TimerHeapInternalTimer<K, N>[] heap = this.queue;
+		final int heapSize = this.size;
+
+		final TimerHeapInternalTimer<K, N> currentTimer = heap[idx];
+		int firstChildIdx = idx << 1;
+		int secondChildIdx = firstChildIdx + 1;
+
+		if (isTimerIndexValid(secondChildIdx, heapSize) &&
+			isTimerLessThen(heap[secondChildIdx], heap[firstChildIdx])) {
+			firstChildIdx = secondChildIdx;
+		}
+
+		while (isTimerIndexValid(firstChildIdx, heapSize) &&
+			isTimerLessThen(heap[firstChildIdx], currentTimer)) {
+			moveElementToIdx(heap[firstChildIdx], idx);
+			idx = firstChildIdx;
+			firstChildIdx = idx << 1;
+			secondChildIdx = firstChildIdx + 1;
+
+			if (isTimerIndexValid(secondChildIdx, heapSize) &&
+				isTimerLessThen(heap[secondChildIdx], heap[firstChildIdx])) {
+				firstChildIdx = secondChildIdx;
+			}
+		}
+
+		moveElementToIdx(currentTimer, idx);
+	}
+
+	private HashMap<TimerHeapInternalTimer<K, N>, TimerHeapInternalTimer<K, N>> getDedupMapForKeyGroup(
+		@Nonnegative int keyGroupIdx) {
+		return deduplicationMapsByKeyGroup[globalKeyGroupToLocalIndex(keyGroupIdx)];
+	}
+
+	private boolean isTimerIndexValid(int timerIndex, int heapSize) {
+		return timerIndex <= heapSize;
+	}
+
+	private boolean isTimerLessThen(TimerHeapInternalTimer<K, N> a, TimerHeapInternalTimer<K, N> b) {
+		return COMPARATOR.compare(a, b) < 0;
+	}
+
+	private void moveElementToIdx(TimerHeapInternalTimer<K, N> element, int idx) {
+		queue[idx] = element;
+		element.setTimerHeapIndex(idx);
+	}
+
+	private HashMap<TimerHeapInternalTimer<K, N>, TimerHeapInternalTimer<K, N>> getDedupMapForTimer(
+		InternalTimer<K, N> timer) {
+		int keyGroup = KeyGroupRangeAssignment.assignToKeyGroup(timer.getKey(), totalNumberOfKeyGroups);
+		return getDedupMapForKeyGroup(keyGroup);
+	}
+
+	private int globalKeyGroupToLocalIndex(int keyGroup) {
+		checkArgument(keyGroupRange.contains(keyGroup));
+		return keyGroup - keyGroupRange.getStartKeyGroup();
+	}
+
+	private int increaseSizeByOne() {
+		final int oldArraySize = queue.length;
+		final int minRequiredNewSize = ++size;
+		if (minRequiredNewSize >= oldArraySize) {
+			final int grow = (oldArraySize < 64) ? oldArraySize + 2 : oldArraySize >> 1;
+			resizeQueueArray(oldArraySize + grow, minRequiredNewSize);
+		}
+		// TODO implement shrinking as well?
+		return minRequiredNewSize;
+	}
+
+	private void resizeForBulkLoad(int totalSize) {
+		if (totalSize > queue.length) {
+			int desiredSize = totalSize + (totalSize >>> 3);
+			resizeQueueArray(desiredSize, totalSize);
+		}
+	}
+
+	private void resizeQueueArray(int desiredSize, int minRequiredSize) {
+		if (isValidArraySize(desiredSize)) {
+			queue = Arrays.copyOf(queue, desiredSize);
+		} else if (isValidArraySize(minRequiredSize)) {
+			queue = Arrays.copyOf(queue, MAX_ARRAY_SIZE);
+		} else {
+			throw new OutOfMemoryError("Required minimum timer heap size " + minRequiredSize +
+				" exceeds maximum size of " + MAX_ARRAY_SIZE + ".");
+		}
+	}
+
+	private static boolean isValidArraySize(int size) {
+		return size >= 0 && size <= MAX_ARRAY_SIZE;
+	}
+
+	/**
+	 * {@link Iterator} implementation for {@link InternalTimerPriorityQueueIterator}.
+	 * {@link Iterator#remove()} is not supported.
+	 */
+	private class InternalTimerPriorityQueueIterator implements Iterator<InternalTimer<K, N>> {
+
+		private int iterationIdx;
+
+		InternalTimerPriorityQueueIterator() {
+			this.iterationIdx = 0;
+		}
+
+		@Override
+		public boolean hasNext() {
+			return iterationIdx < size;
+		}
+
+		@Override
+		public InternalTimer<K, N> next() {
+			if (iterationIdx >= size) {
+				throw new NoSuchElementException("Iterator has no next element.");
+			}
+			return queue[++iterationIdx];
+		}
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimerServiceSerializationProxy.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimerServiceSerializationProxy.java
@@ -22,7 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.core.io.PostVersionedIOReadableWritable;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
-import org.apache.flink.runtime.state.KeyGroupsList;
+import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 
 import java.io.IOException;
@@ -47,7 +47,7 @@ public class InternalTimerServiceSerializationProxy<K, N> extends PostVersionedI
 	/** Properties of restored timer services. */
 	private int keyGroupIdx;
 	private int totalKeyGroups;
-	private KeyGroupsList localKeyGroupRange;
+	private KeyGroupRange localKeyGroupRange;
 	private KeyContext keyContext;
 	private ProcessingTimeService processingTimeService;
 
@@ -58,7 +58,7 @@ public class InternalTimerServiceSerializationProxy<K, N> extends PostVersionedI
 			Map<String, HeapInternalTimerService<K, N>> timerServicesMapToPopulate,
 			ClassLoader userCodeClassLoader,
 			int totalKeyGroups,
-			KeyGroupsList localKeyGroupRange,
+			KeyGroupRange localKeyGroupRange,
 			KeyContext keyContext,
 			ProcessingTimeService processingTimeService,
 			int keyGroupIdx) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimerServiceSerializationProxy.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimerServiceSerializationProxy.java
@@ -34,12 +34,12 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * Serialization proxy for the timer services for a given key-group.
  */
 @Internal
-public class InternalTimerServiceSerializationProxy<K, N> extends PostVersionedIOReadableWritable {
+public class InternalTimerServiceSerializationProxy<K> extends PostVersionedIOReadableWritable {
 
 	public static final int VERSION = 1;
 
 	/** The key-group timer services to write / read. */
-	private Map<String, HeapInternalTimerService<K, N>> timerServices;
+	private Map<String, HeapInternalTimerService<K, ?>> timerServices;
 
 	/** The user classloader; only relevant if the proxy is used to restore timer services. */
 	private ClassLoader userCodeClassLoader;
@@ -55,7 +55,7 @@ public class InternalTimerServiceSerializationProxy<K, N> extends PostVersionedI
 	 * Constructor to use when restoring timer services.
 	 */
 	public InternalTimerServiceSerializationProxy(
-			Map<String, HeapInternalTimerService<K, N>> timerServicesMapToPopulate,
+			Map<String, HeapInternalTimerService<K, ?>> timerServicesMapToPopulate,
 			ClassLoader userCodeClassLoader,
 			int totalKeyGroups,
 			KeyGroupRange localKeyGroupRange,
@@ -76,7 +76,7 @@ public class InternalTimerServiceSerializationProxy<K, N> extends PostVersionedI
 	 * Constructor to use when writing timer services.
 	 */
 	public InternalTimerServiceSerializationProxy(
-			Map<String, HeapInternalTimerService<K, N>> timerServices,
+			Map<String, HeapInternalTimerService<K, ?>> timerServices,
 			int keyGroupIdx) {
 
 		this.timerServices = checkNotNull(timerServices);
@@ -93,9 +93,9 @@ public class InternalTimerServiceSerializationProxy<K, N> extends PostVersionedI
 		super.write(out);
 
 		out.writeInt(timerServices.size());
-		for (Map.Entry<String, HeapInternalTimerService<K, N>> entry : timerServices.entrySet()) {
+		for (Map.Entry<String, HeapInternalTimerService<K, ?>> entry : timerServices.entrySet()) {
 			String serviceName = entry.getKey();
-			HeapInternalTimerService<K, N> timerService = entry.getValue();
+			HeapInternalTimerService<K, ?> timerService = entry.getValue();
 
 			out.writeUTF(serviceName);
 			InternalTimersSnapshotReaderWriters
@@ -111,7 +111,7 @@ public class InternalTimerServiceSerializationProxy<K, N> extends PostVersionedI
 		for (int i = 0; i < noOfTimerServices; i++) {
 			String serviceName = in.readUTF();
 
-			HeapInternalTimerService<K, N> timerService = timerServices.get(serviceName);
+			HeapInternalTimerService<K, ?> timerService = timerServices.get(serviceName);
 			if (timerService == null) {
 				timerService = new HeapInternalTimerService<>(
 					totalKeyGroups,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimersSnapshotReaderWriters.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimersSnapshotReaderWriters.java
@@ -96,7 +96,7 @@ public class InternalTimersSnapshotReaderWriters {
 		public final void writeTimersSnapshot(DataOutputView out) throws IOException {
 			writeKeyAndNamespaceSerializers(out);
 
-			InternalTimer.TimerSerializer<K, N> timerSerializer = new InternalTimer.TimerSerializer<>(
+			TimerHeapInternalTimer.TimerSerializer<K, N> timerSerializer = new TimerHeapInternalTimer.TimerSerializer<>(
 				timersSnapshot.getKeySerializer(),
 				timersSnapshot.getNamespaceSerializer());
 
@@ -215,9 +215,10 @@ public class InternalTimersSnapshotReaderWriters {
 
 			restoreKeyAndNamespaceSerializers(restoredTimersSnapshot, in);
 
-			InternalTimer.TimerSerializer<K, N> timerSerializer = new InternalTimer.TimerSerializer<>(
-				restoredTimersSnapshot.getKeySerializer(),
-				restoredTimersSnapshot.getNamespaceSerializer());
+			TimerHeapInternalTimer.TimerSerializer<K, N> timerSerializer =
+				new TimerHeapInternalTimer.TimerSerializer<>(
+					restoredTimersSnapshot.getKeySerializer(),
+					restoredTimersSnapshot.getNamespaceSerializer());
 
 			// read the event time timers
 			int sizeOfEventTimeTimers = in.readInt();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorStateContext.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorStateContext.java
@@ -49,7 +49,7 @@ public interface StreamOperatorStateContext {
 	 * Returns the internal timer service manager for the stream operator. This method returns null for non-keyed
 	 * operators.
 	 */
-	InternalTimeServiceManager<?, ?> internalTimerServiceManager();
+	InternalTimeServiceManager<?> internalTimerServiceManager();
 
 	/**
 	 * Returns an iterable to obtain input streams for previously stored operator state partitions that are assigned to

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImpl.java
@@ -124,7 +124,7 @@ public class StreamTaskStateInitializerImpl implements StreamTaskStateInitialize
 		OperatorStateBackend operatorStateBackend = null;
 		CloseableIterable<KeyGroupStatePartitionStreamProvider> rawKeyedStateInputs = null;
 		CloseableIterable<StatePartitionStreamProvider> rawOperatorStateInputs = null;
-		InternalTimeServiceManager<?, ?> timeServiceManager;
+		InternalTimeServiceManager<?> timeServiceManager;
 
 		try {
 
@@ -192,7 +192,7 @@ public class StreamTaskStateInitializerImpl implements StreamTaskStateInitialize
 		}
 	}
 
-	protected <K> InternalTimeServiceManager<?, K> internalTimeServiceManager(
+	protected <K> InternalTimeServiceManager<K> internalTimeServiceManager(
 		AbstractKeyedStateBackend<K> keyedStatedBackend,
 		KeyContext keyContext, //the operator
 		Iterable<KeyGroupStatePartitionStreamProvider> rawKeyedStates) throws Exception {
@@ -203,7 +203,7 @@ public class StreamTaskStateInitializerImpl implements StreamTaskStateInitialize
 
 		final KeyGroupRange keyGroupRange = keyedStatedBackend.getKeyGroupRange();
 
-		final InternalTimeServiceManager<?, K> timeServiceManager = new InternalTimeServiceManager<>(
+		final InternalTimeServiceManager<K> timeServiceManager = new InternalTimeServiceManager<>(
 			keyedStatedBackend.getNumberOfKeyGroups(),
 			keyGroupRange,
 			keyContext,
@@ -544,7 +544,7 @@ public class StreamTaskStateInitializerImpl implements StreamTaskStateInitialize
 
 		private final OperatorStateBackend operatorStateBackend;
 		private final AbstractKeyedStateBackend<?> keyedStateBackend;
-		private final InternalTimeServiceManager<?, ?> internalTimeServiceManager;
+		private final InternalTimeServiceManager<?> internalTimeServiceManager;
 
 		private final CloseableIterable<StatePartitionStreamProvider> rawOperatorStateInputs;
 		private final CloseableIterable<KeyGroupStatePartitionStreamProvider> rawKeyedStateInputs;
@@ -553,7 +553,7 @@ public class StreamTaskStateInitializerImpl implements StreamTaskStateInitialize
 			boolean restored,
 			OperatorStateBackend operatorStateBackend,
 			AbstractKeyedStateBackend<?> keyedStateBackend,
-			InternalTimeServiceManager<?, ?> internalTimeServiceManager,
+			InternalTimeServiceManager<?> internalTimeServiceManager,
 			CloseableIterable<StatePartitionStreamProvider> rawOperatorStateInputs,
 			CloseableIterable<KeyGroupStatePartitionStreamProvider> rawKeyedStateInputs) {
 
@@ -581,7 +581,7 @@ public class StreamTaskStateInitializerImpl implements StreamTaskStateInitialize
 		}
 
 		@Override
-		public InternalTimeServiceManager<?, ?> internalTimerServiceManager() {
+		public InternalTimeServiceManager<?> internalTimerServiceManager() {
 			return internalTimeServiceManager;
 		}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/TimerHeapInternalTimer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/TimerHeapInternalTimer.java
@@ -1,0 +1,254 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeutils.CompatibilityResult;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
+import org.apache.flink.api.common.typeutils.base.LongSerializer;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+
+import javax.annotation.Nonnull;
+
+import java.io.IOException;
+
+/**
+ * Implementation of {@link InternalTimer} for the {@link InternalTimerHeap}.
+ *
+ * @param <K> Type of the keys to which timers are scoped.
+ * @param <N> Type of the namespace to which timers are scoped.
+ */
+@Internal
+public final class TimerHeapInternalTimer<K, N> implements InternalTimer<K, N> {
+
+	/** The index that indicates that a tracked internal timer is not tracked. */
+	private static final int NOT_MANAGED_BY_TIMER_QUEUE_INDEX = Integer.MIN_VALUE;
+
+	@Nonnull
+	private final K key;
+
+	@Nonnull
+	private final N namespace;
+
+	private final long timestamp;
+
+	/**
+	 * This field holds the current physical index of this timer when it is managed by a timer heap so that we can
+	 * support fast deletes.
+	 */
+	private transient int timerHeapIndex;
+
+	TimerHeapInternalTimer(long timestamp, @Nonnull K key, @Nonnull N namespace) {
+		this.timestamp = timestamp;
+		this.key = key;
+		this.namespace = namespace;
+		this.timerHeapIndex = NOT_MANAGED_BY_TIMER_QUEUE_INDEX;
+	}
+
+	@Override
+	public long getTimestamp() {
+		return timestamp;
+	}
+
+	@Nonnull
+	@Override
+	public K getKey() {
+		return key;
+	}
+
+	@Nonnull
+	@Override
+	public N getNamespace() {
+		return namespace;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+
+		if (o instanceof InternalTimer) {
+			InternalTimer<?, ?> timer = (InternalTimer<?, ?>) o;
+			return timestamp == timer.getTimestamp()
+				&& key.equals(timer.getKey())
+				&& namespace.equals(timer.getNamespace());
+		}
+
+		return false;
+	}
+
+	/**
+	 * Returns the current index of this timer in the owning timer heap.
+	 */
+	int getTimerHeapIndex() {
+		return timerHeapIndex;
+	}
+
+	/**
+	 * Sets the current index of this timer in the owning timer heap and should only be called by the managing heap.
+	 * @param timerHeapIndex the new index in the timer heap.
+	 */
+	void setTimerHeapIndex(int timerHeapIndex) {
+		this.timerHeapIndex = timerHeapIndex;
+	}
+
+	/**
+	 * This method can be called to indicate that the timer is no longer managed be a timer heap, e.g. because it as
+	 * removed.
+	 */
+	void removedFromTimerQueue() {
+		setTimerHeapIndex(NOT_MANAGED_BY_TIMER_QUEUE_INDEX);
+	}
+
+	@Override
+	public int hashCode() {
+		int result = (int) (timestamp ^ (timestamp >>> 32));
+		result = 31 * result + key.hashCode();
+		result = 31 * result + namespace.hashCode();
+		return result;
+	}
+
+	@Override
+	public String toString() {
+		return "Timer{" +
+				"timestamp=" + timestamp +
+				", key=" + key +
+				", namespace=" + namespace +
+				'}';
+	}
+
+	/**
+	 * A {@link TypeSerializer} used to serialize/deserialize a {@link TimerHeapInternalTimer}.
+	 */
+	public static class TimerSerializer<K, N> extends TypeSerializer<InternalTimer<K, N>> {
+
+		private static final long serialVersionUID = 1119562170939152304L;
+
+		@Nonnull
+		private final TypeSerializer<K> keySerializer;
+
+		@Nonnull
+		private final TypeSerializer<N> namespaceSerializer;
+
+		TimerSerializer(@Nonnull TypeSerializer<K> keySerializer, @Nonnull TypeSerializer<N> namespaceSerializer) {
+			this.keySerializer = keySerializer;
+			this.namespaceSerializer = namespaceSerializer;
+		}
+
+		@Override
+		public boolean isImmutableType() {
+			return false;
+		}
+
+		@Override
+		public TypeSerializer<InternalTimer<K, N>> duplicate() {
+
+			final TypeSerializer<K> keySerializerDuplicate = keySerializer.duplicate();
+			final TypeSerializer<N> namespaceSerializerDuplicate = namespaceSerializer.duplicate();
+
+			if (keySerializerDuplicate == keySerializer &&
+				namespaceSerializerDuplicate == namespaceSerializer) {
+				// all delegate serializers seem stateless, so this is also stateless.
+				return this;
+			} else {
+				// at least one delegate serializer seems to be stateful, so we return a new instance.
+				return new TimerSerializer<>(keySerializerDuplicate, namespaceSerializerDuplicate);
+			}
+		}
+
+		@Override
+		public InternalTimer<K, N> createInstance() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public InternalTimer<K, N> copy(InternalTimer<K, N> from) {
+			return new TimerHeapInternalTimer<>(from.getTimestamp(), from.getKey(), from.getNamespace());
+		}
+
+		@Override
+		public InternalTimer<K, N> copy(InternalTimer<K, N> from, InternalTimer<K, N> reuse) {
+			return copy(from);
+		}
+
+		@Override
+		public int getLength() {
+			// we do not have fixed length
+			return -1;
+		}
+
+		@Override
+		public void serialize(InternalTimer<K, N> record, DataOutputView target) throws IOException {
+			keySerializer.serialize(record.getKey(), target);
+			namespaceSerializer.serialize(record.getNamespace(), target);
+			LongSerializer.INSTANCE.serialize(record.getTimestamp(), target);
+		}
+
+		@Override
+		public InternalTimer<K, N> deserialize(DataInputView source) throws IOException {
+			K key = keySerializer.deserialize(source);
+			N namespace = namespaceSerializer.deserialize(source);
+			Long timestamp = LongSerializer.INSTANCE.deserialize(source);
+			return new TimerHeapInternalTimer<>(timestamp, key, namespace);
+		}
+
+		@Override
+		public InternalTimer<K, N> deserialize(InternalTimer<K, N> reuse, DataInputView source) throws IOException {
+			return deserialize(source);
+		}
+
+		@Override
+		public void copy(DataInputView source, DataOutputView target) throws IOException {
+			keySerializer.copy(source, target);
+			namespaceSerializer.copy(source, target);
+			LongSerializer.INSTANCE.copy(source, target);
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			return obj == this ||
+				(obj != null && obj.getClass() == getClass() &&
+					keySerializer.equals(((TimerSerializer) obj).keySerializer) &&
+					namespaceSerializer.equals(((TimerSerializer) obj).namespaceSerializer));
+		}
+
+		@Override
+		public boolean canEqual(Object obj) {
+			return true;
+		}
+
+		@Override
+		public int hashCode() {
+			return getClass().hashCode();
+		}
+
+		@Override
+		public TypeSerializerConfigSnapshot snapshotConfiguration() {
+			throw new UnsupportedOperationException("This serializer is not registered for managed state.");
+		}
+
+		@Override
+		public CompatibilityResult<InternalTimer<K, N>> ensureCompatibility(TypeSerializerConfigSnapshot configSnapshot) {
+			throw new UnsupportedOperationException("This serializer is not registered for managed state.");
+		}
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/HeapInternalTimerServiceTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/HeapInternalTimerServiceTest.java
@@ -24,7 +24,6 @@ import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
-import org.apache.flink.runtime.state.KeyGroupsList;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
 
@@ -41,6 +40,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
@@ -79,7 +79,7 @@ public class HeapInternalTimerServiceTest {
 
 		int startKeyGroupIdx = 7;
 		int endKeyGroupIdx = 21;
-		KeyGroupsList testKeyGroupList = new KeyGroupRange(startKeyGroupIdx, endKeyGroupIdx);
+		KeyGroupRange testKeyGroupList = new KeyGroupRange(startKeyGroupIdx, endKeyGroupIdx);
 
 		TestKeyContext keyContext = new TestKeyContext();
 
@@ -119,7 +119,7 @@ public class HeapInternalTimerServiceTest {
 		for (int i = 0; i < totalNoOfTimers; i++) {
 
 			// create the timer to be registered
-			InternalTimer<Integer, String> timer = new InternalTimer<>(10 + i, i, "hello_world_" + i);
+			TimerHeapInternalTimer<Integer, String> timer = new TimerHeapInternalTimer<>(10 + i, i, "hello_world_" + i);
 			int keyGroupIdx =  KeyGroupRangeAssignment.assignToKeyGroup(timer.getKey(), totalNoOfKeyGroups);
 
 			// add it in the adequate expected set of timers per keygroup
@@ -136,21 +136,23 @@ public class HeapInternalTimerServiceTest {
 			timerService.registerProcessingTimeTimer(timer.getNamespace(), timer.getTimestamp());
 		}
 
-		Set<InternalTimer<Integer, String>>[] eventTimeTimers = timerService.getEventTimeTimersPerKeyGroup();
-		Set<InternalTimer<Integer, String>>[] processingTimeTimers = timerService.getProcessingTimeTimersPerKeyGroup();
+		List<Set<InternalTimer<Integer, String>>> eventTimeTimers =
+			timerService.getEventTimeTimersPerKeyGroup();
+		List<Set<InternalTimer<Integer, String>>> processingTimeTimers =
+			timerService.getProcessingTimeTimersPerKeyGroup();
 
 		// finally verify that the actual timers per key group sets are the expected ones.
 		for (int i = 0; i < expectedNonEmptyTimerSets.length; i++) {
 			Set<InternalTimer<Integer, String>> expected = expectedNonEmptyTimerSets[i];
-			Set<InternalTimer<Integer, String>> actualEvent = eventTimeTimers[i];
-			Set<InternalTimer<Integer, String>> actualProcessing = processingTimeTimers[i];
+			Set<InternalTimer<Integer, String>> actualEvent = eventTimeTimers.get(i);
+			Set<InternalTimer<Integer, String>> actualProcessing = processingTimeTimers.get(i);
 
 			if (expected == null) {
-				Assert.assertNull(actualEvent);
-				Assert.assertNull(actualProcessing);
+				Assert.assertTrue(actualEvent.isEmpty());
+				Assert.assertTrue(actualProcessing.isEmpty());
 			} else {
-				Assert.assertArrayEquals(expected.toArray(), actualEvent.toArray());
-				Assert.assertArrayEquals(expected.toArray(), actualProcessing.toArray());
+				Assert.assertEquals(expected, actualEvent);
+				Assert.assertEquals(expected, actualProcessing);
 			}
 		}
 	}
@@ -379,10 +381,10 @@ public class HeapInternalTimerServiceTest {
 		timerService.advanceWatermark(10);
 
 		verify(mockTriggerable, times(4)).onEventTime(anyInternalTimer());
-		verify(mockTriggerable, times(1)).onEventTime(eq(new InternalTimer<>(10, key1, "ciao")));
-		verify(mockTriggerable, times(1)).onEventTime(eq(new InternalTimer<>(10, key1, "hello")));
-		verify(mockTriggerable, times(1)).onEventTime(eq(new InternalTimer<>(10, key2, "ciao")));
-		verify(mockTriggerable, times(1)).onEventTime(eq(new InternalTimer<>(10, key2, "hello")));
+		verify(mockTriggerable, times(1)).onEventTime(eq(new TimerHeapInternalTimer<>(10, key1, "ciao")));
+		verify(mockTriggerable, times(1)).onEventTime(eq(new TimerHeapInternalTimer<>(10, key1, "hello")));
+		verify(mockTriggerable, times(1)).onEventTime(eq(new TimerHeapInternalTimer<>(10, key2, "ciao")));
+		verify(mockTriggerable, times(1)).onEventTime(eq(new TimerHeapInternalTimer<>(10, key2, "hello")));
 
 		assertEquals(0, timerService.numEventTimeTimers());
 	}
@@ -424,10 +426,10 @@ public class HeapInternalTimerServiceTest {
 		processingTimeService.setCurrentTime(10);
 
 		verify(mockTriggerable, times(4)).onProcessingTime(anyInternalTimer());
-		verify(mockTriggerable, times(1)).onProcessingTime(eq(new InternalTimer<>(10, key1, "ciao")));
-		verify(mockTriggerable, times(1)).onProcessingTime(eq(new InternalTimer<>(10, key1, "hello")));
-		verify(mockTriggerable, times(1)).onProcessingTime(eq(new InternalTimer<>(10, key2, "ciao")));
-		verify(mockTriggerable, times(1)).onProcessingTime(eq(new InternalTimer<>(10, key2, "hello")));
+		verify(mockTriggerable, times(1)).onProcessingTime(eq(new TimerHeapInternalTimer<>(10, key1, "ciao")));
+		verify(mockTriggerable, times(1)).onProcessingTime(eq(new TimerHeapInternalTimer<>(10, key1, "hello")));
+		verify(mockTriggerable, times(1)).onProcessingTime(eq(new TimerHeapInternalTimer<>(10, key2, "ciao")));
+		verify(mockTriggerable, times(1)).onProcessingTime(eq(new TimerHeapInternalTimer<>(10, key2, "hello")));
 
 		assertEquals(0, timerService.numProcessingTimeTimers());
 	}
@@ -481,10 +483,10 @@ public class HeapInternalTimerServiceTest {
 		timerService.advanceWatermark(10);
 
 		verify(mockTriggerable, times(2)).onEventTime(anyInternalTimer());
-		verify(mockTriggerable, times(1)).onEventTime(eq(new InternalTimer<>(10, key1, "ciao")));
-		verify(mockTriggerable, times(0)).onEventTime(eq(new InternalTimer<>(10, key1, "hello")));
-		verify(mockTriggerable, times(0)).onEventTime(eq(new InternalTimer<>(10, key2, "ciao")));
-		verify(mockTriggerable, times(1)).onEventTime(eq(new InternalTimer<>(10, key2, "hello")));
+		verify(mockTriggerable, times(1)).onEventTime(eq(new TimerHeapInternalTimer<>(10, key1, "ciao")));
+		verify(mockTriggerable, times(0)).onEventTime(eq(new TimerHeapInternalTimer<>(10, key1, "hello")));
+		verify(mockTriggerable, times(0)).onEventTime(eq(new TimerHeapInternalTimer<>(10, key2, "ciao")));
+		verify(mockTriggerable, times(1)).onEventTime(eq(new TimerHeapInternalTimer<>(10, key2, "hello")));
 
 		assertEquals(0, timerService.numEventTimeTimers());
 	}
@@ -538,10 +540,10 @@ public class HeapInternalTimerServiceTest {
 		processingTimeService.setCurrentTime(10);
 
 		verify(mockTriggerable, times(2)).onProcessingTime(anyInternalTimer());
-		verify(mockTriggerable, times(1)).onProcessingTime(eq(new InternalTimer<>(10, key1, "ciao")));
-		verify(mockTriggerable, times(0)).onProcessingTime(eq(new InternalTimer<>(10, key1, "hello")));
-		verify(mockTriggerable, times(0)).onProcessingTime(eq(new InternalTimer<>(10, key2, "ciao")));
-		verify(mockTriggerable, times(1)).onProcessingTime(eq(new InternalTimer<>(10, key2, "hello")));
+		verify(mockTriggerable, times(1)).onProcessingTime(eq(new TimerHeapInternalTimer<>(10, key1, "ciao")));
+		verify(mockTriggerable, times(0)).onProcessingTime(eq(new TimerHeapInternalTimer<>(10, key1, "hello")));
+		verify(mockTriggerable, times(0)).onProcessingTime(eq(new TimerHeapInternalTimer<>(10, key2, "ciao")));
+		verify(mockTriggerable, times(1)).onProcessingTime(eq(new TimerHeapInternalTimer<>(10, key2, "hello")));
 
 		assertEquals(0, timerService.numEventTimeTimers());
 	}
@@ -635,11 +637,11 @@ public class HeapInternalTimerServiceTest {
 		timerService.advanceWatermark(10);
 
 		verify(mockTriggerable2, times(2)).onProcessingTime(anyInternalTimer());
-		verify(mockTriggerable2, times(1)).onProcessingTime(eq(new InternalTimer<>(10, key1, "ciao")));
-		verify(mockTriggerable2, times(1)).onProcessingTime(eq(new InternalTimer<>(10, key2, "hello")));
+		verify(mockTriggerable2, times(1)).onProcessingTime(eq(new TimerHeapInternalTimer<>(10, key1, "ciao")));
+		verify(mockTriggerable2, times(1)).onProcessingTime(eq(new TimerHeapInternalTimer<>(10, key2, "hello")));
 		verify(mockTriggerable2, times(2)).onEventTime(anyInternalTimer());
-		verify(mockTriggerable2, times(1)).onEventTime(eq(new InternalTimer<>(10, key1, "hello")));
-		verify(mockTriggerable2, times(1)).onEventTime(eq(new InternalTimer<>(10, key2, "ciao")));
+		verify(mockTriggerable2, times(1)).onEventTime(eq(new TimerHeapInternalTimer<>(10, key1, "hello")));
+		verify(mockTriggerable2, times(1)).onEventTime(eq(new TimerHeapInternalTimer<>(10, key2, "ciao")));
 
 		assertEquals(0, timerService.numEventTimeTimers());
 	}
@@ -737,11 +739,11 @@ public class HeapInternalTimerServiceTest {
 		timerService1.advanceWatermark(10);
 
 		verify(mockTriggerable1, times(1)).onProcessingTime(anyInternalTimer());
-		verify(mockTriggerable1, times(1)).onProcessingTime(eq(new InternalTimer<>(10, key1, "ciao")));
-		verify(mockTriggerable1, never()).onProcessingTime(eq(new InternalTimer<>(10, key2, "hello")));
+		verify(mockTriggerable1, times(1)).onProcessingTime(eq(new TimerHeapInternalTimer<>(10, key1, "ciao")));
+		verify(mockTriggerable1, never()).onProcessingTime(eq(new TimerHeapInternalTimer<>(10, key2, "hello")));
 		verify(mockTriggerable1, times(1)).onEventTime(anyInternalTimer());
-		verify(mockTriggerable1, times(1)).onEventTime(eq(new InternalTimer<>(10, key1, "hello")));
-		verify(mockTriggerable1, never()).onEventTime(eq(new InternalTimer<>(10, key2, "ciao")));
+		verify(mockTriggerable1, times(1)).onEventTime(eq(new TimerHeapInternalTimer<>(10, key1, "hello")));
+		verify(mockTriggerable1, never()).onEventTime(eq(new TimerHeapInternalTimer<>(10, key2, "ciao")));
 
 		assertEquals(0, timerService1.numEventTimeTimers());
 
@@ -749,11 +751,11 @@ public class HeapInternalTimerServiceTest {
 		timerService2.advanceWatermark(10);
 
 		verify(mockTriggerable2, times(1)).onProcessingTime(anyInternalTimer());
-		verify(mockTriggerable2, never()).onProcessingTime(eq(new InternalTimer<>(10, key1, "ciao")));
-		verify(mockTriggerable2, times(1)).onProcessingTime(eq(new InternalTimer<>(10, key2, "hello")));
+		verify(mockTriggerable2, never()).onProcessingTime(eq(new TimerHeapInternalTimer<>(10, key1, "ciao")));
+		verify(mockTriggerable2, times(1)).onProcessingTime(eq(new TimerHeapInternalTimer<>(10, key2, "hello")));
 		verify(mockTriggerable2, times(1)).onEventTime(anyInternalTimer());
-		verify(mockTriggerable2, never()).onEventTime(eq(new InternalTimer<>(10, key1, "hello")));
-		verify(mockTriggerable2, times(1)).onEventTime(eq(new InternalTimer<>(10, key2, "ciao")));
+		verify(mockTriggerable2, never()).onEventTime(eq(new TimerHeapInternalTimer<>(10, key1, "hello")));
+		verify(mockTriggerable2, times(1)).onEventTime(eq(new TimerHeapInternalTimer<>(10, key2, "ciao")));
 
 		assertEquals(0, timerService2.numEventTimeTimers());
 	}
@@ -795,7 +797,7 @@ public class HeapInternalTimerServiceTest {
 			Triggerable<Integer, String> triggerable,
 			KeyContext keyContext,
 			ProcessingTimeService processingTimeService,
-			KeyGroupsList keyGroupList,
+			KeyGroupRange keyGroupList,
 			int maxParallelism) {
 		HeapInternalTimerService<Integer, String> service =
 			new HeapInternalTimerService<>(
@@ -814,7 +816,7 @@ public class HeapInternalTimerServiceTest {
 			Triggerable<Integer, String> triggerable,
 			KeyContext keyContext,
 			ProcessingTimeService processingTimeService,
-			KeyGroupsList keyGroupsList,
+			KeyGroupRange keyGroupsList,
 			int maxParallelism) throws Exception {
 
 		// create an empty service

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/InternalTimerHeapTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/InternalTimerHeapTest.java
@@ -1,0 +1,301 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators;
+
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.VoidNamespace;
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Tests for {@link InternalTimerHeap}.
+ */
+public class InternalTimerHeapTest extends TestLogger {
+
+	private static final KeyGroupRange KEY_GROUP_RANGE = new KeyGroupRange(0, 1);
+
+	private static void insertRandomTimers(
+		InternalTimerHeap<Integer, VoidNamespace> timerPriorityQueue,
+		int count) {
+		insertRandomTimers(timerPriorityQueue, null, count);
+	}
+
+	private static void insertRandomTimers(
+		@Nonnull InternalTimerHeap<Integer, VoidNamespace> timerPriorityQueue,
+		@Nullable Set<InternalTimer<Integer, VoidNamespace>> checkSet,
+		int count) {
+
+		ThreadLocalRandom localRandom = ThreadLocalRandom.current();
+
+		for (int i = 0; i < count; ++i) {
+			TimerHeapInternalTimer<Integer, VoidNamespace> timer =
+				new TimerHeapInternalTimer<>(localRandom.nextLong(), i, VoidNamespace.INSTANCE);
+			if (checkSet != null) {
+				Preconditions.checkState(checkSet.add(timer));
+			}
+			Assert.assertTrue(timerPriorityQueue.scheduleTimer(
+				timer.getTimestamp(),
+				timer.getKey(),
+				timer.getNamespace()));
+		}
+	}
+
+	private static InternalTimerHeap<Integer, VoidNamespace> newPriorityQueue(int initialCapacity) {
+		return new InternalTimerHeap<>(
+			initialCapacity,
+			KEY_GROUP_RANGE,
+			KEY_GROUP_RANGE.getNumberOfKeyGroups());
+	}
+
+	@Test
+	public void testPeekPollOrder() {
+		final int initialCapacity = 4;
+		final int testSize = 1000;
+		InternalTimerHeap<Integer, VoidNamespace> timerPriorityQueue = newPriorityQueue(initialCapacity);
+		HashSet<InternalTimer<Integer, VoidNamespace>> checkSet = new HashSet<>(testSize);
+
+		insertRandomTimers(timerPriorityQueue, checkSet, testSize);
+
+		long lastTimestamp = Long.MIN_VALUE;
+		int lastSize = timerPriorityQueue.size();
+		Assert.assertEquals(testSize, lastSize);
+		InternalTimer<Integer, VoidNamespace> timer;
+		while ((timer = timerPriorityQueue.peek()) != null) {
+			Assert.assertFalse(timerPriorityQueue.isEmpty());
+			Assert.assertEquals(lastSize, timerPriorityQueue.size());
+			Assert.assertEquals(timer, timerPriorityQueue.poll());
+			Assert.assertTrue(checkSet.remove(timer));
+			Assert.assertTrue(timer.getTimestamp() >= lastTimestamp);
+			lastTimestamp = timer.getTimestamp();
+			--lastSize;
+		}
+
+		Assert.assertTrue(timerPriorityQueue.isEmpty());
+		Assert.assertEquals(0, timerPriorityQueue.size());
+		Assert.assertEquals(0, checkSet.size());
+	}
+
+	@Test
+	public void testStopInsertMixKeepsOrder() {
+
+		InternalTimerHeap<Integer, VoidNamespace> timerPriorityQueue = newPriorityQueue(3);
+
+		final int testSize = 345;
+		HashSet<InternalTimer<Integer, VoidNamespace>> checkSet = new HashSet<>(testSize);
+
+		insertRandomTimers(timerPriorityQueue, checkSet, testSize);
+
+		// check that the whole set is still in order
+		while (!checkSet.isEmpty()) {
+
+			Iterator<InternalTimer<Integer, VoidNamespace>> iterator = checkSet.iterator();
+			InternalTimer<Integer, VoidNamespace> timer = iterator.next();
+			iterator.remove();
+			Assert.assertTrue(timerPriorityQueue.stopTimer(timer.getTimestamp(), timer.getKey(), timer.getNamespace()));
+			Assert.assertEquals(checkSet.size(), timerPriorityQueue.size());
+
+			long lastTimestamp = Long.MIN_VALUE;
+
+			while ((timer = timerPriorityQueue.poll()) != null) {
+				Assert.assertTrue(timer.getTimestamp() >= lastTimestamp);
+				lastTimestamp = timer.getTimestamp();
+			}
+
+			Assert.assertTrue(timerPriorityQueue.isEmpty());
+
+			timerPriorityQueue.bulkAddRestoredTimers(checkSet);
+		}
+	}
+
+	@Test
+	public void testPoll() {
+		InternalTimerHeap<Integer, VoidNamespace> timerPriorityQueue = newPriorityQueue(3);
+
+		Assert.assertNull(timerPriorityQueue.poll());
+
+		final int testSize = 345;
+		HashSet<InternalTimer<Integer, VoidNamespace>> checkSet = new HashSet<>(testSize);
+		insertRandomTimers(timerPriorityQueue, checkSet, testSize);
+
+		long lastTimestamp = Long.MIN_VALUE;
+		while (!timerPriorityQueue.isEmpty()) {
+			InternalTimer<Integer, VoidNamespace> removed = timerPriorityQueue.poll();
+			Assert.assertNotNull(removed);
+			Assert.assertTrue(checkSet.remove(removed));
+			Assert.assertTrue(removed.getTimestamp() >= lastTimestamp);
+			lastTimestamp = removed.getTimestamp();
+		}
+		Assert.assertTrue(checkSet.isEmpty());
+
+		Assert.assertNull(timerPriorityQueue.poll());
+	}
+
+	@Test
+	public void testIsEmpty() {
+		InternalTimerHeap<Integer, VoidNamespace> timerPriorityQueue =
+			newPriorityQueue(1);
+
+		Assert.assertTrue(timerPriorityQueue.isEmpty());
+
+		timerPriorityQueue.scheduleTimer(42L, 4711, VoidNamespace.INSTANCE);
+		Assert.assertFalse(timerPriorityQueue.isEmpty());
+
+		timerPriorityQueue.poll();
+		Assert.assertTrue(timerPriorityQueue.isEmpty());
+	}
+
+	@Test
+	public void testBulkAddRestoredTimers() {
+		final int testSize = 10;
+		HashSet<InternalTimer<Integer, VoidNamespace>> timerSet = new HashSet<>(testSize);
+		for (int i = 0; i < testSize; ++i) {
+			timerSet.add(new TimerHeapInternalTimer<>(i, i, VoidNamespace.INSTANCE));
+		}
+
+		List<InternalTimer<Integer, VoidNamespace>> twoTimesTimerSet = new ArrayList<>(timerSet.size() * 2);
+		twoTimesTimerSet.addAll(timerSet);
+		twoTimesTimerSet.addAll(timerSet);
+
+		InternalTimerHeap<Integer, VoidNamespace> timerPriorityQueue =
+			newPriorityQueue(1);
+
+		timerPriorityQueue.bulkAddRestoredTimers(twoTimesTimerSet);
+		timerPriorityQueue.bulkAddRestoredTimers(twoTimesTimerSet);
+
+		Assert.assertEquals(timerSet.size(), timerPriorityQueue.size());
+
+		for (InternalTimer<Integer, VoidNamespace> timer : timerPriorityQueue) {
+			Assert.assertTrue(timerSet.remove(timer));
+		}
+
+		Assert.assertTrue(timerSet.isEmpty());
+	}
+
+	@Test
+	public void testToArray() {
+		final int testSize = 10;
+		HashSet<InternalTimer<Integer, VoidNamespace>> checkSet = new HashSet<>(testSize);
+		InternalTimerHeap<Integer, VoidNamespace> timerPriorityQueue =
+			newPriorityQueue(1);
+
+		Assert.assertEquals(0, timerPriorityQueue.toArray().length);
+
+		insertRandomTimers(timerPriorityQueue, checkSet, testSize);
+
+		Object[] toArray = timerPriorityQueue.toArray();
+		Assert.assertEquals(timerPriorityQueue.size(), toArray.length);
+
+		for (Object o : toArray) {
+			if (o instanceof TimerHeapInternalTimer) {
+				Assert.assertTrue(checkSet.remove(o));
+			}
+		}
+
+		Assert.assertTrue(checkSet.isEmpty());
+	}
+
+	@Test
+	public void testIterator() {
+		InternalTimerHeap<Integer, VoidNamespace> timerPriorityQueue =
+			newPriorityQueue(1);
+
+		// test empty iterator
+		Iterator<InternalTimer<Integer, VoidNamespace>> iterator = timerPriorityQueue.iterator();
+		Assert.assertFalse(iterator.hasNext());
+		try {
+			iterator.next();
+			Assert.fail();
+		} catch (NoSuchElementException ignore) {
+		}
+
+		// iterate some data
+		final int testSize = 10;
+		HashSet<InternalTimer<Integer, VoidNamespace>> checkSet = new HashSet<>(testSize);
+		insertRandomTimers(timerPriorityQueue, checkSet, testSize);
+		iterator = timerPriorityQueue.iterator();
+		while (iterator.hasNext()) {
+			Assert.assertTrue(checkSet.remove(iterator.next()));
+		}
+		Assert.assertTrue(checkSet.isEmpty());
+
+		// test remove is not supported
+		try {
+			iterator.remove();
+			Assert.fail();
+		} catch (UnsupportedOperationException ignore) {
+		}
+	}
+
+	@Test
+	public void testClear() {
+		InternalTimerHeap<Integer, VoidNamespace> timerPriorityQueue =
+			newPriorityQueue(1);
+
+		int count = 10;
+		insertRandomTimers(timerPriorityQueue, count);
+		Assert.assertEquals(count, timerPriorityQueue.size());
+		timerPriorityQueue.clear();
+		Assert.assertEquals(0, timerPriorityQueue.size());
+	}
+
+	@Test
+	public void testScheduleTimer() {
+		InternalTimerHeap<Integer, VoidNamespace> timerPriorityQueue =
+			newPriorityQueue(1);
+
+		final long timestamp = 42L;
+		final Integer key = 4711;
+		Assert.assertTrue(timerPriorityQueue.scheduleTimer(timestamp, key, VoidNamespace.INSTANCE));
+		Assert.assertFalse(timerPriorityQueue.scheduleTimer(timestamp, key, VoidNamespace.INSTANCE));
+		Assert.assertEquals(1, timerPriorityQueue.size());
+		final InternalTimer<Integer, VoidNamespace> timer = timerPriorityQueue.poll();
+		Assert.assertNotNull(timer);
+		Assert.assertEquals(timestamp, timer.getTimestamp());
+		Assert.assertEquals(key, timer.getKey());
+		Assert.assertEquals(VoidNamespace.INSTANCE, timer.getNamespace());
+	}
+
+	@Test
+	public void testStopTimer() {
+		InternalTimerHeap<Integer, VoidNamespace> timerPriorityQueue =
+			newPriorityQueue(1);
+
+		final long timestamp = 42L;
+		final Integer key = 4711;
+		Assert.assertFalse(timerPriorityQueue.stopTimer(timestamp, key, VoidNamespace.INSTANCE));
+		Assert.assertTrue(timerPriorityQueue.scheduleTimer(timestamp, key, VoidNamespace.INSTANCE));
+		Assert.assertTrue(timerPriorityQueue.stopTimer(timestamp, key, VoidNamespace.INSTANCE));
+		Assert.assertFalse(timerPriorityQueue.stopTimer(timestamp, key, VoidNamespace.INSTANCE));
+		Assert.assertTrue(timerPriorityQueue.isEmpty());
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StateInitializationContextImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StateInitializationContextImplTest.java
@@ -174,7 +174,7 @@ public class StateInitializationContextImplTest {
 			mock(ProcessingTimeService.class)) {
 
 			@Override
-			protected <K> InternalTimeServiceManager<?, K> internalTimeServiceManager(
+			protected <K> InternalTimeServiceManager<K> internalTimeServiceManager(
 				AbstractKeyedStateBackend<K> keyedStatedBackend,
 				KeyContext keyContext,
 				Iterable<KeyGroupStatePartitionStreamProvider> rawKeyedStates) throws Exception {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamOperatorSnapshotRestoreTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamOperatorSnapshotRestoreTest.java
@@ -200,7 +200,7 @@ public class StreamOperatorSnapshotRestoreTest extends TestLogger {
 
 				return new StreamTaskStateInitializerImpl(env, stateBackend, processingTimeService) {
 					@Override
-					protected <K> InternalTimeServiceManager<?, K> internalTimeServiceManager(
+					protected <K> InternalTimeServiceManager<K> internalTimeServiceManager(
 						AbstractKeyedStateBackend<K> keyedStatedBackend,
 						KeyContext keyContext,
 						Iterable<KeyGroupStatePartitionStreamProvider> rawKeyedStates) throws Exception {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImplTest.java
@@ -94,7 +94,7 @@ public class StreamTaskStateInitializerImplTest {
 
 		OperatorStateBackend operatorStateBackend = stateContext.operatorStateBackend();
 		AbstractKeyedStateBackend<?> keyedStateBackend = stateContext.keyedStateBackend();
-		InternalTimeServiceManager<?, ?> timeServiceManager = stateContext.internalTimerServiceManager();
+		InternalTimeServiceManager<?> timeServiceManager = stateContext.internalTimerServiceManager();
 		CloseableIterable<KeyGroupStatePartitionStreamProvider> keyedStateInputs = stateContext.rawKeyedStateInputs();
 		CloseableIterable<StatePartitionStreamProvider> operatorStateInputs = stateContext.rawOperatorStateInputs();
 
@@ -194,7 +194,7 @@ public class StreamTaskStateInitializerImplTest {
 
 		OperatorStateBackend operatorStateBackend = stateContext.operatorStateBackend();
 		AbstractKeyedStateBackend<?> keyedStateBackend = stateContext.keyedStateBackend();
-		InternalTimeServiceManager<?, ?> timeServiceManager = stateContext.internalTimerServiceManager();
+		InternalTimeServiceManager<?> timeServiceManager = stateContext.internalTimerServiceManager();
 		CloseableIterable<KeyGroupStatePartitionStreamProvider> keyedStateInputs = stateContext.rawKeyedStateInputs();
 		CloseableIterable<StatePartitionStreamProvider> operatorStateInputs = stateContext.rawOperatorStateInputs();
 
@@ -271,7 +271,7 @@ public class StreamTaskStateInitializerImplTest {
 				stateBackend,
 				processingTimeService) {
 				@Override
-				protected <K> InternalTimeServiceManager<?, K> internalTimeServiceManager(
+				protected <K> InternalTimeServiceManager<K> internalTimeServiceManager(
 					AbstractKeyedStateBackend<K> keyedStatedBackend,
 					KeyContext keyContext,
 					Iterable<KeyGroupStatePartitionStreamProvider> rawKeyedStates) throws Exception {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -1109,8 +1109,8 @@ public class StreamTaskTest extends TestLogger {
 					}
 
 					@Override
-					public InternalTimeServiceManager<?, ?> internalTimerServiceManager() {
-						InternalTimeServiceManager<?, ?> timeServiceManager = context.internalTimerServiceManager();
+					public InternalTimeServiceManager<?> internalTimerServiceManager() {
+						InternalTimeServiceManager<?> timeServiceManager = context.internalTimerServiceManager();
 						return timeServiceManager != null ? spy(timeServiceManager) : null;
 					}
 


### PR DESCRIPTION
## Brief change log

This PR removes the misleading generic parameter `N` from `InternalTimerServiceManager<K, N>`.

Please notice that this PR is only about commit 4fc3715 and already sits on top of PR #6062.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
