### PR TITLE
[FLINK-9572] Extend InternalAppendingState with internal stored state access

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/AbstractHeapMergingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/AbstractHeapMergingState.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.state.heap;
 
 import org.apache.flink.api.common.state.MergingState;
-import org.apache.flink.api.common.state.State;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.state.StateTransformationFunction;
 import org.apache.flink.runtime.state.internal.InternalMergingState;
@@ -34,11 +33,10 @@ import java.util.Collection;
  * @param <IN> The type of the input elements.
  * @param <SV> The type of the values in the state.
  * @param <OUT> The type of the output elements.
- * @param <S> The type of State
  */
-public abstract class AbstractHeapMergingState<K, N, IN, SV, OUT, S extends State>
-		extends AbstractHeapState<K, N, SV, S>
-		implements InternalMergingState<K, N, IN, SV, OUT> {
+abstract class AbstractHeapMergingState<K, N, IN, SV, OUT>
+	extends AbstractHeapAppendingState<K, N, IN, SV, OUT>
+	implements InternalMergingState<K, N, IN, SV, OUT> {
 
 	/**
 	 * The merge transformation function that implements the merge logic.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/AbstractHeapState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/AbstractHeapState.java
@@ -33,9 +33,8 @@ import org.apache.flink.util.Preconditions;
  * @param <K> The type of the key.
  * @param <N> The type of the namespace.
  * @param <SV> The type of the values in the state.
- * @param <S> The type of State
  */
-public abstract class AbstractHeapState<K, N, SV, S extends State> implements InternalKvState<K, N, SV> {
+public abstract class AbstractHeapState<K, N, SV> implements InternalKvState<K, N, SV> {
 
 	/** Map containing the actual key/value pairs. */
 	protected final StateTable<K, N, SV> stateTable;
@@ -60,7 +59,7 @@ public abstract class AbstractHeapState<K, N, SV, S extends State> implements In
 	 * @param namespaceSerializer The serializer for the namespace.
 	 * @param defaultValue The default value for the state.
 	 */
-	protected AbstractHeapState(
+	AbstractHeapState(
 			StateTable<K, N, SV> stateTable,
 			TypeSerializer<K> keySerializer,
 			TypeSerializer<SV> valueSerializer,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapAggregatingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapAggregatingState.java
@@ -37,9 +37,9 @@ import java.io.IOException;
  * @param <ACC> The type of the value stored in the state (the accumulator type).
  * @param <OUT> The type of the value returned from the state.
  */
-public class HeapAggregatingState<K, N, IN, ACC, OUT>
-		extends AbstractHeapMergingState<K, N, IN, ACC, OUT, AggregatingState<IN, OUT>>
-		implements InternalAggregatingState<K, N, IN, ACC, OUT> {
+class HeapAggregatingState<K, N, IN, ACC, OUT>
+	extends AbstractHeapMergingState<K, N, IN, ACC, OUT>
+	implements InternalAggregatingState<K, N, IN, ACC, OUT> {
 
 	private final AggregateTransformation<IN, ACC, OUT> aggregateTransformation;
 
@@ -53,13 +53,13 @@ public class HeapAggregatingState<K, N, IN, ACC, OUT>
 	 * @param defaultValue The default value for the state.
 	 * @param aggregateFunction The aggregating function used for aggregating state.
 	 */
-	public HeapAggregatingState(
-			StateTable<K, N, ACC> stateTable,
-			TypeSerializer<K> keySerializer,
-			TypeSerializer<ACC> valueSerializer,
-			TypeSerializer<N> namespaceSerializer,
-			ACC defaultValue,
-			AggregateFunction<IN, ACC, OUT> aggregateFunction) {
+	HeapAggregatingState(
+		StateTable<K, N, ACC> stateTable,
+		TypeSerializer<K> keySerializer,
+		TypeSerializer<ACC> valueSerializer,
+		TypeSerializer<N> namespaceSerializer,
+		ACC defaultValue,
+		AggregateFunction<IN, ACC, OUT> aggregateFunction) {
 
 		super(stateTable, keySerializer, valueSerializer, namespaceSerializer, defaultValue);
 		this.aggregateTransformation = new AggregateTransformation<>(aggregateFunction);
@@ -86,8 +86,7 @@ public class HeapAggregatingState<K, N, IN, ACC, OUT>
 
 	@Override
 	public OUT get() {
-
-		ACC accumulator = stateTable.get(currentNamespace);
+		ACC accumulator = getInternal();
 		return accumulator != null ? aggregateTransformation.aggFunction.getResult(accumulator) : null;
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapFoldingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapFoldingState.java
@@ -38,11 +38,11 @@ import java.io.IOException;
  * @deprecated will be removed in a future version
  */
 @Deprecated
-public class HeapFoldingState<K, N, T, ACC>
-		extends AbstractHeapState<K, N, ACC, FoldingState<T, ACC>>
-		implements InternalFoldingState<K, N, T, ACC> {
+class HeapFoldingState<K, N, T, ACC>
+	extends AbstractHeapAppendingState<K, N, T, ACC, ACC>
+	implements InternalFoldingState<K, N, T, ACC> {
 
-	/** The function used to fold the state */
+	/** The function used to fold the state. */
 	private final FoldTransformation foldTransformation;
 
 	/**
@@ -55,13 +55,13 @@ public class HeapFoldingState<K, N, T, ACC>
 	 * @param defaultValue The default value for the state.
 	 * @param foldFunction The fold function used for folding state.
 	 */
-	public HeapFoldingState(
-			StateTable<K, N, ACC> stateTable,
-			TypeSerializer<K> keySerializer,
-			TypeSerializer<ACC> valueSerializer,
-			TypeSerializer<N> namespaceSerializer,
-			ACC defaultValue,
-			FoldFunction<T, ACC> foldFunction) {
+	HeapFoldingState(
+		StateTable<K, N, ACC> stateTable,
+		TypeSerializer<K> keySerializer,
+		TypeSerializer<ACC> valueSerializer,
+		TypeSerializer<N> namespaceSerializer,
+		ACC defaultValue,
+		FoldFunction<T, ACC> foldFunction) {
 		super(stateTable, keySerializer, valueSerializer, namespaceSerializer, defaultValue);
 		this.foldTransformation = new FoldTransformation(foldFunction);
 	}
@@ -87,7 +87,7 @@ public class HeapFoldingState<K, N, T, ACC>
 
 	@Override
 	public ACC get() {
-		return stateTable.get(currentNamespace);
+		return getInternal();
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapListState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapListState.java
@@ -38,9 +38,9 @@ import java.util.List;
  * @param <N> The type of the namespace.
  * @param <V> The type of the value.
  */
-public class HeapListState<K, N, V>
-		extends AbstractHeapMergingState<K, N, V, List<V>, Iterable<V>, ListState<V>>
-		implements InternalListState<K, N, V> {
+class HeapListState<K, N, V>
+	extends AbstractHeapMergingState<K, N, V, List<V>, Iterable<V>>
+	implements InternalListState<K, N, V> {
 
 	/**
 	 * Creates a new key/value state for the given hash map of key/value pairs.
@@ -51,12 +51,12 @@ public class HeapListState<K, N, V>
 	 * @param namespaceSerializer The serializer for the namespace.
 	 * @param defaultValue The default value for the state.
 	 */
-	public HeapListState(
-			StateTable<K, N, List<V>> stateTable,
-			TypeSerializer<K> keySerializer,
-			TypeSerializer<List<V>> valueSerializer,
-			TypeSerializer<N> namespaceSerializer,
-			List<V> defaultValue) {
+	HeapListState(
+		StateTable<K, N, List<V>> stateTable,
+		TypeSerializer<K> keySerializer,
+		TypeSerializer<List<V>> valueSerializer,
+		TypeSerializer<N> namespaceSerializer,
+		List<V> defaultValue) {
 		super(stateTable, keySerializer, valueSerializer, namespaceSerializer, defaultValue);
 	}
 
@@ -81,7 +81,7 @@ public class HeapListState<K, N, V>
 
 	@Override
 	public Iterable<V> get() {
-		return stateTable.get(currentNamespace);
+		return getInternal();
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapMapState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapMapState.java
@@ -38,9 +38,9 @@ import java.util.Map;
  * @param <UK> The type of the keys in the state.
  * @param <UV> The type of the values in the state.
  */
-public class HeapMapState<K, N, UK, UV>
-		extends AbstractHeapState<K, N, Map<UK, UV>, MapState<UK, UV>>
-		implements InternalMapState<K, N, UK, UV> {
+class HeapMapState<K, N, UK, UV>
+	extends AbstractHeapState<K, N, Map<UK, UV>>
+	implements InternalMapState<K, N, UK, UV> {
 
 	/**
 	 * Creates a new key/value state for the given hash map of key/value pairs.
@@ -51,12 +51,12 @@ public class HeapMapState<K, N, UK, UV>
 	 * @param namespaceSerializer The serializer for the namespace.
 	 * @param defaultValue The default value for the state.
 	 */
-	public HeapMapState(
-			StateTable<K, N, Map<UK, UV>> stateTable,
-			TypeSerializer<K> keySerializer,
-			TypeSerializer<Map<UK, UV>> valueSerializer,
-			TypeSerializer<N> namespaceSerializer,
-			Map<UK, UV> defaultValue) {
+	HeapMapState(
+		StateTable<K, N, Map<UK, UV>> stateTable,
+		TypeSerializer<K> keySerializer,
+		TypeSerializer<Map<UK, UV>> valueSerializer,
+		TypeSerializer<N> namespaceSerializer,
+		Map<UK, UV> defaultValue) {
 		super(stateTable, keySerializer, valueSerializer, namespaceSerializer, defaultValue);
 
 		Preconditions.checkState(valueSerializer instanceof MapSerializer, "Unexpected serializer type.");

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapReducingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapReducingState.java
@@ -34,9 +34,9 @@ import java.io.IOException;
  * @param <N> The type of the namespace.
  * @param <V> The type of the value.
  */
-public class HeapReducingState<K, N, V>
-		extends AbstractHeapMergingState<K, N, V, V, V, ReducingState<V>>
-		implements InternalReducingState<K, N, V> {
+class HeapReducingState<K, N, V>
+	extends AbstractHeapMergingState<K, N, V, V, V>
+	implements InternalReducingState<K, N, V> {
 
 	private final ReduceTransformation<V> reduceTransformation;
 
@@ -83,7 +83,7 @@ public class HeapReducingState<K, N, V>
 
 	@Override
 	public V get() {
-		return stateTable.get(currentNamespace);
+		return getInternal();
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/internal/InternalAppendingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/internal/InternalAppendingState.java
@@ -22,7 +22,7 @@ import org.apache.flink.api.common.state.AppendingState;
 
 /**
  * The peer to the {@link AppendingState} in the internal state type hierarchy.
- * 
+ *
  * <p>See {@link InternalKvState} for a description of the internal state hierarchy.
  *
  * @param <K> The type of key the state is associated to
@@ -31,4 +31,22 @@ import org.apache.flink.api.common.state.AppendingState;
  * @param <SV> The type of elements in the state
  * @param <OUT> The type of the resulting element in the state
  */
-public interface InternalAppendingState<K, N, IN, SV, OUT> extends InternalKvState<K, N, SV>, AppendingState<IN, OUT> {}
+public interface InternalAppendingState<K, N, IN, SV, OUT> extends InternalKvState<K, N, SV>, AppendingState<IN, OUT> {
+	/**
+	 * Get internally stored value.
+	 *
+	 * @return internally stored value.
+	 *
+	 * @throws Exception The method may forward exception thrown internally (by I/O or functions).
+	 */
+	SV getInternal() throws Exception;
+
+	/**
+	 * Update internally stored value.
+	 *
+	 * @param valueToStore new value to store.
+	 *
+	 * @throws Exception The method may forward exception thrown internally (by I/O or functions).
+	 */
+	void updateInternal(SV valueToStore) throws Exception;
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
@@ -3293,7 +3293,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 			backend.setCurrentKey(1);
 			state.update(121818273);
 
-			StateTable<?, ?, ?> stateTable = ((AbstractHeapState<?, ?, ? ,?>) kvState).getStateTable();
+			StateTable<?, ?, ?> stateTable = ((AbstractHeapState<?, ?, ?>) kvState).getStateTable();
 			checkConcurrentStateTable(stateTable, numberOfKeyGroups);
 
 		}
@@ -3315,7 +3315,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 			backend.setCurrentKey(1);
 			state.add(121818273);
 
-			StateTable<?, ?, ?> stateTable = ((AbstractHeapState<?, ?, ? , ?>) kvState).getStateTable();
+			StateTable<?, ?, ?> stateTable = ((AbstractHeapState<?, ?, ?>) kvState).getStateTable();
 			checkConcurrentStateTable(stateTable, numberOfKeyGroups);
 		}
 
@@ -3342,7 +3342,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 			backend.setCurrentKey(1);
 			state.add(121818273);
 
-			StateTable<?, ?, ?> stateTable = ((AbstractHeapState<?, ?, ? ,?>) kvState).getStateTable();
+			StateTable<?, ?, ?> stateTable = ((AbstractHeapState<?, ?, ?>) kvState).getStateTable();
 			checkConcurrentStateTable(stateTable, numberOfKeyGroups);
 		}
 
@@ -3369,7 +3369,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 			backend.setCurrentKey(1);
 			state.add(121818273);
 
-			StateTable<?, ?, ?> stateTable = ((AbstractHeapState<?, ?, ? ,?>) kvState).getStateTable();
+			StateTable<?, ?, ?> stateTable = ((AbstractHeapState<?, ?, ?>) kvState).getStateTable();
 			checkConcurrentStateTable(stateTable, numberOfKeyGroups);
 		}
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBAppendingState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBAppendingState.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.state;
+
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.memory.ByteArrayInputStreamWithPos;
+import org.apache.flink.core.memory.DataInputViewStreamWrapper;
+import org.apache.flink.runtime.state.internal.InternalAppendingState;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.RocksDBException;
+
+import java.io.IOException;
+
+abstract class AbstractRocksDBAppendingState <K, N, IN, SV, OUT, S extends State>
+	extends AbstractRocksDBState<K, N, SV, S>
+	implements InternalAppendingState<K, N, IN, SV, OUT> {
+
+	/**
+	 * Creates a new RocksDB backend appending state.
+	 *
+	 * @param columnFamily        The RocksDB column family that this state is associated to.
+	 * @param namespaceSerializer The serializer for the namespace.
+	 * @param valueSerializer     The serializer for the state.
+	 * @param defaultValue        The default value for the state.
+	 * @param backend             The backend for which this state is bind to.
+	 */
+	protected AbstractRocksDBAppendingState(
+		ColumnFamilyHandle columnFamily,
+		TypeSerializer<N> namespaceSerializer,
+		TypeSerializer<SV> valueSerializer,
+		SV defaultValue,
+		RocksDBKeyedStateBackend<K> backend) {
+		super(columnFamily, namespaceSerializer, valueSerializer, defaultValue, backend);
+	}
+
+	@Override
+	public SV getInternal() {
+		return getInternal(getKeyBytes());
+	}
+
+	SV getInternal(byte[] key) {
+		try {
+			byte[] valueBytes = backend.db.get(columnFamily, key);
+			if (valueBytes == null) {
+				return null;
+			}
+			return valueSerializer.deserialize(new DataInputViewStreamWrapper(new ByteArrayInputStreamWithPos(valueBytes)));
+		} catch (IOException | RocksDBException e) {
+			throw new FlinkRuntimeException("Error while retrieving data from RocksDB", e);
+		}
+	}
+
+	@Override
+	public void updateInternal(SV valueToStore) {
+		updateInternal(getKeyBytes(), valueToStore);
+	}
+
+	void updateInternal(byte[] key, SV valueToStore) {
+		try {
+			// write the new value to RocksDB
+			backend.db.put(columnFamily, writeOptions, key, getValueBytes(valueToStore));
+		}
+		catch (RocksDBException e) {
+			throw new FlinkRuntimeException("Error while adding value to RocksDB", e);
+		}
+	}
+}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBMapState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBMapState.java
@@ -29,6 +29,7 @@ import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.queryablestate.client.state.serialization.KvStateSerializer;
 import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
 import org.apache.flink.runtime.state.internal.InternalMapState;
+import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.Preconditions;
 
 import org.rocksdb.ColumnFamilyHandle;
@@ -438,7 +439,7 @@ public class RocksDBMapState<K, N, UK, UV>
 			try {
 				db.delete(columnFamily, writeOptions, rawKeyBytes);
 			} catch (RocksDBException e) {
-				throw new RuntimeException("Error while removing data from RocksDB.", e);
+				throw new FlinkRuntimeException("Error while removing data from RocksDB.", e);
 			}
 		}
 
@@ -448,7 +449,7 @@ public class RocksDBMapState<K, N, UK, UV>
 				try {
 					userKey = deserializeUserKey(userKeyOffset, rawKeyBytes, keySerializer);
 				} catch (IOException e) {
-					throw new RuntimeException("Error while deserializing the user key.", e);
+					throw new FlinkRuntimeException("Error while deserializing the user key.", e);
 				}
 			}
 
@@ -464,7 +465,7 @@ public class RocksDBMapState<K, N, UK, UV>
 					try {
 						userValue = deserializeUserValue(rawValueBytes, valueSerializer);
 					} catch (IOException e) {
-						throw new RuntimeException("Error while deserializing the user value.", e);
+						throw new FlinkRuntimeException("Error while deserializing the user value.", e);
 					}
 				}
 
@@ -486,7 +487,7 @@ public class RocksDBMapState<K, N, UK, UV>
 
 				db.put(columnFamily, writeOptions, rawKeyBytes, rawValueBytes);
 			} catch (IOException | RocksDBException e) {
-				throw new RuntimeException("Error while putting data into RocksDB.", e);
+				throw new FlinkRuntimeException("Error while putting data into RocksDB.", e);
 			}
 
 			return oldValue;

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBValueState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBValueState.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.runtime.state.internal.InternalValueState;
+import org.apache.flink.util.FlinkRuntimeException;
 
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.RocksDBException;
@@ -86,7 +87,7 @@ public class RocksDBValueState<K, N, V>
 			}
 			return valueSerializer.deserialize(new DataInputViewStreamWrapper(new ByteArrayInputStream(valueBytes)));
 		} catch (IOException | RocksDBException e) {
-			throw new RuntimeException("Error while retrieving data from RocksDB.", e);
+			throw new FlinkRuntimeException("Error while retrieving data from RocksDB.", e);
 		}
 	}
 
@@ -104,7 +105,7 @@ public class RocksDBValueState<K, N, V>
 			valueSerializer.serialize(value, out);
 			backend.db.put(columnFamily, writeOptions, key, keySerializationStream.toByteArray());
 		} catch (Exception e) {
-			throw new RuntimeException("Error while adding data to RocksDB", e);
+			throw new FlinkRuntimeException("Error while adding data to RocksDB", e);
 		}
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

Extend InternalAppendingState with get and update methods for internal stored state. 
Implement them in concrete states in backends.

## Brief change log

  - *InternalAppendingState* has now methods *getInternal* and *updateInternal*
  - Heap and Rocksdb merging states implement the methods


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
It should be covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (yes)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
