### PR TITLE
[FLINK-9551][DOCS]FlinkCEP Scala Combining Patterns table has a missing pattern

### DIFF
--- a/docs/dev/libs/cep.md
+++ b/docs/dev/libs/cep.md
@@ -1117,11 +1117,22 @@ pattern.within(Time.seconds(10));
     </thead>
     <tbody>
         <tr>
-            <td><strong>begin()</strong></td>
+            <td><strong>begin(#name)</strong></td>
             <td>
             <p>Defines a starting pattern:</p>
 {% highlight scala %}
 val start = Pattern.begin[Event]("start")
+{% endhighlight %}
+            </td>
+        </tr>
+       <tr>
+            <td><strong>begin(#pattern_sequence)</strong></td>
+            <td>
+            <p>Defines a starting pattern:</p>
+{% highlight scala %}
+val start = Pattern.begin(
+    Pattern.begin[Event]("start").where(...).followedBy("middle").where(...)
+)
 {% endhighlight %}
             </td>
         </tr>


### PR DESCRIPTION
## What is the purpose of the change

in FlinkCEP documentation section related to **Combining Patterns** Scala Table has a missing patterns compare to Java table

`begin(#pattern_sequence)`
and also 
`begin()` pattern has missing `#name` params


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
