### PR TITLE
[FLINK-9569] [avro] Fix confusing construction of GenericRecord AvroSerializers

### DIFF
--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/typeutils/AvroTypeInfo.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/typeutils/AvroTypeInfo.java
@@ -82,7 +82,7 @@ public class AvroTypeInfo<T extends SpecificRecordBase> extends PojoTypeInfo<T> 
 	public TypeSerializer<T> createSerializer(ExecutionConfig config) {
 		return useBackwardsCompatibleSerializer ?
 				new BackwardsCompatibleAvroSerializer<>(getTypeClass()) :
-				new AvroSerializer<>(getTypeClass());
+				AvroSerializer.forNonGeneric(getTypeClass());
 	}
 
 	@SuppressWarnings("unchecked")

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/typeutils/BackwardsCompatibleAvroSerializer.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/typeutils/BackwardsCompatibleAvroSerializer.java
@@ -61,7 +61,7 @@ public class BackwardsCompatibleAvroSerializer<T> extends TypeSerializer<T> {
 	 */
 	public BackwardsCompatibleAvroSerializer(Class<T> type) {
 		this.type = type;
-		this.serializer = new AvroSerializer<>(type);
+		this.serializer = AvroSerializer.forNonGeneric(type);
 	}
 
 	/**

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/typeutils/GenericRecordAvroTypeInfo.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/typeutils/GenericRecordAvroTypeInfo.java
@@ -77,7 +77,7 @@ public class GenericRecordAvroTypeInfo extends TypeInformation<GenericRecord> {
 
 	@Override
 	public TypeSerializer<GenericRecord> createSerializer(ExecutionConfig config) {
-		return new AvroSerializer<>(GenericRecord.class, schema);
+		return AvroSerializer.forGeneric(schema);
 	}
 
 	@Override

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/utils/AvroKryoSerializerUtils.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/utils/AvroKryoSerializerUtils.java
@@ -70,7 +70,7 @@ public class AvroKryoSerializerUtils extends AvroUtils {
 
 	@Override
 	public <T> TypeSerializer<T> createAvroSerializer(Class<T> type) {
-		return new AvroSerializer<>(type);
+		return AvroSerializer.forNonGeneric(type);
 	}
 
 	@Override

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroGenericArraySerializerTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroGenericArraySerializerTest.java
@@ -28,6 +28,6 @@ public class AvroGenericArraySerializerTest extends AbstractGenericArraySerializ
 
 	@Override
 	protected <T> TypeSerializer<T> createComponentSerializer(Class<T> type) {
-		return new AvroSerializer<T>(type);
+		return AvroSerializer.forNonGeneric(type);
 	}
 }

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroGenericTypeComparatorTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroGenericTypeComparatorTest.java
@@ -28,6 +28,6 @@ public class AvroGenericTypeComparatorTest extends AbstractGenericTypeComparator
 
 	@Override
 	protected <T> TypeSerializer<T> createSerializer(Class<T> type) {
-		return new AvroSerializer<>(type);
+		return AvroSerializer.forNonGeneric(type);
 	}
 }

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroGenericTypeSerializerTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroGenericTypeSerializerTest.java
@@ -28,6 +28,6 @@ public class AvroGenericTypeSerializerTest extends AbstractGenericTypeSerializer
 
 	@Override
 	protected <T> TypeSerializer<T> createSerializer(Class<T> type) {
-		return new AvroSerializer<>(type);
+		return AvroSerializer.forNonGeneric(type);
 	}
 }

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroSerializerConcurrencyTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroSerializerConcurrencyTest.java
@@ -40,7 +40,7 @@ public class AvroSerializerConcurrencyTest {
 
 	@Test
 	public void testConcurrentUseOfSerializer() throws Exception {
-		final AvroSerializer<String> serializer = new AvroSerializer<>(String.class);
+		final AvroSerializer<String> serializer = AvroSerializer.forNonGeneric(String.class);
 
 		final BlockerSync sync = new BlockerSync();
 

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroSerializerEmptyArrayTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroSerializerEmptyArrayTest.java
@@ -37,7 +37,7 @@ public class AvroSerializerEmptyArrayTest {
 	public void testBookSerialization() {
 		try {
 			Book b = new Book(123, "This is a test book", 26382648);
-			AvroSerializer<Book> serializer = new AvroSerializer<Book>(Book.class);
+			AvroSerializer<Book> serializer = AvroSerializer.forNonGeneric(Book.class);
 			SerializerTestInstance<Book> test = new SerializerTestInstance<Book>(serializer, Book.class, -1, b);
 			test.testAll();
 		}
@@ -61,7 +61,7 @@ public class AvroSerializerEmptyArrayTest {
 			a.books = books;
 			a.bookType = BookAuthor.BookType.journal;
 
-			AvroSerializer<BookAuthor> serializer = new AvroSerializer<BookAuthor>(BookAuthor.class);
+			AvroSerializer<BookAuthor> serializer = AvroSerializer.forNonGeneric(BookAuthor.class);
 
 			SerializerTestInstance<BookAuthor> test = new SerializerTestInstance<BookAuthor>(serializer, BookAuthor.class, -1, a);
 			test.testAll();

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroSerializerSerializabilityTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroSerializerSerializabilityTest.java
@@ -40,7 +40,7 @@ public class AvroSerializerSerializabilityTest {
 
 	@Test
 	public void testDeserializeSerializer() throws Exception {
-		final AvroSerializer<String> currentSerializer = new AvroSerializer<>(String.class);
+		final AvroSerializer<String> currentSerializer = AvroSerializer.forNonGeneric(String.class);
 
 		try (ObjectInputStream in = new ObjectInputStream(
 				getClass().getClassLoader().getResourceAsStream(RESOURCE_NAME))) {
@@ -57,7 +57,7 @@ public class AvroSerializerSerializabilityTest {
 	// ------------------------------------------------------------------------
 
 	public static void main(String[] args) throws Exception {
-		final AvroSerializer<String> serializer = new AvroSerializer<>(String.class);
+		final AvroSerializer<String> serializer = AvroSerializer.forNonGeneric(String.class);
 
 		final File file = new File("flink-formats/flink-avro/src/test/resources/" + RESOURCE_NAME).getAbsoluteFile();
 

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroSerializerTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroSerializerTest.java
@@ -32,7 +32,7 @@ public class AvroSerializerTest extends SerializerTestBase<User> {
 
 	@Override
 	protected TypeSerializer<User> createSerializer() {
-		return new AvroSerializer<>(User.class);
+		return AvroSerializer.forNonGeneric(User.class);
 	}
 
 	@Override


### PR DESCRIPTION
## What is the purpose of the change

The `AvroSerializer` previously had a `AvroSerializer(Class<T> type, Schema schema)` public constructor when used for generic records.

This is a bit confusing, because when using the `AvroSerializer`, the type to be serialized should always be a `GenericData.Record` type.

This PR fixes this by letting the `AvroSerializer` having similar construction patterns to the `AvroDeserializationSchema`, where we have static factory methods for generic and non-generic Avro types.

## Brief change log

- Remove all public constructors from the `AvroSerializer`
- Add `TypeSerializer<GenericRecord> AvroSerializer.forGeneric(Schema)` method to create an `AvroSerializer` for `GenericRecord`s
- Add `TypeSerializer<T> AvroSerializer.forNonGeneric(Class<T> type)` method to create an `AvroSerializer` for specific or POJO types.
- A previously deprecated constructor in the `AvroSerializer` is completely removed, since it should be assumed that the `AvroSerializer` is an internal API and would not require API deprecation.

## Verifying this change

This is just a code refactor. Required test coverage should not have been effected.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (**yes** / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
