### PR TITLE
[FLINK-9444][table] KafkaAvroTableSource failed to work for map and array fields

### DIFF
--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaAvroTableSourceTestBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaAvroTableSourceTestBase.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.formats.avro.utils.AvroTestUtils;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.Types;
 
 import org.apache.avro.Schema;
@@ -31,7 +30,6 @@ import org.junit.Test;
 
 import java.sql.Timestamp;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -130,82 +128,6 @@ public abstract class KafkaAvroTableSourceTestBase extends KafkaTableSourceTestB
 			source.getDataStream(StreamExecutionEnvironment.getExecutionEnvironment()).getType());
 	}
 
-	@Test
-	public void testHasMapFieldsAvroClass() {
-		KafkaAvroTableSource.Builder b = (KafkaAvroTableSource.Builder) getBuilder();
-		b.forAvroRecordClass(HasMapFieldsAvroClass.class)
-			.forTopic("test")
-			.withKafkaProperties(createSourceProperties())
-			.withSchema(new TableSchema(HasMapFieldsAvroClass.FIELD_NAMES,
-				HasMapFieldsAvroClass.FIELD_TYPES));
-
-		KafkaAvroTableSource source = (KafkaAvroTableSource) b.build();
-
-		// check return type
-		RowTypeInfo returnType = (RowTypeInfo) source.getReturnType();
-		assertNotNull(returnType);
-		assertEquals(6, returnType.getArity());
-		// check field names
-		assertEquals("strMapField", returnType.getFieldNames()[0]);
-		assertEquals("intMapField", returnType.getFieldNames()[1]);
-		assertEquals("longMapField", returnType.getFieldNames()[2]);
-		assertEquals("floatMapField", returnType.getFieldNames()[3]);
-		assertEquals("doubleMapField", returnType.getFieldNames()[4]);
-		assertEquals("boolMapField", returnType.getFieldNames()[5]);
-		// check field types
-		assertEquals(Types.MAP(Types.STRING(), Types.STRING()), returnType.getTypeAt(0));
-		assertEquals(Types.MAP(Types.STRING(), Types.INT()), returnType.getTypeAt(1));
-		assertEquals(Types.MAP(Types.STRING(), Types.LONG()), returnType.getTypeAt(2));
-		assertEquals(Types.MAP(Types.STRING(), Types.FLOAT()), returnType.getTypeAt(3));
-		assertEquals(Types.MAP(Types.STRING(), Types.DOUBLE()), returnType.getTypeAt(4));
-		assertEquals(Types.MAP(Types.STRING(), Types.BOOLEAN()), returnType.getTypeAt(5));
-
-		// check if DataStream type matches with TableSource.getReturnType()
-		assertEquals(source.getReturnType(),
-			source.getDataStream(StreamExecutionEnvironment.getExecutionEnvironment()).getType());
-	}
-
-	@Test
-	public void testHasArrayFieldsAvroClass() {
-		KafkaAvroTableSource.Builder b = (KafkaAvroTableSource.Builder) getBuilder();
-		b.forAvroRecordClass(HasArrayFieldsAvroClass.class)
-			.forTopic("test")
-			.withKafkaProperties(createSourceProperties())
-			.withSchema(new TableSchema(HasArrayFieldsAvroClass.FIELD_NAMES,
-				HasArrayFieldsAvroClass.FIELD_TYPES));
-
-		KafkaAvroTableSource source = (KafkaAvroTableSource) b.build();
-
-		// check return type
-		RowTypeInfo returnType = (RowTypeInfo) source.getReturnType();
-		assertNotNull(returnType);
-		assertEquals(6, returnType.getArity());
-		// check field names
-		assertEquals("strArrayField", returnType.getFieldNames()[0]);
-		assertEquals("intArrayField", returnType.getFieldNames()[1]);
-		assertEquals("longArrayField", returnType.getFieldNames()[2]);
-		assertEquals("floatArrayField", returnType.getFieldNames()[3]);
-		assertEquals("doubleArrayField", returnType.getFieldNames()[4]);
-		assertEquals("boolArrayField", returnType.getFieldNames()[5]);
-		// check field types
-		assertEquals(org.apache.flink.api.common.typeinfo.Types.LIST(Types.STRING()),
-			returnType.getTypeAt(0));
-		assertEquals(org.apache.flink.api.common.typeinfo.Types.LIST(Types.INT()),
-			returnType.getTypeAt(1));
-		assertEquals(org.apache.flink.api.common.typeinfo.Types.LIST(Types.LONG()),
-			returnType.getTypeAt(2));
-		assertEquals(org.apache.flink.api.common.typeinfo.Types.LIST(Types.FLOAT()),
-			returnType.getTypeAt(3));
-		assertEquals(org.apache.flink.api.common.typeinfo.Types.LIST(Types.DOUBLE()),
-			returnType.getTypeAt(4));
-		assertEquals(org.apache.flink.api.common.typeinfo.Types.LIST(Types.BOOLEAN()),
-			returnType.getTypeAt(5));
-
-		// check if DataStream type matches with TableSource.getReturnType()
-		assertEquals(source.getReturnType(),
-			source.getDataStream(StreamExecutionEnvironment.getExecutionEnvironment()).getType());
-	}
-
 	/**
 	 * Avro record that matches the table schema.
 	 */
