### PR TITLE
[FLINK-8500] Get the timestamp of the Kafka message from kafka consumer

### DIFF
--- a/docs/dev/connectors/kafka.md
+++ b/docs/dev/connectors/kafka.md
@@ -153,7 +153,10 @@ produced Java/Scala type to Flink's type system. Users that implement a vanilla 
 to implement the `getProducedType(...)` method themselves.
 
 For accessing both the key and value of the Kafka message, the `KeyedDeserializationSchema` has
-the following deserialize method ` T deserialize(byte[] messageKey, byte[] message, String topic, int partition, long offset)`.
+the following deserialize methods ` T deserialize(byte[] messageKey, byte[] message, String topic, int partition, long offset)` and 
+` T deserialize(byte[] messageKey, byte[] message, String topic, int partition, long offset, long timestamp, TimestampType timestampType)`. 
+The first exists for backward compatibility reasons, for kafka 0.10+ consumers the second is preferred because it 
+also gives access to the kafka timestamp.
 
 For convenience, Flink provides the following schemas:
 

--- a/docs/dev/connectors/kafka.md
+++ b/docs/dev/connectors/kafka.md
@@ -155,8 +155,8 @@ to implement the `getProducedType(...)` method themselves.
 For accessing both the key and value of the Kafka message, the `KeyedDeserializationSchema` has
 the following deserialize methods ` T deserialize(byte[] messageKey, byte[] message, String topic, int partition, long offset)` and 
 ` T deserialize(byte[] messageKey, byte[] message, String topic, int partition, long offset, long timestamp, TimestampType timestampType)`. 
-The first exists for backward compatibility reasons, for kafka 0.10+ consumers the second is preferred because it 
-also gives access to the kafka timestamp.
+The first exists for backward compatibility reasons, for Kafka 0.10+ consumers the second is preferred because it 
+also gives access to the Kafka timestamp.
 
 For convenience, Flink provides the following schemas:
 

--- a/flink-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/SimpleConsumerThread.java
+++ b/flink-connectors/flink-connector-kafka-0.8/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/SimpleConsumerThread.java
@@ -370,7 +370,8 @@ class SimpleConsumerThread<T> extends Thread {
 							}
 
 							final T value = deserializer.deserialize(keyBytes, valueBytes,
-									currentPartition.getTopic(), currentPartition.getPartition(), offset);
+									currentPartition.getTopic(), currentPartition.getPartition(), offset,
+									Long.MIN_VALUE, KeyedDeserializationSchema.TimestampType.NO_TIMESTAMP);
 
 							if (deserializer.isEndOfStream(value)) {
 								// remove partition from subscribed partitions.

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/util/serialization/JSONKeyValueDeserializationSchema.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/util/serialization/JSONKeyValueDeserializationSchema.java
@@ -72,6 +72,31 @@ public class JSONKeyValueDeserializationSchema implements KeyedDeserializationSc
 	}
 
 	@Override
+	public ObjectNode deserialize(byte[] messageKey, byte[] message, String topic, int partition, long offset, long timestamp, TimestampType timestampType) throws IOException {
+		if (mapper == null) {
+			mapper = new ObjectMapper();
+		}
+		ObjectNode node = mapper.createObjectNode();
+		if (messageKey != null) {
+			node.set("key", mapper.readValue(messageKey, JsonNode.class));
+		}
+		if (message != null) {
+			node.set("value", mapper.readValue(message, JsonNode.class));
+		}
+		if (includeMetadata) {
+			ObjectNode metadataNode = node.putObject("metadata");
+			metadataNode.put("offset", offset)
+						.put("topic", topic)
+						.put("partition", partition);
+			if (timestampType != TimestampType.NO_TIMESTAMP) {
+				metadataNode.put("timestamp", timestamp)
+							.put("timestampType", timestampType.toString());
+			}
+		}
+		return node;
+	}
+
+	@Override
 	public boolean isEndOfStream(ObjectNode nextElement) {
 		return false;
 	}

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/util/serialization/KeyedDeserializationSchema.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/util/serialization/KeyedDeserializationSchema.java
@@ -43,7 +43,10 @@ public interface KeyedDeserializationSchema<T> extends Serializable, ResultTypeQ
 	 *
 	 * @return The deserialized message as an object (null if the message cannot be deserialized).
 	 */
