### PR TITLE
[FLINK-9549][DOC]Fix FlickCEP Docs broken link and minor style changes

### DIFF
--- a/docs/dev/libs/cep.md
+++ b/docs/dev/libs/cep.md
@@ -31,7 +31,7 @@ This page describes the API calls available in Flink CEP. We start by presenting
 which allows you to specify the patterns that you want to detect in your stream, before presenting how you can
 [detect and act upon matching event sequences](#detecting-patterns). We then present the assumptions the CEP
 library makes when [dealing with lateness](#handling-lateness-in-event-time) in event time and how you can
-[migrate your job](#migrating-from-an-older-flink-version) from an older Flink version to Flink-1.3.
+[migrate your job](#migrating-from-an-older-flink-versionpre-13) from an older Flink version to Flink-1.3.
 
 * This will be replaced by the TOC
 {:toc}
@@ -408,7 +408,7 @@ input `"a1", "c", "a2", "b"` will have the following results:
 
  1. **Strict Contiguity**: `{a2 b}` -- the `"c"` after `"a1"` causes `"a1"` to be discarded.
 
- 2. **Relaxed Contiguity**: `{a1 b}` and `{a1 a2 b}` -- `c` is ignored.
+ 2. **Relaxed Contiguity**: `{a1 b}` and `{a1 a2 b}` -- `"c"` is ignored.
 
  3. **Non-Deterministic Relaxed Contiguity**: `{a1 b}`, `{a2 b}`, and `{a1 a2 b}`.
 
@@ -834,7 +834,7 @@ them between consecutive patterns, you can use:
 or
 
 1. `notNext()`, if you do not want an event type to directly follow another
-2. `notFollowedBy()`, if you do not want an event type to be anywhere between two other event types
+2. `notFollowedBy()`, if you do not want an event type to be anywhere between two other event types.
 
 {% warn Attention %} A pattern sequence cannot end in `notFollowedBy()`.
 
@@ -886,14 +886,14 @@ val relaxedNot: Pattern[Event, _] = start.notFollowedBy("not").where(...)
 
 Relaxed contiguity means that only the first succeeding matching event will be matched, while
 with non-deterministic relaxed contiguity, multiple matches will be emitted for the same beginning. As an example,
-a pattern `a b`, given the event sequence `"a", "c", "b1", "b2"`, will give the following results:
+a pattern `"a b"`, given the event sequence `"a", "c", "b1", "b2"`, will give the following results:
 
-1. Strict Contiguity between `a` and `b`: `{}` (no match), the `"c"` after `"a"` causes `"a"` to be discarded.
+1. Strict Contiguity between `"a"` and `"b"`: `{}` (no match), the `"c"` after `"a"` causes `"a"` to be discarded.
 
-2. Relaxed Contiguity between `a` and `b`: `{a b1}`, as relaxed continuity is viewed as "skip non-matching events
+2. Relaxed Contiguity between `"a"` and `"b"`: `{a b1}`, as relaxed continuity is viewed as "skip non-matching events
 till the next matching one".
 
-3. Non-Deterministic Relaxed Contiguity between `a` and `b`: `{a b1}`, `{a b2}`, as this is the most general form.
+3. Non-Deterministic Relaxed Contiguity between `"a"` and `"b"`: `{a b1}`, `{a b2}`, as this is the most general form.
 
 It's also possible to define a temporal constraint for the pattern to be valid.
 For example, you can define that a pattern should occur within 10 seconds via the `pattern.within()` method.
@@ -1532,7 +1532,7 @@ seen watermark. Late elements are not further processed. Also, you can specify a
 {% highlight java %}
 PatternStream<Event> patternStream = CEP.pattern(input, pattern);
 
-OutputTag<String> lateDataOutputTag = new OutputTag<String>("late-data""){};
+OutputTag<String> lateDataOutputTag = new OutputTag<String>("late-data"){};
 
 SingleOutputStreamOperator<ComplexEvent> result = patternStream
     .sideOutputLateData(lateDataOutputTag)


### PR DESCRIPTION

## What is the purpose of the change

Fixing FlickCEP broken link and minor style changes

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