@@ -254,85 +176,6 @@ public abstract class KafkaAvroTableSourceTestBase extends KafkaTableSourceTestB
 		public Double otherField3;
 		public Byte otherField4;
 		public Integer otherField5;
-
-		@Override
-		public Schema getSchema() {
-			return null;
-		}
-
-		@Override
-		public Object get(int field) {
-			return null;
-		}
-
-		@Override
-		public void put(int field, Object value) { }
-	}
-
-	/**
-	 * Avro record that has map fields.
-	 */
-	@SuppressWarnings("unused")
-	public static class HasMapFieldsAvroClass extends SpecificRecordBase {
-
-		public static final String[] FIELD_NAMES = new String[]{
-			"strMapField", "intMapField", "longMapField", "floatMapField", "doubleMapField", "boolMapField"};
-		public static final TypeInformation[] FIELD_TYPES = new TypeInformation[]{
-			Types.MAP(Types.STRING(), Types.STRING()), Types.MAP(Types.STRING(), Types.INT()),
-			Types.MAP(Types.STRING(), Types.LONG()), Types.MAP(Types.STRING(), Types.FLOAT()),
-			Types.MAP(Types.STRING(), Types.DOUBLE()), Types.MAP(Types.STRING(), Types.BOOLEAN())};
-
-		//CHECKSTYLE.OFF: StaticVariableNameCheck - Avro accesses this field by name via reflection.
-		public static Schema SCHEMA$ = AvroTestUtils.createFlatAvroSchema(FIELD_NAMES, FIELD_TYPES);
-		//CHECKSTYLE.ON: StaticVariableNameCheck
-
-		public Map<String, String> strMapField;
-		public Map<String, Integer> intMapField;
-		public Map<String, Long> longMapField;
-		public Map<String, Float> floatMapField;
-		public Map<String, Double> doubleMapField;
-		public Map<String, Boolean> boolMapField;
-
-		@Override
-		public Schema getSchema() {
-			return null;
-		}
-
-		@Override
-		public Object get(int field) {
-			return null;
-		}
-
-		@Override
-		public void put(int field, Object value) { }
-	}
-
-	/**
-	 * Avro record that has array fields.
-	 */
-	@SuppressWarnings("unused")
-	public static class HasArrayFieldsAvroClass extends SpecificRecordBase {
-
-		public static final String[] FIELD_NAMES = new String[]{
-			"strArrayField", "intArrayField", "longArrayField", "floatArrayField", "doubleArrayField", "boolArrayField"};
-		public static final TypeInformation[] FIELD_TYPES = new TypeInformation[]{
-			org.apache.flink.api.common.typeinfo.Types.LIST(Types.STRING()),
-			org.apache.flink.api.common.typeinfo.Types.LIST(Types.INT()),
-			org.apache.flink.api.common.typeinfo.Types.LIST(Types.LONG()),
-			org.apache.flink.api.common.typeinfo.Types.LIST(Types.FLOAT()),
-			org.apache.flink.api.common.typeinfo.Types.LIST(Types.DOUBLE()),
-			org.apache.flink.api.common.typeinfo.Types.LIST(Types.BOOLEAN())};
-
-		//CHECKSTYLE.OFF: StaticVariableNameCheck - Avro accesses this field by name via reflection.
-		public static Schema SCHEMA$ = AvroTestUtils.createFlatAvroSchema(FIELD_NAMES, FIELD_TYPES);
-		//CHECKSTYLE.ON: StaticVariableNameCheck
-
-		public List<String> strArrayField;
-		public List<Integer> intArrayField;
-		public List<Long> longArrayField;
-		public List<Float> floatArrayField;
-		public List<Double> doubleArrayField;
-		public List<Boolean> boolArrayField;
 
 		@Override
 		public Schema getSchema() {

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaAvroTableSourceTestBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaAvroTableSourceTestBase.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.formats.avro.utils.AvroTestUtils;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.Types;
 
 import org.apache.avro.Schema;
@@ -30,6 +31,7 @@ import org.junit.Test;
 
 import java.sql.Timestamp;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -128,6 +130,82 @@ public abstract class KafkaAvroTableSourceTestBase extends KafkaTableSourceTestB
 			source.getDataStream(StreamExecutionEnvironment.getExecutionEnvironment()).getType());
 	}
 
+	@Test
+	public void testHasMapFieldsAvroClass() {
+		KafkaAvroTableSource.Builder b = (KafkaAvroTableSource.Builder) getBuilder();
+		b.forAvroRecordClass(HasMapFieldsAvroClass.class)
+			.forTopic("test")
+			.withKafkaProperties(createSourceProperties())
+			.withSchema(new TableSchema(HasMapFieldsAvroClass.FIELD_NAMES,
+				HasMapFieldsAvroClass.FIELD_TYPES));
+
+		KafkaAvroTableSource source = (KafkaAvroTableSource) b.build();
+
+		// check return type
+		RowTypeInfo returnType = (RowTypeInfo) source.getReturnType();
+		assertNotNull(returnType);
+		assertEquals(6, returnType.getArity());
+		// check field names
+		assertEquals("strMapField", returnType.getFieldNames()[0]);
+		assertEquals("intMapField", returnType.getFieldNames()[1]);
+		assertEquals("longMapField", returnType.getFieldNames()[2]);
+		assertEquals("floatMapField", returnType.getFieldNames()[3]);
+		assertEquals("doubleMapField", returnType.getFieldNames()[4]);
+		assertEquals("boolMapField", returnType.getFieldNames()[5]);
+		// check field types
+		assertEquals(Types.MAP(Types.STRING(), Types.STRING()), returnType.getTypeAt(0));
+		assertEquals(Types.MAP(Types.STRING(), Types.INT()), returnType.getTypeAt(1));
+		assertEquals(Types.MAP(Types.STRING(), Types.LONG()), returnType.getTypeAt(2));
+		assertEquals(Types.MAP(Types.STRING(), Types.FLOAT()), returnType.getTypeAt(3));
+		assertEquals(Types.MAP(Types.STRING(), Types.DOUBLE()), returnType.getTypeAt(4));
+		assertEquals(Types.MAP(Types.STRING(), Types.BOOLEAN()), returnType.getTypeAt(5));
+
+		// check if DataStream type matches with TableSource.getReturnType()
+		assertEquals(source.getReturnType(),
+			source.getDataStream(StreamExecutionEnvironment.getExecutionEnvironment()).getType());
+	}
+
+	@Test
+	public void testHasArrayFieldsAvroClass() {
+		KafkaAvroTableSource.Builder b = (KafkaAvroTableSource.Builder) getBuilder();
+		b.forAvroRecordClass(HasArrayFieldsAvroClass.class)
+			.forTopic("test")
+			.withKafkaProperties(createSourceProperties())
+			.withSchema(new TableSchema(HasArrayFieldsAvroClass.FIELD_NAMES,
+				HasArrayFieldsAvroClass.FIELD_TYPES));
+
+		KafkaAvroTableSource source = (KafkaAvroTableSource) b.build();
+
+		// check return type
+		RowTypeInfo returnType = (RowTypeInfo) source.getReturnType();
+		assertNotNull(returnType);
+		assertEquals(6, returnType.getArity());
+		// check field names
+		assertEquals("strArrayField", returnType.getFieldNames()[0]);
+		assertEquals("intArrayField", returnType.getFieldNames()[1]);
+		assertEquals("longArrayField", returnType.getFieldNames()[2]);
+		assertEquals("floatArrayField", returnType.getFieldNames()[3]);
+		assertEquals("doubleArrayField", returnType.getFieldNames()[4]);
+		assertEquals("boolArrayField", returnType.getFieldNames()[5]);
+		// check field types
+		assertEquals(org.apache.flink.api.common.typeinfo.Types.LIST(Types.STRING()),
+			returnType.getTypeAt(0));
+		assertEquals(org.apache.flink.api.common.typeinfo.Types.LIST(Types.INT()),
+			returnType.getTypeAt(1));
+		assertEquals(org.apache.flink.api.common.typeinfo.Types.LIST(Types.LONG()),
+			returnType.getTypeAt(2));
+		assertEquals(org.apache.flink.api.common.typeinfo.Types.LIST(Types.FLOAT()),
+			returnType.getTypeAt(3));
+		assertEquals(org.apache.flink.api.common.typeinfo.Types.LIST(Types.DOUBLE()),
+			returnType.getTypeAt(4));
+		assertEquals(org.apache.flink.api.common.typeinfo.Types.LIST(Types.BOOLEAN()),
+			returnType.getTypeAt(5));
+
+		// check if DataStream type matches with TableSource.getReturnType()
+		assertEquals(source.getReturnType(),
+			source.getDataStream(StreamExecutionEnvironment.getExecutionEnvironment()).getType());
+	}
+
 	/**
 	 * Avro record that matches the table schema.
 	 */
