### PR TITLE
[FLINK-9458] Ignore SharedSlot in CoLocationConstraint when not using legacy mode

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/scheduler/CoLocationConstraint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/scheduler/CoLocationConstraint.java
@@ -99,9 +99,11 @@ public class CoLocationConstraint {
 	 *
 	 * @return True if the location has been assigned and the shared slot is alive,
 	 *         false otherwise.
+	 * @deprecated Should only be called by legacy code (if using {@link Scheduler})
 	 */
+	@Deprecated
 	public boolean isAssignedAndAlive() {
-		return lockedLocation != null && sharedSlot.isAlive();
+		return lockedLocation != null && sharedSlot != null && sharedSlot.isAlive();
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphCoLocationRestartTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphCoLocationRestartTest.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.concurrent.ScheduledExecutor;
+import org.apache.flink.runtime.executiongraph.restart.RestartCallback;
+import org.apache.flink.runtime.executiongraph.restart.RestartStrategy;
+import org.apache.flink.runtime.jobgraph.JobStatus;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobmanager.scheduler.CoLocationConstraint;
+import org.apache.flink.runtime.jobmanager.scheduler.SchedulerTestBase;
+import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
+import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
+import org.apache.flink.util.FlinkException;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static org.apache.flink.runtime.jobgraph.JobStatus.FINISHED;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Additional {@link ExecutionGraph} restart tests {@link ExecutionGraphRestartTest} which
+ * require the usage of a {@link SlotProvider}.
+ */
+@RunWith(Parameterized.class)
+public class ExecutionGraphCoLocationRestartTest extends SchedulerTestBase {
+
+	private static final int NUM_TASKS = 31;
+
+	public ExecutionGraphCoLocationRestartTest(SchedulerType schedulerType) {
+		super(schedulerType);
+	}
+
+	@Test
+	public void testConstraintsAfterRestart() throws Exception {
+		final long timeout = 5000L;
+
+		//setting up
+		testingSlotProvider.addTaskManager(NUM_TASKS);
+
+		JobVertex groupVertex = ExecutionGraphTestUtils.createNoOpVertex(NUM_TASKS);
+		JobVertex groupVertex2 = ExecutionGraphTestUtils.createNoOpVertex(NUM_TASKS);
+
+		SlotSharingGroup sharingGroup = new SlotSharingGroup();
+		groupVertex.setSlotSharingGroup(sharingGroup);
+		groupVertex2.setSlotSharingGroup(sharingGroup);
+		groupVertex.setStrictlyCoLocatedWith(groupVertex2);
+
+		//initiate and schedule job
+		final ExecutionGraph eg = ExecutionGraphTestUtils.createSimpleTestGraph(
+			new JobID(),
+			testingSlotProvider,
+			new OneTimeDirectRestartStrategy(),
+			groupVertex,
+			groupVertex2);
+
+		if (schedulerType == SchedulerType.SLOT_POOL) {
+			// enable the queued scheduling for the slot pool
+			eg.setQueuedSchedulingAllowed(true);
+		}
+
+		assertEquals(JobStatus.CREATED, eg.getState());
+
+		eg.scheduleForExecution();
+
+		ExecutionGraphTestUtils.waitForAllExecutionsPredicate(
+			eg,
+			ExecutionGraphTestUtils.hasResourceAssigned,
+			timeout);
+
+		assertEquals(JobStatus.RUNNING, eg.getState());
+
+		//sanity checks
+		validateConstraints(eg);
+
+		ExecutionGraphTestUtils.failExecutionGraph(eg, new FlinkException("Test exception"));
+
+		// wait until we have restarted
+		ExecutionGraphTestUtils.waitUntilJobStatus(eg, JobStatus.RUNNING, timeout);
+
+		ExecutionGraphTestUtils.waitForAllExecutionsPredicate(
+			eg,
+			ExecutionGraphTestUtils.hasResourceAssigned,
+			timeout);
+
+		//checking execution vertex properties
+		validateConstraints(eg);
+
+		ExecutionGraphTestUtils.finishAllVertices(eg);
+
+		assertThat(eg.getState(), is(FINISHED));
+	}
+
+	private void validateConstraints(ExecutionGraph eg) {
+
+		ExecutionJobVertex[] tasks = eg.getAllVertices().values().toArray(new ExecutionJobVertex[2]);
+
+		for(int i = 0; i < NUM_TASKS; i++){
+			CoLocationConstraint constr1 = tasks[0].getTaskVertices()[i].getLocationConstraint();
+			CoLocationConstraint constr2 = tasks[1].getTaskVertices()[i].getLocationConstraint();
+			assertThat(constr1.isAssigned(), is(true));
+			assertThat(constr1.getLocation(), equalTo(constr2.getLocation()));
+		}
+
+	}
+
+	private static final class OneTimeDirectRestartStrategy implements RestartStrategy {
+		private boolean hasRestarted = false;
+
+		@Override
+		public boolean canRestart() {
+			return !hasRestarted;
+		}
+
+		@Override
+		public void restart(RestartCallback restarter, ScheduledExecutor executor) {
+			hasRestarted = true;
+			restarter.triggerFullRecovery();
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.executiongraph;
 
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
@@ -41,16 +42,16 @@ import org.apache.flink.runtime.instance.HardwareDescription;
 import org.apache.flink.runtime.instance.Instance;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.instance.SimpleSlot;
-import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
+import org.apache.flink.runtime.instance.SimpleSlotContext;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobStatus;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobmanager.scheduler.Scheduler;
-import org.apache.flink.runtime.instance.SimpleSlotContext;
-import org.apache.flink.runtime.jobmaster.SlotOwner;
 import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
+import org.apache.flink.runtime.jobmaster.SlotOwner;
+import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.messages.TaskMessages.CancelTask;
 import org.apache.flink.runtime.messages.TaskMessages.FailIntermediateResultPartitions;
@@ -65,11 +66,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
+
 import java.lang.reflect.Field;
 import java.net.InetAddress;
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Predicate;
 
 import scala.concurrent.ExecutionContext;
 import scala.concurrent.ExecutionContext$;
@@ -144,6 +148,53 @@ public class ExecutionGraphTestUtils {
 		}
 	}
 
+	/**
+	 * Waits until all executions fulfill the given predicate.
+	 *
+	 * @param executionGraph for which to check the executions
+	 * @param executionPredicate predicate which is to be fulfilled
+	 * @param maxWaitMillis timeout for the wait operation
+	 * @throws TimeoutException if the executions did not reach the target state in time
+	 */
+	public static void waitForAllExecutionsPredicate(
+			ExecutionGraph executionGraph,
+			Predicate<Execution> executionPredicate,
+			long maxWaitMillis) throws TimeoutException {
+		final Iterable<ExecutionVertex> allExecutionVertices = executionGraph.getAllExecutionVertices();
+
+		final Deadline deadline = Deadline.fromNow(Duration.ofMillis(maxWaitMillis));
+		boolean predicateResult;
+
+		do {
+			predicateResult = true;
+			for (ExecutionVertex executionVertex : allExecutionVertices) {
+				final Execution currentExecution = executionVertex.getCurrentExecutionAttempt();
+
+				if (currentExecution == null || !executionPredicate.test(currentExecution)) {
+					predicateResult = false;
+					break;
+				}
+			}
+
+			if (!predicateResult) {
+				try {
+					Thread.sleep(2L);
+				} catch (InterruptedException ignored) {
+					Thread.currentThread().interrupt();
+				}
+			}
+		} while (!predicateResult && deadline.hasTimeLeft());
+
+		if (!predicateResult) {
+			throw new TimeoutException("Not all executions fulfilled the predicate in time.");
+		}
+	}
+
+	/**
+	 * Predicate which is true if the given {@link Execution} has a resource assigned.
+	 */
+	public static final Predicate<Execution> hasResourceAssigned = (Execution execution) -> execution.getAssignedResource() != null;
+
 	public static void waitUntilFailoverRegionState(FailoverRegion region, JobStatus status, long maxWaitMillis)
 			throws TimeoutException {
 
@@ -162,6 +213,15 @@ public class ExecutionGraphTestUtils {
 
 		if (System.nanoTime() >= deadline) {
 			throw new TimeoutException();
+		}
+	}
+
+	public static void failExecutionGraph(ExecutionGraph executionGraph, Exception cause) {
+		executionGraph.getAllExecutionVertices().iterator().next().fail(cause);
+		assertEquals(JobStatus.FAILING, executionGraph.getState());
+
+		for (ExecutionVertex vertex : executionGraph.getAllExecutionVertices()) {
+			vertex.getCurrentExecutionAttempt().cancelingComplete();
 		}
 	}
 
@@ -380,6 +440,13 @@ public class ExecutionGraphTestUtils {
 		TaskManagerLocation connection = new TaskManagerLocation(resourceID, address, 10001);
 
 		return new Instance(gateway, connection, new InstanceID(), hardwareDescription, numberOfSlots);
+	}
+
+	public static JobVertex createJobVertex(String task1, int numTasks, Class<NoOpInvokable> invokable) {
+		JobVertex groupVertex = new JobVertex(task1);
+		groupVertex.setInvokableClass(invokable);
+		groupVertex.setParallelism(numTasks);
+		return groupVertex;
 	}
 
 	@SuppressWarnings("serial")

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/SchedulerTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/SchedulerTestBase.java
@@ -72,11 +72,11 @@ public class SchedulerTestBase extends TestLogger {
 
 	protected TestingSlotProvider testingSlotProvider;
 
-	private SchedulerType schedulerType;
+	protected SchedulerType schedulerType;
 
 	private RpcService rpcService;
 
-	enum SchedulerType {
+	public enum SchedulerType {
 		SCHEDULER,
 		SLOT_POOL
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/SchedulerTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/SchedulerTestUtils.java
@@ -23,12 +23,11 @@ import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
-import org.apache.flink.runtime.instance.DummyActorGateway;
+import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
 import org.apache.flink.runtime.instance.HardwareDescription;
 import org.apache.flink.runtime.instance.Instance;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
-import org.apache.flink.runtime.jobmanager.slots.ActorTaskManagerGateway;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 
 import java.net.InetAddress;
@@ -75,7 +74,7 @@ public class SchedulerTestUtils {
 		HardwareDescription resources = new HardwareDescription(4, 4*GB, 3*GB, 2*GB);
 		
 		return new Instance(
-			new ActorTaskManagerGateway(DummyActorGateway.INSTANCE),
+			new SimpleAckingTaskManagerGateway(),
 			ci,
 			new InstanceID(),
 			resources,


### PR DESCRIPTION
## What is the purpose of the change

The SharedSlot in CoLocationConstraint is only set when using the legacy mode. Thus,
CoLocationConstraint#isAssignedAlive should only check the SharedSlot if it was
previously set. This fixes the NPE when restarting a job with a co-location constraint
when using the new mode.

## Verifying this change

- Added `ExecutionGraphCoLocationRestartTest#testConstraintsAfterRestart` which verifies that an `ExecutionGraph` with co-location constraints can be restarted with the legacy as well as the new mode.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