-	T deserialize(byte[] messageKey, byte[] message, String topic, int partition, long offset) throws IOException;
+	@Deprecated
+	default T deserialize(byte[] messageKey, byte[] message, String topic, int partition, long offset) throws IOException {
+		throw new RuntimeException("The deserialize method must be implemented by classes that implement the KeyedDeserializationSchema interface.");
+	}
 
 	/**
 	 * Deserializes the byte message.
@@ -72,7 +75,7 @@ public interface KeyedDeserializationSchema<T> extends Serializable, ResultTypeQ
 	boolean isEndOfStream(T nextElement);
 
 	/**
-	 * The TimestampType is introduced in the kafka clients 0.10+. This interface is also used for the Kafka connector 0.9
+	 * The TimestampType is introduced in the Kafka clients 0.10+. This interface is also used for the Kafka connector 0.9
 	 * so a local enumeration is needed.
 	 */
 	enum TimestampType {

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/util/serialization/KeyedDeserializationSchema.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/util/serialization/KeyedDeserializationSchema.java
@@ -46,6 +46,22 @@ public interface KeyedDeserializationSchema<T> extends Serializable, ResultTypeQ
 	T deserialize(byte[] messageKey, byte[] message, String topic, int partition, long offset) throws IOException;
 
 	/**
+	 * Deserializes the byte message.
+	 *
+	 * @param messageKey the key as a byte array (null if no key has been set).
+	 * @param message The message, as a byte array (null if the message was empty or deleted).
+	 * @param partition The partition the message has originated from.
+	 * @param offset the offset of the message in the original source (for example the Kafka offset).
+	 * @param timestamp the timestamp of the consumer record
+	 * @param timestampType The timestamp type, could be NO_TIMESTAMP, CREATE_TIME or INGEST_TIME.
+	 *
+	 * @return The deserialized message as an object (null if the message cannot be deserialized).
+	 */
+	default T deserialize(byte[] messageKey, byte[] message, String topic, int partition, long offset, long timestamp, TimestampType timestampType) throws IOException {
+		return deserialize(messageKey, message, topic, partition, offset);
+	}
+
+	/**
 	 * Method to decide whether the element signals the end of the stream. If
 	 * true is returned the element won't be emitted.
 	 *
@@ -54,4 +70,12 @@ public interface KeyedDeserializationSchema<T> extends Serializable, ResultTypeQ
 	 * @return True, if the element signals end of stream, false otherwise.
 	 */
 	boolean isEndOfStream(T nextElement);
+
+	/**
+	 * The TimestampType is introduced in the kafka clients 0.10+. This interface is also used for the Kafka connector 0.9
+	 * so a local enumeration is needed.
+	 */
+	enum TimestampType {
+		NO_TIMESTAMP, CREATE_TIME, INGEST_TIME
+	}
 }

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/util/serialization/KeyedDeserializationSchemaWrapper.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/util/serialization/KeyedDeserializationSchemaWrapper.java
@@ -45,6 +45,11 @@ public class KeyedDeserializationSchemaWrapper<T> implements KeyedDeserializatio
 	}
 
 	@Override
+	public T deserialize(byte[] messageKey, byte[] message, String topic, int partition, long offset, long timestamp, TimestampType timestampType) throws IOException {
+		return deserializationSchema.deserialize(message);
+	}
+
+	@Override
 	public boolean isEndOfStream(T nextElement) {
 		return deserializationSchema.isEndOfStream(nextElement);
 	}


### PR DESCRIPTION
## What is the purpose of the change

This pull request make the Kafka timestamp and timestampType available in the message deserialisation so one can use it in the business logic processing.

## Brief change log
- *added new default method with Timestamp/TimestampType parameters to the interface `KeyedDeserializationSchema<T>`

## Verifying this change

This change is already covered by existing tests, such as Kafka Consumer tests and JSONKeyValueDeserializationSchemaTest.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / no / **don't know**)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** / **JavaDocs** / not documented)
