### PR TITLE
[FLINK-9577] Divide-by-zero in PageRank

### DIFF
--- a/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/linkanalysis/PageRank.java
+++ b/flink-libraries/flink-gelly/src/main/java/org/apache/flink/graph/library/linkanalysis/PageRank.java
@@ -424,7 +424,9 @@ extends GraphAlgorithmWrappingDataSet<K, VV, EV, Result<K>> {
 			Iterator<LongValue> vertexCountIterator = vertexCount.iterator();
 			this.vertexCount = vertexCountIterator.hasNext() ? vertexCountIterator.next().getValue() : 0;
 
-			this.uniformlyDistributedScore = ((1 - dampingFactor) + dampingFactor * sumOfSinks) / this.vertexCount;
+			if (this.vertexCount != 0) {
+				this.uniformlyDistributedScore = ((1 - dampingFactor) + dampingFactor * sumOfSinks) / this.vertexCount;
+			}
 		}
 
 		@Override


### PR DESCRIPTION
## What is the purpose of the change

*This pull request fixed a divide-by-zero error in PageRank*

## Brief change log

  - *Add a judgement to avoid divide-by-zero error*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
