### PR TITLE
[FLINK-9368][py][tests] Add Python API E2E test

### DIFF
--- a/flink-end-to-end-tests/run-pre-commit-tests.sh
+++ b/flink-end-to-end-tests/run-pre-commit-tests.sh
@@ -47,6 +47,11 @@ EXIT_CODE=0
 # fi
 
 if [ $EXIT_CODE == 0 ]; then
+    run_test "Batch Python Wordcount end-to-end test" "$END_TO_END_DIR/test-scripts/test_batch_python_wordcount.sh"
+    EXIT_CODE=$?
+fi
+
+if [ $EXIT_CODE == 0 ]; then
     run_test "Streaming Python Wordcount end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_python_wordcount.sh"
     EXIT_CODE=$?
 fi

--- a/flink-end-to-end-tests/test-scripts/test_batch_python_wordcount.sh
+++ b/flink-end-to-end-tests/test-scripts/test_batch_python_wordcount.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+################################################################################
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+source "$(dirname "$0")"/common.sh
+
+start_cluster
+
+$FLINK_DIR/bin/pyflink.sh $FLINK_DIR/examples/python/batch/WordCount.py - $TEST_INFRA_DIR/test-data/words $TEST_DATA_DIR/out/py_wc_out
+check_result_hash "BatchPythonWordCount" $TEST_DATA_DIR/out/py_wc_out "dd9d7a7bbc8b52747c7d4e15c9d2b069"


### PR DESCRIPTION
## What is the purpose of the change

This PR adds en end-to-end test for the batch Python API. It uses the built-in wordcount example.

With this test we now cover the `pyflink.sh` scripts, related `flink-dist` assemblies and the correctness outside of maven.
