### PR TITLE
[FLINK-9451]End-to-end test: Scala Quickstarts

### DIFF
--- a/flink-end-to-end-tests/flink-quickstart-test/pom.xml
+++ b/flink-end-to-end-tests/flink-quickstart-test/pom.xml
@@ -31,10 +31,6 @@ under the License.
 	<name>flink-quickstart-test</name>
 	<packaging>jar</packaging>
 
-	<properties>
-		<scala.binary.version>2.11</scala.binary.version>
-	</properties>
-
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
@@ -46,6 +42,7 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-streaming-scala_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
@@ -53,46 +50,4 @@ under the License.
 			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-shade-plugin</artifactId>
-				<version>3.0.0</version>
-				<executions>
-					<execution>
-						<phase>package</phase>
-						<goals>
-							<goal>shade</goal>
-						</goals>
-						<configuration>
-							<finalName>Elasticsearch5SinkExample</finalName>
-							<artifactSet>
-								<excludes>
-									<exclude>com.google.code.findbugs:jsr305</exclude>
-								</excludes>
-							</artifactSet>
-							<filters>
-								<filter>
-									<artifact>*:*</artifact>
-									<excludes>
-										<exclude>META-INF/*.SF</exclude>
-										<exclude>META-INF/*.DSA</exclude>
-										<exclude>META-INF/*.RSA</exclude>
-									</excludes>
-								</filter>
-							</filters>
-							<transformers>
-								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-									<mainClass>org.apache.flink.quickstarts.test.Elasticsearch5SinkExample</mainClass>
-								</transformer>
-							</transformers>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
-
 </project>

--- a/flink-end-to-end-tests/flink-quickstart-test/pom.xml
+++ b/flink-end-to-end-tests/flink-quickstart-test/pom.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<parent>
+		<groupId>org.apache.flink</groupId>
+		<artifactId>flink-end-to-end-tests</artifactId>
+		<version>1.6-SNAPSHOT</version>
+	</parent>
+	<modelVersion>4.0.0</modelVersion>
+
+	<artifactId>flink-quickstart-test</artifactId>
+	<name>flink-quickstart-test</name>
+	<packaging>jar</packaging>
+
+	<properties>
+		<scala.binary.version>2.11</scala.binary.version>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-scala_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-elasticsearch5_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<version>3.0.0</version>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<finalName>Elasticsearch5SinkExample</finalName>
+							<artifactSet>
+								<excludes>
+									<exclude>com.google.code.findbugs:jsr305</exclude>
+								</excludes>
+							</artifactSet>
+							<filters>
+								<filter>
+									<artifact>*:*</artifact>
+									<excludes>
+										<exclude>META-INF/*.SF</exclude>
+										<exclude>META-INF/*.DSA</exclude>
+										<exclude>META-INF/*.RSA</exclude>
+									</excludes>
+								</filter>
+							</filters>
+							<transformers>
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+									<mainClass>org.apache.flink.quickstarts.test.Elasticsearch5SinkExample</mainClass>
+								</transformer>
+							</transformers>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/flink-end-to-end-tests/flink-quickstart-test/src/main/java/org/apache/flink/quickstarts/test/Elasticsearch5SinkExample.java
+++ b/flink-end-to-end-tests/flink-quickstart-test/src/main/java/org/apache/flink/quickstarts/test/Elasticsearch5SinkExample.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.quickstarts.test;
+
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.connectors.elasticsearch.ElasticsearchSinkFunction;
+import org.apache.flink.streaming.connectors.elasticsearch.RequestIndexer;
+import org.apache.flink.streaming.connectors.elasticsearch5.ElasticsearchSink;
+
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.client.Requests;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * End to end test for Elasticsearch5Sink.
+ */
+public class Elasticsearch5SinkExample {
+
+	public static void main(String[] args) throws Exception {
+
+		final ParameterTool parameterTool = ParameterTool.fromArgs(args);
+
+		if (parameterTool.getNumberOfParameters() < 3) {
+			System.out.println("Missing parameters!\n" +
+				"Usage: --numRecords <numRecords> --index <index> --type <type>");
+			return;
+		}
+
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.getConfig().disableSysoutLogging();
+		env.enableCheckpointing(5000);
+
+		DataStream<String> source = env.generateSequence(0, parameterTool.getInt("numRecords") - 1)
+			.map(new MapFunction<Long, String>() {
+				@Override
+				public String map(Long value) throws Exception {
+					return "message #" + value;
+				}
+			});
+
+		Map<String, String> userConfig = new HashMap<>();
+		userConfig.put("cluster.name", "elasticsearch");
+		// This instructs the sink to emit after every element, otherwise they would be buffered
+		userConfig.put(ElasticsearchSink.CONFIG_KEY_BULK_FLUSH_MAX_ACTIONS, "1");
+
+		List<InetSocketAddress> transports = new ArrayList<>();
+		transports.add(new InetSocketAddress(InetAddress.getByName("127.0.0.1"), 9300));
+
+		source.addSink(new ElasticsearchSink<>(userConfig, transports, new ElasticsearchSinkFunction<String>() {
+			@Override
+			public void process(String element, RuntimeContext ctx, RequestIndexer indexer) {
+				indexer.add(createIndexRequest(element, parameterTool));
+			}
+		}));
+
+		env.execute("Elasticsearch5.x end to end sink test example");
+	}
+
+	private static IndexRequest createIndexRequest(String element, ParameterTool parameterTool) {
+		Map<String, Object> json = new HashMap<>();
+		json.put("data", element);
+
+		return Requests.indexRequest()
+			.index(parameterTool.getRequired("index"))
+			.type(parameterTool.getRequired("type"))
+			.id(element)
+			.source(json);
+	}
+}

