### PR TITLE
[FLINK-8654][Docs] Extend quickstart docs on how to submit jobs

### DIFF
--- a/docs/quickstart/java_api_quickstart.md
+++ b/docs/quickstart/java_api_quickstart.md
@@ -111,7 +111,7 @@ In IntelliJ IDEA recommended way to change JVM options is from the `Help | Edit 
 ## Build Project
 
 If you want to __build/package your project__, go to your project directory and
-run the '`mvn clean package`' command.
+run the `mvn clean package` command.
 You will __find a JAR file__ that contains your application, plus connectors and libraries
 that you may have added as dependencies to the application: `target/<artifact-id>-<version>.jar`.
 
@@ -121,7 +121,7 @@ can run time application from the JAR file without additionally specifying the m
 
 ## Next Steps
 
-Write your application!
+Start writing your application and also you can look into [Quickstart]({{ site.baseurl }}/quickstart/setup_quickstart.html) to run an application.
 
 If you are writing a streaming application and you are looking for inspiration what to write,
 take a look at the [Stream Processing Application Tutorial]({{ site.baseurl }}/quickstart/run_example_quickstart.html#writing-a-flink-program).


### PR DESCRIPTION
## Brief change log

The quickstart documentation explains how to setup the project, build the jar and run things in the IDE, but neither explains how to submit the jar to a cluster nor guides the user to where he could find this information (like the CLI docs).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
