### PR TITLE
[FLINK-9580] Potentially unclosed ByteBufInputStream in RestClient##readRawResponse

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
@@ -292,16 +292,14 @@ public class RestClient {
 			ByteBuf content = msg.content();
 
 			JsonNode rawResponse;
-			try {
-				InputStream in = new ByteBufInputStream(content);
+			try (InputStream in = new ByteBufInputStream(content)) {
 				rawResponse = objectMapper.readTree(in);
 				LOG.debug("Received response {}.", rawResponse);
 			} catch (JsonParseException je) {
 				LOG.error("Response was not valid JSON.", je);
 				// let's see if it was a plain-text message instead
 				content.readerIndex(0);
-				try {
-					ByteBufInputStream in = new ByteBufInputStream(content);
+				try (ByteBufInputStream in = new ByteBufInputStream(content)) {
 					byte[] data = new byte[in.available()];
 					in.readFully(data);
 					String message = new String(data);
@@ -316,6 +314,7 @@ public class RestClient {
 				jsonFuture.completeExceptionally(new RestClientException("Response could not be read.", ioe, msg.getStatus()));
 				return;
 			}
+
 			jsonFuture.complete(new JsonResponse(rawResponse, msg.getStatus()));
 		}
 	}


### PR DESCRIPTION
## What is the purpose of the change

*This pull request fixed potentially stream connection leak*

## Brief change log

  - *Add finally block to close specific input stream*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
