### PR TITLE
[FLINK-9539][build] Integrate flink-shaded 4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@ under the License.
 		<flink.forkCountTestPackage>${flink.forkCount}</flink.forkCountTestPackage>
 		<flink.reuseForks>true</flink.reuseForks>
 		<log4j.configuration>log4j-test.properties</log4j.configuration>
-		<flink.shaded.version>2.0</flink.shaded.version>
+		<flink.shaded.version>4.0</flink.shaded.version>
 		<guava.version>18.0</guava.version>
 		<akka.version>2.4.20</akka.version>
 		<java.version>1.8</java.version>
@@ -247,53 +247,13 @@ under the License.
 			<dependency>
 				<groupId>org.apache.flink</groupId>
 				<artifactId>flink-shaded-jackson</artifactId>
-				<!-- We use a newer version since we didn't have to time to do a proper switch to 3.0 -->
-				<version>${jackson.version}-3.0</version>
-				<!-- Dependencies aren't properly hidden in 3.0 -->
-				<exclusions>
-					<exclusion>
-						<groupId>com.fasterxml.jackson.core</groupId>
-						<artifactId>jackson-core</artifactId>
-					</exclusion>
-					<exclusion>
-						<groupId>com.fasterxml.jackson.core</groupId>
-						<artifactId>jackson-annotations</artifactId>
-					</exclusion>
-					<exclusion>
-						<groupId>com.fasterxml.jackson.core</groupId>
-						<artifactId>jackson-databind</artifactId>
-					</exclusion>
-					<exclusion>
-						<groupId>com.fasterxml.jackson.dataformat</groupId>
-						<artifactId>jackson-dataformat-yaml</artifactId>
-					</exclusion>
-				</exclusions>
+				<version>${jackson.version}-${flink.shaded.version}</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.apache.flink</groupId>
 				<artifactId>flink-shaded-jackson-module-jsonSchema</artifactId>
-				<!-- We use a newer version since we didn't have to time to do a proper switch to 3.0 -->
-				<version>${jackson.version}-3.0</version>
-				<!-- Dependencies aren't properly hidden in 3.0 -->
-				<exclusions>
-					<exclusion>
-						<groupId>com.fasterxml.jackson.core</groupId>
-						<artifactId>jackson-core</artifactId>
-					</exclusion>
-					<exclusion>
-						<groupId>com.fasterxml.jackson.core</groupId>
-						<artifactId>jackson-annotations</artifactId>
-					</exclusion>
-					<exclusion>
-						<groupId>com.fasterxml.jackson.core</groupId>
-						<artifactId>jackson-databind</artifactId>
-					</exclusion>
-					<exclusion>
-						<groupId>com.fasterxml.jackson.module</groupId>
-						<artifactId>jackson-module-jsonSchema</artifactId>
-					</exclusion>
-				</exclusions>
+				<version>${jackson.version}-${flink.shaded.version}</version>
 			</dependency>
 
 			<dependency>
@@ -307,7 +267,7 @@ under the License.
 				errors.
 
 				[1] https://github.com/netty/netty/issues/3704 -->
-				<version>4.0.27.Final-${flink.shaded.version}</version>
+				<version>4.0.27.Final-2.0</version>
 			</dependency>
 
 			<!-- This manages the 'javax.annotation' annotations (JSR305) -->


### PR DESCRIPTION
## What is the purpose of the change

This PR bumps the flink-shaded version to 4.0 . The workarounds for the faulty jackson shading can be removed. Additionally netty was pinned to 2.0; we will bump this as part of FLINK-3952.

Note that travis may fail since the flink-shaded 4.0 artifacts might not be visible yet.