### PR TITLE
[hotfix] [docs] Fixed scala variable declaration without initialization

### DIFF
--- a/docs/dev/event_timestamps_watermarks.md
+++ b/docs/dev/event_timestamps_watermarks.md
@@ -242,7 +242,7 @@ class BoundedOutOfOrdernessGenerator extends AssignerWithPeriodicWatermarks[MyEv
 
     val maxOutOfOrderness = 3500L // 3.5 seconds
 
-    var currentMaxTimestamp: Long
+    var currentMaxTimestamp: Long = _
 
     override def extractTimestamp(element: MyEvent, previousElementTimestamp: Long): Long = {
         val timestamp = element.getCreationTime()


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixes an error in the Scala example for periodic watermarks. 
It is not possible to declare a variable without initializing it, at least not outside of abstract classes.