### PR TITLE
[FLINK-9351][Distributed Coordination] RM stop assigning slot to Job because the TM killed before connecting to JM successfully

### DIFF
--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManager.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManager.java
@@ -619,7 +619,11 @@ public class MesosResourceManager extends ResourceManager<RegisteredMesosWorkerN
 			startNewWorker(launched.profile());
 		}
 
-		closeTaskManagerConnection(id, new Exception(status.getMessage()));
+		final Exception terminatedCause = new Exception(status.getMessage());
+
+		notifyTaskManagerCompleted(id, terminatedCause);
+
+		closeTaskManagerConnection(id, terminatedCause);
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/TaskManagerSlot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/TaskManagerSlot.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.clusterframework.types;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.resourcemanager.registration.TaskExecutorConnection;
 import org.apache.flink.runtime.resourcemanager.slotmanager.PendingSlotRequest;
@@ -44,6 +45,9 @@ public class TaskManagerSlot {
 
 	/** Allocation id for which this slot has been allocated. */
 	private AllocationID allocationId;
+
+	/** Allocation id for which this slot has been allocated. */
+	private JobID jobId;
 
 	/** Assigned slot request if there is currently an ongoing request. */
 	private PendingSlotRequest assignedSlotRequest;
@@ -83,6 +87,10 @@ public class TaskManagerSlot {
 		return allocationId;
 	}
 
+	public JobID getJobId() {
+		return jobId;
+	}
+
 	public PendingSlotRequest getAssignedSlotRequest() {
 		return assignedSlotRequest;
 	}
@@ -96,6 +104,7 @@ public class TaskManagerSlot {
 
 		state = State.FREE;
 		allocationId = null;
+		jobId = null;
 	}
 
 	public void clearPendingSlotRequest() {
@@ -112,21 +121,24 @@ public class TaskManagerSlot {
 		assignedSlotRequest = Preconditions.checkNotNull(pendingSlotRequest);
 	}
 
-	public void completeAllocation(AllocationID allocationId) {
+	public void completeAllocation(AllocationID allocationId, JobID jobId) {
 		Preconditions.checkNotNull(allocationId, "Allocation id must not be null.");
+		Preconditions.checkNotNull(jobId, "Job id must not be null.");
 		Preconditions.checkState(state == State.PENDING, "In order to complete an allocation, the slot has to be allocated.");
 		Preconditions.checkState(Objects.equals(allocationId, assignedSlotRequest.getAllocationId()), "Mismatch between allocation id of the pending slot request.");
 
 		state = State.ALLOCATED;
 		this.allocationId = allocationId;
+		this.jobId = jobId;
 		assignedSlotRequest = null;
 	}
 
-	public void updateAllocation(AllocationID allocationId) {
+	public void updateAllocation(AllocationID allocationId, JobID jobId) {
 		Preconditions.checkState(state == State.FREE, "The slot has to be free in order to set an allocation id.");
 
 		state = State.ALLOCATED;
 		this.allocationId = Preconditions.checkNotNull(allocationId);
+		this.jobId = Preconditions.checkNotNull(jobId);
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -991,6 +991,11 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 			disconnectTaskManager(
 				resourceID,
 				new FlinkRuntimeException("TaskManager with id " + resourceID + " has terminated.", cause));
+		} else {
+			// we try to fail the allocation because the TM might fail to communicate with JM before it exists.
+			for (AllocationID allocationId : allocationIds) {
+				slotPoolGateway.failAllocation(allocationId, cause);
+			}
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -105,6 +105,7 @@ import org.apache.flink.runtime.util.clock.SystemClock;
 import org.apache.flink.runtime.webmonitor.WebMonitorUtils;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.Preconditions;
 
@@ -982,6 +983,15 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 			backPressureStatsTracker.getOperatorBackPressureStats(jobVertex);
 		return CompletableFuture.completedFuture(OperatorBackPressureStatsResponse.of(
 			operatorBackPressureStats.orElse(null)));
+	}
+
+	@Override
+	public void taskManagerTerminated(ResourceID resourceID, Set<AllocationID> allocationIds, Exception cause) {
+		if (registeredTaskManagers.containsKey(resourceID)) {
+			disconnectTaskManager(
+				resourceID,
+				new FlinkRuntimeException("TaskManager with id " + resourceID + " has terminated.", cause));
+		}
 	}
 
 	//----------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
@@ -48,6 +48,7 @@ import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import javax.annotation.Nullable;
 
 import java.util.Collection;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -278,4 +279,13 @@ public interface JobMasterGateway extends
 	 * not available (yet).
 	 */
 	CompletableFuture<OperatorBackPressureStatsResponse> requestOperatorBackPressureStats(JobVertexID jobVertexId);
+
+	/**
+	 * Notifies that the task manager has terminated.
+	 *
+	 * @param resourceID identifying the task manager
+	 * @param allocationIDs held by this job that belong to the task manager
+	 * @param cause of the task manager termination
+	 */
+	void taskManagerTerminated(ResourceID resourceID, Set<AllocationID> allocationIDs, Exception cause);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/ResourceActions.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/ResourceActions.java
@@ -20,9 +20,12 @@ package org.apache.flink.runtime.resourcemanager.slotmanager;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.resourcemanager.exceptions.ResourceManagerException;
+
+import java.util.Set;
 
 /**
  * Resource related actions which the {@link SlotManager} can perform.
@@ -53,4 +56,13 @@ public interface ResourceActions {
 	 * @param cause of the allocation failure
 	 */
 	void notifyAllocationFailure(JobID jobId, AllocationID allocationId, Exception cause);
+
+	/**
+	 * Notifies that the task manager has been terminated.
+	 * @param jobId to be notified
+	 * @param resourceID identifying the terminated task manager
+	 * @param allocationIDs of the job held that belong to this task manager
+	 * @param cause of the task manager termination.
+	 */
+	void notifyTaskManagerTerminated(JobID jobId, ResourceID resourceID, Set<AllocationID> allocationIDs, Exception cause);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -762,7 +762,8 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 
 				log.info(message);
 
-				throw new SlotOccupiedException(message, taskSlotTable.getCurrentAllocation(slotId.getSlotNumber()));
+				final AllocationID allocationID = taskSlotTable.getCurrentAllocation(slotId.getSlotNumber());
+				throw new SlotOccupiedException(message, allocationID, taskSlotTable.getOwningJob(allocationID));
 			}
 
 			if (jobManagerTable.contains(jobId)) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/exceptions/SlotOccupiedException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/exceptions/SlotOccupiedException.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.taskexecutor.exceptions;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.util.Preconditions;
 
@@ -26,22 +27,31 @@ public class SlotOccupiedException extends SlotAllocationException {
 
 	private final AllocationID allocationId;
 
-	public SlotOccupiedException(String message, AllocationID allocationId) {
+	private final JobID jobId;
+
+	public SlotOccupiedException(String message, AllocationID allocationId, JobID jobId) {
 		super(message);
 		this.allocationId = Preconditions.checkNotNull(allocationId);
+		this.jobId = jobId;
 	}
 
-	public SlotOccupiedException(String message, Throwable cause, AllocationID allocationId) {
+	public SlotOccupiedException(String message, Throwable cause, AllocationID allocationId, JobID jobId) {
 		super(message, cause);
 		this.allocationId = Preconditions.checkNotNull(allocationId);
+		this.jobId = jobId;
 	}
 
-	public SlotOccupiedException(Throwable cause, AllocationID allocationId) {
+	public SlotOccupiedException(Throwable cause, AllocationID allocationId, JobID jobId) {
 		super(cause);
 		this.allocationId = Preconditions.checkNotNull(allocationId);
+		this.jobId = jobId;
 	}
 
 	public AllocationID getAllocationId() {
 		return allocationId;
+	}
+
+	public JobID getJobId() {
+		return jobId;
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGateway.java
@@ -53,6 +53,7 @@ import javax.annotation.Nullable;
 
 import java.net.InetSocketAddress;
 import java.util.Collection;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -162,6 +163,11 @@ public class TestingJobMasterGateway implements JobMasterGateway {
 
 	@Override
 	public CompletableFuture<OperatorBackPressureStatsResponse> requestOperatorBackPressureStats(JobVertexID jobVertexId) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void taskManagerTerminated(ResourceID resourceID, Set<AllocationID> allocationIDs, Exception cause) {
 		throw new UnsupportedOperationException();
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceActions.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceActions.java
@@ -20,8 +20,11 @@ package org.apache.flink.runtime.resourcemanager.slotmanager;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.instance.InstanceID;
+
+import java.util.Set;
 
 /**
  * Testing implementation of the {@link ResourceActions}.
@@ -39,6 +42,11 @@ public class TestingResourceActions implements ResourceActions {
 
 	@Override
 	public void notifyAllocationFailure(JobID jobId, AllocationID allocationId, Exception cause) {
+
+	}
+
+	@Override
+	public void notifyTaskManagerTerminated(JobID jobId, ResourceID resourceID, Set<AllocationID> allocationIDs, Exception cause) {
 
 	}
 }

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
@@ -330,13 +330,18 @@ public class YarnResourceManager extends ResourceManager<YarnWorkerNode> impleme
 
 					final ResourceID resourceId = new ResourceID(containerStatus.getContainerId().toString());
 					final YarnWorkerNode yarnWorkerNode = workerNodeMap.remove(resourceId);
+					final Exception completedCause = new Exception(containerStatus.getDiagnostics());
+
+					// tell the job manager the terminated task manager.
+					notifyTaskManagerCompleted(resourceId, completedCause);
 
 					if (yarnWorkerNode != null) {
 						// Container completed unexpectedly ~> start a new one
 						final Container container = yarnWorkerNode.getContainer();
 						requestYarnContainer(container.getResource(), yarnWorkerNode.getContainer().getPriority());
-						closeTaskManagerConnection(resourceId, new Exception(containerStatus.getDiagnostics()));
 					}
+
+					closeTaskManagerConnection(resourceId, completedCause);
 				}
 			}
 		);


### PR DESCRIPTION
## What is the purpose of the change

*This PR bases on https://github.com/apache/flink/pull/6132, it fails the allocation when the TM is killed before communicating with JM.*


## Brief change log

  - *Fail the allocation when the TM is killed before communicating with JM*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

- No