### PR TITLE
[FLINK-9503] Migrate integration tests for iterative aggregators

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/iterative/aggregators/AggregatorsITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/iterative/aggregators/AggregatorsITCase.java
@@ -107,9 +107,6 @@ public class AggregatorsITCase extends MultipleProgramsTestBase {
 			}
 		}).withBroadcastSet(solution, "SOLUTION")).output(new DiscardingOutputFormat<Long>());
 		env.execute();
-		String expected = testString; // this will be a useless verification now.
-
-		compareResultsByLinesInMemory(expected, resultPath);
 	}
 
 	@Test

--- a/flink-tests/src/test/java/org/apache/flink/test/iterative/aggregators/AggregatorsITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/iterative/aggregators/AggregatorsITCase.java
@@ -35,9 +35,7 @@ import org.apache.flink.test.util.MultipleProgramsTestBase;
 import org.apache.flink.types.LongValue;
 import org.apache.flink.util.Collector;
 
-import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -48,6 +46,9 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Random;
 import java.util.UUID;
 
@@ -63,35 +64,24 @@ public class AggregatorsITCase extends MultipleProgramsTestBase {
 	private static final int parallelism = 2;
 	private static final String NEGATIVE_ELEMENTS_AGGR = "count.negative.elements";
 
-	private static String testString = "Et tu, Brute?";
-	private static String testName = "testing_caesar";
-	private static String testPath;
-
 	public AggregatorsITCase(TestExecutionMode mode){
 		super(mode);
 	}
 
-	private String resultPath;
-	private String expected;
-
 	@Rule
 	public TemporaryFolder tempFolder = new TemporaryFolder();
 
-	@Before
-	public void before() throws Exception{
-		final File folder = tempFolder.newFolder();
-		final File resultFile = new File(folder, UUID.randomUUID().toString());
-		testPath = resultFile.toString();
-		resultPath = resultFile.toURI().toString();
-	}
-
-	@After
-	public void after() throws Exception{
-		compareResultsByLinesInMemory(expected, resultPath);
-	}
-
 	@Test
 	public void testDistributedCacheWithIterations() throws Exception{
+		final String testString = "Et tu, Brute?";
+		final String testName = "testing_caesar";
+
+		final File folder = tempFolder.newFolder();
+		final File resultFile = new File(folder, UUID.randomUUID().toString());
+
+		String testPath = resultFile.toString();
+		String resultPath = resultFile.toURI().toString();
+
 		File tempFile = new File(testPath);
 		try (FileWriter writer = new FileWriter(tempFile)) {
 			writer.write(testString);
@@ -117,7 +107,9 @@ public class AggregatorsITCase extends MultipleProgramsTestBase {
 			}
 		}).withBroadcastSet(solution, "SOLUTION")).output(new DiscardingOutputFormat<Long>());
 		env.execute();
-		expected = testString; // this will be a useless verification now.
+		String expected = testString; // this will be a useless verification now.
+
+		compareResultsByLinesInMemory(expected, resultPath);
 	}
 
 	@Test
@@ -141,12 +133,17 @@ public class AggregatorsITCase extends MultipleProgramsTestBase {
 				new NegativeElementsConvergenceCriterion());
 
 		DataSet<Integer> updatedDs = iteration.map(new SubtractOneMap());
-		iteration.closeWith(updatedDs).writeAsText(resultPath);
-		env.execute();
+		List<Integer> result = iteration.closeWith(updatedDs).collect();
+		Collections.sort(result);
 
-		expected =  "-3\n" + "-2\n" + "-2\n" + "-1\n" + "-1\n"
-				+ "-1\n" + "0\n" + "0\n" + "0\n" + "0\n"
-				+ "1\n" + "1\n" + "1\n" + "1\n" + "1\n";
+		List<Integer> expected = new ArrayList<Integer>() {{
+			add(-3); add(-2); add(-2); add(-1); add(-1);
+			add(-1); add(0); add(0); add(0); add(0);
+			add(1); add(1); add(1); add(1); add(1);
+		}};
+		Collections.sort(expected);
+
+		assertEquals(expected, result);
 	}
 
 	@Test
@@ -170,12 +167,17 @@ public class AggregatorsITCase extends MultipleProgramsTestBase {
 				new NegativeElementsConvergenceCriterion());
 
 		DataSet<Integer> updatedDs = iteration.map(new SubtractOneMapWithParam());
-		iteration.closeWith(updatedDs).writeAsText(resultPath);
-		env.execute();
+		List<Integer> result = iteration.closeWith(updatedDs).collect();
+		Collections.sort(result);
 
