### PR TITLE
[FLINK-9562] [flink-optimizer] Wrong wording in flink-optimizer module

### DIFF
--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/costs/Costs.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/costs/Costs.java
@@ -427,7 +427,7 @@ public class Costs implements Comparable<Costs>, Cloneable {
 			return 1;
 		}
 		
-		// next, check the disk cost. again, if we have actual costs on both, use them, otherwise use the heuristic costs.
+		// next, check the CPU cost. again, if we have actual costs on both, use them, otherwise use the heuristic costs.
 		if (this.cpuCost != UNKNOWN && o.cpuCost != UNKNOWN) {
 			return this.cpuCost < o.cpuCost ? -1 : this.cpuCost > o.cpuCost ? 1 : 0;
 		} else if (this.heuristicCpuCost < o.heuristicCpuCost) {

--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/dag/DagConnection.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/dag/DagConnection.java
@@ -54,13 +54,14 @@ public class DagConnection implements EstimateProvider, DumpableConnection<Optim
 	private boolean breakPipeline;  // whether this connection should break the pipeline due to potential deadlocks
 
 	/**
-	 * Creates a new Connection between two nodes. The shipping strategy is by default <tt>NONE</tt>.
-	 * The temp mode is by default <tt>NONE</tt>.
+	 * Creates a new Connection between two nodes. The shipping strategy is by default <tt>null</tt>.
 	 * 
 	 * @param source
 	 *        The source node.
 	 * @param target
 	 *        The target node.
+	 * @param exchangeMode
+	 *        The data exchange mode (pipelined / batch / batch only for shuffles / ... )
 	 */
 	public DagConnection(OptimizerNode source, OptimizerNode target, ExecutionMode exchangeMode) {
 		this(source, target, null, exchangeMode);
@@ -96,10 +97,12 @@ public class DagConnection implements EstimateProvider, DumpableConnection<Optim
 	 * 
 	 * @param source
 	 *        The source node.
+	 * @param exchangeMode
+	 *        The data exchange mode (pipelined / batch / batch only for shuffles / ... )
 	 */
 	public DagConnection(OptimizerNode source, ExecutionMode exchangeMode) {
 		if (source == null) {
-			throw new NullPointerException("Source and target must not be null.");
+			throw new NullPointerException("Source must not be null.");
 		}
 		this.source = source;
 		this.target = null;

--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/dag/SortPartitionNode.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/dag/SortPartitionNode.java
@@ -120,7 +120,7 @@ public class SortPartitionNode extends SingleInputNode {
 		
 		@Override
 		public LocalProperties computeLocalProperties(LocalProperties lProps) {
-			// sort partition is a no-operation operation, such that all global properties are preserved.
+			// sort partition is a no-operation operation, such that all local properties are preserved.
 			return lProps;
 		}
 	}

--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/dag/TwoInputNode.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/dag/TwoInputNode.java
@@ -428,7 +428,7 @@ public abstract class TwoInputNode extends OptimizerNode {
 					}
 					
 					for (RequestedGlobalProperties igps2: intGlobal2) {
-						// create a candidate channel for the first input. mark it cached, if the connection says so
+						// create a candidate channel for the second input. mark it cached, if the connection says so
 						final Channel c2 = new Channel(child2, this.input2.getMaterializationMode());
 						if (this.input2.getShipStrategy() == null) {
 							// free to choose the ship strategy


### PR DESCRIPTION
## What is the purpose of the change

This pull request corrects some typos and copy paste errors in flink-optimizer module


## Brief change log

  - *dag\DagConnection.java - DagConnection() function - in exception strings and function headers*
  - *dag\TwoInputNode.java  - getAlternativePlans() function - in comments*
  - *dag\SortPartitionNode.java - computeLocalProperties() function - in comments*
  - *costs\Costs.java - compareTo() function - in comments*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no


## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
