### PR TITLE
[FLINK-9557] [formats] Parse 'integer' type as BigDecimal

### DIFF
--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaJsonTableSourceFactoryTestBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaJsonTableSourceFactoryTestBase.java
@@ -117,7 +117,7 @@ public abstract class KafkaJsonTableSourceFactoryTestBase {
 				.withSchema(
 					TableSchema.builder()
 						.field("fruit-name", Types.STRING)
-						.field("count", Types.BIG_INT)
+						.field("count", Types.BIG_DEC)
 						.field("event-time", Types.SQL_TIMESTAMP)
 						.field("proc-time", Types.SQL_TIMESTAMP)
 						.build())
@@ -141,7 +141,7 @@ public abstract class KafkaJsonTableSourceFactoryTestBase {
 			.addSchema(
 				new Schema()
 						.field("fruit-name", Types.STRING).from("name")
-						.field("count", Types.BIG_INT) // no from so it must match with the input
+						.field("count", Types.BIG_DEC) // no from so it must match with the input
 						.field("event-time", Types.SQL_TIMESTAMP).rowtime(
 							new Rowtime().timestampsFromField("time").watermarksFromSource())
 						.field("proc-time", Types.SQL_TIMESTAMP).proctime());

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonSchemaConverter.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonSchemaConverter.java
@@ -165,7 +165,9 @@ public final class JsonSchemaConverter {
 						typeSet.add(Types.BIG_DEC);
 						break;
 					case TYPE_INTEGER:
-						typeSet.add(Types.BIG_INT);
+						// use BigDecimal for easier interoperability
+						// without affecting the correctness of the result
+						typeSet.add(Types.BIG_DEC);
 						break;
 					case TYPE_OBJECT:
 						typeSet.add(convertObject(location, node, root));

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonRowDeserializationSchemaTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonRowDeserializationSchemaTest.java
@@ -29,7 +29,6 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
@@ -79,12 +78,12 @@ public class JsonRowDeserializationSchemaTest {
 
 	@Test
 	public void testSchemaDeserialization() throws Exception {
-		final BigInteger id = BigInteger.valueOf(1238123899121L);
+		final BigDecimal id = BigDecimal.valueOf(1238123899121L);
 		final String name = "asdlkjasjkdla998y1122";
 		final byte[] bytes = new byte[1024];
 		ThreadLocalRandom.current().nextBytes(bytes);
-		final BigInteger[] numbers = new BigInteger[] {
-			BigInteger.valueOf(1), BigInteger.valueOf(2), BigInteger.valueOf(3)};
+		final BigDecimal[] numbers = new BigDecimal[] {
+			BigDecimal.valueOf(1), BigDecimal.valueOf(2), BigDecimal.valueOf(3)};
 		final String[] strings = new String[] {"one", "two", "three"};
 
 		final ObjectMapper objectMapper = new ObjectMapper();

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonRowSerializationSchemaTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonRowSerializationSchemaTest.java
@@ -25,7 +25,6 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
@@ -137,7 +136,7 @@ public class JsonRowSerializationSchemaTest {
 			"}");
 
 		final Row row = new Row(11);
-		row.setField(0, BigInteger.valueOf(-333));
+		row.setField(0, BigDecimal.valueOf(-333));
 		row.setField(1, BigDecimal.valueOf(12.2222));
 		row.setField(2, null);
 		row.setField(3, "");
@@ -148,8 +147,8 @@ public class JsonRowSerializationSchemaTest {
 		final byte[] bytes = new byte[1024];
 		ThreadLocalRandom.current().nextBytes(bytes);
 		row.setField(7, bytes);
-		final BigInteger[] numbers = new BigInteger[] {
-			BigInteger.valueOf(1), BigInteger.valueOf(2), BigInteger.valueOf(3)};
+		final BigDecimal[] numbers = new BigDecimal[] {
+			BigDecimal.valueOf(1), BigDecimal.valueOf(2), BigDecimal.valueOf(3)};
 		row.setField(8, numbers);
 		final String[] strings = new String[] {"one", "two", "three"};
 		row.setField(9, strings);

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonSchemaConverterTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonSchemaConverterTest.java
@@ -47,7 +47,7 @@ public class JsonSchemaConverterTest {
 				"email", "tel", "sound", "org"},
 			Types.STRING, Types.STRING, Types.BOOLEAN, Types.ROW(Types.BIG_DEC, Types.STRING, Types.STRING, Types.STRING),
 			Types.OBJECT_ARRAY(Types.STRING), Types.STRING, Types.ROW_NAMED(new String[] {"type", "value"}, Types.STRING, Types.STRING),
-			Types.ROW_NAMED(new String[] {"type", "value"}, Types.BIG_INT, Types.STRING), Types.VOID,
+			Types.ROW_NAMED(new String[] {"type", "value"}, Types.BIG_DEC, Types.STRING), Types.VOID,
 			Types.ROW_NAMED(new String[] {"organizationUnit"}, Types.ROW()));
 
 		assertEquals(expected, result);


### PR DESCRIPTION
## What is the purpose of the change

This PR changes the behavior of how a JSON schema is converted into type information for the `integer` type. Currently, we treat `integer` as a BigInteger. However, the Table and SQL API are not able to handle BigInteger and this cannot be changed easily because there is no equivalent SQL type but only `DECIMAL`. In order to avoid confusion for users and support end-to-end use cases that read and write to JSON formatted connectors, the best solution is to treat `integer` as BigDecimal. The serializers/deserializers still support BigInteger for specific use cases.


## Brief change log

- Change default behavior of the JSON schema converter


## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