-		expected =  "-3\n" + "-2\n" + "-2\n" + "-1\n" + "-1\n"
-				+ "-1\n" + "0\n" + "0\n" + "0\n" + "0\n"
-				+ "1\n" + "1\n" + "1\n" + "1\n" + "1\n";
+		List<Integer> expected = new ArrayList<Integer>() {{
+			add(-3); add(-2); add(-2); add(-1); add(-1);
+			add(-1); add(0); add(0); add(0); add(0);
+			add(1); add(1); add(1); add(1); add(1);
+		}};
+		Collections.sort(expected);
+
+		assertEquals(expected, result);
 	}
 
 	@Test
@@ -199,12 +201,17 @@ public class AggregatorsITCase extends MultipleProgramsTestBase {
 				new NegativeElementsConvergenceCriterionWithParam(3));
 
 		DataSet<Integer> updatedDs = iteration.map(new SubtractOneMap());
-		iteration.closeWith(updatedDs).writeAsText(resultPath);
-		env.execute();
+		List<Integer> result = iteration.closeWith(updatedDs).collect();
+		Collections.sort(result);
 
-		expected = "-3\n" + "-2\n" + "-2\n" + "-1\n" + "-1\n"
-				+ "-1\n" + "0\n" + "0\n" + "0\n" + "0\n"
-				+ "1\n" + "1\n" + "1\n" + "1\n" + "1\n";
+		List<Integer> expected = new ArrayList<Integer>() {{
+			add(-3); add(-2); add(-2); add(-1); add(-1);
+			add(-1); add(0); add(0); add(0); add(0);
+			add(1); add(1); add(1); add(1); add(1);
+		}};
+		Collections.sort(expected);
+
+		assertEquals(expected, result);
 	}
 
 	@Test
@@ -231,14 +238,17 @@ public class AggregatorsITCase extends MultipleProgramsTestBase {
 				.where(0).equalTo(0).flatMap(new UpdateFilter());
 
 		DataSet<Tuple2<Integer, Integer>> iterationRes = iteration.closeWith(newElements, newElements);
-		DataSet<Integer> result = iterationRes.map(new ProjectSecondMapper());
-		result.writeAsText(resultPath);
+		List<Integer> result = iterationRes.map(new ProjectSecondMapper()).collect();
+		Collections.sort(result);
 
-		env.execute();
+		List<Integer> expected = new ArrayList<Integer>() {{
+			add(1); add(2); add(2); add(3); add(3);
+			add(3); add(4); add(4); add(4); add(4);
+			add(5); add(5); add(5); add(5); add(5);
+		}};
+		Collections.sort(expected);
 
-		expected = "1\n" + "2\n" + "2\n" + "3\n" + "3\n"
-				+ "3\n" + "4\n" + "4\n" + "4\n" + "4\n"
-				+ "5\n" + "5\n" + "5\n" + "5\n" + "5\n";
+		assertEquals(expected, result);
 	}
 
 	@Test
@@ -265,14 +275,17 @@ public class AggregatorsITCase extends MultipleProgramsTestBase {
 				.where(0).equalTo(0).flatMap(new UpdateFilter());
 
 		DataSet<Tuple2<Integer, Integer>> iterationRes = iteration.closeWith(newElements, newElements);
-		DataSet<Integer> result = iterationRes.map(new ProjectSecondMapper());
-		result.writeAsText(resultPath);
+		List<Integer> result = iterationRes.map(new ProjectSecondMapper()).collect();
+		Collections.sort(result);
 
-		env.execute();
+		List<Integer> expected = new ArrayList<Integer>() {{
+			add(1); add(2); add(2); add(3); add(3);
+			add(3); add(4); add(4); add(4); add(4);
+			add(5); add(5); add(5); add(5); add(5);
+		}};
+		Collections.sort(expected);
 
-		expected = "1\n" + "2\n" + "2\n" + "3\n" + "3\n"
-				+ "3\n" + "4\n" + "4\n" + "4\n" + "4\n"
-				+ "5\n" + "5\n" + "5\n" + "5\n" + "5\n";
+		assertEquals(result, expected);
 	}
 
 	@Test
@@ -303,14 +316,17 @@ public class AggregatorsITCase extends MultipleProgramsTestBase {
 				.where(0).equalTo(0).projectFirst(0, 1);
 
 		DataSet<Tuple2<Integer, Integer>> iterationRes = iteration.closeWith(newElements, newElements);
-		DataSet<Integer> result = iterationRes.map(new ProjectSecondMapper());
-		result.writeAsText(resultPath);
+		List<Integer> result = iterationRes.map(new ProjectSecondMapper()).collect();
+		Collections.sort(result);
 
-		env.execute();
+		List<Integer> expected = new ArrayList<Integer>() {{
+			add(-3); add(-2); add(-2); add(-1); add(-1);
+			add(-1); add(0); add(0); add(0); add(0);
+			add(1); add(1); add(1); add(1); add(1);
+		}};
+		Collections.sort(expected);
 
-		expected = "-3\n" + "-2\n" + "-2\n" + "-1\n" + "-1\n"
-				+ "-1\n" + "0\n" + "0\n" + "0\n" + "0\n"
-				+ "1\n" + "1\n" + "1\n" + "1\n" + "1\n";
+		assertEquals(expected, result);
 	}
 
 	@SuppressWarnings("serial")