--- a/flink-end-to-end-tests/flink-quickstart-test/src/main/scala/org/apache/flink/quickstarts/test/Elasticsearch5SinkExample.scala
+++ b/flink-end-to-end-tests/flink-quickstart-test/src/main/scala/org/apache/flink/quickstarts/test/Elasticsearch5SinkExample.scala
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.quickstarts.test
+
+import org.apache.flink.api.common.functions.RuntimeContext
+import org.apache.flink.api.java.utils.ParameterTool
+import org.apache.flink.streaming.api.scala._
+import org.apache.flink.streaming.connectors.elasticsearch.{ElasticsearchSinkFunction, RequestIndexer}
+import org.apache.flink.streaming.connectors.elasticsearch5.ElasticsearchSink
+import org.elasticsearch.action.index.IndexRequest
+import org.elasticsearch.client.Requests
+
+import scala.collection.JavaConversions.mapAsJavaMap
+
+import java.net.{InetAddress, InetSocketAddress}
+import java.util
+
+
+object Elasticsearch5SinkExample {
+  def main(args: Array[String]) {
+
+    val parameterTool = ParameterTool.fromArgs(args)
+
+    if (parameterTool.getNumberOfParameters < 3) {
+      println("Missing parameters!\n" + "Usage:" +
+        " --numRecords <numRecords> --index <index> --type <type>")
+      return
+    }
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.getConfig.disableSysoutLogging
+    env.enableCheckpointing(5000)
+
+    val source: DataStream[(String)] = env.generateSequence(0, 20 - 1)
+      .map(v =>  "message #" + v.toString)
+
+    val config = new util.HashMap[String, String]
+    config.put("bulk.flush.max.actions", "1")
+    config.put("cluster.name", "elasticsearch") //default cluster name: elasticsearch
+
+    val transports = new util.ArrayList[InetSocketAddress]
+    transports.add(new InetSocketAddress(InetAddress.getByName("127.0.0.1"), 9300))
+
+    source.addSink(new ElasticsearchSink(config, transports,
+      new ElasticsearchSinkFunction[(String)] {
+      def createIndexRequest(element: (String)): IndexRequest = {
+
+        val json2 = Map(
+          "data" -> element.asInstanceOf[AnyRef]
+        )
+
+        Requests.indexRequest.index(parameterTool.getRequired("index"))
+          .`type`(parameterTool.getRequired("type")).source(mapAsJavaMap(json2))
+      }
+
+      override def process(element: (String), ctx: RuntimeContext, indexer: RequestIndexer) {
+        indexer.add(createIndexRequest(element))
+      }
+    }))
+
+    env.execute("Elasticsearch5.x end to end sink test example")
+  }
+}

