### PR TITLE
[FLINK-9410] [yarn] Replace NMClient with NMClientAsync in YarnResour…

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointType.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointType.java
@@ -27,6 +27,6 @@ public enum CheckpointType {
 	CHECKPOINT,
 
 	/** A savepoint. */
-	SAVEPOINT;
+	SAVEPOINT
 
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcEndpoint.java
@@ -50,7 +50,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * thread, we don't have to reason about concurrent accesses, in the same way in the Actor Model
  * of Erlang or Akka.
  *
- * <p>The RPC endpoint provides provides {@link #runAsync(Runnable)}, {@link #callAsync(Callable, Time)}
+ * <p>The RPC endpoint provides {@link #runAsync(Runnable)}, {@link #callAsync(Callable, Time)}
  * and the {@link #getMainThreadExecutor()} to execute code in the RPC endpoint's main thread.
  */
 public abstract class RpcEndpoint implements RpcGateway {

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
@@ -67,8 +67,8 @@ import org.apache.hadoop.yarn.api.records.NodeId;
 import org.apache.hadoop.yarn.api.records.Priority;
 import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.client.api.AMRMClient;
-import org.apache.hadoop.yarn.client.api.NMClient;
 import org.apache.hadoop.yarn.client.api.async.AMRMClientAsync;
+import org.apache.hadoop.yarn.client.api.async.NMClientAsync;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.junit.After;
 import org.junit.Before;
@@ -143,7 +143,7 @@ public class YarnResourceManagerTest extends TestLogger {
 
 	static class TestingYarnResourceManager extends YarnResourceManager {
 		public AMRMClientAsync<AMRMClient.ContainerRequest> mockResourceManagerClient;
-		public NMClient mockNMClient;
+		public NMClientAsync mockNMClientAsync;
 
 		public TestingYarnResourceManager(
 				RpcService rpcService,
@@ -161,7 +161,7 @@ public class YarnResourceManagerTest extends TestLogger {
 				FatalErrorHandler fatalErrorHandler,
 				@Nullable String webInterfaceUrl,
 				AMRMClientAsync<AMRMClient.ContainerRequest> mockResourceManagerClient,
-				NMClient mockNMClient) {
+				NMClientAsync mockNMClientAsync) {
 			super(
 				rpcService,
 				resourceManagerEndpointId,
@@ -177,7 +177,7 @@ public class YarnResourceManagerTest extends TestLogger {
 				clusterInformation,
 				fatalErrorHandler,
 				webInterfaceUrl);
-			this.mockNMClient = mockNMClient;
+			this.mockNMClientAsync = mockNMClientAsync;
 			this.mockResourceManagerClient = mockResourceManagerClient;
 		}
 
@@ -198,8 +198,8 @@ public class YarnResourceManagerTest extends TestLogger {
 		}
 
 		@Override
-		protected NMClient createAndStartNodeManagerClient(YarnConfiguration yarnConfiguration) {
-			return mockNMClient;
+		protected NMClientAsync createAndStartNodeManagerClient(YarnConfiguration yarnConfiguration) {
+			return mockNMClientAsync;
 		}
 
 		@Override
@@ -231,7 +231,7 @@ public class YarnResourceManagerTest extends TestLogger {
 				ApplicationAttemptId.newInstance(ApplicationId.newInstance(1L, 0), 0), 1);
 		public String taskHost = "host1";
 
-		public NMClient mockNMClient = mock(NMClient.class);
+		public NMClientAsync mockNMClient = mock(NMClientAsync.class);
 		public AMRMClientAsync<AMRMClient.ContainerRequest> mockResourceManagerClient =
 				mock(AMRMClientAsync.class);
 
@@ -348,7 +348,7 @@ public class YarnResourceManagerTest extends TestLogger {
 			when(testingContainer.getPriority()).thenReturn(Priority.UNDEFINED);
 			resourceManager.onContainersAllocated(ImmutableList.of(testingContainer));
 			verify(mockResourceManagerClient).addContainerRequest(any(AMRMClient.ContainerRequest.class));
-			verify(mockNMClient).startContainer(eq(testingContainer), any(ContainerLaunchContext.class));
+			verify(mockNMClient).startContainerAsync(eq(testingContainer), any(ContainerLaunchContext.class));
 
 			// Remote task executor registers with YarnResourceManager.
 			TaskExecutorGateway mockTaskExecutorGateway = mock(TaskExecutorGateway.class);
@@ -395,7 +395,7 @@ public class YarnResourceManagerTest extends TestLogger {
 
 			unregisterAndReleaseFuture.get();
 
-			verify(mockNMClient).stopContainer(any(ContainerId.class), any(NodeId.class));
+			verify(mockNMClient).stopContainerAsync(any(ContainerId.class), any(NodeId.class));
 			verify(mockResourceManagerClient).releaseAssignedContainer(any(ContainerId.class));
 
 			stopResourceManager();

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
@@ -102,9 +102,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 /**
  * General tests for the YARN resource manager component.
@@ -397,6 +395,9 @@ public class YarnResourceManagerTest extends TestLogger {
 
 			verify(mockNMClient).stopContainerAsync(any(ContainerId.class), any(NodeId.class));
 			verify(mockResourceManagerClient).releaseAssignedContainer(any(ContainerId.class));
+
+			resourceManager.onStartContainerError(testingContainer.getId(), any(Throwable.class));
+			verify(mockResourceManagerClient, atLeast(2)).releaseAssignedContainer(testingContainer.getId());
 
 			stopResourceManager();
 

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
@@ -102,7 +102,10 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * General tests for the YARN resource manager component.


### PR DESCRIPTION
## What is the purpose of the change
YarnResourceManager uses the synchronous ```NMClient``` which is called from within the main thread of the ```ResourceManager```. Since these operations are blocking, we should replace the client with the ```NMClientAsync``` and make the calls non blocking.


## Brief change log
Replace NMClient with AsyncNMClient. And change the test also.


## Verifying this change
Run YarnResourceManagerTest verify this.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no )
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
