### PR TITLE
[FLINK-9578] [sql-client] Allow to define an auto watermark interval in SQL Client

### DIFF
--- a/docs/dev/table/sqlClient.md
+++ b/docs/dev/table/sqlClient.md
@@ -185,12 +185,13 @@ tables:
 
 execution:
   type: streaming                   # required: execution mode either 'batch' or 'streaming'
+  result-mode: table                # required: either 'table' or 'changelog'
   time-characteristic: event-time   # optional: 'processing-time' or 'event-time' (default)
   parallelism: 1                    # optional: Flink's parallelism (1 by default)
+  periodic-watermarks-interval: 200 # optional: interval for periodic watermarks (200 ms by default)
   max-parallelism: 16               # optional: Flink's maximum parallelism (128 by default)
   min-idle-state-retention: 0       # optional: table program's minimum idle state time
   max-idle-state-retention: 0       # optional: table program's maximum idle state time
-  result-mode: table                # required: either 'table' or 'changelog'
 
 # Deployment properties allow for describing the cluster to which table programs are submitted to.
 

--- a/flink-libraries/flink-sql-client/conf/sql-client-defaults.yaml
+++ b/flink-libraries/flink-sql-client/conf/sql-client-defaults.yaml
@@ -46,6 +46,8 @@ execution:
   type: streaming
   # allow 'event-time' or only 'processing-time' in sources
   time-characteristic: event-time
+  # interval in ms for emitting periodic watermarks
+  periodic-watermarks-interval: 200
   # 'changelog' or 'table' presentation of results
   result-mode: changelog
   # parallelism of the program

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/config/Execution.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/config/Execution.java
@@ -50,6 +50,12 @@ public class Execution {
 			PropertyStrings.EXECUTION_TYPE_VALUE_STREAMING);
 	}
 
+	public boolean isBatchExecution() {
+		return Objects.equals(
+			properties.get(PropertyStrings.EXECUTION_TYPE),
+			PropertyStrings.EXECUTION_TYPE_VALUE_BATCH);
+	}
+
 	public TimeCharacteristic getTimeCharacteristic() {
 		final String s = properties.getOrDefault(
 			PropertyStrings.EXECUTION_TIME_CHARACTERISTIC,
@@ -62,6 +68,10 @@ public class Execution {
 			default:
 				return TimeCharacteristic.EventTime;
 		}
+	}
+
+	public long getPeriodicWatermarksInterval() {
+		return Long.parseLong(properties.getOrDefault(PropertyStrings.EXECUTION_PERIODIC_WATERMARKS_INTERVAL, Long.toString(200L)));
 	}
 
 	public long getMinStateRetention() {

--- a/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/config/PropertyStrings.java
+++ b/flink-libraries/flink-sql-client/src/main/java/org/apache/flink/table/client/config/PropertyStrings.java
@@ -41,6 +41,8 @@ public final class PropertyStrings {
 
 	public static final String EXECUTION_TIME_CHARACTERISTIC_VALUE_PROCESSING_TIME = "processing-time";
 
+	public static final String EXECUTION_PERIODIC_WATERMARKS_INTERVAL = "periodic-watermarks-interval";
+
 	public static final String EXECUTION_MIN_STATE_RETENTION = "min-idle-state-retention";
 
 	public static final String EXECUTION_MAX_STATE_RETENTION = "max-idle-state-retention";

--- a/flink-libraries/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
+++ b/flink-libraries/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
@@ -122,6 +122,7 @@ public class LocalExecutorITCase extends TestLogger {
 		final Map<String, String> expectedProperties = new HashMap<>();
 		expectedProperties.put("execution.type", "streaming");
 		expectedProperties.put("execution.time-characteristic", "event-time");
+		expectedProperties.put("execution.periodic-watermarks-interval", "99");
 		expectedProperties.put("execution.parallelism", "1");
 		expectedProperties.put("execution.max-parallelism", "16");
 		expectedProperties.put("execution.max-idle-state-retention", "0");
@@ -265,7 +266,7 @@ public class LocalExecutorITCase extends TestLogger {
 
 	private <T> LocalExecutor createDefaultExecutor(ClusterClient<T> clusterClient) throws Exception {
 		return new LocalExecutor(
-			EnvironmentFileUtil.parseUnmodified(DEFAULTS_ENVIRONMENT_FILE),
+			EnvironmentFileUtil.parseModified(DEFAULTS_ENVIRONMENT_FILE, Collections.singletonMap("$VAR_2", "batch")),
 			Collections.emptyList(),
 			clusterClient.getFlinkConfiguration(),
 			new DummyCustomCommandLine<T>(clusterClient));

--- a/flink-libraries/flink-sql-client/src/test/resources/test-sql-client-defaults.yaml
+++ b/flink-libraries/flink-sql-client/src/test/resources/test-sql-client-defaults.yaml
@@ -66,6 +66,7 @@ tables:
 execution:
   type: "$VAR_2"
   time-characteristic: event-time
+  periodic-watermarks-interval: 99
   parallelism: 1
   max-parallelism: 16
   min-idle-state-retention: 0


### PR DESCRIPTION
## What is the purpose of the change

This PR allows for setting the auto watermark interval in a non-programatic way for the SQL Client.


## Brief change log

- Introduction of a property `periodic-watermarks-interval`


## Verifying this change

- Existing tests adapted and new ExecutionContextTest added

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
