### PR TITLE
[FLINK-9430] [table] add cast rule in SQL to cast Object to other assignable types

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/ScalarOperators.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/codegen/calls/ScalarOperators.scala
@@ -24,7 +24,7 @@ import org.apache.calcite.avatica.util.{DateTimeUtils, TimeUnitRange}
 import org.apache.calcite.util.BuiltInMethod
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo._
 import org.apache.flink.api.common.typeinfo._
-import org.apache.flink.api.java.typeutils.{MapTypeInfo, ObjectArrayTypeInfo, RowTypeInfo}
+import org.apache.flink.api.java.typeutils.{GenericTypeInfo, MapTypeInfo, ObjectArrayTypeInfo, RowTypeInfo}
 import org.apache.flink.table.api.TableConfig
 import org.apache.flink.table.codegen.CodeGenUtils._
 import org.apache.flink.table.codegen.calls.CallGenerator.generateCallIfArgsNotNull
@@ -729,6 +729,14 @@ object ScalarOperators {
             s"${classOf[DateTimeUtils].getCanonicalName}.MILLIS_PER_DAY)"
       }
 
+    // Generic type class -> any other type which is assignable.
+    case (s: GenericTypeInfo[_], t: TypeInformation[_])
+      if s.getTypeClass.isAssignableFrom(t.getTypeClass) => {
+      val targetTypeTerm = targetType.getTypeClass.getCanonicalName
+      generateUnaryOperatorIfNotNull(nullCheck, targetType, operand) {
+        (operandTerm) => s"($targetTypeTerm) ($operandTerm)"
+      }
+    }
     // internal temporal casting
     // Date -> Integer
     // Time -> Integer

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/SqlExpressionTest.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/SqlExpressionTest.scala
@@ -22,7 +22,8 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.types.Row
 import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.table.api.ValidationException
-import org.apache.flink.table.expressions.utils.ExpressionTestBase
+import org.apache.flink.table.expressions.utils._
+import org.apache.flink.table.functions.ScalarFunction
 import org.junit.Test
 
 /**
@@ -210,6 +211,8 @@ class SqlExpressionTest extends ExpressionTestBase {
   @Test
   def testTypeConversionFunctions(): Unit = {
     testSqlApi("CAST(2 AS DOUBLE)", "2.0")
+    testSqlApi("CAST(Func20(42) AS DOUBLE)", "42.0")
+    testSqlApi("CAST(Func21(245) AS Int)", "245")
   }
 
   @Test
@@ -246,6 +249,11 @@ class SqlExpressionTest extends ExpressionTestBase {
     testSqlApi("CARDINALITY(ARRAY[TRUE, TRUE, FALSE])", "3")
     testSqlApi("ELEMENT(ARRAY['HELLO WORLD'])", "HELLO WORLD")
   }
+
+  override def functions: Map[String, ScalarFunction] = Map(
+    "Func20" -> Func20,
+    "Func21" -> Func21
+  )
 
   override def testData: Any = new Row(0)
 

--- a/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/utils/userDefinedScalarFunctions.scala
+++ b/flink-libraries/flink-table/src/test/scala/org/apache/flink/table/expressions/utils/userDefinedScalarFunctions.scala
@@ -290,6 +290,18 @@ object Func19 extends ScalarFunction {
 
 }
 
+object Func20 extends ScalarFunction {
+  def eval(i: Int): Object = {
+    double2Double(i)
+  }
+}
+
+object Func21 extends ScalarFunction {
+  def eval(i: Int): Object = {
+    new Integer(i)
+  }
+}
+
 class SplitUDF(deterministic: Boolean) extends ScalarFunction {
   def eval(x: String, sep: String, index: Int): String = {
     val splits = StringUtils.splitByWholeSeparator(x, sep)


### PR DESCRIPTION

## What is the purpose of the change

Add cast rule in SQL to cast Object to other assignable types.


## Brief change log

  - Add Cast rule to handle casting from Object.
  - Add unittests.


## Verifying this change

This change added tests and can be verified as follows:
  - Added unittest to test casting from Object to other basic type.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yno)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
