### PR TITLE
[FLINK-9452] Flink 1.5 document version title shows snapshot

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -27,12 +27,12 @@
 # we change the version for the complete docs when forking of a release branch
 # etc.
 # The full version string as referenced in Maven (e.g. 1.2.1)
-version: "1.6-SNAPSHOT"
+version: "1.5"
 # For stable releases, leave the bugfix version out (e.g. 1.2). For snapshot
 # release this should be the same as the regular version
-version_title: "1.6-SNAPSHOT"
-version_javadocs: "1.6-SNAPSHOT"
-version_scaladocs: "1.6-SNAPSHOT"
+version_title: "1.5"
+version_javadocs: "1.5"
+version_scaladocs: "1.5"
 
 # This suffix is appended to the Scala-dependent Maven artifact names
 scala_version_suffix: "_2.11"


### PR DESCRIPTION
## What is the purpose of the change

*This pull request fixed 1.5 document version title*

## Brief change log

  - *Removed 1.5-SNAPSHOT to  1.5 version*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
