### PR TITLE
[FLINK-8785][rest] Handle JobSubmissionExceptions

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/AbstractRestHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/AbstractRestHandler.java
@@ -92,7 +92,7 @@ public abstract class AbstractRestHandler<T extends RestfulGateway, R extends Re
 					HandlerUtils.sendErrorResponse(
 						ctx,
 						httpRequest,
-						new ErrorResponseBody(rhe.getMessage()),
+						new ErrorResponseBody(rhe.getMessages()),
 						rhe.getHttpResponseStatus(),
 						responseHeaders);
 				} else {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/RestHandlerException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/RestHandlerException.java
@@ -22,6 +22,11 @@ import org.apache.flink.util.FlinkException;
 
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 /**
  * An exception that is thrown if the failure of a REST operation was detected by a handler.
  */
@@ -29,15 +34,26 @@ public class RestHandlerException extends FlinkException {
 	private static final long serialVersionUID = -1358206297964070876L;
 
 	private final int responseCode;
+	private final List<String> errorMessages;
 
 	public RestHandlerException(String errorMessage, HttpResponseStatus httpResponseStatus) {
-		super(errorMessage);
+		this(Collections.singletonList(errorMessage), httpResponseStatus);
+	}
+
+	public RestHandlerException(List<String> errorMessages, HttpResponseStatus httpResponseStatus) {
+		super(errorMessages.toString());
+		this.errorMessages = errorMessages;
 		this.responseCode = httpResponseStatus.code();
 	}
 
 	public RestHandlerException(String errorMessage, HttpResponseStatus httpResponseStatus, Throwable cause) {
 		super(errorMessage, cause);
+		this.errorMessages = Collections.singletonList(errorMessage);
 		this.responseCode = httpResponseStatus.code();
+	}
+
+	public List<String> getMessages() {
+		return errorMessages;
 	}
 
 	public HttpResponseStatus getHttpResponseStatus() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/RestHandlerException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/RestHandlerException.java
@@ -22,8 +22,6 @@ import org.apache.flink.util.FlinkException;
 
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobSubmitHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobSubmitHandler.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.rest.handler.job;
 
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.dispatcher.DispatcherGateway;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.rest.handler.AbstractRestHandler;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobSubmitHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobSubmitHandlerTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.rest.handler.job;
 
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.dispatcher.DispatcherGateway;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.messages.Acknowledge;
@@ -28,6 +29,7 @@ import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
 import org.apache.flink.runtime.rest.messages.job.JobSubmitRequestBody;
 import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.TestLogger;
 
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
@@ -36,6 +38,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Collections;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import static org.mockito.Matchers.any;
@@ -86,5 +89,32 @@ public class JobSubmitHandlerTest extends TestLogger {
 
 		handler.handleRequest(new HandlerRequest<>(request, EmptyMessageParameters.getInstance()), mockGateway)
 			.get();
+	}
+
+	@Test
+	public void testFailedJobSubmission() throws Exception {
+		DispatcherGateway mockGateway = mock(DispatcherGateway.class);
+		when(mockGateway.submitJob(any(JobGraph.class), any(Time.class))).thenReturn(FutureUtils.completedExceptionally(new Exception("test")));
+		GatewayRetriever<DispatcherGateway> mockGatewayRetriever = mock(GatewayRetriever.class);
+
+		JobSubmitHandler handler = new JobSubmitHandler(
+			CompletableFuture.completedFuture("http://localhost:1234"),
+			mockGatewayRetriever,
+			RpcUtils.INF_TIMEOUT,
+			Collections.emptyMap());
+
+		JobGraph job = new JobGraph("testjob");
+		JobSubmitRequestBody request = new JobSubmitRequestBody(job);
+
+		try {
+			handler.handleRequest(new HandlerRequest<>(request, EmptyMessageParameters.getInstance()), mockGateway)
+				.get();
+		} catch (Exception e) {
+			Optional<Throwable> expectedCause = ExceptionUtils.findThrowable(e,
+				candidate -> "[test]".equals(candidate.getMessage()));
+			if (!expectedCause.isPresent()) {
+				throw e;
+			}
+		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointHandlersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointHandlersTest.java
@@ -158,8 +158,8 @@ public class SavepointHandlersTest extends TestLogger {
 		} catch (RestHandlerException rhe) {
 			assertThat(
 				rhe.getMessage(),
-				equalTo("Config key [state.savepoints.dir] is not set. " +
-					"Property [target-directory] must be provided."));
+				equalTo("[Config key [state.savepoints.dir] is not set. " +
+					"Property [target-directory] must be provided.]"));
 			assertThat(rhe.getHttpResponseStatus(), equalTo(HttpResponseStatus.BAD_REQUEST));
 		}
 	}


### PR DESCRIPTION
## What is the purpose of the change

Currently, if a  `JobSubmissionException` occurs the `JobSubmissionHandler` only returns `505 Internal server error.`, with no details about the original exception.
This PR modifies the handler to returns the messages of all exceptions in the stack trace.

## Brief change log

* modify `RestHandlerException` to allow multiple error messages, similar to `ErrorResponseBody`
* modify `JobSubmitHandler` to handle exceptions during the job submission

## Verifying this change

* see `JobSubmitHandlerTest#testFailedJobSubmission

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not applicable)
