### PR TITLE
[FLINK-9560] Add RateLimiting for FileSystem

### DIFF
--- a/docs/ops/filesystems.md
+++ b/docs/ops/filesystems.md
@@ -91,7 +91,7 @@ For example, if the default file system configured as `fs.default-scheme: hdfs:/
 You can limit the total number of connections that a file system can concurrently open. This is useful when the file system cannot handle a large number
 of concurrent reads / writes or open connections at the same time. You can also limit the throughput/bandwidth used to read/write from/to the FileSystem
 
-For example, very small HDFS clusters with few RPC handlers can sometimes be overwhelmed by a large Flink job trying to build up many connections during a checkpoint. 
+For example, very small HDFS clusters with few RPC handlers can sometimes be overwhelmed by a large Flink job trying to build up many connections during a checkpoint.
 
 To limit a specific file system's connections, add the following entries to the Flink configuration. The file system to be limited is identified by
 its scheme.
@@ -102,8 +102,8 @@ fs.<scheme>.limit.input: (number, 0/-1 mean no limit)
 fs.<scheme>.limit.output: (number, 0/-1 mean no limit)
 fs.<scheme>.limit.timeout: (milliseconds, 0 means infinite)
 fs.<scheme>.limit.stream-timeout: (milliseconds, 0 means infinite)
-fs.<scheme>.limit.rateLimitingInput: (bytes/s, 0 means infinite)
-fs.<scheme>.limit.rateLimitingOutput: (bytes/s, 0 means infinite)
+fs.<scheme>.limit.input-rate-limit: (bytes/s, 0 means infinite . By default, there is no limits)
+fs.<scheme>.limit.output-rate-limit: (bytes/s, 0 means infinite. By default, there is no limits)
 {% endhighlight %}
 
 You can limit the number if input/output connections (streams) separately (`fs.<scheme>.limit.input` and `fs.<scheme>.limit.output`), as well as impose a limit on

--- a/docs/ops/filesystems.md
+++ b/docs/ops/filesystems.md
@@ -102,8 +102,8 @@ fs.<scheme>.limit.input: (number, 0/-1 mean no limit)
 fs.<scheme>.limit.output: (number, 0/-1 mean no limit)
 fs.<scheme>.limit.timeout: (milliseconds, 0 means infinite)
 fs.<scheme>.limit.stream-timeout: (milliseconds, 0 means infinite)
-fs.<scheme>.limit.input-rate-limit: (bytes/s, 0 means infinite . By default, there is no limits)
-fs.<scheme>.limit.output-rate-limit: (bytes/s, 0 means infinite. By default, there is no limits)
+fs.<scheme>.limit.input-rate: (bytes/s, 0 means infinite . By default, there is no limit)
+fs.<scheme>.limit.output-rate: (bytes/s, 0 means infinite. By default, there is no limit)
 {% endhighlight %}
 
 You can limit the number if input/output connections (streams) separately (`fs.<scheme>.limit.input` and `fs.<scheme>.limit.output`), as well as impose a limit on

--- a/docs/ops/filesystems.md
+++ b/docs/ops/filesystems.md
@@ -89,9 +89,9 @@ For example, if the default file system configured as `fs.default-scheme: hdfs:/
 #### Connection limiting
 
 You can limit the total number of connections that a file system can concurrently open. This is useful when the file system cannot handle a large number
-of concurrent reads / writes or open connections at the same time.
+of concurrent reads / writes or open connections at the same time. You can also limit the throughput/bandwidth used to read/write from/to the FileSystem
 
-For example, very small HDFS clusters with few RPC handlers can sometimes be overwhelmed by a large Flink job trying to build up many connections during a checkpoint.
+For example, very small HDFS clusters with few RPC handlers can sometimes be overwhelmed by a large Flink job trying to build up many connections during a checkpoint. 
 
 To limit a specific file system's connections, add the following entries to the Flink configuration. The file system to be limited is identified by
 its scheme.
