### PR TITLE
[FLINK-9504]Change the log level of checkpoint duration to debug

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackend.java
@@ -452,7 +452,7 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 					}
 
 					if (asynchronousSnapshots) {
-						LOG.info("DefaultOperatorStateBackend snapshot ({}, asynchronous part) in thread {} took {} ms.",
+						LOG.debug("DefaultOperatorStateBackend snapshot ({}, asynchronous part) in thread {} took {} ms.",
 							streamFactory, Thread.currentThread(), (System.currentTimeMillis() - asyncStartTime));
 					}
 
@@ -467,7 +467,7 @@ public class DefaultOperatorStateBackend implements OperatorStateBackend {
 			task.run();
 		}
 
-		LOG.info("DefaultOperatorStateBackend snapshot ({}, synchronous part) in thread {} took {} ms.",
+		LOG.debug("DefaultOperatorStateBackend snapshot ({}, synchronous part) in thread {} took {} ms.",
 				streamFactory, Thread.currentThread(), (System.currentTimeMillis() - syncStartTime));
 
 		return task;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
@@ -529,7 +529,7 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 
 		@Override
 		public void logOperationCompleted(CheckpointStreamFactory streamFactory, long startTime) {
-			LOG.info("Heap backend snapshot ({}, asynchronous part) in thread {} took {} ms.",
+			LOG.debug("Heap backend snapshot ({}, asynchronous part) in thread {} took {} ms.",
 				streamFactory, Thread.currentThread(), (System.currentTimeMillis() - startTime));
 		}
 
@@ -717,7 +717,7 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 
 			finalizeSnapshotBeforeReturnHook(task);
 
-			LOG.info("Heap backend snapshot (" + primaryStreamFactory + ", synchronous part) in thread " +
+			LOG.debug("Heap backend snapshot (" + primaryStreamFactory + ", synchronous part) in thread " +
 				Thread.currentThread() + " took " + (System.currentTimeMillis() - syncStartTime) + " ms.");
 
 			return task;

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
@@ -1736,14 +1736,14 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 
 						snapshotOperation.writeDBSnapshot();
 
-						LOG.info("Asynchronous RocksDB snapshot ({}, asynchronous part) in thread {} took {} ms.",
+						LOG.debug("Asynchronous RocksDB snapshot ({}, asynchronous part) in thread {} took {} ms.",
 							primaryStreamFactory, Thread.currentThread(), (System.currentTimeMillis() - startTime));
 
 						return snapshotOperation.getSnapshotResultStateHandle();
 					}
 				};
 
-			LOG.info("Asynchronous RocksDB snapshot ({}, synchronous part) in thread {} took {} ms.",
+			LOG.debug("Asynchronous RocksDB snapshot ({}, synchronous part) in thread {} took {} ms.",
 				primaryStreamFactory, Thread.currentThread(), (System.currentTimeMillis() - startTime));
 			return AsyncStoppableTaskWithCallback.from(ioCallable);
 		}
@@ -2185,7 +2185,7 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
 
 			writeDBSnapshot();
 
-			LOG.info("Asynchronous RocksDB snapshot ({}, asynchronous part) in thread {} took {} ms.",
+			LOG.debug("Asynchronous RocksDB snapshot ({}, asynchronous part) in thread {} took {} ms.",
 				checkpointStreamSupplier, Thread.currentThread(), (System.currentTimeMillis() - startTime));
 
 			return getSnapshotResultStateHandle();


### PR DESCRIPTION
Now, every time checkpoint it will log with the OperatorStateBackend and KeyedStateBackend with per partition/parallel time cost, it often lead to too much log in TaskManager , i think the log level should change to the debug, is it ok ? @StephanEwen  