@@ -191,4 +269,82 @@ public abstract class KafkaAvroTableSourceTestBase extends KafkaTableSourceTestB
 		public void put(int field, Object value) { }
 	}
 
+	/**
+	 * Avro record that has map fields.
+	 */
+	@SuppressWarnings("unused")
+	public static class HasMapFieldsAvroClass extends SpecificRecordBase {
+
+		public static final String[] FIELD_NAMES = new String[]{
+			"strMapField", "intMapField", "longMapField", "floatMapField", "doubleMapField", "boolMapField"};
+		public static final TypeInformation[] FIELD_TYPES = new TypeInformation[]{
+			Types.MAP(Types.STRING(), Types.STRING()), Types.MAP(Types.STRING(), Types.INT()),
+			Types.MAP(Types.STRING(), Types.LONG()), Types.MAP(Types.STRING(), Types.FLOAT()),
+			Types.MAP(Types.STRING(), Types.DOUBLE()), Types.MAP(Types.STRING(), Types.BOOLEAN())};
+
+		//CHECKSTYLE.OFF: StaticVariableNameCheck - Avro accesses this field by name via reflection.
+		public static Schema SCHEMA$ = AvroTestUtils.createFlatAvroSchema(FIELD_NAMES, FIELD_TYPES);
+		//CHECKSTYLE.ON: StaticVariableNameCheck
+
+		public Map<String, String> strMapField;
+		public Map<String, Integer> intMapField;
+		public Map<String, Long> longMapField;
+		public Map<String, Float> floatMapField;
+		public Map<String, Double> doubleMapField;
+		public Map<String, Boolean> boolMapField;
+
+		@Override
+		public Schema getSchema() {
+			return null;
+		}
+
+		@Override
+		public Object get(int field) {
+			return null;
+		}
+
+		@Override
+		public void put(int field, Object value) { }
+	}
+
+	/**
+	 * Avro record that has array fields.
+	 */
+	@SuppressWarnings("unused")
+	public static class HasArrayFieldsAvroClass extends SpecificRecordBase {
+
+		public static final String[] FIELD_NAMES = new String[]{
+			"strArrayField", "intArrayField", "longArrayField", "floatArrayField", "doubleArrayField", "boolArrayField"};
+		public static final TypeInformation[] FIELD_TYPES = new TypeInformation[]{
+			org.apache.flink.api.common.typeinfo.Types.LIST(Types.STRING()),
+			org.apache.flink.api.common.typeinfo.Types.LIST(Types.INT()),
+			org.apache.flink.api.common.typeinfo.Types.LIST(Types.LONG()),
+			org.apache.flink.api.common.typeinfo.Types.LIST(Types.FLOAT()),
+			org.apache.flink.api.common.typeinfo.Types.LIST(Types.DOUBLE()),
+			org.apache.flink.api.common.typeinfo.Types.LIST(Types.BOOLEAN())};
+
+		//CHECKSTYLE.OFF: StaticVariableNameCheck - Avro accesses this field by name via reflection.
+		public static Schema SCHEMA$ = AvroTestUtils.createFlatAvroSchema(FIELD_NAMES, FIELD_TYPES);
+		//CHECKSTYLE.ON: StaticVariableNameCheck
+
+		public List<String> strArrayField;
+		public List<Integer> intArrayField;
+		public List<Long> longArrayField;
+		public List<Float> floatArrayField;
+		public List<Double> doubleArrayField;
+		public List<Boolean> boolArrayField;
+
+		@Override
+		public Schema getSchema() {
+			return null;
+		}
+
+		@Override
+		public Object get(int field) {
+			return null;
+		}
+
+		@Override
+		public void put(int field, Object value) { }
+	}
 }

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceTestBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceTestBase.java
@@ -250,7 +250,7 @@ public abstract class KafkaTableSourceTestBase {
 			.withSchema(SCHEMA);
 	}
 
