### PR TITLE
[FLINK-9417][ Distributed Coordination] Send heartbeat requests from RPC endpoint's main thread

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatServices.java
@@ -26,6 +26,9 @@ import org.apache.flink.util.Preconditions;
 
 import org.slf4j.Logger;
 
+import java.util.concurrent.Executor;
+import java.util.function.Supplier;
+
 /**
  * HeartbeatServices gives access to all services needed for heartbeating. This includes the
  * creation of heartbeat receivers and heartbeat senders.
@@ -52,6 +55,7 @@ public class HeartbeatServices {
 	 * @param resourceId Resource Id which identifies the owner of the heartbeat manager
 	 * @param heartbeatListener Listener which will be notified upon heartbeat timeouts for registered
 	 *                          targets
+	 * @param executorSupplier Supplier provides executor to be used to sending heartbeat
 	 * @param scheduledExecutor Scheduled executor to be used for scheduling heartbeat timeouts
 	 * @param log Logger to be used for the logging
 	 * @param <I> Type of the incoming payload
@@ -61,6 +65,7 @@ public class HeartbeatServices {
 	public <I, O> HeartbeatManager<I, O> createHeartbeatManager(
 		ResourceID resourceId,
 		HeartbeatListener<I, O> heartbeatListener,
+		Supplier<Executor> executorSupplier,
 		ScheduledExecutor scheduledExecutor,
 		Logger log) {
 
@@ -68,7 +73,7 @@ public class HeartbeatServices {
 			heartbeatTimeout,
 			resourceId,
 			heartbeatListener,
-			scheduledExecutor,
+			executorSupplier,
 			scheduledExecutor,
 			log);
 	}
@@ -79,6 +84,7 @@ public class HeartbeatServices {
 	 * @param resourceId Resource Id which identifies the owner of the heartbeat manager
 	 * @param heartbeatListener Listener which will be notified upon heartbeat timeouts for registered
 	 *                          targets
+	 * @param executorSupplier Supplier provides executor to be used to sending heartbeat
 	 * @param scheduledExecutor Scheduled executor to be used for scheduling heartbeat timeouts
 	 * @param log Logger to be used for the logging
 	 * @param <I> Type of the incoming payload
@@ -88,6 +94,7 @@ public class HeartbeatServices {
 	public <I, O> HeartbeatManager<I, O> createHeartbeatManagerSender(
 		ResourceID resourceId,
 		HeartbeatListener<I, O> heartbeatListener,
+		Supplier<Executor> executorSupplier,
 		ScheduledExecutor scheduledExecutor,
 		Logger log) {
 
@@ -96,7 +103,7 @@ public class HeartbeatServices {
 			heartbeatTimeout,
 			resourceId,
 			heartbeatListener,
-			scheduledExecutor,
+			executorSupplier,
 			scheduledExecutor,
 			log);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -253,14 +253,16 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 		this.taskManagerHeartbeatManager = heartbeatServices.createHeartbeatManagerSender(
 			resourceId,
 			new TaskManagerHeartbeatListener(selfGateway),
+			() -> getMainThreadExecutor(),
 			rpcService.getScheduledExecutor(),
 			log);
 
 		this.resourceManagerHeartbeatManager = heartbeatServices.createHeartbeatManager(
-				resourceId,
-				new ResourceManagerHeartbeatListener(),
-				rpcService.getScheduledExecutor(),
-				log);
+			resourceId,
+			new ResourceManagerHeartbeatListener(),
+			() -> getMainThreadExecutor(),
+			rpcService.getScheduledExecutor(),
+			log);
 
 		final String jobName = jobGraph.getName();
 		final JobID jid = jobGraph.getJobID();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -169,12 +169,14 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 		this.taskManagerHeartbeatManager = heartbeatServices.createHeartbeatManagerSender(
 			resourceId,
 			new TaskManagerHeartbeatListener(),
+			() -> getMainThreadExecutor(),
 			rpcService.getScheduledExecutor(),
 			log);
 
 		this.jobManagerHeartbeatManager = heartbeatServices.createHeartbeatManagerSender(
 			resourceId,
 			new JobManagerHeartbeatListener(),
+			() -> getMainThreadExecutor(),
 			rpcService.getScheduledExecutor(),
 			log);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -240,12 +240,14 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 		this.jobManagerHeartbeatManager = heartbeatServices.createHeartbeatManager(
 			resourceId,
 			new JobManagerHeartbeatListener(),
+			() -> getMainThreadExecutor(),
 			rpcService.getScheduledExecutor(),
 			log);
 
 		this.resourceManagerHeartbeatManager = heartbeatServices.createHeartbeatManager(
 			resourceId,
 			new ResourceManagerHeartbeatListener(),
+			() -> getMainThreadExecutor(),
 			rpcService.getScheduledExecutor(),
 			log);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/heartbeat/TestingHeartbeatServices.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/heartbeat/TestingHeartbeatServices.java
@@ -24,6 +24,9 @@ import org.apache.flink.util.Preconditions;
 
 import org.slf4j.Logger;
 
+import java.util.concurrent.Executor;
+import java.util.function.Supplier;
+
 /**
  * A {@link HeartbeatServices} that allows the injection of a {@link ScheduledExecutor}.
  */
