### PR TITLE
[FLINK-9545] Support read a file multiple times in Flink DataStream

### DIFF
--- a/docs/dev/datastream_api.md
+++ b/docs/dev/datastream_api.md
@@ -153,11 +153,17 @@ There are several predefined stream sources accessible from the `StreamExecution
 
 File-based:
 
-- `readTextFile(path)` - Reads text files, i.e. files that respect the `TextInputFormat` specification, line-by-line and returns them as Strings.
+- `readTextFile(path)` - Reads once the text files, i.e. files that respect the `TextInputFormat` specification, line-by-line and returns them as Strings.
 
-- `readFile(fileInputFormat, path)` - Reads (once) files as dictated by the specified file input format.
+- `readTextFile(path, numTimes)` - Reads `numTimes` times the text files .
 
-- `readFile(fileInputFormat, path, watchType, interval, pathFilter, typeInfo)` -  This is the method called internally by the two previous ones. It reads files in the `path` based on the given `fileInputFormat`. Depending on the provided `watchType`, this source may periodically monitor (every `interval` ms) the path for new data (`FileProcessingMode.PROCESS_CONTINUOUSLY`), or process once the data currently in the path and exit (`FileProcessingMode.PROCESS_ONCE`). Using the `pathFilter`, the user can further exclude files from being processed.
+- `readFile(fileInputFormat, path)` - Reads once the files as dictated by the specified file input format.
+
+- `readFile(fileInputFormat, path, numTimes)` - Reads `numTimes` times the files as dictated by the specified file input format.
+
+- `readFile(fileInputFormat, path, watchType, interval, pathFilter, typeInfo)` -  This is the method called internally by the two previous ones. It reads files in the `path` based on the given `fileInputFormat`. Depending on the provided `watchType`, this source may periodically monitor (every `interval` ms) the path for new data (`FileProcessingMode.PROCESS_CONTINUOUSLY`), or process once the data currently in the path and exit (`FileProcessingMode.PROCESS_ONCE`). Using `FileProcessingMode.PROCESS_N_TIMES` will be translated into `FileProcessingMode.PROCESS_ONCE`. Using the `pathFilter`, the user can further exclude files from being processed.
+
+- `readFile(fileInputFormat, path, watchType, interval, pathFilter, typeInfo, numTimes)` -  This is the method called internally by the two previous ones. It reads files in the `path` based on the given `fileInputFormat`. Depending on the provided `watchType`, this source may periodically monitor (every `interval` ms) the path for new data (`FileProcessingMode.PROCESS_CONTINUOUSLY`), or process once or `numTimes` times the data currently in the path and exit (`FileProcessingMode.PROCESS_ONCE` or `FileProcessingMode.PROCESS_N_TIMES`). Using the `pathFilter`, the user can further exclude files from being processed.
 
     *IMPLEMENTATION:*
 
@@ -167,7 +173,7 @@ File-based:
 
     1. If the `watchType` is set to `FileProcessingMode.PROCESS_CONTINUOUSLY`, when a file is modified, its contents are re-processed entirely. This can break the "exactly-once" semantics, as appending data at the end of a file will lead to **all** its contents being re-processed.
 
-    2. If the `watchType` is set to `FileProcessingMode.PROCESS_ONCE`, the source scans the path **once** and exits, without waiting for the readers to finish reading the file contents. Of course the readers will continue reading until all file contents are read. Closing the source leads to no more checkpoints after that point. This may lead to slower recovery after a node failure, as the job will resume reading from the last checkpoint.
+    2. If the `watchType` is set to `FileProcessingMode.PROCESS_ONCE` or `FileProcessingMode.PROCESS_N_TIMES`, the source scans the path **once** and exits, without waiting for the readers to finish reading the file contents. Of course the readers will continue reading until all file contents are read. Closing the source leads to no more checkpoints after that point. This may lead to slower recovery after a node failure, as the job will resume reading from the last checkpoint.
 
 Socket-based:
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/FileProcessingMode.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/FileProcessingMode.java
@@ -22,13 +22,16 @@ import org.apache.flink.annotation.PublicEvolving;
 
 /**
  * The mode in which the {@link ContinuousFileMonitoringFunction} operates.
- * This can be either {@link #PROCESS_ONCE} or {@link #PROCESS_CONTINUOUSLY}.
+ * This can be {@link #PROCESS_ONCE}, {@link #PROCESS_N_TIMES}, or {@link #PROCESS_CONTINUOUSLY}.
  */
 @PublicEvolving
 public enum FileProcessingMode {
 
 	/** Processes the current contents of the path and exits. */
 	PROCESS_ONCE,
+
+	/** Processes the current contents of the path n times and exits. */
+	PROCESS_N_TIMES,
 
 	/** Periodically scans the path for new data. */
 	PROCESS_CONTINUOUSLY


### PR DESCRIPTION
## What is the purpose of the change

Motivation: We have the requirements to read a bunch files, each file to read multiple times, to feed our streams

Specifically we need `StreamExecutionEnvironment.readFile/readTextFile` to be able to read a file for a specified `N` times, but currently it only supports reading file once.

We've implemented this internally. Would be good to get it back to the community version. This jira is to add support for the feature. 

## Brief change log

- add a new processing mode as PROCESSING_N_TIMES
- add additional parameter numTimes for StreamExecutionEnvironment.readFile/readTextFile

## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.

## Does this pull request potentially affect one of the following parts:

  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs / JavaDocs)
