### PR TITLE
[hotfix][table] Remove a println statement

### DIFF
--- a/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/join/TimeBoundedStreamJoin.scala
+++ b/flink-libraries/flink-table/src/main/scala/org/apache/flink/table/runtime/join/TimeBoundedStreamJoin.scala
@@ -301,7 +301,6 @@ abstract class TimeBoundedStreamJoin(
               if (!tuple.f1) {
                 // Emit a null padding result if the left row has never been successfully joined.
                 joinCollector.collect(paddingUtil.padLeft(tuple.f0))
-                println(s"Emitting a null padding result for left row ${tuple.f0}")
               }
               i += 1
             }


### PR DESCRIPTION
## What is the purpose of the change

Remove a `println` statement in `TimeBoundedStreamJoin`.

## Brief change log

Remove a `println` statement in `TimeBoundedStreamJoin`.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (N/A)