@@ -41,6 +44,7 @@ public class TestingHeartbeatServices extends HeartbeatServices {
 	public <I, O> HeartbeatManager<I, O> createHeartbeatManagerSender(
 		ResourceID resourceId,
 		HeartbeatListener<I, O> heartbeatListener,
+		Supplier<Executor> executorSupplier,
 		ScheduledExecutor scheduledExecutor,
 		Logger log) {
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/heartbeat/TestingHeartbeatServices.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/heartbeat/TestingHeartbeatServices.java
@@ -53,7 +53,7 @@ public class TestingHeartbeatServices extends HeartbeatServices {
 			heartbeatTimeout,
 			resourceId,
 			heartbeatListener,
-			org.apache.flink.runtime.concurrent.Executors.directExecutor(),
+			executorSupplier,
 			scheduledExecutorToUse,
 			log);
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -128,6 +128,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
@@ -476,6 +477,7 @@ public class TaskExecutorTest extends TestLogger {
 		when(heartbeatServices.createHeartbeatManager(
 			eq(taskManagerLocation.getResourceID()),
 			any(HeartbeatListener.class),
+			any(Supplier.class),
 			any(ScheduledExecutor.class),
 			any(Logger.class))).thenAnswer(
 			new Answer<HeartbeatManagerImpl<SlotReport, Void>>() {
@@ -485,9 +487,9 @@ public class TaskExecutorTest extends TestLogger {
 						heartbeatTimeout,
 						taskManagerLocation.getResourceID(),
 						(HeartbeatListener<SlotReport, Void>)invocation.getArguments()[1],
-						(Executor)invocation.getArguments()[2],
-						(ScheduledExecutor)invocation.getArguments()[2],
-						(Logger)invocation.getArguments()[3]));
+						(Supplier<Executor>)invocation.getArguments()[2],
+						(ScheduledExecutor)invocation.getArguments()[3],
+						(Logger)invocation.getArguments()[4]));
 				}
 			}
 		);
@@ -1736,12 +1738,17 @@ public class TaskExecutorTest extends TestLogger {
 		}
 
 		@Override
-		public <I, O> HeartbeatManager<I, O> createHeartbeatManager(ResourceID resourceId, HeartbeatListener<I, O> heartbeatListener, ScheduledExecutor scheduledExecutor, Logger log) {
+		public <I, O> HeartbeatManager<I, O> createHeartbeatManager(
+			ResourceID resourceId,
+			HeartbeatListener<I, O> heartbeatListener,
+			Supplier<Executor> executor,
+			ScheduledExecutor scheduledExecutor,
+			Logger log) {
 			return new RecordingHeartbeatManagerImpl<>(
 				heartbeatTimeout,
 				resourceId,
 				heartbeatListener,
-				scheduledExecutor,
+				executor,
 				scheduledExecutor,
 				log,
 				unmonitoredTargets,
@@ -1770,7 +1777,7 @@ public class TaskExecutorTest extends TestLogger {
 				long heartbeatTimeoutIntervalMs,
 				ResourceID ownResourceID,
 				HeartbeatListener<I, O> heartbeatListener,
-				Executor executor,
+				Supplier<Executor> executor,
 				ScheduledExecutor scheduledExecutor,
 				Logger log,
 				BlockingQueue<ResourceID> unmonitoredTargets,


### PR DESCRIPTION
## What is the purpose of the change

This PR try to send heartbeat requests from RPC endpoint's main thread to avoid the faker alive information.

## Brief change log

  - *Send heartbeat requests from RPC endpoint's main thread*


## Verifying this change

- *Add `JobMasterTest#testStopSendingHeartbeatWhenJMBlocked()` to verify the JM stop sending heartbeat to TM when it is blocking*
- *Add `ResourceManagerTest#testStopSendingHeartbeatWhenRMBlocked()` to verify the RM stop sending heartbeat to JM and TM when it is blocking*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

- no
