### PR TITLE
[FLINK-9508][Docs]General Spell Check on Flink Docs

### DIFF
--- a/docs/dev/execution_configuration.md
+++ b/docs/dev/execution_configuration.md
@@ -45,13 +45,13 @@ The following configuration options are available: (the default is bold)
 - **`enableClosureCleaner()`** / `disableClosureCleaner()`. The closure cleaner is enabled by default. The closure cleaner removes unneeded references to the surrounding class of anonymous functions inside Flink programs.
 With the closure cleaner disabled, it might happen that an anonymous user function is referencing the surrounding class, which is usually not Serializable. This will lead to exceptions by the serializer.
 
-- `getParallelism()` / `setParallelism(int parallelism)`. Set the default parallelism for the job.
+- `getParallelism()` / `setParallelism(int parallelism)` Set the default parallelism for the job.
 
-- `getMaxParallelism()` / `setMaxParallelism(int parallelism)`. Set the default maximum parallelism for the job. This setting determines the maximum degree of parallelism and specifies the upper limit for dynamic scaling.
+- `getMaxParallelism()` / `setMaxParallelism(int parallelism)` Set the default maximum parallelism for the job. This setting determines the maximum degree of parallelism and specifies the upper limit for dynamic scaling.
 
-- `getNumberOfExecutionRetries()` / `setNumberOfExecutionRetries(int numberOfExecutionRetries)`. Sets the number of times that failed tasks are re-executed. A value of zero effectively disables fault tolerance. A value of `-1` indicates that the system default value (as defined in the configuration) should be used. This is deprecated, use [restart strategies]({{ site.baseurl }}/dev/restart_strategies.html) instead.
+- `getNumberOfExecutionRetries()` / `setNumberOfExecutionRetries(int numberOfExecutionRetries)` Sets the number of times that failed tasks are re-executed. A value of zero effectively disables fault tolerance. A value of `-1` indicates that the system default value (as defined in the configuration) should be used. This is deprecated, use [restart strategies]({{ site.baseurl }}/dev/restart_strategies.html) instead.
 
-- `getExecutionRetryDelay()` / `setExecutionRetryDelay(long executionRetryDelay)`. Sets the delay in milliseconds that the system waits after a job has failed, before re-executing it. The delay starts after all tasks have been successfully been stopped on the TaskManagers, and once the delay is past, the tasks are re-started. This parameter is useful to delay re-execution in order to let certain time-out related failures surface fully (like broken connections that have not fully timed out), before attempting a re-execution and immediately failing again due to the same problem. This parameter only has an effect if the number of execution re-tries is one or more. This is deprecated, use [restart strategies]({{ site.baseurl }}/dev/restart_strategies.html) instead.
+- `getExecutionRetryDelay()` / `setExecutionRetryDelay(long executionRetryDelay)` Sets the delay in milliseconds that the system waits after a job has failed, before re-executing it. The delay starts after all tasks have been successfully been stopped on the TaskManagers, and once the delay is past, the tasks are re-started. This parameter is useful to delay re-execution in order to let certain time-out related failures surface fully (like broken connections that have not fully timed out), before attempting a re-execution and immediately failing again due to the same problem. This parameter only has an effect if the number of execution re-tries is one or more. This is deprecated, use [restart strategies]({{ site.baseurl }}/dev/restart_strategies.html) instead.
 
 - `getExecutionMode()` / `setExecutionMode()`. The default execution mode is PIPELINED. Sets the execution mode to execute the program. The execution mode defines whether data exchanges are performed in a batch or on a pipelined manner.
 
@@ -59,27 +59,27 @@ With the closure cleaner disabled, it might happen that an anonymous user functi
 
 - `enableForceAvro()` / **`disableForceAvro()`**. Avro is not forced by default. Forces the Flink AvroTypeInformation to use the Avro serializer instead of Kryo for serializing Avro POJOs.
 
-- `enableObjectReuse()` / **`disableObjectReuse()`**. By default, objects are not reused in Flink. Enabling the object reuse mode will instruct the runtime to reuse user objects for better performance. Keep in mind that this can lead to bugs when the user-code function of an operation is not aware of this behavior.
+- `enableObjectReuse()` / **`disableObjectReuse()`** By default, objects are not reused in Flink. Enabling the object reuse mode will instruct the runtime to reuse user objects for better performance. Keep in mind that this can lead to bugs when the user-code function of an operation is not aware of this behavior.
 
-- **`enableSysoutLogging()`** / `disableSysoutLogging()`. JobManager status updates are printed to `System.out` by default. This setting allows to disable this behavior.
+- **`enableSysoutLogging()`** / `disableSysoutLogging()` JobManager status updates are printed to `System.out` by default. This setting allows to disable this behavior.
 
-- `getGlobalJobParameters()` / `setGlobalJobParameters(GlobalJobParameters globalJobParameters)`. This method allows users to set custom objects as a global configuration for the job. Since the `ExecutionConfig` is accessible in all user defined functions, this is an easy method for making configuration globally available in a job.
+- `getGlobalJobParameters()` / `setGlobalJobParameters()` This method allows users to set custom objects as a global configuration for the job. Since the `ExecutionConfig` is accessible in all user defined functions, this is an easy method for making configuration globally available in a job.
 
-- `addDefaultKryoSerializer(Class<?> type, Serializer<?> serializer)`. Register a Kryo serializer instance for the given `type`.
+- `addDefaultKryoSerializer(Class<?> type, Serializer<?> serializer)` Register a Kryo serializer instance for the given `type`.
 
-- `addDefaultKryoSerializer(Class<?> type, Class<? extends Serializer<?>> serializerClass)`. Register a Kryo serializer class for the given `type`.
+- `addDefaultKryoSerializer(Class<?> type, Class<? extends Serializer<?>> serializerClass)` Register a Kryo serializer class for the given `type`.
 
-- `registerTypeWithKryoSerializer(Class<?> type, Serializer<?> serializer)`. Register the given type with Kryo and specify a serializer for it. By registering a type with Kryo, the serialization of the type will be much more efficient.
+- `registerTypeWithKryoSerializer(Class<?> type, Serializer<?> serializer)` Register the given type with Kryo and specify a serializer for it. By registering a type with Kryo, the serialization of the type will be much more efficient.
 
-- `registerKryoType(Class<?> type)`. If the type ends up being serialized with Kryo, then it will be registered at Kryo to make sure that only tags (integer IDs) are written. If a type is not registered with Kryo, its entire class-name will be serialized with every instance, leading to much higher I/O costs.
+- `registerKryoType(Class<?> type)` If the type ends up being serialized with Kryo, then it will be registered at Kryo to make sure that only tags (integer IDs) are written. If a type is not registered with Kryo, its entire class-name will be serialized with every instance, leading to much higher I/O costs.
 
