### PR TITLE
[FLINK-9091][build] Dependency convergence run against dependency-red…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -694,6 +694,29 @@ under the License.
 		</profile>
 
 		<profile>
+			<id>check-convergence</id>
+			<activation>
+				<property>
+					<name>check-convergence</name>
+				</property>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-enforcer-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>dependency-convergence</id>
+								<phase>validate</phase>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+
+		<profile>
 			<id>legacyCode</id>
 			<activation>
 				<property>
@@ -1289,6 +1312,7 @@ under the License.
 					</execution>
 					<execution>
 						<id>dependency-convergence</id>
+						<phase>none</phase>
 						<goals>
 							<goal>enforce</goal>
 						</goals>

--- a/tools/check_dependency_convergence.sh
+++ b/tools/check_dependency_convergence.sh
@@ -39,7 +39,7 @@ echo ${FLINK_DIR}
 # searches for directories containing a pom.xml file
 # sorts the list alphabetically
 # only accepts directories starting with "flink" to filter force-shading
-modules=$(find -maxdepth 3 -name 'pom.xml' -printf '%h\n' | sort -u | grep "flink")
+modules=$(find . -maxdepth 3 -name 'pom.xml' -printf '%h\n' | sort -u | grep "flink")
 
 for module in ${modules}
 do

--- a/tools/check_dependency_convergence.sh
+++ b/tools/check_dependency_convergence.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+HERE="`dirname \"$0\"`"				# relative
+HERE="`( cd \"$HERE\" && pwd )`" 	# absolutized and normalized
+if [ -z "$HERE" ] ; then
+	# error; for some reason, the path is not accessible
+	# to the script (e.g. permissions re-evaled after suid)
+	exit 1  # fail
+fi
+
+FLINK_DIR=HERE
+
+if [[ $(basename ${HERE}) == "tools" ]] ; then
+  FLINK_DIR="${HERE}/.."
+fi
+
+FLINK_DIR="`( cd \"${FLINK_DIR}\" && pwd )`" 
+
+echo ${FLINK_DIR}
+
+# get list of all flink modules
+# searches for directories containing a pom.xml file
+# sorts the list alphabetically
+# only accepts directories starting with "flink" to filter force-shading
+modules=$(find -name 'pom.xml' -printf '%h\n' | sort -u | grep "flink")
+
+for module in ${modules}
+do
+    # we are only interested in child modules
+    for other_module in ${modules}
+    do 
+        if [[ "${other_module}" != "${module}" && "${other_module}" = "${module}"* ]]; then
+        echo "excluding ${module} since it is not a leaf module"
+            continue 2
+        fi
+    done
+    
+    cd "${module}"
+    mvn validate -nsu -Dcheckstyle.skip=true -Dcheck-convergence
+    exit_code=$?
+    if [[ ${exit_code} != 0 ]]; then
+        exit ${exit_code}
+    fi
+    cd "${FLINK_DIR}"
+done
+
+exit 0

--- a/tools/check_dependency_convergence.sh
+++ b/tools/check_dependency_convergence.sh
@@ -53,9 +53,12 @@ do
     done
     
     cd "${module}"
-    mvn validate -nsu -Dcheckstyle.skip=true -Dcheck-convergence
+    echo "checking ${module}"
+    output=$(mvn validate -nsu -Dcheckstyle.skip=true -Dcheck-convergence)
     exit_code=$?
     if [[ ${exit_code} != 0 ]]; then
+        echo "dependency convergence failed."
+        echo "${output}"
         exit ${exit_code}
     fi
     cd "${FLINK_DIR}"

--- a/tools/check_dependency_convergence.sh
+++ b/tools/check_dependency_convergence.sh
@@ -39,7 +39,7 @@ echo ${FLINK_DIR}
 # searches for directories containing a pom.xml file
 # sorts the list alphabetically
 # only accepts directories starting with "flink" to filter force-shading
-modules=$(find -name 'pom.xml' -printf '%h\n' | sort -u | grep "flink")
+modules=$(find -maxdepth 3 -name 'pom.xml' -printf '%h\n' | sort -u | grep "flink")
 
 for module in ${modules}
 do

--- a/tools/check_dependency_convergence.sh
+++ b/tools/check_dependency_convergence.sh
@@ -46,7 +46,7 @@ do
     # we are only interested in child modules
     for other_module in ${modules}
     do 
-        if [[ "${other_module}" != "${module}" && "${other_module}" = "${module}"* ]]; then
+        if [[ "${other_module}" != "${module}" && "${other_module}" = "${module}/"* ]]; then
         echo "excluding ${module} since it is not a leaf module"
             continue 2
         fi