-	protected static Properties createSourceProperties() {
+	private static Properties createSourceProperties() {
 		Properties properties = new Properties();
 		properties.setProperty("zookeeper.connect", "dummy");
 		properties.setProperty("group.id", "dummy");

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceTestBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceTestBase.java
@@ -250,7 +250,7 @@ public abstract class KafkaTableSourceTestBase {
 			.withSchema(SCHEMA);
 	}
 
-	private static Properties createSourceProperties() {
+	protected static Properties createSourceProperties() {
 		Properties properties = new Properties();
 		properties.setProperty("zookeeper.connect", "dummy");
 		properties.setProperty("group.id", "dummy");

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroRowDeSerializationSchemaTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroRowDeSerializationSchemaTest.java
@@ -18,16 +18,25 @@
 
 package org.apache.flink.formats.avro;
 
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.formats.avro.generated.Address;
+import org.apache.flink.formats.avro.typeutils.AvroRecordClassConverter;
+import org.apache.flink.formats.avro.typeutils.AvroTypeInfo;
 import org.apache.flink.formats.avro.utils.AvroTestUtils;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.InstantiationUtil;
 
+import org.apache.avro.Schema;
 import org.apache.avro.specific.SpecificRecord;
 import org.apache.avro.specific.SpecificRecordBase;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 
@@ -143,5 +152,115 @@ public class AvroRowDeSerializationSchemaTest {
 		final Row actual = deserCopy.deserialize(bytes);
 
 		assertEquals(testData.f2, actual);
+	}
+
+	@Test
+	public void testHasMapFieldsAvroClass(){
+		AvroRowDeserializationSchema schema = new AvroRowDeserializationSchema(HasMapFieldsAvroClass.class);
+		RowTypeInfo returnType = (RowTypeInfo) schema.getProducedType();
+
+		assertEquals(Types.MAP(Types.STRING, Types.STRING), returnType.getTypeAt(0));
+		assertEquals(Types.MAP(Types.STRING, Types.INT), returnType.getTypeAt(1));
+		assertEquals(Types.MAP(Types.STRING, Types.LONG), returnType.getTypeAt(2));
+		assertEquals(Types.MAP(Types.STRING, Types.FLOAT), returnType.getTypeAt(3));
+		assertEquals(Types.MAP(Types.STRING, Types.DOUBLE), returnType.getTypeAt(4));
+		assertEquals(Types.MAP(Types.STRING, Types.BOOLEAN), returnType.getTypeAt(5));
+		assertEquals(Types.MAP(Types.STRING, AvroRecordClassConverter.convert(Address.class)), returnType.getTypeAt(6));
+	}
+
+	@Test
+	public void testHasArrayFieldsAvroClass(){
+		AvroRowDeserializationSchema schema = new AvroRowDeserializationSchema(HasArrayFieldsAvroClass.class);
+		RowTypeInfo returnType = (RowTypeInfo) schema.getProducedType();
+
+		assertEquals(Types.OBJECT_ARRAY(Types.STRING), returnType.getTypeAt(0));
+		assertEquals(Types.OBJECT_ARRAY(Types.INT), returnType.getTypeAt(1));
+		assertEquals(Types.OBJECT_ARRAY(Types.LONG), returnType.getTypeAt(2));
+		assertEquals(Types.OBJECT_ARRAY(Types.FLOAT), returnType.getTypeAt(3));
+		assertEquals(Types.OBJECT_ARRAY(Types.DOUBLE), returnType.getTypeAt(4));
+		assertEquals(Types.OBJECT_ARRAY(Types.BOOLEAN), returnType.getTypeAt(5));
+		assertEquals(Types.OBJECT_ARRAY(AvroRecordClassConverter.convert(Address.class)), returnType.getTypeAt(6));
+	}
+
+	/**
+	 * Avro record that has map fields.
+	 */
+	@SuppressWarnings("unused")
+	public static class HasMapFieldsAvroClass extends SpecificRecordBase {
+
+		public static final String[] FIELD_NAMES = new String[]{
+			"strMapField", "intMapField", "longMapField", "floatMapField",
+			"doubleMapField", "boolMapField", "recordMapField"};
+		public static final TypeInformation[] FIELD_TYPES = new TypeInformation[]{
+			Types.MAP(Types.STRING, Types.STRING), Types.MAP(Types.STRING, Types.INT),
+			Types.MAP(Types.STRING, Types.LONG), Types.MAP(Types.STRING, Types.FLOAT),
+			Types.MAP(Types.STRING, Types.DOUBLE), Types.MAP(Types.STRING, Types.BOOLEAN),
+			Types.MAP(Types.STRING, new AvroTypeInfo(Address.class))};
+
+		//CHECKSTYLE.OFF: StaticVariableNameCheck - Avro accesses this field by name via reflection.
+		public static Schema SCHEMA$ = AvroTestUtils.createFlatAvroSchema(FIELD_NAMES, FIELD_TYPES);
+		//CHECKSTYLE.ON: StaticVariableNameCheck
+
+		public Map<String, String> strMapField;
+		public Map<String, Integer> intMapField;
+		public Map<String, Long> longMapField;
+		public Map<String, Float> floatMapField;
+		public Map<String, Double> doubleMapField;
+		public Map<String, Boolean> boolMapField;
+		public Map<String, Address> recordMapField;
+
+		@Override
+		public Schema getSchema() {
+			return null;
+		}
+
+		@Override
+		public Object get(int field) {
+			return null;
+		}
+
+		@Override
+		public void put(int field, Object value) { }
+	}
+
+	/**
+	 * Avro record that has array fields.
+	 */
+	@SuppressWarnings("unused")
+	public static class HasArrayFieldsAvroClass extends SpecificRecordBase {
+
+		public static final String[] FIELD_NAMES = new String[]{
+			"strArrayField", "intArrayField", "longArrayField", "floatArrayField",
+			"doubleArrayField", "boolArrayField", "recordArrayField"};
+		public static final TypeInformation[] FIELD_TYPES = new TypeInformation[]{
+			Types.OBJECT_ARRAY(Types.STRING), Types.OBJECT_ARRAY(Types.INT),
+			Types.OBJECT_ARRAY(Types.LONG), Types.OBJECT_ARRAY(Types.FLOAT),
+			Types.OBJECT_ARRAY(Types.DOUBLE), Types.OBJECT_ARRAY(Types.BOOLEAN),
+			Types.OBJECT_ARRAY(new AvroTypeInfo(Address.class))};
+
+		//CHECKSTYLE.OFF: StaticVariableNameCheck - Avro accesses this field by name via reflection.
+		public static Schema SCHEMA$ = AvroTestUtils.createFlatAvroSchema(FIELD_NAMES, FIELD_TYPES);
+		//CHECKSTYLE.ON: StaticVariableNameCheck
+
+		public List<String> strArrayField;
+		public List<Integer> intArrayField;
+		public List<Long> longArrayField;
+		public List<Float> floatArrayField;
+		public List<Double> doubleArrayField;
+		public List<Boolean> boolArrayField;
+		public List<Address> recordArrayField;
+
+		@Override
+		public Schema getSchema() {
+			return null;
+		}
+
+		@Override
+		public Object get(int field) {
+			return null;
+		}
+
+		@Override
+		public void put(int field, Object value) { }
 	}
 }

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/utils/AvroTestUtils.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/utils/AvroTestUtils.java
@@ -18,10 +18,11 @@
 
 package org.apache.flink.formats.avro.utils;
 
+import org.apache.flink.api.common.typeinfo.BasicArrayTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.tuple.Tuple3;
-import org.apache.flink.api.java.typeutils.ListTypeInfo;
 import org.apache.flink.api.java.typeutils.MapTypeInfo;
+import org.apache.flink.api.java.typeutils.ObjectArrayTypeInfo;
 import org.apache.flink.formats.avro.generated.Address;
 import org.apache.flink.formats.avro.generated.Colors;
 import org.apache.flink.formats.avro.generated.User;
@@ -67,9 +68,14 @@ public final class AvroTestUtils {
 				Schema valueSchema = ReflectData.get().getSchema(mapTypeInfo.getValueTypeInfo().getTypeClass());
 				Schema schema = Schema.createMap(valueSchema);
 				fieldAssembler.name(fieldNames[i]).type(schema).noDefault();
-			} else if (fieldTypes[i] instanceof ListTypeInfo) {
-				ListTypeInfo listTypeInfo = (ListTypeInfo) fieldTypes[i];
-				Schema elementSchema = ReflectData.get().getSchema(listTypeInfo.getElementTypeInfo().getTypeClass());
+			} else if (fieldTypes[i] instanceof ObjectArrayTypeInfo) {
+				ObjectArrayTypeInfo arrayTypeInfo = (ObjectArrayTypeInfo) fieldTypes[i];
+				Schema elementSchema = ReflectData.get().getSchema(arrayTypeInfo.getComponentInfo().getTypeClass());
+				Schema schema = Schema.createArray(elementSchema);
+				fieldAssembler.name(fieldNames[i]).type(schema).noDefault();
+			} else if (fieldTypes[i] instanceof BasicArrayTypeInfo) {
+				BasicArrayTypeInfo arrayTypeInfo = (BasicArrayTypeInfo) fieldTypes[i];
+				Schema elementSchema = ReflectData.get().getSchema(arrayTypeInfo.getComponentInfo().getTypeClass());
 				Schema schema = Schema.createArray(elementSchema);
 				fieldAssembler.name(fieldNames[i]).type(schema).noDefault();
 			} else {
@@ -154,8 +160,8 @@ public final class AvroTestUtils {
 		rowUser.setField(4, 1.337d);
 		rowUser.setField(5, null);
 		rowUser.setField(6, false);
-		rowUser.setField(7, new ArrayList<CharSequence>());
-		rowUser.setField(8, new ArrayList<Boolean>());
+		rowUser.setField(7, new String[]{});
+		rowUser.setField(8, new Boolean[]{});
 		rowUser.setField(9, null);
 		rowUser.setField(10, Colors.RED);
 		rowUser.setField(11, new HashMap<CharSequence, Long>());


### PR DESCRIPTION
## What is the purpose of the change

When some Avro schema has map/array fields and the corresponding TableSchema declares **MapTypeInfo**/**ListTypeInfo** for these fields, an exception will be thrown when registering the **KafkaAvroTableSource**, complaining like:

```
Exception in thread "main" org.apache.flink.table.api.ValidationException: Type Map<String, Integer> of table field 'event' does not match with type GenericType<java.util.Map> of the field 'event' of the TableSource return type.
at org.apache.flink.table.api.ValidationException$.apply(exceptions.scala:74)
at org.apache.flink.table.sources.TableSourceUtil$$anonfun$validateTableSource$1.apply(TableSourceUtil.scala:92)
at org.apache.flink.table.sources.TableSourceUtil$$anonfun$validateTableSource$1.apply(TableSourceUtil.scala:71)
at scala.collection.IndexedSeqOptimized$class.foreach(IndexedSeqOptimized.scala:33)
at scala.collection.mutable.ArrayOps$ofRef.foreach(ArrayOps.scala:186)
at org.apache.flink.table.sources.TableSourceUtil$.validateTableSource(TableSourceUtil.scala:71)
at org.apache.flink.table.plan.schema.StreamTableSourceTable.<init>(StreamTableSourceTable.scala:33)
at org.apache.flink.table.api.StreamTableEnvironment.registerTableSourceInternal(StreamTableEnvironment.scala:124)
at org.apache.flink.table.api.TableEnvironment.registerTableSource(TableEnvironment.scala:438)
```

This pull request adds new unit tests to expose the issue and then fixes it. 

**Note: In this implementation, supported Avro primitive types for map values/array elements are: string, int, long, float, double and boolean, which should cater for most use cases.**

## Brief change log

  - Add new unit tests "testHasMapFieldsAvroClass()" and "testHasArrayFieldsAvroClass()" in KafkaAvroTableSourceTestBase
  - Add some logic in "AvroTestUtils.createFlatAvroSchema()" to create Avro MapSchema/ArraySchema
  - Add some logic in "AvroRecordClassConverter.convertType()" to convert "GenericType<java.util.Map>"  into "MapTypeInfo" with matching value types and "GenericType<java.util.List>" into "ListTypeInfo" with matching element types.

## Verifying this change

This change can be verified as follows:
- Run the unit test "testHasMapFieldsAvroClass()" and "testHasArrayFieldsAvroClass()"  added in KafkaAvroTableSourceTestBase by this fix.
- The unit test would fail with similar exceptions thrown described above.
- Merge this fix and run the unit test again, it should pass 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