-- `registerPojoType(Class<?> type)`. Registers the given type with the serialization stack. If the type is eventually serialized as a POJO, then the type is registered with the POJO serializer. If the type ends up being serialized with Kryo, then it will be registered at Kryo to make sure that only tags are written. If a type is not registered with Kryo, its entire class-name will be serialized with every instance, leading to much higher I/O costs.
+- `registerPojoType(Class<?> type)` Registers the given type with the serialization stack. If the type is eventually serialized as a POJO, then the type is registered with the POJO serializer. If the type ends up being serialized with Kryo, then it will be registered at Kryo to make sure that only tags are written. If a type is not registered with Kryo, its entire class-name will be serialized with every instance, leading to much higher I/O costs.
 
 Note that types registered with `registerKryoType()` are not available to Flink's Kryo serializer instance.
 
-- `disableAutoTypeRegistration()`. Automatic type registration is enabled by default. The automatic type registration is registering all types (including sub-types) used by usercode with Kryo and the POJO serializer.
+- `disableAutoTypeRegistration()` Automatic type registration is enabled by default. The automatic type registration is registering all types (including sub-types) used by usercode with Kryo and the POJO serializer.
 
-- `setTaskCancellationInterval(long interval)`. Sets the interval (in milliseconds) to wait between consecutive attempts to cancel a running task. When a task is canceled a new thread is created which periodically calls `interrupt()` on the task thread, if the task thread does not terminate within a certain time. This parameter refers to the time between consecutive calls to `interrupt()` and is set by default to **30000** milliseconds, or **30 seconds**.
+- `setTaskCancellationInterval(long interval)` Sets the interval (in milliseconds) to wait between consecutive attempts to cancel a running task. When a task is canceled a new thread is created which periodically calls `interrupt()` on the task thread, if the task thread does not terminate within a certain time. This parameter refers to the time between consecutive calls to `interrupt()` and is set by default to **30000** milliseconds, or **30 seconds**.
 
 The `RuntimeContext` which is accessible in `Rich*` functions through the `getRuntimeContext()` method also allows to access the `ExecutionConfig` in all user defined functions.
 

--- a/docs/dev/execution_configuration.md
+++ b/docs/dev/execution_configuration.md
@@ -45,41 +45,41 @@ The following configuration options are available: (the default is bold)
 - **`enableClosureCleaner()`** / `disableClosureCleaner()`. The closure cleaner is enabled by default. The closure cleaner removes unneeded references to the surrounding class of anonymous functions inside Flink programs.
 With the closure cleaner disabled, it might happen that an anonymous user function is referencing the surrounding class, which is usually not Serializable. This will lead to exceptions by the serializer.
 
-- `getParallelism()` / `setParallelism(int parallelism)` Set the default parallelism for the job.
+- `getParallelism()` / `setParallelism(int parallelism)`. Set the default parallelism for the job.
 
-- `getMaxParallelism()` / `setMaxParallelism(int parallelism)` Set the default maximum parallelism for the job. This setting determines the maximum degree of parallelism and specifies the upper limit for dynamic scaling.
+- `getMaxParallelism()` / `setMaxParallelism(int parallelism)`. Set the default maximum parallelism for the job. This setting determines the maximum degree of parallelism and specifies the upper limit for dynamic scaling.
 
-- `getNumberOfExecutionRetries()` / `setNumberOfExecutionRetries(int numberOfExecutionRetries)` Sets the number of times that failed tasks are re-executed. A value of zero effectively disables fault tolerance. A value of `-1` indicates that the system default value (as defined in the configuration) should be used. This is deprecated, use [restart strategies]({{ site.baseurl }}/dev/restart_strategies.html) instead.
+- `getNumberOfExecutionRetries()` / `setNumberOfExecutionRetries(int numberOfExecutionRetries)`. Sets the number of times that failed tasks are re-executed. A value of zero effectively disables fault tolerance. A value of `-1` indicates that the system default value (as defined in the configuration) should be used. This is deprecated, use [restart strategies]({{ site.baseurl }}/dev/restart_strategies.html) instead.
 
-- `getExecutionRetryDelay()` / `setExecutionRetryDelay(long executionRetryDelay)` Sets the delay in milliseconds that the system waits after a job has failed, before re-executing it. The delay starts after all tasks have been successfully been stopped on the TaskManagers, and once the delay is past, the tasks are re-started. This parameter is useful to delay re-execution in order to let certain time-out related failures surface fully (like broken connections that have not fully timed out), before attempting a re-execution and immediately failing again due to the same problem. This parameter only has an effect if the number of execution re-tries is one or more. This is deprecated, use [restart strategies]({{ site.baseurl }}/dev/restart_strategies.html) instead.
+- `getExecutionRetryDelay()` / `setExecutionRetryDelay(long executionRetryDelay)`. Sets the delay in milliseconds that the system waits after a job has failed, before re-executing it. The delay starts after all tasks have been successfully been stopped on the TaskManagers, and once the delay is past, the tasks are re-started. This parameter is useful to delay re-execution in order to let certain time-out related failures surface fully (like broken connections that have not fully timed out), before attempting a re-execution and immediately failing again due to the same problem. This parameter only has an effect if the number of execution re-tries is one or more. This is deprecated, use [restart strategies]({{ site.baseurl }}/dev/restart_strategies.html) instead.
 
 - `getExecutionMode()` / `setExecutionMode()`. The default execution mode is PIPELINED. Sets the execution mode to execute the program. The execution mode defines whether data exchanges are performed in a batch or on a pipelined manner.
 
-- `enableForceKryo()` / **`disableForceKryo`**. Kryo is not forced by default. Forces the GenericTypeInformation to use the Kryo serializer for POJOS even though we could analyze them as a POJO. In some cases this might be preferable. For example, when Flink's internal serializers fail to handle a POJO properly.
+- `enableForceKryo()` / **`disableForceKryo`**. Kryo is not forced by default. Forces the GenericTypeInformation to use the Kryo serializer for POJOs even though we could analyze them as a POJO. In some cases this might be preferable. For example, when Flink's internal serializers fail to handle a POJO properly.
 
 - `enableForceAvro()` / **`disableForceAvro()`**. Avro is not forced by default. Forces the Flink AvroTypeInformation to use the Avro serializer instead of Kryo for serializing Avro POJOs.
 
-- `enableObjectReuse()` / **`disableObjectReuse()`** By default, objects are not reused in Flink. Enabling the object reuse mode will instruct the runtime to reuse user objects for better performance. Keep in mind that this can lead to bugs when the user-code function of an operation is not aware of this behavior.
+- `enableObjectReuse()` / **`disableObjectReuse()`**. By default, objects are not reused in Flink. Enabling the object reuse mode will instruct the runtime to reuse user objects for better performance. Keep in mind that this can lead to bugs when the user-code function of an operation is not aware of this behavior.
 
-- **`enableSysoutLogging()`** / `disableSysoutLogging()` JobManager status updates are printed to `System.out` by default. This setting allows to disable this behavior.
+- **`enableSysoutLogging()`** / `disableSysoutLogging()`. JobManager status updates are printed to `System.out` by default. This setting allows to disable this behavior.
 
-- `getGlobalJobParameters()` / `setGlobalJobParameters()` This method allows users to set custom objects as a global configuration for the job. Since the `ExecutionConfig` is accessible in all user defined functions, this is an easy method for making configuration globally available in a job.
+- `getGlobalJobParameters()` / `setGlobalJobParameters(GlobalJobParameters globalJobParameters)`. This method allows users to set custom objects as a global configuration for the job. Since the `ExecutionConfig` is accessible in all user defined functions, this is an easy method for making configuration globally available in a job.
 
-- `addDefaultKryoSerializer(Class<?> type, Serializer<?> serializer)` Register a Kryo serializer instance for the given `type`.
+- `addDefaultKryoSerializer(Class<?> type, Serializer<?> serializer)`. Register a Kryo serializer instance for the given `type`.
 
-- `addDefaultKryoSerializer(Class<?> type, Class<? extends Serializer<?>> serializerClass)` Register a Kryo serializer class for the given `type`.
+- `addDefaultKryoSerializer(Class<?> type, Class<? extends Serializer<?>> serializerClass)`. Register a Kryo serializer class for the given `type`.
 
-- `registerTypeWithKryoSerializer(Class<?> type, Serializer<?> serializer)` Register the given type with Kryo and specify a serializer for it. By registering a type with Kryo, the serialization of the type will be much more efficient.
+- `registerTypeWithKryoSerializer(Class<?> type, Serializer<?> serializer)`. Register the given type with Kryo and specify a serializer for it. By registering a type with Kryo, the serialization of the type will be much more efficient.
 
-- `registerKryoType(Class<?> type)` If the type ends up being serialized with Kryo, then it will be registered at Kryo to make sure that only tags (integer IDs) are written. If a type is not registered with Kryo, its entire class-name will be serialized with every instance, leading to much higher I/O costs.
+- `registerKryoType(Class<?> type)`. If the type ends up being serialized with Kryo, then it will be registered at Kryo to make sure that only tags (integer IDs) are written. If a type is not registered with Kryo, its entire class-name will be serialized with every instance, leading to much higher I/O costs.
 
-- `registerPojoType(Class<?> type)` Registers the given type with the serialization stack. If the type is eventually serialized as a POJO, then the type is registered with the POJO serializer. If the type ends up being serialized with Kryo, then it will be registered at Kryo to make sure that only tags are written. If a type is not registered with Kryo, its entire class-name will be serialized with every instance, leading to much higher I/O costs.
+- `registerPojoType(Class<?> type)`. Registers the given type with the serialization stack. If the type is eventually serialized as a POJO, then the type is registered with the POJO serializer. If the type ends up being serialized with Kryo, then it will be registered at Kryo to make sure that only tags are written. If a type is not registered with Kryo, its entire class-name will be serialized with every instance, leading to much higher I/O costs.
 
 Note that types registered with `registerKryoType()` are not available to Flink's Kryo serializer instance.
 
-- `disableAutoTypeRegistration()` Automatic type registration is enabled by default. The automatic type registration is registering all types (including sub-types) used by usercode with Kryo and the POJO serializer.
+- `disableAutoTypeRegistration()`. Automatic type registration is enabled by default. The automatic type registration is registering all types (including sub-types) used by usercode with Kryo and the POJO serializer.
 
-- `setTaskCancellationInterval(long interval)` Sets the interval (in milliseconds) to wait between consecutive attempts to cancel a running task. When a task is canceled a new thread is created which periodically calls `interrupt()` on the task thread, if the task thread does not terminate within a certain time. This parameter refers to the time between consecutive calls to `interrupt()` and is set by default to **30000** milliseconds, or **30 seconds**.
+- `setTaskCancellationInterval(long interval)`. Sets the interval (in milliseconds) to wait between consecutive attempts to cancel a running task. When a task is canceled a new thread is created which periodically calls `interrupt()` on the task thread, if the task thread does not terminate within a certain time. This parameter refers to the time between consecutive calls to `interrupt()` and is set by default to **30000** milliseconds, or **30 seconds**.
 
 The `RuntimeContext` which is accessible in `Rich*` functions through the `getRuntimeContext()` method also allows to access the `ExecutionConfig` in all user defined functions.
 

--- a/docs/internals/ide_setup.md
+++ b/docs/internals/ide_setup.md
@@ -89,7 +89,7 @@ IntelliJ supports checkstyle within the IDE using the Checkstyle-IDEA plugin.
 3. Set the "Scan Scope" to "Only Java sources (including tests)".
 4. Select _8.4_ in the "Checkstyle Version" dropdown and click apply. **This step is important,
    don't skip it!**
-5. In the "Configuration File" pane, add a new configuration using the plus icon:
+5. In the "Configuration File" page, add a new configuration using the plus icon:
     1. Set the "Description" to "Flink".
     2. Select "Use a local Checkstyle file", and point it to
       `"tools/maven/checkstyle.xml"` within

--- a/docs/internals/ide_setup.md
+++ b/docs/internals/ide_setup.md
@@ -89,7 +89,7 @@ IntelliJ supports checkstyle within the IDE using the Checkstyle-IDEA plugin.
 3. Set the "Scan Scope" to "Only Java sources (including tests)".
 4. Select _8.4_ in the "Checkstyle Version" dropdown and click apply. **This step is important,
    don't skip it!**
-5. In the "Configuration File" page, add a new configuration using the plus icon:
+5. In the "Configuration File" pane, add a new configuration using the plus icon:
     1. Set the "Description" to "Flink".
     2. Select "Use a local Checkstyle file", and point it to
       `"tools/maven/checkstyle.xml"` within

--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -23,8 +23,8 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-Flink provides a command-line interface to run programs that are packaged
-as JAR files, and control their execution.  The command line interface is part
+Flink provides a Command-Line Interface (CLI) to run programs that are packaged
+as JAR files, and control their execution.  The CLI is part
 of any Flink setup, available in local single node setups and in
 distributed setups. It is located under `<flink-home>/bin/flink`
 and connects by default to the running Flink master (JobManager) that was
@@ -47,50 +47,50 @@ The command line can be used to
 
 ## Examples
 
--   Run example program with no arguments.
+-   Run example program with no arguments:
 
         ./bin/flink run ./examples/batch/WordCount.jar
 
--   Run example program with arguments for input and result files
+-   Run example program with arguments for input and result files:
 
         ./bin/flink run ./examples/batch/WordCount.jar \
                              --input file:///home/user/hamlet.txt --output file:///home/user/wordcount_out
 
--   Run example program with parallelism 16 and arguments for input and result files
+-   Run example program with parallelism 16 and arguments for input and result files:
 
         ./bin/flink run -p 16 ./examples/batch/WordCount.jar \
                              --input file:///home/user/hamlet.txt --output file:///home/user/wordcount_out
 
