### PR TITLE
[FLINK-9518][Docs] SSL setup Docs config example has wrong keys password

### DIFF
--- a/docs/ops/security-ssl.md
+++ b/docs/ops/security-ssl.md
@@ -79,20 +79,20 @@ Configure each node in the standalone cluster to pick up the keystore and trusts
 {% highlight yaml %}
 security.ssl.enabled: true
 security.ssl.keystore: /usr/local/node1.keystore
-security.ssl.keystore-password: abc123
-security.ssl.key-password: abc123
+security.ssl.keystore-password: password
+security.ssl.key-password: password
 security.ssl.truststore: /usr/local/ca.truststore
-security.ssl.truststore-password: abc123
+security.ssl.truststore-password: password
 {% endhighlight %}
 
 #### Node 2
 {% highlight yaml %}
 security.ssl.enabled: true
 security.ssl.keystore: /usr/local/node2.keystore
-security.ssl.keystore-password: abc123
-security.ssl.key-password: abc123
+security.ssl.keystore-password: password
+security.ssl.key-password: password
 security.ssl.truststore: /usr/local/ca.truststore
-security.ssl.truststore-password: abc123
+security.ssl.truststore-password: password
 {% endhighlight %}
 
 * Restart the flink components to enable SSL for all of flink's internal communication
@@ -109,10 +109,10 @@ The keystores and truststore should be generated and deployed on all nodes in th
 {% highlight yaml %}
 security.ssl.enabled: true
 security.ssl.keystore: /usr/local/node.keystore
-security.ssl.keystore-password: abc123
-security.ssl.key-password: abc123
+security.ssl.keystore-password: password
+security.ssl.key-password: password
 security.ssl.truststore: /usr/local/ca.truststore
-security.ssl.truststore-password: abc123
+security.ssl.truststore-password: password
 {% endhighlight %}
 
 Now you can start the YARN session from the CLI like you would normally do.


### PR DESCRIPTION
## What is the purpose of the change

In creating keystores and turststore section password is set to `password` but in setup config section it is `abc123`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
