### PR TITLE
[FLINK-8914][CEP]Fix wrong semantic when greedy pattern is the head of the pattern

### DIFF
--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/ComputationState.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/ComputationState.java
@@ -91,6 +91,10 @@ public class ComputationState<T> {
 		return state.isStart() && event == null;
 	}
 
+	public boolean isGreedyState() {
+		return state.isGreedy();
+	}
+
 	public long getTimestamp() {
 		return timestamp;
 	}
@@ -135,6 +139,19 @@ public class ComputationState<T> {
 	@Override
 	public int hashCode() {
 		return Objects.hash(state, event, counter, timestamp, version, startTimestamp, previousState);
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder builder = new StringBuilder();
+
+		builder.append("current state: ").append(state).append("\n")
+			.append("previous state: ").append(previousState).append("\n")
+			.append("start timestamp: ").append(startTimestamp).append("\n")
+			.append("counter: ").append(counter).append("\n")
+			.append("version: ").append(version);
+
+		return builder.toString();
 	}
 
 	public static <T> ComputationState<T> createStartState(final NFA<T> nfa, final State<T> state) {

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/NFA.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/NFA.java
@@ -641,11 +641,10 @@ public class NFA<T> implements Serializable {
 			}
 		}
 
-		for(ComputationState<T> start: startState) {
-			for(ComputationState<T> greedy : greedyState) {
+		for (ComputationState<T> start: startState) {
+			for (ComputationState<T> greedy : greedyState) {
 				if (NFAStateNameHandler.getOriginalNameFromInternal(start.getState().getName()).equals(
-					NFAStateNameHandler.getOriginalNameFromInternal(greedy.getState().getName())))
-				{
+					NFAStateNameHandler.getOriginalNameFromInternal(greedy.getState().getName()))) {
 					redundantStart.add(start);
 				}
 			}

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/State.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/State.java
@@ -60,6 +60,14 @@ public class State<T> implements Serializable {
 		return stateType == StateType.Start;
 	}
 
+	public boolean isStop() {
+		return stateType == StateType.Stop;
+	}
+
+	public boolean isGreedy() {
+		return stateType == StateType.Greedy;
+	}
+
 	public String getName() {
 		return name;
 	}
@@ -131,10 +139,6 @@ public class State<T> implements Serializable {
 		return Objects.hash(name, stateType, stateTransitions);
 	}
 
-	public boolean isStop() {
-		return stateType == StateType.Stop;
-	}
-
 	/**
 	 * Set of valid state types.
 	 */
@@ -142,6 +146,7 @@ public class State<T> implements Serializable {
 		Start, // the state is a starting state for the NFA
 		Final, // the state is a final state for the NFA
 		Normal, // the state is neither a start nor a final state
-		Stop
+		Stop, // the state will lead to the match to failed
+		Greedy // the state has the greedy proerty
 	}
 }

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/StateTransition.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/StateTransition.java
@@ -93,7 +93,7 @@ public class StateTransition<T> implements Serializable {
 				.append("StateTransition(")
 				.append(action).append(", ")
 				.append("from ").append(sourceState.getName())
-				.append("to ").append(targetState.getName())
+				.append(" to ").append(targetState.getName())
 				.append(condition != null ? ", with condition)" : ")")
 				.toString();
 	}

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/compiler/NFACompiler.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/compiler/NFACompiler.java
@@ -573,7 +573,9 @@ public class NFACompiler {
 				return createGroupPatternState((GroupPattern) currentPattern, sinkState, proceedState, isOptional);
 			}
 
-			final State<T> singletonState = createState(currentPattern.getName(), State.StateType.Normal);
+			State.StateType type = currentPattern.getQuantifier().hasProperty(Quantifier.QuantifierProperty.GREEDY) ? State.StateType.Greedy : State.StateType.Normal;
+
+			final State<T> singletonState = createState(currentPattern.getName(), type);
 			// if event is accepted then all notPatterns previous to the optional states are no longer valid
 			final State<T> sink = copyWithoutTransitiveNots(sinkState);
 			singletonState.addTake(sink, takeCondition);
@@ -707,7 +709,9 @@ public class NFACompiler {
 				true);
 
 			IterativeCondition<T> proceedCondition = getTrueFunction();
-			final State<T> loopingState = createState(currentPattern.getName(), State.StateType.Normal);
+			State.StateType type = currentPattern.getQuantifier().hasProperty(Quantifier.QuantifierProperty.GREEDY) ? State.StateType.Greedy : State.StateType.Normal;
+
+			final State<T> loopingState = createState(currentPattern.getName(), type);
 
 			if (currentPattern.getQuantifier().hasProperty(Quantifier.QuantifierProperty.GREEDY)) {
 				if (untilCondition != null) {
@@ -728,7 +732,7 @@ public class NFACompiler {
 			addStopStateToLooping(loopingState);
 
 			if (ignoreCondition != null) {
-				final State<T> ignoreState = createState(currentPattern.getName(), State.StateType.Normal);
+				final State<T> ignoreState = createState(currentPattern.getName(), type);
 				ignoreState.addTake(loopingState, takeCondition);
 				ignoreState.addIgnore(ignoreCondition);
 				loopingState.addIgnore(ignoreState, ignoreCondition);

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/GreedyITCase.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/GreedyITCase.java
@@ -904,4 +904,112 @@ public class GreedyITCase extends TestLogger {
 			Lists.newArrayList(c, a1, a2, a3, a4, d)
 		));
 	}
+
+	@Test
+	public void testGreedyConsecutiveStartState() {
+		List<StreamRecord<Event>> inputEvents = new ArrayList<>();
+
+		Event c = new Event(40, "c", 1.0);
+		Event a1 = new Event(41, "a", 2.0);
+		Event a2 = new Event(42, "a", 2.0);
+		Event a3 = new Event(43, "a", 2.0);
+		Event d = new Event(44, "d", 3.0);
+		Event a4 = new Event(45, "a", 2.0);
+		Event a5 = new Event(46, "a", 2.0);
+		Event d2 = new Event(44, "d", 3.0);
+
+		inputEvents.add(new StreamRecord<>(c, 1));
+		inputEvents.add(new StreamRecord<>(a1, 2));
+		inputEvents.add(new StreamRecord<>(a2, 3));
+		inputEvents.add(new StreamRecord<>(a3, 4));
+		inputEvents.add(new StreamRecord<>(d, 5));
+		inputEvents.add(new StreamRecord<>(a4, 5));
+		inputEvents.add(new StreamRecord<>(a5, 5));
+		inputEvents.add(new StreamRecord<>(d2, 5));
+
+
+		// a* d
+		Pattern<Event, ?> pattern = Pattern.<Event>begin("start").where(new SimpleCondition<Event>() {
+			private static final long serialVersionUID = 5726188262756267490L;
+
+			@Override
+			public boolean filter(Event value) throws Exception {
+				return value.getName().equals("a");
+			}
+		})
+		.oneOrMore()
+		.optional()
+		.consecutive()
+		.greedy()
+		.followedBy("end").where(new SimpleCondition<Event>() {
+			private static final long serialVersionUID = 5726188262756267490L;
+
+			@Override
+			public boolean filter(Event value) throws Exception {
+				return value.getName().equals("d");
+			}
+		});
+
+		NFA<Event> nfa = NFACompiler.compile(pattern, Event.createTypeSerializer(), false);
+
+		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
+		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+			Lists.newArrayList(a1, a2, a3, d),
+			Lists.newArrayList(a4, a5, d2)
+		));
+	}
+
+	@Test
+	public void testGreedyReleaxStartState() {
+		List<StreamRecord<Event>> inputEvents = new ArrayList<>();
+
+		Event c = new Event(40, "c", 1.0);
+		Event a1 = new Event(41, "a", 2.0);
+		Event a2 = new Event(42, "a", 2.0);
+		Event a3 = new Event(43, "a", 2.0);
+		Event d = new Event(44, "d", 3.0);
+		Event a4 = new Event(45, "a", 2.0);
+		Event a5 = new Event(46, "a", 2.0);
+		Event d2 = new Event(47, "d", 3.0);
+
+		inputEvents.add(new StreamRecord<>(c, 1));
+		inputEvents.add(new StreamRecord<>(a1, 2));
+		inputEvents.add(new StreamRecord<>(a2, 3));
+		inputEvents.add(new StreamRecord<>(a3, 4));
+		inputEvents.add(new StreamRecord<>(d, 5));
+		inputEvents.add(new StreamRecord<>(a4, 5));
+		inputEvents.add(new StreamRecord<>(a5, 5));
+		inputEvents.add(new StreamRecord<>(d2, 5));
+
+
+		// a* d
+		Pattern<Event, ?> pattern = Pattern.<Event>begin("start").where(new SimpleCondition<Event>() {
+			private static final long serialVersionUID = 5726188262756267490L;
+
+			@Override
+			public boolean filter(Event value) throws Exception {
+				return value.getName().equals("a");
+			}
+		})
+		.oneOrMore()
+		.optional()
+		.greedy()
+		.followedBy("end").where(new SimpleCondition<Event>() {
+			private static final long serialVersionUID = 5726188262756267490L;
+
+			@Override
+			public boolean filter(Event value) throws Exception {
+				return value.getName().equals("d");
+			}
+		});
+
+		NFA<Event> nfa = NFACompiler.compile(pattern, Event.createTypeSerializer(), false);
+
+		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
+		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+			Lists.newArrayList(a1, a2, a3, d),
+			Lists.newArrayList(a1, a2, a3, a4, a5, d2)
+		));
+	}
+
 }

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/GreedyITCase.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/GreedyITCase.java
@@ -927,7 +927,6 @@ public class GreedyITCase extends TestLogger {
 		inputEvents.add(new StreamRecord<>(a5, 5));
 		inputEvents.add(new StreamRecord<>(d2, 5));
 
-
 		// a* d
 		Pattern<Event, ?> pattern = Pattern.<Event>begin("start").where(new SimpleCondition<Event>() {
 			private static final long serialVersionUID = 5726188262756267490L;
@@ -980,7 +979,6 @@ public class GreedyITCase extends TestLogger {
 		inputEvents.add(new StreamRecord<>(a4, 5));
 		inputEvents.add(new StreamRecord<>(a5, 5));
 		inputEvents.add(new StreamRecord<>(d2, 5));
-
 
 		// a* d
 		Pattern<Event, ?> pattern = Pattern.<Event>begin("start").where(new SimpleCondition<Event>() {


### PR DESCRIPTION
## What is the purpose of the change

As described in the jira [FLINK-8914](https://issues.apache.org/jira/projects/FLINK/issues/FLINK-8914)
There is something wrong with `greedy` when it is the head of the pattern. Because the `NFA` process each `ComputationState` and will produce a new `Start ComputationState`. So when it runs into the greedy match, other `start runs` can also be set up

## Brief change log

*(for example:)*
  - *Add a new StateType `Greedy` for convenience of distinguishing the greedy in computations*
  - *Remove the redundant start state during process*


## Verifying this change

Add two UT in `GreedyITCase`
