### PR TITLE
[FLINK-9473] [table] Added new methods into ExternalCatalogSchema based on interface Schema changes in Calcite

### DIFF
--- a/flink-libraries/flink-table/pom.xml
+++ b/flink-libraries/flink-table/pom.xml
@@ -113,7 +113,7 @@ under the License.
 			<groupId>org.apache.calcite</groupId>
 			<artifactId>calcite-core</artifactId>
 			<!-- When updating the Calcite version, make sure to update the dependency exclusions -->
-			<version>1.16.0</version>
+			<version>1.17.0-SNAPSHOT</version>
 			<exclusions>
 				<!-- Dependencies that are not needed for how we use Calcite right now -->
 				<exclusion>

--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/ExternalCatalogSchema.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/catalog/ExternalCatalogSchema.scala
@@ -18,9 +18,11 @@
 
 package org.apache.flink.table.catalog
 
+import java.util
 import java.util.{Collection => JCollection, Collections => JCollections, LinkedHashSet => JLinkedHashSet, Set => JSet}
 
 import org.apache.calcite.linq4j.tree.Expression
+import org.apache.calcite.rel.`type`.RelProtoDataType
 import org.apache.calcite.schema._
 import org.apache.flink.table.api.{CatalogNotExistException, TableEnvironment, TableNotExistException}
 import org.apache.flink.table.util.Logging
@@ -59,6 +61,14 @@ class ExternalCatalogSchema(
         null
     }
   }
+
+  protected def getTypeMap: util.Map[String, RelProtoDataType] = {
+    JCollections.emptyMap()
+  }
+
+  override def getType(name: String): RelProtoDataType = getTypeMap.get(name)
+
+  override def getTypeNames: JSet[String] = JCollections.emptySet[String]
 
   /**
     * Lists the sub-schemas of the external catalog.


### PR DESCRIPTION
## What is the purpose of the change

Make Flink compilable after Calcite version bump to 1.17.0

## Brief change log

  - *new abstract methods dummy implementation*
  - *bump calcite version to 1.17.0-SNAPSHOT*

## Verifying this change
to verify need to check if it or compilable or not e.g.
*mvn clean package -DskipTests*

This change added tests and can be verified as follows:

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no )
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable )
