### PR TITLE
[FLINK-9582][build] Rework flink-dist assemblies

### DIFF
--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -212,6 +212,7 @@ under the License.
 			<artifactId>flink-metrics-dropwizard</artifactId>
 			<version>${project.version}</version>
 			<scope>provided</scope>
+			<classifier>jar-with-dependencies</classifier>
 		</dependency>
 
 		<dependency>
@@ -219,6 +220,7 @@ under the License.
 			<artifactId>flink-metrics-ganglia</artifactId>
 			<version>${project.version}</version>
 			<scope>provided</scope>
+			<classifier>jar-with-dependencies</classifier>
 		</dependency>
 
 		<dependency>
@@ -226,6 +228,7 @@ under the License.
 			<artifactId>flink-metrics-graphite</artifactId>
 			<version>${project.version}</version>
 			<scope>provided</scope>
+			<classifier>jar-with-dependencies</classifier>
 		</dependency>
 
 		<dependency>
@@ -292,6 +295,7 @@ under the License.
 			<artifactId>flink-gelly-scala_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
 			<scope>provided</scope>
+			<classifier>jar-with-dependencies</classifier>
 		</dependency>
 
 		<dependency>
@@ -299,6 +303,7 @@ under the License.
 			<artifactId>flink-ml_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
 			<scope>provided</scope>
+			<classifier>jar-with-dependencies</classifier>
 		</dependency>
 
 		<dependency>
@@ -524,6 +529,24 @@ under the License.
 						<phase>none</phase>
 					</execution>
 				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+    			<artifactId>maven-dependency-plugin</artifactId>
+    			<executions>
+    				<execution>
+    					<id>copy</id>
+			            <phase>package</phase>
+			            <goals>
+			              <goal>copy-dependencies</goal>
+			            </goals>
+		    			<configuration>
+		    				<includeGroupIds>org.apache.flink</includeGroupIds>
+		        			<outputDirectory>${project.build.directory}/dependencies</outputDirectory>
+		    			</configuration>
+    				</execution>
+    			</executions>
 			</plugin>
 
 			<plugin>

--- a/flink-dist/src/main/assemblies/bin.xml
+++ b/flink-dist/src/main/assemblies/bin.xml
@@ -189,7 +189,7 @@ under the License.
 
 		<!-- copy jar files of the gelly examples -->
 		<fileSet>
-			<directory>../flink-libraries/flink-gelly-examples/target</directory>
+			<directory>target/dependencies</directory>
 			<outputDirectory>examples/gelly</outputDirectory>
 			<fileMode>0644</fileMode>
 			<includes>
@@ -199,7 +199,7 @@ under the License.
 
 		<!-- copy python jar -->
 		<fileSet>
-			<directory>../flink-libraries/flink-python/target</directory>
+			<directory>target/dependencies</directory>
 			<outputDirectory>lib</outputDirectory>
 			<fileMode>0644</fileMode>
 			<includes>

--- a/flink-dist/src/main/assemblies/opt.xml
+++ b/flink-dist/src/main/assemblies/opt.xml
@@ -31,14 +31,14 @@
 	<files>
 		<!-- CEP -->
 		<file>
-			<source>../flink-libraries/flink-cep/target/flink-cep_${scala.binary.version}-${project.version}.jar</source>
+			<source>target/dependencies/flink-cep_${scala.binary.version}-${project.version}.jar</source>
 			<outputDirectory>opt/</outputDirectory>
 			<destName>flink-cep_${scala.binary.version}-${project.version}.jar</destName>
 			<fileMode>0644</fileMode>
 		</file>
 
 		<file>
-			<source>../flink-libraries/flink-cep-scala/target/flink-cep-scala_${scala.binary.version}-${project.version}.jar</source>
+			<source>target/dependencies/flink-cep-scala_${scala.binary.version}-${project.version}.jar</source>
 			<outputDirectory>opt/</outputDirectory>
 			<destName>flink-cep-scala_${scala.binary.version}-${project.version}.jar</destName>
 			<fileMode>0644</fileMode>
@@ -46,14 +46,14 @@
 
 		<!-- Gelly -->
 		<file>