--- a/flink-tests/src/test/java/org/apache/flink/test/iterative/aggregators/AggregatorsITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/iterative/aggregators/AggregatorsITCase.java
@@ -46,7 +46,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
@@ -136,12 +136,7 @@ public class AggregatorsITCase extends MultipleProgramsTestBase {
 		List<Integer> result = iteration.closeWith(updatedDs).collect();
 		Collections.sort(result);
 
-		List<Integer> expected = new ArrayList<Integer>() {{
-			add(-3); add(-2); add(-2); add(-1); add(-1);
-			add(-1); add(0); add(0); add(0); add(0);
-			add(1); add(1); add(1); add(1); add(1);
-		}};
-		Collections.sort(expected);
+		List<Integer> expected = Arrays.asList(-3, -2, -2, -1, -1, -1, 0, 0, 0, 0, 1, 1, 1, 1, 1);
 
 		assertEquals(expected, result);
 	}
@@ -170,12 +165,7 @@ public class AggregatorsITCase extends MultipleProgramsTestBase {
 		List<Integer> result = iteration.closeWith(updatedDs).collect();
 		Collections.sort(result);
 
-		List<Integer> expected = new ArrayList<Integer>() {{
-			add(-3); add(-2); add(-2); add(-1); add(-1);
-			add(-1); add(0); add(0); add(0); add(0);
-			add(1); add(1); add(1); add(1); add(1);
-		}};
-		Collections.sort(expected);
+		List<Integer> expected = Arrays.asList(-3, -2, -2, -1, -1, -1, 0, 0, 0, 0, 1, 1, 1, 1, 1);
 
 		assertEquals(expected, result);
 	}
@@ -204,12 +194,7 @@ public class AggregatorsITCase extends MultipleProgramsTestBase {
 		List<Integer> result = iteration.closeWith(updatedDs).collect();
 		Collections.sort(result);
 
-		List<Integer> expected = new ArrayList<Integer>() {{
-			add(-3); add(-2); add(-2); add(-1); add(-1);
-			add(-1); add(0); add(0); add(0); add(0);
-			add(1); add(1); add(1); add(1); add(1);
-		}};
-		Collections.sort(expected);
+		List<Integer> expected = Arrays.asList(-3, -2, -2, -1, -1, -1, 0, 0, 0, 0, 1, 1, 1, 1, 1);
 
 		assertEquals(expected, result);
 	}
@@ -241,12 +226,7 @@ public class AggregatorsITCase extends MultipleProgramsTestBase {
 		List<Integer> result = iterationRes.map(new ProjectSecondMapper()).collect();
 		Collections.sort(result);
 
-		List<Integer> expected = new ArrayList<Integer>() {{
-			add(1); add(2); add(2); add(3); add(3);
-			add(3); add(4); add(4); add(4); add(4);
-			add(5); add(5); add(5); add(5); add(5);
-		}};
-		Collections.sort(expected);
+		List<Integer> expected = Arrays.asList(1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 5);
 
 		assertEquals(expected, result);
 	}
@@ -278,12 +258,7 @@ public class AggregatorsITCase extends MultipleProgramsTestBase {
 		List<Integer> result = iterationRes.map(new ProjectSecondMapper()).collect();
 		Collections.sort(result);
 
-		List<Integer> expected = new ArrayList<Integer>() {{
-			add(1); add(2); add(2); add(3); add(3);
-			add(3); add(4); add(4); add(4); add(4);
-			add(5); add(5); add(5); add(5); add(5);
-		}};
-		Collections.sort(expected);
+		List<Integer> expected = Arrays.asList(1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 5);
 
 		assertEquals(result, expected);
 	}
@@ -319,12 +294,7 @@ public class AggregatorsITCase extends MultipleProgramsTestBase {
 		List<Integer> result = iterationRes.map(new ProjectSecondMapper()).collect();
 		Collections.sort(result);
 
-		List<Integer> expected = new ArrayList<Integer>() {{
-			add(-3); add(-2); add(-2); add(-1); add(-1);
-			add(-1); add(0); add(0); add(0); add(0);
-			add(1); add(1); add(1); add(1); add(1);
-		}};
-		Collections.sort(expected);
+		List<Integer> expected = Arrays.asList(-3, -2, -2, -1, -1, -1, 0, 0, 0, 0, 1, 1, 1, 1, 1);
 
 		assertEquals(expected, result);
 	}


### PR DESCRIPTION
## What is the purpose of the change

*This pull request migrate integration tests for iterative aggregators*


## Brief change log

  - *Migrate integration tests for iterative aggregators use `collect` api to replace temp file*


## Verifying this change

This change is already covered by existing tests, such as *AggregatorsITCase*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
