### PR TITLE
[FLINK-9570][SQL-CLIENT]Fixed merging environments

### DIFF
--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/config/Environment.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/config/Environment.java
@@ -133,8 +133,8 @@ public class Environment {
 
 		// merge tables
 		final Map<String, TableDescriptor> tables = new HashMap<>(env1.getTables());
-		mergedEnv.getTables().putAll(env2.getTables());
 		mergedEnv.tables = tables;
+		mergedEnv.getTables().putAll(env2.getTables());
 
 		// merge execution properties
 		mergedEnv.execution = Execution.merge(env1.getExecution(), env2.getExecution());

--- a/flink-libraries/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/EnvironmentMerging.java
+++ b/flink-libraries/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/EnvironmentMerging.java
@@ -1,0 +1,40 @@
+package org.apache.flink.table.client.gateway.local;
+
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import org.apache.flink.table.client.config.Environment;
+import org.apache.flink.table.client.gateway.utils.EnvironmentFileUtil;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.*;
+
+public class EnvironmentMerging {
+
+	private static final String FACTORY_ENVIRONMENT_FILE = "test-sql-client-factory.yaml";
+	private static final String TABLE_SOURCE_FACTORY_JAR_FILE = "table-source-factory-test-jar.jar";
+	private static final String[] TABLE_NAMES = {"MergedTable", "TableName1"};
+	@Test
+	public void testIfTwoFilesAreMergedProperly() throws IOException {
+		Environment env1 = EnvironmentFileUtil.parseUnmodified("test-sql-client-defaults.yaml");
+		Environment env2 = EnvironmentFileUtil.parseModified("test-sql-client-factory.yaml", Collections.singletonMap("TableName1", "MergedTable"));
+
+		Set<String> mergedTableNames = Sets.union(env1.getTables().keySet(), env2.getTables().keySet());
+
+		Map<String, String> mergedExecutionProperties = new HashMap<>();
+		mergedExecutionProperties.putAll(env1.getExecution().toProperties());
+		mergedExecutionProperties.putAll(env2.getExecution().toProperties());
+
+		Map<String, String> mergedDeploymentProperties = new HashMap<>();
+		mergedDeploymentProperties.putAll(env1.getDeployment().toProperties());
+		mergedDeploymentProperties.putAll(env2.getDeployment().toProperties());
+
+		Environment merged = Environment.merge(env1, env2);
+
+		Assert.assertEquals(mergedTableNames.size(), merged.getTables().size());
+		Assert.assertEquals(mergedTableNames, merged.getTables().keySet());
+		Assert.assertEquals(mergedDeploymentProperties, merged.getDeployment().toProperties());
+		Assert.assertEquals(mergedExecutionProperties, merged.getExecution().toProperties());
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change
This fixes merging of environments as it was previously throwing an exception.
## Brief change log

- Changed the order of assignments in `Environment.merge()` function

## Verifying this change

This change added tests and can be verified as follows:

Added a simple unit test that tests if the two environments were correctly merged

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