@@ -102,6 +102,8 @@ fs.<scheme>.limit.input: (number, 0/-1 mean no limit)
 fs.<scheme>.limit.output: (number, 0/-1 mean no limit)
 fs.<scheme>.limit.timeout: (milliseconds, 0 means infinite)
 fs.<scheme>.limit.stream-timeout: (milliseconds, 0 means infinite)
+fs.<scheme>.limit.rateLimitingInput: (bytes/s, 0 means infinite)
+fs.<scheme>.limit.rateLimitingOutput: (bytes/s, 0 means infinite)
 {% endhighlight %}
 
 You can limit the number if input/output connections (streams) separately (`fs.<scheme>.limit.input` and `fs.<scheme>.limit.output`), as well as impose a limit on
@@ -110,6 +112,8 @@ If the opening of the stream takes longer than `fs.<scheme>.limit.timeout`, the 
 
 To prevent inactive streams from taking up the complete pool (preventing new connections to be opened), you can add an inactivity timeout for streams:
 `fs.<scheme>.limit.stream-timeout`. If a stream does not read/write any bytes for at least that amount of time, it is forcibly closed.
+
+For limiting the bandwidth used by the checkpoint generation, you can add a fs.<scheme>.limit.rateLimitingOutput
 
 These limits are enforced per TaskManager, so each TaskManager in a Flink application or cluster will open up to that number of connections.
 In addition, the The limit are also enforced only per FileSystem instance. Because File Systems are created per scheme and authority, different

--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -66,6 +66,13 @@ under the License.
 			<!-- managed version -->
 		</dependency>
 
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-shaded-guava</artifactId>
+			<!-- managed version -->
+		</dependency>
+
 		<!-- The common collections are needed for some hash tables used in the collection execution -->
 		<dependency>
 			<groupId>commons-collections</groupId>

--- a/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
@@ -273,6 +273,23 @@ public class CoreOptions {
 		return ConfigOptions.key("fs." + scheme + ".limit.stream-timeout").defaultValue(0L);
 	}
 
+	/**
+	 * The number of bytes allowed to be red by seconds from Filesystem
+	 * Unlimited be default.
+	 */
+	public static ConfigOption<Long> rateLimitingInputBytesPerSeconds(String scheme) {
+		return ConfigOptions.key("fs." + scheme + ".limit.rateLimitingInput").defaultValue(0L);
+	}
+
+	/**
+	 * The number of bytes allowed to be written by seconds to Filesystem
+	 * Unlimited be default.
+	 */
+	public static ConfigOption<Long> rateLimitingOutputBytesPerSeconds(String scheme) {
+		return ConfigOptions.key("fs." + scheme + ".limit.rateLimitingOutput").defaultValue(0L);
+	}
+
+
 	// ------------------------------------------------------------------------
 	//  Distributed architecture
 	// ------------------------------------------------------------------------

