### PR TITLE
[FLINK-9521] Add shade plugin executions to package table example jar

### DIFF
--- a/flink-examples/flink-examples-table/pom.xml
+++ b/flink-examples/flink-examples-table/pom.xml
@@ -75,8 +75,9 @@ under the License.
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
 				<executions>
+
 					<execution>
-						<id>flink-table-examples_${scala.binary.version}</id>
+						<id>fat-jar-wordcount-sql-example</id>
 						<phase>package</phase>
 						<goals>
 							<goal>shade</goal>
@@ -85,8 +86,12 @@ under the License.
 							<shadeTestJar>false</shadeTestJar>
 							<shadedArtifactAttached>false</shadedArtifactAttached>
 							<createDependencyReducedPom>false</createDependencyReducedPom>
-							<finalName>TableExamples</finalName>
-							<outputFile>flink-examples-table-with-dependencies.jar</outputFile>
+							<finalName>WordCountSQL</finalName>
+							<transformers>
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+									<mainClass>org.apache.flink.table.examples.scala.WordCountSQL</mainClass>
+								</transformer>
+							</transformers>
 							<filters>
 								<filter>
 									<artifact>*:*</artifact>
@@ -102,6 +107,135 @@ under the License.
 							</filters>
 						</configuration>
 					</execution>
+
+					<execution>
+						<id>fat-jar-wordcount-table-example</id>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<shadeTestJar>false</shadeTestJar>
+							<shadedArtifactAttached>false</shadedArtifactAttached>
+							<createDependencyReducedPom>false</createDependencyReducedPom>
+							<finalName>WordCountTable</finalName>
+							<transformers>
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+									<mainClass>org.apache.flink.table.examples.scala.WordCountTable</mainClass>
+								</transformer>
+							</transformers>
+							<filters>
+								<filter>
+									<artifact>*:*</artifact>
+									<includes>
+										<include>org/apache/calcite/**</include>
+										<include>org/apache/flink/calcite/shaded/**</include>
+										<include>org/apache/flink/table/**</include>
+										<include>org.codehaus.commons.compiler.properties</include>
+										<include>org/codehaus/janino/**</include>
+										<include>org/codehaus/commons/**</include>
+									</includes>
+								</filter>
+							</filters>
+						</configuration>
+					</execution>
+
+					<execution>
+						<id>fat-jar-stream-sql-example</id>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<shadeTestJar>false</shadeTestJar>
+							<shadedArtifactAttached>false</shadedArtifactAttached>
+							<createDependencyReducedPom>false</createDependencyReducedPom>
+							<finalName>StreamSQL</finalName>
+							<transformers>
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+									<mainClass>org.apache.flink.table.examples.scala.StreamSQLExample</mainClass>
+								</transformer>
+							</transformers>
+							<filters>
+								<filter>
+									<artifact>*:*</artifact>
+									<includes>
+										<include>org/apache/calcite/**</include>
+										<include>org/apache/flink/calcite/shaded/**</include>
+										<include>org/apache/flink/table/**</include>
+										<include>org.codehaus.commons.compiler.properties</include>
+										<include>org/codehaus/janino/**</include>
+										<include>org/codehaus/commons/**</include>
+									</includes>
+								</filter>
+							</filters>
+						</configuration>
+					</execution>
+
+					<execution>
+						<id>fat-jar-stream-table-example</id>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<shadeTestJar>false</shadeTestJar>
+							<shadedArtifactAttached>false</shadedArtifactAttached>
+							<createDependencyReducedPom>false</createDependencyReducedPom>
+							<finalName>StreamTable</finalName>
+							<transformers>
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+									<mainClass>org.apache.flink.table.examples.scala.StreamTableExample</mainClass>
+								</transformer>
+							</transformers>
+							<filters>
+								<filter>
+									<artifact>*:*</artifact>
+									<includes>
+										<include>org/apache/calcite/**</include>
+										<include>org/apache/flink/calcite/shaded/**</include>
+										<include>org/apache/flink/table/**</include>
+										<include>org.codehaus.commons.compiler.properties</include>
+										<include>org/codehaus/janino/**</include>
+										<include>org/codehaus/commons/**</include>
+									</includes>
+								</filter>
+							</filters>
+						</configuration>
+					</execution>
+
+					<execution>
+						<id>fat-jar-TPCHQuery3-table-example</id>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<shadeTestJar>false</shadeTestJar>
+							<shadedArtifactAttached>false</shadedArtifactAttached>
+							<createDependencyReducedPom>false</createDependencyReducedPom>
+							<finalName>TPCHQuery3Table</finalName>
+							<transformers>
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+									<mainClass>org.apache.flink.table.examples.scala.TPCHQuery3Table</mainClass>
+								</transformer>
+							</transformers>
+							<filters>
+								<filter>
+									<artifact>*:*</artifact>
+									<includes>
+										<include>org/apache/calcite/**</include>
+										<include>org/apache/flink/calcite/shaded/**</include>
+										<include>org/apache/flink/table/**</include>
+										<include>org.codehaus.commons.compiler.properties</include>
+										<include>org/codehaus/janino/**</include>
+										<include>org/codehaus/commons/**</include>
+									</includes>
+								</filter>
+							</filters>
+						</configuration>
+					</execution>
+
 				</executions>
 			</plugin>
 		</plugins>


### PR DESCRIPTION
## What is the purpose of the change

*This pull request add shade plugin executions to package table example jar*

## Brief change log

  - *Add shade plugin executions to package table example jar*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