-			<source>../flink-libraries/flink-gelly/target/flink-gelly_${scala.binary.version}-${project.version}.jar</source>
+			<source>target/dependencies/flink-gelly_${scala.binary.version}-${project.version}.jar</source>
 			<outputDirectory>opt/</outputDirectory>
 			<destName>flink-gelly_${scala.binary.version}-${project.version}.jar</destName>
 			<fileMode>0644</fileMode>
 		</file>
 
 		<file>
-			<source>../flink-libraries/flink-gelly-scala/target/flink-gelly-scala_${scala.binary.version}-${project.version}-jar-with-dependencies.jar</source>
+			<source>target/dependencies/flink-gelly-scala_${scala.binary.version}-${project.version}-jar-with-dependencies.jar</source>
 			<outputDirectory>opt/</outputDirectory>
 			<destName>flink-gelly-scala_${scala.binary.version}-${project.version}.jar</destName>
 			<fileMode>0644</fileMode>
@@ -61,7 +61,7 @@
 
 		<!-- Table API-->
 		<file>
-			<source>../flink-libraries/flink-table/target/flink-table_${scala.binary.version}-${project.version}.jar</source>
+			<source>target/dependencies/flink-table_${scala.binary.version}-${project.version}.jar</source>
 			<outputDirectory>opt/</outputDirectory>
 			<destName>flink-table_${scala.binary.version}-${project.version}.jar</destName>
 			<fileMode>0644</fileMode>
@@ -77,7 +77,7 @@
 
 		<!-- ML -->
 		<file>
-			<source>../flink-libraries/flink-ml/target/flink-ml_${scala.binary.version}-${project.version}-jar-with-dependencies.jar</source>
+			<source>target/dependencies/flink-ml_${scala.binary.version}-${project.version}-jar-with-dependencies.jar</source>
 			<outputDirectory>opt/</outputDirectory>
 			<destName>flink-ml_${scala.binary.version}-${project.version}.jar</destName>
 			<fileMode>0644</fileMode>
@@ -85,70 +85,70 @@
 
 		<!-- Metrics -->
 		<file>
-			<source>../flink-metrics/flink-metrics-dropwizard/target/flink-metrics-dropwizard-${project.version}-jar-with-dependencies.jar</source>
+			<source>target/dependencies/flink-metrics-dropwizard-${project.version}-jar-with-dependencies.jar</source>
 			<outputDirectory>opt/</outputDirectory>
 			<destName>flink-metrics-dropwizard-${project.version}.jar</destName>
 			<fileMode>0644</fileMode>
 		</file>
 
 		<file>
-			<source>../flink-metrics/flink-metrics-ganglia/target/flink-metrics-ganglia-${project.version}-jar-with-dependencies.jar</source>
+			<source>target/dependencies/flink-metrics-ganglia-${project.version}-jar-with-dependencies.jar</source>
 			<outputDirectory>opt/</outputDirectory>
 			<destName>flink-metrics-ganglia-${project.version}.jar</destName>
 			<fileMode>0644</fileMode>
 		</file>
 
 		<file>
-			<source>../flink-metrics/flink-metrics-graphite/target/flink-metrics-graphite-${project.version}-jar-with-dependencies.jar</source>
+			<source>target/dependencies/flink-metrics-graphite-${project.version}-jar-with-dependencies.jar</source>
 			<outputDirectory>opt/</outputDirectory>
 			<destName>flink-metrics-graphite-${project.version}.jar</destName>
 			<fileMode>0644</fileMode>
 		</file>
 
 		<file>
-			<source>../flink-metrics/flink-metrics-prometheus/target/flink-metrics-prometheus-${project.version}.jar</source>
+			<source>target/dependencies/flink-metrics-prometheus-${project.version}.jar</source>
 			<outputDirectory>opt/</outputDirectory>
 			<destName>flink-metrics-prometheus-${project.version}.jar</destName>
 			<fileMode>0644</fileMode>
 		</file>
 
 		<file>
-			<source>../flink-metrics/flink-metrics-statsd/target/flink-metrics-statsd-${project.version}.jar</source>
+			<source>target/dependencies/flink-metrics-statsd-${project.version}.jar</source>
 			<outputDirectory>opt/</outputDirectory>
 			<destName>flink-metrics-statsd-${project.version}.jar</destName>
 			<fileMode>0644</fileMode>
 		</file>
 
 		<file>
