### PR TITLE
[FLINK-9458] Unable to recover from job failure on YARN with NPE

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/scheduler/CoLocationConstraint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/scheduler/CoLocationConstraint.java
@@ -101,7 +101,7 @@ public class CoLocationConstraint {
 	 *         false otherwise.
 	 */
 	public boolean isAssignedAndAlive() {
-		return lockedLocation != null && sharedSlot.isAlive();
+		return lockedLocation != null && sharedSlot != null && sharedSlot.isAlive();
 	}
 
 	/**


### PR DESCRIPTION
## What is the purpose of the change

*This pull request fixed a NPE when recover job on YARN*


## Brief change log

  - *Add non-null judge in the expression *


## Verifying this change

This change is already covered by existing tests, such as *CoLocationConstraintTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
