### PR TITLE
[FLINK-9483] 'Building Flink' doc doesn't highlight quick build command

### DIFF
--- a/docs/start/building.md
+++ b/docs/start/building.md
@@ -50,10 +50,10 @@ mvn clean install -DskipTests
 
 This instructs [Maven](http://maven.apache.org) (`mvn`) to first remove all existing builds (`clean`) and then create a new Flink binary (`install`).
 
-To speed up the build you can skip tests, checkstyle, and JavaDocs:
+To speed up the build you can skip tests, QA plugins, and JavaDocs:
 
 {% highlight bash %}
-mvn clean install -DskipTests -Dmaven.javadoc.skip=true -Dcheckstyle.skip=true
+mvn clean install -DskipTests -Dfast
 {% endhighlight %}
 
 The default build adds a Flink-specific JAR for Hadoop 2, to allow using Flink with HDFS and YARN.

--- a/docs/start/building.md
+++ b/docs/start/building.md
@@ -50,7 +50,11 @@ mvn clean install -DskipTests
 
 This instructs [Maven](http://maven.apache.org) (`mvn`) to first remove all existing builds (`clean`) and then create a new Flink binary (`install`).
 
-To speed up the build you can skip tests, checkstyle, and JavaDocs: `mvn clean install -DskipTests -Dmaven.javadoc.skip=true -Dcheckstyle.skip=true`.
+To speed up the build you can skip tests, checkstyle, and JavaDocs:
+
+{% highlight bash %}
+mvn clean install -DskipTests -Dmaven.javadoc.skip=true -Dcheckstyle.skip=true
+{% endhighlight %}
 
 The default build adds a Flink-specific JAR for Hadoop 2, to allow using Flink with HDFS and YARN.
 


### PR DESCRIPTION
## What is the purpose of the change

The blue part isn't corrected highlighted as the red ones

![screen shot 2018-05-31 at 4 12 32 pm](https://user-images.githubusercontent.com/1892692/40813097-ff439950-64ed-11e8-8a10-512934d89116.png)

## Brief change log

Highlight quick build command

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

none

## Documentation

none