--- a/tools/check_dependency_convergence.sh
+++ b/tools/check_dependency_convergence.sh
@@ -46,7 +46,7 @@ do
     # we are only interested in child modules
     for other_module in ${modules}
     do 
-        if [[ "${other_module}" != "${module}" && "${other_module}" = "${module}/"* ]]; then
+        if [[ "${other_module}" != "${module}" && "${other_module}" = "${module}"/* ]]; then
         echo "excluding ${module} since it is not a leaf module"
             continue 2
         fi

--- a/tools/travis_mvn_watchdog.sh
+++ b/tools/travis_mvn_watchdog.sh
@@ -44,6 +44,7 @@ SLEEP_TIME=20
 LOG4J_PROPERTIES=${HERE}/log4j-travis.properties
 
 MODULES_CORE="\
+
 flink-test-utils-parent/flink-test-utils,\
 flink-state-backends/flink-statebackend-rocksdb,\
 flink-clients,\
@@ -537,11 +538,11 @@ esac
 # Run tests if compilation was successful
 if [ $EXIT_CODE == 0 ]; then
 
-    # Start watching $MVN_OUT
-    watchdog &
-    echo "STARTED watchdog (${WD_PID})."
-    
-    WD_PID=$!
+	# Start watching $MVN_OUT
+	watchdog &
+	echo "STARTED watchdog (${WD_PID})."
+
+	WD_PID=$!
 
 	echo "RUNNING '${MVN_TEST}'."
 
@@ -554,9 +555,9 @@ if [ $EXIT_CODE == 0 ]; then
 
 	echo "MVN exited with EXIT CODE: ${EXIT_CODE}."
 
-    # Make sure to kill the watchdog in any case after $MVN_TEST has completed
-    echo "Trying to KILL watchdog (${WD_PID})."
-    ( kill $WD_PID 2>&1 ) > /dev/null
+	# Make sure to kill the watchdog in any case after $MVN_TEST has completed
+	echo "Trying to KILL watchdog (${WD_PID})."
+	( kill $WD_PID 2>&1 ) > /dev/null
 
 	rm $MVN_PID
 	rm $MVN_EXIT

--- a/tools/travis_mvn_watchdog.sh
+++ b/tools/travis_mvn_watchdog.sh
@@ -44,7 +44,6 @@ SLEEP_TIME=20
 LOG4J_PROPERTIES=${HERE}/log4j-travis.properties
 
 MODULES_CORE="\
-
 flink-test-utils-parent/flink-test-utils,\
 flink-state-backends/flink-statebackend-rocksdb,\
 flink-clients,\

--- a/tools/travis_mvn_watchdog.sh
+++ b/tools/travis_mvn_watchdog.sh
@@ -512,6 +512,24 @@ echo "MVN exited with EXIT CODE: ${EXIT_CODE}."
 rm $MVN_PID
 rm $MVN_EXIT
 
+# only run dependency-convergence in misc because it is the only profile building all of Flink
+case $TEST in
+	(misc)
+		if [ $EXIT_CODE == 0 ]; then
+			printf "\n\n==============================================================================\n"
+			printf "Checking dependency convergence\n"
+			printf "==============================================================================\n"
+
+			./tools/check_dependency_convergence.sh
+			EXIT_CODE=$?
+		else
+			printf "\n==============================================================================\n"
+			printf "Previous build failure detected, skipping dependency-convergence check.\n"
+			printf "==============================================================================\n"
+		fi
+	;;
+esac
+
 # Run tests if compilation was successful
 if [ $EXIT_CODE == 0 ]; then
 


### PR DESCRIPTION
## What is the purpose of the change

As outlined in the JIRA the enforcer-plugin may not always work against dependency-reduced poms leading to convergence failures. This heavily conflicts with our approach to shading dependencies. 

This PR ensures that the dependency-convergence , at least on travis, is run against dependency-reduced poms.

The easiest way to achieve this is to run the enforcer plugin separately for each leaf module, for which maven works against the local repository, and thus dependency-reduced poms.
Naturally this cannot be nicely modeled into the maven life-cycle, hence we rely on a bash script to iterate over all modules.

To prevent other devs from running into this problem the enforcer plugin is now disabled by default. It must be explicitly enabled with a profile. To check the convergence locally one may use `tools/check_dependency_convergence.sh`.

This PR subsumes #6073.

## Brief change log

* disable enforcer by default
* add profile to enable enforcer
* add `tools/check_dependency_convergence.sh` script to run convergence check against dependency-reduced poms
* modify travis scripts to run convergence check after compilation

## Verifying this change

* add a dependency-convergence violation and run on travis; optionally run script locally
