### PR TITLE
[FLINK-9366] DistributedCache works with Distributed File System

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/cache/DistributedCache.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/cache/DistributedCache.java
@@ -15,8 +15,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.flink.api.common.cache;
 
+import org.apache.flink.annotation.Public;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.Path;
 
 import java.io.File;
 import java.io.Serializable;
@@ -29,10 +33,6 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
-import org.apache.flink.annotation.Public;
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.core.fs.Path;
-
 /**
  * DistributedCache provides static methods to write the registered cache files into job configuration or decode
  * them from job configuration. It also provides user access to the file locally.
@@ -40,6 +40,9 @@ import org.apache.flink.core.fs.Path;
 @Public
 public class DistributedCache {
 
+	/**
+	 * Meta info about an entry in {@link DistributedCache}.
+	 */
 	public static class DistributedCacheEntry implements Serializable {
 
 		public String filePath;
@@ -48,9 +51,9 @@ public class DistributedCache {
 
 		public byte[] blobKey;
 
-		public DistributedCacheEntry(String filePath, Boolean isExecutable, byte[] blobKey, boolean isZipped){
-			this.filePath=filePath;
-			this.isExecutable=isExecutable;
+		public DistributedCacheEntry(String filePath, Boolean isExecutable, byte[] blobKey, boolean isZipped) {
+			this.filePath = filePath;
+			this.isExecutable = isExecutable;
 			this.blobKey = blobKey;
 			this.isZipped = isZipped;
 		}
@@ -110,7 +113,9 @@ public class DistributedCache {
 		conf.setString(CACHE_FILE_PATH + num, e.filePath);
 		conf.setBoolean(CACHE_FILE_EXE + num, e.isExecutable || new File(e.filePath).canExecute());
 		conf.setBoolean(CACHE_FILE_DIR + num, e.isZipped || new File(e.filePath).isDirectory());
-		conf.setBytes(CACHE_FILE_BLOB_KEY + num, e.blobKey);
+		if (e.blobKey != null) {
+			conf.setBytes(CACHE_FILE_BLOB_KEY + num, e.blobKey);
+		}
 	}
 
 	public static Set<Entry<String, DistributedCacheEntry>> readFileInfoFromConfig(Configuration conf) {

--- a/flink-core/src/main/java/org/apache/flink/api/common/cache/DistributedCache.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/cache/DistributedCache.java
@@ -107,7 +107,7 @@ public class DistributedCache {
 	// ------------------------------------------------------------------------
 
 	public static void writeFileInfoToConfig(String name, DistributedCacheEntry e, Configuration conf) {
-		int num = conf.getInteger(CACHE_FILE_NUM,0) + 1;
+		int num = conf.getInteger(CACHE_FILE_NUM, 0) + 1;
 		conf.setInteger(CACHE_FILE_NUM, num);
 		conf.setString(CACHE_FILE_NAME + num, name);
 		conf.setString(CACHE_FILE_PATH + num, e.filePath);

--- a/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/DistributedCacheDfsTest.java
+++ b/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/DistributedCacheDfsTest.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.hdfstests;
+
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.core.fs.FileStatus;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.test.util.MiniClusterResource;
+import org.apache.flink.util.NetUtils;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for distributing files with {@link org.apache.flink.api.common.cache.DistributedCache} via HDFS.
+ */
+public class DistributedCacheDfsTest {
+
+	private static final String testFileContent = "Goethe - Faust: Der Tragoedie erster Teil\n" + "Prolog im Himmel.\n"
+		+ "Der Herr. Die himmlischen Heerscharen. Nachher Mephistopheles. Die drei\n" + "Erzengel treten vor.\n"
+		+ "RAPHAEL: Die Sonne toent, nach alter Weise, In Brudersphaeren Wettgesang,\n"
+		+ "Und ihre vorgeschriebne Reise Vollendet sie mit Donnergang. Ihr Anblick\n"
+		+ "gibt den Engeln Staerke, Wenn keiner Sie ergruenden mag; die unbegreiflich\n"
+		+ "hohen Werke Sind herrlich wie am ersten Tag.\n"
+		+ "GABRIEL: Und schnell und unbegreiflich schnelle Dreht sich umher der Erde\n"
+		+ "Pracht; Es wechselt Paradieseshelle Mit tiefer, schauervoller Nacht. Es\n"
+		+ "schaeumt das Meer in breiten Fluessen Am tiefen Grund der Felsen auf, Und\n"
+		+ "Fels und Meer wird fortgerissen Im ewig schnellem Sphaerenlauf.\n"
+		+ "MICHAEL: Und Stuerme brausen um die Wette Vom Meer aufs Land, vom Land\n"
+		+ "aufs Meer, und bilden wuetend eine Kette Der tiefsten Wirkung rings umher.\n"
+		+ "Da flammt ein blitzendes Verheeren Dem Pfade vor des Donnerschlags. Doch\n"
+		+ "deine Boten, Herr, verehren Das sanfte Wandeln deines Tags.";
+
+	@ClassRule
+	public static TemporaryFolder tempFolder = new TemporaryFolder();
+
+	private static MiniClusterResource miniClusterResource;
+	private static MiniDFSCluster hdfsCluster;
+	private static Configuration conf = new Configuration();
+
+	private static Path testFile;
+	private static Path testDir;
+
+	@BeforeClass
+	public static void setup() throws Exception {
+		File dataDir = tempFolder.newFolder();
+
+		conf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, dataDir.getAbsolutePath());
+		MiniDFSCluster.Builder builder = new MiniDFSCluster.Builder(conf);
+		hdfsCluster = builder.build();
+
+		String hdfsURI = "hdfs://"
+			+ NetUtils.hostAndPortToUrlString(hdfsCluster.getURI().getHost(), hdfsCluster.getNameNodePort())
+			+ "/";
+
+		miniClusterResource = new MiniClusterResource(
+			new MiniClusterResource.MiniClusterResourceConfiguration(
+				new org.apache.flink.configuration.Configuration(),
+				1,
+				1));
+
+		miniClusterResource.before();
+
+		FileSystem dfs = FileSystem.get(new URI(hdfsURI));
+		testFile = writeFile(dfs, dfs.getHomeDirectory(), "testFile");
+
+		testDir = new Path(dfs.getHomeDirectory(), "testDir");
+		dfs.mkdirs(testDir);
+		writeFile(dfs, testDir, "testFile1");
+		writeFile(dfs, testDir, "testFile2");
+	}
+
+	private static Path writeFile(FileSystem dfs, Path rootDir, String fileName) throws IOException {
+		Path file = new Path(rootDir, fileName);
+		try (
+			DataOutputStream outStream = new DataOutputStream(dfs.create(file,
+				FileSystem.WriteMode.OVERWRITE))) {
+			outStream.writeUTF(testFileContent);
+		}
+		return file;
+	}
+
+	@AfterClass
+	public static void teardown() throws Exception {
+		hdfsCluster.shutdown();
+
+		if (miniClusterResource != null) {
+			miniClusterResource.after();
+		}
+	}
+
+	@Test
+	public void testDistributeFileViaDFS() throws Exception {
+
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setParallelism(1);
+
+		env.registerCachedFile(testFile.toString(), "test_data", false);
+		env.registerCachedFile(testDir.toString(), "test_dir", false);
+
+		env.fromElements(1)
+			.map(new TestMapFunction())
+			.print();
+
+		env.execute("Distributed Cache Via Blob Test Program");
+	}
+
+	static class TestMapFunction extends RichMapFunction<Integer, String> {
+
+		private static final long serialVersionUID = -3917258280687242969L;
+
+		@Override
+		public String map(Integer value) throws Exception {
+			final Path actualFile = new Path(getRuntimeContext().getDistributedCache().getFile("test_data").toURI());
+
+			Path path = new Path(actualFile.toUri());
+			assertFalse(path.getFileSystem().isDistributedFS());
+
+			DataInputStream in = new DataInputStream(actualFile.getFileSystem().open(actualFile));
+			String contents = in.readUTF();
+
+			assertEquals(testFileContent, contents);
+
+			final Path actualDir = new Path(getRuntimeContext().getDistributedCache().getFile("test_dir").toURI());
+			FileStatus fileStatus = actualDir.getFileSystem().getFileStatus(actualDir);
+			assertTrue(fileStatus.isDir());
+			FileStatus[] fileStatuses = actualDir.getFileSystem().listStatus(actualDir);
+			assertEquals(2, fileStatuses.length);
+
+			return contents;
+		}
+	}
+}

--- a/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/DistributedCacheDfsTest.java
+++ b/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/DistributedCacheDfsTest.java
@@ -132,7 +132,7 @@ public class DistributedCacheDfsTest {
 		env.execute("Distributed Cache Via Blob Test Program");
 	}
 
-	static class TestMapFunction extends RichMapFunction<Integer, String> {
+	private static class TestMapFunction extends RichMapFunction<Integer, String> {
 
 		private static final long serialVersionUID = -3917258280687242969L;
 

--- a/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/DistributedCacheDfsTest.java
+++ b/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/DistributedCacheDfsTest.java
@@ -65,10 +65,10 @@ public class DistributedCacheDfsTest {
 		+ "deine Boten, Herr, verehren Das sanfte Wandeln deines Tags.";
 
 	@ClassRule
-	public static TemporaryFolder tempFolder = new TemporaryFolder();
+	public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
 
 	@ClassRule
-	public static MiniClusterResource miniClusterResource  = new MiniClusterResource(
+	public static final MiniClusterResource MINI_CLUSTER_RESOURCE = new MiniClusterResource(
 		new MiniClusterResource.MiniClusterResourceConfiguration(
 			new org.apache.flink.configuration.Configuration(),
 			1,
@@ -82,7 +82,7 @@ public class DistributedCacheDfsTest {
 
 	@BeforeClass
 	public static void setup() throws Exception {
-		File dataDir = tempFolder.newFolder();
+		File dataDir = TEMP_FOLDER.newFolder();
 
 		conf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, dataDir.getAbsolutePath());
 		MiniDFSCluster.Builder builder = new MiniDFSCluster.Builder(conf);

--- a/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/DistributedCacheDfsTest.java
+++ b/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/DistributedCacheDfsTest.java
@@ -67,7 +67,13 @@ public class DistributedCacheDfsTest {
 	@ClassRule
 	public static TemporaryFolder tempFolder = new TemporaryFolder();
 
-	private static MiniClusterResource miniClusterResource;
+	@ClassRule
+	public static MiniClusterResource miniClusterResource  = new MiniClusterResource(
+		new MiniClusterResource.MiniClusterResourceConfiguration(
+			new org.apache.flink.configuration.Configuration(),
+			1,
+			1));
+
 	private static MiniDFSCluster hdfsCluster;
 	private static Configuration conf = new Configuration();
 
@@ -85,14 +91,6 @@ public class DistributedCacheDfsTest {
 		String hdfsURI = "hdfs://"
 			+ NetUtils.hostAndPortToUrlString(hdfsCluster.getURI().getHost(), hdfsCluster.getNameNodePort())
 			+ "/";
-
-		miniClusterResource = new MiniClusterResource(
-			new MiniClusterResource.MiniClusterResourceConfiguration(
-				new org.apache.flink.configuration.Configuration(),
-				1,
-				1));
-
-		miniClusterResource.before();
 
 		FileSystem dfs = FileSystem.get(new URI(hdfsURI));
 		testFile = writeFile(dfs, dfs.getHomeDirectory(), "testFile");
@@ -114,12 +112,8 @@ public class DistributedCacheDfsTest {
 	}
 
 	@AfterClass
-	public static void teardown() throws Exception {
+	public static void teardown() {
 		hdfsCluster.shutdown();
-
-		if (miniClusterResource != null) {
-			miniClusterResource.after();
-		}
 	}
 
 	@Test

--- a/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
@@ -844,7 +844,7 @@ public abstract class ExecutionEnvironment {
 	/**
 	 * Registers a file at the distributed cache under the given name. The file will be accessible
 	 * from any user-defined function in the (distributed) runtime under a local path. Files
-	 * may be local files (which will be distributed viaBlobServer), or files in a distributed file system.
+	 * may be local files (which will be distributed via BlobServer), or files in a distributed file system.
 	 * The runtime will copy the files temporarily to a local cache, if needed.
 	 *
 	 * <p>The {@link org.apache.flink.api.common.functions.RuntimeContext} can be obtained inside UDFs via
@@ -862,7 +862,7 @@ public abstract class ExecutionEnvironment {
 	/**
 	 * Registers a file at the distributed cache under the given name. The file will be accessible
 	 * from any user-defined function in the (distributed) runtime under a local path. Files
-	 * may be local files (which will be distributed viaBlobServer), or files in a distributed file system.
+	 * may be local files (which will be distributed via BlobServer), or files in a distributed file system.
 	 * The runtime will copy the files temporarily to a local cache, if needed.
 	 *
 	 * <p>The {@link org.apache.flink.api.common.functions.RuntimeContext} can be obtained inside UDFs via

--- a/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
@@ -844,7 +844,7 @@ public abstract class ExecutionEnvironment {
 	/**
 	 * Registers a file at the distributed cache under the given name. The file will be accessible
 	 * from any user-defined function in the (distributed) runtime under a local path. Files
-	 * may be local files (as long as all relevant workers have access to it), or files in a distributed file system.
+	 * may be local files (will be distributed via BlobServer), or files in a distributed file system.
 	 * The runtime will copy the files temporarily to a local cache, if needed.
 	 *
 	 * <p>The {@link org.apache.flink.api.common.functions.RuntimeContext} can be obtained inside UDFs via
@@ -862,7 +862,7 @@ public abstract class ExecutionEnvironment {
 	/**
 	 * Registers a file at the distributed cache under the given name. The file will be accessible
 	 * from any user-defined function in the (distributed) runtime under a local path. Files
-	 * may be local files (as long as all relevant workers have access to it), or files in a distributed file system.
+	 * may be local files (will be distributed via BlobServer), or files in a distributed file system.
 	 * The runtime will copy the files temporarily to a local cache, if needed.
 	 *
 	 * <p>The {@link org.apache.flink.api.common.functions.RuntimeContext} can be obtained inside UDFs via

--- a/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
@@ -844,7 +844,7 @@ public abstract class ExecutionEnvironment {
 	/**
 	 * Registers a file at the distributed cache under the given name. The file will be accessible
 	 * from any user-defined function in the (distributed) runtime under a local path. Files
-	 * may be local files (will be distributed via BlobServer), or files in a distributed file system.
+	 * may be local files (which will be distributed viaBlobServer), or files in a distributed file system.
 	 * The runtime will copy the files temporarily to a local cache, if needed.
 	 *
 	 * <p>The {@link org.apache.flink.api.common.functions.RuntimeContext} can be obtained inside UDFs via
@@ -862,7 +862,7 @@ public abstract class ExecutionEnvironment {
 	/**
 	 * Registers a file at the distributed cache under the given name. The file will be accessible
 	 * from any user-defined function in the (distributed) runtime under a local path. Files
-	 * may be local files (will be distributed via BlobServer), or files in a distributed file system.
+	 * may be local files (which will be distributed viaBlobServer), or files in a distributed file system.
 	 * The runtime will copy the files temporarily to a local cache, if needed.
 	 *
 	 * <p>The {@link org.apache.flink.api.common.functions.RuntimeContext} can be obtained inside UDFs via

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/filecache/FileCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/filecache/FileCache.java
@@ -55,7 +55,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
-import static org.apache.flink.util.FileUtils.copy;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -327,7 +326,7 @@ public class FileCache {
 		public Path call() throws IOException {
 			// let exceptions propagate. we can retrieve them later from
 			// the future and report them upon access to the result
-			copy(filePath, cachedPath, this.executable);
+			FileUtils.copy(filePath, cachedPath, this.executable);
 			return cachedPath;
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/filecache/FileCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/filecache/FileCache.java
@@ -55,6 +55,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
+import static org.apache.flink.util.FileUtils.copy;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -204,7 +205,12 @@ public class FileCache {
 				Path target = new Path(tempDirToUse.getAbsolutePath() + "/" + sourceFile);
 
 				// kick off the copying
-				Callable<Path> cp = new CopyFromBlobProcess(entry, jobID, blobService, target);
+				Callable<Path> cp;
+				if (entry.blobKey != null) {
+					cp = new CopyFromBlobProcess(entry, jobID, blobService, target);
+				} else {
+					cp = new CopyFromDFSProcess(entry, target);
+				}
 				FutureTask<Path> copyTask = new FutureTask<>(cp);
 				executorService.submit(copyTask);
 
@@ -299,6 +305,30 @@ public class FileCache {
 				return Path.fromLocalFile(file);
 			}
 
+		}
+	}
+
+	/**
+	 * Asynchronous file copy process.
+	 */
+	private static class CopyFromDFSProcess implements Callable<Path> {
+
+		private final Path filePath;
+		private final Path cachedPath;
+		private boolean executable;
+
+		public CopyFromDFSProcess(DistributedCacheEntry e, Path cachedPath) {
+			this.filePath = new Path(e.filePath);
+			this.executable = e.isExecutable;
+			this.cachedPath = cachedPath;
+		}
+
+		@Override
+		public Path call() throws IOException {
+			// let exceptions propagate. we can retrieve them later from
+			// the future and report them upon access to the result
+			copy(filePath, cachedPath, this.executable);
+			return cachedPath;
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
@@ -37,6 +37,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -580,29 +581,64 @@ public class JobGraph implements Serializable {
 		return "JobGraph(jobId: " + jobID + ")";
 	}
 
-	public void uploadUserArtifacts(InetSocketAddress blobServerAddress, Configuration clientConfig) throws IOException {
-		if (!userArtifacts.isEmpty()) {
+	/**
+	 * Configures JobGraph with user specified artifacts. If the files are in local system it uploads them
+	 * to the BLOB server, otherwise it just puts metadata for future remote access from within task executor.
+	 *
+	 * @param blobServerAddress of the blob server to upload the files to
+	 * @param blobClientConfig the blob client configuration
+	 * @throws IOException Thrown, if the file upload to the Blob server failed.
+	 */
+	public void uploadUserArtifacts(
+			InetSocketAddress blobServerAddress,
+			Configuration blobClientConfig) throws IOException {
+
+		Set<Map.Entry<String, DistributedCache.DistributedCacheEntry>> uploadToBlobServer = new HashSet<>();
+		Set<Map.Entry<String, DistributedCache.DistributedCacheEntry>> distributeViaDFS = new HashSet<>();
+
+		for (Map.Entry<String, DistributedCache.DistributedCacheEntry> userArtifact : userArtifacts.entrySet()) {
+			Path filePath = new Path(userArtifact.getValue().filePath);
+
+			try {
+				if (filePath.getFileSystem().isDistributedFS()) {
+					distributeViaDFS.add(userArtifact);
+				} else {
+					uploadToBlobServer.add(userArtifact);
+				}
+
+			} catch (IOException ex) {
+				distributeViaDFS.add(userArtifact);
+			}
+		}
+
+		uploadViaBlob(blobServerAddress, blobClientConfig, uploadToBlobServer);
+
+		for (Map.Entry<String, DistributedCache.DistributedCacheEntry> userArtifact : distributeViaDFS) {
+			DistributedCache.writeFileInfoToConfig(
+				userArtifact.getKey(),
+				userArtifact.getValue(),
+				jobConfiguration
+			);
+		}
+	}
+
+	private void uploadViaBlob(
+			InetSocketAddress blobServerAddress,
+			Configuration clientConfig,
+			Set<Map.Entry<String, DistributedCache.DistributedCacheEntry>> uploadToBlobServer) throws IOException {
+		if (!uploadToBlobServer.isEmpty()) {
 			try (BlobClient blobClient = new BlobClient(blobServerAddress, clientConfig)) {
-				for (Map.Entry<String, DistributedCache.DistributedCacheEntry> userArtifact : userArtifacts.entrySet()) {
-					Path filePath = new Path(userArtifact.getValue().filePath);
+				for (Map.Entry<String, DistributedCache.DistributedCacheEntry> userArtifact : uploadToBlobServer) {
+					final PermanentBlobKey key = blobClient.uploadFile(jobID,
+						new Path(userArtifact.getValue().filePath));
 
-					if (filePath.getFileSystem().isDistributedFS()) {
-						DistributedCache.writeFileInfoToConfig(
-							userArtifact.getKey(),
-							userArtifact.getValue(),
-							jobConfiguration
-						);
-					} else {
-						final PermanentBlobKey key = blobClient.uploadFile(jobID, filePath);
-
-						DistributedCache.writeFileInfoToConfig(
-							userArtifact.getKey(),
-							new DistributedCache.DistributedCacheEntry(
-								userArtifact.getValue().filePath,
-								userArtifact.getValue().isExecutable,
-								InstantiationUtil.serializeObject(key)),
-							jobConfiguration);
-					}
+					DistributedCache.writeFileInfoToConfig(
+						userArtifact.getKey(),
+						new DistributedCache.DistributedCacheEntry(
+							userArtifact.getValue().filePath,
+							userArtifact.getValue().isExecutable,
+							InstantiationUtil.serializeObject(key)),
+						jobConfiguration);
 				}
 			}
 		}

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
@@ -493,9 +493,9 @@ class ExecutionEnvironment(javaEnv: JavaEnv) {
   /**
    * Registers a file at the distributed cache under the given name. The file will be accessible
    * from any user-defined function in the (distributed) runtime under a local path. Files
-    * may be local files (will be distributed via BlobServer), or files in a distributed file
-    * system. The runtime will copy the files temporarily to a local cache,
-    * if needed.
+   * may be local files (which will be distributed via BlobServer), or files in a distributed file
+   * system. The runtime will copy the files temporarily to a local cache,
+   * if needed.
    *
    * The [[org.apache.flink.api.common.functions.RuntimeContext]] can be obtained inside UDFs
    * via

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
@@ -493,9 +493,9 @@ class ExecutionEnvironment(javaEnv: JavaEnv) {
   /**
    * Registers a file at the distributed cache under the given name. The file will be accessible
    * from any user-defined function in the (distributed) runtime under a local path. Files
-   * may be local files (as long as all relevant workers have access to it),
-   * or files in a distributed file system.
-   * The runtime will copy the files temporarily to a local cache, if needed.
+    * may be local files (will be distributed via BlobServer), or files in a distributed file
+    * system. The runtime will copy the files temporarily to a local cache,
+    * if needed.
    *
    * The [[org.apache.flink.api.common.functions.RuntimeContext]] can be obtained inside UDFs
    * via

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
@@ -494,8 +494,7 @@ class ExecutionEnvironment(javaEnv: JavaEnv) {
    * Registers a file at the distributed cache under the given name. The file will be accessible
    * from any user-defined function in the (distributed) runtime under a local path. Files
    * may be local files (which will be distributed via BlobServer), or files in a distributed file
-   * system. The runtime will copy the files temporarily to a local cache,
-   * if needed.
+   * system. The runtime will copy the files temporarily to a local cache, if needed.
    *
    * The [[org.apache.flink.api.common.functions.RuntimeContext]] can be obtained inside UDFs
    * via

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -1804,7 +1804,7 @@ public abstract class StreamExecutionEnvironment {
 	/**
 	 * Registers a file at the distributed cache under the given name. The file will be accessible
 	 * from any user-defined function in the (distributed) runtime under a local path. Files
-	 * may be local files (which will be distributed viaBlobServer), or files in a distributed file system.
+	 * may be local files (which will be distributed via BlobServer), or files in a distributed file system.
 	 * The runtime will copy the files temporarily to a local cache, if needed.
 	 *
 	 * <p>The {@link org.apache.flink.api.common.functions.RuntimeContext} can be obtained inside UDFs via
@@ -1822,7 +1822,7 @@ public abstract class StreamExecutionEnvironment {
 	/**
 	 * Registers a file at the distributed cache under the given name. The file will be accessible
 	 * from any user-defined function in the (distributed) runtime under a local path. Files
-	 * may be local files (which will be distributed viaBlobServer), or files in a distributed file system.
+	 * may be local files (which will be distributed via BlobServer), or files in a distributed file system.
 	 * The runtime will copy the files temporarily to a local cache, if needed.
 	 *
 	 * <p>The {@link org.apache.flink.api.common.functions.RuntimeContext} can be obtained inside UDFs via

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -1804,7 +1804,7 @@ public abstract class StreamExecutionEnvironment {
 	/**
 	 * Registers a file at the distributed cache under the given name. The file will be accessible
 	 * from any user-defined function in the (distributed) runtime under a local path. Files
-	 * may be local files (as long as all relevant workers have access to it), or files in a distributed file system.
+	 * may be local files (will be distributed via BlobServer), or files in a distributed file system.
 	 * The runtime will copy the files temporarily to a local cache, if needed.
 	 *
 	 * <p>The {@link org.apache.flink.api.common.functions.RuntimeContext} can be obtained inside UDFs via
@@ -1822,7 +1822,7 @@ public abstract class StreamExecutionEnvironment {
 	/**
 	 * Registers a file at the distributed cache under the given name. The file will be accessible
 	 * from any user-defined function in the (distributed) runtime under a local path. Files
-	 * may be local files (as long as all relevant workers have access to it), or files in a distributed file system.
+	 * may be local files (will be distributed via BlobServer), or files in a distributed file system.
 	 * The runtime will copy the files temporarily to a local cache, if needed.
 	 *
 	 * <p>The {@link org.apache.flink.api.common.functions.RuntimeContext} can be obtained inside UDFs via

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -1804,7 +1804,7 @@ public abstract class StreamExecutionEnvironment {
 	/**
 	 * Registers a file at the distributed cache under the given name. The file will be accessible
 	 * from any user-defined function in the (distributed) runtime under a local path. Files
-	 * may be local files (will be distributed via BlobServer), or files in a distributed file system.
+	 * may be local files (which will be distributed viaBlobServer), or files in a distributed file system.
 	 * The runtime will copy the files temporarily to a local cache, if needed.
 	 *
 	 * <p>The {@link org.apache.flink.api.common.functions.RuntimeContext} can be obtained inside UDFs via
@@ -1822,7 +1822,7 @@ public abstract class StreamExecutionEnvironment {
 	/**
 	 * Registers a file at the distributed cache under the given name. The file will be accessible
 	 * from any user-defined function in the (distributed) runtime under a local path. Files
-	 * may be local files (will be distributed via BlobServer), or files in a distributed file system.
+	 * may be local files (which will be distributed viaBlobServer), or files in a distributed file system.
 	 * The runtime will copy the files temporarily to a local cache, if needed.
 	 *
 	 * <p>The {@link org.apache.flink.api.common.functions.RuntimeContext} can be obtained inside UDFs via

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
@@ -693,7 +693,7 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
   /**
     * Registers a file at the distributed cache under the given name. The file will be accessible
     * from any user-defined function in the (distributed) runtime under a local path. Files
-    * may be local files (will be distributed via BlobServer), or files in a distributed file
+    * may be local files (which will be distributed via BlobServer), or files in a distributed file
     * system. The runtime will copy the files temporarily to a local cache,
     * if needed.
     * <p>
@@ -713,7 +713,7 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
   /**
     * Registers a file at the distributed cache under the given name. The file will be accessible
     * from any user-defined function in the (distributed) runtime under a local path. Files
-    * may be local files (will be distributed via BlobServer), or files in a distributed file
+    * may be local files (which will be distributed via BlobServer), or files in a distributed file
     * system. The runtime will copy the files temporarily to a local cache,
     * if needed.
     * <p>

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
@@ -690,33 +690,11 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
     f
   }
 
-
   /**
     * Registers a file at the distributed cache under the given name. The file will be accessible
     * from any user-defined function in the (distributed) runtime under a local path. Files
-    * may be local files (as long as all relevant workers have access to it), or files in a
-    * distributed file system. The runtime will copy the files temporarily to a local cache,
-    * if needed.
-    * <p>
-    * The {@link org.apache.flink.api.common.functions.RuntimeContext} can be obtained inside UDFs
-    * via {@link org.apache.flink.api.common.functions.RichFunction#getRuntimeContext()} and
-    * provides access {@link org.apache.flink.api.common.cache.DistributedCache} via
-    * {@link org.apache.flink.api.common.functions.RuntimeContext#getDistributedCache()}.
-    *
-    * @param filePath The path of the file, as a URI (e.g. "file:///some/path" or
-    *                 "hdfs://host:port/and/path")
-    * @param name     The name under which the file is registered.
-    */
-  def registerCachedFile(filePath: String, name: String): Unit = {
-    javaEnv.registerCachedFile(filePath, name)
-  }
-
-
-  /**
-    * Registers a file at the distributed cache under the given name. The file will be accessible
-    * from any user-defined function in the (distributed) runtime under a local path. Files
-    * may be local files (as long as all relevant workers have access to it), or files in a
-    * distributed file system. The runtime will copy the files temporarily to a local cache,
+    * may be local files (will be distributed via BlobServer), or files in a distributed file
+    * system. The runtime will copy the files temporarily to a local cache,
     * if needed.
     * <p>
     * The {@link org.apache.flink.api.common.functions.RuntimeContext} can be obtained inside UDFs
@@ -729,7 +707,7 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
     * @param name       The name under which the file is registered.
     * @param executable flag indicating whether the file should be executable
     */
-  def registerCachedFile(filePath: String, name: String, executable: Boolean): Unit = {
+  def registerCachedFile(filePath: String, name: String, executable: Boolean = false): Unit = {
     javaEnv.registerCachedFile(filePath, name, executable)
   }
 }

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
@@ -694,9 +694,8 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
     * Registers a file at the distributed cache under the given name. The file will be accessible
     * from any user-defined function in the (distributed) runtime under a local path. Files
     * may be local files (which will be distributed via BlobServer), or files in a distributed file
-    * system. The runtime will copy the files temporarily to a local cache,
-    * if needed.
-    * <p>
+    * system. The runtime will copy the files temporarily to a local cache, if needed.
+    *
     * The {@link org.apache.flink.api.common.functions.RuntimeContext} can be obtained inside UDFs
     * via {@link org.apache.flink.api.common.functions.RichFunction#getRuntimeContext()} and
     * provides access {@link org.apache.flink.api.common.cache.DistributedCache} via
@@ -714,9 +713,8 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
     * Registers a file at the distributed cache under the given name. The file will be accessible
     * from any user-defined function in the (distributed) runtime under a local path. Files
     * may be local files (which will be distributed via BlobServer), or files in a distributed file
-    * system. The runtime will copy the files temporarily to a local cache,
-    * if needed.
-    * <p>
+    * system. The runtime will copy the files temporarily to a local cache, if needed.
+    *
     * The {@link org.apache.flink.api.common.functions.RuntimeContext} can be obtained inside UDFs
     * via {@link org.apache.flink.api.common.functions.RichFunction#getRuntimeContext()} and
     * provides access {@link org.apache.flink.api.common.cache.DistributedCache} via

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
@@ -702,12 +702,32 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
     * provides access {@link org.apache.flink.api.common.cache.DistributedCache} via
     * {@link org.apache.flink.api.common.functions.RuntimeContext#getDistributedCache()}.
     *
+    * @param filePath The path of the file, as a URI (e.g. "file:///some/path" or
+    *                 "hdfs://host:port/and/path")
+    * @param name     The name under which the file is registered.
+    */
+  def registerCachedFile(filePath: String, name: String): Unit = {
+    javaEnv.registerCachedFile(filePath, name)
+  }
+
+  /**
+    * Registers a file at the distributed cache under the given name. The file will be accessible
+    * from any user-defined function in the (distributed) runtime under a local path. Files
+    * may be local files (will be distributed via BlobServer), or files in a distributed file
+    * system. The runtime will copy the files temporarily to a local cache,
+    * if needed.
+    * <p>
+    * The {@link org.apache.flink.api.common.functions.RuntimeContext} can be obtained inside UDFs
+    * via {@link org.apache.flink.api.common.functions.RichFunction#getRuntimeContext()} and
+    * provides access {@link org.apache.flink.api.common.cache.DistributedCache} via
+    * {@link org.apache.flink.api.common.functions.RuntimeContext#getDistributedCache()}.
+    *
     * @param filePath   The path of the file, as a URI (e.g. "file:///some/path" or
     *                   "hdfs://host:port/and/path")
     * @param name       The name under which the file is registered.
     * @param executable flag indicating whether the file should be executable
     */
-  def registerCachedFile(filePath: String, name: String, executable: Boolean = false): Unit = {
+  def registerCachedFile(filePath: String, name: String, executable: Boolean): Unit = {
     javaEnv.registerCachedFile(filePath, name, executable)
   }
 }

--- a/tools/maven/suppressions-core.xml
+++ b/tools/maven/suppressions-core.xml
@@ -76,7 +76,7 @@ under the License.
 		checks="AvoidStarImport|ArrayTypeStyle|Regexp"/>
 
 	<suppress
-		files="(.*)api[/\\]common[/\\](cache|distributions|restartstrategy)[/\\](.*)"
+		files="(.*)api[/\\]common[/\\](distributions|restartstrategy)[/\\](.*)"
 		checks="NewlineAtEndOfFile|RegexpSingleline|TodoComment|RedundantImport|ImportOrder|RedundantModifier|JavadocMethod|JavadocParagraph|JavadocType|JavadocStyle|PackageName|TypeNameCheck|ConstantNameCheck|StaticVariableNameCheck|MemberNameCheck|MethodNameCheck|ParameterName|LocalFinalVariableName|LocalVariableName|LeftCurly|UpperEll|FallThrough|reliefPattern|SimplifyBooleanExpression|EmptyStatement|ModifierOrder|EmptyLineSeparator|WhitespaceAround|WhitespaceAfter|NoWhitespaceAfter|NoWhitespaceBefore|OperatorWrap|ParenPad"/>
 
 	<suppress


### PR DESCRIPTION
## What is the purpose of the change

Allows to use DistributeCache to cache files from cluster internal DFS (reverted behaviour).

## Brief change log

*(for example:)*
  - Local files (based on uri schema) are distributed via BlobServer
  - Files in DFS are cached from DFS

## Verifying this change

* Added test for distributing files through DFS: org.apache.flink.hdfstests.DistributedCacheDfsTest
* local files shipping covered by previous tests 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no 
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no 
  - The S3 file system connector: no 

## Documentation

  - Does this pull request introduce a new feature? no
