### PR TITLE
[FLINK-9546][core] Fix the checking of heartbeatTimeoutIntervalMs in HeartbeatMonitor.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatManagerImpl.java
@@ -277,7 +277,7 @@ public class HeartbeatManagerImpl<I, O> implements HeartbeatManager<I, O> {
 			this.scheduledExecutor = Preconditions.checkNotNull(scheduledExecutor);
 			this.heartbeatListener = Preconditions.checkNotNull(heartbeatListener);
 
-			Preconditions.checkArgument(heartbeatTimeoutIntervalMs >= 0L, "The heartbeat timeout interval has to be larger than 0.");
+			Preconditions.checkArgument(heartbeatTimeoutIntervalMs > 0L, "The heartbeat timeout interval has to be larger than 0.");
 			this.heartbeatTimeoutIntervalMs = heartbeatTimeoutIntervalMs;
 
 			lastHeartbeat = 0L;


### PR DESCRIPTION
## What is the purpose of the change

The heartbeatTimeoutIntervalMs of HeartbeatMonitor should be larger than 0, currently the arg check looks like

```java
Preconditions.checkArgument(heartbeatTimeoutIntervalMs >= 0L, "The heartbeat timeout interval has to be larger than 0.");
```

it should be

```java
Preconditions.checkArgument(heartbeatTimeoutIntervalMs > 0L, "The heartbeat timeout interval has to be larger than 0.");
```

## Brief change log

  - *Fix the checking of heartbeatTimeoutIntervalMs in HeartbeatMonitor.*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

No

## Documentation

No