--- a/flink-end-to-end-tests/pom.xml
+++ b/flink-end-to-end-tests/pom.xml
@@ -47,6 +47,7 @@ under the License.
 		<module>flink-elasticsearch1-test</module>
 		<module>flink-elasticsearch2-test</module>
 		<module>flink-elasticsearch5-test</module>
+		<module>flink-quickstart-test</module>
 	</modules>
 
 	<build>

--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -189,7 +189,12 @@ if [ $EXIT_CODE == 0 ]; then
 fi
 
 if [ $EXIT_CODE == 0 ]; then
-  run_test "Quickstarts nightly end-to-end test" "$END_TO_END_DIR/test-scripts/test_quickstarts.sh"
+  run_test "Quickstarts Java nightly end-to-end test" "$END_TO_END_DIR/test-scripts/test_quickstarts.sh java"
+  EXIT_CODE=$?
+fi
+
+if [ $EXIT_CODE == 0 ]; then
+  run_test "Quickstarts Scala nightly end-to-end test" "$END_TO_END_DIR/test-scripts/test_quickstarts.sh scala"
   EXIT_CODE=$?
 fi
 

--- a/flink-end-to-end-tests/test-scripts/elasticsearch-common.sh
+++ b/flink-end-to-end-tests/test-scripts/elasticsearch-common.sh
@@ -56,13 +56,14 @@ function verify_elasticsearch_process_exist {
 
 function verify_result {
     local numRecords=$1
+    local index=$2
 
     if [ -f "$TEST_DATA_DIR/output" ]; then
         rm $TEST_DATA_DIR/output
     fi
 
     while : ; do
-      curl 'localhost:9200/index/_search?q=*&pretty&size=21' > $TEST_DATA_DIR/output
+      curl "localhost:9200/$index/_search?q=*&pretty&size=21" > $TEST_DATA_DIR/output
 
       if [ -n "$(grep "\"total\" : $numRecords" $TEST_DATA_DIR/output)" ]; then
           echo "Elasticsearch end to end test pass."
@@ -75,6 +76,8 @@ function verify_result {
 }
 
 function shutdown_elasticsearch_cluster {
+   local index=$1
+   curl -X DELETE "http://localhost:9200/$index"
    pid=$(jps | grep Elasticsearch | awk '{print $1}')
    kill -9 $pid
 }

--- a/flink-end-to-end-tests/test-scripts/test_quickstarts.sh
+++ b/flink-end-to-end-tests/test-scripts/test_quickstarts.sh
@@ -18,29 +18,37 @@
 ################################################################################
 
 # End to end test for quick starts test.
+# Usage:
+# FLINK_DIR=<flink dir> flink-end-to-end-tests/test-scripts/test_quickstarts.sh <Type (java or scala)>
 
 source "$(dirname "$0")"/common.sh
 source "$(dirname "$0")"/elasticsearch-common.sh
 
-mkdir -p $TEST_DATA_DIR
+TEST_TYPE=$1
+TEST_CLASS_NAME=Elasticsearch5SinkExample
+TEST_FILE_PATH=flink-quickstart-test/src/main/$TEST_TYPE/org/apache/flink/quickstarts/test/$TEST_CLASS_NAME.$TEST_TYPE
+QUICKSTARTS_FILE_PATH=$TEST_DATA_DIR/flink-quickstart-$TEST_TYPE/src/main/$TEST_TYPE/org/apache/flink/quickstart/$TEST_CLASS_NAME.$TEST_TYPE
+ES_INDEX=index_$TEST_TYPE
 
+mkdir -p $TEST_DATA_DIR
 cd $TEST_DATA_DIR
 
-mvn archetype:generate                             \
-    -DarchetypeGroupId=org.apache.flink            \
-    -DarchetypeArtifactId=flink-quickstart-java    \
-    -DarchetypeVersion=1.6-SNAPSHOT                \
-    -DgroupId=org.apache.flink.quickstart          \
-    -DartifactId=flink-java-project                \
-    -Dversion=0.1                                  \
-    -Dpackage=org.apache.flink.quickstart          \
+mvn archetype:generate                                   \
+    -DarchetypeGroupId=org.apache.flink                  \
+    -DarchetypeArtifactId=flink-quickstart-$TEST_TYPE    \
+    -DarchetypeVersion=1.6-SNAPSHOT                      \
+    -DgroupId=org.apache.flink.quickstart                \
+    -DartifactId=flink-quickstart-$TEST_TYPE             \
+    -Dversion=0.1                                        \
+    -Dpackage=org.apache.flink.quickstart                \
     -DinteractiveMode=false
 
-cd flink-java-project
+cd flink-quickstart-$TEST_TYPE
 
-# use the Flink Elasticsearch sink example job code in flink-elasticsearch5-tests to simulate modifications to contained job
-cp $TEST_INFRA_DIR/../flink-elasticsearch5-test/src/main/java/org/apache/flink/streaming/tests/Elasticsearch5SinkExample.java $TEST_DATA_DIR/flink-java-project/src/main/java/org/apache/flink/quickstart/
-sed -i -e 's/package org.apache.flink.streaming.tests;/package org.apache.flink.quickstart;/' $TEST_DATA_DIR/flink-java-project/src/main/java/org/apache/flink/quickstart/Elasticsearch5SinkExample.java
+
+# use the Flink Elasticsearch sink example job code in flink-quickstart-test to simulate modifications to contained job
+cp $TEST_INFRA_DIR/../$TEST_FILE_PATH $QUICKSTARTS_FILE_PATH
+sed -i -e 's/package org.apache.flink.quickstarts.test/package org.apache.flink.quickstart/' $QUICKSTARTS_FILE_PATH
 
 position=$(awk '/<dependencies>/ {print NR}' pom.xml | head -1)
 
@@ -51,12 +59,12 @@ sed -i -e ''"$(($position + 1))"'i\
 <version>${flink.version}</version>\
 </dependency>' pom.xml
 
-sed -i -e "s/org.apache.flink.quickstart.StreamingJob/org.apache.flink.streaming.tests.Elasticsearch5SinkExample/" pom.xml
+sed -i -e "s/org.apache.flink.quickstart.StreamingJob/org.apache.flink.quickstart.$TEST_CLASS_NAME/" pom.xml
 
 mvn clean package -nsu
 
 cd target
-jar tvf flink-java-project-0.1.jar > contentsInJar.txt
+jar tvf flink-quickstart-$TEST_TYPE-0.1.jar > contentsInJar.txt
 
 if [[ `grep -c "org/apache/flink/api/java" contentsInJar.txt` -eq '0' && \
       `grep -c "org/apache/flink/streaming/api" contentsInJar.txt` -eq '0' && \
@@ -82,25 +90,25 @@ else
     echo "Success: Elasticsearch5SinkExample.class and other user classes are included in the jar."
 fi
 
+start_cluster
 setup_elasticsearch "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.1.2.tar.gz"
 verify_elasticsearch_process_exist
+sleep 5
 
 function shutdownAndCleanup {
-    shutdown_elasticsearch_cluster
 
+    shutdown_elasticsearch_cluster $ES_INDEX
     # make sure to run regular cleanup as well
     cleanup
 }
 trap shutdownAndCleanup INT
 trap shutdownAndCleanup EXIT
 
-TEST_PROGRAM_JAR=$TEST_DATA_DIR/flink-java-project/target/flink-java-project-0.1.jar
-
-start_cluster
+TEST_PROGRAM_JAR=$TEST_DATA_DIR/flink-quickstart-$TEST_TYPE/target/flink-quickstart-$TEST_TYPE-0.1.jar
 
 $FLINK_DIR/bin/flink run -c org.apache.flink.quickstart.Elasticsearch5SinkExample $TEST_PROGRAM_JAR \
   --numRecords 20 \
-  --index index \
+  --index $ES_INDEX \
   --type type
 
-verify_result 20
+verify_result 20 $ES_INDEX

--- a/flink-end-to-end-tests/test-scripts/test_quickstarts.sh
+++ b/flink-end-to-end-tests/test-scripts/test_quickstarts.sh
@@ -30,6 +30,13 @@ TEST_FILE_PATH=flink-quickstart-test/src/main/$TEST_TYPE/org/apache/flink/quicks
 QUICKSTARTS_FILE_PATH=$TEST_DATA_DIR/flink-quickstart-$TEST_TYPE/src/main/$TEST_TYPE/org/apache/flink/quickstart/$TEST_CLASS_NAME.$TEST_TYPE
 ES_INDEX=index_$TEST_TYPE
 
+# get the elasticsearch dependency from flink-quickstart-test
+ES_DEPENDENCY="<dependency>\
+<groupId>org.apache.flink</groupId>\
+$(awk '/elasticsearch/ {print $1}' flink-end-to-end-tests/flink-quickstart-test/pom.xml)\
+<version>\${flink.version}</version>\
+</dependency>"
+
 mkdir -p $TEST_DATA_DIR
 cd $TEST_DATA_DIR
 
@@ -52,12 +59,9 @@ sed -i -e 's/package org.apache.flink.quickstarts.test/package org.apache.flink.
 
 position=$(awk '/<dependencies>/ {print NR}' pom.xml | head -1)
 
-sed -i -e ''"$(($position + 1))"'i\
-<dependency>\
-<groupId>org.apache.flink</groupId>\
-<artifactId>flink-connector-elasticsearch5_${scala.binary.version}</artifactId>\
-<version>${flink.version}</version>\
-</dependency>' pom.xml
+# Add ElasticSearch dependency to pom.xml
+sed -i -e ''$(($position + 1))'i\
+'$ES_DEPENDENCY'' pom.xml
 
 sed -i -e "s/org.apache.flink.quickstart.StreamingJob/org.apache.flink.quickstart.$TEST_CLASS_NAME/" pom.xml
 

--- a/flink-end-to-end-tests/test-scripts/test_streaming_elasticsearch.sh
+++ b/flink-end-to-end-tests/test-scripts/test_streaming_elasticsearch.sh
@@ -31,7 +31,7 @@ verify_elasticsearch_process_exist
 start_cluster
 
 function test_cleanup {
-  shutdown_elasticsearch_cluster
+  shutdown_elasticsearch_cluster index
 
   # make sure to run regular cleanup as well
    cleanup
@@ -48,4 +48,4 @@ $FLINK_DIR/bin/flink run -p 1 $TEST_ES_JAR \
   --index index \
   --type type
 
-verify_result 20
+verify_result 20 index


### PR DESCRIPTION
## What is the purpose of the change

Added an end-to-end test which verifies Flink's quickstarts scala. It does the following:

- create a new Flink project using the quickstarts scala archetype
- add a new Flink ElasticSearch connector dependency to the pom.xml 
- run mvn clean package
- verify that no core dependencies are contained in the jar file
- Run the program

This PR refactors the current QuickStarts test as follow:
- Creating a dedicated `flink-quickstart-test` module with ES dependencies and containing a java and scala example to be used by the quickstarts. 
- Refactoring the scrips to accept arguments:  test class name and test type [scala or java]

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
