### PR TITLE
[FLINK-9468][filesystem] fix calculate outputLimit incorrectly in LimitedConnectionsFileSystem#createStream()

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/fs/LimitedConnectionsFileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/LimitedConnectionsFileSystem.java
@@ -391,7 +391,7 @@ public class LimitedConnectionsFileSystem extends FileSystem {
 			final HashSet<T> openStreams,
 			final boolean output) throws IOException {
 
-		final int outputLimit = output && maxNumOpenInputStreams > 0 ? maxNumOpenOutputStreams : Integer.MAX_VALUE;
+		final int outputLimit = output && maxNumOpenOutputStreams > 0 ? maxNumOpenOutputStreams : Integer.MAX_VALUE;
 		final int inputLimit = !output && maxNumOpenInputStreams > 0 ? maxNumOpenInputStreams : Integer.MAX_VALUE;
 		final int totalLimit = maxNumOpenStreamsTotal > 0 ? maxNumOpenStreamsTotal : Integer.MAX_VALUE;
 		final int outputCredit = output ? 1 : 0;


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes the bug of getting `outputLimit` incorrectly in `LimitedConnectionsFileSystem#createStream()`.

## Brief change log

  - *get outputLimit in LimitedConnectionsFileSystem#createStream() correctly.*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

no