### PR TITLE
[FLINK-9476]Emit late elements in CEP as sideOutPut

### DIFF
--- a/docs/dev/libs/cep.md
+++ b/docs/dev/libs/cep.md
@@ -1460,16 +1460,16 @@ PatternStream<Event> patternStream = CEP.pattern(input, pattern);
 OutputTag<String> outputTag = new OutputTag<String>("side-output"){};
 
 SingleOutputStreamOperator<ComplexEvent> result = patternStream.select(
-    new PatternTimeoutFunction<Event, TimeoutEvent>() {...},
     outputTag,
+    new PatternTimeoutFunction<Event, TimeoutEvent>() {...},
     new PatternSelectFunction<Event, ComplexEvent>() {...}
 );
 
 DataStream<TimeoutEvent> timeoutResult = result.getSideOutput(outputTag);
 
 SingleOutputStreamOperator<ComplexEvent> flatResult = patternStream.flatSelect(
-    new PatternFlatTimeoutFunction<Event, TimeoutEvent>() {...},
     outputTag,
+    new PatternFlatTimeoutFunction<Event, TimeoutEvent>() {...},
     new PatternFlatSelectFunction<Event, ComplexEvent>() {...}
 );
 
@@ -1524,7 +1524,48 @@ In `CEP` the order in which elements are processed matters. To guarantee that el
 
 To guarantee that elements across watermarks are processed in event-time order, Flink's CEP library assumes
 *correctness of the watermark*, and considers as *late* elements whose timestamp is smaller than that of the last