-			<source>../flink-metrics/flink-metrics-datadog/target/flink-metrics-datadog-${project.version}.jar</source>
+			<source>target/dependencies/flink-metrics-datadog-${project.version}.jar</source>
 			<outputDirectory>opt/</outputDirectory>
 			<destName>flink-metrics-datadog-${project.version}.jar</destName>
 			<fileMode>0644</fileMode>
 		</file>
 
 		<file>
-			<source>../flink-metrics/flink-metrics-slf4j/target/flink-metrics-slf4j-${project.version}.jar</source>
+			<source>target/dependencies/flink-metrics-slf4j-${project.version}.jar</source>
 			<outputDirectory>opt/</outputDirectory>
 			<destName>flink-metrics-slf4j-${project.version}.jar</destName>
 			<fileMode>0644</fileMode>
 		</file>
 
 		<file>
-			<source>../flink-filesystems/flink-s3-fs-hadoop/target/flink-s3-fs-hadoop-${project.version}.jar</source>
+			<source>target/dependencies/flink-s3-fs-hadoop-${project.version}.jar</source>
 			<outputDirectory>opt/</outputDirectory>
 			<destName>flink-s3-fs-hadoop-${project.version}.jar</destName>
 			<fileMode>0644</fileMode>
 		</file>
 
 		<file>
-			<source>../flink-filesystems/flink-s3-fs-presto/target/flink-s3-fs-presto-${project.version}.jar</source>
+			<source>target/dependencies/flink-s3-fs-presto-${project.version}.jar</source>
 			<outputDirectory>opt/</outputDirectory>
 			<destName>flink-s3-fs-presto-${project.version}.jar</destName>
 			<fileMode>0644</fileMode>
 		</file>
 
 		<file>
-			<source>../flink-filesystems/flink-swift-fs-hadoop/target/flink-swift-fs-hadoop-${project.version}.jar</source>
+			<source>target/dependencies/flink-swift-fs-hadoop-${project.version}.jar</source>
 			<outputDirectory>opt/</outputDirectory>
 			<destName>flink-swift-fs-hadoop-${project.version}.jar</destName>
 			<fileMode>0644</fileMode>
@@ -156,7 +156,7 @@
 
 		<!-- Queryable State -->
 		<file>
-			<source>../flink-queryable-state/flink-queryable-state-runtime/target/flink-queryable-state-runtime_${scala.binary.version}-${project.version}.jar</source>
+			<source>target/dependencies/flink-queryable-state-runtime_${scala.binary.version}-${project.version}.jar</source>
 			<outputDirectory>opt/</outputDirectory>
 			<destName>flink-queryable-state-runtime_${scala.binary.version}-${project.version}.jar</destName>
 			<fileMode>0644</fileMode>
@@ -164,7 +164,7 @@
 
 		<!-- Streaming Python API -->
 		<file>
-			<source>../flink-libraries/flink-streaming-python/target/flink-streaming-python_${scala.binary.version}-${project.version}.jar</source>
+			<source>target/dependencies/flink-streaming-python_${scala.binary.version}-${project.version}.jar</source>
 			<outputDirectory>opt</outputDirectory>
 			<destName>flink-streaming-python_${scala.binary.version}-${project.version}.jar</destName>
 			<fileMode>0644</fileMode>


### PR DESCRIPTION
## What is the purpose of the change

This PR reworks the `flink-dist` assemblies to not access specific jars outside of the `flink-dist` module.
This allows compiling `flink-dist` without having built any other module (bar `flink-shaded-hadoop2-uber`, but that's another story`).

Instead, the flink jars that flink-dist depends on are copied to `target/dependencies` using the `maven-dependency-plugin`, from which we assemble the final distribution.

## Brief change log

* add `maven-dependency-plugin` execution to flink-dist for copying dependencies to `target/dependencies`
* modify all entries in `flink-dist` assemblies to specific flink jars to use copied jars instead
* added `jar-with-dependencies` classifier to several dependencies of flink-dist to accurately reflect what flink-dist actually requires


## Verifying this change

The general functionality is verified by travis.

I have manually verified that building flink-dist + some other module(s) correctly puts the newly compiled modules in the target directory, instead of downloaded artifacts.
