### PR TITLE
[FLINK-9413] [distributed coordination] Tasks can fail with Partition…

### DIFF
--- a/docs/_includes/generated/task_manager_configuration.html
+++ b/docs/_includes/generated/task_manager_configuration.html
@@ -129,7 +129,7 @@
         </tr>
         <tr>
             <td><h5>taskmanager.network.request-backoff.max</h5></td>
-            <td style="word-wrap: break-word;">10000</td>
+            <td style="word-wrap: break-word;">30000</td>
             <td>Maximum backoff for partition requests of input channels.</td>
         </tr>
         <tr>

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -323,7 +323,7 @@ public class TaskManagerOptions {
 	 */
 	public static final ConfigOption<Integer> NETWORK_REQUEST_BACKOFF_MAX =
 			key("taskmanager.network.request-backoff.max")
-			.defaultValue(10000)
+			.defaultValue(30000)
 			.withDeprecatedKeys("taskmanager.net.request-backoff.max")
 			.withDescription("Maximum backoff for partition requests of input channels.");
 


### PR DESCRIPTION
…NotFoundException if consumer deployment takes too long

## What is the purpose of the change
Tasks can fail with PartitionNotFoundException if consumer deployment takes too long. And the producer has been assigned a slot but we do not wait until it is actually running.

## Brief change log
Do a work around to set the max backoff time higher [30,000] for the data connections.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.