-seen watermark. Late elements are not further processed.
+seen watermark. Late elements are not further processed. Also, you can specify a sideOutput tag to collect the late elements come after the last seen watermark, you can use it like this.
+
+<div class="codetabs" markdown="1">
+<div data-lang="java" markdown="1">
+
+{% highlight java %}
+PatternStream<Event> patternStream = CEP.pattern(input, pattern);
+
+OutputTag<String> lateDataOutputTag = new OutputTag<String>("late-data""){};
+
+SingleOutputStreamOperator<ComplexEvent> result = patternStream
+    .sideOutputLateData(lateDataOutputTag)
+    .select(
+        new PatternSelectFunction<Event, ComplexEvent>() {...}
+    );
+
+DataStream<String> lateData = result.getSideOutput(lateDataOutputTag);
+
+
+{% endhighlight %}
+
+</div>
+
+<div data-lang="scala" markdown="1">
+
+{% highlight scala %}
+
+val patternStream: PatternStream[Event] = CEP.pattern(input, pattern)
+
+val lateDataOutputTag = OutputTag[String]("late-data")
+
+val result: SingleOutputStreamOperator[ComplexEvent] = patternStream
+      .sideOutputLateData(lateDataOutputTag)
+      .select(
+        {pattern: Map[String, Iterable[ComplexEvent]] => ComplexEvent()
+      })
+
+val lateData: DataStream<String> = result.getSideOutput(lateDataOutputTag)
+
+{% endhighlight %}
+
+</div>
 
 ## Examples
 

--- a/docs/dev/libs/cep.md
+++ b/docs/dev/libs/cep.md
@@ -1557,14 +1557,15 @@ val lateDataOutputTag = OutputTag[String]("late-data")
 
 val result: SingleOutputStreamOperator[ComplexEvent] = patternStream
       .sideOutputLateData(lateDataOutputTag)
-      .select(
-        {pattern: Map[String, Iterable[ComplexEvent]] => ComplexEvent()
-      })
+      .select{
+          pattern: Map[String, Iterable[ComplexEvent]] => ComplexEvent()
+      }
 
 val lateData: DataStream<String> = result.getSideOutput(lateDataOutputTag)
 
 {% endhighlight %}
 
+</div>
 </div>
 
 ## Examples

--- a/flink-libraries/flink-cep-scala/src/main/scala/org/apache/flink/cep/scala/PatternStream.scala
+++ b/flink-libraries/flink-cep-scala/src/main/scala/org/apache/flink/cep/scala/PatternStream.scala
@@ -440,6 +440,11 @@ class PatternStream[T](jPatternStream: JPatternStream[T]) {
 
     flatSelect(outputTag, patternFlatTimeoutFun, patternFlatSelectFun)
   }
+
+ def sideOutputLateData(lateDataOutputTag: OutputTag[T]): PatternStream[T] = {
+   jPatternStream.sideOutputLateData(lateDataOutputTag)
+   this
+ }
 }
 
 object PatternStream {

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/CEPOperatorUtils.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/CEPOperatorUtils.java
@@ -59,7 +59,8 @@ public class CEPOperatorUtils {
 			final Pattern<IN, ?> pattern,
 			final EventComparator<IN> comparator,
 			final PatternSelectFunction<IN, OUT> selectFunction,
-			final TypeInformation<OUT> outTypeInfo) {
+			final TypeInformation<OUT> outTypeInfo,
+			final OutputTag<IN> lateDataOutputTag) {
 		return createPatternStream(inputStream, pattern, outTypeInfo, false, comparator, new OperatorBuilder<IN, OUT>() {
 			@Override
 			public OneInputStreamOperator<IN, OUT> build(
@@ -74,7 +75,8 @@ public class CEPOperatorUtils {
 					nfaFactory,
 					comparator,
 					skipStrategy,
-					selectFunction
+					selectFunction,
+					lateDataOutputTag
 				);
 			}
 
@@ -106,7 +108,8 @@ public class CEPOperatorUtils {
 			final Pattern<IN, ?> pattern,
 			final EventComparator<IN> comparator,
 			final PatternFlatSelectFunction<IN, OUT> selectFunction,
-			final TypeInformation<OUT> outTypeInfo) {
+			final TypeInformation<OUT> outTypeInfo,
+			final OutputTag<IN> lateDataOutputTag) {
 		return createPatternStream(inputStream, pattern, outTypeInfo, false, comparator, new OperatorBuilder<IN, OUT>() {
 			@Override
 			public OneInputStreamOperator<IN, OUT> build(
@@ -121,7 +124,8 @@ public class CEPOperatorUtils {
 					nfaFactory,
 					comparator,
 					skipStrategy,
-					selectFunction
+					selectFunction,
+					lateDataOutputTag
 				);
 			}
 
@@ -160,7 +164,8 @@ public class CEPOperatorUtils {
 			final PatternFlatSelectFunction<IN, OUT1> selectFunction,
 			final TypeInformation<OUT1> outTypeInfo,
 			final OutputTag<OUT2> outputTag,
-			final PatternFlatTimeoutFunction<IN, OUT2> timeoutFunction) {
+			final PatternFlatTimeoutFunction<IN, OUT2> timeoutFunction,
+			final OutputTag<IN> lateDataOutputTag) {
 		return createPatternStream(inputStream, pattern, outTypeInfo, true, comparator, new OperatorBuilder<IN, OUT1>() {
 			@Override
 			public OneInputStreamOperator<IN, OUT1> build(
@@ -177,7 +182,8 @@ public class CEPOperatorUtils {
 					skipStrategy,
 					selectFunction,
 					timeoutFunction,
-					outputTag
+					outputTag,
+					lateDataOutputTag
 				);
 			}
 
@@ -216,7 +222,8 @@ public class CEPOperatorUtils {
 			final PatternSelectFunction<IN, OUT1> selectFunction,
 			final TypeInformation<OUT1> outTypeInfo,
 			final OutputTag<OUT2> outputTag,
-			final PatternTimeoutFunction<IN, OUT2> timeoutFunction) {
+			final PatternTimeoutFunction<IN, OUT2> timeoutFunction,
+			final OutputTag<IN> lateDataOutputTag) {
 		return createPatternStream(inputStream, pattern, outTypeInfo, true, comparator, new OperatorBuilder<IN, OUT1>() {
 			@Override
 			public OneInputStreamOperator<IN, OUT1> build(
@@ -233,7 +240,8 @@ public class CEPOperatorUtils {
 					skipStrategy,
 					selectFunction,
 					timeoutFunction,
-					outputTag
+					outputTag,
+					lateDataOutputTag
 				);
 			}
 

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/FlatSelectCepOperator.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/FlatSelectCepOperator.java
@@ -24,6 +24,7 @@ import org.apache.flink.cep.PatternFlatSelectFunction;
 import org.apache.flink.cep.nfa.AfterMatchSkipStrategy;
 import org.apache.flink.cep.nfa.compiler.NFACompiler;
 import org.apache.flink.streaming.api.operators.TimestampedCollector;
+import org.apache.flink.util.OutputTag;
 
 import java.util.List;
 import java.util.Map;
@@ -45,8 +46,9 @@ public class FlatSelectCepOperator<IN, KEY, OUT>
 		NFACompiler.NFAFactory<IN> nfaFactory,
 		EventComparator<IN> comparator,
 		AfterMatchSkipStrategy skipStrategy,
-		PatternFlatSelectFunction<IN, OUT> function) {
-		super(inputSerializer, isProcessingTime, nfaFactory, comparator, skipStrategy, function);
+		PatternFlatSelectFunction<IN, OUT> function,
+		OutputTag<IN> lateDataOutputTag) {
+		super(inputSerializer, isProcessingTime, nfaFactory, comparator, skipStrategy, function, lateDataOutputTag);
 	}
 
 	private transient TimestampedCollector<OUT> collector;

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/FlatSelectTimeoutCepOperator.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/FlatSelectTimeoutCepOperator.java
@@ -61,14 +61,16 @@ public class FlatSelectTimeoutCepOperator<IN, OUT1, OUT2, KEY> extends
 		AfterMatchSkipStrategy skipStrategy,
 		PatternFlatSelectFunction<IN, OUT1> flatSelectFunction,
 		PatternFlatTimeoutFunction<IN, OUT2> flatTimeoutFunction,
-		OutputTag<OUT2> outputTag) {
+		OutputTag<OUT2> outputTag,
+		OutputTag<IN> lateDataOutputTag) {
 		super(
 			inputSerializer,
 			isProcessingTime,
 			nfaFactory,
 			comparator,
 			skipStrategy,
-			new FlatSelectWrapper<>(flatSelectFunction, flatTimeoutFunction));
+			new FlatSelectWrapper<>(flatSelectFunction, flatTimeoutFunction),
+			lateDataOutputTag);
 		this.timedOutOutputTag = outputTag;
 	}
 

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/SelectCepOperator.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/SelectCepOperator.java
@@ -24,6 +24,7 @@ import org.apache.flink.cep.PatternSelectFunction;
 import org.apache.flink.cep.nfa.AfterMatchSkipStrategy;
 import org.apache.flink.cep.nfa.compiler.NFACompiler;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.util.OutputTag;
 
 import java.util.List;
 import java.util.Map;
@@ -43,8 +44,9 @@ public class SelectCepOperator<IN, KEY, OUT>
 		NFACompiler.NFAFactory<IN> nfaFactory,
 		EventComparator<IN> comparator,
 		AfterMatchSkipStrategy skipStrategy,
-		PatternSelectFunction<IN, OUT> function) {
-		super(inputSerializer, isProcessingTime, nfaFactory, comparator, skipStrategy, function);
+		PatternSelectFunction<IN, OUT> function,
+		OutputTag<IN> lateDataOutputTag) {
+		super(inputSerializer, isProcessingTime, nfaFactory, comparator, skipStrategy, function, lateDataOutputTag);
 	}
 
 	@Override

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/SelectTimeoutCepOperator.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/SelectTimeoutCepOperator.java
@@ -56,14 +56,16 @@ public class SelectTimeoutCepOperator<IN, OUT1, OUT2, KEY>
 		AfterMatchSkipStrategy skipStrategy,
 		PatternSelectFunction<IN, OUT1> flatSelectFunction,
 		PatternTimeoutFunction<IN, OUT2> flatTimeoutFunction,
-		OutputTag<OUT2> outputTag) {
+		OutputTag<OUT2> outputTag,
+		OutputTag<IN> lateDataOutputTag) {
 		super(
 			inputSerializer,
 			isProcessingTime,
 			nfaFactory,
 			comparator,
 			skipStrategy,
-			new SelectWrapper<>(flatSelectFunction, flatTimeoutFunction));
+			new SelectWrapper<>(flatSelectFunction, flatTimeoutFunction),
+			lateDataOutputTag);
 		this.timedOutOutputTag = outputTag;
 	}
 

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPOperatorTest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPOperatorTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.cep.operator;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer;
@@ -277,7 +278,7 @@ public class CEPOperatorTest extends TestLogger {
 						}
 					},
 					timedOut
-				), new KeySelector<Event, Integer>() {
+				, null), new KeySelector<Event, Integer>() {
 				private static final long serialVersionUID = 7219185117566268366L;
 
 				@Override
@@ -721,6 +722,50 @@ public class CEPOperatorTest extends TestLogger {
 			assertTrue(!operator.hasNonEmptyNFA(41));
 			assertTrue(!operator.hasNonEmptyPQ(41));
 			assertEquals(0L, harness.numEventTimeTimers());
+		} finally {
+			harness.close();
+		}
+	}
+
+	@Test
+	public void testCEPOperatorSideOutputLateElementsEventTime() throws Exception {
+
+		Event startEvent = new Event(41, "c", 1.0);
+		Event middle1Event1 = new Event(41, "a", 2.0);
+		Event middle1Event2 = new Event(41, "a", 3.0);
+		Event middle1Event3 = new Event(41, "a", 4.0);
+
+		SelectCepOperator<Event, Integer, Map<String, List<Event>>> operator = CepOperatorTestUtilities.getKeyedCepOpearator(
+			false,
+			new ComplexNFAFactory());
+		OneInputStreamOperatorTestHarness<Event, Map<String, List<Event>>> harness = CepOperatorTestUtilities.getCepTestHarness(operator);
+
+		try {
+			harness.open();
+
+			harness.processWatermark(new Watermark(Long.MIN_VALUE));
+			harness.processElement(new StreamRecord<>(startEvent, 6));
+
+			verifyWatermark(harness.getOutput().poll(), Long.MIN_VALUE);
+			harness.processWatermark(new Watermark(6L));
+			verifyWatermark(harness.getOutput().poll(), 6L);
+
+			harness.processElement(new StreamRecord<>(middle1Event1, 4));
+			harness.processElement(new StreamRecord<>(middle1Event2, 5));
+			harness.processElement(new StreamRecord<>(middle1Event3, 7));
+
+			OutputTag<Event> lateDataTag = new OutputTag<Event>("late-data", TypeInformation.of(Event.class));
+
+			List<Event> late = new ArrayList<>();
+
+			while (!harness.getSideOutput(lateDataTag).isEmpty()) {
+				StreamRecord<Event> eventStreamRecord = harness.getSideOutput(lateDataTag).poll();
+				late.add(eventStreamRecord.getValue());
+			}
+
+			List<Event> expected = Lists.newArrayList(middle1Event1, middle1Event2);
+			Assert.assertArrayEquals(expected.toArray(), late.toArray());
+
 		} finally {
 			harness.close();
 		}

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CepOperatorTestUtilities.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CepOperatorTestUtilities.java
@@ -19,6 +19,7 @@
 package org.apache.flink.cep.operator;
 
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.cep.Event;
 import org.apache.flink.cep.EventComparator;
@@ -26,6 +27,7 @@ import org.apache.flink.cep.PatternSelectFunction;
 import org.apache.flink.cep.nfa.compiler.NFACompiler;
 import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.util.OutputTag;
 
 import java.util.List;
 import java.util.Map;
@@ -66,6 +68,9 @@ public class CepOperatorTestUtilities {
 		boolean isProcessingTime,
 		NFACompiler.NFAFactory<Event> nfaFactory,
 		EventComparator<Event> comparator) {
+
+		OutputTag<Event> lateDataTag = new OutputTag<Event>("late-data", TypeInformation.of(Event.class));
+
 		return new SelectCepOperator<>(
 			Event.createTypeSerializer(),
 			isProcessingTime,
@@ -77,7 +82,7 @@ public class CepOperatorTestUtilities {
 				public Map<String, List<Event>> select(Map<String, List<Event>> pattern) throws Exception {
 					return pattern;
 				}
-			});
+			}, lateDataTag);
 	}
 
 	private CepOperatorTestUtilities() {

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CepOperatorTestUtilities.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CepOperatorTestUtilities.java
@@ -71,6 +71,15 @@ public class CepOperatorTestUtilities {
 
 		OutputTag<Event> lateDataTag = new OutputTag<Event>("late-data", TypeInformation.of(Event.class));
 
+		return getKeyedCepOpearator(isProcessingTime, nfaFactory, comparator, null);
+	}
+
+	public static <K> SelectCepOperator<Event, K, Map<String, List<Event>>> getKeyedCepOpearator(
+		boolean isProcessingTime,
+		NFACompiler.NFAFactory<Event> nfaFactory,
+		EventComparator<Event> comparator,
+		OutputTag<Event> outputTag) {
+
 		return new SelectCepOperator<>(
 			Event.createTypeSerializer(),
 			isProcessingTime,
@@ -82,7 +91,7 @@ public class CepOperatorTestUtilities {
 				public Map<String, List<Event>> select(Map<String, List<Event>> pattern) throws Exception {
 					return pattern;
 				}
-			}, lateDataTag);
+			}, outputTag);
 	}
 
 	private CepOperatorTestUtilities() {


### PR DESCRIPTION
Now, when use with Eventtime in CEP library, elements come later than watermark will be dropped,we can put it in side Output with outPutTag