### PR TITLE
[FLINK-9554] flink scala shell doesn't work in yarn mode

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -166,6 +166,10 @@ public class CliFrontend {
 		return copiedConfiguration;
 	}
 
+	public Options getCustomCommandLineOptions() {
+		return customCommandLineOptions;
+	}
+
 	// --------------------------------------------------------------------------------------------
 	//  Execute Actions
 	// --------------------------------------------------------------------------------------------

--- a/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkShell.scala
+++ b/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkShell.scala
@@ -275,25 +275,14 @@ object FlinkShell {
     yarnConfig.queue.foreach((queue) => args ++= Seq("-yqu", queue.toString))
     yarnConfig.slots.foreach((slots) => args ++= Seq("-ys", slots.toString))
 
-    val customCommandLines = CliFrontend.loadCustomCommandLines(
-      configuration,configurationDirectory)
+    val frontend = new CliFrontend(configuration,
+      CliFrontend.loadCustomCommandLines(configuration, configurationDirectory))
+
     val commandOptions = CliFrontendParser.getRunCommandOptions
-    val customCommandLineOptions = new Options()
-    customCommandLines.asScala.foreach(cmd => {
-      cmd.addGeneralOptions(customCommandLineOptions)
-      cmd.addRunOptions(customCommandLineOptions)
-    })
-    val commandLineOptions = CliFrontendParser.mergeOptions(
-      commandOptions, customCommandLineOptions)
+    val commandLineOptions = CliFrontendParser.mergeOptions(commandOptions,
+      frontend.getCustomCommandLineOptions());
+    val commandLine = CliFrontendParser.parse(commandLineOptions, args.toArray, true)
 
-    val commandLine = CliFrontendParser.parse(
-      commandLineOptions,
-      args.toArray,
-      true)
-
-    val frontend = new CliFrontend(
-      configuration,
-      customCommandLines)
     val customCLI = frontend.getActiveCustomCommandLine(commandLine)
 
     val clusterDescriptor = customCLI.createClusterDescriptor(commandLine)

--- a/flink-scala-shell/start-script/start-scala-shell.sh
+++ b/flink-scala-shell/start-script/start-scala-shell.sh
@@ -19,9 +19,6 @@
 
 # from scala-lang 2.10.4
 
-# Uncomment the following line to enable remote debug
-# export FLINK_SCALA_SHELL_JAVA_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005"
-
 # restore stty settings (echo in particular)
 function restoreSttySettings() {
   if [[ -n $SCALA_RUNNER_DEBUG ]]; then
@@ -89,9 +86,9 @@ fi
 
 if ${EXTERNAL_LIB_FOUND}
 then
-    java -Dscala.color $FLINK_SCALA_SHELL_JAVA_OPTS -cp "$FLINK_CLASSPATH" $log_setting org.apache.flink.api.scala.FlinkShell $@ --addclasspath "$EXT_CLASSPATH"
+    java -Dscala.color -cp "$FLINK_CLASSPATH" $log_setting org.apache.flink.api.scala.FlinkShell $@ --addclasspath "$EXT_CLASSPATH"
 else
-    java -Dscala.color $FLINK_SCALA_SHELL_JAVA_OPTS -cp "$FLINK_CLASSPATH" $log_setting org.apache.flink.api.scala.FlinkShell $@
+    java -Dscala.color -cp "$FLINK_CLASSPATH" $log_setting org.apache.flink.api.scala.FlinkShell $@
 fi
 
 #restore echo

--- a/flink-scala-shell/start-script/start-scala-shell.sh
+++ b/flink-scala-shell/start-script/start-scala-shell.sh
@@ -19,6 +19,9 @@
 
 # from scala-lang 2.10.4
 
+# Uncomment the following line to enable remote debug
+# export FLINK_SCALA_SHELL_JAVA_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005"
+
 # restore stty settings (echo in particular)
 function restoreSttySettings() {
   if [[ -n $SCALA_RUNNER_DEBUG ]]; then
@@ -86,9 +89,9 @@ fi
 
 if ${EXTERNAL_LIB_FOUND}
 then
-    java -Dscala.color -cp "$FLINK_CLASSPATH" $log_setting org.apache.flink.api.scala.FlinkShell $@ --addclasspath "$EXT_CLASSPATH"
+    java -Dscala.color $FLINK_SCALA_SHELL_JAVA_OPTS -cp "$FLINK_CLASSPATH" $log_setting org.apache.flink.api.scala.FlinkShell $@ --addclasspath "$EXT_CLASSPATH"
 else
-    java -Dscala.color -cp "$FLINK_CLASSPATH" $log_setting org.apache.flink.api.scala.FlinkShell $@
+    java -Dscala.color $FLINK_SCALA_SHELL_JAVA_OPTS -cp "$FLINK_CLASSPATH" $log_setting org.apache.flink.api.scala.FlinkShell $@
 fi
 
 #restore echo


### PR DESCRIPTION
## What is the purpose of the change

This PR is trying to fix the issue of `scala-shell` unable to run in yarn mode.  

## Brief change log

The root cause is the options of CustomCommandLine is missed which cause the "-m yarn-cluster" can not be parsed correctly.

## Verifying this change

I verify it manually on a single node hadoop cluster. I think it is better to add integration for that so that we can avoid the regression issue in future. If necessary, I can create a ticket for it and do it in another PR. 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no )
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? ( not documented)
