### PR TITLE
[FLINK-7789][DataStream API] Add handler for Async IO operator timeouts

### DIFF
--- a/docs/dev/stream/operators/asyncio.md
+++ b/docs/dev/stream/operators/asyncio.md
@@ -190,6 +190,12 @@ The following two parameters control the asynchronous operations:
     is exhausted.
 
 
+### Timeout Handling
+
+When a async I/O request times out, an exception is thrown and job is restarted.
+If you want to handle timeouts, please override the `AsyncFunction#timeout` method.
+
+
 ### Order of Results
 
 The concurrent requests issued by the `AsyncFunction` frequently complete in some undefined order, based on which request finished first.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/async/AsyncFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/async/AsyncFunction.java
@@ -88,7 +88,7 @@ public interface AsyncFunction<IN, OUT> extends Function, Serializable {
 
 	/**
 	 * {@link AsyncFunction#asyncInvoke} timeout occurred.
-	 * By default, the result future is exceptionally completed with timeout exception.
+	 * By default, the result future is exceptionally completed with a timeout exception.
 	 *
 	 * @param input element coming from an upstream task
 	 * @param resultFuture to be completed with the result data

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/async/AsyncFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/async/AsyncFunction.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.functions.Function;
 
 import java.io.Serializable;
+import java.util.concurrent.TimeoutException;
 
 /**
  * A function to trigger Async I/O operation.
@@ -84,4 +85,17 @@ public interface AsyncFunction<IN, OUT> extends Function, Serializable {
 	 * trigger fail-over process.
 	 */
 	void asyncInvoke(IN input, ResultFuture<OUT> resultFuture) throws Exception;
+
+	/**
+	 * {@link AsyncFunction#asyncInvoke} timeout occurred.
+	 * By default, the result future is exceptionally completed with timeout exception.
+	 *
+	 * @param input element coming from an upstream task
+	 * @param resultFuture to be completed with the result data
+	 */
+	default void timeout(IN input, ResultFuture<OUT> resultFuture) throws Exception {
+		resultFuture.completeExceptionally(
+			new TimeoutException("Async function call has timed out."));
+	}
+
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperator.java
@@ -53,7 +53,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 /**
  * The {@link AsyncWaitOperator} allows to asynchronously process incoming stream records. For that
@@ -209,8 +208,7 @@ public class AsyncWaitOperator<IN, OUT>
 				new ProcessingTimeCallback() {
 					@Override
 					public void onProcessingTime(long timestamp) throws Exception {
-						streamRecordBufferEntry.completeExceptionally(
-							new TimeoutException("Async function call has timed out."));
+						userFunction.timeout(element.getValue(), streamRecordBufferEntry);
 					}
 				});
 

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/AsyncDataStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/AsyncDataStream.scala
@@ -71,6 +71,9 @@ object AsyncDataStream {
       override def asyncInvoke(input: IN, resultFuture: JavaResultFuture[OUT]): Unit = {
         asyncFunction.asyncInvoke(input, new JavaResultFutureWrapper(resultFuture))
       }
+      override def timeout(input: IN, resultFuture: JavaResultFuture[OUT]): Unit = {
+        asyncFunction.timeout(input, new JavaResultFutureWrapper(resultFuture))
+      }
     }
 
     val outType : TypeInformation[OUT] = implicitly[TypeInformation[OUT]]
@@ -197,6 +200,9 @@ object AsyncDataStream {
     val javaAsyncFunction = new JavaAsyncFunction[IN, OUT] {
       override def asyncInvoke(input: IN, resultFuture: JavaResultFuture[OUT]): Unit = {
         asyncFunction.asyncInvoke(input, new JavaResultFutureWrapper[OUT](resultFuture))
+      }
+      override def timeout(input: IN, resultFuture: JavaResultFuture[OUT]): Unit = {
+        asyncFunction.timeout(input, new JavaResultFutureWrapper[OUT](resultFuture))
       }
     }
 

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/async/AsyncFunction.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/async/AsyncFunction.scala
@@ -51,7 +51,7 @@ trait AsyncFunction[IN, OUT] extends Function {
 
   /**
     * [[AsyncFunction.asyncInvoke]] timeout occurred.
-    * By default, the result future is exceptionally completed with timeout exception.
+    * By default, the result future is exceptionally completed with a timeout exception.
     *
     * @param input element coming from an upstream task
     * @param resultFuture to be completed with the result data

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/async/AsyncFunction.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/async/AsyncFunction.scala
@@ -21,6 +21,8 @@ package org.apache.flink.streaming.api.scala.async
 import org.apache.flink.annotation.PublicEvolving
 import org.apache.flink.api.common.functions.Function
 
+import java.util.concurrent.TimeoutException
+
 /**
   * A function to trigger async I/O operations.
   *
@@ -46,4 +48,16 @@ trait AsyncFunction[IN, OUT] extends Function {
     * @param resultFuture to be completed with the result data
     */
   def asyncInvoke(input: IN, resultFuture: ResultFuture[OUT]): Unit
+
+  /**
+    * [[AsyncFunction.asyncInvoke]] timeout occurred.
+    * By default, the result future is exceptionally completed with timeout exception.
+    *
+    * @param input element coming from an upstream task
+    * @param resultFuture to be completed with the result data
+    */
+  def timeout(input: IN, resultFuture: ResultFuture[OUT]): Unit = {
+    resultFuture.completeExceptionally(new TimeoutException("Async function call has timed out."))
+  }
+
 }

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/AsyncDataStreamITCase.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/AsyncDataStreamITCase.scala
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.scala
+
+import java.util.concurrent.TimeUnit
+
+import org.apache.flink.streaming.api.functions.sink.SinkFunction
+import org.apache.flink.streaming.api.functions.source.SourceFunction
+import org.apache.flink.streaming.api.scala.AsyncDataStreamITCase._
+import org.apache.flink.streaming.api.scala.async.{AsyncFunction, ResultFuture}
+import org.apache.flink.test.util.AbstractTestBase
+import org.junit.Assert._
+import org.junit.Test
+
+import scala.collection.mutable
+import scala.concurrent.{ExecutionContext, Future}
+
+object AsyncDataStreamITCase {
+  val timeout = 1000L
+  private var testResult: mutable.ArrayBuffer[Int] = _
+}
+
+class AsyncDataStreamITCase extends AbstractTestBase {
+
+  @Test
+  def testOrderedWait(): Unit = {
+    testAsyncWait(true)
+  }
+
+  @Test
+  def testUnorderedWait(): Unit = {
+    testAsyncWait(false)
+  }
+
+  private def testAsyncWait(ordered: Boolean): Unit = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setParallelism(1)
+
+    val source = env.addSource(new SourceFunction[Int]() {
+      override def run(ctx: SourceFunction.SourceContext[Int]) {
+        ctx.collect(1)
+        ctx.collect(2)
+      }
+      override def cancel() {}
+    })
+
+    val asyncMapped = if (ordered) {
+      AsyncDataStream.orderedWait(
+        source, new MyAsyncFunction(), timeout, TimeUnit.MILLISECONDS)
+    } else {
+      AsyncDataStream.unorderedWait(
+        source, new MyAsyncFunction(), timeout, TimeUnit.MILLISECONDS)
+    }
+
+    testResult = mutable.ArrayBuffer[Int]()
+    asyncMapped.addSink(new SinkFunction[Int]() {
+      override def invoke(value: Int) {
+        testResult += value
+      }
+    })
+
+    env.execute("testAsyncWait")
+
+    val expectedResult = mutable.ArrayBuffer[Int](2, 6)
+    if (ordered) {
+      assertEquals(expectedResult, testResult)
+    } else {
+      assertEquals(expectedResult, testResult.sorted)
+    }
+  }
+
+  @Test
+  def testOrderedWaitUsingAnonymousFunction(): Unit = {
+    testAsyncWaitUsingAnonymousFunction(true)
+  }
+
+  @Test
+  def testUnorderedWaitUsingAnonymousFunction(): Unit = {
+    testAsyncWaitUsingAnonymousFunction(false)
+  }
+
+  private def testAsyncWaitUsingAnonymousFunction(ordered: Boolean): Unit = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    env.setParallelism(1)
+
+    val source = env.addSource(new SourceFunction[Int]() {
+      override def run(ctx: SourceFunction.SourceContext[Int]) {
+        ctx.collect(1)
+        ctx.collect(2)
+      }
+      override def cancel() {}
+    })
+
+    val asyncFunction: (Int, ResultFuture[Int]) => Unit =
+      (input, collector: ResultFuture[Int]) => Future {
+          collector.complete(Seq(input * 2))
+      }(ExecutionContext.global)
+    val asyncMapped = if (ordered) {
+      AsyncDataStream.orderedWait(source, timeout, TimeUnit.MILLISECONDS) {
+        asyncFunction
+      }
+    } else {
+      AsyncDataStream.unorderedWait(source, timeout, TimeUnit.MILLISECONDS) {
+        asyncFunction
+      }
+    }
+
+    testResult = mutable.ArrayBuffer[Int]()
+    asyncMapped.addSink(new SinkFunction[Int]() {
+      override def invoke(value: Int) {
+        testResult += value
+      }
+    })
+
+    env.execute("testAsyncWaitUsingAnonymousFunction")
+
+    val expectedResult = mutable.ArrayBuffer[Int](2, 4)
+    if (ordered) {
+      assertEquals(expectedResult, testResult)
+    } else {
+      assertEquals(expectedResult, testResult.sorted)
+    }
+  }
+
+}
+
+class MyAsyncFunction extends AsyncFunction[Int, Int] {
+  override def asyncInvoke(input: Int, resultFuture: ResultFuture[Int]): Unit = {
+    Future {
+      // trigger the timeout of the even input number
+      if (input % 2 == 0) {
+        Thread.sleep(AsyncDataStreamITCase.timeout + 1000)
+      }
+
+      resultFuture.complete(Seq(input * 2))
+    } (ExecutionContext.global)
+  }
+  override def timeout(input: Int, resultFuture: ResultFuture[Int]): Unit = {
+    resultFuture.complete(Seq(input * 3))
+  }
+}


### PR DESCRIPTION
## What is the purpose of the change

Currently Async IO operator does not provide a mechanism to handle timeouts. This PR fixs the problem by adding a `timeout` method to `AsyncFunction`

## Brief change log

  - Add a `timeout` method to `AsyncFunction` for both Java and Scala API
  - Update `AsyncWaitOperator` to invoke `AsyncFunction#timeout` for Java API
  - Update `AsyncDataStream` to invoke `AsyncFunction#timeout` for Scala API

## Verifying this change

  - Add tests to `AsyncWaitOperatorTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (yes)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs / JavaDocs)