--- a/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
@@ -278,7 +278,7 @@ public class CoreOptions {
 	 * Unlimited be default.
 	 */
 	public static ConfigOption<Long> rateLimitingInputBytesPerSeconds(String scheme) {
-		return ConfigOptions.key("fs." + scheme + ".limit.rateLimitingInput").defaultValue(0L);
+		return ConfigOptions.key("fs." + scheme + ".limit.input-rate-limit").defaultValue(0L);
 	}
 
 	/**
@@ -286,7 +286,7 @@ public class CoreOptions {
 	 * Unlimited be default.
 	 */
 	public static ConfigOption<Long> rateLimitingOutputBytesPerSeconds(String scheme) {
-		return ConfigOptions.key("fs." + scheme + ".limit.rateLimitingOutput").defaultValue(0L);
+		return ConfigOptions.key("fs." + scheme + ".limit.output-rate-limit").defaultValue(0L);
 	}
 
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
@@ -277,16 +277,16 @@ public class CoreOptions {
 	 * The number of bytes allowed to be red by seconds from Filesystem
 	 * Unlimited be default.
 	 */
-	public static ConfigOption<Long> rateLimitingInputBytesPerSeconds(String scheme) {
-		return ConfigOptions.key("fs." + scheme + ".limit.input-rate-limit").defaultValue(0L);
+	public static ConfigOption<Long> fileSystemConnectionLimitInputRate(String scheme) {
+		return ConfigOptions.key("fs." + scheme + ".limit.input-rate").defaultValue(0L);
 	}
 
 	/**
 	 * The number of bytes allowed to be written by seconds to Filesystem
 	 * Unlimited be default.
 	 */
-	public static ConfigOption<Long> rateLimitingOutputBytesPerSeconds(String scheme) {
-		return ConfigOptions.key("fs." + scheme + ".limit.output-rate-limit").defaultValue(0L);
+	public static ConfigOption<Long> fileSystemConnectionLimitOutputRate(String scheme) {
+		return ConfigOptions.key("fs." + scheme + ".limit.output-rate").defaultValue(0L);
 	}
 
 

--- a/flink-core/src/main/java/org/apache/flink/core/fs/ConnectionLimitingFactory.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/ConnectionLimitingFactory.java
@@ -62,7 +62,9 @@ public class ConnectionLimitingFactory implements FileSystemFactory {
 		FileSystem original = factory.create(fsUri);
 		return new LimitedConnectionsFileSystem(original,
 				settings.limitTotal, settings.limitOutput, settings.limitInput,
-				settings.streamOpenTimeout, settings.streamInactivityTimeout);
+				settings.streamOpenTimeout, settings.streamInactivityTimeout,
+				settings.rateLimitingInputBytesPerSecond,
+				settings.rateLimitingOutputBytesPerSecond);
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-core/src/main/java/org/apache/flink/core/fs/ConnectionLimitingFactory.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/ConnectionLimitingFactory.java
@@ -61,8 +61,11 @@ public class ConnectionLimitingFactory implements FileSystemFactory {
 	public FileSystem create(URI fsUri) throws IOException {
 		FileSystem original = factory.create(fsUri);
 		return new LimitedConnectionsFileSystem(original,
-				settings.limitTotal, settings.limitOutput, settings.limitInput,
-				settings.streamOpenTimeout, settings.streamInactivityTimeout,
+				settings.limitTotal,
+				settings.limitOutput,
+				settings.limitInput,
+				settings.streamOpenTimeout,
+				settings.streamInactivityTimeout,
 				settings.rateLimitingInputBytesPerSecond,
 				settings.rateLimitingOutputBytesPerSecond);
 	}

--- a/flink-core/src/test/java/org/apache/flink/core/fs/LimitedConnectionsConfigurationTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/fs/LimitedConnectionsConfigurationTest.java
@@ -67,6 +67,8 @@ public class LimitedConnectionsConfigurationTest {
 		config.setInteger("fs." + fsScheme + ".limit.output", 40);
 		config.setInteger("fs." + fsScheme + ".limit.timeout", 12345);
 		config.setInteger("fs." + fsScheme + ".limit.stream-timeout", 98765);
+		config.setInteger("fs." + fsScheme + ".limit.rateLimitingInput", 123);
+		config.setInteger("fs." + fsScheme + ".limit.rateLimitingOutput", 223);
 
 		try {
 			FileSystem.initialize(config);
@@ -83,6 +85,8 @@ public class LimitedConnectionsConfigurationTest {
 			assertEquals(40, limitedFs.getMaxNumOpenOutputStreams());
 			assertEquals(12345, limitedFs.getStreamOpenTimeout());
 			assertEquals(98765, limitedFs.getStreamInactivityTimeout());
+			assertEquals(123, limitedFs.getRateLimitingInput());
+			assertEquals(223, limitedFs.getRateLimitingOutput());
 		}
 		finally {
 			// clear all settings

--- a/flink-core/src/test/java/org/apache/flink/core/fs/LimitedConnectionsConfigurationTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/fs/LimitedConnectionsConfigurationTest.java
@@ -67,8 +67,8 @@ public class LimitedConnectionsConfigurationTest {
 		config.setInteger("fs." + fsScheme + ".limit.output", 40);
 		config.setInteger("fs." + fsScheme + ".limit.timeout", 12345);
 		config.setInteger("fs." + fsScheme + ".limit.stream-timeout", 98765);
-		config.setInteger("fs." + fsScheme + ".limit.rateLimitingInput", 123);
-		config.setInteger("fs." + fsScheme + ".limit.rateLimitingOutput", 223);
+		config.setInteger("fs." + fsScheme + ".limit.input-rate", 123);
+		config.setInteger("fs." + fsScheme + ".limit.output-rate", 223);
 
 		try {
 			FileSystem.initialize(config);

--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopFsFactory.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopFsFactory.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.net.URI;
 import java.net.UnknownHostException;
+import java.util.Optional;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -166,12 +167,7 @@ public class HadoopFsFactory implements FileSystemFactory {
 			HadoopFileSystem fs = new HadoopFileSystem(hadoopFs);
 
 			// create the Flink file system, optionally limiting the open connections
-			if (flinkConfig != null) {
-				return HadoopUtils.limitIfConfigured(fs, scheme, flinkConfig);
-			}
-			else {
-				return fs;
-			}
+			return HadoopUtils.limitIfConfigured(fs, scheme, Optional.ofNullable(flinkConfig));
 		}
 		catch (ReflectiveOperationException | LinkageError e) {
 			throw new UnsupportedFileSystemSchemeException("Cannot support file system for '" + fsUri.getScheme() +

--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopFsFactory.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopFsFactory.java
@@ -209,7 +209,9 @@ public class HadoopFsFactory implements FileSystemFactory {
 					limitSettings.limitOutput,
 					limitSettings.limitInput,
 					limitSettings.streamOpenTimeout,
-					limitSettings.streamInactivityTimeout);
+					limitSettings.streamInactivityTimeout,
+					limitSettings.rateLimitingInputBytesPerSecond,
+					limitSettings.rateLimitingOutputBytesPerSecond);
 		}
 	}
 }

--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopFsFactory.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopFsFactory.java
@@ -21,8 +21,6 @@ package org.apache.flink.runtime.fs.hdfs;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.FileSystemFactory;
-import org.apache.flink.core.fs.LimitedConnectionsFileSystem;
-import org.apache.flink.core.fs.LimitedConnectionsFileSystem.ConnectionLimitingSettings;
 import org.apache.flink.core.fs.UnsupportedFileSystemSchemeException;
 import org.apache.flink.runtime.util.HadoopUtils;
 
@@ -169,7 +167,7 @@ public class HadoopFsFactory implements FileSystemFactory {
 
 			// create the Flink file system, optionally limiting the open connections
 			if (flinkConfig != null) {
-				return limitIfConfigured(fs, scheme, flinkConfig);
+				return HadoopUtils.limitIfConfigured(fs, scheme, flinkConfig);
 			}
 			else {
 				return fs;
@@ -194,24 +192,4 @@ public class HadoopFsFactory implements FileSystemFactory {
 				"The attempt to use a configured default authority failed: ";
 	}
 
-	private static FileSystem limitIfConfigured(HadoopFileSystem fs, String scheme, Configuration config) {
-		final ConnectionLimitingSettings limitSettings = ConnectionLimitingSettings.fromConfig(config, scheme);
-
-		// decorate only if any limit is configured
-		if (limitSettings == null) {
-			// no limit configured
-			return fs;
-		}
-		else {
-			return new LimitedConnectionsFileSystem(
-					fs,
-					limitSettings.limitTotal,
-					limitSettings.limitOutput,
-					limitSettings.limitInput,
-					limitSettings.streamOpenTimeout,
-					limitSettings.streamInactivityTimeout,
-					limitSettings.rateLimitingInputBytesPerSecond,
-					limitSettings.rateLimitingOutputBytesPerSecond);
-		}
-	}
 }

--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/util/HadoopUtils.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/util/HadoopUtils.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.util.Collection;
+import java.util.Optional;
 
 /**
  * Utility class for working with Hadoop-related classes. This should only be used if Hadoop
@@ -129,8 +130,12 @@ public class HadoopUtils {
 	/**
 	 * Parse configuration and load the limited FS wrapper.
 	 */
-	public static FileSystem limitIfConfigured(FileSystem fs, String scheme, org.apache.flink.configuration.Configuration config) {
-		final ConnectionLimitingSettings limitSettings = ConnectionLimitingSettings.fromConfig(config, scheme);
+	public static FileSystem limitIfConfigured(FileSystem fs, String scheme, Optional<org.apache.flink.configuration.Configuration> optional) {
+		if (!optional.isPresent()) {
+			return fs;
+		}
+
+		final ConnectionLimitingSettings limitSettings = ConnectionLimitingSettings.fromConfig(optional.get(), scheme);
 
 		// decorate only if any limit is configured
 		if (limitSettings == null) {

--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/util/HadoopUtils.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/util/HadoopUtils.java
@@ -19,6 +19,9 @@
 package org.apache.flink.runtime.util;
 
 import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.LimitedConnectionsFileSystem;
+import org.apache.flink.core.fs.LimitedConnectionsFileSystem.ConnectionLimitingSettings;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.HdfsConfiguration;
@@ -121,5 +124,29 @@ public class HadoopUtils {
 			}
 		}
 		return false;
+	}
+
+	/**
+	 * Parse configuration and load the limited FS wrapper.
+	 */
+	public static FileSystem limitIfConfigured(FileSystem fs, String scheme, org.apache.flink.configuration.Configuration config) {
+		final ConnectionLimitingSettings limitSettings = ConnectionLimitingSettings.fromConfig(config, scheme);
+
+		// decorate only if any limit is configured
+		if (limitSettings == null) {
+			// no limit configured
+			return fs;
+		}
+		else {
+			return new LimitedConnectionsFileSystem(
+					fs,
+					limitSettings.limitTotal,
+					limitSettings.limitOutput,
+					limitSettings.limitInput,
+					limitSettings.streamOpenTimeout,
+					limitSettings.streamInactivityTimeout,
+					limitSettings.rateLimitingInputBytesPerSecond,
+					limitSettings.rateLimitingOutputBytesPerSecond);
+		}
 	}
 }

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/java/org/apache/flink/fs/s3hadoop/S3FileSystemFactory.java
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/java/org/apache/flink/fs/s3hadoop/S3FileSystemFactory.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.Optional;
 
 /**
  * Simple factory for the S3 file system.
@@ -132,12 +133,7 @@ public class S3FileSystemFactory implements FileSystemFactory {
 			final S3AFileSystem fs = new S3AFileSystem();
 			fs.initialize(fsUri, hadoopConfig);
 
-			if (flinkConfig != null) {
-				return HadoopUtils.limitIfConfigured(new HadoopFileSystem(fs), scheme, flinkConfig);
-			}
-			else {
-				return new HadoopFileSystem(fs);
-			}
+			return HadoopUtils.limitIfConfigured(new HadoopFileSystem(fs), scheme, Optional.ofNullable(flinkConfig));
 		}
 		catch (IOException e) {
 			throw e;

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/java/org/apache/flink/fs/s3hadoop/S3FileSystemFactory.java
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/java/org/apache/flink/fs/s3hadoop/S3FileSystemFactory.java
@@ -132,7 +132,12 @@ public class S3FileSystemFactory implements FileSystemFactory {
 			final S3AFileSystem fs = new S3AFileSystem();
 			fs.initialize(fsUri, hadoopConfig);
 
-			return new HadoopFileSystem(fs);
+			if (flinkConfig != null) {
+				return HadoopUtils.limitIfConfigured(new HadoopFileSystem(fs), scheme, flinkConfig);
+			}
+			else {
+				return new HadoopFileSystem(fs);
+			}
 		}
 		catch (IOException e) {
 			throw e;

--- a/flink-filesystems/flink-s3-fs-presto/src/main/java/org/apache/flink/fs/s3presto/S3FileSystemFactory.java
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/java/org/apache/flink/fs/s3presto/S3FileSystemFactory.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.Optional;
 
 /**
  * Simple factory for the S3 file system.
@@ -131,13 +132,7 @@ public class S3FileSystemFactory implements FileSystemFactory {
 			final PrestoS3FileSystem fs = new PrestoS3FileSystem();
 			fs.initialize(initUri, hadoopConfig);
 
-			// create the Flink file system, optionally limiting the open connections
-			if (flinkConfig != null) {
-				return HadoopUtils.limitIfConfigured(new HadoopFileSystem(fs), scheme, flinkConfig);
-			}
-			else {
-				return new HadoopFileSystem(fs);
-			}
+			return HadoopUtils.limitIfConfigured(new HadoopFileSystem(fs), scheme, Optional.ofNullable(flinkConfig));
 		}
 		catch (IOException e) {
 			throw e;

--- a/flink-filesystems/flink-s3-fs-presto/src/main/java/org/apache/flink/fs/s3presto/S3FileSystemFactory.java
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/java/org/apache/flink/fs/s3presto/S3FileSystemFactory.java
@@ -131,7 +131,13 @@ public class S3FileSystemFactory implements FileSystemFactory {
 			final PrestoS3FileSystem fs = new PrestoS3FileSystem();
 			fs.initialize(initUri, hadoopConfig);
 
-			return new HadoopFileSystem(fs);
+			// create the Flink file system, optionally limiting the open connections
+			if (flinkConfig != null) {
+				return HadoopUtils.limitIfConfigured(new HadoopFileSystem(fs), scheme, flinkConfig);
+			}
+			else {
+				return new HadoopFileSystem(fs);
+			}
 		}
 		catch (IOException e) {
 			throw e;

--- a/flink-filesystems/flink-swift-fs-hadoop/src/main/java/org/apache/flink/fs/openstackhadoop/SwiftFileSystemFactory.java
+++ b/flink-filesystems/flink-swift-fs-hadoop/src/main/java/org/apache/flink/fs/openstackhadoop/SwiftFileSystemFactory.java
@@ -123,7 +123,12 @@ public class SwiftFileSystemFactory implements FileSystemFactory {
 			final SwiftNativeFileSystem fs = new SwiftNativeFileSystem();
 			fs.initialize(fsUri, hadoopConfig);
 
-			return new HadoopFileSystem(fs);
+			if (flinkConfig != null) {
+				return HadoopUtils.limitIfConfigured(new HadoopFileSystem(fs), scheme, flinkConfig);
+			}
+			else {
+				return new HadoopFileSystem(fs);
+			}
 		}
 		catch (IOException e) {
 			throw e;

--- a/flink-filesystems/flink-swift-fs-hadoop/src/main/java/org/apache/flink/fs/openstackhadoop/SwiftFileSystemFactory.java
+++ b/flink-filesystems/flink-swift-fs-hadoop/src/main/java/org/apache/flink/fs/openstackhadoop/SwiftFileSystemFactory.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.util.Optional;
 
 /**
  * Simple factory for the Swift file system.
@@ -123,12 +124,7 @@ public class SwiftFileSystemFactory implements FileSystemFactory {
 			final SwiftNativeFileSystem fs = new SwiftNativeFileSystem();
 			fs.initialize(fsUri, hadoopConfig);
 
-			if (flinkConfig != null) {
-				return HadoopUtils.limitIfConfigured(new HadoopFileSystem(fs), scheme, flinkConfig);
-			}
-			else {
-				return new HadoopFileSystem(fs);
-			}
+			return HadoopUtils.limitIfConfigured(new HadoopFileSystem(fs), scheme, Optional.ofNullable(flinkConfig));
 		}
 		catch (IOException e) {
 			throw e;


### PR DESCRIPTION
## Contribution Checklist
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](http://flink.apache.org/contribute-code.html#best-practices).

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

## What is the purpose of the change

* Adding rate limiting on FileSystem . Our first purpose is to limit the bandwidth used by the writing of Checkpoint to object storage because it has impact on the global throughput of flink

## Brief change log

Use the existing LimitedConnectionsFileSystem class to add some rate limiting mechanisms to throttle the bandwidth needs. It use the RateLimiter class provided by Guava

## Verifying this change

  - Unit test for validation of the configuration parsing 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): Yes . Flink-core now depends on shaded guava18 
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: No
  - The serializers: No
  - The runtime per-record code paths (performance sensitive): No
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: No
  - The file system connector: Yes

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? Ops documentation updated
