### PR TITLE
[FLINK-9579][CEP]Remove unneeded clear on elementQueueState

### DIFF
--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/AbstractKeyedCEPPatternOperator.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/AbstractKeyedCEPPatternOperator.java
@@ -334,9 +334,6 @@ public abstract class AbstractKeyedCEPPatternOperator<IN, KEY, OUT, F extends Fu
 		}
 
 		// STEP 3
-		if (sortedTimestamps.isEmpty()) {
-			elementQueueState.clear();
-		}
 		updateNFA(nfa);
 	}
 

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/AbstractKeyedCEPPatternOperator.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/AbstractKeyedCEPPatternOperator.java
@@ -293,9 +293,6 @@ public abstract class AbstractKeyedCEPPatternOperator<IN, KEY, OUT, F extends Fu
 		advanceTime(nfaState, timerService.currentWatermark());
 
 		// STEP 4
-		if (sortedTimestamps.isEmpty()) {
-			elementQueueState.clear();
-		}
 		updateNFA(nfaState);
 
 		if (!sortedTimestamps.isEmpty() || !partialMatches.isEmpty()) {


### PR DESCRIPTION
## What is the purpose of the change

Remove unneeded clear on elementQueueState， when soretedTimestamp is empty, the elements in elementQueueState are all removed, so don't need to clear again to waste time on RocksDB operation.

