### PR TITLE
 [FLINK-9573] Extend LeaderElectionService#hasLeadership to take leader session id

### DIFF
--- a/flink-docs/src/main/java/org/apache/flink/docs/rest/RestAPIDocGenerator.java
+++ b/flink-docs/src/main/java/org/apache/flink/docs/rest/RestAPIDocGenerator.java
@@ -54,6 +54,8 @@ import org.apache.flink.shaded.netty4.io.netty.channel.ChannelInboundHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
+
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -369,7 +371,7 @@ public class RestAPIDocGenerator {
 			}
 
 			@Override
-			public boolean hasLeadership() {
+			public boolean hasLeadership(@Nonnull UUID leaderSessionId) {
 				return false;
 			}
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedLeaderService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedLeaderService.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 
@@ -356,8 +357,8 @@ public class EmbeddedLeaderService {
 		}
 
 		@Override
-		public boolean hasLeadership() {
-			return isLeader;
+		public boolean hasLeadership(@Nonnull UUID leaderSessionId) {
+			return isLeader && leaderSessionId.equals(currentLeaderSessionId);
 		}
 
 		void shutdown(Exception cause) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/leaderelection/SingleLeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/leaderelection/SingleLeaderElectionService.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 import java.util.HashSet;
@@ -162,9 +163,9 @@ public class SingleLeaderElectionService implements LeaderElectionService {
 	}
 
 	@Override
-	public boolean hasLeadership() {
+	public boolean hasLeadership(@Nonnull UUID leaderSessionId) {
 		synchronized (lock) {
-			return leader != null;
+			return proposedLeader != null && leaderSessionId.equals(leaderId);
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/leaderelection/SingleLeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/leaderelection/SingleLeaderElectionService.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
+
 import java.util.HashSet;
 import java.util.UUID;
 import java.util.concurrent.Executor;
@@ -40,10 +41,10 @@ import static org.apache.flink.util.Preconditions.checkState;
 /**
  * An implementation of the {@link LeaderElectionService} interface that handles a single
  * leader contender. When started, this service immediately grants the contender the leadership.
- * 
+ *
  * <p>The implementation accepts a single static leader session ID and is hence compatible with
  * pre-configured single leader (no leader failover) setups.
- * 
+ *
  * <p>This implementation supports a series of leader listeners that receive notifications about
  * the leader contender.
  */
@@ -53,31 +54,31 @@ public class SingleLeaderElectionService implements LeaderElectionService {
 
 	// ------------------------------------------------------------------------
 
-	/** lock for all operations on this instance */
+	/** lock for all operations on this instance. */
 	private final Object lock = new Object();
 
-	/** The executor service that dispatches notifications */
+	/** The executor service that dispatches notifications. */
 	private final Executor notificationExecutor;
 
-	/** The leader ID assigned to the immediate leader */
+	/** The leader ID assigned to the immediate leader. */
 	private final UUID leaderId;
 
 	@GuardedBy("lock")
 	private final HashSet<EmbeddedLeaderRetrievalService> listeners;
 
-	/** The currently proposed leader */
+	/** The currently proposed leader. */
 	@GuardedBy("lock")
 	private volatile LeaderContender proposedLeader;
 
-	/** The confirmed leader */
+	/** The confirmed leader. */
 	@GuardedBy("lock")
 	private volatile LeaderContender leader;
 
-	/** The address of the confirmed leader */
+	/** The address of the confirmed leader. */
 	@GuardedBy("lock")
 	private volatile String leaderAddress;
 
-	/** Flag marking this service as shutdown, meaning it cannot be started again */
+	/** Flag marking this service as shutdown, meaning it cannot be started again. */
 	@GuardedBy("lock")
 	private volatile boolean shutdown;
 
@@ -86,7 +87,7 @@ public class SingleLeaderElectionService implements LeaderElectionService {
 	/**
 	 * Creates a new leader election service. The service assigns the given leader ID
 	 * to the leader contender.
-	 * 
+	 *
 	 * @param leaderId The constant leader ID assigned to the leader.
 	 */
 	public SingleLeaderElectionService(Executor notificationsDispatcher, UUID leaderId) {
@@ -172,7 +173,7 @@ public class SingleLeaderElectionService implements LeaderElectionService {
 	void errorOnGrantLeadership(LeaderContender contender, Throwable error) {
 		LOG.warn("Error notifying leader listener about new leader", error);
 		contender.handleError(error instanceof Exception ? (Exception) error : new Exception(error));
-		
+
 		synchronized (lock) {
 			if (proposedLeader == contender) {
 				proposedLeader = null;
@@ -186,7 +187,9 @@ public class SingleLeaderElectionService implements LeaderElectionService {
 	// ------------------------------------------------------------------------
 
 	public boolean isShutdown() {
-		return shutdown;
+		synchronized (lock) {
+			return shutdown;
+		}
 	}
 
 	public void shutdown() {
@@ -232,8 +235,10 @@ public class SingleLeaderElectionService implements LeaderElectionService {
 	// ------------------------------------------------------------------------
 
 	public LeaderRetrievalService createLeaderRetrievalService() {
-		checkState(!shutdown, "leader election service is shut down");
-		return new EmbeddedLeaderRetrievalService();
+		synchronized (lock) {
+			checkState(!shutdown, "leader election service is shut down");
+			return new EmbeddedLeaderRetrievalService();
+		}
 	}
 
 	void addListener(EmbeddedLeaderRetrievalService service, LeaderRetrievalListener listener) {
@@ -347,7 +352,7 @@ public class SingleLeaderElectionService implements LeaderElectionService {
 	// ------------------------------------------------------------------------
 
 	/**
-	 * This runnable informs a leader listener of a new leader
+	 * This runnable informs a leader listener of a new leader.
 	 */
 	private static class NotifyOfLeaderCall implements Runnable {
 
@@ -382,6 +387,4 @@ public class SingleLeaderElectionService implements LeaderElectionService {
 			}
 		}
 	}
-
-
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerRunner.java
@@ -340,7 +340,7 @@ public class JobManagerRunner implements LeaderContender, OnCompletionActions, A
 	}
 
 	private void confirmLeaderSessionIdIfStillLeader(UUID leaderSessionId, CompletableFuture<JobMasterGateway> currentLeaderGatewayFuture) {
-		if (leaderElectionService.hasLeadership()) {
+		if (leaderElectionService.hasLeadership(leaderSessionId)) {
 			currentLeaderGatewayFuture.complete(jobMaster.getSelfGateway(JobMasterGateway.class));
 			leaderElectionService.confirmLeaderSessionID(leaderSessionId);
 		} else {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderElectionService.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.leaderelection;
 
+import javax.annotation.Nonnull;
+
 import java.util.UUID;
 
 /**
@@ -62,10 +64,11 @@ public interface LeaderElectionService {
 
 	/**
 	 * Returns true if the {@link LeaderContender} with which the service has been started owns
-	 * currently the leadership.
+	 * currently the leadership under the given leader session id.
+	 *
+	 * @param leaderSessionId identifying the current leader
 	 *
 	 * @return true if the associated {@link LeaderContender} is the leader, otherwise false
 	 */
-	boolean hasLeadership();
-
+	boolean hasLeadership(@Nonnull UUID leaderSessionId);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/StandaloneLeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/StandaloneLeaderElectionService.java
@@ -21,6 +21,8 @@ package org.apache.flink.runtime.leaderelection;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.util.Preconditions;
 
+import javax.annotation.Nonnull;
+
 import java.util.UUID;
 
 /**
@@ -58,7 +60,7 @@ public class StandaloneLeaderElectionService implements LeaderElectionService {
 	public void confirmLeaderSessionID(UUID leaderSessionID) {}
 
 	@Override
-	public boolean hasLeadership() {
-		return true;
+	public boolean hasLeadership(@Nonnull UUID leaderSessionId) {
+		return (contender != null && HighAvailabilityServices.DEFAULT_LEADER_ID.equals(leaderSessionId));
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionService.java
@@ -37,6 +37,8 @@ import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
@@ -205,8 +207,8 @@ public class ZooKeeperLeaderElectionService implements LeaderElectionService, Le
 	}
 
 	@Override
-	public boolean hasLeadership() {
-		return leaderLatch.hasLeadership();
+	public boolean hasLeadership(@Nonnull UUID leaderSessionId) {
+		return leaderLatch.hasLeadership() && leaderSessionId.equals(issuedLeaderSessionID);
 	}
 
 	@Override

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/jobmanager/JobManager.scala
@@ -490,7 +490,8 @@ class JobManager(
 
             Option(submittedJobGraphOption) match {
               case Some(submittedJobGraph) =>
-                if (!leaderElectionService.hasLeadership()) {
+                if (leaderSessionID.isEmpty ||
+                  !leaderElectionService.hasLeadership(leaderSessionID.get)) {
                   // we've lost leadership. mission: abort.
                   log.warn(s"Lost leadership during recovery. Aborting recovery of $jobId.")
                 } else {
@@ -1381,7 +1382,8 @@ class JobManager(
           jobInfo.notifyClients(
             decorateMessage(JobSubmitSuccess(jobGraph.getJobID)))
 
-          if (leaderElectionService.hasLeadership) {
+          if (leaderSessionID.isDefined &&
+            leaderElectionService.hasLeadership(leaderSessionID.get)) {
             // There is a small chance that multiple job managers schedule the same job after if
             // they try to recover at the same time. This will eventually be noticed, but can not be
             // ruled out from the beginning.

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderElectionTest.java
@@ -1,0 +1,245 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.leaderelection;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.HighAvailabilityOptions;
+import org.apache.flink.runtime.highavailability.nonha.embedded.EmbeddedLeaderService;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.apache.flink.runtime.util.ZooKeeperUtils;
+import org.apache.flink.util.TestLogger;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.test.TestingServer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.UUID;
+import java.util.concurrent.ArrayBlockingQueue;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for leader election.
+ */
+@RunWith(Parameterized.class)
+public class LeaderElectionTest extends TestLogger {
+
+	enum LeaderElectionType {
+		ZooKeeper,
+		Embedded,
+		Standalone
+	}
+
+	@Parameterized.Parameters(name = "Leader election: {0}")
+	public static Collection<LeaderElectionType> parameters () {
+		return Arrays.asList(LeaderElectionType.values());
+	}
+
+	private final ServiceClass serviceClass;
+
+	public LeaderElectionTest(LeaderElectionType leaderElectionType) {
+		switch(leaderElectionType) {
+			case ZooKeeper:
+				serviceClass = new ZooKeeperServiceClass();
+				break;
+			case Embedded:
+				serviceClass = new EmbeddedServiceClass();
+				break;
+			case Standalone:
+				serviceClass = new StandaloneServiceClass();
+				break;
+			default:
+				throw new IllegalArgumentException(String.format("Unknown leader election type: %s.", leaderElectionType));
+		}
+	}
+
+	@Before
+	public void setup() throws Exception {
+		serviceClass.setup();
+	}
+
+	@After
+	public void teardown() throws Exception {
+		serviceClass.teardown();
+	}
+
+	@Test
+	public void testHasLeadership() throws Exception {
+		final LeaderElectionService leaderElectionService = serviceClass.createLeaderElectionService();
+		final ManualLeaderContender manualLeaderContender = new ManualLeaderContender();
+
+		try {
+			assertThat(leaderElectionService.hasLeadership(UUID.randomUUID()), is(false));
+
+			leaderElectionService.start(manualLeaderContender);
+
+			final UUID leaderSessionId = manualLeaderContender.waitForLeaderSessionId();
+
+			assertThat(leaderElectionService.hasLeadership(leaderSessionId), is(true));
+			assertThat(leaderElectionService.hasLeadership(UUID.randomUUID()), is(false));
+
+			leaderElectionService.confirmLeaderSessionID(leaderSessionId);
+
+			assertThat(leaderElectionService.hasLeadership(leaderSessionId), is(true));
+
+			leaderElectionService.stop();
+
+			assertThat(leaderElectionService.hasLeadership(leaderSessionId), is(false));
+		} finally {
+			manualLeaderContender.rethrowError();
+		}
+	}
+
+	private static final class ManualLeaderContender implements LeaderContender {
+
+		private static final UUID NULL_LEADER_SESSION_ID = new UUID(0L, 0L);
+
+		private final ArrayBlockingQueue<UUID> leaderSessionIds = new ArrayBlockingQueue<>(10);
+
+		private volatile Exception exception;
+
+		@Override
+		public void grantLeadership(UUID leaderSessionID) {
+			leaderSessionIds.offer(leaderSessionID);
+		}
+
+		@Override
+		public void revokeLeadership() {
+			leaderSessionIds.offer(NULL_LEADER_SESSION_ID);
+		}
+
+		@Override
+		public String getAddress() {
+			return "foobar";
+		}
+
+		@Override
+		public void handleError(Exception exception) {
+			this.exception = exception;
+		}
+
+		void rethrowError() throws Exception {
+			if (exception != null) {
+				throw exception;
+			}
+		}
+
+		UUID waitForLeaderSessionId() throws InterruptedException {
+			return leaderSessionIds.take();
+		}
+	}
+
+	private interface ServiceClass {
+		void setup() throws Exception;
+
+		void teardown() throws Exception;
+
+		LeaderElectionService createLeaderElectionService() throws Exception;
+	}
+
+	private static final class ZooKeeperServiceClass implements ServiceClass {
+
+		private TestingServer testingServer;
+
+		private CuratorFramework client;
+
+		private Configuration configuration;
+
+		@Override
+		public void setup() throws Exception {
+			try {
+				testingServer = new TestingServer();
+			} catch (Exception e) {
+				throw new RuntimeException("Could not start ZooKeeper testing cluster.", e);
+			}
+
+			configuration = new Configuration();
+
+			configuration.setString(HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, testingServer.getConnectString());
+			configuration.setString(HighAvailabilityOptions.HA_MODE, "zookeeper");
+
+			client = ZooKeeperUtils.startCuratorFramework(configuration);
+		}
+
+		@Override
+		public void teardown() throws Exception {
+			if (client != null) {
+				client.close();
+				client = null;
+			}
+
+			if (testingServer != null) {
+				testingServer.stop();
+				testingServer = null;
+			}
+		}
+
+		@Override
+		public LeaderElectionService createLeaderElectionService() throws Exception {
+			return ZooKeeperUtils.createLeaderElectionService(client, configuration);
+		}
+	}
+
+	private static final class EmbeddedServiceClass implements ServiceClass {
+		private EmbeddedLeaderService embeddedLeaderService;
+
+		@Override
+		public void setup() {
+			embeddedLeaderService = new EmbeddedLeaderService(TestingUtils.defaultExecutionContext());
+		}
+
+		@Override
+		public void teardown() {
+			if (embeddedLeaderService != null) {
+				embeddedLeaderService.shutdown();
+				embeddedLeaderService = null;
+			}
+		}
+
+		@Override
+		public LeaderElectionService createLeaderElectionService() throws Exception {
+			return embeddedLeaderService.createLeaderElectionService();
+		}
+	}
+
+	private static final class StandaloneServiceClass implements ServiceClass {
+
+		@Override
+		public void setup() throws Exception {
+			// noop
+		}
+
+		@Override
+		public void teardown() throws Exception {
+			// noop
+		}
+
+		@Override
+		public LeaderElectionService createLeaderElectionService() throws Exception {
+			return new StandaloneLeaderElectionService();
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionService.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionService.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.leaderelection;
 
+import javax.annotation.Nonnull;
+
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
@@ -30,6 +32,7 @@ public class TestingLeaderElectionService implements LeaderElectionService {
 	private LeaderContender contender;
 	private boolean hasLeadership = false;
 	private CompletableFuture<UUID> confirmationFuture = null;
+	private UUID issuedLeaderSessionId = null;
 
 	/**
 	 * Gets a future that completes when leadership is confirmed.
@@ -58,8 +61,8 @@ public class TestingLeaderElectionService implements LeaderElectionService {
 	}
 
 	@Override
-	public synchronized boolean hasLeadership() {
-		return hasLeadership;
+	public synchronized boolean hasLeadership(@Nonnull UUID leaderSessionId) {
+		return hasLeadership && leaderSessionId.equals(issuedLeaderSessionId);
 	}
 
 	public synchronized CompletableFuture<UUID> isLeader(UUID leaderSessionID) {
@@ -68,6 +71,7 @@ public class TestingLeaderElectionService implements LeaderElectionService {
 		}
 		confirmationFuture = new CompletableFuture<>();
 		hasLeadership = true;
+		issuedLeaderSessionId = leaderSessionID;
 		contender.grantLeadership(leaderSessionID);
 
 		return confirmationFuture;

--- a/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingJobManagerLike.scala
+++ b/flink-runtime/src/test/scala/org/apache/flink/runtime/testingUtils/TestingJobManagerLike.scala
@@ -409,7 +409,7 @@ trait TestingJobManagerLike extends FlinkActor {
       }
 
     case NotifyWhenLeader =>
-      if (leaderElectionService.hasLeadership) {
+      if (leaderSessionID.isDefined && leaderElectionService.hasLeadership(leaderSessionID.get)) {
         sender() ! true
       } else {
         waitForLeader += sender()


### PR DESCRIPTION
## What is the purpose of the change

The new `LeaderElectionService#hasLeadership` also takes the leader session id and verifies whether
this is the correct leader session id associated with the leadership.

## Brief change log

- Extend `LeaderElectionService#hasLeadership` to take a leader session id and check whether it identifies the current leader session
- Adapt the calls to `LeaderElectionService#hasLeadership` to take the current leader session id

## Verifying this change

- Added `LeaderElectionTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
