### PR TITLE
[FLINK-9435][java] Remove per-key selection Tuple instantiation via reflection in ComparableKeySelector and ArrayKeySelector

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple.java
@@ -113,6 +113,37 @@ public abstract class Tuple implements java.io.Serializable {
 
 	// BEGIN_OF_TUPLE_DEPENDENT_CODE
 	// GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
+	public static Tuple newInstance(int arity) {
+		switch (arity) {
+			case 1: return new Tuple1();
+			case 2: return new Tuple2();
+			case 3: return new Tuple3();
+			case 4: return new Tuple4();
+			case 5: return new Tuple5();
+			case 6: return new Tuple6();
+			case 7: return new Tuple7();
+			case 8: return new Tuple8();
+			case 9: return new Tuple9();
+			case 10: return new Tuple10();
+			case 11: return new Tuple11();
+			case 12: return new Tuple12();
+			case 13: return new Tuple13();
+			case 14: return new Tuple14();
+			case 15: return new Tuple15();
+			case 16: return new Tuple16();
+			case 17: return new Tuple17();
+			case 18: return new Tuple18();
+			case 19: return new Tuple19();
+			case 20: return new Tuple20();
+			case 21: return new Tuple21();
+			case 22: return new Tuple22();
+			case 23: return new Tuple23();
+			case 24: return new Tuple24();
+			case 25: return new Tuple25();
+			default: throw new IllegalArgumentException("The tuple arity must be in [0, " + MAX_ARITY + "].");
+		}
+	}
+
 	private static final Class<?>[] CLASSES = new Class<?>[] {
 		Tuple0.class, Tuple1.class, Tuple2.class, Tuple3.class, Tuple4.class, Tuple5.class, Tuple6.class, Tuple7.class, Tuple8.class, Tuple9.class, Tuple10.class, Tuple11.class, Tuple12.class, Tuple13.class, Tuple14.class, Tuple15.class, Tuple16.class, Tuple17.class, Tuple18.class, Tuple19.class, Tuple20.class, Tuple21.class, Tuple22.class, Tuple23.class, Tuple24.class, Tuple25.class
 	};

--- a/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/tuple/Tuple.java
@@ -115,6 +115,7 @@ public abstract class Tuple implements java.io.Serializable {
 	// GENERATED FROM org.apache.flink.api.java.tuple.TupleGenerator.
 	public static Tuple newInstance(int arity) {
 		switch (arity) {
+			case 0: return Tuple0.INSTANCE;
 			case 1: return new Tuple1();
 			case 2: return new Tuple2();
 			case 3: return new Tuple3();

--- a/flink-core/src/test/java/org/apache/flink/api/java/tuple/TupleGenerator.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/tuple/TupleGenerator.java
@@ -135,6 +135,8 @@ class TupleGenerator {
 		StringBuilder sb = new StringBuilder();
 		sb.append("\tpublic static Tuple newInstance(int arity) {\n");
 		sb.append("\t\tswitch (arity) {\n");
+		// special case for Tuple0:
+		sb.append("\t\t\tcase 0: return Tuple0.INSTANCE;\n");
 		for (int i = FIRST; i <= LAST; i++) {
 			sb.append("\t\t\tcase ").append(i).append(": return new Tuple").append(i).append("();\n");
 		}

--- a/flink-core/src/test/java/org/apache/flink/api/java/tuple/TupleGenerator.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/tuple/TupleGenerator.java
@@ -133,6 +133,15 @@ class TupleGenerator {
 	private static void modifyTupleType(File root) throws IOException {
 		// generate code
 		StringBuilder sb = new StringBuilder();
+		sb.append("\tpublic static Tuple newInstance(int arity) {\n");
+		sb.append("\t\tswitch (arity) {\n");
+		for (int i = FIRST; i <= LAST; i++) {
+			sb.append("\t\t\tcase ").append(i).append(": return new Tuple").append(i).append("();\n");
+		}
+		sb.append("\t\t\tdefault: throw new IllegalArgumentException(\"The tuple arity must be in [0, \" + MAX_ARITY + \"].\");\n");
+		sb.append("\t\t}\n");
+		sb.append("\t}\n\n");
+
 		sb.append("\tprivate static final Class<?>[] CLASSES = new Class<?>[] {\n\t\tTuple0.class");
 		for (int i = FIRST; i <= LAST; i++) {
 			sb.append(", Tuple").append(i).append(".class");

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/keys/KeySelectorUtil.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/keys/KeySelectorUtil.java
@@ -172,28 +172,16 @@ public final class KeySelectorUtil {
 		@SuppressWarnings("NonSerializableFieldInSerializableClass")
 		private final Object[] keyArray;
 
-		/**
-		 * Template tuple object for the key.
-		 *
-		 * <p>We will create copies of this to return in {@link #getKey(Object)}.
-		 */
-		private final Tuple templateKey;
-
 		ComparableKeySelector(TypeComparator<IN> comparator, int keyLength, TupleTypeInfo<Tuple> tupleTypeInfo) {
 			this.comparator = comparator;
 			this.keyLength = keyLength;
 			this.tupleTypeInfo = tupleTypeInfo;
 			this.keyArray = new Object[keyLength];
-			try {
-				this.templateKey = Tuple.getTupleClass(keyLength).newInstance();
-			} catch (ReflectiveOperationException e) {
-				throw new InvalidTypesException("Cannot create tuple of length " + keyLength, e);
-			}
 		}
 
 		@Override
 		public Tuple getKey(IN value) {
-			Tuple key = templateKey.copy();
+			Tuple key = Tuple.newInstance(keyLength);
 			comparator.extractKeys(value, keyArray, 0);
 			for (int i = 0; i < keyLength; i++) {
 				key.setField(keyArray[i], i);
@@ -224,26 +212,14 @@ public final class KeySelectorUtil {
 		private final int[] fields;
 		private transient TupleTypeInfo<Tuple> returnType;
 
-		/**
-		 * Template tuple object for the key.
-		 *
-		 * <p>We will create copies of this to return in {@link #getKey(Object)}.
-		 */
-		private final Tuple templateKey;
-
 		ArrayKeySelector(int[] fields, TupleTypeInfo<Tuple> returnType) {
 			this.fields = requireNonNull(fields);
 			this.returnType = requireNonNull(returnType);
-			try {
-				this.templateKey = Tuple.getTupleClass(fields.length).newInstance();
-			} catch (ReflectiveOperationException e) {
-				throw new InvalidTypesException("Cannot create tuple of length " + fields.length, e);
-			}
 		}
 
 		@Override
 		public Tuple getKey(IN value) {
-			Tuple key = templateKey.copy();
+			Tuple key = Tuple.newInstance(fields.length);
 			for (int i = 0; i < fields.length; i++) {
 				key.setField(Array.get(value, fields[i]), i);
 			}


### PR DESCRIPTION
## What is the purpose of the change

Inside `KeySelectorUtil`, every `ComparableKeySelector#getKey()` call currently creates a new tuple from `Tuple.getTupleClass(keyLength).newInstance();` which seems expensive. Instead, we could get a template tuple and use `Tuple#copy()` which copies the right sub-class in a more optimal way.

Similarly, `ArrayKeySelector` instantiates new Tuple instances via reflection (albeit caching the required tuple class for the returned key) which can be changed the same way.

With the micro-benchmarks added for a very simple job basically only doing a `keyBy()` (https://github.com/dataArtisans/flink-benchmarks/pull/5), I get these results:

```
Benchmark                    Mode  Cnt     Score     Error   Units
------------- old ---------------
KeyByBenchmarks.arrayKeyBy  thrpt    9  1055.706 ± 170.221  ops/ms
KeyByBenchmarks.tupleKeyBy  thrpt    9  1537.923 ± 271.665  ops/ms
------------- new ---------------
KeyByBenchmarks.arrayKeyBy  thrpt    9  1213.073 ±  39.672  ops/ms
KeyByBenchmarks.tupleKeyBy  thrpt    9  1848.172 ± 188.013  ops/ms
```
That is roughly 15% more for the `ArrayKeySelector` and 20% more for the `ComparableKeySelector`.

## Brief change log

- optimise `ComparableKeySelector` using a template `Tuple` instance determined once
- optimise `ArrayKeySelector` using a template `Tuple` instance determined once

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **yes**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