--   Run example program with flink log output disabled
+-   Run example program with flink log output disabled:
 
-            ./bin/flink run -q ./examples/batch/WordCount.jar
+        ./bin/flink run -q ./examples/batch/WordCount.jar
 
--   Run example program in detached mode
+-   Run example program in detached mode:
 
-            ./bin/flink run -d ./examples/batch/WordCount.jar
+        ./bin/flink run -d ./examples/batch/WordCount.jar
 
 -   Run example program on a specific JobManager:
 
         ./bin/flink run -m myJMHost:8081 \
-                               ./examples/batch/WordCount.jar \
-                               --input file:///home/user/hamlet.txt --output file:///home/user/wordcount_out
+                             ./examples/batch/WordCount.jar \
+                             --input file:///home/user/hamlet.txt --output file:///home/user/wordcount_out
 
 -   Run example program with a specific class as an entry point:
 
         ./bin/flink run -c org.apache.flink.examples.java.wordcount.WordCount \
-                               ./examples/batch/WordCount.jar \
-                               --input file:///home/user/hamlet.txt --output file:///home/user/wordcount_out
+                             ./examples/batch/WordCount.jar \
+                             --input file:///home/user/hamlet.txt --output file:///home/user/wordcount_out
 
 -   Run example program using a [per-job YARN cluster]({{site.baseurl}}/ops/deployment/yarn_setup.html#run-a-single-flink-job-on-hadoop-yarn) with 2 TaskManagers:
 
         ./bin/flink run -m yarn-cluster -yn 2 \
-                               ./examples/batch/WordCount.jar \
-                               --input hdfs:///user/hamlet.txt --output hdfs:///user/wordcount_out
+                             ./examples/batch/WordCount.jar \
+                             --input hdfs:///user/hamlet.txt --output hdfs:///user/wordcount_out
 
 -   Display the optimized execution plan for the WordCount example program as JSON:
 
         ./bin/flink info ./examples/batch/WordCount.jar \
-                                --input file:///home/user/hamlet.txt --output file:///home/user/wordcount_out
+                             --input file:///home/user/hamlet.txt --output file:///home/user/wordcount_out
 
 -   List scheduled and running jobs (including their JobIDs):
 
@@ -104,7 +104,7 @@ The command line can be used to
 
         ./bin/flink list -r
 
--   List running Flink jobs inside Flink YARN session:
+-   List running jobs inside Flink YARN session:
 
         ./bin/flink list -m yarn-cluster -yid <yarnApplicationID> -r
 
@@ -114,14 +114,14 @@ The command line can be used to
 
 -   Cancel a job with a savepoint:
 
-        ./bin/flink cancel -s [targetDirectory] <jobID>
+        ./bin/flink cancel -s [savepointDirectory] <jobID>
 
 -   Stop a job (streaming jobs only):
 
         ./bin/flink stop <jobID>
 
 
-The difference between cancelling and stopping a (streaming) job is the following:
+**NOTE**: The difference between cancelling and stopping a (streaming) job is the following:
 
 On a cancel call, the operators in a job immediately receive a `cancel()` method call to cancel them as
 soon as possible.
@@ -135,7 +135,7 @@ This allows the job to finish processing all inflight data.
 
 ### Savepoints
 
-[Savepoints]({{site.baseurl}}/ops/state/savepoints.html) are controlled via the command line client:
+[Savepoints]({{site.baseurl}}/ops/state/savepoints.html) are controlled via the CLI:
 
 #### Trigger a Savepoint
 
@@ -148,7 +148,7 @@ This will trigger a savepoint for the job with ID `jobId`, and returns the path 
 
 Furthermore, you can optionally specify a target file system directory to store the savepoint in. The directory needs to be accessible by the JobManager.
 
-If you don't specify a target directory, you need to have [configured a default directory](#configuration) (see [Savepoints]({{site.baseurl}}/ops/state/savepoints.html#configuration)). Otherwise, triggering the savepoint will fail.
+If you don't specify a target directory, you need to have [configured a default directory]({{site.baseurl}}/ops/state/savepoints.html#configuration). Otherwise, triggering the savepoint will fail.
 
 #### Trigger a Savepoint with YARN
 
@@ -158,14 +158,14 @@ If you don't specify a target directory, you need to have [configured a default 
 
 This will trigger a savepoint for the job with ID `jobId` and YARN application ID `yarnAppId`, and returns the path of the created savepoint.
 
-Everything else is the same as described in the above **Trigger a Savepoint** section.
+Everything else is the same as described in the [Trigger a Savepoint]({{site.baseurl}}/ops/cli.html#trigger-a-savepoint) section.
 
 #### Cancel with a savepoint
 
 You can atomically trigger a savepoint and cancel a job.
 
 {% highlight bash %}
-./bin/flink cancel -s  [savepointDirectory] <jobID>
+./bin/flink cancel -s [savepointDirectory] <jobID>
 {% endhighlight %}
 
 If no savepoint directory is configured, you need to configure a default savepoint directory for the Flink installation (see [Savepoints]({{site.baseurl}}/ops/state/savepoints.html#configuration)).

--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -63,34 +63,34 @@ The command line can be used to
 
 -   Run example program with flink log output disabled:
 
-        ./bin/flink run -q ./examples/batch/WordCount.jar
+            ./bin/flink run -q ./examples/batch/WordCount.jar
 
 -   Run example program in detached mode:
 
-        ./bin/flink run -d ./examples/batch/WordCount.jar
+            ./bin/flink run -d ./examples/batch/WordCount.jar
 
 -   Run example program on a specific JobManager:
 
         ./bin/flink run -m myJMHost:8081 \
-                             ./examples/batch/WordCount.jar \
-                             --input file:///home/user/hamlet.txt --output file:///home/user/wordcount_out
+                               ./examples/batch/WordCount.jar \
+                               --input file:///home/user/hamlet.txt --output file:///home/user/wordcount_out
 
 -   Run example program with a specific class as an entry point:
 
         ./bin/flink run -c org.apache.flink.examples.java.wordcount.WordCount \
-                             ./examples/batch/WordCount.jar \
-                             --input file:///home/user/hamlet.txt --output file:///home/user/wordcount_out
+                               ./examples/batch/WordCount.jar \
+                               --input file:///home/user/hamlet.txt --output file:///home/user/wordcount_out
 
 -   Run example program using a [per-job YARN cluster]({{site.baseurl}}/ops/deployment/yarn_setup.html#run-a-single-flink-job-on-hadoop-yarn) with 2 TaskManagers:
 
         ./bin/flink run -m yarn-cluster -yn 2 \
-                             ./examples/batch/WordCount.jar \
-                             --input hdfs:///user/hamlet.txt --output hdfs:///user/wordcount_out
+                               ./examples/batch/WordCount.jar \
+                               --input hdfs:///user/hamlet.txt --output hdfs:///user/wordcount_out
 
 -   Display the optimized execution plan for the WordCount example program as JSON:
 
         ./bin/flink info ./examples/batch/WordCount.jar \
-                             --input file:///home/user/hamlet.txt --output file:///home/user/wordcount_out
+                                --input file:///home/user/hamlet.txt --output file:///home/user/wordcount_out
 
 -   List scheduled and running jobs (including their JobIDs):
 
@@ -104,7 +104,7 @@ The command line can be used to
 
         ./bin/flink list -r
 
--   List running jobs inside Flink YARN session:
+-   List running Flink jobs inside Flink YARN session:
 
         ./bin/flink list -m yarn-cluster -yid <yarnApplicationID> -r
 
@@ -114,7 +114,7 @@ The command line can be used to
 
 -   Cancel a job with a savepoint:
 
-        ./bin/flink cancel -s [savepointDirectory] <jobID>
+        ./bin/flink cancel -s [targetDirectory] <jobID>
 
 -   Stop a job (streaming jobs only):
 
@@ -135,7 +135,7 @@ This allows the job to finish processing all inflight data.
 
 ### Savepoints
 
-[Savepoints]({{site.baseurl}}/ops/state/savepoints.html) are controlled via the CLI:
+[Savepoints]({{site.baseurl}}/ops/state/savepoints.html) are controlled via the command line client:
 
 #### Trigger a Savepoint
 
@@ -148,7 +148,7 @@ This will trigger a savepoint for the job with ID `jobId`, and returns the path 
 
 Furthermore, you can optionally specify a target file system directory to store the savepoint in. The directory needs to be accessible by the JobManager.
 
-If you don't specify a target directory, you need to have [configured a default directory]({{site.baseurl}}/ops/state/savepoints.html#configuration). Otherwise, triggering the savepoint will fail.
+If you don't specify a target directory, you need to have [configured a default directory](#configuration) (see [Savepoints]({{site.baseurl}}/ops/state/savepoints.html#configuration)). Otherwise, triggering the savepoint will fail.
 
 #### Trigger a Savepoint with YARN
 
@@ -158,7 +158,7 @@ If you don't specify a target directory, you need to have [configured a default 
 
 This will trigger a savepoint for the job with ID `jobId` and YARN application ID `yarnAppId`, and returns the path of the created savepoint.
 
-Everything else is the same as described in the [Trigger a Savepoint]({{site.baseurl}}/ops/cli.html#trigger-a-savepoint) section.
+Everything else is the same as described in the above **Trigger a Savepoint** section.
 
 #### Cancel with a savepoint
 

--- a/docs/ops/filesystems.md
+++ b/docs/ops/filesystems.md
@@ -70,20 +70,21 @@ That way, Flink seamlessly supports all of Hadoop file systems, and all Hadoop-c
   - **har**
   - ...
 
+
 ## Common File System configurations
 
 The following configuration settings exist across different file systems
 
 #### Default File System
 
-If path to files do not explicitly specify a file system scheme (and authority), a default scheme (and authority) will be used.
+If paths to files do not explicitly specify a file system scheme (and authority), a default scheme (and authority) will be used.
 
 {% highlight yaml %}
 fs.default-scheme: <default-fs>
 {% endhighlight %}
 
 For example, if the default file system configured as `fs.default-scheme: hdfs://localhost:9000/`, then a file path of
-`'/user/hugo/in.txt'` is interpreted as `'hdfs://localhost:9000/user/hugo/in.txt'`
+`/user/hugo/in.txt` is interpreted as `hdfs://localhost:9000/user/hugo/in.txt`
 
 #### Connection limiting
 
@@ -111,8 +112,9 @@ To prevent inactive streams from taking up the complete pool (preventing new con
 `fs.<scheme>.limit.stream-timeout`. If a stream does not read/write any bytes for at least that amount of time, it is forcibly closed.
 
 These limits are enforced per TaskManager, so each TaskManager in a Flink application or cluster will open up to that number of connections.
-In addition, the limit are also enforced only per FileSystem instance. Because File Systems are created per scheme and authority, different
+In addition, the limits are also only enforced per FileSystem instance. Because File Systems are created per scheme and authority, different
 authorities will have their own connection pool. For example `hdfs://myhdfs:50010/` and `hdfs://anotherhdfs:4399/` will have separate pools.
+
 
 ## Adding new File System Implementations
 

--- a/docs/ops/filesystems.md
+++ b/docs/ops/filesystems.md
@@ -70,21 +70,20 @@ That way, Flink seamlessly supports all of Hadoop file systems, and all Hadoop-c
   - **har**
   - ...
 
-
 ## Common File System configurations
 
 The following configuration settings exist across different file systems
 
 #### Default File System
 
-If paths to files do not explicitly specify a file system scheme (and authority), a default scheme (and authority) will be used.
+If path to files do not explicitly specify a file system scheme (and authority), a default scheme (and authority) will be used.
 
 {% highlight yaml %}
 fs.default-scheme: <default-fs>
 {% endhighlight %}
 
-For example, if the default file system configured as `fs.default-scheme: hdfs://localhost:9000/`, then a a file path of
-`/user/hugo/in.txt'` is interpreted as `hdfs://localhost:9000/user/hugo/in.txt'`
+For example, if the default file system configured as `fs.default-scheme: hdfs://localhost:9000/`, then a file path of
+`'/user/hugo/in.txt'` is interpreted as `'hdfs://localhost:9000/user/hugo/in.txt'`
 
 #### Connection limiting
 
@@ -112,9 +111,8 @@ To prevent inactive streams from taking up the complete pool (preventing new con
 `fs.<scheme>.limit.stream-timeout`. If a stream does not read/write any bytes for at least that amount of time, it is forcibly closed.
 
 These limits are enforced per TaskManager, so each TaskManager in a Flink application or cluster will open up to that number of connections.
-In addition, the The limit are also enforced only per FileSystem instance. Because File Systems are created per scheme and authority, different
+In addition, the limit are also enforced only per FileSystem instance. Because File Systems are created per scheme and authority, different
 authorities will have their own connection pool. For example `hdfs://myhdfs:50010/` and `hdfs://anotherhdfs:4399/` will have separate pools.
-
 
 ## Adding new File System Implementations
 

--- a/docs/ops/security-ssl.md
+++ b/docs/ops/security-ssl.md
@@ -22,22 +22,22 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-This page provides instructions on how to enable SSL for the network communication between different flink components.
+This page provides instructions on how to enable SSL for the network communication between different Flink components.
 
 ## SSL Configuration
 
-SSL can be enabled for all network communication between flink components. SSL keystores and truststore has to be deployed on each flink node and configured (conf/flink-conf.yaml) using keys in the security.ssl.* namespace (Please see the [configuration page](config.html) for details). SSL can be selectively enabled/disabled for different transports using the following flags. These flags are only applicable when security.ssl.enabled is set to true.
+SSL can be enabled for all network communication between Flink components. SSL keystores and truststore has to be deployed on each Flink node and configured (conf/flink-conf.yaml) using keys in the `security.ssl.*` namespace (Please see the [configuration page](config.html) for details). SSL can be selectively enabled/disabled for different transports using the following flags. These flags are only applicable when `security.ssl.enabled` is set to true.
 
 * **taskmanager.data.ssl.enabled**: SSL flag for data communication between task managers
 * **blob.service.ssl.enabled**: SSL flag for blob service client/server communication
-* **akka.ssl.enabled**: SSL flag for the akka based control connection between the flink client, jobmanager and taskmanager 
-* **jobmanager.web.ssl.enabled**: Flag to enable https access to the jobmanager's web frontend
+* **akka.ssl.enabled**: SSL flag for akka based control connection between the Flink client, JobManager and TaskManager 
+* **jobmanager.web.ssl.enabled**: Flag to enable https access to the JobManager's web frontend
 
 ## Deploying Keystores and Truststores
 
-You need to have a Java Keystore generated and copied to each node in the flink cluster. The common name or subject alternative names in the certificate should match the node's hostname and IP address. Keystores and truststores can be generated using the [keytool utility](https://docs.oracle.com/javase/8/docs/technotes/tools/unix/keytool.html). All flink components should have read access to the keystore and truststore files.
+You need to have a Java Keystore generated and copied to each node in the Flink cluster. The common name or subject alternative names in the certificate should match the node's hostname and IP address. Keystores and truststores can be generated using the [keytool utility](https://docs.oracle.com/javase/8/docs/technotes/tools/unix/keytool.html). All Flink components should have read access to the keystore and truststore files.
 
-### Example: Creating self signed CA and keystores for a 2 node cluster
+### Example: Creating self signed CA and keystores for a two-node cluster
 
 Execute the following keytool commands to create a truststore with a self signed CA
 
@@ -47,7 +47,7 @@ keytool -keystore ca.keystore -storepass password -alias ca -exportcert > ca.cer
 keytool -importcert -keystore ca.truststore -alias ca -storepass password -noprompt -file ca.cer
 {% endhighlight %}
 
-Now create keystores for each node with certificates signed by the above CA. Let node1.company.org and node2.company.org be the hostnames with IPs 192.168.1.1 and 192.168.1.2 respectively
+Now create keystores for each node with certificates signed by the above CA. Let `node1.company.org` and `node2.company.org` be the hostnames with IPs `192.168.1.1` and `192.168.1.2` respectively.
 
 #### Node 1
 {% highlight bash %}
@@ -70,59 +70,59 @@ keytool -importcert -keystore node2.keystore -storepass password -file node2.cer
 ## Standalone Deployment
 Configure each node in the standalone cluster to pick up the keystore and truststore files present in the local file system.
 
-### Example: 2 node cluster
+### Example: Two-node cluster
 
-* Generate 2 keystores, one for each node, and copy them to the filesystem on the respective node. Also copy the pulic key of the CA (which was used to sign the certificates in the keystore) as a Java truststore on both the nodes
-* Configure conf/flink-conf.yaml to pick up these files
+* Generate two keystores, one for each node, and copy them to the filesystem on the respective node. Also copy the pulic key of the CA (which was used to sign the certificates in the keystore) as a Java truststore on both the nodes
+* Configure `conf/flink-conf.yaml` to pick up these files
 
 #### Node 1
 {% highlight yaml %}
 security.ssl.enabled: true
 security.ssl.keystore: /usr/local/node1.keystore
-security.ssl.keystore-password: abc123
-security.ssl.key-password: abc123
+security.ssl.keystore-password: password
+security.ssl.key-password: password
 security.ssl.truststore: /usr/local/ca.truststore
-security.ssl.truststore-password: abc123
+security.ssl.truststore-password: password
 {% endhighlight %}
 
 #### Node 2
 {% highlight yaml %}
 security.ssl.enabled: true
 security.ssl.keystore: /usr/local/node2.keystore
-security.ssl.keystore-password: abc123
-security.ssl.key-password: abc123
+security.ssl.keystore-password: password
+security.ssl.key-password: password
 security.ssl.truststore: /usr/local/ca.truststore
-security.ssl.truststore-password: abc123
+security.ssl.truststore-password: password
 {% endhighlight %}
 
-* Restart the flink components to enable SSL for all of flink's internal communication
-* Verify by accessing the jobmanager's UI using https url. The task manager's path in the UI should show akka.ssl.tcp:// as the protocol
-* The blob server and task manager's data communication can be verified from the log files
+* Restart the Flink components to enable SSL for all of Flink's internal communication
+* Verify by accessing the JobManager's UI using https url. The TaskManager's path in the UI should show `akka.ssl.tcp://` as the protocol
+* The blob server and TaskManager's data communication can be verified from the log files
 
 ## YARN Deployment
-The keystores and truststore can be deployed in a YARN setup in multiple ways depending on the cluster setup. Following are 2 ways to achieve this
+The keystores and truststore can be deployed in a YARN setup in multiple ways depending on the cluster setup. Following are two ways to achieve this
 
 ### 1. Deploy keystores before starting the YARN session
-The keystores and truststore should be generated and deployed on all nodes in the YARN setup where flink components can potentially be executed. The same flink config file from the flink YARN client is used for all the flink components running in the YARN cluster. Therefore we need to ensure the keystore is deployed and accessible using the same filepath in all the YARN nodes.
+The keystores and truststore should be generated and deployed on all nodes in the YARN setup where Flink components can potentially be executed. The same Flink config file from the Flink YARN client is used for all the Flink components running in the YARN cluster. Therefore we need to ensure the keystore is deployed and accessible using the same filepath in all the YARN nodes.
 
 #### Example config
 {% highlight yaml %}
 security.ssl.enabled: true
 security.ssl.keystore: /usr/local/node.keystore
-security.ssl.keystore-password: abc123
-security.ssl.key-password: abc123
+security.ssl.keystore-password: password
+security.ssl.key-password: password
 security.ssl.truststore: /usr/local/ca.truststore
-security.ssl.truststore-password: abc123
+security.ssl.truststore-password: password
 {% endhighlight %}
 
 Now you can start the YARN session from the CLI like you would normally do.
 
-### 2. Use YARN cli to deploy the keystores and truststore
-We can use the YARN client's ship files option (-yt) to distribute the keystores and truststore. Since the same keystore will be deployed at all nodes, we need to ensure a single certificate in the keystore can be served for all nodes. This can be done by either using the Subject Alternative Name(SAN) extension in the certificate and setting it to cover all nodes (hostname and ip addresses) in the cluster or by using wildcard subdomain names (if the cluster is setup accordingly). 
+### 2. Use YARN CLI to deploy the keystores and truststore
+We can use the YARN client's ship files option (`-yt`) to distribute the keystores and truststore. Since the same keystore will be deployed at all nodes, we need to ensure a single certificate in the keystore can be served for all nodes. This can be done by either using the Subject Alternative Name (SAN) extension in the certificate and setting it to cover all nodes (hostname and ip addresses) in the cluster or by using wildcard subdomain names (if the cluster is setup accordingly). 
 
 #### Example
-* Supply the following parameters to the keytool command when generating the keystore: -ext SAN=dns:node1.company.org,ip:192.168.1.1,dns:node2.company.org,ip:192.168.1.2
-* Copy the keystore and the CA's truststore into a local directory (at the cli's working directory), say deploy-keys/
+* Supply the following parameters to the keytool command when generating the keystore: `-ext SAN=dns:node1.company.org,ip:192.168.1.1,dns:node2.company.org,ip:192.168.1.2`
+* Copy the keystore and the CA's truststore into a local directory (at the CLI's working directory), say `deploy-keys/`
 * Update the configuration to pick up the files from a relative path
 
 {% highlight yaml %}
@@ -134,12 +134,12 @@ security.ssl.truststore: deploy-keys/ca.truststore
 security.ssl.truststore-password: password
 {% endhighlight %}
 
-* Start the YARN session using the -yt parameter
+* Start the YARN session using the `-yt` parameter
 
 {% highlight bash %}
 flink run -m yarn-cluster -yt deploy-keys/ TestJob.jar
 {% endhighlight %}
 
-When deployed using YARN, flink's web dashboard is accessible through YARN proxy's Tracking URL. To ensure that the YARN proxy is able to access flink's https url you need to configure YARN proxy to accept flink's SSL certificates. Add the custom CA certificate into Java's default truststore on the YARN Proxy node.
+When deployed using YARN, Flink's web dashboard is accessible through YARN proxy's Tracking URL. To ensure that the YARN proxy is able to access Flink's https url you need to configure YARN proxy to accept Flink's SSL certificates. Add the custom CA certificate into Java's default truststore on the YARN Proxy node.
 
 {% top %}

--- a/docs/ops/security-ssl.md
+++ b/docs/ops/security-ssl.md
@@ -26,12 +26,12 @@ This page provides instructions on how to enable SSL for the network communicati
 
 ## SSL Configuration
 
-SSL can be enabled for all network communication between Flink components. SSL keystores and truststore has to be deployed on each Flink node and configured (conf/flink-conf.yaml) using keys in the `security.ssl.*` namespace (Please see the [configuration page](config.html) for details). SSL can be selectively enabled/disabled for different transports using the following flags. These flags are only applicable when `security.ssl.enabled` is set to true.
+SSL can be enabled for all network communication between Flink components. SSL keystores and truststore has to be deployed on each Flink node and configured (conf/flink-conf.yaml) using keys in the security.ssl.* namespace (Please see the [configuration page](config.html) for details). SSL can be selectively enabled/disabled for different transports using the following flags. These flags are only applicable when security.ssl.enabled is set to true.
 
 * **taskmanager.data.ssl.enabled**: SSL flag for data communication between task managers
 * **blob.service.ssl.enabled**: SSL flag for blob service client/server communication
-* **akka.ssl.enabled**: SSL flag for akka based control connection between the Flink client, JobManager and TaskManager 
-* **jobmanager.web.ssl.enabled**: Flag to enable https access to the JobManager's web frontend
+* **akka.ssl.enabled**: SSL flag for akka based control connection between the Flink client, jobmanager and taskmanager 
+* **jobmanager.web.ssl.enabled**: Flag to enable https access to the jobmanager's web frontend
 
 ## Deploying Keystores and Truststores
 
@@ -47,7 +47,7 @@ keytool -keystore ca.keystore -storepass password -alias ca -exportcert > ca.cer
 keytool -importcert -keystore ca.truststore -alias ca -storepass password -noprompt -file ca.cer
 {% endhighlight %}
 
-Now create keystores for each node with certificates signed by the above CA. Let `node1.company.org` and `node2.company.org` be the hostnames with IPs `192.168.1.1` and `192.168.1.2` respectively.
+Now create keystores for each node with certificates signed by the above CA. Let node1.company.org and node2.company.org be the hostnames with IPs 192.168.1.1 and 192.168.1.2 respectively
 
 #### Node 1
 {% highlight bash %}
@@ -72,32 +72,32 @@ Configure each node in the standalone cluster to pick up the keystore and trusts
 
 ### Example: Two-node cluster
 
-* Generate two keystores, one for each node, and copy them to the filesystem on the respective node. Also copy the pulic key of the CA (which was used to sign the certificates in the keystore) as a Java truststore on both the nodes
-* Configure `conf/flink-conf.yaml` to pick up these files
+* Generate two keystores, one for each node, and copy them to the filesystem on the respective node. Also copy the public key of the CA (which was used to sign the certificates in the keystore) as a Java truststore on both the nodes
+* Configure conf/flink-conf.yaml to pick up these files
 
 #### Node 1
 {% highlight yaml %}
 security.ssl.enabled: true
 security.ssl.keystore: /usr/local/node1.keystore
-security.ssl.keystore-password: password
-security.ssl.key-password: password
+security.ssl.keystore-password: abc123
+security.ssl.key-password: abc123
 security.ssl.truststore: /usr/local/ca.truststore
-security.ssl.truststore-password: password
+security.ssl.truststore-password: abc123
 {% endhighlight %}
 
 #### Node 2
 {% highlight yaml %}
 security.ssl.enabled: true
 security.ssl.keystore: /usr/local/node2.keystore
-security.ssl.keystore-password: password
-security.ssl.key-password: password
+security.ssl.keystore-password: abc123
+security.ssl.key-password: abc123
 security.ssl.truststore: /usr/local/ca.truststore
-security.ssl.truststore-password: password
+security.ssl.truststore-password: abc123
 {% endhighlight %}
 
 * Restart the Flink components to enable SSL for all of Flink's internal communication
-* Verify by accessing the JobManager's UI using https url. The TaskManager's path in the UI should show `akka.ssl.tcp://` as the protocol
-* The blob server and TaskManager's data communication can be verified from the log files
+* Verify by accessing the jobmanager's UI using https url. The taskmanager's path in the UI should show akka.ssl.tcp:// as the protocol
+* The blob server and taskmanager's data communication can be verified from the log files
 
 ## YARN Deployment
 The keystores and truststore can be deployed in a YARN setup in multiple ways depending on the cluster setup. Following are two ways to achieve this
@@ -109,20 +109,20 @@ The keystores and truststore should be generated and deployed on all nodes in th
 {% highlight yaml %}
 security.ssl.enabled: true
 security.ssl.keystore: /usr/local/node.keystore
-security.ssl.keystore-password: password
-security.ssl.key-password: password
+security.ssl.keystore-password: abc123
+security.ssl.key-password: abc123
 security.ssl.truststore: /usr/local/ca.truststore
-security.ssl.truststore-password: password
+security.ssl.truststore-password: abc123
 {% endhighlight %}
 
 Now you can start the YARN session from the CLI like you would normally do.
 
 ### 2. Use YARN CLI to deploy the keystores and truststore
-We can use the YARN client's ship files option (`-yt`) to distribute the keystores and truststore. Since the same keystore will be deployed at all nodes, we need to ensure a single certificate in the keystore can be served for all nodes. This can be done by either using the Subject Alternative Name (SAN) extension in the certificate and setting it to cover all nodes (hostname and ip addresses) in the cluster or by using wildcard subdomain names (if the cluster is setup accordingly). 
+We can use the YARN client's ship files option (-yt) to distribute the keystores and truststore. Since the same keystore will be deployed at all nodes, we need to ensure a single certificate in the keystore can be served for all nodes. This can be done by either using the Subject Alternative Name (SAN) extension in the certificate and setting it to cover all nodes (hostname and ip addresses) in the cluster or by using wildcard subdomain names (if the cluster is setup accordingly). 
 
 #### Example
-* Supply the following parameters to the keytool command when generating the keystore: `-ext SAN=dns:node1.company.org,ip:192.168.1.1,dns:node2.company.org,ip:192.168.1.2`
-* Copy the keystore and the CA's truststore into a local directory (at the CLI's working directory), say `deploy-keys/`
+* Supply the following parameters to the keytool command when generating the keystore: -ext SAN=dns:node1.company.org,ip:192.168.1.1,dns:node2.company.org,ip:192.168.1.2
+* Copy the keystore and the CA's truststore into a local directory (at the CLI's working directory), say deploy-keys/
 * Update the configuration to pick up the files from a relative path
 
 {% highlight yaml %}
@@ -134,7 +134,7 @@ security.ssl.truststore: deploy-keys/ca.truststore
 security.ssl.truststore-password: password
 {% endhighlight %}
 
-* Start the YARN session using the `-yt` parameter
+* Start the YARN session using the -yt parameter
 
 {% highlight bash %}
 flink run -m yarn-cluster -yt deploy-keys/ TestJob.jar

--- a/docs/ops/upgrading.md
+++ b/docs/ops/upgrading.md
@@ -37,19 +37,19 @@ There are two ways of taking a savepoint from a running streaming application.
 
 * Taking a savepoint and continue processing.
 {% highlight bash %}
-$ ./bin/flink savepoint <jobID> [savepointDirectory]
+> ./bin/flink savepoint <jobID> [pathToSavepoint]
 {% endhighlight %}
 It is recommended to periodically take savepoints in order to be able to restart an application from a previous point in time.
 
 * Taking a savepoint and stopping the application as a single action. 
 {% highlight bash %}
-$ ./bin/flink cancel -s [savepointDirectory] <jobID>
+> ./bin/flink cancel -s [pathToSavepoint] <jobID>
 {% endhighlight %}
 This means that the application is canceled immediately after the savepoint completed, i.e., no other checkpoints are taken after the savepoint.
 
 Given a savepoint taken from an application, the same or a compatible application (see [Application State Compatibility](#application-state-compatibility) section below) can be started from that savepoint. Starting an application from a savepoint means that the state of its operators is initialized with the operator state persisted in the savepoint. This is done by starting an application using a savepoint.
 {% highlight bash %}
-$ ./bin/flink run -d -s [savepointPath] ~/application.jar
+> ./bin/flink run -d -s [pathToSavepoint] ~/application.jar
 {% endhighlight %}
 
 The operators of the started application are initialized with the operator state of the original application (i.e., the application the savepoint was taken from) at the time when the savepoint was taken. The started application continues processing from exactly this point on. 
@@ -107,7 +107,7 @@ When upgrading an application by changing its topology, a few things need to be 
 * **Adding a stateful operator:** The state of the operator will be initialized with the default state unless it takes over the state of another operator.
 * **Removing a stateful operator:** The state of the removed operator is lost unless another operator takes it over. When starting the upgraded application, you have to explicitly agree to discard the state.
 * **Changing of input and output types of operators:** When adding a new operator before or behind an operator with internal state, you have to ensure that the input or output type of the stateful operator is not modified to preserve the data type of the internal operator state (see above for details).
-* **Changing operator chaining:** Operators can be chained together for improved performance. When restoring from a savepoint taken since 1.3.x it is possible to modify chains while preserving state consistency. It is possible a break the chain such that a stateful operator is moved out of the chain. It is also possible to append or inject a new or existing stateful operator into a chain, or to modify the operator order within a chain. However, when upgrading a savepoint to 1.3.x it is paramount that the topology did not change in regards to chaining. All operators that are part of a chain should be assigned an ID as described in the [Matching Operator State](#matching-operator-state) section above.
+* **Changing operator chaining:** Operators can be chained together for improved performance. When restoring from a savepoint taken since 1.3.x it is possible to modify chains while preserving state consistency. It is possible a break the chain such that a stateful operator is moved out of the chain. It is also possible to append or inject a new or existing stateful operator into a chain, or to modify the operator order within a chain. However, when upgrading a savepoint to 1.3.x it is paramount that the topology did not change in regards to chaining. All operators that are part of a chain should be assigned an ID as described in the [Matching Operator State](#Matching Operator State) section above.
 
 ## Upgrading the Flink Framework Version
 
@@ -172,7 +172,7 @@ First major step in job migration is taking a savepoint of your job running in t
 You can do this with the command:
 
 {% highlight shell %}
-$ ./bin/flink savepoint <jobId> [savepointDirectory]
+$ bin/flink savepoint :jobId [:targetDirectory]
 {% endhighlight %}
 
 For more details, please read the [savepoint documentation]({{ site.baseurl }}/ops/state/savepoints.html).
@@ -183,7 +183,7 @@ In this step, we update the framework version of the cluster. What this basicall
 the Flink installation with the new version. This step can depend on how you are running Flink in your cluster (e.g. 
 standalone, on Mesos, ...).
 
-If you are unfamiliar with installing Flink in your cluster, please read the [clusters and deployment setup documentation]({{ site.baseurl }}/ops/deployment/cluster_setup.html).
+If you are unfamiliar with installing Flink in your cluster, please read the [deployment and cluster setup documentation]({{ site.baseurl }}/ops/deployment/cluster_setup.html).
 
 ### STEP 3: Resume the job under the new Flink version from savepoint.
 
@@ -191,7 +191,7 @@ As the last step of job migration, you resume from the savepoint taken above on 
 this with the command:
 
 {% highlight shell %}
-$ ./bin/flink run -s <savepointPath> [runArgs]
+$ bin/flink run -s :savepointPath [:runArgs]
 {% endhighlight %}
 
 Again, for more details, please take a look at the [savepoint documentation]({{ site.baseurl }}/ops/state/savepoints.html).


### PR DESCRIPTION
## What is the purpose of the change

- Spell check for Flink docs


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
